### PR TITLE
Updating submission output parsing to deal with newlines

### DIFF
--- a/utils/perl5lib/Batch/BatchUtils.pm
+++ b/utils/perl5lib/Batch/BatchUtils.pm
@@ -201,7 +201,13 @@ sub submitSingleJob()
 
 	eval {
         open (my $RUN, "-|", $runcmd) // die "job submission failed, $!";
-        $output = <$RUN>;
+
+		foreach (<$RUN>) {
+			chomp;
+			print "$_\n";
+			$output .= $_;
+		}
+
 		close $RUN or die "job submission failed: |$?|, |$!|"
 	};
 	my $exitstatus = ($?>>8);


### PR DESCRIPTION
This merge updates the submission portion of the BatchUtils file to
remove newlines from within the output of the submission command.

If a newline exists (i.e. the jobid is not on the first line of the
command output) the previous formulation fails. This new version fixes
the issue.