### PR TITLE
Deacme py

### DIFF
--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -1758,9 +1758,4 @@
     </environment_variables>
   </machine>
 
-  <default_run_suffix>
-    <default_run_exe>$config{'EXEROOT'}/cesm.exe </default_run_exe>
-    <default_run_misc_suffix> >> cesm.log.$LID 2>&amp;1 </default_run_misc_suffix>
-  </default_run_suffix>
-
 </config_machines>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -1559,7 +1559,7 @@
 
   <machine MACH="yellowstone">
     <DESC>NCAR IBM, os is Linux, 16 pes/node, batch system is LSF</DESC>
-    <NODENAME_REGEX>yslogin</NODENAME_REGEX>
+    <NODENAME_REGEX>(yslogin.*|pronghorn.*|caldera.*)</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,pgi,gnu,intel15</COMPILERS>
     <MPILIBS>mpich2,pempi,mpi-serial</MPILIBS>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -1559,6 +1559,7 @@
 
   <machine MACH="yellowstone">
     <DESC>NCAR IBM, os is Linux, 16 pes/node, batch system is LSF</DESC>
+    <NODENAME_REGEX>yslogin</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,pgi,gnu,intel15</COMPILERS>
     <MPILIBS>mpich2,pempi,mpi-serial</MPILIBS>
@@ -1757,5 +1758,9 @@
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
   </machine>
-
+  <default_run_suffix>
+    <default_run_exe>$config{'EXEROOT'}/cesm.exe </default_run_exe>
+    <default_run_misc_suffix> >> cesm.log.$LID 2>&amp;1 </default_run_misc_suffix>
+  </default_run_suffix>
+  
 </config_machines>

--- a/scripts-python/bless_test_results
+++ b/scripts-python/bless_test_results
@@ -140,7 +140,7 @@ def bless_history(test_name, baseline_tag, baseline_dir_for_test, testcase_dir_f
     case = os.path.basename(testcase_dir_for_test)
     cime_root = acme_util.get_cime_root()
     compgen = os.path.join(cime_root, "scripts", "Tools", "component_compgen_baseline.sh")
-    machine_env = os.path.join(cime_root, "cime_config", "acme", "machines", "env_mach_specific.%s" % acme_util.probe_machine_name())
+    machine_env = os.path.join(cime_root, "cime_config", "acme", "machines", ".env_mach_specific.csh")
     run_dir = os.path.join(acme_root, case, "run")
     cprnc_loc = acme_util.get_machine_info("CPRNC_ROOT")
     compgen_cmd = "tcsh -c 'source %s && %s -baseline_dir %s -testcase %s -testcase_base %s -test_dir %s -cprnc_exe %s -generate_tag %s'" % \

--- a/scripts-python/create_test
+++ b/scripts-python/create_test
@@ -1,23 +1,23 @@
 #!/usr/bin/env python
 
 """
-Script to run ACME tests.
+Script to run CIME tests.
 
 Runs single tests or test suites based on either the input list or the testname.
 
-This is currently a wrapper around CESM's create_test, but this will eventually replace
+This is currently a wrapper around cime perl create_test, but this will eventually replace
 that tool entirely.
 
 If this tool is missing any feature that you need, please notify jgfouca@sandia.gov.
 """
 
 import add_util_path
-import acme_util
-acme_util.check_minimum_python_version(2, 7)
+import cime_util
+cime_util.check_minimum_python_version(2, 7)
 
 import argparse, sys, os, doctest, tempfile
 import update_acme_tests, create_test_impl
-from acme_util import expect, warning, verbose_print, run_cmd
+from cime_util import expect, warning, verbose_print, run_cmd
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -54,9 +54,10 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
-    default_project = acme_util.get_machine_project()
-    default_compiler = acme_util.get_machine_info("COMPILERS")[0]
-    default_baseline_name = acme_util.get_current_branch(repo=acme_util.get_cime_root())
+    default_project = cime_util.get_machine_project()
+
+    default_compiler = cime_util.get_machine_info("COMPILERS")[0]
+    default_baseline_name = cime_util.get_current_branch(repo=cime_util.get_cime_root())
 
     parser.add_argument("testargs", nargs="+", help="Tests or test suites to run. Testnames expect in form CASE.GRID.COMPSET")
 
@@ -96,7 +97,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         "That will be done for you.")
 
     parser.add_argument("--compiler", default=default_compiler,
-                        help="Compiler to use to build ACME.")
+                        help="Compiler to use to build cime.")
 
     parser.add_argument("-n", "--namelists-only", action="store_true",
                         help="Only perform namelist actions for tests")
@@ -118,9 +119,11 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     parser.add_argument("--old", action="store_true", help="Use CIME Perl impl")
 
+
+
     args = parser.parse_args(args[1:])
 
-    acme_util.set_verbosity(args.verbose)
+    cime_util.set_verbosity(args.verbose)
 
     expect(not (args.generate and args.compare),
            "Cannot generate and compare baselines at the same time")
@@ -135,9 +138,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     if (args.no_build):
         args.no_run = True
 
-    use_batch = acme_util.does_machine_have_batch()
+    use_batch = cime_util.does_machine_have_batch()
     scratch_root, baseline_root = \
-        acme_util.get_machine_info(["CESMSCRATCHROOT", "CCSM_BASELINE"], project=args.project)
+        cime_util.get_machine_info(["CESMSCRATCHROOT", "CCSM_BASELINE"], project=args.project)
 
     if (not args.no_batch and not use_batch):
         args.no_batch = True
@@ -171,7 +174,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                    "Missing baseline comparison directory %s" % full_baseline_dir)
 
     if (args.test_id is None):
-        args.test_id = acme_util.get_utc_timestamp()
+        args.test_id = cime_util.get_utc_timestamp()
 
     return args.testargs, args.compiler, args.no_run, args.no_build, args.no_batch, args.test_root, args.baseline_root, \
         args.clean, args.compare, args.generate, args.baseline_name, args.namelists_only, args.project, args.test_id, args.old, args.parallel_jobs
@@ -181,12 +184,12 @@ def create_test(testargs, compiler, no_run, no_build, no_batch, test_root,
                 baseline_root, clean, compare, generate,
                 baseline_name, namelists_only, project, test_id, old, parallel_jobs):
 ###############################################################################
-    machine = acme_util.probe_machine_name()
+    machine = cime_util.probe_machine_name()
 
     tests_to_run = update_acme_tests.get_full_test_names(testargs, machine, compiler)
 
     if (parallel_jobs is None):
-        parallel_jobs = min(len(tests_to_run), int(acme_util.get_machine_info("MAX_TASKS_PER_NODE")))
+        parallel_jobs = min(len(tests_to_run), int(cime_util.get_machine_info("MAX_TASKS_PER_NODE")))
 
     expect(len(tests_to_run) > 0, "No tests to run")
 
@@ -231,8 +234,8 @@ def create_test(testargs, compiler, no_run, no_build, no_batch, test_root,
         if (no_batch):
             create_test_cmd = "%s -autosubmit off -nobatch on" % create_test_cmd
 
-        stat = acme_util.run_cmd(create_test_cmd,
-                                 from_dir=os.path.join(acme_util.get_cime_root(), "scripts"),
+        stat = cime_util.run_cmd(create_test_cmd,
+                                 from_dir=os.path.join(cime_util.get_cime_root(), "scripts"),
                                  ok_to_fail=True,
                                  verbose=True,
                                  arg_stdout=None, arg_stderr=None)[0]
@@ -245,14 +248,14 @@ def create_test(testargs, compiler, no_run, no_build, no_batch, test_root,
 def _main_func(description):
 ###############################################################################
     if ("--test" in sys.argv):
-        acme_util.run_cmd("python -m doctest %s/create_test_impl.py -v" % acme_util.get_python_libs_root(), arg_stdout=None, arg_stderr=None)
+        cime_util.run_cmd("python -m doctest %s/create_test_impl.py -v" % cime_util.get_python_libs_root(), arg_stdout=None, arg_stderr=None)
         return
 
-    acme_util.stop_buffering_output()
+    cime_util.stop_buffering_output()
 
     testargs, compiler, no_run, no_build, no_batch, test_root, baseline_root, clean, \
-        compare, generate, baseline_name, namelists_only, project, test_id, old, parallel_jobs = \
-        parse_command_line(sys.argv, description)
+        compare, generate, baseline_name, namelists_only, project, test_id, old, parallel_jobs, \
+        = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(testargs, compiler, no_run, no_build, no_batch, test_root, baseline_root, clean,
                          compare, generate, baseline_name, namelists_only, project, test_id, old, parallel_jobs))

--- a/scripts-python/create_test
+++ b/scripts-python/create_test
@@ -252,7 +252,8 @@ def _main_func(description):
         return
 
     cime_util.stop_buffering_output()
-
+    model = os.getenv("CIME_MODEL","acme")
+    cime_util.set_model(model)
     testargs, compiler, no_run, no_build, no_batch, test_root, baseline_root, clean, \
         compare, generate, baseline_name, namelists_only, project, test_id, old, parallel_jobs, \
         = parse_command_line(sys.argv, description)

--- a/scripts-python/cs_status
+++ b/scripts-python/cs_status
@@ -6,8 +6,8 @@ no errors occured (not based on test statuses).
 """
 
 import add_util_path
-import acme_util
-acme_util.check_minimum_python_version(2, 7)
+import cime_util
+cime_util.check_minimum_python_version(2, 7)
 import wait_for_tests
 
 import argparse, sys, os
@@ -39,7 +39,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     args = parser.parse_args(args[1:])
 
-    acme_util.set_verbosity(args.verbose)
+    cime_util.set_verbosity(args.verbose)
 
     return args.paths
 
@@ -56,7 +56,7 @@ def cs_status(test_paths):
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    acme_util.stop_buffering_output()
+    cime_util.stop_buffering_output()
 
     test_paths = parse_command_line(sys.argv, description)
 

--- a/scripts-python/xml_bridge
+++ b/scripts-python/xml_bridge
@@ -10,6 +10,9 @@ sub main
     my @dirs = ("$cimeroot/scripts/Tools", "$cimeroot/utils/perl5lib/Config", "$cimeroot/utils/perl5lib");
     unshift @INC, @dirs;
     require ConfigCase;
+    require Log::Log4perl;
+    Log::Log4perl->easy_init({level=>"INFO",
+			  layout=>'%m%n'});
 
     my $mach_dir = shift;
     my $machine  = shift;

--- a/utils/python/compare_namelists.py
+++ b/utils/python/compare_namelists.py
@@ -1,6 +1,6 @@
 import argparse, sys, os, re
 
-from acme_util import expect, warning, verbose_print
+from cime_util import expect, warning, verbose_print
 
 ###############################################################################
 def parse_namelists(namelist_lines, filename):

--- a/utils/python/create_test_impl.py
+++ b/utils/python/create_test_impl.py
@@ -215,10 +215,10 @@ class CreateTest(object):
             # Parallelizing builds introduces potential sync problems with sharedlibroot
             # Just let every case build it's own
             sharedlibroot = os.path.join(test_dir, "sharedlibroot.%s" % self._test_id)
-
-        create_newcase_cmd = "%s -model acme -case %s -res %s -mach %s -compiler %s -compset %s -testname %s -project %s -nosavetiming -sharedlibroot %s" % \
-                              (os.path.join(self._cime_root, "scripts", "create_newcase"),
-                               test_dir, grid, machine, compiler, compset, test_case, self._project,
+        model = cime_util.get_model()
+        create_newcase_cmd = "%s -model %s -case %s -res %s -mach %s -compiler %s -compset %s -testname %s -project %s -nosavetiming -sharedlibroot %s" % \
+                              (os.path.join(self._cime_root,"scripts", "create_newcase"),
+                               model,test_dir, grid, machine, compiler, compset, test_case, self._project,
                                sharedlibroot)
         if (case_opts is not None):
             create_newcase_cmd += " -confopts _%s" % ("_".join(case_opts))
@@ -239,7 +239,7 @@ class CreateTest(object):
         xml_file = os.path.join(self._get_test_dir(test_name), "env_test.xml")
         xml_bridge_cmd = os.path.join(cime_util.get_acme_scripts_root(), "xml_bridge")
 
-        mach_dir = os.path.join(self._cime_root, "acme", "machines-acme")
+        mach_dir = os.path.join(self._cime_root, cime_util.get_model(), "machines")
         xml_bridge_cmd += " %s %s %s" % (mach_dir, machine, xml_file)
 
         xml_bridge_cmd += " TESTCASE,%s" % test_case
@@ -277,7 +277,7 @@ class CreateTest(object):
         test_case = cime_util.parse_test_name(test_name)[0]
         test_dir  = self._get_test_dir(test_name)
         test_case_definition_dir = os.path.join(self._cime_root, "scripts", "Testing", "Testcases")
-        test_build = os.path.join(test_dir, "%s.test_build" % self._get_case_id(test_name))
+        test_build = os.path.join(test_dir, "case.test_build" )
 
         if (os.path.exists(os.path.join(test_case_definition_dir, "%s_build.csh" % test_case))):
             shutil.copy(os.path.join(test_case_definition_dir, "%s_build.csh" % test_case), test_build)
@@ -342,17 +342,16 @@ class CreateTest(object):
     ###########################################################################
         case_id = self._get_case_id(test_name)
         test_dir = self._get_test_dir(test_name)
-        return self._run_phase_command(test_name, "./%s.test_build" % case_id, BUILD_PHASE, from_dir=test_dir)
+        return self._run_phase_command(test_name, "./case.test_build", BUILD_PHASE, from_dir=test_dir)
 
     ###########################################################################
     def _run_phase(self, test_name):
     ###########################################################################
-        case_id = self._get_case_id(test_name)
         test_dir = self._get_test_dir(test_name)
         if (self._no_batch):
-            return self._run_phase_command(test_name, "./%s.test" % case_id, RUN_PHASE, from_dir=test_dir)
+            return self._run_phase_command(test_name, "./case.test", RUN_PHASE, from_dir=test_dir)
         else:
-            return self._run_phase_command(test_name, "./%s.submit" % case_id, RUN_PHASE, from_dir=test_dir)
+            return self._run_phase_command(test_name, "./case.submit", RUN_PHASE, from_dir=test_dir)
 
     ###########################################################################
     def _update_test_status_file(self, test_name):

--- a/utils/python/create_test_impl.py
+++ b/utils/python/create_test_impl.py
@@ -4,9 +4,9 @@ Implementation of create_test functionality from CIME
 
 import sys, os, shutil, traceback, stat, glob, threading, time, thread
 
-import acme_util, compare_namelists, wait_for_tests
+import cime_util, compare_namelists, wait_for_tests
 
-from acme_util import expect, warning, verbose_print, run_cmd
+from cime_util import expect, warning, verbose_print, run_cmd
 from wait_for_tests import TEST_PASS_STATUS, TEST_FAIL_STATUS, TEST_PENDING_STATUS, TEST_STATUS_FILENAME, NAMELIST_FAIL_STATUS, RUN_PHASE, NAMELIST_PHASE
 
 INITIAL_PHASE = "INIT"
@@ -32,25 +32,25 @@ class CreateTest(object):
                  compare=False, generate=False, namelists_only=False,
                  project=None, parallel_jobs=None):
     ###########################################################################
-        self._cime_root      = acme_util.get_cime_root()
+        self._cime_root      = cime_util.get_cime_root()
         self._test_names     = test_names
         self._no_build       = no_build      if not namelists_only else True
         self._no_run         = no_run        if not self._no_build else True
-        self._no_batch       = no_batch      if no_batch is not None else not acme_util.does_machine_have_batch()
-        self._test_root      = test_root     if test_root is not None else acme_util.get_machine_info("CESMSCRATCHROOT")
-        self._test_id        = test_id       if test_id is not None else acme_util.get_utc_timestamp()
-        self._project        = project       if project is not None else acme_util.get_machine_project()
-        self._baseline_root  = baseline_root if baseline_root is not None else acme_util.get_machine_info("CCSM_BASELINE", project=self._project)
+        self._no_batch       = no_batch      if no_batch is not None else not cime_util.does_machine_have_batch()
+        self._test_root      = test_root     if test_root is not None else cime_util.get_machine_info("CESMSCRATCHROOT")
+        self._test_id        = test_id       if test_id is not None else cime_util.get_utc_timestamp()
+        self._project        = project       if project is not None else cime_util.get_machine_project()
+        self._baseline_root  = baseline_root if baseline_root is not None else cime_util.get_machine_info("CCSM_BASELINE", project=self._project)
         self._baseline_name  = None
-        self._compiler       = compiler      if compiler is not None else acme_util.get_machine_info("COMPILERS")[0]
+        self._compiler       = compiler      if compiler is not None else cime_util.get_machine_info("COMPILERS")[0]
         self._clean          = clean
         self._compare        = compare
         self._generate       = generate
         self._namelists_only = namelists_only
-        self._parallel_jobs  = parallel_jobs if parallel_jobs is not None else min(len(self._test_names), int(acme_util.get_machine_info("MAX_TASKS_PER_NODE")))
+        self._parallel_jobs  = parallel_jobs if parallel_jobs is not None else min(len(self._test_names), int(cime_util.get_machine_info("MAX_TASKS_PER_NODE")))
 
         # Oversubscribe by 1/4
-        pes = int(acme_util.get_machine_info("MAX_TASKS_PER_NODE"))
+        pes = int(cime_util.get_machine_info("MAX_TASKS_PER_NODE"))
 
         # This is the only data that multiple threads will simultaneously access
         # Each test has it's own index and setting/retrieving items from a list
@@ -74,7 +74,7 @@ class CreateTest(object):
             self._phases.remove(NAMELIST_PHASE)
         else:
             if (baseline_name is None):
-                branch_name = acme_util.get_current_branch(repo=self._cime_root)
+                branch_name = cime_util.get_current_branch(repo=self._cime_root)
                 expect(branch_name is not None, "Could not determine baseline name from branch, please use -b option")
                 self._baseline_name = os.path.join(self._compiler, branch_name)
             else:
@@ -205,11 +205,11 @@ class CreateTest(object):
     ###########################################################################
         test_dir = self._get_test_dir(test_name)
 
-        test_case, case_opts, grid, compset, machine, compiler, test_mods = acme_util.parse_test_name(test_name)
+        test_case, case_opts, grid, compset, machine, compiler, test_mods = cime_util.parse_test_name(test_name)
         if (compiler != self._compiler):
             raise StandardError("Test '%s' has compiler that does not match instance compliler '%s'" % (test_name, self._compiler))
         if (self._parallel_jobs == 1):
-            scratch_dir = acme_util.get_machine_info("CESMSCRATCHROOT", machine=machine, project=self._project)
+            scratch_dir = cime_util.get_machine_info("CESMSCRATCHROOT", machine=machine, project=self._project)
             sharedlibroot = os.path.join(scratch_dir, "sharedlibroot.%s" % self._test_id)
         else:
             # Parallelizing builds introduces potential sync problems with sharedlibroot
@@ -234,10 +234,10 @@ class CreateTest(object):
     ###########################################################################
     def _xml_phase(self, test_name):
     ###########################################################################
-        test_case, _, _, _, machine, _, _ = acme_util.parse_test_name(test_name)
+        test_case, _, _, _, machine, _, _ = cime_util.parse_test_name(test_name)
 
         xml_file = os.path.join(self._get_test_dir(test_name), "env_test.xml")
-        xml_bridge_cmd = os.path.join(acme_util.get_acme_scripts_root(), "xml_bridge")
+        xml_bridge_cmd = os.path.join(cime_util.get_acme_scripts_root(), "xml_bridge")
 
         mach_dir = os.path.join(self._cime_root, "acme", "machines-acme")
         xml_bridge_cmd += " %s %s %s" % (mach_dir, machine, xml_file)
@@ -274,7 +274,7 @@ class CreateTest(object):
     ###########################################################################
     def _setup_phase(self, test_name):
     ###########################################################################
-        test_case = acme_util.parse_test_name(test_name)[0]
+        test_case = cime_util.parse_test_name(test_name)[0]
         test_dir  = self._get_test_dir(test_name)
         test_case_definition_dir = os.path.join(self._cime_root, "scripts", "Testing", "Testcases")
         test_build = os.path.join(test_dir, "%s.test_build" % self._get_case_id(test_name))
@@ -293,8 +293,8 @@ class CreateTest(object):
         casedoc_dir       = os.path.join(test_dir, "CaseDocs")
         baseline_dir      = os.path.join(self._baseline_root, self._baseline_name, test_name)
         baseline_casedocs = os.path.join(baseline_dir, "CaseDocs")
-        compare_nl        = os.path.join(acme_util.get_acme_scripts_root(), "compare_namelists")
-        simple_compare    = os.path.join(acme_util.get_acme_scripts_root(), "simple_compare")
+        compare_nl        = os.path.join(cime_util.get_acme_scripts_root(), "compare_namelists")
+        simple_compare    = os.path.join(cime_util.get_acme_scripts_root(), "simple_compare")
 
         if (self._compare):
             has_fails = False
@@ -511,8 +511,8 @@ class CreateTest(object):
     def _setup_cs_files(self):
     ###########################################################################
         try:
-            python_libs_root = acme_util.get_python_libs_root()
-            acme_scripts_root = acme_util.get_acme_scripts_root()
+            python_libs_root = cime_util.get_python_libs_root()
+            acme_scripts_root = cime_util.get_acme_scripts_root()
             template_file = os.path.join(python_libs_root, "cs.status.template")
             template = open(template_file, "r").read()
             template = template.replace("<PATH>", acme_scripts_root).replace("<TESTID>", self._test_id)

--- a/utils/python/update_acme_tests.py
+++ b/utils/python/update_acme_tests.py
@@ -1,7 +1,7 @@
 import os, tempfile
 
-import acme_util
-from acme_util import expect, warning
+import cime_util
+from cime_util import expect, warning
 
 # Here are the tests belonging to acme suites. Format is
 # <test>.<grid>.<compset>.
@@ -115,8 +115,8 @@ def get_test_suite(suite, machine=None, compiler=None):
     """
     expect(suite in _TEST_SUITES, "Unknown test suite: '%s'" % suite)
 
-    machine = acme_util.probe_machine_name() if machine is None else machine
-    compiler = acme_util.get_machine_info("COMPILERS", machine=machine)[0] if compiler is None else compiler
+    machine = cime_util.probe_machine_name() if machine is None else machine
+    compiler = cime_util.get_machine_info("COMPILERS", machine=machine)[0] if compiler is None else compiler
 
     inherits_from, tests_raw = _TEST_SUITES[suite]
     tests = []
@@ -139,7 +139,7 @@ def get_test_suite(suite, machine=None, compiler=None):
                 if (machine in test_mod_machines):
                     test_mod = item[1]
 
-        tests.append(acme_util.get_full_test_name(test_name, machine, compiler, testmod=test_mod))
+        tests.append(cime_util.get_full_test_name(test_name, machine, compiler, testmod=test_mod))
 
     if (inherits_from is not None):
         inherited_tests = get_test_suite(inherits_from, machine, compiler)
@@ -191,16 +191,16 @@ def get_full_test_names(testargs, machine, compiler):
         elif (testarg in acme_test_suites):
             tests_to_run.update(get_test_suite(testarg, machine, compiler))
         else:
-            tests_to_run.add(acme_util.get_full_test_name(testarg, machine, compiler))
+            tests_to_run.add(cime_util.get_full_test_name(testarg, machine, compiler))
 
     for negation in negations:
         if (negation in acme_test_suites):
             for test, testmod in get_test_suite(negation, machine, compiler):
-                fullname = acme_util.get_full_test_name(test, machine, compiler, testmod)
+                fullname = cime_util.get_full_test_name(test, machine, compiler, testmod)
                 if (fullname in tests_to_run):
                     tests_to_run.remove(fullname)
         else:
-            fullname = acme_util.get_full_test_name(negation, machine, compiler)
+            fullname = cime_util.get_full_test_name(negation, machine, compiler)
             if (fullname in tests_to_run):
                 tests_to_run.remove(fullname)
 
@@ -215,11 +215,11 @@ def find_all_supported_platforms():
     tree. A platform is defined by a triple (machine name, compiler,
     mpi library).
     """
-    machines = acme_util.get_machines()
+    machines = cime_util.get_machines()
     platform_set = set()
 
     for machine in machines:
-        compilers, mpilibs = acme_util.get_machine_info(["COMPILERS", "MPILIBS"], machine=machine)
+        compilers, mpilibs = cime_util.get_machine_info(["COMPILERS", "MPILIBS"], machine=machine)
         for compiler in compilers:
             for mpilib in mpilibs:
                 platform_set.add((machine, compiler, mpilib))
@@ -274,10 +274,10 @@ def update_acme_tests(xml_file, categories, platform=None):
         # Prune the non-supported platforms from our list.
         for p in platforms:
             if p not in supported_platforms:
-                acme_util.verbose_print("pruning unsupported platform %s"%repr(p))
+                cime_util.verbose_print("pruning unsupported platform %s"%repr(p))
         platforms = [p for p in platforms if p in supported_platforms]
 
-    manage_xml_entries = os.path.join(acme_util.get_cime_root(), "scripts", "manage_testlists")
+    manage_xml_entries = os.path.join(cime_util.get_cime_root(), "scripts", "manage_testlists")
 
     expect(os.path.isfile(manage_xml_entries),
            "Couldn't find manage_testlists, expected it to be here: '%s'" % manage_xml_entries)
@@ -285,15 +285,15 @@ def update_acme_tests(xml_file, categories, platform=None):
     for category in categories:
         # Remove any existing acme test category from the file.
         if (platform is None):
-            acme_util.run_cmd("%s -model acme -component allactive -removetests -category %s" % (manage_xml_entries, category))
+            cime_util.run_cmd("%s -model acme -component allactive -removetests -category %s" % (manage_xml_entries, category))
         else:
-            acme_util.run_cmd("%s -model acme -component allactive -removetests -category %s -machine %s -compiler %s"
+            cime_util.run_cmd("%s -model acme -component allactive -removetests -category %s -machine %s -compiler %s"
                               % (manage_xml_entries, category, platforms[0][0], platforms[0][1]))
 
         # Generate a list of test entries corresponding to our suite at the top
         # of the file.
         new_test_file = generate_acme_test_entries(category, platforms)
-        acme_util.run_cmd("%s -model acme -component allactive -addlist -file %s -category %s" %
+        cime_util.run_cmd("%s -model acme -component allactive -addlist -file %s -category %s" %
                           (manage_xml_entries, new_test_file, category))
         os.unlink(new_test_file)
 

--- a/utils/python/wait_for_tests.py
+++ b/utils/python/wait_for_tests.py
@@ -2,8 +2,8 @@ import os, doctest, time, threading, Queue, socket, signal, distutils.spawn, shu
 
 import xml.etree.ElementTree as xmlet
 
-import acme_util
-from acme_util import expect, warning, verbose_print
+import cime_util
+from cime_util import expect, warning, verbose_print
 from collections import OrderedDict
 
 TEST_STATUS_FILENAME      = "TestStatus"
@@ -40,7 +40,7 @@ def set_up_signal_handlers():
 def get_test_time(test_path):
 ###############################################################################
     cmd = "grep TIME %s" % os.path.join(test_path, TEST_STATUS_FILENAME)
-    stat, output, _ = acme_util.run_cmd(cmd, ok_to_fail=True)
+    stat, output, _ = cime_util.run_cmd(cmd, ok_to_fail=True)
     if (stat == 0):
         return int(output.split()[-1])
     else:
@@ -60,7 +60,7 @@ def get_test_output(test_path):
 ###############################################################################
 def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time, current_time, hostname):
 ###############################################################################
-    git_commit = acme_util.get_current_commit(repo=acme_util.get_cime_root())
+    git_commit = cime_util.get_current_commit(repo=cime_util.get_cime_root())
 
     data_rel_path = os.path.join("Testing", utc_time)
 
@@ -162,7 +162,7 @@ def create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_ti
                     full_results["RUN"]   != TEST_PASS_STATUS):
 
                     param = "EXEROOT" if full_results["BUILD"] != TEST_PASS_STATUS else "RUNDIR"
-                    src_dir = acme_util.run_cmd("./xmlquery %s -value" % param, from_dir=os.path.dirname(test_path))
+                    src_dir = cime_util.run_cmd("./xmlquery %s -value" % param, from_dir=os.path.dirname(test_path))
                     log_dst_dir = os.path.join(log_dir, "%s_%s_logs" % (test_name, param))
                     os.makedirs(log_dst_dir)
                     for log_file in glob.glob(os.path.join(src_dir, "*log*")):
@@ -176,8 +176,8 @@ def create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_ti
             if (os.path.exists(tarball)):
                 os.remove(tarball)
 
-            acme_util.run_cmd("tar -cf - %s | gzip -c > %s" % (log_dir, tarball))
-            base64 = acme_util.run_cmd("base64 %s" % tarball)
+            cime_util.run_cmd("tar -cf - %s | gzip -c > %s" % (log_dir, tarball))
+            base64 = cime_util.run_cmd("base64 %s" % tarball)
 
             xml_text = \
 r"""<?xml version="1.0" encoding="UTF-8"?>
@@ -217,7 +217,7 @@ def create_cdash_xml(results, cdash_build_name, cdash_project, cdash_build_group
     utc_time_tuple = time.gmtime(current_time)
     cdash_timestamp = time.strftime("%H:%M:%S", utc_time_tuple)
 
-    hostname = acme_util.probe_machine_name()
+    hostname = cime_util.probe_machine_name()
     if (hostname is None):
         hostname = socket.gethostname().split(".")[0]
         warning("Could not convert hostname '%s' into an ACME machine name" % (hostname))
@@ -265,7 +265,7 @@ NightlyStartTime: %s UTC
 
     create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_time, hostname)
 
-    acme_util.run_cmd("ctest -VV -D NightlySubmit", verbose=True)
+    cime_util.run_cmd("ctest -VV -D NightlySubmit", verbose=True)
 
 ###############################################################################
 def reduce_stati(stati, check_throughput=False, check_memory=False, ignore_namelists=False):


### PR DESCRIPTION
This PR will allow the python create_test to work with cesm.  It removes 'acme' as a hardcoded path and uses a new variable model which reads an environment variable CIME_MODEL and defaults to acme if the variable doesn't exist.   