### PR TITLE
Change order of definition of some get functions.

### DIFF
--- a/utils/python/cime_util.py
+++ b/utils/python/cime_util.py
@@ -325,11 +325,6 @@ def get_python_libs_location_within_cime():
     return os.path.join("utils", "python")
 
 ###############################################################################
-def get_model_config_location_within_cime(model=get_model()):
-###############################################################################
-    return os.path.join("cime_config", model)
-
-###############################################################################
 def get_cime_root():
 ###############################################################################
     """
@@ -341,6 +336,27 @@ def get_cime_root():
     acme_script_absdir = os.path.abspath(os.path.join(os.path.dirname(__file__)))
     assert acme_script_absdir.endswith(get_python_libs_location_within_cime()), acme_script_absdir
     return os.path.normpath(acme_script_absdir[:len(acme_script_absdir)-len(get_python_libs_location_within_cime())])
+
+###############################################################################
+def get_model():
+###############################################################################
+    global _MODEL
+    if (_MODEL is None):
+        try:
+            _MODEL = os.environ["CIME_MODEL"]
+        except KeyError:
+            modelroot = os.path.join(get_cime_root(), "cime_config")
+            models = os.listdir(modelroot)
+            msg = "Environment variable CIME_MODEL must be set to one of: "
+            for model in models:
+                if(os.path.isdir(os.path.join(modelroot,model)) and model != "xml_schemas"):
+                    msg += model + " ,"
+            expect(False, msg)
+
+###############################################################################
+def get_model_config_location_within_cime(model=get_model()):
+###############################################################################
+    return os.path.join("cime_config", model)
 
 ###############################################################################
 def get_acme_root():
@@ -502,24 +518,6 @@ def set_model(model):
 ###############################################################################
     global _MODEL
     _MODEL = model
-
-###############################################################################
-def get_model():
-###############################################################################
-    global _MODEL
-    if (_MODEL is None):
-        try:
-            _MODEL = os.environ["CIME_MODEL"]
-        except KeyError:
-            modelroot = os.path.join(get_cime_root(), "cime_config")
-            models = os.listdir(modelroot)
-            msg = "Environment variable CIME_MODEL must be set to one of: "
-            for model in models:
-                if(os.path.isdir(os.path.join(modelroot,model)) and model != "xml_schemas"):
-                    msg += model + " ,"
-            expect(False, msg)
-
-    return _MODEL
 
 ###############################################################################
 def parse_config_machines():


### PR DESCRIPTION
The order was changed from
get_model_config_location_within_cime
get_cime_root
get_model

To
get_cime_root
get_model
get_model_config_location_within_cime

This was needed to avoid "name 'function' is not definied" errors on
blues with python 2.7.6