### PR TITLE
Minor fixes and cleanups to recent PR.

### DIFF
--- a/scripts-python/acme_bisect
+++ b/scripts-python/acme_bisect
@@ -7,8 +7,11 @@ script is intended to be run by git bisect.
 
 from standard_script_setup import *
 from CIME.utils import expect, run_cmd
+from CIME.XML.machines import Machines
 
 import argparse, sys, os, doctest, traceback
+
+_MACHINE = Machines()
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -29,8 +32,8 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
-    default_project  = CIME.utils.get_machine_project()
-    default_compiler = CIME.utils.get_machine_info("COMPILER")
+    default_project  = CIME.utils.get_project()
+    default_compiler = _MACHINE.get_default_compiler()
 
     CIME.utils.setup_standard_logging_options(parser)
 
@@ -66,7 +69,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     CIME.utils.handle_standard_logging_options(args)
 
     if (args.test_root is None):
-        args.test_root = os.path.join(CIME.utils.get_machine_info("CESMSCRATCHROOT", project=args.project), "acme_bisect")
+        args.test_root = os.path.join(_MACHINE.get_value("CESMSCRATCHROOT"), "acme_bisect")
 
     return args.testname, args.good, args.bad, args.test_root, args.compiler, args.project, args.baseline_name, args.check_namelists, args.check_throughput, args.check_memory
 
@@ -96,7 +99,7 @@ def acme_bisect(testname, good, bad, testroot, compiler, project, baseline_name,
     bisect_cmd = "/bin/rm -rf %s/*acme_bisect && %s %s --test-root %s -t acme_bisect --compiler %s -p %s %s" % \
         (testroot, create_test, testname, testroot, compiler, project, compare_args)
 
-    is_batch = CIME.utils.does_machine_have_batch()
+    is_batch = _MACHINE.has_batch_system()
     if (is_batch):
         # Forumulate the wait_for_tests command.
 

--- a/scripts-python/bless_test_results
+++ b/scripts-python/bless_test_results
@@ -19,6 +19,8 @@ from CIME.XML.machines import Machines
 
 import argparse, sys, os, glob, doctest, time
 
+_MACHINE = Machines()
+
 ###############################################################################
 def parse_command_line(args, description):
 ###############################################################################
@@ -48,10 +50,8 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
     default_baseline_name = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
-    machobj = Machines()
-    machobj.probe_machine_name()
-    default_compiler      = machobj.get_default_compiler()
-    scratch_root          = machobj.get_resolved_value(machobj.get_value("CESMSCRATCHROOT"))
+    default_compiler      = _MACHINE.get_default_compiler()
+    scratch_root          = _MACHINE.get_value("CESMSCRATCHROOT")
     default_testroot      = os.path.join(scratch_root)
 
     CIME.utils.setup_standard_logging_options(parser)
@@ -142,9 +142,7 @@ def bless_history(test_name, baseline_tag, baseline_dir_for_test, testcase_dir_f
     compgen = os.path.join(cime_root, "scripts", "Tools", "component_compgen_baseline.sh")
     machine_env = os.path.join(testcase_dir_for_test, ".env_mach_specific.sh")
     run_dir = os.path.join(acme_root, case, "run")
-    machobj = Machines()
-    machobj.probe_machine_name()
-    cprnc_loc = machobj.get_resolved_value(machobj.get_value("CCSM_CPRNC"))
+    cprnc_loc = _MACHINE.get_value("CCSM_CPRNC")
     compgen_cmd = "source %s && %s -baseline_dir %s -testcase %s -testcase_base %s -test_dir %s -cprnc_exe %s -generate_tag %s" % \
                   (machine_env, compgen, baseline_dir_for_test, case, test_name, run_dir, cprnc_loc, baseline_tag)
 
@@ -176,15 +174,13 @@ def bless_test_results(baseline_name, test_root, compiler, test_id=None, namelis
     test_status_files = glob.glob("%s/%s/TestStatus" % (test_root, test_id_glob))
     expect(test_status_files, "No matching test cases found in for %s/%s/TestStatus" % (test_root, test_id_glob))
 
-    machobj = Machines()
-    machobj.probe_machine_name()
-    baseline_root = machobj.get_resolved_value(machobj.get_value("CCSM_BASELINE"))
+    baseline_root = _MACHINE.get_value("CCSM_BASELINE")
     baseline_tag  = os.path.join(compiler, baseline_name)
     baseline_area = os.path.join(baseline_root, baseline_tag)
 
     # The env_mach_specific script may need these to be defined
-    os.environ["COMPILER"] = machobj.get_default_compiler() # this MUST match compiler that cprnc was built with
-    os.environ["MPILIB"] = machobj.get_default_MPIlib()
+    os.environ["COMPILER"] = _MACHINE.get_default_compiler() # this MUST match compiler that cprnc was built with
+    os.environ["MPILIB"] = _MACHINE.get_default_MPIlib()
 
     broken_blesses = []
     for test_status_file in test_status_files:

--- a/scripts-python/create_test
+++ b/scripts-python/create_test
@@ -121,8 +121,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="Number of tasks create_test should perform simultaneously. Default "
                         "will be min(num_cores, num_tests).")
 
-    parser.add_argument("--old", action="store_true", help="Use CIME Perl impl")
-
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
@@ -146,24 +144,23 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
         args.no_run   = True
         args.no_batch = True
 
-
     if (args.test_id is None):
         args.test_id = CIME.utils.get_utc_timestamp()
 
     return args.testargs, args.compiler, args.machine, args.no_run, args.no_build, args.no_batch, \
         args.test_root, args.baseline_root, args.clean, args.compare, args.generate, args.baseline_name, \
-        args.namelists_only, args.project, args.test_id, args.old, args.parallel_jobs
+        args.namelists_only, args.project, args.test_id, args.parallel_jobs
 
 ###############################################################################
 def create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, test_root,
                 baseline_root, clean, compare, generate,
-                baseline_name, namelists_only, project, test_id, old, parallel_jobs):
+                baseline_name, namelists_only, project, test_id, parallel_jobs):
 ###############################################################################
     impl = CreateTest(testargs,
                       no_run=no_run, no_build=no_build, no_batch=no_batch,
                       test_root=test_root, test_id=test_id,
                       baseline_root=baseline_root, baseline_name=baseline_name,
-                      clean=clean, machine_name=machine_name,compiler=compiler,
+                      clean=clean, machine_name=machine_name, compiler=compiler,
                       compare=compare, generate=generate, namelists_only=namelists_only,
                       project=project, parallel_jobs=parallel_jobs)
     return 0 if impl.create_test() else CIME.utils.TESTS_FAILED_ERR_CODE
@@ -175,14 +172,13 @@ def _main_func(description):
         CIME.utils.run_cmd("python -m doctest %s/create_test_impl.py -v" % CIME.utils.get_python_libs_root(), arg_stdout=None, arg_stderr=None)
         return
 
-
     testargs, compiler, machine_name, no_run, no_build, no_batch, test_root, baseline_root, clean, \
-        compare, generate, baseline_name, namelists_only, project, test_id, old, parallel_jobs, \
+        compare, generate, baseline_name, namelists_only, project, test_id, parallel_jobs, \
         = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, test_root,
                          baseline_root, clean, compare, generate, baseline_name, namelists_only,
-                         project, test_id, old, parallel_jobs))
+                         project, test_id, parallel_jobs))
 
 ###############################################################################
 

--- a/scripts-python/jenkins_generic_job
+++ b/scripts-python/jenkins_generic_job
@@ -10,6 +10,7 @@ ensures that the batch system is left in a clean state.
 from standard_script_setup import *
 import wait_for_tests
 from CIME.utils import expect
+from CIME.XML.machines import Machines
 
 import argparse, sys, os, shutil, glob, doctest, time, signal
 
@@ -17,6 +18,8 @@ SENTINEL_FILE = "ONGOING_TEST"
 
 # Don't know if this belongs here longterm
 MACHINES_THAT_MAINTAIN_BASELINES = ("redsky", "melvin", "skybridge")
+
+_MACHINE = Machines()
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -42,8 +45,8 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
-    machine = CIME.utils.probe_machine_name()
-    default_test_suite = CIME.utils.get_machine_info("TESTS")
+    machine = _MACHINE.get_machine_name()
+    default_test_suite = _MACHINE.get_value("TESTS")
     default_maintain_baselines = machine in MACHINES_THAT_MAINTAIN_BASELINES
 
     CIME.utils.setup_standard_logging_options(parser)
@@ -111,14 +114,16 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, baseline_name,
     """
     start_time = time.time()
 
-    use_batch = CIME.utils.does_machine_have_batch()
-    compiler, test_suite, scratch_root, proxy = \
-        CIME.utils.get_machine_info(["COMPILER", "TESTS", "CESMSCRATCHROOT", "PROXY"])
+    use_batch = _MACHINE.has_batch_system()
+    compiler = _MACHINE.get_default_compiler()
+    test_suite = _MACHINE.get_value("TESTS")
+    scratch_root = _MACHINE.get_value("CESMSCRATCHROOT")
+    proxy = _MACHINE.get_value("PROXY")
     test_suite = test_suite if arg_test_suite is None else arg_test_suite
     test_root = os.path.join(scratch_root, "jenkins")
 
     if (use_batch):
-        batch_system = CIME.utils.get_batch_system()
+        batch_system = _MACHINE.get_batch_system_type()
         expect(batch_system is not None, "Bad XML. Batch machine has no batch_system configuration.")
 
     #

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -7,10 +7,10 @@ from standard_module_setup import *
 from CIME.utils import expect
 from generic_xml import GenericXML
 
-
 class EntryID(GenericXML):
+
     def __init__(self, infile=None):
-        GenericXML.__init__(self,infile)
+        GenericXML.__init__(self, infile)
 
     def set_default_value(self, vid, attributes=None):
         """
@@ -18,27 +18,29 @@ class EntryID(GenericXML):
         vid can be an xml node pointer or a string identifier of a node
         """
         value = None
-        if(type(vid) != type(str())):
+        if (type(vid) != type(str())):
             node = vid
             vid = node.attrib("id")
         else:
-            nodes = self.get_node("entry",{"id":vid})
-            if(nodes is None):
+            nodes = self.get_node("entry", {"id":vid})
+            if (nodes is None):
                 return
-            expect(len(nodes) == 1,"More than one match found for id " + vid)
+            expect(len(nodes) == 1, "More than one match found for id " + vid)
             node = nodes[0]
+
         valnodes = self.get_node("value",root=node)
-        if(valnodes is not None):
+        if (valnodes is not None):
             for valnode in valnodes:
                 for att in valnode.attributes:
-                    if(att.key in attributes):
-                        if(re.search(attributes[att.key],att.text)):
+                    if (att.key in attributes):
+                        if (re.search(attributes[att.key],att.text)):
                             value = valnode.text
                             logging.info("id %s value %s" % (vid, valnode.text))
-        if(value is None):
-            value = self.get_node("default_value",root=node)
-        if(value is not None):
-            node.set("value",value)
+
+        if (value is None):
+            value = self.get_node("default_value", root=node)
+        if (value is not None):
+            node.set("value", value)
             return value[0].text
 
     def set_value(self, vid, value):
@@ -47,18 +49,20 @@ class EntryID(GenericXML):
         Returns the value or None if not found
         """
         val = None
-        if(type(vid) != type(str())):
+        if (type(vid) != type(str())):
             node = vid
             vid = node.attrib("id")
         else:
-            nodes = self.get_node("entry",{"id":vid})
-            if(nodes is None):
-                return
-            expect(len(nodes) == 0,"More than one match found for id " + vid)
+            nodes = self.get_node("entry", {"id":vid})
+            if (nodes is None):
+                return None
+            expect(len(nodes) == 0, "More than one match found for id " + vid)
             node = nodes[0]
-        if(node is not None):
+
+        if (node is not None):
             val = value
             node.set("value",value)
+
         return val
 
     def get_value(self, vid, attribute=None, resolved=True):
@@ -68,54 +72,56 @@ class EntryID(GenericXML):
         and matches
         """
         val = None
-        if(type(vid) != type(str())):
+        if (type(vid) != type(str())):
             node = vid
             vid = node.attrib("id")
         else:
-            nodes = self.get_node("entry",{"id":vid})
-            if(len(nodes) == 0):
-                val = GenericXML.get_value(self,vid,resolved)
+            nodes = self.get_node("entry", {"id":vid})
+            if (len(nodes) == 0):
+                val = GenericXML.get_value(self, vid, resolved)
                 return val
             else:
                 node = nodes[0]
 
-        if(attribute is not None):
-            valnodes = self.get_node("value",attribute)
-            if(valnodes is not None and len(valnodes) == 1):
+        if (attribute is not None):
+            valnodes = self.get_node("value", attribute)
+            if (valnodes is not None and len(valnodes) == 1):
                 val = valnodes[0].text
-        elif(node.get("value") is not None):
+        elif (node.get("value") is not None):
             val = node.get("value")
         else:
             val = self.set_default_value(vid)
 
-        if(val is None):
-            """ if all else fails """
+        if (val is None):
+            # if all else fails
             val = GenericXML.get_value(self,vid,resolved)
 
-        if(resolved):
+        if (resolved):
             val = self.get_resolved_value(val)
 
         return val
 
-    def get_values(self,vid,att):
+    def get_values(self, vid, att):
         """
         If an entry includes a list of values return a dict matching each
         attribute to its associated value
         """
         values = {}
-        if(type(vid) != type(str())):
+        if (type(vid) != type(str())):
             node = vid
             vid = node.attrib("id")
         else:
-            nodes = self.get_node("entry",{"id":vid})
-            if(nodes is None):
+            nodes = self.get_node("entry", {"id":vid})
+            if (nodes is None):
                 return
             node = nodes[0]
-        valnodes = self.get_node("value",node=node)
-        if(valnodes is not None):
+
+        valnodes = self.get_node("value", node=node)
+        if (valnodes is not None):
             for valnode in valnodes:
                 vatt = valnode.attrib(att)
                 values[vatt] = valnode.text
+
         return values
 
 

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -79,7 +79,7 @@ class GenericXML:
             root = self.root
         self.tree.insert(root, node)
 
-    def get_value(self, item,resolved=False):
+    def get_value(self, item,resolved=True):
         """
         get_value is expected to be defined by the derived classes, if you get here it is an error.
         """

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -8,27 +8,41 @@ from files import Files
 from CIME.utils import expect
 
 class Machines(GenericXML):
-    def __init__(self,infile=None,files=None):
+
+    def __init__(self, infile=None, files=None, machine=None):
         """
         initialize an object
         if a filename is provided it will be used,
         otherwise if a files object is provided it will be used
         otherwise create a files object from default values
         """
-        if(infile is None):
-            if(files is None):
-                files = Files()
-            infile = files.get_value('MACHINES_SPEC_FILE')
-        logging.info("Open file "+infile)
-        GenericXML.__init__(self,infile)
         self.machine = None
-        self.name = None
+        self.name    = None
 
-    def get_node(self,nodename,attributes=None,root=None):
-        if(self.machine is not None and root is None and nodename is not "machine"):
-            node = GenericXML.get_node(self,nodename,attributes,root=self.machine)
+        if (infile is None):
+            if (files is None):
+                files = Files()
+            infile = files.get_value("MACHINES_SPEC_FILE")
+
+        logging.info("Open file " + infile)
+        GenericXML.__init__(self, infile)
+
+        if (machine is None):
+            machine = self.probe_machine_name()
+
+        self.set_machine(machine)
+
+    def get_machine_name(self):
+        """
+        Return the name of the machine
+        """
+        return self.name
+
+    def get_node(self, nodename, attributes=None, root=None):
+        if (self.machine is not None and root is None and nodename is not "machine"):
+            node = GenericXML.get_node(self, nodename, attributes, root=self.machine)
         else:
-            node = GenericXML.get_node(self,nodename,attributes,root)
+            node = GenericXML.get_node(self, nodename, attributes, root)
         return node
 
     def list_available_machines(self):
@@ -36,7 +50,7 @@ class Machines(GenericXML):
         Return a list of machines defined for a given CIME_MODEL
         """
         machines = []
-        nodes  = self.get_node('machine')
+        nodes  = self.get_node("machine")
         for node in nodes:
             mach = node.get("MACH")
             machines.append(mach)
@@ -49,72 +63,79 @@ class Machines(GenericXML):
         """
         machine = None
         nametomatch = socket.gethostname().split(".")[0]
-        nodes = self.get_node('machine')
+        nodes = self.get_node("machine")
+
         for node in nodes:
-            machtocheck = node.get('MACH')
-            logging.debug("machine is "+machtocheck)
+            machtocheck = node.get("MACH")
+            logging.debug("machine is " + machtocheck)
             self.set_machine(machtocheck)
-            regex_str_nodes =  self.get_node('NODENAME_REGEX',root=self.machine)
-            
-            if(len(regex_str_nodes)>0):
+            regex_str_nodes = self.get_node("NODENAME_REGEX", root=self.machine)
+
+            if (regex_str_nodes):
                 regex_str = regex_str_nodes[0].text
             else:
                 regex_str = machtocheck
+
             if (regex_str is not None):
-                logging.debug("machine regex string is "+ regex_str)
+                logging.debug("machine regex string is " + regex_str)
                 regex = re.compile(regex_str)
                 if (regex.match(nametomatch)):
-                    logging.info("Found machine: %s matches %s" %(machtocheck,nametomatch))
+                    logging.info("Found machine: %s matches %s" % (machtocheck, nametomatch))
                     machine = machtocheck
                     break
+
+        if (machine is None):
+            logging.warning("Could not probe machine for hostname '%s'" % nametomatch)
+
         return machine
 
-
-    def set_machine(self,machine):
+    def set_machine(self, machine):
         """
         Sets the machine block in the Machines object
 
         >>> machobj = Machines()
-        >>> machobj.set_machine('melvin')
+        >>> machobj.set_machine("melvin")
         'melvin'
-        >>> machobj.set_machine('trump')
+        >>> machobj.set_machine("trump")
         Traceback (most recent call last):
         ...
         SystemExit: ERROR: No machine trump found
         """
-        if(self.machine is not None and self.name is not machine):
+        if (self.machine is not None and self.name is not machine):
             self.machine = None
-        mach_nodes = self.get_node('machine',{'MACH':machine})
+        mach_nodes = self.get_node("machine", {"MACH":machine})
         expect(mach_nodes, "No machine %s found" % machine)
         self.machine = mach_nodes[0]
         self.name = machine
         return machine
 
-    def get_value(self,name,resolved=True):
+    def get_value(self, name, resolved=True):
         """
         Get Value of fields in the config_machines.xml file
         """
         expect(self.machine is not None, "Machine object has no machine defined")
         value = None
-        """
-        COMPILER and MPILIB are special, if called without arguments they get the default value from the
-        COMPILERS and MPILIBS lists in the file.
-        """
-        if(name == "COMPILER"):
+
+        # COMPILER and MPILIB are special, if called without arguments they get the default value from the
+        # COMPILERS and MPILIBS lists in the file.
+        if (name == "COMPILER"):
             value = self.get_default_compiler()
-        elif(name == "MPILIB"):
+        elif (name == "MPILIB"):
             value = self.get_default_MPIlib()
         else:
-            nodes = self.get_node(name,root=self.machine)
-            if(len(nodes)>0):
+            nodes = self.get_node(name, root=self.machine)
+            if (nodes):
                 node = nodes[0]
-                expect(node is not None,"No match found for %s in machine %s" % (name,self.name))
+                expect(node is not None, "No match found for %s in machine %s" % (name, self.name))
                 value = node.text
-        if(value is None):
-            """ if all else fails """
-            value = GenericXML.get_value(self,name)
-        if(resolved):
+
+        if (value is None):
+            # if all else fails
+            value = GenericXML.get_value(self, name)
+
+        if (resolved):
             value = self.get_resolved_value(value)
+
         return value
 
     def get_field_from_list(self, listname, reqval=None):
@@ -126,44 +147,46 @@ class Machines(GenericXML):
         expect(self.machine is not None, "Machine object has no machine defined")
         supported_values = self.get_value(listname)
         expect(supported_values is not None,
-               "No list found for "+listname+" on machine "+self.name)
-        supported_values = supported_values.split(',')
-        if(reqval is None or reqval == "UNSET"):
+               "No list found for " + listname + " on machine " + self.name)
+        supported_values = supported_values.split(",")
+
+        if (reqval is None or reqval == "UNSET"):
             return supported_values[0]
         for val in supported_values:
-            if(val == reqval):
+            if (val == reqval):
                 return reqval
-        expect(False,"%s value %s not supported for machine %s" %
+
+        expect(False, "%s value %s not supported for machine %s" %
                (listname, reqval, self.name))
 
     def get_default_compiler(self):
         """
         Get the compiler to use from the list of COMPILERS
         """
-        return self.get_field_from_list('COMPILERS')
+        return self.get_field_from_list("COMPILERS")
 
     def get_default_MPIlib(self):
         """
         Get the MPILIB to use from the list of MPILIBS
         """
-        return self.get_field_from_list('MPILIBS')
+        return self.get_field_from_list("MPILIBS")
 
     def is_valid_compiler(self,compiler):
         """
         Check the compiler is valid for the current machine
 
         >>> machobj = Machines()
-        >>> name = machobj.set_machine('edison')
+        >>> name = machobj.set_machine("edison")
         >>> machobj.get_default_compiler()
         'intel'
-        >>> machobj.is_valid_compiler('cray')
+        >>> machobj.is_valid_compiler("cray")
         True
-        >>> machobj.is_valid_compiler('nag')
+        >>> machobj.is_valid_compiler("nag")
         Traceback (most recent call last):
         ...
         SystemExit: ERROR: COMPILERS value nag not supported for machine edison
         """
-        if(self.get_field_from_list('COMPILERS',compiler) is not None):
+        if (self.get_field_from_list("COMPILERS", compiler) is not None):
             return True
         return False
 
@@ -173,10 +196,10 @@ class Machines(GenericXML):
 
         >>> machobj = Machines()
         >>> name = machobj.probe_machine_name()
-        >>> machobj.is_valid_MPIlib('mpi-serial')
+        >>> machobj.is_valid_MPIlib("mpi-serial")
         True
         """
-        if(self.get_field_from_list('MPILIBS',mpilib) is not None):
+        if (self.get_field_from_list("MPILIBS", mpilib) is not None):
             return True
         return False
 
@@ -185,20 +208,20 @@ class Machines(GenericXML):
         Return if this machine has a batch system
 
         >>> machobj = Machines()
-        >>> machobj.set_machine('edison')
+        >>> machobj.set_machine("edison")
         'edison'
         >>> machobj.has_batch_system()
         True
-        >>> machobj.set_machine('melvin')
+        >>> machobj.set_machine("melvin")
         'melvin'
         >>> machobj.has_batch_system()
         False
         """
         result = False
         batch_system = self.get_node("batch_system")
-        if(batch_system):
-            result = (batch_system[0].get('type') != "none")
-        logging.debug("Machine %s has batch: %s" %(self.name,result))
+        if (batch_system):
+            result = (batch_system[0].get("type") != "none")
+        logging.debug("Machine %s has batch: %s" % (self.name, result))
         return result
 
     def get_batch_system_type(self):
@@ -206,9 +229,9 @@ class Machines(GenericXML):
         Return the batch system using on this machine
 
         >>> machobj = Machines()
-        >>> name = machobj.set_machine('edison')
+        >>> name = machobj.set_machine("edison")
         >>> machobj.get_batch_system_type()
         'slurm'
         """
         batch_system = self.get_node("batch_system")
-        return batch_system[0].get('type')
+        return batch_system[0].get("type")

--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -16,12 +16,9 @@ SCRIPT_DIR = CIME.utils.get_acme_scripts_root()
 DART_CONFIG = "DartConfiguration.tcl"
 DART_BACKUP = "temp_dart_backup"
 
+_MACHINE = Machines()
+
 logging.basicConfig()
-
-#def load_tests(loader, tests, ignore):
-#    tests.addTests(doctest.DocTestSuite(os.path.join))
-#    return tests
-
 
 ###############################################################################
 class RunUnitTests(unittest.TestCase):
@@ -54,7 +51,7 @@ class RunUnitTests(unittest.TestCase):
 
     def test_resolve_variable_name(self):
         files = Files()
-        machinefile = files.get_value("MACHINES_SPEC_FILE",resolved=True)
+        machinefile = files.get_value("MACHINES_SPEC_FILE")
         self.assertTrue(os.path.isfile(machinefile),
                         msg="Path did not resolve to existing file %s" % machinefile)
 
@@ -120,13 +117,10 @@ def assert_dashboard_has_build(tester, build_name, expected_count=1):
 def setup_proxy():
 ###############################################################################
     if ("http_proxy" not in os.environ):
-        machine = Machines()
-        mach_name = machine.probe_machine_name()
-        if (mach_name is not None):
-            proxy = machine.get_value('PROXY')
-            if (proxy is not None):
-                os.environ["http_proxy"] = proxy
-                return True
+        proxy = _MACHINE.get_value("PROXY")
+        if (proxy is not None):
+            os.environ["http_proxy"] = proxy
+            return True
 
     return False
 
@@ -315,17 +309,16 @@ class TestCreateTestCommon(unittest.TestCase):
     ###########################################################################
     def setUp(self):
     ###########################################################################
-        machine = Machines()
         self._thread_error      = None
         self._unset_proxy       = setup_proxy()
         self._baseline_name     = "fake_testing_only_%s" % CIME.utils.get_utc_timestamp()
-        self._machine           = machine.probe_machine_name()
-        self._baseline_area     = machine.get_value("CCSM_BASELINE")
-        self._testroot          = machine.get_value("CESMSCRATCHROOT")
+        self._machine           = _MACHINE.get_machine_name()
+        self._baseline_area     = _MACHINE.get_value("CCSM_BASELINE")
+        self._testroot          = _MACHINE.get_value("CESMSCRATCHROOT")
         self._jenkins_root      = os.path.join(self._testroot, "jenkins")
-        self._compiler          = machine.get_default_compiler()
-        self._hasbatch       = machine.has_batch_system()
-        self._compiler        = machine.get_value('COMPILER')
+        self._compiler          = _MACHINE.get_default_compiler()
+        self._hasbatch          = _MACHINE.has_batch_system()
+        self._compiler          = _MACHINE.get_value('COMPILER')
         # wait_for_tests could blow away our dart config, need to back it up
         if (os.path.exists(DART_CONFIG)):
             shutil.move(DART_CONFIG, DART_BACKUP)
@@ -601,9 +594,8 @@ class TestBlessTestResults(TestCreateTestCommon):
     ###########################################################################
     def simple_test(self, expect_works, extra_args):
     ###########################################################################
-        stat, output, errput = run_cmd("%s/create_test  %s %s" % (SCRIPT_DIR, self._test_name, extra_args), ok_to_fail=True)
+        stat, output, errput = run_cmd("%s/create_test %s %s" % (SCRIPT_DIR, self._test_name, extra_args), ok_to_fail=True)
 
-        
         if (self._hasbatch):
             self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
             test_id = extra_args.split()[extra_args.split().index("-t") + 1]
@@ -618,12 +610,11 @@ class TestBlessTestResults(TestCreateTestCommon):
     def test_create_test_rebless_namelist(self):
     ###############################################################################
         # Generate some namelist baselines
-        machobj = Machines()
-        machobj.probe_machine_name()
         self.simple_test(True, "-g -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, CIME.utils.get_utc_timestamp()))
+
         # Change baseline
-        baseline_area = machobj.get_value("CCSM_BASELINE",resolved=True)
-        compiler      = machobj.get_default_compiler()
+        baseline_area = _MACHINE.get_value("CCSM_BASELINE")
+        compiler      = _MACHINE.get_default_compiler()
         baseline_glob = glob.glob(os.path.join(baseline_area, compiler, self._baseline_name, "%s*" % self._test_name))
         self.assertEqual(len(baseline_glob), 1, msg="Expected one match, got:\n%s" % "\n".join(baseline_glob))
 
@@ -647,24 +638,24 @@ class TestBlessTestResults(TestCreateTestCommon):
 
 # ###############################################################################
 # class TestUpdateACMETests(unittest.TestCase):
-# # ###############################################################################
+# ###############################################################################
 
-# #     ###########################################################################
+#     ###########################################################################
 #     def setUp(self):
-# #     ###########################################################################
-# #         # Grab all active tests
+#     ###########################################################################
+#         # Grab all active tests
 #         self._testlist_allactive = os.path.join(CIME.utils.get_model_config_root(), "allactive", "testlist_allactive.xml")
 #         shutil.copy2(self._testlist_allactive, ".")
 
-# #     ###########################################################################
+#     ###########################################################################
 #     def tearDown(self):
-# #     ###########################################################################
+#     ###########################################################################
 #         shutil.copy2("testlist_allactive.xml", self._testlist_allactive)
 
-# #     ###########################################################################
+#     ###########################################################################
 #     def test_update_acme_tests(self):
-# #     ###########################################################################
-# #         # Add some testable stuff to acme tests
+#     ###########################################################################
+#         # Add some testable stuff to acme tests
 #         update_acme_tests._TEST_SUITES["acme_tiny"] = \
 #             (None, (("ERS.f19_g16_rx1.A", "jgftestmodtest/test_mod"),
 #                     ("NCK.f19_g16_rx1.A", "jgftestmodtest/test_mod"))
@@ -679,13 +670,13 @@ class TestBlessTestResults(TestCreateTestCommon):
 #         stat = run_cmd("grep 'jgftestmodtest/test_mod' %s" % os.path.basename(self._testlist_allactive), ok_to_fail=True)[0]
 #         self.assertEqual(stat, 0, msg="update_acme_tests did not update XML")
 
-# #     ###########################################################################
+#     ###########################################################################
 #     def test_update_acme_tests_test_mods(self):
-# #     ###########################################################################
+#     ###########################################################################
 #         machine = "melvin"
 #         not_my_machine = "%s_jgftest" % machine
 
-# #         # Add some testable stuff to acme tests
+#         # Add some testable stuff to acme tests
 #         update_acme_tests._TEST_SUITES["acme_tiny"] = \
 #             (None, (("ERS.f19_g16_rx1.A", "test_mod"),
 #                     ("ERS.f19_g16_rx1.B", "test_mod", machine),
@@ -714,7 +705,26 @@ class TestBlessTestResults(TestCreateTestCommon):
 #         self.assertEqual(stat, 0,
 #                          msg="COMMAND SHOULD HAVE WORKED\cs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
+###############################################################################
+class FullSystemTest(TestCreateTestCommon):
+###############################################################################
+
+    ###########################################################################
+    def test_full_system(self):
+    ###########################################################################
+        stat, output, errput = run_cmd("%s/create_test cime_developer -t %s" % (SCRIPT_DIR, self._baseline_name), ok_to_fail=True)
+        self.assertEqual(stat, 0,
+                         msg="COMMAND SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+
+        if (_MACHINE.has_batch_system()):
+            stat, output, errput = run_cmd("%s/wait_for_tests *%s*/TestStatus" % (SCRIPT_DIR, self._baseline_name), ok_to_fail=True, from_dir=self._testroot)
+            self.assertEqual(stat, 0,
+                             msg="COMMAND SHOULD HAVE WORKED\wait_for_tests output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+
+
+        stat, output, errput = run_cmd("%s/cs_status.%s" % (self._testroot, self._baseline_name), ok_to_fail=True)
+        self.assertEqual(stat, 0,
+                         msg="COMMAND SHOULD HAVE WORKED\cs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
 if (__name__ == "__main__"):
     unittest.main(verbosity=2)
-###########################################################################

--- a/utils/python/update_acme_tests.py
+++ b/utils/python/update_acme_tests.py
@@ -114,13 +114,11 @@ def get_test_suite(suite, machine=None, compiler=None):
     Return a list of FULL test names for a suite.
     """
     expect(suite in _TEST_SUITES, "Unknown test suite: '%s'" % suite)
-    machobj = Machines()
-    if(machine is None):
-        machine = machobj.probe_machine_name()
-    else:
-        machobj.set_machine(machine)
+    machobj = Machines(machine=machine)
+    machine = machobj.get_machine_name()
+
     if(compiler is None):
-        compiler = machine.get_default_compiler()
+        compiler = machobj.get_default_compiler()
     expect(machobj.is_valid_compiler(compiler),"Compiler %s not valid for machine %s" %
            (compiler,machine))
 
@@ -183,8 +181,8 @@ def get_full_test_names(testargs, machine, compiler):
     >>> get_full_test_names(["acme_tiny", "^NCK.f19_g16_rx1.A"], "melvin", "gnu")
     ['ERS.f19_g16_rx1.A.melvin_gnu']
     """
-    expect(machine is not None,"Must define a machine")
-    expect(compiler is not None,"Must define a compiler")
+    expect(machine is not None, "Must define a machine")
+    expect(compiler is not None, "Must define a compiler")
     acme_test_suites = get_test_suites()
 
     tests_to_run = set()
@@ -221,10 +219,12 @@ def find_all_supported_platforms():
     mpi library).
     """
     machines = CIME.utils.get_machines()
+    machobj = Machines(machine=machine)
     platform_set = set()
 
     for machine in machines:
-        compilers, mpilibs = CIME.utils.get_machine_info(["COMPILERS", "MPILIBS"], machine=machine)
+        machobj.set_machine(machine)
+        compilers, mpilibs = machobj.get_value("COMPILERS"), machobj.get_value("MPILIBS")
         for compiler in compilers:
             for mpilib in mpilibs:
                 platform_set.add((machine, compiler, mpilib))

--- a/utils/python/wait_for_tests.py
+++ b/utils/python/wait_for_tests.py
@@ -4,6 +4,7 @@ import xml.etree.ElementTree as xmlet
 
 import CIME.utils
 from CIME.utils import expect
+from CIME.XML.machines import Machines
 from collections import OrderedDict
 
 TEST_STATUS_FILENAME      = "TestStatus"
@@ -216,7 +217,7 @@ def create_cdash_xml(results, cdash_build_name, cdash_project, cdash_build_group
     utc_time_tuple = time.gmtime(start_time)
     cdash_timestamp = time.strftime("%H:%M:%S", utc_time_tuple)
 
-    hostname = CIME.utils.probe_machine_name()
+    hostname = Machines().get_machine_name()
     if (hostname is None):
         hostname = socket.gethostname().split(".")[0]
         logging.warning("Could not convert hostname '%s' into an ACME machine name" % (hostname))
@@ -352,7 +353,6 @@ def interpret_status(file_contents, check_throughput=False, check_memory=False, 
     ('testname', 'DIFF')
     """
     statuses, test_name = parse_test_status(file_contents)
-    logging.warning("status %s test_name %s" %(statuses, test_name))
     reduced_status = reduce_stati(statuses, check_throughput, check_memory, ignore_namelists)
 
     if (RUN_PHASE not in statuses.keys() and reduced_status != TEST_FAIL_STATUS):


### PR DESCRIPTION
1) Use single Machines object in scripts to avoid reparsing XML.
2) No need to call get_resolved_value when get_value should already resolve
3) Get rid of unsupported --old arg to create_test
4) PEP cleanup for some CIME/XML classes
 * Spaces between operators, commas, ifs
5) Machines constructor will probe machine if user doesn't supply one
 * Removes lots of probe calls
6) Some cleanup/fixes to argument handling in CreateTest
7) Encapsulate CIMECONFIG global
8) Add FullSystemTest back into scripts_regression_tests until we find better place for it