### PR TITLE
Jedwards/testlists

### DIFF
--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<testlist>
+<testlist version="2.0">
   <test name="CME_D_Ld5" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="yellowstone" compiler="intel" category="prebeta">

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -1,1202 +1,769 @@
 <?xml version="1.0"?>
 <testlist>
-
-  <compset name="B1850RG">
-    <grid name="f09_g16">
-      <test name="ERS_Ld11">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
-      </test>
-      <test name="SMS_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01io">yellowstone</machine>
-      </test>
-      <test name="PFS">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cesm2dev01">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850R">
-
-  <compset name="A">
-    <grid name="f19_g16_rx1">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_tiny">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="intel" testtype="acme_tiny">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="gnu" testtype="acme_tiny">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="ibm" testtype="acme_tiny">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="gnu" testtype="acme_tiny">mustang</machine>
-        <machine compiler="intel" testtype="acme_tiny">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="intel" testtype="acme_tiny">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="pgi" testtype="acme_tiny">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-        <machine compiler="gnu" testtype="acme_tiny">wolf</machine>
-        <machine compiler="intel" testtype="acme_tiny">wolf</machine>
-      </test>
-      <test name="ERS_IOP">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="ERS_IOP4c">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="ERS_IOP4p">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="NCK">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_tiny">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="intel" testtype="acme_tiny">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="gnu" testtype="acme_tiny">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="ibm" testtype="acme_tiny">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="gnu" testtype="acme_tiny">mustang</machine>
-        <machine compiler="intel" testtype="acme_tiny">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="intel" testtype="acme_tiny">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="pgi" testtype="acme_tiny">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-        <machine compiler="gnu" testtype="acme_tiny">wolf</machine>
-        <machine compiler="intel" testtype="acme_tiny">wolf</machine>
-      </test>
-    </grid>
-    <grid name="f45_g37_rx1">
-      <test name="PEA_P1_M">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="PET_PT">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-    <grid name="ne30_f19_g16_rx1">
-      <test name="SMS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-    <grid name="ne30_g16_rx1">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="ERS_IOP">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="ERS_IOP4c">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="ERS_IOP4p">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B">
-    <grid name="f19_g16">
-      <test name="ERR_N2">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
-      </test>
-    </grid>
-    <grid name="f45_g37">
-      <test name="PEA_P1">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">hobart</machine>
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">hobart</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850C4L40CNRBDRD">
-    <grid name="f09_g16">
-      <test name="ERS_Ld11">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850RW">
-    <grid name="f19_g16">
-      <test name="ERS_Ld11">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850C4L45BGCRBPRP">
-    <grid name="f19_g16">
-      <test name="ERS_Ld11">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850C5L40SPR">
-    <grid name="f19_g16">
-      <test name="PET_PT">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-      </test>
-    </grid>
-    <grid name="f45_g37">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="ERS_D">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="SEQ_PFC">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-    <grid name="ne16_g37">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="ERT">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-    <grid name="ne30_g16">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850W">
-    <grid name="f09_g16">
-      <test name="ERS">
-        <machine compiler="pgi" testtype="prealpha" testmods="allactive/defaultio">bluewaters</machine>
-        <machine compiler="ibm" testtype="prealpha" testmods="allactive/defaultio">mira</machine>
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850">
-    <grid name="f19_g16">
-      <test name="CME_D_Ld5">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-      <test name="CME_Ld5">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
-      </test>
-      <test name="ERS_E_Ld7">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-      <test name="NCR_P15x1D">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-    <grid name="f09_g16">
-      <test name="ERI">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
-      </test>
-      <test name="PFS">
-        <machine compiler="pgi " testtype="prebeta" testmods="allactive/default">bluewaters</machine>
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/default">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/default">yellowstone</machine>
-      </test>
-    </grid>
-    <grid name="f19_g16">
-      <test name="ERS_D_Ld7">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-      <test name="PET_PT">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">titan</machine>
-        <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-    <grid name="ne120_g16">
-      <test name="ERS_Ld9">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-      </test>
-    </grid>
-    <grid name="ne30_g16">
-      <test name="ERI">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-      <test name="ERS_D_Ld7">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-      </test>
-      <test name="ERS_IOP_Ld7">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-        <machine compiler="gnu" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-      <test name="ERS_Ld7">
-        <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="gnu" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-      <test name="ERS_Ld9">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">titan</machine>
-      </test>
-      <test name="PET_PT">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
-      </test>
-      <test name="PFS">
-        <machine compiler="ibm " testtype="prebeta" testmods="allactive/default">mira</machine>
-        <machine compiler="intel " testtype="prealpha" testmods="allactive/default">yellowstone</machine>
-        <machine compiler="intel " testtype="prebeta" testmods="allactive/default">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850R">
-    <grid name="f09_g16">
-      <test name="NOC">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850C4RCO2L40CNR">
-    <grid name="f09_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-      </test>
-    </grid>
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850C5WCCML45CNR">
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4FCHML40CNR">
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4WCBCL40CNR">
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">janus</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B20TRC5">
-    <grid name="f19_g16">
-      <test name="SMS_D">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC5L40SPR">
-    <grid name="ne16_g37">
-      <test name="ERS_Ld7">
-        <machine compiler="intel15" testtype="prebeta" testmods="allactive/defaultio">babbageKnc</machine>
-      </test>
-      <test name="SMS_Ld7">
-        <machine compiler="intel15" testtype="prebeta" testmods="allactive/defaultio">babbageKnc</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC5">
-    <grid name="ne16_g37">
-      <test name="ERS_Ld7">
-        <machine compiler="intel15" testtype="prebeta" testmods="allactive/defaultio">babbageKnc</machine>
-      </test>
-      <test name="SMS_Ld7">
-        <machine compiler="intel15" testtype="prebeta" testmods="allactive/defaultio">babbageKnc</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC5L45BGCR">
-    <grid name="f19_g16">
-      <test name="NCK_Ld5">
-        <machine compiler="gnu" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
-        <machine compiler="gnu" testtype="prebeta" testmods="allactive/cism/test_coupling">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850C5L45BGCR">
-    <grid name="T31_g37">
-      <test name="ERS_Ld5">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850C5L45BGCRG2">
-    <grid name="T31_g37_gl20">
-      <test name="SMS_D_Ld5">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/cism/test_coupling">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC5L45BGCRG">
-    <grid name="T31_g37_gl20">
-      <test name="SMS_D_Ld5">
-        <machine compiler="nag" testtype="prebeta" testmods="allactive/cism/test_coupling">hobart</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC5L45BGCRG">
-    <grid name="f19_g16">
-      <test name="NCK_Ld5">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/cism/test_coupling">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/cism/test_coupling">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BHISTC4L40CNRBDRD">
-    <grid name="f09_g16">
-      <test name="ERS_Ld11">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BHISTC5L40CNR">
-    <grid name="f19_g16">
-      <test name="ERS_N2_Ld7">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
-        <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="gnu" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="B1850C5L45BGCR">
-    <grid name="ne120_g16">
-      <test name="ERS_Ld9">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BHISTC4FCHML40CNR">
-    <grid name="f09_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">eos</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4TMOZL40SPR">
-    <grid name="f45_g37">
-      <test name="ERS_Ld7">
-        <machine compiler="gnu" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BHISTC5L45BGCR">
-    <grid name="f09_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-      </test>
-      <test name="SMS_D">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
-      </test>
-    </grid>
-    <grid name="f19_g16">
-      <test name="ERS_IOP_Ld7">
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">bluewaters</machine>
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-      <test name="ERS_N2_Ld7">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">hobart</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BRCP26C4L40CNR">
-    <grid name="f09_g16">
-      <test name="ERS_PT_Ld7">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">janus</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BRCP45C4L40CNRBDRD">
-    <grid name="f09_g16">
-      <test name="ERS_Ld11">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BRCP85C4L40CNRBPRP">
-    <grid name="f09_g16">
-      <test name="SMS_Ld5">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BRCP85C5L45BGCR">
-    <grid name="f09_g16">
-      <test name="ERS">
-        <machine compiler="ibm" testtype="prebeta" testmods="allactive/defaultio">mira</machine>
-      </test>
-      <test name="ERS_PT_Ld7">
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">edison</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4SSOAL40SPR">
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="pgi" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4SSOAL40SPR">
-    <grid name="f19_g16">
-      <test name="ERS_D_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4WCMAL40SPR">
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="gnu" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="gnu" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4WCMAL40SPR">
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="intel" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="BC4WTSML40SPR">
-    <grid name="f19_g16">
-      <test name="ERS_Ld7">
-        <machine compiler="pgi" testtype="prealpha" testmods="allactive/defaultio">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta" testmods="allactive/defaultio">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="E1850C5L40CNRTEST">
-    <grid name="f19_g16">
-      <test name="ERS_Ld5">
-	<machine compiler="pgi" testtype="prebeta" testmods="cice/default">yellowstone</machine>
-	</test>
-    </grid>
-  </compset>
-
-  <compset name="C_MPAS_NORMAL_YEAR">
-    <grid name="T62_mpas120">
-      <test name="ERS_Ld5">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="DTEST">
-    <grid name="f45_g37_rx1">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="ERS_IOP">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="FAMIPC5">
-    <grid name="f19_f19">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="ERS_IOP_Ld3">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="FC5">
-    <grid name="ne16_g37">
-      <test name="ERS_Ld3">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-    <grid name="ne16_ne16">
-      <test name="SMS_D_Ld3">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-    <grid name="ne30_ne30">
-      <test name="ERS_Ld3">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="PFS">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="FC5AQUAP">
-    <grid name="ne16_ne16">
-      <test name="SMS">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="FC5MAM4">
-    <grid name="ne16_ne16">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="FC5PLMOD">
-    <grid name="ne16_ne16">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="FC5PM">
-    <grid name="ne16_ne16">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="I1850CLM45CN">
-    <grid name="f09_g16">
-      <test name="SMS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-    <grid name="f19_f19">
-      <test name="SMS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="I1850CRUCLM45CN">
-    <grid name="hcru_hcru">
-      <test name="SMS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="IGCLM45_MLI">
-    <grid name="f09_g16_a">
-      <test name="SMS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="MPASLIALB_ONLY">
-    <grid name="f09_g16_a">
-      <test name="SMS">
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="MPASLI_ONLY">
-    <grid name="f09_g16_g">
-      <test name="ERS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="MPAS_LISIO_TEST">
-    <grid name="T62_mpas120_gis20">
-      <test name="SMS">
-        <machine compiler="intel" testtype="acme_developer">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_developer">edison</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_developer">melvin</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_developer">mira</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_developer">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">mustang</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_developer">skybridge</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_developer">titan</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_developer">wolf</machine>
-        <machine compiler="intel" testtype="acme_developer">wolf</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="X">
-    <grid name="f19_g16">
-      <test name="PET_PT">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-      <test name="SEQ_IOP_PFC">
-        <machine compiler="intel" testtype="acme_integration">blues</machine>
-        <machine compiler="intel" testtype="acme_integration">edison</machine>
-        <machine compiler="gnu" testtype="acme_integration">melvin</machine>
-        <machine compiler="ibm" testtype="acme_integration">mira</machine>
-        <machine compiler="gnu" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">mustang</machine>
-        <machine compiler="intel" testtype="acme_integration">skybridge</machine>
-        <machine compiler="pgi" testtype="acme_integration">titan</machine>
-        <machine compiler="gnu" testtype="acme_integration">wolf</machine>
-        <machine compiler="intel" testtype="acme_integration">wolf</machine>
-      </test>
-    </grid>
-  </compset>
+  <test name="CME_D_Ld5" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="CME_Ld5" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERI" grid="f09_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERI" grid="ne30_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERR_N2" grid="f19_g16" compset="B1850R" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS" grid="f09_g16" compset="B1850W" testmods="allactive/defaultio">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="mira" compiler="ibm" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS" grid="f09_g16" compset="BRCP85C5L45BGCR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="mira" compiler="ibm" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_D_Ld7" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_D_Ld7" grid="ne30_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="mira" compiler="ibm" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_D_Ld7" grid="f19_g16" compset="BC4SSOAL40SPR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_E_Ld7" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_IOP_Ld7" grid="ne30_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="mira" compiler="ibm" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_IOP_Ld7" grid="f19_g16" compset="BHISTC5L45BGCR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld11" grid="f09_g16" compset="B1850RG" testmods="allactive/cesm2dev01io">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld11" grid="f09_g16" compset="B1850C4L40CNRBDRD" testmods="allactive/defaultio">
+    <machines>
+      <machine name="mira" compiler="ibm" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld11" grid="f19_g16" compset="B1850RW" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld11" grid="f19_g16" compset="B1850C4L45BGCRBPRP" testmods="allactive/defaultio">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld11" grid="f09_g16" compset="BHISTC4L40CNRBDRD" testmods="allactive/defaultio">
+    <machines>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld11" grid="f09_g16" compset="BRCP45C4L40CNRBDRD" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld5" grid="T31_g37" compset="B1850C5L45BGCR" testmods="allactive/cism/test_coupling">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld5" grid="f19_g16" compset="E1850C5L40CNRTEST" testmods="cice/default">
+    <machines>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="ne30_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="gnu" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f09_g16" compset="B1850C4RCO2L40CNR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="mira" compiler="ibm" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f19_g16" compset="B1850C4RCO2L40CNR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f19_g16" compset="B1850C5WCCML45CNR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="mira" compiler="ibm" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f19_g16" compset="BC4FCHML40CNR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f19_g16" compset="BC4WCBCL40CNR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="janus" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="ne16_g37" compset="BC5L40SPR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="babbageKnc" compiler="intel15" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f09_g16" compset="BHISTC4FCHML40CNR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f45_g37" compset="BC4TMOZL40SPR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f09_g16" compset="BHISTC5L45BGCR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f19_g16" compset="BC4SSOAL40SPR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f19_g16" compset="BC4WCMAL40SPR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="gnu" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld7" grid="f19_g16" compset="BC4WTSML40SPR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld9" grid="ne120_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="mira" compiler="ibm" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld9" grid="ne30_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="titan" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld9" grid="ne120_g16" compset="B1850C5L45BGCR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_N2_Ld7" grid="f19_g16" compset="BHISTC5L40CNR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_N2_Ld7" grid="f19_g16" compset="BHISTC5L45BGCR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="hobart" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_PT_Ld7" grid="f09_g16" compset="BRCP26C4L40CNR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="janus" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_PT_Ld7" grid="f09_g16" compset="BRCP85C5L45BGCR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="NCK_Ld5" grid="f19_g16" compset="BC5L45BGCR" testmods="allactive/cism/test_coupling">
+    <machines>
+      <machine name="yellowstone" compiler="gnu" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="NCK_Ld5" grid="f19_g16" compset="BC5L45BGCRG" testmods="allactive/cism/test_coupling">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="NCR_P15x1D" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="NOC" grid="f09_g16" compset="B1850R" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PEA_P1" grid="f45_g37" compset="B1850R" testmods="allactive/defaultio">
+    <machines>
+      <machine name="hobart" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PET_PT" grid="f19_g16" compset="B1850C5L40SPR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PET_PT" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="titan" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PET_PT" grid="ne30_g16" compset="B1850" testmods="allactive/defaultio">
+    <machines>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PFS" grid="f09_g16" compset="B1850RG" testmods="allactive/cesm2dev01">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PFS" grid="f09_g16" compset="B1850" testmods="allactive/default">
+    <machines>
+      <machine name="bluewaters" compiler="pgi " category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PFS" grid="ne30_g16" compset="B1850" testmods="allactive/default">
+    <machines>
+      <machine name="mira" compiler="ibm " category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel " category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel " category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SMS_D" grid="f09_g16" compset="BHISTC5L45BGCR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SMS_D_Ld5" grid="T31_g37_gl20" compset="B1850C5L45BGCRG2" testmods="allactive/cism/test_coupling">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SMS_D_Ld5" grid="T31_g37_gl20" compset="BC5L45BGCRG" testmods="allactive/cism/test_coupling">
+    <machines>
+      <machine name="hobart" compiler="nag" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SMS_Ld5" grid="f09_g16" compset="BRCP85C4L40CNRBPRP" testmods="allactive/defaultio">
+    <machines>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SMS_Ld7" grid="f09_g16" compset="B1850RG" testmods="allactive/cesm2dev01io">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SMS_Ld7" grid="ne16_g37" compset="BC5L40SPR" testmods="allactive/defaultio">
+    <machines>
+      <machine name="babbageKnc" compiler="intel15" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
 </testlist>

--- a/driver_cpl/cime_config/testdefs/testlist_drv.xml
+++ b/driver_cpl/cime_config/testdefs/testlist_drv.xml
@@ -1,212 +1,789 @@
 <?xml version="1.0"?>
 <testlist>
-  <compset name="A">
-    <grid name="T31_g37_rx1">
-      <test name="ERI">
-        <machine compiler="intel " testtype="prebeta">yellowstone</machine>
-        <machine compiler="cray" testtype="prebeta">edison</machine>
-      </test>
-      <test name="ERI_D">
-        <machine compiler="intel" testtype="prebeta">hobart</machine>
-        <machine compiler="pgi" testtype="prebeta">hobart</machine>
-        <machine compiler="intel" testtype="prebeta">edison</machine>
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-      <test name="ERS_Ld3">
-        <machine compiler="pgi" testtype="prebeta">bluewaters</machine>
-        <machine compiler="intel" testtype="prealpha">edison</machine>
-        <machine compiler="intel" testtype="prebeta">edison</machine>
-        <machine compiler="gnu" testtype="prebeta">melvin</machine>
-        <machine compiler="intel" testtype="prebeta">skybridge</machine>
-        <machine compiler="intel" testtype="prealpha">eos</machine>
-        <machine compiler="cray" testtype="prebeta">eos</machine>
-      </test>
-      <test name="ERS_Ld3">
-        <machine compiler="pgi" testtype="prealpha">bluewaters</machine>
-        <machine compiler="cray" testtype="prebeta">edison</machine>
-      </test>
-      <test name="ERS_N2_Ld3">
-        <machine compiler="intel" testtype="prebeta">hobart</machine>
-        <machine compiler="pgi" testtype="prebeta">hobart</machine>
-        <machine compiler="intel" testtype="prebeta">edison</machine>
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-    </grid>
-    <grid name="f19_g16_rx1">
-      <test name="ERS_IOP_Ld3">
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-      <test name="ERS_N2_Ld3">
-        <machine compiler="pgi" testtype="prebeta">bluewaters</machine>
-        <machine compiler="intel" testtype="prebeta">edison</machine>
-        <machine compiler="gnu" testtype="prebeta">melvin</machine>
-        <machine compiler="intel" testtype="prebeta">skybridge</machine>
-        <machine compiler="intel" testtype="prebeta">eos</machine>
-      </test>
-      <test name="NCK_Ld3">
-        <machine compiler="intel" testtype="prebeta">hobart</machine>
-        <machine compiler="pgi" testtype="prebeta">hobart</machine>
-        <machine compiler="intel" testtype="prebeta">eos</machine>
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-      <test name="PEM">
-        <machine compiler="intel" testtype="prealpha">yellowstone</machine>
-      </test>
-    </grid>
-    <grid name="f45_g37_rx1">
-      <test name="CME_Ld3">
-        <machine compiler="intel" testtype="prealpha">yellowstone</machine>
-      </test>
-      <test name="ERR">
-        <machine compiler="intel" testtype="prealpha">yellowstone</machine>
-        <machine compiler="nag" testtype="prealpha">hobart</machine>
-        <machine compiler="cray" testtype="prealpha">eos</machine>
-        <machine compiler="intel" testtype="prealpha">edison</machine>
-        <machine compiler="pgi" testtype="prealpha">bluewaters</machine>
-        <machine compiler="ibm" testtype="prealpha">mira</machine>
-      </test>
-      <test name="ERS_Ld3">
-        <machine compiler="intel" testtype="prebeta">edison</machine>
-        <machine compiler="intel" testtype="prealpha">hobart</machine>
-        <machine compiler="pgi" testtype="prealpha">hobart</machine>
-        <machine compiler="gnu" testtype="prebeta">melvin</machine>
-        <machine compiler="intel" testtype="prebeta">skybridge</machine>
-        <machine compiler="intel" testtype="prealpha">goldbach</machine>
-        <machine compiler="pgi" testtype="prealpha">goldbach</machine>
-        <machine compiler="intel" testtype="prealpha">stampede</machine>
-        <machine compiler="intel" testtype="prealpha">yellowstone</machine>
-        <machine compiler="pgi" testtype="prealpha">yellowstone</machine>
-      </test>
-      <test name="ERS_Ld3">
-        <machine compiler="intel" testtype="prealpha">hobart</machine>
-        <machine compiler="pgi" testtype="prealpha">hobart</machine>
-        <machine compiler="lahey" testtype="prebeta">hobart</machine>
-      </test>
-      <test name="NCK_Ld3">
-        <machine compiler="pgi" testtype="prebeta">bluewaters</machine>
-        <machine compiler="intel" testtype="prebeta">edison</machine>
-        <machine compiler="gnu" testtype="prebeta">melvin</machine>
-        <machine compiler="intel" testtype="prebeta">skybridge</machine>
-        <machine compiler="intel" testtype="prebeta">eos</machine>
-      </test>
-      <test name="PEA_P1_Ld3">
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-      <test name="PET_PT_Ld3">
-        <machine compiler="cray" testtype="prebeta">eos</machine>
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-      <test name="SMS_D_Ld3">
-        <machine compiler="nag" testtype="prealpha">hobart</machine>
-        <machine compiler="nag" testtype="prebeta">hobart</machine>
-      </test>
-    </grid>
-    <grid name="ne30_f19_g16_rx1">
-      <test name="ERS_Ld3">
-        <machine compiler="pgi" testtype="prealpha">bluewaters</machine>
-        <machine compiler="pgi" testtype="prebeta">bluewaters</machine>
-        <machine compiler="intel" testtype="prebeta">eos</machine>
-      </test>
-      <test name="SMS_Ld3">
-        <machine compiler="pgi" testtype="prebeta">hobart</machine>
-        <machine compiler="cray" testtype="prebeta">eos</machine>
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-    </grid>
-    <grid name="ne30_g16_rx1">
-      <test name="ERS_IOP_Ld3">
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-      <test name="ERS_Ld3">
-        <machine compiler="intel" testtype="prebeta">edison</machine>
-        <machine compiler="gnu" testtype="prebeta">melvin</machine>
-        <machine compiler="intel" testtype="prebeta">skybridge</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="AWAV">
-    <grid name="ww3a_ww3a">
-      <test name="SMS_Ld3">
-        <machine compiler="pgi" testtype="prebeta">hobart</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="AIAF">
-    <grid name="T62_g16">
-      <test name="ERS_Lm3">
-        <machine compiler="intel" testtype="prealpha">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
-  <compset name="X">
-    <grid name="T31_g37">
-      <test name="PEA_P1_Ld3">
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-    </grid>
-    <grid name="f09_g16">
-      <test name="SEQ_PFC_Ld3">
-        <machine compiler="intel" testtype="prebeta">edison</machine>
-        <machine compiler="gnu" testtype="prebeta">melvin</machine>
-        <machine compiler="intel" testtype="prebeta">skybridge</machine>
-      </test>
-    </grid>
-    <grid name="f19_g16">
-      <test name="ERS_Ld3">
-        <machine compiler="intel" testtype="prealpha">hobart</machine>
-        <machine compiler="pgi" testtype="prealpha">hobart</machine>
-        <machine compiler="intel" testtype="prealpha">edison</machine>
-        <machine compiler="intel" testtype="prealpha">yellowstone</machine>
-        <machine compiler="pgi" testtype="prealpha">yellowstone</machine>
-      </test>
-      <test name="PET_E_CG">
-        <machine compiler="intel" testtype="prealpha">yellowstone</machine>
-      </test>
-      <test name="PET_PT_Ld3">
-        <machine compiler="pgi" testtype="prebeta">hobart</machine>
-        <machine compiler="cray" testtype="prebeta">eos</machine>
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-      <test name="SEQ_IOP_PFC_Ld3">
-        <machine compiler="pgi" testtype="prebeta">hobart</machine>
-        <machine compiler="cray" testtype="prebeta">eos</machine>
-        <machine compiler="gnu" testtype="prebeta">yellowstone</machine>
-        <machine compiler="intel" testtype="prebeta">yellowstone</machine>
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-      <test name="SEQ_PFC_Ld3">
-        <machine compiler="intel" testtype="prebeta">eos</machine>
-      </test>
-    </grid>
-    <grid name="f45_g37">
-      <test name="ERS_Ld3">
-        <machine compiler="lahey" testtype="prebeta">hobart</machine>
-      </test>
-    </grid>
-    <grid name="ne30_g16">
-      <test name="ERI">
-        <machine compiler="pgi" testtype="prebeta">yellowstone</machine>
-      </test>
-    </grid>
-  </compset>
+  <test name="CME_Ld3" grid="f45_g37_rx1" compset="A">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERI" grid="T31_g37_rx1" compset="A">
+    <machines>
+      <machine name="yellowstone" compiler="intel " category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="cray" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERI" grid="ne30_g16" compset="X">
+    <machines>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERI_D" grid="T31_g37_rx1" compset="A">
+    <machines>
+      <machine name="hobart" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERR" grid="f45_g37_rx1" compset="A">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="nag" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="cray" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="bluewaters" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="mira" compiler="ibm" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_IOP_Ld3" grid="f19_g16_rx1" compset="A">
+    <machines>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_IOP_Ld3" grid="ne30_g16_rx1" compset="A">
+    <machines>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld3" grid="T31_g37_rx1" compset="A">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="melvin" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="skybridge" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="cray" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="bluewaters" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="cray" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld3" grid="f45_g37_rx1" compset="A">
+    <machines>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="melvin" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="skybridge" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="goldbach" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="goldbach" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="stampede" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="lahey" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld3" grid="ne30_f19_g16_rx1" compset="A">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld3" grid="ne30_g16_rx1" compset="A">
+    <machines>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="melvin" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="skybridge" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld3" grid="f19_g16" compset="X">
+    <machines>
+      <machine name="hobart" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Ld3" grid="f45_g37" compset="X">
+    <machines>
+      <machine name="hobart" compiler="lahey" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_Lm3" grid="T62_g16" compset="AIAF">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_N2_Ld3" grid="T31_g37_rx1" compset="A">
+    <machines>
+      <machine name="hobart" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="ERS_N2_Ld3" grid="f19_g16_rx1" compset="A">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="melvin" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="skybridge" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="NCK_Ld3" grid="f19_g16_rx1" compset="A">
+    <machines>
+      <machine name="hobart" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="NCK_Ld3" grid="f45_g37_rx1" compset="A">
+    <machines>
+      <machine name="bluewaters" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="melvin" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="skybridge" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PEA_P1_Ld3" grid="f45_g37_rx1" compset="A">
+    <machines>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PEA_P1_Ld3" grid="T31_g37" compset="X">
+    <machines>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PEM" grid="f19_g16_rx1" compset="A">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PET_E_CG" grid="f19_g16" compset="X">
+    <machines>
+      <machine name="yellowstone" compiler="intel" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PET_PT_Ld3" grid="f45_g37_rx1" compset="A">
+    <machines>
+      <machine name="eos" compiler="cray" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PET_PT_Ld3" grid="f19_g16" compset="X">
+    <machines>
+      <machine name="hobart" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="cray" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SEQ_IOP_PFC_Ld3" grid="f19_g16" compset="X">
+    <machines>
+      <machine name="hobart" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="cray" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SEQ_PFC_Ld3" grid="f09_g16" compset="X">
+    <machines>
+      <machine name="edison" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="melvin" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="skybridge" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SEQ_PFC_Ld3" grid="f19_g16" compset="X">
+    <machines>
+      <machine name="eos" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SMS_D_Ld3" grid="f45_g37_rx1" compset="A">
+    <machines>
+      <machine name="hobart" compiler="nag" category="prealpha">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="hobart" compiler="nag" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SMS_Ld3" grid="ne30_f19_g16_rx1" compset="A">
+    <machines>
+      <machine name="hobart" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="eos" compiler="cray" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+      <machine name="yellowstone" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">4:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="SMS_Ld3" grid="ww3a_ww3a" compset="AWAV">
+    <machines>
+      <machine name="hobart" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">2:00</option>
+          <option name="pecount">L</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
 </testlist>

--- a/driver_cpl/cime_config/testdefs/testlist_drv.xml
+++ b/driver_cpl/cime_config/testdefs/testlist_drv.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<testlist>
+<testlist version="2.0">
   <test name="CME_Ld3" grid="f45_g37_rx1" compset="A">
     <machines>
       <machine name="yellowstone" compiler="intel" category="prealpha">

--- a/scripts-python/create_test
+++ b/scripts-python/create_test
@@ -15,8 +15,6 @@ from standard_script_setup import *
 import update_acme_tests
 from CIME.create_test import CreateTest
 from CIME.utils import expect
-from CIME.XML.machines import Machines
-from CIME.XML.files import Files
 
 import argparse, doctest, tempfile
 
@@ -25,6 +23,8 @@ def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
         usage="""\n%s <TEST|SUITE> [<TEST|SUITE> ...] [--verbose]
+OR
+%s --xml_category [CATEGORY] [--xml_machine ...]
 OR
 %s --help
 OR
@@ -48,7 +48,7 @@ OR
 
     \033[1;32m# Run all tests in a suite except for tests that are in another suite \033[0m
     > %s <SUITE1> ^<SUITE2>
-""" % ((os.path.basename(args[0]), ) * 9),
+""" % ((os.path.basename(args[0]), ) * 10),
 
 description=description,
 
@@ -59,7 +59,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    parser.add_argument("testargs", nargs="+", help="Tests or test suites to run. Testnames expect in form CASE.GRID.COMPSET")
+    parser.add_argument("testargs", nargs="*", help="Tests or test suites to run. Testnames expect in form CASE.GRID.COMPSET")
 
     parser.add_argument("--no-run", action="store_true",
                         help="Do not run generated tests")
@@ -99,7 +99,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     parser.add_argument("-m", "--machine",
                         help="The machine for which to build tests, this machine must be defined in the "
-                        "config_mahines.xml file for the given model. Default is to match the name of the "
+                        "config_machines.xml file for the given model. Default is to match the name of the "
                         "machine in the test name or the name of the machine "
                         "this script is run on to the NODENAME_REGEX field in config_machines.xml"  )
 
@@ -120,6 +120,13 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-j", "--parallel-jobs", type=int, default=None,
                         help="Number of tasks create_test should perform simultaneously. Default "
                         "will be min(num_cores, num_tests).")
+
+
+    parser.add_argument("--xml_machine",help="Use this machine key in the lookup in testlist.xml")
+    parser.add_argument("--xml_compiler",help="Use this compiler key in the lookup in testlist.xml")
+    parser.add_argument("--xml_category",help="Use this category key in the lookup in testlist.xml")
+    parser.add_argument("--xml_testlist",help="Use this testlist to lookup tests")
+
 
     args = parser.parse_args(args[1:])
 
@@ -149,12 +156,14 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     return args.testargs, args.compiler, args.machine, args.no_run, args.no_build, args.no_batch, \
         args.test_root, args.baseline_root, args.clean, args.compare, args.generate, args.baseline_name, \
-        args.namelists_only, args.project, args.test_id, args.parallel_jobs
+        args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.xml_machine, args.xml_compiler,\
+        args.xml_category, args.xml_testlist
 
 ###############################################################################
 def create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, test_root,
                 baseline_root, clean, compare, generate,
-                baseline_name, namelists_only, project, test_id, parallel_jobs):
+                baseline_name, namelists_only, project, test_id, parallel_jobs,
+                xml_machine, xml_compiler, xml_category, xml_testlist):
 ###############################################################################
     impl = CreateTest(testargs,
                       no_run=no_run, no_build=no_build, no_batch=no_batch,
@@ -162,7 +171,9 @@ def create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, te
                       baseline_root=baseline_root, baseline_name=baseline_name,
                       clean=clean, machine_name=machine_name, compiler=compiler,
                       compare=compare, generate=generate, namelists_only=namelists_only,
-                      project=project, parallel_jobs=parallel_jobs)
+                      project=project, parallel_jobs=parallel_jobs,
+                      xml_machine=xml_machine,xml_compiler=xml_compiler,
+                      xml_category=xml_category,xml_testlist=xml_testlist)
     return 0 if impl.create_test() else CIME.utils.TESTS_FAILED_ERR_CODE
 
 ###############################################################################
@@ -174,11 +185,12 @@ def _main_func(description):
 
     testargs, compiler, machine_name, no_run, no_build, no_batch, test_root, baseline_root, clean, \
         compare, generate, baseline_name, namelists_only, project, test_id, parallel_jobs, \
+        xml_machine, xml_compiler, xml_category, xml_testlist\
         = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, test_root,
                          baseline_root, clean, compare, generate, baseline_name, namelists_only,
-                         project, test_id, parallel_jobs))
+                         project, test_id, parallel_jobs, xml_machine, xml_compiler, xml_category, xml_testlist))
 
 ###############################################################################
 

--- a/scripts-python/create_test
+++ b/scripts-python/create_test
@@ -24,7 +24,7 @@ def parse_command_line(args, description):
     parser = argparse.ArgumentParser(
         usage="""\n%s <TEST|SUITE> [<TEST|SUITE> ...] [--verbose]
 OR
-%s --xml_category [CATEGORY] [--xml_machine ...]
+%s --xml-category [CATEGORY] [--xml-machine ...]
 OR
 %s --help
 OR
@@ -122,10 +122,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         "will be min(num_cores, num_tests).")
 
 
-    parser.add_argument("--xml_machine",help="Use this machine key in the lookup in testlist.xml")
-    parser.add_argument("--xml_compiler",help="Use this compiler key in the lookup in testlist.xml")
-    parser.add_argument("--xml_category",help="Use this category key in the lookup in testlist.xml")
-    parser.add_argument("--xml_testlist",help="Use this testlist to lookup tests")
+    parser.add_argument("--xml-machine",help="Use this machine key in the lookup in testlist.xml")
+    parser.add_argument("--xml-compiler",help="Use this compiler key in the lookup in testlist.xml")
+    parser.add_argument("--xml-category",help="Use this category key in the lookup in testlist.xml")
+    parser.add_argument("--xml-testlist",help="Use this testlist to lookup tests")
 
 
     args = parser.parse_args(args[1:])
@@ -156,14 +156,14 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     return args.testargs, args.compiler, args.machine, args.no_run, args.no_build, args.no_batch, \
         args.test_root, args.baseline_root, args.clean, args.compare, args.generate, args.baseline_name, \
-        args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.xml_machine, args.xml_compiler,\
-        args.xml_category, args.xml_testlist
+        args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.xml-machine, args.xml-compiler,\
+        args.xml-category, args.xml-testlist
 
 ###############################################################################
 def create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, test_root,
                 baseline_root, clean, compare, generate,
                 baseline_name, namelists_only, project, test_id, parallel_jobs,
-                xml_machine, xml_compiler, xml_category, xml_testlist):
+                xml-machine, xml-compiler, xml-category, xml-testlist):
 ###############################################################################
     impl = CreateTest(testargs,
                       no_run=no_run, no_build=no_build, no_batch=no_batch,
@@ -172,8 +172,8 @@ def create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, te
                       clean=clean, machine_name=machine_name, compiler=compiler,
                       compare=compare, generate=generate, namelists_only=namelists_only,
                       project=project, parallel_jobs=parallel_jobs,
-                      xml_machine=xml_machine,xml_compiler=xml_compiler,
-                      xml_category=xml_category,xml_testlist=xml_testlist)
+                      xml-machine=xml-machine,xml-compiler=xml-compiler,
+                      xml-category=xml-category,xml-testlist=xml-testlist)
     return 0 if impl.create_test() else CIME.utils.TESTS_FAILED_ERR_CODE
 
 ###############################################################################
@@ -185,12 +185,12 @@ def _main_func(description):
 
     testargs, compiler, machine_name, no_run, no_build, no_batch, test_root, baseline_root, clean, \
         compare, generate, baseline_name, namelists_only, project, test_id, parallel_jobs, \
-        xml_machine, xml_compiler, xml_category, xml_testlist\
+        xml-machine, xml-compiler, xml-category, xml-testlist\
         = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, test_root,
                          baseline_root, clean, compare, generate, baseline_name, namelists_only,
-                         project, test_id, parallel_jobs, xml_machine, xml_compiler, xml_category, xml_testlist))
+                         project, test_id, parallel_jobs, xml-machine, xml-compiler, xml-category, xml-testlist))
 
 ###############################################################################
 

--- a/scripts-python/create_test
+++ b/scripts-python/create_test
@@ -3,10 +3,8 @@
 """
 Script to run CIME tests.
 
-Runs single tests or test suites based on either the input list or the testname.
-
-This is currently a wrapper around cime perl create_test, but this will eventually replace
-that tool entirely.
+Runs single tests or test suites based on either the input list or the testname or based
+on an xml testlist if the xml suboption is provided.
 
 If this tool is missing any feature that you need, please notify jgfouca@sandia.gov.
 """
@@ -24,7 +22,7 @@ def parse_command_line(args, description):
     parser = argparse.ArgumentParser(
         usage="""\n%s <TEST|SUITE> [<TEST|SUITE> ...] [--verbose]
 OR
-%s --xml-category [CATEGORY] [--xml-machine ...]
+%s xml --category [CATEGORY] [--machine ...] [--compiler ...] [ --testlist ...]
 OR
 %s --help
 OR
@@ -48,7 +46,11 @@ OR
 
     \033[1;32m# Run all tests in a suite except for tests that are in another suite \033[0m
     > %s <SUITE1> ^<SUITE2>
-""" % ((os.path.basename(args[0]), ) * 10),
+
+    \033[1;32m# Run all tests in the xml prealpha category and yellowstone machine \033[0m
+    > %s --xml_machine yellowstone --xml_category prealpha
+
+""" % ((os.path.basename(args[0]), ) * 11),
 
 description=description,
 
@@ -121,11 +123,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="Number of tasks create_test should perform simultaneously. Default "
                         "will be min(num_cores, num_tests).")
 
-
-    parser.add_argument("--xml-machine",help="Use this machine key in the lookup in testlist.xml")
-    parser.add_argument("--xml-compiler",help="Use this compiler key in the lookup in testlist.xml")
-    parser.add_argument("--xml-category",help="Use this category key in the lookup in testlist.xml")
-    parser.add_argument("--xml-testlist",help="Use this testlist to lookup tests")
+    parser.add_argument("--xml_machine",help="Use this machine key in the lookup in testlist.xml")
+    parser.add_argument("--xml_compiler",help="Use this compiler key in the lookup in testlist.xml")
+    parser.add_argument("--xml_category",help="Use this category key in the lookup in testlist.xml")
+    parser.add_argument("--xml_testlist",help="Use this testlist to lookup tests")
 
 
     args = parser.parse_args(args[1:])
@@ -141,6 +142,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     if (args.parallel_jobs is not None):
         expect(args.parallel_jobs > 0,
                "Invalid value for parallel_jobs: %d" % args.parallel_jobs)
+    if(args.xml_testlist is not None):
+        expect(not (args.xml_machine is None and args.xml_compiler is  None and args.xml_category is None),
+                "If an xml_testlist is present at least one of --xml_machine, --xml_compiler, --xml_category must also be present")
 
     if (args.no_build):
         args.no_run = True
@@ -154,16 +158,17 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     if (args.test_id is None):
         args.test_id = CIME.utils.get_utc_timestamp()
 
+
     return args.testargs, args.compiler, args.machine, args.no_run, args.no_build, args.no_batch, \
         args.test_root, args.baseline_root, args.clean, args.compare, args.generate, args.baseline_name, \
-        args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.xml-machine, args.xml-compiler,\
-        args.xml-category, args.xml-testlist
+        args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.xml_machine, args.xml_compiler,\
+        args.xml_category, args.xml_testlist
 
 ###############################################################################
 def create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, test_root,
                 baseline_root, clean, compare, generate,
                 baseline_name, namelists_only, project, test_id, parallel_jobs,
-                xml-machine, xml-compiler, xml-category, xml-testlist):
+                xml_machine, xml_compiler, xml_category, xml_testlist):
 ###############################################################################
     impl = CreateTest(testargs,
                       no_run=no_run, no_build=no_build, no_batch=no_batch,
@@ -172,8 +177,8 @@ def create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, te
                       clean=clean, machine_name=machine_name, compiler=compiler,
                       compare=compare, generate=generate, namelists_only=namelists_only,
                       project=project, parallel_jobs=parallel_jobs,
-                      xml-machine=xml-machine,xml-compiler=xml-compiler,
-                      xml-category=xml-category,xml-testlist=xml-testlist)
+                      xml_machine=xml_machine,xml_compiler=xml_compiler,
+                      xml_category=xml_category,xml_testlist=xml_testlist)
     return 0 if impl.create_test() else CIME.utils.TESTS_FAILED_ERR_CODE
 
 ###############################################################################
@@ -185,12 +190,12 @@ def _main_func(description):
 
     testargs, compiler, machine_name, no_run, no_build, no_batch, test_root, baseline_root, clean, \
         compare, generate, baseline_name, namelists_only, project, test_id, parallel_jobs, \
-        xml-machine, xml-compiler, xml-category, xml-testlist\
+        xml_machine, xml_compiler, xml_category, xml_testlist\
         = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, test_root,
                          baseline_root, clean, compare, generate, baseline_name, namelists_only,
-                         project, test_id, parallel_jobs, xml-machine, xml-compiler, xml-category, xml-testlist))
+                         project, test_id, parallel_jobs, xml_machine, xml_compiler, xml_category, xml_testlist))
 
 ###############################################################################
 

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -102,7 +102,7 @@ class EntryID(GenericXML):
 
         return val
 
-    def get_values(self, vid, att):
+    def get_values(self, vid, att, resolved=True):
         """
         If an entry includes a list of values return a dict matching each
         attribute to its associated value
@@ -117,11 +117,15 @@ class EntryID(GenericXML):
                 return
             node = nodes[0]
 
-        valnodes = self.get_node("value", node=node)
+        valnodes = self.get_node("value", root=node)
         if (valnodes is not None):
             for valnode in valnodes:
-                vatt = valnode.attrib(att)
-                values[vatt] = valnode.text
+                vatt = valnode.attrib[att]
+                if(resolved):
+                    values[vatt] = self.get_resolved_value(valnode.text)
+                else:
+                    values[vatt] = valnode.text
+
 
         return values
 

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -70,7 +70,7 @@ class GenericXML:
                 xpath += "@%s=\'%s\'" % (key,attributes[key])
                 cnt=cnt+1
             xpath += "]"
-        logging.warn("xpath = "+ xpath)
+        logging.debug("xpath = "+ xpath)
         nodes = root.findall(xpath)
         return nodes
 

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -57,21 +57,27 @@ class GenericXML:
         """
         if(root is None):
             root = self.root
-
+        nodes = []
         xpath = ".//"+nodename
         if(attributes is not None):
             keys = list(attributes.keys())
-            cnt = 0
+            # xml.etree has limited support for xpath and does not allow more than
+            # one attribute in an xpath query so we query seperately for each attribute
+            # and create a result with the intersection of those lists
             for key in keys:
-                if(cnt == 0):
-                    xpath += "["
+                xpath = ".//%s[@%s=\'%s\']" % (nodename,key,attributes[key])
+                newnodes = root.findall(xpath)
+                if(not nodes):
+                    nodes = newnodes
                 else:
-                    xpath += " and "
-                xpath += "@%s=\'%s\'" % (key,attributes[key])
-                cnt=cnt+1
-            xpath += "]"
-        logging.debug("xpath = "+ xpath)
-        nodes = root.findall(xpath)
+                    for node in nodes[:]:
+                        if (node not in newnodes):
+                            nodes.remove(node)
+                if(not nodes):
+                    return []
+        else:
+            nodes = root.findall(xpath)
+
         return nodes
 
     def add_child(self, node, root=None):

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -70,7 +70,7 @@ class GenericXML:
                 xpath += "@%s=\'%s\'" % (key,attributes[key])
                 cnt=cnt+1
             xpath += "]"
-        logging.info("xpath = "+ xpath)
+        logging.warn("xpath = "+ xpath)
         nodes = root.findall(xpath)
         return nodes
 

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -37,9 +37,15 @@ class GenericXML:
         """
         Read and parse an xml file into the object
         """
-        logging.debug("read: "+infile)
+        logging.info("read: "+infile)
         self.tree = ET.parse(infile)
         self.root = self.tree.getroot()
+        if ("version" in self.root.attrib):
+            self.version = self.root.attrib["version"]
+        else:
+            self.version = "1.0"
+        logging.info("File version is "+self.version)
+
 
     def write(self, infile=None):
         """

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -93,8 +93,8 @@ class Machines(GenericXML):
         """
         Sets the machine block in the Machines object
 
-        >>> machobj = Machines()
-        >>> machobj.set_machine("melvin")
+        >>> machobj = Machines(machine="melvin")
+        >>> machobj.get_machine_name()
         'melvin'
         >>> machobj.set_machine("trump")
         Traceback (most recent call last):
@@ -175,8 +175,7 @@ class Machines(GenericXML):
         """
         Check the compiler is valid for the current machine
 
-        >>> machobj = Machines()
-        >>> name = machobj.set_machine("edison")
+        >>> machobj = Machines(machine="edison")
         >>> machobj.get_default_compiler()
         'intel'
         >>> machobj.is_valid_compiler("cray")
@@ -194,8 +193,7 @@ class Machines(GenericXML):
         """
         Check the MPILIB is valid for the current machine
 
-        >>> machobj = Machines()
-        >>> name = machobj.probe_machine_name()
+        >>> machobj = Machines(machine="edison")
         >>> machobj.is_valid_MPIlib("mpi-serial")
         True
         """
@@ -207,9 +205,7 @@ class Machines(GenericXML):
         """
         Return if this machine has a batch system
 
-        >>> machobj = Machines()
-        >>> machobj.set_machine("edison")
-        'edison'
+        >>> machobj = Machines(machine="edison")
         >>> machobj.has_batch_system()
         True
         >>> machobj.set_machine("melvin")
@@ -228,8 +224,7 @@ class Machines(GenericXML):
         """
         Return the batch system using on this machine
 
-        >>> machobj = Machines()
-        >>> name = machobj.set_machine("edison")
+        >>> machobj = Machines(machine="edison")
         >>> machobj.get_batch_system_type()
         'slurm'
         """

--- a/utils/python/CIME/XML/standard_module_setup.py
+++ b/utils/python/CIME/XML/standard_module_setup.py
@@ -1,10 +1,7 @@
 import logging
 import os
 import sys
-#import libxml2
-#import xml.etree.ElementTree as ET
-#import lxml
-import lxml.etree as ET
+import xml.etree.ElementTree as ET
 import re
 LIB_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(LIB_DIR)

--- a/utils/python/CIME/XML/standard_module_setup.py
+++ b/utils/python/CIME/XML/standard_module_setup.py
@@ -1,9 +1,10 @@
 import logging
 import os
 import sys
+#import libxml2
 #import xml.etree.ElementTree as ET
-import lxml
-import lxml.etree.ElementTree as ET
+#import lxml
+import lxml.etree as ET
 import re
 LIB_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(LIB_DIR)

--- a/utils/python/CIME/XML/standard_module_setup.py
+++ b/utils/python/CIME/XML/standard_module_setup.py
@@ -1,7 +1,9 @@
 import logging
 import os
 import sys
-import xml.etree.ElementTree as ET
+#import xml.etree.ElementTree as ET
+import lxml
+import lxml.etree.ElementTree as ET
 import re
 LIB_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(LIB_DIR)

--- a/utils/python/CIME/XML/testlist.py
+++ b/utils/python/CIME/XML/testlist.py
@@ -14,7 +14,7 @@ class Testlist(GenericXML):
         GenericXML.__init__(self,infile)
 
     def get_tests(self, machine=None, category=None, compiler=None):
-        tests = {}
+        tests = []
         testnodes = self.get_node("test")
         machatts = {}
         if(machine is not None):
@@ -29,10 +29,12 @@ class Testlist(GenericXML):
 
             if(machnodes):
                 teststr = "%s.%s.%s"%(tnode.attrib["name"],tnode.attrib["grid"],tnode.attrib["compset"])
-
+                thistest = {}
                 for mach in machnodes:
-                    thistest = "%s.%s_%s"%(teststr, mach.attrib["name"],mach.attrib["compiler"])
-                    print "Found "+thistest
+                    thistest["name"] = "%s.%s_%s"%(teststr, mach.attrib["name"],mach.attrib["compiler"])
                     optionnodes = self.get_node("option")
-
+                    for onode in optionnodes:
+                       thistest[onode.attrib['name']]=onode.text
+                    tests.append(thistest)
+        return tests
 

--- a/utils/python/CIME/XML/testlist.py
+++ b/utils/python/CIME/XML/testlist.py
@@ -1,0 +1,38 @@
+"""
+Interface to the config_files.xml file.  This class inherits from EntryID.py
+"""
+from standard_module_setup import *
+
+from generic_xml import GenericXML
+from CIME.utils import expect, get_cime_root, get_model
+
+class Testlist(GenericXML):
+    def __init__(self,infile):
+        """
+        initialize an object
+        """
+        GenericXML.__init__(self,infile)
+
+    def get_tests(self, machine=None, category=None, compiler=None):
+        tests = {}
+        testnodes = self.get_node("test")
+        machatts = {}
+        if(machine is not None):
+            machatts["name"]      = machine
+        if(category is not None):
+            machatts["category"]  = category
+        if(compiler is not None):
+            machatts["compiler"]  = compiler
+
+        for tnode in testnodes:
+            machnodes = self.get_node("machine",machatts,root=tnode)
+
+            if(machnodes):
+                teststr = "%s.%s.%s"%(tnode.attrib["name"],tnode.attrib["grid"],tnode.attrib["compset"])
+
+                for mach in machnodes:
+                    thistest = "%s.%s_%s"%(teststr, mach.attrib["name"],mach.attrib["compiler"])
+                    print "Found "+thistest
+                    optionnodes = self.get_node("option")
+
+

--- a/utils/python/CIME/XML/testlist.py
+++ b/utils/python/CIME/XML/testlist.py
@@ -13,7 +13,35 @@ class Testlist(GenericXML):
         """
         GenericXML.__init__(self,infile)
 
-    def get_tests(self, machine=None, category=None, compiler=None):
+    def get_testsv1(self, machine=None, category=None, compiler=None):
+        tests = []
+        compsetnodes = self.get_node("compset")
+        machatts = {}
+        if(category is not None):
+            machatts["testtype"]  = category
+        if(compiler is not None):
+            machatts["compiler"]  = compiler
+        for cnode in compsetnodes:
+            gridnodes = self.get_node("grid",root=cnode)
+            for gnode in gridnodes:
+                testnamenodes = self.get_node("test",root=gnode)
+                for tnode in testnamenodes:
+                    machnodes = self.get_node("machine",machatts)
+                    for mach in machnodes:
+                        thistest = {}
+                        if (machine is None or (machine is not None and mach.text == machine)):
+                            thistest["compiler"] = mach.attrib["compiler"]
+                            thistest["category"] = mach.attrib["testtype"]
+                            thistest["machine"] = mach.text
+                            thistest["testname"] = tnode.attrib["name"]
+                            thistest["grid"] = gnode.attrib["name"]
+                            thistest["compset"] = cnode.attrib["name"]
+                            if ("testmods" in mach.attrib):
+                                thistest["testmods"] = mach.attrib["testmods"]
+                            tests.append(thistest)
+        return tests
+
+    def get_testsv2(self, machine=None, category=None, compiler=None):
         tests = []
         testnodes = self.get_node("test")
         machatts = {}
@@ -26,15 +54,32 @@ class Testlist(GenericXML):
 
         for tnode in testnodes:
             machnodes = self.get_node("machine",machatts,root=tnode)
+            thistest = {}
 
             if(machnodes):
-                teststr = "%s.%s.%s"%(tnode.attrib["name"],tnode.attrib["grid"],tnode.attrib["compset"])
-                thistest = {}
+                for key in tnode.attrib.keys():
+                    if(key == "name"):
+                        thistest["testname"] = tnode.attrib[key]
+                    else:
+                        thistest[key] = tnode.attrib[key]
                 for mach in machnodes:
-                    thistest["name"] = "%s.%s_%s"%(teststr, mach.attrib["name"],mach.attrib["compiler"])
-                    optionnodes = self.get_node("option")
+                    for key in mach.attrib.keys():
+                        if (key == "name"):
+                            thistest["machine"] = mach.attrib[key]
+                        else:
+                            thistest[key] = mach.attrib[key]
+                    optionnodes = self.get_node("option", root=mach)
                     for onode in optionnodes:
                        thistest[onode.attrib['name']]=onode.text
                     tests.append(thistest)
         return tests
+
+    def get_tests(self, machine=None, category=None, compiler=None):
+        if (self.version == "1.0"):
+            return self.get_testsv1(machine,category,compiler)
+        elif (self.version == "2.0"):
+            return self.get_testsv2(machine,category,compiler)
+        else:
+            logging.critical("Did not recognize testlist file version %s for file %s"
+                             % (self.version,self.filename))
 

--- a/utils/python/CIME/XML/testlist.py
+++ b/utils/python/CIME/XML/testlist.py
@@ -1,5 +1,6 @@
 """
-Interface to the config_files.xml file.  This class inherits from EntryID.py
+Interface to the config_files.xml file.  This class inherits from generic_xml.py
+It supports versions 1.0 and 2.0 of the testlist.xml file
 """
 from standard_module_setup import *
 

--- a/utils/python/CIME/create_test.py
+++ b/utils/python/CIME/create_test.py
@@ -114,9 +114,7 @@ class CreateTest(object):
         # This is the only data that multiple threads will simultaneously access
         # Each test has it's own index and setting/retrieving items from a list
         # is atomic, so this should be fine to use without mutex
-        for test in self._tests:
-            test["phase"] = INITIAL_PHASE
-            test["status"] = TEST_PASS_STATUS
+        self._test_states = [ (INITIAL_PHASE, TEST_PASS_STATUS) ] * len(self._tests)
 
         # Oversubscribe by 1/4
         pes = int(self._machobj.get_value("PES_PER_NODE"))
@@ -170,7 +168,7 @@ class CreateTest(object):
     ###########################################################################
     def _get_test_data(self, test):
     ###########################################################################
-        return (test["phase"],test["status"])
+        return self._test_states[test["state_idx"]]
 
     ###########################################################################
     def _is_broken(self, test):
@@ -221,8 +219,7 @@ class CreateTest(object):
                    "New phase should be set to pending status")
             expect(self._phases.index(old_phase) == phase_idx - 1,
                    "Skipped phase?")
-        test["phase"] = phase
-        test["status"] = status
+        self._test_states[test["state_idx"]] = (phase, status)
 
     ###########################################################################
     def _run_phase_command(self, test, cmd, phase, from_dir=None):

--- a/utils/python/CIME/create_test.py
+++ b/utils/python/CIME/create_test.py
@@ -3,6 +3,7 @@ Implementation of create_test functionality from CIME
 """
 import shutil, traceback, stat, glob, threading, time, thread
 from XML.standard_module_setup import *
+from copy import deepcopy
 import compare_namelists
 import CIME.utils
 from CIME.utils import expect, run_cmd
@@ -116,7 +117,7 @@ class CreateTest(object):
             test["status"] = TEST_PASS_STATUS
 
         # Oversubscribe by 1/4
-        pes = int(self._machobj.get_value("MAX_TASKS_PER_NODE"))
+        pes = int(self._machobj.get_value("PES_PER_NODE"))
         self._proc_pool = int(pes * 1.25)
 
         # Since the name-list phase can fail without aborting later phases, we
@@ -400,6 +401,7 @@ class CreateTest(object):
         test_dir = self._get_test_dir(test["name"])
         if ('wallclock' in test):
             out = run_cmd("./xmlchange JOB_WALLCLOCK_TIME=%s"%test["wallclock"], from_dir=test_dir)
+
         return self._run_phase_command(test, "./case.submit", RUN_PHASE, from_dir=test_dir)
 
     ###########################################################################
@@ -688,9 +690,10 @@ class CreateTest(object):
         return listoftests
 
     def _convert_testlist_to_dict(self,test_names):
+        from copy import deepcopy
         listoftests = []
         test = {}
         for name in test_names:
             test["name"] = name
-            listoftests.append(test)
+            listoftests.append(deepcopy(test))
         return listoftests

--- a/utils/python/CIME/create_test.py
+++ b/utils/python/CIME/create_test.py
@@ -403,6 +403,8 @@ class CreateTest(object):
     def _run_phase(self, test):
     ###########################################################################
         test_dir = self._get_test_dir(test["name"])
+        # wallclock is an optional field in the version 2.0 testlist.xml file
+        # setting wallclock time close to the expected test time will help queue throughput
         if ('wallclock' in test):
             out = run_cmd("./xmlchange JOB_WALLCLOCK_TIME=%s"%test["wallclock"], from_dir=test_dir)
 

--- a/utils/python/CIME/create_test.py
+++ b/utils/python/CIME/create_test.py
@@ -38,7 +38,6 @@ class CreateTest(object):
                  xml_machine=None, xml_compiler=None, xml_category=None,xml_testlist=None):
     ###########################################################################
         self._cime_root = CIME.utils.get_cime_root()
-
         self._machobj   = Machines(machine=machine_name)
         machine_name    = self._machobj.get_machine_name()
 
@@ -639,7 +638,7 @@ class CreateTest(object):
         """
         Parse testlists for a list of tests
         """
-        test_names = {}
+        test_names = []
         testlistfiles = []
         if(xml_testlist is not None):
              expect(os.path.isfile(xml_testlist), "Testlist not found or not readable "+xml_testlist)
@@ -653,5 +652,6 @@ class CreateTest(object):
 
         for testlistfile in testlistfiles:
             thistestlistfile = Testlist(testlistfile)
-            thistestlistfile.get_tests(xml_machine, xml_category, xml_compiler)
+            test_names.append(thistestlistfile.get_tests(xml_machine, xml_category, xml_compiler))
 
+        return test_names

--- a/utils/python/CIME/create_test.py
+++ b/utils/python/CIME/create_test.py
@@ -39,6 +39,8 @@ class CreateTest(object):
                  xml_machine=None, xml_compiler=None, xml_category=None,xml_testlist=None):
     ###########################################################################
         self._cime_root = CIME.utils.get_cime_root()
+        # needed for perl interface
+        os.environ["CIMEROOT"] = self._cime_root
         self._machobj   = Machines(machine=machine_name)
         machine_name    = self._machobj.get_machine_name()
 
@@ -338,8 +340,9 @@ class CreateTest(object):
         return self._run_phase_command(test, "./case.setup", SETUP_PHASE, from_dir=test_dir)
 
     ###########################################################################
-    def _nlcomp_phase(self, test_name):
+    def _nlcomp_phase(self, test):
     ###########################################################################
+        test_name = test["name"]
         test_dir          = self._get_test_dir(test_name)
         casedoc_dir       = os.path.join(test_dir, "CaseDocs")
         baseline_dir      = os.path.join(self._baseline_root, self._baseline_name, test_name)
@@ -466,7 +469,6 @@ class CreateTest(object):
             # the CIME scripts never got a chance to set the state.
             elif (test_phase == RUN_PHASE and not success):
                 test_status_file = os.path.join(self._get_test_dir(test_name), TEST_STATUS_FILENAME)
-
                 statuses = wait_for_tests.parse_test_status_file(test_status_file)[0]
                 if ( RUN_PHASE not in statuses or
                      statuses[RUN_PHASE] in [TEST_PASS_STATUS, TEST_PENDING_STATUS] ):

--- a/utils/python/CIME/test_utils.py
+++ b/utils/python/CIME/test_utils.py
@@ -1,0 +1,51 @@
+# Utility functions used in create_test.py
+from XML.standard_module_setup import *
+from copy import deepcopy
+
+def  _get_tests_from_xml(xml_machine=None,xml_category=None,xml_compiler=None, xml_testlist=None,
+                         machine=None, compiler=None):
+    """
+    Parse testlists for a list of tests
+    """
+    listoftests = []
+    testlistfiles = []
+    if(machine is not None):
+        thismach=machine
+    if(compiler is not None):
+        thiscompiler = compiler
+
+    if(xml_testlist is not None):
+        expect(os.path.isfile(xml_testlist), "Testlist not found or not readable "+xml_testlist)
+        testlistfiles.append(xml_testlist)
+    else:
+        files = Files()
+        test_spec_files = files.get_values("TESTS_SPEC_FILE","component")
+        for spec_file in test_spec_files.viewvalues():
+            if(os.path.isfile(spec_file)):
+                testlistfiles.append(spec_file)
+
+    for testlistfile in testlistfiles:
+        thistestlistfile = Testlist(testlistfile)
+        newtests =  thistestlistfile.get_tests(xml_machine, xml_category, xml_compiler)
+        for test in newtests:
+            if(machine is None):
+                thismach = test["machine"]
+            if(compiler is None):
+                thiscompiler = test["compiler"]
+            test["name"] = "%s.%s.%s.%s_%s"%(test["testname"],test["grid"],test["compset"],thismach,thiscompiler)
+            if ("testmods" in test):
+                (moddir, modname) = test["testmods"].split("/")
+                test["name"] += ".%s_%s"%(moddir, modname)
+            logging.info("Adding test "+test["name"])
+        listoftests += newtests
+
+    return listoftests
+
+def _convert_testlist_to_dict(test_names):
+    from copy import deepcopy
+    listoftests = []
+    test = {}
+    for name in test_names:
+        test["name"] = name
+        listoftests.append(deepcopy(test))
+    return listoftests

--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -324,26 +324,26 @@ class TestCreateTestCommon(unittest.TestCase):
             shutil.move(DART_CONFIG, DART_BACKUP)
 
     ###########################################################################
-    # def tearDown(self):
-    # ###########################################################################
-    #     kill_subprocesses()
+    def tearDown(self):
+    ###########################################################################
+        kill_subprocesses()
 
-    #     if (self._unset_proxy):
-    #         del os.environ["http_proxy"]
+        if (self._unset_proxy):
+            del os.environ["http_proxy"]
 
-    #     baselines = os.path.join(self._baseline_area, self._compiler, self._baseline_name)
-    #     if (os.path.isdir(baselines)):
-    #         shutil.rmtree(baselines)
+        baselines = os.path.join(self._baseline_area, self._compiler, self._baseline_name)
+        if (os.path.isdir(baselines)):
+            shutil.rmtree(baselines)
 
-    #     for root in [self._testroot, self._jenkins_root]:
-    #         for test_id in ["master", self._baseline_name]:
-    #             for leftover in glob.glob(os.path.join(root, "*%s*/" % test_id)):
-    #                 shutil.rmtree(leftover)
-    #             for leftover in glob.glob(os.path.join(root, "*%s*" % test_id)):
-    #                 os.remove(leftover)
+        for root in [self._testroot, self._jenkins_root]:
+            for test_id in ["master", self._baseline_name]:
+                for leftover in glob.glob(os.path.join(root, "*%s*/" % test_id)):
+                    shutil.rmtree(leftover)
+                for leftover in glob.glob(os.path.join(root, "*%s*" % test_id)):
+                    os.remove(leftover)
 
-    #     if (os.path.exists(DART_BACKUP)):
-    #         shutil.move(DART_BACKUP, DART_CONFIG)
+        if (os.path.exists(DART_BACKUP)):
+            shutil.move(DART_BACKUP, DART_CONFIG)
 
 ###############################################################################
 class TestCreateTest(TestCreateTestCommon):
@@ -701,7 +701,7 @@ class TestBlessTestResults(TestCreateTestCommon):
 #                              msg="COMMAND SHOULD HAVE WORKED\wait_for_tests output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
 
-#         stat, output, errput = run_cmd("%s/cs_status.%s" % (self._testroot, self._baseline_name), ok_to_fail=True)
+#         stat, output, errput = run_cmd("%s/cs.status.%s" % (self._testroot, self._baseline_name), ok_to_fail=True)
 #         self.assertEqual(stat, 0,
 #                          msg="COMMAND SHOULD HAVE WORKED\cs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
@@ -722,7 +722,7 @@ class FullSystemTest(TestCreateTestCommon):
                              msg="COMMAND SHOULD HAVE WORKED\wait_for_tests output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
 
-        stat, output, errput = run_cmd("%s/cs_status.%s" % (self._testroot, self._baseline_name), ok_to_fail=True)
+        stat, output, errput = run_cmd("%s/cs.status.%s" % (self._testroot, self._baseline_name), ok_to_fail=True)
         self.assertEqual(stat, 0,
                          msg="COMMAND SHOULD HAVE WORKED\cs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 

--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -318,7 +318,7 @@ class TestCreateTestCommon(unittest.TestCase):
         self._jenkins_root      = os.path.join(self._testroot, "jenkins")
         self._compiler          = _MACHINE.get_default_compiler()
         self._hasbatch          = _MACHINE.has_batch_system()
-        self._compiler          = _MACHINE.get_value('COMPILER')
+
         # wait_for_tests could blow away our dart config, need to back it up
         if (os.path.exists(DART_CONFIG)):
             shutil.move(DART_CONFIG, DART_BACKUP)
@@ -415,7 +415,7 @@ class TestCreateTestImpl(TestCreateTestCommon):
         self.assertTrue("RUNPASS" in pass_test, msg="Wrong test '%s'" % pass_test)
 
         for idx, phase in enumerate(ct._phases):
-            for test in tests:
+            for test in ct._tests:
                 if (phase == CIME.create_test.INITIAL_PHASE):
                     continue
 

--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -324,26 +324,26 @@ class TestCreateTestCommon(unittest.TestCase):
             shutil.move(DART_CONFIG, DART_BACKUP)
 
     ###########################################################################
-    def tearDown(self):
-    ###########################################################################
-        kill_subprocesses()
+    # def tearDown(self):
+    # ###########################################################################
+    #     kill_subprocesses()
 
-        if (self._unset_proxy):
-            del os.environ["http_proxy"]
+    #     if (self._unset_proxy):
+    #         del os.environ["http_proxy"]
 
-        baselines = os.path.join(self._baseline_area, self._compiler, self._baseline_name)
-        if (os.path.isdir(baselines)):
-            shutil.rmtree(baselines)
+    #     baselines = os.path.join(self._baseline_area, self._compiler, self._baseline_name)
+    #     if (os.path.isdir(baselines)):
+    #         shutil.rmtree(baselines)
 
-        for root in [self._testroot, self._jenkins_root]:
-            for test_id in ["master", self._baseline_name]:
-                for leftover in glob.glob(os.path.join(root, "*%s*/" % test_id)):
-                    shutil.rmtree(leftover)
-                for leftover in glob.glob(os.path.join(root, "*%s*" % test_id)):
-                    os.remove(leftover)
+    #     for root in [self._testroot, self._jenkins_root]:
+    #         for test_id in ["master", self._baseline_name]:
+    #             for leftover in glob.glob(os.path.join(root, "*%s*/" % test_id)):
+    #                 shutil.rmtree(leftover)
+    #             for leftover in glob.glob(os.path.join(root, "*%s*" % test_id)):
+    #                 os.remove(leftover)
 
-        if (os.path.exists(DART_BACKUP)):
-            shutil.move(DART_BACKUP, DART_CONFIG)
+    #     if (os.path.exists(DART_BACKUP)):
+    #         shutil.move(DART_BACKUP, DART_CONFIG)
 
 ###############################################################################
 class TestCreateTest(TestCreateTestCommon):


### PR DESCRIPTION
This adds support for testlist.xml files.  It supports both the older (version 1.0) and newer (version 2.0) formats for testlist files.   version 2.0 files have an optional wallclock field which allows you to set the
wallclock time for each test thus improving throughput.   In create_test the self._test_names list of
tests was replaced by a self._tests dict.    