### PR TITLE
Major progress converting perl to python: case.build and check_input_…

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -94,52 +94,130 @@
 </machine>
 
 <machine MACH="edison">
-         <DESC>NERSC XC30, os is CNL, 24 pes/node, batch system is PBS</DESC>
-         <NODENAME_REGEX>edison</NODENAME_REGEX>
-         <TESTS>acme_developer</TESTS>
-	 <COMPILERS>intel,gnu,cray</COMPILERS>
-	 <MPILIBS>mpt,mpi-serial</MPILIBS>
-         <CESMSCRATCHROOT>$ENV{SCRATCH}/acme_scratch</CESMSCRATCHROOT>
-         <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
-         <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
-         <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
-         <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-         <DOUT_S_ROOT>$CESMSCRATCHROOT/archive/$CASE</DOUT_S_ROOT>
-         <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-         <CCSM_BASELINE>/project/projectdirs/acme/baselines</CCSM_BASELINE>
-         <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.edison/cprnc</CCSM_CPRNC>
-         <SAVE_TIMING_DIR>/project/projectdirs/$PROJECT</SAVE_TIMING_DIR>
-         <OS>CNL</OS>
-         <BATCHQUERY>sqs -f</BATCHQUERY>
-         <BATCHSUBMIT>sbatch</BATCHSUBMIT>
-         <BATCHREDIRECT></BATCHREDIRECT>
-         <SUPPORTED_BY>acme</SUPPORTED_BY>
-         <GMAKE_J>8</GMAKE_J>
-         <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
-    	 <PES_PER_NODE>24</PES_PER_NODE>
-         <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-	 <PROJECT>acme</PROJECT>
-         <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
-         <batch_system type="slurm" version="x.y">
-           <queues>
-             <queue walltimemax="36:00:00" jobmin="1" jobmax="682" default="true">regular</queue>
-             <queue walltimemax="36:00:00" jobmin="683" jobmax="5462" >regular</queue>
-             <queue walltimemax="00:30:00" jobmin="1" jobmax="512">debug</queue>
-           </queues>
-           <walltimes>
-             <walltime default="true">01:15:00</walltime>
-             <walltime ccsm_estcost="1">01:50:00</walltime>
-             <walltime ccsm_estcost="3">05:00:00</walltime>
-           </walltimes>
-         </batch_system>
-         <mpirun mpilib="default">
-           <executable>srun</executable>
-           <arguments>
-             <arg name="label"> --label</arg>
-             <arg name="num_tasks" > -n {{ num_tasks }}</arg>
-             <arg name="thread_count" > -c {{ thread_count }}</arg>
-           </arguments>
-         </mpirun>
+  <DESC>NERSC XC30, os is CNL, 24 pes/node, batch system is PBS</DESC>
+  <NODENAME_REGEX>edison</NODENAME_REGEX>
+  <TESTS>acme_developer</TESTS>
+  <COMPILERS>intel,gnu,cray</COMPILERS>
+  <MPILIBS>mpt,mpi-serial</MPILIBS>
+  <CESMSCRATCHROOT>$ENV{SCRATCH}/acme_scratch</CESMSCRATCHROOT>
+  <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
+  <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
+  <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
+  <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+  <DOUT_S_ROOT>$CESMSCRATCHROOT/archive/$CASE</DOUT_S_ROOT>
+  <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
+  <CCSM_BASELINE>/project/projectdirs/acme/baselines</CCSM_BASELINE>
+  <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.edison/cprnc</CCSM_CPRNC>
+  <SAVE_TIMING_DIR>/project/projectdirs/$PROJECT</SAVE_TIMING_DIR>
+  <OS>CNL</OS>
+  <BATCHQUERY>sqs -f</BATCHQUERY>
+  <BATCHSUBMIT>sbatch</BATCHSUBMIT>
+  <BATCHREDIRECT></BATCHREDIRECT>
+  <SUPPORTED_BY>acme</SUPPORTED_BY>
+  <GMAKE_J>8</GMAKE_J>
+  <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
+  <PES_PER_NODE>24</PES_PER_NODE>
+  <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+  <PROJECT>acme</PROJECT>
+  <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
+  <batch_system type="slurm" version="x.y">
+    <queues>
+      <queue walltimemax="36:00:00" jobmin="1" jobmax="682" default="true">regular</queue>
+      <queue walltimemax="36:00:00" jobmin="683" jobmax="5462" >regular</queue>
+      <queue walltimemax="00:30:00" jobmin="1" jobmax="512">debug</queue>
+    </queues>
+    <walltimes>
+      <walltime default="true">01:15:00</walltime>
+      <walltime ccsm_estcost="1">01:50:00</walltime>
+      <walltime ccsm_estcost="3">05:00:00</walltime>
+    </walltimes>
+  </batch_system>
+  <mpirun mpilib="default">
+    <executable>srun</executable>
+    <arguments>
+      <arg name="label"> --label</arg>
+      <arg name="num_tasks" > -n {{ num_tasks }}</arg>
+      <arg name="thread_count" > -c {{ thread_count }}</arg>
+    </arguments>
+  </mpirun>
+  <module_system type="module">
+    <init_path lang="perl">/opt/modules/default/init/perl.pm</init_path>
+    <init_path lang="sh">/opt/modules/default/init/sh</init_path>
+    <init_path lang="csh">/opt/modules/default/init/csh</init_path>
+    <cmd_path lang="perl">/opt/modules/default/bin/modulecmd perl</cmd_path>
+    <cmd_path lang="sh">module</cmd_path>
+    <cmd_path lang="csh">module</cmd_path>
+    <modules>
+      <command name="rm">PrgEnv-intel</command>
+      <command name="rm">PrgEnv-cray</command>
+      <command name="rm">PrgEnv-gnu</command>
+      <command name="rm">intel</command>
+      <command name="rm">cce</command>
+      <command name="rm">cray-parallel-netcdf</command>
+      <command name="rm">cray-parallel-hdf5</command>
+      <command name="rm">pmi</command>
+      <command name="rm">cray-libsci</command>
+      <command name="rm">cray-mpich2</command>
+      <command name="rm">cray-mpich</command>
+      <command name="rm">cray-netcdf</command>
+      <command name="rm">cray-hdf5</command>
+      <command name="rm">cray-netcdf-hdf5parallel</command>
+      <command name="rm">craype-sandybridge</command>
+      <command name="rm">craype-ivybridge</command>
+      <command name="rm">craype</command>
+    </modules>
+
+    <modules compiler="intel">
+      <command name="load">PrgEnv-intel</command>
+      <command name="switch">intel intel/15.0.1.133</command>
+      <command name="rm">cray-libsci</command>
+      <command name="use">/global/project/projectdirs/ccsm1/modulefiles/edison</command>
+    </modules>
+    <modules compiler="intel" mpilib="!mpi-serial" >
+      <command name="load">esmf/6.3.0rp1-defio-intel15.0-mpi-O</command>
+    </modules>
+    <modules compiler="intel" mpilib="mpi-serial" >
+      <command name="load">esmf/6.3.0rp1-defio-intel15.0-mpiuni-O</command>
+    </modules>
+    <modules compiler="cray">
+      <command name="load">PrgEnv-cray</command>
+      <command name="switch">cce cce/8.4.2</command>
+    </modules>
+    <modules compiler="gnu">
+      <command name="load">PrgEnv-gnu</command>
+      <command name="switch">gcc gcc/5.2.0</command>
+    </modules>
+    <modules>
+      <command name="load">papi/5.4.1.3</command>
+      <command name="swap">craype craype/2.5.0</command>
+      <command name="load">craype-ivybridge</command>
+    </modules>
+    <modules compiler="!intel">
+      <command name="switch">cray-libsci/13.3.0</command>
+    </modules>
+    <modules>
+      <command name="load">cray-mpich/7.3.0</command>
+      <!--	<command name="load">pmi/5.0.6-1.0000.10439.140.2.ari</command> -->
+    </modules>
+    <modules mpilib="mpi-serial">
+      <command name="load">cray-hdf5/1.8.14</command>
+      <command name="load">cray-netcdf/4.3.3.1</command>
+    </modules>
+    <modules mpilib="!mpi-serial">
+      <command name="load">cray-netcdf-hdf5parallel/4.3.3.1</command>
+      <command name="load">cray-hdf5-parallel/1.8.14</command>
+      <command name="load">cray-parallel-netcdf/1.6.1</command>
+    </modules>
+    <modules>
+      <command name="load">perl/5.20.0</command>
+      <command name="load">cmake/3.0.0</command>
+    </modules>
+  </module_system>
+
+  <environment_variables>
+    <env name="OMP_STACKSIZE">64M</env>
+  </environment_variables>
+
 </machine>
 
 <machine MACH="hopper">
@@ -397,9 +475,11 @@
       </arguments>
     </mpirun>
     <module_system type="module">
+      <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
       <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
       <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
       <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
+      <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
       <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -641,7 +641,7 @@
     <default_value></default_value>
     <group>build_def</group>
     <file>env_build.xml</file>
-    <desc>email address of person (or group) that supports the build and port for this machine (do not edit)></desc>
+    <desc>email address of person (or group) that supports the build and port for this machine (do not edit)</desc>
   </entry> 
 
   <entry id="MPILIB"> 
@@ -662,7 +662,7 @@
     <default_value>NO_LEAP</default_value>
     <group>build_def</group>
     <file>env_build.xml</file>
-    <desc>calendar type></desc>
+    <desc>calendar type</desc>
   </entry>
 
   <entry id="COMP_INTERFACE"> 
@@ -774,7 +774,7 @@
     <default_value>FALSE</default_value>
     <group>build_status</group>
     <file>env_build.xml</file>
-    <desc>Status output: if TRUE, models have been built successfully. (DO NOT EDIT)></desc>
+    <desc>Status output: if TRUE, models have been built successfully. (DO NOT EDIT)</desc>
   </entry> 
 
   <entry id="SMP_BUILD"> 
@@ -783,7 +783,7 @@
     <default_value>0</default_value>
     <group>build_status</group>
     <file>env_build.xml</file>
-    <desc>Status: smp status of previous build, coded string. (DO NOT EDIT)></desc>
+    <desc>Status: smp status of previous build, coded string. (DO NOT EDIT)</desc>
   </entry> 
 
   <entry id="SMP_VALUE"> 
@@ -792,7 +792,7 @@
     <default_value>0</default_value>
     <group>build_status</group>
     <file>env_build.xml</file>
-    <desc>Status: smp status of current case, coded string (DO NOT EDIT)></desc>
+    <desc>Status: smp status of current case, coded string (DO NOT EDIT)</desc>
   </entry> 
 
   <entry id="NINST_BUILD"> 
@@ -801,7 +801,7 @@
     <default_value>0</default_value>
     <group>build_status</group>
     <file>env_build.xml</file>
-    <desc>Status: ninst status of previous build, coded string. (DO NOT EDIT)></desc>
+    <desc>Status: ninst status of previous build, coded string. (DO NOT EDIT)</desc>
   </entry> 
 
   <entry id="NINST_VALUE"> 
@@ -810,7 +810,7 @@
     <default_value>0</default_value>
     <group>build_status</group>
     <file>env_build.xml</file>
-    <desc>Status: ninst status of current case, coded string (DO NOT EDIT)></desc>
+    <desc>Status: ninst status of current case, coded string (DO NOT EDIT)</desc>
   </entry> 
 
   <entry id="BUILD_STATUS"> 
@@ -819,7 +819,7 @@
     <default_value>0</default_value>
     <group>build_status</group>
     <file>env_build.xml</file>
-    <desc>Status: of prior build. (DO NOT EDIT)></desc>
+    <desc>Status: of prior build. (DO NOT EDIT)</desc>
   </entry> 
 
   <entry id="OBJROOT"> 

--- a/scripts-python/case.build
+++ b/scripts-python/case.build
@@ -1,0 +1,508 @@
+#!/usr/bin/env python
+
+"""
+Script to build a case.
+"""
+
+from standard_script_setup import *
+
+from CIME.utils import expect, run_cmd
+from CIME.case import Case
+from CIME.env_module import EnvModule
+
+import argparse, doctest, shutil, glob
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n%s [<casedir>] [--verbose]
+OR
+%s --help
+OR
+%s --test
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Build case \033[0m
+    > %s
+""" % ((os.path.basename(args[0]), ) * 4),
+
+description=description,
+
+formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
+                        help="Case directory to build")
+
+    parser.add_argument("-t", "--testmode", action="store_true",
+                        help="Unknown TODO")
+
+    args = parser.parse_args(args[1:])
+
+    CIME.utils.handle_standard_logging_options(args)
+
+    return args.caseroot, args.testmode
+
+###############################################################################
+def check_input_data(case):
+###############################################################################
+    run_cmd("./check_input_data --download")
+
+    get_refcase  = case.get_value("GET_REFCASE")
+    run_type     = case.get_value("RUN_TYPE")
+    continue_run = case.get_value("CONTINUE_RUN")
+
+    # JGF - I don't have the foggiest idea what this is for so this is just
+    # a 1-1 perl->python conversion
+    if (get_refcase == "TRUE" and run_type != "startup" and continue_run == "FALSE"):
+        din_loc_root = case.get_value("DIN_LOC_ROOT")
+        run_refdate  = case.get_value("RUN_REFDATE")
+        run_refcase  = case.get_value("RUN_REFCASE")
+        run_refdir   = case.get_value("RUN_REFDIR")
+        rundir       = case.get_value("RUNDIR")
+
+        refdir = os.path.join(run_refdir, run_refcase, run_refdate)
+        expect(os.path.isdir(refdir),
+"""
+*****************************************************************
+ccsm_prestage ERROR: $refdir is not on local disk
+obtain this data from the svn input data repository
+> mkdir -p %s
+> cd %s
+> cd ..
+> svn export --force https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/%s
+or set GET_REFCASE to FALSE in env_run.xml
+and prestage the restart data to $RUNDIR manually
+*****************************************************************""" % (refdir, refdir, refdir))
+
+        logging.info(" - Prestaging REFCASE (%s) to %s" % (refdir, rundir))
+
+        # prestage the reference case's files.
+
+        if (not os.path.exists(rundir)):
+            os.makedirs(rundir)
+
+        refcasefiles = glob.glob("%s/%s/*%s*" % (din_loc_root, refdir, run_refcase))
+        for rcfile in refcasefiles:
+            rcbaseline = os.path.basename(rcfile)
+            if (not os.path.exists("%s/%s" % (rundir, rcbaseline))):
+                os.symlink(rcfile, "%s/%s" % ((rundir, rcbaseline)))
+
+            # copy the refcases' rpointer files to the run directory
+            rpointerfiles = glob.glob("%s/%s/*rpointer*" % (din_loc_root, refdir))
+            for rpointerfile in rpointerfiles:
+                shutil.copy(rpointerfile, rundir)
+
+            cam2_list = glob.glob("%s/*.cam2.*" % rundir)
+            for cam2file in cam2_list:
+                camfile = cam2file.replace("cam2", "cam")
+                os.symlink(cam2file, camfile)
+
+            allrundirfiles = glob.glob("%s/*" % rundir)
+            for runfile in allrundirfiles:
+                os.chmod(runfile, 0755)
+
+###############################################################################
+def build_checks(case, build_threaded, comp_interface, use_esmf_lib, mpilib,
+                 nthrds_cpl, nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof, ninst_build, smp_value):
+###############################################################################
+    ninst_atm    = int(case.get_value("NINST_ATM"))
+    ninst_lnd    = int(case.get_value("NINST_LND"))
+    ninst_ice    = int(case.get_value("NINST_ICE"))
+    ninst_ocn    = int(case.get_value("NINST_OCN"))
+    ninst_glc    = int(case.get_value("NINST_GLC"))
+    ninst_wav    = int(case.get_value("NINST_WAV"))
+    ninst_rof    = int(case.get_value("NINST_ROF"))
+    ninst_value  = case.get_value("NINST_VALUE")
+    smp_build    = int(case.get_value("SMP_BUILD"))
+    build_status = int(case.get_value("BUILD_STATUS"))
+
+    atmstr = 1 if (build_threaded == "TRUE" or nthrds_atm > 1) else 0
+    lndstr = 1 if (build_threaded == "TRUE" or nthrds_lnd > 1) else 0
+    icestr = 1 if (build_threaded == "TRUE" or nthrds_ice > 1) else 0 # not in perl
+    ocnstr = 1 if (build_threaded == "TRUE" or nthrds_ocn > 1) else 0
+    rofstr = 1 if (build_threaded == "TRUE" or nthrds_rof > 1) else 0
+    glcstr = 1 if (build_threaded == "TRUE" or nthrds_glc > 1) else 0
+    wavstr = 1 if (build_threaded == "TRUE" or nthrds_wav > 1) else 0
+    cplstr = 1 if (build_threaded == "TRUE" or nthrds_cpl > 1) else 0
+
+    if (nthrds_atm > 1 or nthrds_lnd > 1 or nthrds_ice > 1 or nthrds_ocn > 1 or
+        nthrds_rof > 1 or nthrds_glc > 1 or nthrds_wav > 1 or nthrds_cpl > 1):
+        os.environ["SMP"] = "TRUE"
+    else:
+        os.environ["SMP"] = "FALSE"
+
+    smpstr = "a%dl%dr%di%do%dg%dw%dc%d" % \
+        (atmstr, lndstr, rofstr, icestr, ocnstr,  glcstr, wavstr, cplstr)
+
+    case.set_value("SMP_VALUE", smpstr)
+    os.environ["SMP_VALUE"] = smpstr
+
+    inststr = "a%dl%dr%di%do%dg%dw%d" % \
+        (ninst_atm, ninst_lnd, ninst_rof, ninst_ice, ninst_ocn, ninst_glc, ninst_wav)
+
+    case.set_value("NINST_VALUE", inststr)
+    os.environ["NINST_VALUE"] = inststr
+
+    expect( ninst_build == ninst_value or ninst_build == "0",
+            """
+ERROR, NINST VALUES HAVE CHANGED
+  NINST_BUILD = %s
+  NINST_VALUE = %s
+  A manual clean of your obj directories is strongly recommended
+  You should execute the following:
+    ./case.clean_build
+  Then rerun the build script interactively
+  ---- OR ----
+  You can override this error message at your own risk by executing:
+    ./xmlchange -file env_build.xml -id NINST_BUILD -val 0
+  Then rerun the build script interactively
+""" % (ninst_build, ninst_value))
+
+    expect( smp_build == smpstr or smp_build == 0,
+            """
+ERROR, SMP VALUES HAVE CHANGED
+  SMP_BUILD = %s
+  SMP_VALUE = %s
+  A manual clean of your obj directories is strongly recommended
+  You should execute the following:
+    ./case.clean_build
+  Then rerun the build script interactively
+  ---- OR ----
+  You can override this error message at your own risk by executing:
+    ./xmlchange -file env_build.xml -id SMP_BUILD -val 0
+  Then rerun the build script interactively
+""" % (smp_build, smp_value))
+
+    expect(build_status == 0,
+           """
+ERROR env_build HAS CHANGED
+  A manual clean of your obj directories is required
+  You should execute the following:
+    ./case.clean_build all
+""")
+
+    expect(comp_interface != "ESMF" or use_esmf_lib == "TRUE",
+           """
+ERROR COMP_INTERFACE IS ESMF BUT USE_ESMF_LIB IS NOT TRUE
+  SET USE_ESMF_LIB to TRUE with:
+    ./xmlchange -file env_build.xml -id USE_ESMF_LIB -value TRUE
+""")
+
+    expect(mpilib != "mpi-serial" or use_esmf_lib != "TRUE",
+           """
+ERROR MPILIB is mpi-serial and USE_ESMF_LIB IS TRUE
+  MPILIB can only be used with an ESMF library built with mpiuni on
+  Set USE_ESMF_LIB to FALSE with
+    ./xmlchange -file env_build.xml -id USE_ESMF_LIB -val FALSE
+  ---- OR ----
+  Make sure the ESMF_LIBDIR used was built with mipuni (or change it to one that was)
+  And comment out this if block in Tools/models_buildexe
+""")
+
+    case.set_value("BUILD_COMPLETE", "FALSE")
+
+    case.flush()
+
+###############################################################################
+def build_libraries(exeroot, caseroot, cimeroot, libroot, sharedlibroot, compiler, mpilib, build_threaded, debug, lid, machines_file):
+###############################################################################
+
+    if (mpilib == "mpi-serial"):
+        for header_to_copy in glob.glob(os.path.join(cimeroot, "externals/mct/mpi-serial/*.h")):
+            shutil.copy(header_to_copy, os.path.join(libroot, "include"))
+
+    debugdir = "debug" if debug else "nodebug"
+
+    threaddir = "threads" if os.environ["SMP"] == "TRUE" or build_threaded == "TRUE" else "nothreads"
+
+    sharedpath = os.path.join(sharedlibroot, compiler, mpilib, debugdir, threaddir)
+    os.environ["SHAREDPATH"] = sharedpath
+    shared_lib = os.path.join(sharedpath, "lib")
+    shared_inc = os.path.join(sharedpath, "include")
+    for shared_item in [shared_lib, shared_inc]:
+        if (not os.path.exists(shared_item)):
+            os.makedirs(shared_item)
+
+    libs = ["mct", "gptl", "pio", "csm_share"]
+    logs = []
+
+    for lib in libs:
+        full_lib_path = os.path.join(sharedpath, lib)
+        if (not os.path.exists(full_lib_path)):
+            os.makedirs(full_lib_path)
+
+        file_build = os.path.join(sharedpath, "%s.bldlog.%s" % (lib, lid))
+        with open(file_build, "w") as fd:
+            fd.write("Current env:\n%s" % "\n".join(["  %s = %s" % (env, os.environ[env]) for env in sorted(os.environ)]))
+
+        my_file = os.path.join(os.path.dirname(machines_file), "buildlib.%s" % lib)
+        stat = run_cmd("%s %s %s >> %s 2>&1" % (my_file, sharedpath, caseroot, file_build), from_dir=exeroot, ok_to_fail=True)[0]
+        expect(stat == 0, "ERROR: buildlib.%s failed, cat %s" % (lib, file_build))
+        logs.append(file_build)
+
+    return logs
+
+###############################################################################
+def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
+                comp_atm,   comp_lnd,   comp_ice,   comp_ocn,   comp_glc,   comp_wav,   comp_rof,
+                nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof, lid, caseroot, cimeroot):
+###############################################################################
+    config_atm_dir = os.path.dirname(case.get_value("CONFIG_ATM_FILE"))
+    config_lnd_dir = os.path.dirname(case.get_value("CONFIG_LND_FILE"))
+    config_ice_dir = os.path.dirname(case.get_value("CONFIG_ICE_FILE"))
+    config_ocn_dir = os.path.dirname(case.get_value("CONFIG_OCN_FILE"))
+    config_glc_dir = os.path.dirname(case.get_value("CONFIG_GLC_FILE"))
+    config_wav_dir = os.path.dirname(case.get_value("CONFIG_WAV_FILE"))
+    config_rof_dir = os.path.dirname(case.get_value("CONFIG_ROF_FILE"))
+
+    # Also defines build order
+    models_build_data = [("atm", comp_atm, config_atm_dir, nthrds_atm),
+                         ("lnd", comp_lnd, config_lnd_dir, nthrds_lnd),
+                         ("ice", comp_ice, config_ice_dir, nthrds_ice),
+                         ("ocn", comp_ocn, config_ocn_dir, nthrds_ocn),
+                         ("glc", comp_glc, config_glc_dir, nthrds_glc),
+                         ("wav", comp_wav, config_wav_dir, nthrds_wav),
+                         ("rof", comp_rof, config_rof_dir, nthrds_rof)]
+
+    logs = []
+    overall_smp = os.environ["SMP"]
+
+    for model, comp, config_dir, nthrds in models_build_data:
+        os.environ["MODEL"] = model
+        if (nthrds > 1 or build_threaded == "TRUE"):
+            os.environ["SMP"] = "TRUE"
+        else:
+            os.environ["SMP"] = "FALSE"
+
+        # TODO - Special case for clm?
+        # TODO - bldroot?
+
+        objdir = os.path.join(exeroot, model, "obj")
+        libdir = os.path.join(exeroot, model)
+        for build_dir in [objdir, libdir]:
+            if (not os.path.exists(build_dir)):
+                os.makedirs(build_dir)
+
+        file_build = os.path.join(exeroot, "%s.bldlog.%s" % (model, lid))
+
+        # build the component library
+        stat = run_cmd("%s/buildlib %s %s >> %s 2>&1" % (config_dir, caseroot, comp, file_build),
+                       from_dir=os.path.join(exeroot, model), ok_to_fail=True)[0]
+        expect(stat == 0,
+               "ERROR: %s.buildlib failed, see %s" % (comp, file_build))
+
+        for mod_file in glob.glob(os.path.join(objdir, "*_[Cc][Oo][Mm][Pp]_*")):
+            shutil.copy(mod_file, incroot)
+
+        logs.append(file_build)
+
+    #
+    # Now build the executable
+    #
+
+    os.environ["SMP"] = overall_smp
+
+    # model is overloaded here, confusing
+    model = CIME.utils.get_model()
+    file_build = os.path.join(exeroot, "%s.bldlog.%s" % (model, lid))
+
+    objdir = os.path.join(exeroot, model, "obj")
+    libdir = os.path.join(exeroot, model)
+    for build_dir in [objdir, libdir]:
+        if (not os.path.exists(build_dir)):
+            os.makedirs(build_dir)
+
+    stat = run_cmd("%s/driver_cpl/cime_config/buildexe %s >> %s 2>&1" % (cimeroot, caseroot, file_build),
+                   from_dir=os.path.join(exeroot, model), ok_to_fail=True)[0]
+    expect(stat == 0, "ERROR: buildexe failed, cat %s" % file_build)
+
+    # Copy the just-built ${MODEL}.exe to ${MODEL}.exe.$LID
+    shutil.copy("%s/%s.exe" % (exeroot, model), "%s/%s.exe.%s" % (exeroot, model, lid))
+
+    logs.append(file_build)
+
+    return logs
+
+###############################################################################
+def post_build(case, logs, exeroot):
+###############################################################################
+    logdir = case.get_value("LOGDIR")
+
+    #zip build logs to CASEROOT/logs
+    if (logdir):
+        bldlogdir = os.path.join(logdir, "bld")
+        if (not os.path.exists(bldlogdir)):
+            os.makedirs(bldlogdir)
+
+        for log in logs:
+            run_cmd("gzip %s" % log, from_dir=bldlogdir)
+
+    # Set XML to indicate build complete
+    case.set_value("BUILD_COMPLETE", "TRUE")
+    case.set_value("BUILD_STATUS", "0")
+    case.set_value("SMP_BUILD", os.environ["SMP_VALUE"])
+    case.flush()
+
+    if (os.path.exists("LockedFiles/env_build.xml")):
+        os.remove("LockedFiles/env_build.xml")
+
+    shutil.copy("env_build.xml", "LockedFiles")
+
+###############################################################################
+def case_build(caseroot, testmode):
+###############################################################################
+    expect(os.path.isdir(caseroot), "'%s' is not a valid directory" % caseroot)
+    os.chdir(caseroot)
+
+    expect(os.path.exists("case.run"), "ERROR: must invoke case.setup script before calling build script ")
+
+    case = Case()
+    testcase = case.get_value("TESTCASE")
+    cimeroot = case.get_value("CIMEROOT")
+    expect( not (testcase is not None and os.path.exists("%s/scripts/Testing/Testcases/%s_build.csh" % (cimeroot, testcase)) and not testmode),
+            "%s build must be invoked via case.testbuild script" % testcase)
+
+    check_input_data(case)
+
+    run_cmd("./Tools/check_lockedfiles -cimeroot %s" % cimeroot)
+
+    # Retrieve relevant case data
+    build_threaded      = case.get_value("BUILD_THREADED")
+    casetools           = case.get_value("CASETOOLS")
+    exeroot             = case.get_value("EXEROOT")
+    incroot             = case.get_value("INCROOT")
+    libroot             = case.get_value("LIBROOT")
+    sharedlibroot       = case.get_value("SHAREDLIBROOT")
+    comp_atm            = case.get_value("COMP_ATM")
+    comp_lnd            = case.get_value("COMP_LND")
+    comp_ice            = case.get_value("COMP_ICE")
+    comp_ocn            = case.get_value("COMP_OCN")
+    comp_glc            = case.get_value("COMP_GLC")
+    comp_wav            = case.get_value("COMP_WAV")
+    comp_rof            = case.get_value("COMP_ROF")
+    compiler            = case.get_value("COMPILER")
+    comp_interface      = case.get_value("COMP_INTERFACE")
+    mpilib              = case.get_value("MPILIB")
+    use_esmf_lib        = case.get_value("USE_ESMF_LIB")
+    debug               = case.get_value("DEBUG")
+    ninst_build         = case.get_value("NINST_BUILD")
+    smp_value           = case.get_value("SMP_VALUE")
+    clm_use_petsc       = case.get_value("CLM_USE_PETSC")
+    cism_use_trilinos   = case.get_value("CISM_USE_TRILINOS")
+    mpasli_use_albany   = case.get_value("MPASLI_USE_ALBANY")
+    clm_config_opts     = case.get_value("CLM_CONFIG_OPTS")
+    cam_config_opts     = case.get_value("CAM_CONFIG_OPTS")
+    pio_config_opts     = case.get_value("PIO_CONFIG_OPTS")
+    ninst_value         = case.get_value("NINST_VALUE")
+    mach                = case.get_value("MACH")
+    os_                 = case.get_value("OS")
+    comp_cpl            = case.get_value("COMP_CPL")
+    machines_file       = case.get_value("MACHINES_SPEC_FILE")
+    ocn_submodel        = case.get_value("OCN_SUBMODEL")
+    profile_papi_enable = case.get_value("PROFILE_PAPI_ENABLE")
+    nthrds_cpl          = int(case.get_value("NTHRDS_CPL"))
+    nthrds_atm          = int(case.get_value("NTHRDS_ATM"))
+    nthrds_lnd          = int(case.get_value("NTHRDS_LND"))
+    nthrds_ice          = int(case.get_value("NTHRDS_ICE"))
+    nthrds_ocn          = int(case.get_value("NTHRDS_OCN"))
+    nthrds_glc          = int(case.get_value("NTHRDS_GLC"))
+    nthrds_wav          = int(case.get_value("NTHRDS_WAV"))
+    nthrds_rof          = int(case.get_value("NTHRDS_ROF"))
+
+    # Load some params into env
+    os.environ["CIMEROOT"]             = cimeroot
+    os.environ["CASETOOLS"]            = casetools
+    os.environ["EXEROOT"]              = exeroot
+    os.environ["INCROOT"]              = incroot
+    os.environ["LIBROOT"]              = libroot
+    os.environ["SHAREDLIBROOT"]        = sharedlibroot
+    os.environ["CASEROOT"]             = caseroot
+    os.environ["COMPILER"]             = compiler
+    os.environ["COMP_INTERFACE"]       = comp_interface
+    os.environ["NINST_VALUE"]          = ninst_value
+    os.environ["BUILD_THREADED"]       = build_threaded
+    os.environ["MACH"]                 = mach
+    os.environ["USE_ESMF_LIB"]         = use_esmf_lib
+    os.environ["MPILIB"]               = mpilib
+    os.environ["DEBUG"]                = debug
+    os.environ["OS"]                   = os_
+    os.environ["COMP_CPL"]             = comp_cpl
+    os.environ["COMP_ATM"]             = comp_atm
+    os.environ["COMP_LND"]             = comp_lnd
+    os.environ["COMP_ICE"]             = comp_ice
+    os.environ["COMP_OCN"]             = comp_ocn
+    os.environ["COMP_GLC"]             = comp_glc
+    os.environ["COMP_WAV"]             = comp_wav
+    os.environ["COMP_ROF"]             = comp_rof
+    os.environ["CLM_CONFIG_OPTS"]      = clm_config_opts     if clm_config_opts     is not None else ""
+    os.environ["CAM_CONFIG_OPTS"]      = cam_config_opts     if cam_config_opts     is not None else ""
+    os.environ["PIO_CONFIG_OPTS"]      = pio_config_opts     if pio_config_opts     is not None else ""
+    os.environ["OCN_SUBMODEL"]         = ocn_submodel        if ocn_submodel        is not None else ""
+    os.environ["PROFILE_PAPI_ENABLE"]  = profile_papi_enable if profile_papi_enable is not None else ""
+    os.environ["CLM_USE_PETSC"]        = clm_use_petsc       if clm_use_petsc       is not None else ""
+    os.environ["CISM_USE_TRILINOS"]    = cism_use_trilinos   if cism_use_trilinos   is not None else ""
+    os.environ["MPASLI_USE_ALBANY"]    = mpasli_use_albany   if mpasli_use_albany   is not None else ""
+    lid                                = run_cmd("date +%y%m%d-%H%M%S") # why not testid?
+    os.environ["LID"]                  = lid
+
+    # Set the overall USE_PETSC variable to TRUE if any of the
+    # XXX_USE_PETSC variables are TRUE.
+    # For now, there is just the one CLM_USE_PETSC variable, but in
+    # the future there may be others -- so USE_PETSC will be true if
+    # ANY of those are true.
+
+    use_petsc = "TRUE" if clm_use_petsc == "TRUE" else "FALSE"
+    case.set_value("USE_PETSC", use_petsc)
+    os.environ["USE_PETSC"] = use_petsc
+
+    # Set the overall USE_TRILINOS variable to TRUE if any of the
+    # XXX_USE_TRILINOS variables are TRUE.
+    # For now, there is just the one CISM_USE_TRILINOS variable, but in
+    # the future there may be others -- so USE_TRILINOS will be true if
+    # ANY of those are true.
+
+    use_trilinos = "TRUE" if cism_use_trilinos == "TRUE" else "FALSE"
+    case.set_value("USE_TRILINOS", use_trilinos)
+    os.environ["USE_TRILINOS"] = use_trilinos
+
+    # Set the overall USE_ALBANY variable to TRUE if any of the
+    # XXX_USE_ALBANY variables are TRUE.
+    # For now, there is just the one MPASLI_USE_ALBANY variable, but in
+    # the future there may be others -- so USE_ALBANY will be true if
+    # ANY of those are true.
+
+    use_albany = "TRUE" if mpasli_use_albany == "TRUE" else "FALSE"
+    case.set_value("USE_ALBANY", use_albany)
+    os.environ["USE_ALBANY"] = use_albany
+
+    # Load modules
+    env_module = EnvModule(mach, compiler, cimeroot, caseroot, mpilib, debug)
+    env_module.load_env_for_case()
+
+    run_cmd("./preview_namelists")
+
+    build_checks(case, build_threaded, comp_interface, use_esmf_lib, mpilib,
+                 nthrds_cpl, nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof, ninst_build, smp_value)
+    logs = build_libraries(exeroot, caseroot, cimeroot, libroot, sharedlibroot, compiler, mpilib, build_threaded, debug, lid, machines_file)
+    logs.extend(build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
+                            comp_atm,   comp_lnd,   comp_ice,   comp_ocn,   comp_glc,   comp_wav,   comp_rof,
+                            nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof, lid, caseroot, cimeroot))
+    post_build(case, logs, exeroot)
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    if ("--test" in sys.argv):
+        test_results = doctest.testmod(verbose=True)
+        sys.exit(1 if test_results.failed > 0 else 0)
+
+    caseroot, testmode = parse_command_line(sys.argv, description)
+
+    case_build(caseroot, testmode)
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/scripts-python/case.build
+++ b/scripts-python/case.build
@@ -38,7 +38,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="Case directory to build")
 
     parser.add_argument("-t", "--testmode", action="store_true",
-                        help="Unknown TODO")
+                        help="Some of the tests require multiple model builds, to accommodate that we have a case.test_build script. If you are in a test that requires multiple builds, provide this flag.")
 
     args = parser.parse_args(args[1:])
 
@@ -55,8 +55,12 @@ def check_input_data(case):
     run_type     = case.get_value("RUN_TYPE")
     continue_run = case.get_value("CONTINUE_RUN")
 
-    # JGF - I don't have the foggiest idea what this is for so this is just
-    # a 1-1 perl->python conversion
+    # We do not fully populate the inputdata directory on every
+    # machine and do not expect every user to download the 3TB+ of
+    # data in our inputdata repository. This code checks for the
+    # existence of inputdata in the local inputdata directory and
+    # attempts to download data from the server if it's needed and
+    # missing.
     if (get_refcase == "TRUE" and run_type != "startup" and continue_run == "FALSE"):
         din_loc_root = case.get_value("DIN_LOC_ROOT")
         run_refdate  = case.get_value("RUN_REFDATE")
@@ -249,7 +253,7 @@ def build_libraries(exeroot, caseroot, cimeroot, libroot, sharedlibroot, compile
 ###############################################################################
 def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
                 comp_atm,   comp_lnd,   comp_ice,   comp_ocn,   comp_glc,   comp_wav,   comp_rof,
-                nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof, lid, caseroot, cimeroot):
+                nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof, lid, caseroot, cimeroot, use_esmf_lib, comp_interface):
 ###############################################################################
     config_atm_dir = os.path.dirname(case.get_value("CONFIG_ATM_FILE"))
     config_lnd_dir = os.path.dirname(case.get_value("CONFIG_LND_FILE"))
@@ -270,6 +274,7 @@ def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
 
     logs = []
     overall_smp = os.environ["SMP"]
+    sharedpath = os.environ["SHAREDPATH"]
 
     for model, comp, config_dir, nthrds in models_build_data:
         os.environ["MODEL"] = model
@@ -278,11 +283,30 @@ def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
         else:
             os.environ["SMP"] = "FALSE"
 
-        # TODO - Special case for clm?
-        # TODO - bldroot?
+        bldroot = exeroot # What is this for?
 
         objdir = os.path.join(exeroot, model, "obj")
         libdir = os.path.join(exeroot, model)
+        compspec = comp
+
+        # Special case for clm
+        if (comp == "clm"):
+            esmfdir = "esmf" if use_esmf_lib == "TRUE" else "noesmf"
+            if ("clm4_0" in clm_config_opts):
+                logging.info("         - Building clm4_0 Library ")
+                compspec = "lnd"
+            else:
+                logging.info("         - Building clm4_5/clm5_0 Library ")
+                bldroot = os.path.join(sharedpath, comp_interface, esmfdir)
+                objdir = os.path.join(bldroot, comp, "obj")
+                libdir = os.path.join(bldroot, "lib")
+                compspec = "clm"
+
+        logging.debug("bldroot is %s" % bldroot)
+        logging.debug("objdir is %s" % objdir)
+        logging.debug("libdir is %s" % libdir)
+
+        # Make sure obj, lib dirs exist
         for build_dir in [objdir, libdir]:
             if (not os.path.exists(build_dir)):
                 os.makedirs(build_dir)
@@ -290,7 +314,7 @@ def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
         file_build = os.path.join(exeroot, "%s.bldlog.%s" % (model, lid))
 
         # build the component library
-        stat = run_cmd("%s/buildlib %s %s >> %s 2>&1" % (config_dir, caseroot, comp, file_build),
+        stat = run_cmd("%s/buildlib %s %s %s >> %s 2>&1" % (config_dir, caseroot, bldroot, compspec, file_build),
                        from_dir=os.path.join(exeroot, model), ok_to_fail=True)[0]
         expect(stat == 0,
                "ERROR: %s.buildlib failed, see %s" % (comp, file_build))
@@ -306,29 +330,28 @@ def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
 
     os.environ["SMP"] = overall_smp
 
-    # model is overloaded here, confusing
-    model = CIME.utils.get_model()
-    file_build = os.path.join(exeroot, "%s.bldlog.%s" % (model, lid))
+    cime_model = CIME.utils.get_model()
+    file_build = os.path.join(exeroot, "%s.bldlog.%s" % (cime_model, lid))
 
-    objdir = os.path.join(exeroot, model, "obj")
-    libdir = os.path.join(exeroot, model)
+    objdir = os.path.join(exeroot, cime_model, "obj")
+    libdir = os.path.join(exeroot, cime_model)
     for build_dir in [objdir, libdir]:
         if (not os.path.exists(build_dir)):
             os.makedirs(build_dir)
 
     stat = run_cmd("%s/driver_cpl/cime_config/buildexe %s >> %s 2>&1" % (cimeroot, caseroot, file_build),
-                   from_dir=os.path.join(exeroot, model), ok_to_fail=True)[0]
+                   from_dir=os.path.join(exeroot, cime_model), ok_to_fail=True)[0]
     expect(stat == 0, "ERROR: buildexe failed, cat %s" % file_build)
 
     # Copy the just-built ${MODEL}.exe to ${MODEL}.exe.$LID
-    shutil.copy("%s/%s.exe" % (exeroot, model), "%s/%s.exe.%s" % (exeroot, model, lid))
+    shutil.copy("%s/%s.exe" % (exeroot, cime_model), "%s/%s.exe.%s" % (exeroot, cime_model, lid))
 
     logs.append(file_build)
 
     return logs
 
 ###############################################################################
-def post_build(case, logs, exeroot):
+def post_build(case, logs):
 ###############################################################################
     logdir = case.get_value("LOGDIR")
 
@@ -446,7 +469,11 @@ def case_build(caseroot, testmode):
     os.environ["CLM_USE_PETSC"]        = clm_use_petsc       if clm_use_petsc       is not None else ""
     os.environ["CISM_USE_TRILINOS"]    = cism_use_trilinos   if cism_use_trilinos   is not None else ""
     os.environ["MPASLI_USE_ALBANY"]    = mpasli_use_albany   if mpasli_use_albany   is not None else ""
-    lid                                = run_cmd("date +%y%m%d-%H%M%S") # why not testid?
+
+    # This is a timestamp for the build , not the same as the testid,
+    # and this case may not be a test anyway. For a production
+    # experiment there may be many builds of the same case.
+    lid                                = run_cmd("date +%y%m%d-%H%M%S")
     os.environ["LID"]                  = lid
 
     # Set the overall USE_PETSC variable to TRUE if any of the
@@ -490,8 +517,8 @@ def case_build(caseroot, testmode):
     logs = build_libraries(exeroot, caseroot, cimeroot, libroot, sharedlibroot, compiler, mpilib, build_threaded, debug, lid, machines_file)
     logs.extend(build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
                             comp_atm,   comp_lnd,   comp_ice,   comp_ocn,   comp_glc,   comp_wav,   comp_rof,
-                            nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof, lid, caseroot, cimeroot))
-    post_build(case, logs, exeroot)
+                            nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof, lid, caseroot, cimeroot, use_esmf_lib, comp_interface))
+    post_build(case, logs)
 
 ###############################################################################
 def _main_func(description):

--- a/scripts-python/check_input_data
+++ b/scripts-python/check_input_data
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+"""
+Check (and optionally download) input data files.
+
+Should be run from case.
+"""
+from standard_script_setup import *
+
+from CIME.utils import expect, get_model, run_cmd
+from CIME.XML.machines import Machines
+from CIME.case import Case
+
+import argparse, doctest, fnmatch
+
+# Should probably be in XML somewhere
+SVN_LOCS = {
+    "acme" : "https://acme-svn2.ornl.gov/acme-repo/acme/inputdata",
+    "cesm" : "https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata"
+}
+
+MACHINE = Machines()
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n%s [--download] [--verbose]
+OR
+%s --help
+OR
+%s --test
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Download input data \033[0m
+    > %s --download
+""" % ((os.path.basename(args[0]), ) * 4),
+
+description=description,
+
+formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("-s", "--svn-loc", default=SVN_LOCS[get_model()],
+                        help="The input data repository from which to download data.")
+
+    parser.add_argument("-i", "--input-data-root", default=MACHINE.get_value("DIN_LOC_ROOT"),
+                        help="The root directory where input data goes")
+
+    parser.add_argument("--data-list-dir", default="Buildconf",
+                        help="Where to find list of input files")
+
+    parser.add_argument("--download", action="store_true",
+                        help="Attempt to download missing input files")
+
+    args = parser.parse_args(args[1:])
+
+    CIME.utils.handle_standard_logging_options(args)
+
+    return args.svn_loc, args.input_data_root, args.data_list_dir, args.download
+
+###############################################################################
+def find_files(rootdir, pattern):
+###############################################################################
+    result = []
+    for root, dirs, files in os.walk(rootdir):
+        for filename in files:
+            if (fnmatch.fnmatch(filename, pattern)):
+                result.append(os.path.join(root, filename))
+
+    return result
+
+###############################################################################
+def download_if_in_repo(svn_loc, input_data_root, rel_path):
+###############################################################################
+    full_url = os.path.join(svn_loc, rel_path)
+    full_path = os.path.join(input_data_root, rel_path)
+    logging.info("Trying to download file: '%s' to path '%s'" % (full_url, full_path))
+
+    stat = run_cmd("svn --non-interactive --trust-server-cert ls %s" % full_url, ok_to_fail=True)
+    if (stat != 0):
+        logging.warning("SVN repo '%s' does not have file '%s'" % (svn_loc, rel_path))
+        return False
+    else:
+        stat, output, errput = \
+            run_cmd("svn --non-interactive --trust-server-cert export %s %s" % (full_url, full_path))
+        if (stat != 0):
+            logging.warning("svn export failed with output: %s and errput %s" % (output, errput))
+            return False
+        else:
+            return True
+
+###############################################################################
+def check_input_data(svn_loc, input_data_root, data_list_dir, download):
+###############################################################################
+    """
+    Return True if no files missing
+    """
+    expect(os.path.isdir(input_data_root), "Invalid input_data_root directory: '%s'" % input_data_root)
+    expect(os.path.isdir(data_list_dir), "Invalid data_list_dir directory: '%s'" % data_list_dir)
+
+    data_list_files = find_files(data_list_dir, "*.input_data_list")
+    expect(data_list_files, "No .input_data_list files found in dir '%s'" % data_list_dir)
+
+    case = Case()
+    no_files_missing = True
+
+    for data_list_file in data_list_files:
+        logging.info("Loading input file: '%s'" % data_list_file)
+        with open(data_list_file, "r") as fd:
+            lines = fd.readlines()
+
+        for line in lines:
+            line = line.strip()
+            if (line and not line.startswith("#")):
+                tokens = line.split()
+                expect(len(tokens) == 3,
+                       "Expected three tokens in line '%s' in file '%s'" % (line, data_list_file))
+                expect(tokens[1] == "=",
+                       "Expected format 'a = b' in line '%s' in file '%s'" % (line, data_list_file))
+
+                description, full_path = tokens[0], tokens[2]
+
+                # expand xml variables
+                full_path = case.get_resolved_value(full_path)
+                rel_path  = full_path.replace(input_data_root, "")
+
+                if (not os.path.exists(full_path)):
+                    logging.warning("Missing file '%s'" % full_path)
+
+                    if (download):
+                        success = download_if_in_repo(svn_loc, input_data_root, rel_path)
+                        if (not success):
+                            # If ACME, try CESM repo as backup
+                            if (get_model() == "acme" and svn_loc != SVN_LOCS["cesm"]):
+                                success = download_if_in_repo(SVN_LOCS["cesm"], input_data_root, rel_path)
+                                if (not success):
+                                    no_files_missing = False
+                            else:
+                                no_files_missing = False
+                    else:
+                        no_files_missing = False
+                else:
+                    logging.info("Already had input file: '%s'" % full_path)
+
+    return no_files_missing
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    if ("--test" in sys.argv):
+        test_results = doctest.testmod(verbose=True)
+        sys.exit(1 if test_results.failed > 0 else 0)
+
+    svn_loc, input_data_root, data_list_file, download = parse_command_line(sys.argv, description)
+
+    sys.exit(0 if check_input_data(svn_loc, input_data_root, data_list_file, download) else 1)
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/scripts/Testing/Testcases/CME_build.csh
+++ b/scripts/Testing/Testcases/CME_build.csh
@@ -13,7 +13,7 @@ set EXEROOT  = `./xmlquery EXEROOT -value`
 ./xmlchange COMP_INTERFACE=MCT
 ./case.clean_build
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 
@@ -25,7 +25,7 @@ cp -f env_build.xml      env_build.xml.mct
 ./xmlchange COMP_INTERFACE=ESMF
 ./case.clean_build
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/ERP_build.csh
+++ b/scripts/Testing/Testcases/ERP_build.csh
@@ -28,7 +28,7 @@ endif
 
 ./xmlchange -file env_build.xml -id SMP_BUILD -val 0
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 
@@ -164,7 +164,7 @@ endif
 
 ./xmlchange -file env_build.xml -id SMP_BUILD -val 0
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/ICP_build.csh
+++ b/scripts/Testing/Testcases/ICP_build.csh
@@ -151,7 +151,7 @@ foreach bx ($bxvals)
       cp env_build.xml LockedFiles/env_build.xml
 
       if ($precheck == 0) then
-        ./case.build -testmode
+        ./case.build --testmode
         if ($status != 0) then
           exit -1    
         endif 

--- a/scripts/Testing/Testcases/LII_build.csh
+++ b/scripts/Testing/Testcases/LII_build.csh
@@ -35,7 +35,7 @@ setenv CIMEROOT `./xmlquery CIMEROOT    -value`
 # NOTE - Are assumming that are already in $CASEROOT here
 set CASE     = `./xmlquery CASE    -value`
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    echo "Error: build failed" >! ./TestStatus
    echo "CFAIL $CASE" > ./TestStatus

--- a/scripts/Testing/Testcases/NCK_build.csh
+++ b/scripts/Testing/Testcases/NCK_build.csh
@@ -61,7 +61,7 @@ endif
 
 ./case.clean_build
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 
@@ -110,7 +110,7 @@ set NTASKS_CPL  = `./xmlquery NTASKS_CPL -value`
 
 ./case.clean_build 
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/NCR_build.csh
+++ b/scripts/Testing/Testcases/NCR_build.csh
@@ -87,7 +87,7 @@ set NTASKS_CPL  = `./xmlquery NTASKS_CPL  -value`
 
 ./case.clean_build 
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 
@@ -156,7 +156,7 @@ set NTASKS_CPL  = `./xmlquery NTASKS_CPL	-value`
 
 ./case.cleanbuild
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/NOC_build.csh
+++ b/scripts/Testing/Testcases/NOC_build.csh
@@ -45,7 +45,7 @@ endif
 ./case.setup -clean
 ./case.setup
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/PEA_build.csh
+++ b/scripts/Testing/Testcases/PEA_build.csh
@@ -31,7 +31,7 @@ endif
 #----------------------------
 
 ./case.clean_build
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 
@@ -50,7 +50,7 @@ mv -f Macros Macros.1
 ./case.setup
 
 ./case.clean_build
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/PEM_build.csh
+++ b/scripts/Testing/Testcases/PEM_build.csh
@@ -16,7 +16,7 @@ endif
 ./case.setup -clean
 ./case.setup
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 
@@ -70,7 +70,7 @@ endif
 ./case.setup -clean -testmode
 ./case.setup
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/PET_build.csh
+++ b/scripts/Testing/Testcases/PET_build.csh
@@ -65,7 +65,7 @@ cp -f env_mach_pes.xml env_mach_pes.xml.1
 ./case.setup -clean 
 ./case.setup 
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/PMT_build.csh
+++ b/scripts/Testing/Testcases/PMT_build.csh
@@ -21,7 +21,7 @@ cp -f env_mach_pes.xml LockedFiles/env_mach_pes.xml
 ./xmlchange -file env_run.xml -id BFBFLAG -val TRUE
 echo "b4b_flag=.true." >> user_nl_pop
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 
@@ -104,7 +104,7 @@ endif
 ./case.setup
 ./case.clean_build -all 
 
-./case.build -testmode
+./case.build --testmode
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Tools/check_lockedfiles
+++ b/scripts/Tools/check_lockedfiles
@@ -60,7 +60,7 @@ foreach my $lockedfile (@lockedfiles) {
     if (!-f $file) {
 	$logger->logdie ("Locked file $file cannot be found");
     }
-    my $sysmod = "cmp -s $lockedfile $file ";
+    my $sysmod = "diff -w $lockedfile $file ";
     if (system($sysmod) != 0) {
 	$logger->warn( "$file has been modified and is different than the LockedFiles version ");
 	if ($file =~ /env_build/ ) {

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -272,8 +272,6 @@ foreach my $file (values (%id_file))
     my $xml = XML::LibXML->new( no_blanks => 1)->parse_file($file); 
 
     my $fh = IO::File->new($file, '>' ) or $logger->logdie ("can't open file: $file");
-    print $fh "<?xml version=\"1.0\"?> \n";
-    print $fh "\n";
     print $fh "<config_definition> \n";
     print $fh "\n";
 

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -875,7 +875,6 @@ sub _create_caseroot_tools
     my @files = (
 	"$cimeroot/scripts/Tools/case.setup", 
 	"$cimeroot/scripts/Tools/testcase.setup", 
-	"$cimeroot/scripts/Tools/check_input_data", 
 	"$cimeroot/scripts/Tools/archive_metadata.sh", 
 	"$cimeroot/scripts/Tools/check_case", 
 	"$cimeroot/scripts/Tools/create_production_test", 
@@ -938,7 +937,9 @@ sub _create_caseroot_files
     }
 
     # Create $caseroot/Buildconf/build.pl
-    $sysmod = "cp $cimeroot/scripts/Tools/case.build  $caseroot/case.build";
+    $sysmod = "ln -s $cimeroot/scripts-python/check_input_data $caseroot/check_input_data";
+    system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
+    $sysmod = "ln -s $cimeroot/scripts-python/case.build  $caseroot/case.build";
     system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}
     $sysmod = "chmod 755 $caseroot/case.build";
     system ($sysmod); if ($? == -1) {die "$sysmod failed: $!\n";}

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -55,14 +55,14 @@ class EntryID(GenericXML):
             vid = node.attrib("id")
         else:
             nodes = self.get_node("entry", {"id":vid})
-            if (nodes is None):
+            if (not nodes):
                 return
             expect(len(nodes) == 1, "More than one match found for id " + vid)
             node = nodes[0]
 
         if (node is not None):
             val = value
-            node.set("value",value)
+            node.set("value", value)
 
         return val
 

--- a/utils/python/CIME/XML/env_archive.py
+++ b/utils/python/CIME/XML/env_archive.py
@@ -1,0 +1,13 @@
+"""
+Interface to the env_archive.xml file.  This class inherits from EnvBase
+"""
+from standard_module_setup import *
+
+from env_base import EnvBase
+
+class EnvArchive(EnvBase):
+    def __init__(self, case_root=os.getcwd(), infile="env_archive.xml"):
+        """
+        initialize an object interface to file env_archive.xml in the case directory
+        """
+        EnvBase.__init__(self, case_root, infile)

--- a/utils/python/CIME/XML/env_base.py
+++ b/utils/python/CIME/XML/env_base.py
@@ -1,0 +1,16 @@
+"""
+Base class for env files .  This class inherits from EntryID.py
+"""
+from standard_module_setup import *
+
+from entry_id import EntryID
+from headers import Headers
+
+class EnvBase(EntryID):
+    def __init__(self, case_root, infile):
+        fullpath = os.path.join(case_root, infile)
+        EntryID.__init__(self, fullpath)
+        if (not os.path.isfile(fullpath)):
+            headerobj = Headers()
+            headernode = headerobj.get_header_node(os.path.basename(fullpath))
+            self.root.append(headernode)

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -1,0 +1,13 @@
+"""
+Interface to the env_batch.xml file.  This class inherits from EnvBase
+"""
+from standard_module_setup import *
+
+from env_base import EnvBase
+
+class EnvBatch(EnvBase):
+    def __init__(self, case_root=os.getcwd(), infile="env_batch.xml"):
+        """
+        initialize an object interface to file env_batch.xml in the case directory
+        """
+        EnvBase.__init__(self, case_root, infile)

--- a/utils/python/CIME/XML/env_build.py
+++ b/utils/python/CIME/XML/env_build.py
@@ -1,0 +1,13 @@
+"""
+Interface to the env_build.xml file.  This class inherits from EnvBase
+"""
+from standard_module_setup import *
+
+from env_base import EnvBase
+
+class EnvBuild(EnvBase):
+    def __init__(self, case_root=os.getcwd(), infile="env_build.xml"):
+        """
+        initialize an object interface to file env_build.xml in the case directory
+        """
+        EnvBase.__init__(self, case_root, infile)

--- a/utils/python/CIME/XML/env_case.py
+++ b/utils/python/CIME/XML/env_case.py
@@ -1,0 +1,13 @@
+"""
+Interface to the env_case.xml file.  This class inherits from EnvBase
+"""
+from standard_module_setup import *
+
+from env_base import EnvBase
+
+class EnvCase(EnvBase):
+    def __init__(self, case_root=os.getcwd(), infile="env_case.xml"):
+        """
+        initialize an object interface to file env_case.xml in the case directory
+        """
+        EnvBase.__init__(self, case_root, infile)

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -1,0 +1,13 @@
+"""
+Interface to the env_mach_pes.xml file.  This class inherits from EnvBase
+"""
+from standard_module_setup import *
+
+from env_base import EnvBase
+
+class EnvMachPes(EnvBase):
+    def __init__(self, case_root=os.getcwd(), infile="env_mach_pes.xml"):
+        """
+        initialize an object interface to file env_mach_pes.xml in the case directory
+        """
+        EnvBase.__init__(self, case_root, infile)

--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -1,0 +1,14 @@
+"""
+Interface to the env_mach_specific.xml file.  This class inherits from EnvBase
+"""
+from standard_module_setup import *
+
+from env_base import EnvBase
+
+class EnvMachSpecific(EnvBase):
+
+    def __init__(self, caseroot=os.getcwd(), infile="env_mach_specific.xml"):
+        """
+        initialize an object interface to file env_mach_specific.xml in the case directory
+        """
+        EnvBase.__init__(self, caseroot, infile)

--- a/utils/python/CIME/XML/env_run.py
+++ b/utils/python/CIME/XML/env_run.py
@@ -1,0 +1,13 @@
+"""
+Interface to the env_run.xml file.  This class inherits from EnvBase
+"""
+from standard_module_setup import *
+
+from env_base import EnvBase
+
+class EnvRun(EnvBase):
+    def __init__(self, case_root=os.getcwd(), infile="env_run.xml"):
+        """
+        initialize an object interface to file env_run.xml in the case directory
+        """
+        EnvBase.__init__(self, case_root, infile)

--- a/utils/python/CIME/XML/env_test.py
+++ b/utils/python/CIME/XML/env_test.py
@@ -1,21 +1,13 @@
 """
-Interface to the env_test.xml file.  This class inherits from EntryID.py
+Interface to the env_test.xml file.  This class inherits from EnvBase
 """
 from standard_module_setup import *
 
-from entry_id import EntryID
-from CIME.utils import expect, get_cime_root, get_model
-from CIME.XML.headers import Headers
+from env_base import EnvBase
 
-class EnvTest(EntryID):
-    def __init__(self, infile=None):
+class EnvTest(EnvBase):
+    def __init__(self, case_root=os.getcwd(), infile="env_test.xml"):
         """
         initialize an object interface to file env_test.xml in the case directory
         """
-        if(infile is None):
-            infile = "env_test.xml"
-        EntryID.__init__(self,infile)
-        if(not os.path.isfile(infile)):
-            headerobj = Headers()
-            headernode = headerobj.get_header_node('env_test.xml')
-            self.root.append(headernode)
+        EnvBase.__init__(self, case_root, infile)

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -6,7 +6,7 @@ from standard_module_setup import *
 
 from CIME.utils import expect, get_cime_root
 
-class GenericXML:
+class GenericXML(object):
 
     def __init__(self, infile=None):
         """
@@ -33,7 +33,7 @@ class GenericXML:
             self.root.set('id',infile)
             self.tree = ET.ElementTree(root)
 
-    def read(self,infile):
+    def read(self, infile):
         """
         Read and parse an xml file into the object
         """
@@ -41,15 +41,12 @@ class GenericXML:
         self.tree = ET.parse(infile)
         self.root = self.tree.getroot()
 
-    def write(self, infile=None):
+    def write(self, outfile=None):
         """
         Write an xml file from data in self
         """
-        logging.info("write: "+ infile)
-        if(infile != None):
-            self.tree.write(infile)
-        else:
-            self.tree.write(self.filename)
+        logging.info("write: %s" % outfile if outfile is not None else self.filename)
+        self.tree.write(outfile if outfile is not None else self.filename)
 
     def get_node(self, nodename, attributes=None, root=None):
         """

--- a/utils/python/CIME/XML/headers.py
+++ b/utils/python/CIME/XML/headers.py
@@ -22,8 +22,8 @@ class Headers(EntryID):
         EntryID.__init__(self,infile)
 
     def get_header_node(self,fname):
-        fnode=self.get_node("file",{"name":fname})
-        expect(len(fnode)==1,"Invalid match count in headers")
+        fnode=self.get_node("file", attributes={"name":fname})
+        expect(len(fnode)==1,"Invalid match count in headers for filename '%s'" % fname)
         headernode = self.get_node('header',root=fnode[0])
-        expect(len(headernode)==1,"Invalid match count in headers")
+        expect(len(headernode)==1,"Invalid match count in headers for filename '%s'" % fname)
         return headernode[0]

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -226,7 +226,7 @@ class Machines(GenericXML):
 
     def get_batch_system_type(self):
         """
-        Return the batch system using on this machine
+        Return the batch system used on this machine
 
         >>> machobj = Machines()
         >>> name = machobj.set_machine("edison")
@@ -235,3 +235,33 @@ class Machines(GenericXML):
         """
         batch_system = self.get_node("batch_system")
         return batch_system[0].get("type")
+
+    def get_module_system_type(self):
+        """
+        Return the module system used on this machine
+
+        >>> machobj = Machines()
+        >>> name = machobj.set_machine("edison")
+        >>> machobj.get_module_system_type()
+        'module'
+        """
+        module_system = self.get_node("module_system")
+        return module_system[0].get("type")
+
+    def get_module_system_init_paths(self):
+        result = {}
+        init_nodes = self.get_node("init_path")
+        for init_node in init_nodes:
+            lang = init_node.get("lang")
+            result[lang] = init_node.text
+
+        return result
+
+    def get_module_system_cmd_paths(self):
+        result = {}
+        cmd_nodes = self.get_node("cmd_path")
+        for cmd_node in cmd_nodes:
+            lang = cmd_node.get("lang")
+            result[lang] = cmd_node.text
+
+        return result

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -248,20 +248,12 @@ class Machines(GenericXML):
         module_system = self.get_node("module_system")
         return module_system[0].get("type")
 
-    def get_module_system_init_paths(self):
-        result = {}
-        init_nodes = self.get_node("init_path")
-        for init_node in init_nodes:
-            lang = init_node.get("lang")
-            result[lang] = init_node.text
+    def get_module_system_init_paths(self, lang):
+        init_nodes = self.get_node("init_path", attributes={"lang":lang})
+        expect(len(init_nodes) == 1, "Could not find init_path for lang '%s'" % lang)
+        return init_nodes[0].text
 
-        return result
-
-    def get_module_system_cmd_paths(self):
-        result = {}
-        cmd_nodes = self.get_node("cmd_path")
-        for cmd_node in cmd_nodes:
-            lang = cmd_node.get("lang")
-            result[lang] = cmd_node.text
-
-        return result
+    def get_module_system_cmd_paths(self, lang):
+        cmd_nodes = self.get_node("cmd_path", attributes={"lang":lang})
+        expect(len(cmd_nodes) == 1, "Could not find cmd_path for lang '%s'" % lang)
+        return cmd_nodes[0].text

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -1,0 +1,80 @@
+"""
+Wrapper around all env XML for a case.
+
+All interaction with and between the module files in XML/ takes place
+through the Case module.
+"""
+
+from XML.standard_module_setup import *
+import CIME.utils
+from CIME.utils import expect, run_cmd
+from CIME.XML.machines import Machines
+
+from CIME.XML.env_test          import EnvTest
+from CIME.XML.env_mach_specific import EnvMachSpecific
+from CIME.XML.env_case          import EnvCase
+from CIME.XML.env_mach_pes      import EnvMachPes
+from CIME.XML.env_build         import EnvBuild
+from CIME.XML.env_run           import EnvRun
+from CIME.XML.env_archive       import EnvArchive
+from CIME.XML.env_batch         import EnvBatch
+
+class Case(object):
+
+    def __init__(self, case_root=os.getcwd()):
+        expect(os.path.isdir(case_root),
+               "Case root directory '%s' does not exist" % case_root)
+
+        self._env_files = []
+        self._env_files_that_need_rewrite = set()
+
+        self._env_files.append(EnvTest(case_root))
+        self._env_files.append(EnvMachSpecific(case_root))
+        self._env_files.append(EnvCase(case_root))
+        self._env_files.append(EnvMachPes(case_root))
+        self._env_files.append(EnvBuild(case_root))
+        self._env_files.append(EnvArchive(case_root))
+        self._env_files.append(EnvBatch(case_root))
+
+    def __del__(self):
+        self.flush()
+
+    def flush(self):
+        for env_file in self._env_files_that_need_rewrite:
+            env_file.write()
+
+        self._env_files_that_need_rewrite = set()
+
+    def get_value(self, item):
+        for env_file in self._env_files:
+            result = env_file.get_value(item)
+            if (result is not None):
+                return self.get_resolved_value(result)
+
+        logging.warning("Not able to retreive value for item '%s'" % item)
+
+    def get_resolved_value(self, item):
+        # TODO HACK - surely there is a better way?
+        num_unresolved = item.count("$")
+        if (num_unresolved > 0):
+            for env_file in self._env_files:
+                result = env_file.get_resolved_value(item)
+                if (result.count("$") < num_unresolved):
+                    num_unresolved = result.count("$")
+                    item = result
+                    if ("$" not in item):
+                        return item
+
+            logging.warning("Not able to fully resolve item '%s'" % item)
+
+        return item
+
+    def set_value(self, item, value):
+        for env_file in self._env_files:
+            result = env_file.set_value(item, value)
+            if (result is not None):
+                self._env_files_that_need_rewrite.add(env_file)
+                return result
+
+        logging.warning("Not able to set value for item '%s'" % item)
+

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -29,6 +29,7 @@ class Case(object):
         self._env_files_that_need_rewrite = set()
 
         self._env_files.append(EnvTest(case_root))
+        self._env_files.append(EnvRun(case_root))
         self._env_files.append(EnvMachSpecific(case_root))
         self._env_files.append(EnvCase(case_root))
         self._env_files.append(EnvMachPes(case_root))

--- a/utils/python/CIME/create_test.py
+++ b/utils/python/CIME/create_test.py
@@ -276,8 +276,7 @@ class CreateTest(object):
     def _xml_phase(self, test_name):
     ###########################################################################
         test_case = CIME.utils.parse_test_name(test_name)[0]
-        xml_file = os.path.join(self._get_test_dir(test_name), "env_test.xml")
-        envtest = EnvTest()
+        envtest = EnvTest(self._get_test_dir(test_name))
 
         files = Files()
         drv_config_file = files.get_value("CONFIG_DRV_FILE")
@@ -308,7 +307,7 @@ class CreateTest(object):
         envtest.set_value("GENERATE_BASELINE", "TRUE" if self._generate else "FALSE")
         envtest.set_value("COMPARE_BASELINE", "TRUE" if self._compare else "FALSE")
         envtest.set_value("CCSM_CPRNC", self._machobj.get_value("CCSM_CPRNC",resolved=False))
-        envtest.write(xml_file)
+        envtest.write()
         return True
 
     ###########################################################################

--- a/utils/python/CIME/env_module.py
+++ b/utils/python/CIME/env_module.py
@@ -1,0 +1,109 @@
+"""
+API for actions related to model environment
+"""
+
+from XML.standard_module_setup import *
+import CIME.utils
+from CIME.utils import expect, run_cmd
+from CIME.XML.machines import Machines
+from CIME.XML.env_mach_specific import EnvMachSpecific
+
+class EnvModule(object):
+
+    # Public API
+
+    def __init__(self, machine, compiler, cimeroot, caseroot, mpilib, debug=False):
+        self._machine  = Machines(machine=machine)
+        self._compiler = compiler
+        self._cimeroot = cimeroot
+        self._caseroot = caseroot
+        self._mpilib   = mpilib
+        self._debug    = debug
+
+        self._module_system = self._machine.get_module_system_type()
+        self._init_paths    = self._machine.get_module_system_init_paths()
+        self._cmd_paths     = self._machine.get_module_system_cmd_paths()
+
+    def load_env_for_case(self):
+        mach_specific = EnvMachSpecific(caseroot=self._caseroot)
+
+        module_nodes = mach_specific.get_node("modules")
+        env_nodes    = mach_specific.get_node("environment_variables")
+
+        if (module_nodes is not None):
+            modules_to_load = self._compute_module_actions(module_nodes)
+            self.load_modules(modules_to_load)
+        if (env_nodes is not None):
+            envs_to_set = self._compute_env_actions(env_nodes)
+            self.load_envs(envs_to_set)
+
+    def load_modules(self, modules_to_load):
+        if (self._module_system == "module"):
+            self._load_module_modules(modules_to_load)
+        elif (self._module_system == "soft"):
+            self._load_soft_modules(modules_to_load)
+        elif (self._module_system == "dotkit"):
+            self._load_dotkit_modules(modules_to_load)
+        elif (self._module_system == "none"):
+            self._load_none_modules(modules_to_load)
+        else:
+            expect(False, "Unhandled module system '%s'" % self._module_system)
+
+    def load_envs(self, envs_to_set):
+        for env_name, env_value in envs_to_set:
+            # Let bash do the work on evaluating and resolving env_value
+            os.environ[env_name] = run_cmd("echo %s" % env_value)
+
+    # Private API
+
+    def _compute_module_actions(self, module_nodes):
+        return self._compute_actions(module_nodes, "command")
+
+    def _compute_env_actions(self, env_nodes):
+        return self._compute_actions(env_nodes, "env")
+
+    def _compute_actions(self, nodes, child_tag):
+        result = [] # list of tuples ("name", "argument")
+
+        for node in nodes:
+            if (self._match_attribs(node.attrib)):
+                for child in node:
+                    expect(child.tag == child_tag, "Expected %s element" % child_tag)
+                    result.append( (child.get("name"), child.text) )
+
+        return result
+
+    def _match_attribs(self, attribs):
+        if ("compiler" in attribs and
+            not self._match(self._compiler, attribs["compiler"])):
+            return False
+        elif ("mpilib" in attribs and
+            not self._match(self._mpilib, attribs["mpilib"])):
+            return False
+        elif ("debug" in attribs and
+            not self._match("TRUE" if self._debug else "FALSE", attribs["debug"].upper())):
+            return False
+
+        return True
+
+    def _match(self, my_value, xml_value):
+        if (xml_value.startswith("!")):
+            return my_value != xml_value[1:]
+        else:
+            return my_value == xml_value
+
+    def _load_module_modules(self, modules_to_load):
+        python_mod_cmd = self._cmd_paths["python"]
+        for action, argument in modules_to_load:
+            cmd = "%s %s %s" % (python_mod_cmd, action, argument)
+            py_module_code = run_cmd(cmd)
+            exec(py_module_code)
+
+    def _load_soft_modules(self, modules_to_load):
+        expect(False, "Not implemented")
+
+    def _load_dotkit_modules(self, modules_to_load):
+        expect(False, "Not implemented")
+
+    def _load_none_modules(self, modules_to_load):
+        expect(False, "Not implemented")

--- a/utils/python/CIME/env_module.py
+++ b/utils/python/CIME/env_module.py
@@ -10,6 +10,8 @@ from CIME.XML.env_mach_specific import EnvMachSpecific
 
 class EnvModule(object):
 
+    # TODO - write env_mach_specific files into case
+
     # Public API
 
     def __init__(self, machine, compiler, cimeroot, caseroot, mpilib, debug=False):
@@ -21,8 +23,6 @@ class EnvModule(object):
         self._debug    = debug
 
         self._module_system = self._machine.get_module_system_type()
-        self._init_paths    = self._machine.get_module_system_init_paths()
-        self._cmd_paths     = self._machine.get_module_system_cmd_paths()
 
     def load_env_for_case(self):
         mach_specific = EnvMachSpecific(caseroot=self._caseroot)
@@ -93,17 +93,17 @@ class EnvModule(object):
             return my_value == xml_value
 
     def _load_module_modules(self, modules_to_load):
-        python_mod_cmd = self._cmd_paths["python"]
+        python_mod_cmd = self._machine.get_module_system_cmd_paths("python")
         for action, argument in modules_to_load:
             cmd = "%s %s %s" % (python_mod_cmd, action, argument)
             py_module_code = run_cmd(cmd)
             exec(py_module_code)
 
     def _load_soft_modules(self, modules_to_load):
-        expect(False, "Not implemented")
+        expect(False, "Not yet implemented")
 
     def _load_dotkit_modules(self, modules_to_load):
-        expect(False, "Not implemented")
+        expect(False, "Not yet implemented")
 
     def _load_none_modules(self, modules_to_load):
-        expect(False, "Not implemented")
+        expect(False, "Not yet implemented")

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -28,8 +28,8 @@ def expect(condition, error_msg):
     """
     if (not condition):
         # Uncomment these to bring up a debugger when an expect fails
-        # import pdb
-        # pdb.set_trace()
+        #import pdb
+        #pdb.set_trace()
         raise SystemExit("ERROR: %s" % error_msg)
 
 # Should only be called from get_cime_config()

--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -9,7 +9,8 @@ import CIME.utils, update_acme_tests, wait_for_tests
 import CIME.create_test
 from  CIME.create_test import CreateTest
 from  CIME.XML.machines import Machines
-from CIME.XML.files import Files
+from  CIME.XML.files import Files
+from  CIME.case import Case
 
 SCRIPT_DIR = CIME.utils.get_acme_scripts_root()
 
@@ -698,12 +699,12 @@ class TestBlessTestResults(TestCreateTestCommon):
 #         if (CIME.utils.does_machine_have_batch()):
 #             stat, output, errput = run_cmd("%s/wait_for_tests *%s*/TestStatus" % (SCRIPT_DIR, self._baseline_name), ok_to_fail=True, from_dir=self._testroot)
 #             self.assertEqual(stat, 0,
-#                              msg="COMMAND SHOULD HAVE WORKED\wait_for_tests output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+#                              msg="COMMAND SHOULD HAVE WORKED\nwait_for_tests output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
 
 #         stat, output, errput = run_cmd("%s/cs_status.%s" % (self._testroot, self._baseline_name), ok_to_fail=True)
 #         self.assertEqual(stat, 0,
-#                          msg="COMMAND SHOULD HAVE WORKED\cs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+#                          msg="COMMAND SHOULD HAVE WORKED\ncs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
 ###############################################################################
 class FullSystemTest(TestCreateTestCommon):
@@ -719,12 +720,43 @@ class FullSystemTest(TestCreateTestCommon):
         if (_MACHINE.has_batch_system()):
             stat, output, errput = run_cmd("%s/wait_for_tests *%s*/TestStatus" % (SCRIPT_DIR, self._baseline_name), ok_to_fail=True, from_dir=self._testroot)
             self.assertEqual(stat, 0,
-                             msg="COMMAND SHOULD HAVE WORKED\wait_for_tests output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+                             msg="COMMAND SHOULD HAVE WORKED\nwait_for_tests output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
 
         stat, output, errput = run_cmd("%s/cs_status.%s" % (self._testroot, self._baseline_name), ok_to_fail=True)
         self.assertEqual(stat, 0,
-                         msg="COMMAND SHOULD HAVE WORKED\cs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+                         msg="COMMAND SHOULD HAVE WORKED\ncs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+
+###############################################################################
+class TestCimeCase(TestCreateTestCommon):
+###############################################################################
+
+    ###########################################################################
+    def test_cime_case(self):
+    ###########################################################################
+        stat, output, errput = run_cmd("%s/create_test acme_test_only -t %s --no-build" % (SCRIPT_DIR, self._baseline_name), ok_to_fail=True)
+        self.assertEqual(stat, 0,
+                         msg="COMMAND SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+
+        casedir = os.path.join(self._testroot,
+                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_P1.f19_g16_rx1.A", self._machine, self._compiler), self._baseline_name))
+        self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
+        case = Case(casedir)
+
+        build_complete = case.get_value("BUILD_COMPLETE")
+        self.assertEqual(build_complete, "FALSE",
+                         msg="Build complete had wrong value '%s'" % build_complete)
+
+        case.set_value("BUILD_COMPLETE", "TRUE")
+        build_complete = case.get_value("BUILD_COMPLETE")
+        self.assertEqual(build_complete, "TRUE",
+                         msg="Build complete had wrong value '%s'" % build_complete)
+
+        case.flush()
+
+        build_complete = run_cmd("./xmlquery BUILD_COMPLETE -value", from_dir=casedir)
+        self.assertEqual(build_complete, "TRUE",
+                         msg="Build complete had wrong value '%s'" % build_complete)
 
 if (__name__ == "__main__"):
     unittest.main(verbosity=2)


### PR DESCRIPTION
…data

Things to note:
1) Machines will now need to specific python information in the modules
section of config_machines.xml
2) Fix a few mistakes in config_component.xml, errant ">" character
3) Implemented Case class from perl-OO branch
       -This should replace xmlquery/xmlchange
4) Had to get rid of XML version in xmlchange. This was causing XML
files to diff between locked files. This restriction can go away
once everything is using Case.
5) New python tools that need to be in caseroot are symlinked instead
of copied. This makes it so all the python/utils don't have to be copied.
6) Add classes for all the env*.xml files. They all inherit from a common
base class to reduce code duplication.
7) Add new env_module module to replace ModuleLoader.pm