### PR TITLE
cprnc bug fix locating matching times when time index does not match

### DIFF
--- a/tools/cprnc/compare_vars_mod.F90.in
+++ b/tools/cprnc/compare_vars_mod.F90.in
@@ -116,10 +116,10 @@ contains
        do t=1,udim%dimsize,udim%kount
           t1 = t   ! need to find mathing times - assumed for now
           t2 = t
-
           if(.not. ignoretime) then
-             tdiff = abs(time(t1,1) - time(t2,2))
-             do while(t1<=ns1 .and. t2<= ns2 .and. tdiff > timeepsilon) 
+             do while(t1<=ns1 .and. t2<= ns2) 
+                tdiff = abs(time(t1,1) - time(t2,2))  
+                if ( tdiff <= timeepsilon) exit
                 if(time(t1,1) < time(t2,2)) then
                    Write(6,*) 'Skipping a time sample on file 1'
                    t1=t1+1


### PR DESCRIPTION
When indicies are advanced, need to recompute time difference, tdiff,
and dont compute tdiff if time indicies exceed array bounds.