### PR TITLE
create_test: Immediately submit to queue once build is done.

### DIFF
--- a/scripts-python/create_test
+++ b/scripts-python/create_test
@@ -170,16 +170,16 @@ def create_test(testargs, compiler, machine_name, no_run, no_build, no_batch, te
                 baseline_name, namelists_only, project, test_id, parallel_jobs,
                 xml_machine, xml_compiler, xml_category, xml_testlist):
 ###############################################################################
-    if(testargs and machine_name is None and compiler is None):
+    if (testargs and machine_name is None and compiler is None):
         for test in testargs:
             testsplit = CIME.utils.parse_test_name(test)
-            if(testsplit[4] is not None):
-                if(machine_name is None):
+            if (testsplit[4] is not None):
+                if (machine_name is None):
                     machine_name = testsplit[4]
                 else:
                     expect(machine_name == testsplit[4], "abiguity in machine, please use the --machine option")
-            if(testsplit[5] is not None):
-                if(compiler is None):
+            if (testsplit[5] is not None):
+                if (compiler is None):
                    compiler = testsplit[5]
                 else:
                     expect(compiler == testsplit[5], "abiguity in compiler, please use the --compiler option")

--- a/utils/python/CIME/system_test.py
+++ b/utils/python/CIME/system_test.py
@@ -15,7 +15,6 @@ from CIME.XML.component import Component
 from CIME.XML.testlist import Testlist
 import CIME.test_utils
 
-
 INITIAL_PHASE = "INIT"
 CREATE_NEWCASE_PHASE = "CREATE_NEWCASE"
 XML_PHASE   = "XML"
@@ -549,6 +548,13 @@ class SystemTest(object):
         if (not success):
             status_str += "    Case dir: %s\n" % self._get_test_dir(test)
         sys.stdout.write(status_str)
+
+        # On batch systems, we want to immediately submit to the queue, because
+        # it's very cheap to submit and will get us a better spot in line
+        if (not self._no_run and not self._no_batch and test_phase == BUILD_PHASE):
+            sys.stdout.write("Starting %s for test %s with %d procs\n" % (RUN_PHASE, test, 1))
+            self._update_test_status(test, RUN_PHASE, TEST_PENDING_STATUS)
+            self._consumer(test, RUN_PHASE, self._run_phase)
 
     ###########################################################################
     def _producer(self):


### PR DESCRIPTION
The old behavior was highly suboptimal in the case where there were more
builds to do than number of threads. This could result in a very long gap
in time between when a build was completed and when the testcase was
submitted to the queue.

This commit causes the run phase to be done as the last part of the build
phase if on a batch system.