### PR TITLE
fix nck build on acme side

### DIFF
--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -802,7 +802,7 @@ cleanatm:
 	cd $(EXEROOT)/atm/obj;  $(RM) -f *.o *.mod
 
 cleancpl:
-	cd $(EXEROOT)/drv/obj;  $(RM) -f *.o *.mod
+	cd $(EXEROOT)/cpl/obj;  $(RM) -f *.o *.mod
 
 cleanocn:
 	$(RM) -f $(LIBROOT)/libocn.a

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -101,15 +101,8 @@ def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
     cime_model = get_model()
     file_build = os.path.join(exeroot, "%s.bldlog.%s" % (cime_model, lid))
 
-    objdir = os.path.join(exeroot, cime_model, "obj")
-    libdir = os.path.join(exeroot, cime_model)
-    for build_dir in [objdir, libdir]:
-        if not os.path.exists(build_dir):
-            os.makedirs(build_dir)
-
     stat = run_cmd("%s/driver_cpl/cime_config/buildexe %s >> %s 2>&1" %
                    (cimeroot, caseroot, file_build),
-                   from_dir=os.path.join(exeroot, cime_model),
                    ok_to_fail=True,
                    verbose=True)[0]
     expect(stat == 0, "ERROR: buildexe failed, cat %s" % file_build)


### PR DESCRIPTION
Sorry - I made the correct fix on the cesm side but goofed on the acme side.  It's corrected now,
I also found and removed the code that created the unused bld/$model/obj directory. 