### PR TITLE
Restore ability to share sharedlibs in create_test.

### DIFF
--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -2,7 +2,7 @@
 # Common Makefile: a framework for building all CIME components and more
 #
 # Command-line variables
-#   MODEL=<model>  ~ a standard macro definition, often found in the included 
+#   MODEL=<model>  ~ a standard macro definition, often found in the included
 #                    MACFILE, used to trigger special compilation flags
 # Supported compilers
 # ibm, bgl, bgp, pgi, intel, pathscale, gnu, nag
@@ -13,20 +13,20 @@ null  :=
 comma := ,
 
 # Load dependency search path.
-dirs := . 
+dirs := .
 dirs += $(shell cat Filepath)
 
 cpp_dirs := $(dirs)
 # Add INCROOT to path for Depends and Include
-MINCROOT := 
+MINCROOT :=
 ifdef INCROOT
   cpp_dirs += $(INCROOT)
   MINCROOT := $(INCROOT)
 endif
 
 # Expand any tildes in directory names. Change spaces to colons.
-VPATH := $(foreach dir,$(cpp_dirs),$(wildcard $(dir))) 
-VPATH := $(subst $(space),:,$(VPATH))               
+VPATH := $(foreach dir,$(cpp_dirs),$(wildcard $(dir)))
+VPATH := $(subst $(space),:,$(VPATH))
 
 RM    := rm
 CP    := cp
@@ -35,7 +35,7 @@ exec_se: $(EXEC_SE)  $(CURDIR)/Depends
 complib: $(COMPLIB)  $(CURDIR)/Depends
 
 # Determine whether to compile threaded or not
-# Set the THREADDIR for the shared build 
+# Set the THREADDIR for the shared build
 # based on the threaded build status
 compile_threaded = false
 ifeq ($(strip $(SMP)),TRUE)
@@ -82,7 +82,7 @@ endif
 # set CPP options (must use this before any flags or cflags settings)
 #===============================================================================
 
-CPPDEFS := $(USER_CPPDEFS) -D$(OS) 
+CPPDEFS := $(USER_CPPDEFS) -D$(OS)
 
 # Unless DEBUG mode is enabled, use NDEBUG to turn off assert statements.
 ifneq ($(strip $(DEBUG)),TRUE)
@@ -155,9 +155,9 @@ ifeq ($(USE_CXX), true)
     LD := $(MPIFC)
   endif
 endif
-# Use this if LD has not already been defined.   
+# Use this if LD has not already been defined.
 ifeq ($(origin LD), default)
-  ifeq ($(strip $(MPILIB)),mpi-serial)	
+  ifeq ($(strip $(MPILIB)),mpi-serial)
     LD := $(SFC)
   else
     LD := $(MPIFC)
@@ -270,17 +270,17 @@ endif
 
 ifdef CPRE
   FPPDEFS := $(subst $(comma),\\$(comma),$(CPPDEFS))
-  FPPDEFS := $(patsubst -D%,$(CPRE)%,$(FPPDEFS)) 
+  FPPDEFS := $(patsubst -D%,$(CPRE)%,$(FPPDEFS))
 else
   FPPDEFS := $(CPPDEFS)
 endif
 
 
 #===============================================================================
-# Set config args for pio and mct to blank and then enable serial 
+# Set config args for pio and mct to blank and then enable serial
 #===============================================================================
 ifndef CONFIG_ARGS
-  CONFIG_ARGS := 
+  CONFIG_ARGS :=
 endif
 ifeq ($(MPILIB),mpi-serial)
    CONFIG_ARGS+= --enable-mpiserial
@@ -296,7 +296,7 @@ endif
 # User-specified INCLDIR
 #===============================================================================
 
-INCLDIR := -I. 
+INCLDIR := -I.
 ifdef USER_INCLDIR
   INCLDIR += $(USER_INCLDIR)
 endif
@@ -343,7 +343,7 @@ ifdef MOD_NETCDF
 endif
 ifdef INC_MPI
   INCLDIR += -I$(INC_MPI)
-endif 
+endif
 ifdef INC_PNETCDF
   INCLDIR += -I$(INC_PNETCDF)
 endif
@@ -402,7 +402,7 @@ endif
 INCLDIR +=	-I$(SHAREDPATH)/include -I$(CIMEROOT)/share/csm_share/shr \
 		-I$(CIMEROOT)/share/csm_share/include -I$(CIMEROOT)/share/shr_RandNum/include
 #
-# Use the MCT dir for the cache for all configure calls because it is the first one 
+# Use the MCT dir for the cache for all configure calls because it is the first one
 #
 CFLAGS+=$(CPPDEFS)
 CXXFLAGS := $(CFLAGS)
@@ -410,7 +410,7 @@ CXXFLAGS := $(CFLAGS)
 CONFIG_ARGS +=  CC="$(SCC)" FC="$(SFC)" MPICC="$(MPICC)" \
                 MPIFC="$(MPIFC)" FCFLAGS="$(FFLAGS) $(FREEFLAGS) $(INCLDIR)" \
                 CPPDEFS="$(CPPDEFS)" CFLAGS="$(CFLAGS) -I.. $(INCLDIR)" \
-                NETCDF_PATH=$(NETCDF_PATH) LDFLAGS="$(LDFLAGS)" 
+                NETCDF_PATH=$(NETCDF_PATH) LDFLAGS="$(LDFLAGS)"
 ifeq ($(COMPILER),nag)
   CONFIG_ARGS += LIBS="$(SLIBS)"
 endif
@@ -456,9 +456,9 @@ ifdef ESMF_LIBDIR
 endif
 
 
-# System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.) 
+# System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)
 ifndef SLIBS
-   SLIBS := -L$(LIB_NETCDF) -lnetcdf 
+   SLIBS := -L$(LIB_NETCDF) -lnetcdf
 endif
 ifdef LIB_PNETCDF
    SLIBS += -L$(LIB_PNETCDF) -lpnetcdf
@@ -469,13 +469,13 @@ endif
 ifdef LIB_MPI
    ifndef MPI_LIB_NAME
       SLIBS += -L$(LIB_MPI) -lmpi
-   else  
+   else
       SLIBS += -L$(LIB_MPI) -l$(MPI_LIB_NAME)
    endif
 endif
 
 # For compiling and linking with external ESMF.
-# If linking to external ESMF library then include esmf.mk 
+# If linking to external ESMF library then include esmf.mk
 # ESMF_F90COMPILEPATHS
 # ESMF_F90LINKPATHS
 # ESMF_F90LINKRPATHS
@@ -525,11 +525,11 @@ endif
 #------------------------------------------------------------------------------
 
 
-$(MCT_LIBDIR)/Makefile.conf: 
+$(MCT_LIBDIR)/Makefile.conf:
 	@echo "SHAREDLIBROOT |$(SHAREDLIBROOT)| SHAREDPATH |$(SHAREDPATH)|"; \
 	$(CONFIG_SHELL) $(CIMEROOT)/externals/mct/configure $(CONFIG_ARGS) --srcdir $(CIMEROOT)/externals/mct
 
-$(MCT_LIBDIR)/mpi-serial/Makefile.conf: 
+$(MCT_LIBDIR)/mpi-serial/Makefile.conf:
 	@echo "SHAREDLIBROOT |$(SHAREDLIBROOT)| SHAREDPATH |$(SHAREDPATH)|"; \
 	$(CONFIG_SHELL) $(CIMEROOT)/externals/mct/mpi-serial/configure $(CONFIG_ARGS) --srcdir $(CIMEROOT)/externals/mct
 
@@ -559,7 +559,7 @@ else
 endif
 #endif
 
-MCTLIBS = $(MCT_LIBDIR)/libmct.a $(MCT_LIBDIR)/libmpeu.a 
+MCTLIBS = $(MCT_LIBDIR)/libmct.a $(MCT_LIBDIR)/libmpeu.a
 
 GPTLLIB = $(GPTL_LIBDIR)/libgptl.a
 
@@ -570,7 +570,7 @@ ULIBS += -L$(SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/csm_share -
 #------------------------------------------------------------------------------
 
 ifndef CMAKE_OPTS
-  CMAKE_OPTS := 
+  CMAKE_OPTS :=
 endif
 # note that the fortran flags include neither the FREEFLAGS nor the
 # FIXEDFLAGS, so that both free & fixed code can be built (cmake
@@ -586,7 +586,7 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
               -D USER_CMAKE_MODULE_PATH:STRING=$(CIMEROOT)/externals/CMake
 
 ifdef PNETCDF_PATH
-	CMAKE_OPTS += -D PNETCDF_DIR:STRING="$(PNETCDF_PATH)" 
+	CMAKE_OPTS += -D PNETCDF_DIR:STRING="$(PNETCDF_PATH)"
 else
         CMAKE_OPTS += -D WITH_PNETCDF:LOGICAL=FALSE -D PIO_USE_MPIIO:LOGICAL=FALSE
 endif
@@ -601,23 +601,23 @@ CMAKE_OPTS += $(USER_CMAKE_OPTS)
 # CMAKE_C_COMPILER, etc., when you rerun cmake with an existing
 # cache. So doing this via environment variables instead.
 ifndef CMAKE_ENV_VARS
-  CMAKE_ENV_VARS := 
+  CMAKE_ENV_VARS :=
 endif
 CMAKE_ENV_VARS += CC=$(CC) \
                   CXX=$(CXX) \
                   FC=$(FC) \
-                  LDFLAGS="$(LDFLAGS)" 
+                  LDFLAGS="$(LDFLAGS)"
 
 
 # We declare $(GLC_DIR)/Makefile to be a phony target so that cmake is
 # always rerun whenever invoking 'make $(GLC_DIR)/Makefile'; this is
 # desirable to pick up any new source files that may have been added
-.PHONY: $(GLC_DIR)/Makefile 
+.PHONY: $(GLC_DIR)/Makefile
 $(GLC_DIR)/Makefile:
 	cd $(GLC_DIR); \
 	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(CIMEROOT)/../components/cism/glimmer-cism
 
-$(PIO_LIBDIR)/Makefile: 
+$(PIO_LIBDIR)/Makefile:
 	cd $(PIO_LIBDIR); \
 	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(PIO_SRC_DIR)
 
@@ -625,7 +625,7 @@ $(PIO_LIBDIR)/Makefile:
 # Build & include dependency files
 #-------------------------------------------------------------------------------
 
-touch_filepath: 
+touch_filepath:
 	touch $(CURDIR)/Filepath
 
 # Get list of files and build dependency file for all .o files
@@ -634,7 +634,7 @@ touch_filepath:
 SOURCES := $(shell cat Srcfiles)
 BASENAMES := $(basename $(basename $(SOURCES)))
 OBJS    := $(addsuffix .o, $(BASENAMES))
-INCS    := $(foreach dir,$(cpp_dirs),-I$(dir)) 
+INCS    := $(foreach dir,$(cpp_dirs),-I$(dir))
 
 CURDIR := $(shell pwd)
 
@@ -646,7 +646,7 @@ $(CURDIR)/Deppath: $(CURDIR)/Filepath
 	@echo "$(MINCROOT)" >> $@
 
 $(CURDIR)/Srcfiles: $(CURDIR)/Filepath
-	$(CASETOOLS)/mkSrcfiles 
+	$(CASETOOLS)/mkSrcfiles
 
 $(CURDIR)/Filepath:
 	@echo "$(VPATH)" > $@
@@ -694,10 +694,10 @@ ifeq ($(ULIBDEP),$(null))
      ULIBDEP += $(LIBROOT)/libice.a
      ifeq ($(findstring clm5_0,$(CLM_CONFIG_OPTS)),clm5_0)
           LNDLIB := libclm.a
-     else	
+     else
           ifeq ($(findstring clm4_5,$(CLM_CONFIG_OPTS)),clm4_5)
                LNDLIB := libclm.a
-          else	
+          else
                LNDLIB := liblnd.a
           endif
      endif
@@ -750,7 +750,7 @@ CSMSHARELIB = $(SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/csm_shar
 ULIBDEP += $(CSMSHARELIB)
 
 #-------------------------------------------------------------------------------
-# build rules: 
+# build rules:
 #-------------------------------------------------------------------------------
 
 .SUFFIXES:
@@ -762,14 +762,14 @@ ifeq ($(MPILIB),mpi-serial)
   CMAKE_OPTS += -DMPI_C_INCLUDE_PATH=$(SHAREDPATH)/include \
       -DMPI_Fortran_INCLUDE_PATH=$(SHAREDPATH)/include \
       -DMPI_C_LIBRARIES=$(SHAREDPATH)/lib/libmpi-serial.a \
-      -DMPI_Fortran_LIBRARIES=$(SHAREDPATH)/lib/libmpi-serial.a 
+      -DMPI_Fortran_LIBRARIES=$(SHAREDPATH)/lib/libmpi-serial.a
 endif
 
 $(MCTLIBS)  : $(MPISERIAL)
 
 $(PIOLIB) : $(MPISERIAL) $(GPTLLIB)
 
-$(CSMSHARELIB):  $(MCTLIBS) $(PIOLIB) $(GPTLLIB) 
+$(CSMSHARELIB):  $(MCTLIBS) $(PIOLIB) $(GPTLLIB)
 ifneq ($(MODEL),csm_share)
   $(OBJS):  $(CSMSHARELIB)
 endif
@@ -777,7 +777,7 @@ endif
 $(EXEC_SE): $(OBJS) $(ULIBDEP) $(CSMSHARELIB) $(MCTLIBS) $(PIOLIB) $(GPTLLIB)
 	$(LD) -o $(EXEC_SE) $(OBJS) $(CLIBS) $(ULIBS) $(SLIBS) $(MLIBS) $(LDFLAGS)
 
-$(COMPLIB): $(OBJS) 
+$(COMPLIB): $(OBJS)
 	$(AR) -r $(COMPLIB) $(OBJS)
 
 
@@ -802,29 +802,29 @@ cleanatm:
 	cd $(EXEROOT)/atm/obj;  $(RM) -f *.o *.mod
 
 cleancpl:
-	cd $(EXEROOT)/drv/obj;  $(RM) -f *.o *.mod
+	cd $(EXEROOT)/cpl/obj;  $(RM) -f *.o *.mod
 
-cleanocn: 
-	$(RM) -f $(LIBROOT)/libocn.a 
+cleanocn:
+	$(RM) -f $(LIBROOT)/libocn.a
 	cd $(EXEROOT)/ocn/obj ; $(RM) -f *.o *.mod
 
-cleanwav: 
+cleanwav:
 	$(RM) -f $(LIBROOT)/libwav.a
 	cd $(EXEROOT)/wav/obj ; $(RM) -f *.o *.mod
 
-cleanglc: 
+cleanglc:
 	$(RM) -f $(LIBROOT)/libglc.a
-	$(RM) -fr $(EXEROOT)/glc 
+	$(RM) -fr $(EXEROOT)/glc
 
-cleanice: 
+cleanice:
 	$(RM) -f $(LIBROOT)/libice.a
 	cd $(EXEROOT)/ice/obj ; $(RM) -f *.o *.mod
 
-cleanrof: 
+cleanrof:
 	$(RM) -f $(LIBROOT)/librof.a
 	cd $(EXEROOT)/rof/obj ; $(RM) -f *.o *.mod
 
-cleanlnd: 
+cleanlnd:
 	$(RM) -f $(LIBROOT)/liblnd.a
 	cd $(EXEROOT)/lnd/obj ; $(RM) -f *.o *.mod
 

--- a/cime_config/acme/machines/template.case.run
+++ b/cime_config/acme/machines/template.case.run
@@ -206,7 +206,7 @@ sub doPreRunChecks()
     $logger->info(" - To prestage restarts, untar a restart.tar file into $config{'RUNDIR'}");
 
     # Run preview namelists.. should turn this into a module at some point..
-    system("./preview_namelists -loglevel $opts{loglevel} ");
+    system("./preview_namelists");
 
     if($?)
     {

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -2,7 +2,7 @@
 # Common Makefile: a framework for building all CIME components and more
 #
 # Command-line variables
-#   MODEL=<model>  ~ a standard macro definition, often found in the included 
+#   MODEL=<model>  ~ a standard macro definition, often found in the included
 #                    MACFILE, used to trigger special compilation flags
 # Supported compilers
 # ibm, bgl, bgp, pgi, intel, pathscale, gnu, nag
@@ -13,20 +13,20 @@ null  :=
 comma := ,
 
 # Load dependency search path.
-dirs := . 
+dirs := .
 dirs += $(shell cat Filepath)
 
 cpp_dirs := $(dirs)
 # Add INCROOT to path for Depends and Include
-MINCROOT := 
+MINCROOT :=
 ifdef INCROOT
   cpp_dirs += $(INCROOT)
   MINCROOT := $(INCROOT)
 endif
 
 # Expand any tildes in directory names. Change spaces to colons.
-VPATH := $(foreach dir,$(cpp_dirs),$(wildcard $(dir))) 
-VPATH := $(subst $(space),:,$(VPATH))               
+VPATH := $(foreach dir,$(cpp_dirs),$(wildcard $(dir)))
+VPATH := $(subst $(space),:,$(VPATH))
 
 RM    := rm
 CP    := cp
@@ -35,7 +35,7 @@ exec_se: $(EXEC_SE)  $(CURDIR)/Depends
 complib: $(COMPLIB)  $(CURDIR)/Depends
 
 # Determine whether to compile threaded or not
-# Set the THREADDIR for the shared build 
+# Set the THREADDIR for the shared build
 # based on the threaded build status
 compile_threaded = false
 ifeq ($(strip $(SMP)),TRUE)
@@ -80,7 +80,7 @@ endif
 # set CPP options (must use this before any flags or cflags settings)
 #===============================================================================
 
-CPPDEFS := $(USER_CPPDEFS) -D$(OS) 
+CPPDEFS := $(USER_CPPDEFS) -D$(OS)
 
 # Unless DEBUG mode is enabled, use NDEBUG to turn off assert statements.
 ifneq ($(strip $(DEBUG)),TRUE)
@@ -153,9 +153,9 @@ ifeq ($(USE_CXX), true)
     LD := $(MPIFC)
   endif
 endif
-# Use this if LD has not already been defined.   
+# Use this if LD has not already been defined.
 ifeq ($(origin LD), default)
-  ifeq ($(strip $(MPILIB)),mpi-serial)	
+  ifeq ($(strip $(MPILIB)),mpi-serial)
     LD := $(SFC)
   else
     LD := $(MPIFC)
@@ -235,17 +235,17 @@ endif
 
 ifdef CPRE
   FPPDEFS := $(subst $(comma),\\$(comma),$(CPPDEFS))
-  FPPDEFS := $(patsubst -D%,$(CPRE)%,$(FPPDEFS)) 
+  FPPDEFS := $(patsubst -D%,$(CPRE)%,$(FPPDEFS))
 else
   FPPDEFS := $(CPPDEFS)
 endif
 
 
 #===============================================================================
-# Set config args for pio and mct to blank and then enable serial 
+# Set config args for pio and mct to blank and then enable serial
 #===============================================================================
 ifndef CONFIG_ARGS
-  CONFIG_ARGS := 
+  CONFIG_ARGS :=
 endif
 ifeq ($(MPILIB),mpi-serial)
    CONFIG_ARGS+= --enable-mpiserial
@@ -261,7 +261,7 @@ endif
 # User-specified INCLDIR
 #===============================================================================
 
-INCLDIR := -I. 
+INCLDIR := -I.
 ifdef USER_INCLDIR
   INCLDIR += $(USER_INCLDIR)
 endif
@@ -308,7 +308,7 @@ ifdef MOD_NETCDF
 endif
 ifdef INC_MPI
   INCLDIR += -I$(INC_MPI)
-endif 
+endif
 ifdef INC_PNETCDF
   INCLDIR += -I$(INC_PNETCDF)
 endif
@@ -364,7 +364,7 @@ endif
 INCLDIR +=	-I$(SHAREDPATH)/include -I$(CIMEROOT)/share/csm_share/shr \
 		-I$(CIMEROOT)/share/csm_share/include -I$(CIMEROOT)/share/shr_RandNum/include
 #
-# Use the MCT dir for the cache for all configure calls because it is the first one 
+# Use the MCT dir for the cache for all configure calls because it is the first one
 #
 CFLAGS+=$(CPPDEFS)
 CXXFLAGS := $(CFLAGS)
@@ -372,7 +372,7 @@ CXXFLAGS := $(CFLAGS)
 CONFIG_ARGS +=  CC="$(SCC)" FC="$(SFC)" MPICC="$(MPICC)" \
                 MPIFC="$(MPIFC)" FCFLAGS="$(FFLAGS) $(FREEFLAGS) $(INCLDIR)" \
                 CPPDEFS="$(CPPDEFS)" CFLAGS="$(CFLAGS) -I.. $(INCLDIR)" \
-                NETCDF_PATH=$(NETCDF_PATH) LDFLAGS="$(LDFLAGS)" 
+                NETCDF_PATH=$(NETCDF_PATH) LDFLAGS="$(LDFLAGS)"
 ifeq ($(COMPILER),nag)
   CONFIG_ARGS += LIBS="$(SLIBS)"
 endif
@@ -418,9 +418,9 @@ ifdef ESMF_LIBDIR
 endif
 
 
-# System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.) 
+# System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)
 ifndef SLIBS
-   SLIBS := -L$(LIB_NETCDF) -lnetcdf 
+   SLIBS := -L$(LIB_NETCDF) -lnetcdf
 endif
 ifdef LIB_PNETCDF
    SLIBS += -L$(LIB_PNETCDF) -lpnetcdf
@@ -431,13 +431,13 @@ endif
 ifdef LIB_MPI
    ifndef MPI_LIB_NAME
       SLIBS += -L$(LIB_MPI) -lmpi
-   else  
+   else
       SLIBS += -L$(LIB_MPI) -l$(MPI_LIB_NAME)
    endif
 endif
 
 # For compiling and linking with external ESMF.
-# If linking to external ESMF library then include esmf.mk 
+# If linking to external ESMF library then include esmf.mk
 # ESMF_F90COMPILEPATHS
 # ESMF_F90LINKPATHS
 # ESMF_F90LINKRPATHS
@@ -477,11 +477,11 @@ endif
 #------------------------------------------------------------------------------
 
 
-$(MCT_LIBDIR)/Makefile.conf: 
+$(MCT_LIBDIR)/Makefile.conf:
 	@echo "SHAREDLIBROOT |$(SHAREDLIBROOT)| SHAREDPATH |$(SHAREDPATH)|"; \
 	$(CONFIG_SHELL) $(CIMEROOT)/externals/mct/configure $(CONFIG_ARGS) --srcdir $(CIMEROOT)/externals/mct
 
-$(MCT_LIBDIR)/mpi-serial/Makefile.conf: 
+$(MCT_LIBDIR)/mpi-serial/Makefile.conf:
 	@echo "SHAREDLIBROOT |$(SHAREDLIBROOT)| SHAREDPATH |$(SHAREDPATH)|"; \
 	$(CONFIG_SHELL) $(CIMEROOT)/externals/mct/mpi-serial/configure $(CONFIG_ARGS) --srcdir $(CIMEROOT)/externals/mct
 
@@ -510,7 +510,7 @@ else
   endif
 endif
 
-MCTLIBS = $(MCT_LIBDIR)/libmct.a $(MCT_LIBDIR)/libmpeu.a 
+MCTLIBS = $(MCT_LIBDIR)/libmct.a $(MCT_LIBDIR)/libmpeu.a
 
 GPTLLIB = $(GPTL_LIBDIR)/libgptl.a
 
@@ -521,7 +521,7 @@ ULIBS += -L$(SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/csm_share -
 #------------------------------------------------------------------------------
 
 ifndef CMAKE_OPTS
-  CMAKE_OPTS := 
+  CMAKE_OPTS :=
 endif
 # note that the fortran flags include neither the FREEFLAGS nor the
 # FIXEDFLAGS, so that both free & fixed code can be built (cmake
@@ -537,7 +537,7 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
               -D USER_CMAKE_MODULE_PATH:STRING=$(CIMEROOT)/externals/CMake
 
 ifdef PNETCDF_PATH
-	CMAKE_OPTS += -D PNETCDF_DIR:STRING="$(PNETCDF_PATH)" 
+	CMAKE_OPTS += -D PNETCDF_DIR:STRING="$(PNETCDF_PATH)"
 else
         CMAKE_OPTS += -D WITH_PNETCDF:LOGICAL=FALSE -D PIO_USE_MPIIO:LOGICAL=FALSE
 endif
@@ -552,23 +552,23 @@ CMAKE_OPTS += $(USER_CMAKE_OPTS)
 # CMAKE_C_COMPILER, etc., when you rerun cmake with an existing
 # cache. So doing this via environment variables instead.
 ifndef CMAKE_ENV_VARS
-  CMAKE_ENV_VARS := 
+  CMAKE_ENV_VARS :=
 endif
 CMAKE_ENV_VARS += CC=$(CC) \
                   CXX=$(CXX) \
                   FC=$(FC) \
-                  LDFLAGS="$(LDFLAGS)" 
+                  LDFLAGS="$(LDFLAGS)"
 
 
 # We declare $(GLC_DIR)/Makefile to be a phony target so that cmake is
 # always rerun whenever invoking 'make $(GLC_DIR)/Makefile'; this is
 # desirable to pick up any new source files that may have been added
-.PHONY: $(GLC_DIR)/Makefile 
+.PHONY: $(GLC_DIR)/Makefile
 $(GLC_DIR)/Makefile:
 	cd $(GLC_DIR); \
 	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(CIMEROOT)/../components/cism/glimmer-cism
 
-$(PIO_LIBDIR)/Makefile: 
+$(PIO_LIBDIR)/Makefile:
 	cd $(PIO_LIBDIR); \
 	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(PIO_SRC_DIR)
 
@@ -576,7 +576,7 @@ $(PIO_LIBDIR)/Makefile:
 # Build & include dependency files
 #-------------------------------------------------------------------------------
 
-touch_filepath: 
+touch_filepath:
 	touch $(CURDIR)/Filepath
 
 # Get list of files and build dependency file for all .o files
@@ -585,7 +585,7 @@ touch_filepath:
 SOURCES := $(shell cat Srcfiles)
 BASENAMES := $(basename $(basename $(SOURCES)))
 OBJS    := $(addsuffix .o, $(BASENAMES))
-INCS    := $(foreach dir,$(cpp_dirs),-I$(dir)) 
+INCS    := $(foreach dir,$(cpp_dirs),-I$(dir))
 
 CURDIR := $(shell pwd)
 
@@ -597,7 +597,7 @@ $(CURDIR)/Deppath: $(CURDIR)/Filepath
 	@echo "$(MINCROOT)" >> $@
 
 $(CURDIR)/Srcfiles: $(CURDIR)/Filepath
-	$(CASETOOLS)/mkSrcfiles 
+	$(CASETOOLS)/mkSrcfiles
 
 $(CURDIR)/Filepath:
 	@echo "$(VPATH)" > $@
@@ -645,10 +645,10 @@ ifeq ($(ULIBDEP),$(null))
      ULIBDEP += $(LIBROOT)/libice.a
      ifeq ($(findstring clm5_0,$(CLM_CONFIG_OPTS)),clm5_0)
           LNDLIB := libclm.a
-     else	
+     else
           ifeq ($(findstring clm4_5,$(CLM_CONFIG_OPTS)),clm4_5)
                LNDLIB := libclm.a
-          else	
+          else
                LNDLIB := liblnd.a
           endif
      endif
@@ -704,7 +704,7 @@ CSMSHARELIB = $(SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/csm_shar
 ULIBDEP += $(CSMSHARELIB)
 
 #-------------------------------------------------------------------------------
-# build rules: 
+# build rules:
 #-------------------------------------------------------------------------------
 
 .SUFFIXES:
@@ -716,14 +716,14 @@ ifeq ($(MPILIB),mpi-serial)
   CMAKE_OPTS += -DMPI_C_INCLUDE_PATH=$(SHAREDPATH)/include \
       -DMPI_Fortran_INCLUDE_PATH=$(SHAREDPATH)/include \
       -DMPI_C_LIBRARIES=$(SHAREDPATH)/lib/libmpi-serial.a \
-      -DMPI_Fortran_LIBRARIES=$(SHAREDPATH)/lib/libmpi-serial.a 
+      -DMPI_Fortran_LIBRARIES=$(SHAREDPATH)/lib/libmpi-serial.a
 endif
 
 $(MCTLIBS)  : $(MPISERIAL)
 
 $(PIOLIB) : $(MPISERIAL) $(GPTLLIB)
 
-$(CSMSHARELIB):  $(MCTLIBS) $(PIOLIB) $(GPTLLIB) 
+$(CSMSHARELIB):  $(MCTLIBS) $(PIOLIB) $(GPTLLIB)
 ifneq ($(MODEL),csm_share)
   $(OBJS):  $(CSMSHARELIB)
 endif
@@ -731,7 +731,7 @@ endif
 $(EXEC_SE): $(OBJS) $(ULIBDEP) $(CSMSHARELIB) $(MCTLIBS) $(PIOLIB) $(GPTLLIB)
 	$(LD) -o $(EXEC_SE) $(OBJS) $(CLIBS) $(ULIBS) $(SLIBS) $(MLIBS) $(LDFLAGS)
 
-$(COMPLIB): $(OBJS) 
+$(COMPLIB): $(OBJS)
 	$(AR) -r $(COMPLIB) $(OBJS)
 
 $(LIBROOT)/libcvmix.a:
@@ -758,29 +758,29 @@ cleanatm:
 	cd $(EXEROOT)/atm/obj;  $(RM) -f *.o *.mod
 
 cleancpl:
-	cd $(EXEROOT)/drv/obj;  $(RM) -f *.o *.mod
+	cd $(EXEROOT)/cpl/obj;  $(RM) -f *.o *.mod
 
-cleanocn: 
+cleanocn:
 	$(RM) -f $(LIBROOT)/libocn.a $(LIBROOT)/libcvmix.a
 	cd $(EXEROOT)/ocn/obj ; $(RM) -f *.o *.mod
 
-cleanwav: 
+cleanwav:
 	$(RM) -f $(LIBROOT)/libwav.a
 	cd $(EXEROOT)/wav/obj ; $(RM) -f *.o *.mod
 
-cleanglc: 
+cleanglc:
 	$(RM) -f $(LIBROOT)/libglc.a
-	$(RM) -fr $(EXEROOT)/glc 
+	$(RM) -fr $(EXEROOT)/glc
 
-cleanice: 
+cleanice:
 	$(RM) -f $(LIBROOT)/libice.a
 	cd $(EXEROOT)/ice/obj ; $(RM) -f *.o *.mod
 
-cleanrof: 
+cleanrof:
 	$(RM) -f $(LIBROOT)/librof.a
 	cd $(EXEROOT)/rof/obj ; $(RM) -f *.o *.mod
 
-cleanlnd: 
+cleanlnd:
 	$(RM) -f $(LIBROOT)/liblnd.a
 	cd $(EXEROOT)/lnd/obj ; $(RM) -f *.o *.mod
 

--- a/cime_config/cesm/machines/template.case.run
+++ b/cime_config/cesm/machines/template.case.run
@@ -208,7 +208,7 @@ sub doPreRunChecks()
     $logger->info(" - To prestage restarts, untar a restart.tar file into $config{'RUNDIR'}");
 
     # Run preview namelists.. should turn this into a module at some point..
-    system("./preview_namelists -loglevel $opts{loglevel} ");
+    system("./preview_namelists");
 
     if($?)
     {

--- a/driver_cpl/cime_config/buildexe
+++ b/driver_cpl/cime_config/buildexe
@@ -17,7 +17,7 @@ my $GMAKE_J   = `./xmlquery GMAKE_J   -value`;
 my $MODEL     = `./xmlquery MODEL     -value`;
 $ENV{PIO_VERSION}  = `./xmlquery PIO_VERSION   -value`;
 
-chdir "${OBJROOT}/${MODEL}/obj";
+chdir "${OBJROOT}/cpl/obj";
 
 open(file,">Filepath") or die "Could not open file Filepath to write";
 print file "${CASEROOT}/SourceMods/src.drv\n";

--- a/scripts/Testing/Testcases/ICP_build.csh
+++ b/scripts/Testing/Testcases/ICP_build.csh
@@ -151,7 +151,7 @@ foreach bx ($bxvals)
       cp env_build.xml LockedFiles/env_build.xml
 
       if ($precheck == 0) then
-        ./case.build --testmode
+        ./case.build --testmode $*
         if ($status != 0) then
           exit -1    
         endif 

--- a/scripts/Testing/Testcases/LII_build.csh
+++ b/scripts/Testing/Testcases/LII_build.csh
@@ -35,7 +35,7 @@ setenv CIMEROOT `./xmlquery CIMEROOT    --value`
 # NOTE - Are assumming that are already in $CASEROOT here
 set CASE     = `./xmlquery CASE    --value`
 
-./case.build --testmode
+./case.build --testmode $*
 if ($status != 0) then
    echo "Error: build failed" >! ./TestStatus
    echo "CFAIL $CASE" > ./TestStatus

--- a/scripts/Testing/Testcases/NCR_build.csh
+++ b/scripts/Testing/Testcases/NCR_build.csh
@@ -87,7 +87,7 @@ set NTASKS_CPL  = `./xmlquery NTASKS_CPL  --value`
 
 ./case.clean_build 
 
-./case.build --testmode
+./case.build --testmode $*
 if ($status != 0) then
    exit -1    
 endif 
@@ -156,7 +156,7 @@ set NTASKS_CPL  = `./xmlquery NTASKS_CPL	--value`
 
 ./case.cleanbuild
 
-./case.build --testmode
+./case.build --testmode $*
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/NOC_build.csh
+++ b/scripts/Testing/Testcases/NOC_build.csh
@@ -45,7 +45,7 @@ endif
 ./case.setup -clean
 ./case.setup
 
-./case.build --testmode
+./case.build --testmode $*
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/PMT_build.csh
+++ b/scripts/Testing/Testcases/PMT_build.csh
@@ -21,7 +21,7 @@ cp -f env_mach_pes.xml LockedFiles/env_mach_pes.xml
 ./xmlchange --file env_run.xml --id BFBFLAG --val TRUE
 echo "b4b_flag=.true." >> user_nl_pop
 
-./case.build --testmode
+./case.build --testmode $*
 if ($status != 0) then
    exit -1    
 endif 
@@ -104,7 +104,7 @@ endif
 ./case.setup
 ./case.clean_build -all 
 
-./case.build --testmode
+./case.build --testmode $*
 if ($status != 0) then
    exit -1    
 endif 

--- a/scripts/Testing/Testcases/tests_build.csh
+++ b/scripts/Testing/Testcases/tests_build.csh
@@ -6,7 +6,7 @@ setenv CIMEROOT `./xmlquery CIMEROOT    --value`
 # NOTE - Are assumming that are already in $CASEROOT here
 set CASE     = `./xmlquery CASE    --value`
 
-./case.build
+./case.build $*
 if ($status != 0) then
    exit -1
 endif

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -36,11 +36,17 @@ OR
                         "that we have a case.test_build script. If you are in a test that requires"
                         " multiple builds, provide this flag.")
 
+    parser.add_argument("-s", "--sharedlib-only", action="store_true",
+                        help="Only build sharedlibs")
+
+    parser.add_argument("-m", "--model-only", action="store_true",
+                        help="Assume shared libs already built")
+
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
 
-    return args.caseroot, args.testmode
+    return args.caseroot, args.testmode, args.sharedlib_only, args.model_only
 
 ###############################################################################
 def _main_func(description):
@@ -49,10 +55,10 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, testmode = parse_command_line(sys.argv, description)
+    caseroot, testmode, sharedlib_only, model_only = parse_command_line(sys.argv, description)
     logging.info("calling build.case_build with caseroot=%s and testmode=%s"
                  %(caseroot, testmode))
-    build.case_build(caseroot, testmode)
+    build.case_build(caseroot, testmode, sharedlib_only, model_only)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -321,7 +321,7 @@ if (! $clean ) {
     # Run preview namelists for scripts
     #--------------------------------------------------------------------------
     $logger->info("Running preview_namelist script with loglevel $opts{loglevel}");
-    system(" $caseroot/preview_namelists -loglevel $opts{loglevel} ");
+    system("$caseroot/preview_namelists");
     if($?){
 	$logger->logdie("ERROR: $caseroot/preview_namelists failed: $?")
     }

--- a/scripts/Tools/case.test_build
+++ b/scripts/Tools/case.test_build
@@ -1,13 +1,12 @@
 #!/usr/bin/env python2
 """
- This is the system test build script for CIME
-
+This is the system test build script for CIME
 """
 
 from standard_script_setup import *
 
 from CIME.case import Case
-from CIME.SystemTests.system_tests_common import TESTRUNDIFF, TESTRUNFAIL, TESTRUNPASS
+from CIME.SystemTests.system_tests_common import TESTRUNDIFF, TESTRUNFAIL, TESTRUNPASS, TESTBUILDFAIL, TESTRUNSLOWPASS
 from CIME.SystemTests.sms import SMS
 from CIME.SystemTests.cme import CME
 from CIME.SystemTests.erp import ERP
@@ -20,9 +19,7 @@ from CIME.SystemTests.eri import ERI
 from CIME.SystemTests.seq import SEQ
 from CIME.utils import expect
 
-###############################################################################
 def parse_command_line(args, description):
-###############################################################################
     parser = argparse.ArgumentParser(
         usage="""\n%s [<testname>] [--verbose]
 OR
@@ -34,9 +31,7 @@ OR
     \033[1;32m# case.test_build SMS\033[0m
     > %s
 """ % ((os.path.basename(args[0]), ) * 4),
-
         description=description,
-
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
@@ -48,36 +43,40 @@ OR
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
 
+    parser.add_argument("-s", "--sharedlib-only", action="store_true",
+                        help="Only build sharedlibs")
+
+    parser.add_argument("-m", "--model-only", action="store_true",
+                        help="Assume shared libs already built")
+
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
 
-    return args.caseroot, args.testname
+    return args.caseroot, args.testname, args.sharedlib_only, args.model_only
 
-def cimetestbuild(caseroot, testname):
+def cimetestbuild(caseroot, testname, sharedlib_only, model_only):
     case = Case(caseroot)
-    test = object()
     if testname is None:
         testname = case.get_value('TESTCASE')
 
-    logging.warn("Building test for %s"%testname)
+    logging.warn("Building test for %s" % testname)
 
     try:
         test = globals()[testname](caseroot, case)
-    except:
-        expect(False,"Could not find a test called '%s'"%testname)
+    except KeyError:
+        expect(False, "Could not find a test called '%s'" % testname)
 
-    test.build()
-
+    test.build(sharedlib_only=sharedlib_only, model_only=model_only)
 
 def _main_func(description):
     if "--test" in sys.argv:
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, testname = parse_command_line(sys.argv, description)
+    caseroot, testname, sharedlib_only, model_only = parse_command_line(sys.argv, description)
 
-    cimetestbuild(caseroot, testname)
+    cimetestbuild(caseroot, testname, sharedlib_only, model_only)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/Tools/case_diff
+++ b/scripts/Tools/case_diff
@@ -1,0 +1,143 @@
+#! /usr/bin/env python
+
+"""
+Try to calculate and succinctly present the differences between two large
+directory trees.
+"""
+
+from standard_script_setup import *
+from CIME.utils import expect, run_cmd
+
+import argparse, sys, os, doctest, glob
+
+IGNORE = [".git", "bin", "bakefiles", "SNTools.project"]
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n%s case1 case2
+OR
+%s --help
+OR
+%s --test
+
+\033[1mEXAMPLES:\033[0m
+    > %s case1 case2
+""" % ((os.path.basename(args[0]), ) * 4),
+
+description=description,
+
+formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("case1", help="First case.")
+
+    parser.add_argument("case2", help="Second case.")
+
+    args = parser.parse_args(args[1:])
+
+    CIME.utils.handle_standard_logging_options(args)
+
+    return args.case1, args.case2
+
+###############################################################################
+def recursive_diff(dir1, dir2):
+###############################################################################
+    """
+    Starting at dir1, dir2 respectively, compare their contents
+    """
+    # The assertions below hurt performance
+    #assert os.path.isdir(dir1), dir1 + " not a directory"
+    #assert os.path.isdir(dir2), dir2 + " not a directory"
+
+    # Get contents of both directories
+    dir1_contents = set(os.listdir(dir1))
+    dir2_contents = set(os.listdir(dir2))
+
+    # Use set operations to figure out what they have in common
+    dir1_only = dir1_contents - dir2_contents
+    dir2_only = dir2_contents - dir1_contents
+    both      = dir1_contents & dir2_contents
+
+    num_differing_files = 0
+
+    # Print the unique items
+    for dirname, set_obj in [(dir1, dir1_only), (dir2, dir2_only)]:
+        for item in sorted(set_obj):
+            if (item not in IGNORE):
+                print os.path.join(dirname, item), "is unique"
+                num_differing_files += 1
+
+    # Handling of the common items is trickier
+    for item in sorted(both):
+        if (item in IGNORE):
+            continue
+        path1 = os.path.join(dir1, item)
+        path2 = os.path.join(dir2, item)
+        path1isdir = os.path.isdir(path1)
+
+        # If the directory status of the files differs, report diff
+        if (path1isdir != os.path.isdir(path2)):
+            print path1 + " DIFFERS (directory status)"
+            num_differing_files += 1
+            continue
+
+        # If the link status of the files differs, report diff
+        if (os.path.islink(path1) != os.path.islink(path2)):
+            print path1 + " DIFFERS (link status)"
+            num_differing_files += 1
+            continue
+
+        # If the paths are sym links, check if they are both broken/unbroken
+        paths_are_links = os.path.islink(path1)
+        if (paths_are_links):
+            if (os.path.exists(path1) != os.path.exists(path2)):
+                print path1 + " DIFFERS (brokeness of links)"
+                num_differing_files += 1
+                continue
+
+            # No need to move on to checking contents if the links are broken
+            paths_are_broken_links = not os.path.exists(path1)
+            if (paths_are_broken_links):
+                continue
+
+        # If we've made it this far, the files' status is the same. If the
+        # files are directories, recursively check them, otherwise check
+        # that the file contents match
+        if (path1isdir):
+            num_differing_files += recursive_diff(path1, path2)
+        else:
+            # # As a (huge) performance enhancement, if the files have the same
+            # # size, we assume the contents match
+            # if (os.path.getsize(path1) != os.path.getsize(path2)):
+            #     print path1 + " DIFFERS (contents)"
+
+            stat, out, _ = run_cmd("diff -w %s %s" % (path1, path2), ok_to_fail=True)
+            if (stat != 0):
+                print "==============================================================================="
+                print path1 + " DIFFERS (contents)"
+                num_differing_files += 1
+                print "  ", out
+
+    return num_differing_files
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    if ("--test" in sys.argv):
+        test_results = doctest.testmod(verbose=True)
+        sys.exit(1 if test_results.failed > 0 else 0)
+
+    case1, case2 = parse_command_line(sys.argv, description)
+
+    num_differing_files = recursive_diff(case1, case2)
+    print num_differing_files, "files are different"
+    sys.exit(0 if num_differing_files == 0 else 1)
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/scripts/Tools/check_case
+++ b/scripts/Tools/check_case
@@ -52,7 +52,7 @@ system($sysmod) == 0 or $logger->logdie ("ERROR: $sysmod failed: $?");
 my $CASE           = `./xmlquery CASE           -value`;
 my $BUILD_COMPLETE = `./xmlquery BUILD_COMPLETE -value`;
 
-my $sysmod = "./preview_namelists -loglevel $opts{loglevel}";
+my $sysmod = "./preview_namelists";
 system($sysmod) == 0 or $logger->logdie ("ERROR: $sysmod failed: $?");
 
 if ($BUILD_COMPLETE ne "TRUE") {

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -63,9 +63,13 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    svn_loc, input_data_root, data_list_file, download = parse_command_line(sys.argv, description)
+    svn_loc, input_data_root, data_list_dir, download = parse_command_line(sys.argv, description)
 
-    sys.exit(0 if check_input_data(svn_loc, input_data_root, data_list_file, download) else 1)
+    sys.exit(0 if check_input_data(case=None,
+                                   svn_loc=svn_loc,
+                                   input_data_root=input_data_root,
+                                   data_list_dir=data_list_dir,
+                                   download=download) else 1)
 
 ###############################################################################
 

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -10,14 +10,9 @@ from standard_script_setup import *
 from CIME.utils import expect, get_model, run_cmd
 from CIME.XML.machines import Machines
 from CIME.case import Case
+from CIME.check_input_data import check_input_data, SVN_LOCS
 
 import argparse, doctest, fnmatch
-
-# Should probably be in XML somewhere
-SVN_LOCS = {
-    "acme" : "https://acme-svn2.ornl.gov/acme-repo/acme/inputdata",
-    "cesm" : "https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata"
-}
 
 MACHINE = Machines()
 
@@ -60,91 +55,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     CIME.utils.handle_standard_logging_options(args)
 
     return args.svn_loc, args.input_data_root, args.data_list_dir, args.download
-
-###############################################################################
-def find_files(rootdir, pattern):
-###############################################################################
-    result = []
-    for root, dirs, files in os.walk(rootdir):
-        for filename in files:
-            if (fnmatch.fnmatch(filename, pattern)):
-                result.append(os.path.join(root, filename))
-
-    return result
-
-###############################################################################
-def download_if_in_repo(svn_loc, input_data_root, rel_path):
-###############################################################################
-    full_url = os.path.join(svn_loc, rel_path)
-    full_path = os.path.join(input_data_root, rel_path)
-    logging.info("Trying to download file: '%s' to path '%s'" % (full_url, full_path))
-
-    stat = run_cmd("svn --non-interactive --trust-server-cert ls %s" % full_url, ok_to_fail=True)
-    if (stat != 0):
-        logging.warning("SVN repo '%s' does not have file '%s'" % (svn_loc, rel_path))
-        return False
-    else:
-        stat, output, errput = \
-            run_cmd("svn --non-interactive --trust-server-cert export %s %s" % (full_url, full_path))
-        if (stat != 0):
-            logging.warning("svn export failed with output: %s and errput %s" % (output, errput))
-            return False
-        else:
-            return True
-
-###############################################################################
-def check_input_data(svn_loc, input_data_root, data_list_dir, download):
-###############################################################################
-    """
-    Return True if no files missing
-    """
-    expect(os.path.isdir(input_data_root), "Invalid input_data_root directory: '%s'" % input_data_root)
-    expect(os.path.isdir(data_list_dir), "Invalid data_list_dir directory: '%s'" % data_list_dir)
-
-    data_list_files = find_files(data_list_dir, "*.input_data_list")
-    expect(data_list_files, "No .input_data_list files found in dir '%s'" % data_list_dir)
-
-    case = Case()
-    no_files_missing = True
-
-    for data_list_file in data_list_files:
-        logging.info("Loading input file: '%s'" % data_list_file)
-        with open(data_list_file, "r") as fd:
-            lines = fd.readlines()
-
-        for line in lines:
-            line = line.strip()
-            if (line and not line.startswith("#")):
-                tokens = line.split('=')
-                description, full_path = tokens[0].strip(), tokens[1].strip()
-                if(full_path):
-                # expand xml variables
-                    full_path = case.get_resolved_value(full_path)
-                    rel_path  = full_path.replace(input_data_root, "")
-
-                    if (not os.path.exists(full_path)):
-                        model = os.path.basename(data_list_file).split('.')[0]
-                        logging.warning("Model %s missing file %s = '%s'" % (model,description,full_path))
-
-                        if (download):
-                            success = download_if_in_repo(svn_loc, input_data_root, rel_path)
-                            if (not success):
-                                # If ACME, try CESM repo as backup
-                                if (get_model() == "acme" and svn_loc != SVN_LOCS["cesm"]):
-                                    success = download_if_in_repo(SVN_LOCS["cesm"], input_data_root, rel_path)
-                                    if (not success):
-                                        no_files_missing = False
-                                else:
-                                    no_files_missing = False
-                            else:
-                                no_files_missing = False
-                        else:
-                            logging.info("Already had input file: '%s'" % full_path)
-                else:
-                    model = os.path.basename(data_list_file).split('.')[0]
-                    logging.warning("Model %s no file specified for %s"%(model,description))
-
-    return no_files_missing
 
 ###############################################################################
 def _main_func(description):

--- a/scripts/Tools/normalize_cases
+++ b/scripts/Tools/normalize_cases
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+"""
+Remove uninteresting diffs between cases by changing the
+first to be more like the second.
+
+This is for debugging purposes and meant to assist the user
+when they want to run case_diff.
+"""
+
+from standard_script_setup import *
+from CIME.utils import expect, run_cmd
+
+import argparse, sys, os, doctest, glob
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n%s case1 case2
+OR
+%s --help
+OR
+%s --test
+
+\033[1mEXAMPLES:\033[0m
+    > %s case1 case2
+""" % ((os.path.basename(args[0]), ) * 4),
+
+description=description,
+
+formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("case1", help="First case. This one will be changed")
+
+    parser.add_argument("case2", help="Second case. This one will not be changed")
+
+    args = parser.parse_args(args[1:])
+
+    CIME.utils.handle_standard_logging_options(args)
+
+    return args.case1, args.case2
+
+###############################################################################
+def normalize_cases(case1, case2):
+###############################################################################
+    # gunzip all build logs
+    run_cmd("gunzip *.gz", from_dir=os.path.join(case1, "bld"))
+    run_cmd("gunzip *.gz", from_dir=os.path.join(case2, "bld"))
+
+    # Change case1 to be as if it had same test-id as case2
+    test_id1 = case1.split(".")[-1]
+    test_id2 = case2.split(".")[-1]
+    run_cmd("for item in $(find -type f); do  sed -i 's/%s/%s/g' $item; done" % (test_id1, test_id2),
+            from_dir=case1)
+
+    # Get all LIDs
+    case1_lids = set()
+    for logfile in glob.glob("%s/bld/*.bldlog.*" % case1):
+        case1_lids.add(logfile.split(".")[-1])
+
+    case2_lids = set()
+    for logfile in glob.glob("%s/bld/*.bldlog.*" % case2):
+        case2_lids.add(logfile.split(".")[-1])
+
+    case1_lids = list(sorted(case1_lids))
+    case2_lids = list(sorted(case2_lids))
+
+    # Change case1 to look as if it is was built/run at exact same time as case2
+    for case1_lid, case2_lid in zip(case1_lids, case2_lids):
+        run_cmd("for item in $(find -type f); do  sed -i 's/%s/%s/g' $item; done" % (case1_lid, case2_lid),
+                from_dir=case1)
+
+    for case1_lid, case2_lid in zip(case1_lids, case2_lids):
+        files_needing_rename = run_cmd('find -depth -name "*.%s"' % case1_lid, from_dir=case1).splitlines()
+        for file_needing_rename in files_needing_rename:
+            expect(file_needing_rename.endswith(case1_lid), "broken")
+            new_name = file_needing_rename.rstrip(case1_lid) + case2_lid
+            os.rename(os.path.join(case1, file_needing_rename), os.path.join(case1, new_name))
+
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    if ("--test" in sys.argv):
+        test_results = doctest.testmod(verbose=True)
+        sys.exit(1 if test_results.failed > 0 else 0)
+
+    case1, case2 = parse_command_line(sys.argv, description)
+
+    normalize_cases(case1, case2)
+
+###############################################################################
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -45,7 +45,6 @@ my $EXEROOT		= `./xmlquery  EXEROOT		-value`;
 my $LIBROOT		= `./xmlquery  LIBROOT		-value`;
 my $INCROOT		= `./xmlquery  INCROOT		-value`;
 my $RUNDIR		= `./xmlquery  RUNDIR	 	-value`;
-my $SHAREDLIBROOT	= `./xmlquery  SHAREDLIBROOT	-value`;
 my $CASEROOT		= `./xmlquery  CASEROOT		-value`;
 my $CASEBUILD		= `./xmlquery  CASEBUILD	-value`;
 my $COMP_CPL		= `./xmlquery  COMP_CPL		-value`;
@@ -131,7 +130,7 @@ if($dryrun){
     # Make necessary directories
     # -------------------------------------------------------------------------
 
-    my @dirs = ("$EXEROOT", "$LIBROOT", "$INCROOT", "$RUNDIR", "$SHAREDLIBROOT");
+    my @dirs = ("$EXEROOT", "$LIBROOT", "$INCROOT", "$RUNDIR");
     foreach my $dir (@dirs) {
 	if (! -d $dir) {
 	    mkpath($dir, 0755) or $logger->logdie("Could not create directory $dir");
@@ -145,11 +144,6 @@ if($dryrun){
 	if (! -d $objdir) {
 	    mkpath($objdir, 0755) or $logger->logdie("Could not create directory $objdir");
 	    $logger->debug("Created directory $objdir");
-	}
-	my $libdir = "$EXEROOT/$model";
-	if (! -d $libdir) {
-	    mkpath($libdir, 0755) or $logger->logdie("Could not create directory $libdir");
-	    $logger->debug("Created directory $libdir");
 	}
     }
 }

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -967,7 +967,7 @@ sub _create_caseroot_files
 
     # Create $caseroot preview_namelist file
     my $file = "${caseroot}/preview_namelists";
-    $sysmod = "cp  $cimeroot/scripts/Tools/preview_namelists $file";
+    $sysmod = "ln -s $cimeroot/scripts/Tools/preview_namelists $file";
     system($sysmod) == 0 or $logger->logdie( "ERROR: $sysmod failed: $?\n");
 
     $sysmod = "chmod 755 $file";

--- a/utils/python/CIME/SystemTests/cme.py
+++ b/utils/python/CIME/SystemTests/cme.py
@@ -7,7 +7,6 @@ from CIME.case import Case
 import CIME.utils
 from system_tests_common import SystemTestsCommon
 
-
 class CME(SystemTestsCommon):
     def __init__(self, caseroot, case):
         """
@@ -15,7 +14,7 @@ class CME(SystemTestsCommon):
         """
         SystemTestsCommon.__init__(self, caseroot, case)
 
-    def build(self):
+    def build(self, sharedlib_only=False, model_only=False):
         """
         Build two exectuables for the CME test, one with ESMF interfaces
         the other with MCT interfaces and compare results - they should be exact
@@ -27,9 +26,10 @@ class CME(SystemTestsCommon):
             self._case.set_value('COMP_INTERFACE',CPL)
             self._case.flush()
             run_cmd('case.clean_build')
-            SystemTestsCommon.build(self)
-            shutil.move("%s/%s.exe"%(exeroot,cime_model),
-                        "%s/%s.exe.%s"%(exeroot,cime_model,CPL))
+            SystemTestsCommon.build(self, sharedlib_only=sharedlib_only, model_only=model_only)
+            if (not sharedlib_only):
+                shutil.move("%s/%s.exe"%(exeroot,cime_model),
+                            "%s/%s.exe.%s"%(exeroot,cime_model,CPL))
             shutil.copy("env_build.xml",os.path.join("LockedFiles","env_build_%s.xml"%CPL))
 
     def run(self):

--- a/utils/python/CIME/SystemTests/eri.py
+++ b/utils/python/CIME/SystemTests/eri.py
@@ -4,7 +4,6 @@ CIME ERI test  This class inherits from SystemTestsCommon
 from CIME.XML.standard_module_setup import *
 from system_tests_common import SystemTestsCommon
 
-
 class ERI(SystemTestsCommon):
     def __init__(self, caseroot, case):
         """

--- a/utils/python/CIME/SystemTests/erp.py
+++ b/utils/python/CIME/SystemTests/erp.py
@@ -7,7 +7,6 @@ from CIME.case import Case
 import CIME.utils
 from system_tests_common import SystemTestsCommon
 
-
 class ERP(SystemTestsCommon):
     def __init__(self, caseroot, case):
         """
@@ -15,7 +14,7 @@ class ERP(SystemTestsCommon):
         """
         SystemTestsCommon.__init__(self, caseroot, case)
 
-    def build(self):
+    def build(self, sharedlib_only=False, model_only=False):
         """
         Build two cases.  Case one uses defaults, case2 uses half the number of threads
         and tasks.   This test will fail for components (pop) that do not reproduce exactly
@@ -50,16 +49,17 @@ class ERP(SystemTestsCommon):
             run_cmd("case.setup -clean -testmode")
             run_cmd("case.setup")
             run_cmd('case.clean_build')
-            SystemTestsCommon.build(self)
-            shutil.move("%s/%s.exe"%(exeroot,cime_model),
-                        "%s/%s.exe.ERP%s"%(exeroot,cime_model,bld))
+            SystemTestsCommon.build(self, sharedlib_only=sharedlib_only, model_only=model_only)
+            if (not sharedlib_only):
+                shutil.move("%s/%s.exe"%(exeroot,cime_model),
+                            "%s/%s.exe.ERP%s"%(exeroot,cime_model,bld))
             shutil.copy("env_build.xml",os.path.join("LockedFiles","env_build_ERP%s.xml"%bld))
 
-#
-# Because mira/cetus interprets its run script differently than
-# other systems we need to copy the original env_mach_pes.xml
-# back
-#
+        #
+        # Because mira/cetus interprets its run script differently than
+        # other systems we need to copy the original env_mach_pes.xml
+        # back
+        #
         shutil.copy(machpes1,"env_mach_pes.xml")
         shutil.copy("env_mach_pes.xml",
                     os.path.join("LockedFiles","env_mach_pes.xml"))

--- a/utils/python/CIME/SystemTests/err.py
+++ b/utils/python/CIME/SystemTests/err.py
@@ -5,7 +5,6 @@ ERR tests short term archiving and restart capabilities
 from CIME.XML.standard_module_setup import *
 from system_tests_common import SystemTestsCommon
 
-
 class ERR(SystemTestsCommon):
     def __init__(self, caseroot, case):
         """

--- a/utils/python/CIME/SystemTests/ers.py
+++ b/utils/python/CIME/SystemTests/ers.py
@@ -4,7 +4,6 @@ CIME restart test  This class inherits from SystemTestsCommon
 from CIME.XML.standard_module_setup import *
 from system_tests_common import SystemTestsCommon
 
-
 class ERS(SystemTestsCommon):
     def __init__(self, caseroot, case):
         """

--- a/utils/python/CIME/SystemTests/icp.py
+++ b/utils/python/CIME/SystemTests/icp.py
@@ -12,10 +12,8 @@ class ICP(SystemTestsCommon):
         """
         SystemTestsCommon.__init__(self, caseroot, case)
 
-    def build(self):
+    def build(self, sharedlib_only=False, model_only=False):
         self._case.set_value("CICE_AUTO_DECOMP","false")
-
-
 
     def run(self):
         self._case.set_value("CONTINUE_RUN","FALSE")

--- a/utils/python/CIME/SystemTests/nck.py
+++ b/utils/python/CIME/SystemTests/nck.py
@@ -7,7 +7,6 @@ from CIME.case import Case
 import CIME.utils
 from system_tests_common import SystemTestsCommon
 
-
 class NCK(SystemTestsCommon):
     def __init__(self, caseroot, case):
         """
@@ -15,7 +14,7 @@ class NCK(SystemTestsCommon):
         """
         SystemTestsCommon.__init__(self, caseroot, case)
 
-    def build(self):
+    def build(self, sharedlib_only=False, model_only=False):
         exeroot = self._case.get_value("EXEROOT")
         cime_model = CIME.utils.get_model()
 
@@ -41,21 +40,21 @@ class NCK(SystemTestsCommon):
                         self._case.set_value("ROOTPE_%s"%comp, "%s"%int(rootpe/2))
             self._case.flush()
 
-
             run_cmd("case.setup -clean -testmode")
             run_cmd("case.setup")
             run_cmd('case.clean_build')
-            SystemTestsCommon.build(self)
-            shutil.move("%s/%s.exe"%(exeroot,cime_model),
-                        "%s/%s.exe.NCK%s"%(exeroot,cime_model,bld))
+            SystemTestsCommon.build(self, sharedlib_only=sharedlib_only, model_only=model_only)
+            if (not sharedlib_only):
+                shutil.move("%s/%s.exe"%(exeroot,cime_model),
+                            "%s/%s.exe.NCK%s"%(exeroot,cime_model,bld))
             shutil.copy("env_build.xml",os.path.join("LockedFiles","env_build.NCK%s.xml"%bld))
             shutil.copy("env_mach_pes.xml", machpes)
-#
-# Because mira/cetus interprets its run script differently than
-# other systems we need to copy the original env_mach_pes.xml
-# back
-#
 
+        #
+        # Because mira/cetus interprets its run script differently than
+        # other systems we need to copy the original env_mach_pes.xml
+        # back
+        #
         shutil.copy(machpes1,"env_mach_pes.xml")
         shutil.copy("env_mach_pes.xml",
                     os.path.join("LockedFiles","env_mach_pes.xml"))

--- a/utils/python/CIME/SystemTests/pea.py
+++ b/utils/python/CIME/SystemTests/pea.py
@@ -7,7 +7,6 @@ from CIME.case import Case
 import CIME.utils
 from system_tests_common import SystemTestsCommon
 
-
 class PEA(SystemTestsCommon):
     def __init__(self, caseroot, case):
         """
@@ -15,13 +14,11 @@ class PEA(SystemTestsCommon):
         """
         SystemTestsCommon.__init__(self, caseroot, case)
 
-
-    def build(self):
+    def build(self, sharedlib_only=False, model_only=False):
         exeroot = self._case.get_value("EXEROOT")
         cime_model = CIME.utils.get_model()
         for comp in ['ATM','CPL','OCN','WAV','GLC','ICE','ROF','LND']:
             self._case.set_value("NTASKS_%s"%comp,"1")
-
 
         build1 = os.path.join("LockedFiles","env_build.PEA1.xml")
         if ( os.path.isfile(build1) ):
@@ -35,9 +32,10 @@ class PEA(SystemTestsCommon):
             run_cmd("case.setup -clean ")
             run_cmd("case.setup")
             run_cmd('case.clean_build')
-            SystemTestsCommon.build(self)
-            shutil.move("%s/%s.exe"%(exeroot,cime_model),
-                        "%s/%s.exe.PEA_%s"%(exeroot,cime_model,mpilib))
+            SystemTestsCommon.build(self, sharedlib_only=sharedlib_only, model_only=model_only)
+            if (not sharedlib_only):
+                shutil.move("%s/%s.exe"%(exeroot,cime_model),
+                            "%s/%s.exe.PEA_%s"%(exeroot,cime_model,mpilib))
             shutil.copy("env_build.xml",os.path.join("LockedFiles",
                                                      "env_build_PEA_%s.xml"%mpilib))
 

--- a/utils/python/CIME/SystemTests/pem.py
+++ b/utils/python/CIME/SystemTests/pem.py
@@ -15,7 +15,7 @@ class PEM(SystemTestsCommon):
         """
         SystemTestsCommon.__init__(self, caseroot, case)
 
-    def build(self):
+    def build(self, sharedlib_only=False, model_only=False):
         """
         build two cases, the first is default the second has halve the tasks per component
         """
@@ -32,27 +32,29 @@ class PEM(SystemTestsCommon):
             run_cmd("case.setup -clean -testmode")
             run_cmd("case.setup")
             run_cmd('case.clean_build')
-            SystemTestsCommon.build(self)
+            SystemTestsCommon.build(self, sharedlib_only=sharedlib_only, model_only=model_only)
             machpes = os.path.join("LockedFiles","env_mach_pes.PEM%s.xml"%bld)
-            shutil.move("%s/%s.exe"%(exeroot,cime_model),
-                        "%s/%s.exe.PEM%s"%(exeroot,cime_model,bld))
+
+            if (not sharedlib_only):
+                shutil.move("%s/%s.exe"%(exeroot,cime_model),
+                            "%s/%s.exe.PEM%s"%(exeroot,cime_model,bld))
+
             shutil.copy("env_build.xml",os.path.join("LockedFiles","env_build_PEM%s.xml"%bld))
             shutil.copy("env_mach_pes.xml", machpes)
 
-            if(bld == 1):
-                    ntasks      = int(self._case.get_value("NTASKS_%s"%comp))
-                    rootpe      = int(self._case.get_value("ROOTPE_%s"%comp))
-                    if ( ntasks > 1 ):
-                        self._case.set_value("NTASKS_%s"%comp, "%s"%int(ntasks/2))
-                        self._case.set_value("ROOTPE_%s"%comp, "%s"%int(rootpe/2))
+            if bld == 1:
+                ntasks = int(self._case.get_value("NTASKS_%s"%comp))
+                rootpe = int(self._case.get_value("ROOTPE_%s"%comp))
+                if ntasks > 1:
+                    self._case.set_value("NTASKS_%s"%comp, "%s"%int(ntasks/2))
+                    self._case.set_value("ROOTPE_%s"%comp, "%s"%int(rootpe/2))
 
 
-#
-# Because mira/cetus interprets its run script differently than
-# other systems we need to copy the original env_mach_pes.xml
-# back
-#
-
+        #
+        # Because mira/cetus interprets its run script differently than
+        # other systems we need to copy the original env_mach_pes.xml
+        # back
+        #
         shutil.copy(machpes1,"env_mach_pes.xml")
         shutil.copy("env_mach_pes.xml",
                     os.path.join("LockedFiles","env_mach_pes.xml"))

--- a/utils/python/CIME/SystemTests/pet.py
+++ b/utils/python/CIME/SystemTests/pet.py
@@ -16,7 +16,7 @@ class PET(SystemTestsCommon):
         SystemTestsCommon.__init__(self, caseroot, case)
 
 
-    def build(self):
+    def build(self, sharedlib_only=False, model_only=False):
         exeroot = self._case.get_value("EXEROOT")
         cime_model = CIME.utils.get_model()
 
@@ -28,7 +28,7 @@ class PET(SystemTestsCommon):
         run_cmd("case.setup -clean ")
         run_cmd("case.setup")
         run_cmd('case.clean_build')
-        SystemTestsCommon.build(self)
+        SystemTestsCommon.build(self, sharedlib_only=sharedlib_only, model_only=model_only)
 
     def run(self):
         SystemTestsCommon.run(self)

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -28,8 +28,9 @@ class SystemTestsCommon(object):
             shutil.copy("env_run.xml",
                         os.path.join(lockedfiles, "env_run.orig.xml"))
 
-    def build(self):
-        build.case_build(self._caseroot, True)
+    def build(self, sharedlib_only=False, model_only=False):
+        build.case_build(self._caseroot, testmode=True,
+                         sharedlib_only=sharedlib_only, model_only=model_only)
 
     def run(self):
         run_cmd("case.run")
@@ -44,9 +45,9 @@ class SystemTestsCommon(object):
         cpllogfile = min(glob.iglob(os.path.join(rundir, "cpl.log*")), key=os.path.getctime)
 
     def compare_env_run(self, expected=None):
-        f1obj = EnvRun(caseroot, "env_run.xml")
-        f2obj = EnvRun(caseroot, os.path.join("LockedFiles", "env_run.orig.xml"))
-        diffs = fi1obj.compare_xml(f2obj)
+        f1obj = EnvRun(self._caseroot, "env_run.xml")
+        f2obj = EnvRun(self._caseroot, os.path.join("LockedFiles", "env_run.orig.xml"))
+        diffs = f1obj.compare_xml(f2obj)
         for key in diffs.keys():
             if key in expected:
                 logging.warn("  Resetting %s for test"%key)
@@ -59,57 +60,78 @@ class SystemTestsCommon(object):
                 return False
         return True
 
-class TESTRUNPASS(SystemTestsCommon):
-    def build(self):
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = self._case.get_value("MODEL")
-        rundir = self._case.get_value("RUNDIR")
-        cimeroot = self._case.get_value("CIMEROOT")
-        case = self._case.get_value("CASE")
-        modelexe = os.path.join(exeroot, "%s.exe"%cime_model)
-        with open(modelexe, 'w') as f:
-            f.write("#!/bin/bash\n")
-            f.write("echo Insta pass\n")
-            f.write("echo SUCCESSFUL TERMINATION > %s/cpl.log.$LID\n"%rundir)
-        f.closed
-        os.chmod(modelexe, 0755)
-        self._case.set_value("BUILD_COMPLETE", "TRUE")
-        self._case.flush()
+class FakeTest(SystemTestsCommon):
 
-class TESTRUNDIFF(SystemTestsCommon):
-    def build(self):
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = self._case.get_value("MODEL")
-        rundir = self._case.get_value("RUNDIR")
-        cimeroot = self._case.get_value("CIMEROOT")
-        case = self._case.get_value("CASE")
-        modelexe = os.path.join(exeroot, "%s.exe"%cime_model)
-        with open(modelexe, 'w') as f:
-            f.write("#!/bin/bash\n")
-            f.write("echo Insta pass\n")
-            f.write("echo SUCCESSFUL TERMINATION > %s/cpl.log.$LID\n"%rundir)
-            f.write("cp %s/utils/python/tests/cpl.hi1.nc.test %s/%s.cpl.hi.0.nc.base\n"%
-                    (cimeroot, rundir, case))
-        f.closed
-        os.chmod(modelexe, 0755)
-        self._case.set_value("BUILD_COMPLETE", "TRUE")
-        self._case.flush()
+    def fake_build(self, script, sharedlib_only=False, model_only=False):
+        if (not sharedlib_only):
+            exeroot = self._case.get_value("EXEROOT")
+            cime_model = self._case.get_value("MODEL")
+            modelexe = os.path.join(exeroot, "%s.exe"%cime_model)
 
-class TESTRUNFAIL(SystemTestsCommon):
-    def build(self):
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = self._case.get_value("MODEL")
+            with open(modelexe, 'w') as f:
+                f.write("#!/bin/bash\n")
+                f.write(script)
+
+            os.chmod(modelexe, 0755)
+            self._case.set_value("BUILD_COMPLETE", "TRUE")
+            self._case.flush()
+
+class TESTRUNPASS(FakeTest):
+
+    def build(self, sharedlib_only=False, model_only=False):
+        rundir = self._case.get_value("RUNDIR")
+        script = \
+"""
+echo Insta pass
+echo SUCCESSFUL TERMINATION > %s/cpl.log.$LID
+""" % rundir
+        self.fake_build(script,
+                        sharedlib_only=sharedlib_only, model_only=model_only)
+
+class TESTRUNDIFF(FakeTest):
+
+    def build(self, sharedlib_only=False, model_only=False):
         rundir = self._case.get_value("RUNDIR")
         cimeroot = self._case.get_value("CIMEROOT")
         case = self._case.get_value("CASE")
-        modelexe = os.path.join(exeroot, "%s.exe"%cime_model)
-        with open(modelexe, 'w') as f:
-            f.write("#!/bin/bash\n")
-            f.write("echo Insta fail\n")
-            f.write("echo model failed > %s/cpl.log.$LID\n"%rundir)
-            f.write("$LID\n")
-            f.write("exit -1\n")
-        f.closed
-        os.chmod(modelexe, 0755)
-        self._case.set_value("BUILD_COMPLETE", "TRUE")
-        self._case.flush()
+        script = \
+"""
+echo Insta pass
+echo SUCCESSFUL TERMINATION > %s/cpl.log.$LID
+cp %s/utils/python/tests/cpl.hi1.nc.test %s/%s.cpl.hi.0.nc.base
+""" % (rundir, cimeroot, rundir, case)
+        self.fake_build(script,
+                        sharedlib_only=sharedlib_only, model_only=model_only)
+
+class TESTRUNFAIL(FakeTest):
+
+    def build(self, sharedlib_only=False, model_only=False):
+        rundir = self._case.get_value("RUNDIR")
+        script = \
+"""
+echo Insta fail
+echo model failed > %s/cpl.log.$LID
+exit -1
+""" % rundir
+        self.fake_build(script,
+                        sharedlib_only=sharedlib_only, model_only=model_only)
+
+class TESTBUILDFAIL(FakeTest):
+
+    def build(self, sharedlib_only=False, model_only=False):
+        if (not sharedlib_only):
+            expect(False, "ERROR: Intentional fail for testing infrastructure")
+
+class TESTRUNSLOWPASS(FakeTest):
+
+    def build(self, sharedlib_only=False, model_only=False):
+        rundir = self._case.get_value("RUNDIR")
+        script = \
+"""
+sleep 300
+echo Slow pass
+echo SUCCESSFUL TERMINATION > %s/cpl.log.$LID
+""" % rundir
+        self.fake_build(script,
+                        sharedlib_only=sharedlib_only, model_only=model_only)
+

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -29,7 +29,7 @@ class SystemTestsCommon(object):
                         os.path.join(lockedfiles, "env_run.orig.xml"))
 
     def build(self, sharedlib_only=False, model_only=False):
-        build.case_build(self._caseroot, testmode=True,
+        build.case_build(self._caseroot, case=self._case, testmode=True,
                          sharedlib_only=sharedlib_only, model_only=model_only)
 
     def run(self):

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -140,7 +140,7 @@ def post_build(case, logs):
     shutil.copy("env_build.xml", "LockedFiles")
 
 ###############################################################################
-def case_build(caseroot, testmode=False, sharedlib_only=False, model_only=False):
+def case_build(caseroot, case=None, testmode=False, sharedlib_only=False, model_only=False):
 ###############################################################################
     t1 = time.time()
 
@@ -156,7 +156,7 @@ def case_build(caseroot, testmode=False, sharedlib_only=False, model_only=False)
     expect(os.path.exists("case.run"),
            "ERROR: must invoke case.setup script before calling build script ")
 
-    case = Case()
+    case = Case() if case is None else case
     testcase = case.get_value("TESTCASE")
     cimeroot = case.get_value("CIMEROOT")
     expect(not (testcase is not None and
@@ -286,9 +286,10 @@ def case_build(caseroot, testmode=False, sharedlib_only=False, model_only=False)
     env_module = EnvModule(mach, compiler, cimeroot, caseroot, mpilib, debug)
     env_module.load_env_for_case()
 
+    # Need to flush case xml to disk before calling preview_namelists
+    case.flush()
+
     if not sharedlib_only:
-        # Need to flush case xml to disk before calling preview_namelists
-        case.flush()
         run_cmd("./preview_namelists")
 
     build_checks(case, build_threaded, comp_interface, use_esmf_lib, compiler, mpilib, debug, sharedlibroot,

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -1,12 +1,16 @@
 """
 functions for building CIME models
 """
-import glob, shutil
 from XML.standard_module_setup import *
 from case import Case
 from utils import expect, run_cmd, get_model
 from env_module import EnvModule
+from CIME.preview_namelists import preview_namelists
+from CIME.check_input_data import check_input_data
 
+import glob, shutil, time, threading
+
+###############################################################################
 def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
                 comp_atm, comp_lnd, comp_ice, comp_ocn, comp_glc, comp_wav, comp_rof,
                 nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav,
@@ -33,6 +37,7 @@ def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
     overall_smp = os.environ["SMP"]
     sharedpath = os.environ["SHAREDPATH"]
 
+    thread_bad_results = []
     for model, comp, config_dir, nthrds in models_build_data:
         os.environ["MODEL"] = model
         if nthrds > 1 or build_threaded == "TRUE":
@@ -71,17 +76,21 @@ def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
         file_build = os.path.join(exeroot, "%s.bldlog.%s" % (model, lid))
 
         # build the component library
-        stat = run_cmd("%s/buildlib %s %s %s >> %s 2>&1" %
-                       (config_dir, caseroot, bldroot, compspec, file_build),
-                       from_dir=os.path.join(exeroot, model),
-                       ok_to_fail=True, verbose=True)[0]
-        expect(stat == 0,
-               "ERROR: %s.buildlib failed, see %s" % (comp, file_build))
+        t = threading.Thread(target=_build_model_thread,
+            args=(config_dir, caseroot, bldroot, compspec, file_build,
+                  exeroot, model, comp, objdir, incroot, thread_bad_results))
+        t.start()
 
         for mod_file in glob.glob(os.path.join(objdir, "*_[Cc][Oo][Mm][Pp]_*.mod")):
             shutil.copy(mod_file, incroot)
 
         logs.append(file_build)
+
+    # Wait for threads to finish
+    while(threading.active_count() > 1):
+        time.sleep(1)
+
+    expect(not thread_bad_results, "\n".join(thread_bad_results))
 
     #
     # Now build the executable
@@ -92,15 +101,8 @@ def build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
     cime_model = get_model()
     file_build = os.path.join(exeroot, "%s.bldlog.%s" % (cime_model, lid))
 
-    objdir = os.path.join(exeroot, cime_model, "obj")
-    libdir = os.path.join(exeroot, cime_model)
-    for build_dir in [objdir, libdir]:
-        if not os.path.exists(build_dir):
-            os.makedirs(build_dir)
-
     stat = run_cmd("%s/driver_cpl/cime_config/buildexe %s >> %s 2>&1" %
                    (cimeroot, caseroot, file_build),
-                   from_dir=os.path.join(exeroot, cime_model),
                    ok_to_fail=True,
                    verbose=True)[0]
     expect(stat == 0, "ERROR: buildexe failed, cat %s" % file_build)
@@ -138,8 +140,16 @@ def post_build(case, logs):
     shutil.copy("env_build.xml", "LockedFiles")
 
 ###############################################################################
-def case_build(caseroot, testmode):
+def case_build(caseroot, testmode=False, sharedlib_only=False, model_only=False):
 ###############################################################################
+    t1 = time.time()
+
+    expect(not (sharedlib_only and model_only),
+           "Contradiction: both sharedlib_only and model_only")
+
+    logging.info("sharedlib_only is %s" % sharedlib_only)
+    logging.info("model_only is %s" % model_only)
+
     expect(os.path.isdir(caseroot), "'%s' is not a valid directory" % caseroot)
     os.chdir(caseroot)
 
@@ -154,7 +164,8 @@ def case_build(caseroot, testmode):
                                (cimeroot, testcase)) and not testmode),
            "%s build must be invoked via case.testbuild script" % testcase)
 
-    check_input_data(case)
+    if not sharedlib_only:
+        check_all_input_data(case)
 
     run_cmd("./Tools/check_lockedfiles --caseroot %s" % caseroot)
 
@@ -238,8 +249,8 @@ def case_build(caseroot, testmode):
     # This is a timestamp for the build , not the same as the testid,
     # and this case may not be a test anyway. For a production
     # experiment there may be many builds of the same case.
-    lid                                = run_cmd("date +%y%m%d-%H%M%S")
-    os.environ["LID"]                  = lid
+    lid               = run_cmd("date +%y%m%d-%H%M%S")
+    os.environ["LID"] = lid
 
     # Set the overall USE_PETSC variable to TRUE if any of the
     # XXX_USE_PETSC variables are TRUE.
@@ -274,25 +285,41 @@ def case_build(caseroot, testmode):
     # Load modules
     env_module = EnvModule(mach, compiler, cimeroot, caseroot, mpilib, debug)
     env_module.load_env_for_case()
-    # Need to flush case xml to disk before calling preview_namelists
-    case.flush()
-    run_cmd("./preview_namelists")
 
-    build_checks(case, build_threaded, comp_interface, use_esmf_lib, mpilib,
+    if not sharedlib_only:
+        # Need to flush case xml to disk before calling preview_namelists
+        case.flush()
+        run_cmd("./preview_namelists")
+
+    build_checks(case, build_threaded, comp_interface, use_esmf_lib, compiler, mpilib, debug, sharedlibroot,
                  nthrds_cpl, nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav,
                  nthrds_rof, ninst_build, smp_value)
-    logs = build_libraries(exeroot, caseroot, cimeroot, libroot, sharedlibroot, compiler, mpilib,
-                           build_threaded, debug, lid, machines_file)
-    logs.extend(build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
-                            comp_atm, comp_lnd, comp_ice, comp_ocn, comp_glc, comp_wav, comp_rof,
-                            nthrds_atm, nthrds_lnd, nthrds_ice,
-                            nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof,
-                            lid, caseroot, cimeroot, use_esmf_lib, comp_interface))
-    post_build(case, logs)
 
-def check_input_data(case):
+    t2 = time.time()
+    logs = []
+
+    if not model_only:
+        logs = build_libraries(exeroot, caseroot, cimeroot, libroot, mpilib, lid, machines_file)
+    if not sharedlib_only:
+        logs.extend(build_model(case, build_threaded, exeroot, clm_config_opts, incroot,
+                                comp_atm,   comp_lnd,   comp_ice,   comp_ocn,   comp_glc,   comp_wav,   comp_rof,
+                                nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc, nthrds_wav, nthrds_rof,
+                                lid, caseroot, cimeroot, use_esmf_lib, comp_interface))
+
+    if not sharedlib_only:
+        post_build(case, logs)
+
+    t3 = time.time()
+
+    logging.info("Time spent not building: %f sec" % (t2 - t1))
+    logging.info("Time spent building: %f sec" % (t3 - t2))
+
 ###############################################################################
-    run_cmd("./check_input_data --download")
+def check_all_input_data(case):
+###############################################################################
+    success = check_input_data(case=case, download=True)
+    expect(success, "Failed to download input data")
+
     get_refcase  = case.get_value("GET_REFCASE")
     run_type     = case.get_value("RUN_TYPE")
     continue_run = case.get_value("CONTINUE_RUN")
@@ -352,9 +379,9 @@ and prestage the restart data to $RUNDIR manually
                 os.chmod(runfile, 0755)
 
 ###############################################################################
-def build_checks(case, build_threaded, comp_interface, use_esmf_lib, mpilib,
-                 nthrds_cpl, nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn, nthrds_glc,
-                 nthrds_wav, nthrds_rof, ninst_build, smp_value):
+def build_checks(case, build_threaded, comp_interface, use_esmf_lib, debug, compiler, mpilib,
+                 sharedlibroot, nthrds_cpl, nthrds_atm, nthrds_lnd, nthrds_ice, nthrds_ocn,
+                 nthrds_glc, nthrds_wav, nthrds_rof, ninst_build, smp_value):
 ###############################################################################
     ninst_atm    = int(case.get_value("NINST_ATM"))
     ninst_lnd    = int(case.get_value("NINST_LND"))
@@ -381,6 +408,11 @@ def build_checks(case, build_threaded, comp_interface, use_esmf_lib, mpilib,
         os.environ["SMP"] = "TRUE"
     else:
         os.environ["SMP"] = "FALSE"
+
+    debugdir = "debug" if debug else "nodebug"
+    threaddir = "threads" if (os.environ["SMP"] == "TRUE" or build_threaded == "TRUE") else "nothreads"
+    sharedpath = os.path.join(sharedlibroot, compiler, mpilib, debugdir, threaddir)
+    os.environ["SHAREDPATH"] = sharedpath
 
     smpstr = "a%dl%dr%di%do%dg%dw%dc%d" % \
         (atmstr, lndstr, rofstr, icestr, ocnstr,  glcstr, wavstr, cplstr)
@@ -456,19 +488,14 @@ ERROR MPILIB is mpi-serial and USE_ESMF_LIB IS TRUE
     case.flush()
 
 ###############################################################################
-def build_libraries(exeroot, caseroot, cimeroot, libroot, sharedlibroot, compiler, mpilib, build_threaded, debug, lid, machines_file):
+def build_libraries(exeroot, caseroot, cimeroot, libroot, mpilib, lid, machines_file):
 ###############################################################################
 
     if (mpilib == "mpi-serial"):
         for header_to_copy in glob.glob(os.path.join(cimeroot, "externals/mct/mpi-serial/*.h")):
             shutil.copy(header_to_copy, os.path.join(libroot, "include"))
 
-    debugdir = "debug" if (debug== "TRUE") else "nodebug"
-
-    threaddir = "threads" if os.environ["SMP"] == "TRUE" or build_threaded == "TRUE" else "nothreads"
-
-    sharedpath = os.path.join(sharedlibroot, compiler, mpilib, debugdir, threaddir)
-    os.environ["SHAREDPATH"] = sharedpath
+    sharedpath = os.environ["SHAREDPATH"]
     shared_lib = os.path.join(sharedpath, "lib")
     shared_inc = os.path.join(sharedpath, "include")
     for shared_item in [shared_lib, shared_inc]:
@@ -498,3 +525,14 @@ def build_libraries(exeroot, caseroot, cimeroot, libroot, sharedlibroot, compile
     return logs
 
 ###############################################################################
+def _build_model_thread(config_dir, caseroot, bldroot, compspec, file_build,
+                        exeroot, model, comp, objdir, incroot, thread_bad_results):
+###############################################################################
+    stat = run_cmd("%s/buildlib %s %s %s >> %s 2>&1" %
+                   (config_dir, caseroot, bldroot, compspec, file_build),
+                   from_dir=os.path.join(exeroot, model), ok_to_fail=True)[0]
+    if (stat != 0):
+        thread_bad_results.append("ERROR: %s.buildlib failed, see %s" % (comp, file_build))
+
+    for mod_file in glob.glob(os.path.join(objdir, "*_[Cc][Oo][Mm][Pp]_*.mod")):
+        shutil.copy(mod_file, incroot)

--- a/utils/python/CIME/check_input_data.py
+++ b/utils/python/CIME/check_input_data.py
@@ -1,0 +1,104 @@
+"""
+API for checking input for testcase
+"""
+
+from XML.standard_module_setup import *
+from CIME.utils import expect, run_cmd, get_model
+from CIME.case import Case
+
+import fnmatch
+
+# Should probably be in XML somewhere
+SVN_LOCS = {
+    "acme" : "https://acme-svn2.ornl.gov/acme-repo/acme/inputdata",
+    "cesm" : "https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata"
+}
+
+def find_files(rootdir, pattern):
+    """
+    recursively find all files matching a pattern
+    """
+    result = []
+    for root, dirs, files in os.walk(rootdir):
+        for filename in files:
+            if (fnmatch.fnmatch(filename, pattern)):
+                result.append(os.path.join(root, filename))
+
+    return result
+
+def download_if_in_repo(svn_loc, input_data_root, rel_path):
+    """
+    Return True if successfully downloaded
+    """
+    full_url = os.path.join(svn_loc, rel_path)
+    full_path = os.path.join(input_data_root, rel_path)
+    logging.info("Trying to download file: '%s' to path '%s'" % (full_url, full_path))
+
+    stat = run_cmd("svn --non-interactive --trust-server-cert ls %s" % full_url, ok_to_fail=True)
+    if (stat != 0):
+        logging.warning("SVN repo '%s' does not have file '%s'" % (svn_loc, rel_path))
+        return False
+    else:
+        stat, output, errput = \
+            run_cmd("svn --non-interactive --trust-server-cert export %s %s" % (full_url, full_path))
+        if (stat != 0):
+            logging.warning("svn export failed with output: %s and errput %s" % (output, errput))
+            return False
+        else:
+            return True
+
+def check_input_data(case=None, svn_loc=None, input_data_root=None, data_list_dir="Buildconf", download=False):
+    """
+    Return True if no files missing
+    """
+    # Fill in defaults as needed
+    case = Case() if case is None else case
+    svn_loc = SVN_LOCS[get_model()] if svn_loc is None else snv_loc
+    input_data_root = case.get_value("DIN_LOC_ROOT") if input_data_root is None else input_data_root
+
+    expect(os.path.isdir(input_data_root), "Invalid input_data_root directory: '%s'" % input_data_root)
+    expect(os.path.isdir(data_list_dir), "Invalid data_list_dir directory: '%s'" % data_list_dir)
+
+    data_list_files = find_files(data_list_dir, "*.input_data_list")
+    expect(data_list_files, "No .input_data_list files found in dir '%s'" % data_list_dir)
+
+    no_files_missing = True
+
+    for data_list_file in data_list_files:
+        logging.info("Loading input file: '%s'" % data_list_file)
+        with open(data_list_file, "r") as fd:
+            lines = fd.readlines()
+
+        for line in lines:
+            line = line.strip()
+            if (line and not line.startswith("#")):
+                tokens = line.split('=')
+                description, full_path = tokens[0].strip(), tokens[1].strip()
+                if(full_path):
+                # expand xml variables
+                    full_path = case.get_resolved_value(full_path)
+                    rel_path  = full_path.replace(input_data_root, "")
+
+                    if (not os.path.exists(full_path)):
+                        model = os.path.basename(data_list_file).split('.')[0]
+                        logging.warning("Model %s missing file %s = '%s'" % (model,description,full_path))
+
+                        if (download):
+                            success = download_if_in_repo(svn_loc, input_data_root, rel_path)
+                            if (not success):
+                                # If ACME, try CESM repo as backup
+                                if (get_model() == "acme" and svn_loc != SVN_LOCS["cesm"]):
+                                    success = download_if_in_repo(SVN_LOCS["cesm"], input_data_root, rel_path)
+                                    if (not success):
+                                        no_files_missing = False
+                                else:
+                                    no_files_missing = False
+                            else:
+                                no_files_missing = False
+                        else:
+                            logging.info("Already had input file: '%s'" % full_path)
+                else:
+                    model = os.path.basename(data_list_file).split('.')[0]
+                    logging.warning("Model %s no file specified for %s"%(model,description))
+
+    return no_files_missing

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -1,0 +1,88 @@
+"""
+API for preview namelist
+"""
+
+from XML.standard_module_setup import *
+from CIME.utils import expect, run_cmd
+from CIME.case import Case
+
+import glob, shutil
+
+def preview_namelists(dryrun=False, case=None, casedir=None):
+    if (case is None):
+        if (casedir is None):
+            case = Case()
+        else:
+            case = Case(case_root=casedir)
+
+    # Get data from XML
+    exeroot = case.get_value("EXEROOT")
+    libroot = case.get_value("LIBROOT")
+    incroot = case.get_value("INCROOT")
+    rundir = case.get_value("RUNDIR")
+    sharedlibroot = case.get_value("SHAREDLIBROOT")
+    caseroot = case.get_value("CASEROOT")
+    casebuild = case.get_value("CASEBUILD")
+    testcase = case.get_value("TESTCASE")
+
+    dryrun = True if (testcase == "SBN") else dryrun
+
+    models = ["atm", "lnd", "ice", "ocn", "glc", "wav", "rof", "cpl"]
+    docdir = os.path.join(caseroot, "CaseDocs")
+
+    if (dryrun):
+        # Only create rundir
+        try:
+            os.makedirs(rundir)
+        except OSError:
+            logging.warning("Not able to create $RUNDIR, trying a subdirectory of $CASEROOT")
+            rundir = os.path.join(caseroot, rundir)
+            try:
+                os.makedirs(rundir)
+                logging.info("Success! Setting RUNDIR=%s" % rundir)
+                case.set_value("RUNDIR", rundir)
+            except OSError:
+                expect(False, "Could not create rundir")
+
+    else:
+        # Make necessary directories
+        dirs_to_make = [os.path.join(exeroot, model, "obj") for model in models]
+        dirs_to_make.extend([exeroot, libroot, incroot, rundir, sharedlibroot, docdir])
+
+        for dir_to_make in dirs_to_make:
+            if (not os.path.isdir(dir_to_make)):
+                try:
+                    os.makedirs(dir_to_make)
+                except OSError as e:
+                    expect(False, "Could not make directory '%s', error: %s" % (dir_to_make, e))
+
+    # Create namelists
+    for model in models:
+        model_str = "drv" if model == "cpl" else model
+        config_file = case.get_value("CONFIG_%s_FILE" % model_str.upper())
+        config_dir = os.path.dirname(config_file)
+        cmd = os.path.join(config_dir, "buildnml")
+
+        if (logging.getLogger().level == logging.DEBUG):
+            run_cmd("PREVIEW_NML=1 %s %s" % (cmd, caseroot))
+        else:
+            run_cmd("%s %s" % (cmd, caseroot))
+
+    # Save namelists to docdir
+    if (not os.path.isdir(docdir)):
+        try:
+            with open(os.path.join(docdir, "README"), "w") as fd:
+                fd.write(" CESM Resolved Namelist Files\n   For documentation only DO NOT MODIFY\n")
+        except (OSError, IOError) as e:
+            expect(False, "Failed to write %s/README: %s" % (docdir, e))
+
+
+    for cpglob in ["*_in_[0-9]*", "*modelio*", "*_in",
+                   "*streams*txt*", "*stxt", "*maps.rc", "*cism.config*"]:
+        for file_to_copy in glob.glob(os.path.join(rundir, cpglob)):
+            shutil.copy2(file_to_copy, docdir)
+
+    # Copy over chemistry mechanism docs if they exist
+    if (os.path.isdir(os.path.join(casebuild, "camconf"))):
+        for file_to_copy in glob.glob(os.path.join(casebuild, "camconf", "*chem_mech*")):
+            shutil.copy2(file_to_copy, docdir)

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -149,8 +149,7 @@ def run_cmd(cmd, ok_to_fail=False, input_str=None, from_dir=None, verbose=None,
     if (arg_stderr is _hack):
         arg_stderr = subprocess.PIPE
 
-    if(verbose):
-        print "RUN: %s" % cmd
+    logging.info("RUN: %s" % cmd)
 
     if (input_str is not None):
         stdin = subprocess.PIPE
@@ -514,5 +513,20 @@ def handle_standard_logging_options(args):
 
     if (args.verbose == True):
         root_logger.setLevel(logging.INFO)
+    # DEBUG trumps INFO
     if (args.debug == True):
         root_logger.setLevel(logging.DEBUG)
+
+def get_logging_options():
+    """
+    Use to pass same logging options as was used for current
+    executable to subprocesses.
+    """
+    root_logger = logging.getLogger()
+
+    if (root_logger.level == logging.INFO):
+        return "--verbose"
+    elif (root_logger.level == logging.DEBUG):
+        return "--debug"
+    else:
+        return ""

--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -432,7 +432,7 @@ class TestSystemTest(TestCreateTestCommon):
             for test in ct._tests:
                 if (phase == CIME.system_test.INITIAL_PHASE):
                     continue
-                elif (phase == CIME.system_test.BUILD_PHASE):
+                elif (phase == CIME.system_test.MODEL_BUILD_PHASE):
                     ct._update_test_status(test, phase, wait_for_tests.TEST_PENDING_STATUS)
 
                     if (test == build_fail_test):
@@ -509,7 +509,7 @@ class TestSystemTest(TestCreateTestCommon):
         for test_status in test_statuses:
             status, test_name = wait_for_tests.parse_test_status_file(test_status)
             if (test_name == build_fail_test):
-                self.assertEqual(status[CIME.system_test.BUILD_PHASE], wait_for_tests.TEST_FAIL_STATUS)
+                self.assertEqual(status[CIME.system_test.MODEL_BUILD_PHASE], wait_for_tests.TEST_FAIL_STATUS)
             elif (test_name == run_fail_test):
                 self.assertEqual(status[CIME.system_test.RUN_PHASE], wait_for_tests.TEST_FAIL_STATUS)
             else:


### PR DESCRIPTION
Change list:
1) Split BUILD phase into MODEL_BUILD and SHAREDLIB_BUILD
2) case.build now builds all models in parallel!
3) Sharedlib builds are serialized by clever use of procs_needed
4) Crucial Makefile fix from Jim Edwards
5) Add --model-only, --sharedlib-only options to case.build
6) Add --model-only, --sharedlib-only options to case.test_build
7) Add support for model-only, sharedlib-only to all the SystemTest classes
8) New tools for debugging: case_diff, normalize_cases.
 - Used to find subte differences in infrastructure behavior at the case level

9) Move most of check_input_files into a library
10) Remove non-threadsafe things from preview_namelists
11) Encapsulate fake system tests into a common base class
12) Add some missing fake system tests (TESTBUILDFAIL, TESTRUNSLOWPASS)
13) Add some timing data to case.build to assist future optimizations
14) Add prototype replacement for preview_namelists (not yet active)