### PR TITLE
Take a close look at CIME/XML

### DIFF
--- a/utils/python/CIME/XML/component.py
+++ b/utils/python/CIME/XML/component.py
@@ -9,6 +9,7 @@ from CIME.utils import expect, get_cime_root, get_model
 logger = logging.getLogger(__name__)
 
 class Component(EntryID):
+
     def __init__(self,infile):
         """
         initialize an object
@@ -16,13 +17,12 @@ class Component(EntryID):
         EntryID.__init__(self,infile)
 
     def get_value(self, name, attribute={}, resolved=False):
-        if(name == "component"):
+        if name == "component":
             components = []
             compnode = self.get_node("components")
-            expect(len(compnode)==1,"Unexpected number of components lists found")
-            comps = self.get_node("comp",root=compnode[0])
+            comps = self.get_nodes("comp", root=compnode)
             for comp in comps:
                 components.append(comp.text())
             return components
         else:
-            return EntryID.get_value(self,name,attribute,resolved)
+            return EntryID.get_value(self, name, attribute, resolved)

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -19,7 +19,14 @@ class EntryID(GenericXML):
         """
         Set the value of an entry to the default value for that entry
         """
-        # Need comment here
+        # Hangle this case:
+        # <entry id ...>
+        #  <values>
+        #   <value A="a1">X</value>
+        #   <value A="a2">Y</value>
+        #   <value A="a3">Z</value>
+        #  </values>
+        # </entry>
         valnodes = self.get_nodes("value", root=node)
         for valnode in valnodes:
             for att in valnode.attributes:

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -15,92 +15,66 @@ class EntryID(GenericXML):
         GenericXML.__init__(self, infile)
         self.groups={}
 
-    def set_default_value(self, vid, attributes=None):
+    def set_default_value(self, node, attributes=None):
         """
         Set the value of an entry to the default value for that entry
-        vid can be an xml node pointer or a string identifier of a node
         """
-        value = None
-        if (type(vid) != type(str())):
-            node = vid
-            vid = node.attrib["id"]
-        else:
-            nodes = self.get_node("entry", {"id":vid})
-            if (nodes is None):
-                return
-            expect(len(nodes) == 1, "More than one match found for id " + vid)
-            node = nodes[0]
+        # Need comment here
+        valnodes = self.get_nodes("value", root=node)
+        for valnode in valnodes:
+            for att in valnode.attributes:
+                if att.key in attributes:
+                    if re.search(attributes[att.key], att.text):
+                        node.set("value", valnode.text)
+                        return valnode.text
+                        logger.info("id %s value %s" % (vid, valnode.text))
 
-        valnodes = self.get_node("value",root=node)
-        if (valnodes is not None):
-            for valnode in valnodes:
-                for att in valnode.attributes:
-                    if (att.key in attributes):
-                        if (re.search(attributes[att.key],att.text)):
-                            value = valnode.text
-                            logger.info("id %s value %s" % (vid, valnode.text))
+        # Fall back to default value
+        value = self.get_optional_node("default_value", root=node)
+        if value is not None:
+            node.set("value", value.text)
+            return value.text
 
-        if (value is None):
-            value = self.get_node("default_value", root=node)
-        if (value is not None):
-            node.set("value", value[0].text)
-            return value[0].text
-
-    def set_value(self, vid, value,subgroup=None):
+    def set_value(self, vid, value, subgroup=None):
         """
         Set the value of an entry-id field to value
         Returns the value or None if not found
         subgroup is ignored in the general routine and applied in specific methods
         """
+        node = self.get_optional_node("entry", {"id":vid})
         val = None
-        if (type(vid) != type(str())):
-            node = vid
-            vid = node.attrib["id"]
-        else:
-            nodes = self.get_node("entry", {"id":vid})
-            if (not nodes):
-                return
-            expect(len(nodes) == 1, "More than one match found for id " + vid)
-            node = nodes[0]
-
-        if (node is not None):
+        if node is not None:
             val = value
             node.set("value", value)
 
         return val
 
-    def get_value(self, vid, attribute={}, resolved=True,subgroup=None):
+    def get_value(self, vid, attribute={}, resolved=True, subgroup=None):
         """
         get a value for entry with id attribute vid.
         or from the values field if the attribute argument is provided
         and matches
         """
         val = None
-        if (type(vid) != type(str())):
-            node = vid
-            vid = node.attrib["id"]
-        else:
-            nodes = self.get_node("entry", {"id":vid})
-            if (len(nodes) == 0):
-                val = GenericXML.get_value(self, vid, resolved)
-                return val
-            else:
-                node = nodes[0]
+        node = self.get_optional_node("entry", {"id":vid})
+        if node is None:
+            val = GenericXML.get_value(self, vid, resolved)
+            return val
 
-        if (attribute):
-            valnodes = self.get_node("value", attribute,root=node)
-            if (valnodes is not None and len(valnodes) == 1):
-                val = valnodes[0].text
-        elif (node.get("value") is not None):
+        if attribute:
+            valnodes = self.get_optional_node("value", attribute, root=node)
+            if valnodes is not None:
+                val = valnodes.text
+        elif node.get("value") is not None:
             val = node.get("value")
         else:
-            val = self.set_default_value(vid)
+            val = self.set_default_value(node)
 
-        if (val is None):
+        if val is None:
             # if all else fails
             val = GenericXML.get_value(self,vid,resolved)
 
-        if (resolved):
+        if resolved:
             val = self.get_resolved_value(val)
 
         return val
@@ -111,82 +85,77 @@ class EntryID(GenericXML):
         attribute to its associated value
         """
         values = {}
-        if (type(vid) != type(str())):
-            node = vid
-            vid = node.attrib("id")
-        else:
-            nodes = self.get_node("entry", {"id":vid})
-            if (nodes is None):
-                return
-            node = nodes[0]
+        node = self.get_optional_node("entry", {"id":vid})
+        if node is None:
+            return
 
-        valnodes = self.get_node("value", root=node)
-        if (valnodes is not None):
-            for valnode in valnodes:
-                vatt = valnode.attrib[att]
-                if(resolved):
-                    values[vatt] = self.get_resolved_value(valnode.text)
-                else:
-                    values[vatt] = valnode.text
-
+        valnodes = self.get_nodes("value", root=node)
+        for valnode in valnodes:
+            vatt = valnode.attrib[att]
+            if resolved:
+                values[vatt] = self.get_resolved_value(valnode.text)
+            else:
+                values[vatt] = valnode.text
 
         return values
 
-    def get_child_content(self,id,childname):
+    def get_child_content(self, vid, childname):
         val = None
-        node = self.get_node("entry",{"id":id})
-        if(node):
-            childmatch  = self.get_node(childname, root=node[0])
-            if(len(childmatch) == 1):
-                val = childmatch[0].text
+        node = self.get_optional_node("entry", {"id" : vid})
+        if node is not None:
+            childmatch  = self.get_optional_node(childname, root=node[0])
+            if childmatch is not None:
+                val = childmatch.text
+
         return val
 
     def get_elements_from_child_content(self, childname, childcontent):
-        nodes = self.get_node("entry")
+        nodes = self.get_nodes("entry")
         elements = []
         for node in nodes:
-            childnodes = self.get_node(childname,root=node)
-            expect(len(childnodes)==1,"Unexpected number of matchs for %s in %s"%(childname, node.get("id")))
-            content = childnodes[0].text
-            if(content == childcontent):
-                elements.append( node)
+            childnode = self.get_node(childname,root=node)
+            content = childnode.text
+            if content == childcontent:
+                elements.append(node)
 
         return elements
 
     def add_elements_by_group(self, srcobj, attlist, infile):
-        nodelist = srcobj.get_elements_from_child_content('file',infile)
+        nodelist = srcobj.get_elements_from_child_content('file', infile)
         for node in nodelist:
             gnode = node.find(".//group")
             gname = gnode.text
-            if(gname not in self.groups.keys()):
+            if gname not in self.groups.keys():
                 newgroup = ET.Element("group")
                 newgroup.set("id",gname)
                 self.add_child(newgroup)
                 self.groups[gname] = newgroup
+
             self.set_default_value(node, attlist)
             node = self.cleanupnode(node)
             self.groups[gname].append(node)
-            logger.debug ("Adding to group "+gname)
+            logger.debug ("Adding to group " + gname)
+
         return nodelist
 
-    def cleanupnode(self,node):
+    def cleanupnode(self, node):
         fnode = node.find(".//file")
         gnode = node.find(".//group")
         node.remove(fnode)
         node.remove(gnode)
         vnode = node.find(".//values")
-        if(vnode):
+        if vnode is not None:
             node.remove(vnode)
         return node
 
     def compare_xml(self, other):
         xmldiffs = {}
-        f1nodes = self.get_node("entry")
+        f1nodes = self.get_nodes("entry")
         for node in f1nodes:
             vid = node.attrib["id"]
             f2val = other.get_value(vid, resolved=False)
-            if(f2val is not None):
-                if(f2val != node.attrib["value"]):
+            if f2val is not None:
+                if f2val != node.attrib["value"]:
                     xmldiffs[vid] = [node.attrib["value"], f2val]
 
         return xmldiffs

--- a/utils/python/CIME/XML/env_archive.py
+++ b/utils/python/CIME/XML/env_archive.py
@@ -8,6 +8,7 @@ from env_base import EnvBase
 logger = logging.getLogger(__name__)
 
 class EnvArchive(EnvBase):
+
     def __init__(self, case_root=os.getcwd(), infile="env_archive.xml"):
         """
         initialize an object interface to file env_archive.xml in the case directory

--- a/utils/python/CIME/XML/env_base.py
+++ b/utils/python/CIME/XML/env_base.py
@@ -9,14 +9,15 @@ from headers import Headers
 logger = logging.getLogger(__name__)
 
 class EnvBase(EntryID):
+
     def __init__(self, case_root, infile):
-        if(os.path.isabs(infile)):
+        if os.path.isabs(infile):
             fullpath = infile
         else:
             fullpath = os.path.join(case_root, infile)
+
         EntryID.__init__(self, fullpath)
-        if (not os.path.isfile(fullpath)):
+        if not os.path.isfile(fullpath):
             headerobj = Headers()
             headernode = headerobj.get_header_node(os.path.basename(fullpath))
             self.root.append(headernode)
-

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -8,6 +8,7 @@ from env_base import EnvBase
 logger = logging.getLogger(__name__)
 
 class EnvBatch(EnvBase):
+
     def __init__(self, case_root=os.getcwd(), infile="env_batch.xml"):
         """
         initialize an object interface to file env_batch.xml in the case directory
@@ -16,37 +17,33 @@ class EnvBatch(EnvBase):
 
     def set_value(self, item, value, subgroup=None):
         val = None
-        if(subgroup is None):
-            nodes = self.get_node("entry",{"id":item})
+        if subgroup is None:
+            nodes = self.get_nodes("entry", {"id":item})
             for node in nodes:
                 val = EnvBase.set_value(self, node, value)
         else:
-            nodes = self.get_node("job",{"name":subgroup})
+            nodes = self.get_nodes("job",{"name":subgroup})
             for node in nodes:
-                vnode = self.get_node("entry",{"id":item},root=node)
-                if( len(vnode)>0 ):
-                    val = EnvBase.set_value(self,vnode[0],value)
+                vnode = self.get_optional_node("entry", {"id":item}, root=node)
+                if vnode is not None:
+                    val = EnvBase.set_value(self, vnode, value)
 
         return val
 
     def get_value(self, item, attribute={}, resolved=True, subgroup=None):
-        value = {}
-        nodes = self.get_node("entry",{"id":item})
-        if(len(nodes)>0):
-            if(subgroup is None):
-                nodes = self.get_node("job")
+        value = None
+        nodes = self.get_nodes("entry",{"id":item})
+        if len(nodes) > 0:
+            value = {} # Not consistent with return values for other classes' get_value methods
+            if subgroup is None:
+                nodes = self.get_nodes("job")
             else:
-                nodes = self.get_node("job",{"name":subgroup})
+                nodes = self.get_nodes("job", {"name":subgroup})
+
             for node in nodes:
                 val = EnvBase.get_value(self, node,
-                                        item,attribute,resolved)
-                if(val):
+                                        item, attribute, resolved)
+                if val is not None:
                     value[node.attrib["name"]] = val
-            return value
 
-
-
-
-
-
-
+        return value

--- a/utils/python/CIME/XML/env_build.py
+++ b/utils/python/CIME/XML/env_build.py
@@ -8,6 +8,7 @@ from env_base import EnvBase
 logger = logging.getLogger(__name__)
 
 class EnvBuild(EnvBase):
+
     def __init__(self, case_root=os.getcwd(), infile="env_build.xml"):
         """
         initialize an object interface to file env_build.xml in the case directory

--- a/utils/python/CIME/XML/env_case.py
+++ b/utils/python/CIME/XML/env_case.py
@@ -8,6 +8,7 @@ from env_base import EnvBase
 logger = logging.getLogger(__name__)
 
 class EnvCase(EnvBase):
+
     def __init__(self, case_root=os.getcwd(), infile="env_case.xml"):
         """
         initialize an object interface to file env_case.xml in the case directory

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -8,6 +8,7 @@ from env_base import EnvBase
 logger = logging.getLogger(__name__)
 
 class EnvMachPes(EnvBase):
+
     def __init__(self, case_root=os.getcwd(), infile="env_mach_pes.xml"):
         """
         initialize an object interface to file env_mach_pes.xml in the case directory

--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -13,8 +13,8 @@ class EnvMachSpecific(GenericXML):
         """
         initialize an object interface to file env_mach_specific.xml in the case directory
         """
-	if(os.path.isabs(infile)):
+	if os.path.isabs(infile):
 	    fullpath = infile
         else:
-            fullpath = os.path.join(caseroot,infile)
+            fullpath = os.path.join(caseroot, infile)
         GenericXML.__init__(self, fullpath)

--- a/utils/python/CIME/XML/env_run.py
+++ b/utils/python/CIME/XML/env_run.py
@@ -8,6 +8,7 @@ from env_base import EnvBase
 logger = logging.getLogger(__name__)
 
 class EnvRun(EnvBase):
+
     def __init__(self, case_root=os.getcwd(), infile="env_run.xml"):
         """
         initialize an object interface to file env_run.xml in the case directory

--- a/utils/python/CIME/XML/env_test.py
+++ b/utils/python/CIME/XML/env_test.py
@@ -8,6 +8,7 @@ from env_base import EnvBase
 logger = logging.getLogger(__name__)
 
 class EnvTest(EnvBase):
+
     def __init__(self, case_root=os.getcwd(), infile="env_test.xml"):
         """
         initialize an object interface to file env_test.xml in the case directory

--- a/utils/python/CIME/XML/files.py
+++ b/utils/python/CIME/XML/files.py
@@ -9,6 +9,7 @@ from CIME.utils import expect, get_cime_root, get_model
 logger = logging.getLogger(__name__)
 
 class Files(EntryID):
+
     def __init__(self):
         """
         initialize an object
@@ -17,5 +18,5 @@ class Files(EntryID):
         >>> files.get_value('CASEFILE_HEADERS',resolved=False)
         '$CIMEROOT/cime_config/config_headers.xml'
         """
-        infile = os.path.join(get_cime_root(),"cime_config",get_model(),"config_files.xml")
-        EntryID.__init__(self,infile)
+        infile = os.path.join(get_cime_root(), "cime_config", get_model(), "config_files.xml")
+        EntryID.__init__(self, infile)

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -16,7 +16,13 @@ class GenericXML(object):
         """
         self.tree = None
 
-        # Hold arbitary values? Why?
+        # Hold arbitary values. In create_newcase we may set values
+        # for xml files that haven't been created yet. We need a place
+        # to store them until we are ready to create the file. At file
+        # creation we get the values for those fields from this lookup
+        # table and then remove the entry. This was what I came up
+        # with in the perl anyway and I think that we still need it
+        # here.
         self.lookups = {}
         self.lookups['CIMEROOT'] = get_cime_root()
 

--- a/utils/python/CIME/XML/headers.py
+++ b/utils/python/CIME/XML/headers.py
@@ -18,14 +18,12 @@ class Headers(EntryID):
         >>> files.get_value('CASEFILE_HEADERS',resolved=False)
         '$CIMEROOT/cime_config/config_headers.xml'
         """
-        if(infile is None):
+        if infile is None:
             files = Files()
-            infile = files.get_value('CASEFILE_HEADERS',resolved=True)
-        EntryID.__init__(self,infile)
+            infile = files.get_value('CASEFILE_HEADERS', resolved=True)
+        EntryID.__init__(self, infile)
 
     def get_header_node(self,fname):
-        fnode=self.get_node("file", attributes={"name":fname})
-        expect(len(fnode)==1,"Invalid match count in headers for filename '%s'" % fname)
-        headernode = self.get_node('header',root=fnode[0])
-        expect(len(headernode)==1,"Invalid match count in headers for filename '%s'" % fname)
-        return headernode[0]
+        fnode = self.get_node("file", attributes={"name" : fname})
+        headernode = self.get_node("header", root=fnode)
+        return headernode

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -21,14 +21,14 @@ class Machines(GenericXML):
         self.machine = None
         self.name    = None
 
-        if (infile is None):
-            if (files is None):
+        if infile is None:
+            if files is None:
                 files = Files()
             infile = files.get_value("MACHINES_SPEC_FILE")
 
         GenericXML.__init__(self, infile)
 
-        if (machine is None):
+        if machine is None:
             machine = self.probe_machine_name()
 
         self.set_machine(machine)
@@ -39,19 +39,27 @@ class Machines(GenericXML):
         """
         return self.name
 
-    def get_node(self, nodename, attributes=None, root=None):
-        if (self.machine is not None and root is None and nodename is not "machine"):
-            node = GenericXML.get_node(self, nodename, attributes, root=self.machine)
-        else:
-            node = GenericXML.get_node(self, nodename, attributes, root)
-        return node
+
+    def get_node(self, nodename, attributes=None):
+        """
+        Return data on a node for a machine
+        """
+        expect(self.machine is not None, "Machine not set, use parent get_node?")
+        return GenericXML.get_node(self, nodename, attributes, root=self.machine)
+
+    def get_optional_node(self, nodename, attributes=None):
+        """
+        Return data on a node for a machine
+        """
+        expect(self.machine is not None, "Machine not set, use parent get_node?")
+        return GenericXML.get_optional_node(self, nodename, attributes, root=self.machine)
 
     def list_available_machines(self):
         """
         Return a list of machines defined for a given CIME_MODEL
         """
         machines = []
-        nodes  = self.get_node("machine")
+        nodes  = self.get_nodes("machine")
         for node in nodes:
             mach = node.get("MACH")
             machines.append(mach)
@@ -64,28 +72,23 @@ class Machines(GenericXML):
         """
         machine = None
         nametomatch = socket.gethostname().split(".")[0]
-        nodes = self.get_node("machine")
+        nodes = self.get_nodes("machine")
 
         for node in nodes:
             machtocheck = node.get("MACH")
             logger.debug("machine is " + machtocheck)
-            self.set_machine(machtocheck)
-            regex_str_nodes = self.get_node("NODENAME_REGEX", root=self.machine)
+            regex_str_node = GenericXML.get_optional_node(self, "NODENAME_REGEX", root=node)
+            regex_str = machtocheck if regex_str_node is None else regex_str_node.text
 
-            if (regex_str_nodes):
-                regex_str = regex_str_nodes[0].text
-            else:
-                regex_str = machtocheck
-
-            if (regex_str is not None):
+            if regex_str is not None:
                 logger.debug("machine regex string is " + regex_str)
                 regex = re.compile(regex_str)
-                if (regex.match(nametomatch)):
+                if regex.match(nametomatch):
                     logger.info("Found machine: %s matches %s" % (machtocheck, nametomatch))
                     machine = machtocheck
                     break
 
-        if (machine is None):
+        if machine is None:
             logger.warning("Could not probe machine for hostname '%s'" % nametomatch)
 
         return machine
@@ -102,12 +105,11 @@ class Machines(GenericXML):
         ...
         SystemExit: ERROR: No machine trump found
         """
-        if (self.machine is not None and self.name is not machine):
-            self.machine = None
-        mach_nodes = self.get_node("machine", {"MACH":machine})
-        expect(mach_nodes, "No machine %s found" % machine)
-        self.machine = mach_nodes[0]
-        self.name = machine
+        if self.name != machine:
+            self.machine = GenericXML.get_optional_node(self, "machine", {"MACH" : machine})
+            expect(self.machine is not None, "No machine %s found" % machine)
+            self.name = machine
+
         return machine
 
     def get_value(self, name, resolved=True):
@@ -119,25 +121,23 @@ class Machines(GenericXML):
 
         # COMPILER and MPILIB are special, if called without arguments they get the default value from the
         # COMPILERS and MPILIBS lists in the file.
-        if (name == "COMPILER"):
+        if name == "COMPILER":
             value = self.get_default_compiler()
-        elif (name == "MPILIB"):
+        elif name == "MPILIB":
             value = self.get_default_MPIlib()
         else:
-            nodes = self.get_node(name, root=self.machine)
-            if (nodes):
-                node = nodes[0]
-                expect(node is not None, "No match found for %s in machine %s" % (name, self.name))
+            node = self.get_optional_node(name)
+            if node is not None:
                 value = node.text
 
-        if (value is None):
+        if value is None:
             # if all else fails
             value = GenericXML.get_value(self, name)
 
-        if (resolved):
-            if(value is not None):
+        if resolved:
+            if value is not None:
                 value = self.get_resolved_value(value)
-            elif(name in os.environ):
+            elif name in os.environ:
                 value = os.environ[name]
 
         return value
@@ -154,10 +154,10 @@ class Machines(GenericXML):
                "No list found for " + listname + " on machine " + self.name)
         supported_values = supported_values.split(",")
 
-        if (reqval is None or reqval == "UNSET"):
+        if reqval is None or reqval == "UNSET":
             return supported_values[0]
         for val in supported_values:
-            if (val == reqval):
+            if val == reqval:
                 return reqval
 
         expect(False, "%s value %s not supported for machine %s" %
@@ -189,7 +189,7 @@ class Machines(GenericXML):
         ...
         SystemExit: ERROR: COMPILERS value nag not supported for machine edison
         """
-        if (self.get_field_from_list("COMPILERS", compiler) is not None):
+        if self.get_field_from_list("COMPILERS", compiler) is not None:
             return True
         return False
 
@@ -201,7 +201,7 @@ class Machines(GenericXML):
         >>> machobj.is_valid_MPIlib("mpi-serial")
         True
         """
-        if (self.get_field_from_list("MPILIBS", mpilib) is not None):
+        if self.get_field_from_list("MPILIBS", mpilib) is not None:
             return True
         return False
 
@@ -218,9 +218,9 @@ class Machines(GenericXML):
         False
         """
         result = False
-        batch_system = self.get_node("batch_system")
-        if (batch_system):
-            result = (batch_system[0].get("type") != "none")
+        batch_system = self.get_optional_node("batch_system")
+        if batch_system is not None:
+            result = (batch_system.get("type") != "none")
         logger.debug("Machine %s has batch: %s" % (self.name, result))
         return result
 
@@ -233,7 +233,7 @@ class Machines(GenericXML):
         'slurm'
         """
         batch_system = self.get_node("batch_system")
-        return batch_system[0].get("type")
+        return batch_system.get("type")
 
     def get_module_system_type(self):
         """
@@ -245,14 +245,12 @@ class Machines(GenericXML):
         'module'
         """
         module_system = self.get_node("module_system")
-        return module_system[0].get("type")
+        return module_system.get("type")
 
     def get_module_system_init_path(self, lang):
         init_nodes = self.get_node("init_path", attributes={"lang":lang})
-        expect(len(init_nodes) == 1, "Could not find init_path for lang '%s'" % lang)
-        return init_nodes[0].text
+        return init_nodes.text
 
     def get_module_system_cmd_path(self, lang):
         cmd_nodes = self.get_node("cmd_path", attributes={"lang":lang})
-        expect(len(cmd_nodes) == 1, "Could not find cmd_path for lang '%s'" % lang)
-        return cmd_nodes[0].text
+        return cmd_nodes.text

--- a/utils/python/CIME/XML/testlist.py
+++ b/utils/python/CIME/XML/testlist.py
@@ -10,6 +10,7 @@ from CIME.utils import expect, get_cime_root, get_model
 logger = logging.getLogger(__name__)
 
 class Testlist(GenericXML):
+
     def __init__(self,infile):
         """
         initialize an object
@@ -18,25 +19,27 @@ class Testlist(GenericXML):
 
     def _get_testsv1(self, machine=None, category=None, compiler=None):
         tests = []
-        compsetnodes = self.get_node("compset")
+
         machatts = {}
-        if(category is not None):
-            machatts["testtype"]  = category
-        if(compiler is not None):
-            machatts["compiler"]  = compiler
-        logger.debug("compsetnodes %d"%len(compsetnodes))
+        if category is not None:
+            machatts["testtype"] = category
+        if compiler is not None:
+            machatts["compiler"] = compiler
+
+        compsetnodes = self.get_nodes("compset")
+        logger.debug("compsetnodes %d" % len(compsetnodes))
         for cnode in compsetnodes:
-            gridnodes = self.get_node("grid",root=cnode)
+            gridnodes = self.get_nodes("grid", root=cnode)
             logger.debug("  gridnodes %d"%len(gridnodes))
             for gnode in gridnodes:
-                testnamenodes = self.get_node("test",root=gnode)
+                testnamenodes = self.get_nodes("test",root=gnode)
                 logger.debug("    testnamenodes %d"%len(testnamenodes))
                 for tnode in testnamenodes:
-                    machnodes = self.get_node("machine",machatts,root=tnode)
+                    machnodes = self.get_nodes("machine",machatts,root=tnode)
                     logger.debug("      machnodes %d"%len(machnodes))
                     for mach in machnodes:
                         thistest = {}
-                        if (machine is None or (machine is not None and mach.text == machine)):
+                        if machine is None or (machine is not None and mach.text == machine):
                             thistest["compiler"] = mach.attrib["compiler"]
                             thistest["category"] = mach.attrib["testtype"]
                             thistest["machine"] = mach.text
@@ -50,43 +53,45 @@ class Testlist(GenericXML):
 
     def _get_testsv2(self, machine=None, category=None, compiler=None):
         tests = []
-        testnodes = self.get_node("test")
+        testnodes = self.get_nodes("test")
         machatts = {}
-        if(machine is not None):
+        if machine is not None:
             machatts["name"]      = machine
-        if(category is not None):
+        if category is not None:
             machatts["category"]  = category
-        if(compiler is not None):
+        if compiler is not None:
             machatts["compiler"]  = compiler
 
         for tnode in testnodes:
-            machnodes = self.get_node("machine",machatts,root=tnode)
+            machnodes = self.get_nodes("machine",machatts,root=tnode)
             thistest = {}
 
-            if(machnodes):
+            if machnodes:
                 for key in tnode.attrib.keys():
-                    if(key == "name"):
+                    if key == "name":
                         thistest["testname"] = tnode.attrib[key]
                     else:
                         thistest[key] = tnode.attrib[key]
+
                 for mach in machnodes:
                     for key in mach.attrib.keys():
-                        if (key == "name"):
+                        if key == "name":
                             thistest["machine"] = mach.attrib[key]
                         else:
                             thistest[key] = mach.attrib[key]
-                    optionnodes = self.get_node("option", root=mach)
+                    optionnodes = self.get_nodes("option", root=mach)
                     for onode in optionnodes:
-                       thistest[onode.attrib['name']]=onode.text
+                       thistest[onode.attrib['name']] = onode.text
                     tests.append(thistest)
+
         return tests
 
     def get_tests(self, machine=None, category=None, compiler=None):
-        if (self.version == "1.0"):
-            return self._get_testsv1(machine,category,compiler)
-        elif (self.version == "2.0"):
-            return self._get_testsv2(machine,category,compiler)
+        if self.version == "1.0":
+            return self._get_testsv1(machine, category, compiler)
+        elif self.version == "2.0":
+            return self._get_testsv2(machine, category, compiler)
         else:
             logger.critical("Did not recognize testlist file version %s for file %s"
-                             % (self.version,self.filename))
+                             % (self.version, self.filename))
 

--- a/utils/python/CIME/XML/testspec.py
+++ b/utils/python/CIME/XML/testspec.py
@@ -11,21 +11,21 @@ _VERSION = "1.0"
 logger = logging.getLogger(__name__)
 
 class TestSpec(GenericXML):
-    def __init__(self,infile):
+
+    def __init__(self, infile):
         """
         initialize an object
         """
-        GenericXML.__init__(self,infile)
+        GenericXML.__init__(self, infile)
         self._testnodes = {}
-        if(os.path.isfile(infile)):
-            testnodes = self.get_node('test')
+        if os.path.isfile(infile):
+            testnodes = self.get_nodes('test')
             for node in testnodes:
                 self._testnodes[node.attrib["name"]] = node
         else:
-            self.root.set('version',_VERSION)
+            self.root.set('version', _VERSION)
 
-
-    def set_header(self, testroot, machine, testid, baselinetag=None,baselineroot=None):
+    def set_header(self, testroot, machine, testid, baselinetag=None, baselineroot=None):
         tlelem = ET.Element('testlist')
         elem = ET.Element('testroot')
         elem.text = testroot
@@ -36,36 +36,36 @@ class TestSpec(GenericXML):
         elem = ET.Element('testid')
         elem.text = testid
         tlelem.append(elem)
-        if(baselinetag is not None):
+        if baselinetag is not None:
             elem = ET.Element('baselinetag')
             elem.text = baselinetag
             tlelem.append(elem)
-        if(baselineroot is not None):
+        if baselineroot is not None:
             elem = ET.Element('baselineroot')
             elem.text = baselineroot
             tlelem.append(elem)
         self.add_child(tlelem)
         self._testlist_node = tlelem
 
-    def add_test(self,compiler, mpilib, testname):
-        expect(testname not in self._testnodes,"Test %s already in testlist" % testname)
+    def add_test(self, compiler, mpilib, testname):
+        expect(testname not in self._testnodes, "Test %s already in testlist" % testname)
         telem = ET.Element("test")
         telem.set("name", testname)
         elem = ET.Element("compiler")
-        elem.text=compiler
+        elem.text = compiler
         telem.append(elem)
         elem = ET.Element("mpilib")
-        elem.text=mpilib
+        elem.text = mpilib
         telem.append(elem)
         self.add_child(telem, root=self._testlist_node)
         self._testnodes[testname] = telem
 
     def update_test_status(self, testname, phase, status):
-        expect(testname in self._testnodes,"Test %s not defined in testlist" % testname)
+        expect(testname in self._testnodes, "Test %s not defined in testlist" % testname)
         root = self._testnodes[testname]
-        pnode = self.get_node("section", {"name":phase}, root=root)
-        if(pnode):
-           pnode[0].set("status", status)
+        pnode = self.get_optional_node("section", {"name":phase}, root=root)
+        if pnode is not None:
+           pnode.set("status", status)
         else:
             pnode = ET.Element("section")
             pnode.set("name", phase)

--- a/utils/python/CIME/env_module.py
+++ b/utils/python/CIME/env_module.py
@@ -29,8 +29,8 @@ class EnvModule(object):
     def load_env_for_case(self):
         mach_specific = EnvMachSpecific(caseroot=self._caseroot)
 
-        module_nodes = mach_specific.get_node("modules")
-        env_nodes    = mach_specific.get_node("environment_variables")
+        module_nodes = mach_specific.get_nodes("modules")
+        env_nodes    = mach_specific.get_nodes("environment_variables")
 
         if (module_nodes is not None):
             modules_to_load = self._compute_module_actions(module_nodes)

--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -172,12 +172,13 @@ class TestWaitForTests(unittest.TestCase):
     ###########################################################################
     def simple_test(self, testdir, expected_results, extra_args=""):
     ###########################################################################
-        stat, output, errput = run_cmd("%s/wait_for_tests -p ACME_test TestStatus* %s" % (TOOLS_DIR, extra_args), ok_to_fail=True, from_dir=testdir)
+        cmd = "%s/wait_for_tests -p ACME_test TestStatus* %s" % (TOOLS_DIR, extra_args)
+        stat, output, errput = run_cmd(cmd, ok_to_fail=True, from_dir=testdir)
         if (expected_results == ["PASS"]*len(expected_results)):
-            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\nwait_for_tests output:\n%s\n\nerrput:\n%s" % (output, errput))
+            self.assertEqual(stat, 0, msg="COMMAND '%s' SHOULD HAVE WORKED\nwait_for_tests output:\n%s\n\nerrput:\n%s" % (cmd, output, errput))
         else:
             self.assertEqual(stat, CIME.utils.TESTS_FAILED_ERR_CODE,
-                             msg="COMMAND SHOULD HAVE DETECTED FAILED TESTS\nwait_for_tests output:\n%s\n\nerrput:\n%s" % (output, errput))
+                             msg="COMMAND '%s' SHOULD HAVE DETECTED FAILED TESTS\nwait_for_tests output:\n%s\n\nerrput:\n%s" % (cmd, output, errput))
 
         lines = [line for line in output.splitlines() if line.startswith("Test '")]
         self.assertEqual(len(lines), 10)
@@ -366,11 +367,12 @@ class TestCreateTest(TestCreateTestCommon):
     ###########################################################################
     def simple_test(self, expect_works, extra_args):
     ###########################################################################
-        stat, output, errput = run_cmd("%s/create_test acme_test_only_pass %s" % (SCRIPT_DIR, extra_args), ok_to_fail=True)
+        cmd = "%s/create_test acme_test_only_pass %s" % (SCRIPT_DIR, extra_args)
+        stat, output, errput = run_cmd(cmd, ok_to_fail=True)
         if (expect_works):
-            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+            self.assertEqual(stat, 0, msg="COMMAND '%s' SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (cmd, output, errput, stat))
         else:
-            self.assertEqual(stat, CIME.utils.TESTS_FAILED_ERR_CODE, msg="COMMAND SHOULD HAVE DETECTED FAILED TESTS\ncreate_test output:\n%s\n\nerrput:\n%ss\n\ncode: %d" % (output, errput, stat))
+            self.assertEqual(stat, CIME.utils.TESTS_FAILED_ERR_CODE, msg="COMMAND '%s' SHOULD HAVE DETECTED FAILED TESTS\ncreate_test output:\n%s\n\nerrput:\n%ss\n\ncode: %d" % (cmd, output, errput, stat))
 
     ###############################################################################
     def test_create_test_rebless_namelist(self):
@@ -524,11 +526,12 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
     ###########################################################################
     def simple_test(self, expect_works, extra_args):
     ###########################################################################
-        stat, output, errput = run_cmd("%s/jenkins_generic_job %s" % (TOOLS_DIR, extra_args), ok_to_fail=True)
+        cmd = "%s/jenkins_generic_job %s" % (TOOLS_DIR, extra_args)
+        stat, output, errput = run_cmd(cmd, ok_to_fail=True)
         if (expect_works):
-            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
+            self.assertEqual(stat, 0, msg="COMMAND '%s' SHOULD HAVE WORKED\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (cmd, output, errput))
         else:
-            self.assertEqual(stat, CIME.utils.TESTS_FAILED_ERR_CODE, msg="COMMAND SHOULD HAVE DETECTED FAILED TESTS\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (output, errput))
+            self.assertEqual(stat, CIME.utils.TESTS_FAILED_ERR_CODE, msg="COMMAND '%s' SHOULD HAVE DETECTED FAILED TESTS\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (cmd, output, errput))
 
     ###########################################################################
     def threaded_test(self, expect_works, extra_args):
@@ -608,17 +611,18 @@ class TestBlessTestResults(TestCreateTestCommon):
     ###########################################################################
     def simple_test(self, expect_works, extra_args):
     ###########################################################################
-        stat, output, errput = run_cmd("%s/create_test %s %s" % (SCRIPT_DIR, self._test_name, extra_args), ok_to_fail=True)
+        cmd = "%s/create_test %s %s" % (SCRIPT_DIR, self._test_name, extra_args)
+        stat, output, errput = run_cmd(cmd, ok_to_fail=True)
 
         if (self._hasbatch):
-            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+            self.assertEqual(stat, 0, msg="COMMAND '%s' SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (cmd, output, errput, stat))
             test_id = extra_args.split()[extra_args.split().index("-t") + 1]
             stat, output, errput = run_cmd("%s/wait_for_tests *%s*/TestStatus" % (TOOLS_DIR, test_id), ok_to_fail=True, from_dir=self._testroot)
 
         if (expect_works):
-            self.assertEqual(stat, 0, msg="COMMAND SHOULD HAVE WORKED\nOutput:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
+            self.assertEqual(stat, 0, msg="COMMAND '%s' SHOULD HAVE WORKED\nOutput:\n%s\n\nerrput:\n%s\n\ncode: %d" % (cmd, output, errput, stat))
         else:
-            self.assertEqual(stat, CIME.utils.TESTS_FAILED_ERR_CODE, msg="COMMAND SHOULD HAVE DETECTED FAILED TESTS\nOutput:\n%s\n\nerrput:\n%ss\n\ncode: %d" % (output, errput, stat))
+            self.assertEqual(stat, CIME.utils.TESTS_FAILED_ERR_CODE, msg="COMMAND '%s' SHOULD HAVE DETECTED FAILED TESTS\nOutput:\n%s\n\nerrput:\n%ss\n\ncode: %d" % (cmd, output, errput, stat))
 
     ###############################################################################
     def test_create_test_rebless_namelist(self):
@@ -772,8 +776,10 @@ class TestCimeCase(TestCreateTestCommon):
         self.assertEqual(build_complete, "TRUE",
                          msg="Build complete had wrong value '%s'" % build_complete)
 
-def _main_func():
 ###############################################################################
+
+def _main_func():
+
     if ("--fast" in sys.argv):
         sys.argv.remove("--fast")
         global FAST_ONLY


### PR DESCRIPTION
Preparing for type-aware get_value.

1) Formatting changes all over to meet agreed-upon python coding convention
2) Split get_node into get_nodes, get_node, get_optional_node
3) Only accept string ids or XML elements, never both
4) Machines refactor: call super class for 'normal' get_node behavior, call Machine.get_node for machine-specific behavior