### PR TITLE
allow xmlchange to set one variable to another with --force option

### DIFF
--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -355,7 +355,7 @@
   </entry>
 
   <entry id="REST_N">
-    <type>char</type>
+    <type>integer</type>
     <default_value>$STOP_N</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -21,7 +21,7 @@ import argparse, doctest, shutil, glob
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n%s [<changeargs>] [--verbose][--file file][--id id][--val value][--noecho][--append][--warn]
+        usage="""\n%s [<changeargs>] [--verbose][--file file][--id id][--val value][--noecho][--append][--warn][--force]
 OR
 %s --help
 OR
@@ -69,6 +69,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-subgroup","--subgroup",
                         help="apply to this subgroup only")
 
+    parser.add_argument("-f","--force", action="store_true",
+                        help="ignore typing checks and store value")
+
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
@@ -77,10 +80,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     if( len(args.listofsettings) == 1 ):
         listofsettings = args.listofsettings[0].split(',')
 
-    return args.caseroot, listofsettings, args.file, args.id, args.val, args.subgroup, args.append, args.noecho, args.warn
+    return args.caseroot, listofsettings, args.file, args.id, args.val, args.subgroup, args.append, args.noecho, args.warn, args.force
 
 def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=None, subgroup=None,
-              append=None, noecho=False, warn=None):
+              append=None, noecho=False, warn=None, force=False):
     case = Case(caseroot)
     if(listofsettings ):
         for setting in listofsettings:
@@ -89,13 +92,15 @@ def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=No
             if(append is True):
                 value = case.get_value(xmlid, resolved=False, subgroup=subgroup)
                 xmlval = "%s %s" %(xmlval, value)
-            case.set_value(xmlid, convert_to_type(xmlval, type_str, xmlid), subgroup)
+            xmlval = convert_to_type(xmlval, type_str, xmlid, ok_to_fail=force)
+            case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
     else:
         if(append is True):
             value = case.get_value(xmlid, resolved=False, subgroup=subgroup)
             xmlval = "%s %s" %(xmlval, value)
         type_str = case.get_type_info(xmlid)
-        case.set_value(xmlid, convert_to_type(xmlval, type_str, xmlid), subgroup)
+        xmlval = convert_to_type(xmlval, type_str, xmlid, ok_to_fail=force)
+        case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
     case.flush()
 
     if(noecho is False):
@@ -110,9 +115,9 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup, append, noecho, warn = parse_command_line(sys.argv, description)
+    caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup, append, noecho, warn, force = parse_command_line(sys.argv, description)
 
-    xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup, append, noecho, warn)
+    xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup, append, noecho, warn, force)
 
 if (__name__ == "__main__"):
     _main_func(__doc__)

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -85,8 +85,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=None, subgroup=None,
               append=None, noecho=False, warn=None, force=False):
     case = Case(caseroot)
-    import pdb
-    pdb.set_trace()
     if(listofsettings ):
         for setting in listofsettings:
             (xmlid, xmlval) = setting.split('=', 1)

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -85,6 +85,8 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=None, subgroup=None,
               append=None, noecho=False, warn=None, force=False):
     case = Case(caseroot)
+    import pdb
+    pdb.set_trace()
     if(listofsettings ):
         for setting in listofsettings:
             (xmlid, xmlval) = setting.split('=', 1)
@@ -92,14 +94,16 @@ def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=No
             if(append is True):
                 value = case.get_value(xmlid, resolved=False, subgroup=subgroup)
                 xmlval = "%s %s" %(xmlval, value)
-            xmlval = convert_to_type(xmlval, type_str, xmlid, ok_to_fail=force)
+            if not force:
+                xmlval = convert_to_type(xmlval, type_str, xmlid)
             case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
     else:
         if(append is True):
             value = case.get_value(xmlid, resolved=False, subgroup=subgroup)
             xmlval = "%s %s" %(xmlval, value)
         type_str = case.get_type_info(xmlid)
-        xmlval = convert_to_type(xmlval, type_str, xmlid, ok_to_fail=force)
+        if not force:
+            xmlval = convert_to_type(xmlval, type_str, xmlid)
         case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
     case.flush()
 

--- a/utils/perl5lib/Config/SetupTools.pm
+++ b/utils/perl5lib/Config/SetupTools.pm
@@ -13,10 +13,10 @@ BEGIN{
 }
 #-----------------------------------------------------------------------------------------------
 # SYNOPSIS
-# 
+#
 # The following routines are contained here
 #
-# is_valid_value() 
+# is_valid_value()
 #       Returns true if the specified parameter name is contained in
 #       the configuration definition file, and either 1) the specified value is
 #       listed as a valid_value in the definition file, or 2) the definition file
@@ -63,12 +63,12 @@ sub expand_env
        $subst = $ENV{$1} unless defined $subst;
        $value =~ s/\$\{*${1}\}*/$subst/g;
     }
-    
+
     if ($value =~ /\$\{*[\w_]+\}*.*$/) {
-	$value = expand_env($value, $xmlvars_ref) 
+	$value = expand_env($value, $xmlvars_ref)
     }
-    return $value; 
-}       
+    return $value;
+}
 
 #-------------------------------------------------------------------------------
 sub expand_xml_var
@@ -96,43 +96,43 @@ sub expand_xml_var
 	    $value = expand_env($value, $xmlvars_ref) ;
 	}
     }
-	    
+
     if ($value =~ /\$\{*[\w_]+\}*.*$/) {
 	$value = expand_xml_var($value, $xmlvars_ref) ;
     }
-    return $value; 
-}       
+    return $value;
+}
 
 #-------------------------------------------------------------------------------
-sub getAllResolved 
+sub getAllResolved
 {
-    # hash for all the parsers, and a hash for  all the config variables. 
+    # hash for all the parsers, and a hash for  all the config variables.
     my %parsers;
     my %masterconfig;
-    
+
     # Get all the env*.xml files into an array...
     my @xmlfiles = qw( env_build.xml env_case.xml env_mach_pes.xml env_run.xml);
     push(@xmlfiles, "env_test.xml") if(-e "./env_test.xml");
     push(@xmlfiles, "env_archive.xml") if(-e "./env_archive.xml");
-    
-    # Set up a new XML::LibXML parser for each xml file. 
+
+    # Set up a new XML::LibXML parser for each xml file.
     foreach my $basefile(@xmlfiles)
     {
 	my $xml = XML::LibXML->new()->parse_file($basefile);
 	$parsers{$basefile} = $xml;
     }
-    
-    # find all the variable nodes. 
+
+    # find all the variable nodes.
     foreach my $basefile(@xmlfiles)
     {
-	my $parser = $parsers{$basefile};	
+	my $parser = $parsers{$basefile};
 	my @nodes = $parser->findnodes("//entry");
 	foreach my $node(@nodes)
 	{
 	    my $id = $node->getAttribute('id');
 	    my $value = $node->getAttribute('value');
-	    # if the variable value has an unresolved variable, 
-	    # we need to find it in whatever file it might be in. 
+	    # if the variable value has an unresolved variable,
+	    # we need to find it in whatever file it might be in.
 	    $value = _resolveValues($value, \%parsers);
 	    $masterconfig{$id} = $value;
 	}
@@ -153,13 +153,13 @@ sub getSingleResolved
     my @xmlfiles = qw (env_build.xml env_case.xml env_mach_pes.xml env_run.xml );
     push(@xmlfiles, "env_test.xml") if ( -e "./env_test.xml");
     push(@xmlfiles, "env_archive.xml") if ( -e "./env_archive.xml");
-    
+
     foreach my $basefile(@xmlfiles)
     {
         my $xml = XML::LibXML->new()->parse_file($basefile);
         $parsers{$basefile} = $xml;
     }
-        
+
     my @nodes;
     foreach my $basefile(@xmlfiles)
     {
@@ -173,7 +173,7 @@ sub getSingleResolved
             {
                 $value = _resolValues($value, \%parsers);
             }
-            
+
         }
         else
         {
@@ -188,7 +188,7 @@ sub getSingleResolved
     {
         return undef;
     }
-}           
+}
 
 #-------------------------------------------------------------------------------
 sub getxmlvars
@@ -218,7 +218,7 @@ sub set_compiler
     # first, then use the standard compiler file if it is not available.
     my ($os,$compiler_file, $compiler, $machine, $mpilib, $macrosfile, $output_format) = @_;
 
-    # Read compiler xml 
+    # Read compiler xml
     my @compiler_settings;
     my @files = ("$ENV{\"HOME\"}/.cime/config_compilers.xml", "$compiler_file");
     foreach my $file (@files) {
@@ -231,17 +231,17 @@ sub set_compiler
 		my $MACH     = $node->getAttribute('MACH');
 		my $OS       = $node->getAttribute('OS');
 		my $MPILIB   = $node->getAttribute('MPILIB');
-		
+
 		# Only pick up settings for which the defined attributes match
 		next if (defined $COMPILER && $COMPILER ne $compiler);
 		next if (defined $MACH     && $MACH     ne $machine );
 		next if (defined $OS       && $OS       ne $os      );
 		next if (defined $MPILIB   && $MPILIB   ne $mpilib  );
-		
+
 		# compiler settings comprises child xml nodes
 		push (@compiler_settings ,$node->findnodes(".//*"));
 	    }
-	}	
+	}
     }
     if ($#compiler_settings <= 0) {
 	$logger->logdie( "set_compiler: unrecognized compiler") unless($#compiler_settings);
@@ -263,7 +263,7 @@ sub set_compiler
 
 	my %a = ();
 	my @attrs = $flag->attributes();
-	
+
 	foreach my $attr (@attrs) {
 	    if(defined $attr){
 		my $attr_value = $attr->getValue();
@@ -367,20 +367,20 @@ sub set_compiler
 	    }elsif($_ =~ /FFLAGS/){
 		print MACROS "add_flags(CMAKE_Fortran_FLAGS $value)\n\n";
             }elsif($_ =~ /CPPDEFS/){
-		print MACROS "list(APPEND COMPILE_DEFINITIONS $value)\n\n"; 
+		print MACROS "list(APPEND COMPILE_DEFINITIONS $value)\n\n";
             }elsif($_ =~ /SLIBS/ or $_ =~ /LDFLAGS/){
-		print MACROS "add_flags(CMAKE_EXE_LINKER_FLAGS $value)\n\n"; 
+		print MACROS "add_flags(CMAKE_EXE_LINKER_FLAGS $value)\n\n";
 		#	    }elsif($_ =~ /^ADD_(.*)/){
 		#		print MACROS "add_flags($1 $value)\n\n";
 		#	    }else{
 		#		print MACROS "add_flags($_ $value)\n\n";
 	    }
-	}	
+	}
 
     }
-    # Recursively print the conditionals, combining tests to avoid repetition    
+    # Recursively print the conditionals, combining tests to avoid repetition
     _parse_hash($macros->{_COND_}, 0, $output_format);
-	
+
     close MACROS;
 }
 
@@ -392,7 +392,7 @@ sub is_valid_value
 
     # Check that a list value is not supplied when parameter takes a scalar value.
     unless ($is_list_value) {  # this conditional is satisfied when the list attribute is false, i.e., for scalars
-	if ($value =~ /.*,.*/) {    
+	if ($value =~ /.*,.*/) {
 	    # the pattern matches when $value contains a comma, i.e., is a list
  	    $logger->logdie( "Error is_valid_value; variable $id is a scalar but has a list value $value ");
 	}
@@ -400,13 +400,13 @@ sub is_valid_value
 
     # Check that the value is valid
     # if no valid values are specified, then $value is automatically valid
-    if ( $valid_values ne "" ) {  
+    if ( $valid_values ne "" ) {
 	if ($is_list_value) {
-	    unless (_list_value_ok($value, $valid_values)) { 
+	    unless (_list_value_ok($value, $valid_values)) {
 		$logger->logdie( "ERROR is_valid_value: $id has value $value which is not a valid value ");
 	    }
 	} else {
-	    unless (_value_ok($value, $valid_values)) { 
+	    unless (_value_ok($value, $valid_values)) {
 		$logger->logdie("ERROR is_valid_value: $id has value $value which is not a valid value ");
 	    }
 	}
@@ -450,12 +450,12 @@ sub validate_variable_value
     my $valreal_repeat = "${valint}\\*$valreal1|${valint}\\*$valreal2";
 
     # Match for all valid data-types: integer, real or logical
-    # note: valreal MUST come before valint in this string to prevent integer portion of real 
+    # note: valreal MUST come before valint in this string to prevent integer portion of real
     #       being separated from decimal portion
     my $valall = "$vallogical|$valreal|$valint";
 
     # Match for all valid data-types with repeater: integer, real, logical, or string data
-    # note: valrepeat MUST come before valall in this string to prevent integer repeat specifier 
+    # note: valrepeat MUST come before valall in this string to prevent integer repeat specifier
     #       being accepted alone as a value
     my $valrepeat = "$vallogical_repeat|$valreal_repeat|$valint_repeat";
 
@@ -497,7 +497,7 @@ sub validate_variable_value
 	    } elsif ( $$type_ref{'type'} eq "real" ) {
 		$compare = $valreal;
 	    } else {
-		$logger->logdie( "ERROR: in $nm (package $pkg_nm): Type of variable name $var is " . 
+		$logger->logdie( "ERROR: in $nm (package $pkg_nm): Type of variable name $var is " .
 		    "not a valid FORTRAN type (logical, integer, real, or char).");
 	    }
 	    if ( $i =~ /USERDEFINED/) {
@@ -530,7 +530,7 @@ sub _parse_hash
 			printf(MACROS "%${width}s"," ") if($width>0);
 			printf(MACROS "ifeq (\$(%s), %s) \n",$k1,$k2);
 		    }
-		    
+
 		    _parse_hash($href->{$k1}{$k2},$depth+1, $output_format, $k2);
 		}
 	    }
@@ -553,7 +553,7 @@ sub _parse_hash
 		    }elsif($k1 =~ /CPPDEF/){
 			printf(MACROS "add_config_definitions(DEBUG $value)\n\n");
 		    }elsif($_ =~ /SLIBS/ or $_ =~ /LDFLAGS/){
-			print MACROS "add_flags(CMAKE_EXE_LINKER_FLAGS_DEBUG $value)\n\n"; 
+			print MACROS "add_flags(CMAKE_EXE_LINKER_FLAGS_DEBUG $value)\n\n";
 		    }
 		}else{
 		    if($k1 =~ /CFLAGS/){
@@ -563,42 +563,42 @@ sub _parse_hash
 		    }elsif($k1 =~ /CPPDEF/){
 			printf(MACROS "add_config_definitions(RELEASE $value)\n\n");
 		    }elsif($_ =~ /SLIBS/ or $_ =~ /LDFLAGS/){
-			print MACROS "add_flags(CMAKE_EXE_LINKER_FLAGS_RELEASE $value)\n\n"; 
+			print MACROS "add_flags(CMAKE_EXE_LINKER_FLAGS_RELEASE $value)\n\n";
 		    }
-		}		    
+		}
 	    }
 	}
     }
     $width-=2;
     if($output_format eq "make"){
 	printf(MACROS "%${width}s"," ") if($width>0);
-	printf(MACROS "endif\n\n") if($depth>0) ;    
+	printf(MACROS "endif\n\n") if($depth>0) ;
     }
 }
 
 #-----------------------------------------------------------------------------------------------
 sub _resolveValues
 {
-    # Recursively resolve the unresolved vars in an variable value.  
+    # Recursively resolve the unresolved vars in an variable value.
     # Check the value passed in, and if it still has an unresolved var, keep calling the function
-    # until all pieces of the variable are resolved.  
+    # until all pieces of the variable are resolved.
 
     my $value = shift;
     my $parsers = shift;
 
     #print "in _resolveValues: value: $value\n";
-    # We want to resolve $values from either tthe other xml files, or 
-    # the value can come from the 
+    # We want to resolve $values from either tthe other xml files, or
+    # the value can come from the
     if($value =~ /(\$[\w_]+)/)
     {
 # too noisy
 #	$logger->debug( "in _resolveValues: value: $value\n");
 	my $unresolved = $1;
-	
+
 	#print "need to resolve: $unresolved\n";
 	my $needed = $unresolved;
 	$needed =~ s/\$//g;
-	
+
 	my $found = 0;
 	foreach my $parser(values %$parsers)
 	{
@@ -616,7 +616,7 @@ sub _resolveValues
 		}
 	    }
 	}
-	# Check the environment if not found in the xml files. 
+	# Check the environment if not found in the xml files.
 	if(!$found)
 	{
 	    if(exists $ENV{$needed})
@@ -627,7 +627,7 @@ sub _resolveValues
 	    }
 	}
 	#if the value is not found in any of the xml files or in the environment, then
-	# return undefined. 
+	# return undefined.
 	if(!$found)
 	{
 	    return undef;

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -57,12 +57,16 @@ class EntryID(GenericXML):
         else:
             return self._get_type_info(node)
 
-    def _set_value(self, node, vid, value, subgroup=None):
-        type_str = self._get_type_info(node)
-        node.set("value", convert_to_string(value, type_str, vid))
+    def _set_value(self, node, vid, value, subgroup=None, ignore_type=False):
+        if ignore_type:
+            expect(type(value) is str, "Value must be type string if ignore_type is true")
+            node.set("value",value)
+        else:
+            type_str = self._get_type_info(node)
+            node.set("value", convert_to_string(value, type_str, vid))
         return value
 
-    def set_value(self, vid, value, subgroup=None):
+    def set_value(self, vid, value, subgroup=None, ignore_type=False):
         """
         Set the value of an entry-id field to value
         Returns the value or None if not found
@@ -70,7 +74,7 @@ class EntryID(GenericXML):
         """
         node = self.get_optional_node("entry", {"id":vid})
         if node is not None:
-            return self._set_value(node, vid, value, subgroup)
+            return self._set_value(node, vid, value, subgroup, ignore_type)
         else:
             return None
 

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -15,20 +15,20 @@ class EnvBatch(EnvBase):
         """
         EnvBase.__init__(self, case_root, infile)
 
-    def set_value(self, item, value, subgroup=None):
+    def set_value(self, item, value, subgroup=None, ignore_type=False):
         val = None
         # allow the user to set all instances of item if subgroup is not provided
         if subgroup is None:
             nodes = self.get_nodes("entry", {"id":item})
             for node in nodes:
-                self._set_value(node, item, value)
+                self._set_value(node, item, value, ignore_type)
                 val = value
         else:
             nodes = self.get_nodes("job",{"name":subgroup})
             for node in nodes:
                 vnode = self.get_optional_node("entry", {"id":item}, root=node)
                 if vnode is not None:
-                    val = EnvBase.set_value(self, vnode, value)
+                    val = EnvBase.set_value(self, vnode, value, ignore_type)
 
         return val
 

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -144,7 +144,10 @@ class GenericXML(object):
 
         return result
 
-    def set_value(self, vid, value):
+    def set_value(self, vid, value, ignore_type=True):
+        """
+        ignore_type is not used in this flavor
+        """
         valnodes = self.get_nodes(vid)
         if valnodes:
             for node in valnodes:

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -92,9 +92,9 @@ class Case(object):
 
         return item
 
-    def set_value(self, item, value, subgroup=None):
+    def set_value(self, item, value, subgroup=None, ignore_type=False):
         for env_file in self._env_entryid_files:
-            result = env_file.set_value(item, value, subgroup)
+            result = env_file.set_value(item, value, subgroup, ignore_type)
             if (result is not None):
                 self._env_files_that_need_rewrite.add(env_file)
                 return result

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -581,7 +581,7 @@ def get_logging_options():
     else:
         return ""
 
-def convert_to_type(value, type_str, vid=""):
+def convert_to_type(value, type_str, vid="", ok_to_fail=False):
     """
     Convert value from string to another type.
     vid is only for generating better error messages.
@@ -595,42 +595,57 @@ def convert_to_type(value, type_str, vid=""):
             try:
                 value = int(value)
             except ValueError:
-                expect(False, "Entry %s was listed as type int but value '%s' is not valid int" % (vid, value))
+                if not ok_to_fail:
+                    expect(False, "Entry %s was listed as type int but value '%s' is not valid int" % (vid, value))
 
         elif type_str == "logical":
-            expect(value in ["TRUE", "FALSE","true","false"],
-                   "Entry %s was listed as type logical but had val '%s' instead of TRUE or FALSE" % (vid, value))
-            value = value == "TRUE" or value == "true"
+            if ok_to_fail:
+                pass
+            else:
+                expect(value in ["TRUE", "FALSE","true","false"],
+                       "Entry %s was listed as type logical but had val '%s' instead of TRUE or FALSE" % (vid, value))
+                value = value == "TRUE" or value == "true"
 
         elif type_str == "real":
             try:
                 value = float(value)
             except:
-                expect(False, "Entry %s was listed as type real but value '%s' is not valid real" % (vid, value))
+                if not ok_to_fail:
+                    expect(False, "Entry %s was listed as type real but value '%s' is not valid real" % (vid, value))
 
         else:
             expect(False, "Unknown type '%s'" % type_str)
 
     return value
 
-def convert_to_string(value, type_str, vid=""):
+def convert_to_string(value, type_str=None, vid=""):
     """
     Convert value back to string.
     vid is only for generating better error messages.
     """
     if value is not None:
-        if type_str == "char":
-            expect(type(value) is str, "Wrong type for entry id '%s'" % vid)
-        elif type_str == "integer":
-            expect(type(value) is int, "Wrong type for entry id '%s'" % vid)
-            value = str(value)
-        elif type_str == "logical":
-            expect(type(value) is bool, "Wrong type for entry id '%s'" % vid)
-            value = "TRUE" if value else "FALSE"
-        elif type_str == "real":
-            expect(type(value) is float, "Wrong type for entry id '%s'" % vid)
-            value = str(value)
+        if type_str is None:
+            if type(value) is str:
+                pass
+            elif type(value) is bool:
+                value = "TRUE" if value else "FALSE"
+            elif type(value) is int or type(value) is float:
+                value = str(value)
+            else:
+                expect(False, "Unknown type '%s'" % type_str)
         else:
-            expect(False, "Unknown type '%s'" % type_str)
+            if type_str == "char":
+                expect(type(value) is str, "Wrong type for entry id '%s'" % vid)
+            elif type_str == "integer":
+                expect(type(value) is int, "Wrong type for entry id '%s'" % vid)
+                value = str(value)
+            elif type_str == "logical":
+                expect(type(value) is bool, "Wrong type for entry id '%s'" % vid)
+                value = "TRUE" if value else "FALSE"
+            elif type_str == "real":
+                expect(type(value) is float, "Wrong type for entry id '%s'" % vid)
+                value = str(value)
+            else:
+                expect(False, "Unknown type '%s'" % type_str)
 
     return value

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -581,7 +581,7 @@ def get_logging_options():
     else:
         return ""
 
-def convert_to_type(value, type_str, vid="", ok_to_fail=False):
+def convert_to_type(value, type_str, vid=""):
     """
     Convert value from string to another type.
     vid is only for generating better error messages.
@@ -595,57 +595,42 @@ def convert_to_type(value, type_str, vid="", ok_to_fail=False):
             try:
                 value = int(value)
             except ValueError:
-                if not ok_to_fail:
-                    expect(False, "Entry %s was listed as type int but value '%s' is not valid int" % (vid, value))
+                expect(False, "Entry %s was listed as type int but value '%s' is not valid int" % (vid, value))
 
         elif type_str == "logical":
-            if ok_to_fail:
-                pass
-            else:
-                expect(value in ["TRUE", "FALSE","true","false"],
-                       "Entry %s was listed as type logical but had val '%s' instead of TRUE or FALSE" % (vid, value))
-                value = value == "TRUE" or value == "true"
+            expect(value in ["TRUE", "FALSE","true","false"],
+                   "Entry %s was listed as type logical but had val '%s' instead of TRUE or FALSE" % (vid, value))
+            value = value == "TRUE" or value == "true"
 
         elif type_str == "real":
             try:
                 value = float(value)
             except:
-                if not ok_to_fail:
-                    expect(False, "Entry %s was listed as type real but value '%s' is not valid real" % (vid, value))
+                expect(False, "Entry %s was listed as type real but value '%s' is not valid real" % (vid, value))
 
         else:
             expect(False, "Unknown type '%s'" % type_str)
 
     return value
 
-def convert_to_string(value, type_str=None, vid=""):
+def convert_to_string(value, type_str, vid=""):
     """
     Convert value back to string.
     vid is only for generating better error messages.
     """
     if value is not None:
-        if type_str is None:
-            if type(value) is str:
-                pass
-            elif type(value) is bool:
-                value = "TRUE" if value else "FALSE"
-            elif type(value) is int or type(value) is float:
-                value = str(value)
-            else:
-                expect(False, "Unknown type '%s'" % type_str)
+        if type_str == "char":
+            expect(type(value) is str, "Wrong type for entry id '%s'" % vid)
+        elif type_str == "integer":
+            expect(type(value) is int, "Wrong type for entry id '%s'" % vid)
+            value = str(value)
+        elif type_str == "logical":
+            expect(type(value) is bool, "Wrong type for entry id '%s'" % vid)
+            value = "TRUE" if value else "FALSE"
+        elif type_str == "real":
+            expect(type(value) is float, "Wrong type for entry id '%s'" % vid)
+            value = str(value)
         else:
-            if type_str == "char":
-                expect(type(value) is str, "Wrong type for entry id '%s'" % vid)
-            elif type_str == "integer":
-                expect(type(value) is int, "Wrong type for entry id '%s'" % vid)
-                value = str(value)
-            elif type_str == "logical":
-                expect(type(value) is bool, "Wrong type for entry id '%s'" % vid)
-                value = "TRUE" if value else "FALSE"
-            elif type_str == "real":
-                expect(type(value) is float, "Wrong type for entry id '%s'" % vid)
-                value = str(value)
-            else:
-                expect(False, "Unknown type '%s'" % type_str)
+            expect(False, "Unknown type '%s'" % type_str)
 
     return value


### PR DESCRIPTION
You should be able to set an xml variable to the value of another using xmlchange
This PR implements that functionality by adding a --force option to the xmlchange command
and providing a code path that ignores the strong typing rules.