### PR TITLE
read in soft keys in python the same way it is done in perl

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -656,8 +656,8 @@
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/a_softenv.csh</init_path>
       <init_path lang="sh">/etc/profile.d/a_softenv.sh</init_path>
-      <cmd_path lang="csh">/soft/softenv/1.6.2/bin/soft-dec csh</cmd_path>
-      <cmd_path lang="sh">/soft/softenv/1.6.2/bin/soft-dec sh</cmd_path>
+      <cmd_path lang="csh">soft</cmd_path>
+      <cmd_path lang="sh">soft</cmd_path>
       <modules compiler="gnu">
 	<command name="add">+gcc-5.2</command>
 	<command name="add">+netcdf-4.3.3.1-gnu5.2-serial</command>


### PR DESCRIPTION
The current cime4 perl implementation of soft modules involve creating a temporary sh or csh script that sources the init_path file and then adds each soft key using the cmd_path value (`soft`). This script is then run and the new environment compared against the old environment. This is incompatible with the python implementation I initially wrote which runs successive cmd_path (`/soft/softenv/1.6.2/bin/soft-dec sh`) commands (soft-dec prints out the commands used to set the environment) and parses the output to set the environment variables.

The python scripts worked fine, but the perl scripts did not set the soft keys correctly would cause the user's default soft keys to be used.

Now both perl and python accept the `soft` command as the cmd_path value.