### PR TITLE
blues doesn't allow '-q' PBS batch option, this disables the pbs batc…

### DIFF
--- a/utils/python/CIME/XML/batch.py
+++ b/utils/python/CIME/XML/batch.py
@@ -107,7 +107,6 @@ class Batch(GenericXML):
         for node in nodes:
             directive = self.get_resolved_value("" if node.text is None else node.text)
             directive = batch_maker.transform_vars(directive, default=node.get("default"))
-            if directive != ' -q ':
-                result.append("%s %s" % (directive_prefix, directive))
+            result.append("%s %s" % (directive_prefix, directive))
 
         return result

--- a/utils/python/CIME/XML/batch.py
+++ b/utils/python/CIME/XML/batch.py
@@ -107,7 +107,7 @@ class Batch(GenericXML):
         for node in nodes:
             directive = self.get_resolved_value("" if node.text is None else node.text)
             directive = batch_maker.transform_vars(directive, default=node.get("default"))
-
-            result.append("%s %s" % (directive_prefix, directive))
+            if directive != ' -q ':
+                result.append("%s %s" % (directive_prefix, directive))
 
         return result

--- a/utils/python/CIME/batch_maker.py
+++ b/utils/python/CIME/batch_maker.py
@@ -228,7 +228,6 @@ within model's Machines directory, and add a batch system type for this machine
             m = directive_re.search(text)
             variable = m.groups()[0]
             whole_match = m.group()
-
             if hasattr(self, variable.lower()) and getattr(self, variable.lower()) is not None:
                 repl = getattr(self, variable.lower())
                 text = text.replace(whole_match, str(repl))
@@ -238,8 +237,12 @@ within model's Machines directory, and add a batch system type for this machine
             elif default is not None:
                 text = text.replace(whole_match, default)
             else:
-                logger.warn("Could not replace variable '%s'" % variable)
-                text = text.replace(whole_match, "")
+                # If no queue exists, then the directive '-q' by itself will cause an error
+                if text.find('-q {{ queue }}')>0:
+                    text = ""
+                else:
+                    logger.warn("Could not replace variable '%s'" % variable)
+                    text = text.replace(whole_match, "")
 
         return text
 


### PR DESCRIPTION
Resolves #128 

Blues doesn't allow #PBS -q <queue> in case.run

This PR just checks to see if the directive line is ' -q ' and ignores it (-q itself will cause errors).

There may be a better fix for this, please feel free to opine.
