### PR TITLE
Bluesport

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -77,10 +77,13 @@
     <batch_directive>#PBS</batch_directive>
     <jobid_pattern>^(\d+)\.</jobid_pattern>
     <depend_string> -W depend=afterok:jobid</depend_string>
+    <submit_args>
+      <arg flag="-q" name="JOB_QUEUE"/>
+      <arg flag="-l walltime=" name="JOB_WALLCLOCK_TIME"/>
+      <arg flag="-A" name="PROJECT"/>
+    </submit_args>
     <directives>
       <directive> -N {{ job_id }}</directive>
-      <directive> -q {{ queue }}</directive>
-      <directive> -l walltime={{ wall_time }}</directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
       <!-- <directive> -j oe {{ output_error_path }} </directive> -->
       <directive> -j oe </directive>
@@ -127,7 +130,7 @@
     <!-- blues is PBS -->
     <batch_system MACH="blues" version="x.y">
       <directives>
-        <directive>-A {{ project }}</directive>
+        <directive>-A {{ PROJECT }}</directive>
         <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
       </directives>
     </batch_system>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -598,6 +598,9 @@
          <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	 <PROJECT>ACME</PROJECT>
          <batch_system type="pbs" version="x.y">
+	   <queues>
+	     <queue>shared</queue>
+           </queues>
            <walltimes>
              <walltime default="true">15:00</walltime>
            </walltimes>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -574,7 +574,7 @@
 
 <machine MACH="blues">
          <DESC>ANL/LCRC Linux Cluster</DESC>
-         <NODENAME_REGEX>blogin</NODENAME_REGEX>
+         <NODENAME_REGEX>(blogin|^b\d)</NODENAME_REGEX>
          <TESTS>acme_integration,acme_developer</TESTS>
          <COMPILERS>gnu,intel</COMPILERS>
          <MPILIBS>mvapich</MPILIBS>

--- a/cime_config/acme/machines/template.case.run
+++ b/cime_config/acme/machines/template.case.run
@@ -47,9 +47,16 @@ def parse_command_line(args):
 
     CIME.utils.setup_standard_logging_options(parser)
 
+    parser.add_argument("--caseroot", default=os.getcwd(),
+                        help="Case directory to build")
+
     args = parser.parse_args()
 
     CIME.utils.handle_standard_logging_options(args)
+
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
+    return args.caseroot
 
 ###############################################################################
 def preRunCheck(case):
@@ -284,10 +291,10 @@ def _main_func():
 
     # Set up the run, run the model, do the postrun steps
 
-    parse_command_line(sys.argv)
+    caseroot = parse_command_line(sys.argv)
 
-    case = Case()
-
+    case = Case(caseroot)
+    print "Caseroot is %s"%caseroot
     run_with_submit = case.get_value("RUN_WITH_SUBMIT")
     expect (run_with_submit,
              "You are not calling the run script via the submit script. "

--- a/cime_config/acme/machines/template.case.run
+++ b/cime_config/acme/machines/template.case.run
@@ -25,9 +25,9 @@ from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.preview_namelists         import preview_namelists
 import gzip
 
-workdir = os.environ.get("PBS_O_WORKDIR")
-if workdir is not None:
-    os.chdir(workdir)
+#workdir = os.environ.get("PBS_O_WORKDIR")
+#if workdir is not None:
+#    os.chdir(workdir)
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ def parse_command_line(args):
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    parser.add_argument("--caseroot", default=os.getcwd(),
+    parser.add_argument("--caseroot", 
                         help="Case directory to build")
 
     args = parser.parse_args()
@@ -292,14 +292,14 @@ def _main_func():
     # Set up the run, run the model, do the postrun steps
 
     caseroot = parse_command_line(sys.argv)
-
     case = Case(caseroot)
-    print "Caseroot is %s"%caseroot
     run_with_submit = case.get_value("RUN_WITH_SUBMIT")
+    logger.warn("run_with_submit is %s"%str(run_with_submit))
+    logger.warn("caseroot is %s"%caseroot)
     expect (run_with_submit,
              "You are not calling the run script via the submit script. "
              "As a result, short-term archiving will not be called automatically."
-             "Please submit your run by runnint the submit script like so:"
+             "Please submit your run using the submit script like so:"
             " ./case.submit")
 
     data_assimilation = case.get_value("DATA_ASSIMILATION")

--- a/cime_config/acme/machines/template.case.run
+++ b/cime_config/acme/machines/template.case.run
@@ -25,10 +25,6 @@ from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.preview_namelists         import preview_namelists
 import gzip
 
-#workdir = os.environ.get("PBS_O_WORKDIR")
-#if workdir is not None:
-#    os.chdir(workdir)
-
 logger = logging.getLogger(__name__)
 
 # Batch system directives
@@ -294,8 +290,6 @@ def _main_func():
     caseroot = parse_command_line(sys.argv)
     case = Case(caseroot)
     run_with_submit = case.get_value("RUN_WITH_SUBMIT")
-    logger.warn("run_with_submit is %s"%str(run_with_submit))
-    logger.warn("caseroot is %s"%caseroot)
     expect (run_with_submit,
              "You are not calling the run script via the submit script. "
              "As a result, short-term archiving will not be called automatically."

--- a/cime_config/acme/machines/template.case.test
+++ b/cime_config/acme/machines/template.case.test
@@ -57,6 +57,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.handle_standard_logging_options(args)
 
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
+
     return args.caseroot, args.testname
 
 def cimetest(caseroot, testname=None):
@@ -65,6 +68,7 @@ def cimetest(caseroot, testname=None):
     if(testname is None):
         testname = case.get_value('TESTCASE')
 
+    expect(testname is not None,"testname argument not resolved %s"%caseroot)
     logging.warn("Running test for %s"%testname)
 
     test = globals()[testname](caseroot, case)

--- a/cime_config/acme/machines/template.case.test
+++ b/cime_config/acme/machines/template.case.test
@@ -6,10 +6,6 @@
 """
 import os, sys
 
-#workdir = os.environ.get("PBS_O_WORKDIR")
-#if workdir is not None:
-#    os.chdir(workdir)
-
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
     raise SystemExit("ERROR: must set CIMEROOT environment variable")

--- a/cime_config/acme/machines/template.case.test
+++ b/cime_config/acme/machines/template.case.test
@@ -6,9 +6,9 @@
 """
 import os, sys
 
-workdir = os.environ.get("PBS_O_WORKDIR")
-if workdir is not None:
-    os.chdir(workdir)
+#workdir = os.environ.get("PBS_O_WORKDIR")
+#if workdir is not None:
+#    os.chdir(workdir)
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -50,7 +50,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("testname", nargs="?",default=None,
                         help="Name of the test to run, default is set in TESTCASE in env_test.xml")
 
-    parser.add_argument("--caseroot", default=os.getcwd(),
+    parser.add_argument("--caseroot", 
                         help="Case directory to build")
 
     args = parser.parse_args(args[1:])

--- a/cime_config/acme/machines/template.lt_archive
+++ b/cime_config/acme/machines/template.lt_archive
@@ -17,10 +17,6 @@ from CIME.XML.standard_module_setup import *
 from CIME.case                      import Case
 from CIME.utils                     import expect, get_model, run_cmd, does_file_have_string, appendStatus
 
-#workdir = os.environ.get("PBS_O_WORKDIR")
-#if workdir is not None:
-#    os.chdir(workdir)
-
 logger = logging.getLogger(__name__)
 
 # Batch system directives

--- a/cime_config/acme/machines/template.lt_archive
+++ b/cime_config/acme/machines/template.lt_archive
@@ -36,9 +36,15 @@ def parse_command_line(args):
 
     CIME.utils.setup_standard_logging_options(parser)
 
+    parser.add_argument("--caseroot", default=os.getcwd(),
+                        help="Case directory to build")
+
     args = parser.parse_args()
 
     CIME.utils.handle_standard_logging_options(args)
+
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
 
 ###############################################################################
 def _main_func():

--- a/cime_config/acme/machines/template.lt_archive
+++ b/cime_config/acme/machines/template.lt_archive
@@ -17,9 +17,9 @@ from CIME.XML.standard_module_setup import *
 from CIME.case                      import Case
 from CIME.utils                     import expect, get_model, run_cmd, does_file_have_string, appendStatus
 
-workdir = os.environ.get("PBS_O_WORKDIR")
-if workdir is not None:
-    os.chdir(workdir)
+#workdir = os.environ.get("PBS_O_WORKDIR")
+#if workdir is not None:
+#    os.chdir(workdir)
 
 logger = logging.getLogger(__name__)
 

--- a/cime_config/acme/machines/template.st_archive
+++ b/cime_config/acme/machines/template.st_archive
@@ -36,9 +36,15 @@ def parse_command_line(args):
 
     CIME.utils.setup_standard_logging_options(parser)
 
+    parser.add_argument("--caseroot", default=os.getcwd(),
+                        help="Case directory to build")
+
     args = parser.parse_args()
 
     CIME.utils.handle_standard_logging_options(args)
+
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
 
 ###############################################################################
 def _main_func():

--- a/cime_config/acme/machines/template.st_archive
+++ b/cime_config/acme/machines/template.st_archive
@@ -17,10 +17,6 @@ from CIME.XML.standard_module_setup import *
 from CIME.case                      import Case
 from CIME.utils                     import get_model, run_cmd, appendStatus
 
-#workdir = os.environ.get("PBS_O_WORKDIR")
-#if workdir is not None:
-#    os.chdir(workdir)
-
 logger = logging.getLogger(__name__)
 
 # Batch system directives

--- a/cime_config/acme/machines/template.st_archive
+++ b/cime_config/acme/machines/template.st_archive
@@ -17,9 +17,9 @@ from CIME.XML.standard_module_setup import *
 from CIME.case                      import Case
 from CIME.utils                     import get_model, run_cmd, appendStatus
 
-workdir = os.environ.get("PBS_O_WORKDIR")
-if workdir is not None:
-    os.chdir(workdir)
+#workdir = os.environ.get("PBS_O_WORKDIR")
+#if workdir is not None:
+#    os.chdir(workdir)
 
 logger = logging.getLogger(__name__)
 

--- a/cime_config/cesm/machines/template.case.run
+++ b/cime_config/cesm/machines/template.case.run
@@ -25,10 +25,6 @@ from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.preview_namelists         import preview_namelists
 import gzip
 
-#workdir = os.environ.get("PBS_O_WORKDIR")
-#if workdir is not None:
-#    os.chdir(workdir)
-
 logger = logging.getLogger(__name__)
 
 # Batch system directives
@@ -294,8 +290,6 @@ def _main_func():
     caseroot = parse_command_line(sys.argv)
     case = Case(caseroot)
     run_with_submit = case.get_value("RUN_WITH_SUBMIT")
-    logger.warn("run_with_submit is %s"%str(run_with_submit))
-    logger.warn("caseroot is %s"%caseroot)
     expect (run_with_submit,
              "You are not calling the run script via the submit script. "
              "As a result, short-term archiving will not be called automatically."

--- a/cime_config/cesm/machines/template.case.run
+++ b/cime_config/cesm/machines/template.case.run
@@ -25,9 +25,9 @@ from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.preview_namelists         import preview_namelists
 import gzip
 
-workdir = os.environ.get("PBS_O_WORKDIR")
-if workdir is not None:
-    os.chdir(workdir)
+#workdir = os.environ.get("PBS_O_WORKDIR")
+#if workdir is not None:
+#    os.chdir(workdir)
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +47,16 @@ def parse_command_line(args):
 
     CIME.utils.setup_standard_logging_options(parser)
 
+    parser.add_argument("--caseroot", 
+                        help="Case directory to build")
+
     args = parser.parse_args()
 
     CIME.utils.handle_standard_logging_options(args)
+
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
+    return args.caseroot
 
 ###############################################################################
 def preRunCheck(case):
@@ -284,15 +291,15 @@ def _main_func():
 
     # Set up the run, run the model, do the postrun steps
 
-    parse_command_line(sys.argv)
-
-    case = Case()
-
+    caseroot = parse_command_line(sys.argv)
+    case = Case(caseroot)
     run_with_submit = case.get_value("RUN_WITH_SUBMIT")
+    logger.warn("run_with_submit is %s"%str(run_with_submit))
+    logger.warn("caseroot is %s"%caseroot)
     expect (run_with_submit,
              "You are not calling the run script via the submit script. "
              "As a result, short-term archiving will not be called automatically."
-             "Please submit your run by runnint the submit script like so:"
+             "Please submit your run using the submit script like so:"
             " ./case.submit")
 
     data_assimilation = case.get_value("DATA_ASSIMILATION")

--- a/cime_config/cesm/machines/template.case.test
+++ b/cime_config/cesm/machines/template.case.test
@@ -6,9 +6,9 @@
 """
 import os, sys
 
-workdir = os.environ.get("PBS_O_WORKDIR")
-if workdir is not None:
-    os.chdir(workdir)
+#workdir = os.environ.get("PBS_O_WORKDIR")
+#if workdir is not None:
+#    os.chdir(workdir)
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -50,12 +50,15 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("testname", nargs="?",default=None,
                         help="Name of the test to run, default is set in TESTCASE in env_test.xml")
 
-    parser.add_argument("--caseroot", default=os.getcwd(),
+    parser.add_argument("--caseroot", 
                         help="Case directory to build")
 
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
+
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
 
     return args.caseroot, args.testname
 
@@ -65,6 +68,7 @@ def cimetest(caseroot, testname=None):
     if(testname is None):
         testname = case.get_value('TESTCASE')
 
+    expect(testname is not None,"testname argument not resolved %s"%caseroot)
     logging.warn("Running test for %s"%testname)
 
     test = globals()[testname](caseroot, case)

--- a/cime_config/cesm/machines/template.case.test
+++ b/cime_config/cesm/machines/template.case.test
@@ -6,10 +6,6 @@
 """
 import os, sys
 
-#workdir = os.environ.get("PBS_O_WORKDIR")
-#if workdir is not None:
-#    os.chdir(workdir)
-
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
     raise SystemExit("ERROR: must set CIMEROOT environment variable")

--- a/cime_config/cesm/machines/template.lt_archive
+++ b/cime_config/cesm/machines/template.lt_archive
@@ -17,10 +17,6 @@ from CIME.XML.standard_module_setup import *
 from CIME.case                      import Case
 from CIME.utils                     import expect, get_model, run_cmd, does_file_have_string, appendStatus
 
-#workdir = os.environ.get("PBS_O_WORKDIR")
-#if workdir is not None:
-#    os.chdir(workdir)
-
 logger = logging.getLogger(__name__)
 
 # Batch system directives

--- a/cime_config/cesm/machines/template.lt_archive
+++ b/cime_config/cesm/machines/template.lt_archive
@@ -17,9 +17,9 @@ from CIME.XML.standard_module_setup import *
 from CIME.case                      import Case
 from CIME.utils                     import expect, get_model, run_cmd, does_file_have_string, appendStatus
 
-workdir = os.environ.get("PBS_O_WORKDIR")
-if workdir is not None:
-    os.chdir(workdir)
+#workdir = os.environ.get("PBS_O_WORKDIR")
+#if workdir is not None:
+#    os.chdir(workdir)
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +36,15 @@ def parse_command_line(args):
 
     CIME.utils.setup_standard_logging_options(parser)
 
+    parser.add_argument("--caseroot", default=os.getcwd(),
+                        help="Case directory to build")
+
     args = parser.parse_args()
 
     CIME.utils.handle_standard_logging_options(args)
+
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
 
 ###############################################################################
 def _main_func():

--- a/cime_config/cesm/machines/template.st_archive
+++ b/cime_config/cesm/machines/template.st_archive
@@ -17,9 +17,9 @@ from CIME.XML.standard_module_setup import *
 from CIME.case                      import Case
 from CIME.utils                     import get_model, run_cmd, appendStatus
 
-workdir = os.environ.get("PBS_O_WORKDIR")
-if workdir is not None:
-    os.chdir(workdir)
+#workdir = os.environ.get("PBS_O_WORKDIR")
+#if workdir is not None:
+#    os.chdir(workdir)
 
 logger = logging.getLogger(__name__)
 
@@ -36,9 +36,15 @@ def parse_command_line(args):
 
     CIME.utils.setup_standard_logging_options(parser)
 
+    parser.add_argument("--caseroot", default=os.getcwd(),
+                        help="Case directory to build")
+
     args = parser.parse_args()
 
     CIME.utils.handle_standard_logging_options(args)
+
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
 
 ###############################################################################
 def _main_func():

--- a/cime_config/cesm/machines/template.st_archive
+++ b/cime_config/cesm/machines/template.st_archive
@@ -17,10 +17,6 @@ from CIME.XML.standard_module_setup import *
 from CIME.case                      import Case
 from CIME.utils                     import get_model, run_cmd, appendStatus
 
-#workdir = os.environ.get("PBS_O_WORKDIR")
-#if workdir is not None:
-#    os.chdir(workdir)
-
 logger = logging.getLogger(__name__)
 
 # Batch system directives

--- a/scripts/manage_case
+++ b/scripts/manage_case
@@ -83,7 +83,7 @@ def query_component(name):
     # Loop through the elements for each component class (in config_files.xml)
     # and see if there is a match for the the target component in the component attribute
     match_found = False
-    valid_components = list()
+    valid_components = []
     for comp in components:
         string = "CONFIG_%s_FILE"%comp
 

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -48,7 +48,7 @@ class SystemTestsCommon(object):
 
 
     def run(self):
-        
+        logger.warn( "here caseroot is %s"%self._caseroot)
         rc, out, err = run_cmd("./case.run --caseroot %s"%self._caseroot, ok_to_fail=True)
         if rc == 0 and self.coupler_log_indicates_run_complete():
             self._runstatus = "PASS"

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -48,7 +48,6 @@ class SystemTestsCommon(object):
 
 
     def run(self):
-        logger.warn( "here caseroot is %s"%self._caseroot)
         rc, out, err = run_cmd("./case.run --caseroot %s"%self._caseroot, ok_to_fail=True)
         if rc == 0 and self.coupler_log_indicates_run_complete():
             self._runstatus = "PASS"

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -91,7 +91,7 @@ class SystemTestsCommon(object):
         Examine memory usage as recorded in the cpl log file and look for unexpected
         increases.
         """
-        memlist = list()
+        memlist = []
         meminfo = re.compile(".*model date =\s+(\w+).*memory =\s+(\d+\.?\d+).*highwater")
         if cpllog is not None:
             with gzip.open(cpllog, "rb") as f:

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -18,7 +18,6 @@ class SystemTestsCommon(object):
         does not exist copy the current env_run.xml file.  If it does exist restore values
         changed in a previous run of the test.
         """
-        print caseroot
         self._caseroot = caseroot
         self._runstatus = None
         # Needed for sh scripts
@@ -36,7 +35,7 @@ class SystemTestsCommon(object):
                 os.stat(lockedfiles)
             except:
                 os.mkdir(lockedfiles)
-            shutil.copy("env_run.xml",
+            shutil.copy(os.path.join(caseroot,"env_run.xml"),
                         os.path.join(lockedfiles, "env_run.orig.xml"))
 
         self._case.set_initial_test_values()
@@ -49,7 +48,8 @@ class SystemTestsCommon(object):
 
 
     def run(self):
-        rc, out, err = run_cmd("./case.run", ok_to_fail=True)
+        
+        rc, out, err = run_cmd("./case.run --caseroot %s"%self._caseroot, ok_to_fail=True)
         if rc == 0 and self.coupler_log_indicates_run_complete():
             self._runstatus = "PASS"
         else:

--- a/utils/python/CIME/XML/batch.py
+++ b/utils/python/CIME/XML/batch.py
@@ -115,7 +115,7 @@ class Batch(GenericXML):
         Return a list of jobs with the first element the name of the case script
         and the second a dict of qualifiers for the job
         """
-        jobs = list()
+        jobs = []
         bnode = self.get_node("batch_jobs")
         for jnode in bnode:
             if jnode.tag == "job":
@@ -132,11 +132,11 @@ class Batch(GenericXML):
         '''
         return a list of touples (flag, name)
         '''
-        values = list()
+        values = []
         bs_nodes = self.get_nodes("batch_system",{"type":self.batch_system})
         if machine is not None:
             bs_nodes += self.get_nodes("batch_system",{"MACH":machine})
-        submit_arg_nodes = list()
+        submit_arg_nodes = []
         for node in bs_nodes:
             submit_arg_nodes += self.get_nodes("arg",root=node)
         for arg in submit_arg_nodes:

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -34,6 +34,17 @@ class EntryID(GenericXML):
             value = ""
         return value
 
+    def set_default_value(self, vid, val, attributes={}):
+        node = self.get_optional_node("entry", {"id":vid})
+        if node is not None:
+            default_node = self.get_optional_node("default_value", root=node)
+            if default_node is not None:
+                default_node.text = val
+            else:
+                logger.warn("Called set_default_value on a node without default_value field")
+
+        return val
+
     def get_value_match(self, vid, attributes={}):
         # Handle this case:
         # <entry id ...>

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -105,3 +105,16 @@ class EnvBatch(EnvBase):
                 newjob.append(deepcopy(child))
             group.append(newjob)
 
+    def cleanupnode(self, node):
+        if node.get("id") == "batch_system":
+            fnode = node.find(".//file")
+            node.remove(fnode)
+            gnode = node.find(".//group")
+            node.remove(gnode)
+            vnode = node.find(".//values")
+            if vnode is not None:
+                node.remove(vnode)
+        else:
+            node = EnvBase.cleanupnode(self, node)
+        return node
+

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -69,7 +69,7 @@ class EnvBatch(EnvBase):
         return type_info
 
     def get_jobs(self):
-        result = list()
+        result = []
         for node in self.get_nodes("job"):
             name = node.get("name")
             pdict = {}
@@ -85,7 +85,7 @@ class EnvBatch(EnvBase):
         group = self.get_node("group", {"id":"job_submission"})
         # look to see if any jobs are already defined
         cjobs = self.get_jobs()
-        childnodes = list()
+        childnodes = []
 
         expect(len(cjobs)==0," Looks like job groups have already been created")
 

--- a/utils/python/CIME/XML/files.py
+++ b/utils/python/CIME/XML/files.py
@@ -24,7 +24,7 @@ class Files(EntryID):
     def get_components(self, nodename, resolved=True):
         node = self.get_optional_node("entry", {"id":nodename})
         valnodes = self.get_nodes("value", root=node)
-        values = list();
+        values = []
         for valnode in valnodes:
             value = valnode.get("component")
             values.append(value)

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -225,7 +225,7 @@ class Machines(GenericXML):
         >>> machobj.is_valid_MPIlib("mpi-serial")
         True
         """
-        if self.get_field_from_list("MPILIBS", mpilib) is not None:
+        if mpilib == "mpi-serial" or self.get_field_from_list("MPILIBS", mpilib) is not None:
             return True
         return False
 

--- a/utils/python/CIME/batch_maker.py
+++ b/utils/python/CIME/batch_maker.py
@@ -234,8 +234,8 @@ within model's Machines directory, and add a batch system type for this machine
             if hasattr(self, variable.lower()) and getattr(self, variable.lower()) is not None:
                 repl = getattr(self, variable.lower())
                 text = text.replace(whole_match, str(repl))
-            elif self.case.get_value(variable.upper()) is not None:
-                repl = self.case.get_value(variable.upper())
+            elif self.case.get_value(variable.upper(),subgroup=self.job) is not None:
+                repl = self.case.get_value(variable.upper(),subgroup=self.job)
                 text = text.replace(whole_match, str(repl))
             elif default is not None:
                 text = text.replace(whole_match, default)

--- a/utils/python/CIME/batch_maker.py
+++ b/utils/python/CIME/batch_maker.py
@@ -114,7 +114,7 @@ class BatchMaker(object):
             return
 
         # Make sure to check default queue first.
-        all_queues = list()
+        all_queues = []
         all_queues.append( self.config_machines_parser.get_default_queue())
         all_queues = all_queues + self.config_machines_parser.get_all_queues()
         for queue in all_queues:

--- a/utils/python/CIME/batch_utils.py
+++ b/utils/python/CIME/batch_utils.py
@@ -74,9 +74,10 @@ class BatchUtils(object):
             depid[job] = self.submit_single_job(job, batchtype, jobid)
 
     def submit_single_job(self, job, batchtype, depid=None):
+        caseroot = self.case.get_value("CASEROOT")
         if batchtype == "none":
             logger.info("Starting job script %s"%job)
-            run_cmd(os.path.join(".", job))
+            run_cmd("%s --caseroot %s"%(os.path.join(".", job),caseroot))
             return
 
         submitargs = self.get_submit_args(job, batchtype)
@@ -90,7 +91,7 @@ class BatchUtils(object):
         batchsubmit = self.case.get_value("BATCHSUBMIT",subgroup=None)
         batchredirect = self.case.get_value("BATCHREDIRECT",subgroup=None)
         submitcmd = batchsubmit + " " + submitargs + " " + batchredirect + \
-            " " + job
+            " " + job + " --caseroot %s"%caseroot
         logger.info("Submitting job script %s"%submitcmd)
         output = run_cmd(submitcmd)
         jobid = self.get_job_id(batchtype, output)
@@ -114,7 +115,6 @@ class BatchUtils(object):
             self.batchmaker.override_node_count = int(task_count)
 
         self.batchmaker.set_job(job)
-
         submit_args = self.batchobj.get_submit_args()
         submitargs=""
         for flag, name in submit_args:
@@ -127,4 +127,5 @@ class BatchUtils(object):
                         submitargs+=" %s%s"%(flag,val)
                     else:
                         submitargs+=" %s %s"%(flag,val)
+        logger.debug("Submit args are %s"%" ".join(submitargs))
         return submitargs

--- a/utils/python/CIME/batch_utils.py
+++ b/utils/python/CIME/batch_utils.py
@@ -23,7 +23,7 @@ class BatchUtils(object):
         self.batchobj = None
         self.override_node_count = None
         self.batchmaker = None
-        self.jobs = list()
+        self.jobs = []
         self.prereq_jobid = prereq_jobid
 
     def submit_jobs(self, no_batch=False):
@@ -53,7 +53,7 @@ class BatchUtils(object):
             if dependancy is not None:
                 deps = dependancy.split()
             else:
-                deps = list()
+                deps = []
             jobid = ""
             if job == self.job and self.prereq_jobid is not None:
                 jobid = self.prereq_jobid

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -386,6 +386,7 @@ class Case(object):
         bjobs = batch.get_batch_jobs()
         env_batch = self._get_env("batch")
         env_batch.set_value("batch_system", batch_system)
+        env_batch.set_default_value("batch_system", batch_system)
         env_batch.create_job_groups(bjobs)
 
         self._env_files_that_need_rewrite.add(env_batch)

--- a/utils/python/CIME/case_submit.py
+++ b/utils/python/CIME/case_submit.py
@@ -54,7 +54,7 @@ def submit(caseroot, job=None, resubmit=None, no_batch=False, prereq_jobid=None)
     env_module.load_env_for_case()
     batchobj = BatchUtils(job, case, prereq_jobid=prereq_jobid)
     case.set_value("RUN_WITH_SUBMIT",True)
-    case.flush(flushall=True)
+    case.flush()
     batchobj.submit_jobs(no_batch=no_batch)
 
 def check_case(case,caseroot):

--- a/utils/python/CIME/case_submit.py
+++ b/utils/python/CIME/case_submit.py
@@ -40,7 +40,8 @@ def submit(caseroot, job=None, resubmit=None, no_batch=False, prereq_jobid=None)
         if no_batch:
             batch_system = "none"
         else:
-            batch_system = env_batch.get_default_value("batch_system")
+            bs_node = env_batch.get_node("entry", {"id":"batch_system"})
+            batch_system = env_batch.get_default_value(bs_node)
         env_batch.set_value("batch_system", batch_system)
     else:
         if case.get_value("batch_system") == "none":

--- a/utils/python/CIME/env_module.py
+++ b/utils/python/CIME/env_module.py
@@ -21,9 +21,9 @@ class EnvModule(object):
         self._caseroot = caseroot
         self._mpilib   = mpilib
         self._debug    = debug
-        self._cshscript = list()
+        self._cshscript = []
         self._cshscript.append( self._mach_specific_header("csh"))
-        self._shscript = list()
+        self._shscript = []
         self._shscript.append( self._mach_specific_header("sh"))
         self._module_system = self._machine.get_module_system_type()
 
@@ -106,7 +106,7 @@ class EnvModule(object):
 
     def _get_module_module_commands(self, modules_to_load, shell):
         mod_cmd = self._machine.get_module_system_cmd_path(shell)
-        cmds = list()
+        cmds = []
         for action, argument in modules_to_load:
             if argument is None:
                 argument = ""

--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -134,7 +134,9 @@ class B_TestCreateNewcase(unittest.TestCase):
 ###############################################################################
     def setUp(self):
         self._testroot = MACHINE.get_value("CESMSCRATCHROOT")
-        self._testdir = os.path.join(self._testroot, tempfile.mktemp())
+        self._testdir = os.path.join(self._testroot, 'scripts_regression_tests.testcreatenewcase')
+        if os.path.exists(self._testdir):
+            shutil.rmtree(self._testdir)
         self._do_teardown = False
 
     def test_createnewcase(self):


### PR DESCRIPTION
Fix issues in --no-batch so that tests work on blues
To test on blues I did the following:

```
qsub -I -q shared -l nodes=1:ppn=16
export CIME_MODEL=acme
cd cime/utils/python/tests
./scripts_regression_tests --no-batch

```