### PR TITLE
Get all tests working again on melvin.

### DIFF
--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -105,18 +105,20 @@ def kill_python_subprocesses(sig=signal.SIGKILL, expected_num_killed=None, teste
 ###########################################################################
 def assert_dashboard_has_build(tester, build_name, expected_count=1):
 ###########################################################################
-    time.sleep(10) # Give chance for cdash to update
+    # Do not test ACME dashboard if model is CESM
+    if CIME.utils.get_model() == "acme":
+        time.sleep(10) # Give chance for cdash to update
 
-    wget_file = tempfile.mktemp()
+        wget_file = tempfile.mktemp()
 
-    run_cmd("wget http://my.cdash.org/index.php?project=ACME_test -O %s" % wget_file)
+        run_cmd("wget http://my.cdash.org/index.php?project=ACME_test -O %s" % wget_file)
 
-    raw_text = open(wget_file, "r").read()
-    os.remove(wget_file)
+        raw_text = open(wget_file, "r").read()
+        os.remove(wget_file)
 
-    num_found = raw_text.count(build_name)
-    tester.assertEqual(num_found, expected_count,
-                       msg="Dashboard did not have expected num occurances of build name '%s'. Expected %s, found %s" % (build_name, expected_count, num_found))
+        num_found = raw_text.count(build_name)
+        tester.assertEqual(num_found, expected_count,
+                           msg="Dashboard did not have expected num occurances of build name '%s'. Expected %s, found %s" % (build_name, expected_count, num_found))
 
 ###############################################################################
 def setup_proxy():
@@ -587,15 +589,19 @@ class E_TestSystemTest(TestCreateTestCommon):
                     self.assertEqual(status["memleak"], wait_for_tests.TEST_PASS_STATUS)
 
 ###############################################################################
-@unittest.skipIf(CIME.utils.get_model() == 'cesm', "skip Jenkins tests in cesm")
 class TestJenkinsGenericJob(TestCreateTestCommon):
 ###############################################################################
 
     ###########################################################################
-    def simple_test(self, expect_works, extra_args):
+    def simple_test(self, expect_works, extra_args, build_name=None):
     ###########################################################################
         if NO_BATCH:
             extra_args += " --no-batch"
+
+        # Need these flags to test dashboard if acme
+        if CIME.utils.get_model() == "acme" and build_name is not None:
+            extra_args += " -p ACME_test --submit-to-cdash --cdash-build-group=Nightly -c %s" % build_name
+
         cmd = "%s/jenkins_generic_job %s" % (TOOLS_DIR, extra_args)
         stat, output, errput = run_cmd(cmd, ok_to_fail=True)
         if (expect_works):
@@ -604,10 +610,10 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
             self.assertEqual(stat, CIME.utils.TESTS_FAILED_ERR_CODE, msg="COMMAND '%s' SHOULD HAVE DETECTED FAILED TESTS\njenkins_generic_job output:\n%s\n\nerrput:\n%s" % (cmd, output, errput))
 
     ###########################################################################
-    def threaded_test(self, expect_works, extra_args):
+    def threaded_test(self, expect_works, extra_args, build_name=None):
     ###########################################################################
         try:
-            self.simple_test(expect_works, extra_args)
+            self.simple_test(expect_works, extra_args, build_name)
         except AssertionError as e:
             self._thread_error = str(e)
 
@@ -648,7 +654,7 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
         self.assert_num_leftovers()
 
         build_name = "jenkins_generic_job_pass_%s" % CIME.utils.get_utc_timestamp()
-        self.simple_test(True, "-t acme_test_only_pass -p ACME_test -b %s --submit-to-cdash -c %s --cdash-build-group=Nightly" % (self._baseline_name, build_name))
+        self.simple_test(True, "-t acme_test_only_pass -b %s" % self._baseline_name, build_name=build_name)
         self.assert_num_leftovers() # jenkins_generic_job should have automatically cleaned up leftovers from prior run
         self.assert_no_sentinel()
         assert_dashboard_has_build(self, build_name)
@@ -657,11 +663,11 @@ class TestJenkinsGenericJob(TestCreateTestCommon):
     def test_jenkins_generic_job_kill(self):
     ###########################################################################
         build_name = "jenkins_generic_job_kill_%s" % CIME.utils.get_utc_timestamp()
-        run_thread = threading.Thread(target=self.threaded_test, args=(False, " -t acme_test_only_slow_pass -p ACME_test -b master --baseline-compare=no --submit-to-cdash -c %s --cdash-build-group=Nightly" % build_name))
+        run_thread = threading.Thread(target=self.threaded_test, args=(False, " -t acme_test_only_slow_pass -b master --baseline-compare=no", build_name))
         run_thread.daemon = True
         run_thread.start()
 
-        time.sleep(60)
+        time.sleep(120)
 
         kill_subprocesses(sig=signal.SIGTERM)
 


### PR DESCRIPTION
This fixes the test_jenkins_generic_job_kill test working again by increasing
wait time. A performance slowdown caused this, need to track it down at some
point.

Also, turn jenkins_generic_job tests back on for CESM, just disable dashboard
checking if model is CESM. These are the only tests that check signal recovery
for core testing scripts, so both models need to keep these working.