### PR TITLE
Make sure user knows if exeroot already exists, abort if test

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -156,7 +156,7 @@ def _main_func():
     caseobj.configure(compset, grid, machine_name=machine, project=project,
                       pecount=pecount, compiler=compiler, mpilib=mpilib,
                       user_compset=user_compset, pesfile=pesfile,
-                      user_grid=user_grid, gridfile=gridfile, ninst=ninst)
+                      user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test)
 
     caseobj.create_caseroot()
 

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -386,7 +386,7 @@ class Case(object):
     def configure(self, compset_name, grid_name, machine_name=None,
                   project=None, pecount=None, compiler=None, mpilib=None,
                   user_compset=False, pesfile=None,
-                  user_grid=False, gridfile=None, ninst=1):
+                  user_grid=False, gridfile=None, ninst=1, test=False):
 
         #--------------------------------------------
         # compset, pesfile, and compset components
@@ -456,6 +456,18 @@ class Case(object):
 
         machdir = machobj.get_machines_dir()
         self.set_value("MACHDIR", machdir)
+
+        # Overwriting an existing exeroot or rundir can cause problems
+        exeroot = self.get_value("EXEROOT")
+        rundir = self.get_value("RUNDIR")
+        for wdir in (exeroot, rundir):
+            if os.path.exists(wdir):
+                expect(not test, "Directory %s already exists, aborting test"% wdir)
+                response = raw_input("\nDirectory %s already exists, (r)eplace, (a)bort, or (u)se existing?"% wdir)
+                if response.startswith("r"):
+                    shutil.rmtree(wdir)
+                else:
+                    expect(response.startswith("u"), "Aborting by user request")
 
         # the following go into the env_mach_specific file
         vars = ("module_system", "environment_variables", "batch_system", "mpirun")


### PR DESCRIPTION
Check for existance of EXEROOT and RUNDIR, abort if this is a test and they exist,
otherwise give the user an option to use them or replace them or abort create_newcase. 

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status:[bit for bit

Fixes:

User interface changes?: 

Code review: 

