### PR TITLE
Port changes made on ACME side to CIME for anlworkstations

### DIFF
--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -616,6 +616,7 @@ for mct, etc.
   <ADD_CFLAGS DEBUG="FALSE"> -O2  </ADD_CFLAGS>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <NETCDF_PATH>$(NETCDFROOT)</NETCDF_PATH>
+  <PNETCDF_PATH>$(PNETCDFROOT)</PNETCDF_PATH>
   <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -lblas -llapack</ADD_SLIBS>
   <ADD_CPPFLAGS> -DHAVE_COMM_F2C </ADD_CPPFLAGS>
   <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -409,13 +409,15 @@
       <cmd_path lang="sh">source /software/common/adm/packages/softenv-1.4.2/etc/softenv-aliases.sh ; soft</cmd_path>
       <modules compiler="gnu">
 	<command name="add">+gcc-5.1.0</command>
-	<command name="add">+mpich-3.2-gcc-5.1</command>
+	<command name="add" mpilib="!mpi-serial">+mpich-3.2-gcc-5.1</command>
 	<command name="add">+netcdf-4.3.3.1-parallel-gcc5.1-mpich3.2</command>
+	<command name="add" mpilib="!mpi-serial">+pnetcdf-1.6.1-gcc-5.1-mpich-3.2</command>
 	<command name="add">+cmake-2.8.12</command>
       </modules>
     </module_system>
     <environment_variables>
       <env name="NETCDFROOT">$(dirname $(dirname $(which ncdump)))</env>
+      <env name="PNETCDFROOT" mpilib="!mpi-serial">$(dirname $(dirname $(which pnetcdf_version)))</env>
     </environment_variables>
 </machine>
 

--- a/cime_config/acme/machines/config_pio.xml
+++ b/cime_config/acme/machines/config_pio.xml
@@ -46,7 +46,6 @@
       <value>pnetcdf</value>
       <value mach="userdefined">netcdf</value>
       <value mach="eastwind">netcdf</value>
-      <value mach="anlworkstation">netcdf</value>
       <value mach="pleiades.*">netcdf</value>
       <value mach="hobart" compiler="pgi">netcdf</value>
       <value mpilib="mpi-serial">netcdf</value>

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -68,28 +68,37 @@ class EntryID(GenericXML):
         Note that the component class has a specific version of this function
         '''
         match_value = None
-        match_max = 0
+        match_max = -1
         match_count = 0
         expect(node is not None," Empty node in _get_value_match")
+
         values = self.get_optional_node("values", root=node)
         if values is None:
             return
-        for valnode in self.get_nodes("value", root=node):
+
+        for valnode in self.get_nodes("value", root=values):
             # loop through all the keys in valnode (value nodes) attributes
-            for key,value in valnode.attrib.iteritems():
-                # determine if key is in attributes dictionary
+            if len(valnode.attrib) == 0:
                 match_count = 0
-                if key in attributes:
-                    if re.search(value, attributes[key]):
-                        logger.debug("Value %s and key %s match with value %s"%(value, key, attributes[key]))
-                        match_count += 1
-                    else:
-                        match_count = 0
-                        break
-            if match_count > 0:
-                if match_count > match_max:
-                    match_max = match_count
-                    match_value = valnode.text
+            else:
+                for key,value in valnode.attrib.iteritems():
+                    # determine if key is in attributes dictionary
+                    match_count = 0
+                    if key in attributes:
+                        if re.search(value, attributes[key]):
+                            logger.debug("Value %s and key %s match with value %s"%(value, key, attributes[key]))
+                            match_count += 1
+                        else:
+                            match_count = -1
+                            break
+
+            if match_count > match_max:
+                match_max = match_count
+                match_value = valnode.text
+            elif match_count == match_max:
+                logger.debug("Ambiguous match for node '%s' for attributes '%s', falling back to order precedence" %
+                             (node.attrib["id"], attributes))
+
         return match_value
 
     def _get_type_info(self, node):

--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -116,7 +116,8 @@ class EnvMachSpecific(EnvBase):
             if (self._match_attribs(node.attrib)):
                 for child in node:
                     expect(child.tag == child_tag, "Expected %s element" % child_tag)
-                    result.append( (child.get("name"), child.text) )
+                    if (self._match_attribs(child.attrib)):
+                        result.append( (child.get("name"), child.text) )
 
         return result
 

--- a/utils/python/CIME/XML/pio.py
+++ b/utils/python/CIME/XML/pio.py
@@ -17,13 +17,21 @@ class PIO(EntryID):
 
         EntryID.__init__(self, infile)
 
-    def get_defaults(self, grid=None, compset=None, mach=None, compiler=None):
+    def get_defaults(self, grid=None, compset=None, mach=None, compiler=None, mpilib=None):
         # should we have a env_pio file
         defaults = {}
+
+        # Load args into attribute dict
+        attributes = {}
+        for attrib in ["grid", "compset", "mach", "compiler", "mpilib"]:
+            if locals()[attrib] is not None:
+                attributes[attrib] = locals()[attrib]
+
+        # Find defauts
         for node in self.get_nodes("entry"):
-            attributes = {"grid":grid,"compset":compset,"mach":mach,"compiler":compiler}
             value = self.get_default_value(node, attributes)
             if value:
                 defaults[node.get("id")] = value
+
         return defaults
 

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -577,7 +577,8 @@ class Case(object):
         compiler = self.get_value("COMPILER")
         mach = self.get_value("MACH")
         compset = self.get_value("COMPSET")
-        defaults = pioobj.get_defaults(grid=grid,compset=compset,mach=mach,compiler=compiler)
+        mpilib = self.get_value("MPILIB")
+        defaults = pioobj.get_defaults(grid=grid,compset=compset,mach=mach,compiler=compiler, mpilib=mpilib)
         for vid, value in defaults.items():
             self.set_value(vid,value)
 


### PR DESCRIPTION
This exposed some important errors. First, pio.py was not providing
the mpilib in the attribute list when ask for PIO data. This meant that
the selection of mpiserial was not causing us to use netcdf instead of
pnetcdf as PIO_TYPENAME.

The second error was in entry_id. The algorithm for computing best match
was not picking up defaults in the case where the XML <value> tag has
no attributes.

Another error is that attributes were not being checked when loading
modules or setting env variables.

Test suite: cime_developer
Test baseline: 
Test namelist changes: 
Test status: bit for bit, roundoff

User interface changes?: No

Code review: @jedwards4b 