### PR TITLE
Things were badly broken on skybridge.

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -60,14 +60,14 @@
     <directives>
       <directive                       > -n {{ totaltasks }} </directive>
       <directive                       > -R "span[ptile={{ ptile }}]"</directive>
-      <directive                       > -q {{ queue }} </directive>
+      <directive                       > -q {{ job_queue }} </directive>
       <directive                       > -N  </directive>
       <directive default="poe"         > -a {{ poe }} </directive>
       <directive                       > -x {{ queue_exclusive }} </directive>
       <directive default="acme.stdout" > -o {{ acme_stdout }}.%J  </directive>
       <directive default="acme.stderr" > -e {{ acme_stderr }}.%J  </directive>
       <directive                       > -J {{ job_id }} </directive>
-      <directive                       > -W {{ wall_time }} </directive>
+      <directive                       > -W {{ job_wallclock_time }} </directive>
       <directive                       > -P {{ account }}  </directive>
     </directives>
   </batch_system>
@@ -101,7 +101,7 @@
     <depend_string> -W depend=afterok:jobid</depend_string>
     <directives>
       <directive> -N {{ job_id }}</directive>
-      <directive> -l walltime={{ wall_time }}</directive>
+      <directive> -l walltime={{ job_wallclock_time }}</directive>
       <directive> -j oe </directive>
       <directive> -A {{ project }} </directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
@@ -122,8 +122,8 @@
        <directive> --ntasks-per-node={{ tasks_per_node }}</directive>
        <directive> --output={{ output_error_path }}   </directive>
        <directive> --exclusive                        </directive>
-       <directive> --time={{ wall_time }}</directive>
-       <directive> --partition={{ queue }}</directive>
+       <directive> --time={{ job_wallclock_time }}</directive>
+       <directive> --partition={{ job_queue }}</directive>
        <directive> --account={{ project }}</directive>
      </directives>
    </batch_system>

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -2,7 +2,7 @@
 
 from Tools.standard_script_setup import *
 
-from CIME.utils import expect, get_model, run_cmd, get_project
+from CIME.utils import expect, get_model
 from CIME.case  import Case
 
 import stat

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -216,7 +216,7 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
     batch = Batch(batch_system=mach.get_batch_system_type(), machine=machine_name)
 
     if project is None:
-        project = CIME.utils.get_project()
+        project = CIME.utils.get_project(mach)
         if project is None:
             project = mach.get_value("PROJECT")
 

--- a/utils/python/CIME/XML/batch.py
+++ b/utils/python/CIME/XML/batch.py
@@ -93,29 +93,6 @@ class Batch(GenericXML):
 
         return value
 
-    def get_batch_directives(self, batch_maker=None):
-        """
-        """
-        result = []
-        directive_prefix = self.get_node("batch_directive", root=self.batch_system_node).text
-        directive_prefix = "" if directive_prefix is None else directive_prefix
-
-        roots = [self.machine_node, self.batch_system_node]
-        for root in roots:
-            if root is not None:
-                nodes = self.get_nodes("directive", root=root)
-                for node in nodes:
-                    directive = self.get_resolved_value("" if node.text is None else node.text)
-                    if batch_maker is None:
-                        default = node.get("default")
-                        directive = transform_vars(directive, default=default)
-                    else:
-                        directive = batch_maker.transform_vars_bm(directive, default=node.get("default"))
-
-                    result.append("%s %s" % (directive_prefix, directive))
-
-        return result
-
     def get_batch_jobs(self):
         """
         Return a list of jobs with the first element the name of the case script
@@ -133,22 +110,3 @@ class Batch(GenericXML):
             jobs.append((name, jdict))
 
         return jobs
-
-    def get_submit_args(self):
-        '''
-        return a list of touples (flag, name)
-        '''
-        arg_nodes = self.get_nodes("arg", root=self.batch_system_node)
-        if self.machine_node is not None:
-            arg_nodes.extend(self.get_nodes("arg", root=self.machine_node))
-
-        values = []
-        bs_nodes = self.get_nodes("batch_system",{"type":self.batch_system})
-        if self.machine is not None:
-            bs_nodes += self.get_nodes("batch_system",{"MACH":self.machine})
-        submit_arg_nodes = []
-        for node in bs_nodes:
-            submit_arg_nodes += self.get_nodes("arg",root=node)
-        for arg in submit_arg_nodes:
-            values.append((arg.get("flag"),arg.get("name")))
-        return values

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -346,12 +346,12 @@ class EnvBatch(EnvBase):
             if slen == 0:
                 jobid = None
 
-            depid[job] = self.submit_single_job(case, job, jobid)
+            depid[job] = self.submit_single_job(case, job, jobid, no_batch=no_batch)
 
-    def submit_single_job(self, case, job, depid=None):
+    def submit_single_job(self, case, job, depid=None, no_batch=False):
         caseroot = case.get_value("CASEROOT")
         batch_system = self.get_value("BATCH_SYSTEM", subgroup=None)
-        if batch_system is None or batch_system == "none":
+        if batch_system is None or batch_system == "none" or no_batch:
             # Import here to avoid circular include
             from CIME.case_test       import case_test
             from CIME.case_run        import case_run
@@ -378,7 +378,8 @@ class EnvBatch(EnvBase):
         if depid is not None:
             dep_string = self.get_value("depend_string", subgroup=None)
             dep_string = dep_string.replace("jobid",depid.strip())
-            submitargs += " "+dep_string
+            submitargs += " " + dep_string
+
         batchsubmit = self.get_value("batch_submit", subgroup=None)
         batchredirect = self.get_value("batch_redirect", subgroup=None)
         submitcmd = ''
@@ -398,9 +399,9 @@ class EnvBatch(EnvBase):
     def get_batch_system_type(self):
         nodes = self.get_nodes("batch_system")
         for node in nodes:
-            type = node.get("type")
-            if type is not None:
-                self.batchtype = type
+            type_ = node.get("type")
+            if type_ is not None:
+                self.batchtype = type_
         return self.batchtype
 
     def set_batch_system_type(self, batchtype):
@@ -428,13 +429,9 @@ class EnvBatch(EnvBase):
         return None
 
     def get_max_walltime(self, queue):
-        walltime = None
         for queue_node in self.get_all_queues():
             if queue_node.text == queue:
                 return queue_node.get("walltimemax")
-
-    def get_walltimes(self):
-        return self.get_nodes("walltime", root=self.machine_node)
 
     def get_default_walltime(self):
         return self.get_value("walltime", attribute={"default" : "true"}, subgroup=None)

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -195,26 +195,26 @@ class EnvBatch(EnvBase):
 
         task_maker = TaskMaker(case)
 
-        self.maxthreads = task_maker.max_threads
-        self.taskgeometry = task_maker.task_geom
-        self.threadgeometry = task_maker.thread_geom
-        self.taskcount = task_maker.task_count
+        self.maxthreads = task_maker.maxthreads
+        self.taskgeometry = task_maker.taskgeometry
+        self.threadgeometry = task_maker.threadgeometry
+        self.taskcount = task_maker.taskcount
         self.thread_count = task_maker.thread_count
         self.pedocumentation = task_maker.document()
         self.ptile = task_maker.ptile
-        self.tasks_per_node = task_maker.task_per_node
+        self.tasks_per_node = task_maker.tasks_per_node
         self.max_tasks_per_node = task_maker.MAX_TASKS_PER_NODE
-        self.tasks_per_numa = task_maker.task_per_numa
-        self.num_tasks = task_maker.total_tasks
+        self.tasks_per_numa = task_maker.tasks_per_numa
+        self.num_tasks = task_maker.totaltasks
 
         task_count = self.get_value("task_count")
         if task_count == "default":
-            self.sumpes = task_maker.full_sum
-            self.totaltasks = task_maker.total_tasks
-            self.fullsum = task_maker.full_sum
-            self.sumtasks = task_maker.total_tasks
-            self.task_count = task_maker.full_sum
-            self.num_nodes = task_maker.node_count
+            self.sumpes = task_maker.fullsum
+            self.totaltasks = task_maker.totaltasks
+            self.fullsum = task_maker.fullsum
+            self.sumtasks = task_maker.totaltasks
+            self.task_count = task_maker.fullsum
+            self.num_nodes = task_maker.num_nodes
         else:
             self.sumpes = task_count
             self.totaltasks = task_count

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -295,16 +295,6 @@ class Machines(GenericXML):
                 expect(key in attribs, "Unhandled MPI property '%s'" % key)
 
             if all_match:
-                arg_node = self.get_optional_node("arguments", root=mpirun_node)
-                if arg_node is not None:
-                    arg_nodes = self.get_nodes("arg", root=arg_node)
-                    for arg_node in arg_nodes:
-                        arg_value = transform_vars(arg_node.text,
-                                                   case=case,
-                                                   subgroup=job,
-                                                   check_members=check_members,
-                                                   default=arg_node.get("default"))
-                        args[arg_node.get("name")] = arg_value
                 if is_default:
                     if matches > best_num_matched_default:
                         default_match = mpirun_node
@@ -318,6 +308,18 @@ class Machines(GenericXML):
                "Could not find a matching MPI for attributes: %s" % attribs)
 
         the_match = best_match if best_match is not None else default_match
+
+        # Now that we know the best match, compute the arguments
+        arg_node = self.get_optional_node("arguments", root=the_match)
+        if arg_node is not None:
+            arg_nodes = self.get_nodes("arg", root=arg_node)
+            for arg_node in arg_nodes:
+                arg_value = transform_vars(arg_node.text,
+                                           case=case,
+                                           subgroup=job,
+                                           check_members=check_members,
+                                           default=arg_node.get("default"))
+                args[arg_node.get("name")] = arg_value
 
 
         executable = self.get_node("executable", root=the_match)

--- a/utils/python/CIME/buildlib.py
+++ b/utils/python/CIME/buildlib.py
@@ -3,9 +3,9 @@ common utilities for buildlib
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect, run_cmd, handle_standard_logging_options
+from CIME.utils import expect, run_cmd, handle_standard_logging_options, setup_standard_logging_options
 from CIME.case  import Case
-import sys, os
+import sys, os, argparse
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ def parse_input(argv):
 
     parser = argparse.ArgumentParser()
 
-    CIME.utils.setup_standard_logging_options(parser)
+    setup_standard_logging_options(parser)
 
     parser.add_argument("caseroot", default=os.getcwd(),
                         help="Case directory")

--- a/utils/python/CIME/buildnml.py
+++ b/utils/python/CIME/buildnml.py
@@ -5,9 +5,9 @@ These are used by components/<model_type>/<component>/cime_config/buildnml
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect, handle_standard_logging_options
+from CIME.utils import expect, handle_standard_logging_options, setup_standard_logging_options
 from CIME.case import Case
-import sys, os, shutil, glob
+import sys, os, shutil, glob, argparse
 
 ###############################################################################
 def parse_input(argv):
@@ -19,7 +19,7 @@ def parse_input(argv):
 
     parser = argparse.ArgumentParser()
 
-    CIME.utils.setup_standard_logging_options(parser)
+    setup_standard_logging_options(parser)
 
     parser.add_argument("caseroot", default=os.getcwd(),
                         help="Case directory")

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -84,10 +84,6 @@ class Case(object):
         self._env_generic_files.append(EnvArchive(case_root))
         self._files = self._env_entryid_files + self._env_generic_files
 
-
-        # self._case_root = case_root
-
-
         # Hold arbitary values. In create_newcase we may set values
         # for xml files that haven't been created yet. We need a place
         # to store them until we are ready to create the file. At file
@@ -104,7 +100,6 @@ class Case(object):
         self._gridfile = None
         self._components = []
         self._component_config_files = []
-
 
     def __del__(self):
         self.flush()
@@ -549,11 +544,11 @@ class Case(object):
 
         # Set project id
         if project is None:
-            project = get_project()
+            project = get_project(machobj)
         if project is not None:
             self.set_value("PROJECT", project)
         elif machobj.get_value("PROJECT_REQUIRED"):
-            expect(project is not None, " PROJECT_REQUIRED is true but no project found")
+            expect(project is not None, "PROJECT_REQUIRED is true but no project found")
 
     def get_compset_var_settings(self):
         compset_obj = Compsets(infile=self.get_value("COMPSETS_SPEC_FILE"))
@@ -758,7 +753,7 @@ class Case(object):
         # user's case. However, note that, if a project is not given, the fallback will
         # be to copy it from the clone, just like other xml variables are copied.
         if project is None:
-            project = get_project()
+            project = self.get_value("PROJECT")
         if project is not None:
             newcase.set_value("PROJECT", project)
 
@@ -775,7 +770,6 @@ class Case(object):
         # copy SourceMod and Buildconf files
         for casesub in ("SourceMods", "Buildconf"):
             shutil.copytree(os.path.join(cloneroot, casesub), os.path.join(newcaseroot, casesub))
-
 
         # copy env_case.xml to LockedFiles
         shutil.copy(os.path.join(newcaseroot,"env_case.xml"), os.path.join(newcaseroot,"LockedFiles"))

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -753,7 +753,7 @@ class Case(object):
         # user's case. However, note that, if a project is not given, the fallback will
         # be to copy it from the clone, just like other xml variables are copied.
         if project is None:
-            project = self.get_value("PROJECT")
+            project = self.get_value("PROJECT", subgroup="case.run")
         if project is not None:
             newcase.set_value("PROJECT", project)
 

--- a/utils/python/CIME/case_run.py
+++ b/utils/python/CIME/case_run.py
@@ -97,7 +97,6 @@ def runModel(case):
     # Run the model
     logger.info("%s MODEL EXECUTION BEGINS HERE" %(time.strftime("%Y-%m-%d %H:%M:%S")))
 
-    # Compute mpirun command
     machine = Machines(machine=case.get_value("MACH"))
     cmd = machine.get_full_mpirun(tm, case, "case.run")
     cmd = case.get_resolved_value(cmd)

--- a/utils/python/CIME/task_maker.py
+++ b/utils/python/CIME/task_maker.py
@@ -101,7 +101,7 @@ class TaskMaker(object):
         aprun = ""
         pbsrs = ""
 
-        task_per_node, total_node_count, max_total_node_count = 0, 0, 0
+        tasks_per_node, total_node_count, max_total_node_count = 0, 0, 0
         for c1 in xrange(1, total_tasks):
             sum_ += maxt[c1]
 
@@ -115,16 +115,16 @@ class TaskMaker(object):
             thread_geom += ":%d" % maxt[c1]
 
             if maxt[c1] != thread_count:
-                task_per_node = min(self.PES_PER_NODE, self.MAX_TASKS_PER_NODE / thread_count)
+                tasks_per_node = min(self.PES_PER_NODE, self.MAX_TASKS_PER_NODE / thread_count)
 
-                task_per_node = min(task_count, task_per_node)
+                tasks_per_node = min(task_count, tasks_per_node)
 
-                aprun += " -n %d -N %d -d %d %s :" % (task_count, task_per_node, thread_count, self.DEFAULT_RUN_EXE_TEMPLATE_STR)
+                aprun += " -n %d -N %d -d %d %s :" % (task_count, tasks_per_node, thread_count, self.DEFAULT_RUN_EXE_TEMPLATE_STR)
 
-                node_count = int(math.ceil(float(task_count) / task_per_node))
+                node_count = int(math.ceil(float(task_count) / tasks_per_node))
 
                 total_node_count += node_count
-                pbsrs += "%d:ncpus=%d:mpiprocs=%d:ompthreads=%d:model=" % (node_count, self.MAX_TASKS_PER_NODE, task_per_node, thread_count)
+                pbsrs += "%d:ncpus=%d:mpiprocs=%d:ompthreads=%d:model=" % (node_count, self.MAX_TASKS_PER_NODE, tasks_per_node, thread_count)
 
                 thread_count = maxt[c1]
                 max_thread_count = max(max_thread_count, maxt[c1])
@@ -133,47 +133,47 @@ class TaskMaker(object):
             else:
                 task_count = 1
 
-        max_task_per_node = min(self.MAX_TASKS_PER_NODE / max_thread_count, self.PES_PER_NODE, max_task_count)
-        max_total_node_count = int(math.ceil(float(max_task_count) / max_task_per_node))
+        max_tasks_per_node = min(self.MAX_TASKS_PER_NODE / max_thread_count, self.PES_PER_NODE, max_task_count)
+        max_total_node_count = int(math.ceil(float(max_task_count) / max_tasks_per_node))
 
         full_sum += sum_
-        self.full_sum = full_sum
+        self.sumpes = full_sum
         task_geom += ")"
-        self.task_geom = task_geom
+        self.taskgeometry = task_geom
         if self.PES_PER_NODE > 0:
-            task_per_node = min(self.PES_PER_NODE, self.MAX_TASKS_PER_NODE / thread_count)
+            tasks_per_node = min(self.PES_PER_NODE, self.MAX_TASKS_PER_NODE / thread_count)
         else:
-            task_per_node = self.MAX_TASKS_PER_NODE / thread_count
-        task_per_node = min(task_count, task_per_node)
+            tasks_per_node = self.MAX_TASKS_PER_NODE / thread_count
+        tasks_per_node = min(task_count, tasks_per_node)
 
-        total_node_count += int(math.ceil(float(task_count) / task_per_node))
+        total_node_count += int(math.ceil(float(task_count) / tasks_per_node))
 
-        task_per_numa = int(math.ceil(task_per_node / 2.0))
-        if self.COMPILER == "intel" and task_per_node > 1:
+        task_per_numa = int(math.ceil(tasks_per_node / 2.0))
+        if self.COMPILER == "intel" and tasks_per_node > 1:
             aprun += " -S %d -cc numa_node " % task_per_numa
 
-        aprun += " -n %d -N %d -d %d %s " % (task_count, task_per_node, thread_count, self.DEFAULT_RUN_EXE_TEMPLATE_STR)
+        aprun += " -n %d -N %d -d %d %s " % (task_count, tasks_per_node, thread_count, self.DEFAULT_RUN_EXE_TEMPLATE_STR)
 
 	# add all the calculated numbers as instance data.
-        self.total_tasks = total_tasks
+        self.totaltasks = total_tasks
         self.num_tasks   = total_tasks
-        self.task_per_node = max_task_per_node
-        self.task_per_numa = task_per_numa
-        self.max_threads = max_threads
+        self.tasks_per_node = max_tasks_per_node
+        self.tasks_per_numa = task_per_numa
+        self.maxthreads = max_threads
         self.min_threads = min_threads
-        self.task_geom = task_geom
-        self.thread_geom = thread_geom
-        self.task_count = task_count
+        self.taskgeometry = task_geom
+        self.threadgeometry = thread_geom
+        self.taskcount = task_count
         self.thread_count = max_thread_count
         self.aprun = aprun
         self.opt_node_count = total_node_count
-        self.node_count = max_total_node_count
-        self.pbsrs = pbsrs + "%d:ncpus=%d:mpiprocs=%d:ompthreads=%d:model=" % (max_total_node_count, self.MAX_TASKS_PER_NODE, task_per_node, thread_count)
+        self.num_nodes = max_total_node_count
+        self.pbsrs = pbsrs + "%d:ncpus=%d:mpiprocs=%d:ompthreads=%d:model=" % (max_total_node_count, self.MAX_TASKS_PER_NODE, tasks_per_node, thread_count)
 
         # calculate ptile..
         ptile = self.MAX_TASKS_PER_NODE / 2
-        if self.max_threads > 1:
-            ptile = int(math.floor(float(self.MAX_TASKS_PER_NODE) / self.max_threads))
+        if self.maxthreads > 1:
+            ptile = int(math.floor(float(self.MAX_TASKS_PER_NODE) / self.maxthreads))
 
         self.ptile = ptile
 
@@ -200,13 +200,13 @@ class TaskMaker(object):
 # PE Layout:
 #   Total number of tasks: %d
 #   Maximum threads per task: %d
-""" % (self.total_tasks, self.max_threads)
+""" % (self.totaltasks, self.maxthreads)
 
         for comp, ntasks, nthrds, rootpe, ninst, pstrid in zip(self.COMP, self.NTASKS, self.NTHRDS, self.ROOTPE, self.NINST, self.PSTRID):
             doc += "#    %s ntasks=%d nthreads=%d rootpe=%d ninst=%d pstrid=%d\n" % (comp, ntasks, nthrds, rootpe, ninst, pstrid)
 
         doc += "#\n"
-        doc +=  "#    total number of hw pes = %d\n" % self.full_sum
+        doc +=  "#    total number of hw pes = %d\n" % self.sumpes
 
         for comp, ntasks, nthrds, rootpe, pstrid in zip(self.COMP, self.NTASKS, self.NTHRDS, self.ROOTPE, self.PSTRID):
             tt = rootpe + (ntasks - 1) * pstrid

--- a/utils/python/CIME/task_maker.py
+++ b/utils/python/CIME/task_maker.py
@@ -137,7 +137,7 @@ class TaskMaker(object):
         max_total_node_count = int(math.ceil(float(max_task_count) / max_tasks_per_node))
 
         full_sum += sum_
-        self.sumpes = full_sum
+        self.fullsum = full_sum
         task_geom += ")"
         self.taskgeometry = task_geom
         if self.PES_PER_NODE > 0:
@@ -206,7 +206,7 @@ class TaskMaker(object):
             doc += "#    %s ntasks=%d nthreads=%d rootpe=%d ninst=%d pstrid=%d\n" % (comp, ntasks, nthrds, rootpe, ninst, pstrid)
 
         doc += "#\n"
-        doc +=  "#    total number of hw pes = %d\n" % self.sumpes
+        doc +=  "#    total number of hw pes = %d\n" % self.fullsum
 
         for comp, ntasks, nthrds, rootpe, pstrid in zip(self.COMP, self.NTASKS, self.NTHRDS, self.ROOTPE, self.PSTRID):
             tt = rootpe + (ntasks - 1) * pstrid


### PR DESCRIPTION
Fix list:
1) {{ queue }} and {{ wall_time }} are apparently no longer supported, use job_queue and job_wallclock_time instead.
2) get_project needs to optionally look at config_machines.xml as its documentation advertises
3) Remove methods from batch.py that have been replaced by methods in env_batch.py (cleanup, not fix)
4) env_batch::get_value needs to use attributes when looking for optional node
5) Need to take job and case into account when getting batch directives
6) Fix env_batch::get_default_walltime
7) Fallback to default walltime if queue does not provide max walltime
8) Namespace errors in buildnml and buildlib
9) clone_case should use the PROJECT from the previous case
10) Make names line up better between env_batch and task_maker. This will allow
    easier substitution between the two when resolving {{ tokens }}.
11) Mpi args were not being handled correctly. Do not determine args until an
    mpirun has been selected.
12) empty-dict attributes was breaking get_nodes

Test suite: cime_developer
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: [CIME Github issue #]

User interface changes?: no

Code review: @mvertens 

