### PR TITLE
Raise an error if batch_submit isn't found.

### DIFF
--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -381,6 +381,8 @@ class EnvBatch(EnvBase):
             submitargs += " " + dep_string
 
         batchsubmit = self.get_value("batch_submit", subgroup=None)
+        expect(batchsubmit is not None,
+               "Unable to determine the correct command for batch submission.")
         batchredirect = self.get_value("batch_redirect", subgroup=None)
         submitcmd = ''
         for string in (batchsubmit, submitargs, batchredirect, job):


### PR DESCRIPTION
There seems to be a problem on yellowstone relating to lookup of batch_submit.

While I'm still working on tracking down that error, in the meantime, we should
improve the error message that results from this problem.