### PR TITLE
Go back to using python instead of python2 as the executable

### DIFF
--- a/cime_config/acme/machines/template.case.run
+++ b/cime_config/acme/machines/template.case.run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 template to create a case run script. This should only ever be called

--- a/cime_config/acme/machines/template.case.test
+++ b/cime_config/acme/machines/template.case.test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 {{ batchdirectives }}
 """
 This is the system test submit script for CIME. This should only ever be called

--- a/cime_config/acme/machines/template.lt_archive
+++ b/cime_config/acme/machines/template.lt_archive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 template to create a case longterm term archiving script. This should only ever be called

--- a/cime_config/acme/machines/template.st_archive
+++ b/cime_config/acme/machines/template.st_archive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 template to create a case short term archiving script. This should only ever be called

--- a/cime_config/cesm/machines/template.case.run
+++ b/cime_config/cesm/machines/template.case.run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 template to create a case run script. This should only ever be called

--- a/cime_config/cesm/machines/template.case.test
+++ b/cime_config/cesm/machines/template.case.test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 {{ batchdirectives }}
 """
 This is the system test submit script for CIME. This should only ever be called

--- a/cime_config/cesm/machines/template.lt_archive
+++ b/cime_config/cesm/machines/template.lt_archive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 template to create a case longterm term archiving script. This should only ever be called

--- a/cime_config/cesm/machines/template.st_archive
+++ b/cime_config/cesm/machines/template.st_archive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 template to create a case short term archiving script. This should only ever be called

--- a/components/data_comps/datm/cime_config/buildlib
+++ b/components/data_comps/datm/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/dice/cime_config/buildlib
+++ b/components/data_comps/dice/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/dlnd/cime_config/buildlib
+++ b/components/data_comps/dlnd/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/docn/cime_config/buildlib
+++ b/components/data_comps/docn/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/drof/cime_config/buildlib
+++ b/components/data_comps/drof/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/dwav/cime_config/buildlib
+++ b/components/data_comps/dwav/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/stub_comps/satm/cime_config/buildlib
+++ b/components/stub_comps/satm/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model library

--- a/components/stub_comps/satm/cime_config/buildnml
+++ b/components/stub_comps/satm/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model namelist

--- a/components/stub_comps/sesp/cime_config/buildlib
+++ b/components/stub_comps/sesp/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model library

--- a/components/stub_comps/sesp/cime_config/buildnml
+++ b/components/stub_comps/sesp/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model namelist

--- a/components/stub_comps/sglc/cime_config/buildlib
+++ b/components/stub_comps/sglc/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model library

--- a/components/stub_comps/sglc/cime_config/buildnml
+++ b/components/stub_comps/sglc/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model namelist

--- a/components/stub_comps/sice/cime_config/buildlib
+++ b/components/stub_comps/sice/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model library

--- a/components/stub_comps/sice/cime_config/buildnml
+++ b/components/stub_comps/sice/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model namelist

--- a/components/stub_comps/slnd/cime_config/buildlib
+++ b/components/stub_comps/slnd/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model library

--- a/components/stub_comps/slnd/cime_config/buildnml
+++ b/components/stub_comps/slnd/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model namelist

--- a/components/stub_comps/socn/cime_config/buildlib
+++ b/components/stub_comps/socn/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model library

--- a/components/stub_comps/socn/cime_config/buildnml
+++ b/components/stub_comps/socn/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model namelist

--- a/components/stub_comps/srof/cime_config/buildlib
+++ b/components/stub_comps/srof/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model library

--- a/components/stub_comps/srof/cime_config/buildnml
+++ b/components/stub_comps/srof/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model namelist

--- a/components/stub_comps/swav/cime_config/buildlib
+++ b/components/stub_comps/swav/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model library

--- a/components/stub_comps/swav/cime_config/buildnml
+++ b/components/stub_comps/swav/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build stub model namelist

--- a/components/xcpl_comps/xatm/cime_config/buildlib
+++ b/components/xcpl_comps/xatm/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xatm/cime_config/buildnml
+++ b/components/xcpl_comps/xatm/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xglc/cime_config/buildlib
+++ b/components/xcpl_comps/xglc/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xglc/cime_config/buildnml
+++ b/components/xcpl_comps/xglc/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xice/cime_config/buildlib
+++ b/components/xcpl_comps/xice/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xice/cime_config/buildnml
+++ b/components/xcpl_comps/xice/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xlnd/cime_config/buildlib
+++ b/components/xcpl_comps/xlnd/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xlnd/cime_config/buildnml
+++ b/components/xcpl_comps/xlnd/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xocn/cime_config/buildlib
+++ b/components/xcpl_comps/xocn/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xocn/cime_config/buildnml
+++ b/components/xcpl_comps/xocn/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xrof/cime_config/buildlib
+++ b/components/xcpl_comps/xrof/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xrof/cime_config/buildnml
+++ b/components/xcpl_comps/xrof/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xwav/cime_config/buildlib
+++ b/components/xcpl_comps/xwav/cime_config/buildlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/components/xcpl_comps/xwav/cime_config/buildnml
+++ b/components/xcpl_comps/xwav/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model library

--- a/driver_cpl/cime_config/buildexe
+++ b/driver_cpl/cime_config/buildexe
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build model executable

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 build data model namelist input

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 Script to build a case.

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 case.setup - create the $caseroot/case.run script and user_nl_xxx component namelist mod files

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 case.submit - Submit a cesm workflow to the queueing system or run it if there is no queueing system.   A cesm workflow may include multiple jobs.

--- a/scripts/Tools/check_lockedfiles
+++ b/scripts/Tools/check_lockedfiles
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 """
 This script compares xml files
 """

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 preview_namelists runs the buildnml script for each case component

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
  This utility allows the user to change a env_*xml file via a commandline interface.

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 This utility allows the CIME user to view a field in a env_*xml file via a commandline interface.

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from Tools.standard_script_setup import *
 

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from Tools.standard_script_setup import *
 from shutil import copyfile

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 Script to run CIME tests.

--- a/scripts/manage_case
+++ b/scripts/manage_case
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from Tools.standard_script_setup import *
 

--- a/scripts/manage_pes
+++ b/scripts/manage_pes
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 """
 Manage pes layouts -- Adds or queries pes with the xml pe-layout
 files for a pes file set by the argument "-pes_setby"

--- a/utils/python/CIME/case_submit.py
+++ b/utils/python/CIME/case_submit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """
 case.submit - Submit a cesm workflow to the queueing system or run it

--- a/utils/python/tests/scripts_regression_tests
+++ b/utils/python/tests/scripts_regression_tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import unittest, sys, os, tempfile, shutil, re, threading, time, signal, glob, traceback, logging
 


### PR DESCRIPTION
python2 was causing much grief to users of systems that did not
use this convention.

Test suite: None
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes: [CIME Github issue #]

User interface changes?: 

Code review: @mvertens 

