### PR TITLE
Fix typo in `system_tests_common`.

### DIFF
--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -239,7 +239,7 @@ class SystemTestsCommon(object):
         basecmp_dir = os.path.join(baselineroot, self._case.get_value("BASECMP_CASE"))
         for bdir in (baselineroot, basecmp_dir):
             if not os.path.isdir(bdir):
-                append_status("GFAIL %s baseline\n",self._case.get_value("CASEBASEID"),
+                append_status("GFAIL %s baseline\n"%self._case.get_value("CASEBASEID"),
                              sfile="TestStatus")
                 append_status("ERROR %s does not exist"%bdir, sfile="TestStatus.log")
                 return -1


### PR DESCRIPTION
As-is, there's a line that's trying to use `CASEBASEID` as a
relative path to a case directory, which makes no sense.
I think that it meant to use a `%` instead of `,`, so that
`CASEBASEID` is part of the error message, not an
argument to `append_status`.