### PR TITLE
Fix errors when running `cs.status.*`.

### DIFF
--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -239,8 +239,8 @@ class SystemTestsCommon(object):
         basecmp_dir = os.path.join(baselineroot, self._case.get_value("BASECMP_CASE"))
         for bdir in (baselineroot, basecmp_dir):
             if not os.path.isdir(bdir):
-                append_status("GFAIL %s baseline\n"%self._case.get_value("CASEBASEID"),
-                             sfile="TestStatus")
+                append_status("BFAIL %s compare\n"%self._case.get_value("CASEBASEID"),
+                              sfile="TestStatus")
                 append_status("ERROR %s does not exist"%bdir, sfile="TestStatus.log")
                 return -1
         compgen = os.path.join(self._case.get_value("SCRIPTSROOT"),"Tools",
@@ -268,9 +268,13 @@ class SystemTestsCommon(object):
             curmem = memlist[-1][1]
             diff = (curmem-blmem)/blmem
             if(diff < 0.1):
-                append_status("PASS  Memory usage baseline compare ",sfile="TestStatus")
+                append_status("PASS %s memcomp\n"%self._case.get_value("CASEBASEID"),
+                              sfile="TestStatus")
             else:
-                append_status("FAIL  Memory usage increase > 10% from baseline",sfile="TestStatus")
+                append_status("FAIL %s memcomp\n"%self._case.get_value("CASEBASEID"),
+                              sfile="TestStatus")
+                append_status("Error in memory compare: Memory usage increase > 10% from baseline",
+                              sfile="TestStatus.log")
         # compare throughput to baseline
         current = self._get_throughput(newestcpllogfile)
         baseline = self._get_throughput(baselog)
@@ -278,11 +282,13 @@ class SystemTestsCommon(object):
         if baseline is not None and current is not None:
             diff = (baseline - current)/baseline
             if(diff < 0.25):
-                append_status("PASS  Throughput baseline compare ",sfile="TestStatus")
+                append_status("PASS %s tputcomp\n"%self._case.get_value("CASEBASEID"),
+                              sfile="TestStatus")
             else:
-                append_status("FAIL  Throughput increase > 25% from baseline",sfile="TestStatus")
-
-
+                append_status("FAIL %s tputcomp\n"%self._case.get_value("CASEBASEID"),
+                              sfile="TestStatus")
+                append_status("Error in throughput compare: Computation time increase > 25% from baseline",
+                              sfile="TestStatus.log")
 
     def generate_baseline(self):
         """
@@ -297,7 +303,7 @@ class SystemTestsCommon(object):
         basegen_dir = os.path.join(baselineroot, self._case.get_value("BASEGEN_CASE"))
         for bdir in (baselineroot, basegen_dir):
             if not os.path.isdir(bdir):
-                append_status("GFAIL %s baseline\n" % self._case.get_value("CASEBASEID"),
+                append_status("FAIL %s generate\n" % self._case.get_value("CASEBASEID"),
                              sfile="TestStatus")
                 append_status("ERROR %s does not exist" % bdir, sfile="TestStatus.log")
                 return -1

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -239,7 +239,7 @@ class SystemTestsCommon(object):
         basecmp_dir = os.path.join(baselineroot, self._case.get_value("BASECMP_CASE"))
         for bdir in (baselineroot, basecmp_dir):
             if not os.path.isdir(bdir):
-                append_status("BFAIL %s compare\n"%self._case.get_value("CASEBASEID"),
+                append_status("FAIL %s compare\n"%self._case.get_value("CASEBASEID"),
                               sfile="TestStatus")
                 append_status("ERROR %s does not exist"%bdir, sfile="TestStatus.log")
                 return -1

--- a/utils/python/wait_for_tests.py
+++ b/utils/python/wait_for_tests.py
@@ -13,6 +13,7 @@ TEST_PASS_STATUS          = "PASS"
 TEST_FAIL_STATUS          = "FAIL"
 TEST_DIFF_STATUS          = "DIFF"
 NAMELIST_FAIL_STATUS      = "NLFAIL"
+BASELINE_MISSING_STATUS   = "BFAIL"
 COMMENT_STATUS            = "COMMENT"
 SLEEP_INTERVAL_SEC        = .1
 THROUGHPUT_TEST_STR       = "tputcomp"
@@ -321,11 +322,13 @@ def parse_test_status(file_contents):
             else:
                 expect(test_name == curr_test_name, "inconsistent test name in parse_test_status: '%s' != '%s'"%(test_name, curr_test_name))
 
-            expect(status in [TEST_PENDING_STATUS ,TEST_PASS_STATUS, \
-                              TEST_FAIL_STATUS, TEST_DIFF_STATUS, NAMELIST_FAIL_STATUS],
+            expect(status in [TEST_PENDING_STATUS ,TEST_PASS_STATUS,
+                              TEST_FAIL_STATUS, TEST_DIFF_STATUS, NAMELIST_FAIL_STATUS,
+                              BASELINE_MISSING_STATUS],
                    "Unexpected status '%s' in parse_test_status" % status)
             expect(phase in ["INIT","CREATE_NEWCASE","XML","SETUP","SHAREDLIB_BUILD",
-                             "tputcomp","nlcomp","MODEL_BUILD", "compare", "generate", "memleak", "RUN"],
+                             "nlcomp","MODEL_BUILD", "compare", "generate",
+                             "memleak", "RUN", MEMORY_TEST_STR, THROUGHPUT_TEST_STR],
                    "phase '%s' not expected in parse_test_status" % phase)
 
             if (phase in rv):

--- a/utils/python/wait_for_tests.py
+++ b/utils/python/wait_for_tests.py
@@ -13,7 +13,6 @@ TEST_PASS_STATUS          = "PASS"
 TEST_FAIL_STATUS          = "FAIL"
 TEST_DIFF_STATUS          = "DIFF"
 NAMELIST_FAIL_STATUS      = "NLFAIL"
-BASELINE_MISSING_STATUS   = "BFAIL"
 COMMENT_STATUS            = "COMMENT"
 SLEEP_INTERVAL_SEC        = .1
 THROUGHPUT_TEST_STR       = "tputcomp"
@@ -323,8 +322,7 @@ def parse_test_status(file_contents):
                 expect(test_name == curr_test_name, "inconsistent test name in parse_test_status: '%s' != '%s'"%(test_name, curr_test_name))
 
             expect(status in [TEST_PENDING_STATUS ,TEST_PASS_STATUS,
-                              TEST_FAIL_STATUS, TEST_DIFF_STATUS, NAMELIST_FAIL_STATUS,
-                              BASELINE_MISSING_STATUS],
+                              TEST_FAIL_STATUS, TEST_DIFF_STATUS, NAMELIST_FAIL_STATUS],
                    "Unexpected status '%s' in parse_test_status" % status)
             expect(phase in ["INIT","CREATE_NEWCASE","XML","SETUP","SHAREDLIB_BUILD",
                              "nlcomp","MODEL_BUILD", "compare", "generate",


### PR DESCRIPTION
There were several errors related to baseline tests, including memory
and throughput baselines, when running the `cs.status.*` script. (This
is the script generated in the root directory for a test suite, for
checking the current status of all tests in the suite.)

Most of the necessary changes are in `system_tests_common`, where the
output produced using `append_status` needs to use a format and phase
identifiers that can be recognized by
`wait_for_tests.parse_test_status`. `parse_test_status` also needs to
recognize the memory and throughput comparisons as valid test phases, as
well as recognizing "BFAIL" (the status resulting from a *missing*
baseline directory) as a valid status.

Testing:

   There are no formal regression tests for this functionality, but the
   CAM tests on yellowstone have been run with these changes, and
   cs.status runs without throwing an exception.