### PR TITLE
Changed error message, variable name identical to entry in xml now

### DIFF
--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -76,7 +76,7 @@ def _build_usernl_files(case, model, comp):
                     shutil.copy(model_nl, nlfile)
 
 ###############################################################################
-def case_setup(case, clean=False, test_mode=False, reset=False):
+def  (case, clean=False, test_mode=False, reset=False):
 ###############################################################################
     caseroot = case.get_value("CASEROOT")
     os.chdir(caseroot)
@@ -166,7 +166,7 @@ def case_setup(case, clean=False, test_mode=False, reset=False):
                 if ntasks == 1:
                     case.set_value("NTASKS_%s" % comp, ninst)
                 else:
-                    expect(False, "%s NINST value %d greater than %s NTASKS %d" % (comp, ninst, comp, ntasks))
+                    expect(False, "NINST_%s value %d greater than NTASKS_%s %d" % (comp, ninst, comp, ntasks))
 
         expect(not (case.get_value("BUILD_THREADED") and case.get_value("COMPILER") == "nag"),
                "it is not possible to run with OpenMP if using the NAG Fortran compiler")

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -76,7 +76,7 @@ def _build_usernl_files(case, model, comp):
                     shutil.copy(model_nl, nlfile)
 
 ###############################################################################
-def  (case, clean=False, test_mode=False, reset=False):
+def case_setup(case, clean=False, test_mode=False, reset=False):
 ###############################################################################
     caseroot = case.get_value("CASEROOT")
     os.chdir(caseroot)


### PR DESCRIPTION
Change in error message, prints real variable name now.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes: #248 

User interface changes?: 

Code review: 

