### PR TITLE
Make `Case` a context manager.

### DIFF
--- a/cime_config/acme/machines/template.case.run
+++ b/cime_config/acme/machines/template.case.run
@@ -74,7 +74,7 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         success = case_run(case)
 
     sys.exit(0 if success else 1)

--- a/cime_config/acme/machines/template.case.run
+++ b/cime_config/acme/machines/template.case.run
@@ -74,8 +74,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-    success = case_run(case)
+    with Case(caseroot) as case:
+        success = case_run(case)
 
     sys.exit(0 if success else 1)
 

--- a/cime_config/acme/machines/template.case.test
+++ b/cime_config/acme/machines/template.case.test
@@ -66,7 +66,7 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, testname = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         success = case_test(case, testname)
 
     sys.exit(0 if success else 1)

--- a/cime_config/acme/machines/template.case.test
+++ b/cime_config/acme/machines/template.case.test
@@ -66,8 +66,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, testname = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-    success = case_test(case, testname)
+    with Case(caseroot) as case:
+        success = case_test(case, testname)
 
     sys.exit(0 if success else 1)
 

--- a/cime_config/acme/machines/template.lt_archive
+++ b/cime_config/acme/machines/template.lt_archive
@@ -67,8 +67,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
-        success = case_lt_archive(case)
+    case = Case(caseroot)
+    success = case_lt_archive(case)
 
     sys.exit(0 if success else 1)
 

--- a/cime_config/acme/machines/template.lt_archive
+++ b/cime_config/acme/machines/template.lt_archive
@@ -67,8 +67,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-    success = case_lt_archive(case)
+    with Case(caseroot) as case:
+        success = case_lt_archive(case)
 
     sys.exit(0 if success else 1)
 

--- a/cime_config/acme/machines/template.st_archive
+++ b/cime_config/acme/machines/template.st_archive
@@ -66,8 +66,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-    success = case_st_archive(case)
+    with Case(caseroot) as case:
+        success = case_st_archive(case)
 
     sys.exit(0 if success else 1)
 

--- a/cime_config/acme/machines/template.st_archive
+++ b/cime_config/acme/machines/template.st_archive
@@ -66,7 +66,7 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         success = case_st_archive(case)
 
     sys.exit(0 if success else 1)

--- a/cime_config/cesm/machines/template.case.run
+++ b/cime_config/cesm/machines/template.case.run
@@ -74,7 +74,7 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         success = case_run(case)
 
     sys.exit(0 if success else 1)

--- a/cime_config/cesm/machines/template.case.run
+++ b/cime_config/cesm/machines/template.case.run
@@ -74,8 +74,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-    success = case_run(case)
+    with Case(caseroot) as case:
+        success = case_run(case)
 
     sys.exit(0 if success else 1)
 

--- a/cime_config/cesm/machines/template.case.test
+++ b/cime_config/cesm/machines/template.case.test
@@ -66,7 +66,7 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, testname = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         success = case_test(case, testname)
 
     sys.exit(0 if success else 1)

--- a/cime_config/cesm/machines/template.case.test
+++ b/cime_config/cesm/machines/template.case.test
@@ -66,8 +66,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, testname = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-    success = case_test(case, testname)
+    with Case(caseroot) as case:
+        success = case_test(case, testname)
 
     sys.exit(0 if success else 1)
 

--- a/cime_config/cesm/machines/template.lt_archive
+++ b/cime_config/cesm/machines/template.lt_archive
@@ -67,8 +67,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
-        success = case_lt_archive(case)
+    case = Case(caseroot)
+    success = case_lt_archive(case)
 
     sys.exit(0 if success else 1)
 

--- a/cime_config/cesm/machines/template.lt_archive
+++ b/cime_config/cesm/machines/template.lt_archive
@@ -67,8 +67,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-    success = case_lt_archive(case)
+    with Case(caseroot) as case:
+        success = case_lt_archive(case)
 
     sys.exit(0 if success else 1)
 

--- a/cime_config/cesm/machines/template.st_archive
+++ b/cime_config/cesm/machines/template.st_archive
@@ -67,7 +67,7 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         success = case_st_archive(case)
 
     sys.exit(0 if success else 1)

--- a/cime_config/cesm/machines/template.st_archive
+++ b/cime_config/cesm/machines/template.st_archive
@@ -67,8 +67,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-    success = case_st_archive(case)
+    with Case(caseroot) as case:
+        success = case_st_archive(case)
 
     sys.exit(0 if success else 1)
 

--- a/driver_cpl/cime_config/buildexe
+++ b/driver_cpl/cime_config/buildexe
@@ -26,16 +26,14 @@ def _main_func():
 
     logger.info("Building a single executable version of target coupled model")
 
-    case = Case(caseroot)
-
-    casetools = case.get_value("CASETOOLS")
-    cimeroot  = case.get_value("CIMEROOT")
-    exeroot   = case.get_value("EXEROOT")
-    gmake     = case.get_value("GMAKE")
-    gmake_j   = case.get_value("GMAKE_J")
-    model     = case.get_value("MODEL")
-
-    os.environ["PIO_VERSION"] = str(case.get_value("PIO_VERSION"))
+    with Case(caseroot) as case:
+        casetools = case.get_value("CASETOOLS")
+        cimeroot  = case.get_value("CIMEROOT")
+        exeroot   = case.get_value("EXEROOT")
+        gmake     = case.get_value("GMAKE")
+        gmake_j   = case.get_value("GMAKE_J")
+        model     = case.get_value("MODEL")
+        os.environ["PIO_VERSION"] = str(case.get_value("PIO_VERSION"))
 
     with open('Filepath', 'w') as out:
         out.write(os.path.join(caseroot, "SourceMods", "src.drv") + "\n")

--- a/driver_cpl/cime_config/buildexe
+++ b/driver_cpl/cime_config/buildexe
@@ -26,14 +26,16 @@ def _main_func():
 
     logger.info("Building a single executable version of target coupled model")
 
-    with Case(caseroot) as case:
-        casetools = case.get_value("CASETOOLS")
-        cimeroot  = case.get_value("CIMEROOT")
-        exeroot   = case.get_value("EXEROOT")
-        gmake     = case.get_value("GMAKE")
-        gmake_j   = case.get_value("GMAKE_J")
-        model     = case.get_value("MODEL")
-        os.environ["PIO_VERSION"] = str(case.get_value("PIO_VERSION"))
+    case = Case(caseroot)
+
+    casetools = case.get_value("CASETOOLS")
+    cimeroot  = case.get_value("CIMEROOT")
+    exeroot   = case.get_value("EXEROOT")
+    gmake     = case.get_value("GMAKE")
+    gmake_j   = case.get_value("GMAKE_J")
+    model     = case.get_value("MODEL")
+
+    os.environ["PIO_VERSION"] = str(case.get_value("PIO_VERSION"))
 
     with open('Filepath', 'w') as out:
         out.write(os.path.join(caseroot, "SourceMods", "src.drv") + "\n")

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -23,40 +23,42 @@ def _main_func():
 
     caseroot = parse_input(sys.argv)
 
-    with Case(caseroot) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        caseroot = case.get_value("CASEROOT")
-        casebuild = case.get_value("CASEBUILD")
-        rundir = case.get_value("RUNDIR")
-        grid = case.get_value("GRID")
-        atm_grid = case.get_value("ATM_GRID")
-        lnd_grid = case.get_value("LND_GRID")
-        ocn_grid = case.get_value("OCN_GRID")
-        rof_grid = case.get_value("ROF_GRID")
-        wav_grid = case.get_value("WAV_GRID")
-        comp_atm = case.get_value("COMP_ATM")
-        pio_version = case.get_value("PIO_VERSION")
+    case = Case(caseroot)
 
-        confdir = os.path.join(casebuild, "cplconf")
-        if not os.path.isdir(confdir):
-            os.makedirs(confdir)
+    cimeroot	= case.get_value("CIMEROOT")
+    caseroot	= case.get_value("CASEROOT")
+    casebuild	= case.get_value("CASEBUILD")
+    rundir	= case.get_value("RUNDIR")
+    grid	= case.get_value("GRID")
+    atm_grid	= case.get_value("ATM_GRID")
+    lnd_grid	= case.get_value("LND_GRID")
+    ocn_grid	= case.get_value("OCN_GRID")
+    rof_grid	= case.get_value("ROF_GRID")
+    wav_grid	= case.get_value("WAV_GRID")
+    comp_atm	= case.get_value("COMP_ATM")
+    pio_version = case.get_value("PIO_VERSION")
 
-        # create cplconf/namelist
-        infile_text = ""
-        if comp_atm == 'cam':
-            # *** FIXME - this is confusing!!!***
-            # cam is actually changing the driver namelist settings
-            cam_config_opts = case.get_value("CAM_CONFIG_OPTS")
-            if "adiabatic" in cam_config_opts:
-                infile_text = "atm_adiabatic = .true."
-            if "ideal" in cam_config_opts:
-                infile_text = "atm_ideal_phys = .true."
-            if "aquaplanet" in cam_config_opts:
-                infile_text = "aqua_planet = .true. \n aqua_planet_sst = 1"
+    confdir = os.path.join(casebuild, "cplconf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
-        user_nl_file = os.path.join(caseroot, "user_nl_cpl")
-        namelist_infile = os.path.join(confdir, "namelist")
-        create_namelist_infile(case, user_nl_file, namelist_infile, infile_text)
+    # create cplconf/namelist
+
+    infile_text = ""
+    if comp_atm == 'cam':
+        # *** FIXME - this is confusing!!!***
+        # cam is actually changing the driver namelist settings
+        cam_config_opts = case.get_value("CAM_CONFIG_OPTS")
+        if "adiabatic" in cam_config_opts:
+            infile_text = "atm_adiabatic = .true."
+        if "ideal" in cam_config_opts:
+            infile_text = "atm_ideal_phys = .true."
+        if "aquaplanet" in cam_config_opts:
+            infile_text = "aqua_planet = .true. \n aqua_planet_sst = 1"
+
+    user_nl_file = os.path.join(caseroot, "user_nl_cpl")
+    namelist_infile = os.path.join(confdir, "namelist")
+    create_namelist_infile(case, user_nl_file, namelist_infile, infile_text)
 
     # call build-namelist
 

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -23,42 +23,40 @@ def _main_func():
 
     caseroot = parse_input(sys.argv)
 
-    case = Case(caseroot)
+    with Case(caseroot) as case:
+        cimeroot = case.get_value("CIMEROOT")
+        caseroot = case.get_value("CASEROOT")
+        casebuild = case.get_value("CASEBUILD")
+        rundir = case.get_value("RUNDIR")
+        grid = case.get_value("GRID")
+        atm_grid = case.get_value("ATM_GRID")
+        lnd_grid = case.get_value("LND_GRID")
+        ocn_grid = case.get_value("OCN_GRID")
+        rof_grid = case.get_value("ROF_GRID")
+        wav_grid = case.get_value("WAV_GRID")
+        comp_atm = case.get_value("COMP_ATM")
+        pio_version = case.get_value("PIO_VERSION")
 
-    cimeroot	= case.get_value("CIMEROOT")
-    caseroot	= case.get_value("CASEROOT")
-    casebuild	= case.get_value("CASEBUILD")
-    rundir	= case.get_value("RUNDIR")
-    grid	= case.get_value("GRID")
-    atm_grid	= case.get_value("ATM_GRID")
-    lnd_grid	= case.get_value("LND_GRID")
-    ocn_grid	= case.get_value("OCN_GRID")
-    rof_grid	= case.get_value("ROF_GRID")
-    wav_grid	= case.get_value("WAV_GRID")
-    comp_atm	= case.get_value("COMP_ATM")
-    pio_version = case.get_value("PIO_VERSION")
+        confdir = os.path.join(casebuild, "cplconf")
+        if not os.path.isdir(confdir):
+            os.makedirs(confdir)
 
-    confdir = os.path.join(casebuild, "cplconf")
-    if not os.path.isdir(confdir):
-        os.makedirs(confdir)
+        # create cplconf/namelist
+        infile_text = ""
+        if comp_atm == 'cam':
+            # *** FIXME - this is confusing!!!***
+            # cam is actually changing the driver namelist settings
+            cam_config_opts = case.get_value("CAM_CONFIG_OPTS")
+            if "adiabatic" in cam_config_opts:
+                infile_text = "atm_adiabatic = .true."
+            if "ideal" in cam_config_opts:
+                infile_text = "atm_ideal_phys = .true."
+            if "aquaplanet" in cam_config_opts:
+                infile_text = "aqua_planet = .true. \n aqua_planet_sst = 1"
 
-    # create cplconf/namelist
-
-    infile_text = ""
-    if comp_atm == 'cam':
-        # *** FIXME - this is confusing!!!***
-        # cam is actually changing the driver namelist settings
-        cam_config_opts = case.get_value("CAM_CONFIG_OPTS")
-        if "adiabatic" in cam_config_opts:
-            infile_text = "atm_adiabatic = .true."
-        if "ideal" in cam_config_opts:
-            infile_text = "atm_ideal_phys = .true."
-        if "aquaplanet" in cam_config_opts:
-            infile_text = "aqua_planet = .true. \n aqua_planet_sst = 1"
-
-    user_nl_file = os.path.join(caseroot, "user_nl_cpl")
-    namelist_infile = os.path.join(confdir, "namelist")
-    create_namelist_infile(case, user_nl_file, namelist_infile, infile_text)
+        user_nl_file = os.path.join(caseroot, "user_nl_cpl")
+        namelist_infile = os.path.join(confdir, "namelist")
+        create_namelist_infile(case, user_nl_file, namelist_infile, infile_text)
 
     # call build-namelist
 

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -91,7 +91,7 @@ def _main_func(description):
     caseroot, sharedlib_only, model_only, cleanlist = parse_command_line(sys.argv, description)
     logging.info("calling build.case_build with caseroot=%s" %caseroot)
 
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         testname = case.get_value('TESTCASE')
 
         if cleanlist:

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -91,29 +91,30 @@ def _main_func(description):
     caseroot, sharedlib_only, model_only, cleanlist = parse_command_line(sys.argv, description)
     logging.info("calling build.case_build with caseroot=%s" %caseroot)
 
-    case = Case(caseroot)
-    testname = case.get_value('TESTCASE')
+    with Case(caseroot) as case:
+        testname = case.get_value('TESTCASE')
 
-    if cleanlist:
-        build.clean(case, cleanlist)
-    elif(testname is not None):
-        logging.warn("Building test for %s in directory %s" % (testname, caseroot))
-        try:
-            test = globals()[testname](case)
-        except KeyError:
-            expect(False, "Could not find a test called '%s'" % testname)
-        append_status("case.testbuild starting ",
-                     caseroot=caseroot,sfile="CaseStatus")
-        test.build(sharedlib_only=sharedlib_only, model_only=model_only)
-        append_status("case.testbuild complete",
-                     caseroot=caseroot,sfile="CaseStatus")
-    else:
-        append_status("case.build starting",
-                     caseroot=caseroot,sfile="CaseStatus")
-        build.case_build(caseroot, case=case, sharedlib_only=sharedlib_only,
-                     model_only=model_only)
-        append_status("case.build complete",
-                     caseroot=caseroot,sfile="CaseStatus")
+        if cleanlist:
+            build.clean(case, cleanlist)
+        elif(testname is not None):
+            logging.warn("Building test for %s in directory %s" %
+                         (testname, caseroot))
+            try:
+                test = globals()[testname](case)
+            except KeyError:
+                expect(False, "Could not find a test called '%s'" % testname)
+            append_status("case.testbuild starting ",
+                         caseroot=caseroot,sfile="CaseStatus")
+            test.build(sharedlib_only=sharedlib_only, model_only=model_only)
+            append_status("case.testbuild complete",
+                         caseroot=caseroot,sfile="CaseStatus")
+        else:
+            append_status("case.build starting",
+                         caseroot=caseroot,sfile="CaseStatus")
+            build.case_build(caseroot, case=case, sharedlib_only=sharedlib_only,
+                         model_only=model_only)
+            append_status("case.build complete",
+                         caseroot=caseroot,sfile="CaseStatus")
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -58,9 +58,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, clean, test_mode, reset = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-
-    case_setup(case, clean, test_mode, reset)
+    with Case(caseroot) as case:
+        case_setup(case, clean, test_mode, reset)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -58,7 +58,7 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, clean, test_mode, reset = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         case_setup(case, clean, test_mode, reset)
 
 if __name__ == "__main__":

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -56,9 +56,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, job, no_batch, prereq = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-
-    submit(case, job=job, no_batch=no_batch, prereq_jobid=prereq)
+    with Case(caseroot) as case:
+        submit(case, job=job, no_batch=no_batch, prereq_jobid=prereq)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -56,7 +56,7 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, job, no_batch, prereq = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         submit(case, job=job, no_batch=no_batch, prereq_jobid=prereq)
 
 if __name__ == "__main__":

--- a/scripts/Tools/check_case
+++ b/scripts/Tools/check_case
@@ -54,10 +54,10 @@ def _main_func(description):
 
     check_lockedfiles()
 
-    case  = Case()
-    preview_namelists(case)
+    with Case() as case:
+        preview_namelists(case)
+        build_complete = case.get_value("BUILD_COMPLETE")
 
-    build_complete = case.get_value("BUILD_COMPLETE")
     if not build_complete:
         expect(False,
                "Please rebuild the model interactively by calling case.build")

--- a/scripts/Tools/check_case
+++ b/scripts/Tools/check_case
@@ -54,7 +54,7 @@ def _main_func(description):
 
     check_lockedfiles()
 
-    with Case() as case:
+    with Case(read_only=False) as case:
         preview_namelists(case)
         build_complete = case.get_value("BUILD_COMPLETE")
 

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -10,6 +10,7 @@ from standard_script_setup import *
 from CIME.utils import expect, get_model, run_cmd
 from CIME.XML.machines import Machines
 from CIME.check_input_data import check_input_data, SVN_LOCS
+from CIME.case import Case
 
 import argparse, doctest, fnmatch
 
@@ -64,8 +65,12 @@ def _main_func(description):
 
     svn_loc, input_data_root, data_list_dir, download = parse_command_line(sys.argv, description)
 
-    sys.exit(0 if check_input_data(svn_loc=svn_loc, input_data_root=input_data_root,
-                                   data_list_dir=data_list_dir, download=download) else 1)
+    with Case() as case:
+        sys.exit(0 if check_input_data(case,
+                                       svn_loc=svn_loc,
+                                       input_data_root=input_data_root,
+                                       data_list_dir=data_list_dir,
+                                       download=download) else 1)
 
 ###############################################################################
 

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -65,12 +65,12 @@ def _main_func(description):
 
     svn_loc, input_data_root, data_list_dir, download = parse_command_line(sys.argv, description)
 
-    with Case() as case:
-        sys.exit(0 if check_input_data(case,
-                                       svn_loc=svn_loc,
-                                       input_data_root=input_data_root,
-                                       data_list_dir=data_list_dir,
-                                       download=download) else 1)
+    case = Case()
+    sys.exit(0 if check_input_data(case,
+                                   svn_loc=svn_loc,
+                                   input_data_root=input_data_root,
+                                   data_list_dir=data_list_dir,
+                                   download=download) else 1)
 
 ###############################################################################
 

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -65,12 +65,12 @@ def _main_func(description):
 
     svn_loc, input_data_root, data_list_dir, download = parse_command_line(sys.argv, description)
 
-    case = Case()
-    sys.exit(0 if check_input_data(case,
-                                   svn_loc=svn_loc,
-                                   input_data_root=input_data_root,
-                                   data_list_dir=data_list_dir,
-                                   download=download) else 1)
+    with Case() as case:
+        sys.exit(0 if check_input_data(case,
+                                       svn_loc=svn_loc,
+                                       input_data_root=input_data_root,
+                                       data_list_dir=data_list_dir,
+                                       download=download) else 1)
 
 ###############################################################################
 

--- a/scripts/Tools/getTiming
+++ b/scripts/Tools/getTiming
@@ -120,55 +120,55 @@ class TimingParser:
 
 
     def getTiming(self):
-        case = Case(self.caseroot)
-        components=case.get_value("COMP_CLASSES").split(',')
-        components[components.index("DRV")]="CPL"
-        for s in components:
-            self.models[s] = getTimingInfo(s)
-        atm = self.models['ATM']
-        lnd = self.models['LND']
-        rof = self.models['ROF']
-        wav = self.models['WAV']
-        ice = self.models['ICE']
-        ocn = self.models['OCN']
-        glc = self.models['GLC']
-        cpl = self.models['CPL']
-        cime_model = case.get_value("MODEL")
-        caseid = case.get_value("CASE")
-        mach = case.get_value("MACH")
-        user = case.get_value("USER")
-        continue_run = case.get_value("CONTINUE_RUN")
-        rundir = case.get_value("RUNDIR")
-        run_type = case.get_value("RUN_TYPE")
-        ncpl_base_period = case.get_value("NCPL_BASE_PERIOD")
-        atm_ncpl = case.get_value("ATM_NCPL")
-        ocn_ncpl = case.get_value("OCN_NCPL")
-        ccsm_compset = case.get_value("CCSM_COMPSET")
-        if ccsm_compset is None:
-            ccsm_compset = ""
-        grid = case.get_value("GRID")
-        run_type = case.get_value("RUN_TYPE")
-        stop_option = case.get_value("STOP_OPTION")
-        stop_n = case.get_value("STOP_N")
-        cost_pes = case.get_value("COST_PES")
-        totalpes = case.get_value("TOTALPES")
-        pes_per_node = case.get_value("PES_PER_NODE")
+        with Case(self.caseroot) as case:
+            components=case.get_value("COMP_CLASSES").split(',')
+            components[components.index("DRV")]="CPL"
+            for s in components:
+                self.models[s] = getTimingInfo(s)
+            atm = self.models['ATM']
+            lnd = self.models['LND']
+            rof = self.models['ROF']
+            wav = self.models['WAV']
+            ice = self.models['ICE']
+            ocn = self.models['OCN']
+            glc = self.models['GLC']
+            cpl = self.models['CPL']
+            cime_model = case.get_value("MODEL")
+            caseid = case.get_value("CASE")
+            mach = case.get_value("MACH")
+            user = case.get_value("USER")
+            continue_run = case.get_value("CONTINUE_RUN")
+            rundir = case.get_value("RUNDIR")
+            run_type = case.get_value("RUN_TYPE")
+            ncpl_base_period = case.get_value("NCPL_BASE_PERIOD")
+            atm_ncpl = case.get_value("ATM_NCPL")
+            ocn_ncpl = case.get_value("OCN_NCPL")
+            ccsm_compset = case.get_value("CCSM_COMPSET")
+            if ccsm_compset is None:
+                ccsm_compset = ""
+            grid = case.get_value("GRID")
+            run_type = case.get_value("RUN_TYPE")
+            stop_option = case.get_value("STOP_OPTION")
+            stop_n = case.get_value("STOP_N")
+            cost_pes = case.get_value("COST_PES")
+            totalpes = case.get_value("TOTALPES")
+            pes_per_node = case.get_value("PES_PER_NODE")
 
-        if cost_pes > 0:
-            pecost = cost_pes
-        else:
-            pecost = totalpes
+            if cost_pes > 0:
+                pecost = cost_pes
+            else:
+                pecost = totalpes
 
-        for m in self.models.values():
-            for key in ["NTASKS", "ROOTPE", "PSTRID", "NTHRDS", "NINST"]:
-                if key == "NINST" and m.name == "CPL":
-                    m.ninst = 1
-                else:
-                    setattr(m, key.lower(),
-                            int(case.get_value("%s_%s" % (key, m.name))))
+            for m in self.models.values():
+                for key in ["NTASKS", "ROOTPE", "PSTRID", "NTHRDS", "NINST"]:
+                    if key == "NINST" and m.name == "CPL":
+                        m.ninst = 1
+                    else:
+                        setattr(m, key.lower(),
+                                int(case.get_value("%s_%s" % (key, m.name))))
 
-            m.comp = case.get_value("COMP_%s" % (m.name))
-            m.pemax = m.rootpe + m.ntasks * m.pstrid - 1
+                m.comp = case.get_value("COMP_%s" % (m.name))
+                m.pemax = m.rootpe + m.ntasks * m.pstrid - 1
 
         now = datetime.datetime.ctime(datetime.datetime.now())
         inittype = "FALSE"

--- a/scripts/Tools/getTiming
+++ b/scripts/Tools/getTiming
@@ -120,55 +120,55 @@ class TimingParser:
 
 
     def getTiming(self):
-        with Case(self.caseroot) as case:
-            components=case.get_value("COMP_CLASSES").split(',')
-            components[components.index("DRV")]="CPL"
-            for s in components:
-                self.models[s] = getTimingInfo(s)
-            atm = self.models['ATM']
-            lnd = self.models['LND']
-            rof = self.models['ROF']
-            wav = self.models['WAV']
-            ice = self.models['ICE']
-            ocn = self.models['OCN']
-            glc = self.models['GLC']
-            cpl = self.models['CPL']
-            cime_model = case.get_value("MODEL")
-            caseid = case.get_value("CASE")
-            mach = case.get_value("MACH")
-            user = case.get_value("USER")
-            continue_run = case.get_value("CONTINUE_RUN")
-            rundir = case.get_value("RUNDIR")
-            run_type = case.get_value("RUN_TYPE")
-            ncpl_base_period = case.get_value("NCPL_BASE_PERIOD")
-            atm_ncpl = case.get_value("ATM_NCPL")
-            ocn_ncpl = case.get_value("OCN_NCPL")
-            ccsm_compset = case.get_value("CCSM_COMPSET")
-            if ccsm_compset is None:
-                ccsm_compset = ""
-            grid = case.get_value("GRID")
-            run_type = case.get_value("RUN_TYPE")
-            stop_option = case.get_value("STOP_OPTION")
-            stop_n = case.get_value("STOP_N")
-            cost_pes = case.get_value("COST_PES")
-            totalpes = case.get_value("TOTALPES")
-            pes_per_node = case.get_value("PES_PER_NODE")
+        case = Case(self.caseroot)
+        components=case.get_value("COMP_CLASSES").split(',')
+        components[components.index("DRV")]="CPL"
+        for s in components:
+            self.models[s] = getTimingInfo(s)
+        atm = self.models['ATM']
+        lnd = self.models['LND']
+        rof = self.models['ROF']
+        wav = self.models['WAV']
+        ice = self.models['ICE']
+        ocn = self.models['OCN']
+        glc = self.models['GLC']
+        cpl = self.models['CPL']
+        cime_model = case.get_value("MODEL")
+        caseid = case.get_value("CASE")
+        mach = case.get_value("MACH")
+        user = case.get_value("USER")
+        continue_run = case.get_value("CONTINUE_RUN")
+        rundir = case.get_value("RUNDIR")
+        run_type = case.get_value("RUN_TYPE")
+        ncpl_base_period = case.get_value("NCPL_BASE_PERIOD")
+        atm_ncpl = case.get_value("ATM_NCPL")
+        ocn_ncpl = case.get_value("OCN_NCPL")
+        ccsm_compset = case.get_value("CCSM_COMPSET")
+        if ccsm_compset is None:
+            ccsm_compset = ""
+        grid = case.get_value("GRID")
+        run_type = case.get_value("RUN_TYPE")
+        stop_option = case.get_value("STOP_OPTION")
+        stop_n = case.get_value("STOP_N")
+        cost_pes = case.get_value("COST_PES")
+        totalpes = case.get_value("TOTALPES")
+        pes_per_node = case.get_value("PES_PER_NODE")
 
-            if cost_pes > 0:
-                pecost = cost_pes
-            else:
-                pecost = totalpes
+        if cost_pes > 0:
+            pecost = cost_pes
+        else:
+            pecost = totalpes
 
-            for m in self.models.values():
-                for key in ["NTASKS", "ROOTPE", "PSTRID", "NTHRDS", "NINST"]:
-                    if key == "NINST" and m.name == "CPL":
-                        m.ninst = 1
-                    else:
-                        setattr(m, key.lower(),
-                                int(case.get_value("%s_%s" % (key, m.name))))
+        for m in self.models.values():
+            for key in ["NTASKS", "ROOTPE", "PSTRID", "NTHRDS", "NINST"]:
+                if key == "NINST" and m.name == "CPL":
+                    m.ninst = 1
+                else:
+                    setattr(m, key.lower(),
+                            int(case.get_value("%s_%s" % (key, m.name))))
 
-                m.comp = case.get_value("COMP_%s" % (m.name))
-                m.pemax = m.rootpe + m.ntasks * m.pstrid - 1
+            m.comp = case.get_value("COMP_%s" % (m.name))
+            m.pemax = m.rootpe + m.ntasks * m.pstrid - 1
 
         now = datetime.datetime.ctime(datetime.datetime.now())
         inittype = "FALSE"

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -55,8 +55,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, dryrun = parse_command_line(sys.argv, description)
-    case = Case(caseroot)
-    preview_namelists(case, dryrun=False)
+    with Case(caseroot) as case:
+        preview_namelists(case, dryrun=False)
 
 if (__name__ == "__main__"):
     _main_func(__doc__)

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -55,7 +55,7 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot, dryrun = parse_command_line(sys.argv, description)
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         preview_namelists(case, dryrun=False)
 
 if (__name__ == "__main__"):

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -84,28 +84,28 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
 def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=None, subgroup=None,
               append=None, noecho=False, warn=None, force=False):
-    case = Case(caseroot)
-    if(listofsettings ):
-        for setting in listofsettings:
-            (xmlid, xmlval) = setting.split('=', 1)
-            type_str = case.get_type_info(xmlid)
-            if(append is True):
+    with Case(caseroot) as case:
+        if listofsettings:
+            for setting in listofsettings:
+                (xmlid, xmlval) = setting.split('=', 1)
+                type_str = case.get_type_info(xmlid)
+                if(append is True):
+                    value = case.get_value(xmlid, resolved=False,
+                                           subgroup=subgroup)
+                    xmlval = "%s %s" %(xmlval, value)
+                if not force:
+                    xmlval = convert_to_type(xmlval, type_str, xmlid)
+                case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
+        else:
+            if append is True:
                 value = case.get_value(xmlid, resolved=False, subgroup=subgroup)
                 xmlval = "%s %s" %(xmlval, value)
+            type_str = case.get_type_info(xmlid)
             if not force:
                 xmlval = convert_to_type(xmlval, type_str, xmlid)
             case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
-    else:
-        if(append is True):
-            value = case.get_value(xmlid, resolved=False, subgroup=subgroup)
-            xmlval = "%s %s" %(xmlval, value)
-        type_str = case.get_type_info(xmlid)
-        if not force:
-            xmlval = convert_to_type(xmlval, type_str, xmlid)
-        case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
-    case.flush()
 
-    if (noecho is False):
+    if not noecho:
         argstr = ""
         for arg in sys.argv:
             argstr += "%s "%arg

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -84,7 +84,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
 def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=None, subgroup=None,
               append=None, noecho=False, warn=None, force=False):
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         if listofsettings:
             for setting in listofsettings:
                 (xmlid, xmlval) = setting.split('=', 1)

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -105,26 +105,24 @@ def xmlquery(caseroot, args, listofattributes=[] ,  subgroup=None, noecho=False,
     True
     """
     # Initialize case ; read in all xml files from caseroot
-    with Case(caseroot) as case:
-        values  = []
-        results = [] # List of formatted strings containing the search results
+    case    = Case(caseroot)
+    values  = []
+    results = [] # List of formatted strings containing the search results
 
-        if(listofattributes and len(listofattributes) >= 1):
+    if(listofattributes and len(listofattributes) >= 1):
 
-            for xmlattr in listofattributes:
-                # type_str = case.get_type_info(xmlattr)
-                logger.debug("Searching for %s", xmlattr)
-                attribute_hits = case.get_values(xmlattr, resolved=args.resolve,
-                                                 subgroup=subgroup)
-                results       += attribute_hits
+        for xmlattr in listofattributes:
+            # type_str = case.get_type_info(xmlattr)
+            logger.debug("Searching for %s", xmlattr)
+            attribute_hits = case.get_values(xmlattr, resolved=args.resolve, subgroup=subgroup)
+      
+            results       += attribute_hits
 
-        elif (args.listall):
-            logger.warning("Retrieving all values.")
-            results = case.get_values(None, resolved=args.resolve,
-                                      subgroup=subgroup)
-        else:
-            logger.warning("No attributes (%s) or listall option",
-                           listofattributes)
+    elif (args.listall):
+        logger.warning("Retrieving all values.")
+        results = case.get_values(None, resolved=args.resolve, subgroup=subgroup)
+    else:
+        logger.warning("No attributes (%s) or listall option" , listofattributes)
 
     # Formatting of return strings
     if ( len(results) > 0) :

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -105,24 +105,26 @@ def xmlquery(caseroot, args, listofattributes=[] ,  subgroup=None, noecho=False,
     True
     """
     # Initialize case ; read in all xml files from caseroot
-    case    = Case(caseroot)
-    values  = []
-    results = [] # List of formatted strings containing the search results
+    with Case(caseroot) as case:
+        values  = []
+        results = [] # List of formatted strings containing the search results
 
-    if(listofattributes and len(listofattributes) >= 1):
+        if(listofattributes and len(listofattributes) >= 1):
 
-        for xmlattr in listofattributes:
-            # type_str = case.get_type_info(xmlattr)
-            logger.debug("Searching for %s", xmlattr)
-            attribute_hits = case.get_values(xmlattr, resolved=args.resolve, subgroup=subgroup)
-      
-            results       += attribute_hits
+            for xmlattr in listofattributes:
+                # type_str = case.get_type_info(xmlattr)
+                logger.debug("Searching for %s", xmlattr)
+                attribute_hits = case.get_values(xmlattr, resolved=args.resolve,
+                                                 subgroup=subgroup)
+                results       += attribute_hits
 
-    elif (args.listall):
-        logger.warning("Retrieving all values.")
-        results = case.get_values(None, resolved=args.resolve, subgroup=subgroup)
-    else:
-        logger.warning("No attributes (%s) or listall option" , listofattributes)
+        elif (args.listall):
+            logger.warning("Retrieving all values.")
+            results = case.get_values(None, resolved=args.resolve,
+                                      subgroup=subgroup)
+        else:
+            logger.warning("No attributes (%s) or listall option",
+                           listofattributes)
 
     # Formatting of return strings
     if ( len(results) > 0) :

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -66,7 +66,7 @@ def _main_func():
     expect(os.path.isdir(cloneroot),
            "Missing cloneroot directory %s " % cloneroot)
 
-    with Case(cloneroot) as clone:
+    with Case(cloneroot, read_only=False) as clone:
         clone.create_clone(case, keepexe, mach_dir, project)
 
 ###############################################################################

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -66,8 +66,8 @@ def _main_func():
     expect(os.path.isdir(cloneroot),
            "Missing cloneroot directory %s " % cloneroot)
 
-    clone = Case(cloneroot)
-    clone.create_clone(case, keepexe, mach_dir, project)
+    with Case(cloneroot) as clone:
+        clone.create_clone(case, keepexe, mach_dir, project)
 
 ###############################################################################
 

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -135,41 +135,39 @@ def _main_func():
 ###############################################################################
     cimeroot  = os.path.abspath(CIME.utils.get_cime_root())
 
-    case, compset, grid, machine, compiler, \
+    caseroot, compset, grid, machine, compiler, \
         mpilib, project, pecount,  \
         machine_dir, user_mods_dir, user_compset, pesfile, \
         user_grid, gridfile, srcroot, test, ninst, walltime \
         = parse_command_line(sys.argv, cimeroot)
 
-    caseroot = os.path.abspath(case)
-    case = os.path.basename(case)
+    caseroot = os.path.abspath(caseroot)
 
     # create_test creates the caseroot before calling create_newcase
     # otherwise throw an error if this directory exists
     expect(not (os.path.exists(caseroot) and not test),
            "Case directory %s already exists"%caseroot)
 
-    # Set the case object
-    caseobj = Case(caseroot)
+    with Case(caseroot) as case:
+        # Set values for env_case.xml
+        case.set_value("CASE", os.path.basename(caseroot))
+        case.set_value("CASEROOT", caseroot)
+        case.set_value("SRCROOT", srcroot)
 
-    # Set values for env_case.xml
-    caseobj.set_value("CASE", os.path.basename(case))
-    caseobj.set_value("CASEROOT", caseroot)
-    caseobj.set_value("SRCROOT", srcroot)
+        # Configure the Case
+        case.configure(compset, grid, machine_name=machine, project=project,
+                          pecount=pecount, compiler=compiler, mpilib=mpilib,
+                          user_compset=user_compset, pesfile=pesfile,
+                          user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
+                          walltime=walltime)
 
-    # Configure the Case
-    caseobj.configure(compset, grid, machine_name=machine, project=project,
-                      pecount=pecount, compiler=compiler, mpilib=mpilib,
-                      user_compset=user_compset, pesfile=pesfile,
-                      user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
-                      walltime=walltime)
+        case.create_caseroot()
 
-    caseobj.create_caseroot()
+        # Write out the case files
+        case.flush(flushall=True)
 
-    # Write out the case files
-    caseobj.flush(flushall=True)
+        case.apply_user_mods(user_mods_dir)
 
-    caseobj.apply_user_mods(user_mods_dir)
     # Copy env_case.xml into LockedFiles
     copyfile(os.path.join(caseroot,"env_case.xml"),
              os.path.join(caseroot,"LockedFiles","env_case.xml"))

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -148,7 +148,7 @@ def _main_func():
     expect(not (os.path.exists(caseroot) and not test),
            "Case directory %s already exists"%caseroot)
 
-    with Case(caseroot) as case:
+    with Case(caseroot, read_only=False) as case:
         # Set values for env_case.xml
         case.set_value("CASE", os.path.basename(caseroot))
         case.set_value("CASEROOT", caseroot)

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -256,12 +256,12 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
     testcase_dirs = glob.glob("%s/*%s*/TestStatus" % (test_root, test_id))
     expect(testcase_dirs, "No test case dirs found!?")
     first_case = os.path.abspath(os.path.dirname(testcase_dirs[0]))
-    case = Case(first_case)
-    env_batch = env_batch = case._get_env("batch")
+    with Case(first_case) as case:
+        env_batch = case._get_env("batch")
 
-    directives = env_batch.get_batch_directives(case, "case.run", raw=True)
-    submit_cmd  = env_batch.get_value("batch_submit", subgroup=None)
-    submit_args = env_batch.get_submit_args(case, "case.run")
+        directives = env_batch.get_batch_directives(case, "case.run", raw=True)
+        submit_cmd  = env_batch.get_value("batch_submit", subgroup=None)
+        submit_args = env_batch.get_submit_args(case, "case.run")
 
     tasks_per_node = int(mach.get_value("PES_PER_NODE"))
     num_nodes = int(math.ceil(float(proc_pool) / tasks_per_node))

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -256,7 +256,7 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
     testcase_dirs = glob.glob("%s/*%s*/TestStatus" % (test_root, test_id))
     expect(testcase_dirs, "No test case dirs found!?")
     first_case = os.path.abspath(os.path.dirname(testcase_dirs[0]))
-    with Case(first_case) as case:
+    with Case(first_case, read_only=False) as case:
         env_batch = case._get_env("batch")
 
         directives = env_batch.get_batch_directives(case, "case.run", raw=True)

--- a/utils/python/CIME/SystemTests/erp.py
+++ b/utils/python/CIME/SystemTests/erp.py
@@ -75,17 +75,11 @@ class ERP(SystemTestsCommon):
                         self._case.set_value("NTASKS_%s"%comp, ntasks/2)
                         self._case.set_value("ROOTPE_%s"%comp, rootpe/2)
 
-#            self._case.flush()
-
             # Note, some components, like CESM-CICE, have
             # decomposition information in env_build.xml
             # case_setup(self._case, test_mode=True, reset=True)that
             # needs to be regenerated for the above new tasks and thread counts
             case_setup(self._case, test_mode=True, reset=True)
-
-            # update the case to the new values
-#            self._case = None
-#            self._case = Case(self._caseroot)
 
             # Now rebuild the system, given updated information in env_build.xml
 

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -139,7 +139,7 @@ def post_build(case, logs):
     shutil.copy("env_build.xml", "LockedFiles")
 
 ###############################################################################
-def case_build(caseroot, case=None, sharedlib_only=False, model_only=False):
+def case_build(caseroot, case, sharedlib_only=False, model_only=False):
 ###############################################################################
 
     t1 = time.time()
@@ -156,7 +156,6 @@ def case_build(caseroot, case=None, sharedlib_only=False, model_only=False):
     expect(os.path.exists("case.run"),
            "ERROR: must invoke case.setup script before calling build script ")
 
-    case = Case() if case is None else case
     cimeroot = case.get_value("CIMEROOT")
 
     comp_classes = case.get_value("COMP_CLASSES").split(',')

--- a/utils/python/CIME/buildlib.py
+++ b/utils/python/CIME/buildlib.py
@@ -43,18 +43,18 @@ def build_data_lib(argv, compclass):
 
     caseroot, libroot, bldroot = parse_input(argv)
 
-    case = Case(caseroot)
+    with Case(caseroot) as case:
 
-    cimeroot  = case.get_value("CIMEROOT")
+        cimeroot  = case.get_value("CIMEROOT")
 
-    # Write directory list (Filepath)
-    compname = "d" + compclass
-    with open('Filepath', 'w') as out:
-        out.write(os.path.join(caseroot, "SourceMods", "src.%s" %compname) + "\n")
-        out.write(os.path.join(cimeroot, "components", "data_comps", compname) + "\n")
+        # Write directory list (Filepath)
+        compname = "d" + compclass
+        with open('Filepath', 'w') as out:
+            out.write(os.path.join(caseroot, "SourceMods", "src.%s" %compname) + "\n")
+            out.write(os.path.join(cimeroot, "components", "data_comps", compname) + "\n")
 
-    # Build the component
-    run_gmake(case, compclass, libroot)
+        # Build the component
+        run_gmake(case, compclass, libroot)
 
 ###############################################################################
 def build_xcpl_lib(argv, compclass):
@@ -62,19 +62,19 @@ def build_xcpl_lib(argv, compclass):
 
     caseroot, libroot, bldroot = parse_input(argv)
 
-    case = Case(caseroot)
+    with Case(caseroot) as case:
 
-    cimeroot  = case.get_value("CIMEROOT")
+        cimeroot  = case.get_value("CIMEROOT")
 
-    # Write directory list
-    compname = "x" + compclass
-    with open('Filepath', 'w') as out:
-        out.write(os.path.join(caseroot, "SourceMods", "src.%s", compname) + "\n")
-        out.write(os.path.join(cimeroot, "components", "xcpl_comps", "xshare") + "\n")
-        out.write(os.path.join(cimeroot, "components", "xcpl_comps",compname, "cpl") + "\n")
+        # Write directory list
+        compname = "x" + compclass
+        with open('Filepath', 'w') as out:
+            out.write(os.path.join(caseroot, "SourceMods", "src.%s", compname) + "\n")
+            out.write(os.path.join(cimeroot, "components", "xcpl_comps", "xshare") + "\n")
+            out.write(os.path.join(cimeroot, "components", "xcpl_comps",compname, "cpl") + "\n")
 
-    # Build the component
-    run_gmake(case, compclass, libroot)
+        # Build the component
+        run_gmake(case, compclass, libroot)
 
 ###############################################################################
 def build_stub_lib(argv, compclass):
@@ -82,19 +82,19 @@ def build_stub_lib(argv, compclass):
 
     caseroot, libroot, bldroot = parse_input(argv)
 
-    case = Case(caseroot)
+    with Case(caseroot) as case:
 
-    cimeroot = case.get_value("CIMEROOT")
+        cimeroot = case.get_value("CIMEROOT")
 
-    # Write directory list
-    compname = "s" + compclass
-    with open('Filepath', 'w') as out:
-        out.write(os.path.join(caseroot, "SourceMods", "src.%s", compname) + "\n")
-        out.write(os.path.join(cimeroot, "components", "stub_comps", "xshare") + "\n")
-        out.write(os.path.join(cimeroot, "components", "stub_comps",compname, "cpl") + "\n")
+        # Write directory list
+        compname = "s" + compclass
+        with open('Filepath', 'w') as out:
+            out.write(os.path.join(caseroot, "SourceMods", "src.%s", compname) + "\n")
+            out.write(os.path.join(cimeroot, "components", "stub_comps", "xshare") + "\n")
+            out.write(os.path.join(cimeroot, "components", "stub_comps",compname, "cpl") + "\n")
 
-    # Build the component
-    run_gmake(case, compclass, libroot)
+        # Build the component
+        run_gmake(case, compclass, libroot)
 
 ###############################################################################
 def run_gmake(case, compclass, libroot, libname="", user_cppdefs=""):

--- a/utils/python/CIME/buildlib.py
+++ b/utils/python/CIME/buildlib.py
@@ -43,18 +43,18 @@ def build_data_lib(argv, compclass):
 
     caseroot, libroot, bldroot = parse_input(argv)
 
-    with Case(caseroot) as case:
+    case = Case(caseroot)
 
-        cimeroot  = case.get_value("CIMEROOT")
+    cimeroot  = case.get_value("CIMEROOT")
 
-        # Write directory list (Filepath)
-        compname = "d" + compclass
-        with open('Filepath', 'w') as out:
-            out.write(os.path.join(caseroot, "SourceMods", "src.%s" %compname) + "\n")
-            out.write(os.path.join(cimeroot, "components", "data_comps", compname) + "\n")
+    # Write directory list (Filepath)
+    compname = "d" + compclass
+    with open('Filepath', 'w') as out:
+        out.write(os.path.join(caseroot, "SourceMods", "src.%s" %compname) + "\n")
+        out.write(os.path.join(cimeroot, "components", "data_comps", compname) + "\n")
 
-        # Build the component
-        run_gmake(case, compclass, libroot)
+    # Build the component
+    run_gmake(case, compclass, libroot)
 
 ###############################################################################
 def build_xcpl_lib(argv, compclass):
@@ -62,19 +62,19 @@ def build_xcpl_lib(argv, compclass):
 
     caseroot, libroot, bldroot = parse_input(argv)
 
-    with Case(caseroot) as case:
+    case = Case(caseroot)
 
-        cimeroot  = case.get_value("CIMEROOT")
+    cimeroot  = case.get_value("CIMEROOT")
 
-        # Write directory list
-        compname = "x" + compclass
-        with open('Filepath', 'w') as out:
-            out.write(os.path.join(caseroot, "SourceMods", "src.%s", compname) + "\n")
-            out.write(os.path.join(cimeroot, "components", "xcpl_comps", "xshare") + "\n")
-            out.write(os.path.join(cimeroot, "components", "xcpl_comps",compname, "cpl") + "\n")
+    # Write directory list
+    compname = "x" + compclass
+    with open('Filepath', 'w') as out:
+        out.write(os.path.join(caseroot, "SourceMods", "src.%s", compname) + "\n")
+        out.write(os.path.join(cimeroot, "components", "xcpl_comps", "xshare") + "\n")
+        out.write(os.path.join(cimeroot, "components", "xcpl_comps",compname, "cpl") + "\n")
 
-        # Build the component
-        run_gmake(case, compclass, libroot)
+    # Build the component
+    run_gmake(case, compclass, libroot)
 
 ###############################################################################
 def build_stub_lib(argv, compclass):
@@ -82,19 +82,19 @@ def build_stub_lib(argv, compclass):
 
     caseroot, libroot, bldroot = parse_input(argv)
 
-    with Case(caseroot) as case:
+    case = Case(caseroot)
 
-        cimeroot = case.get_value("CIMEROOT")
+    cimeroot = case.get_value("CIMEROOT")
 
-        # Write directory list
-        compname = "s" + compclass
-        with open('Filepath', 'w') as out:
-            out.write(os.path.join(caseroot, "SourceMods", "src.%s", compname) + "\n")
-            out.write(os.path.join(cimeroot, "components", "stub_comps", "xshare") + "\n")
-            out.write(os.path.join(cimeroot, "components", "stub_comps",compname, "cpl") + "\n")
+    # Write directory list
+    compname = "s" + compclass
+    with open('Filepath', 'w') as out:
+        out.write(os.path.join(caseroot, "SourceMods", "src.%s", compname) + "\n")
+        out.write(os.path.join(cimeroot, "components", "stub_comps", "xshare") + "\n")
+        out.write(os.path.join(cimeroot, "components", "stub_comps",compname, "cpl") + "\n")
 
-        # Build the component
-        run_gmake(case, compclass, libroot)
+    # Build the component
+    run_gmake(case, compclass, libroot)
 
 ###############################################################################
 def run_gmake(case, compclass, libroot, libname="", user_cppdefs=""):

--- a/utils/python/CIME/buildnml.py
+++ b/utils/python/CIME/buildnml.py
@@ -42,13 +42,12 @@ def build_xcpl_nml(argv, compclass):
 
     caseroot = parse_input(argv)
 
-    with Case(caseroot) as case:
-        rundir = case.get_value("RUNDIR")
-        ninst  = case.get_value("NINST_%s" % compclass.upper())
-        nx     = case.get_value("%s_NX" % compclass.upper())
-        ny     = case.get_value("%s_NY" % compclass.upper())
-        if compname == "xrof":
-            flood_mode = case.get_value('XROF_FLOOD_MODE')
+    case = Case(caseroot)
+
+    rundir = case.get_value("RUNDIR")
+    ninst  = case.get_value("NINST_%s" % compclass.upper())
+    nx     = case.get_value("%s_NX" % compclass.upper())
+    ny     = case.get_value("%s_NY" % compclass.upper())
 
     extras = []
     dtype = 1
@@ -70,6 +69,7 @@ def build_xcpl_nml(argv, compclass):
         dtype = 4
     elif compname == "xrof":
         dtype = 11
+        flood_mode = Case('XROF_FLOOD_MODE')
         if flood_mode == "ACTIVE":
             extras = [[".true.", "flood flag"]]
         else:
@@ -98,15 +98,10 @@ def build_xcpl_nml(argv, compclass):
 ###############################################################################
 def build_data_nml(argv, compclass):
 ###############################################################################
-    # This function is just a wrapper for the one below, to avoid having to
-    # indent everything for the "with" block.
-    caseroot = parse_input(argv)
-    with Case(caseroot) as case:
-        _build_data_nml(case, compclass)
 
-###############################################################################
-def _build_data_nml(case, compclass):
-###############################################################################
+    caseroot = parse_input(argv)
+
+    case = Case(caseroot)
 
     cimeroot = case.get_value("CIMEROOT")
     rundir   = case.get_value("RUNDIR")

--- a/utils/python/CIME/buildnml.py
+++ b/utils/python/CIME/buildnml.py
@@ -42,12 +42,13 @@ def build_xcpl_nml(argv, compclass):
 
     caseroot = parse_input(argv)
 
-    case = Case(caseroot)
-
-    rundir = case.get_value("RUNDIR")
-    ninst  = case.get_value("NINST_%s" % compclass.upper())
-    nx     = case.get_value("%s_NX" % compclass.upper())
-    ny     = case.get_value("%s_NY" % compclass.upper())
+    with Case(caseroot) as case:
+        rundir = case.get_value("RUNDIR")
+        ninst  = case.get_value("NINST_%s" % compclass.upper())
+        nx     = case.get_value("%s_NX" % compclass.upper())
+        ny     = case.get_value("%s_NY" % compclass.upper())
+        if compname == "xrof":
+            flood_mode = case.get_value('XROF_FLOOD_MODE')
 
     extras = []
     dtype = 1
@@ -69,7 +70,6 @@ def build_xcpl_nml(argv, compclass):
         dtype = 4
     elif compname == "xrof":
         dtype = 11
-        flood_mode = Case('XROF_FLOOD_MODE')
         if flood_mode == "ACTIVE":
             extras = [[".true.", "flood flag"]]
         else:
@@ -98,10 +98,15 @@ def build_xcpl_nml(argv, compclass):
 ###############################################################################
 def build_data_nml(argv, compclass):
 ###############################################################################
-
+    # This function is just a wrapper for the one below, to avoid having to
+    # indent everything for the "with" block.
     caseroot = parse_input(argv)
+    with Case(caseroot) as case:
+        _build_data_nml(case, compclass)
 
-    case = Case(caseroot)
+###############################################################################
+def _build_data_nml(case, compclass):
+###############################################################################
 
     cimeroot = case.get_value("CIMEROOT")
     rundir   = case.get_value("RUNDIR")

--- a/utils/python/CIME/buildnml.py
+++ b/utils/python/CIME/buildnml.py
@@ -42,12 +42,13 @@ def build_xcpl_nml(argv, compclass):
 
     caseroot = parse_input(argv)
 
-    case = Case(caseroot)
-
-    rundir = case.get_value("RUNDIR")
-    ninst  = case.get_value("NINST_%s" % compclass.upper())
-    nx     = case.get_value("%s_NX" % compclass.upper())
-    ny     = case.get_value("%s_NY" % compclass.upper())
+    with Case(caseroot) as case:
+        rundir = case.get_value("RUNDIR")
+        ninst  = case.get_value("NINST_%s" % compclass.upper())
+        nx     = case.get_value("%s_NX" % compclass.upper())
+        ny     = case.get_value("%s_NY" % compclass.upper())
+        if compname == "xrof":
+            flood_mode = case.get_value('XROF_FLOOD_MODE')
 
     extras = []
     dtype = 1
@@ -69,7 +70,6 @@ def build_xcpl_nml(argv, compclass):
         dtype = 4
     elif compname == "xrof":
         dtype = 11
-        flood_mode = Case('XROF_FLOOD_MODE')
         if flood_mode == "ACTIVE":
             extras = [[".true.", "flood flag"]]
         else:
@@ -98,10 +98,15 @@ def build_xcpl_nml(argv, compclass):
 ###############################################################################
 def build_data_nml(argv, compclass):
 ###############################################################################
-
+    # This function is just a wrapper for the one below, to avoid having to
+    # indent everything for the "with" block.
     caseroot = parse_input(argv)
+    with Case(caseroot) as case:
+        _build_data_nml(case, caseroot, compclass)
 
-    case = Case(caseroot)
+###############################################################################
+def _build_data_nml(case, caseroot, compclass):
+###############################################################################
 
     cimeroot = case.get_value("CIMEROOT")
     rundir   = case.get_value("RUNDIR")

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -62,7 +62,7 @@ class Case(object):
     by reading and interpreting the CIME config classes.
 
     """
-    def __init__(self, case_root=None):
+    def __init__(self, case_root=None, read_only=True):
 
         if case_root is None:
             case_root = os.getcwd()
@@ -70,6 +70,7 @@ class Case(object):
         logger.debug("Initializing Case.")
         self._env_files_that_need_rewrite = set()
         self._read_only_mode = True
+        self._force_read_only = read_only
         self.read_xml(case_root)
 
         # Hold arbitary values. In create_newcase we may set values
@@ -93,7 +94,8 @@ class Case(object):
     # Define __enter__ and __exit__ so that we can use this as a context manager
     # and force a flush on exit.
     def __enter__(self):
-        self._read_only_mode = False
+        if not self._force_read_only:
+            self._read_only_mode = False
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/utils/python/CIME/check_input_data.py
+++ b/utils/python/CIME/check_input_data.py
@@ -55,12 +55,11 @@ def download_if_in_repo(svn_loc, input_data_root, rel_path):
             logging.info("SUCCESS\n")
             return True
 
-def check_input_data(case=None, svn_loc=None, input_data_root=None, data_list_dir="Buildconf", download=False):
+def check_input_data(case, svn_loc=None, input_data_root=None, data_list_dir="Buildconf", download=False):
     """
     Return True if no files missing
     """
     # Fill in defaults as needed
-    case = Case() if case is None else case
     svn_loc = SVN_LOCS[get_model()] if svn_loc is None else svn_loc
     input_data_root = case.get_value("DIN_LOC_ROOT") if input_data_root is None else input_data_root
 

--- a/utils/python/CIME/system_test.py
+++ b/utils/python/CIME/system_test.py
@@ -529,7 +529,7 @@ class SystemTest(object):
         shutil.copy(os.path.join(test_dir,"env_run.xml"),
                     os.path.join(lockedfiles, "env_run.orig.xml"))
 
-        with Case(test_dir) as case:
+        with Case(test_dir, read_only=False) as case:
             case.set_value("SHAREDLIBROOT",
                            os.path.join(self._test_root,
                                         "sharedlibroot.%s"%self._test_id))

--- a/utils/python/CIME/system_test.py
+++ b/utils/python/CIME/system_test.py
@@ -529,12 +529,12 @@ class SystemTest(object):
         shutil.copy(os.path.join(test_dir,"env_run.xml"),
                     os.path.join(lockedfiles, "env_run.orig.xml"))
 
-        case = Case(test_dir)
-        case.set_value("SHAREDLIBROOT",
-                       os.path.join(self._test_root,
-                                    "sharedlibroot.%s"%self._test_id))
+        with Case(test_dir) as case:
+            case.set_value("SHAREDLIBROOT",
+                           os.path.join(self._test_root,
+                                        "sharedlibroot.%s"%self._test_id))
+            envtest.set_initial_values(case)
 
-        envtest.set_initial_values(case)
         return True
 
     ###########################################################################

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -871,7 +871,7 @@ class TestCimeCase(TestCreateTestCommon):
                                "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_Mmpi-serial.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
         self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
 
-        with Case(casedir) as case:
+        with Case(casedir, read_only=False) as case:
             build_complete = case.get_value("BUILD_COMPLETE")
             self.assertFalse(build_complete,
                              msg="Build complete had wrong value '%s'" %

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -870,29 +870,33 @@ class TestCimeCase(TestCreateTestCommon):
         casedir = os.path.join(self._testroot,
                                "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_Mmpi-serial.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
         self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
-        case = Case(casedir)
 
-        build_complete = case.get_value("BUILD_COMPLETE")
-        self.assertFalse(build_complete,
-                         msg="Build complete had wrong value '%s'" % build_complete)
+        with Case(casedir) as case:
+            build_complete = case.get_value("BUILD_COMPLETE")
+            self.assertFalse(build_complete,
+                             msg="Build complete had wrong value '%s'" %
+                             build_complete)
 
-        case.set_value("BUILD_COMPLETE", True)
-        build_complete = case.get_value("BUILD_COMPLETE")
-        self.assertTrue(build_complete,
-                        msg="Build complete had wrong value '%s'" % build_complete)
+            case.set_value("BUILD_COMPLETE", True)
+            build_complete = case.get_value("BUILD_COMPLETE")
+            self.assertTrue(build_complete,
+                            msg="Build complete had wrong value '%s'" %
+                            build_complete)
 
-        case.flush()
+            case.flush()
 
-        build_complete = run_cmd("./xmlquery BUILD_COMPLETE -value", from_dir=casedir)
-        self.assertTrue(build_complete,
-                        msg="Build complete had wrong value '%s'" % build_complete)
+            build_complete = run_cmd("./xmlquery BUILD_COMPLETE -value",
+                                     from_dir=casedir)
+            self.assertTrue(build_complete,
+                            msg="Build complete had wrong value '%s'" %
+                            build_complete)
 
-        # Test some test properties
-        self.assertEqual(case.get_value("TESTCASE"), "TESTRUNPASS")
-        self.assertEqual(case.get_value("MPILIB"), "mpi-serial")
+            # Test some test properties
+            self.assertEqual(case.get_value("TESTCASE"), "TESTRUNPASS")
+            self.assertEqual(case.get_value("MPILIB"), "mpi-serial")
 
-        # Serial cases should not be using pnetcdf
-        self.assertEqual(case.get_value("PIO_TYPENAME"), "netcdf")
+            # Serial cases should not be using pnetcdf
+            self.assertEqual(case.get_value("PIO_TYPENAME"), "netcdf")
 
 ###############################################################################
 class TestSingleSubmit(TestCreateTestCommon):


### PR DESCRIPTION
This change guarantees that a `Case` is always flushed, even if an
exception is thrown, using this syntax:

```python
with Case(caseroot) as case:
    # do stuff with the case
```

I haven't tested this much yet, so it shouldn't be merged, but I wanted to get feedback on this change.