### PR TITLE
Jgfouca/python3 better error

### DIFF
--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -124,12 +124,9 @@ def get_model():
             model = 'acme'
         logger.info("Guessing CIME_MODEL=%s, set environment variable if this is incorrect"%model)
 
-
     if model is not None:
         set_model(model)
         return model
-
-
 
     modelroot = os.path.join(get_cime_root(), "cime_config")
     models = os.listdir(modelroot)
@@ -138,7 +135,6 @@ def get_model():
                       if os.path.isdir(os.path.join(modelroot,model))
                       and model != "xml_schemas"])
     expect(False, msg)
-
 
 _hack=object()
 def run_cmd(cmd, ok_to_fail=False, input_str=None, from_dir=None, verbose=None,
@@ -379,7 +375,8 @@ def get_cime_location_within_acme():
     """
     return "cime"
 
-def get_model_config_location_within_cime(model=get_model()):
+def get_model_config_location_within_cime(model=None):
+    model = get_model() if model is None else model
     return os.path.join("cime_config", model)
 
 def get_acme_root():
@@ -408,13 +405,14 @@ def get_python_libs_root():
     """
     return os.path.join(get_cime_root(), get_python_libs_location_within_cime())
 
-def get_model_config_root(model=get_model()):
+def get_model_config_root(model=None):
     """
     Get absolute path to model config area"
 
     >>> os.path.isdir(get_model_config_root())
     True
     """
+    model = get_model() if model is None else model
     return os.path.join(get_cime_root(), get_model_config_location_within_cime(model))
 
 def stop_buffering_output():

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -807,7 +807,7 @@ def wait_for_unlocked(filepath):
             file_object = open(filepath, 'a', buffer_size)
             if file_object:
                 locked = False
-        except IOError, message:
+        except IOError:
             locked = True
             time.sleep(1)
         finally:

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -60,6 +60,13 @@ def get_cime_config():
 
     return _CIMECONFIG
 
+def reset_cime_config():
+    """
+    Useful to keep unit tests from interfering with each other
+    """
+    global _CIMECONFIG
+    _CIMECONFIG = None
+
 def get_python_libs_location_within_cime():
     """
     From within CIME, return subdirectory of python libraries
@@ -104,6 +111,7 @@ def get_model():
     >>> set_model('rocky')
     >>> get_model()
     'rocky'
+    >>> reset_cime_config()
     """
     model = os.environ.get("CIME_MODEL")
     if (model is not None):

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -212,7 +212,7 @@ def check_minimum_python_version(major, minor):
     >>>
     """
     expect(sys.version_info[0] == major and sys.version_info[1] >= minor,
-           "Python %d.%d+ is required, you have %d.%d" %
+           "Python %d, minor verion %d+ is required, you have %d.%d" %
            (major, minor, sys.version_info[0], sys.version_info[1]))
 
 def normalize_case_id(case_id):

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -8,7 +8,6 @@ import sys
 import os
 import time
 import re
-from ConfigParser import SafeConfigParser as config_parser
 
 # Return this error code if the scripts worked but tests failed
 TESTS_FAILED_ERR_CODE = 100
@@ -40,6 +39,8 @@ def _read_cime_config_file():
     CIME_MODEL=acme,cesm
     PROJECT=someprojectnumber
     """
+    from ConfigParser import SafeConfigParser as config_parser
+
     cime_config_file = os.path.abspath(os.path.join(os.path.expanduser("~"),
                                                   ".cime","config"))
     cime_config = config_parser()


### PR DESCRIPTION
Avoid users seeing stacktrace when trying to run cime tools with python3. They should see a nice, clear error instead.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes: [CIME Github issue #]

User interface changes?: 

Code review: @jedwards4b @jayeshkrishna 
