### PR TITLE
Update testreporter to handle the new ESMCI TestStatus files.

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -260,6 +260,11 @@
   <!-- SOM compsets -->
 
   <compset>
+    <alias>ETEST</alias>
+    <lname>2000_CAM55_CLM50_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
+  </compset>
+
+  <compset>
     <alias>E1850C5L45TEST</alias>
     <lname>1850_CAM50_CLM45%SP_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
   </compset>

--- a/scripts/Testing/testreporter.pl
+++ b/scripts/Testing/testreporter.pl
@@ -8,12 +8,12 @@ use XML::LibXML;
 use Cwd qw(abs_path);
 #-------------------------------------------------------------------------------
 # testreporter.pl
-# Perl script that watches the CIME tests as they progress, and sends the reports to
+# Perl script that watches the CIME tests as they progress, and sends the reports to 
 # the testdb application at csegweb.cgd.ucar.edu
 
 #-------------------------------------------------------------------------------
 # Constants. Filenames we look in for test results, and the time we sleep between
-# reporting test results.
+# reporting test results.  
 #-------------------------------------------------------------------------------
 my $teststatusfilename = "TestStatus";
 my $teststatusoutfilename = "TestStatus.out";
@@ -22,21 +22,21 @@ my $casestatusfilename = "CaseStatus";
 my $sleeptime = 120;
 my $baselinetag;
 my $testspecfile;
-# The URL we send test results to.
+# The URL we send test results to. 
 my $posturl = "https://csegweb.cgd.ucar.edu/testdb/cgi-bin/processXMLtest.cgi";
 
 # Options and global variables.
 #-------------------------------------------------------------------------------
-# root of the test suite currently running.
+# root of the test suite currently running. 
 my $testroot = undef;
-# The tag name you are testing.
+# The tag name you are testing. 
 my $tagname = undef;
-# the testid parameter specified for ./create_test_suite.  This script uses this parameter to
-# find the tests you are running.
+# the testid parameter specified for ./create_test_suite.  This script uses this parameter to 
+# find the tests you are running.  
 my $testid = undef;
-# the email address to send test reports to.
+# the email address to send test reports to. 
 my $email = undef;
-# the test type: should be one of prealpha, prebeta, or prerelease.
+# the test type: should be one of prealpha, prebeta, or prerelease. 
 my $testtype = undef;
 my $debug = 0;
 my $dumpxml = 0;
@@ -47,9 +47,9 @@ my $password = undef;
 
 #-------------------------------------------------------------------------------
 # Main
-# Get the options first.
-# Then, get the test directories, get the test suite info, get the test status for all the tests,
-# and send the results.
+# Get the options first. 
+# Then, get the test directories, get the test suite info, get the test status for all the tests, 
+# and send the results. 
 #-------------------------------------------------------------------------------
 opts();
 authenticate();
@@ -62,6 +62,7 @@ my %suiteinfo;
 my $teststatus;
 my $nlfailreport;
 ($teststatus, $nlfailreport) = getTestStatus(\@testdirs, $tagname, $testid);
+#print %teststatus;
 &Debug( eval { Dumper $teststatus} );
 &Debug( eval { Dumper \%suiteinfo } );
 my $testxml = &makeResultsXml($teststatus, \%suiteinfo, $nlfailreport);
@@ -76,7 +77,7 @@ if(!$dryrun)
 #-------------------------------------------------------------------------------
 
 #-------------------------------------------------------------------------------
-# Get the options.
+# Get the options. 
 #-------------------------------------------------------------------------------
 sub opts
 {
@@ -93,18 +94,18 @@ sub opts
 	"dryrun"    => \$dryrun,
 	);
 
-    # Show usage if the required options aren't specified.
+    # Show usage if the required options aren't specified. 
     &help if (defined $opt_help);
     &usage if ( (! defined $testroot) ||(! defined $tagname) || (! defined $testid) || (!defined $testtype));
 }
 
 #-------------------------------------------------------------------------------
-# Show the usage, and exit.
+# Show the usage, and exit.  
 #-------------------------------------------------------------------------------
 sub usage
 {
     print <<'END';
-  Usage:
+  Usage: 
     ./testreporter.pl --testroot /glade/scratch/$user/tests/cesm1_1_alphaXX --tagname cesm1_1_alpha15c --testid testid --testtype prealpha|prebeta|prerelease [--dumpxml|--printreport]
 END
     exit(1);
@@ -112,30 +113,30 @@ END
 
 sub help
 {
-
+    
     print <<'END';
-    This is the CIME test reporter script, intended to be used to simplify the reporting of CIME test sets.
+    This is the CIME test reporter script, intended to be used to simplify the reporting of CIME test sets.  
 	Usage is as follows:
-	./testreporter --testroot /glade/scratch/$user/tests/cesm1_1_alphaXX
+	./testreporter --testroot /glade/scratch/$user/tests/cesm1_1_alphaXX 
 	--tagname cesm1_1_alpha15c --testid testid --testtype prealpha
-	It gathers all the test results found in the --testroot, gets the relevant test
-	status fields, and sends the results to the test reporting system on csegweb.
+	It gathers all the test results found in the --testroot, gets the relevant test 
+	status fields, and sends the results to the test reporting system on csegweb. 
 
       Options:
 	--testroot This is the testroot you defined when running the test suite
-	--tagname  The name of the tag you are testing.
-	For example, if you are testing a sandbox that will eventilally
-	become cesm1_1_alpha16c, then put cesm1_1_alpha16c. If you are
+	--tagname  The name of the tag you are testing. 
+	For example, if you are testing a sandbox that will eventilally 
+	become cesm1_1_alpha16c, then put cesm1_1_alpha16c. If you are 
 	running a suite that will become a beta tag, put the last alpha
-	tag used.
-	--testid   The testid you specified to create_test_suite.
-	--testtype The type of test you are running: prealpha, prebeta, or prerelease.
-
+	tag used.  
+	--testid   The testid you specified to create_test_suite.  
+	--testtype The type of test you are running: prealpha, prebeta, or prerelease. 
+	
 END
 }
 
 #-------------------------------------------------------------------------------
-# Show debugging information if desired.
+# Show debugging information if desired. 
 #-------------------------------------------------------------------------------
 sub Debug
 {
@@ -150,20 +151,20 @@ sub Debug
 
 #-------------------------------------------------------------------------------
 # Using the testroot, find the test directories that end with the specified testid.
-# If no matching directories are found, then exit.
+# If no matching directories are found, then exit. 
 #-------------------------------------------------------------------------------
 sub getTestDirs
 {
     my ($testd, $tid) = @_;
 
-    # Abort if the testroot does not exist.
+    # Abort if the testroot does not exist.  
     if ( ! -d $testd)
     {
 	print STDERR "The testroot does not exist! Aborting...\n";
 	exit(1);
     }
-    # open the testroot, find the test directories.  If no test directories ending in
-    # the testid exist, then abort.
+    # open the testroot, find the test directories.  If no test directories ending in 
+    # the testid exist, then abort. 
     opendir(my $DIR, $testd) or die "can't open $testd, error was $!";
     my @testdirs = grep { $_ =~ /($tid)$/ } readdir($DIR);
     closedir $DIR;
@@ -176,19 +177,19 @@ sub getTestDirs
     else
     {
 	print STDERR "It appears that the test root exists, but there aren't any test directories\n";
-	print STDERR "in the testroot. Aborting...\n";
+	print STDERR "in the testroot. Aborting...\n"; 
 	exit(1);
     }
     return @testdirs;
 }
 
 #-------------------------------------------------------------------------------
-# Get the suite info and send it back.
+# Get the suite info and send it back.  
 #-------------------------------------------------------------------------------
 sub getTestSuiteInfo
 {
     my $testlist = shift;
-    my %caseinfo;
+    my %caseinfo; 
     my $testpath;
     foreach my $testdir(@$testlist)
     {
@@ -199,58 +200,39 @@ sub getTestSuiteInfo
 	}
     }
     &Debug("test path:  $testpath\n");
-
-    # We need to find SetupTools in a path-independent manner.
-    # so parse out the cimeroot from testspec.*.xml,
-    # get rid of the tags, and then we have
+    
+    # We need to find SetupTools in a path-independent manner.  
+    # so parse out the cimeroot from testspec.*.xml, 
+    # get rid of the tags, and then we have 
     #my $testspecfile = "$testroot/testspec.$testid.$caseinfo{'mach'}.xml";
     my $testspecfile = "$testroot/testspec.$testid.xml";
     Debug( "testspecfile: $testspecfile\n");
-    open my $SPEC, '<', $testspecfile or die "could not open $testspecfile, $!";
-    my @testspeclines =  <$SPEC>;
-    my @cimerootlines = grep { /<cimeroot>/ } @testspeclines;
-    #my @cimerootlines = grep { /^<cimeroot>/ } <$SPEC>;
-    close $SPEC;
-    chomp @cimerootlines;
-    my $cimeroot = $cimerootlines[0];
-    if(! defined $cimeroot)
-    {
-	die "cimeroot not defined, aborting..";
-    }
-
-    $cimeroot =~ s/<cimeroot>|<\/cimeroot>|^\s+|\s+$//g;
-    Debug("cimeroot is now: |$cimeroot|");
-    my @dirs = ( $testpath, "$cimeroot/utils/perl5lib");
-    unshift @INC, @dirs;
-
-    # SetupTools needs a case to work, so why not just cd to the
+    
+    # SetupTools needs a case to work, so why not just cd to the 
     # first test directory, and run SetupTools there?? :)
     my $firsttestdir = $testroot . "/" . $$testlist[0];
     Debug("first test dir: $firsttestdir");
-    require Config::SetupTools;
     chdir $firsttestdir;
+    my $cimeroot = `./xmlquery CIMEROOT --value`;
+    my @dirs = ( $testpath, "$cimeroot/utils/perl5lib");
+    unshift @INC, @dirs;
+    require Config::SetupTools;
 
     my %config = SetupTools::getAllResolved();
     $caseinfo{'mach'}     = $config{'MACH'};
     $caseinfo{'compiler'} = $config{'COMPILER'};
     $caseinfo{'mpilib'}   = $config{'MPILIB'};
+    $caseinfo{'baselinetag'}   = $config{'BASELINE_NAME_CMP'};
 
     chdir $testroot;
-
-    my $parser = XML::LibXML->new;
-    my $spec = $parser->parse_file($testspecfile);
-    my $root = $spec->getDocumentElement();
-    my @bltagnodes = $root->findnodes('/testlist/baselinetag');
-    $caseinfo{'baselinetag'} = $bltagnodes[0]->textContent();
-    &Debug( "baselinetag: $caseinfo{'baselinetag'}\n") ;
 
     &Debug("caseinfo: " . eval { Dumper \%caseinfo} );
     return %caseinfo;
 }
 
 #-------------------------------------------------------------------------------
-# Get the test status. open the $testroot , look for all the test directories,
-# then get the test status.
+# Get the test status. open the $testroot , look for all the test directories, 
+# then get the test status. 
 #-------------------------------------------------------------------------------
 sub getTestStatus
 {
@@ -259,11 +241,11 @@ sub getTestStatus
     my %nlreporthash;
     my $time = localtime;
     print "$time\n";
-
-    # Iterate through each of the test directories, and get the requisite test information.
+    
+    # Iterate through each of the test directories, and get the requisite test information. 
     foreach my $testcase(@$testdirs)
     {
-	# Get the test status
+	# Get the test status 
 	&Debug("testcase $testcase");
 	my $testbaseid = $testcase;
 	$testbaseid =~ s/$testid//g;
@@ -271,8 +253,12 @@ sub getTestStatus
 	$testbaseid =~ s/\.C\.//g;
 	$testbaseid =~ s/\.GC\.//g;
 	&Debug("testbaseid $testbaseid");
-
-	my $statusfile = $testroot  . "/"  . $testcase .  "/" . $teststatusfilename;
+	if( ! -e $testroot . "/" . $testcase . "/" . "env_case.xml")
+        {
+            next;
+        }
+	
+	my $statusfile = $testroot  . "/"  . $testcase .  "/" . $teststatusfilename; 
 	if( ! -e $statusfile)
 	{
 	    warn("$statusfile does not exist, skipping to next test.");
@@ -288,70 +274,158 @@ sub getTestStatus
 	$teststatus = (split(/\s+/, $teststatus))[0];
 
 	&Debug("Testcase:   $testcase\n");
-	&Debug("Teststatus: $teststatus\n");
+	&Debug("Teststatus: $teststatus\n"); 
 
         my $testsummary = $teststatus;
 
-	# Now go through the TestStats getting the memleak, compare, baseline tag, throughput, and comments if any.
-	my @statuslines = <$teststatusfile>;
+  	# Now go through the TestStats getting the memleak, compare, baseline tag, throughput, and comments if any. 
+        my @statuslines = <$teststatusfile>;
 	chomp @statuslines;
+          
 
-        if($testsummary ~~ /DONE/)
-        {
+        # If the 'test functionality summary' is not PASS, then report the
+        # test functionality summary as the teststatus field.
+        # Namelist compare
+        my @testsummarylines = grep { /nlcomp/ } @statuslines;
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        $teststatushash{$testcase}{'nlcomp'} = (length($testsummary) > 0) ? $testsummary : "----";
 
-	# If the 'test functionality summary' is not PASS, then report the
-	# test functionality summary as the teststatus field.
-	my @testsummarylines = grep { /test functionality summary/ } @statuslines;
-	  $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
-	if(defined $testsummary && $testsummary !~ /PASS/)
-	{
-	    ##$teststatus = $testsummary;
-	    $teststatushash{$testcase}{'comment'} = "Overall Test status failed! Check the history files!!";
-	}
-	##$teststatushash{$testcase}{'status'} = $teststatus;
-	if(length($testsummary) == 0)
-	{
-	    $testsummary = 'FAIL';
-	}
+        # Memory leak 
+        my @testsummarylines = grep { /memleak/ } grep { !/^COMMENT/} @statuslines;
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        $teststatushash{$testcase}{'memleak'} = (length($testsummary) > 0) ? $testsummary : "----";
+
+        # Compare memory usage to baseline
+        my @testsummarylines = grep { /Memory/} grep { /baseline/} @statuslines;
+        my $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        $teststatushash{$testcase}{'memcomp'} = (length($testsummary) > 0) ? $testsummary : "----";
+        if (length($testsummary) == 0){
+          my @testsummarylines = grep { /memcomp/}  @statuslines;
+          my $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+          $teststatushash{$testcase}{'memcomp'} = (length($testsummary) > 0) ? $testsummary : "----";
         }
-	$teststatushash{$testcase}{'status'} = $testsummary;
 
-	# Get the baseline compare summary
-	my @comparelines = grep { / compare/} @statuslines;
-	my ($comparestatus,$comparetest)  = split(/\s+/, $comparelines[0]);
-	$teststatushash{$testcase}{'compare'} = (length($comparestatus) > 0) ? $comparestatus : "----";
-	my $comparetag = (split(/\./, $comparetest))[-1];
-	$baselinetag = $comparetag unless defined $baselinetag;
+        # Compare through put to baseline
+        my @testsummarylines = grep { /Throughput/} grep { /baseline/} @statuslines;
+        my $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        $teststatushash{$testcase}{'tputcomp'} = (length($testsummary) > 0) ? $testsummary : "----";
+        if (length($testsummary) == 0){
+          my @testsummarylines = grep { /tputcomp/}  @statuslines;
+          my $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+          $teststatushash{$testcase}{'tputcomp'} = (length($testsummary) > 0) ? $testsummary : "----";
+        }
 
-	# If this a normal test, ie NOT a set of SBN tests, then
-	# send the following fields. If this is a namelist test, then skip these fields, they
-	# will never be filled in for SBN tests.
-	if($testtype ne 'namelist')
-	{
-	    my @memleaklines = grep { /memleak/ } @statuslines;
-	    my $memleakstatus = (split(/\s+/, $memleaklines[0]))[0];
-	    $teststatushash{$testcase}{'memleak'} = (length($memleakstatus) > 0) ? $memleakstatus : "----";
+        #Compare to baseline
+        my ( $index ) = grep { $statuslines[$_] =~ /baseline compare summary/ } 0..$#statuslines;
+        my @testsummarylines = $statuslines[$index-1];
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        $teststatushash{$testcase}{'compare'} = (length($index) > 0) ? $testsummary : "----";
 
-	    my @memcomplines = grep { /memcomp/} @statuslines;
-	    my $memcompstatus = (split(/\s+/, $memcomplines[0]))[0];
-	    $teststatushash{$testcase}{'memcomp'} = (length($memcompstatus) > 0) ? $memcompstatus : "----";
+        # Check for INIT failure
+        my @testsummarylines = grep { /INIT/ } @statuslines;
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = "SFAIL";
+            $teststatushash{$testcase}{'comment'} = "Failed during INIT!";
+            next;
+        }
 
-	    my @tputcomplines = grep { /tputcomp/ } @statuslines;
-	    my $tputcompstatus = (split(/\s+/, $tputcomplines[0]))[0];
-	    $teststatushash{$testcase}{'tputcomp'} = (length($tputcompstatus) > 0) ? $tputcompstatus : "----";
-	}
+        # Check for CREATE_NEWCASE failure
+        my @testsummarylines = grep { /CREATE_NEWCASE/ } @statuslines;
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = "SFAIL";
+            $teststatushash{$testcase}{'comment'} = "Failed in CREATE_NEWCASE!";
+            next;
+        }
 
-	my @nlcomplines = grep { /nlcomp/i } @statuslines;
-	my $nlcompstatus = (split(/\s+/, $nlcomplines[0]))[0];
-	$teststatushash{$testcase}{'nlcomp'} = (length($nlcompstatus) > 0) ? $nlcompstatus : "----";
+        # Check for XML failure
+        my @testsummarylines = grep { /XML/ } @statuslines;
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = "SFAIL";
+            $teststatushash{$testcase}{'comment'} = "Failed in XML!";
+            next;
+        }
 
-	my @commentlines = grep { /COMMENT/ } @statuslines;
-	my $comment = (split(/\s+/, $commentlines[0], 2) )[1];
-	chomp $comment;
-	$teststatushash{$testcase}{'comment'} = $comment;
+        # Check for SETUP failure
+        my @testsummarylines = grep { /SETUP/ } @statuslines;
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = "SFAIL";
+            $teststatushash{$testcase}{'comment'} = "Failed during SETUP!";
+            next;
+        }
 
+        # Check for SHARELIB_BUILD failure
+        my @testsummarylines = grep { /SHAREDLIB_BUILD/ } @statuslines;
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = "CFAIL";
+            $teststatushash{$testcase}{'comment'} = "Failed during SHAREDLIB_BUILD!";
+            next;
+        }
+
+        # Check for MODEL_BUILD failure
+        my @testsummarylines = grep { /MODEL_BUILD/ } @statuslines;
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = "CFAIL";
+            $teststatushash{$testcase}{'comment'} = "Failed during MODEL_BUILD!";
+            next;
+        }
+
+        # Check for RUN failure
+        my @testsummarylines = grep { /RUN/ } @statuslines;
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = $testsummary;
+            next;
+        }
+
+        #Compare for functionality
+        my ( $index ) = grep { $statuslines[$_] =~ /functionality summary \(restart/ } 0..$#statuslines;
+        my @testsummarylines = $statuslines[$index-1];
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(length($index) > 0 &&defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = "FAIL";
+            $teststatushash{$testcase}{'comment'} = "Functionality failed with restart!";
+            next;
+        }
+
+        my ( $index ) = grep { $statuslines[$_] =~ /functionality summary \(hybrid/ } 0..$#statuslines;
+        my @testsummarylines = $statuslines[$index-1];
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(length($index) > 0 && defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = "FAIL";
+            $teststatushash{$testcase}{'comment'} = "Functionality failed with hybrid!";
+            next;
+        }
+
+        my ( $index ) = grep { $statuslines[$_] =~ /functionality/ } 0..$#statuslines;
+        my @testsummarylines = $statuslines[$index-1];
+        $testsummary = (split(/\s+/, $testsummarylines[0]))[0];
+        if(length($index) > 0 && defined $testsummary && $testsummary !~ /PASS/)
+        {
+	    $teststatushash{$testcase}{'status'} = "FAIL";
+            $teststatushash{$testcase}{'comment'} = "Functionality failed!";
+            next;
+        }
+
+	$teststatushash{$testcase}{'status'} = 'PASS';
+
+	
 	close $teststatusfile;
-
+    
 	# Check the CaseStatus, and print out the last line...
 	my $casestatusfile = $testroot . "/"  . $testcase . "/" . $casestatusfilename;
 	if( -e $casestatusfile)
@@ -380,8 +454,8 @@ sub getTestStatus
 	    $teststatushash{$testcase}{'isioptest'} = "true";
 	}
 
-	# Get the IOP test status if the file exists.
-	# If so, create separate iop* entries in the teststatus hash for this test.
+	# Get the IOP test status if the file exists.   
+	# If so, create separate iop* entries in the teststatus hash for this test.  
 	my $iopstatusfile = $testroot . "/" . $testcase . "/" . $iopstatusfilename;
 	if( -e $iopstatusfile)
 	{
@@ -391,7 +465,7 @@ sub getTestStatus
 	    $iopstatus = (split(/\s+/, $iopstatus))[0];
 	    $teststatushash{$testcase}{'iopstatus'} = $iopstatus;
 	    @statuslines = <$iopstatusfile>;
-
+	    
 	    @memleaklines = grep { /memleak/ } @statuslines;
 	    $memleakstatus = (split(/\s+/, $memleaklines[0]))[0];
 	    $teststatushash{$testcase}{'iopmemleak'} = (length($memleakstatus) > 0) ? $memleakstatus : "---";
@@ -418,9 +492,9 @@ sub getTestStatus
 	    $comment = (split(/\s+/, $commentlines[0], 2) )[1];
 	    chomp $comment;
 	    $teststatushash{$testcase}{'iopcomment'} = $comment;
-
+	    
 	    $teststatushash{$testcase}{'iopcasestatus'} = $teststatushash{$testcase}{'casestatus'};
-
+	    
 	    close $iopfh;
 	}
 
@@ -430,13 +504,13 @@ sub getTestStatus
 	    if( -e $statusoutfile  && $teststatushash{$testcase}{'nlcomp'} eq 'FAIL')
 	    {
 		open my $STATUSOUT, "<", $statusoutfile or warn "can't open $statusoutfile, $!";
-		my @statusoutlines = <$STATUSOUT>;
+		my @statusoutlines = <$STATUSOUT>;	
 		my $commentflag = 0;
 		foreach my $soline(@statusoutlines)
 		{
 		    chomp $soline;
 		    next if ($soline =~ /^$/);
-		    $commentflag = 1 if ($soline =~ /^FAIL/);
+		    $commentflag = 1 if ($soline =~ /^FAIL/);	
 		    $commentflag = 0 if ($soline =~ /^PASS/);
 		    if($commentflag)
 		    {
@@ -459,6 +533,7 @@ sub getTestStatus
 	delete $nlreporthash{$blank} if(length $nlreporthash{$blank} == 0);
     }
 
+#    print Dumper (\%teststatushash);
     return \%teststatushash, \%nlreporthash;
 }
 
@@ -546,7 +621,7 @@ sub makeResultsXml
 	print $xmldumpfile $testxml->toString(1);
 	close $xmldumpfile;
 	print "wrote xml test report to testreporter.dump.xml\n";
-    }
+    }	
     return $testxml;
 }
 
@@ -556,15 +631,15 @@ sub sendresults
     my $resultsstr = $testxml->toString(1);
 
     my $useragent = LWP::UserAgent->new(ssl_opts => {verify_hostname => 0});
-
+    
     # Do not do the HTTP post this way, any string data in the variable $resultsstr
-    # will break the POST on the CGI side
+    # will break the POST on the CGI side 
     #my $req = HTTP::Request->new(POST => $posturl);
     #$req->content_type('application/x-www-form-urlencoded');
     #$req->content("username=$username&password=$password&testXML=$resultsstr");
 
-    # This method of doing the POST makes sure that everything is escaped properly
-    my $req = POST "$posturl",
+    # This method of doing the POST makes sure that everything is escaped properly 
+    my $req = POST "$posturl", 
     [ username => $username, password => $password, testXML => $resultsstr ];
     my $response = $useragent->request($req);
 


### PR DESCRIPTION
Update testreporter to handle the new ESMCI TestStatus files.
Add back in ETEST compset that's needed for testing.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 
