### PR TITLE
workflow now working on mira

### DIFF
--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -42,13 +42,17 @@ OR
                         help="Specify a prerequiset job id, this job will not start until the "
                         "job with this id is completed (batch mode only)")
 
+    parser.add_argument("--resubmit", action="store_true",
+                        help="Used with tests only, to continue rather than restart a test. ")
+                        
+
     args = parser.parse_args(args[1:])
 
     CIME.utils.expect(args.prereq is None, "--prereq not currently supported")
 
     CIME.utils.handle_standard_logging_options(args)
 
-    return args.caseroot, args.job, args.no_batch
+    return args.caseroot, args.job, args.no_batch, args.resubmit
 
 ###############################################################################
 def _main_func(description):
@@ -57,9 +61,9 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, job, no_batch = parse_command_line(sys.argv, description)
+    caseroot, job, no_batch, resubmit = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        submit(case, job=job, no_batch=no_batch)
+        submit(case, job=job, no_batch=no_batch, resubmit=resubmit)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/utils/python/CIME/case_st_archive.py
+++ b/utils/python/CIME/case_st_archive.py
@@ -377,8 +377,8 @@ def case_st_archive(case):
             expect(os.path.isfile(".original_host"), "ERROR alcf host file not found")
             with open(".original_host", "r") as fd:
                 sshhost = fd.read()
-            run_cmd("ssh %s `cd %s; CIMEROOT=%s ./case.submit --resubmit' "\
-                        %(sshhost, caseroot, case.get_value("CIMEROOT")))
+            run_cmd("ssh cooleylogin1 ssh %s '%s/case.submit %s --resubmit' "\
+                        %(sshhost, caseroot, caseroot), verbose=True)
         else:
             submit(case, resubmit=True)
 


### PR DESCRIPTION
This completes the workflow port to mira - it is a unique system in that the workflow passes between mira/cetus and cooley via ssh

The tests ERR_Ld3.f45_g37_rx1.A.mira_ibm and ERI.f45_g37.X.mira_ibm from cime_developer now run to completion.

Test suite: cime_developer (cannot run scripts_regression_tests on mira)
    all pass except SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A.mira_ibm (no mpi serial support on mira)
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Code review: jayesh

