### PR TITLE
Edison port fixes

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -150,7 +150,7 @@
     </batch_system>
 
     <!-- edison is SLURM as of Jan-4-2016 -->
-    <batch_system MACH="edison" version="x.y">
+    <batch_system MACH="edison" type="slurm">
       <directives>
         <directive> -A {{ account }} </directive>
       </directives>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -466,6 +466,7 @@
   <machine MACH="edison">
     <DESC>NERSC XC30, os is CNL, 24 pes/node, batch system is SLURM</DESC>
     <COMPILERS>intel,gnu,cray</COMPILERS>
+    <NODENAME_REGEX>edison</NODENAME_REGEX>
     <MPILIBS>mpt,mpi-serial</MPILIBS>
     <CESMSCRATCHROOT>$ENV{SCRATCH}</CESMSCRATCHROOT>
     <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>

--- a/driver_cpl/cime_config/testdefs/testlist_drv.xml
+++ b/driver_cpl/cime_config/testdefs/testlist_drv.xml
@@ -4,13 +4,12 @@
     <machines>
       <machine name="yellowstone" compiler="intel " category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="cray" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -19,7 +18,7 @@
     <machines>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -28,37 +27,32 @@
     <machines>
       <machine name="hobart" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="hobart" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -86,37 +80,32 @@
     <machines>
       <machine name="yellowstone" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="hobart" compiler="nag" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="cray" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="bluewaters" compiler="pgi" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="mira" compiler="ibm" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -125,19 +114,17 @@
     <machines>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -146,19 +133,17 @@
     <machines>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -167,43 +152,37 @@
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="cray" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="bluewaters" compiler="pgi" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="cray" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -212,43 +191,37 @@
     <machines>
       <machine name="edison" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="hobart" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="hobart" compiler="pgi" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="stampede" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="hobart" compiler="lahey" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -257,19 +230,17 @@
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prealpha">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="bluewaters" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -278,7 +249,7 @@
     <machines>
       <machine name="edison" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -287,31 +258,27 @@
     <machines>
       <machine name="hobart" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="hobart" compiler="pgi" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prealpha">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -320,7 +287,7 @@
     <machines>
       <machine name="hobart" compiler="lahey" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -329,7 +296,7 @@
     <machines>
       <machine name="yellowstone" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -338,37 +305,32 @@
     <machines>
       <machine name="hobart" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="hobart" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -377,19 +339,17 @@
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -398,37 +358,32 @@
     <machines>
       <machine name="hobart" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="hobart" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -437,19 +392,17 @@
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="edison" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -458,19 +411,17 @@
     <machines>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -479,19 +430,17 @@
     <machines>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -500,7 +449,7 @@
     <machines>
       <machine name="yellowstone" compiler="intel" category="prealpha">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -509,25 +458,22 @@
     <machines>
       <machine name="eos" compiler="cray" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -536,31 +482,27 @@
     <machines>
       <machine name="hobart" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="cray" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -569,31 +511,27 @@
     <machines>
       <machine name="hobart" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="cray" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -602,7 +540,7 @@
     <machines>
       <machine name="edison" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -611,7 +549,7 @@
     <machines>
       <machine name="eos" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -620,13 +558,12 @@
     <machines>
       <machine name="hobart" compiler="nag" category="prealpha">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="hobart" compiler="nag" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
@@ -635,32 +572,28 @@
     <machines>
       <machine name="hobart" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="eos" compiler="cray" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
       <machine name="yellowstone" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">4:00</option>
-          <option name="pecount">L</option>
-        </options>
+          <option name="wallclock">00:30:00</option>
+         </options>
       </machine>
     </machines>
   </test>
@@ -668,7 +601,7 @@
     <machines>
       <machine name="hobart" compiler="pgi" category="prebeta">
         <options>
-          <option name="wallclock">2:00</option>
+          <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>

--- a/scripts/Tools/code_checker
+++ b/scripts/Tools/code_checker
@@ -51,7 +51,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def run_pylint(on_file):
 ###############################################################################
     pylint = find_executable("pylint")
-    expect(pylint is not None,"pylint not found")
 
     cmd = "%s --disable I,C,R,logging-not-lazy,wildcard-import,unused-wildcard-import,fixme,broad-except,bare-except,eval-used,exec-used,global-statement %s" % (pylint, on_file)
     stat, out, err = run_cmd(cmd)
@@ -89,6 +88,9 @@ def _main_func(description):
     if ("--test" in sys.argv):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
+
+    pylint = find_executable("pylint")
+    expect(pylint is not None,"pylint not found")
 
     dir_to_check, num_procs = parse_command_line(sys.argv, description)
 

--- a/utils/python/CIME/SystemTests/erp.py
+++ b/utils/python/CIME/SystemTests/erp.py
@@ -106,7 +106,7 @@ class ERP(SystemTestsCommon):
             shutil.copy("env_build.xml", os.path.join("LockedFiles","env_build.xml"))
 
             # update the case to use the new values
-            self._case.read_xml(self._caseroot)
+            self._case.read_xml()
 
             # Use the second executable that was created
             exeroot = self._case.get_value("EXEROOT")

--- a/utils/python/CIME/SystemTests/nck.py
+++ b/utils/python/CIME/SystemTests/nck.py
@@ -46,7 +46,7 @@ class NCK(SystemTestsCommon):
             if model_only:
                 # This file should have been created in the sharedlib_only phase
                 shutil.copy(machpes,"env_mach_pes.xml")
-                self._case.read_xml(self._caseroot)
+                self._case.read_xml()
             else:
                 for comp in ['ATM','OCN','WAV','GLC','ICE','ROF','LND']:
                     self._case.set_value("NINST_%s"%comp, bld)

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -477,7 +477,9 @@ class EnvBatch(EnvBase):
                 return queue_node.get("walltimemax")
 
     def get_default_walltime(self):
-        return self.get_value("walltime", attribute={"default" : "true"}, subgroup=None)
+        walltime = self.get_value("walltime", attribute={"default" : "true"}, subgroup=None)
+        expect(walltime is not None,"Could not find walltime setting in config_batch.xml")
+        return 
 
     def get_default_queue(self):
         return self.get_optional_node("queue", attributes={"default" : "true"})

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -77,7 +77,7 @@ def preview_namelists(case, dryrun=False):
             expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
 
     # refresh case xml object from file
-    case.read_xml(caseroot)
+    case.read_xml()
     # Save namelists to docdir
     if (not os.path.isdir(docdir)):
         os.makedirs(docdir)


### PR DESCRIPTION
Fix issues on edison - NODENAME_REGEX was not defined for cesm config_batch entry error for acme, do not call flush if error occurs before case directory is created. 

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: jgfouca
