### PR TITLE
need to return default walltime

### DIFF
--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -479,7 +479,7 @@ class EnvBatch(EnvBase):
     def get_default_walltime(self):
         walltime = self.get_value("walltime", attribute={"default" : "true"}, subgroup=None)
         expect(walltime is not None,"Could not find walltime setting in config_batch.xml")
-        return 
+        return walltime
 
     def get_default_queue(self):
         return self.get_optional_node("queue", attributes={"default" : "true"})


### PR DESCRIPTION
Fix issue with getting default wallclock time.
This bug was introduced in aeac91a28fe1cb1a70eaabb559a973875cd56ac7 .

Test suite: cime-developer on mira
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes

User interface changes?: 

Code review: jayesh

