### PR TITLE
replaced ww3 with stub wave in several tests that are known to fail

### DIFF
--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="ERI" grid="f09_g16" compset="B1850" testmods="allactive/defaultio">
+  <test name="ERI" grid="f09_g16" compset="B1850Ws" testmods="allactive/defaultio">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>
       <options>
@@ -8,7 +8,7 @@
       </options>
     </machines>
   </test>
-  <test name="ERI" grid="f09_g16" compset="B1850" testmods="allactive/cesm2dev01">
+  <test name="ERI" grid="f09_g16" compset="B1850Ws" testmods="allactive/cesm2dev01">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
       <options>
@@ -16,7 +16,7 @@
       </options>
     </machines>
   </test>
-  <test name="ERI" grid="ne30_g16" compset="B1850" testmods="allactive/defaultio">
+  <test name="ERI" grid="ne30_g16" compset="B1850Ws" testmods="allactive/defaultio">
     <machines>
       <machine name="yellowstone" compiler="intel" category="prealpha"/>
       <options>


### PR DESCRIPTION
in CESM - replaced ww3 with stub wave in several tests that are known to fail

Test suite: none
Test baseline: none
Test namelist changes: none
Test status: bit for bit

Fixes [CIME Github issue #] None

User interface changes?: None

Code review: 

