### PR TITLE
output from buildnml scripts now prints

### DIFF
--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -68,14 +68,14 @@ def preview_namelists(case, dryrun=False):
         config_file = case.get_value("CONFIG_%s_FILE" % model_str.upper())
         config_dir = os.path.dirname(config_file)
         cmd = os.path.join(config_dir, "buildnml")
-        logger.info("Running %s"%cmd)
+        logger.info("Running %s:"%cmd)
         if (logger.level == logging.DEBUG):
             rc, out, err = run_cmd("PREVIEW_NML=1 %s %s" % (cmd, caseroot))
-            expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
+            expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))      
         else:
             rc, out, err = run_cmd("%s %s" % (cmd, caseroot))
             expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
-
+        logger.info("     %s"%out)
     # refresh case xml object from file
     case.read_xml()
     # Save namelists to docdir

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -39,8 +39,8 @@ class A_RunUnitTests(unittest.TestCase):
         stat, output, _ = run_cmd("./%s --test 2>&1" % script, from_dir=from_dir)
         self.assertEqual(stat, 0, msg=output)
 
-    def test_acme_bisect_unit_test(self):
-        self.do_unit_tests("acme_bisect",from_dir=TOOLS_DIR)
+    def test_cime_bisect_unit_test(self):
+        self.do_unit_tests("cime_bisect",from_dir=TOOLS_DIR)
 
     def test_compare_namelists_unit_test(self):
         self.do_unit_tests("compare_namelists",from_dir=TOOLS_DIR)


### PR DESCRIPTION
Output from component buildnml scripts was being lost.  Also changed a test in scripts_regression_tests from acme_bisect to cime_bisect.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #281 

User interface changes?: 

Code review: 

