### PR TITLE
Users should get a nice error when their python is too old

### DIFF
--- a/scripts/Tools/standard_script_setup.py
+++ b/scripts/Tools/standard_script_setup.py
@@ -3,7 +3,7 @@ Encapsulate the importing of python utils and logging setup, things
 that every script should do.
 """
 
-import sys, os, logging, doctest, argparse
+import sys, os
 import __main__ as main
 _CIMEROOT = os.environ.get("CIMEROOT")
 if(_CIMEROOT is None):
@@ -15,3 +15,5 @@ sys.path.append(_LIB_DIR)
 import CIME.utils
 CIME.utils.check_minimum_python_version(2, 7)
 CIME.utils.stop_buffering_output()
+
+import logging, doctest, argparse

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -3,7 +3,6 @@ Common functions used by cime python scripts
 Warning: you cannot use CIME Classes in this module as it causes circular dependencies
 """
 import logging, gzip, sys, os, time, re, shutil
-from importlib import import_module
 
 # Return this error code if the scripts worked but tests failed
 TESTS_FAILED_ERR_CODE = 100
@@ -882,6 +881,8 @@ def find_system_test(testname, case):
     path to that directory to sys.path if its not there and return the test object
     Fail if the test is not found in any of the paths.
     '''
+    from importlib import import_module
+
     system_test_path = None
     if testname.startswith("TEST"):
         system_test_path =  "CIME.SystemTests.system_tests_common.%s"%(testname)

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -218,7 +218,7 @@ def check_minimum_python_version(major, minor):
     >>>
     """
     expect(sys.version_info[0] == major and sys.version_info[1] >= minor,
-           "Python %d, minor verion %d+ is required, you have %d.%d" %
+           "Python %d, minor version %d+ is required, you have %d.%d" %
            (major, minor, sys.version_info[0], sys.version_info[1]))
 
 def normalize_case_id(case_id):


### PR DESCRIPTION
Due an added import in utils.py, this capability was lost. The fix was to more import to inside the function that needed it.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #321

User interface changes?: 

Code review: Rob

