### PR TITLE
moved batchdirectives to top of the template

### DIFF
--- a/cime_config/acme/machines/template.case.run
+++ b/cime_config/acme/machines/template.case.run
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Batch system directives
+{{ batchdirectives }}
+
 """
 template to create a case run script. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
@@ -21,8 +24,6 @@ logger = logging.getLogger(__name__)
 
 import argparse, doctest
 
-# Batch system directives
-{{ batchdirectives }}
 
 # PE Layout Documentation:
 {{ pedocumentation }}

--- a/cime_config/acme/machines/template.lt_archive
+++ b/cime_config/acme/machines/template.lt_archive
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Batch system directives
+{{ batchdirectives }}
+
 """
 template to create a case longterm term archiving script. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
@@ -19,8 +22,6 @@ from CIME.case_lt_archive           import case_lt_archive
 
 logger = logging.getLogger(__name__)
 
-# Batch system directives
-{{ batchdirectives }}
 
 ###############################################################################
 def parse_command_line(args, description):

--- a/cime_config/acme/machines/template.st_archive
+++ b/cime_config/acme/machines/template.st_archive
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Batch system directives
+{{ batchdirectives }}
+
 """
 template to create a case short term archiving script. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
@@ -18,8 +21,6 @@ from CIME.case_st_archive import case_st_archive
 
 logger = logging.getLogger(__name__)
 
-# Batch system directives
-{{ batchdirectives }}
 
 ###############################################################################
 def parse_command_line(args, description):


### PR DESCRIPTION
This merge updates the ACME template files to put the batch directives in the proper location for other batch systems that haven't been added to the ACME machines yet (such as moab).

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 

