### PR TITLE
Fix mismatch between MPI_PATH and the mpi module being loaded

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -537,10 +537,10 @@
       <command name="load">sems-python/2.7.9</command>
       <command name="load">gnu/4.9.2</command>
       <command name="load">intel/intel-15.0.3.187</command>
-      <command name="load" mpilib="!mpi-serial">openmpi-intel/1.6</command>
+      <command name="load" mpilib="!mpi-serial">openmpi-intel/1.8</command>
       <command name="load">libraries/intel-mkl-15.0.2.164</command>
       <command name="load">libraries/intel-mkl-15.0.2.164</command>
-      <command name="load" mpilib="!mpi-serial">sems-hdf5/1.8.11/parallel</command>
+      <command name="load" mpilib="!mpi-serial">sems-hdf5/1.8.12/parallel</command>
       <command name="load" mpilib="!mpi-serial">sems-netcdf/4.3.2/parallel</command>
       <command name="load" mpilib="mpi-serial">sems-hdf5/1.8.11/base</command>
       <command name="load" mpilib="mpi-serial">sems-netcdf/4.3.2/base</command>


### PR DESCRIPTION
Test suite: cime_developer
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: No

Code review: None, trival env fix

