### PR TITLE
create_test was not failing the create_newcase phase when project inf…

### DIFF
--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -368,9 +368,11 @@ class TestScheduler(object):
             machine, compiler, test_mods = CIME.utils.parse_test_name(test)
 
         create_newcase_cmd = "%s --case %s --res %s --mach %s --compiler %s --compset %s"\
-                               " --project %s --test"%\
+                               " --test" % \
                               (os.path.join(self._cime_root, "scripts", "create_newcase"),
-                               test_dir, grid, machine, compiler, compset, self._project)
+                               test_dir, grid, machine, compiler, compset)
+        if self._project is not None:
+            create_newcase_cmd += " --project %s " % self._project
 
         if test_mods is not None:
             files = Files()


### PR DESCRIPTION
…o was missing

The problem is that test_scheduler was passing --project None to create_newcase
when it did not have project info. create_newcase was interpreting this as a string
"None", which is not what we want. This commit changes test_scheduler to not pass
--project unless there's a project.

Test suite: None, just tested by hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #334

User interface changes?: No

Code review: None

