### PR TITLE
Autosave environment information in case_setup.

### DIFF
--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -19,8 +19,6 @@ class EnvMachSpecific(EnvBase):
         """
         fullpath = infile if os.path.isabs(infile) else os.path.join(caseroot, infile)
         EnvBase.__init__(self, caseroot, fullpath)
-        self._cshscript = []
-        self._shscript = []
 
     def get_values(self, item, attribute=None, resolved=True, subgroup=None):
         """Returns the value as a string of the first xml element with item as attribute value.
@@ -59,27 +57,32 @@ class EnvMachSpecific(EnvBase):
 
         return results
 
-    def load_env_for_case(self, compiler, debug, mpilib):
+    def _get_env_for_case(self, compiler, debug, mpilib):
         module_nodes = self.get_nodes("modules")
         env_nodes    = self.get_nodes("environment_variables")
 
-        if (module_nodes is not None):
+        modules_to_load = None
+        if module_nodes is not None:
             modules_to_load = self._compute_module_actions(module_nodes, compiler, debug, mpilib)
-            self.load_modules(modules_to_load)
-        if (env_nodes is not None):
+
+        envs_to_set = None
+        if env_nodes is not None:
             envs_to_set = self._compute_env_actions(env_nodes, compiler, debug, mpilib)
+
+        return modules_to_load, envs_to_set
+
+    def load_env_for_case(self, compiler, debug, mpilib):
+        modules_to_load, envs_to_set = self._get_env_for_case(compiler, debug, mpilib)
+
+        if (modules_to_load is not None):
+            self.load_modules(modules_to_load)
+        if (envs_to_set is not None):
             self.load_envs(envs_to_set)
-        with open(".env_mach_specific.csh",'w') as f:
-            f.write("\n".join(self._cshscript))
-        with open(".env_mach_specific.sh",'w') as f:
-            f.write("\n".join(self._shscript))
 
     def load_modules(self, modules_to_load):
         module_system = self.get_module_system_type()
         if (module_system == "module"):
             self._load_module_modules(modules_to_load)
-            self._cshscript += self._get_module_module_commands(modules_to_load,"csh")
-            self._shscript += self._get_module_module_commands(modules_to_load,"sh")
         elif (module_system == "soft"):
             self._load_soft_modules(modules_to_load)
         elif (module_system == "dotkit"):
@@ -89,12 +92,44 @@ class EnvMachSpecific(EnvBase):
         else:
             expect(False, "Unhandled module system '%s'" % module_system)
 
+    def list_modules(self):
+        module_system = self.get_module_system_type()
+        if (module_system == "module"):
+            return run_cmd_no_fail("module list 2>&1")
+        elif (module_system == "soft"):
+            return run_cmd_no_fail("softenv")
+        elif (module_system == "dotkit"):
+            return run_cmd_no_fail("use -lv")
+        elif (module_system == "none"):
+            return ""
+        else:
+            expect(False, "Unhandled module system '%s'" % module_system)
+
+    def make_env_mach_specific_file(self, compiler, debug, mpilib, shell):
+        modules_to_load, envs_to_set = self._get_env_for_case(compiler, debug, mpilib)
+
+        filename = ".env_mach_specific.%s" % shell
+        lines = []
+        if modules_to_load is not None:
+            lines.extend(self._get_module_commands(modules_to_load, shell))
+
+        if envs_to_set is not None:
+            for env_name, env_value in envs_to_set:
+                # Let bash do the work on evaluating and resolving env_value
+                if shell == "sh":
+                    lines.append("export %s=%s" % (env_name, env_value))
+                elif shell == "csh":
+                    lines.append("setenv %s %s" % (env_name, env_value))
+                else:
+                    expect(False, "Unknown shell type: '%s'" % shell)
+
+        with open(filename, "w") as fd:
+            fd.write("\n".join(lines))
+
     def load_envs(self, envs_to_set):
         for env_name, env_value in envs_to_set:
             # Let bash do the work on evaluating and resolving env_value
             os.environ[env_name] = run_cmd_no_fail("echo %s" % env_value)
-            self._cshscript.append("setenv %s %s"%(env_name,env_value))
-            self._shscript.append("export %s=%s"%(env_name,env_value))
 
     # Private API
 
@@ -135,7 +170,8 @@ class EnvMachSpecific(EnvBase):
         else:
             return my_value == xml_value
 
-    def _get_module_module_commands(self, modules_to_load, shell):
+    def _get_module_commands(self, modules_to_load, shell):
+        # Note this is independent of module system type
         mod_cmd = self.get_module_system_cmd_path(shell)
         cmds = []
         for action, argument in modules_to_load:
@@ -145,7 +181,7 @@ class EnvMachSpecific(EnvBase):
         return cmds
 
     def _load_module_modules(self, modules_to_load):
-        for cmd in self._get_module_module_commands(modules_to_load, "python"):
+        for cmd in self._get_module_commands(modules_to_load, "python"):
             py_module_code = run_cmd_no_fail(cmd)
             exec(py_module_code)
 


### PR DESCRIPTION
Software_environment.txt will always be created during case_setup.
This file will contain a list of loaded modules and a full dump
of the current environment.

This branch also includes some minor refactoring of env_mach_specific.py

Test suite: cime_developer
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #319

User interface changes?: New env provenance file

Code review: None, maybe @jedwards4b when he gets back

