### PR TITLE
Remove `GenericXML` check for env variables.

### DIFF
--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -218,8 +218,5 @@ class GenericXML(object):
             elif var == "SRCROOT":
                 srcroot = os.path.join(get_cime_root(),"..")
                 item_data = item_data.replace(m.group(), srcroot)
-            elif var in os.environ:
-                logging.debug("resolve from env: " + var)
-                item_data = item_data.replace(m.group(), os.environ[var])
 
         return item_data


### PR DESCRIPTION
When a user set a variable in their environment, it could sometimes
override settings in XML files when resolving variables. This change
prevents that from happening.

Fixes #326

Tested using `scripts_regression_tests.py`.