### PR TITLE
Wilke/scripts/xmlchange

### DIFF
--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -78,10 +78,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.handle_standard_logging_options(args)
     
-    logger.warning(args.listofsettings)
     listofsettings = []
-    if( len(args.listofsettings) == 1 ):
-        listofsettings = args.listofsettings[0].split(',')
+    if( len(args.listofsettings) ):
+        listofsettings = args.listofsettings.split(',')
 
     return args.caseroot, listofsettings, args.file, args.id, args.val, args.subgroup, args.append, args.noecho, args.warn, args.force
 
@@ -91,17 +90,20 @@ def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=No
         if len(listofsettings):
             logger.warning("List of attributes to change: %s" , listofsettings)
 
-            # Error handling, exit with grace if xmlval or equal sign is missing. Check first before changing any attributes 
+            # Error handling, exit with grace if xmlval or equal sign is missing. Check first all attributes before changing
             for setting in listofsettings:
-                (xmlid, xmlval) = setting.split('=', 1)         
-                if xmlval is None :
-                    logger.error("Missing value for %s. Please all settings have to be in the form of attribute=value." , xmlid)
-                    sys.exit(1)
-                    
+                # Test for equal sign
+                pair = setting.split("=")
+                expect(len(pair) == 2 , "Wrong format for %s. Expecting a key value pair in form of key=value." % (setting) ) 
+                (xmlid, xmlval) = pair
+    
             # Change values         
             for setting in listofsettings:
-                (xmlid, xmlval) = setting.split('=', 1)
-                        
+                
+                pair = setting.split("=")
+                expect(len(pair) == 2 , "Expecting a key value pair in the form of key=value.") 
+                (xmlid, xmlval) = pair
+                
                 type_str = case.get_type_info(xmlid)
                 if(append is True):
                     value = case.get_value(xmlid, resolved=False,

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -88,7 +88,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=None, subgroup=None,
               append=None, noecho=False, warn=None, force=False):
     with Case(caseroot, read_only=False) as case:
-        if listofsettings:
+        if len(listofsettings):
             logger.warning("List of attributes to change: %s" , listofsettings)
 
             # Error handling, exit with grace if xmlval or equal sign is missing. Check first before changing any attributes 

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -41,7 +41,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    parser.add_argument("listofsettings", nargs="*",
+    parser.add_argument("listofsettings", nargs="?", default='' ,
                         help="Comma seperated list of settings in the form: var1=value,var2=value,...")
 
     parser.add_argument("--caseroot", default=os.getcwd(),
@@ -77,7 +77,8 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
-
+    
+    logger.warning(args.listofsettings)
     listofsettings = []
     if( len(args.listofsettings) == 1 ):
         listofsettings = args.listofsettings[0].split(',')
@@ -88,11 +89,12 @@ def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=No
               append=None, noecho=False, warn=None, force=False):
     with Case(caseroot, read_only=False) as case:
         if listofsettings:
-            
+            logger.warning("List of attributes to change: %s" , listofsettings)
+
             # Error handling, exit with grace if xmlval or equal sign is missing. Check first before changing any attributes 
             for setting in listofsettings:
                 (xmlid, xmlval) = setting.split('=', 1)         
-                if xmlval == None :
+                if xmlval is None :
                     logger.error("Missing value for %s. Please all settings have to be in the form of attribute=value." , xmlid)
                     sys.exit(1)
                     

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -17,6 +17,8 @@ from CIME.case import Case
 
 import argparse, doctest, shutil, glob, time
 
+logger = logging.getLogger("xmlchange")
+
 ###############################################################################
 def parse_command_line(args, description):
 ###############################################################################
@@ -86,8 +88,18 @@ def xmlchange(caseroot, listofsettings=None, xmlfile=None, xmlid=None, xmlval=No
               append=None, noecho=False, warn=None, force=False):
     with Case(caseroot, read_only=False) as case:
         if listofsettings:
+            
+            # Error handling, exit with grace if xmlval or equal sign is missing. Check first before changing any attributes 
+            for setting in listofsettings:
+                (xmlid, xmlval) = setting.split('=', 1)         
+                if xmlval == None :
+                    logger.error("Missing value for %s. Please all settings have to be in the form of attribute=value." , xmlid)
+                    sys.exit(1)
+                    
+            # Change values         
             for setting in listofsettings:
                 (xmlid, xmlval) = setting.split('=', 1)
+                        
                 type_str = case.get_type_info(xmlid)
                 if(append is True):
                     value = case.get_value(xmlid, resolved=False,


### PR DESCRIPTION
Limiting the number of positional command  line arguments to 1 or 0. 
Implicit provided argument is in the form of key=value. 

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes  #323

User interface changes?: 

Code review: 
