### PR TITLE
get acme cime dev working on mira

### DIFF
--- a/cime_config/acme/allactive/config_pesall.xml
+++ b/cime_config/acme/allactive/config_pesall.xml
@@ -3812,6 +3812,43 @@
     </mach>
   </grid>
   <grid name="a%ne30np4_l%ne30np4_oi%gx1v6">
+    <mach name="cetus|mira">
+      <pes compset="A" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>8</ntasks_atm>
+          <ntasks_lnd>8</ntasks_lnd>
+          <ntasks_rof>8</ntasks_rof>
+          <ntasks_ice>8</ntasks_ice>
+          <ntasks_ocn>8</ntasks_ocn>
+          <ntasks_glc>8</ntasks_glc>
+          <ntasks_wav>8</ntasks_wav>
+          <ntasks_cpl>8</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>16</nthrds_atm>
+          <nthrds_lnd>16</nthrds_lnd>
+          <nthrds_rof>16</nthrds_rof>
+          <nthrds_ice>16</nthrds_ice>
+          <nthrds_ocn>16</nthrds_ocn>
+          <nthrds_glc>16</nthrds_glc>
+          <nthrds_wav>16</nthrds_wav>
+          <nthrds_cpl>16</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+  <grid name="a%ne30np4_l%ne30np4_oi%gx1v6">
     <mach name="cetus">
       <pes compset="any" pesize="any">
         <comment>none</comment>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -680,7 +680,7 @@
          <BATCH_SYSTEM>cobalt</BATCH_SYSTEM>
          <SUPPORTED_BY>   jayesh -at- mcs.anl.gov</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
-         <PES_PER_NODE>8</PES_PER_NODE>
+         <PES_PER_NODE>4</PES_PER_NODE>
          <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
          <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	 <PROJECT>HiRes_EarthSys_2</PROJECT>
@@ -690,14 +690,13 @@
              <arguments>
                <arg name="label"> --label short</arg>
                <!-- Ranks per node!! -->
-               <arg name="tasks_per_node"> -p {{ tasks_per_node }}</arg>
+               <arg name="tasks_per_node"> --ranks-per-node $PES_PER_NODE</arg>
                <!-- Total MPI Tasks -->
-               <arg name="num_tasks"> -n {{ num_tasks }}</arg>
+               <arg name="num_tasks"> --np $TOTALPES</arg>
                <arg name="locargs"> --block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
                <arg name="bg_threadlayout"> --envs BG_THREADLAYOUT=1</arg>
                <arg name="omp_stacksize"> --envs OMP_STACKSIZE=64M</arg>
                <arg name="thread_count"> --envs OMP_NUM_THREADS={{ thread_count }}</arg>
-               <arg name="colon">:</arg>
              </arguments>
          </mpirun>
     <module_system type="soft">
@@ -803,7 +802,7 @@
 	 <BATCH_SYSTEM>cobalt</BATCH_SYSTEM>
          <SUPPORTED_BY>   mickelso -at- mcs.anl.gov</SUPPORTED_BY>
          <GMAKE_J>4</GMAKE_J>
-         <PES_PER_NODE>8</PES_PER_NODE>
+         <PES_PER_NODE>4</PES_PER_NODE>
          <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
          <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	 <PROJECT>HiRes_EarthSys_2</PROJECT>
@@ -813,9 +812,9 @@
              <arguments>
                <arg name="label"> --label short</arg>
                <!-- Ranks per node!! -->
-               <arg name="tasks_per_node"> -p {{ tasks_per_node }}</arg>
+               <arg name="tasks_per_node"> --ranks-per-node $PES_PER_NODE</arg>
                <!-- Total MPI Tasks -->
-               <arg name="num_tasks"> -n {{ num_tasks }}</arg>
+               <arg name="num_tasks"> --np $TOTALPES</arg>
                <arg name="locargs"> --block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
                <arg name="bg_threadlayout"> --envs BG_THREADLAYOUT=1</arg>
                <arg name="omp_stacksize"> --envs OMP_STACKSIZE=64M</arg>


### PR DESCRIPTION
This commit gets cime_developer running on Mira with the ACME model.

Test suite: cime_developer
Test baseline: 
Test namelist changes: None
Test status: bit for bit

Fixes #346 

User interface changes?: None

Code review: @jgfouca 

