### PR TITLE
Add support for LANL's mustang and wolf to cime

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -255,7 +255,6 @@
 
 
    <batch_system MACH="mustang" type="moab" version="x.y">
-   <batch_directive>#MSUB</batch_directive>
    <directives>
      <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
    </directives>
@@ -267,13 +266,9 @@
    </batch_system>
 
    <batch_system MACH="wolf" type="moab" version="x.y">
-     <batch_directive>#MSUB</batch_directive>
 	<directives>
 		<directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
 	</directives>
-	<BATCHQUERY>mshow</BATCHQUERY>
-	<BATCHSUBMIT>msub</BATCHSUBMIT>
-	<BATCHREDIRECT></BATCHREDIRECT>
 	<walltimes>
 	  <walltime default="true">00:30:00</walltime>
 	  <walltime ccsm_estcost="1">02:00:00</walltime>

--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -1175,4 +1175,23 @@ for mct, etc.
 	<GPTL_CPPDEFS> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY </GPTL_CPPDEFS>
 </compiler>
 
+<compiler MACH="mustang">
+    <NETCDF_PATH>$(NETCDF)</NETCDF_PATH>
+    <PNETCDF_PATH>$(PARALLEL_NETCDF)</PNETCDF_PATH>
+</compiler>
+
+<compiler MACH="wolf">
+    <NETCDF_PATH>$(NETCDF)</NETCDF_PATH>
+    <PNETCDF_PATH>$(PARALLEL_NETCDF)</PNETCDF_PATH>
+</compiler>
+
+<compiler COMPILER="gnu" MACH="mustang">
+	<ADD_CFLAGS>  -std=c99 </ADD_CFLAGS>
+</compiler>
+
+<compiler COMPILER="gnu" MACH="wolf">
+	<ADD_CFLAGS>  -std=c99 </ADD_CFLAGS>
+</compiler>
+
+
 </config_compilers>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -1047,8 +1047,8 @@
 
 <machine MACH="mustang">
 	<DESC>LANL Linux Cluster, 24 pes/node, batch system Moab</DESC>
-        <NODENAME_REGEX>mustang</NODENAME_REGEX>
-        <TESTS>acme_developer</TESTS>
+    <NODENAME_REGEX>mu.*.lanl.gov</NODENAME_REGEX>
+    <TESTS>acme_developer</TESTS>
 	<COMPILERS>intel,gnu</COMPILERS>
 	<MPILIBS>openmpi,mvapich,mpi-serial</MPILIBS>
 	<OS>LINUX</OS>
@@ -1059,8 +1059,51 @@
 	<DOUT_S_ROOT>/lustre/scratch1/turquoise/$ENV{USER}/ACME/archive/$CASE</DOUT_S_ROOT>
 	<DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
 	<CCSM_BASELINE>/lustre/scratch1/turquoise/$ENV{USER}/ACME/input_data/ccsm_baselines</CCSM_BASELINE>
-	<CESMSCRATCHROOT>/lustre/scratch1/turquoise/$ENV{USER}/ACME</CESMSCRATCHROOT>
+	<CESMSCRATCHROOT>/lustre/scratch1/turquoise/$ENV{USER}/ACME/scratch</CESMSCRATCHROOT>
 	<CCSM_CPRNC>/turquoise/usr/projects/climate/SHARED_CLIMATE/software/mustang/cprnc/v0.40/cprnc</CCSM_CPRNC>
+	<module_system type="module">
+	   <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
+	   <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+	   <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
+	   <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
+	   <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+	   <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
+	   <cmd_path lang="sh">module</cmd_path>
+	   <cmd_path lang="csh">module</cmd_path>
+	   <modules>
+		  <command name="list"/>
+	      <command name="purge"/>
+		  <command name="use">/usr/projects/climate/SHARED_CLIMATE/modulefiles/all</command>
+		  <command name="load">friendly-testing</command>
+		  <command name="load">python/anaconda-2.7-climate</command>
+	   </modules>
+	   <modules compiler="intel">
+	      <command name="load">intel/15.0.5</command>
+	      <command name="load">mkl/11.3.3</command>
+	   </modules>
+	   <modules compiler="gnu">
+	      <command name="load">gcc/4.8.2</command>
+	   </modules>
+	   <modules mpilib="openmpi">
+	      <command name="load">openmpi/1.6.5</command>
+	   </modules>
+	   <modules mpilib="mvapich">
+	      <command name="load">mvapich2/1.8</command>
+	   </modules>
+	   <modules>
+	      <command name="load">netcdf/4.4.0</command>
+	   </modules>
+	   <modules mpilib="!mpi-serial">
+	      <command name="load">parallel-netcdf/1.5.0</command>
+	   </modules>
+	   <modules>
+		  <command name="list"/>
+	   </modules>
+	</module_system>
+	<environment_variables>
+	   <env name="LD_LIBRARY_PATH">$LD_LIBRARY_PATH:$NETCDF_ROOT/lib</env>
+	</environment_variables>
+
 	<BATCH_SYSTEM>moab</BATCH_SYSTEM>
 	<mpirun mpilib="default">
 		<executable>mpirun</executable>
@@ -1085,14 +1128,15 @@
 	</mpirun>
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
+	<PES_PER_NODE>24</PES_PER_NODE>
 	<PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	<SUPPORTED_BY>jacobsen.douglas -at- gmail.com</SUPPORTED_BY>
 </machine>
 
 <machine MACH="wolf">
 	<DESC>LANL Linux Cluster, 16 pes/node, batch system Moab</DESC>
-        <NODENAME_REGEX>wolf</NODENAME_REGEX>
-        <TESTS>acme_developer</TESTS>
+    <NODENAME_REGEX>wf-fe.*.lanl.gov</NODENAME_REGEX>
+    <TESTS>acme_developer</TESTS>
 	<COMPILERS>intel,gnu</COMPILERS>
 	<MPILIBS>openmpi,mvapich,mpi-serial</MPILIBS>
 	<OS>LINUX</OS>
@@ -1103,8 +1147,47 @@
 	<DOUT_S_ROOT>/lustre/scratch1/turquoise/$ENV{USER}/ACME/archive/$CASE</DOUT_S_ROOT>
 	<DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
 	<CCSM_BASELINE>/lustre/scratch1/turquoise/$ENV{USER}/ACME/input_data/ccsm_baselines</CCSM_BASELINE>
-	<CESMSCRATCHROOT>/lustre/scratch1/turquoise/$ENV{USER}/ACME</CESMSCRATCHROOT>
+	<CESMSCRATCHROOT>/lustre/scratch1/turquoise/$ENV{USER}/ACME/scratch</CESMSCRATCHROOT>
 	<CCSM_CPRNC>/turquoise/usr/projects/climate/SHARED_CLIMATE/software/wolf/cprnc/v0.40/cprnc</CCSM_CPRNC>
+	<module_system type="module">
+	   <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
+	   <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+	   <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
+	   <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
+	   <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+	   <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
+	   <cmd_path lang="sh">module</cmd_path>
+	   <cmd_path lang="csh">module</cmd_path>
+	   <modules>
+	      <command name="purge"/>
+		  <command name="use">/usr/projects/climate/SHARED_CLIMATE/modulefiles/all</command>
+		  <command name="load">friendly-testing</command>
+		  <command name="load">python/anaconda-2.7-climate</command>
+	   </modules>
+	   <modules compiler="intel">
+	      <command name="load">intel/15.0.5</command>
+	      <command name="load">mkl/11.3.3</command>
+	   </modules>
+	   <modules compiler="gnu">
+	      <command name="load">gcc/4.8.2</command>
+	   </modules>
+	   <modules mpilib="openmpi">
+	      <command name="load">openmpi/1.6.5</command>
+	   </modules>
+	   <modules mpilib="mvapich">
+	      <command name="load">mvapich2/1.8</command>
+	   </modules>
+	   <modules>
+	      <command name="load">netcdf/4.4.0</command>
+	   </modules>
+	   <modules mpilib="!mpi-serial">
+	      <command name="load">parallel-netcdf/1.5.0</command>
+	   </modules>
+	</module_system>
+	<environment_variables>
+	   <env name="LD_LIBRARY_PATH">$LD_LIBRARY_PATH:$NETCDF_ROOT/lib</env>
+	</environment_variables>
+
 	<BATCH_SYSTEM>moab</BATCH_SYSTEM>
 	<mpirun mpilib="default">
 		<executable>mpirun</executable>
@@ -1129,6 +1212,7 @@
 	</mpirun>
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
+	<PES_PER_NODE>16</PES_PER_NODE>
 	<PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	<SUPPORTED_BY>jacobsen.douglas -at- gmail.com</SUPPORTED_BY>
 </machine>


### PR DESCRIPTION
This merge adds support to LANL's IC machines: mustang and wolf.

These machines use the following compilers / libraries:

Compiler: gnu 4.8.2 or intel 1.6.5
MPI: OpenMPI 1.6.5 or MVAPIC2 1.8
NetCDF: F-4.4.0, C-4.3.2
PNetCDF: 1.5.0

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 
