### PR TITLE
Set CHECK_TIMING to true in addition to SAVE_TIMING if --save-timing …

### DIFF
--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -514,6 +514,7 @@ class TestScheduler(object):
             envtest.set_initial_values(case)
             if self._save_timing:
                 case.set_value("SAVE_TIMING", True)
+                case.set_value("CHECK_TIMING", True)
 
         return True
 


### PR DESCRIPTION
…given to create_test

Test suite: scripts_regression_tests.py TestSaveTimings
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: No

Code review: @jedwards4b 

