### PR TITLE
Fixpionml

### DIFF
--- a/driver_cpl/bld/build-namelist
+++ b/driver_cpl/bld/build-namelist
@@ -236,8 +236,13 @@ my $cfg = Build::Config->new("$CASEROOT/Buildconf/cplconf/config_cache.xml");
 # output namelist variables are in the definition file, and are output in the correct
 # namelist groups.
 my $definition = Build::NamelistDefinition->new( shift(@nl_definition_paths) );
+my $modelio_definition;
 foreach my $nl_defin_file ( @nl_definition_paths ) {
-  $definition->add( "$nl_defin_file" );
+  if ( $nl_defin_file =~ /modio/ ) {
+    $modelio_definition = Build::NamelistDefinition->new( $nl_defin_file );
+  } else {
+    $definition->add( "$nl_defin_file" );
+  }
 }
 
 # Create a namelist defaults object.  This object provides default values for variables
@@ -940,6 +945,8 @@ check_input_files($nl, $DIN_LOC_ROOT, "../cpl.input_data_list");
 # (4) Write out model_modelio.nml files
 #-----------------------------------------------------------------------------------------------
 
+$definition = $modelio_definition;
+
 foreach my $model (qw(cpl atm lnd ice ocn glc rof wav esp)) {
 
     my $LID     = "$ENV{'LID'}";
@@ -1042,6 +1049,9 @@ foreach my $model (qw(cpl atm lnd ice ocn glc rof wav esp)) {
 	    add_default($nlio, 'pio_typename',   'val'=>"$xmlvars{'GLC_PIO_TYPENAME'}");
 	    add_default($nlio, 'pio_rearranger',  'val'=>"$xmlvars{'GLC_PIO_REARRANGER'}");
 	}
+        # Validate that the namelist is correct
+        $definition->validate($nlio);
+
 	$nlio->write($modeliofile, 'groups'=>\@iogroup);
 	if ($print>=2) { print "Writing io namelist to $modeliofile $eol"; }
 	$inst_index = $inst_index + 1;

--- a/driver_cpl/bld/testdir/env_build.xml
+++ b/driver_cpl/bld/testdir/env_build.xml
@@ -1,103 +1,71 @@
-<?xml version="1.0"?> 
-
-<config_definition> 
-
-<header>
-
+<?xml version="1.0"?>
+<file id="env_build.xml">
+  <header>
     These variables SHOULD NOT be changed once the model has been built.
     urrently, these variables are not cached.
     Note1: users SHOULD NOT modify BUILD_COMPETE below
     this is done automatically by the scripts.
-    </header> 
-
-<groups>
-   <group>build_component_cism</group> 
-   <group>build_component_clm</group> 
-   <group>build_component_mosart</group> 
-   <group>build_def</group> 
-   <group>build_derived</group> 
-   <group>build_grid</group> 
-   <group>build_macros</group> 
-   <group>build_status</group> 
-</groups>
-
-
-  <entry id="CALENDAR"  value="NO_LEAP">
-    <type>char</type> 
-    <valid_values>NO_LEAP,GREGORIAN</valid_values> 
-    <group>build_def</group> 
-    <desc>calendar type></desc> 
-  </entry> 
-
-  <entry id="ATM_GRID"  value="1.9x2.5">
-    <type>char</type> 
-    <group>build_grid</group> 
-    <desc>atmosphere grid - DO NOT EDIT (for experts only)</desc> 
-  </entry> 
-
-  <entry id="GRID"  value="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null">
-    <type>char</type> 
-    <group>build_grid</group> 
-    <desc>Model grid - DO NOT EDIT (for experts only)</desc> 
-  </entry> 
-
-  <entry id="ICE_GRID"  value="gx1v6">
-    <type>char</type> 
-    <group>build_grid</group> 
-    <desc>ice grid (must equal ocn grid) - DO NOT EDIT (for experts only)</desc> 
-  </entry> 
-
-  <entry id="ICE_NCAT"  value="1">
-    <type>integer</type> 
-    <group>build_grid</group> 
-    <desc>number of ice thickness categories - DO NOT EDIT (set by CICE configure)</desc> 
-  </entry> 
-
-  <entry id="LND_GRID"  value="1.9x2.5">
-    <type>char</type> 
-    <group>build_grid</group> 
-    <desc>land grid - DO NOT EDIT (for experts only)</desc> 
-  </entry> 
-
-  <entry id="OCN_GRID"  value="gx1v6">
-    <type>char</type> 
-    <group>build_grid</group> 
-    <desc>ocn grid - DO NOT EDIT (for experts only)</desc> 
-  </entry> 
-
-  <entry id="ROF_GRID"  value="r05">
-    <type>char</type> 
-    <group>build_grid</group> 
-    <desc>river runoff (rof) grid</desc> 
-  </entry> 
-
-  <entry id="WAV_GRID"  value="null">
-    <type>char</type> 
-    <group>build_grid</group> 
-    <desc>wave model (wav) grid</desc> 
-  </entry> 
-
-  <entry id="MPILIB"  value="mpich2">
-    <type>char</type> 
-    <group>build_macros</group> 
-    <desc>mpi library (must match one of the supported libraries) -
+    </header>
+  <group id="build_grid">
+    <entry id="GRID" value="a%1x1_tropicAtl_l%1x1_tropicAtl_oi%1x1_tropicAtl_r%null_m%reg_g%null_w%null">
+      <type>char</type>
+      <desc>Model grid - DO NOT EDIT (for experts only)</desc>
+    </entry>
+    <entry id="ATM_GRID" value="1x1_tropicAtl">
+      <type>char</type>
+      <desc>atmosphere grid - DO NOT EDIT (for experts only)</desc>
+    </entry>
+    <entry id="LND_GRID" value="1x1_tropicAtl">
+      <type>char</type>
+      <desc>land grid - DO NOT EDIT (for experts only)</desc>
+    </entry>
+    <entry id="OCN_GRID" value="1x1_tropicAtl">
+      <type>char</type>
+      <desc>ocn grid - DO NOT EDIT (for experts only)</desc>
+    </entry>
+    <entry id="ICE_GRID" value="1x1_tropicAtl">
+      <type>char</type>
+      <desc>ice grid (must equal ocn grid) - DO NOT EDIT (for experts only)</desc>
+    </entry>
+    <entry id="ROF_GRID" value="null">
+      <type>char</type>
+      <desc>river runoff (rof) grid</desc>
+    </entry>
+    <entry id="GLC_GRID" value="null">
+      <type>char</type>
+      <valid_values>gland20,gland10,gland5,gland5UM,gland4,null</valid_values>
+      <desc>glacier (glc) grid - DO NOT EDIT (for experts only)</desc>
+    </entry>
+    <entry id="WAV_GRID" value="null">
+      <type>char</type>
+      <desc>wave model (wav) grid</desc>
+    </entry>
+    <entry id="MASK_GRID" value="UNSET">
+      <type>char</type>
+      <desc>grid mask - DO NOT EDIT (for experts only)</desc>
+    </entry>
+  </group>
+  <group id="build_def">
+    <entry id="CALENDAR" value="NO_LEAP">
+      <type>char</type>
+      <valid_values>NO_LEAP,GREGORIAN</valid_values>
+      <desc>calendar type</desc>
+    </entry>
+  </group>
+  <group id="build_macros">
+    <entry id="MPILIB" value="mpich2">
+      <type>char</type>
+      <valid_values/>
+      <desc>mpi library (must match one of the supported libraries) -
     ignored once Macros has been created
-    Set in /glade/p/work/erik/clm_gswp3drflds/cime/machines/config_machines.xml for each supported machine.
-    Must be explicitly set in env_build.xml for userdefined machine.</desc> 
-  </entry> 
+    Set in $CIMEROOT/machines/config_machines.xml for each supported machine.
+    Must be explicitly set in env_build.xml for userdefined machine.</desc>
+    </entry>
+    <entry id="PIO_VERSION" value="1">
+      <type>integer</type>
+      <valid_values>1,2</valid_values>
+      <desc>PIO library version</desc>
+    </entry>
 
-  <entry id="MPILIBS"  value="mpich2,pempi,mpi-serial">
-    <type>char</type> 
-    <group>build_macros</group> 
-    <desc>Supported mpi libraries for target machine - set in config_machines.xml - (DO NOT EDIT)
-      Set in /glade/p/work/erik/clm_gswp3drflds/cime/machines/config_machines.xml for each supported machine.
-      Must be explicitly set in env_build.xml for userdefined machine.</desc> 
-  </entry> 
-
-  <entry id="OS"  value="LINUX">
-    <type>char</type> 
-    <group>build_macros</group> 
-    <desc>Operating system - DO NOT EDIT UNLESS for userdefined machine - ignored once Macros has been created.</desc> 
-  </entry> 
-
-</config_definition> 
+  </group>
+</file>

--- a/driver_cpl/bld/testdir/env_case.xml
+++ b/driver_cpl/bld/testdir/env_case.xml
@@ -1,36 +1,20 @@
-<?xml version="1.0"?> 
-
-<config_definition> 
-
-<header>
-
+<?xml version="1.0"?>
+<file id="env_case.xml">
+  <header>
     These variables CANNOT BE CHANGED once a case has been created.
     Invoke create_newcase again if a different grid or component
     combination is required.
     </header>
-
-
-<groups>
-   <group>case_comp</group> 
-   <group>case_cost</group> 
-   <group>case_def</group> 
-   <group>case_der</group> 
-   <group>case_desc</group> 
-   <group>case_last</group> 
-   <group>config_batch</group> 
-   <group>run_machine</group> 
-</groups>
-
-  <entry id="CASE"  value="testdir">
-    <type>char*256</type> 
-    <group>case_def</group> 
-    <desc>case name</desc> 
-  </entry> 
-
-  <entry id="USER"  value="erik">
-    <type>char</type> 
-    <group>case_desc</group> 
-    <desc>case user name</desc> 
-  </entry> 
-
-</config_definition> 
+  <group id="case_def">
+    <entry id="CASE" value="testdir">
+      <type>char</type>
+      <desc>case name</desc>
+    </entry>
+  </group>
+  <group id="case_desc">
+    <entry id="USER" value="UNSET">
+      <type>char</type>
+      <desc>case user name</desc>
+    </entry>
+  </group>
+</file>

--- a/driver_cpl/bld/testdir/env_mach_pes.xml
+++ b/driver_cpl/bld/testdir/env_mach_pes.xml
@@ -1,43 +1,40 @@
-<?xml version="1.0"?> 
+<?xml version="1.0"?>
+<file id="env_mach_pes.xml">
+  <header>
+    These variables CANNOT be modified once case_setup has been
+    invoked without first invoking case_setup -clean.
 
-<config_definition> 
+    component task/thread settings
+    if the user wants to change the values below after ./case_setup, run
+    ./case_setup -clean
+    ./case_setup
+    to reset the pes for the run
 
-<header>
-
-    These variables CANNOT be modified once case_setup has been           
-    invoked without first invoking case_setup -clean.                     
-      
-    component task/thread settings                                             
-    if the user wants to change the values below after ./case_setup, run       
-    ./case_setup -clean                                                     
-    ./case_setup                                                            
-    to reset the pes for the run                                              
-    
-    NTASKS are the total number of MPI tasks, a negative value in this field 
+    NTASKS are the total number of MPI tasks, a negative value in this field
                  indicates nodes rather than tasks.
-    NTHRDS are the number of OpenMP threads per MPI task                        
-    ROOTPE is the global mpi task associated with the root task               
-    of that component, a negative value in this field indicates nodes rather than tasks.           PSTRID is the stride of MPI tasks across the global                       
-    set of pes (for now this is set to 1)                              
-    NINST is the number of instances of the component (will be spread         
-    evenly across NTASKS)                                               
+    NTHRDS are the number of OpenMP threads per MPI task
+    ROOTPE is the global mpi task associated with the root task
+    of that component, a negative value in this field indicates nodes rather than tasks.           PSTRID is the stride of MPI tasks across the global
+    set of pes (for now this is set to 1)
+    NINST is the number of instances of the component (will be spread
+    evenly across NTASKS)
 
-    for example, for a setting with                                             
-    NTASKS = 8                                                              
-    NTHRDS = 2                                                              
-    ROOTPE = 32                                                             
-    NINST  = 2                                                              
-    the MPI tasks would be placed starting on global pe 32                    
-    and each pe would be threaded 2-ways for this component.                    
-    These tasks will be divided amongst both instances (4 tasks each).        
-    
-    Note: PEs that support threading never have an MPI task associated        
-    with them for performance reasons.  As a result, NTASKS and ROOTPE      
-    are relatively independent of NTHRDS and they determine                 
-    the layout of mpi processors between components.  NTHRDS is used        
-    to determine how those mpi tasks should be placed across the machine.   
-    
-    The following values should not be set by the user since they'll be        
+    for example, for a setting with
+    NTASKS = 8
+    NTHRDS = 2
+    ROOTPE = 32
+    NINST  = 2
+    the MPI tasks would be placed starting on global pe 32
+    and each pe would be threaded 2-ways for this component.
+    These tasks will be divided amongst both instances (4 tasks each).
+
+    Note: PEs that support threading never have an MPI task associated
+    with them for performance reasons.  As a result, NTASKS and ROOTPE
+    are relatively independent of NTHRDS and they determine
+    the layout of mpi processors between components.  NTHRDS is used
+    to determine how those mpi tasks should be placed across the machine.
+
+    The following values should not be set by the user since they'll be
     overwritten by scripts.
     TOTALPES
     CCSM_PCOST
@@ -47,385 +44,281 @@
     PES_PER_NODE
     CCSM_TCOST
     CCSM_ESTCOST
-    
+
     The user can copy env_mach_pes.xml from another run, but they'll need to
     do the following
     ./case_setup -clean
     ./case_setup
     ./CASE.build
-    </header> 
-
-<groups>
-   <group>mach_pes_atm</group> 
-   <group>mach_pes_cpl</group> 
-   <group>mach_pes_glc</group> 
-   <group>mach_pes_ice</group> 
-   <group>mach_pes_last</group> 
-   <group>mach_pes_lnd</group> 
-   <group>mach_pes_ocn</group> 
-   <group>mach_pes_rof</group> 
-   <group>mach_pes_stride</group> 
-   <group>mach_pes_wav</group> 
-</groups>
-
-
-  <entry id="NINST_ATM"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_atm</group> 
-    <desc>Number of atmosphere instances</desc> 
-  </entry> 
-
-  <entry id="NINST_ATM_LAYOUT"  value="concurrent">
-    <type>char</type> 
-    <valid_values>sequential,concurrent</valid_values> 
-    <group>mach_pes_atm</group> 
-    <desc>Layout of atmosphere instances</desc> 
-  </entry> 
-
-  <entry id="NTASKS_ATM"  value="30">
-    <type>integer</type> 
-    <group>mach_pes_atm</group> 
-    <desc>number of atmosphere tasks</desc> 
-  </entry> 
-
-  <entry id="NTHRDS_ATM"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_atm</group> 
-    <desc>number of atmosphere threads</desc> 
-  </entry> 
-
-  <entry id="ROOTPE_ATM"  value="540">
-    <type>integer</type> 
-    <group>mach_pes_atm</group> 
-    <desc>root atm mpi task</desc> 
-  </entry> 
-
-  <entry id="NTASKS_CPL"  value="540">
-    <type>integer</type> 
-    <group>mach_pes_cpl</group> 
-    <desc>number of coupler mpi tasks</desc> 
-  </entry> 
-
-  <entry id="NTHRDS_CPL"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_cpl</group> 
-    <desc>number of coupler mpi threads</desc> 
-  </entry> 
-
-  <entry id="ROOTPE_CPL"  value="0">
-    <type>integer</type> 
-    <group>mach_pes_cpl</group> 
-    <desc>root cpl mpi task</desc> 
-  </entry> 
-
-  <entry id="NINST_GLC"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_glc</group> 
-    <desc>Number of glacier instances</desc> 
-  </entry> 
-
-  <entry id="NINST_GLC_LAYOUT"  value="concurrent">
-    <type>char</type> 
-    <valid_values>sequential,concurrent</valid_values> 
-    <group>mach_pes_glc</group> 
-    <desc>Layout of glacier instances</desc> 
-  </entry> 
-
-  <entry id="NTASKS_GLC"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_glc</group> 
-    <desc>number of glc mpi tasks</desc> 
-  </entry> 
-
-  <entry id="NTHRDS_GLC"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_glc</group> 
-    <desc>number of glc mpi threads</desc> 
-  </entry> 
-
-  <entry id="ROOTPE_GLC"  value="0">
-    <type>integer</type> 
-    <group>mach_pes_glc</group> 
-    <desc>root glc mpi task</desc> 
-  </entry> 
-
-  <entry id="NINST_ICE"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_ice</group> 
-    <desc>Number of sea ice instances</desc> 
-  </entry> 
-
-  <entry id="NINST_ICE_LAYOUT"  value="concurrent">
-    <type>integer</type> 
-    <valid_values>equential,concurrent</valid_values> 
-    <group>mach_pes_ice</group> 
-    <desc>Layout of sea ice instances</desc> 
-  </entry> 
-
-  <entry id="NTASKS_ICE"  value="540">
-    <type>integer</type> 
-    <group>mach_pes_ice</group> 
-    <desc>number of ice mpi tasks</desc> 
-  </entry> 
-
-  <entry id="NTHRDS_ICE"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_ice</group> 
-    <desc>number of ice mpi threads</desc> 
-  </entry> 
-
-  <entry id="ROOTPE_ICE"  value="0">
-    <type>integer</type> 
-    <group>mach_pes_ice</group> 
-    <desc>root ice mpi task</desc> 
-  </entry> 
-
-  <entry id="NINST_ESP"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_esp</group> 
-    <desc>Number of ESP instances</desc> 
-  </entry> 
-
-  <entry id="NINST_ESP_LAYOUT"  value="concurrent">
-    <type>char</type> 
-    <valid_values>sequential,concurrent</valid_values> 
-    <group>mach_pes_esp</group> 
-    <desc>Layout of ESP instances</desc> 
-  </entry> 
-
-  <entry id="NTASKS_ESP"  value="30">
-    <type>integer</type> 
-    <group>mach_pes_esp</group> 
-    <desc>number of ESP  tasks</desc> 
-  </entry> 
-
-  <entry id="NTHRDS_ESP"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_esp</group> 
-    <desc>number of ESP  threads</desc> 
-  </entry> 
-
-  <entry id="ROOTPE_ESP"  value="540">
-    <type>integer</type> 
-    <group>mach_pes_esp</group> 
-    <desc>root esp mpi task</desc> 
-  </entry> 
-
-  <entry id="CCSM_ESTCOST"  value="5">
-    <type>integer</type> 
-    <group>mach_pes_last</group> 
-    <desc>relative total cost of case (DO NOT EDIT)</desc> 
-  </entry> 
-
-  <entry id="CCSM_PCOST"  value="-3">
-    <type>integer</type> 
-    <group>mach_pes_last</group> 
-    <desc>cost relative to 64 pes (DO NOT EDIT)</desc> 
-  </entry> 
-
-  <entry id="CCSM_TCOST"  value="0">
-    <type>integer</type> 
-    <group>mach_pes_last</group> 
-    <desc>relative cost of test where ERS is 1 (DO NOT EDIT)</desc> 
-  </entry> 
-
-  <entry id="COST_PES"  value="0">
-    <type>integer</type> 
-    <group>mach_pes_last</group> 
-    <desc>pes or cores used relative to PES_PER_NODE for accounting (0 means TOTALPES is valid)</desc> 
-  </entry> 
-
-  <entry id="MAX_TASKS_PER_NODE"  value="30">
-    <type>integer</type> 
-    <group>mach_pes_last</group> 
-    <desc>maximum number of tasks/ threads allowed per node</desc> 
-  </entry> 
-
-  <entry id="PES_PER_NODE"  value="15">
-    <type>integer</type> 
-    <group>mach_pes_last</group> 
-    <desc>pes or cores per node for accounting purposes</desc> 
-  </entry> 
-
-  <entry id="TOTALPES"  value="570">
-    <type>integer</type> 
-    <group>mach_pes_last</group> 
-    <desc>total number of tasks and threads (setup automatically - DO NOT EDIT)</desc> 
-  </entry> 
-
-  <entry id="NINST_LND"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_lnd</group> 
-    <desc>Number of land instances</desc> 
-  </entry> 
-
-  <entry id="NINST_LND_LAYOUT"  value="concurrent">
-    <type>integer</type> 
-    <valid_values>sequential,concurrent</valid_values> 
-    <group>mach_pes_lnd</group> 
-    <desc>Layout of land instances</desc> 
-  </entry> 
-
-  <entry id="NTASKS_LND"  value="540">
-    <type>integer</type> 
-    <group>mach_pes_lnd</group> 
-    <desc>number of land mpi tasks</desc> 
-  </entry> 
-
-  <entry id="NTHRDS_LND"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_lnd</group> 
-    <desc>number of land mpi threads</desc> 
-  </entry> 
-
-  <entry id="ROOTPE_LND"  value="0">
-    <type>integer</type> 
-    <group>mach_pes_lnd</group> 
-    <desc>root lnd mpi task</desc> 
-  </entry> 
-
-  <entry id="NINST_OCN"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_ocn</group> 
-    <desc>Number of ocean instances</desc> 
-  </entry> 
-
-  <entry id="NINST_OCN_LAYOUT"  value="concurrent">
-    <type>char</type> 
-    <valid_values>sequential,concurrent</valid_values> 
-    <group>mach_pes_ocn</group> 
-    <desc>Layout of ocean instances</desc> 
-  </entry> 
-
-  <entry id="NTASKS_OCN"  value="540">
-    <type>integer</type> 
-    <group>mach_pes_ocn</group> 
-    <desc>number of ocean mpi tasks</desc> 
-  </entry> 
-
-  <entry id="NTHRDS_OCN"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_ocn</group> 
-    <desc>number of ocean mpi threads</desc> 
-  </entry> 
-
-  <entry id="ROOTPE_OCN"  value="0">
-    <type>integer</type> 
-    <group>mach_pes_ocn</group> 
-    <desc>root ocn mpi task</desc> 
-  </entry> 
-
-  <entry id="NINST_ROF"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_rof</group> 
-    <desc>Number of river runoff instances</desc> 
-  </entry> 
-
-  <entry id="NINST_ROF_LAYOUT"  value="concurrent">
-    <type>char</type> 
-    <group>mach_pes_rof</group> 
-    <desc>Layout of river runoff instances</desc> 
-  </entry> 
-
-  <entry id="NTASKS_ROF"  value="540">
-    <type>integer</type> 
-    <group>mach_pes_rof</group> 
-    <desc>number of river runoff tasks</desc> 
-  </entry> 
-
-  <entry id="NTHRDS_ROF"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_rof</group> 
-    <desc>number of river runoff threads</desc> 
-  </entry> 
-
-  <entry id="ROOTPE_ROF"  value="0">
-    <type>integer</type> 
-    <group>mach_pes_rof</group> 
-    <desc>root rof mpi task</desc> 
-  </entry> 
-
-  <entry id="PSTRID_ATM"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_stride</group> 
-    <desc>stride of mpi tasks for atm comp - currently should always be set to 1</desc> 
-  </entry> 
-
-  <entry id="PSTRID_CPL"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_stride</group> 
-    <desc>stride of mpi tasks for cpl comp - currently should always be set to 1</desc> 
-  </entry> 
-
-  <entry id="PSTRID_GLC"  value="1">
-    <type>integer</type> 
-    <valid_values>1</valid_values> 
-    <group>mach_pes_stride</group> 
-    <desc>stride of mpi tasks for glc comp - currently should always be set to 1</desc> 
-  </entry> 
-
-  <entry id="PSTRID_ICE"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_stride</group> 
-    <desc>stride of mpi tasks for ice comp - currently should always be set to 1</desc> 
-  </entry> 
-
-  <entry id="PSTRID_LND"  value="1">
-    <type>integer</type> 
-    <valid_values>1</valid_values> 
-    <group>mach_pes_stride</group> 
-    <desc>stride of mpi tasks for lnd comp - currently should always be set to 1</desc> 
-  </entry> 
-
-  <entry id="PSTRID_OCN"  value="1">
-    <type>integer</type> 
-    <valid_values>1</valid_values> 
-    <group>mach_pes_stride</group> 
-    <desc>stride of mpi tasks for ocn comp - currently should always be set to 1</desc> 
-  </entry> 
-
-  <entry id="PSTRID_ROF"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_stride</group> 
-    <desc>stride of mpi tasks for rof comp - currently should always be set to 1</desc> 
-  </entry> 
-
-  <entry id="PSTRID_WAV"  value="1">
-    <type>integer</type> 
-    <valid_values>1</valid_values> 
-    <group>mach_pes_stride</group> 
-    <desc>stride of mpi tasks for wav comp - currently should always be set to 1</desc> 
-  </entry> 
-
-  <entry id="NINST_WAV"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_wav</group> 
-    <desc>Number of wave instances</desc> 
-  </entry> 
-
-  <entry id="NINST_WAV_LAYOUT"  value="concurrent">
-    <type>char</type> 
-    <valid_values>sequential,concurrent</valid_values> 
-    <group>mach_pes_wav</group> 
-    <desc>Layout of wave instances</desc> 
-  </entry> 
-
-  <entry id="NTASKS_WAV"  value="540">
-    <type>integer</type> 
-    <group>mach_pes_wav</group> 
-    <desc>number of wav mpi tasks</desc> 
-  </entry> 
-
-  <entry id="NTHRDS_WAV"  value="1">
-    <type>integer</type> 
-    <group>mach_pes_wav</group> 
-    <desc>number of wav mpi threads</desc> 
-  </entry> 
-
-  <entry id="ROOTPE_WAV"  value="0">
-    <type>integer</type> 
-    <group>mach_pes_wav</group> 
-    <desc>root wav mpi task</desc> 
-  </entry> 
-
-</config_definition> 
+    </header>
+  <group id="mach_pes_last">
+    <entry id="CCSM_PCOST" value="3">
+      <type>integer</type>
+      <desc>cost relative to 64 pes (DO NOT EDIT)</desc>
+    </entry>
+    <entry id="CCSM_TCOST" value="-1">
+      <type>integer</type>
+      <desc>relative cost of test where ERS is 1 (DO NOT EDIT)</desc>
+    </entry>
+    <entry id="CCSM_ESTCOST" value="7">
+      <type>integer</type>
+      <desc>relative total cost of case (DO NOT EDIT)</desc>
+    </entry>
+    <entry id="COST_PES" value="0">
+      <type>integer</type>
+      <desc>pes or cores used relative to PES_PER_NODE for accounting (0 means TOTALPES is valid)</desc>
+    </entry>
+    <entry id="TOTALPES" value="1">
+      <type>integer</type>
+      <desc>total number of tasks and threads (setup automatically - DO NOT EDIT)</desc>
+    </entry>
+    <entry id="MAX_TASKS_PER_NODE" value="30">
+      <type>integer</type>
+      <desc>maximum number of tasks/ threads allowed per node </desc>
+    </entry>
+    <entry id="PES_PER_NODE" value="15">
+      <type>integer</type>
+      <desc>pes or cores per node for accounting purposes </desc>
+    </entry>
+  </group>
+  <group id="mach_pes_atm">
+    <entry id="NTASKS_ATM" value="1">
+      <type>integer</type>
+      <desc>number of atmosphere tasks</desc>
+    </entry>
+    <entry id="NTHRDS_ATM" value="1">
+      <type>integer</type>
+      <desc>number of atmosphere threads</desc>
+    </entry>
+    <entry id="ROOTPE_ATM" value="0">
+      <type>integer</type>
+      <desc>root atm mpi task</desc>
+    </entry>
+    <entry id="NINST_ATM" value="1">
+      <type>integer</type>
+      <desc>Number of atmosphere instances</desc>
+    </entry>
+    <entry id="NINST_ATM_LAYOUT" value="concurrent">
+      <type>char</type>
+      <valid_values>sequential,concurrent</valid_values>
+      <desc>Layout of atmosphere instances</desc>
+    </entry>
+  </group>
+  <group id="mach_pes_lnd">
+    <entry id="NTASKS_LND" value="1">
+      <type>integer</type>
+      <desc>number of land mpi tasks</desc>
+    </entry>
+    <entry id="NTHRDS_LND" value="1">
+      <type>integer</type>
+      <desc>number of land mpi threads</desc>
+    </entry>
+    <entry id="ROOTPE_LND" value="0">
+      <type>integer</type>
+      <desc>root lnd mpi task</desc>
+    </entry>
+    <entry id="NINST_LND" value="1">
+      <type>integer</type>
+      <desc>Number of land instances</desc>
+    </entry>
+    <entry id="NINST_LND_LAYOUT" value="concurrent">
+      <type>char</type>
+      <valid_values>sequential,concurrent</valid_values>
+      <desc>Layout of land instances</desc>
+    </entry>
+  </group>
+  <group id="mach_pes_ice">
+    <entry id="NTASKS_ICE" value="1">
+      <type>integer</type>
+      <desc>number of ice mpi tasks</desc>
+    </entry>
+    <entry id="NTHRDS_ICE" value="1">
+      <type>integer</type>
+      <desc>number of ice mpi threads</desc>
+    </entry>
+    <entry id="ROOTPE_ICE" value="0">
+      <type>integer</type>
+      <desc>root ice mpi task</desc>
+    </entry>
+    <entry id="NINST_ICE" value="1">
+      <type>integer</type>
+      <desc>Number of sea ice instances</desc>
+    </entry>
+    <entry id="NINST_ICE_LAYOUT" value="concurrent">
+      <type>char</type>
+      <valid_values>equential,concurrent</valid_values>
+      <desc>Layout of sea ice instances</desc>
+    </entry>
+  </group>
+  <group id="mach_pes_ocn">
+    <entry id="NTASKS_OCN" value="1">
+      <type>integer</type>
+      <desc>number of ocean mpi tasks</desc>
+    </entry>
+    <entry id="NTHRDS_OCN" value="1">
+      <type>integer</type>
+      <desc>number of ocean mpi threads</desc>
+    </entry>
+    <entry id="ROOTPE_OCN" value="0">
+      <type>integer</type>
+      <desc>root ocn mpi task</desc>
+    </entry>
+    <entry id="NINST_OCN" value="1">
+      <type>integer</type>
+      <desc>Number of ocean instances</desc>
+    </entry>
+    <entry id="NINST_OCN_LAYOUT" value="concurrent">
+      <type>char</type>
+      <valid_values>sequential,concurrent</valid_values>
+      <desc>Layout of ocean instances</desc>
+    </entry>
+  </group>
+  <group id="mach_pes_cpl">
+    <entry id="NTASKS_CPL" value="1">
+      <type>integer</type>
+      <desc>number of coupler mpi tasks</desc>
+    </entry>
+    <entry id="NTHRDS_CPL" value="1">
+      <type>integer</type>
+      <desc>number of coupler mpi threads</desc>
+    </entry>
+    <entry id="ROOTPE_CPL" value="0">
+      <type>integer</type>
+      <desc>root cpl mpi task</desc>
+    </entry>
+  </group>
+  <group id="mach_pes_glc">
+    <entry id="NTASKS_GLC" value="1">
+      <type>integer</type>
+      <desc>number of glc mpi tasks</desc>
+    </entry>
+    <entry id="NTHRDS_GLC" value="1">
+      <type>integer</type>
+      <desc>number of glc mpi threads</desc>
+    </entry>
+    <entry id="ROOTPE_GLC" value="0">
+      <type>integer</type>
+      <desc>root glc mpi task</desc>
+    </entry>
+    <entry id="NINST_GLC" value="1">
+      <type>integer</type>
+      <desc>Number of glacier instances</desc>
+    </entry>
+    <entry id="NINST_GLC_LAYOUT" value="concurrent">
+      <type>char</type>
+      <valid_values>sequential,concurrent</valid_values>
+      <desc>Layout of glacier instances</desc>
+    </entry>
+  </group>
+  <group id="mach_pes_rof">
+    <entry id="NTASKS_ROF" value="1">
+      <type>integer</type>
+      <desc>number of river runoff tasks</desc>
+    </entry>
+    <entry id="NTHRDS_ROF" value="1">
+      <type>integer</type>
+      <desc>number of river runoff threads</desc>
+    </entry>
+    <entry id="ROOTPE_ROF" value="0">
+      <type>integer</type>
+      <desc>root rof mpi task</desc>
+    </entry>
+    <entry id="NINST_ROF" value="1">
+      <type>integer</type>
+      <desc>Number of river runoff instances</desc>
+    </entry>
+    <entry id="NINST_ROF_LAYOUT" value="concurrent">
+      <type>char</type>
+      <desc>Layout of river runoff instances</desc>
+    </entry>
+  </group>
+  <group id="mach_pes_wav">
+    <entry id="NTASKS_WAV" value="1">
+      <type>integer</type>
+      <desc>number of wav mpi tasks</desc>
+    </entry>
+    <entry id="NTHRDS_WAV" value="1">
+      <type>integer</type>
+      <desc>number of wav mpi threads</desc>
+    </entry>
+    <entry id="ROOTPE_WAV" value="0">
+      <type>integer</type>
+      <desc>root wav mpi task</desc>
+    </entry>
+    <entry id="NINST_WAV" value="1">
+      <type>integer</type>
+      <desc>Number of wave instances</desc>
+    </entry>
+    <entry id="NINST_WAV_LAYOUT" value="concurrent">
+      <type>char</type>
+      <valid_values>sequential,concurrent</valid_values>
+      <desc>Layout of wave instances</desc>
+    </entry>
+  </group>
+  <group id="mach_pes_esp">
+    <entry id="NTASKS_ESP" value="1">
+      <type>integer</type>
+      <desc>number of external processing tool mpi tasks</desc>
+    </entry>
+    <entry id="NTHRDS_ESP" value="0">
+      <type>integer</type>
+      <desc>number of external processing tool mpi threads</desc>
+    </entry>
+    <entry id="ROOTPE_ESP" value="0">
+      <type>integer</type>
+      <desc>root ocn mpi task</desc>
+    </entry>
+    <entry id="NINST_ESP" value="1">
+      <type>integer</type>
+      <desc>Number of external processing tool instances</desc>
+    </entry>
+    <entry id="NINST_ESP_LAYOUT" value="concurrent">
+      <type>char</type>
+      <valid_values>sequential,concurrent</valid_values>
+      <desc>Layout of external processing tool instances</desc>
+    </entry>
+  </group>
+  <group id="mach_pes_stride">
+    <entry id="PSTRID_ATM" value="1">
+      <type>integer</type>
+      <desc>stride of mpi tasks for atm comp - currently should always be set to 1</desc>
+    </entry>
+    <entry id="PSTRID_LND" value="1">
+      <type>integer</type>
+      <valid_values>1</valid_values>
+      <desc>stride of mpi tasks for lnd comp - currently should always be set to 1</desc>
+    </entry>
+    <entry id="PSTRID_ICE" value="1">
+      <type>integer</type>
+      <desc>stride of mpi tasks for ice comp - currently should always be set to 1</desc>
+    </entry>
+    <entry id="PSTRID_OCN" value="1">
+      <type>integer</type>
+      <valid_values>1</valid_values>
+      <desc>stride of mpi tasks for ocn comp - currently should always be set to 1</desc>
+    </entry>
+    <entry id="PSTRID_CPL" value="1">
+      <type>integer</type>
+      <desc>stride of mpi tasks for cpl comp - currently should always be set to 1</desc>
+    </entry>
+    <entry id="PSTRID_GLC" value="1">
+      <type>integer</type>
+      <valid_values>1</valid_values>
+      <desc>stride of mpi tasks for glc comp - currently should always be set to 1</desc>
+    </entry>
+    <entry id="PSTRID_ROF" value="1">
+      <type>integer</type>
+      <desc>stride of mpi tasks for rof comp - currently should always be set to 1</desc>
+    </entry>
+    <entry id="PSTRID_WAV" value="1">
+      <type>integer</type>
+      <valid_values>1</valid_values>
+      <desc>stride of mpi tasks for wav comp - currently should always be set to 1</desc>
+    </entry>
+    <entry id="PSTRID_ESP" value="1">
+      <type>integer</type>
+      <valid_values>1</valid_values>
+      <desc>stride of mpi tasks for esp comp - currently should always be set to 1</desc>
+    </entry>
+  </group>
+</file>

--- a/driver_cpl/bld/testdir/env_run.xml
+++ b/driver_cpl/bld/testdir/env_run.xml
@@ -1,138 +1,36 @@
-<?xml version="1.0"?> 
-
-<config_definition> 
-
-<header>
-
+<?xml version="1.0"?>
+<file id="env_run.xml">
+  <header>
     These variables MAY BE CHANGED ANYTIME during a run.
     Additional machine speific variables that can be changed
     during a run are contained in the env_mach_specific file
     Note1: users SHOULD NOT modify BUILD_COMPETE in env_build.xml
     this is done automatically by the scripts.
-    </header> 
-
-<groups>
-   <group>external_tools</group> 
-   <group>run_begin_stop_restart</group> 
-   <group>run_budgets</group> 
-   <group>run_cesm</group> 
-   <group>run_co2</group> 
-   <group>run_component_cism</group> 
-   <group>run_component_clm</group> 
-   <group>run_component_cpl</group> 
-   <group>run_component_datm</group> 
-   <group>run_component_mosart</group> 
-   <group>run_coupling</group> 
-   <group>run_data_archive</group> 
-   <group>run_desc</group> 
-   <group>run_din</group> 
-   <group>run_domain</group> 
-   <group>run_dout</group> 
-   <group>run_drv_history</group> 
-   <group>run_flags</group> 
-   <group>run_glc</group> 
-   <group>run_machine</group> 
-   <group>run_mpi</group> 
-   <group>run_pio</group> 
-</groups>
-
-
-  <entry id="BARRIER_DATE"  value="-999">
-    <type>char</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Alternative date in yyyymmdd format
-      sets periodic model barriers with BARRIER_OPTION and BARRIER_N for synchronization</desc> 
-  </entry> 
-
-  <entry id="BARRIER_N"  value="1">
-    <type>char</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>sets periodic model barriers with BARRIER_OPTION and BARRIER_DATE for synchronization</desc> 
-  </entry> 
-
-  <entry id="BARRIER_OPTION"  value="ndays">
-    <type>char</type> 
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values> 
-    <group>run_begin_stop_restart</group> 
-    <desc>sets frequency of full model barrier (same options as STOP_OPTION) for synchronization with BARRIER_N and BARRIER_DATE</desc> 
-  </entry> 
-
-  <entry id="BRNCH_RETAIN_CASENAME"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Allow same branch casename as reference casename. Only used for branch runs.</desc> 
-  </entry> 
-
-  <entry id="CONTINUE_RUN"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_begin_stop_restart</group> 
-    <desc>A setting of TRUE implies a continuation run
-      When you first begin a branch, hybrid or startup run, CONTINUE_RUN
-      must be set to FALSE. When you successfully run and get a restart
-      file, you will need to change CONTINUE_RUN to TRUE for the remainder
-      of your run. This variable determines if the run is a restart run.
-      Set to FALSE when initializing a startup, branch or hybrid case.
-      Set to TRUE when continuing a run.</desc> 
-  </entry> 
-
-  <entry id="REST_DATE"  value="$STOP_DATE">
-    <type>char</type>
-    <group>run_begin_stop_restart</group>
-    <desc>Alternative date in yyyymmdd format
-      sets model restart write date with REST_OPTION and REST_N</desc>
-  </entry>
-
-  <entry id="REST_N"  value="$STOP_N">
-    <type>char</type>
-    <group>run_begin_stop_restart</group>
-    <desc>sets model restart writes with REST_OPTION and REST_DATE</desc>
-  </entry>
-
-  <entry id="REST_OPTION"  value="$STOP_OPTION">
-    <type>char</type>
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
-    <group>run_begin_stop_restart</group>
-    <desc>sets frequency of model restart writes (same options as STOP_OPTION) (must be nyear(s) for _GLC compsets)
-      (must be nyear(s) for _GLC compsets)</desc>
-  </entry>
-
-  <entry id="RUN_REFCASE"  value="case.std">
-    <type>char*256</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Reference case for hybrid or branch runs</desc> 
-  </entry> 
-
-  <entry id="RUN_REFDATE"  value="0001-01-01">
-    <type>char*10</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Reference date for hybrid or branch runs (yyyy-mm-dd)</desc> 
-  </entry> 
-
-  <entry id="RUN_REFDIR"  value="ccsm4_init">
-    <type>char*256</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Reference directory containing RUN_REFCASE data - used for hybrid or branch runs</desc> 
-  </entry> 
-
-  <entry id="RUN_REFTOD"  value="00000">
-    <type>char</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Reference time of day (seconds) for hybrid or branch runs (sssss)</desc> 
-  </entry> 
-
-  <entry id="RUN_STARTDATE"  value="0001-01-01">
-    <type>char</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Run start date (yyyy-mm-dd). Only used for startup or hybrid runs.</desc> 
-  </entry> 
-
-  <entry id="RUN_TYPE"  value="startup">
-    <type>char</type> 
-    <valid_values>startup,hybrid,branch</valid_values> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Determines the model run initialization type.
+    </header>
+  <group id="run_desc">
+    <entry id="LOGDIR" value="$CASEROOT/logs">
+      <type>char</type>
+      <desc>Extra copies of the component log files will be saved here.</desc>
+    </entry>
+    <entry id="CASESTR" value="UNSET">
+      <type>char</type>
+      <desc>case description</desc>
+    </entry>
+    <entry id="RUNDIR" value="/glade/scratch/erik/$CASE/run">
+      <type>char</type>
+      <desc>
+      The directory where the executable will be run.
+      By default this is set to EXEROOT/../run.
+      RUNDIR allows you to keep the run directory separate from the build directory
+    </desc>
+    </entry>
+  </group>
+  <group id="run_begin_stop_restart">
+    <entry id="RUN_TYPE" value="startup">
+      <type>char</type>
+      <valid_values>startup,hybrid,branch</valid_values>
+      <desc>
+      Determines the model run initialization type.
       This setting is only important for the initial run of a production run when the
       CONTINUE_RUN variable is set to FALSE.  After the initial run, the CONTINUE_RUN
       variable is set to TRUE, and the model restarts exactly using input
@@ -181,115 +79,859 @@
       namelists are changed in the hybrid run.  In a hybrid initialization,
       the ocean model does not start until the second ocean coupling
       (normally the second day), and the coupler does a cold start without
-      a restart file.</desc> 
-  </entry> 
-
-  <entry id="START_TOD"  value="0">
-    <type>integer</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Run start time-of-day</desc> 
-  </entry> 
-
-  <entry id="STOP_DATE"  value="-999">
-    <type>integer</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Alternative date yyyymmdd date option, sets the run length with STOP_OPTION and STOP_N
-      negative value implies off</desc> 
-  </entry> 
-
-  <entry id="STOP_N"  value="13">
-    <type>integer</type> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Provides a numerical count for $STOP_OPTION.</desc> 
-  </entry> 
-
-  <entry id="STOP_OPTION"  value="nmonths">
-    <type>char</type> 
-    <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values> 
-    <group>run_begin_stop_restart</group> 
-    <desc>Sets the run length along with STOP_N and STOP_DATE (must be nyear(s) for _GLC compsets for restarts to work properly).</desc> 
-  </entry> 
-
-  <entry id="BUDGETS"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_budgets</group> 
-    <desc>logical that turns on diagnostic budgets for driver</desc> 
-  </entry> 
-
-  <entry id="PROFILE_PAPI_ENABLE"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_cesm</group> 
-    <desc>Enables the papi hardware counters in gptl
+      a restart file.
+    </desc>
+    </entry>
+    <entry id="RUN_REFDIR" value="ccsm4_init">
+      <type>char</type>
+      <desc>
+      Reference directory containing RUN_REFCASE data - used for hybrid or branch runs
+    </desc>
+    </entry>
+    <entry id="RUN_REFCASE" value="case.std">
+      <type>char</type>
+      <desc>
+      Reference case for hybrid or branch runs
+    </desc>
+    </entry>
+    <entry id="RUN_REFDATE" value="0001-01-01">
+      <type>char</type>
+      <desc>
+      Reference date for hybrid or branch runs (yyyy-mm-dd)
+    </desc>
+    </entry>
+    <entry id="RUN_REFTOD" value="00000">
+      <type>char</type>
+      <desc>
+      Reference time of day (seconds) for hybrid or branch runs (sssss)
+    </desc>
+    </entry>
+    <entry id="BRNCH_RETAIN_CASENAME" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>
+      Allow same branch casename as reference casename. Only used for branch runs.
+    </desc>
+    </entry>
+    <entry id="GET_REFCASE" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>
+      Flag for automatically prestaging the refcase restart dataset.
+      If TRUE, then the refcase data is prestaged into the executable directory
+    </desc>
+    </entry>
+    <entry id="RUN_STARTDATE" value="1938-01-01">
+      <type>char</type>
+      <desc>
+      Run start date (yyyy-mm-dd). Only used for startup or hybrid runs.
+    </desc>
+    </entry>
+    <entry id="START_TOD" value="0">
+      <type>integer</type>
+      <desc>
+      Run start time-of-day
+    </desc>
+    </entry>
+    <entry id="STOP_OPTION" value="nyears">
+      <type>char</type>
+      <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+      <desc>
+      Sets the run length along with STOP_N and STOP_DATE (must be nyear(s) for _GLC compsets for restarts to work properly).
+    </desc>
+    </entry>
+    <entry id="STOP_N" value="8">
+      <type>integer</type>
+      <desc>
+      Provides a numerical count for $STOP_OPTION.
+    </desc>
+    </entry>
+    <entry id="STOP_DATE" value="-999">
+      <type>integer</type>
+      <desc>
+      Alternative date yyyymmdd date option, sets the run length with STOP_OPTION and STOP_N
+      negative value implies off
+    </desc>
+    </entry>
+    <entry id="REST_OPTION" value="$STOP_OPTION">
+      <type>char</type>
+      <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+      <desc>
+      sets frequency of model restart writes (same options as STOP_OPTION) (must be nyear(s) for _GLC compsets)
+      (must be nyear(s) for _GLC compsets)
+    </desc>
+    </entry>
+    <entry id="REST_N" value="$STOP_N">
+      <type>integer</type>
+      <desc>
+      sets model restart writes with REST_OPTION and REST_DATE
+    </desc>
+    </entry>
+    <entry id="REST_DATE" value="$STOP_DATE">
+      <type>char</type>
+      <desc>
+      Alternative date in yyyymmdd format
+      sets model restart write date with REST_OPTION and REST_N
+    </desc>
+    </entry>
+    <entry id="BARRIER_OPTION" value="ndays">
+      <type>char</type>
+      <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
+      <desc>
+      sets frequency of full model barrier (same options as STOP_OPTION) for synchronization with BARRIER_N and BARRIER_DATE
+    </desc>
+    </entry>
+    <entry id="BARRIER_N" value="1">
+      <type>char</type>
+      <desc>
+      sets periodic model barriers with BARRIER_OPTION and BARRIER_DATE for synchronization
+    </desc>
+    </entry>
+    <entry id="BARRIER_DATE" value="-999">
+      <type>char</type>
+      <desc>
+      Alternative date in yyyymmdd format
+      sets periodic model barriers with BARRIER_OPTION and BARRIER_N for synchronization
+    </desc>
+    </entry>
+    <entry id="CONTINUE_RUN" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>
+      A setting of TRUE implies a continuation run
+      When you first begin a branch, hybrid or startup run, CONTINUE_RUN
+      must be set to FALSE. When you successfully run and get a restart
+      file, you will need to change CONTINUE_RUN to TRUE for the remainder
+      of your run. This variable determines if the run is a restart run.
+      Set to FALSE when initializing a startup, branch or hybrid case.
+      Set to TRUE when continuing a run.
+    </desc>
+    </entry>
+    <entry id="RESUBMIT" value="0">
+      <type>integer</type>
+      <desc>If RESUBMIT is greater than 0, then case will automatically resubmit
+    Enables the model to automatically resubmit a new run.  To get
+    multiple runs, set RESUBMIT greater than 0, then RESUBMIT will be
+    decremented and the case will be resubmitted.  The case will stop automatically
+    resubmitting when the RESUBMIT value reaches 0.
+    Long runs can easily outstrip supercomputer queue time limits. For
+    this reason, a case is usually run as a series of jobs, each
+    restarting where the previous finished.
+    </desc>
+    </entry>
+    <entry id="RESUBMIT_SETS_CONTINUE_RUN" value="TRUE">
+      <type>logical</type>
+      <desc>This flag controls whether the RESUBMIT flag causes
+      CONTINUE_RUN to toggle from FALSE to TRUE.  The default is
+      TRUE.  This flag might be used in conjunction with COMP_RUN_BARRIERS for
+      timing tests.
+    </desc>
+    </entry>
+    <entry id="RUN_WITH_SUBMIT" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>Logical to determine whether CESM run has been submitted with the submit script or not</desc>
+    </entry>
+  </group>
+  <group id="run_data_archive">
+    <entry id="DOUT_S" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>Logical to turn on short term archiving.
+    If TRUE, short term archiving will be turned on.</desc>
+    </entry>
+    <entry id="DOUT_S_SAVE_INTERIM_RESTART_FILES" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>Logical to archive all interim restart files, not just those at eor
+    If TRUE, perform short term archiving on all interim restart files,
+    not just those at the end of the run. By default, this value is FALSE.
+    The restart files are saved under the specific component directory
+    ($DOUT_S_ROOT/$CASE/$COMPONENT/rest rather than the top-level $DOUT_S_ROOT/$CASE/rest directory).
+    Interim restart files are created using the REST_N and REST_OPTION variables.
+    This is for expert users ONLY and requires expert knowledge.
+    We will not document this further in this guide.</desc>
+    </entry>
+    <entry id="DOUT_L_MS" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>If TRUE, perform long-term archiving on the output data.
+      logical to turn on long term archiving (if DOUT_S is also TRUE)</desc>
+    </entry>
+    <entry id="DOUT_L_HPSS_ACCNT" value="00000000">
+      <type>char</type>
+      <desc/>
+    </entry>
+  </group>
+  <group id="run_flags">
+    <entry id="CHECK_TIMING" value="TRUE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>logical to diagnose model timing at the end of the run</desc>
+    </entry>
+    <entry id="SAVE_TIMING" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>logical to save timing files in rundir</desc>
+    </entry>
+    <entry id="SAVE_TIMING_DIR" value="UNSET">
+      <type>char</type>
+      <valid_values/>
+      <desc>Where to auto archive timing data</desc>
+    </entry>
+    <entry id="TIMER_LEVEL" value="12">
+      <type>integer</type>
+      <desc>timer output depth</desc>
+    </entry>
+    <entry id="COMP_RUN_BARRIERS" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>Turns on component barriers for component timing.
+          This variable is for testing and debugging only and should never
+          be set for a production run.
+    </desc>
+    </entry>
+    <entry id="FLDS_WISO" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>Turn on the passing of water isotope fields through the coupler</desc>
+    </entry>
+    <entry id="DRV_THREADING" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>Turns on component varying thread control in the driver.
+    Used to set the driver namelist variable "drv_threading".</desc>
+    </entry>
+    <entry id="CPL_DECOMP" value="0">
+      <type>integer</type>
+      <valid_values>0,1,2,3,4,5,6</valid_values>
+      <desc>Coupler decomposition option.</desc>
+    </entry>
+    <entry id="BFBFLAG" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>turns on coupler bit-for-bit reproducibility with varying pe counts</desc>
+    </entry>
+    <entry id="INFO_DBUG" value="1">
+      <type>integer</type>
+      <valid_values>0,1,2,3</valid_values>
+      <desc>level of debug output, 0=minimum, 1=normal, 2=more, 3=too much</desc>
+    </entry>
+  </group>
+  <group id="run_cesm">
+    <entry id="PROFILE_PAPI_ENABLE" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>Enables the papi hardware counters in gptl
     The papi library must be included in the build step for
-    this to work.</desc> 
-  </entry> 
-
-  <entry id="GLC_GRID"  value="gland5UM">
-    <type>char</type> 
-    <valid_values>gland20,gland10,gland5,gland5UM,gland4,null</valid_values> 
-    <group>run_component_cism</group> 
-    <desc>glacier (glc) grid - DO NOT EDIT (for experts only)</desc> 
-  </entry> 
-
-  <entry id="CPL_ALBAV"  value="false">
-    <type>logical</type> 
-    <valid_values>true,false</valid_values> 
-    <group>run_component_cpl</group> 
-    <desc>Only used for compsets with DATM and POP (currently C and G):
-      If true, compute albedos to work with daily avg SW down
-      If false (default), albedos are computed with the assumption that downward
-      solar radiation from the atm component has a diurnal cycle and zenith-angle
-      dependence. This is normally the case when using an active atm component
-      If true, albedos are computed with the assumption that downward
-      solar radiation from the atm component is a daily average quantity and
-      does not have a zenith-angle dependence. This is often the case when
-      using a data atm component. Only used for compsets with DATM and POP (currently C and G)</desc> 
-  </entry> 
-
-  <entry id="CPL_EPBAL"  value="off">
-    <type>char</type> 
-    <valid_values>off,ocn</valid_values> 
-    <group>run_component_cpl</group> 
-    <desc>Only used for compsets with DATM and POP (currently C and G):
-      If ocn, ocn provides EP balance factor for precipitation.
-      Provides EP balance factor for precip for POP. A factor computed by
-      POP is applied to precipitation so that precipitation balances
-      evaporation and ocn global salinity does not drift. This is intended
-      for use when coupling POP to a DATM. Only used for C and G compsets.
-      Default is off</desc> 
-  </entry> 
-
-  <entry id="ATM_NCPL"  value="48">
-    <type>char</type> 
-    <group>run_coupling</group> 
-    <desc>Number of atm coupling intervals per NCPL_BASE_PERIOD.
-    This is used to set the driver namelist atm_cpl_dt, equal to basedt/ATM_NCPL,
-    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc> 
-  </entry> 
-
-  <entry id="CCSM_BGC"  value="none">
-    <type>char</type> 
-    <valid_values>none,CO2A,CO2B,CO2C,CO2_DMSA</valid_values> 
-    <group>run_coupling</group> 
-    <desc>Flag to turn on new fields in coupling.
-    If the value is not none, the coupler is compiled so that optional
-    BGC related fields are exchanged between component models.</desc> 
-  </entry> 
-
-  <entry id="CPL_I2O_PER_CAT"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_coupling</group> 
-    <desc>determine if per ice thickness category fields are passed from ice to ocean - DO NOT EDIT (set by POP build-namelist)</desc> 
-  </entry> 
-
-  <entry id="CPL_SEQ_OPTION"  value="CESM1_MOD">
-    <type>char</type> 
-    <valid_values>CESM1_ORIG,CESM1_ORIG_TIGHT,CESM1_MOD,CESM1_MOD_TIGHT,RASM_OPTION1,RASM_OPTION2</valid_values> 
-    <group>run_coupling</group> 
-    <desc>Coupler sequencing option. This is used to set the driver namelist variable cpl_seq_option.
+    this to work.</desc>
+    </entry>
+  </group>
+  <group id="run_domain">
+    <entry id="PTS_MODE" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>Operate on only a single point of the global grid  - DO NOT EDIT (for experts only)</desc>
+    </entry>
+    <entry id="PTS_LAT" value="-999.99">
+      <type>real</type>
+      <desc>Latitude to find nearest points for points mode (only used if PTS_MODE is TRUE)</desc>
+    </entry>
+    <entry id="PTS_LON" value="-999.99">
+      <type>real</type>
+      <desc>Longitude to find nearest points for points mode (only used if PTS_MODE is TRUE)</desc>
+    </entry>
+    <entry id="ATM_DOMAIN_FILE" value="domain.lnd.1x1pt-tropicAtl_test.111004.nc">
+      <type>char</type>
+      <desc>atm domain file</desc>
+    </entry>
+    <entry id="ATM_DOMAIN_PATH" value="$DIN_LOC_ROOT/share/domains/domain.clm">
+      <type>char</type>
+      <desc>path of atm domain file</desc>
+    </entry>
+    <entry id="LND_DOMAIN_FILE" value="domain.lnd.1x1pt-tropicAtl_test.111004.nc">
+      <type>char</type>
+      <desc>lnd domain file</desc>
+    </entry>
+    <entry id="LND_DOMAIN_PATH" value="$DIN_LOC_ROOT/share/domains/domain.clm">
+      <type>char</type>
+      <desc>path of lnd domain file</desc>
+    </entry>
+    <entry id="ROF_DOMAIN_FILE" value="UNSET">
+      <type>char</type>
+      <desc>rof domain file</desc>
+    </entry>
+    <entry id="ROF_DOMAIN_PATH" value="$DIN_LOC_ROOT/share/domains">
+      <type>char</type>
+      <desc>path of rof domain file</desc>
+    </entry>
+    <entry id="WAV_DOMAIN_FILE" value="UNSET">
+      <type>char</type>
+      <desc>wav domain file</desc>
+    </entry>
+    <entry id="WAV_DOMAIN_PATH" value="$DIN_LOC_ROOT/share/domains">
+      <type>char</type>
+      <desc>path of wav domain file</desc>
+    </entry>
+    <entry id="ICE_DOMAIN_FILE" value="UNSET">
+      <type>char</type>
+      <desc>ice domain file</desc>
+    </entry>
+    <entry id="ICE_DOMAIN_PATH" value="$DIN_LOC_ROOT/share/domains">
+      <type>char</type>
+      <desc>path of ice domain file</desc>
+    </entry>
+    <entry id="OCN_DOMAIN_FILE" value="UNSET">
+      <type>char</type>
+      <desc>ocn domain file</desc>
+    </entry>
+    <entry id="OCN_DOMAIN_PATH" value="$DIN_LOC_ROOT/share/domains">
+      <type>char</type>
+      <desc>path of ocn domain file</desc>
+    </entry>
+    <entry id="GLC_DOMAIN_FILE" value="UNSET">
+      <type>char</type>
+      <desc>glc domain file</desc>
+    </entry>
+    <entry id="GLC_DOMAIN_PATH" value="$DIN_LOC_ROOT/share/domains">
+      <type>char</type>
+      <desc>path of glc domain file</desc>
+    </entry>
+    <entry id="ATM2OCN_FMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>atm2ocn flux mapping file</desc>
+    </entry>
+    <entry id="ATM2OCN_FMAPTYPE" value="X">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>atm2ocn flux mapping file decomp type</desc>
+    </entry>
+    <entry id="ATM2OCN_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>atm2ocn state mapping file</desc>
+    </entry>
+    <entry id="ATM2OCN_SMAPTYPE" value="X">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>atm2ocn state mapping file decomp type</desc>
+    </entry>
+    <entry id="ATM2OCN_VMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>atm2ocn vector mapping file</desc>
+    </entry>
+    <entry id="ATM2OCN_VMAPTYPE" value="X">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>atm2ocn vector mapping file decomp type</desc>
+    </entry>
+    <entry id="ATM2LND_FMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>atm2lnd flux mapping file</desc>
+    </entry>
+    <entry id="ATM2LND_FMAPTYPE" value="X">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>atm2lnd flux mapping file decomp type</desc>
+    </entry>
+    <entry id="ATM2LND_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>atm2lnd state mapping file</desc>
+    </entry>
+    <entry id="ATM2LND_SMAPTYPE" value="X">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>atm2lnd state mapping file decomp type</desc>
+    </entry>
+    <entry id="ATM2WAV_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>atm2wav state mapping file</desc>
+    </entry>
+    <entry id="ATM2WAV_SMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>atm2wav state mapping file decomp type</desc>
+    </entry>
+    <entry id="OCN2ATM_FMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>ocn2atm flux mapping file</desc>
+    </entry>
+    <entry id="OCN2ATM_FMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>ocn2atm flux mapping file decomp type</desc>
+    </entry>
+    <entry id="OCN2ATM_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>ocn2atm state mapping file</desc>
+    </entry>
+    <entry id="OCN2ATM_SMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>ocn2atm state mapping file decomp type</desc>
+    </entry>
+    <entry id="LND2ATM_FMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>lnd2atm flux mapping file</desc>
+    </entry>
+    <entry id="LND2ATM_FMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>lnd2atm flux mapping file decomp type</desc>
+    </entry>
+    <entry id="LND2ATM_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>lnd2atm state mapping file</desc>
+    </entry>
+    <entry id="LND2ATM_SMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>lnd2atm state mapping file decomp type</desc>
+    </entry>
+    <entry id="LND2GLC_FMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>lnd2glc flux mapping file</desc>
+    </entry>
+    <entry id="LND2GLC_FMAPTYPE" value="X">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>lnd2glc flux mapping file decomp type</desc>
+    </entry>
+    <entry id="LND2GLC_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>lnd2glc state mapping file</desc>
+    </entry>
+    <entry id="LND2GLC_SMAPTYPE" value="X">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>lnd2glc state mapping file decomp type</desc>
+    </entry>
+    <entry id="LND2ROF_FMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>lnd2rof flux mapping file</desc>
+    </entry>
+    <entry id="LND2ROF_FMAPTYPE" value="X">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>lnd2rof flux mapping file decomp type</desc>
+    </entry>
+    <entry id="ROF2LND_FMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>rof2lnd flux mapping file</desc>
+    </entry>
+    <entry id="ROF2LND_FMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>rof2lnd flux mapping file decomp type</desc>
+    </entry>
+    <entry id="ROF2OCN_FMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>rof2ocn flux mapping file</desc>
+    </entry>
+    <entry id="ROF2OCN_FMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>rof2ocn flux mapping file decomp type</desc>
+    </entry>
+    <entry id="ROF2OCN_RMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>rof2ocn runoff mapping file</desc>
+    </entry>
+    <entry id="ROF2OCN_RMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>rof2ocn runoff mapping file decomp type</desc>
+    </entry>
+    <entry id="GLC2LND_FMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>glc2lnd flux mapping file</desc>
+    </entry>
+    <entry id="GLC2LND_FMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>glc2lnd flux mapping file decomp type</desc>
+    </entry>
+    <entry id="GLC2LND_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>glc2lnd state mapping file</desc>
+    </entry>
+    <entry id="GLC2LND_SMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>glc2lnd state mapping file decomp type</desc>
+    </entry>
+    <entry id="GLC2ICE_RMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>glc2ice runoff mapping file</desc>
+    </entry>
+    <entry id="GLC2ICE_RMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>glc2ice runoff mapping file decomp type</desc>
+    </entry>
+    <entry id="GLC2OCN_RMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>glc2ocn runoff mapping file</desc>
+    </entry>
+    <entry id="GLC2OCN_RMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>glc2ocn runoff mapping file decomp type</desc>
+    </entry>
+    <entry id="OCN2WAV_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>ocn2wav state mapping file</desc>
+    </entry>
+    <entry id="OCN2WAV_SMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>ocn2wav state mapping file decomp type</desc>
+    </entry>
+    <entry id="ICE2WAV_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>ice2wav state mapping file</desc>
+    </entry>
+    <entry id="ICE2WAV_SMAPTYPE" value="Y">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>ice2wav state mapping file decomp type</desc>
+    </entry>
+    <entry id="WAV2OCN_SMAPNAME" value="idmap">
+      <type>char</type>
+      <desc>wav2ocn state mapping file</desc>
+    </entry>
+    <entry id="WAV2OCN_SMAPTYPE" value="X">
+      <type>char</type>
+      <valid_values>X,Y</valid_values>
+      <desc>wav2ocn state mapping file decomp type</desc>
+    </entry>
+    <entry id="VECT_MAP" value="cart3d">
+      <type>char</type>
+      <valid_values>none,npfix,cart3d,cart3d_diag,cart3d_uvw,cart3d_uvw_diag</valid_values>
+      <desc>vector mapping option</desc>
+    </entry>
+    <entry id="EPS_FRAC" value="1.0e-02">
+      <type>char</type>
+      <desc>Error tolerance for differences in fractions in domain checking</desc>
+    </entry>
+    <entry id="EPS_AAREA" value="9.0e-07">
+      <type>real</type>
+      <desc>Error tolerance for differences in atm/land areas in domain checking</desc>
+    </entry>
+    <entry id="EPS_AMASK" value="1.0e-13">
+      <type>real</type>
+      <desc>Error tolerance for differences in atm/land masks in domain checking</desc>
+    </entry>
+    <entry id="EPS_AGRID" value="1.0e-12">
+      <type>real</type>
+      <desc>Error tolerance for differences in atm/land lat/lon in domain checking</desc>
+    </entry>
+    <entry id="EPS_OAREA" value="1.0e-01">
+      <type>real</type>
+      <desc>Error tolerance for differences in ocean/ice lon/lat in domain checking</desc>
+    </entry>
+    <entry id="EPS_OMASK" value="1.0e-06">
+      <type>real</type>
+      <desc>Error tolerance for differences in ocean/ice lon/lat in domain checking</desc>
+    </entry>
+    <entry id="EPS_OGRID" value="1.0e-02">
+      <type>real</type>
+      <desc>Error tolerance for differences in ocean/ice lon/lat in domain checking</desc>
+    </entry>
+  </group>
+  <group id="run_din">
+    <entry id="NODENAME_REGEX" value=".*yellowstone">
+      <type>char</type>
+      <desc>
+      A regular expression to match machine node names to ACME machine.
+    </desc>
+    </entry>
+    <entry id="PROXY" value="UNSET">
+      <type>char</type>
+      <desc>
+      Proxy (if any) setting for http_proxy to allow web access on this machine.
+    </desc>
+    </entry>
+    <entry id="TEST" value="FALSE">
+      <type>logical</type>
+      <desc>
+      Indicates to case.submit that this is a test case.
+    </desc>
+    </entry>
+    <entry id="DIN_LOC_ROOT" value="/glade/p/cesmdata/cseg/inputdata">
+      <type>char</type>
+      <desc>
+      The root directory of all CIME and component input data for the selected machine.
+      This is usually a shared disk area.
+      Default values for the target machine are in the
+      $CIMEROOT/machines/config_machines.xml
+    </desc>
+    </entry>
+    <entry id="DIN_LOC_ROOT_CLMFORC" value="/glade/p/cesm/lmwg">
+      <type>char</type>
+      <desc>CLM-specific root directory for CLM type input forcing data
+    This directory will only be used for I (CLM/DATM) compsets and only
+    for datm forcing data that is NOT checked into the svn repository
+    (datasets other than the Qian or single-point forcing).
+    This is usually a shared disk area.
+    Default values for the target machine are in the
+    $CIMEROOT/machines/config_machines.xml</desc>
+    </entry>
+  </group>
+  <group id="run_dout">
+    <entry id="DOUT_S_ROOT" value="/glade/scratch/erik/archive/$CASE">
+      <type>char</type>
+      <desc>Root directory for short term archiving. This directory must be visible to compute nodes.</desc>
+    </entry>
+    <entry id="DOUT_L_MSROOT" value="csm/$CASE">
+      <type>char</type>
+      <desc>Root directory on long term archiving store system for long-term data archives.</desc>
+    </entry>
+  </group>
+  <group id="run_mpi">
+    <entry id="MPI_RUN_COMMAND" value="UNSET">
+      <type>char</type>
+      <desc>mpi run command</desc>
+    </entry>
+  </group>
+  <group id="run_pio">
+    <entry id="PIO_ASYNC_INTERFACE" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>TRUE implies perform asynchronous i/o</desc>
+    </entry>
+    <entry id="PIO_STRIDE" value="$PES_PER_NODE">
+      <type>integer</type>
+      <desc>mpi task stride between io tasks</desc>
+    </entry>
+    <entry id="PIO_ROOT" value="-1">
+      <type>integer</type>
+      <desc>pio root processor</desc>
+    </entry>
+    <entry id="PIO_NUMTASKS" value="-1">
+      <type>integer</type>
+      <desc>pio number of io tasks</desc>
+    </entry>
+    <entry id="PIO_REARRANGER" value="$PIO_VERSION">
+      <type>integer</type>
+      <desc>pio rearranger choice box=1, subset=2 </desc>
+    </entry>
+    <entry id="PIO_REARR_COMM_TYPE" value="p2p">
+      <type>char</type>
+      <valid_values>p2p,coll,default</valid_values>
+      <desc>pio rearranger communication type</desc>
+    </entry>
+    <entry id="PIO_REARR_COMM_FCD" value="2denable">
+      <type>char</type>
+      <valid_values>2denable,io2comp,comp2io,disable,default</valid_values>
+      <desc>pio rearranger communication flow control direction</desc>
+    </entry>
+    <entry id="PIO_REARR_COMM_MAX_PEND_REQ" value="64">
+      <type>integer</type>
+      <valid_values/>
+      <desc>pio rearranger communication max pending requests</desc>
+    </entry>
+    <entry id="PIO_REARR_COMM_ENABLE_HS" value="TRUE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>pio rearranger communiation options: TRUE implies enable handshake</desc>
+    </entry>
+    <entry id="PIO_REARR_COMM_ENABLE_ISEND" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>pio rearranger communiation options: TRUE implies enable isend</desc>
+    </entry>
+    <entry id="PIO_TYPENAME" value="pnetcdf">
+      <type>char</type>
+      <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,default</valid_values>
+      <desc>pio io type</desc>
+    </entry>
+    <entry id="PIO_DEBUG_LEVEL" value="0">
+      <type>integer</type>
+      <desc>pio debug level</desc>
+    </entry>
+    <entry id="PIO_BLOCKSIZE" value="-1">
+      <type>integer</type>
+      <desc>pio blocksize for box decompositions</desc>
+    </entry>
+    <entry id="PIO_BUFFER_SIZE_LIMIT" value="-1">
+      <type>integer</type>
+      <desc>pio buffer size limit for pnetcdf output</desc>
+    </entry>
+    <entry id="OCN_PIO_STRIDE" value="-99">
+      <type>integer</type>
+      <desc>pio stride</desc>
+    </entry>
+    <entry id="OCN_PIO_REARRANGER" value="-99">
+      <type>integer</type>
+      <desc>pio rearranger choice box=1, subset=2 </desc>
+    </entry>
+    <entry id="OCN_PIO_ROOT" value="0">
+      <type>integer</type>
+      <desc>pio root processor</desc>
+    </entry>
+    <entry id="OCN_PIO_NUMTASKS" value="-99">
+      <type>integer</type>
+      <desc>pio number of io tasks</desc>
+    </entry>
+    <entry id="OCN_PIO_TYPENAME" value="nothing">
+      <type>char</type>
+      <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
+      <desc>pio io type</desc>
+    </entry>
+    <entry id="LND_PIO_STRIDE" value="-99">
+      <type>integer</type>
+      <desc>pio stride</desc>
+    </entry>
+    <entry id="LND_PIO_REARRANGER" value="1">
+      <type>integer</type>
+      <desc>pio rearranger choice box=1, subset=2 </desc>
+    </entry>
+    <entry id="LND_PIO_ROOT" value="-99">
+      <type>integer</type>
+      <desc>pio root processor</desc>
+    </entry>
+    <entry id="LND_PIO_NUMTASKS" value="-99">
+      <type>integer</type>
+      <desc>pio number of io tasks</desc>
+    </entry>
+    <entry id="LND_PIO_TYPENAME" value="nothing">
+      <type>char</type>
+      <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
+      <desc>pio io type</desc>
+    </entry>
+    <entry id="ROF_PIO_STRIDE" value="-99">
+      <type>integer</type>
+      <desc>pio stride</desc>
+    </entry>
+    <entry id="ROF_PIO_REARRANGER" value="-99">
+      <type>integer</type>
+      <desc>pio rearranger choice box=1, subset=2 </desc>
+    </entry>
+    <entry id="ROF_PIO_ROOT" value="-99">
+      <type>integer</type>
+      <desc>pio root processor</desc>
+    </entry>
+    <entry id="ROF_PIO_NUMTASKS" value="-99">
+      <type>integer</type>
+      <desc>pio number of io tasks</desc>
+    </entry>
+    <entry id="ROF_PIO_TYPENAME" value="nothing">
+      <type>char</type>
+      <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
+      <desc>pio io type</desc>
+    </entry>
+    <entry id="ICE_PIO_STRIDE" value="-99">
+      <type>integer</type>
+      <desc>pio stride</desc>
+    </entry>
+    <entry id="ICE_PIO_REARRANGER" value="-99">
+      <type>integer</type>
+      <desc>pio rearranger choice box=1, subset=2 </desc>
+    </entry>
+    <entry id="ICE_PIO_ROOT" value="-99">
+      <type>integer</type>
+      <desc>pio root processor</desc>
+    </entry>
+    <entry id="ICE_PIO_NUMTASKS" value="-99">
+      <type>integer</type>
+      <desc>pio number of io tasks</desc>
+    </entry>
+    <entry id="ICE_PIO_TYPENAME" value="nothing">
+      <type>char</type>
+      <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
+      <desc>pio io type</desc>
+    </entry>
+    <entry id="ATM_PIO_STRIDE" value="-99">
+      <type>integer</type>
+      <desc>pio stride</desc>
+    </entry>
+    <entry id="ATM_PIO_REARRANGER" value="-99">
+      <type>integer</type>
+      <desc>pio rearranger choice box=1, subset=2 </desc>
+    </entry>
+    <entry id="ATM_PIO_ROOT" value="-99">
+      <type>integer</type>
+      <desc>pio root processor</desc>
+    </entry>
+    <entry id="ATM_PIO_NUMTASKS" value="-99">
+      <type>integer</type>
+      <desc>pio number of io tasks, -99 value means inherit whatever the driver uses</desc>
+    </entry>
+    <entry id="ATM_PIO_TYPENAME" value="netcdf">
+      <type>char</type>
+      <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
+      <desc>pio io type</desc>
+    </entry>
+    <entry id="CPL_PIO_STRIDE" value="-99">
+      <type>integer</type>
+      <desc>pio stride</desc>
+    </entry>
+    <entry id="CPL_PIO_REARRANGER" value="-99">
+      <type>integer</type>
+      <desc>pio rearranger choice box=1, subset=2 </desc>
+    </entry>
+    <entry id="CPL_PIO_ROOT" value="-99">
+      <type>integer</type>
+      <desc>pio root processor</desc>
+    </entry>
+    <entry id="CPL_PIO_NUMTASKS" value="-99">
+      <type>integer</type>
+      <desc>pio number of io tasks</desc>
+    </entry>
+    <entry id="CPL_PIO_TYPENAME" value="nothing">
+      <type>char</type>
+      <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
+      <desc>pio io type</desc>
+    </entry>
+    <entry id="GLC_PIO_STRIDE" value="-99">
+      <type>integer</type>
+      <desc>pio stride</desc>
+    </entry>
+    <entry id="GLC_PIO_REARRANGER" value="-99">
+      <type>integer</type>
+      <desc>pio rearranger choice box=1, subset=2 </desc>
+    </entry>
+    <entry id="GLC_PIO_ROOT" value="-99">
+      <type>integer</type>
+      <desc>pio root processor</desc>
+    </entry>
+    <entry id="GLC_PIO_NUMTASKS" value="-99">
+      <type>integer</type>
+      <desc>pio number of io tasks</desc>
+    </entry>
+    <entry id="GLC_PIO_TYPENAME" value="nothing">
+      <type>char</type>
+      <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
+      <desc>pio io type</desc>
+    </entry>
+    <entry id="WAV_PIO_STRIDE" value="-99">
+      <type>integer</type>
+      <desc>pio stride</desc>
+    </entry>
+    <entry id="WAV_PIO_REARRANGER" value="-99">
+      <type>integer</type>
+      <desc>pio rearranger choice box=1, subset=2 </desc>
+    </entry>
+    <entry id="WAV_PIO_ROOT" value="-99">
+      <type>integer</type>
+      <desc>pio root processor</desc>
+    </entry>
+    <entry id="WAV_PIO_NUMTASKS" value="-99">
+      <type>integer</type>
+      <desc>pio number of io tasks</desc>
+    </entry>
+    <entry id="WAV_PIO_TYPENAME" value="nothing">
+      <type>char</type>
+      <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
+      <desc>pio io type</desc>
+    </entry>
+  </group>
+  <group id="run_coupling">
+    <entry id="CPL_SEQ_OPTION" value="CESM1_MOD">
+      <type>char</type>
+      <valid_values>CESM1_ORIG,CESM1_ORIG_TIGHT,CESM1_MOD,CESM1_MOD_TIGHT,RASM_OPTION1,RASM_OPTION2</valid_values>
+      <desc>
+      Coupler sequencing option. This is used to set the driver namelist variable cpl_seq_option.
       CESM1_ORIG is the cesm1.1 implementation.
       CESM1_MOD includes a cesm1.3 mod that swaps ocean merging and atm/ocn flux
       computation.
@@ -302,859 +944,326 @@
       CESM1_ORIG_TIGHT and CESM1_MOD_TIGHT are consistent with the old variables
       ocean_tight_coupling = true in the driver.  That namelist is gone and the
       cpl_seq_option flags take it's place.
-      TIGHT coupling makes no sense with the OPTION5 and OPTION6 flags.</desc> 
-  </entry> 
-
-  <entry id="GLC_NCPL"  value="1">
-    <type>char</type> 
-    <group>run_coupling</group> 
-    <desc>Number of glc coupling intervals per NCPL_BASE_PERIOD.</desc> 
-  </entry> 
-
-  <entry id="ICE_NCPL"  value="$ATM_NCPL">
-    <type>char</type> 
-    <group>run_coupling</group> 
-    <desc>Number of ice coupling intervals per NCPL_BASE_PERIOD.
-    This is used to set the driver namelist ice_cpl_dt, equal to basedt/ICE_NCPL
-    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc> 
-  </entry> 
-
-  <entry id="LND_NCPL"  value="$ATM_NCPL">
-    <type>char</type> 
-    <group>run_coupling</group> 
-    <desc>Number of land coupling intervals per NCPL_BASE_PERIOD.
-    This is used to set the driver namelist atm_cpl_dt, equal to basedt/LND_NCPL,
-    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc> 
-  </entry> 
-
-  <entry id="NCPL_BASE_PERIOD"  value="day">
-    <type>char</type> 
-    <valid_values>hour,day,year,decade</valid_values> 
-    <group>run_coupling</group> 
-    <desc>Base period associated with NCPL coupling frequency.
+      TIGHT coupling makes no sense with the OPTION5 and OPTION6 flags.
+    </desc>
+    </entry>
+    <entry id="CPL_I2O_PER_CAT" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>determine if per ice thickness category fields are passed from ice to ocean - DO NOT EDIT (set by POP build-namelist)</desc>
+    </entry>
+    <entry id="CCSM_BGC" value="CO2A">
+      <type>char</type>
+      <valid_values>none,CO2A,CO2B,CO2C,CO2_DMSA</valid_values>
+      <desc>Flag to turn on new fields in coupling.
+    If the value is not none, the coupler is compiled so that optional
+    BGC related fields are exchanged between component models.
+    </desc>
+    </entry>
+    <entry id="NCPL_BASE_PERIOD" value="day">
+      <type>char</type>
+      <valid_values>hour,day,year,decade</valid_values>
+      <desc>Base period associated with NCPL coupling frequency.
     This xml variable is only used to set the driver namelist variables,
-    atm_cpl_dt, lnd_cpl_dt, ocn_cpl_dt, ice_cpl_dt, glc_cpl_dt, rof_cpl_dt and wav_cpl_dt.</desc> 
-  </entry> 
-
-  <entry id="OCN_NCPL"  value="$ATM_NCPL">
-    <type>char</type> 
-    <group>run_coupling</group> 
-    <desc>Number of ocn coupling intervals per NCPL_BASE_PERIOD.
+    atm_cpl_dt, lnd_cpl_dt, ocn_cpl_dt, ice_cpl_dt, glc_cpl_dt, rof_cpl_dt, wav_cpl_dt, and esp_dt.</desc>
+    </entry>
+    <entry id="ATM_NCPL" value="48">
+      <type>integer</type>
+      <desc>Number of atm coupling intervals per NCPL_BASE_PERIOD.
+    This is used to set the driver namelist atm_cpl_dt, equal to basedt/ATM_NCPL,
+    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
+    </entry>
+    <entry id="LND_NCPL" value="$ATM_NCPL">
+      <type>integer</type>
+      <desc>Number of land coupling intervals per NCPL_BASE_PERIOD.
+    This is used to set the driver namelist atm_cpl_dt, equal to basedt/LND_NCPL,
+    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
+    </entry>
+    <entry id="ICE_NCPL" value="$ATM_NCPL">
+      <type>integer</type>
+      <desc>Number of ice coupling intervals per NCPL_BASE_PERIOD.
+    This is used to set the driver namelist ice_cpl_dt, equal to basedt/ICE_NCPL
+    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
+    </entry>
+    <entry id="OCN_NCPL" value="1">
+      <type>integer</type>
+      <desc>Number of ocn coupling intervals per NCPL_BASE_PERIOD.
     Thisn is used to set the driver namelist ocn_cpl_dt, equal to basedt/OCN_NCPL
-    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc> 
-  </entry> 
-
-  <entry id="ROF_NCPL"  value="8">
-    <type>char</type> 
-    <group>run_coupling</group> 
-    <desc>Number of rof coupling intervals per NCPL_BASE_PERIOD.
+    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
+    </entry>
+    <entry id="GLC_NCPL" value="1">
+      <type>integer</type>
+      <desc>Number of glc coupling intervals per NCPL_BASE_PERIOD.</desc>
+    </entry>
+    <entry id="ROF_NCPL" value="8">
+      <type>integer</type>
+      <desc>Number of rof coupling intervals per NCPL_BASE_PERIOD.
     This is used to set the driver namelist rof_cpl_dt, equal to basedt/ROF_NCPL
-    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc> 
-  </entry> 
-
-  <entry id="WAV_NCPL"  value="$ATM_NCPL">
-    <type>char</type> 
-    <group>run_coupling</group> 
-    <desc>Number of wav coupling intervals per NCPL_BASE_PERIOD.
+    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
+    </entry>
+    <entry id="WAV_NCPL" value="$ATM_NCPL">
+      <type>integer</type>
+      <desc>Number of wav coupling intervals per NCPL_BASE_PERIOD.
     This is used to set the driver namelist wav_cpl_dt, equal to basedt/WAV_NCPL
-    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc> 
-  </entry> 
-
-  <entry id="CASESTR"  value="UNSET">
-    <type>char</type> 
-    <group>run_desc</group> 
-    <desc>case description</desc> 
-  </entry> 
-
-  <entry id="EPS_AAREA"  value="9.0e-07">
-    <type>real</type>
-    <group>run_domain</group>
-    <desc>Error tolerance for differences in atm/land areas in domain checking</desc>
-  </entry>
-
-  <entry id="EPS_AGRID"  value="1.0e-12">
-    <type>real</type>
-    <group>run_domain</group>
-    <desc>Error tolerance for differences in atm/land lat/lon in domain checking</desc>
-  </entry>
-
-  <entry id="EPS_AMASK"  value="1.0e-13">
-    <type>real</type>
-    <group>run_domain</group>
-    <desc>Error tolerance for differences in atm/land masks in domain checking</desc>
-  </entry>
-
-  <entry id="EPS_FRAC"  value="1.0e-02">
-    <type>char</type>
-    <group>run_domain</group>
-    <desc>Error tolerance for differences in fractions in domain checking</desc>
-  </entry>
-
-  <entry id="EPS_OAREA"  value="1.0e-01">
-    <type>real</type>
-    <group>run_domain</group>
-    <desc>Error tolerance for differences in ocean/ice lon/lat in domain checking</desc>
-  </entry>
-
-  <entry id="EPS_OGRID"  value="1.0e-02">
-    <type>real</type>
-    <group>run_domain</group>
-    <desc>Error tolerance for differences in ocean/ice lon/lat in domain checking</desc>
-  </entry>
-
-  <entry id="EPS_OMASK"  value="1.0e-06">
-    <type>real</type>
-    <group>run_domain</group>
-    <desc>Error tolerance for differences in ocean/ice lon/lat in domain checking</desc>
-  </entry>
-
-  <entry id="RUNDIR"  value="./run">
-    <type>char</type> 
-    <group>run_desc</group> 
-    <desc>The directory where the executable will be run.
-      By default this is set to EXEROOT/../run.
-      RUNDIR allows you to keep the run directory separate from the build directory</desc> 
-  </entry> 
-
-  <entry id="DIN_LOC_ROOT"  value="/glade/p/cesmdata/cseg/inputdata">
-    <type>char</type> 
-    <group>run_din</group> 
-    <desc>The root directory of all CIME and component input data for the selected machine.
-      This is usually a shared disk area.
-      Default values for the target machine are in the
-      /glade/p/work/erik/clm_gswp3drflds/cime/machines/config_machines.xml</desc> 
-  </entry> 
-
-  <entry id="PTS_LAT"  value="-999.99">
-    <type>real(1)</type> 
-    <group>run_domain</group> 
-    <desc>Latitude to find nearest points for points mode (only used if PTS_MODE is TRUE)</desc> 
-  </entry> 
-
-  <entry id="PTS_LON"  value="-999.99">
-    <type>real(1)</type> 
-    <group>run_domain</group> 
-    <desc>Longitude to find nearest points for points mode (only used if PTS_MODE is TRUE)</desc> 
-  </entry> 
-
-  <entry id="PTS_MODE"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_domain</group> 
-    <desc>Operate on only a single point of the global grid  - DO NOT EDIT (for experts only)</desc> 
-  </entry> 
-
-  <entry id="VECT_MAP"  value="cart3d">
-    <type>char</type>
-    <valid_values>none,npfix,cart3d,cart3d_diag,cart3d_uvw,cart3d_uvw_diag</valid_values>
-    <group>run_domain</group>
-    <desc>vector mapping option</desc>
-  </entry>
-
-  <entry id="BFBFLAG"  value="FALSE">
-    <type>logical</type>
-    <valid_values>TRUE,FALSE</valid_values>
-    <group>run_flags</group>
-    <desc>turns on coupler bit-for-bit reproducibility with varying pe counts</desc>
-  </entry>
-
-  <entry id="COMP_RUN_BARRIERS"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_flags</group> 
-    <desc>Turns on component barriers for component timing.
-          This variable is for testing and debugging only and should never
-          be set for a production run.</desc> 
-  </entry> 
-
-  <entry id="DRV_THREADING"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_flags</group> 
-    <desc>Turns on component varying thread control in the driver.
-    Used to set the driver namelist variable "drv_threading".</desc> 
-  </entry> 
-
-  <entry id="INFO_DBUG"  value="1">
-    <type>integer</type>
-    <valid_values>0,1,2,3</valid_values>
-    <group>run_flags</group>
-    <desc>level of debug output, 0=minimum, 1=normal, 2=more, 3=too much</desc>
-  </entry>
-
-  <entry id="TIMER_LEVEL"  value="12">
-    <type>integer</type> 
-    <group>run_flags</group> 
-    <desc>timer output depth</desc> 
-  </entry> 
-
-  <entry id="GLC_NEC"  value="10">
-    <type>integer</type> 
-    <valid_values>0,1,3,5,10,36</valid_values> 
-    <group>run_glc</group> 
-    <desc>Glacier model number of elevation classes, 0 implies no glacier land unit in clm
-    Used by both CLM and CISM (even if CISM is not running, and only SGLC is used).</desc> 
-  </entry> 
-
-  <entry id="ATM2LND_FMAPNAME"  value="idmap">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>atm2lnd flux mapping file</desc> 
-  </entry> 
-
-  <entry id="ATM2LND_FMAPTYPE"  value="X">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>atm2lnd flux mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="ATM2LND_SMAPNAME"  value="idmap">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>atm2lnd state mapping file</desc> 
-  </entry> 
-
-  <entry id="ATM2LND_SMAPTYPE"  value="X">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>atm2lnd state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="ATM2OCN_FMAPNAME"  value="cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v6_aave.130322.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>atm2ocn flux mapping file</desc> 
-  </entry> 
-
-  <entry id="ATM2OCN_FMAPTYPE"  value="X">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>atm2ocn flux mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="ATM2OCN_SMAPNAME"  value="cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v6_blin.130322.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>atm2ocn state mapping file</desc> 
-  </entry> 
-
-  <entry id="ATM2OCN_SMAPTYPE"  value="X">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>atm2ocn state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="ATM2OCN_VMAPNAME"  value="cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v6_patc.130322.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>atm2ocn vector mapping file</desc> 
-  </entry> 
-
-  <entry id="ATM2OCN_VMAPTYPE"  value="X">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>atm2ocn vector mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="ATM2WAV_SMAPNAME"  value="idmap">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>atm2wav state mapping file</desc> 
-  </entry> 
-
-  <entry id="ATM2WAV_SMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>atm2wav state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="GLC2ICE_RMAPNAME"  value="idmap">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>glc2ice runoff mapping file</desc> 
-  </entry> 
-
-  <entry id="GLC2ICE_RMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>glc2ice runoff mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="GLC2LND_FMAPNAME"  value="cpl/gridmaps/gland5km/map_gland5km_TO_fv1.9x2.5_aave.150514.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>glc2lnd flux mapping file</desc> 
-  </entry> 
-
-  <entry id="GLC2LND_FMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>glc2lnd flux mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="GLC2LND_SMAPNAME"  value="cpl/gridmaps/gland5km/map_gland5km_TO_fv1.9x2.5_aave.150514.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>glc2lnd state mapping file</desc> 
-  </entry> 
-
-  <entry id="GLC2LND_SMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>glc2lnd state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="GLC2OCN_RMAPNAME"  value="cpl/gridmaps/gland5km/map_gland5km_to_gx1v6_nnsm_e1000r300_150512.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>glc2ocn runoff mapping file</desc> 
-  </entry> 
-
-  <entry id="GLC2OCN_RMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>glc2ocn runoff mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="ICE2WAV_SMAPNAME"  value="idmap">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>ice2wav state mapping file</desc> 
-  </entry> 
-
-  <entry id="ICE2WAV_SMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>ice2wav state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="LND2ATM_FMAPNAME"  value="idmap">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>lnd2atm flux mapping file</desc> 
-  </entry> 
-
-  <entry id="LND2ATM_FMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>lnd2atm flux mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="LND2ATM_SMAPNAME"  value="idmap">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>lnd2atm state mapping file</desc> 
-  </entry> 
-
-  <entry id="LND2ATM_SMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>lnd2atm state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="LND2GLC_FMAPNAME"  value="cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland5km_aave.150514.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>lnd2glc flux mapping file</desc> 
-  </entry> 
-
-  <entry id="LND2GLC_FMAPTYPE"  value="X">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>lnd2glc flux mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="LND2GLC_SMAPNAME"  value="cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland5km_blin.150514.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>lnd2glc state mapping file</desc> 
-  </entry> 
-
-  <entry id="LND2GLC_SMAPTYPE"  value="X">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>lnd2glc state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="LND2ROF_FMAPNAME"  value="lnd/clm2/mappingdata/maps/1.9x2.5/map_1.9x2.5_nomask_to_0.5x0.5_nomask_aave_da_c120522.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>lnd2rof flux mapping file</desc> 
-  </entry> 
-
-  <entry id="LND2ROF_FMAPTYPE"  value="X">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>lnd2rof flux mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="OCN2ATM_FMAPNAME"  value="cpl/gridmaps/gx1v6/map_gx1v6_TO_fv1.9x2.5_aave.130322.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>ocn2atm flux mapping file</desc> 
-  </entry> 
-
-  <entry id="OCN2ATM_FMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>ocn2atm flux mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="OCN2ATM_SMAPNAME"  value="cpl/gridmaps/gx1v6/map_gx1v6_TO_fv1.9x2.5_aave.130322.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>ocn2atm state mapping file</desc> 
-  </entry> 
-
-  <entry id="OCN2ATM_SMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>ocn2atm state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="OCN2WAV_SMAPNAME"  value="idmap">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>ocn2wav state mapping file</desc> 
-  </entry> 
-
-  <entry id="OCN2WAV_SMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>ocn2wav state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="ROF2LND_FMAPNAME"  value="lnd/clm2/mappingdata/maps/1.9x2.5/map_0.5x0.5_nomask_to_1.9x2.5_nomask_aave_da_c120709.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>rof2lnd flux mapping file</desc> 
-  </entry> 
-
-  <entry id="ROF2LND_FMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>rof2lnd flux mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="ROF2OCN_FMAPNAME"  value="cpl/cpl6/map_r05_TO_g16_aave.120920.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>rof2ocn flux mapping file</desc> 
-  </entry> 
-
-  <entry id="ROF2OCN_FMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>rof2ocn flux mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="ROF2OCN_RMAPNAME"  value="cpl/cpl6/map_r05_to_gx1v6_e1000r300_090226.nc">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>rof2ocn runoff mapping file</desc> 
-  </entry> 
-
-  <entry id="ROF2OCN_RMAPTYPE"  value="Y">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>rof2ocn runoff mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="WAV2OCN_SMAPNAME"  value="idmap">
-    <type>char</type> 
-    <group>run_domain</group> 
-    <desc>wav2ocn state mapping file</desc> 
-  </entry> 
-
-  <entry id="WAV2OCN_SMAPTYPE"  value="X">
-    <type>char</type> 
-    <valid_values>X,Y</valid_values> 
-    <group>run_domain</group> 
-    <desc>wav2ocn state mapping file decomp type</desc> 
-  </entry> 
-
-  <entry id="AVGHIST_DATE"  value="-999">
-    <type>integer</type> 
-    <group>run_drv_history</group> 
-    <desc>yyyymmdd format, sets driver average history date (like REST_DATE)</desc> 
-  </entry> 
-
-  <entry id="AVGHIST_N"  value="-999">
-    <type>char</type> 
-    <group>run_drv_history</group> 
-    <desc>Sets driver average history file frequency (like REST_N)</desc> 
-  </entry> 
-
-  <entry id="AVGHIST_OPTION"  value="never">
-    <type>char</type> 
-    <group>run_drv_history</group> 
-    <desc>Sets driver average history file frequency (like REST_OPTION)</desc> 
-  </entry> 
-
-  <entry id="HIST_DATE"  value="-999">
-    <type>integer</type> 
-    <group>run_drv_history</group> 
-    <desc>yyyymmdd format, sets coupler snapshot history date (like REST_DATE)</desc> 
-  </entry> 
-
-  <entry id="HIST_N"  value="13">
-    <type>integer</type> 
-    <group>run_drv_history</group> 
-    <desc>Sets driver snapshot history file frequency (like REST_N)</desc> 
-  </entry> 
-
-  <entry id="HIST_OPTION"  value="nmonths">
-    <type>char</type> 
-    <group>run_drv_history</group> 
-    <desc>Sets driver snapshot history file frequency (like REST_OPTION)</desc> 
-  </entry> 
-
-  <entry id="CHECK_TIMING"  value="TRUE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_flags</group> 
-    <desc>logical to diagnose model timing at the end of the run</desc> 
-  </entry> 
-
-  <entry id="CPL_DECOMP"  value="0">
-    <type>integer</type> 
-    <valid_values>0,1,2,3,4,5,6</valid_values> 
-    <group>run_flags</group> 
-    <desc>Coupler decomposition option.</desc> 
-  </entry> 
-
-  <entry id="DRV_THREADING"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_flags</group> 
-    <desc>Turns on component varying thread control in the driver.
-    Used to set the driver namelist variable "drv_threading".</desc> 
-  </entry>
-
-  <entry id="ATM_PIO_NUMTASKS"  value="1">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio number of io tasks, -99 value means inherit whatever the driver uses</desc> 
-  </entry> 
-
-  <entry id="ATM_PIO_REARRANGER"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio rearranger choice box=1, subset=2</desc> 
-  </entry> 
-
-  <entry id="ATM_PIO_ROOT"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio root processor</desc> 
-  </entry> 
-
-  <entry id="ATM_PIO_STRIDE"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio stride</desc> 
-  </entry> 
-
-  <entry id="ATM_PIO_TYPENAME"  value="netcdf">
-    <type>char</type> 
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values> 
-    <group>run_pio</group> 
-    <desc>pio io type</desc> 
-  </entry> 
-
-  <entry id="CPL_PIO_NUMTASKS"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio number of io tasks</desc> 
-  </entry> 
-
-  <entry id="CPL_PIO_REARRANGER"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio rearranger choice box=1, subset=2</desc> 
-  </entry> 
-
-  <entry id="CPL_PIO_ROOT"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio root processor</desc> 
-  </entry> 
-
-  <entry id="CPL_PIO_STRIDE"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio stride</desc> 
-  </entry> 
-
-  <entry id="CPL_PIO_TYPENAME"  value="nothing">
-    <type>char</type> 
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values> 
-    <group>run_pio</group> 
-    <desc>pio io type</desc> 
-  </entry> 
-
-  <entry id="GLC_PIO_NUMTASKS"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio number of io tasks</desc> 
-  </entry> 
-
-  <entry id="GLC_PIO_REARRANGER"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio rearranger choice box=1, subset=2</desc> 
-  </entry> 
-
-  <entry id="GLC_PIO_ROOT"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio root processor</desc> 
-  </entry> 
-
-  <entry id="GLC_PIO_STRIDE"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio stride</desc> 
-  </entry> 
-
-  <entry id="GLC_PIO_TYPENAME"  value="nothing">
-    <type>char</type> 
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values> 
-    <group>run_pio</group> 
-    <desc>pio io type</desc> 
-  </entry> 
-
-  <entry id="ICE_PIO_NUMTASKS"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio number of io tasks</desc> 
-  </entry> 
-
-  <entry id="ICE_PIO_REARRANGER"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio rearranger choice box=1, subset=2</desc> 
-  </entry> 
-
-  <entry id="ICE_PIO_ROOT"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio root processor</desc> 
-  </entry> 
-
-  <entry id="ICE_PIO_STRIDE"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio stride</desc> 
-  </entry> 
-
-  <entry id="ICE_PIO_TYPENAME"  value="nothing">
-    <type>char</type> 
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values> 
-    <group>run_pio</group> 
-    <desc>pio io type</desc> 
-  </entry> 
-
-  <entry id="LND_PIO_NUMTASKS"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio number of io tasks</desc> 
-  </entry> 
-
-  <entry id="LND_PIO_REARRANGER"  value="1">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio rearranger choice box=1, subset=2</desc> 
-  </entry> 
-
-  <entry id="LND_PIO_ROOT"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio root processor</desc> 
-  </entry> 
-
-  <entry id="LND_PIO_STRIDE"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio stride</desc> 
-  </entry> 
-
-  <entry id="LND_PIO_TYPENAME"  value="nothing">
-    <type>char</type> 
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values> 
-    <group>run_pio</group> 
-    <desc>pio io type</desc> 
-  </entry> 
-
-  <entry id="OCN_PIO_NUMTASKS"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio number of io tasks</desc> 
-  </entry> 
-
-  <entry id="OCN_PIO_REARRANGER"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio rearranger choice box=1, subset=2</desc> 
-  </entry> 
-
-  <entry id="OCN_PIO_ROOT"  value="0">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio root processor</desc> 
-  </entry> 
-
-  <entry id="OCN_PIO_STRIDE"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio stride</desc> 
-  </entry> 
-
-  <entry id="OCN_PIO_TYPENAME"  value="nothing">
-    <type>char</type> 
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values> 
-    <group>run_pio</group> 
-    <desc>pio io type</desc> 
-  </entry> 
-
-  <entry id="PIO_ASYNC_INTERFACE"  value="FALSE">
-    <type>logical</type> 
-    <valid_values>TRUE,FALSE</valid_values> 
-    <group>run_pio</group> 
-    <desc>TRUE implies perform asynchronous i/o</desc> 
-  </entry> 
-
-  <entry id="PIO_BLOCKSIZE"  value="-1">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio blocksize for box decompositions</desc> 
-  </entry> 
-
-  <entry id="PIO_BUFFER_SIZE_LIMIT"  value="-1">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio buffer size limit for pnetcdf output</desc> 
-  </entry> 
-
-  <entry id="PIO_DEBUG_LEVEL"  value="0">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio debug level</desc> 
-  </entry> 
-
-  <entry id="PIO_NUMTASKS"  value="-1">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio number of io tasks</desc> 
-  </entry> 
-
-  <entry id="PIO_REARRANGER"  value="1">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio rearranger choice box=1, subset=2</desc> 
-  </entry> 
-
-  <entry id="PIO_ROOT"  value="-1">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio root processor</desc> 
-  </entry> 
-
-  <entry id="PIO_STRIDE"  value="15">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>mpi task stride between io tasks</desc> 
-  </entry> 
-
-  <entry id="PIO_TYPENAME"  value="pnetcdf">
-    <type>char</type> 
-    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,default</valid_values> 
-    <group>run_pio</group> 
-    <desc>pio io type</desc> 
-  </entry> 
-
-  <entry id="ROF_PIO_NUMTASKS"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio number of io tasks</desc> 
-  </entry> 
-
-  <entry id="ROF_PIO_REARRANGER"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio rearranger choice box=1, subset=2</desc> 
-  </entry> 
-
-  <entry id="ROF_PIO_ROOT"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio root processor</desc> 
-  </entry> 
-
-  <entry id="ROF_PIO_STRIDE"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio stride</desc> 
-  </entry> 
-
-  <entry id="ROF_PIO_TYPENAME"  value="nothing">
-    <type>char</type> 
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values> 
-    <group>run_pio</group> 
-    <desc>pio io type</desc> 
-  </entry> 
-
-  <entry id="WAV_PIO_NUMTASKS"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio number of io tasks</desc> 
-  </entry> 
-
-  <entry id="WAV_PIO_REARRANGER"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio rearranger choice box=1, subset=2</desc> 
-  </entry> 
-
-  <entry id="WAV_PIO_ROOT"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio root processor</desc> 
-  </entry> 
-
-  <entry id="WAV_PIO_STRIDE"  value="-99">
-    <type>integer</type> 
-    <group>run_pio</group> 
-    <desc>pio stride</desc> 
-  </entry> 
-
-  <entry id="WAV_PIO_TYPENAME"  value="nothing">
-    <type>char</type> 
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values> 
-    <group>run_pio</group> 
-    <desc>pio io type</desc> 
-  </entry> 
-
-</config_definition> 
+    where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
+    </entry>
+  </group>
+  <group id="run_component_cpl">
+    <entry id="CPL_ALBAV" value="false">
+      <type>logical</type>
+      <valid_values>true,false</valid_values>
+      <desc>
+      Only used for compsets with DATM and POP (currently C, G and J):
+      If true, compute albedos to work with daily avg SW down
+      If false (default), albedos are computed with the assumption that downward
+      solar radiation from the atm component has a diurnal cycle and zenith-angle
+      dependence. This is normally the case when using an active atm component
+      If true, albedos are computed with the assumption that downward
+      solar radiation from the atm component is a daily average quantity and
+      does not have a zenith-angle dependence. This is often the case when
+      using a data atm component. Only used for compsets with DATM and POP (currently C, G and J).
+      NOTE: This should really depend on the datm forcing and not the compset per se.
+      So, for example, whether it is set in a J compset should depend on
+      what datm forcing is used.
+    </desc>
+    </entry>
+    <entry id="CPL_EPBAL" value="off">
+      <type>char</type>
+      <valid_values>off,ocn</valid_values>
+      <desc>
+      Only used for compsets with DATM and POP (currently C, G and J):
+      If ocn, ocn provides EP balance factor for precipitation.
+      Provides EP balance factor for precip for POP. A factor computed by
+      POP is applied to precipitation so that precipitation balances
+      evaporation and ocn global salinity does not drift. This is intended
+      for use when coupling POP to a DATM. Only used for C, G and J compsets.
+      Default is off
+    </desc>
+    </entry>
+  </group>
+  <group id="run_drv_history">
+    <entry id="HIST_OPTION" value="never">
+      <type>char</type>
+      <valid_values/>
+      <desc>Sets driver snapshot history file frequency (like REST_OPTION)</desc>
+    </entry>
+    <entry id="HIST_N" value="-999">
+      <type>integer</type>
+      <valid_values/>
+      <desc>Sets driver snapshot history file frequency (like REST_N)
+    </desc>
+    </entry>
+    <entry id="HIST_DATE" value="-999">
+      <type>integer</type>
+      <valid_values/>
+      <desc>yyyymmdd format, sets coupler snapshot history date (like REST_DATE)</desc>
+    </entry>
+    <entry id="AVGHIST_OPTION" value="never">
+      <type>char</type>
+      <valid_values/>
+      <desc>Sets driver average history file frequency (like REST_OPTION)</desc>
+    </entry>
+    <entry id="AVGHIST_N" value="-999">
+      <type>char</type>
+      <valid_values/>
+      <desc>Sets driver average history file frequency (like REST_N)</desc>
+    </entry>
+    <entry id="AVGHIST_DATE" value="-999">
+      <type>integer</type>
+      <valid_values/>
+      <desc>yyyymmdd format, sets driver average history date (like REST_DATE)</desc>
+    </entry>
+  </group>
+  <group id="run_budgets">
+    <entry id="BUDGETS" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>logical that turns on diagnostic budgets for driver</desc>
+    </entry>
+  </group>
+  <group id="run_co2">
+    <entry id="CCSM_CO2_PPMV" value="367.0">
+      <type>real</type>
+      <valid_values/>
+      <desc>This set the namelist values of CO2 ppmv for CAM and CLM. This variables is
+      introduced to coordinate this value among multiple components.</desc>
+    </entry>
+  </group>
+  <group id="run_glc">
+    <entry id="GLC_NEC" value="0">
+      <type>integer</type>
+      <valid_values>0,1,3,5,10,36</valid_values>
+      <desc>Glacier model number of elevation classes, 0 implies no glacier land unit in clm
+    Used by both CLM and CISM (even if CISM is not running, and only SGLC is used).</desc>
+    </entry>
+    <entry id="GLC_TWO_WAY_COUPLING" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>Whether the glacier component feeds back to the rest of the system
+      This affects:
+      (1) Whether CLM updates its areas based on glacier areas sent from GLC
+      (2) Whether GLC sends fluxes (e.g., calving fluxes) to the coupler
+      Note that this is set to TRUE by default for TG compsets - even though there are
+      no feedbacks for TG compsets, this enables extra coupler diagnostics for these
+      compsets.</desc>
+    </entry>
+  </group>
+  <group id="external_tools">
+    <entry id="DATA_ASSIMILATION" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc> Run the external tool pointed to by DATA_ASSIMILATION_SCRIPT after the model run completes </desc>
+    </entry>
+    <entry id="DATA_ASSIMILATION_CYCLES" value="1">
+      <type>integer</type>
+      <valid_values/>
+      <desc> Number of model run - data assimilation steps to complete </desc>
+    </entry>
+    <entry id="DATA_ASSIMILATION_SCRIPT" value="">
+      <type>char</type>
+      <valid_values/>
+      <desc>External script to be run after model completion</desc>
+    </entry>
+  </group>
+  <group id="run_component_datm">
+    <entry id="DATM_MODE" value="CLM_QIAN">
+      <type>char</type>
+      <valid_values>CORE2_NYF,CORE2_IAF,TN460,CLM_QIAN,CLM1PT,CLMCRUNCEP,CLMCRUNCEP_V5,CLMGSWP3,CPLHIST3HrWx,COPYALL_NPS_v1,COPYALL_NPS_CORE2_v1,WRF,WW3</valid_values>
+      <desc>Mode for data atmosphere component.
+      The default is CORE2_NYF (CORE2 normal year forcing) is the 
+      DATM mode used in C and G compsets. CLM_QIAN, CLMCRUNCEP, CLMGSWP3 and CLM1PT are 
+      modes using observational data for forcing CLM in I compsets.</desc>
+    </entry>
+    <entry id="DATM_PRESAERO" value="trans_1850-2000">
+      <type>char</type>
+      <valid_values>none,clim_1850,clim_2000,trans_1850-2000,rcp2.6,rcp4.5,rcp6.0,rcp8.5,pt1_pt1</valid_values>
+      <desc>DATM prescribed aerosol forcing</desc>
+    </entry>
+    <entry id="DATM_TOPO" value="observed">
+      <type>char</type>
+      <valid_values>none,observed</valid_values>
+      <desc>DATM surface topography forcing</desc>
+    </entry>
+    <entry id="DATM_CO2_TSERIES" value="20tr">
+      <type>char</type>
+      <valid_values>none,20tr,rcp2.6,rcp4.5,rcp6.0,rcp8.5</valid_values>
+      <desc>DATM CO2 time series</desc>
+    </entry>
+    <entry id="DATM_CPLHIST_CASE" value="UNSET">
+      <type>char</type>
+      <valid_values/>
+      <desc>case name for coupler history data mode (only used for CPLHIST3HrWx mode)</desc>
+    </entry>
+    <entry id="DATM_CPLHIST_YR_ALIGN" value="1">
+      <type>integer</type>
+      <valid_values/>
+      <desc>Simulation year corresponding to starting year (only used for CPLHIST3HrWx mode)</desc>
+    </entry>
+    <entry id="DATM_CPLHIST_YR_START" value="-999">
+      <type>integer</type>
+      <valid_values/>
+      <desc>starting year to loop data over (only used for CPLHIST3HrWx mode)</desc>
+    </entry>
+    <entry id="DATM_CPLHIST_YR_END" value="-999">
+      <type>integer</type>
+      <valid_values/>
+      <desc>ending year to loop data over (only used for CPLHIST3HrWx mode)</desc>
+    </entry>
+    <entry id="DATM_CLMNCEP_YR_ALIGN" value="1895">
+      <type>integer</type>
+      <valid_values/>
+      <desc>year align</desc>
+    </entry>
+    <entry id="DATM_CLMNCEP_YR_START" value="1948">
+      <type>integer</type>
+      <valid_values/>
+      <desc>starting year to loop data over</desc>
+    </entry>
+    <entry id="DATM_CLMNCEP_YR_END" value="1972">
+      <type>integer</type>
+      <valid_values/>
+      <desc>ending year to loop data over</desc>
+    </entry>
+  </group>
+  <group id="run_component_clm">
+    <entry id="LND_TUNING_MODE" value="clm4_5_CRUNCEP">
+      <type>char</type>
+      <desc>Tuning parameters should be optimized for what CLM model version and what meteorlogical forcing combination?
+    </desc>
+      <valid_values>clm4_0_default,clm5_0_cam5.5,clm5_0_GSW3P,clm4_5_CRUNCEP</valid_values>
+    </entry>
+    <entry id="CLM_NML_USE_CASE" value="20thC_transient">
+      <type>char</type>
+      <desc>CLM namelist use_case.
+      Determines the use-case that will be sent to the CLM build-namelist utility.
+      This is normally set by the component set. This is an advanced flag and should only be
+      used by expert users.</desc>
+    </entry>
+    <entry id="CLM_BLDNML_OPTS" value="-fire_emis -bgc bgc">
+      <type>char</type>
+      <desc>CLM build-namelist options</desc>
+    </entry>
+    <entry id="CLM_CO2_TYPE" value="diagnostic">
+      <type>char</type>
+      <valid_values>constant,diagnostic,prognostic</valid_values>
+      <list>1</list>
+      <desc>Determines how CLM will determine where CO2 is set.
+      If value is constant, it will be set to CCSM_CO2_PPMV,
+      if value is either diagnostic or prognostic, the atmosphere model
+      MUST send it to CLM. CLM_CO2_TYPE is normally set by the specific
+      compset, since it HAS to be coordinated with settings for the
+      atmospheric model. Do not modify this variable. If you want to modify for
+      your experiment, use your own user-defined component set
+      This is an advanced flag and should only be used by expert users.</desc>
+    </entry>
+    <entry id="CLM_NAMELIST_OPTS" value="">
+      <type>char</type>
+      <desc>CLM-specific namelist settings for -namelist option in the CLM
+      build-namelist. CLM_NAMELIST_OPTS is normally set as a compset variable
+      and in general should not be modified for supported compsets.
+      It is recommended that if you want to modify this value for your experiment,
+      you should use your own user-defined component sets via using create_newcase
+      with a compset_file argument.
+      This is an advanced flag and should only be used by expert users.</desc>
+    </entry>
+    <entry id="CLM_ACCELERATED_SPINUP" value="off">
+      <type>char</type>
+      <valid_values>on,off</valid_values>
+      <desc>Turn on any settings for accellerating the model spinup.
+    </desc>
+    </entry>
+    <entry id="CLM_USRDAT_NAME" value="UNSET">
+      <type>char</type>
+      <desc>Dataset name for user-created datasets. This is used as the argument
+      in Buildconf/clm.buildnml to build-namelist -clm_usr_name. An example of
+      such a dataset would be 1x1pt_boulderCO_c090722. The default value is UNSET.
+      This is an advanced flag and should only be used by expert users.</desc>
+    </entry>
+    <entry id="CLM_FORCE_COLDSTART" value="off">
+      <type>char</type>
+      <valid_values>on,off</valid_values>
+      <desc>Flag to the CLM build-namelist command to force CLM to do a
+      cold start (finidat will be set to blanks).
+      A value of on forces the model to spin up from a cold-start
+      (arbitrary initial conditions). Setting this value in the xml file will take
+      precedence over any settings for finidat in the $CASEROOT/user_clm_clm file.</desc>
+    </entry>
+  </group>
+  <group id="run_component_rtm">
+    <entry id="RTM_BLDNML_OPTS" value="-simyr 1850">
+      <type>char</type>
+      <valid_values/>
+      <desc>RTM build-namelist options</desc>
+    </entry>
+    <entry id="RTM_NAMELIST_OPTS" value="rtm_effvel='ACTIVE'">
+      <type>char</type>
+      <valid_values/>
+      <desc>RTM-specific namelist settings in the RTM build-namelist.
+      RTM_NAMELIST_OPTS is normally set as a compset variable
+      and in general should not be modified for supported compsets. 
+      It is recommended that if you want to modify this value for your experiment, 
+      you should use your own user-defined component sets via using create_newcase 
+      with a compset_file argument.</desc>
+    </entry>
+  </group>
+</file>

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -71,9 +71,11 @@ def _main_func():
     rc, out, err = run_cmd(cmd, from_dir=confdir)
     expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
 
-    # copy drv_in, seq_maps.rc and all *modio* files to rundir
+    # copy drv_in, drv_flds_in, seq_maps.rc and all *modio* files to rundir
 
     shutil.copy(os.path.join(confdir,"drv_in"), rundir)
+
+    shutil.copy(os.path.join(confdir,"drv_flds_in"), rundir)
 
     shutil.copy(os.path.join(confdir,"seq_maps.rc"), rundir)
 


### PR DESCRIPTION
Fix so driver_cpl modelio namelist definition is separate from

Test namelist changes: Gets pnetcdf into base pio_typename in drv_in namelist by
keeping modelio namelist_definition seperate from everything else.

Also get driver_cpl/bld/testdir standalone namelist test working with cime5

Also fix issue where drv_flds_in wasn't being copied over as should be in buildnml.

Fixes: CESM-Development/cime#473

User interface changes?: no

Code review: @jedwards4b 
