### PR TITLE
Add -mismatch_all when compiling cism with nag

### DIFF
--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -419,6 +419,12 @@ for mct, etc.
   <ADD_FFLAGS_NOOPT compile_threaded="true"> -openmp </ADD_FFLAGS_NOOPT>
   <ADD_LDFLAGS compile_threaded="true"> -openmp </ADD_LDFLAGS>
 
+  <!-- The SLAP library (which is part of the CISM build) has many instances of
+       arguments being passed to different types. So disable argument type
+       checking when building CISM. This can be removed once we remove SLAP from
+       CISM. -->
+  <ADD_FFLAGS MODEL="cism"> -mismatch_all </ADD_FFLAGS>
+
   <FC_AUTO_R8> -r8 </FC_AUTO_R8>
   <FIXEDFLAGS> -fixed </FIXEDFLAGS>
   <FREEFLAGS> -free </FREEFLAGS>


### PR DESCRIPTION
This is needed for building SLAP, to avoid errors like this:

Error:
/home/sacks/cesm_code/cesm2_0_alpha01/components/cism/glimmer-cism/libglimmer-solve/SLAP/xersla.f:
Argument MESSG (no. 1) in reference to XERABT from XERRWV has the wrong data
type CHARACTER (expected INTEGER)

(and many other similar errors)

Test suite: hobart aux_glc
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Ran tests out of the latest cesm2_0_alpha01 branch

These tests pass:
SMS_D_Ly3.f09_g16_gl5.TG.hobart_nag
SMS_D_Ly3_P24x1.f09_g16_gl20.TGIS2.hobart_nag

This test passes except for a memleak which I think is okay:
SMS_D_Ld5_P24x1.T31_g37_gl20.IGCLM45IS2.hobart_nag.cism-test_coupling

This test fails due to hitting a cpu-time limit that I'm still trying to understand:
SMS_D_Ly1_P24x1.f09_g16_gl4.TGIS2.hobart_nag

Fixes: None

User interface changes?: None

Code review: none
