### PR TITLE
Fix several issues in acme machines

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -145,7 +145,7 @@
 	<queue>shared</queue>
       </queues>
       <walltimes>
-	<walltime default="true">00:15:00</walltime>
+	<walltime default="true">01:00:00</walltime>
       </walltimes>
     </batch_system>
 

--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -151,9 +151,6 @@
 
     <!-- edison is SLURM as of Jan-4-2016 -->
     <batch_system MACH="edison" type="slurm" version="x.y">
-      <directives>
-        <directive> -A {{ account }} </directive>
-      </directives>
       <queues>
         <queue walltimemax="36:00:00" jobmin="1" jobmax="130181" default="true">regular</queue>
 	<queue walltimemax="00:30:00" jobmin="1" jobmax="12288">debug</queue>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -75,6 +75,7 @@
   <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <CCSM_BASELINE>/project/projectdirs/acme/baselines</CCSM_BASELINE>
   <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.edison/cprnc</CCSM_CPRNC>
+  <SAVE_TIMING_DIR>/project/projectdirs/$PROJECT</SAVE_TIMING_DIR>
   <mpirun mpilib="default">
     <executable>srun</executable>
     <arguments>


### PR DESCRIPTION
Fix issues found in acme machines files while testing the new CIME with ACME.

blues:  increase default walltime from 15 mins to 1 hour
edison:  remove -A directive;  define SAVE_TIMING_DIR

Tested with an X-case on blues and edison.
Test namelist changes:  none
Test status: bit for bit

Fixes #354 
