### PR TITLE
user_nl_ file was being removed if a user_nl file in any mods directo…

### DIFF
--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -23,11 +23,12 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
 
     include_dirs = build_include_dirs_list(user_mods_path)
     for include_dir in include_dirs:
-
         # write user_nl_xxx file in caseroot
         for user_nl in glob.iglob(os.path.join(include_dir,"user_nl_*")):
             with open(os.path.join(include_dir, user_nl), "r") as fd:
                 newcontents = fd.read()
+            if len(newcontents) == 0:
+                continue
             case_user_nl = user_nl.replace(include_dir, caseroot)
             comp = case_user_nl.split('_')[-1]
             if ninst is not None and comp in ninst.keys():


### PR DESCRIPTION
The user_nl_* files were being over written if any mod directory had empty contents for that file.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #358

User interface changes?: 

Code review: 

…ry was missing