### PR TITLE
fix bug in translation from perl

### DIFF
--- a/utils/python/CIME/task_maker.py
+++ b/utils/python/CIME/task_maker.py
@@ -137,7 +137,7 @@ class TaskMaker(object):
                 task_count = 1
 
             else:
-                task_count = 1
+                task_count += 1
 
         max_tasks_per_node = min(self.MAX_TASKS_PER_NODE / max_thread_count, self.PES_PER_NODE, max_task_count)
         max_total_node_count = int(math.ceil(float(max_task_count) / max_tasks_per_node))


### PR DESCRIPTION
In TaskMaker._compute_values():
Python code mistakenly sets task_counter = 1 always, this error forces tasks_per_node and tasks_per_numa to also always be 1

From taskmaker.pl:
```
    else {
      $taskcnt = $taskcnt + 1;
    }
```
Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 

before fix tasks_per_node would always be 1