### PR TITLE
case.build needs to check success in order to return a sane error code

### DIFF
--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -76,6 +76,7 @@ def _main_func(description):
     caseroot, sharedlib_only, model_only, cleanlist = parse_command_line(sys.argv, description)
     logging.info("calling build.case_build with caseroot=%s" %caseroot)
 
+    success = True
     with Case(caseroot, read_only=False) as case:
         testname = case.get_value('TESTCASE')
 
@@ -88,16 +89,20 @@ def _main_func(description):
 
             append_status("case.testbuild starting ",
                           caseroot=caseroot,sfile="CaseStatus")
-            test.build(sharedlib_only=sharedlib_only, model_only=model_only)
-            append_status("case.testbuild complete",
-                          caseroot=caseroot,sfile="CaseStatus")
+            success = test.build(sharedlib_only=sharedlib_only, model_only=model_only)
+            if success:
+                append_status("case.testbuild complete",
+                              caseroot=caseroot,sfile="CaseStatus")
         else:
             append_status("case.build starting",
                           caseroot=caseroot,sfile="CaseStatus")
-            build.case_build(caseroot, case=case, sharedlib_only=sharedlib_only,
+            success = build.case_build(caseroot, case=case, sharedlib_only=sharedlib_only,
                              model_only=model_only)
-            append_status("case.build complete",
-                          caseroot=caseroot,sfile="CaseStatus")
+            if success:
+                append_status("case.build complete",
+                              caseroot=caseroot,sfile="CaseStatus")
+
+    sys.exit(0 if success else 1)
 
 if __name__ == "__main__":
     _main_func(__doc__)


### PR DESCRIPTION
Test suite: acme_test_only
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?: case.build return code

Code review: jedwards

