### PR TITLE
work on support for external systems

### DIFF
--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -901,17 +901,11 @@ for mct, etc.
 <compiler MACH="stampede">
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <NETCDF_PATH>$(TACC_NETCDF_DIR)</NETCDF_PATH>
-  <!--PNETCDF_PATH>$(TACC_NETCDF_DIR)</PNETCDF_PATH-->
+  <PNETCDF_PATH>$(TACC_PNETCDF_DIR)</PNETCDF_PATH>
   <ADD_CPPDEFS> -DHAVE_NANOTIME </ADD_CPPDEFS>
 </compiler>
 
 <compiler MACH="stampede" COMPILER="intel">
-  <MPICC>mpicc</MPICC>
-  <MPIFC>mpif90</MPIFC>
-  <MPICXX>mpicxx</MPICXX>
-  <SFC>ifort</SFC>
-  <SCC>icc</SCC>
-  <SCXX>icpc</SCXX>
   <ADD_FFLAGS> -xHost </ADD_FFLAGS>
   <ADD_CFLAGS> -xHost </ADD_CFLAGS>
   <ADD_SLIBS>$(shell $(NETCDF_PATH)/bin/nf-config --flibs) -L$(TACC_HDF5_LIB) -lhdf5</ADD_SLIBS>

--- a/utils/python/CIME/XML/batch.py
+++ b/utils/python/CIME/XML/batch.py
@@ -26,6 +26,12 @@ class Batch(GenericXML):
         self.batch_system      = batch_system
         self.machine           = machine
 
+        #Append the contents of $HOME/.cime/config_batch.xml if it exists
+        #This could cause problems if node matchs are repeated when only one is expected
+        infile = os.path.join(os.environ.get("HOME"),".cime","config_batch.xml")
+        if os.path.exists(infile):
+            GenericXML.read(self, infile)
+
         if self.batch_system is not None:
             self.set_batch_system(self.batch_system, machine=machine)
 

--- a/utils/python/CIME/XML/compilers.py
+++ b/utils/python/CIME/XML/compilers.py
@@ -26,15 +26,15 @@ class Compilers(GenericXML):
         self.mpilib         = mpilib
         self.compiler_nodes = None # Listed from last to first
         self.compiler       = compiler
-
-        if self.compiler is not None:
-            self.set_compiler(compiler)
-
         #Append the contents of $HOME/.cime/config_compilers.xml if it exists
         #This could cause problems if node matchs are repeated when only one is expected
         infile = os.path.join(os.environ.get("HOME"),".cime","config_compilers.xml")
         if os.path.exists(infile):
             GenericXML.read(self, infile)
+
+        if self.compiler is not None:
+            self.set_compiler(compiler)
+
 
     def get_compiler(self):
         """


### PR DESCRIPTION
Allows for a machine to be defined in xml in $HOME/.cime/config_*.xml (machines, compiler, batch)   This is useful for vendors and other users who do not want to have their machine defined in our distributed xml files.  

Test suite: scripts_regression_tests on yellowstone after removing all reference to yellowstone from the cime_config/cesm/machines directory.    
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 

