### PR TITLE
Fix vars resolved too early

### DIFF
--- a/driver_cpl/bld/build-namelist
+++ b/driver_cpl/bld/build-namelist
@@ -276,24 +276,12 @@ if (defined $opts{'infile'}) {
     $nl->merge_nl($nl_infile_valid);
 }
 
+unshift @INC, "${CIMEROOT}/utils/perl5lib";
+require Config::SetupTools;
+
 #-----------------------------------------------------------------------------------------------
 # Determine xml variables
 #-----------------------------------------------------------------------------------------------
-
-my %xmlvars = ();
-my @files = <${CASEROOT}/*xml>;
-foreach my $file (@files) {
-    my $xml = XML::Lite->new( "$file" );
-    my @e = $xml->elements_by_name('entry');
-    while ( my $e = shift @e ) {
-	my %a = $e->get_attributes();
-	my $val = $a{value};
-	$xmlvars{$a{'id'}} = $a{'value'};
-    }
-}
-
-unshift @INC, "${CIMEROOT}/utils/perl5lib";
-require Config::SetupTools;
 
 my %xmlvars = ();
 SetupTools::getxmlvars($CASEROOT, \%xmlvars);

--- a/driver_cpl/bld/build-namelist
+++ b/driver_cpl/bld/build-namelist
@@ -47,7 +47,7 @@ OPTIONS
 
 NOTE: The precedence for setting the values of namelist variables is (highest to lowest):
       1. values read from the file specified by -infile,
-      2. values from the namelist defaults file 
+      2. values from the namelist defaults file
 EOF
 }
 
@@ -192,7 +192,7 @@ EOF
 (-f "$perl5lib_dir/Build/Namelist.pm")  or  die <<"EOF";
 ** $ProgName - Cannot find perl module \"Build/Namelist.pm\" in directory \"$perl5lib_dir\" **
 EOF
-my @nl_definition_filenames = ( "namelist_definition_drv.xml", 
+my @nl_definition_filenames = ( "namelist_definition_drv.xml",
                                 "namelist_definition_drv_flds.xml",
                                 "namelist_definition_modio.xml" );
 my @nl_definition_paths;
@@ -287,14 +287,11 @@ foreach my $file (@files) {
     my @e = $xml->elements_by_name('entry');
     while ( my $e = shift @e ) {
 	my %a = $e->get_attributes();
+	my $val = $a{value};
 	$xmlvars{$a{'id'}} = $a{'value'};
     }
 }
-my $DIN_LOC_ROOT = $xmlvars{'DIN_LOC_ROOT'};
-if ($print>=2) { print "inputdata root directory: $DIN_LOC_ROOT$eol"; }
 
-# Note - $USER is not in the config_defintion.xml file - it is only in the environment
-$xmlvars{'USER'} = $ENV{'USER'};
 unshift @INC, "${CIMEROOT}/utils/perl5lib";
 require Config::SetupTools;
 
@@ -303,6 +300,9 @@ SetupTools::getxmlvars($CASEROOT, \%xmlvars);
 foreach my $attr (keys %xmlvars) {
     $xmlvars{$attr} = SetupTools::expand_xml_var($xmlvars{$attr}, \%xmlvars);
 }
+
+my $DIN_LOC_ROOT = $xmlvars{'DIN_LOC_ROOT'};
+if ($print>=2) { print "inputdata root directory: $DIN_LOC_ROOT$eol"; }
 
 #-----------------------------------------------------------------------------------------------
 # Read in versions fo the drv_flds_in file from different components and merge them together
@@ -324,14 +324,14 @@ foreach my $fldsin ( @fldsinfiles ) {
        if ($@) {
           die "$ProgName - ERROR: Invalid namelist variable in '-infile' $opts{'infile'}.\n $@";
        }
-   
+
        # Merge input values into namelist.  Die if a conflict is found.
        $nl->merge_nl($nl_infile_valid, die_on_conflict=>1);
    }
 }
 
 #-----------------------------------------------------------------------------------------------
-# Determine drv namelist 
+# Determine drv namelist
 #-----------------------------------------------------------------------------------------------
 
 #############################################
@@ -882,7 +882,7 @@ $definition->validate($nl);
 # (1) Write output namelist files (drv_in, and drv_flds_in)
 #-----------------------------------------------------------------------------------------------
 
-# Write out drv_in namelist groups 
+# Write out drv_in namelist groups
 my @groups = qw(seq_cplflds_inparm
 		seq_cplflds_userspec
 		seq_infodata_inparm
@@ -901,7 +901,7 @@ if ($print>=2) { print "Writing driver namelist to $outfile $eol"; }
 my $outfile = "./drv_flds_in";
 $nl->write($outfile, 'groups'=>\@groups);
 if ($print>=2) { print "Writing driver fields namelist to $outfile $eol"; }
-               
+
 #-----------------------------------------------------------------------------------------------
 # (2) Write out seq_map.rc file
 #-----------------------------------------------------------------------------------------------
@@ -925,7 +925,7 @@ print $fh <<"EOF";
 #                   if necessary
 #
 # NOTE:  For bfb on different processor counts, set all maptypes to "X".
-################################################################## 
+##################################################################
 EOF
 $fh->close();
 

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -154,7 +154,7 @@
 
   <entry id="USER">
     <type>char</type>
-    <default_value>UNSET</default_value>
+    <default_value>$ENV{USER}</default_value>
     <group>case_desc</group>
     <file>env_case.xml</file>
     <desc>case user name</desc>

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -491,9 +491,10 @@ class Case(object):
                       'COMPILER' not in x and 'MPILIB' not in x]
 
         for nodename in nodenames:
-            value = machobj.get_value(nodename)
+            value = machobj.get_value(nodename, resolved=False)
             type_str = self.get_type_info(nodename)
             if type_str is not None:
+                logger.debug("machine nodname %s value %s"%(nodename, value))
                 self.set_value(nodename, convert_to_type(value, type_str, nodename))
 
         if compiler is None:


### PR DESCRIPTION
Some variables in env_*.xml files were being resolved too early - this resulted in a number of problems including one found by John Truesdale:  If the variable CASE was defined in the environent when you ran create_newcase then the EXEROOT and RUNDIR would be defined using the CASE from the environment instead of the one in the create_newcase argument. 

Another possible test for this would be for user b to try to clone a case created by user a - if this results in failures because user a paths are still in the case cloned by user b than there are likely other variables being resolved too early.  
Test suite: cime_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Code review: mvertens, jgfouca
