### PR TITLE
Do not get cwd in arg defaults

### DIFF
--- a/utils/python/CIME/check_lockedfiles.py
+++ b/utils/python/CIME/check_lockedfiles.py
@@ -9,10 +9,14 @@ from CIME.XML.env_mach_pes import EnvMachPes
 
 import glob
 
-def check_lockedfiles(caseroot=os.getcwd()):
+def check_lockedfiles(caseroot=None):
     """
     Check that all lockedfiles match what's in case
+
+    If caseroot is not specified, it is set to the current working directory
     """
+    if caseroot is None:
+        caseroot = os.getcwd()
     lockedfiles = glob.glob(os.path.join(caseroot, "LockedFiles", "*.xml"))
     for lfile in lockedfiles:
         fpart = os.path.basename(lfile)

--- a/utils/python/CIME/test_status.py
+++ b/utils/python/CIME/test_status.py
@@ -62,7 +62,14 @@ def _test_helper2(file_contents, wait_for_run=False, check_throughput=False, che
 
 class TestStatus(object):
 
-    def __init__(self, test_dir=os.getcwd(), test_name=None):
+    def __init__(self, test_dir=None, test_name=None):
+        """
+        Create a TestStatus object
+
+        If test_dir is not specified, it is set to the current working directory
+        """
+        if test_dir is None:
+            test_dir = os.getcwd()
         self._filename = os.path.join(test_dir, TEST_STATUS_FILENAME)
         self._phase_statuses = OrderedDict() # {name -> (status, comments)}
         self._test_name = test_name


### PR DESCRIPTION
In two functions - check_lockedfiles and TestStatus.__init__ - there was
a directory argument whose default was given by os.getcwd(). However, my
understanding of python's default arguments is that these defaults were
evaluated at the time the function was loaded, not at the time the
function was called.

This PR changes the behavior so that os.getcwd is evaluated at the time
the functions are called, if the respective arguments are not provided.

Without this change, I was getting failures in a few tests in
scripts_regression_tests on yellowstone, with messages like this:

```
======================================================================
FAIL: test_create_test_rebless_namelist (__main__.C_TestCreateTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./scripts_regression_tests.py", line 468, in test_create_test_rebless_namelist
    self.simple_test(True, "-g -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, CIME.utils.get_utc_timestamp()))
  File "./scripts_regression_tests.py", line 459, in simple_test
    self.assertEqual(stat, 0, msg="COMMAND '%s' SHOULD HAVE WORKED\ncreate_test output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (cmd, output, errput, stat))
AssertionError: COMMAND '/glade/p/work/sacks/cime/scripts/create_test cime_test_only_pass -g -n -b fake_testing_only_20160815_202538 -t fake_testing_only_20160815_202538-20160815_202538' SHOULD HAVE WORKED
create_test output:


errput:
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
Traceback (most recent call last):
  File "/glade/p/work/sacks/cime/scripts/create_test", line 14, in <module>
    from CIME.test_scheduler import TestScheduler, RUN_PHASE
  File "/glade/p/work/sacks/cime/scripts/Tools/../../utils/python/CIME/test_scheduler.py", line 16, in <module>
    from CIME.test_status import *
  File "/glade/p/work/sacks/cime/scripts/Tools/../../utils/python/CIME/test_status.py", line 63, in <module>
    class TestStatus(object):
  File "/glade/p/work/sacks/cime/scripts/Tools/../../utils/python/CIME/test_status.py", line 65, in TestStatus
    def __init__(self, test_dir=os.getcwd(), test_name=None):
OSError: [Errno 2] No such file or directory

code: 1
```

The changes here seem to resolve that problem. It's not clear to me why
I sometimes ran into that problem and sometimes didn't, but this change
seems more "right" to me anyway, since it seems problematic to resolve
the current directory at the time the function happens to be loaded.

From a quick look, it looks like this change could, in principle, change
behavior for case_setup, which does:

    os.chdir(caseroot)

before calling:

            check_lockedfiles()

I cannot find any instances of TestStatus.__init__ being called without
an explicit test_dir argument, so it doesn't look like that behavior
would be affected by this change.

Test suite: scripts_regression_tests on yellowstone
Test baseline: 
Test namelist changes: 
Test status: bit for bit

   All passed except for the same 4 failures that I got in testing master:

```
test_check_code (__main__.CheckCode) ... FAIL
test_b_full (__main__.E_TestTestScheduler) ... FAIL
test_save_timings (__main__.TestSaveTimings) ... FAIL
test_full_system (__main__.Z_FullSystemTest) ... FAIL
```

Fixes none

User interface changes?: none

Code review: none yet
