### PR TITLE
Sarich/eos config

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -79,7 +79,7 @@
     <batch_query args="-u $USER" >qselect</batch_query>
     <batch_submit>qsub </batch_submit>
     <batch_directive>#PBS</batch_directive>
-    <jobid_pattern>^(\d+)\.</jobid_pattern>
+    <jobid_pattern>^(\d+)</jobid_pattern>
     <depend_string> -W depend=afterok:jobid</depend_string>
     <walltime_format>%H:%M:%S</walltime_format>
     <submit_args>
@@ -164,10 +164,8 @@
 
     <!-- eos is PBS -->
     <batch_system MACH="eos" type="pbs" version="x.y">
-    <jobid_pattern>^(\d+)</jobid_pattern>
     <directives>
       <directive>-A {{ project }}</directive>
-      <directive>-l mppwidth={{ mppwidth }}</directive>
       <directive>-l  nodes={{ num_nodes }}</directive>
     </directives>
     <queues>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -1010,18 +1010,18 @@
          <DESC>ORNL XC30, os is CNL, 16 pes/node, batch system is PBS</DESC>
          <NODENAME_REGEX>eos</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
-         <COMPILERS>intel,cray,gnu</COMPILERS>
+         <COMPILERS>intel</COMPILERS>
          <MPILIBS>mpich,mpi-serial</MPILIBS>
-         <CESMSCRATCHROOT>$ENV{HOME}/acme_scratch/$PROJECT</CESMSCRATCHROOT>
-         <RUNDIR>$MEMBERWORK/$PROJECT/$CASE/run</RUNDIR>
+         <CESMSCRATCHROOT>$ENV{HOME}/acme_scratch/cli112</CESMSCRATCHROOT>
+         <RUNDIR>$MEMBERWORK/cli112/$CASE/run</RUNDIR>
          <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
          <DIN_LOC_ROOT>/lustre/atlas1/cli900/world-shared/cesm/inputdata</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-         <DOUT_S_ROOT>$MEMBERWORK/$PROJECT/archive/$CASE</DOUT_S_ROOT>
+         <DOUT_S_ROOT>$MEMBERWORK/cli112/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
          <CCSM_BASELINE>/lustre/atlas1/cli900/world-shared/cesm/baselines</CCSM_BASELINE>
          <CCSM_CPRNC>/lustre/atlas1/cli900/world-shared/cesm/tools/cprnc/cprnc.eos</CCSM_CPRNC>
-         <SAVE_TIMING_DIR>$ENV{PROJWORK}/$PROJECT</SAVE_TIMING_DIR>
+         <SAVE_TIMING_DIR>$ENV{PROJWORK}/cli112</SAVE_TIMING_DIR>
          <OS>CNL</OS>
          <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
          <SUPPORTED_BY>acme</SUPPORTED_BY>
@@ -1053,7 +1053,6 @@
 	   <cmd_path lang="csh">module</cmd_path>
 	   <cmd_path lang="perl">$MODULESHOME/bin/modulecmd perl</cmd_path>
 	   <cmd_path lang="python">$MODULESHOME/bin/modulecmd python</cmd_path>
-	   
 	   <modules>
 	     <command name="rm">intel</command>
 	     <command name="rm">cray</command>
@@ -1065,6 +1064,7 @@
 	   </modules>
 	   <modules compiler="intel">
 	     <command name="load">intel/16.0.1.150</command>
+	     <command name="load">papi</command>
 	   </modules>
 	   <modules compiler="cray">
 	     <command name="load">PrgEnv-cray</command>
@@ -1080,13 +1080,15 @@
 	     <command name="load">cray-netcdf/4.3.2</command>
 	   </modules>
 	   <modules milib="!mpi-serial">
-	     <command name="load">cray-netcdf-hdf5parallel/4.3.3.1</command>
-	     <command name="load">cray-parallel-netcdf/1.6.1</command>
+	     <!-- <command name="load">cray-netcdf-hdf5parallel/4.3.3.1</command>
+	     <command name="load">cray-parallel-netcdf/1.6.1</command> -->
+	     <command name="load">cray-netcdf-hdf5parallel</command>
+	     <command name="load">cray-parallel-netcdf</command>
 	   </modules>
 	   <modules>
 	     <command name="load">cmake/2.8.11.2</command>
 	   </modules>
-	   <environment_variables >
+	   <environment_variables>
 	     <env name="MPICH_ENV_DISPLAY">1</env>
 	     <env name="MPICH_VERSION_DISPLAY">1</env>
 	     <!-- This increases the stack size, which is necessary
@@ -1094,7 +1096,7 @@
 	     <env name="OMP_STACKSIZE">64M</env>
 	     
 	   </environment_variables>
-
+	 </module_system>
 </machine>
 
 <machine MACH="mustang">

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -1079,7 +1079,7 @@
 	   <modules mpilib="mpi-serial">
 	     <command name="load">cray-netcdf/4.3.2</command>
 	   </modules>
-	   <modules milib="!mpi-serial">
+	   <modules mpilib="!mpi-serial">
 	     <command name="load">cray-netcdf-hdf5parallel</command>
 	     <command name="load">cray-parallel-netcdf</command>
 	   </modules>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -1087,6 +1087,7 @@
 	   </modules>
 	   <modules>
 	     <command name="load">cmake/2.8.11.2</command>
+	     <command name="load">python/2.7.9</command>
 	   </modules>
 	   <environment_variables>
 	     <env name="MPICH_ENV_DISPLAY">1</env>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -1012,16 +1012,16 @@
          <TESTS>acme_developer</TESTS>
          <COMPILERS>intel</COMPILERS>
          <MPILIBS>mpich,mpi-serial</MPILIBS>
-         <CESMSCRATCHROOT>$ENV{HOME}/acme_scratch/cli112</CESMSCRATCHROOT>
-         <RUNDIR>$MEMBERWORK/cli112/$CASE/run</RUNDIR>
+         <CESMSCRATCHROOT>$ENV{HOME}/acme_scratch/$PROJECT</CESMSCRATCHROOT>
+         <RUNDIR>$MEMBERWORK/$PROJECT/$CASE/run</RUNDIR>
          <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
          <DIN_LOC_ROOT>/lustre/atlas1/cli900/world-shared/cesm/inputdata</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-         <DOUT_S_ROOT>$MEMBERWORK/cli112/archive/$CASE</DOUT_S_ROOT>
+         <DOUT_S_ROOT>$MEMBERWORK/$PROJECT/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
          <CCSM_BASELINE>/lustre/atlas1/cli900/world-shared/cesm/baselines</CCSM_BASELINE>
          <CCSM_CPRNC>/lustre/atlas1/cli900/world-shared/cesm/tools/cprnc/cprnc.eos</CCSM_CPRNC>
-         <SAVE_TIMING_DIR>$ENV{PROJWORK}/cli112</SAVE_TIMING_DIR>
+         <SAVE_TIMING_DIR>$ENV{PROJWORK}/$PROJECT</SAVE_TIMING_DIR>
          <OS>CNL</OS>
          <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
          <SUPPORTED_BY>acme</SUPPORTED_BY>
@@ -1080,8 +1080,8 @@
 	     <command name="load">cray-netcdf/4.3.2</command>
 	   </modules>
 	   <modules mpilib="!mpi-serial">
-	     <command name="load">cray-netcdf-hdf5parallel</command>
-	     <command name="load">cray-parallel-netcdf</command>
+	     <command name="load">cray-netcdf-hdf5parallel/4.3.3.1</command>
+	     <command name="load">cray-parallel-netcdf/1.6.1</command>
 	   </modules>
 	   <modules>
 	     <command name="load">cmake/2.8.11.2</command>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -1038,7 +1038,6 @@
              <arg name="num_tasks" > -n {{ num_tasks }}</arg>
              <arg name="tasks_per_node" > -N {{ tasks_per_node }}</arg>
              <arg name="thread_count" > -d {{ thread_count }}</arg>
-	     <arg name="debugging"> -D 7</arg>
              <arg name="numa_node" > -cc numa_node</arg>
            </arguments>
          </mpirun>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -1013,11 +1013,11 @@
          <COMPILERS>intel</COMPILERS>
          <MPILIBS>mpich,mpi-serial</MPILIBS>
          <CESMSCRATCHROOT>$ENV{HOME}/acme_scratch/$PROJECT</CESMSCRATCHROOT>
-         <RUNDIR>$MEMBERWORK/$PROJECT/$CASE/run</RUNDIR>
+         <RUNDIR>$ENV{MEMBERWORK}/$PROJECT/$CASE/run</RUNDIR>
          <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
          <DIN_LOC_ROOT>/lustre/atlas1/cli900/world-shared/cesm/inputdata</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-         <DOUT_S_ROOT>$MEMBERWORK/$PROJECT/archive/$CASE</DOUT_S_ROOT>
+         <DOUT_S_ROOT>$ENV{MEMBERWORK}/$PROJECT/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
          <CCSM_BASELINE>/lustre/atlas1/cli900/world-shared/cesm/baselines</CCSM_BASELINE>
          <CCSM_CPRNC>/lustre/atlas1/cli900/world-shared/cesm/tools/cprnc/cprnc.eos</CCSM_CPRNC>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -1038,7 +1038,8 @@
              <arg name="num_tasks" > -n {{ num_tasks }}</arg>
              <arg name="tasks_per_node" > -N {{ tasks_per_node }}</arg>
              <arg name="thread_count" > -d {{ thread_count }}</arg>
-             <arg name="numa_node" > -cc {{ numa_node }}</arg>
+	     <arg name="debugging"> -D 7</arg>
+             <arg name="numa_node" > -cc numa_node</arg>
            </arguments>
          </mpirun>
          <mpirun mpilib="mpi-serial">
@@ -1080,8 +1081,6 @@
 	     <command name="load">cray-netcdf/4.3.2</command>
 	   </modules>
 	   <modules milib="!mpi-serial">
-	     <!-- <command name="load">cray-netcdf-hdf5parallel/4.3.3.1</command>
-	     <command name="load">cray-parallel-netcdf/1.6.1</command> -->
 	     <command name="load">cray-netcdf-hdf5parallel</command>
 	     <command name="load">cray-parallel-netcdf</command>
 	   </modules>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -1010,7 +1010,7 @@
          <DESC>ORNL XC30, os is CNL, 16 pes/node, batch system is PBS</DESC>
          <NODENAME_REGEX>eos</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
-         <COMPILERS>intel</COMPILERS>
+         <COMPILERS>intel,cray,gnu</COMPILERS>
          <MPILIBS>mpich,mpi-serial</MPILIBS>
          <CESMSCRATCHROOT>$ENV{HOME}/acme_scratch/$PROJECT</CESMSCRATCHROOT>
          <RUNDIR>$MEMBERWORK/$PROJECT/$CASE/run</RUNDIR>
@@ -1044,6 +1044,57 @@
          <mpirun mpilib="mpi-serial">
            <executable></executable>
          </mpirun>
+	 <module_system type="module">
+	   <init_path lang="sh">$MODULESHOME/init/sh</init_path>
+	   <init_path lang="csh">$MODULESHOME/init/csh</init_path>
+	   <init_path lang="perl">$MODULESHOME/init/perl.pm</init_path>
+	   <init_path lang="python">$MODULESHOME/init/python.py</init_path>
+	   <cmd_path lang="sh">module</cmd_path>
+	   <cmd_path lang="csh">module</cmd_path>
+	   <cmd_path lang="perl">$MODULESHOME/bin/modulecmd perl</cmd_path>
+	   <cmd_path lang="python">$MODULESHOME/bin/modulecmd python</cmd_path>
+	   
+	   <modules>
+	     <command name="rm">intel</command>
+	     <command name="rm">cray</command>
+	     <command name="rm">cray-parallel-netcdf</command>
+	     <command name="rm">cray-libsci</command>
+	     <command name="rm">cray-netcdf</command>
+	     <command name="rm">cray-netcdf-hdf5parallel</command>
+	     <command name="rm">netcdf</command>
+	   </modules>
+	   <modules compiler="intel">
+	     <command name="load">intel/16.0.1.150</command>
+	   </modules>
+	   <modules compiler="cray">
+	     <command name="load">PrgEnv-cray</command>
+	     <command name="switch">cce cce/8.1.9</command>
+	     <command name="load">cray-libsci/12.1.00</command>
+	   </modules>
+	   <modules compiler="gnu">
+	     <command name="load">PrgEnv-gnu</command>
+	     <command name="switch">gcc gcc/4.8.0</command>
+	     <command name="load">cray-libsci/12.1.00</command>
+	   </modules>
+	   <modules mpilib="mpi-serial">
+	     <command name="load">cray-netcdf/4.3.2</command>
+	   </modules>
+	   <modules milib="!mpi-serial">
+	     <command name="load">cray-netcdf-hdf5parallel/4.3.3.1</command>
+	     <command name="load">cray-parallel-netcdf/1.6.1</command>
+	   </modules>
+	   <modules>
+	     <command name="load">cmake/2.8.11.2</command>
+	   </modules>
+	   <environment_variables >
+	     <env name="MPICH_ENV_DISPLAY">1</env>
+	     <env name="MPICH_VERSION_DISPLAY">1</env>
+	     <!-- This increases the stack size, which is necessary
+		  for CICE to run threaded on this machine -->
+	     <env name="OMP_STACKSIZE">64M</env>
+	     
+	   </environment_variables>
+
 </machine>
 
 <machine MACH="mustang">


### PR DESCRIPTION
initial configuration xml setup for eos.ccs.ornl.gov


Test suite: Passes cime_developer tests except for 
`SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A.eos_intel.20160816_191851`
```
/autofs/nccs-svm1_proj/cli112/sarich/cime/externals/pio1/pio/piolib_mod.F90(1566): error #6404: This nam\
e does not have a type, and must have an explicit type.   [MPI_ORDER_FORTRAN]
            mpi_order_fortran,mpidatatype, iodesc2%filetype, ierr)
------------^

```

That code is recent, from commit b874c8a886f06e3532d4f5ca41303bde6c4222b3

Guessing CIME_MODEL=acme, set environment variable if this is incorrect
ERI.f45_g37.X.eos_intel (Overall: PASS), details:
  PASS CREATE_NEWCASE
  PASS XML
  PASS SETUP
  PASS SHAREDLIB_BUILD
  PASS MODEL_BUILD
  PASS RUN
  PASS COMPARE_base_hybrid
  PASS COMPARE_base_rest
  PASS MEMLEAK
ERR_Ld3.f45_g37_rx1.A.eos_intel (Overall: PASS), details:
  PASS CREATE_NEWCASE
  PASS XML
  PASS SETUP
  PASS SHAREDLIB_BUILD
  PASS MODEL_BUILD
  PASS RUN
  PASS MEMLEAK
  PASS COMPARE_base_rest
ERS_Ld3.ne30_g16_rx1.A.eos_intel (Overall: PASS), details:
  PASS CREATE_NEWCASE
  PASS XML
  PASS SETUP
  PASS SHAREDLIB_BUILD
  PASS MODEL_BUILD
ERS_N2_Ld3.f19_g16_rx1.A.eos_intel (Overall: PASS), details:
  PASS CREATE_NEWCASE
  PASS XML
  PASS SETUP
  PASS SHAREDLIB_BUILD
  PASS MODEL_BUILD
  PASS RUN
  PASS COMPARE_base_rest
  PASS MEMLEAK
NCK_Ld3.f45_g37_rx1.A.eos_intel (Overall: PASS), details:
  PASS CREATE_NEWCASE
  PASS XML
  PASS SETUP
  PASS SHAREDLIB_BUILD
  PASS MODEL_BUILD
  PASS RUN
  PASS COMPARE_base_multiinst
  PASS MEMLEAK
SEQ_Ln9.f19_g16_rx1.A.eos_intel (Overall: PASS), details:
  PASS CREATE_NEWCASE
  PASS XML
  PASS SETUP
  PASS SHAREDLIB_BUILD
  PASS MODEL_BUILD
  PASS RUN
  PASS COMPARE_base_seq
  PASS MEMLEAK
SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A.eos_intel (Overall: FAIL), details:
  PASS CREATE_NEWCASE
  PASS XML
  PASS SETUP
  FAIL SHAREDLIB_BUILD

Closes #282

Code review: