### PR TITLE
Introducing quotes around timing event names

### DIFF
--- a/scripts/Tools/getTiming
+++ b/scripts/Tools/getTiming
@@ -212,7 +212,7 @@ class TimingParser:
         else:
             logger.warning("Unknown NCPL_BASE_PERIOD=%s" % ncpl_base_period)
 
-        nprocs, ncount = self.gettime2('CPL:CLOCK_ADVANCE ')
+        nprocs, ncount = self.gettime2('"CPL:CLOCK_ADVANCE" ')
         nsteps = ncount / nprocs
         adays = nsteps*tlen/atm_ncpl
         odays = adays
@@ -269,24 +269,24 @@ class TimingParser:
                        % (m.name.lower(), m.comp, m.ntasks, m.rootpe,
                           m.ntasks, m.nthrds, m.ninst, m.pstrid))
 
-        nmin, nmax, found = self.gettime(' CPL:INIT ')
-        tmin, tmax, found = self.gettime(' CPL:RUN_LOOP ')
-        wtmin, wtmax, found = self.gettime(' CPL:TPROF_WRITE ')
-        fmin, fmax, found = self.gettime(' CPL:FINAL ')
+        nmin, nmax, found = self.gettime(' "CPL:INIT" ')
+        tmin, tmax, found = self.gettime(' "CPL:RUN_LOOP" ')
+        wtmin, wtmax, found = self.gettime(' "CPL:TPROF_WRITE" ')
+        fmin, fmax, found = self.gettime(' "CPL:FINAL" ')
         for k in components:
             if k != "CPL":
                 m = self.models[k]
-            m.tmin, m.tmax, found = self.gettime(' CPL:%s_RUN ' %  m.name)
-        otmin, otmax, found = self.gettime(' CPL:OCNT_RUN ')
+            m.tmin, m.tmax, found = self.gettime(' "CPL:%s_RUN" ' %  m.name)
+        otmin, otmax, found = self.gettime(' "CPL:OCNT_RUN" ')
 
         # pick OCNT_RUN for tight coupling
         if otmax > ocn.tmax:
             ocn.tmin = otmin
             ocn.tmax = otmax
 
-        cpl.tmin, cpl.tmax, found = self.gettime(' CPL:RUN ')
-        xmin, xmax, found = self.gettime(' CPL:COMM ')
-        ocnwaittime, ignore, found = self.gettime(' CPL:C2O_INITWAIT')
+        cpl.tmin, cpl.tmax, found = self.gettime(' "CPL:RUN" ')
+        xmin, xmax, found = self.gettime(' "CPL:COMM" ')
+        ocnwaittime, ignore, found = self.gettime(' "CPL:C2O_INITWAIT"')
 
         if odays != 0:
             ocnrunitime = ocn.tmax * (adays/odays - 1.0)

--- a/share/timing/ChangeLog
+++ b/share/timing/ChangeLog
@@ -1,3 +1,6 @@
+timing_160816: Added quotes to timing event names in t_startf and t_stopf
+               before calling GPTL routines.
+               [Patrick Worley, at request of Sean Patrick Santos]
 timing_160320: Added routines t_set_prefixf and t_unset_prefixf.
                Setting the prefix adds this to the beginning of all subsequent 
                timer event names (defined in t_startf/t_stopf).

--- a/share/timing/perf_mod.F90
+++ b/share/timing/perf_mod.F90
@@ -742,21 +742,23 @@ contains
 
       write(cdetail,'(i2.2)') cur_timing_detail
       if (prefix_len > 0) then
-         str_length = min(SHR_KIND_CM-prefix_len-3,len_trim(event))
+         str_length = min(SHR_KIND_CM-prefix_len-5,len_trim(event))
          ierr = GPTLstart( &
-            cdetail//"_"//event_prefix(1:prefix_len)//event(1:str_length))
+          '"'//cdetail//'_'//event_prefix(1:prefix_len)//event(1:str_length)//'"')
       else
-         str_length = min(SHR_KIND_CM-3,len_trim(event))
-         ierr = GPTLstart(cdetail//"_"//event(1:str_length))
+         str_length = min(SHR_KIND_CM-5,len_trim(event))
+         ierr = GPTLstart('"'//cdetail//'_'//event(1:str_length)//'"')
       endif
 
    else
 
       if (prefix_len > 0) then
-         str_length = min(SHR_KIND_CM-prefix_len,len_trim(event))
-         ierr = GPTLstart(event_prefix(1:prefix_len)//event(1:str_length))
+         str_length = min(SHR_KIND_CM-prefix_len-2,len_trim(event))
+         ierr = GPTLstart( &
+          '"'//event_prefix(1:prefix_len)//event(1:str_length)//'"')
       else
-         ierr = GPTLstart(trim(event))
+         str_length = min(SHR_KIND_CM-2,len_trim(event))
+         ierr = GPTLstart('"'//event(1:str_length)//'"')
       endif
 
 !pw   if ( present (handle) ) then
@@ -790,8 +792,7 @@ contains
 !---------------------------Local workspace-----------------------------
 !
    integer  ierr                          ! GPTL error return
-   integer  str_length, i                 ! support for adding
-                                          !  detail prefix
+   integer  str_length, i                 ! support for adding prefix
    character(len=2) cdetail               ! char variable for detail
 !
 !-----------------------------------------------------------------------
@@ -803,21 +804,23 @@ contains
 
       write(cdetail,'(i2.2)') cur_timing_detail
       if (prefix_len > 0) then
-         str_length = min(SHR_KIND_CM-prefix_len-3,len_trim(event))
+         str_length = min(SHR_KIND_CM-prefix_len-5,len_trim(event))
          ierr = GPTLstop( &
-           cdetail//"_"//event_prefix(1:prefix_len)//event(1:str_length))
+          '"'//cdetail//'_'//event_prefix(1:prefix_len)//event(1:str_length)//'"')
       else
-         str_length = min(SHR_KIND_CM-3,len_trim(event))
-         ierr = GPTLstop(cdetail//"_"//event(1:str_length))
+         str_length = min(SHR_KIND_CM-5,len_trim(event))
+         ierr = GPTLstop('"'//cdetail//'_'//event(1:str_length)//'"')
       endif
 
    else
 
       if (prefix_len > 0) then
-         str_length = min(SHR_KIND_CM-prefix_len,len_trim(event))
-         ierr = GPTLstop(event_prefix(1:prefix_len)//event(1:str_length))
+         str_length = min(SHR_KIND_CM-prefix_len-2,len_trim(event))
+         ierr = GPTLstop( &
+          '"'//event_prefix(1:prefix_len)//event(1:str_length)//'"')
      else
-         ierr = GPTLstop(trim(event))
+         str_length = min(SHR_KIND_CM-2,len_trim(event))
+         ierr = GPTLstop('"'//event(1:str_length)//'"')
      endif
 
 !pw   if ( present (handle) ) then


### PR DESCRIPTION
As it is legal for white spaces to appear in timing event names, but
parsing the timing data is complicated by this, modified t_startf and
t_stopf in perf_mod.F90 to prepend and append double quotes to each
timing event name.

The getTiming script looks for particular timing events in order to
calculate the performance summary. These event names now are quoted,
and the script was modified to look for the modified names.


Test suite: none yet
Test baseline: none yet
Test namelist changes: none
Test status: bit for bit (but changes format of timing files)

Connects to #2

User interface changes?: 

Code review: