### PR TITLE
Pea test fix

### DIFF
--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -348,9 +348,12 @@ LII    CLM initial condition interpolation test
   <test NAME="PEA">
     <DESC>single pe bfb test (default length)</DESC>
     <INFO_DBUG>1</INFO_DBUG>
-    <REST_OPTION>never</REST_OPTION>
     <CCSM_TCOST>1</CCSM_TCOST>
     <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>never</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
   </test>
 
   <test NAME="PEM">

--- a/utils/python/CIME/SystemTests/pea.py
+++ b/utils/python/CIME/SystemTests/pea.py
@@ -1,101 +1,39 @@
 """
-Implementation of the CIME PEA test.  This class inherits from SystemTestsCommon
+Implementation of the CIME PEA test.
+
+Verifies that interpolation of initial conditions onto an identical
+configuration gives identical results:
+Builds runs and compares a single processor mpi model to a model built using mpi-serial
+(1) do a run with default mpi library (suffix base)
+(2) do a run with mpi-serial (suffix mpi-serial)
 """
-import shutil
+
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.XML.standard_module_setup import *
 from CIME.case_setup import case_setup
-import CIME.utils
-from CIME.SystemTests.system_tests_common import SystemTestsCommon
 
 logger = logging.getLogger(__name__)
 
-class PEA(SystemTestsCommon):
+class PEA(SystemTestsCompareTwo):
 
     def __init__(self, case):
-        """
-        initialize a test object
-        """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCompareTwo.__init__(self, case,
+                                       separate_builds = True,
+                                       run_two_suffix = 'mpi-serial',
+                                       run_one_description = 'default mpi library',
+                                       run_two_description = 'mpi-serial')
 
-    def build_phase(self, sharedlib_only=False, model_only=False):
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = CIME.utils.get_model()
-
-        # first set all component mpi tasks to 1
-        for comp in ['ATM','CPL','OCN','WAV','GLC','ICE','ROF','LND']:
+    def _common_setup(self):
+        for comp in self._case.get_value("COMP_CLASSES").split(','):
+            if comp == "DRV":
+                comp = "CPL"
             self._case.set_value("NTASKS_%s"%comp, 1)
+            self._case.set_value("NTHRDS_%s"%comp, 1)
+            self._case.set_value("ROOTPE_%s"%comp, 0)
 
-        build1 = os.path.join("LockedFiles","env_build.PEA1.xml")
-        if ( os.path.isfile(build1) ):
-            shutil.copy(build1,"env_build.xml")
-
-        mpilib = self._case.get_value("MPILIB")
-        for mpilib in [mpilib, "mpi-serial"]:
-            logging.warn("Starting bld for %s"%mpilib)
-            self._case.set_value("MPILIB",mpilib)
-            self._case.flush()
-            # We need to explicitly remove the Macros file for this test
-            if  os.path.isfile("Macros"):
-                os.remove("Macros")
-            case_setup(self._case, reset=True)
-            self.clean_build()
-            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-            if (not sharedlib_only):
-                shutil.move("%s/%s.exe"%(exeroot,cime_model),
-                            "%s/%s.exe.PEA_%s"%(exeroot,cime_model,mpilib))
-            shutil.copy("env_build.xml",os.path.join("LockedFiles",
-                                                     "env_build_PEA_%s.xml"%mpilib))
-
-    def _pea_first_phase(self):
-
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = CIME.utils.get_model()
-        exefile  = "%s/%s.exe"%(exeroot,cime_model)
-        exefile1 = "%s/%s.exe.PEA1"%(exeroot,cime_model)
-        if (os.path.isfile(exefile)):
-            os.remove(exefile)
-        shutil.copy(exefile1, exefile)
-
-        self._case.set_value("CONTINUE_RUN",False)
-        self._case.set_value("REST_OPTION","none")
-        self._case.set_value("HIST_OPTION","$STOP_OPTION")
-        self._case.set_value("HIST_N","$STOP_N")
-        self._case.flush()
-
-        stop_n = self._case.get_value("STOP_N")
-        stop_option = self._case.get_value("STOP_OPTION")
-        logger.info("doing an %d %s initial test with 1pe and mpi, no restarts written"
-                    % (stop_n, stop_option))
-
-        self.run_indv()
-
-    def _pea_second_phase(self):
-
-        expect(os.path.isfile("env_mach_pes.xml.2"),
-               "ERROR: env_mach_pes.xml.2 does not exist, run case.build" )
-
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = CIME.utils.get_model()
-        exefile  = "%s/%s.exe"%(exeroot,cime_model)
-        exefile2 = "%s/%s.exe.PEA2"%(exeroot,cime_model)
-        if (os.path.isfile(exefile)):
-            os.remove(exefile)
-        shutil.copy(exefile2, exefile)
-
-        self._case.set_value("CONTINUE_RUN",False)
-        self._case.set_value("REST_OPTION","none")
-        self._case.set_value("HIST_OPTION","$STOP_OPTION")
-        self._case.set_value("HIST_N","$STOP_N")
-        self._case.flush()
-
-        stop_n = self._case.get_value("STOP_N")
-        stop_option = self._case.get_value("STOP_OPTION")
-        logger.info("doing an %d %s initial test with 1pe and serial mpi, no restarts written"
-                    % (stop_n, stop_option))
-
-        self.run_indv(suffix="mpiserial")
-        self._component_compare_test("base", "mpiserial")
-
-    def run_phase(self):
-        self._pea_first_phase()
-        self._pea_second_phase()
+    def _case_one_setup(self):
+        pass
+    def _case_two_setup(self):
+        self._case.set_value("MPILIB","mpi-serial")
+        os.remove("Macros")
+        case_setup(self._case, reset=True, test_mode=True)

--- a/utils/python/CIME/SystemTests/pea.py
+++ b/utils/python/CIME/SystemTests/pea.py
@@ -33,5 +33,6 @@ class PEA(SystemTestsCompareTwo):
         pass
     def _case_two_setup(self):
         self._case.set_value("MPILIB","mpi-serial")
-        os.remove("Macros")
+        if os.path.isfile("Macros"):
+            os.remove("Macros")
         case_setup(self._case, reset=True, test_mode=True)

--- a/utils/python/CIME/SystemTests/pea.py
+++ b/utils/python/CIME/SystemTests/pea.py
@@ -35,7 +35,8 @@ class PEA(SystemTestsCommon):
             self._case.set_value("MPILIB",mpilib)
             self._case.flush()
             # We need to explicitly remove the Macros file for this test
-            os.remove("Macros")
+            if  os.path.isfile("Macros"):
+                os.remove("Macros")
             case_setup(self._case, reset=True)
             self.clean_build()
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)

--- a/utils/python/CIME/SystemTests/pea.py
+++ b/utils/python/CIME/SystemTests/pea.py
@@ -1,8 +1,6 @@
 """
 Implementation of the CIME PEA test.
 
-Verifies that interpolation of initial conditions onto an identical
-configuration gives identical results:
 Builds runs and compares a single processor mpi model to a model built using mpi-serial
 (1) do a run with default mpi library (suffix base)
 (2) do a run with mpi-serial (suffix mpi-serial)

--- a/utils/python/CIME/SystemTests/system_tests_compare_two.py
+++ b/utils/python/CIME/SystemTests/system_tests_compare_two.py
@@ -21,8 +21,6 @@ In addition, they MAY require the following method:
     that's needed in both cases. This is called before _case_one_setup or
     _case_two_setup.
 
-NOTE: Currently assumes that only one build is needed - i.e., there are no
-build-time settings that need to be changed between the two cases.
 """
 
 from CIME.XML.standard_module_setup import *
@@ -145,11 +143,6 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
     def build_phase(self, sharedlib_only=False, model_only=False):
-        # TODO(wjs, 2016-08-05) This currently assumes that the two cases use
-        # the same build. Once we relax that assumption, we'll need a
-        # conditional here: If the two cases use the same build (based on
-        # self._separate_builds), then use the below logic; otherwise, do two
-        # builds.
         if self._separate_builds:
             self._case_one_build(sharedlib_only, model_only)
             self._case_two_build(sharedlib_only, model_only)

--- a/utils/python/CIME/SystemTests/system_tests_compare_two.py
+++ b/utils/python/CIME/SystemTests/system_tests_compare_two.py
@@ -21,14 +21,6 @@ In addition, they MAY require the following method:
     that's needed in both cases. This is called before _case_one_setup or
     _case_two_setup.
 
-(2) _case_one_build
-    This method will be called to build case one when separate_builds is True
-
-(2) _case_two_build
-    This method will be called to build case two when separate_builds is True
-
-
-
 """
 
 from CIME.XML.standard_module_setup import *
@@ -142,18 +134,13 @@ class SystemTestsCompareTwo(SystemTestsCommon):
     # ========================================================================
     # Main public methods
     # ========================================================================
-    def _case_one_build(self, sharedlib_only=False, model_only=False):
-        self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-
-    def _case_two_build(self, sharedlib_only=False, model_only=False):
-        self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
     def build_phase(self, sharedlib_only=False, model_only=False):
         if self._separate_builds:
             self._activate_case1()
-            self._case_one_build(sharedlib_only, model_only)
+            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
             self._activate_case2()
-            self._case_two_build(sharedlib_only, model_only)
+            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
         else:
             self._activate_case1()
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)

--- a/utils/python/CIME/SystemTests/system_tests_compare_two.py
+++ b/utils/python/CIME/SystemTests/system_tests_compare_two.py
@@ -21,6 +21,14 @@ In addition, they MAY require the following method:
     that's needed in both cases. This is called before _case_one_setup or
     _case_two_setup.
 
+(2) _case_one_build
+    This method will be called to build case one when separate_builds is True
+
+(2) _case_two_build
+    This method will be called to build case two when separate_builds is True
+
+
+
 """
 
 from CIME.XML.standard_module_setup import *
@@ -135,16 +143,16 @@ class SystemTestsCompareTwo(SystemTestsCommon):
     # Main public methods
     # ========================================================================
     def _case_one_build(self, sharedlib_only=False, model_only=False):
-        self._activate_case1()
         self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
     def _case_two_build(self, sharedlib_only=False, model_only=False):
-        self._activate_case2()
         self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
     def build_phase(self, sharedlib_only=False, model_only=False):
         if self._separate_builds:
+            self._activate_case1()
             self._case_one_build(sharedlib_only, model_only)
+            self._activate_case2()
             self._case_two_build(sharedlib_only, model_only)
         else:
             self._activate_case1()

--- a/utils/python/CIME/buildnml.py
+++ b/utils/python/CIME/buildnml.py
@@ -154,7 +154,7 @@ def _build_data_nml(case, caseroot, compclass):
 
         rc, out, err = run_cmd(cmd, from_dir=confdir)
         expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
-        if out is not None:
+        if out is not None and len(out) > 0:
             logger.debug("cmd=%s"%cmd)
             logger.info("out = %s"%out)
         # copy namelist files and stream text files, to rundir

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -71,11 +71,12 @@ def preview_namelists(case, dryrun=False):
         logger.info("Running %s:"%cmd)
         if (logger.level == logging.DEBUG):
             rc, out, err = run_cmd("PREVIEW_NML=1 %s %s" % (cmd, caseroot))
-            expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))      
+            expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
         else:
             rc, out, err = run_cmd("%s %s" % (cmd, caseroot))
             expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
-        logger.info("     %s"%out)
+        if out is not None:
+            logger.info("     %s"%out)
     # refresh case xml object from file
     case.read_xml()
     # Save namelists to docdir


### PR DESCRIPTION
Rewrite of the pea test to use the system_tests_compare_two framework.  This includes extending that framework to do two build. 
Test suite: scripts_regression_tests , PEA_P1_Ld3.f45_g37_rx1.A.yellowstone_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #423 

User interface changes?: 

Code review: 
