### PR TITLE
Prevent infinite recursion in `Case`.

### DIFF
--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -259,7 +259,9 @@ class Case(object):
             else:
                 item = self.get_resolved_value(item,recurse=recurse+1)
 
-        if(recurse >= recurse_limit):
+        if recurse >= 2*recurse_limit:
+            logging.warning("Not able to fully resolve item '%s'" % item)
+        elif recurse >= recurse_limit:
             #try env_batch first
             env_batch = self.get_env("batch")
             item = env_batch.get_resolved_value(item)


### PR DESCRIPTION
This commit prevents `Case.get_resolved_value` from getting stuck in an
infinitely recursive loop.

Passes `scripts_regression_tests` (except for some pre-existing broken
tests due to `pylint` issues).