### PR TITLE
Fix problems discovered by pylint / code_checker

### DIFF
--- a/utils/python/CIME/SystemTests/test_utils/user_nl_utils.py
+++ b/utils/python/CIME/SystemTests/test_utils/user_nl_utils.py
@@ -2,7 +2,6 @@
 This module contains functions for working with user_nl files in system tests.
 """
 
-import shutil
 import os
 import glob
 

--- a/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -4,6 +4,11 @@
 This module contains unit tests of the core logic in SystemTestsCompareTwo.
 """
 
+# Ignore privacy concerns for unit tests, so that unit tests can access
+# protected members of the system under test
+#
+# pylint:disable=protected-access
+
 import unittest
 from collections import namedtuple
 import os
@@ -18,19 +23,17 @@ from CIME.tests.case_fake import CaseFake
 # Structure for storing information about calls made to methods
 # ========================================================================
 
-"""
-You can create a Call object to record a single call made to a method:
-
-Call(method, arguments)
-    method (str): name of method
-    arguments (dict): dictionary mapping argument names to values
-
-Example:
-    If you want to record a call to foo(bar = 1, baz = 2):
-        somecall = Call(method = 'foo', arguments = {'bar': 1, 'baz': 2})
-    Or simply:
-        somecall = Call('foo', {'bar': 1, 'baz': 2})
-"""
+# You can create a Call object to record a single call made to a method:
+#
+# Call(method, arguments)
+#     method (str): name of method
+#     arguments (dict): dictionary mapping argument names to values
+#
+# Example:
+#     If you want to record a call to foo(bar = 1, baz = 2):
+#         somecall = Call(method = 'foo', arguments = {'bar': 1, 'baz': 2})
+#     Or simply:
+#         somecall = Call('foo', {'bar': 1, 'baz': 2})
 Call = namedtuple('Call', ['method', 'arguments'])
 
 # ========================================================================
@@ -135,7 +138,7 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
     # SystemTestsCommon
     # ------------------------------------------------------------------------
 
-    def run_indv(self, suffix="base"):
+    def run_indv(self, suffix="base", coupler_log_path=None, st_archive=False):
         """
         This fake implementation appends to the log and raises an exception if
         it's supposed to
@@ -295,9 +298,9 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
 
         # Exercise
         with self.assertRaises(Exception):
-            mytest = SystemTestsCompareTwoFake(case1,
-                                               run_two_suffix = 'test',
-                                               case2setup_raises_exception = True)
+            SystemTestsCompareTwoFake(case1,
+                                      run_two_suffix = 'test',
+                                      case2setup_raises_exception = True)
 
         # Verify
         self.assertFalse(os.path.exists(os.path.join(case1root, 'case1.test')))

--- a/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two_link_to_case2_output.py
+++ b/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two_link_to_case2_output.py
@@ -5,6 +5,11 @@ This module contains unit tests of the method
 SystemTestsCompareTwo._link_to_case2_output
 """
 
+# Ignore privacy concerns for unit tests, so that unit tests can access
+# protected members of the system under test
+#
+# pylint:disable=protected-access
+
 import unittest
 import os
 import shutil
@@ -132,7 +137,7 @@ class TestLinkToCase2Output(unittest.TestCase):
         run2_suffix = 'run2'
 
         mytest = self.setup_test_and_directories(casename1, run2_suffix)
-        filepath1 = self.create_file_in_rundir2(mytest, 'clm2.h0', run2_suffix)
+        self.create_file_in_rundir2(mytest, 'clm2.h0', run2_suffix)
 
         # Create initial link via a call to _link_to_case2_output
         mytest._link_to_case2_output()

--- a/utils/python/CIME/tests/SystemTests/test_utils/test_user_nl_utils.py
+++ b/utils/python/CIME/tests/SystemTests/test_utils/test_user_nl_utils.py
@@ -105,7 +105,7 @@ class TestUserNLCopier(unittest.TestCase):
 
         # Setup
         # Create file in caseroot for component_exists, but not for component_for_append
-        filename = self.write_user_nl_file(component_exists, 'irrelevant contents')
+        self.write_user_nl_file(component_exists, 'irrelevant contents')
 
         # Exercise & verify
         self.assertRaisesRegexp(RuntimeError, "No user_nl files found",

--- a/utils/python/CIME/tests/case_fake.py
+++ b/utils/python/CIME/tests/case_fake.py
@@ -22,7 +22,7 @@ class CaseFake(object):
         casename = os.path.basename(case_root)
         self.set_value('CASE', casename)
         self.set_value('CASEBASEID', casename)
-        self._set_rundir()
+        self.set_rundir()
 
     def get_value(self, item):
         """
@@ -58,11 +58,15 @@ class CaseFake(object):
         newcase.set_value('CASE', newcasename)
         newcase.set_value('CASEBASEID', newcasename)
         newcase.set_value('CASEROOT', newcaseroot)
-        newcase._set_rundir()
+        newcase.set_rundir()
 
         return newcase
 
     def create_clone(self, newcase, keepexe=False):
+        # Need to disable unused-argument checking: keepexe is needed to match
+        # the interface of Case, but is not used in this fake implementation
+        #
+        # pylint: disable=unused-argument
         """
         Create a clone of the current case. Also creates the CASEROOT directory
         for the clone case (given by newcase).
@@ -90,7 +94,7 @@ class CaseFake(object):
         """
         os.makedirs(self.get_value('RUNDIR'))
 
-    def _set_rundir(self):
+    def set_rundir(self):
         """
         Assumes CASEROOT is already set; sets an appropriate RUNDIR (nested
         inside CASEROOT)


### PR DESCRIPTION
Apparently my recently-added code was full of lint.

This PR gets the B_CheckCode test to pass

Test suite: 
    scripts_regression_tests.py A_RunUnitTests
    scripts_regression_tests.py B_CheckCode
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

This testing seemed sufficient since, other than removing one unnecessary 'import' statement, all changes were restricted to unit tests.

Fixes none

User interface changes?: no

Code review: none yet