### PR TITLE
Remove unused argument from run_indv

### DIFF
--- a/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -138,7 +138,7 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
     # SystemTestsCommon
     # ------------------------------------------------------------------------
 
-    def run_indv(self, suffix="base", coupler_log_path=None, st_archive=False):
+    def run_indv(self, suffix="base", st_archive=False):
         """
         This fake implementation appends to the log and raises an exception if
         it's supposed to


### PR DESCRIPTION
Fixes last remaining pylint-flagged mistake in this file.

Test suite: None
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: No

Code review: @billsacks 

