### PR TITLE
 Changed jobid_pattern in config_batch,xml

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -79,7 +79,7 @@
     <batch_query args="-u $USER" >qselect</batch_query>
     <batch_submit>qsub </batch_submit>
     <batch_directive>#PBS</batch_directive>
-    <jobid_pattern>^(\d+)\.</jobid_pattern>
+    <jobid_pattern>^(\d+)</jobid_pattern>
     <depend_string> -W depend=afterok:jobid</depend_string>
     <walltime_format>%H:%M:%S</walltime_format>
     <submit_args>
@@ -321,7 +321,9 @@
    </batch_system>
 
    <batch_system MACH="titan" type="pbs" version="x.y">
-     <jobid_pattern>(\d+)</jobid_pattern>
+     <!-- needs to be unique, already in general pbs section: 
+	  <jobid_pattern>(\d+)</jobid_pattern>
+	  -->
      <directives>
        <directive>-A {{ project }}</directive>
        <directive>-l nodes={{ num_nodes }}</directive>


### PR DESCRIPTION
XML attribute jobid_patern was not unique. It occurred in 
- \<batch_system type="pbs" version="x.y"\>
- \<batch_system MACH="titan" type="pbs" version="x.y"\>

It has to be unique. Removed from titan section and made pattern less specific in pbs section.



Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #431
User interface changes?: 

Code review: 

…obid_pattern in Titan section