### PR TITLE
check for pylint version

### DIFF
--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1088,6 +1088,15 @@ class B_CheckCode(unittest.TestCase):
     ###########################################################################
     def test_check_code(self):
     ###########################################################################
+        from distutils.spawn import find_executable
+        pylint = find_executable("pylint")
+        if pylint is not None:
+            stat, output, _ = run_cmd("pylint --version")
+            pylintver = re.search(r"pylint\s+(\d+)\.(\d+).(\d+)", output)
+            major = pylintver.group(1)
+            minor = pylintver.group(2)
+        if pylint is None or (major <= 1 and minor <= 5):
+            self.skipTest("pylint version 1.5 or newer not found")
         stat, output, _ = run_cmd(os.path.join(TOOLS_DIR, "code_checker -d 2>&1"))
         self.assertEqual(stat, 0, msg=output)
 

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1093,12 +1093,13 @@ class B_CheckCode(unittest.TestCase):
         if pylint is not None:
             stat, output, _ = run_cmd("pylint --version")
             pylintver = re.search(r"pylint\s+(\d+)\.(\d+).(\d+)", output)
-            major = pylintver.group(1)
-            minor = pylintver.group(2)
-        if pylint is None or (major <= 1 and minor <= 5):
+            major = int(pylintver.group(1))
+            minor = int(pylintver.group(2))
+        if pylint is None or (major <= 1 and minor < 5):
             self.skipTest("pylint version 1.5 or newer not found")
-        stat, output, _ = run_cmd(os.path.join(TOOLS_DIR, "code_checker -d 2>&1"))
-        self.assertEqual(stat, 0, msg=output)
+        else:
+            stat, output, _ = run_cmd(os.path.join(TOOLS_DIR, "code_checker -d 2>&1"))
+            self.assertEqual(stat, 0, msg=output)
 
 # Machinery for Macros generation tests.
 


### PR DESCRIPTION
Skip the CheckCode test if pylint is not found or version is < 1.5 

Test suite: scripts_regression_tests on machines with pylint < 1.5 and > 1.5
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?:  

Code review: 

