### PR TITLE
refuse to overwrite existing baseline directory in cesm workflow

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -170,6 +170,10 @@ OR
     parser.add_argument("--testfile",
                         help="A file containing an ascii list of tests to run")
 
+    parser.add_argument("--allow-baseline-overwrite", action="store_true",
+                        help="If the generate baseline option is specified with a baseline directory option "
+                        "existing tests in that directory will not be overwritten unless this flag is provided.")
+
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
@@ -228,7 +232,7 @@ OR
         args.test_root, args.baseline_root, args.clean, args.compare, args.generate, \
         args.baseline_name, args.namelists_only, args.project, args.test_id, args.parallel_jobs, \
         args.xml_machine, args.xml_compiler, args.xml_category, args.xml_testlist, args.walltime, \
-        args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue
+        args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue, args.allow_baseline_overwrite
 
 ###############################################################################
 def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost_map, wall_time, test_root):
@@ -334,7 +338,7 @@ def create_test(testargs, compiler, machine_name, no_run, no_build, no_setup, no
                 baseline_root, clean, compare, generate,
                 baseline_name, namelists_only, project, test_id, parallel_jobs,
                 xml_machine, xml_compiler, xml_category, xml_testlist, walltime,
-                single_submit, proc_pool, use_existing, save_timing, queue):
+                single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite):
 ###############################################################################
     if testargs and machine_name is None and compiler is None:
         for test in testargs:
@@ -356,7 +360,7 @@ def create_test(testargs, compiler, machine_name, no_run, no_build, no_setup, no
                       xml_machine=xml_machine, xml_compiler=xml_compiler,
                       xml_category=xml_category, xml_testlist=xml_testlist, walltime=walltime,
                       proc_pool=proc_pool, use_existing=use_existing, save_timing=save_timing,
-                      queue=queue)
+                      queue=queue, allow_baseline_overwrite=allow_baseline_overwrite)
 
     success = impl.run_tests()
 
@@ -395,13 +399,14 @@ def _main_func(description):
     testargs, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root, baseline_root, clean, \
         compare, generate, baseline_name, namelists_only, project, test_id, parallel_jobs, \
         xml_machine, xml_compiler, xml_category, xml_testlist, walltime, single_submit, proc_pool, \
-        use_existing, save_timing, queue \
+        use_existing, save_timing, queue, allow_baseline_overwrite \
         = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(testargs, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                          baseline_root, clean, compare, generate, baseline_name, namelists_only,
                          project, test_id, parallel_jobs, xml_machine, xml_compiler, xml_category,
-                         xml_testlist, walltime, single_submit, proc_pool, use_existing, save_timing, queue))
+                         xml_testlist, walltime, single_submit, proc_pool, use_existing, save_timing,
+                         queue, allow_baseline_overwrite))
 
 ###############################################################################
 

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -170,7 +170,7 @@ OR
     parser.add_argument("--testfile",
                         help="A file containing an ascii list of tests to run")
 
-    parser.add_argument("--allow-baseline-overwrite", action="store_true",
+    parser.add_argument("-o", "--allow-baseline-overwrite", action="store_true",
                         help="If the generate baseline option is specified with a baseline directory option "
                         "existing tests in that directory will not be overwritten unless this flag is provided.")
 

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -44,7 +44,7 @@ class TestScheduler(object):
                  project=None, parallel_jobs=None,
                  xml_machine=None, xml_compiler=None, xml_category=None,
                  xml_testlist=None, walltime=None, proc_pool=None,
-                 use_existing=False, save_timing=False, queue=None):
+                 use_existing=False, save_timing=False, queue=None, allow_baseline_overwrite=False):
     ###########################################################################
         self._cime_root  = CIME.utils.get_cime_root()
         self._cime_model = CIME.utils.get_model()
@@ -148,7 +148,7 @@ class TestScheduler(object):
                 if generate is not None and isinstance(generate, str):
                     self._baseline_gen_name = generate
                     self._generate = True
-                    self._overwrite_baselines = False
+                    self._overwrite_baselines = allow_baseline_overwrite
                 if self._compare and self._baseline_cmp_name is None:
                     branch_name = CIME.utils.get_current_branch(repo=self._cime_root)
                     expect(branch_name is not None,

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -137,6 +137,8 @@ class TestScheduler(object):
         self._baseline_gen_name = None
         self._compare = False
         self._generate = False
+        # the following is to assure that in the cesm testing workflow existing generate directory is not overwritten
+        self._overwrite_baselines = True
         if compare or generate:
             # Figure out what baseline name to use
             if baseline_name is None:
@@ -146,7 +148,7 @@ class TestScheduler(object):
                 if generate is not None and isinstance(generate, str):
                     self._baseline_gen_name = generate
                     self._generate = True
-
+                    self._overwrite_baselines = False
                 if self._compare and self._baseline_cmp_name is None:
                     branch_name = CIME.utils.get_current_branch(repo=self._cime_root)
                     expect(branch_name is not None,
@@ -432,6 +434,10 @@ class TestScheduler(object):
         test_argv = "-testname %s -testroot %s" % (test, self._test_root)
         if self._generate:
             test_argv += " -generate %s" % self._baseline_gen_name
+            basegen_case_fullpath = os.path.join(self._baseline_root,self._baseline_gen_name, test)
+            logger.warn("basegen_case is %s"%basegen_case_fullpath)
+            expect(self._overwrite_baselines or not os.path.isdir(basegen_case_fullpath),
+                   "Refusing to overwrite existing baseline directory %s"%basegen_case_fullpath)
             envtest.set_value("BASELINE_NAME_GEN", self._baseline_gen_name)
             envtest.set_value("BASEGEN_CASE", os.path.join(self._baseline_gen_name, test))
         if self._compare:


### PR DESCRIPTION
Cowardly refuse to overwrite existing baseline directory in cesm workflow.

Test suite: scripts_regression_tests, Tests using --generate with and without existing baseline.
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes 

User interface changes?: 

Code review: 

