### PR TITLE
Return to the original directory after unit tests

### DIFF
--- a/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -227,10 +227,15 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
 class TestSystemTestsCompareTwo(unittest.TestCase):
 
     def setUp(self):
+        self.original_wd = os.getcwd()
         # create a sandbox in which case directories can be created
         self.tempdir = tempfile.mkdtemp()
 
     def tearDown(self):
+        # Some tests trigger a chdir call in the SUT; make sure we return to the
+        # original directory at the end of the test
+        os.chdir(self.original_wd)
+
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def test_setup(self):

--- a/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two_link_to_case2_output.py
+++ b/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two_link_to_case2_output.py
@@ -68,10 +68,15 @@ class TestLinkToCase2Output(unittest.TestCase):
     # ========================================================================
 
     def setUp(self):
+        self.original_wd = os.getcwd()
         # Create a sandbox in which case directories can be created
         self.tempdir = tempfile.mkdtemp()
 
     def tearDown(self):
+        # Some tests trigger a chdir call in the SUT; make sure we return to the
+        # original directory at the end of the test
+        os.chdir(self.original_wd)
+
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def setup_test_and_directories(self, casename1, run2_suffix):


### PR DESCRIPTION
This is needed because some of the SystemTestsCompareTwo tests trigger
code that includes an os.chdir call. Because these chdirs happen into a
temporary directory that is later removed, this was calling os.getcwd()
calls in later tests to fail.

Test suite: scripts_regression_tests.py A_RunUnitTests
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

In doing these tests, I also added a print of os.getcwd() in the
tearDown method. This showed that, prior to this fix, os.getcwd() failed
after running test_unittests; after this fix, os.getcwd() shows that we
are back in the original directory after running test_unittests.

Fixes: None

User interface changes?: No

Code review: @quantheory 