### PR TITLE
Jgfouca/remove compiler in baseline dir

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -306,6 +306,8 @@ OR
                 baseline_gen_name = args.generate
         else:
             baseline_name = args.baseline_name if args.baseline_name else CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
+            if not baseline_name.startswith("%s/" % args.compiler): # pylint: disable=maybe-no-member
+                baseline_name = os.path.join(args.compiler, baseline_name)
             expect(baseline_name is not None,
                    "Could not determine baseline name from branch, please use -b option")
             if args.compare:

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -23,10 +23,26 @@ logger = logging.getLogger(__name__)
 ###############################################################################
 def parse_command_line(args, description):
 ###############################################################################
-    parser = argparse.ArgumentParser(
-        usage="""\n%s <TEST|SUITE> [<TEST|SUITE> ...] [--verbose]
-OR
+    model = CIME.utils.get_model()
+
+    if model == "cesm":
+        help_str = \
+"""
 %s --xml-category [CATEGORY] [--xml-machine ...] [--xml-compiler ...] [ --xml-testlist ...]
+OR
+%s --help
+OR
+%s --test
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Run all tests in the xml prealpha category and yellowstone machine \033[0m
+    > %s --xml-machine yellowstone --xml-category prealpha
+""" % ((os.path.basename(args[0]), ) * 4)
+
+    else:
+        help_str = \
+"""
+%s <TEST|SUITE> [<TEST|SUITE> ...] [--verbose]
 OR
 %s --help
 OR
@@ -50,22 +66,13 @@ OR
 
     \033[1;32m# Run all tests in a suite except for tests that are in another suite \033[0m
     > %s <SUITE1> ^<SUITE2>
+""" % ((os.path.basename(args[0]), ) * 9)
 
-    \033[1;32m# Run all tests in the xml prealpha category and yellowstone machine \033[0m
-    > %s --xml-machine yellowstone --xml-category prealpha
-
-""" % ((os.path.basename(args[0]), ) * 11),
-
-        description=description,
-
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
+    parser = argparse.ArgumentParser(usage=help_str,
+                                     description=description,
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     CIME.utils.setup_standard_logging_options(parser)
-
-    parser.add_argument("testargs", nargs="*",
-                        help="Tests or test suites to run."
-                        " Testnames expect in form CASE.GRID.COMPSET")
 
     parser.add_argument("--no-run", action="store_true",
                         help="Do not run generated tests")
@@ -104,31 +111,58 @@ OR
                         "all object executables, and data files will"
                         " be removed after tests are run")
 
-    parser.add_argument("-c", "--compare", const=True, nargs="?",
-                        help="While testing, compare baselines,"
-                        " optionally provide a compare directory ")
+    if model == "cesm":
+        parser.add_argument("-c", "--compare",
+                            help="While testing, compare baselines"
+                            "  against the given compare directory ")
 
-    parser.add_argument("-g", "--generate", const=True, nargs="?",
-                        help="While testing, generate baselines,"
-                        " optionally provide a generate directory")
+        parser.add_argument("-g", "--generate",
+                            help="While testing, generate baselines,"
+                            " to the given generate directory")
 
-    parser.add_argument("-b", "--baseline-name",
-                        help="If comparing or generating baselines with default paths,"
-                        " use this directory under baseline root. "
-                        "Default will be current branch name. Do NOT add the compiler to"
-                        " this argument that will be done for you.  If you provide directories"
-                        " in the generate and or compare argument do not use this option.")
+        parser.add_argument("--xml-machine",
+                            help="Use this machine key in the lookup in testlist.xml, default is all if any --xml- argument is used")
+
+        parser.add_argument("--xml-compiler",
+                            help="Use this compiler key in the lookup in testlist.xml, default is all if any --xml- argument is used")
+
+        parser.add_argument("--xml-category",
+                            help="Use this category key in the lookup in testlist.xml, default is all if any --xml- argument is used")
+
+        parser.add_argument("--xml-testlist",
+                            help="Use this testlist to lookup tests, default specified in config_files.xml")
+
+        parser.add_argument("testargs", nargs="*",
+                            help="Tests or test suites to run."
+                            " Testnames expect in form CASE.GRID.COMPSET[.MACHINE_COMPILER]")
+
+        parser.add_argument("-m", "--machine",
+                            help="The machine for which to build tests, this machine must be defined"
+                            " in the config_machines.xml file for the given model. "
+                            "Default is to match the name of the machine in the test name or "
+                            "the name of the machine this script is run on to the "
+                            "NODENAME_REGEX field in config_machines.xml")
+
+    else:
+
+        parser.add_argument("testargs", nargs="+",
+                            help="Tests or test suites to run."
+                            " Testnames expect in form CASE.GRID.COMPSET[.MACHINE_COMPILER]")
+
+        parser.add_argument("-b", "--baseline-name",
+                            help="If comparing or generating baselines,"
+                            " use this directory under baseline root. "
+                            "Default will be current branch name.")
+
+        parser.add_argument("-c", "--compare", action="store_true",
+                            help="While testing, compare baselines")
+
+        parser.add_argument("-g", "--generate", action="store_true",
+                            help="While testing, generate baselines")
 
     parser.add_argument("--compiler",
                         help="Compiler to use to build cime.  Default will be the name in"
                         " the Testnames or the default defined for the machine.")
-
-    parser.add_argument("-m", "--machine",
-                        help="The machine for which to build tests, this machine must be defined"
-                        " in the config_machines.xml file for the given model. "
-                        "Default is to match the name of the machine in the test name or "
-                        "the name of the machine this script is run on to the "
-                        "NODENAME_REGEX field in config_machines.xml")
 
     parser.add_argument("-n", "--namelists-only", action="store_true",
                         help="Only perform namelist actions for tests")
@@ -159,43 +193,42 @@ OR
     parser.add_argument("-q", "--queue", default=None,
                         help="Force batch system to use a certain queue")
 
-    parser.add_argument("--xml-machine",
-                        help="Use this machine key in the lookup in testlist.xml, default is all if any --xml- argument is used")
-    parser.add_argument("--xml-compiler",
-                        help="Use this compiler key in the lookup in testlist.xml, default is all if any --xml- argument is used")
-    parser.add_argument("--xml-category",
-                        help="Use this category key in the lookup in testlist.xml, default is all if any --xml- argument is used")
-    parser.add_argument("--xml-testlist",
-                        help="Use this testlist to lookup tests, default specified in config_files.xml")
-    parser.add_argument("--testfile",
+    parser.add_argument("-f", "--testfile",
                         help="A file containing an ascii list of tests to run")
 
     parser.add_argument("-o", "--allow-baseline-overwrite", action="store_true",
                         help="If the generate baseline option is specified with a baseline directory option "
-                        "existing tests in that directory will not be overwritten unless this flag is provided.")
+                        "existing tests in that directory will not be overwritten unless this flag is provided."
+                        "You can use bless-test-results to bless baselines from a recent run.")
 
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
 
     # generate and compare flags may not point to the same directory
-    if args.generate is not None:
-        expect(not (args.generate == args.compare),
-               "Cannot generate and compare baselines at the same time")
-    expect(not (args.baseline_name is not None and (not args.compare and not args.generate)),
-           "Provided baseline name but did not specify compare or generate")
+    if model == "cesm":
+        if args.generate is not None:
+            expect(not (args.generate == args.compare),
+                   "Cannot generate and compare baselines at the same time")
+
+        if args.xml_testlist is not None:
+            expect(not (args.xml_machine is None and args.xml_compiler
+                        is  None and args.xml_category is None),
+                   "If an xml-testlist is present at least one of --xml-machine, "
+                   "--xml-compiler, --xml-category must also be present")
+
+    else:
+        expect(not (args.baseline_name is not None and (not args.compare and not args.generate)),
+               "Provided baseline name but did not specify compare or generate")
+        expect(not (args.compare and args.generate),
+               "Tried to compare and generate at same time")
+
     expect(not (args.namelists_only and not (args.generate or args.compare)),
            "Must provide either --compare or --generate with --namelists-only")
 
     if args.parallel_jobs is not None:
         expect(args.parallel_jobs > 0,
                "Invalid value for parallel_jobs: %d" % args.parallel_jobs)
-
-    if args.xml_testlist is not None:
-        expect(not (args.xml_machine is None and args.xml_compiler
-                    is  None and args.xml_category is None),
-               "If an xml-testlist is present at least one of --xml-machine, "
-               "--xml-compiler, --xml-category must also be present")
 
     if args.use_existing:
         expect(args.test_id is not None, "Must provide test-id of pre-existing cases")
@@ -223,15 +256,66 @@ OR
         args.test_id = CIME.utils.get_utc_timestamp()
 
     if args.testfile is not None:
-        with open(args.testfile[0], "r") as fd:
-            args.testargs.extend( fd.read().splitlines() )
-    # Remove empty items if any
-    args.testargs = filter(None, args.testargs)
+        with open(args.testfile, "r") as fd:
+            args.testargs.extend( [line.strip() for line in fd.read().splitlines() if line.strip()] )
 
-    return args.testargs, args.compiler, args.machine, args.no_run, args.no_build, args.no_setup, args.no_batch,\
-        args.test_root, args.baseline_root, args.clean, args.compare, args.generate, \
-        args.baseline_name, args.namelists_only, args.project, args.test_id, args.parallel_jobs, \
-        args.xml_machine, args.xml_compiler, args.xml_category, args.xml_testlist, args.walltime, \
+    # Compute list of fully-resolved test_names
+    test_extra_data = {}
+    if model == "cesm":
+        machine_name = args.xml_machine if args.machine is None else args.machine
+
+        # If it's still unclear what machine to use, look at test names
+        if machine_name is None:
+            for test in args.testargs:
+                testsplit = CIME.utils.parse_test_name(test)
+                if testsplit[4] is not None:
+                    if machine_name is None:
+                        machine_name = testsplit[4]
+                    else:
+                        expect(machine_name == testsplit[4],
+                               "ambiguity in machine, please use the --machine option")
+
+        mach_obj = Machines(machine=machine_name)
+        args.compiler = args.xml_compiler if args.compiler is None else args.compiler
+        args.compiler = mach_obj.get_default_compiler() if args.compiler is None else args.compiler
+
+        test_data = CIME.test_utils.get_tests_from_xml(args.xml_machine, args.xml_category,
+                                                       args.xml_compiler, args.xml_testlist,
+                                                       machine_name, args.compiler)
+        test_names = [item["name"] for item in test_data]
+        logger.info("Testnames: %s" % test_names)
+        for test_datum in test_data:
+            test_extra_data[test_datum["name"]] = test_datum
+    else:
+        mach_obj = Machines()
+        args.compiler = mach_obj.get_default_compiler() if args.compiler is None else args.compiler
+
+        test_names = update_acme_tests.get_full_test_names(args.testargs, mach_obj.get_machine_name(), args.compiler)
+
+    expect(mach_obj.is_valid_compiler(args.compiler),
+           "Compiler %s not valid for machine %s" % (args.compiler, mach_obj.get_machine_name()))
+
+    # Normalize compare/generate between the models
+    baseline_cmp_name = None
+    baseline_gen_name = None
+    if args.compare or args.generate:
+        if model == "cesm":
+            if args.compare is not None:
+                baseline_cmp_name = args.compare
+            if args.generate is not None:
+                baseline_gen_name = args.generate
+        else:
+            baseline_name = args.baseline_name if args.baseline_name else CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
+            expect(baseline_name is not None,
+                   "Could not determine baseline name from branch, please use -b option")
+            if args.compare:
+                baseline_cmp_name = baseline_name
+            elif args.generate:
+                baseline_gen_name = baseline_name
+
+    return test_names, test_extra_data, args.compiler, mach_obj.get_machine_name(), args.no_run, args.no_build, args.no_setup, args.no_batch,\
+        args.test_root, args.baseline_root, args.clean, baseline_cmp_name, baseline_gen_name, \
+        args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.walltime, \
         args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue, args.allow_baseline_overwrite
 
 ###############################################################################
@@ -334,33 +418,20 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
     run_cmd_no_fail(submit_cmd, input_str=script, arg_stdout=None, arg_stderr=None, verbose=True)
 
 ###############################################################################
-def create_test(testargs, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
-                baseline_root, clean, compare, generate,
-                baseline_name, namelists_only, project, test_id, parallel_jobs,
-                xml_machine, xml_compiler, xml_category, xml_testlist, walltime,
-                single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite):
+def create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
+                baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, project, test_id, parallel_jobs,
+                walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite):
 ###############################################################################
-    if testargs and machine_name is None and compiler is None:
-        for test in testargs:
-            testsplit = CIME.utils.parse_test_name(test)
-            if testsplit[4] is not None:
-                if machine_name is None:
-                    machine_name = testsplit[4]
-                else:
-                    expect(machine_name == testsplit[4],
-                           "ambiguity in machine, please use the --machine option")
-
-    impl = TestScheduler(testargs,
-                      no_run=no_run, no_build=no_build, no_setup=no_setup, no_batch=no_batch,
-                      test_root=test_root, test_id=test_id,
-                      baseline_root=baseline_root, baseline_name=baseline_name,
-                      clean=clean, machine_name=machine_name, compiler=compiler,
-                      compare=compare, generate=generate, namelists_only=namelists_only,
-                      project=project, parallel_jobs=parallel_jobs,
-                      xml_machine=xml_machine, xml_compiler=xml_compiler,
-                      xml_category=xml_category, xml_testlist=xml_testlist, walltime=walltime,
-                      proc_pool=proc_pool, use_existing=use_existing, save_timing=save_timing,
-                      queue=queue, allow_baseline_overwrite=allow_baseline_overwrite)
+    impl = TestScheduler(test_names, test_data=test_data,
+                         no_run=no_run, no_build=no_build, no_setup=no_setup, no_batch=no_batch,
+                         test_root=test_root, test_id=test_id,
+                         baseline_root=baseline_root, baseline_cmp_name=baseline_cmp_name,
+                         baseline_gen_name=baseline_gen_name,
+                         clean=clean, machine_name=machine_name, compiler=compiler,
+                         namelists_only=namelists_only,
+                         project=project, parallel_jobs=parallel_jobs, walltime=walltime,
+                         proc_pool=proc_pool, use_existing=use_existing, save_timing=save_timing,
+                         queue=queue, allow_baseline_overwrite=allow_baseline_overwrite)
 
     success = impl.run_tests()
 
@@ -396,16 +467,14 @@ def _main_func(description):
                                    CIME.utils.get_python_libs_root(), arg_stdout=None, arg_stderr=None)
         return
 
-    testargs, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root, baseline_root, clean, \
-        compare, generate, baseline_name, namelists_only, project, test_id, parallel_jobs, \
-        xml_machine, xml_compiler, xml_category, xml_testlist, walltime, single_submit, proc_pool, \
-        use_existing, save_timing, queue, allow_baseline_overwrite \
+    test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root, baseline_root, clean, \
+        baseline_cmp_name, baseline_gen_name, namelists_only, project, test_id, parallel_jobs, \
+        walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite \
         = parse_command_line(sys.argv, description)
 
-    sys.exit(create_test(testargs, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
-                         baseline_root, clean, compare, generate, baseline_name, namelists_only,
-                         project, test_id, parallel_jobs, xml_machine, xml_compiler, xml_category,
-                         xml_testlist, walltime, single_submit, proc_pool, use_existing, save_timing,
+    sys.exit(create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
+                         baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only,
+                         project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, save_timing,
                          queue, allow_baseline_overwrite))
 
 ###############################################################################

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -306,8 +306,6 @@ OR
                 baseline_gen_name = args.generate
         else:
             baseline_name = args.baseline_name if args.baseline_name else CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
-            if not baseline_name.startswith("%s/" % args.compiler): # pylint: disable=maybe-no-member
-                baseline_name = os.path.join(args.compiler, baseline_name)
             expect(baseline_name is not None,
                    "Could not determine baseline name from branch, please use -b option")
             if args.compare:

--- a/utils/python/CIME/bless_test_results.py
+++ b/utils/python/CIME/bless_test_results.py
@@ -28,7 +28,7 @@ def bless_namelists(test_name, report_only, force, baseline_name, baseline_root)
 def bless_history(test_name, testcase_dir_for_test, baseline_name, baseline_root, report_only, force):
 ###############################################################################
     with Case(testcase_dir_for_test) as case:
-        baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
+        baseline_full_dir = os.path.join(baseline_root, case.get_value("COMPILER"), baseline_name, case.get_value("CASEBASEID"))
         result, comments = compare_baseline(case, baseline_dir=baseline_full_dir)
         if result:
             return True, None

--- a/utils/python/CIME/bless_test_results.py
+++ b/utils/python/CIME/bless_test_results.py
@@ -28,7 +28,7 @@ def bless_namelists(test_name, report_only, force, baseline_name, baseline_root)
 def bless_history(test_name, testcase_dir_for_test, baseline_name, baseline_root, report_only, force):
 ###############################################################################
     with Case(testcase_dir_for_test) as case:
-        baseline_full_dir = os.path.join(baseline_root, case.get_value("COMPILER"), baseline_name, case.get_value("CASEBASEID"))
+        baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
         result, comments = compare_baseline(case, baseline_dir=baseline_full_dir)
         if result:
             return True, None

--- a/utils/python/CIME/compare_test_results.py
+++ b/utils/python/CIME/compare_test_results.py
@@ -10,7 +10,7 @@ import os, glob
 def compare_history(testcase_dir_for_test, baseline_name, baseline_root):
 ###############################################################################
     with Case(testcase_dir_for_test) as case:
-        baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
+        baseline_full_dir = os.path.join(baseline_root, case.get_value("COMPILER"), baseline_name, case.get_value("CASEBASEID"))
         result, comments = compare_baseline(case, baseline_dir=baseline_full_dir)
         if result:
             return True, None

--- a/utils/python/CIME/compare_test_results.py
+++ b/utils/python/CIME/compare_test_results.py
@@ -10,7 +10,7 @@ import os, glob
 def compare_history(testcase_dir_for_test, baseline_name, baseline_root):
 ###############################################################################
     with Case(testcase_dir_for_test) as case:
-        baseline_full_dir = os.path.join(baseline_root, case.get_value("COMPILER"), baseline_name, case.get_value("CASEBASEID"))
+        baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
         result, comments = compare_baseline(case, baseline_dir=baseline_full_dir)
         if result:
             return True, None

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -14,7 +14,6 @@ import CIME.compare_namelists
 import CIME.utils
 from CIME.utils import append_status
 from CIME.test_status import *
-import update_acme_tests
 from CIME.XML.machines import Machines
 from CIME.XML.env_test import EnvTest
 from CIME.XML.files import Files
@@ -35,15 +34,14 @@ class TestScheduler(object):
 ###############################################################################
 
     ###########################################################################
-    def __init__(self, test_names,
+    def __init__(self, test_names, test_data=None,
                  no_run=False, no_build=False, no_setup=False, no_batch=None,
                  test_root=None, test_id=None,
                  machine_name=None, compiler=None,
-                 baseline_root=None, baseline_name=None,
-                 clean=False, compare=False, generate=False, namelists_only=False,
+                 baseline_root=None, baseline_cmp_name=None, baseline_gen_name=None,
+                 clean=False, namelists_only=False,
                  project=None, parallel_jobs=None,
-                 xml_machine=None, xml_compiler=None, xml_category=None,
-                 xml_testlist=None, walltime=None, proc_pool=None,
+                 walltime=None, proc_pool=None,
                  use_existing=False, save_timing=False, queue=None, allow_baseline_overwrite=False):
     ###########################################################################
         self._cime_root  = CIME.utils.get_cime_root()
@@ -51,17 +49,12 @@ class TestScheduler(object):
 
         self._save_timing = save_timing
         self._queue       = queue
+        self._test_data   = {} if test_data is None else test_data # Format:  {test_name -> {data_name -> data}}
 
         # needed for perl interface
         os.environ["CIMEROOT"] = self._cime_root
 
-        # if machine_name is set use it, otherwise if xml_machine is set use it,
-        # otherwise probe for machine_name
-        if machine_name is None:
-            machine_name = xml_machine
-
         self._machobj = Machines(machine=machine_name)
-        machine_name = self._machobj.get_machine_name()
 
         self._no_setup = no_setup
         self._no_build = no_build or no_setup or namelists_only
@@ -81,49 +74,18 @@ class TestScheduler(object):
         expect(not (self._no_batch and self._queue is not None),
                "Does not make sense to request a queue without batch system")
 
-        self._test_root = test_root if test_root is not None \
-            else self._machobj.get_value("CESMSCRATCHROOT")
-
+        # Determine and resolve test_root
+        self._test_root = self._machobj.get_value("CESMSCRATCHROOT") if test_root is None else test_root
         if self._project is not None:
             self._test_root = self._test_root.replace("$PROJECT", self._project)
 
         self._test_root = os.path.abspath(self._test_root)
         self._test_id   = test_id if test_id is not None else CIME.utils.get_utc_timestamp()
 
-        # if compiler is set use it, otherwise if xml_compiler is set use it,
-        # otherwise use the default compiler for the machine
-        if compiler is not None:
-            self._compiler = compiler
-        elif xml_compiler is not None:
-            self._compiler = xml_compiler
-        else:
-            self._compiler = self._machobj.get_default_compiler()
-
-        expect(self._machobj.is_valid_compiler(self._compiler),
-               "Compiler %s not valid for machine %s" % (self._compiler, machine_name))
+        self._compiler = self._machobj.get_default_compiler() if compiler is None else compiler
 
         self._clean          = clean
         self._namelists_only = namelists_only
-
-        # Extra data associated with tests, do not modify after construction
-        # test_name -> test_data
-        #   test_data: name -> value
-        self._test_xml = {}
-
-        # If xml options are provided get tests from xml file, otherwise use acme dictionary
-        if not test_names and (xml_machine is not None or xml_category is not None or
-                               xml_compiler is not None or xml_testlist is not None):
-            test_data = CIME.test_utils.get_tests_from_xml(xml_machine, xml_category,
-                                                           xml_compiler, xml_testlist,
-                                                           machine_name, compiler)
-            test_names = [item["name"] for item in test_data]
-            logger.info("Testnames: %s"%test_names)
-            for test_datum in test_data:
-                self._test_xml[test_datum["name"]] = test_datum
-        else:
-            expect(len(test_names) > 0, "No tests to run")
-            test_names = update_acme_tests.get_full_test_names(test_names,
-                                                               machine_name, self._compiler)
 
         self._walltime = walltime
 
@@ -133,46 +95,10 @@ class TestScheduler(object):
         else:
             self._parallel_jobs = parallel_jobs
 
-        self._baseline_cmp_name = None
-        self._baseline_gen_name = None
-        self._compare = False
-        self._generate = False
-        # the following is to assure that in the cesm testing workflow existing generate directory is not overwritten
-        self._overwrite_baselines = True
-        if compare or generate:
-            # Figure out what baseline name to use
-            if baseline_name is None:
-                if compare is not None and isinstance(compare, str):
-                    self._baseline_cmp_name = compare
-                    self._compare = True
-                if generate is not None and isinstance(generate, str):
-                    self._baseline_gen_name = generate
-                    self._generate = True
-                    self._overwrite_baselines = allow_baseline_overwrite
-                if self._compare and self._baseline_cmp_name is None:
-                    branch_name = CIME.utils.get_current_branch(repo=self._cime_root)
-                    expect(branch_name is not None,
-                           "Could not determine baseline name from branch, please use -b option")
-                    self._baseline_cmp_name = os.path.join(self._compiler, branch_name)
-                if self._generate and self._baseline_gen_name is None:
-                    branch_name = CIME.utils.get_current_branch(repo=self._cime_root)
-                    expect(branch_name is not None,
-                           "Could not determine baseline name from branch, please use -b option")
-                    self._baseline_gen_name = os.path.join(self._compiler, branch_name)
-            else:
-                if compare:
-                    self._compare = True
-                    self._baseline_cmp_name = baseline_name
-                    if not self._baseline_cmp_name.startswith("%s/" % self._compiler): # pylint: disable=maybe-no-member
-                        self._baseline_cmp_name = os.path.join(self._compiler,
-                                                               self._baseline_cmp_name)
-                if generate:
-                    self._generate = True
-                    self._baseline_gen_name  = baseline_name
-                    if not self._baseline_gen_name.startswith("%s/" % self._compiler): # pylint: disable=maybe-no-member
-                        self._baseline_gen_name = os.path.join(self._compiler,
-                                                               self._baseline_gen_name)
+        self._baseline_cmp_name = baseline_cmp_name # Implies comparison should be done if not None
+        self._baseline_gen_name = baseline_gen_name # Implies generation should be done if not None
 
+        if baseline_cmp_name or baseline_gen_name:
             # Compute baseline_root
             self._baseline_root = baseline_root if baseline_root is not None \
                 else self._machobj.get_value("CCSM_BASELINE")
@@ -182,10 +108,17 @@ class TestScheduler(object):
 
             self._baseline_root = os.path.abspath(self._baseline_root)
 
-            if self._compare:
+            if self._baseline_cmp_name:
                 full_baseline_dir = os.path.join(self._baseline_root, self._baseline_cmp_name)
                 expect(os.path.isdir(full_baseline_dir),
                        "Missing baseline comparison directory %s" % full_baseline_dir)
+
+            # the following is to assure that the existing generate directory is not overwritten
+            if self._baseline_gen_name and not allow_baseline_overwrite:
+                full_baseline_dir = os.path.join(self._baseline_root, self._baseline_gen_name)
+                expect(not os.path.isdir(full_baseline_dir),
+                       "Refusing to overwrite existing baseline directory, use -o to force overwrite %s" % full_baseline_dir)
+
         else:
             self._baseline_root = None
 
@@ -217,7 +150,7 @@ class TestScheduler(object):
             self._phases.remove(MODEL_BUILD_PHASE)
         if self._no_run:
             self._phases.remove(RUN_PHASE)
-        if not self._compare and not self._generate:
+        if not self._baseline_cmp_name and not self._baseline_gen_name:
             self._phases.remove(NAMELIST_PHASE)
 
         if use_existing:
@@ -251,9 +184,9 @@ class TestScheduler(object):
     def _get_case_id(self, test):
     ###########################################################################
         baseline_action_code = ""
-        if self._generate:
+        if self._baseline_gen_name:
             baseline_action_code += "G"
-        if self._compare:
+        if self._baseline_cmp_name:
             baseline_action_code += "C"
         if len(baseline_action_code) > 0:
             return "%s.%s.%s" % (test, baseline_action_code, self._test_id)
@@ -405,8 +338,8 @@ class TestScheduler(object):
 
         if self._walltime is not None:
             create_newcase_cmd += " --walltime %s" % self._walltime
-        elif test in self._test_xml and "wallclock" in self._test_xml[test]:
-            create_newcase_cmd += " --walltime %s" % self._test_xml[test]['wallclock']
+        elif test in self._test_data and "wallclock" in self._test_data[test]:
+            create_newcase_cmd += " --walltime %s" % self._test_data[test]['wallclock']
 
         logger.debug("Calling create_newcase: " + create_newcase_cmd)
         return self._shell_cmd_for_phase(test, create_newcase_cmd, CREATE_NEWCASE_PHASE)
@@ -432,15 +365,13 @@ class TestScheduler(object):
         envtest.set_value("CASEBASEID", test)
 
         test_argv = "-testname %s -testroot %s" % (test, self._test_root)
-        if self._generate:
+        if self._baseline_gen_name:
             test_argv += " -generate %s" % self._baseline_gen_name
             basegen_case_fullpath = os.path.join(self._baseline_root,self._baseline_gen_name, test)
             logger.warn("basegen_case is %s"%basegen_case_fullpath)
-            expect(self._overwrite_baselines or not os.path.isdir(basegen_case_fullpath),
-                   "Refusing to overwrite existing baseline directory %s"%basegen_case_fullpath)
             envtest.set_value("BASELINE_NAME_GEN", self._baseline_gen_name)
             envtest.set_value("BASEGEN_CASE", os.path.join(self._baseline_gen_name, test))
-        if self._compare:
+        if self._baseline_cmp_name:
             test_argv += " -compare %s" % self._baseline_cmp_name
             envtest.set_value("BASELINE_NAME_CMP", self._baseline_cmp_name)
             envtest.set_value("BASECMP_CASE", os.path.join(self._baseline_cmp_name, test))
@@ -448,10 +379,10 @@ class TestScheduler(object):
         envtest.set_value("TEST_ARGV", test_argv)
         envtest.set_value("CLEANUP", self._clean)
 
-        if self._generate or self._compare:
+        if self._baseline_gen_name or self._baseline_cmp_name:
             envtest.set_value("BASELINE_ROOT", self._baseline_root)
-        envtest.set_value("GENERATE_BASELINE", self._generate)
-        envtest.set_value("COMPARE_BASELINE", self._compare)
+        envtest.set_value("GENERATE_BASELINE", self._baseline_gen_name is not None)
+        envtest.set_value("COMPARE_BASELINE", self._baseline_cmp_name is not None)
         envtest.set_value("CCSM_CPRNC", self._machobj.get_value("CCSM_CPRNC", resolved=False))
 
         # Add the test instructions from config_test to env_test in the case
@@ -542,7 +473,7 @@ class TestScheduler(object):
         compare_nl     = os.path.join(CIME.utils.get_scripts_root(), "Tools", "compare_namelists")
         simple_compare = os.path.join(CIME.utils.get_scripts_root(), "Tools", "simple_compare")
 
-        if self._compare:
+        if self._baseline_cmp_name:
             has_fails         = False
             baseline_dir      = os.path.join(self._baseline_root, self._baseline_cmp_name, test)
             baseline_casedocs = os.path.join(baseline_dir, "CaseDocs")
@@ -577,7 +508,7 @@ class TestScheduler(object):
             if has_fails:
                 self._test_has_nl_problem(test)
 
-        if self._generate:
+        if self._baseline_gen_name:
             baseline_dir      = os.path.join(self._baseline_root, self._baseline_gen_name, test)
             baseline_casedocs = os.path.join(baseline_dir, "CaseDocs")
             if not os.path.isdir(baseline_dir):

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -542,7 +542,6 @@ def get_project(machobj=None):
 
 def setup_standard_logging_options(parser):
     helpfile = "%s.log"%sys.argv[0]
-    helpfile = os.path.join(os.getcwd(),os.path.basename(helpfile))
     parser.add_argument("-d", "--debug", action="store_true",
                         help="Print debug information (very verbose) to file %s" % helpfile)
     parser.add_argument("-v", "--verbose", action="store_true",

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -542,6 +542,7 @@ def get_project(machobj=None):
 
 def setup_standard_logging_options(parser):
     helpfile = "%s.log"%sys.argv[0]
+    helpfile = os.path.join(os.getcwd(),os.path.basename(helpfile))
     parser.add_argument("-d", "--debug", action="store_true",
                         help="Print debug information (very verbose) to file %s" % helpfile)
     parser.add_argument("-v", "--verbose", action="store_true",

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -426,7 +426,7 @@ class TestCreateTestCommon(unittest.TestCase):
 
         files_to_clean = []
 
-        baselines = os.path.join(self._baseline_area, self._baseline_name)
+        baselines = os.path.join(self._baseline_area, self._compiler, self._baseline_name)
         if (os.path.isdir(baselines)):
             files_to_clean.append(baselines)
 
@@ -481,7 +481,7 @@ class N_TestCreateTest(TestCreateTestCommon):
 /"""
         baseline_area = self._baseline_area
         compiler      = self._compiler
-        baseline_glob = glob.glob(os.path.join(baseline_area, self._baseline_name, "TEST*"))
+        baseline_glob = glob.glob(os.path.join(baseline_area, compiler, self._baseline_name, "TEST*"))
         self.assertEqual(len(baseline_glob), 3, msg="Expected three matches, got:\n%s" % "\n".join(baseline_glob))
 
         baseline_dir = baseline_glob[0]

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -426,7 +426,7 @@ class TestCreateTestCommon(unittest.TestCase):
 
         files_to_clean = []
 
-        baselines = os.path.join(self._baseline_area, self._compiler, self._baseline_name)
+        baselines = os.path.join(self._baseline_area, self._baseline_name)
         if (os.path.isdir(baselines)):
             files_to_clean.append(baselines)
 
@@ -481,7 +481,7 @@ class N_TestCreateTest(TestCreateTestCommon):
 /"""
         baseline_area = self._baseline_area
         compiler      = self._compiler
-        baseline_glob = glob.glob(os.path.join(baseline_area, compiler, self._baseline_name, "TEST*"))
+        baseline_glob = glob.glob(os.path.join(baseline_area, self._baseline_name, "TEST*"))
         self.assertEqual(len(baseline_glob), 3, msg="Expected three matches, got:\n%s" % "\n".join(baseline_glob))
 
         baseline_dir = baseline_glob[0]

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -497,7 +497,7 @@ class N_TestCreateTest(TestCreateTestCommon):
         self.simple_test(False, "-c -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, CIME.utils.get_utc_timestamp()))
 
         # Regen
-        self.simple_test(True, "-g -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, CIME.utils.get_utc_timestamp()))
+        self.simple_test(True, "-g -o -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, CIME.utils.get_utc_timestamp()))
 
         # Basic namelist compare should now pass again
         self.simple_test(True, "-c -n -b %s -t %s-%s" % (self._baseline_name, self._baseline_name, CIME.utils.get_utc_timestamp()))

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -480,7 +480,6 @@ class N_TestCreateTest(TestCreateTestCommon):
    fake = .true.
 /"""
         baseline_area = self._baseline_area
-        compiler      = self._compiler
         baseline_glob = glob.glob(os.path.join(baseline_area, self._baseline_name, "TEST*"))
         self.assertEqual(len(baseline_glob), 3, msg="Expected three matches, got:\n%s" % "\n".join(baseline_glob))
 
@@ -1091,8 +1090,8 @@ class B_CheckCode(unittest.TestCase):
         from distutils.spawn import find_executable
         pylint = find_executable("pylint")
         if pylint is not None:
-            stat, output, _ = run_cmd("pylint --version")
-            pylintver = re.search(r"pylint\s+(\d+)\.(\d+).(\d+)", output)
+            output = run_cmd_no_fail("pylint --version")
+            pylintver = re.search(r"pylint\s+(\d+)[.](\d+)[.](\d+)", output)
             major = int(pylintver.group(1))
             minor = int(pylintver.group(2))
         if pylint is None or (major <= 1 and minor < 5):


### PR DESCRIPTION
Also:
1) Pull interface handling out of test_scheduler and put into create_test
2) acme/cime models now have different interfaces to create_test

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes  #451

User interface changes?: create_test, minor

Code review: jedwards billsacks
