### PR TITLE
Convert `configure` to Python.

### DIFF
--- a/cime_config/cesm/machines/config_build.xml
+++ b/cime_config/cesm/machines/config_build.xml
@@ -340,13 +340,9 @@ for mct, etc.
     <base> -r8 </base>
   </FC_AUTO_R8>
   <FFLAGS>
-    <!-- Yes, you really do need this huge -wmismatch flag for NAG to work.    -->
-    <!-- More specifically, it exempts MPI functions without explicit          -->
-    <!-- interfaces from certain argument checks. Should not be necessary in   -->
-    <!-- libraries that only use the F90 module interface. mpibcast and        -->
-    <!-- mpiscatterv are actually CAM wrappers for MPI.                        -->
-    <!--  <FFLAGS      > -Wp,-macro=no_com -wmismatch=mpi_send,mpi_recv,mpi_bcast,mpi_allreduce,mpi_reduce,mpi_isend,mpi_irecv,mpi_irsend,mpi_rsend,mpi_gatherv,mpi_gather,mpi_scatterv,mpi_allgather,mpi_alltoallv,mpi_file_read_all,mpi_file_write_all,mpibcast,mpiscatterv    -convert=BIG_ENDIAN </FFLAGS>-->
-    <base>  -Wp,-macro=no_com -convert=BIG_ENDIAN -mismatch_all </base>
+    <!-- The indirect flag below is to deal with MPI functions that violate    -->
+    <!-- the Fortran standard, by adding a large set of arguments from a file. -->
+    <base>-Wp,-macro=no_com -convert=BIG_ENDIAN -indirect <env>CIMEROOT</env>/cime_config/cesm/machines/nag_mpi_argument.txt</base>
     <!-- DEBUG vs. non-DEBUG runs.                                             -->
     <append DEBUG="FALSE"> -ieee=full -O2 </append>
     <!-- The "-gline" option is nice, but it doesn't work with OpenMP.         -->
@@ -354,6 +350,11 @@ for mct, etc.
     <append DEBUG="TRUE"> -C=all -g -time -f2003 -ieee=stop </append>
     <append DEBUG="TRUE" compile_threaded="false"> -gline </append>
     <append compile_threaded="true"> -openmp </append>
+    <!-- The SLAP library (which is part of the CISM build) has many instances of
+       arguments being passed to different types. So disable argument type
+       checking when building CISM. This can be removed once we remove SLAP from
+       CISM. -->
+    <append MODEL="cism"> -mismatch_all </append>
   </FFLAGS>
   <FFLAGS_NOOPT>
     <base> <var>FFLAGS</var> </base>
@@ -944,15 +945,19 @@ for mct, etc.
     <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
   </CPPDEFS>
   <LAPACK_LIBDIR> /usr/lib64 </LAPACK_LIBDIR>
-  <MPI_LIB_NAME MPILIB="openmpi"> mpi</MPI_LIB_NAME>
   <MPI_LIB_NAME MPILIB="mvapich2"> mpich</MPI_LIB_NAME>
+  <NETCDF_PATH><env>NETCDF_PATH</env></NETCDF_PATH>
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell></append>
   </SLIBS>
 </compiler>
 
 <compiler MACH="hobart" COMPILER="intel">
+  <CFLAGS>
+    <append> -lifcore</append>
+  </CFLAGS>
   <FFLAGS>
+    <append> -lifcore</append>
     <append MPILIB="mpi-serial"> -mcmodel medium </append>
   </FFLAGS>
   <LDFLAGS>
@@ -961,6 +966,7 @@ for mct, etc.
     <append> -Wl,-rpath,<env>COMPILER_PATH</env>/lib/intel64 </append>
     <append> -Wl,-rpath,<env>COMPILER_PATH</env>/mkl/lib/intel64 </append>
     <append> -Wl,-rpath,<env>MPI_PATH</env>/lib</append>
+    <append> -lifcore</append>
   </LDFLAGS>
   <PFUNIT_PATH>/home/santos/pFUnit/pFUnit_Intel_3_0</PFUNIT_PATH>
   <SLIBS>
@@ -1031,36 +1037,6 @@ for mct, etc.
   <SLIBS>
     <append>-L/bgsys/local/netcdf/lib -lnetcdf -L/bgsys/drivers/ppcfloor/comm/lib </append>
   </SLIBS>
-</compiler>
-
-<compiler MACH="logan">
-  <LAPACK_LIBDIR> /usr/lib64 </LAPACK_LIBDIR>
-  <MPI_LIB_NAME MPILIB="openmpi"> mpi</MPI_LIB_NAME>
-  <SLIBS>
-    <append><shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell></append>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="logan" COMPILER="intel">
-  <LDFLAGS>
-    <append> -Wl,-rpath,<var>NETCDF_PATH</var>/lib </append>
-    <append> -Wl,-rpath,<env>COMPILER_PATH</env>/lib/intel64 </append>
-  </LDFLAGS>
-</compiler>
-
-<compiler MACH="logan" COMPILER="pgi">
-  <CFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </CFLAGS>
-  <FFLAGS>
-    <append DEBUG="FALSE"> -O2 </append>
-  </FFLAGS>
-  <LDFLAGS>
-    <append> -lgomp </append>
-    <append> -Wl,-R<var>NETCDF_PATH</var>/lib</append>
-    <append> -Wl,-R<env>COMPILER_PATH</env>/lib</append>
-    <append> -Wl,-R<env>COMPILER_PATH</env>/libso</append>
-  </LDFLAGS>
 </compiler>
 
 <compiler MACH="melvin" COMPILER="gnu">
@@ -1235,11 +1211,11 @@ for mct, etc.
 
 <compiler MACH="stampede">
   <CPPDEFS>
-    <!--PNETCDF_PATH>$(TACC_NETCDF_DIR)</PNETCDF_PATH-->
     <append> -DHAVE_NANOTIME </append>
   </CPPDEFS>
   <NETCDF_PATH><env>TACC_NETCDF_DIR</env></NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+  <PNETCDF_PATH><env>TACC_PNETCDF_DIR</env></PNETCDF_PATH>
 </compiler>
 
 <compiler MACH="stampede" COMPILER="intel">
@@ -1253,12 +1229,6 @@ for mct, etc.
   <LDFLAGS>
     <append>-L<env>TACC_HDF5_LIB</env> -lhdf5</append>
   </LDFLAGS>
-  <MPICC>mpicc</MPICC>
-  <MPICXX>mpicxx</MPICXX>
-  <MPIFC>mpif90</MPIFC>
-  <SCC>icc</SCC>
-  <SCXX>icpc</SCXX>
-  <SFC>ifort</SFC>
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -L<env>TACC_HDF5_LIB</env> -lhdf5</append>
   </SLIBS>

--- a/cime_config/cesm/machines/config_build.xml
+++ b/cime_config/cesm/machines/config_build.xml
@@ -1337,6 +1337,8 @@ for mct, etc.
   <PAPI_LIB MPILIB="mpich2">/glade/apps/opt/papi/5.3.0/intel/12.1.5/lib64 </PAPI_LIB>
   <PFUNIT_PATH><env>CESMDATAROOT</env>/tools/pFUnit/pFUnit3.1_Intel15.0.1_MPI</PFUNIT_PATH>
   <!-- Needed due to the way that netcdf is loaded on yellowstone -->
+  <SCC MPILIB="mpi-serial">icc</SCC>
+  <SFC MPILIB="mpi-serial">ifort</SFC>
   <SCC MPILIB="mpich2"><var>MPICC</var></SCC>
   <SFC MPILIB="mpich2"><var>MPIFC</var></SFC>
   <SLIBS>

--- a/tools/configure
+++ b/tools/configure
@@ -32,9 +32,8 @@ The pieces of information that will be written include:
     parser = argparse.ArgumentParser(description=description)
     CIME.utils.setup_standard_logging_options(parser)
 
-    parser.add_argument("--machine", required=True,
-                        help="(required) The machine to create build "
-                        "information for.")
+    parser.add_argument("--machine",
+                        help="The machine to create build information for.")
     parser.add_argument("--machines-dir",
                         help="The machines directory to take build information "
                         "from. Overrides the CIME_MODEL environment variable, "

--- a/tools/configure
+++ b/tools/configure
@@ -1,291 +1,147 @@
-#!/usr/bin/env perl
-#-----------------------------------------------------------------------------------------------
-#
-# configure
-#
-# This utility allows the CIME utilities user to specify configuration
-# options via a commandline interface.
-#
-#-----------------------------------------------------------------------------------------------
+#!/usr/bin/env python
 
-use strict;
-#use warnings;
-#use diagnostics;
+import os
+import shutil
+import sys
 
-use Cwd qw( getcwd abs_path chdir);
-use English;
-use Getopt::Long;
-use IO::File;
-use IO::Handle;
-use File::Copy;
+_CIMEROOT = os.environ.get("CIMEROOT")
+if _CIMEROOT is None:
+    raise SystemExit("ERROR: must set CIMEROOT environment variable")
 
+_LIBDIR = os.path.join(_CIMEROOT, "scripts", "Tools")
+sys.path.append(_LIBDIR)
 
-# Check for manditory case input if not just listing valid values
-my $model;
-my $mach;
-my $compiler;
-my $mpilib;
-my $output_format='make';
-my $cimeroot;
-my $machdir;
-my $eol="\n";
-my $layout = '%m%n';
+from standard_script_setup import *
+from CIME.macros import MacroMaker
+from CIME.utils import expect
+from CIME.XML.env_mach_specific import EnvMachSpecific
+from CIME.XML.machines import Machines
 
+logger = logging.getLogger(__name__)
 
-#-----------------------------------------------------------------------------------------------
-# Set the directory that contains the CCSM configuration scripts.  If the create_newcase command was
-# issued using a relative or absolute path, that path is in $ProgDir.  Otherwise assume the
-# command was issued from the current working directory.
+def parse_command_line(args):
+    """Command line argument parser for configure."""
+    description = """This script writes CIME build information to a directory.
 
-(my $ProgName = $0) =~ s!(.*)/!!;      # name of this script
-my $ProgDir = $1;                      # name of directory containing this script -- may be a
-                                       # relative or absolute path, or null if the script is in
-                                       # the user's PATH
+The pieces of information that will be written include:
 
+1. Machine-specific build settings (i.e. the "Macros" file).
+2. File-specific build settings (i.e. "Depends" files).
+3. Environment variable loads (i.e. the env_mach_specific file).
+"""
+    parser = argparse.ArgumentParser(description=description)
+    CIME.utils.setup_standard_logging_options(parser)
 
-#-----------------------------------------------------------------------------------------------
-if ($#ARGV == -1) {
-    usage();
-}
+    parser.add_argument("--machine", required=True,
+                        help="(required) The machine to create build "
+                        "information for.")
+    parser.add_argument("--machines-dir",
+                        help="The machines directory to take build information "
+                        "from. Overrides the CIME_MODEL environment variable, "
+                        "and must be specified if that variable is not set.")
+    parser.add_argument("--macros-format", action='append',
+                        choices=['Makefile', 'CMake'],
+                        help="The format of Macros file to generate. If "
+                        "'Makefile' is passed in, a file called 'Macros.make' "
+                        "is generated. If 'CMake' is passed in, a file called "
+                        "'Macros.cmake' is generated. This option can be "
+                        "specified multiple times to generate multiple files. "
+                        "If not used at all, Macros generation is skipped. "
+                        "Note that Depends files are currently always in "
+                        "Makefile format, regardless of this option.")
+    parser.add_argument("--output-dir", default=os.getcwd(),
+                        help="The directory to write files to. If not "
+                        "specified, defaults to the current working directory.")
+    parser.add_argument("--shell-opts",
+                        help="Specification of the build configuration to "
+                        "generate env_mach_specific shell scripts for. This "
+                        "should be of the form COMPILER,MPILIB,DEBUG. "
+                        "For example, 'intel,mpich2,true' is a valid setting "
+                        "for this option, as long as ICC and MPICH2 are "
+                        "available on this machine. If this option is not "
+                        "specified, only the XML file is generated (mainly for "
+                        "documentation/testing), with no shell scripts.")
 
-#-----------------------------------------------------------------------------------------------
+    args = parser.parse_args()
+    CIME.utils.handle_standard_logging_options(args)
 
-sub usage {
-	die <<EOF;
-SYNOPSIS
-     configure [options]
-OPTIONS
-     User supplied values are denoted in angle brackets (<>).  Any value that contains
-     white-space must be quoted.  Long option names may be supplied with either single
-     or double leading dashes.  A consequence of this is that single letter options may
-     NOT be bundled.
+    opts = {}
+    if args.machines_dir is not None:
+        machines_file = os.path.join(args.machines_dir, "config_machines.xml")
+        opts['machobj'] = Machines(infile=machines_file, machine=args.machine)
+    else:
+        if os.environ.get('CIME_MODEL') is not None:
+            opts['machobj'] = Machines(machine=args.machine)
+        else:
+            expect(False, "Either --mach-dir or the CIME_MODEL environment "
+                   "variable must be specified!")
 
-     -cimeroot            Specify the toplevel cime directory.
-                          default: use CIMEROOT environment variable
-     -model <name>        Specify the CIME component model to test.
-                          default: cesm
-     -mach <name>         Specify a machine (required).
-     -compiler <name>     Specify a compiler for the target machine (optional)
-                          default: default compiler for the target machine
-     -mpilib <name>       Specify a mpi library for the target machine (optional)
-                          default:  mpi-serial
-     -mach_dir <path>     Specify the locations of the Machines directory (optional).
+    if args.macros_format is None:
+        opts['macros_format'] = []
+    else:
+        opts['macros_format'] = args.macros_format
 
-     -output_dir <path>   default: current working directory
-     -output_format <value> Output format can be make or cmake.
-                          default: make
-     -help [or -h]        Print usage to STDOUT (optional).
-     -loglevel <level>    Set the message level for perl
-                          valid: FATAL ERROR WARN INFO DEBUG
-			  default: INFO
+    expect(os.path.isdir(args.output_dir),
+           "Output directory '%s' does not exist." % args.output_dir)
 
-EXAMPLES
+    opts['output_dir'] = args.output_dir
 
-  ./configure -mach bluefire -compiler ibm
-  ./configure -mach generic_CNL -compiler cray
+    if args.shell_opts is not None:
+        compiler, mpilib, debug = tuple(args.shell_opts.split(","))
+        expect(opts['machobj'].is_valid_compiler(compiler),
+               "Invalid compiler vender passed in --shell-opts: %s" % compiler)
+        opts['compiler'] = compiler
+        expect(opts['machobj'].is_valid_MPIlib(mpilib),
+               "Invalid MPI library name passed in --shell-opts: %s" % mpilib)
+        opts['mpilib'] = mpilib
+        debug_normed = debug.lower()
+        if debug_normed == "true":
+            opts['debug'] = True
+        elif debug_normed == "false":
+            opts['debug'] = False
+        else:
+            expect(False,
+                   "Invalid DEBUG value passed in --shell-opts "
+                   "(must be true or false): %s" % debug)
 
-EOF
-}
+    return opts
 
-#-----------------------------------------------------------------------------------------------
-# Save commandline
-my $commandline = "configure @ARGV";
+def _main():
+    opts = parse_command_line(sys.argv)
+    machobj = opts['machobj']
+    output_dir = opts['output_dir']
 
-#-----------------------------------------------------------------------------------------------
-# Parse command-line options.
-my %opts = (
-    mpilib => "mpi-serial",
-    model => "cesm",
-    loglevel => "INFO",
-    max_tasks_per_node => 1,
-    );
-GetOptions(
-    "cimeroot=s"                => \$opts{'cimeroot'},
-    "compiler=s"                => \$opts{'compiler'},
-    "model=s"                   => \$opts{'model'},
-    "mpilib=s"                  => \$opts{'mpilib'},
-    "h|help"                    => \$opts{'help'},
-    "list"                      => \$opts{'list'},
-    "mach=s"                    => \$opts{'mach'},
-    "mach_dir=s"                => \$opts{'mach_dir'},
-    "output_dir=s"              => \$opts{'output_dir'},
-    "output_format=s"           => \$opts{'output_format'},
-    "loglevel=s"                => \$opts{'loglevel'},
-    "scratchroot=s"             => \$opts{'scratchroot'},
-    "din_loc_root=s"            => \$opts{'din_loc_root'},
-    "max_tasks_per_node=i"      => \$opts{'max_tasks_per_node'},
-    )  or usage();
+    # Macros generation.
+    suffixes = {'Makefile': '.make', 'CMake': '.cmake'}
+    macro_maker = MacroMaker(machobj)
+    build_file_name = os.path.join(machobj.machines_dir, "config_build.xml")
+    for form in opts['macros_format']:
+        out_file_name = os.path.join(output_dir,
+                                     "Macros"+suffixes[form])
+        with open(out_file_name, "w") as macros_file:
+            macro_maker.write_macros(form, build_file_name, macros_file)
 
-# Give usage message.
-usage() if $opts{'help'};
+    # Depends file copy.
+    mach_depends = os.path.join(machobj.machines_dir,
+                                "Depends."+machobj.get_machine_name())
+    if os.path.isfile(mach_depends):
+        shutil.copy(mach_depends, output_dir)
+    compilers = machobj.get_value("COMPILERS").split(",")
+    for compiler in compilers:
+        compiler_depends = os.path.join(machobj.machines_dir,
+                                        "Depends."+compiler)
+        if os.path.isfile(compiler_depends):
+            shutil.copy(compiler_depends, output_dir)
 
-
-# Check for unparsed argumentss
-if (@ARGV) {
-    print "ERROR: unrecognized arguments: @ARGV\n";
-    usage();
-}
-
-
-if($opts{'cimeroot'}) {
-    $cimeroot = $opts{'cimeroot'};
-}else{
-    $cimeroot = abs_path($ENV{CIMEROOT}) if(defined $ENV{CIMEROOT});
-}
-if(! -d "$cimeroot"){
-    #use die here because Log needs cimeroot
-    die("Cannot find cimeroot directory \"$cimeroot\" \n") ;
-}
-
-
-#-----------------------------------------------------------------------------------------------
-my @dirs = ("$cimeroot/utils/perl5lib","$cimeroot/utils/perl5lib/Config" );
-
-unshift @INC, @dirs;
-require SetupTools;
-require Module::ModuleLoader;
-require ConfigMachine;
-require ConfigCase;
-require Log::Log4perl;
-
-my $level = Log::Log4perl::Level::to_priority($opts{loglevel});
-Log::Log4perl->easy_init({level=>$level,
-			  layout=>$layout});
+    # env_mach_specific generation.
+    ems_file = EnvMachSpecific(output_dir)
+    ems_file.populate(machobj)
+    ems_file.write()
+    if 'compiler' in opts:
+        for shell in ('sh', 'csh'):
+            ems_file.make_env_mach_specific_file(opts['compiler'], opts['debug'],
+                                                 opts['mpilib'], shell)
 
 
-my $logger = Log::Log4perl::get_logger();
-
-
-if (!$opts{'list'}) {
-    # Check for manditory machine input
-    if ($opts{'mach'}) {
-	$mach = $opts{'mach'};
-    } else {
-	$logger->fatal("ERROR: configure must include the input argument, -mach \n");
-	exit();
-    }
-    if ($opts{'compiler'}) {
-	$compiler = $opts{'compiler'};
-    }
-    if ($opts{'model'}) {
-	$model = $opts{'model'};
-    }
-    if ($opts{'mpilib'}) {
-	$mpilib = $opts{'mpilib'};
-    }
-    if($opts{'output_format'}){
-	$output_format = $opts{'output_format'};
-    }
-
-    if($opts{'mach_dir'}){
-	$machdir = $opts{'mach_dir'};
-    } else {
-	$machdir  = "$cimeroot/cime_config/${model}/machines" unless defined($machdir);
-    }
-    if (! -d "$machdir") {
-	$logger->fatal(" Cannot find machines directory \"$machdir\"  ");
-    }
-}
-
-
-my $output_dir = ".";
-$output_dir = $opts{output_dir} if defined( $opts{output_dir} );
-#
-# Make sure the output_dir exists or can be created
-#
-if(! -d "$output_dir") {
-  unless( mkpath $output_dir, "0755"){
-      $logger->fatal("Could not find or create $output_dir");
-  }
-}
-
-#-----------------------------------------------------------------------------------------------
-# Make sure we can find required perl modules and configuration files.
-# Look for them in the directory that contains the configure script.
-
-# Machines definition file.
-my $machine_file = 'config_machines.xml';
-if(! -f "$machdir/$machine_file"){
-    $logger->fatal("Cannot find machine parameters file \"$machine_file\" in directory \"$machdir\"");
-    exit;
-}
-
-# Compiler definition file.
-my $compiler_file = 'config_compilers.xml';
-if(! -f "$machdir/$compiler_file"){
-    $logger->fatal("Cannot find compiler parameters file \"$compiler_file\" in directory \"$machdir\"");
-    exit;
-}
-
-
-#-----------------------------------------------------------------------------------------------
-# If just listing valid values then exit after completion of lists
-if ($opts{'list'}) {
-    #TODO add this correctly - since there is no longer a print_machines in ConfigCase
-    #    ConfigCase::print_machines("$machdir/$machine_file");
-    # to do - add print_compilers
-    $logger->info( "finished listing valid values, now exiting $eol");
-    exit;
-}
-
-#-----------------------------------------------------------------------------------------------
-# Create new config object if not just listing valid values
-my $config = ConfigCase->new("");
-my $files_spec_file = "$cimeroot/cime_config/${model}/config_files.xml";
-# srcroot is not used here
-my $srcroot = "";
-$config->add_config_variables($files_spec_file, $srcroot, $cimeroot, $model);
-# todo:
-#$config->set('MACHDIR', "$machdir");
-my $file = $config->get('CONFIG_DRV_FILE');
-
-$config->add_config_variables($file, $srcroot, $cimeroot, $model);
-
-ConfigMachine::setMachineValues($file, "", $mach, $config);
-
-
-# This will be the compiler argument passed in or the default if not provided
-$compiler = $config->get('COMPILER');
-
-$logger->info( "Machine specifier: $mach.$eol");
-
-# Copy Depends files if they exist
-if( -e "$machdir/Depends.$mach" ) {
-    unless(copy("$machdir/Depends.$mach",$output_dir)){
-	$logger->logdie( "ERROR:  copy $machdir/Depends.$mach $output_dir failed$eol");
-	exit;
-    }
-}
-if( -e "$machdir/Depends.$compiler" ) {
-    unless(copy("$machdir/Depends.$compiler",$output_dir)){
-	$logger->logdie( "ERROR:  copy $machdir/Depends.$compiler $output_dir failed$eol");
-    }
-}
-
-my $dbug = $config->get("DEBUG");
-
-my $moduleloader = Module::ModuleLoader->new(machine  => $mach,
-					     compiler => $compiler,
-					     mpilib   => $mpilib,
-					     caseroot => $output_dir,
-					     debug    => $dbug,
-					     cimeroot => $cimeroot,
-					     model    => $model);
-
-$moduleloader->moduleInit();
-$moduleloader->writeXMLFileForCase();
-
-
-
-$moduleloader->writeCshModuleFile();
-$moduleloader->writeShModuleFile();
-
-
-SetupTools::set_compiler($config->get('OS'),"$machdir/$compiler_file",$compiler,
-			 $mach, $mpilib, "$output_dir/Macros.$output_format", $output_format);
-
-$logger->info("Successfully created auxilary build files for $mach $eol");
-
-exit 0;
-
-
+if __name__ == "__main__":
+    _main()

--- a/tools/configure
+++ b/tools/configure
@@ -121,16 +121,23 @@ def parse_command_line(args):
 
     return opts
 
-def _main():
-    opts = parse_command_line(sys.argv)
-    machobj = opts['machobj']
-    output_dir = opts['output_dir']
+def configure(machobj, output_dir, macros_format, compiler, mpilib, debug):
+    """Add Macros, Depends, and env_mach_specific files to a directory.
 
+    Arguments:
+    machobj - Machines argument for this machine.
+    output_dir - Directory in which to place output.
+    macros_format - Container containing the string 'Makefile' to produce
+                    Makefile Macros output, and/or 'CMake' for CMake output.
+    compiler - String containing the compiler vendor to configure for.
+    mpilib - String containing the MPI implementation to configure for.
+    debug - Boolean specifying whether debugging options are enabled.
+    """
     # Macros generation.
     suffixes = {'Makefile': '.make', 'CMake': '.cmake'}
     macro_maker = Build(machobj)
     build_file_name = os.path.join(machobj.machines_dir, "config_build.xml")
-    for form in opts['macros_format']:
+    for form in macros_format:
         out_file_name = os.path.join(output_dir,
                                      "Macros"+suffixes[form])
         with open(out_file_name, "w") as macros_file:
@@ -141,12 +148,9 @@ def _main():
                                 "Depends."+machobj.get_machine_name())
     if os.path.isfile(mach_depends):
         shutil.copy(mach_depends, output_dir)
-    compilers = machobj.get_value("COMPILERS").split(",")
-    for compiler in compilers:
-        compiler_depends = os.path.join(machobj.machines_dir,
-                                        "Depends."+compiler)
-        if os.path.isfile(compiler_depends):
-            shutil.copy(compiler_depends, output_dir)
+    compiler_depends = os.path.join(machobj.machines_dir, "Depends."+compiler)
+    if os.path.isfile(compiler_depends):
+        shutil.copy(compiler_depends, output_dir)
 
     # env_mach_specific generation.
     ems_path = os.path.join(output_dir, "env_mach_specific.xml")
@@ -156,14 +160,17 @@ def _main():
     ems_file.populate(machobj)
     ems_file.write()
     for shell in ('sh', 'csh'):
-        ems_file.make_env_mach_specific_file(opts['compiler'], opts['debug'],
-                                             opts['mpilib'], shell)
+        ems_file.make_env_mach_specific_file(compiler, debug, mpilib, shell)
         shell_path = os.path.join(output_dir, ".env_mach_specific." + shell)
         with open(shell_path, 'a') as shell_file:
-            shell_file.write("\nexport COMPILER=%s\n" % opts['compiler'])
-            shell_file.write("export MPILIB=%s\n" % opts['mpilib'])
-            shell_file.write("export DEBUG=%s\n" % repr(opts['debug']).upper())
+            shell_file.write("\nexport COMPILER=%s\n" % compiler)
+            shell_file.write("export MPILIB=%s\n" % mpilib)
+            shell_file.write("export DEBUG=%s\n" % repr(debug).upper())
 
+def _main():
+    opts = parse_command_line(sys.argv)
+    configure(opts['machobj'], opts['output_dir'], opts['macros_format'],
+              opts['compiler'], opts['mpilib'], opts['debug'])
 
 if __name__ == "__main__":
     _main()

--- a/tools/configure
+++ b/tools/configure
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+"""This script writes CIME build information to a directory.
+
+The pieces of information that will be written include:
+
+1. Machine-specific build settings (i.e. the "Macros" file).
+2. File-specific build settings (i.e. "Depends" files).
+3. Environment variable loads (i.e. the env_mach_specific files).
+
+The .env_mach_specific.sh and .env_mach_specific.csh files are specific to a
+given compiler, MPI library, and DEBUG setting. By default, these will be the
+machine's default compiler, the machine's default MPI library, and FALSE,
+respectively. These can be changed by setting the environment variables
+COMPILER, MPILIB, and DEBUG, respectively.
+"""
+
 import os
 import shutil
 import sys
@@ -21,20 +36,7 @@ logger = logging.getLogger(__name__)
 
 def parse_command_line(args):
     """Command line argument parser for configure."""
-    description = """This script writes CIME build information to a directory.
-
-The pieces of information that will be written include:
-
-1. Machine-specific build settings (i.e. the "Macros" file).
-2. File-specific build settings (i.e. "Depends" files).
-3. Environment variable loads (i.e. the env_mach_specific files).
-
-The .env_mach_specific.sh and .env_mach_specific.csh files are specific to a
-given compiler, MPI library, and DEBUG setting. By default, these will be the
-machine's default compiler, the machine's default MPI library, and FALSE,
-respectively. These can be changed by setting the environment variables
-COMPILER, MPILIB, and DEBUG, respectively.
-"""
+    description = __doc__
     parser = argparse.ArgumentParser(description=description)
     CIME.utils.setup_standard_logging_options(parser)
 

--- a/tools/configure
+++ b/tools/configure
@@ -27,7 +27,13 @@ The pieces of information that will be written include:
 
 1. Machine-specific build settings (i.e. the "Macros" file).
 2. File-specific build settings (i.e. "Depends" files).
-3. Environment variable loads (i.e. the env_mach_specific file).
+3. Environment variable loads (i.e. the env_mach_specific files).
+
+The .env_mach_specific.sh and .env_mach_specific.csh files are specific to a
+given compiler, MPI library, and DEBUG setting. By default, these will be the
+machine's default compiler, the machine's default MPI library, and FALSE,
+respectively. These can be changed by setting the environment variables
+COMPILER, MPILIB, and DEBUG, respectively.
 """
     parser = argparse.ArgumentParser(description=description)
     CIME.utils.setup_standard_logging_options(parser)
@@ -51,15 +57,6 @@ The pieces of information that will be written include:
     parser.add_argument("--output-dir", default=os.getcwd(),
                         help="The directory to write files to. If not "
                         "specified, defaults to the current working directory.")
-    parser.add_argument("--shell-opts",
-                        help="Specification of the build configuration to "
-                        "generate env_mach_specific shell scripts for. This "
-                        "should be of the form COMPILER,MPILIB,DEBUG. "
-                        "For example, 'intel,mpich2,true' is a valid setting "
-                        "for this option, as long as ICC and MPICH2 are "
-                        "available on this machine. If this option is not "
-                        "specified, only the XML file is generated (mainly for "
-                        "documentation/testing), with no shell scripts.")
 
     args = parser.parse_args()
     CIME.utils.handle_standard_logging_options(args)
@@ -67,13 +64,15 @@ The pieces of information that will be written include:
     opts = {}
     if args.machines_dir is not None:
         machines_file = os.path.join(args.machines_dir, "config_machines.xml")
-        opts['machobj'] = Machines(infile=machines_file, machine=args.machine)
+        machobj = Machines(infile=machines_file, machine=args.machine)
     else:
         if os.environ.get('CIME_MODEL') is not None:
-            opts['machobj'] = Machines(machine=args.machine)
+            machobj = Machines(machine=args.machine)
         else:
             expect(False, "Either --mach-dir or the CIME_MODEL environment "
                    "variable must be specified!")
+
+    opts['machobj'] = machobj
 
     if args.macros_format is None:
         opts['macros_format'] = []
@@ -85,23 +84,38 @@ The pieces of information that will be written include:
 
     opts['output_dir'] = args.output_dir
 
-    if args.shell_opts is not None:
-        compiler, mpilib, debug = tuple(args.shell_opts.split(","))
-        expect(opts['machobj'].is_valid_compiler(compiler),
-               "Invalid compiler vender passed in --shell-opts: %s" % compiler)
-        opts['compiler'] = compiler
-        expect(opts['machobj'].is_valid_MPIlib(mpilib),
-               "Invalid MPI library name passed in --shell-opts: %s" % mpilib)
-        opts['mpilib'] = mpilib
-        debug_normed = debug.lower()
-        if debug_normed == "true":
-            opts['debug'] = True
-        elif debug_normed == "false":
-            opts['debug'] = False
-        else:
-            expect(False,
-                   "Invalid DEBUG value passed in --shell-opts "
-                   "(must be true or false): %s" % debug)
+    # Set compiler.
+    if "COMPILER" in os.environ:
+        compiler = os.environ["COMPILER"]
+    else:
+        compiler = machobj.get_default_compiler()
+        os.environ["COMPILER"] = compiler
+    expect(opts['machobj'].is_valid_compiler(compiler),
+           "Invalid compiler vendor given in COMPILER environment variable: %s"
+           % compiler)
+    opts['compiler'] = compiler
+
+    # Set MPI library.
+    if "MPILIB" in os.environ:
+        mpilib = os.environ["MPILIB"]
+    else:
+        mpilib = machobj.get_default_MPIlib()
+        os.environ["MPILIB"] = mpilib
+    expect(opts['machobj'].is_valid_MPIlib(mpilib),
+           "Invalid MPI library name given in MPILIB environment variable: %s" %
+           mpilib)
+    opts['mpilib'] = mpilib
+
+    # Set DEBUG flag.
+    if "DEBUG" in os.environ:
+        expect(os.environ["DEBUG"].lower() in ('true', 'false'),
+               "Invalid DEBUG environment variable value (must be 'TRUE' or "
+               "'FALSE'): %s" % os.environ["DEBUG"])
+        debug = os.environ["DEBUG"].lower() == "true"
+    else:
+        debug = False
+        os.environ["DEBUG"] = "FALSE"
+    opts['debug'] = debug
 
     return opts
 
@@ -133,13 +147,15 @@ def _main():
             shutil.copy(compiler_depends, output_dir)
 
     # env_mach_specific generation.
+    ems_path = os.path.join(output_dir, "env_mach_specific.xml")
+    if os.path.exists(ems_path):
+        os.remove(ems_path)
     ems_file = EnvMachSpecific(output_dir)
     ems_file.populate(machobj)
     ems_file.write()
-    if 'compiler' in opts:
-        for shell in ('sh', 'csh'):
-            ems_file.make_env_mach_specific_file(opts['compiler'], opts['debug'],
-                                                 opts['mpilib'], shell)
+    for shell in ('sh', 'csh'):
+        ems_file.make_env_mach_specific_file(opts['compiler'], opts['debug'],
+                                             opts['mpilib'], shell)
 
 
 if __name__ == "__main__":

--- a/tools/configure
+++ b/tools/configure
@@ -156,6 +156,11 @@ def _main():
     for shell in ('sh', 'csh'):
         ems_file.make_env_mach_specific_file(opts['compiler'], opts['debug'],
                                              opts['mpilib'], shell)
+        shell_path = os.path.join(output_dir, ".env_mach_specific." + shell)
+        with open(shell_path, 'a') as shell_file:
+            shell_file.write("\nexport COMPILER=%s\n" % opts['compiler'])
+            shell_file.write("export MPILIB=%s\n" % opts['mpilib'])
+            shell_file.write("export DEBUG=%s\n" % repr(opts['debug']).upper())
 
 
 if __name__ == "__main__":

--- a/tools/configure
+++ b/tools/configure
@@ -12,8 +12,8 @@ _LIBDIR = os.path.join(_CIMEROOT, "scripts", "Tools")
 sys.path.append(_LIBDIR)
 
 from standard_script_setup import *
-from CIME.macros import MacroMaker
 from CIME.utils import expect
+from CIME.XML.build import Build
 from CIME.XML.env_mach_specific import EnvMachSpecific
 from CIME.XML.machines import Machines
 
@@ -126,7 +126,7 @@ def _main():
 
     # Macros generation.
     suffixes = {'Makefile': '.make', 'CMake': '.cmake'}
-    macro_maker = MacroMaker(machobj)
+    macro_maker = Build(machobj)
     build_file_name = os.path.join(machobj.machines_dir, "config_build.xml")
     for form in opts['macros_format']:
         out_file_name = os.path.join(output_dir,

--- a/tools/cprnc/README
+++ b/tools/cprnc/README
@@ -11,10 +11,19 @@ Quick Start Guide:
 On cime supported systems you can generate a Macros file using the following
 (assuming you are running the command from the directory cime/tools/cprnc):
 
-../configure -cimeroot ../../ -mach $machinename -compiler $compilername
+CIMEROOT=../.. ../configure --macros-format=Makefile
 
-Then run make to build cprnc and put the resulting executable in
-CCSM_CPRNC as defined in config_machines.xml
+To change the compiler or MPI library used, or to enable debugging options,
+set the COMPILER, MPILIB, or DEBUG environment variables prior to running
+configure.
+
+Next, run make to build cprnc. For instance, using sh/bash as a login shell:
+
+CIMEROOT=../.. source .env_mach_specific.sh && make
+
+Finally, put the resulting executable in CCSM_CPRNC as defined in
+config_machines.xml.
+
 You can also build cprnc using cmake.
 
  Usage: cprnc  [-v] [-d dimname:start[:count]] file1 [file2]

--- a/tools/cprnc/compare_vars_mod.F90.in
+++ b/tools/cprnc/compare_vars_mod.F90.in
@@ -270,7 +270,7 @@ contains
        s2 = vdimsize(file(2)%dim, file(2)%var(vid(2))%dimids)
 
        if(s1 /= s2) then
-          write(6,*), 'WARNING: Variable ',trim(file(1)%var(vid(1))%name),' sizes differ'
+          write(6,*) 'WARNING: Variable ',trim(file(1)%var(vid(1))%name),' sizes differ'
           write(6,'(a,a32)') ' DIMSIZEDIFF ', file(1)%var(vid(1))%name
           ifail = 1
           return

--- a/utils/python/CIME/XML/build.py
+++ b/utils/python/CIME/XML/build.py
@@ -1,9 +1,9 @@
 """
 Classes used to build the CIME Macros file.
 
-The main "public" class here is MacroMaker. It is initialized with machine-
-specific information, and its write_macros method is the driver for translating
-the config_build.xml file into a Makefile or CMake-format Macros file.
+The main "public" class here is Build. It is initialized with machine-specific
+information, and its write_macros method is the driver for translating the
+config_build.xml file into a Makefile or CMake-format Macros file.
 
 For developers, here's the role of the other classes in the process:
 
@@ -20,14 +20,14 @@ For developers, here's the role of the other classes in the process:
 
 In more detail:
 
-- MacroMaker.write_macros immediately creates a MakeMacroWriter or
-  CMakeMacroWriter to translate strings for the build system.
+- Build.write_macros immediately creates a MakeMacroWriter or CMakeMacroWriter
+  to translate strings for the build system.
 
 - It also creates value_lists, a dictionary of PossibleValues objects, with
   variable names as the keys. Each variable has a single PossibleValues object
   associated with it.
 
-- For each <compiler> element, MacroMaker.write_macros creates a CompilerBlock
+- For each <compiler> element, Build.write_macros creates a CompilerBlock
   instance. This object is responsible for translating the XML in its block, in
   order to populate the PossibleValues instances. This includes handling the
   <var>/<env>/<shell> tags, and keeping track of dependencies induced by one
@@ -47,11 +47,11 @@ In more detail:
   translated to. The lists in the PossibleValues class contain these objects.
 
 - Once the XML has all been read in and the PossibleValues objects are
-  populated, the dependencies among variables are checked in
-  MacroMaker.write_macros. For each variable, if all its dependencies have been
-  handled, it is converted to a MacroConditionTree merged with all other trees
-  for variables that are ready, and written out. Then we loop through the
-  variable list again to check for variables whose dependencies are all handled.
+  populated, the dependencies among variables are checked in Build.write_macros.
+  For each variable, if all its dependencies have been handled, it is converted
+  to a MacroConditionTree merged with all other trees for variables that are
+  ready, and written out. Then we loop through the variable list again to check
+  for variables whose dependencies are all handled.
 
 - The MacroConditionTree acts as a primitive syntax tree. Its __init__ method
   reorganizes the data into conditional blocks, and its write_out method writes
@@ -68,7 +68,7 @@ from CIME.utils import get_cime_root
 from CIME.XML.machines import Machines # pylint: disable=unused-import
 from CIME.XML.standard_module_setup import *
 
-__all__ = ["MacroMaker"]
+__all__ = ["Build"]
 
 logger = logging.getLogger(__name__)
 
@@ -648,7 +648,7 @@ class CompilerBlock(object):
             return True
 
 
-class MacroMaker(object):
+class Build(object):
 
     """Class to convert config_build.xml input into a macros file.
 
@@ -663,7 +663,7 @@ class MacroMaker(object):
     """
 
     def __init__(self, machobj, schema_path=None):
-        """Construct a MacroMaker given machine-specific information.
+        """Construct a Build given machine-specific information.
 
         In the process some information about possible variables is read in
         from the schema file.
@@ -672,9 +672,9 @@ class MacroMaker(object):
         machobj - A Machines object for this machine.
         schema_path (optional) - Path to config_build.xsd within CIME.
 
-        >>> "CFLAGS" in MacroMaker('MyMach').flag_vars
+        >>> "CFLAGS" in Build('MyMach').flag_vars
         True
-        >>> "MPICC" in MacroMaker('MyMach').flag_vars
+        >>> "MPICC" in Build('MyMach').flag_vars
         False
         """
         self.machobj = machobj

--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -20,6 +20,14 @@ class EnvMachSpecific(EnvBase):
         fullpath = infile if os.path.isabs(infile) else os.path.join(caseroot, infile)
         EnvBase.__init__(self, caseroot, fullpath)
 
+    def populate(self, machobj):
+        """Add entries to the file using information from a Machines object."""
+        items = ("module_system", "environment_variables", "mpirun")
+        for item in items:
+            nodes = machobj.get_first_child_nodes(item)
+            for node in nodes:
+                self.add_child(node)
+
     def get_values(self, item, attribute=None, resolved=True, subgroup=None):
         """Returns the value as a string of the first xml element with item as attribute value.
         <element_name attribute='attribute_value>value</element_name>"""

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -28,8 +28,10 @@ class Machines(GenericXML):
             if files is None:
                 files = Files()
             infile = files.get_value("MACHINES_SPEC_FILE", resolved=False)
-            self.machines_dir = os.path.dirname(infile)
             infile = files.get_resolved_value(infile)
+
+        self.machines_dir = os.path.dirname(infile)
+
         GenericXML.__init__(self, infile)
 
         # Append the contents of $HOME/.cime/config_machines.xml if it exists

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -715,12 +715,12 @@ class Case(object):
         # Create Macros file.
         machine = self.get_value("MACH")
         if os.getenv("CIME_USE_CONFIG_BUILD") == "TRUE":
-            os_ = self.get_value("OS")
             files = Files()
             build_file = files.get_value("BUILD_SPEC_FILE")
             machobj = Machines(machine=machine, files=files)
-            macro_maker = MacroMaker(os_, machobj)
-            with open(os.path.join(self._caseroot, "Macros"), "w") as macros_file:
+            macro_maker = MacroMaker(machobj)
+            macros_path = os.path.join(self._caseroot, "Macros")
+            with open(macros_path, "w") as macros_file:
                 macro_maker.write_macros('Makefile', build_file, macros_file)
 
         # Copy any system or compiler Depends files to the case.

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -10,6 +10,7 @@ from CIME.XML.standard_module_setup import *
 
 from CIME.utils                     import expect, get_cime_root, append_status
 from CIME.utils                     import convert_to_type, get_model, get_project
+from CIME.XML.build                 import Build
 from CIME.XML.machines              import Machines
 from CIME.XML.pes                   import Pes
 from CIME.XML.files                 import Files
@@ -30,7 +31,6 @@ from CIME.XML.env_batch             import EnvBatch
 
 from CIME.user_mod_support          import apply_user_mods
 from CIME.case_setup import case_setup
-from CIME.macros import MacroMaker
 
 logger = logging.getLogger(__name__)
 
@@ -714,7 +714,7 @@ class Case(object):
             files = Files()
             build_file = files.get_value("BUILD_SPEC_FILE")
             machobj = Machines(machine=machine, files=files)
-            macro_maker = MacroMaker(machobj)
+            macro_maker = Build(machobj)
             macros_path = os.path.join(self._caseroot, "Macros")
             with open(macros_path, "w") as macros_file:
                 macro_maker.write_macros('Makefile', build_file, macros_file)

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -525,13 +525,9 @@ class Case(object):
         machdir = machobj.get_machines_dir()
         self.set_value("MACHDIR", machdir)
 
-        # the following go into the env_mach_specific file
-        items = ("module_system", "environment_variables", "mpirun")
+        # Create env_mach_specific settings from machine info.
         env_mach_specific_obj = self.get_env("mach_specific")
-        for item in items:
-            nodes = machobj.get_first_child_nodes(item)
-            for node in nodes:
-                env_mach_specific_obj.add_child(node)
+        env_mach_specific_obj.populate(machobj)
         self.schedule_rewrite(env_mach_specific_obj)
 
         #--------------------------------------------

--- a/utils/python/CIME/macros.py
+++ b/utils/python/CIME/macros.py
@@ -623,14 +623,11 @@ class CompilerBlock(object):
             else:
                 self._add_elem_to_lists(elem.tag, elem, value_lists)
 
-    def matches_machine(self, os_):
+    def matches_machine(self):
         """Check whether this block matches a machine/os.
 
         This also sets the specificity of the block, so this must be called
         before add_settings_to_lists if machine-specific output is needed.
-
-        Arguments:
-        os_ - Operating system to match.
         """
         self._specificity = 0
         if "MACH" in self._compiler_elem.keys():
@@ -640,7 +637,7 @@ class CompilerBlock(object):
             else:
                 return False
         if "OS" in self._compiler_elem.keys():
-            if os_ == self._compiler_elem.get("OS"):
+            if self._machobj.get_value("OS") == self._compiler_elem.get("OS"):
                 self._specificity += 1
             else:
                 return False
@@ -665,23 +662,21 @@ class MacroMaker(object):
     write_macros
     """
 
-    def __init__(self, os_, machobj, schema_path=None):
+    def __init__(self, machobj, schema_path=None):
         """Construct a MacroMaker given machine-specific information.
 
         In the process some information about possible variables is read in
         from the schema file.
 
         Arguments:
-        os_ - Name of a machine's operating system.
         machobj - A Machines object for this machine.
         schema_path (optional) - Path to config_build.xsd within CIME.
 
-        >>> "CFLAGS" in MacroMaker('FakeOS', 'MyMach').flag_vars
+        >>> "CFLAGS" in MacroMaker('MyMach').flag_vars
         True
-        >>> "MPICC" in MacroMaker('FakeOS', 'MyMach').flag_vars
+        >>> "MPICC" in MacroMaker('MyMach').flag_vars
         False
         """
-        self.os = os_
         self.machobj = machobj
 
         # The schema is used to figure out which variables contain
@@ -724,7 +719,7 @@ class MacroMaker(object):
         for compiler_elem in ET.parse(xml_file).findall("compiler"):
             block = CompilerBlock(writer, compiler_elem, self.machobj)
             # If this block matches machine settings, use it.
-            if block.matches_machine(self.os):
+            if block.matches_machine():
                 block.add_settings_to_lists(self.flag_vars, value_lists)
 
         # Now that we've scanned through the input, output the variable

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1107,15 +1107,22 @@ class MockMachines(object):
 
     """A mock version of the Machines object to simplify testing."""
 
-    def __init__(self, name):
+    def __init__(self, name, os_):
         """Store the name."""
         self.name = name
+        self.os = os_
 
     def get_machine_name(self):
         """Return the name we were given."""
         return self.name
 
-    def is_valid_compiler(self, _):
+    def get_value(self, var_name):
+        """Allow the operating system to be queried."""
+        assert var_name == "OS", "MacrosMaker asked for a value not " \
+            "implemented in the testing infrastructure."
+        return self.os
+
+    def is_valid_compiler(self, _): # pylint:disable=no-self-use
         """Assume all compilers are valid."""
         return True
 
@@ -1351,19 +1358,19 @@ class G_TestMacrosBasic(unittest.TestCase):
     def test_script_is_callable(self):
         """The test script can be called on valid output without dying."""
         # This is really more a smoke test of this script than anything else.
-        maker = MacroMaker("SomeOS", MockMachines("mymachine"))
+        maker = MacroMaker(MockMachines("mymachine", "SomeOS"))
         test_xml = _wrap_config_build_xml("<compiler><SUPPORTS_CXX>FALSE</SUPPORTS_CXX></compiler>")
         get_macros(maker, test_xml, "Makefile")
 
     def test_script_rejects_bad_xml(self):
         """The macro writer rejects input that's not valid XML."""
-        maker = MacroMaker("SomeOS", MockMachines("mymachine"))
+        maker = MacroMaker(MockMachines("mymachine", "SomeOS"))
         with self.assertRaises(ParseError):
             get_macros(maker, "This is not valid XML.", "Makefile")
 
     def test_script_rejects_bad_build_system(self):
         """The macro writer rejects a bad build system string."""
-        maker = MacroMaker("SomeOS", MockMachines("mymachine"))
+        maker = MacroMaker(MockMachines("mymachine", "SomeOS"))
         bad_string = "argle-bargle."
         with self.assertRaisesRegexp(
                 SystemExit,
@@ -1387,7 +1394,7 @@ class H_TestMakeMacros(unittest.TestCase):
     test_machine = "mymachine"
 
     def setUp(self):
-        self._maker = MacroMaker(self.test_os, MockMachines(self.test_machine))
+        self._maker = MacroMaker(MockMachines(self.test_machine, self.test_os))
 
     def xml_to_tester(self, xml_string):
         """Helper that directly converts an XML string to a MakefileTester."""


### PR DESCRIPTION
This change set passes `scripts_regression_tests`, and I was able to use `configure` with CESM's `config_build.xml` to build `cprnc`.

Fixes #299.