### PR TITLE
Clean up some help text

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -117,8 +117,9 @@ OR
                             "  against the given compare directory ")
 
         parser.add_argument("-g", "--generate",
-                            help="While testing, generate baselines,"
-                            " to the given generate directory")
+                            help="While testing, generate baselines"
+                            " to the given generate directory; "
+                            "this can also be done after the fact with bless_test_results")
 
         parser.add_argument("--xml-machine",
                             help="Use this machine key in the lookup in testlist.xml, default is all if any --xml- argument is used")
@@ -158,7 +159,8 @@ OR
                             help="While testing, compare baselines")
 
         parser.add_argument("-g", "--generate", action="store_true",
-                            help="While testing, generate baselines")
+                            help="While testing, generate baselines; "
+                            "this can also be done after the fact with bless_test_results")
 
     parser.add_argument("--compiler",
                         help="Compiler to use to build cime.  Default will be the name in"
@@ -197,9 +199,10 @@ OR
                         help="A file containing an ascii list of tests to run")
 
     parser.add_argument("-o", "--allow-baseline-overwrite", action="store_true",
-                        help="If the generate baseline option is specified with a baseline directory option "
-                        "existing tests in that directory will not be overwritten unless this flag is provided."
-                        "You can use bless-test-results to bless baselines from a recent run.")
+                        help="If the --generate option is given, then by default "
+                        "an attempt to overwrite an existing baseline directory "
+                        "will raise an error. Specifying this option allows "
+                        "existing baseline directories to be silently overwritten.")
 
     args = parser.parse_args(args[1:])
 


### PR DESCRIPTION
This cleans up the help text for --allow-baseline-overwrite, as I discussed via email with @jedwards4b . I also moved the text added by @jgfouca regarding bless_test_results into the help for the --generate option, where it seems more appropriate.

The current help text for --allow-baseline-overwrite assumes that this is needed in both the acme and cesm workflows, which I believe is now the case. @jgfouca , is this correct?

Test suite: just ran create_test -h with CIME_MODEL=cesm and acme
Test baseline: N/A
Test namelist changes: N/A
Test status: N/A

Fixes: None

User interface changes?: No

Code review: @jedwards4b 