### PR TITLE
Rewrite NCK test to use SystemTestsCompareTwo infrastructure

### DIFF
--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -393,6 +393,10 @@ LII    CLM initial condition interpolation test
     <INFO_DBUG>1</INFO_DBUG>
     <CCSM_TCOST>-1</CCSM_TCOST>
     <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>none</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
   </test>
 
   <test NAME="NCR">

--- a/utils/python/CIME/SystemTests/nck.py
+++ b/utils/python/CIME/SystemTests/nck.py
@@ -32,19 +32,19 @@ class NCK(SystemTestsCompareTwo):
         # think that the halving was unnecessary; but it's needed in case the
         # original NTASKS was odd. (e.g., for NTASKS originally 15, we want to
         # use NTASKS = int(15/2) * 2 = 14 tasks for case two.)
-        for comp in _COMPONENT_LIST:
+        for comp in self._COMPONENT_LIST:
             ntasks = self._case.get_value("NTASKS_%s"%comp)
             if ( ntasks > 1 ):
                 self._case.set_value("NTASKS_%s"%comp, int(ntasks/2))
 
     def _case_one_setup(self):
-        for comp in _COMPONENT_LIST:
+        for comp in self._COMPONENT_LIST:
             self._case.set_value("NINST_%s"%comp, 1)
 
         case_setup(self._case, test_mode=True, reset=True)
 
     def _case_two_setup(self):
-        for comp in _COMPONENT_LIST:
+        for comp in self._COMPONENT_LIST:
             self._case.set_value("NINST_%s"%comp, 2)
             ntasks = self._case.get_value("NTASKS_%s"%comp)
             self._case.set_value("NTASKS_%s"%comp, ntasks*2)

--- a/utils/python/CIME/SystemTests/nck.py
+++ b/utils/python/CIME/SystemTests/nck.py
@@ -1,126 +1,52 @@
 """
-Implementation of the CIME NCK test.  This class inherits from SystemTestsCommon
+Implementation of the CIME NCK test: Tests multi-instance
 
-Build two exectuables for this test, the first is a default build the
-second halves the number of tasks and runs two instances for each component
+This does two runs: In the first, we use one instance per component; in the
+second, we use two instances per components. NTASKS are changed in each run so
+that the number of tasks per instance is the same for both runs.
+
 Lay all of the components out sequentially
 """
-import shutil
+
 from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.case_setup import case_setup
-import CIME.utils
-from CIME.SystemTests.system_tests_common import SystemTestsCommon
 
 logger = logging.getLogger(__name__)
 
-class NCK(SystemTestsCommon):
+class NCK(SystemTestsCompareTwo):
+
+    _COMPONENT_LIST = ('ATM','OCN','WAV','GLC','ICE','ROF','LND')
 
     def __init__(self, case):
-        """
-        initialize a test object
-        """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCompareTwo.__init__(self, case,
+                                       separate_builds = True,
+                                       run_two_suffix = 'multiinst',
+                                       run_one_description = 'one instance',
+                                       run_two_description = 'two instances')
 
-    def build_phase(self, sharedlib_only=False, model_only=False):
-        '''
-        build can be called once (sharedlib_only and model_only both False)
-        or twice (once with each true)
-        This test requires a sharedlib build for both phases
-        we must handle both cases correctly
-        '''
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = CIME.utils.get_model()
-        if not model_only:
-            machpes1 = os.path.join("LockedFiles","env_mach_pes.orig.xml")
-            if os.path.isfile(machpes1):
-                shutil.copy(machpes1,"env_mach_pes.xml")
-            else:
-                shutil.copy("env_mach_pes.xml", machpes1)
+    def _common_setup(self):
+        # We start by halving the number of tasks for both cases. This ensures
+        # that we use the same number of tasks per instance in both cases: For
+        # the two-instance case, we'll double this halved number, so you may
+        # think that the halving was unnecessary; but it's needed in case the
+        # original NTASKS was odd. (e.g., for NTASKS originally 15, we want to
+        # use NTASKS = int(15/2) * 2 = 14 tasks for case two.)
+        for comp in _COMPONENT_LIST:
+            ntasks = self._case.get_value("NTASKS_%s"%comp)
+            if ( ntasks > 1 ):
+                self._case.set_value("NTASKS_%s"%comp, int(ntasks/2))
 
-        # Build two exectuables for this test, the first is a default build, the
-        # second halves the number of tasks and runs two instances for each component
-        # Lay all of the components out sequentially
-        for bld in range(1,3):
-            logging.warn("Starting bld %s"%bld)
-            machpes = os.path.join("LockedFiles","env_mach_pes.NCK%s.xml"%bld)
-            if model_only:
-                # This file should have been created in the sharedlib_only phase
-                shutil.copy(machpes,"env_mach_pes.xml")
-                self._case.read_xml()
-            else:
-                for comp in ['ATM','OCN','WAV','GLC','ICE','ROF','LND']:
-                    self._case.set_value("NINST_%s"%comp, bld)
-                    ntasks      = self._case.get_value("NTASKS_%s"%comp)
-                    if(bld == 1):
-                        if ( ntasks > 1 ):
-                            self._case.set_value("NTASKS_%s"%comp, int(ntasks/2))
-                    else:
-                        self._case.set_value("NTASKS_%s"%comp, ntasks*2)
-                    self._case.flush()
+    def _case_one_setup(self):
+        for comp in _COMPONENT_LIST:
+            self._case.set_value("NINST_%s"%comp, 1)
 
-            case_setup(self._case, test_mode=True, reset=True)
-            if not sharedlib_only:
-                self.clean_build()
+        case_setup(self._case, test_mode=True, reset=True)
 
-            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-            if not model_only:
-                shutil.copy("env_mach_pes.xml", machpes)
-            if not sharedlib_only:
-                shutil.move("%s/%s.exe"%(exeroot,cime_model),"%s/%s.exe.NCK%s"%(exeroot,cime_model,bld))
-                shutil.copy("env_build.xml",os.path.join("LockedFiles","env_build.NCK%s.xml"%bld))
+    def _case_two_setup(self):
+        for comp in _COMPONENT_LIST:
+            self._case.set_value("NINST_%s"%comp, 2)
+            ntasks = self._case.get_value("NTASKS_%s"%comp)
+            self._case.set_value("NTASKS_%s"%comp, ntasks*2)
 
-        # Because mira/cetus interprets its run script differently than
-        # other systems we need to copy the original env_mach_pes.xml back
-#        shutil.copy(machpes1,"env_mach_pes.xml")
-#        shutil.copy("env_mach_pes.xml",
-#                    os.path.join("LockedFiles","env_mach_pes.xml"))
-
-    def run_phase(self):
-        os.chdir(self._caseroot)
-
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = CIME.utils.get_model()
-
-        # Reset beginning test settings
-        expect(os.path.exists("LockedFiles/env_mach_pes.NCK1.xml"),
-               "ERROR: LockedFiles/env_mach_pes.NCK1.xml does not exist\n"
-               "   this would been produced in the build - must run case.test_build")
-
-        shutil.copy("LockedFiles/env_mach_pes.NCK1.xml", "env_mach_pes.xml")
-        shutil.copy("env_mach_pes.xml", "LockedFiles/env_mach_pes.xml")
-        shutil.copy("%s/%s.exe.NCK1" % (exeroot, cime_model),
-                    "%s/%s.exe" % (exeroot, cime_model))
-        shutil.copy("LockedFiles/env_build.NCK1.xml", "env_build.xml")
-        shutil.copy("env_build.xml", "LockedFiles/env_build.xml")
-
-        stop_n      = self._case.get_value("STOP_N")
-        stop_option = self._case.get_value("STOP_OPTION")
-
-        self._case.set_value("HIST_N", stop_n)
-        self._case.set_value("HIST_OPTION", stop_option)
-        self._case.set_value("CONTINUE_RUN", False)
-        self._case.set_value("REST_OPTION", "none")
-        self._case.flush()
-
-        #======================================================================
-        # do an initial run test with NINST 1
-        #======================================================================
-        logger.info("default: doing a %s %s with NINST1" % (stop_n, stop_option))
-        self.run_indv()
-
-        #======================================================================
-        # do an initial run test with NINST 2
-        # want to run on same pe counts per instance and same cpl pe count
-        #======================================================================
-
-        os.remove("%s/%s.exe" % (exeroot, cime_model))
-        shutil.copy("%s/%s.exe.NCK2" % (exeroot, cime_model),
-                    "%s/%s.exe" % (exeroot, cime_model))
-        shutil.copy("LockedFiles/env_build.NCK2.xml", "env_build.xml")
-        shutil.copy("env_build.xml", "LockedFiles/env_build.xml")
-        shutil.copy("LockedFiles/env_mach_pes.NCK2.xml", "env_mach_pes.xml")
-        shutil.copy("env_mach_pes.xml", "LockedFiles/env_mach_pes.xml")
-
-        logger.info("default: doing a %s %s with NINST2" % (stop_n, stop_option))
-        self.run_indv(suffix="multiinst")
-        self._component_compare_test("base", "multiinst")
+        case_setup(self._case, test_mode=True, reset=True)


### PR DESCRIPTION
I was seeing problems in the NCK test - particularly, issue #469. I was
hopeful that rewriting it using the SystemTestsCompareTwo infrastructure
would fix these problems. It didn't. But we wanted to do this rewrite
anyway, and it does make the behavior of #465 more correct for NCK tests
-- I'll add a comment there describing how.

Test suite: NCK_D_Ld3.f10_f10.ICLM45.yellowstone_gnu.clm-default
   Ran out of a branch where I merged this branch with the branch from
   PR #465. For the sake of this test, I manually copied user_nl_clm to
   user_nl_clm_0001 and user_nl_clm_0002 as a workaround for #469.
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

   Also, for this test as well as
   NCK_D_Ld3_P15x1.f10_f10.ICLM45.yellowstone_gnu.clm-default and
   NCK_D.f09_g16_gl5.TG.yellowstone_gnu, I compared the PE layouts with
   the cime4 NCK test to ensure we're getting the same PE layouts for
   both runs.

Fixes #443

User interface changes?: No

Code review: @jedwards4b