### PR TITLE
provide a machine name in manage_case

### DIFF
--- a/scripts/manage_case
+++ b/scripts/manage_case
@@ -34,8 +34,10 @@ def query_machines():
     config_file = files.get_value("MACHINES_SPEC_FILE")
     expect(os.path.isfile(config_file),
            "Cannot find config_file %s on disk" %config_file)
+    # provide a machine name that is defined for both cesm and acme
+    # to avoid an error here on machines not in config_machines.xml
+    machines = Machines(config_file, machine="edison")
 
-    machines = Machines(config_file)
     machines.print_values()
 
 ###############################################################################


### PR DESCRIPTION
Provide a machine name common to acme and cesm projects so that manage_case --query_machines will not fail.  

Test suite: manage_case --query_machines on undefined machine
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes CIME Github issue #479 

User interface changes?: 

Code review: 

