### PR TITLE
Config pes fix

### DIFF
--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -1407,7 +1407,7 @@
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="yellowstone">
-      <pes pesize="X" compset="CAM.+CLM.+CICE.+POP.+">
+      <pes pesize="X2" compset="CAM.+CLM.+CICE.+POP.+">
 	<PES_PER_NODE>16</PES_PER_NODE>
 	<MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
 	<comment>none</comment>

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -15,7 +15,7 @@ class EnvMachPes(EnvBase):
         """
         EnvBase.__init__(self, case_root, infile)
 
-    def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None):
+    def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
         if "NTASKS" in vid or "ROOTPE" in vid and pes_per_node is None:
             pes_per_node = self.get_value("PES_PER_NODE")
@@ -26,7 +26,7 @@ class EnvMachPes(EnvBase):
                 value = -1*value*pes_per_node
         return value
 
-    def set_value(self, vid, value, subgroup=None, ignore_type=False, pes_per_node=None):
+    def set_value(self, vid, value, subgroup=None, ignore_type=False, pes_per_node=None): # pylint: disable=arguments-differ
         """
         Set the value of an entry-id field to value
         Returns the value or None if not found
@@ -40,7 +40,7 @@ class EnvMachPes(EnvBase):
 
 
 
-    def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False, pes_per_node=None):
+    def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False, pes_per_node=None): # pylint: disable=arguments-differ
         if vid is None:
             vid = node.get("id")
 

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -15,28 +15,41 @@ class EnvMachPes(EnvBase):
         """
         EnvBase.__init__(self, case_root, infile)
 
-    def get_value(self, vid, attribute=None, resolved=True, subgroup=None):
+    def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None):
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
-        if "NTASKS" in vid and value < 0:
-            value = -1*value*self.get_value("PES_PER_NODE")
-        if "NTHRDS" in vid and value < 0:
-            value = -1*value*self.get_value("PES_PER_NODE")
-        if "ROOTPE" in vid and value < 0:
-            value = -1*value*self.get_value("PES_PER_NODE")
-        return value
-    #
-    # We need a set value until we full transition from perl
-    #
+        if "NTASKS" in vid or "ROOTPE" in vid and pes_per_node is None:
+            pes_per_node = self.get_value("PES_PER_NODE")
 
-    def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False):
+            if "NTASKS" in vid and value < 0:
+                value = -1*value*pes_per_node
+            if "ROOTPE" in vid and value < 0:
+                value = -1*value*pes_per_node
+        return value
+
+    def set_value(self, vid, value, subgroup=None, ignore_type=False, pes_per_node=None):
+        """
+        Set the value of an entry-id field to value
+        Returns the value or None if not found
+        subgroup is ignored in the general routine and applied in specific methods
+        """
+        val = None
+        node = self.get_optional_node("entry", {"id":vid})
+        if node is not None:
+            val = self._set_value(node, value, vid, subgroup, ignore_type, pes_per_node=pes_per_node)
+        return val
+
+
+
+    def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False, pes_per_node=None):
         if vid is None:
             vid = node.get("id")
 
+        if "NTASKS" in vid or "ROOTPE" in vid and pes_per_node is None:
+            pes_per_node = self.get_value("PES_PER_NODE")
+
         if "NTASKS" in vid and value < 0:
-            value = -1*value*self.get_value("PES_PER_NODE")
-        if "NTHRDS" in vid and value < 0:
-            value = -1*value*self.get_value("PES_PER_NODE")
+            value = -1*value*pes_per_node
         if "ROOTPE" in vid and value < 0:
-            value = -1*value*self.get_value("PES_PER_NODE")
+            value = -1*value*pes_per_node
         val = EnvBase._set_value(self, node, value, vid, subgroup, ignore_type)
         return val

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -564,20 +564,22 @@ class Case(object):
 
         mach_pes_obj = self.get_env("mach_pes")
         totaltasks = {}
-        for key, value in pes_ntasks.items():
-            totaltasks[key[-3:]] = int(value)
-            mach_pes_obj.set_value(key,int(value))
-        for key, value in pes_rootpe.items():
-            totaltasks[key[-3:]] += int(value)
-            mach_pes_obj.set_value(key,int(value))
-        for key, value in pes_nthrds.items():
-            totaltasks[key[-3:]] *= int(value)
-            mach_pes_obj.set_value(key,int(value))
+        # Since other items may include PES_PER_NODE we need to do this first
+        # we can get rid of this code when all of the perl is removed
         for key, value in other.items():
             self.set_value(key, value)
+        pes_per_node = self.get_value("PES_PER_NODE")
+        for key, value in pes_ntasks.items():
+            totaltasks[key[-3:]] = int(value)
+            mach_pes_obj.set_value(key,int(value), pes_per_node=pes_per_node)
+        for key, value in pes_rootpe.items():
+            totaltasks[key[-3:]] += int(value)
+            mach_pes_obj.set_value(key,int(value), pes_per_node=pes_per_node)
+        for key, value in pes_nthrds.items():
+            totaltasks[key[-3:]] *= int(value)
+            mach_pes_obj.set_value(key,int(value), pes_per_node=pes_per_node)
 
         maxval = 1
-        pes_per_node = mach_pes_obj.get_value("PES_PER_NODE")
         for key, val in totaltasks.items():
             if val < 0:
                 val = -1*val*pes_per_node


### PR DESCRIPTION
The PES_PER_NODE value should be modifiable in the config_pes.xml file but in cime5.0.9 that value was being ignored when computing the NTASK_ values.   

Test suite: scripts_regression_tests, PFS_PX2.f09_g16.B1850.yellowstone_intel.allactive-default
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #486 
User interface changes?: 

Code review: 
