### PR TITLE
Update lanl machine files, and add c99 standard to csm_share

### DIFF
--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -1175,16 +1175,6 @@ for mct, etc.
 	<GPTL_CPPDEFS> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY </GPTL_CPPDEFS>
 </compiler>
 
-<compiler MACH="mustang">
-    <NETCDF_PATH>$(NETCDF)</NETCDF_PATH>
-    <PNETCDF_PATH>$(PARALLEL_NETCDF)</PNETCDF_PATH>
-</compiler>
-
-<compiler MACH="wolf">
-    <NETCDF_PATH>$(NETCDF)</NETCDF_PATH>
-    <PNETCDF_PATH>$(PARALLEL_NETCDF)</PNETCDF_PATH>
-</compiler>
-
 <compiler COMPILER="gnu" MACH="mustang">
 	<ADD_CFLAGS>  -std=c99 </ADD_CFLAGS>
 </compiler>

--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -1175,13 +1175,8 @@ for mct, etc.
 	<GPTL_CPPDEFS> -DHAVE_VPRINTF -DHAVE_GETTIMEOFDAY </GPTL_CPPDEFS>
 </compiler>
 
-<compiler COMPILER="gnu" MACH="mustang">
-	<ADD_CFLAGS>  -std=c99 </ADD_CFLAGS>
+<compiler COMPILER="gnu">
+	<ADD_CFLAGS MODEL="csm_share"> -std=c99 </ADD_CFLAGS>
 </compiler>
-
-<compiler COMPILER="gnu" MACH="wolf">
-	<ADD_CFLAGS>  -std=c99 </ADD_CFLAGS>
-</compiler>
-
 
 </config_compilers>


### PR DESCRIPTION
This merge updates the LANL machine files to remove a redundant definition of the parallel netcdf and netcdf variables required for PIO. Additionally, it adds -std=c99 when building csm_share with a gnu compiler.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes:

User interface changes?: 

Code review: 
