### PR TITLE
undo the changes to the hist_utils move tool and remove suffix in ssp…

### DIFF
--- a/utils/python/CIME/SystemTests/ssp.py
+++ b/utils/python/CIME/SystemTests/ssp.py
@@ -56,7 +56,7 @@ class SSP(SystemTestsCommon):
         clone.flush()
 
         dout_sr = clone.get_value("DOUT_S_ROOT")
-        self.run_indv(suffix="spinup", st_archive=True)
+        self.run_indv(suffix="", st_archive=True)
 
         #-------------------------------------------------------------------
         # (2) do a hybrid, non-spinup run in orig_case

--- a/utils/python/CIME/SystemTests/ssp.py
+++ b/utils/python/CIME/SystemTests/ssp.py
@@ -56,7 +56,8 @@ class SSP(SystemTestsCommon):
         clone.flush()
 
         dout_sr = clone.get_value("DOUT_S_ROOT")
-        self.run_indv(suffix="", st_archive=True)
+        # No history files expected, set suffix=None to avoid compare error
+        self.run_indv(suffix=None, st_archive=True)
 
         #-------------------------------------------------------------------
         # (2) do a hybrid, non-spinup run in orig_case

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -223,12 +223,8 @@ class SystemTestsCommon(object):
         return False
 
     def _component_compare_move(self, suffix):
-        success, comments = move(self._case, suffix)
+        comments = move(self._case, suffix)
         append_status(comments, sfile="TestStatus.log")
-        status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
-        with self._test_status:
-            self._test_status.set_status("%s_%s" % (COMPARE_PHASE, suffix), status)
-        return success
 
     def _component_compare_test(self, suffix1, suffix2):
         """

--- a/utils/python/CIME/hist_utils.py
+++ b/utils/python/CIME/hist_utils.py
@@ -75,12 +75,9 @@ def move(case, suffix):
             comments += "    Copying '%s' to '%s'\n" % (test_hist, new_file)
             shutil.copy(test_hist, new_file)
 
-    all_success = True
-    if num_moved == 0:
-        all_success = False
-        comments += "WARNING: No hist files found in rundir '%s'" % rundir
+     expect(num_moved > 0, "move failed: no hist files found in rundir '%s'" % rundir)
 
-    return all_success, comments
+    return comments
 
 
 def _hists_match(model, hists1, hists2, suffix1="", suffix2=""):
@@ -312,11 +309,11 @@ def get_extension(model, filepath):
 
     m = ext_regex.match(basename)
     expect(m is not None, "Failed to get extension for file '%s'" % filepath)
+
     if m.group(1) is not None:
         result = m.group(1)+'.'+m.group(2)
     else:
         result = m.group(2)
-
 
     return result
 


### PR DESCRIPTION
undo the changes to the hist_utils move tool and remove suffix in ssp test (no hist files produced)

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 

