### PR TITLE
If move is unable to move any files, error

### DIFF
--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -223,12 +223,8 @@ class SystemTestsCommon(object):
         return False
 
     def _component_compare_move(self, suffix):
-        success, comments = move(self._case, suffix)
+        comments = move(self._case, suffix)
         append_status(comments, sfile="TestStatus.log")
-        status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
-        with self._test_status:
-            self._test_status.set_status("%s_%s" % (COMPARE_PHASE, suffix), status)
-        return success
 
     def _component_compare_test(self, suffix1, suffix2):
         """

--- a/utils/python/CIME/hist_utils.py
+++ b/utils/python/CIME/hist_utils.py
@@ -75,13 +75,9 @@ def move(case, suffix):
             comments += "    Copying '%s' to '%s'\n" % (test_hist, new_file)
             shutil.copy(test_hist, new_file)
 
-    all_success = True
-    if num_moved == 0:
-        all_success = False
-        comments += "WARNING: No hist files found in rundir '%s'" % rundir
+    expect(num_moved > 0, "move failed: no hist files found in rundir '%s'" % rundir)
 
-    return all_success, comments
-
+    return comments
 
 def _hists_match(model, hists1, hists2, suffix1="", suffix2=""):
     """


### PR DESCRIPTION
If a test does not have files to move, use suffix=None for run_indv

@jedwards4b I was not able to figure out which test was producing no hist files. You can add to this branch when you see this PR.

Test suite: cime_developer
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: None

Code review: @jedwards4b 

