### PR TITLE
Mask grid fix

### DIFF
--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -895,7 +895,7 @@
   <entry id="SAVE_TIMING_DIR">
     <type>char</type>
     <valid_values></valid_values>
-    <default_value>UNSET</default_value>
+    <default_value>timing</default_value>
     <group>run_flags</group>
     <file>env_run.xml</file>
     <desc>Where to auto archive timing data</desc>
@@ -1144,6 +1144,14 @@
     <group>build_grid</group>
     <file>env_build.xml</file>
     <desc>number of wav cells in j direction - DO NOT EDIT (for experts only)</desc>
+  </entry>
+
+  <entry id="MASK_GRID">
+    <type>char</type>
+    <default_value>UNSET</default_value>
+    <group>build_grid</group>
+    <file>env_build.xml</file>
+    <desc>grid mask - DO NOT EDIT (for experts only)</desc>
   </entry>
 
   <entry id="PTS_MODE">

--- a/driver_cpl/cime_config/config_compsets.xml
+++ b/driver_cpl/cime_config/config_compsets.xml
@@ -4,9 +4,9 @@
 
   <help>
     =========================================
-    compset naming convention 
+    compset naming convention
     =========================================
-    The compset longname below has the specified order 
+    The compset longname below has the specified order
     atm, lnd, ice, ocn, river, glc wave esp cesm-options
 
     The notation for the compset longname is
@@ -21,29 +21,29 @@
     GLC  = [CISM1, CISM2, SGLC]
     WAV  = [SWAV]
     ESP  = [SESP]
-    BGC  = optional BGC scenario 
+    BGC  = optional BGC scenario
 
     The OPTIONAL %phys attributes specify submodes of the given system
     For example DOCN%DOM is the data ocean model for DOCN
-    ALL the possible %phys choices for each component are listed 
+    ALL the possible %phys choices for each component are listed
     with the -list command for create_newcase
-    ALL data models must have a %phys option that corresponds to the data  model mode 
+    ALL data models must have a %phys option that corresponds to the data  model mode
 
     Each compset node is associated with the following elements
-    - lname      
-    - alias        
+    - lname
+    - alias
     - support  (optional description of the support level for this compset)
     Each compset node can also have the following attributes
     - grid  (optional regular expression match for grid to work with the compset)
   </help>
 
   <compset>
-    <alias>A</alias>           
+    <alias>A</alias>
     <lname>2000_DATM%NYF_DLND%NULL_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV</lname>
   </compset>
 
   <compset>
-    <alias>AWAV</alias>           
+    <alias>AWAV</alias>
     <lname>2000_DATM%WW3_DLND%NULL_DICE%COPY_DOCN%COPY_DROF%NULL_SGLC_WW3</lname>
   </compset>
 
@@ -53,12 +53,12 @@
   </compset>
 
   <compset>
-    <alias>S</alias>           
+    <alias>S</alias>
     <lname>2000_SATM_SLND_SICE_SOCN_SROF_SGLC_SWAV_SESP</lname>
   </compset>
 
   <compset>
-    <alias>X</alias>           
+    <alias>X</alias>
     <lname>2000_XATM_XLND_XICE_XOCN_XROF_XGLC_XWAV</lname>
   </compset>
 

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -233,7 +233,7 @@ class EnvBatch(EnvBase):
         self.tasks_per_numa = task_maker.tasks_per_numa
         self.num_tasks = task_maker.totaltasks
 
-        task_count = self.get_value("task_count")
+        task_count = self.get_value("task_count", subgroup=job)
         if task_count == "default":
             self.sumpes = task_maker.fullsum
             self.totaltasks = task_maker.totaltasks

--- a/utils/python/CIME/XML/grids.py
+++ b/utils/python/CIME/XML/grids.py
@@ -114,8 +114,9 @@ class Grids(GenericXML):
                 mask_name = "ocn_mask"
             root = self.get_optional_node(nodename="domain", attributes={"name":grid[1]})
             if root is not None:
-                domains[grid[0]+"_NX"] = int(self.get_value("nx", root=root))
-                domains[grid[0]+"_NY"] = int(self.get_value("ny", root=root))
+                if grid[0] != "MASK":
+                    domains[grid[0]+"_NX"] = int(self.get_value("nx", root=root))
+                    domains[grid[0]+"_NY"] = int(self.get_value("ny", root=root))
                 domains[grid[0] + "_GRID"] = grid[1]
                 if mask_name is not None:
                     file_ = self.get_value("file", attributes={mask_name:mask}, root=root)

--- a/utils/python/CIME/XML/grids.py
+++ b/utils/python/CIME/XML/grids.py
@@ -98,6 +98,7 @@ class Grids(GenericXML):
                  ("OCN", component_grids[2]), \
                  ("ICE", component_grids[2]), \
                  ("ROF", component_grids[3]), \
+                 ("MASK", component_grids[4]), \
                  ("GLC", component_grids[5]), \
                  ("WAV", component_grids[6])]
         mask = component_grids[4]

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -85,19 +85,20 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
             os.chmod(shell_command_file, 0777)
             run_cmd_no_fail(shell_command_file)
 
-def build_include_dirs_list(user_mods_path, include_dirs=None):
+def build_include_dirs_list(user_mods_path, include_dirs=[]):
     '''
     If user_mods_path has a file "include_user_mods" read that
     file and add directories to the include_dirs, recursively check
     each of those directories for further directories.
     The file may also include comments deleneated with # in the first column
     '''
+    if user_mods_path is None or user_mods_path == 'UNSET':
+        return include_dirs
     expect(os.path.isabs(user_mods_path),
            "Expected full directory path, got '%s'"%user_mods_path)
     expect(os.path.isdir(user_mods_path),
            "Directory not found %s"%user_mods_path)
     logger.info("Adding user mods directory %s"%user_mods_path)
-    include_dirs = [] if include_dirs is None else include_dirs
     include_dirs.append(os.path.normpath(user_mods_path))
     include_file = os.path.join(include_dirs[-1],"include_user_mods")
     if os.path.isfile(include_file):

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -85,13 +85,14 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
             os.chmod(shell_command_file, 0777)
             run_cmd_no_fail(shell_command_file)
 
-def build_include_dirs_list(user_mods_path, include_dirs=[]):
+def build_include_dirs_list(user_mods_path, include_dirs=None):
     '''
     If user_mods_path has a file "include_user_mods" read that
     file and add directories to the include_dirs, recursively check
     each of those directories for further directories.
     The file may also include comments deleneated with # in the first column
     '''
+    include_dirs = [] if include_dirs is None else include_dirs
     if user_mods_path is None or user_mods_path == 'UNSET':
         return include_dirs
     expect(os.path.isabs(user_mods_path),

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1010,21 +1010,18 @@ class L_TestSaveTimings(TestCreateTestCommon):
         if manual_timing:
             run_cmd_assert_result(self, "cd %s && %s/save_provenance postrun" % (casedir, TOOLS_DIR))
 
-        provenance_dir = os.path.join(timing_dir, "performance_archive", getpass.getuser(), casename, lids[0])
-        self.assertTrue(os.path.isdir(provenance_dir), msg="'%s' was missing" % provenance_dir)
+        if CIME.utils.get_model() != "acme":
+            provenance_dir = os.path.join(timing_dir, "performance_archive", getpass.getuser(), casename, lids[0])
+            self.assertTrue(os.path.isdir(provenance_dir), msg="'%s' was missing" % provenance_dir)
 
     ###########################################################################
     def test_save_timings(self):
     ###########################################################################
-        if CIME.utils.get_model() != "acme":
-            self.skipTest("Skipping test. ACME feature")
         self.simple_test()
 
     ###########################################################################
     def test_save_timings_manual(self):
     ###########################################################################
-        if CIME.utils.get_model() != "acme":
-            self.skipTest("Skipping test. ACME feature")
         self.simple_test(manual_timing=True)
 
 ###############################################################################

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1016,11 +1016,15 @@ class L_TestSaveTimings(TestCreateTestCommon):
     ###########################################################################
     def test_save_timings(self):
     ###########################################################################
+        if CIME.utils.get_model() != "acme":
+            self.skipTest("Skipping test. ACME feature")
         self.simple_test()
 
     ###########################################################################
     def test_save_timings_manual(self):
     ###########################################################################
+        if CIME.utils.get_model() != "acme":
+            self.skipTest("Skipping test. ACME feature")
         self.simple_test(manual_timing=True)
 
 ###############################################################################


### PR DESCRIPTION
It appeared that the MASK_GRID xml variable was not being used and so it was removed in an earlier commit, this commit restores it and sets it's value so that it can be used be the clm buildnml

Test suite: scripts_regression_tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #510 
Fixes #511 

User interface changes?: 

Code review: 
