### PR TITLE
fix mechanism to read project from file

### DIFF
--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -530,7 +530,10 @@ def get_project(machobj=None):
     projectfile = os.path.abspath(os.path.join(os.path.expanduser("~"), ".cesm_proj"))
     if (os.path.isfile(projectfile)):
         with open(projectfile,'r') as myfile:
-            project = myfile.read().rstrip()
+            for line in myfile:
+                project = line.rstrip()
+                if not project.startswith("#"):
+                    break
             logger.info("Using project from .cesm_proj: " + project)
             cime_config.set('main','PROJECT',project)
             return project

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1010,7 +1010,7 @@ class L_TestSaveTimings(TestCreateTestCommon):
         if manual_timing:
             run_cmd_assert_result(self, "cd %s && %s/save_provenance postrun" % (casedir, TOOLS_DIR))
 
-        if CIME.utils.get_model() != "acme":
+        if CIME.utils.get_model() == "acme":
             provenance_dir = os.path.join(timing_dir, "performance_archive", getpass.getuser(), casename, lids[0])
             self.assertTrue(os.path.isdir(provenance_dir), msg="'%s' was missing" % provenance_dir)
 


### PR DESCRIPTION
The mechanism to read the .cesm_proj file for a project number was reading the entire file,
this change causes it to read until the first line not beginning with # and use that for the project id
Also fix a minor issue in scripts_regression_tests

Test suite: tested several possible project files on yellowstone  
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #505 

User interface changes?: 

Code review: 

