### PR TITLE
if model is cesm and not test set DOUT_S true by default

### DIFF
--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -580,11 +580,12 @@ class Case(object):
             mach_pes_obj.set_value(key,int(value), pes_per_node=pes_per_node)
 
         maxval = 1
-        for key, val in totaltasks.items():
-            if val < 0:
-                val = -1*val*pes_per_node
-            if val > maxval:
-                maxval = val
+        if mpilib != "mpi-serial":
+            for key, val in totaltasks.items():
+                if val < 0:
+                    val = -1*val*pes_per_node
+                if val > maxval:
+                    maxval = val
 
         # Make sure that every component has been accounted for
         # set, nthrds and ntasks to 1 otherwise. Also set the ninst values here.
@@ -650,9 +651,7 @@ class Case(object):
         if self.get_value("RUN_TYPE") == 'hybrid':
             self.set_value("GET_REFCASE", True)
 
-# Turn on short term archiving as cesm default setting
-        import pdb
-        pdb.set_trace()
+        # Turn on short term archiving as cesm default setting
         model = get_model()
         if model == "cesm" and not test:
             self.set_value("DOUT_S",True)

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -650,6 +650,15 @@ class Case(object):
         if self.get_value("RUN_TYPE") == 'hybrid':
             self.set_value("GET_REFCASE", True)
 
+# Turn on short term archiving as cesm default setting
+        import pdb
+        pdb.set_trace()
+        model = get_model()
+        if model == "cesm" and not test:
+            self.set_value("DOUT_S",True)
+
+
+
     def get_compset_var_settings(self):
         compset_obj = Compsets(infile=self.get_value("COMPSETS_SPEC_FILE"))
         matches = compset_obj.get_compset_var_settings(self._compsetname, self._gridname)
@@ -765,7 +774,7 @@ class Case(object):
         if not os.path.exists(directory):
             os.makedirs(directory)
 
-        if get_model() is "cesm":
+        if get_model() == "cesm":
         # Note: this is CESM specific, given that we are referencing cism explitly
             if "cism" in components:
                 directory = os.path.join(self._caseroot, "SourceMods", "src.cism", "glimmer-cism")


### PR DESCRIPTION
Make DOUT_S True by default if model is cesm and not test, also fix a bug in test for get_model and make sure that totaltasks is 1 for mpi-serial. 

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #511 (already closed but only partially addressed)

User interface changes?: 

Code review: 

