### PR TITLE
fix issues with timing cost calculation on SMT machines

### DIFF
--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -189,7 +189,17 @@ def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, r
             check_lockedfiles()
 
             tm = TaskMaker(case)
-            pestot = tm.fullsum
+            mtpn = case.get_value("MAX_TASKS_PER_NODE")
+            pespn = case.get_value("PES_PER_NODE")
+            # This is hardcoded because on yellowstone by default we
+            # run with 15 pes per node
+            # but pay for 16 pes per node.  See github issue #518
+            if case.get_value("MACH") == "yellowstone":
+                pespn = 16
+            pestot = tm.totaltasks
+            if mtpn > pespn:
+                pestot = pestot * (mtpn // pespn)
+                case.set_value("COST_PES", tm.num_nodes*pespn)
             case.set_value("TOTALPES", pestot)
 
             # Compute cost based on PE count


### PR DESCRIPTION
The timing cost estimates were not taking into account the use of hyperthreads, this addresses that issue.   

Test suite: scripts_regression_tests , PFS.f19_g16.F1850.yellowstone_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Connects to #518 

User interface changes?: 

Code review: 

