### PR TITLE
Add test mods support for mosart via user_nl_mosart

### DIFF
--- a/cime_config/cesm/allactive/testmods_dirs/allactive/defaultio/user_nl_mosart
+++ b/cime_config/cesm/allactive/testmods_dirs/allactive/defaultio/user_nl_mosart
@@ -1,0 +1,13 @@
+!----------------------------------------------------------------------------------
+! Users should add all user specific namelist changes below in the form of
+! namelist_var = new_namelist_value
+! NOTE: namelist variable rtm_tstep CAN ONLY be changed by modifying the value
+!       of the xml variable ROF_NCPL in env_run.xml
+! NOTE: if the xml variable RTM_MODE in env_run.xml is set to 'NULL', then
+!        then rtm will set rtm_present to .false. - and will ignore everything else
+!----------------------------------------------------------------------------------
+rtmhist_ndens     = 1
+rtmhist_nhtfrq    =-24
+rtmhist_mfilt     = 1
+
+


### PR DESCRIPTION
The cesm testmods dir default and defaultio were missing
support for mosart.

Test suite: ERS.f19_g16.B1850.yellowstone_intel.allactive-defaultio
Test baseline: none
Test namelist changes: user_nl_mosart
Test status: bit for bit

Fixes: none

Code review: