### PR TITLE
Add MPAS short term archive support

### DIFF
--- a/cime_config/acme/config_archive.xml
+++ b/cime_config/acme/config_archive.xml
@@ -79,6 +79,15 @@
     </rpointer>
   </comp_archive_spec>
 
+  <comp_archive_spec compname="mpascice" compclass="ice">
+    <rest_file_extension>\.rst.*</rest_file_extension>
+    <hist_file_extension>\.hist.*</hist_file_extension>
+    <rest_history_varname>unset</rest_history_varname>
+    <rpointer>
+      <rpointer_file>rpointer.ice</rpointer_file>
+    </rpointer>
+  </comp_archive_spec>
+
   <comp_archive_spec compname="dice" compclass="ice">
     <rest_file_extension>\.r.*</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
@@ -102,6 +111,15 @@
     </rpointer>
   </comp_archive_spec>
 
+  <comp_archive_spec compname="mpaso" compclass="ocn">
+    <rest_file_extension>\.rst.*</rest_file_extension>
+    <hist_file_extension>\.hist.*</hist_file_extension>
+    <rest_history_varname>unset</rest_history_varname>
+    <rpointer>
+      <rpointer_file>rpointer.ocn</rpointer_file>
+    </rpointer>
+  </comp_archive_spec>
+
   <comp_archive_spec compname="docn" compclass="ocn">
     <rest_file_extension>\.r.*</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
@@ -118,6 +136,15 @@
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.glc</rpointer_file>
       <rpointer_content>./$CASE.cism$NINST_STRING.r.$DATENAME.nc</rpointer_content>
+    </rpointer>
+  </comp_archive_spec>
+
+  <comp_archive_spec compname="mpasli" compclass="glc">
+    <rest_file_extension>\.rst.*</rest_file_extension>
+    <hist_file_extension>\.hist.*</hist_file_extension>
+    <rest_history_varname>unset</rest_history_varname>
+    <rpointer>
+      <rpointer_file>rpointer.glc</rpointer_file>
     </rpointer>
   </comp_archive_spec>
 


### PR DESCRIPTION
This merge adds support to the ACME config_archive.xml file for
archiving MPAS restart and output files.

This version of config_archive.xml requires the
formats to be as follows:

restarts: ${component_name}.rst.${date}_${tod}.nc
history: ${component_name}.hist.*.nc

In this case, ${tod} needs to be seconds within the day.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #422

User interface changes?: 

Code review: 
