### PR TITLE
Rasm fix

### DIFF
--- a/driver_cpl/driver/cesm_comp_mod.F90
+++ b/driver_cpl/driver/cesm_comp_mod.F90
@@ -2277,6 +2277,19 @@ end subroutine cesm_init
          enddo
          call t_drvstopf  ('CPL:atmocnp_ocnalb',hashint=hashint(5))
 
+         !----------------------------------------------------------
+         !| ocn budget (rasm_option1)
+         !----------------------------------------------------------
+
+         if (do_budgets) then
+            call cesm_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:BUDGET0_BARRIER')
+            call t_drvstartf ('CPL:BUDGET0',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
+            xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
+            call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), &
+                 do_o2x=.true., do_x2o=.true., do_xao=.true.)
+            call t_drvstopf ('CPL:BUDGET0',cplrun=.true.,budget=.true.)
+         endif
+
          if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
          call t_drvstopf  ('CPL:ATMOCN1',cplrun=.true.,hashint=hashint(4))
       endif
@@ -2764,6 +2777,19 @@ end subroutine cesm_init
          enddo
          call t_drvstopf  ('CPL:atmocnp_ocnalb')
 
+         !----------------------------------------------------------
+         !| ocn budget (cesm1_orig, cesm1_orig_tight, cesm1_mod or cesm1_mod_tight)
+         !----------------------------------------------------------
+
+         if (do_budgets) then
+            call cesm_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:BUDGET0_BARRIER')
+            call t_drvstartf ('CPL:BUDGET0',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
+            xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
+            call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), &
+                 do_o2x=.true., do_x2o=.true., do_xao=.true.)
+            call t_drvstopf ('CPL:BUDGET0',cplrun=.true.,budget=.true.)
+         endif
+
          if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
          call t_drvstopf  ('CPL:ATMOCNP',cplrun=.true.,hashint=hashint(7))
       endif
@@ -2933,16 +2959,6 @@ end subroutine cesm_init
          if (rof_present) then
             call seq_diag_rof_mct(rof(ens1), fractions_rx(ens1))
          endif
-         if (ocn_present .and. &
-            (trim(cpl_seq_option) == 'CESM1_ORIG'       .or. &
-             trim(cpl_seq_option) == 'CESM1_ORIG_TIGHT' .or. &
-             trim(cpl_seq_option) == 'CESM1_MOD'        .or. &
-             trim(cpl_seq_option) == 'CESM1_MOD_TIGHT'  .or. &
-             trim(cpl_seq_option) == 'RASM_OPTION1' )) then
-            xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
-            call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), &
-                 do_o2x=.true., do_x2o=.true., do_xao=.true.)
-         endif
          if (ice_present) then
             call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), &
                  do_x2i=.true.)
@@ -3093,6 +3109,19 @@ end subroutine cesm_init
             call seq_flux_ocnalb_mct(infodata, ocn(1), a2x_ox(eai), fractions_ox(efi), xao_ox(exi))
          enddo
          call t_drvstopf  ('CPL:atmocnp_ocnalb')
+
+         !----------------------------------------------------------
+         !| ocn budget (rasm_option2)
+         !----------------------------------------------------------
+
+         if (do_budgets) then
+            call cesm_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:BUDGET0_BARRIER')
+            call t_drvstartf ('CPL:BUDGET0',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
+            xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
+            call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), &
+                 do_o2x=.true., do_x2o=.true., do_xao=.true.)
+            call t_drvstopf ('CPL:BUDGET0',cplrun=.true.,budget=.true.)
+         endif
 
          if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
          call t_drvstopf  ('CPL:ATMOCN2',cplrun=.true.)
@@ -3392,12 +3421,6 @@ end subroutine cesm_init
          call cesm_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:BUDGET2_BARRIER')
 
          call t_drvstartf ('CPL:BUDGET2',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
-         if (ocn_present .and. &
-            (trim(cpl_seq_option) == 'RASM_OPTION2' )) then
-            xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
-            call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), &
-                 do_o2x=.true., do_x2o=.true., do_xao=.true.)
-         endif
          if (atm_present) then
             call seq_diag_atm_mct(atm(ens1), fractions_ax(ens1), &
                  do_a2x=.true., do_x2a=.true.)


### PR DESCRIPTION
Update coupler budget calculation to correct an error when using 
RASM_OPTION1 and RASM_OPTION2. Does not change coupling or
science, just budget diagnostics. The old implementation was using
an averaged valued for ocean fluxes on ocean coupling timesteps instead
of the instantaneous value. This was corrected by rearranging the call
to the ocean budget diagnostic.


Test suite: B1850 
Test baseline: cesm1_5_beta07
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes:

User interface changes?: 

Code review: