### PR TITLE
Check against valid values

### DIFF
--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -157,15 +157,17 @@ class EntryID(GenericXML):
         subgroup is ignored in the general routine and applied in specific methods
         """
         expect(subgroup is None, "Subgroup not supported")
+        valid_values = self.get_optional_node("valid_values", root=node)
         if ignore_type:
             expect(type(value) is str, "Value must be type string if ignore_type is true")
-            node.set("value",value)
+            str_value = value
         else:
             type_str = self._get_type_info(node)
-            valid_values = self.get_optional_node("valid_values", root=node)
-            if valid_values.text is not None:
-                expect(value in valid_values.text.split(','), "Did not find %s in valid values:%s"%(value, valid_values.text))
-            node.set("value", convert_to_string(value, type_str, vid))
+            str_value = convert_to_string(value, type_str, vid)
+        if valid_values is not None and valid_values.text is not None and not str_value.startswith('$'):
+            vvlist = map(str.lstrip, valid_values.text.split(','))
+            expect(str_value in vvlist, "Did not find %s in valid values:%s"%(value, vvlist))
+        node.set("value", str_value)
 
         return value
 

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -162,7 +162,11 @@ class EntryID(GenericXML):
             node.set("value",value)
         else:
             type_str = self._get_type_info(node)
+            valid_values = self.get_optional_node("valid_values", root=node)
+            if valid_values.text is not None:
+                expect(value in valid_values.text.split(','), "Did not find %s in valid values:%s"%(value, valid_values.text))
             node.set("value", convert_to_string(value, type_str, vid))
+
         return value
 
     def set_value(self, vid, value, subgroup=None, ignore_type=False):


### PR DESCRIPTION
This is a response to @gold2718 comment in issue #408 xmlchange should check against the list of valid values.    The fix is in entry_id.py routine _set_value and so checks against valid values for more than just xmlchange.    Note that although ```xmlchange STOP_OPTION=foo``` now traps and reports an error  ```xmlchange STOP_OPTION=\$foo``` is still allowed.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Connects to #550 

User interface changes?: 

Code review: 
