### PR TITLE
Fix PFS test case.

### DIFF
--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -388,6 +388,7 @@ LII    CLM initial condition interpolation test
     <REST_OPTION>none</REST_OPTION>
     <CCSM_TCOST>0</CCSM_TCOST>
     <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
   </test>
 
   <test NAME="NCK">

--- a/utils/python/CIME/SystemTests/pfs.py
+++ b/utils/python/CIME/SystemTests/pfs.py
@@ -18,11 +18,5 @@ class PFS(SystemTestsCommon):
         SystemTestsCommon.__init__(self, case)
 
     def run_phase(self):
-        self._case.set_value("STOP_OPTION", "ndays")
-        self._case.set_value("STOP_N", 20)
-        self._case.set_value("REST_OPTION","none")
-        self._case.set_value("CONTINUE_RUN", False)
-        self._case.flush()
-
         logger.info("doing an 20 day initial test, no restarts written")
-        self.run_indv()
+        self.run_indv(suffix=None)


### PR DESCRIPTION
Since it does not write history files, the suffix to run_indv
should be None so it does not try to move non-existant history
files. Also, remove some redundant case settings.

Test suite: None
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #543

User interface changes?: None

Code review: jedwards
