### PR TITLE
Add setting of BARRIER_OPTION back in to cime5

### DIFF
--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -376,6 +376,9 @@
     <type>char</type>
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
     <default_value>never</default_value>
+    <values>
+      <value compset="_DATM.+_CLM">ndays</value>
+    </values>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
     <desc>


### PR DESCRIPTION
Set BARRIER_OPTION to daily for I compsets in driver config_component.xml

Sets BARRIER_OPTION=ndays for compsets that match DATM and CLM

Testing: Test some I compsets in clm test suite
Test status: bit for bit

Fixes: ESMCI/cime/#551