### PR TITLE
Added a new test for data assimilation and added new DA params

### DIFF
--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -156,7 +156,7 @@ LAR    long term archive test
     Data Assimilation Tests
 ======================================================================
 
-DAE    data assimilation test -- non answer changing
+DAE    data assimilation test: non answer changing
 
 ======================================================================
     Other component-specific tests

--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -3,16 +3,17 @@
 <!--
 
 The following are the test functionality categories:
-  1) smoke tests
-  2) basic reproducibility tests
-  3) restart tests
-  4) threading/pe-count modification tests
-  5) sequencing (layout) modification tests
-  6) multi-instance tests
-  7) archiving (short-term and long-term) tests
-  8) performance tests
-  9) spinup tests
-  10) other component-specific tests
+   1) smoke tests
+   2) basic reproducibility tests
+   3) restart tests
+   4) threading/pe-count modification tests
+   5) sequencing (layout) modification tests
+   6) multi-instance tests
+   7) archiving (short-term and long-term) tests
+   8) performance tests
+   9) spinup tests
+  10) data assimilation tests
+  11) other component-specific tests
 
 NOTES:
 - unless otherwise noted everything is run in one executable directory
@@ -152,6 +153,12 @@ SPO    smoke spinup-ocean test
 LAR    long term archive test
 
 ======================================================================
+    Data Assimilation Tests
+======================================================================
+
+DAS    data assimilation test
+
+======================================================================
     Other component-specific tests
 ======================================================================
 
@@ -161,6 +168,18 @@ LII    CLM initial condition interpolation test
 -->
 
 <config_test>
+
+  <test NAME="DAE">
+    <DESC>data assimilation test, default 1 day, two DA cycles, no data modification</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <STOP_OPTION>ndays</STOP_OPTION>
+    <STOP_N>4</STOP_N>
+    <HIST_OPTION>ndays</HIST_OPTION>
+    <HIST_N>1</HIST_N>
+    <CCSM_TCOST>0</CCSM_TCOST>
+    <DOUT_S>FALSE</DOUT_S>
+    <BUILD_THREADED>TRUE</BUILD_THREADED>
+  </test>
 
   <test NAME="ERI">
     <DESC>hybrid/branch/exact restart test, default 3+19/10+9/5+4 days</DESC>

--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -156,7 +156,7 @@ LAR    long term archive test
     Data Assimilation Tests
 ======================================================================
 
-DAS    data assimilation test
+DAE    data assimilation test -- non answer changing
 
 ======================================================================
     Other component-specific tests

--- a/utils/data_assimilation/da_no_data_mod.sh
+++ b/utils/data_assimilation/da_no_data_mod.sh
@@ -1,0 +1,30 @@
+#! /bin/bash
+
+##############################################################################
+###
+### A stub data assimilation script that prints out information but makes
+### no modifications to model data.
+### Tests using this script should be BFB with a non-data assimilation run
+###
+##############################################################################
+
+errcode=0
+if [ $# -ne 2 ]; then
+  echo "ERROR: Wrong number of arguments, $# (should be 2)"
+  errcode=$(( errcode + 1 ))
+else
+  cycle=$1
+  shift
+  total_cycles=$1
+  shift
+  if [ -n ${CASEROOT} ]; then
+    echo "caseroot: ${CASEROOT}"
+  else
+    echo "ERROR: CASEROOT not defined"
+    errcode=$(( errcode + 1 ))
+  fi
+  echo "cycle: ${cycle}"
+  echo "total_cycles: ${total_cycles}"
+fi
+
+exit $errcode

--- a/utils/python/CIME/SystemTests/dae.py
+++ b/utils/python/CIME/SystemTests/dae.py
@@ -1,0 +1,107 @@
+"""
+Implementation of the CIME data assimilation test: Tests simple DA script
+which does not change the CAM input. Compares answers to non-DA run.
+
+"""
+
+import os.path
+import logging
+import glob
+
+import CIME.XML.standard_module_setup as sms
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
+from CIME.utils import expect
+from CIME.case_setup import case_setup
+
+###############################################################################
+class DAE(SystemTestsCompareTwo):
+###############################################################################
+    """
+    Implementation of the CIME data assimilation test: Tests simple DA script
+    which does not change the CAM input. Compares answers to non-DA run.
+    Refers to a faux data assimilation script in the
+    cime/utils/data_assimilation directory
+    """
+
+    ###########################################################################
+    def __init__(self, case):
+    ###########################################################################
+        SystemTestsCompareTwo.__init__(self, case,
+                                       separate_builds=False,
+                                       run_two_suffix='da',
+                                       run_one_description='no data assimilation',
+                                       run_two_description='data assimilation')
+
+    ###########################################################################
+    def _case_one_setup(self):
+    ###########################################################################
+        case_setup(self._case, test_mode=True, reset=True)
+
+    ###########################################################################
+    def _case_two_setup(self):
+    ###########################################################################
+        # Set up data assimilation in config_tests.xml once that's ready
+        # We need to find the utils/data_assimilation directory
+        # LIB_DIR should be our parent dir
+        da_dir = os.path.join(os.path.dirname(sms.LIB_DIR), "data_assimilation")
+        expect(os.path.isdir(da_dir), "ERROR: da_dir, '%s', does not exist"%da_dir)
+        da_file = os.path.join(da_dir, "da_no_data_mod.sh")
+        expect(os.path.isfile(da_file), "ERROR: da_file, '%s', does not exist"%da_file)
+
+        # Set up two data assimilation cycles each half of the full run
+        self._case.set_value("DATA_ASSIMILATION", "TRUE")
+        self._case.set_value("DATA_ASSIMILATION_SCRIPT", da_file)
+        self._case.set_value("DATA_ASSIMILATION_CYCLES", 2)
+        stopn = self._case.get_value("STOP_N")
+        expect((stopn % 2) == 0, "ERROR: DAE test requires that STOP_N be even")
+        stopn = stopn / 2
+        self._case.set_value("STOP_N", stopn)
+
+        self._case.flush()
+
+    ###########################################################################
+    def run_phase(self):
+    ###########################################################################
+        SystemTestsCompareTwo.run_phase(self)
+        # Do some checks on the data assimilation 'output' from case2
+        self._activate_case2()
+        case_root = self._get_caseroot2()
+        da_files = glob.glob(os.path.join(case_root, 'da.log.*'))
+        if da_files is None:
+            logger = logging.getLogger(__name__)
+            logger.warning("No DA files in %s", os.path.join(case_root, 'da.log.*'))
+
+        da_cycles = self._case.get_value("DATA_ASSIMILATION_CYCLES")
+        expect((da_files is not None) and (len(da_files) == da_cycles),
+               "ERROR: There were %d DA cycles in run but %d DA files were found"%
+               (da_cycles, len(da_files) if da_files is not None else 0))
+        da_files.sort()
+        cycle_num = 0
+        for fname in da_files:
+            found_caseroot = False
+            found_cycle = False
+            found_total = False
+            with open(fname) as dfile:
+                for line in dfile:
+                    expect(line[0:5] != 'ERROR', "ERROR, error line found in %s"%fname)
+                    if line[0:8] == 'caseroot':
+                        found_caseroot = True
+                    elif line[0:5] == 'cycle':
+                        found_cycle = True
+                        expect(int(line[7:]) == cycle_num,
+                               "ERROR: Wrong cycle (%d) found in %s (expected %d)"%
+                               (int(line[7:]), fname, cycle_num))
+                    elif line[0:12] == 'total_cycles':
+                        found_total = True
+                        expect(int(line[14:]) == da_cycles,
+                               "ERROR: Wrong total cycle count (%d) found in %s (expected %d)"%
+                               (int(line[14:]), fname, da_cycles))
+                    else:
+                        expect(False, "ERROR: Unrecognized line ('%s') found in %s"%(line, fname))
+
+                # End of for loop
+                expect(found_caseroot, "ERROR: No caseroot found in %s"%fname)
+                expect(found_cycle, "ERROR: No cycle found in %s"%fname)
+                expect(found_total, "ERROR: No total_cycles found in %s"%fname)
+            # End of with
+            cycle_num = cycle_num + 1

--- a/utils/python/CIME/case_run.py
+++ b/utils/python/CIME/case_run.py
@@ -171,8 +171,7 @@ def resubmit_check(case):
     elif dout_s and mach == 'mira':
         caseroot = case.get_value("CASEROOT")
         cimeroot = case.get_value("CIMEROOT")
-        cmd = "ssh cooleylogin1 'cd %s; CIMEROOT=%s ./case.submit %s"%(caseroot, cimeroot, caseroot)
-        cmd = cmd + " --job case.st_archive' "
+        cmd = "ssh cooleylogin1 'cd %s; CIMEROOT=%s ./case.submit %s --job case.st_archive'"%(caseroot, cimeroot, caseroot)
         run_cmd(cmd, verbose=True)
 
     if resubmit:


### PR DESCRIPTION
The new DAE test type creates a reference run and then a separate run
with two data assimilation cycles. The data assimilation script prints
out useful information but does not change any model data. This output is
checked to ensure that the proper data assimilation cycles are called.

The new DA script parameters (cycle number and total DA cycles) were requested
by Kevin Raeder of DARES.

Test suite: scripts_regression_test.py
Test baseline: current
Test namelist changes: NA
Test status: [bit for bit]

Fixes #154 

User interface changes?: NA

Code review: 
