### PR TITLE
Add OMP_STACKSIZE to envs for skybridge and redsky

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -555,6 +555,7 @@
   <environment_variables>
     <env name="NETCDFROOT">$SEMS_NETCDF_ROOT</env>
     <env name="PNETCDFROOT" mpilib="!mpi-serial">$SEMS_NETCDF_ROOT</env>
+    <env name="OMP_STACKSIZE">64M</env>
   </environment_variables>
 </machine>
 
@@ -624,6 +625,7 @@
   <environment_variables>
     <env name="NETCDFROOT">$SEMS_NETCDF_ROOT</env>
     <env name="PNETCDFROOT" mpilib="!mpi-serial">$SEMS_NETCDF_ROOT</env>
+    <env name="OMP_STACKSIZE">64M</env>
   </environment_variables>
 </machine>
 


### PR DESCRIPTION
This gets the last of the acme_integration tests passing

Test suite: None
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: None 

Code review: None

