### PR TITLE
Machine file changes for ORNL clusters

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -286,22 +286,37 @@
    <batch_system MACH="oic2" type="pbs" version="x.y">
          <directives>
                  <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
+		 <directive>-q esd08q</directive>
          </directives>
-            <queues>
-              <queue default="true">esd08q</queue>
-            </queues>
-            <walltimes>
-              <walltime default="true">24:00:00</walltime>
-            </walltimes>
+         <queues>
+           <queue default="true">esd08q</queue>
+         </queues>
+         <walltimes>
+           <walltime default="true">24:00:00</walltime>
+         </walltimes>
    </batch_system>
 
    <batch_system MACH="oic5" type="pbs" version="x.y">
          <directives>
                  <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
+		 <directive>-q esd13q</directive>
          </directives>
          <queues>
            <queue default="true">esd13q</queue>
            <queue walltimemax="1:00">esddbg13q</queue>
+         </queues>
+         <walltimes>
+           <walltime default="true">24:00:00</walltime>
+         </walltimes>
+   </batch_system>
+
+   <batch_system MACH="cades" type="pbs" version="x.y">
+         <directives>
+                 <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
+                 <directive>-W group_list=cades-ccsi</directive>
+         </directives>
+         <queues>
+           <queue default="true">batch</queue>
          </queues>
          <walltimes>
            <walltime default="true">24:00:00</walltime>

--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -725,6 +725,42 @@ for mct, etc.
   <NETCDF_PATH>/home/zdr/opt/netcdf-4.1.3_pgf95</NETCDF_PATH>
 </compiler>
 
+<compiler COMPILER="gnu" MACH="cades">
+      <ADD_CPPDEFS> -DFORTRANUNDERSCORE -DNO_R16</ADD_CPPDEFS>
+      <ADD_CFLAGS compile_threaded="true"> -fopenmp </ADD_CFLAGS>
+      <ADD_FFLAGS compile_threaded="true"> -fopenmp </ADD_FFLAGS>
+      <ADD_LDFLAGS compile_threaded="true"> -L$(GCC_ROOT)/lib64/gcc/x86_64-unknown-linux-gnu/5.3.0 -fopenmp </ADD_LDFLAGS>
+      <ADD_CMAKE_OPTS MODEL="cism"> -D CISM_GNU=ON </ADD_CMAKE_OPTS>
+      <FIXEDFLAGS>  -ffixed-form </FIXEDFLAGS>
+      <FREEFLAGS> -ffree-form </FREEFLAGS>
+      <ADD_FFLAGS DEBUG="TRUE"> -g -Wall </ADD_FFLAGS>
+      <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS 
+                                 so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
+      <FFLAGS> -O -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none -fno-range-check</FFLAGS>
+      <FFLAGS_NOOPT> -O0 </FFLAGS_NOOPT>
+      <FC_AUTO_R8> -fdefault-real-8 </FC_AUTO_R8>
+      <!-- user install gcc -->
+      <SFC>/software/tools/spack/opt/spack/linux-x86_64/gcc-4.8.5/gcc-5.3.0-5hy3c4b3xqemygnfwyl5dsc753gbvzrc/bin/gfortran</SFC>
+      <SCC>/software/tools/spack/opt/spack/linux-x86_64/gcc-4.8.5/gcc-5.3.0-5hy3c4b3xqemygnfwyl5dsc753gbvzrc/bin/gcc</SCC>
+      <SCXX>/software/tools/spack/opt/spack/linux-x86_64/gcc-4.8.5/gcc-5.3.0-5hy3c4b3xqemygnfwyl5dsc753gbvzrc/bin/gcpp</SCXX>
+      <MPIFC>/software/tools/spack/opt/spack/linux-x86_64/gcc-5.3.0/openmpi-1.10.2-w26llp27jmybo7wlgoqxjrtptltmripg/bin/mpif90</MPIFC>
+      <MPICC>/software/tools/spack/opt/spack/linux-x86_64/gcc-5.3.0/openmpi-1.10.2-w26llp27jmybo7wlgoqxjrtptltmripg/bin/mpicc</MPICC>
+      <MPICXX>/software/tools/spack/opt/spack/linux-x86_64/gcc-5.3.0/openmpi-1.10.2-w26llp27jmybo7wlgoqxjrtptltmripg/bin/mpic++</MPICXX>
+      <CXX_LINKER>FORTRAN</CXX_LINKER>
+      <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+      <!-- user installed/loaded NETCDF/HDF5/LAPACK libraries, install directories MUST be specified in 'env_mach_specific.cades -->
+      <NETCDF_PATH>/software/user_tools/current/cades-ccsi/netcdf4/4.4.0/openmpi-1.10.2-gcc-5.3</NETCDF_PATH>
+      <HDF5_ROOT>/software/user_tools/current/cades-ccsi/hdf5/1.8.16/openmpi-1.10.2-gcc-5.3</HDF5_ROOT>
+      <LAPACK_LIBDIR>/software/tools/spack/opt/spack/linux-x86_64/gcc-5.3.0/netlib-lapack-3.5.0-ktb3cldqesiba6ndoiifvr3irojqhdhc/lib/</LAPACK_LIBDIR>
+      <BLAS_LIBDIR>/software/tools/spack/opt/spack/linux-x86_64/gcc-5.3.0/netlib-blas-3.5.0-cxsdr3okwvgr6u7kusa5ee5vhsyqxwgg/lib/</BLAS_LIBDIR>
+      <ADD_LDFLAGS MODEL="driver" > -L$(NETCDF_PATH)/lib -Wl,-rpath=$(NETCDF_PATH)/lib -lnetcdff -lnetcdf \
+              -L$(HDF5_ROOT)/lib -Wl,-rpath=$(HDF5_ROOT)/lib -lhdf5_hl -lhdf5 \
+              -L$(LAPACK_LIBDIR) -Wl,-rpath=$(LAPACK_LIBDIR) \
+              -L$(BLAS_LIBDIR) -Wl,-rpath=$(BLAS_LIBDIR)
+      </ADD_LDFLAGS>
+      <PFUNIT_PATH></PFUNIT_PATH>
+</compiler>
+
 <compiler COMPILER="intel" MACH="titan">
   <ADD_CFLAGS DEBUG="FALSE"> -O2 </ADD_CFLAGS>
   <ADD_FFLAGS DEBUG="FALSE"> -O2 </ADD_FFLAGS>

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -960,6 +960,7 @@
 	 </mpirun>
 
 </machine>
+
 <machine MACH="oic2">
          <DESC>ORNL XK6, os is Linux, 8 pes/node, batch system is PBS</DESC>
          <NODENAME_REGEX>oic2</NODENAME_REGEX>
@@ -976,21 +977,40 @@
 	 <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
          <SUPPORTED_BY>dmricciuto</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
+	 <PES_PER_NODE>8</PES_PER_NODE>
          <MAX_TASKS_PER_NODE>8</MAX_TASKS_PER_NODE>
          <mpirun mpilib="mpich">
               <executable args="default">/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpirun </executable>
 	      <arguments>
 			<arg name="num_tasks"> -np {{ num_tasks }}</arg>
-			<arg name="machine_file">-hostfile $ENV{'PBS_NODEFILE'}</arg>
+			<arg name="machine_file">--hostfile $ENV{PBS_NODEFILE}</arg>
 	      </arguments>
          </mpirun>
          <mpirun mpilib = "mpi-serial">
               <executable> </executable>
          </mpirun>
+	 <module_system type="module">
+	   <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
+	   <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
+	   <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
+	   <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+	   <cmd_path lang="sh">module</cmd_path>
+	   <cmd_path lang="csh">module</cmd_path>
+	   <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+	   <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
+
+	   <environment_variables>
+	     <env name="MPICH_ENV_DISPLAY">1</env>
+	     <env name="MPICH_VERSION_DISPLAY">1</env>
+	     <!-- This increases the stack size, which is necessary
+		  for CICE to run threaded on this machine -->
+	     <env name="OMP_STACKSIZE">64M</env>
+	   </environment_variables>
+	 </module_system>
 </machine>
 
 <machine MACH="oic5">
-         <DESC>ORNL XK6, os is Linux, 8 pes/node, batch system is PBS</DESC>
+         <DESC>ORNL XK6, os is Linux, 32 pes/node, batch system is PBS</DESC>
          <NODENAME_REGEX>oic5</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>gnu</COMPILERS>
@@ -1001,21 +1021,75 @@
          <DIN_LOC_ROOT>/home/zdr/models/ccsm_inputdata</DIN_LOC_ROOT>
          <DIN_LOC_ROOT_CLMFORC>/home/zdr/models/ccsm_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/home/$USER/models/ACME/run/archive/$CASE</DOUT_S_ROOT>
+         <OS>LINUX</OS>
 	 <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
          <SUPPORTED_BY>dmricciuto</SUPPORTED_BY>
-         <OS>LINUX</OS>
          <GMAKE_J>32</GMAKE_J>
+	 <PES_PER_NODE>32</PES_PER_NODE>
          <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
          <mpirun mpilib="mpich">
               <executable args="default">/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpirun </executable>
 	      <arguments>
 			<arg name="num_tasks"> -np {{ num_tasks }}</arg>
-                        <arg name="machine_file">-f $ENV{'PBS_NODEFILE'}</arg>
+                        <arg name="machine_file">--hostfile $ENV{PBS_NODEFILE}</arg>
 	      </arguments>
          </mpirun>
          <mpirun mpilib = "mpi-serial">
               <executable> </executable>
          </mpirun>
+</machine>
+
+<machine MACH="cades">
+   <!-- customize these fields as appropriate for your system (max tasks) and
+                              desired layout (change '${group}/${USER}' to your
+        prefered location). -->
+      <DESC> OR-CONDO, CADES-CCSI, os is Linux, 32 pes/nodes, batch system is PBS</DESC>
+      <NODENAME_REGEX>or-condo-*.ornl.gov</NODENAME_REGEX>
+      <TESTS>acme_developer</TESTS>
+      <OS>LINUX</OS>
+      <COMPILERS>gnu,intel</COMPILERS>
+      <MPILIBS>openmpi,mpi-serial</MPILIBS>
+      <RUNDIR>/lustre/pfs1/cades-ccsi/scratch/$USER/$CASE/run</RUNDIR>
+      <EXEROOT>/lustre/pfs1/cades-ccsi/scratch/$USER/$CASE/bld</EXEROOT>
+      <DIN_LOC_ROOT>/lustre/pfs1/cades-ccsi/proj-shared/project_acme/ACME_inputdata</DIN_LOC_ROOT>
+      <DIN_LOC_ROOT_CLMFORC>/lustre/pfs1/cades-ccsi/proj-shared/project_acme/ACME_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+      <DOUT_S_ROOT>/lustre/pfs1/cades-ccsi/proj-shared/project_acme/archives/$CASE</DOUT_S_ROOT>
+      <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
+      <CESMSCRATCHROOT>/lustre/pfs1/cades-ccsi/scratch</CESMSCRATCHROOT>
+      <CCSM_BASELINE>/lustre/pfs1/cades-ccsi/proj-shared/project_acme/baselines</CCSM_BASELINE>
+      <CCSM_CPRNC>$CIMEROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
+      <SUPPORTED_BY>Fengming Yuan</SUPPORTED_BY>
+      <GMAKE_J>4</GMAKE_J>
+      <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+      <PES_PER_NODE>32</PES_PER_NODE>
+      <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
+      <mpirun mpilib="openmpi" compiler="gnu">
+        <executable args="default">/software/tools/spack/opt/spack/linux-x86_64/gcc-5.3.0/openmpi-1.10.2-w26llp27jmybo7wlgoqxjrtptltmripg/bin/mpirun</executable>
+        <arguments>
+          <arg name="num_tasks"> -np {{ num_tasks }}</arg>
+          <arg name="machine_file">--hostfile $ENV{PBS_NODEFILE}</arg>
+        </arguments>
+      </mpirun>
+        <mpirun mpilib = "mpi-serial">
+        <executable> </executable>
+      </mpirun>
+      <module_system type="module">
+	<init_path lang="sh">/usr/share/Modules/init/sh</init_path>
+	<init_path lang="csh">/usr/share/Modules/init/csh</init_path>
+	<init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
+	<init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+	<cmd_path lang="sh">module</cmd_path>
+	<cmd_path lang="csh">module</cmd_path>
+	<cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+	<cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
+	<modules compiler="gnu">
+	  <command name="load">linux-x86_64/gcc@5.3.0%gcc@4.8.5+gold-5hy3c4b</command>
+	  <command name="load">linux-x86_64/openmpi@1.10.2%gcc@5.3.0~psm~tm~verbs-w26llp2</command>
+	  <command name="load">linux-x86_64/netlib-lapack@3.5.0%gcc@5.3.0+shared-ktb3cld</command>
+	  <command name="load">linux-x86_64/netlib-blas@3.5.0%gcc@5.3.0+fpic-cxsdr3o</command>
+	  <command name="load">linux-x86_64/cmake@3.4.0%gcc@5.3.0+ncurses-sr4jjqc</command>
+	</modules>
+      </module_system>
 </machine>
 
 <machine MACH="titan">

--- a/cime_config/acme/machines/config_pio.xml
+++ b/cime_config/acme/machines/config_pio.xml
@@ -49,6 +49,9 @@
       <value mach="constance">netcdf</value>
       <value mach="pleiades.*">netcdf</value>
       <value mach="hobart" compiler="pgi">netcdf</value>
+      <value mach="oic2">netcdf</value>
+      <value mach="oic5">netcdf</value>
+      <value mach="cades">netcdf</value>
       <value mpilib="mpi-serial">netcdf</value>
     </values>
   </entry>


### PR DESCRIPTION
CIME5 machine file changes for ORNL oic clusters (oic2, oic5)
Adds support for new ORNL cades cluster

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes:  none 

Code review: 
