### PR TITLE
Cesm xml args fix

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -281,6 +281,7 @@ OR
 
         mach_obj = Machines(machine=machine_name)
         if args.testargs:
+            args.compiler = mach_obj.get_default_compiler() if args.compiler is None else args.compiler
             test_names = update_acme_tests.get_full_test_names(args.testargs,
                                                                mach_obj.get_machine_name(), args.compiler)
         else:

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -280,8 +280,6 @@ OR
                                "ambiguity in machine, please use the --machine option")
 
         mach_obj = Machines(machine=machine_name)
-        args.compiler = args.xml_compiler if args.compiler is None else args.compiler
-        args.compiler = mach_obj.get_default_compiler() if args.compiler is None else args.compiler
         if args.testargs:
             test_names = update_acme_tests.get_full_test_names(args.testargs,
                                                                mach_obj.get_machine_name(), args.compiler)


### PR DESCRIPTION
The compiler option for cesm xml based tests is always retreved from the file and should not be forced to the default compiler. 

Test suite: scripts_regression_tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #574 
Fixes #294 

User interface changes?: 

Code review: 

