### PR TITLE
Budgets bugfix

### DIFF
--- a/driver_cpl/bld/build-namelist
+++ b/driver_cpl/bld/build-namelist
@@ -35,6 +35,7 @@ OPTIONS
      -help [or -h]         Print usage to STDOUT.
      -silent               Turn on silent mode
      -verbose              Turn on verbose echoing of informational messages.
+     -cime_model           CIME_MODEL (acme or cesm)
      -caseroot             CASEROOT directory variable
      -cimeroot             CIMEROOT directory variable
      -grid                 GRID variable
@@ -74,6 +75,7 @@ if ($ProgDir) {
 
 my %opts = ( help        => 0,
 	     silent      => 0,
+	     cime_model  => 0,
 	     caseroot    => 0,
 	     cimeroot    => 0,
 	     grid        => 0,
@@ -89,6 +91,7 @@ GetOptions(
     "infile=s"      => \$opts{'infile'},
     "s|silent"      => \$opts{'silent'},
     "v|verbose"     => \$opts{'verbose'},
+    "cime_model=s"  => \$opts{'cime_model'},
     "caseroot=s"    => \$opts{'caseroot'},
     "cimeroot=s"    => \$opts{'cimeroot'},
     "grid=s"        => \$opts{'grid'},
@@ -118,6 +121,7 @@ if ($opts{'silent'})  { $print = 0; }
 if ($opts{'verbose'}) { $print = 2; }
 my $eol = "\n";
 
+my $CIME_MODEL  = $opts{'cime_model'};
 my $CASEROOT    = $opts{'caseroot'};
 my $CIMEROOT    = $opts{'cimeroot'};
 my $GRID        = $opts{'grid'};
@@ -368,6 +372,8 @@ add_default($nl, 'cplflds_custom', 'val'=>'');
 #############################################
 # namelist group: seq_infodata_inparm       #
 #############################################
+
+add_default($nl, 'cime_model', 'val'=>$CIME_MODEL);
 
 my $PTS_MODE = "$xmlvars{'PTS_MODE'}";
 

--- a/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
+++ b/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
@@ -184,6 +184,15 @@ Modify user_nl_cpl to edit this.
 <!-- =========================== -->
 
 <entry
+id="cime_model"
+type="char*8"
+category="expdef"
+group="seq_infodata_inparm"
+valid_values="acme,cesm">
+cime model 
+</entry>
+
+<entry
 id="atm_adiabatic"
 type="logical"
 category="expdef"

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -13,7 +13,7 @@ sys.path.append(os.path.join(os.environ["CIMEROOT"],"scripts","Tools"))
 from standard_script_setup import *
 from CIME.case             import Case
 from CIME.buildnml         import create_namelist_infile, parse_input
-from CIME.utils            import expect, run_cmd
+from CIME.utils            import expect, run_cmd, get_model
 
 logger = logging.getLogger(__name__)
 
@@ -62,8 +62,10 @@ def _main_func():
 
     bldnamelist = os.path.join(cimeroot, "driver_cpl", "bld", "build-namelist")
 
-    cmd = "%s -caseroot %s -cimeroot %s  -infile %s -pio_version %s" \
-        % (bldnamelist, caseroot, cimeroot, namelist_infile, pio_version)
+    cime_model = get_model()
+
+    cmd = "%s -cime_model %s -caseroot %s -cimeroot %s  -infile %s -pio_version %s" \
+        % (bldnamelist, cime_model, caseroot, cimeroot, namelist_infile, pio_version)
 
     cmd = cmd + " -grid %s -atm_grid %s -lnd_grid %s -rof_grid %s -ocn_grid %s -wav_grid %s" \
         % (grid, atm_grid, lnd_grid, rof_grid, ocn_grid, wav_grid)

--- a/driver_cpl/driver/cesm_comp_mod.F90
+++ b/driver_cpl/driver/cesm_comp_mod.F90
@@ -2931,11 +2931,11 @@ end subroutine cesm_init
          call cesm_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:BUDGET1_BARRIER')
          call t_drvstartf ('CPL:BUDGET1',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
          if (lnd_present) then
-            call seq_diag_lnd_mct(lnd(ens1), fractions_lx(ens1), &
-                 do_l2x=.true., do_x2l=.true., infodata=infodata)
+            call seq_diag_lnd_mct(lnd(ens1), fractions_lx(ens1), infodata, &
+                 do_l2x=.true., do_x2l=.true.)
          endif
          if (rof_present) then
-            call seq_diag_rof_mct(rof(ens1), fractions_rx(ens1), infodata=infodata)
+            call seq_diag_rof_mct(rof(ens1), fractions_rx(ens1), infodata)
          endif
          if (ocn_present .and. &
             (trim(cpl_seq_option) == 'CESM1_ORIG'       .or. &
@@ -2944,12 +2944,12 @@ end subroutine cesm_init
              trim(cpl_seq_option) == 'CESM1_MOD_TIGHT'  .or. &
              trim(cpl_seq_option) == 'RASM_OPTION1' )) then
             xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
-            call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), &
-                 do_o2x=.true., do_x2o=.true., do_xao=.true., infodata=infodata)
+            call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), infodata, &
+                 do_o2x=.true., do_x2o=.true., do_xao=.true.)
          endif
          if (ice_present) then
-            call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), &
-                 do_x2i=.true., infodata=infodata)
+            call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), infodata, &
+                 do_x2i=.true.)
          endif
          call t_drvstopf  ('CPL:BUDGET1',cplrun=.true.,budget=.true.)
       endif
@@ -3399,16 +3399,16 @@ end subroutine cesm_init
          if (ocn_present .and. &
             (trim(cpl_seq_option) == 'RASM_OPTION2' )) then
             xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
-            call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), &
-                 do_o2x=.true., do_x2o=.true., do_xao=.true., infodata=infodata)
+            call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), infodata, &
+                 do_o2x=.true., do_x2o=.true., do_xao=.true.)
          endif
          if (atm_present) then
-            call seq_diag_atm_mct(atm(ens1), fractions_ax(ens1), &
-                 do_a2x=.true., do_x2a=.true., infodata=infodata)
+            call seq_diag_atm_mct(atm(ens1), fractions_ax(ens1), infodata, &
+                 do_a2x=.true., do_x2a=.true.)
          endif
          if (ice_present) then
-            call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), &
-                 do_i2x=.true., infodata=infodata)
+            call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), infodata, &
+                 do_i2x=.true.)
          endif
          call t_drvstopf  ('CPL:BUDGET2',cplrun=.true.,budget=.true.)
 

--- a/driver_cpl/driver/cesm_comp_mod.F90
+++ b/driver_cpl/driver/cesm_comp_mod.F90
@@ -823,16 +823,20 @@ subroutine cesm_pre_init2()
    call shr_mem_init(prt=iamroot_CPLID)
 
    !----------------------------------------------------------
-   !| Initialize coupled fields
-   !----------------------------------------------------------
-
-   call seq_flds_set(nlfilename,GLOID)
-
-   !----------------------------------------------------------
    !| Initialize infodata
    !----------------------------------------------------------
 
    call seq_infodata_init(infodata,nlfilename, GLOID, pioid)
+
+   !----------------------------------------------------------
+   !| Initialize coupled fields (depends on infodata)
+   !----------------------------------------------------------
+
+   call seq_flds_set(nlfilename, GLOID, infodata)
+
+   !----------------------------------------------------------
+   !| Obtain infodata info
+   !----------------------------------------------------------
 
    call seq_infodata_GetData(infodata, &
         info_debug=info_debug)
@@ -2928,10 +2932,10 @@ end subroutine cesm_init
          call t_drvstartf ('CPL:BUDGET1',cplrun=.true.,budget=.true.,barrier=mpicom_CPLID)
          if (lnd_present) then
             call seq_diag_lnd_mct(lnd(ens1), fractions_lx(ens1), &
-                 do_l2x=.true., do_x2l=.true.)
+                 do_l2x=.true., do_x2l=.true., infodata=infodata)
          endif
          if (rof_present) then
-            call seq_diag_rof_mct(rof(ens1), fractions_rx(ens1))
+            call seq_diag_rof_mct(rof(ens1), fractions_rx(ens1), infodata=infodata)
          endif
          if (ocn_present .and. &
             (trim(cpl_seq_option) == 'CESM1_ORIG'       .or. &
@@ -2941,11 +2945,11 @@ end subroutine cesm_init
              trim(cpl_seq_option) == 'RASM_OPTION1' )) then
             xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
             call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), &
-                 do_o2x=.true., do_x2o=.true., do_xao=.true.)
+                 do_o2x=.true., do_x2o=.true., do_xao=.true., infodata=infodata)
          endif
          if (ice_present) then
             call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), &
-                 do_x2i=.true.)
+                 do_x2i=.true., infodata=infodata)
          endif
          call t_drvstopf  ('CPL:BUDGET1',cplrun=.true.,budget=.true.)
       endif
@@ -3396,15 +3400,15 @@ end subroutine cesm_init
             (trim(cpl_seq_option) == 'RASM_OPTION2' )) then
             xao_ox => prep_aoflux_get_xao_ox() ! array over all instances
             call seq_diag_ocn_mct(ocn(ens1), xao_ox(1), fractions_ox(ens1), &
-                 do_o2x=.true., do_x2o=.true., do_xao=.true.)
+                 do_o2x=.true., do_x2o=.true., do_xao=.true., infodata=infodata)
          endif
          if (atm_present) then
             call seq_diag_atm_mct(atm(ens1), fractions_ax(ens1), &
-                 do_a2x=.true., do_x2a=.true.)
+                 do_a2x=.true., do_x2a=.true., infodata=infodata)
          endif
          if (ice_present) then
             call seq_diag_ice_mct(ice(ens1), fractions_ix(ens1), &
-                 do_i2x=.true.)
+                 do_i2x=.true., infodata=infodata)
          endif
          call t_drvstopf  ('CPL:BUDGET2',cplrun=.true.,budget=.true.)
 

--- a/driver_cpl/driver/seq_diag_mct.F90
+++ b/driver_cpl/driver/seq_diag_mct.F90
@@ -31,7 +31,7 @@ module seq_diag_mct
 ! !USES:
 
    use shr_kind_mod, only: r8 => shr_kind_r8, in=>shr_kind_in
-   use shr_kind_mod, only: i8 => shr_kind_i8,  cl=>shr_kind_cl
+   use shr_kind_mod, only: i8 => shr_kind_i8,  cl=>shr_kind_cl, cs=>shr_kind_cs
    use shr_sys_mod       ! system calls
    use shr_mpi_mod       ! mpi wrappers
    use shr_const_mod     ! shared constants
@@ -41,6 +41,7 @@ module seq_diag_mct
    use seq_comm_mct  ! mpi comm groups & related
    use seq_timemgr_mod
    use component_type_mod
+   use seq_infodata_mod, only : seq_infodata_type, seq_infodata_getdata
 
    implicit none
    save
@@ -577,7 +578,7 @@ end subroutine seq_diag_sum0_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_atm_mct( atm, frac_a, do_a2x, do_x2a )
+subroutine seq_diag_atm_mct( atm, frac_a, do_a2x, do_x2a, infodata)
 
 ! !INPUT/OUTPUT PARAMETERS:
 
@@ -585,6 +586,7 @@ subroutine seq_diag_atm_mct( atm, frac_a, do_a2x, do_x2a )
    type(mct_aVect)     , intent(in) :: frac_a ! frac bundle
    logical, optional   , intent(in) :: do_a2x
    logical, optional   , intent(in) :: do_x2a
+   type(seq_infodata_type), optional, intent(in) :: infodata
 
 !EOP
 
@@ -793,12 +795,13 @@ end subroutine seq_diag_atm_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_lnd_mct( lnd, frac_l, do_l2x, do_x2l)
+subroutine seq_diag_lnd_mct( lnd, frac_l, do_l2x, do_x2l, infodata)
 
    type(component_type), intent(in) :: lnd    ! component type for instance1
    type(mct_aVect)     , intent(in) :: frac_l ! frac bundle
    logical, optional   , intent(in) :: do_l2x
    logical, optional   , intent(in) :: do_x2l
+   type(seq_infodata_type), optional, intent(in) :: infodata
 
 !EOP
 
@@ -1012,10 +1015,11 @@ end subroutine seq_diag_lnd_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_rof_mct( rof, frac_r)
+subroutine seq_diag_rof_mct( rof, frac_r, infodata)
 
    type(component_type), intent(in) :: rof    ! component type for instance1
    type(mct_aVect)     , intent(in) :: frac_r ! frac bundle
+   type(seq_infodata_type), optional, intent(in) :: infodata
 
 !EOP
 
@@ -1183,10 +1187,11 @@ end subroutine seq_diag_rof_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_glc_mct( glc, frac_g)
+subroutine seq_diag_glc_mct( glc, frac_g, infodata)
 
    type(component_type), intent(in) :: glc    ! component type for instance1
    type(mct_aVect)     , intent(in) :: frac_g ! frac bundle
+   type(seq_infodata_type), optional, intent(in) :: infodata
 
 !EOP
 
@@ -1251,7 +1256,7 @@ end subroutine seq_diag_glc_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, do_o2x, do_x2o, do_xao)
+subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, do_o2x, do_x2o, do_xao, infodata)
 
    type(component_type) , intent(in)          :: ocn    ! component type for instance1
    type(mct_aVect)      , intent(in)          :: frac_o ! frac bundle
@@ -1259,6 +1264,7 @@ subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, do_o2x, do_x2o, do_xao)
    logical              , intent(in),optional :: do_o2x
    logical              , intent(in),optional :: do_x2o
    logical              , intent(in),optional :: do_xao
+   type(seq_infodata_type), optional, intent(in) :: infodata
 
 !EOP
 
@@ -1274,6 +1280,7 @@ subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, do_o2x, do_x2o, do_xao)
    real(r8)                 :: da,di,do,dl  ! area of a grid cell
    logical,save             :: first_time    = .true.
    logical,save             :: flds_wiso_ocn = .false.
+   character(len=cs)        :: cime_model
 
    !----- formats -----
    character(*),parameter :: subName = '(seq_diag_ocn_mct) '
@@ -1302,10 +1309,15 @@ subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, do_o2x, do_x2o, do_xao)
    ko    = mct_aVect_indexRA(frac_o,ofracname)
    ki    = mct_aVect_indexRA(frac_o,ifracname)
 
+   call seq_infodata_GetData(infodata, cime_model=cime_model)
+
    if (present(do_o2x)) then
       if (first_time) then
-         index_o2x_Fioo_frazil = mct_aVect_indexRA(o2x_o,'Fioo_frazil') !acme
-         index_o2x_Fioo_q      = mct_aVect_indexRA(o2x_o,'Fioo_q')      !cesm
+         if (trim(cime_model) == 'acme') then
+            index_o2x_Fioo_frazil = mct_aVect_indexRA(o2x_o,'Fioo_frazil') 
+         else if (trim(cime_model) == 'cesm') then
+            index_o2x_Fioo_q = mct_aVect_indexRA(o2x_o,'Fioo_q')      
+         end if
       end if
 
       lSize = mct_avect_lSize(o2x_o)
@@ -1314,9 +1326,9 @@ subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, do_o2x, do_x2o, do_xao)
          do =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ko,n)
          di =  dom_o%data%rAttr(kArea,n) * frac_o%rAttr(ki,n)
          if = f_area; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + do
-         if (index_o2x_Fioo_frazil /= 0) then
+         if (trim(cime_model) == 'acme') then
             if = f_hfrz; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + (do+di)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_frazil,n))
-         else if (index_o2x_Fioo_q /= 0) then
+         else if (trim(cime_model) == 'cesm') then
             if = f_hfrz; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + (do+di)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
          end if
       end do
@@ -1499,12 +1511,13 @@ end subroutine seq_diag_ocn_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_ice_mct( ice, frac_i, do_i2x, do_x2i)
+subroutine seq_diag_ice_mct( ice, frac_i, do_i2x, do_x2i, infodata)
 
    type(component_type), intent(in)           :: ice    ! component type for instance1
    type(mct_aVect)     , intent(in)           :: frac_i ! frac bundle
    logical             , intent(in), optional :: do_i2x
    logical             , intent(in), optional :: do_x2i
+   type(seq_infodata_type), optional, intent(in) :: infodata
 
 !EOP
 
@@ -1521,6 +1534,7 @@ subroutine seq_diag_ice_mct( ice, frac_i, do_i2x, do_x2i)
    logical,save             :: first_time        = .true.
    logical,save             :: flds_wiso_ice     = .false.
    logical,save             :: flds_wiso_ice_x2i = .false.
+   character(len=cs)        :: cime_model
 
    !----- formats -----
    character(*),parameter :: subName = '(seq_diag_ice_mct) '
@@ -1613,8 +1627,11 @@ subroutine seq_diag_ice_mct( ice, frac_i, do_i2x, do_x2i)
          index_x2i_Faxa_lwdn   = mct_aVect_indexRA(x2i_i,'Faxa_lwdn')
          index_x2i_Faxa_rain   = mct_aVect_indexRA(x2i_i,'Faxa_rain')
          index_x2i_Faxa_snow   = mct_aVect_indexRA(x2i_i,'Faxa_snow')
-         index_x2i_Fioo_frazil = mct_aVect_indexRA(x2i_i,'Fioo_frazil') !acme
-         index_x2i_Fioo_q      = mct_aVect_indexRA(x2i_i,'Fioo_q')      !cesm
+         if (trim(cime_model) == 'acme') then
+            index_x2i_Fioo_frazil = mct_aVect_indexRA(x2i_i,'Fioo_frazil') 
+         else if (trim(cime_model) == 'cesm') then
+            index_x2i_Fioo_q      = mct_aVect_indexRA(x2i_i,'Fioo_q')      
+         end if
          index_x2i_Fixx_rofi   = mct_aVect_indexRA(x2i_i,'Fixx_rofi')
 
          index_x2i_Faxa_rain_16O   = mct_aVect_indexRA(x2i_i,'Faxa_rain_16O', perrWith='quiet')
@@ -1644,9 +1661,9 @@ subroutine seq_diag_ice_mct( ice, frac_i, do_i2x, do_x2i)
          if = f_wsnow; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + di*x2i_i%rAttr(index_x2i_Faxa_snow,n)
          if = f_wioff; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + di*x2i_i%rAttr(index_x2i_Fixx_rofi,n)
 
-         if (index_o2x_Fioo_frazil /= 0) then
+         if (trim(cime_model) == 'acme') then
             if = f_hfrz ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) - (do+di)*max(0.0_r8,x2i_i%rAttr(index_x2i_Fioo_frazil,n))
-         else if (index_o2x_Fioo_q /= 0) then
+         else if (trim(cime_model) == 'cesm') then
             if = f_hfrz ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) - (do+di)*max(0.0_r8,x2i_i%rAttr(index_x2i_Fioo_q,n))
          end if
          if ( flds_wiso_ice_x2i )then
@@ -1674,18 +1691,18 @@ subroutine seq_diag_ice_mct( ice, frac_i, do_i2x, do_x2i)
       ic = c_inh_is
       budg_dataL(f_hlatf,ic,ip) = -budg_dataL(f_wsnow,ic,ip)*shr_const_latice
       budg_dataL(f_hioff,ic,ip) = -budg_dataL(f_wioff,ic,ip)*shr_const_latice
-      if (index_o2x_Fioo_frazil /= 0) then
+      if (trim(cime_model) == 'acme') then
          budg_dataL(f_wfrz ,ic,ip) =  budg_dataL(f_hfrz ,ic,ip)*HFLXtoWFLX *  shr_const_rhoice * shr_const_latice
-      else if (index_o2x_Fioo_q /= 0) then
+      else if (trim(cime_model) == 'cesm') then
          budg_dataL(f_wfrz ,ic,ip) =  budg_dataL(f_hfrz ,ic,ip)*HFLXtoWFLX
       end if
 
       ic = c_ish_is
       budg_dataL(f_hlatf,ic,ip) = -budg_dataL(f_wsnow,ic,ip)*shr_const_latice
       budg_dataL(f_hioff,ic,ip) = -budg_dataL(f_wioff,ic,ip)*shr_const_latice
-      if (index_o2x_Fioo_frazil /= 0) then
+      if (trim(cime_model) == 'acme') then
          budg_dataL(f_wfrz ,ic,ip) =  budg_dataL(f_hfrz ,ic,ip)*HFLXtoWFLX *  shr_const_rhoice * shr_const_latice
-      else if (index_o2x_Fioo_q /= 0) then
+      else if (trim(cime_model) == 'cesm') then
          budg_dataL(f_wfrz ,ic,ip) =  budg_dataL(f_hfrz ,ic,ip)*HFLXtoWFLX
       end if
    end if
@@ -2153,8 +2170,6 @@ end subroutine seq_diag_print_mct
 
 SUBROUTINE seq_diag_avect_mct(infodata, id, av, dom, gsmap, comment)
 
-   use seq_infodata_mod
-
    implicit none
 
 ! !INPUT/OUTPUT PARAMETERS:
@@ -2348,8 +2363,6 @@ end subroutine seq_diag_avect_mct
 ! !INTERFACE: ------------------------------------------------------------------
 
 SUBROUTINE seq_diag_avloc_mct(av, comment)
-
-   use seq_infodata_mod
 
    implicit none
 

--- a/driver_cpl/driver/seq_diag_mct.F90
+++ b/driver_cpl/driver/seq_diag_mct.F90
@@ -578,15 +578,15 @@ end subroutine seq_diag_sum0_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_atm_mct( atm, frac_a, do_a2x, do_x2a, infodata)
+subroutine seq_diag_atm_mct( atm, frac_a, infodata, do_a2x, do_x2a)
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   type(component_type), intent(in) :: atm    ! component type for instance1
-   type(mct_aVect)     , intent(in) :: frac_a ! frac bundle
-   logical, optional   , intent(in) :: do_a2x
-   logical, optional   , intent(in) :: do_x2a
-   type(seq_infodata_type), optional, intent(in) :: infodata
+   type(component_type)    , intent(in)           :: atm    ! component type for instance1
+   type(mct_aVect)         , intent(in)           :: frac_a ! frac bundle
+   type(seq_infodata_type) , intent(in)           :: infodata
+   logical                 , intent(in), optional :: do_a2x
+   logical                 , intent(in), optional :: do_x2a
 
 !EOP
 
@@ -795,13 +795,13 @@ end subroutine seq_diag_atm_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_lnd_mct( lnd, frac_l, do_l2x, do_x2l, infodata)
+subroutine seq_diag_lnd_mct( lnd, frac_l, infodata, do_l2x, do_x2l)
 
-   type(component_type), intent(in) :: lnd    ! component type for instance1
-   type(mct_aVect)     , intent(in) :: frac_l ! frac bundle
-   logical, optional   , intent(in) :: do_l2x
-   logical, optional   , intent(in) :: do_x2l
-   type(seq_infodata_type), optional, intent(in) :: infodata
+   type(component_type)    , intent(in)           :: lnd    ! component type for instance1
+   type(mct_aVect)         , intent(in)           :: frac_l ! frac bundle
+   type(seq_infodata_type) , intent(in)           :: infodata
+   logical                 , intent(in), optional :: do_l2x
+   logical                 , intent(in), optional :: do_x2l
 
 !EOP
 
@@ -1017,9 +1017,9 @@ end subroutine seq_diag_lnd_mct
 
 subroutine seq_diag_rof_mct( rof, frac_r, infodata)
 
-   type(component_type), intent(in) :: rof    ! component type for instance1
-   type(mct_aVect)     , intent(in) :: frac_r ! frac bundle
-   type(seq_infodata_type), optional, intent(in) :: infodata
+   type(component_type)    , intent(in) :: rof    ! component type for instance1
+   type(mct_aVect)         , intent(in) :: frac_r ! frac bundle
+   type(seq_infodata_type) , intent(in) :: infodata
 
 !EOP
 
@@ -1189,9 +1189,9 @@ end subroutine seq_diag_rof_mct
 
 subroutine seq_diag_glc_mct( glc, frac_g, infodata)
 
-   type(component_type), intent(in) :: glc    ! component type for instance1
-   type(mct_aVect)     , intent(in) :: frac_g ! frac bundle
-   type(seq_infodata_type), optional, intent(in) :: infodata
+   type(component_type)    , intent(in) :: glc    ! component type for instance1
+   type(mct_aVect)         , intent(in) :: frac_g ! frac bundle
+   type(seq_infodata_type) , intent(in) :: infodata
 
 !EOP
 
@@ -1256,15 +1256,15 @@ end subroutine seq_diag_glc_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, do_o2x, do_x2o, do_xao, infodata)
+subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, infodata, do_o2x, do_x2o, do_xao)
 
-   type(component_type) , intent(in)          :: ocn    ! component type for instance1
-   type(mct_aVect)      , intent(in)          :: frac_o ! frac bundle
-   type(mct_aVect)      , intent(in)          :: xao_o
-   logical              , intent(in),optional :: do_o2x
-   logical              , intent(in),optional :: do_x2o
-   logical              , intent(in),optional :: do_xao
-   type(seq_infodata_type), optional, intent(in) :: infodata
+   type(component_type)    , intent(in)          :: ocn    ! component type for instance1
+   type(mct_aVect)         , intent(in)          :: frac_o ! frac bundle
+   type(mct_aVect)         , intent(in)          :: xao_o
+   type(seq_infodata_type) , intent(in)          :: infodata
+   logical                 , intent(in),optional :: do_o2x
+   logical                 , intent(in),optional :: do_x2o
+   logical                 , intent(in),optional :: do_xao
 
 !EOP
 
@@ -1332,9 +1332,9 @@ subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, do_o2x, do_x2o, do_xao, infodat
             if = f_hfrz; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + (do+di)*max(0.0_r8,o2x_o%rAttr(index_o2x_Fioo_q,n))
          end if
       end do
-      if (index_o2x_Fioo_frazil /= 0) then
+      if (trim(cime_model) == 'acme') then
          budg_dataL(f_wfrz,ic,ip) = budg_dataL(f_hfrz,ic,ip) * HFLXtoWFLX * shr_const_rhoice * shr_const_latice
-      else if (index_o2x_Fioo_q /= 0) then
+      else if (trim(cime_model) == 'cesm') then
          budg_dataL(f_wfrz,ic,ip) = budg_dataL(f_hfrz,ic,ip) * HFLXtoWFLX
       end if
    end if
@@ -1511,13 +1511,13 @@ end subroutine seq_diag_ocn_mct
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_diag_ice_mct( ice, frac_i, do_i2x, do_x2i, infodata)
+subroutine seq_diag_ice_mct( ice, frac_i, infodata, do_i2x, do_x2i)
 
-   type(component_type), intent(in)           :: ice    ! component type for instance1
-   type(mct_aVect)     , intent(in)           :: frac_i ! frac bundle
-   logical             , intent(in), optional :: do_i2x
-   logical             , intent(in), optional :: do_x2i
-   type(seq_infodata_type), optional, intent(in) :: infodata
+   type(component_type)    , intent(in)           :: ice    ! component type for instance1
+   type(mct_aVect)         , intent(in)           :: frac_i ! frac bundle
+   type(seq_infodata_type) , intent(in)           :: infodata
+   logical                 , intent(in), optional :: do_i2x
+   logical                 , intent(in), optional :: do_x2i
 
 !EOP
 
@@ -1542,6 +1542,8 @@ subroutine seq_diag_ice_mct( ice, frac_i, do_i2x, do_x2i, infodata)
 !-------------------------------------------------------------------------------
 !
 !-------------------------------------------------------------------------------
+
+   call seq_infodata_GetData(infodata, cime_model=cime_model)
 
    !---------------------------------------------------------------------------
    ! add values found in this bundle to the budget table

--- a/driver_cpl/shr/seq_flds_mod.F90
+++ b/driver_cpl/shr/seq_flds_mod.F90
@@ -631,9 +631,11 @@ module seq_flds_mod
 
      ! pressure at the lowest model level (Pa)
      call seq_flds_add(a2x_states,"Sa_pbot")
-     call seq_flds_add(x2o_states,"Sa_pbot")
      call seq_flds_add(x2l_states,"Sa_pbot")
      call seq_flds_add(x2i_states,"Sa_pbot")
+     if (cime_model == 'acme') then
+        call seq_flds_add(x2o_states,"Sa_pbot")
+     end if
      longname = 'Pressure at the lowest model level'
      stdname  = 'air_pressure'
      units    = 'Pa'
@@ -1362,14 +1364,16 @@ module seq_flds_mod
      attname  = 'Fioo_q'
      call metadata_set(attname, longname, stdname, units)
 
-     ! Ocean melt (q<0) potential
-     call seq_flds_add(o2x_fluxes,"Fioo_meltp")
-     call seq_flds_add(x2i_fluxes,"Fioo_meltp")
-     longname = 'Ocean melt (q<0) potential'
-     stdname  = 'surface_snow_and_ice_melt_heat_flux'
-     units    = 'W m-2'
-     attname  = 'Fioo_meltp'
-     call metadata_set(attname, longname, stdname, units)
+     if (trim(cime_model) == 'acme') then
+        ! Ocean melt (q<0) potential
+        call seq_flds_add(o2x_fluxes,"Fioo_meltp")
+        call seq_flds_add(x2i_fluxes,"Fioo_meltp")
+        longname = 'Ocean melt (q<0) potential'
+        stdname  = 'surface_snow_and_ice_melt_heat_flux'
+        units    = 'W m-2'
+        attname  = 'Fioo_meltp'
+        call metadata_set(attname, longname, stdname, units)
+     end if
 
      if (trim(cime_model) == 'acme') then
         ! Ocean frazil production
@@ -1507,7 +1511,7 @@ module seq_flds_mod
      !------------------------------
      ! ice<->ocn only exchange - BGC
      !------------------------------
-     if (flds_bgc) then
+     if (trim(cime_model) == 'acme' .and. flds_bgc) then
 
         ! Ocean algae concentration 1 - diatoms?
         call seq_flds_add(o2x_states,"So_algae1")

--- a/driver_cpl/shr/seq_flds_mod.F90
+++ b/driver_cpl/shr/seq_flds_mod.F90
@@ -252,19 +252,21 @@ module seq_flds_mod
  contains
 !----------------------------------------------------------------------------
 
-   subroutine seq_flds_set(nmlfile, ID)
+   subroutine seq_flds_set(nmlfile, ID, infodata)
 
 ! !USES:
      use shr_file_mod,   only : shr_file_getUnit, shr_file_freeUnit
      use shr_string_mod, only : shr_string_listIntersect
      use shr_mpi_mod,    only : shr_mpi_bcast
      use glc_elevclass_mod, only : glc_elevclass_init
+     use seq_infodata_mod, only : seq_infodata_type, seq_infodata_getdata
 
 ! !INPUT/OUTPUT PARAMETERS:
      character(len=*), intent(in) :: nmlfile   ! Name-list filename
      integer         , intent(in) :: ID        ! seq_comm ID
+     type(seq_infodata_type), intent(in) :: infodata
 
-     !----- local -----
+! !LOCAL VARIABLES:
      integer :: mpicom             ! MPI communicator
      integer :: ierr               ! I/O error code
      integer :: unitn              ! Namelist unit number to read
@@ -276,6 +278,7 @@ module seq_flds_mod
      integer            :: num
      character(len=  2) :: cnum
      character(len=CSS) :: name
+     character(len=CSS) :: cime_model
 
      character(CXX) :: dom_coord  = ''
      character(CXX) :: dom_other  = ''
@@ -351,6 +354,8 @@ module seq_flds_mod
 !-------------------------------------------------------------------------------
 
      call seq_comm_setptrs(ID,mpicom=mpicom)
+
+     call seq_infodata_GetData(infodata, cime_model=cime_model)
 
      !---------------------------------------------------------------------------
      ! Read in namelist for use cases
@@ -1337,16 +1342,18 @@ module seq_flds_mod
      attname  = 'Si_ifrac'
      call metadata_set(attname, longname, stdname, units)
 
-     ! Sea ice basal pressure (ACME only)
-     call seq_flds_add(i2x_states,"Si_bpress")
-     call seq_flds_add(x2o_states,"Si_bpress")
-     longname = 'Sea ice basal pressure'
-     stdname  = 'cice_basal_pressure'
-     units    = 'Pa'
-     attname  = 'Si_bpress'
-     call metadata_set(attname, longname, stdname, units)
+     if (trim(cime_model) == 'acme') then
+        ! Sea ice basal pressure 
+        call seq_flds_add(i2x_states,"Si_bpress")
+        call seq_flds_add(x2o_states,"Si_bpress")
+        longname = 'Sea ice basal pressure'
+        stdname  = 'cice_basal_pressure'
+        units    = 'Pa'
+        attname  = 'Si_bpress'
+        call metadata_set(attname, longname, stdname, units)
+     end if
 
-     ! Ocean melt and freeze potential -- ONLY used by data models
+     ! Ocean melt and freeze potential 
      call seq_flds_add(o2x_fluxes,"Fioo_q")
      call seq_flds_add(x2i_fluxes,"Fioo_q")
      longname = 'Ocean melt and freeze potential'
@@ -1364,14 +1371,16 @@ module seq_flds_mod
      attname  = 'Fioo_meltp'
      call metadata_set(attname, longname, stdname, units)
 
-     ! Ocean frazil production
-     call seq_flds_add(o2x_fluxes,"Fioo_frazil")
-     call seq_flds_add(x2i_fluxes,"Fioo_frazil")
-     longname = 'Ocean frazil production'
-     stdname  = 'ocean_frazil_ice_production'
-     units    = 'kg m-2 s-1'
-     attname  = 'Fioo_frazil'
-     call metadata_set(attname, longname, stdname, units)
+     if (trim(cime_model) == 'acme') then
+        ! Ocean frazil production
+        call seq_flds_add(o2x_fluxes,"Fioo_frazil")
+        call seq_flds_add(x2i_fluxes,"Fioo_frazil")
+        longname = 'Ocean frazil production'
+        stdname  = 'ocean_frazil_ice_production'
+        units    = 'kg m-2 s-1'
+        attname  = 'Fioo_frazil'
+        call metadata_set(attname, longname, stdname, units)
+     end if
 
      ! Heat flux from melting
      call seq_flds_add(i2x_fluxes,"Fioi_melth")


### PR DESCRIPTION
fix budget problems in seq_diag_mct 

A new seq_infodata namelist variable, `cime_model` is introduced that permits selective setting of fields passed between components in seq_flds_mod.F90 and then also permits budgets to be calculated differently based on the setting of this flag in seq_diag_mct_mod.F90.  

infdatdata is now a required argument in the following routines
`seq_diag_atm_mct`, `seq_diag_lnd_mct`, `seq_diag_rof_mct, seq_diag_glc_mct`, `seq_diag_ocn_mct`, `seq_diag_ice_mct` and the value of `cime_model` is accessed via a call to `seq_infodata_get`.

Test suite: scripts_regression_tests.py
Test baseline: NA
Test namelist changes: manually tested new namelist `cime_model` in `seq_infodata_mod.F90`
Test status: bit-for-bit

Fixes [CIME Github issue #] #561 

User interface changes?: yes
A new namelist variable cime_model has been introduced in the drv namelist group `seq_infodata_inparm`.

Code review: sacks
