### PR TITLE
ignore final cpl mem entry in memleak test

### DIFF
--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -251,6 +251,9 @@ class SystemTestsCommon(object):
                     m = meminfo.match(line)
                     if m:
                         memlist.append((float(m.group(1)), float(m.group(2))))
+        # Remove the last mem record, it's sometimes artificially high
+        if len(memlist) > 0:
+            memlist.pop()
         return memlist
 
     def _get_throughput(self, cpllog):


### PR DESCRIPTION
Ignore final cpl memleak entry in memleak check 
Test suite: ERS_Ly20_N2_P2.f09_g16_gl10.TG.yellowstone_pgi
Test baseline: 
Test namelist changes: 
Test status: bit for bit, memleak test now passes

Fixes #586 

User interface changes?: 

Code review: 

