### PR TITLE
Rename 'move' to 'copy' in hist_utils

### DIFF
--- a/scripts/Testing/Testcases/NOC_script
+++ b/scripts/Testing/Testcases/NOC_script
@@ -75,10 +75,10 @@ else
 endif
 
 echo "moving relevant history files to suffix with command " >>& $TESTSTATUS_LOG
-echo "$SCRIPTSROOT/Tools/component_compare_move base" >>& $TESTSTATUS_LOG
+echo "$SCRIPTSROOT/Tools/component_compare_copy base" >>& $TESTSTATUS_LOG
 echo "" >>& $TESTSTATUS_LOG
 
-$SCRIPTSROOT/Tools/component_compare_move base
+$SCRIPTSROOT/Tools/component_compare_copy base
 
 #======================================================================
 # do an initial run test with NINST 2, with the
@@ -117,10 +117,10 @@ else
 endif
 
 echo "moving relevant history files to suffix with commands " >>& $TESTSTATUS_LOG
-echo "$SCRIPTSROOT/Tools/component_compare_move inst2mod"  >>& $TESTSTATUS_LOG
+echo "$SCRIPTSROOT/Tools/component_compare_copy inst2mod"  >>& $TESTSTATUS_LOG
 echo "" >>& $TESTSTATUS_LOG
 
-$SCRIPTSROOT/Tools/component_compare_move inst2mod
+$SCRIPTSROOT/Tools/component_compare_copy inst2mod
 
 #======================================================================
 # Check test status for all relevant component history files

--- a/scripts/Tools/component_compare_copy
+++ b/scripts/Tools/component_compare_copy
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
 """
-Change the suffix for the most recent batch of hist files. This allows us
-to save these results if we want to run the case again.
+Copy the most recent batch of hist files in a case, adding the given suffix.
+This allows us to save these results if we want to run the case again.
 """
 
 from standard_script_setup import *
 
 from CIME.case       import Case
-from CIME.hist_utils import move
+from CIME.hist_utils import copy
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -47,7 +47,7 @@ def _main_func(description):
 ###############################################################################
     suffix, caseroot = parse_command_line(sys.argv, description)
     with Case(caseroot) as case:
-        move(case, suffix)
+        copy(case, suffix)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/utils/python/CIME/SystemTests/eri.py
+++ b/utils/python/CIME/SystemTests/eri.py
@@ -191,7 +191,7 @@ class ERI(SystemTestsCommon):
             newfile = os.path.basename(newfile)
             os.symlink(item, os.path.join(rundir, newfile))
 
-        self._component_compare_move("hybrid")
+        self._component_compare_copy("hybrid")
 
         # run branch case (short term archiving is off)
         self.run_indv()

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -206,7 +206,7 @@ class SystemTestsCommon(object):
             expect(False, "Coupler did not indicate run passed")
 
         if suffix is not None:
-            self._component_compare_move(suffix)
+            self._component_compare_copy(suffix)
 
         if st_archive:
             case_st_archive(self._case)
@@ -222,8 +222,8 @@ class SystemTestsCommon(object):
             logger.info("%s is not compressed, assuming run failed"%newestcpllogfile)
         return False
 
-    def _component_compare_move(self, suffix):
-        comments = move(self._case, suffix)
+    def _component_compare_copy(self, suffix):
+        comments = copy(self._case, suffix)
         append_status(comments, sfile="TestStatus.log")
 
     def _component_compare_test(self, suffix1, suffix2):


### PR DESCRIPTION
It does a copy, so it should be called copy.

Test suite: scripts_regression_tests on yellowstone
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: #583

User interface changes?: No

Code review: