### PR TITLE
Add new history file extension for cism

### DIFF
--- a/cime_config/acme/config_archive.xml
+++ b/cime_config/acme/config_archive.xml
@@ -131,7 +131,8 @@
 
   <comp_archive_spec compname="cism" compclass="glc">
     <rest_file_extension>\.[ri]\..*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <hist_file_extension>\.h\..*\.nc$</hist_file_extension>
+    <hist_file_extension>\.initial_hist\..*\.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.glc</rpointer_file>

--- a/cime_config/cesm/config_archive.xml
+++ b/cime_config/cesm/config_archive.xml
@@ -113,7 +113,8 @@
 
   <comp_archive_spec compname="cism" compclass="glc">
     <rest_file_extension>\.[ri]\..*</rest_file_extension>
-    <hist_file_extension>\.h.*.nc$</hist_file_extension>
+    <hist_file_extension>\.h\..*\.nc$</hist_file_extension>
+    <hist_file_extension>\.initial_hist\..*\.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.glc</rpointer_file>


### PR DESCRIPTION
This new history file extension (.initial_hist) is being added in cism2_1_21

Also make cism regexes more robust

Test suite: CESM aux_glc, with cism at what will soon be cism2_1_21
Test baseline: cesm2_0_beta01 with cism at 2_1_20, cime at f55da30
Test namelist changes: N/A
Test status: bit for bit

Also ran a TG case with DOUT_S set to TRUE; confirmed that all
history files (.initial_hist as well as .h) were archived.

Fixes: None

User interface changes?: No

Code review: