### PR TITLE
change walltime format on cobalt systems

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -39,7 +39,7 @@
      <batch_directive></batch_directive>
      <jobid_pattern>(\d+)</jobid_pattern>
      <depend_string> --dependencies</depend_string>
-     <walltime_format>%M</walltime_format>
+     <walltime_format>%H:%M:%S</walltime_format>
      <submit_args>
        <arg flag="--cwd" name="CASEROOT"/>
        <arg flag="-A" name="PROJECT"/>
@@ -194,21 +194,21 @@
 
     <batch_system MACH="mira" type="cobalt">
       <queues>
-        <queue walltimemin="0" walltimemax="360" jobmin="512" jobmax="4096" default="true">default</queue>
+        <queue walltimemax="06:00:00" jobmin="1" jobmax="786432" default="true">default</queue>
       </queues>
       <walltimes>
-        <walltime default="true">30</walltime>
-        <walltime ccsm_estcost="-3">60</walltime>
-        <walltime ccsm_estcost="0">60</walltime>
+        <walltime default="true">00:30:00</walltime>
+        <walltime ccsm_estcost="-3">01:00:00</walltime>
+        <walltime ccsm_estcost="0">01:00:00</walltime>
       </walltimes>
     </batch_system>
 
     <batch_system MACH="cetus" type="cobalt">
       <queues>
-        <queue walltimemin="5" walltimemax="59" jobmin="64" jobmax="2048" default="true">default</queue>
+        <queue walltimemax="01:00:00" jobmin="1" jobmax="4096" default="true">default</queue>
       </queues>
       <walltimes>
-        <walltime default="true">59</walltime>
+        <walltime default="true">01:00:00</walltime>
       </walltimes>
     </batch_system>
 

--- a/cime_config/cesm/machines/config_batch.xml
+++ b/cime_config/cesm/machines/config_batch.xml
@@ -256,7 +256,7 @@
 
   <batch_system MACH="mira" type="cobalt">
     <queues>
-      <queue walltimemax="360" jobmin="1" jobmax="786432" default="true">default</queue>
+      <queue walltimemax="06:00:00" jobmin="1" jobmax="786432" default="true">default</queue>
     </queues>
     <walltimes>
       <walltime default="true">01:00:00</walltime>

--- a/cime_config/cesm/machines/config_batch.xml
+++ b/cime_config/cesm/machines/config_batch.xml
@@ -61,7 +61,7 @@
      <batch_directive></batch_directive>
      <jobid_pattern>(\d+)</jobid_pattern>
      <depend_string> --dependencies</depend_string>
-    <walltime_format>%M</walltime_format>
+    <walltime_format>%H:%M:%s</walltime_format>
      <submit_args>
        <arg flag="--cwd" name="CASEROOT"/>
        <arg flag="-A" name="PROJECT"/>
@@ -256,12 +256,12 @@
 
   <batch_system MACH="mira" type="cobalt">
     <queues>
-      <queue waltimemin="0" walltimemax="360" jobmin="512" jobmax="4096" default="true">default</queue>
+      <queue walltimemax="360" jobmin="1" jobmax="786432" default="true">default</queue>
     </queues>
     <walltimes>
-      <walltime default="true">60</walltime>
-      <walltime ccsm_estcost="-3">60</walltime>
-      <walltime ccsm_estcost="0">60</walltime>
+      <walltime default="true">01:00:00</walltime>
+      <walltime ccsm_estcost="-3">01:00:00</walltime>
+      <walltime ccsm_estcost="0">01:00:00</walltime>
     </walltimes>
   </batch_system>
 

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -282,7 +282,6 @@ class EnvBatch(EnvBase):
             if walltime is None:
                 logger.warn("Could not find a queue matching task count %d, falling back to depreciated default walltime parameter"%task_count)
                 walltime = self.get_default_walltime()
-
             self.set_value( "JOB_WALLCLOCK_TIME", walltime , subgroup=job)
             logger.info("Job %s queue %s walltime %s"%(job, queue, walltime))
 


### PR DESCRIPTION
Specification of wall clock time for mira and cetus was not allowing for times longer than 59 minutes, this changes the format to HH:MM:SS

Test suite: cime_developer on cetus
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Code review: @jayeshkrishna

