### PR TITLE
Add walltimemax for blues

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -143,7 +143,7 @@
         <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
       </directives>
       <queues>
-	<queue>shared</queue>
+	<queue walltimemax="01:00:00" jobmin="1" jobmax="4096" default="true">shared</queue>
       </queues>
     </batch_system>
 


### PR DESCRIPTION
Add walltimemax for blues

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit-for-bit
Fixes #616 

User interface changes?: 

Code review: @jgfouca 

The walltimemax attribute is now required for all queue settings.
Without this setting create_newcase will fail with the following
error message,

ERROR: Could not find walltime setting in config_batch.xml
