### PR TITLE
Utility to list tests from testlist xml files

### DIFF
--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -303,8 +303,8 @@
   </test>
   <test name="PFS" grid="ne30_g16" compset="B1850" testmods="allactive/default">
     <machines>
-      <machine name="yellowstone" compiler="intel " category="prealpha"/>
-      <machine name="yellowstone" compiler="intel " category="prebeta"/>
+      <machine name="yellowstone" compiler="intel" category="prealpha"/>
+      <machine name="yellowstone" compiler="intel" category="prebeta"/>
       <options>
 	<option name="wallclock"> 00:20 </option>
       </options>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -285,7 +285,7 @@
   </test>
   <test name="PFS" grid="f09_g16" compset="B1850" testmods="allactive/default">
     <machines>
-      <machine name="bluewaters" compiler="pgi " category="prebeta"/>
+      <machine name="bluewaters" compiler="pgi" category="prebeta"/>
       <machine name="yellowstone" compiler="intel" category="prealpha"/>
       <machine name="yellowstone" compiler="intel" category="prebeta"/>
       <options>

--- a/driver_cpl/cime_config/testdefs/testlist_drv.xml
+++ b/driver_cpl/cime_config/testdefs/testlist_drv.xml
@@ -2,7 +2,7 @@
 <testlist version="2.0">
   <test name="ERI" grid="T31_g37_rx1" compset="A">
     <machines>
-      <machine name="yellowstone" compiler="intel " category="prebeta">
+      <machine name="yellowstone" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -103,6 +103,6 @@ def _main_func(description):
         count_test_data(test_data)
     else:
         print_test_data(test_data)
-    
+
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -51,15 +51,17 @@ def print_test_data(test_data):
                        one_test['category'] == category]
         for one_test in test_subset:
             print("%-*s: %s"%(max_category_len, category, one_test['name']))
-            # FIXME(wjs, 2016-10-02) User logger.info instead of print???
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
     args = parse_command_line(description)
 
-    test_data = get_tests_from_xml(args.xml_machine, args.xml_category,
-                                   args.xml_compiler, args.xml_testlist)
+    test_data = get_tests_from_xml(
+        xml_machine = args.xml_machine,
+        xml_category = args.xml_category,
+        xml_compiler = args.xml_compiler,
+        xml_testlist = args.xml_testlist)
 
     print_test_data(test_data)
     

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -31,6 +31,8 @@ def parse_command_line(description):
 
     args = parser.parse_args()
 
+    CIME.utils.handle_standard_logging_options(args)
+
     return args
 
 ###############################################################################

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -6,6 +6,7 @@ Script to query xml test lists.
 from __future__ import print_function
 from Tools.standard_script_setup import *
 from CIME.test_utils import get_tests_from_xml
+from CIME.utils import expect
 
 logger = logging.getLogger(__name__)
 
@@ -20,14 +21,23 @@ def parse_command_line(description):
     parser.add_argument("--count", action="store_true",
                         help="Rather than listing tests, just give counts by category/machine/compiler")
 
+    parser.add_argument("--list", dest='list_type',
+                        choices = ['category', 'categories',
+                                   'machine', 'machines',
+                                   'compiler', 'compilers'],
+                        help="Rather than listing tests, list the available options for "
+                        "--xml-category, --xml-machine, or --xml-compiler. "
+                        "(The singular and plural forms are equivalent - so '--list category' "
+                        "is equivalent to '--list categories', etc.)")
+
+    parser.add_argument("--xml-category",
+                        help="Use this category key in the lookup in testlist.xml, default is all")
+
     parser.add_argument("--xml-machine",
                         help="Use this machine key in the lookup in testlist.xml, default is all")
 
     parser.add_argument("--xml-compiler",
                         help="Use this compiler key in the lookup in testlist.xml, default is all")
-
-    parser.add_argument("--xml-category",
-                        help="Use this category key in the lookup in testlist.xml, default is all")
 
     parser.add_argument("--xml-testlist",
                         help="Use this testlist to lookup tests, default specified in config_files.xml")
@@ -36,7 +46,30 @@ def parse_command_line(description):
 
     CIME.utils.handle_standard_logging_options(args)
 
+    expect(not(args.count and args.list_type),
+           "Cannot specify both --count and --list arguments.")
+
+    if args.list_type:
+        _process_list_type(args)
+
     return args
+
+###############################################################################
+def _process_list_type(args):
+###############################################################################
+    """Convert args.list_type into a name that matches one of the keys of the
+    test data dictionaries
+
+    Args:
+        args: object containing list_type string attribute
+    """
+
+    if args.list_type == 'categories':
+        args.list_type = 'category'
+    elif args.list_type == 'machines':
+        args.list_type = 'machine'
+    elif args.list_type == 'compilers':
+        args.list_type = 'compiler'
 
 ###############################################################################
 def print_test_data(test_data):
@@ -89,6 +122,23 @@ def count_test_data(test_data):
                 print("%s%s: %d"%(tab_stop*2, compiler, len(tests_this_compiler)))
 
 ###############################################################################
+def list_test_data(test_data, list_type):
+###############################################################################
+    """List categories, machines or compilers
+
+    Args:
+        test_data (dict): dictionary of test data, containing at least these keys:
+            - category
+            - machine
+            - compiler
+        list_type (str): one of 'category', 'machine' or 'compiler'
+    """
+
+    items = sorted(set([one_test[list_type] for one_test in test_data]))
+    for item in items:
+        print(item)
+
+###############################################################################
 def _main_func(description):
 ###############################################################################
     args = parse_command_line(description)
@@ -101,6 +151,8 @@ def _main_func(description):
 
     if args.count:
         count_test_data(test_data)
+    elif args.list_type:
+        list_test_data(test_data, args.list_type)
     else:
         print_test_data(test_data)
 

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -34,33 +34,22 @@ def parse_command_line(description):
     return args
 
 ###############################################################################
-def print_test_data(test_data, query_all_categories):
+def print_test_data(test_data):
     """
     Args:
         test_data (dict): dictionary of test data, containing at least these keys:
             - name: full test name
             - category: test category
-        query_all_categories (bool): if the query was for all categories
-            (as opposed to being for a single category)
     """
 
-    if query_all_categories:
-        # If we're aggregating across all categories, then do some extra work to
-        # report tests separated by category
-        categories = sorted(set([item['category'] for item in test_data]))
-        max_category_len = max([len(category) for category in categories])
-        for category in categories:
-            test_subset = [one_test for one_test in test_data if
-                           one_test['category'] == category]
-            for one_test in test_subset:
-                print("%-*s: %s"%(max_category_len, category, one_test['name']))
-                # FIXME(wjs, 2016-10-02) User logger.info instead of print???
-    else:
-        # FIXME(wjs, 2016-10-02) Actually, probably delete this, just printing
-        # the category always (and so also delete the query_all_categories
-        # argument)
-        for one_test in test_data:
-            print("%s"%(one_test['name']))
+    categories = sorted(set([item['category'] for item in test_data]))
+    max_category_len = max([len(category) for category in categories])
+    for category in categories:
+        test_subset = [one_test for one_test in test_data if
+                       one_test['category'] == category]
+        for one_test in test_subset:
+            print("%-*s: %s"%(max_category_len, category, one_test['name']))
+            # FIXME(wjs, 2016-10-02) User logger.info instead of print???
 
 ###############################################################################
 def _main_func(description):
@@ -70,8 +59,7 @@ def _main_func(description):
     test_data = get_tests_from_xml(args.xml_machine, args.xml_category,
                                    args.xml_compiler, args.xml_testlist)
 
-    query_all_categories = (args.xml_category is None)
-    print_test_data(test_data, query_all_categories)
+    print_test_data(test_data)
     
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -17,6 +17,9 @@ def parse_command_line(description):
 
     CIME.utils.setup_standard_logging_options(parser)
 
+    parser.add_argument("--count", action="store_true",
+                        help="Rather than listing tests, just give counts by category/machine/compiler")
+
     parser.add_argument("--xml-machine",
                         help="Use this machine key in the lookup in testlist.xml, default is all")
 
@@ -37,6 +40,7 @@ def parse_command_line(description):
 
 ###############################################################################
 def print_test_data(test_data):
+###############################################################################
     """
     Args:
         test_data (dict): dictionary of test data, containing at least these keys:
@@ -53,6 +57,38 @@ def print_test_data(test_data):
             print("%-*s: %s"%(max_category_len, category, one_test['name']))
 
 ###############################################################################
+def count_test_data(test_data):
+###############################################################################
+    """
+    Args:
+        test_data (dict): dictionary of test data, containing at least these keys:
+            - name: full test name
+            - category: test category
+            - machine
+            - compiler
+    """
+
+    tab_stop = ' '*4
+
+    categories = sorted(set([item['category'] for item in test_data]))
+    for category in categories:
+        tests_this_category = [one_test for one_test in test_data if
+                               one_test['category'] == category]
+        print("%s: %d"%(category, len(tests_this_category)))
+
+        machines = sorted(set([item['machine'] for item in tests_this_category]))
+        for machine in machines:
+            tests_this_machine = [one_test for one_test in tests_this_category if
+                                  one_test['machine'] == machine]
+            print("%s%s: %d"%(tab_stop, machine, len(tests_this_machine)))
+
+            compilers = sorted(set([item['compiler'] for item in tests_this_machine]))
+            for compiler in compilers:
+                tests_this_compiler = [one_test for one_test in tests_this_machine if
+                                       one_test['compiler'] == compiler]
+                print("%s%s: %d"%(tab_stop*2, compiler, len(tests_this_compiler)))
+
+###############################################################################
 def _main_func(description):
 ###############################################################################
     args = parse_command_line(description)
@@ -63,7 +99,10 @@ def _main_func(description):
         xml_compiler = args.xml_compiler,
         xml_testlist = args.xml_testlist)
 
-    print_test_data(test_data)
+    if args.count:
+        count_test_data(test_data)
+    else:
+        print_test_data(test_data)
     
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+"""
+Script to query xml test lists.
+"""
+from __future__ import print_function
+from Tools.standard_script_setup import *
+from CIME.test_utils import get_tests_from_xml
+
+logger = logging.getLogger(__name__)
+
+###############################################################################
+def parse_command_line(description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        description=description)
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("--xml-machine",
+                        help="Use this machine key in the lookup in testlist.xml, default is all")
+
+    parser.add_argument("--xml-compiler",
+                        help="Use this compiler key in the lookup in testlist.xml, default is all")
+
+    parser.add_argument("--xml-category",
+                        help="Use this category key in the lookup in testlist.xml, default is all")
+
+    parser.add_argument("--xml-testlist",
+                        help="Use this testlist to lookup tests, default specified in config_files.xml")
+
+    args = parser.parse_args()
+
+    return args
+
+###############################################################################
+def print_test_data(test_data, query_all_categories):
+    """
+    Args:
+        test_data (dict): dictionary of test data, containing at least these keys:
+            - name: full test name
+            - category: test category
+        query_all_categories (bool): if the query was for all categories
+            (as opposed to being for a single category)
+    """
+
+    if query_all_categories:
+        # If we're aggregating across all categories, then do some extra work to
+        # report tests separated by category
+        categories = sorted(set([item['category'] for item in test_data]))
+        max_category_len = max([len(category) for category in categories])
+        for category in categories:
+            test_subset = [one_test for one_test in test_data if
+                           one_test['category'] == category]
+            for one_test in test_subset:
+                print("%-*s: %s"%(max_category_len, category, one_test['name']))
+                # FIXME(wjs, 2016-10-02) User logger.info instead of print???
+    else:
+        # FIXME(wjs, 2016-10-02) Actually, probably delete this, just printing
+        # the category always (and so also delete the query_all_categories
+        # argument)
+        for one_test in test_data:
+            print("%s"%(one_test['name']))
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    args = parse_command_line(description)
+
+    test_data = get_tests_from_xml(args.xml_machine, args.xml_category,
+                                   args.xml_compiler, args.xml_testlist)
+
+    query_all_categories = (args.xml_category is None)
+    print_test_data(test_data, query_all_categories)
+    
+if __name__ == "__main__":
+    _main_func(__doc__)

--- a/utils/python/CIME/test_utils.py
+++ b/utils/python/CIME/test_utils.py
@@ -47,6 +47,6 @@ def get_tests_from_xml(xml_machine=None,xml_category=None,xml_compiler=None, xml
                                                          testmod=None if "testmods" not in test else test["testmods"])
             logger.debug("Adding test %s with compiler %s"%(test["name"], test["compiler"]))
         listoftests += newtests
-        logger.info("Found %d tests"% len(listoftests))
+        logger.debug("Found %d tests"% len(listoftests))
 
     return listoftests

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1709,16 +1709,26 @@ class I_TestCMakeMacros(H_TestMakeMacros):
 class S_TestManageAndQuery(unittest.TestCase):
     """Tests various scripts to manage and query xml files"""
 
-    def test_query_testlists_runs(self):
-        """Make sure that query_testlists runs successfully"""
+    def _run_and_assert_query_testlist(self, extra_args=""):
+        """Ensure that query_testlist runs successfully with the given extra arguments"""
 
         testlist_allactive = os.path.join(CIME.utils.get_model_config_root(), "allactive", "testlist_allactive.xml")
 
-        # Simply make sure that query_testlists doesn't generate any errors when
-        # it runs. This helps ensure that changes in other utilities don't break
-        # query_testlists.
         run_cmd_assert_result(self, "%s/query_testlists --xml-testlist %s"%
                               (SCRIPT_DIR, testlist_allactive))
+
+    def test_query_testlists_runs(self):
+        """Make sure that query_testlists runs successfully
+
+        This simply makes sure that query_testlists doesn't generate any errors
+        when it runs. This helps ensure that changes in other utilities don't
+        break query_testlists.
+        """
+        self._run_and_assert_query_testlist()
+
+    def test_query_testlists_count_runs(self):
+        """Make sure that query_testlists runs successfully with the --count argument"""
+        self._run_and_assert_query_testlist(extra_args="--count")
 
 ###############################################################################
 

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1730,6 +1730,10 @@ class S_TestManageAndQuery(unittest.TestCase):
         """Make sure that query_testlists runs successfully with the --count argument"""
         self._run_and_assert_query_testlist(extra_args="--count")
 
+    def test_query_testlists_list_runs(self):
+        """Make sure that query_testlists runs successfully with the --list argument"""
+        self._run_and_assert_query_testlist(extra_args="--list categories")
+
 ###############################################################################
 
 

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1705,6 +1705,20 @@ class I_TestCMakeMacros(H_TestMakeMacros):
         test_xml = _wrap_config_build_xml(xml_string)
         return CMakeTester(self, get_macros(self._maker, test_xml, "CMake"))
 
+###############################################################################
+class S_TestManageAndQuery(unittest.TestCase):
+    """Tests various scripts to manage and query xml files"""
+
+    def test_query_testlists_runs(self):
+        """Make sure that query_testlists runs successfully"""
+
+        testlist_allactive = os.path.join(CIME.utils.get_model_config_root(), "allactive", "testlist_allactive.xml")
+
+        # Simply make sure that query_testlists doesn't generate any errors when
+        # it runs. This helps ensure that changes in other utilities don't break
+        # query_testlists.
+        run_cmd_assert_result(self, "%s/query_testlists --xml-testlist %s"%
+                              (SCRIPT_DIR, testlist_allactive))
 
 ###############################################################################
 

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1714,8 +1714,8 @@ class S_TestManageAndQuery(unittest.TestCase):
 
         testlist_allactive = os.path.join(CIME.utils.get_model_config_root(), "allactive", "testlist_allactive.xml")
 
-        run_cmd_assert_result(self, "%s/query_testlists --xml-testlist %s"%
-                              (SCRIPT_DIR, testlist_allactive))
+        run_cmd_assert_result(self, "%s/query_testlists --xml-testlist %s %s"%
+                              (SCRIPT_DIR, testlist_allactive, extra_args))
 
     def test_query_testlists_runs(self):
         """Make sure that query_testlists runs successfully


### PR DESCRIPTION
This PR adds a new script, query_testlists, in cime/scripts/. This is
similar to the older manage_testlists, but only providing the query
functionality (along with related functionality --list and --count). The
motivation for creating this new tool is that the old manage_testlists
doesn't work with the new testlist xml format; this new tool works with
both (implicitly, because it simply calls other new code that works with
both formats).

Test suite: scripts_regression_tests on yellowstone
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes: #624 
(Addresses that issue sufficiently.)

User interface changes?: none

Code review: 
