### PR TITLE
Show comments and options in query_testlists

### DIFF
--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -86,11 +86,16 @@ def print_test_data(test_data, show_options):
 
     categories = sorted(set([item['category'] for item in test_data]))
     max_category_len = max([len(category) for category in categories])
+    max_test_len = max([len(item['name']) for item in test_data])
     for category in categories:
         test_subset = [one_test for one_test in test_data if
                        one_test['category'] == category]
         for one_test in test_subset:
-            print(test_to_string(one_test, max_category_len, show_options))
+            print(test_to_string(
+                test = one_test,
+                category_field_width = max_category_len,
+                test_field_width = max_test_len,
+                show_options = show_options))
 
 ###############################################################################
 def count_test_data(test_data):

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -5,7 +5,7 @@ Script to query xml test lists.
 """
 from __future__ import print_function
 from Tools.standard_script_setup import *
-from CIME.test_utils import get_tests_from_xml
+from CIME.test_utils import get_tests_from_xml, test_to_string
 from CIME.utils import expect
 
 logger = logging.getLogger(__name__)
@@ -29,6 +29,9 @@ def parse_command_line(description):
                         "--xml-category, --xml-machine, or --xml-compiler. "
                         "(The singular and plural forms are equivalent - so '--list category' "
                         "is equivalent to '--list categories', etc.)")
+
+    parser.add_argument("--show-options", action="store_true",
+                        help="Print options given for each test")
 
     parser.add_argument("--xml-category",
                         help="Use this category key in the lookup in testlist.xml, default is all")
@@ -72,7 +75,7 @@ def _process_list_type(args):
         args.list_type = 'compiler'
 
 ###############################################################################
-def print_test_data(test_data):
+def print_test_data(test_data, show_options):
 ###############################################################################
     """
     Args:
@@ -87,7 +90,7 @@ def print_test_data(test_data):
         test_subset = [one_test for one_test in test_data if
                        one_test['category'] == category]
         for one_test in test_subset:
-            print("%-*s: %s"%(max_category_len, category, one_test['name']))
+            print(test_to_string(one_test, max_category_len, show_options))
 
 ###############################################################################
 def count_test_data(test_data):
@@ -154,7 +157,7 @@ def _main_func(description):
     elif args.list_type:
         list_test_data(test_data, args.list_type)
     else:
-        print_test_data(test_data)
+        print_test_data(test_data, args.show_options)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/utils/python/CIME/test_utils.py
+++ b/utils/python/CIME/test_utils.py
@@ -52,13 +52,14 @@ def get_tests_from_xml(xml_machine=None,xml_category=None,xml_compiler=None, xml
 
     return listoftests
 
-def test_to_string(test, category_field_width=0, show_options=False):
+def test_to_string(test, category_field_width=0, test_field_width=0, show_options=False):
     """Given a test dictionary, return a string representation suitable for printing
 
     Args:
         test (dict): dictionary for a single test - e.g., one element from the
                      list returned by get_tests_from_xml
         category_field_width (int): minimum amount of space to use for printing the test category
+        test_field_width (int): minimum amount of space to use for printing the test category
         show_options (bool): if True, print test options, too (note that the 'comment'
                              option is always printed, if present)
 
@@ -70,20 +71,20 @@ def test_to_string(test, category_field_width=0, show_options=False):
     Printing comments:
     >>> mytest = {'name': 'SMS.f19_g16.A.yellowstone_intel', 'category': 'prealpha', 'options': {'comment': 'my remarks'}}
     >>> test_to_string(mytest, 10)
-    'prealpha  : SMS.f19_g16.A.yellowstone_intel  # my remarks'
+    'prealpha  : SMS.f19_g16.A.yellowstone_intel # my remarks'
 
     Printing other options, too:
     >>> mytest = {'name': 'SMS.f19_g16.A.yellowstone_intel', 'category': 'prealpha', 'options': {'comment': 'my remarks', 'wallclock': '0:20', 'memleak_tolerance': 0.2}}
     >>> test_to_string(mytest, 10, show_options=True)
-    'prealpha  : SMS.f19_g16.A.yellowstone_intel  # my remarks  # memleak_tolerance: 0.2  # wallclock: 0:20'
+    'prealpha  : SMS.f19_g16.A.yellowstone_intel # my remarks  # memleak_tolerance: 0.2  # wallclock: 0:20'
     """
 
-    mystr = "%-*s: %s"%(category_field_width, test['category'], test['name'])
+    mystr = "%-*s: %-*s"%(category_field_width, test['category'], test_field_width, test['name'])
     if 'options' in test:
         myopts = test['options'].copy()
         comment = myopts.pop('comment', None)
         if comment:
-            mystr += "  # %s"%(comment)
+            mystr += " # %s"%(comment)
         if show_options:
             for one_opt in sorted(myopts):
                 mystr += "  # %s: %s"%(one_opt, myopts[one_opt])

--- a/utils/python/CIME/test_utils.py
+++ b/utils/python/CIME/test_utils.py
@@ -1,5 +1,6 @@
 """
-Utility functions used in test_scheduler.py
+Utility functions used in test_scheduler.py, and by other utilities that need to
+get test lists.
 """
 
 from CIME.XML.standard_module_setup import *
@@ -50,3 +51,41 @@ def get_tests_from_xml(xml_machine=None,xml_category=None,xml_compiler=None, xml
         logger.debug("Found %d tests"% len(listoftests))
 
     return listoftests
+
+def test_to_string(test, category_field_width=0, show_options=False):
+    """Given a test dictionary, return a string representation suitable for printing
+
+    Args:
+        test (dict): dictionary for a single test - e.g., one element from the
+                     list returned by get_tests_from_xml
+        category_field_width (int): minimum amount of space to use for printing the test category
+        show_options (bool): if True, print test options, too (note that the 'comment'
+                             option is always printed, if present)
+
+    Basic functionality:
+    >>> mytest = {'name': 'SMS.f19_g16.A.yellowstone_intel', 'category': 'prealpha', 'options': {}}
+    >>> test_to_string(mytest, 10)
+    'prealpha  : SMS.f19_g16.A.yellowstone_intel'
+
+    Printing comments:
+    >>> mytest = {'name': 'SMS.f19_g16.A.yellowstone_intel', 'category': 'prealpha', 'options': {'comment': 'my remarks'}}
+    >>> test_to_string(mytest, 10)
+    'prealpha  : SMS.f19_g16.A.yellowstone_intel  # my remarks'
+
+    Printing other options, too:
+    >>> mytest = {'name': 'SMS.f19_g16.A.yellowstone_intel', 'category': 'prealpha', 'options': {'comment': 'my remarks', 'wallclock': '0:20', 'memleak_tolerance': 0.2}}
+    >>> test_to_string(mytest, 10, show_options=True)
+    'prealpha  : SMS.f19_g16.A.yellowstone_intel  # my remarks  # memleak_tolerance: 0.2  # wallclock: 0:20'
+    """
+
+    mystr = "%-*s: %s"%(category_field_width, test['category'], test['name'])
+    if 'options' in test:
+        myopts = test['options'].copy()
+        comment = myopts.pop('comment', None)
+        if comment:
+            mystr += "  # %s"%(comment)
+        if show_options:
+            for one_opt in sorted(myopts):
+                mystr += "  # %s: %s"%(one_opt, myopts[one_opt])
+
+    return mystr

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1724,7 +1724,7 @@ class S_TestManageAndQuery(unittest.TestCase):
         when it runs. This helps ensure that changes in other utilities don't
         break query_testlists.
         """
-        self._run_and_assert_query_testlist()
+        self._run_and_assert_query_testlist(extra_args="--show-options")
 
     def test_query_testlists_count_runs(self):
         """Make sure that query_testlists runs successfully with the --count argument"""


### PR DESCRIPTION
Adds functionality to query_testlists to:

(1) Show any 'comments' entries (always)

(2) Show other test options, if --show-options is given

Output will look like this:

```
prebeta : ERI.f09_g16.B1850Ws.bluewaters_pgi.allactive-defaultio                       # wallclock:  00:20
prebeta : ERI.f09_g16.B1850Ws.edison_intel.allactive-default                           # wallclock:  00:20
prebeta : ERR_N3.f19_g16.B1850.edison_intel.allactive-defaultio                        # wallclock:  00:20
prebeta : ERS.f19_g16.B1850C4L45BGCRBPRPWs.bluewaters_pgi.allactive-defaultio
```

Each separate option is separated by a '#' character. If there is a comment, this will appear first.

Test suite: scripts_regression_tests.py on yellowstone
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes #627 
(I have addressed points 1 and 4 in that issue; punting on points 2 and 3)

User interface changes?: none, except new option in query_testlists

Code review: 
