### PR TITLE
Refactor TestStatus

### DIFF
--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -81,7 +81,7 @@ class SystemTestsCommon(object):
                                        (MODEL_BUILD_PHASE, not sharedlib_only)]:
             if phase_bool:
                 with self._test_status:
-                    self._test_status.set_status(phase_name, TEST_PENDING_STATUS)
+                    self._test_status.set_status(phase_name, TEST_PEND_STATUS)
 
                 start_time = time.time()
                 try:
@@ -133,7 +133,7 @@ class SystemTestsCommon(object):
             expect(self._test_status.get_status(MODEL_BUILD_PHASE) == TEST_PASS_STATUS,
                    "Model was not built!")
             with self._test_status:
-                self._test_status.set_status(RUN_PHASE, TEST_PENDING_STATUS)
+                self._test_status.set_status(RUN_PHASE, TEST_PEND_STATUS)
 
             self.run_phase()
 

--- a/utils/python/CIME/test_status.py
+++ b/utils/python/CIME/test_status.py
@@ -9,11 +9,11 @@ from collections import OrderedDict
 TEST_STATUS_FILENAME = "TestStatus"
 
 # The statuses that a phase can be in
-TEST_PENDING_STATUS  = "PEND"
-TEST_PASS_STATUS     = "PASS"
-TEST_FAIL_STATUS     = "FAIL"
+TEST_PEND_STATUS = "PEND"
+TEST_PASS_STATUS = "PASS"
+TEST_FAIL_STATUS = "FAIL"
 
-ALL_PHASE_STATUSES = [TEST_PENDING_STATUS, TEST_PASS_STATUS, TEST_FAIL_STATUS]
+ALL_PHASE_STATUSES = [TEST_PEND_STATUS, TEST_PASS_STATUS, TEST_FAIL_STATUS]
 
 # Special statuses that the overall test can be in
 TEST_DIFF_STATUS     = "DIFF"   # Implies a failure in one of the COMPARE phases
@@ -151,11 +151,14 @@ class TestStatus(object):
 
         if phase in CORE_PHASES and phase != CORE_PHASES[0]:
             previous_core_phase = CORE_PHASES[CORE_PHASES.index(phase)-1]
-            expect(previous_core_phase in self._phase_statuses, "Core phase '%s' was skipped" % previous_core_phase)
-            expect(self._phase_statuses[previous_core_phase][0] == TEST_PASS_STATUS,
-                   "Cannot move past core phase '%s', it didn't pass" % previous_core_phase)
+            #TODO: enamble check below
+            #expect(previous_core_phase in self._phase_statuses, "Core phase '%s' was skipped" % previous_core_phase)
 
-        reran_phase = (phase in self._phase_statuses and self._phase_statuses[phase][0] != TEST_PENDING_STATUS)
+            if previous_core_phase in self._phase_statuses:
+                expect(self._phase_statuses[previous_core_phase][0] == TEST_PASS_STATUS,
+                       "Cannot move past core phase '%s', it didn't pass" % previous_core_phase)
+
+        reran_phase = (phase in self._phase_statuses and self._phase_statuses[phase][0] != TEST_PEND_STATUS)
         if reran_phase:
             # All subsequent phases are invalidated
             phase_idx = ALL_PHASES.index(phase)
@@ -171,7 +174,7 @@ class TestStatus(object):
 
         if status == TEST_PASS_STATUS and phase in CORE_PHASES and phase != CORE_PHASES[-1]:
             next_core_phase = CORE_PHASES[CORE_PHASES.index(phase)+1]
-            self._phase_statuses[next_core_phase] = (TEST_PENDING_STATUS, "")
+            self._phase_statuses[next_core_phase] = (TEST_PEND_STATUS, "")
 
     def get_status(self, phase):
         return self._phase_statuses[phase][0] if phase in self._phase_statuses else None
@@ -283,7 +286,7 @@ class TestStatus(object):
             if phase == RUN_PHASE:
                 run_phase_found = True
 
-            if (status == TEST_PENDING_STATUS):
+            if (status == TEST_PEND_STATUS):
                 return status
 
             elif (status == TEST_FAIL_STATUS):
@@ -306,6 +309,6 @@ class TestStatus(object):
         # The test did not fail but the RUN phase was not found, so if the user requested
         # that we wait for the RUN phase, then the test must still be considered pending.
         if rv != TEST_FAIL_STATUS and not run_phase_found and wait_for_run:
-            rv = TEST_PENDING_STATUS
+            rv = TEST_PEND_STATUS
 
         return rv

--- a/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -107,9 +107,8 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
         # Need to tell test status that case has been built, since this is
         # checked in the run call
         with self._test_status:
-            self._test_status.set_status(
-                test_status.MODEL_BUILD_PHASE,
-                test_status.TEST_PASS_STATUS)
+            for phase in test_status.CORE_PHASES[:-1]:
+                self._test_status.set_status(phase, test_status.TEST_PASS_STATUS)
 
         self.run_pass_casenames = []
         if run_one_should_pass:

--- a/utils/python/CIME/wait_for_tests.py
+++ b/utils/python/CIME/wait_for_tests.py
@@ -111,7 +111,7 @@ def create_cdash_test_xml(results, cdash_build_name, cdash_build_group, utc_time
             ("text/string",    "Exit Code",         test_status),
             ("text/string",    "Exit Value",        "0" if test_passed else "1"),
             ("numeric_double", "Execution Time",    str(get_test_time(test_norm_path))),
-            ("text/string",    "Completion Status", "Not Completed" if test_status == TEST_PENDING_STATUS else "Completed"),
+            ("text/string",    "Completion Status", "Not Completed" if test_status == TEST_PEND_STATUS else "Completed"),
             ("text/string",    "Command line",      "create_test")
         )
 
@@ -276,7 +276,7 @@ def wait_for_test(test_path, results, wait, check_throughput, check_memory, igno
                                                      check_memory=check_memory, ignore_namelists=ignore_namelists,
                                                      ignore_memleak=ignore_memleak)
 
-            if (test_status == TEST_PENDING_STATUS and (wait and not SIGNAL_RECEIVED)):
+            if (test_status == TEST_PEND_STATUS and (wait and not SIGNAL_RECEIVED)):
                 time.sleep(SLEEP_INTERVAL_SEC)
                 logging.debug("Waiting for test to finish")
             else:

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -551,7 +551,7 @@ class O_TestTestScheduler(TestCreateTestCommon):
 
         for idx, phase in enumerate(ct._phases):
             for test in ct._tests:
-                if (phase == CIME.test_scheduler.INITIAL_PHASE):
+                if (phase == CIME.test_scheduler.TEST_START):
                     continue
                 elif (phase == CIME.test_scheduler.MODEL_BUILD_PHASE):
                     ct._update_test_status(test, phase, TEST_PENDING_STATUS)


### PR DESCRIPTION
Make recent PENDing state change work regardless of whether
a phase was run from create_test or by hand.

Other more minor refactors like demoting the INIT_PHASE from an
official phase to just a book-keeping item for test_scheduler.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Yes, changes in management of TestStatus file

Code review: jedwards, billsacks

