### PR TITLE
Add xsd and test xml

### DIFF
--- a/cime_config/cesm/config_files.xml
+++ b/cime_config/cesm/config_files.xml
@@ -206,6 +206,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing all non-component specific case configuration variables (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/config_component.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ATM_FILE">

--- a/cime_config/cesm/config_files.xml
+++ b/cime_config/cesm/config_files.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" ?>
 
-<files>
+<entry_id>
 
   <entry id="MODEL">
     <type>char</type>
@@ -206,7 +206,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing all non-component specific case configuration variables (for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/cime_config/xml_schemas/config_component.xsd</schema>
+    <schema>$CIMEROOT/cime_config/xml_schemas/entry_id.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ATM_FILE">
@@ -221,6 +221,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/entry_id.xsd</schema>
   </entry>
 
   <entry id="CONFIG_LND_FILE">
@@ -236,6 +237,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/entry_id.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ROF_FILE">
@@ -251,6 +253,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/entry_id.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ICE_FILE">
@@ -265,6 +268,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/entry_id.xsd</schema>
   </entry>
 
   <entry id="CONFIG_OCN_FILE">
@@ -281,6 +285,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/entry_id.xsd</schema>
   </entry>
 
   <entry id="CONFIG_GLC_FILE">
@@ -295,6 +300,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/entry_id.xsd</schema>
   </entry>
 
   <entry id="CONFIG_WAV_FILE">
@@ -309,6 +315,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/entry_id.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ESP_FILE">
@@ -320,7 +327,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/entry_id.xsd</schema>
   </entry>
 
-</files>
+</entry_id>
 

--- a/cime_config/xml_schemas/config_component.xsd
+++ b/cime_config/xml_schemas/config_component.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="definitions_variables">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="entry"/>
+        <xs:element ref="description"/>
+        <xs:element ref="help" minOccurs="0"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="entry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="type"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="default_value"/>
+          <xs:element ref="file"/>
+          <xs:element ref="group"/>
+          <xs:element ref="valid_values"/>
+          <xs:element ref="values"/>
+        </xs:choice>
+        <xs:element ref="desc"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:NCName"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="type" type="xs:NCName"/>
+  <xs:element name="default_value" type="xs:string"/>
+  <xs:element name="file" type="xs:NCName"/>
+  <xs:element name="group" type="xs:NCName"/>
+  <xs:element name="valid_values" type="xs:string"/>
+  <xs:element name="values">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="value"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="value">
+    <xs:complexType mixed="true">
+      <xs:attribute name="compset"/>
+      <xs:attribute name="grid"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="description">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="desc"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="help" type="xs:string"/>
+  <xs:element name="desc">
+    <xs:complexType mixed="true">
+      <xs:attribute name="compset"/>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/cime_config/xml_schemas/entry_id.xsd
+++ b/cime_config/xml_schemas/entry_id.xsd
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-  <xs:element name="definitions_variables">
+  <xs:element name="entry_id">
     <xs:complexType>
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="entry"/>
-        <xs:element ref="description"/>
+        <xs:element ref="description" minOccurs="0"/>
         <xs:element ref="help" minOccurs="0"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
   <xs:element name="entry">
     <xs:complexType>
-      <xs:sequence>
+      <xs:choice maxOccurs="unbounded">
         <xs:element ref="type"/>
-        <xs:choice maxOccurs="unbounded">
-          <xs:element ref="default_value"/>
-          <xs:element ref="file"/>
-          <xs:element ref="group"/>
-          <xs:element ref="valid_values"/>
-          <xs:element ref="values"/>
-        </xs:choice>
+        <xs:element ref="valid_values"/>
+        <xs:element ref="default_value"/>
+        <xs:element ref="file"/>
+        <xs:element ref="group"/>
+        <xs:element ref="values"/>
         <xs:element ref="desc"/>
-      </xs:sequence>
+        <xs:element ref="schema" minOccurs="0"/>
+      </xs:choice>
       <xs:attribute name="id" use="required" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
@@ -30,15 +29,18 @@
   <xs:element name="file" type="xs:NCName"/>
   <xs:element name="group" type="xs:NCName"/>
   <xs:element name="valid_values" type="xs:string"/>
+  <xs:element name="schema" type="xs:string"/>
   <xs:element name="values">
     <xs:complexType>
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="value"/>
       </xs:sequence>
+         <xs:attribute name="modifier" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="value">
     <xs:complexType mixed="true">
+      <xs:attribute name="component"/>
       <xs:attribute name="compset"/>
       <xs:attribute name="grid"/>
     </xs:complexType>

--- a/components/data_comps/datm/cime_config/config_component.xml
+++ b/components/data_comps/datm/cime_config/config_component.xml
@@ -2,7 +2,7 @@
 
 <?xml-stylesheet type="text/xsl" href="definitions_components.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ATM">
     <type>char</type>
@@ -259,5 +259,5 @@
     =========================================
   </help>
 
-</definitions_variables>
+</entry_id>
 

--- a/components/data_comps/dice/cime_config/config_component.xml
+++ b/components/data_comps/dice/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ICE">
     <type>char</type>
@@ -58,4 +58,4 @@
     =========================================
   </help>
 
-</definitions_variables>
+</entry_id>

--- a/components/data_comps/dlnd/cime_config/config_component.xml
+++ b/components/data_comps/dlnd/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_LND">
     <type>char</type>
@@ -112,5 +112,5 @@
     =========================================
   </help>
 
-</definitions_variables>
+</entry_id>
 

--- a/components/data_comps/docn/cime_config/config_component.xml
+++ b/components/data_comps/docn/cime_config/config_component.xml
@@ -2,7 +2,7 @@
 
 <?xml-stylesheet type="text/xsl" href="setup_comp.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_OCN">
     <type>char</type>
@@ -188,7 +188,6 @@
   </entry>
 
   <entry id="SSTICE_YEAR_END">
-    <name>value</name>
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>0</default_value>
@@ -219,5 +218,5 @@
     =========================================
   </help>
 
-</definitions_variables>
+</entry_id>
 

--- a/components/data_comps/drof/cime_config/config_component.xml
+++ b/components/data_comps/drof/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ROF">
     <type>char</type>
@@ -92,4 +92,4 @@
     =========================================
   </help>
 
-</definitions_variables>
+</entry_id>

--- a/components/data_comps/dwav/cime_config/config_component.xml
+++ b/components/data_comps/dwav/cime_config/config_component.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_WAV">
     <type>char</type>
@@ -37,4 +37,4 @@
     =========================================
   </help>
 
-</definitions_variables>
+</entry_id>

--- a/components/stub_comps/satm/cime_config/config_component.xml
+++ b/components/stub_comps/satm/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ATM">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_SATM">Stub atm component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/stub_comps/sesp/cime_config/config_component.xml
+++ b/components/stub_comps/sesp/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ESP">
     <type>char</type>
@@ -18,4 +18,4 @@
     <desc compset="_SESP">Stub esp component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/stub_comps/sglc/cime_config/config_component.xml
+++ b/components/stub_comps/sglc/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_GLC">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_SGLC">Stub glc component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/stub_comps/sice/cime_config/config_component.xml
+++ b/components/stub_comps/sice/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ICE">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_SICE">Stub ice component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/stub_comps/slnd/cime_config/config_component.xml
+++ b/components/stub_comps/slnd/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_LND">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_SLND">Stub lnd component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/stub_comps/socn/cime_config/config_component.xml
+++ b/components/stub_comps/socn/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_OCN">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_SOCN">Stub ocn component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/stub_comps/srof/cime_config/config_component.xml
+++ b/components/stub_comps/srof/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ROF">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_SROF">Stub river component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/stub_comps/swav/cime_config/config_component.xml
+++ b/components/stub_comps/swav/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_WAV">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_SWAV">Stub wave component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/xcpl_comps/xatm/cime_config/config_component.xml
+++ b/components/xcpl_comps/xatm/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ATM">
     <type>char</type>
@@ -17,5 +17,5 @@
     <desc compset="_XATM">Dead atm component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>
 

--- a/components/xcpl_comps/xglc/cime_config/config_component.xml
+++ b/components/xcpl_comps/xglc/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_GLC">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_XGLC">Dead land-ice component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/xcpl_comps/xice/cime_config/config_component.xml
+++ b/components/xcpl_comps/xice/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ICE">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_XICE">Dead ice component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/xcpl_comps/xlnd/cime_config/config_component.xml
+++ b/components/xcpl_comps/xlnd/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_LND">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_XLND">Dead land component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/xcpl_comps/xocn/cime_config/config_component.xml
+++ b/components/xcpl_comps/xocn/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_OCN">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_XOCN">Dead ocean component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/xcpl_comps/xrof/cime_config/config_component.xml
+++ b/components/xcpl_comps/xrof/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_ROF">
     <type>char</type>
@@ -30,4 +30,4 @@
     <desc compset="_XROF">Dead river component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/components/xcpl_comps/xwav/cime_config/config_component.xml
+++ b/components/xcpl_comps/xwav/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_variables.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
   <entry id="COMP_WAV">
     <type>char</type>
@@ -17,4 +17,4 @@
     <desc compset="_XWAV">Dead wave component</desc>
   </description>
 
-</definitions_variables>
+</entry_id>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2,7 +2,7 @@
 
 <?xml-stylesheet type="text/xsl" href="config_compsets.xsl" ?>
 
-<definitions_variables>
+<entry_id>
 
 <!-- The list of component classes that this coupler/driver knows how
      to deal with.  Stub and data models for each component class
@@ -3632,6 +3632,6 @@
     =========================================
   </help>
 
-</definitions_variables>
+</entry_id>
 
 

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2,7 +2,7 @@
 
 <?xml-stylesheet type="text/xsl" href="config_compsets.xsl" ?>
 
-<entries>
+<definitions_variables>
 
 <!-- The list of component classes that this coupler/driver knows how
      to deal with.  Stub and data models for each component class
@@ -3632,6 +3632,6 @@
     =========================================
   </help>
 
-</entries>
+</definitions_variables>
 
 

--- a/utils/python/CIME/XML/component.py
+++ b/utils/python/CIME/XML/component.py
@@ -5,6 +5,7 @@ from CIME.XML.standard_module_setup import *
 
 from CIME.XML.entry_id import EntryID
 from CIME.XML.files import Files
+from distutils.spawn import find_executable
 
 logger = logging.getLogger(__name__)
 
@@ -14,12 +15,20 @@ class Component(EntryID):
         """
         initialize an object
         """
+        files = Files()
         if infile is None:
-            files = Files()
             infile = files.get_value("CONFIG_DRV_FILE")
 
+        # use xmllint to validate infile
+        xmllint = find_executable("xmllint")
+        if xmllint is not None:
+            schema = files.get_schema("CONFIG_DRV_FILE")
+            if schema is not None:
+                logger.warn("Checking file %s against %s"%(infile, schema))
+                run_cmd_no_fail("%s --noout --schema %s %s"%(xmllint, schema, infile))
+            
         EntryID.__init__(self,infile)
-
+        
     def get_value(self, name, attribute=None, resolved=False, subgroup=None):
         expect(subgroup is None, "This class does not support subgroups")
         return EntryID.get_value(self, name, attribute, resolved)

--- a/utils/python/CIME/XML/component.py
+++ b/utils/python/CIME/XML/component.py
@@ -11,17 +11,16 @@ logger = logging.getLogger(__name__)
 
 class Component(EntryID):
 
-    def __init__(self, infile=None):
+    def __init__(self, infile):
         """
         initialize an object
         """
         files = Files()
-        if infile is None:
-            infile = files.get_value("CONFIG_DRV_FILE")
 
         # use xmllint to validate infile
         xmllint = find_executable("xmllint")
         if xmllint is not None:
+            # all components refer to the same schema so referencing config_drv_file is okay
             schema = files.get_schema("CONFIG_DRV_FILE")
             if schema is not None:
                 logger.warn("Checking file %s against %s"%(infile, schema))

--- a/utils/python/CIME/XML/files.py
+++ b/utils/python/CIME/XML/files.py
@@ -21,6 +21,13 @@ class Files(EntryID):
         infile = os.path.join(get_cime_root(), "cime_config", get_model(), "config_files.xml")
         EntryID.__init__(self, infile)
 
+    def get_schema(self, nodename):
+        node = self.get_optional_node("entry", {"id":nodename})
+        schemanode = self.get_optional_node("schema", root=node)
+        if schemanode is not None:
+            return self.get_resolved_value(schemanode.text)
+        return None
+                            
     def get_components(self, nodename):
         node = self.get_optional_node("entry", {"id":nodename})
         valnodes = self.get_nodes("value", root=node)

--- a/utils/python/CIME/XML/files.py
+++ b/utils/python/CIME/XML/files.py
@@ -25,6 +25,7 @@ class Files(EntryID):
         node = self.get_optional_node("entry", {"id":nodename})
         schemanode = self.get_optional_node("schema", root=node)
         if schemanode is not None:
+            logger.warn("Found schema for %s"%(nodename))
             return self.get_resolved_value(schemanode.text)
         return None
                             

--- a/utils/python/CIME/XML/files.py
+++ b/utils/python/CIME/XML/files.py
@@ -25,10 +25,10 @@ class Files(EntryID):
         node = self.get_optional_node("entry", {"id":nodename})
         schemanode = self.get_optional_node("schema", root=node)
         if schemanode is not None:
-            logger.warn("Found schema for %s"%(nodename))
+            logger.debug("Found schema for %s"%(nodename))
             return self.get_resolved_value(schemanode.text)
         return None
-                            
+
     def get_components(self, nodename):
         node = self.get_optional_node("entry", {"id":nodename})
         valnodes = self.get_nodes("value", root=node)


### PR DESCRIPTION
Defines and implements a schema definition for entry_id style xml files.   Tests all config_component.xml files against this schema.  This is the first step in a plan to add schema testing for all xml files used by cime.    Some changes will be required to component config_component.xml files before they can be updated to the new cime however these reformatted files should be backward compatible with older cime versions.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Code review: 
