### PR TITLE
improved format for entry_id schema file

### DIFF
--- a/cime_config/xml_schemas/entry_id.xsd
+++ b/cime_config/xml_schemas/entry_id.xsd
@@ -1,61 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-  <xs:element name="entry_id">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="entry"/>
-        <xs:element ref="description" minOccurs="0"/>
-        <xs:element ref="help" minOccurs="0"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="entry">
-    <xs:complexType>
-      <xs:choice maxOccurs="unbounded">
-        <xs:element ref="type"/>
-        <xs:element ref="valid_values"/>
-        <xs:element ref="default_value"/>
-        <xs:element ref="file"/>
-        <xs:element ref="group"/>
-        <xs:element ref="values"/>
-        <xs:element ref="desc"/>
-        <xs:element ref="schema" minOccurs="0"/>
-      </xs:choice>
-      <xs:attribute name="id" use="required" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
+
+  <!-- attributes -->
+  <xs:attribute name="id" type="xs:NCName"/>
+  <xs:attribute name="compset" type="xs:string"/>
+  <xs:attribute name="component" type="xs:string"/>
+  <xs:attribute name="grid"  type="xs:string"/>
+  <xs:attribute name="modifier" type="xs:NCName"/>
+
+  <!-- simple elements -->
+  <xs:element name="help" type="xs:string"/>
   <xs:element name="type" type="xs:NCName"/>
   <xs:element name="default_value" type="xs:string"/>
   <xs:element name="file" type="xs:NCName"/>
   <xs:element name="group" type="xs:NCName"/>
   <xs:element name="valid_values" type="xs:string"/>
   <xs:element name="schema" type="xs:string"/>
-  <xs:element name="values">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="value"/>
-      </xs:sequence>
-         <xs:attribute name="modifier" type="xs:NCName"/>
-    </xs:complexType>
-  </xs:element>
+
+  <!-- complex elements -->
   <xs:element name="value">
     <xs:complexType mixed="true">
-      <xs:attribute name="component"/>
-      <xs:attribute name="compset"/>
-      <xs:attribute name="grid"/>
+      <xs:attribute ref="component"/>
+      <xs:attribute ref="compset"/>
+      <xs:attribute ref="grid"/>
     </xs:complexType>
   </xs:element>
+
+  <xs:element name="desc">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="compset"/>
+    </xs:complexType>
+  </xs:element>
+
   <xs:element name="description">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="desc"/>
+	<xs:element ref="desc" maxOccurs="unbounded" />
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="help" type="xs:string"/>
-  <xs:element name="desc">
-    <xs:complexType mixed="true">
-      <xs:attribute name="compset"/>
+
+  <xs:element name="values">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="value" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute ref="modifier"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="entry">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+	<xs:element ref="type"/>
+	<xs:element ref="valid_values"/>
+	<xs:element ref="default_value"/>
+	<xs:element ref="file"/>
+	<xs:element ref="group"/>
+	<xs:element ref="values"/>
+	<xs:element ref="desc"/>
+	<xs:element ref="schema" minOccurs="0"/>
+      </xs:choice>
+      <xs:attribute ref="id" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="entry_id">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="entry" maxOccurs="unbounded" />
+	<xs:element ref="description" minOccurs="0"/>
+	<xs:element ref="help" minOccurs="0"/>
+      </xs:sequence>
     </xs:complexType>
   </xs:element>
 </xs:schema>


### PR DESCRIPTION
Alice suggested a more human readable format for the xsd file.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Code review: 

