### PR TITLE
PEA should not always fail on machines without mpi-serial

### DIFF
--- a/utils/python/CIME/SystemTests/pea.py
+++ b/utils/python/CIME/SystemTests/pea.py
@@ -9,6 +9,7 @@ Builds runs and compares a single processor mpi model to a model built using mpi
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.XML.standard_module_setup import *
 from CIME.case_setup import case_setup
+from CIME.XML.machines import Machines
 
 logger = logging.getLogger(__name__)
 
@@ -28,13 +29,18 @@ class PEA(SystemTestsCompareTwo):
             self._case.set_value("NTASKS_%s"%comp, 1)
             self._case.set_value("NTHRDS_%s"%comp, 1)
             self._case.set_value("ROOTPE_%s"%comp, 0)
-            
 
     def _case_one_setup(self):
         case_setup(self._case, reset=True, test_mode=True)
 
     def _case_two_setup(self):
-        self._case.set_value("MPILIB","mpi-serial")
+        mach_name = self._case.get_value("MACH")
+        mach_obj = Machines(machine=mach_name)
+        if mach_obj.is_valid_MPIlib("mpi-serial"):
+            self._case.set_value("MPILIB","mpi-serial")
+        else:
+            logger.warning("mpi-serial is not supported on machine '%s', so we have to fall back to default MPI and therefore very little is being tested" % mach_name)
+
         if os.path.isfile("Macros"):
             os.remove("Macros")
         case_setup(self._case, reset=True, test_mode=True)


### PR DESCRIPTION
Test suite: Pylint (PEA not currently tested)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: No

Code review: jedwards

