### PR TITLE
Separate baseline and non-baseline compare phases

### DIFF
--- a/scripts/Testing/testreporter.pl
+++ b/scripts/Testing/testreporter.pl
@@ -305,7 +305,7 @@ sub getTestStatus
         $teststatushash{$testcase}{'comment'} .= " @testsummary_arr[3..$#testsummary_arr]";
 
         #Compare to baseline
-        my @testsummarylines = grep { /COMPARE_baseline/} @statuslines;
+        my @testsummarylines = grep { /BASELINE/} @statuslines;
         my @testsummary_arr = (split(/\s+/, $testsummarylines[0]));
         $teststatushash{$testcase}{'compare'} = ($#testsummarylines > -1) ? @testsummary_arr[0] : "----";
         $teststatushash{$testcase}{'comment'} .= " @testsummary_arr[3..$#testsummary_arr]";

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -339,7 +339,7 @@ class SystemTestsCommon(object):
             append_status(comments, sfile="TestStatus.log")
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             ts_comments = comments if "\n" not in comments else None
-            self._test_status.set_status("%s_baseline" % COMPARE_PHASE, status, comments=ts_comments)
+            self._test_status.set_status(BASELINE_PHASE, status, comments=ts_comments)
             basecmp_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASECMP_CASE"))
 
             # compare memory usage to baseline

--- a/utils/python/CIME/hist_utils.py
+++ b/utils/python/CIME/hist_utils.py
@@ -48,7 +48,6 @@ def _get_latest_hist_files(testcase, model, from_dir, suffix=""):
         histlist.append(latest_files[key])
     return histlist
 
-
 def copy(case, suffix):
     """Copy the most recent batch of hist files in a case, adding the given suffix.
 


### PR DESCRIPTION
The new BASELINE phase does not need decorators because there is
at most one per test.

Test suite: scripts_regression_tests.py --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #396 

User interface changes?: Yes, new BASELINE phase will appear in TestStatus

Code review: jedwards, billsacks

