### PR TITLE
Get values rename

### DIFF
--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -114,13 +114,13 @@ def xmlquery(caseroot, args, listofattributes=[] ,  subgroup=None, noecho=False,
             for xmlattr in listofattributes:
                 # type_str = case.get_type_info(xmlattr)
                 logger.debug("Searching for %s", xmlattr)
-                attribute_hits = case.get_values(xmlattr, resolved=resolved,
+                attribute_hits = case.get_full_records(xmlattr, resolved=resolved,
                                                  subgroup=subgroup)
                 results       += attribute_hits
 
         elif (args.listall):
             logger.warning("Retrieving all values.")
-            results = case.get_values(None, resolved=resolved,
+            results = case.get_full_records(None, resolved=resolved,
                                       subgroup=subgroup)
         else:
             logger.warning("No attributes (%s) or listall option",

--- a/utils/python/CIME/SystemTests/nck.py
+++ b/utils/python/CIME/SystemTests/nck.py
@@ -31,7 +31,7 @@ class NCK(SystemTestsCompareTwo):
         # think that the halving was unnecessary; but it's needed in case the
         # original NTASKS was odd. (e.g., for NTASKS originally 15, we want to
         # use NTASKS = int(15/2) * 2 = 14 tasks for case two.)
-        self._comp_classes = self._case.get_value("COMP_CLASSES").split(',')
+        self._comp_classes = self._case.get_values("COMP_CLASSES")
         self._comp_classes.remove("DRV")
         for comp in self._comp_classes:
             ntasks = self._case.get_value("NTASKS_%s"%comp)

--- a/utils/python/CIME/SystemTests/pea.py
+++ b/utils/python/CIME/SystemTests/pea.py
@@ -22,13 +22,13 @@ class PEA(SystemTestsCompareTwo):
                                        run_two_description = 'mpi-serial')
 
     def _common_setup(self):
-        for comp in self._case.get_value("COMP_CLASSES").split(','):
+        for comp in self._case.get_values("COMP_CLASSES"):
             if comp == "DRV":
                 comp = "CPL"
             self._case.set_value("NTASKS_%s"%comp, 1)
             self._case.set_value("NTHRDS_%s"%comp, 1)
             self._case.set_value("ROOTPE_%s"%comp, 0)
-            
+
 
     def _case_one_setup(self):
         case_setup(self._case, reset=True, test_mode=True)

--- a/utils/python/CIME/SystemTests/seq.py
+++ b/utils/python/CIME/SystemTests/seq.py
@@ -38,7 +38,7 @@ class SEQ(SystemTestsCommon):
             logging.info("Copying env_mach_pes.xml to %s"%(machpes1))
             shutil.copy("env_mach_pes.xml", machpes1)
 
-        comp_classes = self._case.get_value("COMP_CLASSES").split(',')
+        comp_classes = self._case.get_values("COMP_CLASSES")
         for comp in comp_classes:
             if comp != "DRV":
                 any_changes |= self._case.get_value("ROOTPE_%s" % comp) != 0

--- a/utils/python/CIME/XML/component.py
+++ b/utils/python/CIME/XML/component.py
@@ -23,11 +23,11 @@ class Component(EntryID):
             # all components refer to the same schema so referencing config_drv_file is okay
             schema = files.get_schema("CONFIG_DRV_FILE")
             if schema is not None:
-                logger.warn("Checking file %s against %s"%(infile, schema))
+                logger.debug("Checking file %s against %s"%(infile, schema))
                 run_cmd_no_fail("%s --noout --schema %s %s"%(xmllint, schema, infile))
-            
+
         EntryID.__init__(self,infile)
-        
+
     def get_value(self, name, attribute=None, resolved=False, subgroup=None):
         expect(subgroup is None, "This class does not support subgroups")
         return EntryID.get_value(self, name, attribute, resolved)

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -220,12 +220,12 @@ class EntryID(GenericXML):
             type_str = self._get_type_info(node)
             return convert_to_type(val, type_str, vid)
 
-    def get_values(self, item, attribute=None, resolved=True, subgroup=None): # (self, vid, att, resolved=True , subgroup=None ):
+    def get_full_records(self, item, attribute=None, resolved=True, subgroup=None): # (self, vid, att, resolved=True , subgroup=None ):
         """
         If an entry includes a list of values return a list of dict matching each
         attribute to its associated value and group
         """
-        logger.debug("(get_values) Input values: %s , %s , %s , %s , %s" ,  self.__class__.__name__ , item, attribute, resolved, subgroup)
+        logger.debug("(get_full_records) Input values: %s , %s , %s , %s , %s" ,  self.__class__.__name__ , item, attribute, resolved, subgroup)
 
         nodes   = [] # List of identified xml elements
         results = [] # List of identified parameters
@@ -244,16 +244,16 @@ class EntryID(GenericXML):
                 nodes = self.get_nodes("entry",{"id" : item} , root=group)
             else :
                 # Return all nodes
-                logger.debug("Retrieving all parameter")
+                logger.debug("(get_full_records) Retrieving all parameter")
                 nodes = self.get_nodes("entry" , root=group)
 
             if (len(nodes) == 0) :
-                logger.debug("Found no nodes for %s" , item)
+                logger.debug("(get_full_records) Found no nodes for %s" , item)
             else :
-                logger.debug("Building return structure for %s nodes" , len(nodes))
+                logger.debug("(get_full_records) Building return structure for %s nodes" , len(nodes))
 
             for node in nodes :
-                logger.debug("Node tag=%s attribute=%s" , node.tag , node.attrib )
+                logger.debug("(get_full_records) Node tag=%s attribute=%s" , node.tag , node.attrib )
 
                 g       = self._get_group(group)
                 val     = node.attrib['value']
@@ -265,13 +265,13 @@ class EntryID(GenericXML):
                 try :
                     file_   = self.filename
                 except AttributeError:
-                    logger.debug("Can't call filename on %s (%s)" , self , self.__class__.__name__ )
+                    logger.debug("(get_full_records) Can't call filename on %s (%s)" , self , self.__class__.__name__ )
                 #t   =  super(EnvBase , self).get_type( node )
                 v = { 'group' : g , 'attribute' : attr , 'value' : val , 'type' : t , 'description' : desc , 'default' : default , 'file' : file_}
 
                 results.append(v)
 
-        logger.debug("(get_values) Returning %s items" , len(results) )
+        logger.debug("(get_full_records) Returning %s items" , len(results) )
         return results
 
     def get_child_content(self, vid, childname):

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -88,11 +88,11 @@ class EnvBatch(EnvBase):
                         value = convert_to_type(value, type_str, item)
         return value
 
-    def get_values(self, item, attribute=None, resolved=True, subgroup=None):
+    def get_full_records(self, item, attribute=None, resolved=True, subgroup=None):
         """Returns the value as a string of the first xml element with item as attribute value.
         <elememt_name attribute='attribute_value>value</element_name>"""
 
-        logger.debug("(get_values) Input values: %s , %s , %s , %s , %s" , self.__class__.__name__ , item, attribute, resolved, subgroup)
+        logger.debug("(get_full_records) Input values: %s , %s , %s , %s , %s" , self.__class__.__name__ , item, attribute, resolved, subgroup)
 
         nodes   = [] # List of identified xml elements
         results = [] # List of identified parameters
@@ -144,12 +144,12 @@ class EnvBatch(EnvBase):
                     filename        = self.filename
 
                     tmp = { 'group' : group_name , 'attribute' : attr , 'value' : val , 'type' : attribute_type , 'description' : desc , 'default' : default , 'file' : filename}
-                    logger.debug("Found node with value for %s = %s" , item , tmp )
+                    logger.debug("(get_full_records) Found node with value for %s = %s" , item , tmp )
 
                     # add single result to list
                     results.append(tmp)
 
-        logger.debug("(get_values) Return value:  %s" , results )
+        logger.debug("(get_full_records) Return value:  %s" , results )
 
         return results
 

--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -52,11 +52,11 @@ class EnvMachSpecific(EnvBase):
                     self.add_child(node)
 
 
-    def get_values(self, item, attribute=None, resolved=True, subgroup=None):
+    def get_full_records(self, item, attribute=None, resolved=True, subgroup=None):
         """Returns the value as a string of the first xml element with item as attribute value.
         <element_name attribute='attribute_value>value</element_name>"""
 
-        logger.debug("(get_values) Input values: %s , %s , %s , %s , %s" , self.__class__.__name__ , item, attribute, resolved, subgroup)
+        logger.debug("(get_full_records) Input values: %s , %s , %s , %s , %s" , self.__class__.__name__ , item, attribute, resolved, subgroup)
 
         nodes   = [] # List of identified xml elements
         results = [] # List of identified parameters
@@ -67,7 +67,7 @@ class EnvMachSpecific(EnvBase):
             nodes = self.get_nodes("*",{"name" : item})
         else :
             # Return all nodes
-            logger.debug("Retrieving all parameter")
+            logger.debug("(get_full_records) Retrieving all parameter")
             nodes = self.get_nodes("env")
 
         # Return value for first occurence of node with attribute value = item
@@ -84,7 +84,7 @@ class EnvMachSpecific(EnvBase):
 
             #t   =  super(EnvBase , self).get_type( node )
             v = { 'group' : group , 'attribute' : attr , 'value' : val , 'type' : t , 'description' : desc , 'default' : default , 'file' : filename}
-            logger.debug("Found node with value for %s = %s" , item , v )
+            logger.debug("(get_full_records) Found node with value for %s = %s" , item , v )
             results.append(v)
 
         return results

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -163,7 +163,7 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
 
     cimeroot = case.get_value("CIMEROOT")
 
-    comp_classes = case.get_value("COMP_CLASSES").split(',')
+    comp_classes = case.get_values("COMP_CLASSES")
 
     if not sharedlib_only:
         check_all_input_data(case)
@@ -490,7 +490,7 @@ def clean(case, cleanlist=None):
     clm_config_opts = case.get_value("CLM_CONFIG_OPTS")
     comp_lnd = case.get_value("COMP_LND")
     if cleanlist is None:
-        cleanlist = case.get_value("COMP_CLASSES").split(',')
+        cleanlist = case.get_values("COMP_CLASSES")
         cleanlist = [x.lower().replace('drv','cpl') for x in cleanlist]
         testcase        = case.get_value("TESTCASE")
         # we only want to clean clm here if it is clm4_0 otherwise remove

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -168,11 +168,45 @@ class Case(object):
             env_file.write()
         self._env_files_that_need_rewrite = set()
 
+    def get_values(self, item, attribute=None, resolved=True, subgroup=None):
+        results = []
+        for env_file in self._env_entryid_files:
+            # Wait and resolve in self rather than in env_file
+            results = env_file.get_values(item, attribute, resolved=False, subgroup=subgroup)
+
+            if len(results) > 0:
+                new_results = []
+                vtype = env_file.get_type_info(item)
+                if resolved:
+                    for result in results:
+                        if type(result) is str:
+                            result = self.get_resolved_value(result)
+                            new_results.append(convert_to_type(result, vtype, item))
+                        else:
+                            new_results.append(result)
+                else:
+                    new_results = results
+                return new_results
+
+        for env_file in self._env_generic_files:
+            results = env_file.get_values(item, attribute, resolved=False, subgroup=subgroup)
+            if len(results) > 0:
+                if resolved:
+                    for result in results:
+                        if type(result) is str:
+                            new_results.append(self.get_resolved_value(result))
+                        else:
+                            new_results.append(result)
+                else:
+                    new_results = results
+                return new_results
+        # Return empty result
+        return results
+
     def get_value(self, item, attribute=None, resolved=True, subgroup=None):
         result = None
         for env_file in self._env_entryid_files:
             # Wait and resolve in self rather than in env_file
-
             result = env_file.get_value(item, attribute, resolved=False, subgroup=subgroup)
 
             if result is not None:

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -195,37 +195,37 @@ class Case(object):
         return result
 
 
-    def get_values(self, item=None, attribute=None, resolved=True, subgroup=None):
+    def get_full_records(self, item=None, attribute=None, resolved=True, subgroup=None):
 
         """
         Return info object for given item, return all info for all item if item is empty.
         """
 
-        logger.debug("(get_values) Input values: %s , %s , %s , %s , %s" , self.__class__.__name__ , item, attribute, resolved, subgroup)
+        logger.debug("(get_full_records) Input values: %s , %s , %s , %s , %s" , self.__class__.__name__ , item, attribute, resolved, subgroup)
 
         # Empty result list
         results = []
 
         for env_file in self._env_entryid_files:
             # Wait and resolve in self rather than in env_file
-            logger.debug("Searching in %s" , env_file.__class__.__name__)
+            logger.debug("(get_full_records) Searching in %s" , env_file.__class__.__name__)
             result = None
 
             try:
-                # env_batch has its own implementation of get_values otherwise in entry_id
-                result = env_file.get_values(item, attribute, resolved=False, subgroup=subgroup)
+                # env_batch has its own implementation of get_full_records otherwise in entry_id
+                result = env_file.get_full_records(item, attribute, resolved=False, subgroup=subgroup)
                 # Method exists, and was used.
             except AttributeError:
                 # Method does not exist.  What now?
                 traceback.print_exc()
-                logger.debug("No get_values method for class %s (%s)" , env_file.__class__.__name__ , AttributeError)
+                logger.debug("(get_full_records) No get_full_records method for class %s (%s)" , env_file.__class__.__name__ , AttributeError)
 
             if result is not None and (len(result) >= 1):
 
                 if resolved :
                     for r in result :
                         if type(r['value']) is str:
-                            logger.debug("Resolving %s" , r['value'])
+                            logger.debug("(get_full_records) Resolving %s" , r['value'])
                             r['value'] = self.get_resolved_value(r['value'])
 
                 if subgroup :
@@ -237,7 +237,7 @@ class Case(object):
                 else:
                     results = results + result
 
-        logger.debug("(get_values) Return value:  %s" , results )
+        logger.debug("(get_full_records) Return value:  %s" , results )
         return results
 
     def get_type_info(self, item):

--- a/utils/python/CIME/case_run.py
+++ b/utils/python/CIME/case_run.py
@@ -81,7 +81,7 @@ def run_model(case):
 
     # Set OMP_NUM_THREADS
     env_mach_pes = case.get_env("mach_pes")
-    os.environ["OMP_NUM_THREADS"] = str(env_mach_pes.get_max_thread_count(case.get_value("COMP_CLASSES").split(',')))
+    os.environ["OMP_NUM_THREADS"] = str(env_mach_pes.get_max_thread_count(case.get_values("COMP_CLASSES")))
 
     # Run the model
     logger.info("%s MODEL EXECUTION BEGINS HERE" %(time.strftime("%Y-%m-%d %H:%M:%S")))

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -136,7 +136,7 @@ def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, r
         append_status(msg, caseroot=caseroot, sfile="CaseStatus")
 
     if not clean:
-        models = case.get_value("COMP_CLASSES").split(",")
+        models = case.get_values("COMP_CLASSES")
 
         mach, compiler, debug, mpilib = \
             case.get_value("MACH"), case.get_value("COMPILER"), case.get_value("DEBUG"), case.get_value("MPILIB")

--- a/utils/python/CIME/get_timing.py
+++ b/utils/python/CIME/get_timing.py
@@ -102,7 +102,7 @@ class _TimingParser:
         return (0, 0, False)
 
     def getTiming(self):
-        components=self.case.get_value("COMP_CLASSES").split(',')
+        components=self.case.get_values("COMP_CLASSES")
         components[components.index("DRV")]="CPL"
         for s in components:
             self.models[s] = _GetTimingInfo(s)

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -853,7 +853,7 @@ def get_build_threaded(case):
     force_threaded = case.get_value("BUILD_THREADED")
     if force_threaded:
         return True
-    comp_classes = case.get_value("COMP_CLASSES").split(',')
+    comp_classes = case.get_values("COMP_CLASSES")
     for comp_class in comp_classes:
         if comp_class == "DRV":
             comp_class = "CPL"


### PR DESCRIPTION
The get_values functionality used by xmlquery has been renamed to get_full_records so that 
get_values can provide functionality similar to the get_value function but returning a list instead of a single value.   get_value calls to COMP_CLASSES have been replaced by calls to get_values.   This work is in preparation for better integration of the build_namelists update in PR #640.    
I'm not attached to the name get_full_records and would be happy to change it again if you have a better suggestion.

Test suite:  scripts_regression_tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes

User interface changes?: 

Code review: 
