### PR TITLE
fix problem getting thread_count

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -81,7 +81,7 @@
     <arguments>
       <arg name="label"> --label</arg>
       <arg name="num_tasks" > -n $TOTALPES</arg>
-      <arg name="thread_count" > -c {{ thread_count }}</arg>
+      <arg name="thread_count" > -c $OMP_NUM_THREADS</arg>
 
     </arguments>
   </mpirun>
@@ -197,7 +197,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-	<arg name="thread_count" > -c {{ thread_count }}</arg>
+	<arg name="thread_count" > -c $OMP_NUM_THREADS</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -744,7 +744,7 @@
                <arg name="locargs"> --block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
                <arg name="bg_threadlayout"> --envs BG_THREADLAYOUT=1</arg>
                <arg name="omp_stacksize"> --envs OMP_STACKSIZE=64M</arg>
-               <arg name="thread_count"> --envs OMP_NUM_THREADS={{ thread_count }}</arg>
+               <arg name="thread_count"> --envs OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
              </arguments>
          </mpirun>
     <module_system type="soft">
@@ -843,7 +843,7 @@
                <arg name="locargs"> --block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
                <arg name="bg_threadlayout"> --envs BG_THREADLAYOUT=1</arg>
                <arg name="omp_stacksize"> --envs OMP_STACKSIZE=64M</arg>
-               <arg name="thread_count"> --envs OMP_NUM_THREADS={{ thread_count }}</arg>
+               <arg name="thread_count"> --envs OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
              </arguments>
          </mpirun>
     <module_system type="soft">
@@ -1109,7 +1109,7 @@
         <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
         <arg name="num_tasks" > -n $TOTALPES</arg>
         <arg name="tasks_per_node" > -N $PES_PER_NODE</arg>
-        <arg name="thread_count" > -d {{ thread_count }}</arg>
+        <arg name="thread_count" > -d $OMP_NUM_THREADS</arg>
         <arg name="numa_node" > -cc numa_node </arg>
       </arguments>
 
@@ -1276,7 +1276,7 @@
              <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
              <arg name="num_tasks" > -n $TOTALPES</arg>
              <arg name="tasks_per_node" > -N $PES_PER_NODE</arg>
-             <arg name="thread_count" > -d {{ thread_count }}</arg>
+             <arg name="thread_count" > -d $OMP_NUM_THREADS</arg>
              <arg name="numa_node" > -cc numa_node</arg>
            </arguments>
          </mpirun>
@@ -1641,7 +1641,7 @@
                 <arg name="num_tasks"> -n $TOTALPES</arg>
                 <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg>
                 <arg name="tasks_per_node"> -N $PES_PER_NODE</arg>
-                <arg name="thread_count"> -d {{ thread_count }}</arg>
+                <arg name="thread_count"> -d $OMP_NUM_THREADS</arg>
              </arguments>
          </mpirun>
 </machine>
@@ -1680,7 +1680,7 @@
                 <arg name="num_tasks"> -n $TOTALPES</arg>
                 <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg>
                 <arg name="tasks_per_node"> -N $PES_PER_NODE</arg>
-                <arg name="thread_count"> -d {{ thread_count }} </arg>
+                <arg name="thread_count"> -d $OMP_NUM_THREADS </arg>
              </arguments>
          </mpirun>
 </machine>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -75,7 +75,7 @@
 	<arg name="num_tasks"> -n $TOTALPES</arg>
 	<!-- <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg> -->
 	<arg name="tasks_per_node"> -N $PES_PER_NODE</arg>
-	<arg name="thread_count"> -d {{ thread_count }}</arg>
+	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -323,7 +323,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-	<arg name="thread_count" > -c {{ thread_count }}</arg>
+	<arg name="thread_count" > -c $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -489,7 +489,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-     	<arg name="thread_count" > -c {{ thread_count }}</arg>
+     	<arg name="thread_count" > -c $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -669,7 +669,7 @@
 	<arg name="num_tasks" > -n $TOTALPES</arg>
 	<arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
 	<arg name="tasks_per_node" > -N $PES_PER_NODE</arg>
-	<arg name="thread_count" > -d {{ thread_count }}</arg>
+	<arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpi-serial">
@@ -863,7 +863,7 @@
 	<arg name="locargs">--block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
 	<arg name="bg_threadlayout"> --envs BG_THREADLAYOUT=1</arg>
 	<arg name="omp_stacksize"> --envs OMP_STACKSIZE=32M</arg>
-	<arg name="thread_count"> --envs OMP_NUM_THREADS={{ thread_count }}</arg>
+	<arg name="thread_count"> --envs OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="soft">
@@ -1174,7 +1174,7 @@
       <arguments>
         <arg name="num_tasks"> -n $TOTALPES</arg>
         <arg name="tasks_per_node"> -N $PES_PER_NODE</arg>
-        <arg name="thread_count"> -d {{ thread_count }}</arg>
+        <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1249,7 +1249,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-     	<arg name="thread_count" > -c {{ thread_count }}</arg>
+     	<arg name="thread_count" > -c $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mvapich2">
@@ -1257,7 +1257,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-     	<arg name="thread_count" > -c {{ thread_count }}</arg>
+     	<arg name="thread_count" > -c $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpi-serial">


### PR DESCRIPTION
Replace {{ thread_count }} in config_machines.xml with $OMP_NUM_THREADS

Test suite: scripts_regression_tests on edison
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Code review: 

