### PR TITLE
Mfdeakin sandia/system tests compare two/pem

### DIFF
--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -364,6 +364,8 @@ LII    CLM initial condition interpolation test
     <DOUT_S>FALSE</DOUT_S>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>none</REST_OPTION>
   </test>
 
   <test NAME="PET">

--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -362,6 +362,8 @@ LII    CLM initial condition interpolation test
     <BFBFLAG>TRUE</BFBFLAG>
     <REST_OPTION>never</REST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
   </test>
 
   <test NAME="PET">

--- a/utils/python/CIME/SystemTests/pem.py
+++ b/utils/python/CIME/SystemTests/pem.py
@@ -37,25 +37,11 @@ class PEM(SystemTestsCompareTwo):
             ntasks = self._case.get_value("NTASKS_%s"%comp)
             if ( ntasks > 1 ):
                 self._case.set_value("NTASKS_%s"%comp, ntasks/2)
-
-    def _pem_first_phase(self):
-        stop_n = self._case.get_value("STOP_N")
-        stop_option = self._case.get_value("STOP_OPTION")
-
-        self._case.flush()
-
-        self.run_indv()
-
-    def _pem_second_phase(self):
-        stop_n = self._case.get_value("STOP_N")
-        stop_option = self._case.get_value("STOP_OPTION")
-
-        self._case.flush()
-
-        self.run_indv(suffix="modpes")
-        self._component_compare_test("base", "modpes")
+        case_setup(self._case, clean=False, test_mode=False, reset=True)
 
     def _config_run(self):
+        # These options must be set in the run phase,
+        # as their environment variables don't exist before then
         for f in (self._activate_case1, self._activate_case2):
             f()
             self._case.set_value("HIST_OPTION","$STOP_OPTION")
@@ -63,5 +49,4 @@ class PEM(SystemTestsCompareTwo):
 
     def run_phase(self):
         self._config_run()
-        self._pem_first_phase()
-        self._pem_second_phase()
+        SystemTestsCompareTwo.run_phase(self)

--- a/utils/python/CIME/SystemTests/pem.py
+++ b/utils/python/CIME/SystemTests/pem.py
@@ -36,7 +36,7 @@ class PEM(SystemTestsCompareTwo):
         for comp in ['ATM','CPL','OCN','WAV','GLC','ICE','ROF','LND']:
             ntasks = self._case.get_value("NTASKS_%s"%comp)
             if ( ntasks > 1 ):
-                self._case.set_value("NTASKS_%s"%comp, ntasks/2)
+                self._case.set_value("NTASKS_%s"%comp, int(ntasks/2))
         case_setup(self._case, clean=False, test_mode=False, reset=True)
 
     def _config_run(self):

--- a/utils/python/CIME/SystemTests/pem.py
+++ b/utils/python/CIME/SystemTests/pem.py
@@ -28,8 +28,6 @@ class PEM(SystemTestsCompareTwo):
         self._case.set_value("SMP_BUILD","0")
         self._case.set_value("CONTINUE_RUN",False)
         self._case.set_value("REST_OPTION","none")
-        self._case.set_value("HIST_OPTION","$STOP_OPTION")
-        self._case.set_value("HIST_N","$STOP_N")
 
     def _case_one_setup(self):
         pass
@@ -57,6 +55,13 @@ class PEM(SystemTestsCompareTwo):
         self.run_indv(suffix="modpes")
         self._component_compare_test("base", "modpes")
 
+    def _config_run(self):
+        for f in (self._activate_case1, self._activate_case2):
+            f()
+            self._case.set_value("HIST_OPTION","$STOP_OPTION")
+            self._case.set_value("HIST_N","$STOP_N")
+
     def run_phase(self):
+        self._config_run()
         self._pem_first_phase()
         self._pem_second_phase()

--- a/utils/python/CIME/SystemTests/pem.py
+++ b/utils/python/CIME/SystemTests/pem.py
@@ -24,11 +24,6 @@ class PEM(SystemTestsCompareTwo):
         """
         SystemTestsCompareTwo.__init__(self, case, True)
 
-    def _common_setup(self):
-        self._case.set_value("SMP_BUILD","0")
-        self._case.set_value("CONTINUE_RUN",False)
-        self._case.set_value("REST_OPTION","none")
-
     def _case_one_setup(self):
         pass
 

--- a/utils/python/CIME/SystemTests/pem.py
+++ b/utils/python/CIME/SystemTests/pem.py
@@ -8,10 +8,8 @@ count are modified the second time.
 (2) Do an initial run with half the number of tasks (suffix modpes)
 """
 
-import shutil
 from CIME.XML.standard_module_setup import *
 from CIME.case_setup import case_setup
-import CIME.utils
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 
 logger = logging.getLogger(__name__)

--- a/utils/python/CIME/SystemTests/pem.py
+++ b/utils/python/CIME/SystemTests/pem.py
@@ -38,15 +38,3 @@ class PEM(SystemTestsCompareTwo):
             if ( ntasks > 1 ):
                 self._case.set_value("NTASKS_%s"%comp, int(ntasks/2))
         case_setup(self._case, clean=False, test_mode=False, reset=True)
-
-    def _config_run(self):
-        # These options must be set in the run phase,
-        # as their environment variables don't exist before then
-        for f in (self._activate_case1, self._activate_case2):
-            f()
-            self._case.set_value("HIST_OPTION","$STOP_OPTION")
-            self._case.set_value("HIST_N","$STOP_N")
-
-    def run_phase(self):
-        self._config_run()
-        SystemTestsCompareTwo.run_phase(self)

--- a/utils/python/CIME/SystemTests/pem.py
+++ b/utils/python/CIME/SystemTests/pem.py
@@ -12,115 +12,47 @@ import shutil
 from CIME.XML.standard_module_setup import *
 from CIME.case_setup import case_setup
 import CIME.utils
-from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 
 logger = logging.getLogger(__name__)
 
-class PEM(SystemTestsCommon):
+class PEM(SystemTestsCompareTwo):
 
     def __init__(self, case):
         """
         initialize a test object
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCompareTwo.__init__(self, case, True)
 
-    def build_phase(self, sharedlib_only=False, model_only=False):
-        """
-        Build two cases.  Case one uses defaults, case2 uses half the number of threads
-        and tasks. This test will fail for components (e.g. pop) that do not reproduce exactly
-        with different numbers of mpi tasks.
-        """
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = CIME.utils.get_model()
-
-        machpes1 = os.path.join("LockedFiles","env_mach_pes.PEM1.xml")
-        if ( os.path.isfile(machpes1) ):
-            shutil.copy(machpes1,"env_mach_pes.xml")
-        else:
-            logging.warn("Copying env_mach_pes.xml to %s"%(machpes1))
-            shutil.copy("env_mach_pes.xml", machpes1)
-
+    def _common_setup(self):
         self._case.set_value("SMP_BUILD","0")
-        for bld in range(1,3):
-            logging.warn("Starting bld %s"%bld)
-
-            if (bld == 2):
-                # halve the number of tasks
-                for comp in ['ATM','CPL','OCN','WAV','GLC','ICE','ROF','LND']:
-                    ntasks    = self._case.get_value("NTASKS_%s"%comp)
-                    if ( ntasks > 1 ):
-                        self._case.set_value("NTASKS_%s"%comp, ntasks/2)
-
-            self._case.flush()
-            case_setup(self._case, test_mode=True, reset=True)
-            self.clean_build()
-            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-            if (not sharedlib_only):
-                shutil.move("%s/%s.exe"%(exeroot,cime_model),
-                            "%s/%s.exe.PEM%s"%(exeroot,cime_model,bld))
-
-            shutil.copy("env_mach_pes.xml", "env_mach_pes.xml.%s"%bld )
-        #
-        # Because mira/cetus interprets its run script differently than
-        # other systems we need to copy the original env_mach_pes.xml# back
-        #
-        shutil.copy(machpes1,"env_mach_pes.xml")
-        shutil.copy("env_mach_pes.xml", os.path.join("LockedFiles","env_mach_pes.xml"))
-
-    def _pem_first_phase(self):
-
-        # Reset beginning test settings
-        expect(os.path.isfile("env_mach_pes.xml.1"),
-               "ERROR: env_mach_pes.xml.1 does not exist, run case.build" )
-
-        shutil.copy("env_mach_pes.xml.1", "env_mach_pes.xml")
-        shutil.copy("env_mach_pes.xml.1", "LockedFiles/env_mach_pes.xml")
-
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = CIME.utils.get_model()
-        exefile  = "%s/%s.exe"%(exeroot,cime_model)
-        exefile1 = "%s/%s.exe.PEM1"%(exeroot,cime_model)
-        if (os.path.isfile(exefile)):
-            os.remove(exefile)
-        shutil.copy(exefile1, exefile)
-
         self._case.set_value("CONTINUE_RUN",False)
         self._case.set_value("REST_OPTION","none")
         self._case.set_value("HIST_OPTION","$STOP_OPTION")
         self._case.set_value("HIST_N","$STOP_N")
+
+    def _case_one_setup(self):
+        pass
+
+    def _case_two_setup(self):
+        for comp in ['ATM','CPL','OCN','WAV','GLC','ICE','ROF','LND']:
+            ntasks = self._case.get_value("NTASKS_%s"%comp)
+            if ( ntasks > 1 ):
+                self._case.set_value("NTASKS_%s"%comp, ntasks/2)
+
+    def _pem_first_phase(self):
         stop_n = self._case.get_value("STOP_N")
         stop_option = self._case.get_value("STOP_OPTION")
 
         self._case.flush()
-        logger.info("doing an %d %s initial test, no restarts written" % (stop_n, stop_option))
 
         self.run_indv()
 
     def _pem_second_phase(self):
-
-        expect(os.path.isfile("env_mach_pes.xml.2"),
-               "ERROR: env_mach_pes.xml.2 does not exist, run case.build" )
-
-        shutil.copy("env_mach_pes.xml.2", "env_mach_pes.xml")
-        shutil.copy("env_mach_pes.xml.2", "LockedFiles/env_mach_pes.xml")
-
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = CIME.utils.get_model()
-        exefile  = "%s/%s.exe"%(exeroot,cime_model)
-        exefile2 = "%s/%s.exe.PEM2"%(exeroot,cime_model)
-        if (os.path.isfile(exefile)):
-            os.remove(exefile)
-        shutil.copy(exefile2, exefile)
-
-        self._case.set_value("CONTINUE_RUN",False)
-        self._case.set_value("REST_OPTION","none")
-        self._case.set_value("HIST_OPTION","$STOP_OPTION")
-        self._case.set_value("HIST_N","$STOP_N")
         stop_n = self._case.get_value("STOP_N")
         stop_option = self._case.get_value("STOP_OPTION")
 
         self._case.flush()
-        logger.info("doing an %d %s initial test, no restarts written" % (stop_n, stop_option))
 
         self.run_indv(suffix="modpes")
         self._component_compare_test("base", "modpes")

--- a/utils/python/CIME/SystemTests/system_tests_compare_two.py
+++ b/utils/python/CIME/SystemTests/system_tests_compare_two.py
@@ -299,7 +299,6 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # Flush the case so that, if errors occur later, then at least case2 is
         # in a correct, post-setup state
         self._case.flush()
-        case_setup(self._case, clean=False, test_mode=False, reset=True)
 
         # Go back to case 1 to ensure that's where we are for any following code
         self._activate_case1()

--- a/utils/python/CIME/SystemTests/system_tests_compare_two.py
+++ b/utils/python/CIME/SystemTests/system_tests_compare_two.py
@@ -26,6 +26,7 @@ In addition, they MAY require the following method:
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case import Case
+from CIME.case_setup import case_setup
 
 import shutil, os, glob
 
@@ -298,6 +299,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # Flush the case so that, if errors occur later, then at least case2 is
         # in a correct, post-setup state
         self._case.flush()
+        case_setup(self._case, clean=False, test_mode=False, reset=True)
 
         # Go back to case 1 to ensure that's where we are for any following code
         self._activate_case1()

--- a/utils/python/CIME/SystemTests/system_tests_compare_two.py
+++ b/utils/python/CIME/SystemTests/system_tests_compare_two.py
@@ -26,7 +26,6 @@ In addition, they MAY require the following method:
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case import Case
-from CIME.case_setup import case_setup
 
 import shutil, os, glob
 


### PR DESCRIPTION
This makes the PEM test class a subclass of SystemTestsCompareTwo and utilizes it's framework to implement the test 

Test suite: Most of cime_developer
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 446

User interface changes?: No

Code review: 
