### PR TITLE
Minor cleanup and documentation of recent test_status changes

### DIFF
--- a/utils/python/CIME/test_status.py
+++ b/utils/python/CIME/test_status.py
@@ -79,6 +79,9 @@ class TestStatus(object):
         Create a TestStatus object
 
         If test_dir is not specified, it is set to the current working directory
+
+        no_io is intended only for testing, and should be kept False in
+        production code
         """
         test_dir = os.getcwd() if test_dir is None else test_dir
         self._filename = os.path.join(test_dir, TEST_STATUS_FILENAME)

--- a/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/utils/python/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -75,6 +75,9 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
         """
         Initialize a SystemTestsCompareTwoFake object
 
+        The core test phases prior to RUN_PHASE are set to TEST_PASS_STATUS;
+        RUN_PHASE is left unset (as is any later phase)
+
         Args:
             case1 (CaseFake): existing case
             run_one_suffix (str, optional): Suffix used for first run. Defaults
@@ -104,10 +107,13 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
             separate_builds = False,
             run_two_suffix = run_two_suffix)
 
-        # Need to tell test status that case has been built, since this is
-        # checked in the run call
+        # Need to tell test status that all phases prior to the run phase have
+        # passed, since this is checked in the run call (at least for the build
+        # phase status)
         with self._test_status:
-            for phase in test_status.CORE_PHASES[:-1]:
+            for phase in test_status.CORE_PHASES:
+                if phase == test_status.RUN_PHASE:
+                    break
                 self._test_status.set_status(phase, test_status.TEST_PASS_STATUS)
 
         self.run_pass_casenames = []


### PR DESCRIPTION
A bit of documentation

Made setup for test_system_test_compare_two more robust (I think)

Test suite: ./scripts_regression_tests.py A_RunUnitTests
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: None

User interface changes?: No

Code review: @jgfouca 