### PR TITLE
Updating modules on anlworkstation

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -471,15 +471,17 @@
       </arguments>
     </mpirun>
     <module_system type="soft">
-      <init_path lang="csh">/software/common/adm/packages/softenv-1.4.2/etc/softenv-load.csh</init_path>
-      <init_path lang="sh">/software/common/adm/packages/softenv-1.4.2/etc/softenv-load.sh</init_path>
-      <cmd_path lang="csh">source /software/common/adm/packages/softenv-1.4.2/etc/softenv-aliases.csh ; soft</cmd_path>
-      <cmd_path lang="sh">source /software/common/adm/packages/softenv-1.4.2/etc/softenv-aliases.sh ; soft</cmd_path>
+      <init_path lang="csh">/software/common/adm/packages/softenv-1.6.2/etc/softenv-load.csh</init_path>
+      <init_path lang="sh">/software/common/adm/packages/softenv-1.6.2/etc/softenv-load.sh</init_path>
+      <cmd_path lang="csh">source /software/common/adm/packages/softenv-1.6.2/etc/softenv-aliases.csh ; soft</cmd_path>
+      <cmd_path lang="sh">source /software/common/adm/packages/softenv-1.6.2/etc/softenv-aliases.sh ; soft</cmd_path>
       <modules compiler="gnu">
-	<command name="add">+gcc-5.1.0</command>
-	<command name="add" mpilib="!mpi-serial">+mpich-3.2-gcc-5.1</command>
-	<command name="add">+netcdf-4.3.3.1-parallel-gcc5.1-mpich3.2</command>
-	<command name="add" mpilib="!mpi-serial">+pnetcdf-1.6.1-gcc-5.1-mpich-3.2</command>
+	<command name="add">+gcc-6.2.0</command>
+	<command name="add">+szip-2.1-gcc-6.2.0</command>
+	<command name="add" mpilib="!mpi-serial">+mpich-3.2-gcc-6.2.0</command>
+	<command name="add">+hdf5-1.8.16-gcc-6.2.0-mpich-3.2-parallel</command>
+	<command name="add">+netcdf-4.3.3.1c-4.2cxx-4.4.2f-parallel-gcc6.2.0-mpich3.2</command>
+	<command name="add" mpilib="!mpi-serial">+pnetcdf-1.6.1-gcc-6.2.0-mpich-3.2</command>
 	<command name="add">+cmake-2.8.12</command>
       </modules>
     </module_system>


### PR DESCRIPTION
Updating modules on anlworkstation (compute*) after OS+compiler
upgrade.

Test suite: cime_developer
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 

The gnu compiler is now updated on anlworkstation from 5.1 to
6.2.0. Also using the newly updated libraries and soft env.