### PR TITLE
code_checker: don't be so verbose in debug mode

### DIFF
--- a/scripts/Tools/code_checker
+++ b/scripts/Tools/code_checker
@@ -13,6 +13,8 @@ import argparse, sys, os, doctest
 from multiprocessing.dummy import Pool as ThreadPool
 from distutils.spawn import find_executable
 
+logger = logging.getLogger(__name__)
+
 ###############################################################################
 def parse_command_line(args, description):
 ###############################################################################
@@ -56,12 +58,14 @@ def run_pylint(on_file):
     pylint = find_executable("pylint")
 
     cmd = "%s --disable I,C,R,logging-not-lazy,wildcard-import,unused-wildcard-import,fixme,broad-except,bare-except,eval-used,exec-used,global-statement %s" % (pylint, on_file)
-    stat, out, err = run_cmd(cmd)
+    stat, out, err = run_cmd(cmd, verbose=False)
     if stat != 0:
-        logging.info("File %s has pylint problems, please fix\n    Use command: %s" % (on_file, cmd))
+        logger.info("File %s has pylint problems, please fix\n    Use command: %s" % (on_file, cmd))
+        if (logger.isEnabledFor(logging.DEBUG)):
+            logger.info(out + "\n" + err)
         return False
     else:
-        logging.info("File %s has no pylint problems" % on_file)
+        logger.info("File %s has no pylint problems" % on_file)
         return True
 
 ###############################################################################
@@ -88,7 +92,7 @@ def check_code(dir_to_check, num_procs, files):
         os.environ["PYTHONPATH"] = dir_to_check
 
     # Get list of files to check
-    files_to_check = run_cmd_no_fail('git ls-files %s' % dir_to_check).splitlines()
+    files_to_check = run_cmd_no_fail('git ls-files %s' % dir_to_check, verbose=False).splitlines()
     if files:
         files_to_check = [item for item in files_to_check if matches(item, files)]
     else:

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -156,7 +156,7 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
     if (arg_stderr is _hack):
         arg_stderr = subprocess.PIPE
 
-    if (verbose or logger.isEnabledFor(logging.DEBUG)):
+    if (verbose != False and (verbose or logger.isEnabledFor(logging.DEBUG))):
         logger.info("RUN: %s" % cmd)
 
     if (input_str is not None):
@@ -177,7 +177,7 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
     errput = errput.strip() if errput is not None else errput
     stat = proc.wait()
 
-    if (verbose or logger.isEnabledFor(logging.DEBUG)):
+    if (verbose != False and (verbose or logger.isEnabledFor(logging.DEBUG))):
         if stat != 0:
             logger.info("  stat: %d\n" % stat)
         if output:


### PR DESCRIPTION
debug mode should only show pylint output for files with
pylint errors. This required some minor tweaks to run_cmd in
order to allow users to turn off verbose output even if
we're in debug mode.

Test suite: scripts_regression_tests --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #669

User interface changes?: Output changes to code_checker

Code review: jedwards

