### PR TITLE
Enhance use_existing capability for create_test, add test

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -84,7 +84,7 @@ OR
                         help="Do not setup generated tests, implies --no-build and --no-run")
 
     parser.add_argument("-u", "--use-existing", action="store_true",
-                        help="Use pre-existing case directories. Requires test-id")
+                        help="Use pre-existing case directories they will pick up at the latest PEND state or re-run the first failed state. Requires test-id")
 
     parser.add_argument("--save-timing", action="store_true",
                         help="Enable archiving of performance data.")

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -498,11 +498,14 @@ class TESTRUNFAILEXC(TESTRUNPASS):
     def run_phase(self):
         raise RuntimeError("Exception from run_phase")
 
-class TESTBUILDFAIL(FakeTest):
+class TESTBUILDFAIL(TESTRUNPASS):
 
     def build_phase(self, sharedlib_only=False, model_only=False):
-        if (not sharedlib_only):
-            expect(False, "Intentional fail for testing infrastructure")
+        if "TESTBUILDFAIL_PASS" in os.environ:
+            TESTRUNPASS.build_phase(self, sharedlib_only, model_only)
+        else:
+            if (not sharedlib_only):
+                expect(False, "Intentional fail for testing infrastructure")
 
 class TESTBUILDFAILEXC(FakeTest):
 

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -160,8 +160,13 @@ class TestScheduler(object):
             for test in self._tests:
                 ts = TestStatus(self._get_test_dir(test))
                 for phase, status in ts:
-                    self._update_test_status(test, phase, TEST_PEND_STATUS)
-                    self._update_test_status(test, phase, status)
+                    if phase in CORE_PHASES:
+                        if status in [TEST_PEND_STATUS, TEST_FAIL_STATUS]:
+                            # We need to pick up here
+                            break
+                        else:
+                            self._update_test_status(test, phase, TEST_PEND_STATUS)
+                            self._update_test_status(test, phase, status)
         else:
             # None of the test directories should already exist.
             for test in self._tests:


### PR DESCRIPTION
It will now not only resume tests that were not completed due to a previous run with --no-run or --no-build, it will now also try to rerun failed tests from the point of their most recent passed core phase.

Test suite: ./scripts_regression_tests.py O_TestTestScheduler.test_c_use_existing
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #666

User interface changes?: Enhance -u option to create_test

Code review: jedwards

