### PR TITLE
Set walltime for queue option

### DIFF
--- a/cime_config/cesm/machines/config_batch.xml
+++ b/cime_config/cesm/machines/config_batch.xml
@@ -382,6 +382,7 @@
       <queue walltimemax="24:00" jobmin="1" jobmax="8" >caldera</queue>
       <queue walltimemax="12:00" jobmin="9" jobmax="16384" default="true">regular</queue>
       <queue walltimemax="12:00" jobmin="16385" jobmax="65536">capability</queue>
+      <queue walltimemax="12:00" jobmin="1" jobmax="16384">premium</queue>
     </queues>
   </batch_system>
 

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -34,12 +34,10 @@ class EnvBatch(EnvBase):
         """
         val = None
         if item == "JOB_WALLCLOCK_TIME":
-            """
-            Most systems use %H:%M:%S format for wallclock but LSF
-            uses %H:%M this code corrects the value passed in to be
-            the correct format - if we find we have more exceptions
-            than this we may need to generalize this further
-            """
+            #Most systems use %H:%M:%S format for wallclock but LSF
+            #uses %H:%M this code corrects the value passed in to be
+            #the correct format - if we find we have more exceptions
+            #than this we may need to generalize this further
             walltime_format = self.get_value("walltime_format", subgroup=None)
             if walltime_format is not None and walltime_format.count(":") != value.count(":"): # pylint: disable=maybe-no-member
                 if value.count(":") == 1:
@@ -275,10 +273,8 @@ class EnvBatch(EnvBase):
             walltime = self.get_max_walltime(queue) if walltime is None else walltime
             if walltime is None:
                 logger.warn("Could not find a queue matching task count %d, falling back to depreciated default walltime parameter"%task_count)
-                """
-                if the user names a queue which is not defined in config_batch.xml and does not set a
-                walltime, fall back to the max walltime in the default queue
-                """
+                #if the user names a queue which is not defined in config_batch.xml and does not set a
+                #walltime, fall back to the max walltime in the default queue
                 if force_queue:
                     self.get_default_queue()
                 walltime = self._default_walltime

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -25,14 +25,21 @@ class EnvBatch(EnvBase):
         EnvBase.__init__(self, case_root, infile)
         self.prereq_jobid = None
         self.batchtype = None
+        # This arbitrary setting should always be overwritten
+        self._default_walltime = "00:20:00"
 
     def set_value(self, item, value, subgroup=None, ignore_type=False):
+        """
+        Override the entry_id set_value function with some special cases for this class
+        """
         val = None
         if item == "JOB_WALLCLOCK_TIME":
-            # Most systems use %H:%M:%S format for wallclock but LSF
-            # uses %H:%M this code corrects the value passed in to be
-            # the correct format - if we find we have more exceptions
-            # than this we may need to generalize this further
+            """
+            Most systems use %H:%M:%S format for wallclock but LSF
+            uses %H:%M this code corrects the value passed in to be
+            the correct format - if we find we have more exceptions
+            than this we may need to generalize this further
+            """
             walltime_format = self.get_value("walltime_format", subgroup=None)
             if walltime_format is not None and walltime_format.count(":") != value.count(":"): # pylint: disable=maybe-no-member
                 if value.count(":") == 1:
@@ -268,7 +275,13 @@ class EnvBatch(EnvBase):
             walltime = self.get_max_walltime(queue) if walltime is None else walltime
             if walltime is None:
                 logger.warn("Could not find a queue matching task count %d, falling back to depreciated default walltime parameter"%task_count)
-                walltime = self.get_default_walltime()
+                """
+                if the user names a queue which is not defined in config_batch.xml and does not set a
+                walltime, fall back to the max walltime in the default queue
+                """
+                if force_queue:
+                    self.get_default_queue()
+                walltime = self._default_walltime
 
             self.set_value( "JOB_WALLCLOCK_TIME", walltime , subgroup=job)
             logger.info("Job %s queue %s walltime %s"%(job, queue, walltime))
@@ -479,13 +492,10 @@ class EnvBatch(EnvBase):
             if queue_node.text == queue:
                 return queue_node.get("walltimemax")
 
-    def get_default_walltime(self):
-        walltime = self.get_value("walltime", attribute={"default" : "true"}, subgroup=None)
-        expect(walltime is not None,"Could not find walltime setting in config_batch.xml")
-        return walltime
-
     def get_default_queue(self):
-        return self.get_optional_node("queue", attributes={"default" : "true"})
+        node = self.get_optional_node("queue", attributes={"default" : "true"})
+        self._default_walltime = node.get("walltimemax")
+        return(node)
 
     def get_all_queues(self):
         return self.get_nodes("queue")


### PR DESCRIPTION
Makes sure that a walltime is set even if the user specifies a queue not defined in config_batch.xml and does not specify a walltime.   Update cesm config_batch.xml with settings for the yellowstone premium queue.  

Test suite: scripts_regression_tests , bug specific testing
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #675 

User interface changes?: 

Code review: 
