### PR TITLE
summarize_cprnc_diffs uses .nc.cprnc.out rather than .base.cprnc.out

### DIFF
--- a/tools/cprnc/summarize_cprnc_diffs
+++ b/tools/cprnc/summarize_cprnc_diffs
@@ -132,7 +132,7 @@ sub process_cprnc_output {
    foreach my $test_dir (@test_dirs) {
       my $test_dir_base = basename($test_dir);
 
-      my @cprnc_files = glob "${test_dir}/run/*.base.cprnc.out";
+      my @cprnc_files = glob "${test_dir}/run/*.nc.cprnc.out";
 
       foreach my $cprnc_file (@cprnc_files) {
          my $cprnc_file_base = basename($cprnc_file);


### PR DESCRIPTION
The suffix for the cprnc output files has changed with cime5, because
the baseline comparison uses *.nc files rather than *.nc.base files.

Test suite: None
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: None

User interface changes?: No

Code review: