### PR TITLE
In addition to printing the commit, print the current cime_model

### DIFF
--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -52,12 +52,17 @@ ERRPUT: %s
     return output
 
 ###############################################################################
-class AA_ReportCommit(unittest.TestCase):
+class AA_ReportProvenance(unittest.TestCase):
 ###############################################################################
 
-    def test_report_tested_commit(self):
+    def test_report_provenance(self):
+        # This doesn't really test anything. Rather, it abuses the test system
+        # to print some provenance information about what we're testing.
         curr_commit = get_current_commit(repo=LIB_DIR)
         logging.info("\nTesting commit %s" % curr_commit)
+        cime_model = CIME.utils.get_model()
+        logging.info("Using cime_model = %s" % cime_model)
+
 
 ###############################################################################
 class A_RunUnitTests(unittest.TestCase):


### PR DESCRIPTION
Today I had to run a bunch of tests both with CIME_MODEL=cesm and with
CIME_MODEL=acme. I had a hard time remembering which test suite was run
with each. This change helps with that.

However, I'm not sure if this breaks anything that parses the tested
commit (do we have anything like that?).

Test suite: start of scripts_regression_tests.py, both with cesm and acme
   aborted after the first few tests, because it didn't seem important to run it further
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: None

User interface changes?: No

Code review: