### PR TITLE
Bugfix for failing C compset DEBUG tests

### DIFF
--- a/driver_cpl/driver/prep_ocn_mod.F90
+++ b/driver_cpl/driver/prep_ocn_mod.F90
@@ -1200,10 +1200,10 @@ contains
     do eri = 1,num_inst_rof
        r2x_rx => component_get_c2x_cx(rof(eri))
        call seq_map_map(mapper_Rr2o_liq, r2x_rx, r2x_ox(eri), &
-            fldlist='Forr_rofl:Forr_rofl_16O:Forr_rofl_18O:Forr_rofl_HDO', norm=.false.)
+            fldlist=seq_flds_r2o_liq_fluxes, norm=.false.)
 
        call seq_map_map(mapper_Rr2o_ice, r2x_rx, r2x_ox(eri), &
-            fldlist='Forr_rofi:Forr_rofi_16O:Forr_rofi_18O:Forr_rofi_HDO', norm=.false.)
+            fldlist=seq_flds_r2o_ice_fluxes, norm=.false.)
 
        if (flood_present) then
           call seq_map_map(mapper_Fr2o, r2x_rx, r2x_ox(eri), &

--- a/driver_cpl/shr/seq_flds_mod.F90
+++ b/driver_cpl/shr/seq_flds_mod.F90
@@ -1967,6 +1967,7 @@ module seq_flds_mod
 
      call seq_flds_add(r2x_fluxes,'Forr_rofl')
      call seq_flds_add(x2o_fluxes,'Foxx_rofl')
+     call seq_flds_add(r2o_liq_fluxes,'Forr_rofl')
      longname = 'Water flux due to runoff (liquid)'
      stdname  = 'water_flux_into_sea_water'
      units    = 'kg m-2 s-1'
@@ -1977,6 +1978,7 @@ module seq_flds_mod
 
      call seq_flds_add(r2x_fluxes,'Forr_rofi')
      call seq_flds_add(x2o_fluxes,'Foxx_rofi')
+     call seq_flds_add(r2o_ice_fluxes,'Forr_rofi')
      longname = 'Water flux due to runoff (frozen)'
      stdname  = 'frozen_water_flux_into_sea_water'
      units    = 'kg m-2 s-1'
@@ -2468,10 +2470,6 @@ module seq_flds_mod
 
      endif
 
-     ! Runoff to ocean fluxes
-     call seq_flds_add(r2o_liq_fluxes,'Forr_rofl')
-     call seq_flds_add(r2o_ice_fluxes,'Forr_rofi')
-
      if (flds_wiso) then
         call seq_flds_add(o2x_states, "So_roce_16O")
         call seq_flds_add(x2i_states, "So_roce_16O")
@@ -2847,12 +2845,6 @@ module seq_flds_mod
 
        !Iso-Runoff
        ! r2o, l2x, x2r
-       call seq_flds_add(r2o_liq_fluxes,'Forr_rofl_16O')
-       call seq_flds_add(r2o_liq_fluxes,'Forr_rofl_18O')
-       call seq_flds_add(r2o_liq_fluxes,'Forr_rofl_HDO')
-       call seq_flds_add(r2o_ice_fluxes,'Forr_rofi_16O')
-       call seq_flds_add(r2o_ice_fluxes,'Forr_rofi_18O')
-       call seq_flds_add(r2o_ice_fluxes,'Forr_rofi_HDO')
 
        units    = 'kg m-2 s-1'
        call seq_flds_add(l2x_fluxes,'Flrl_rofi_16O')
@@ -2896,6 +2888,7 @@ module seq_flds_mod
        ! r2x, x2o
        call seq_flds_add(r2x_fluxes,'Forr_rofl_16O')
        call seq_flds_add(x2o_fluxes,'Foxx_rofl_16O')
+       call seq_flds_add(r2o_liq_fluxes,'Forr_rofl_16O')
        longname = 'H2_16O Water flux due to liq runoff '
        stdname  = 'H2_16O_water_flux_into_sea_water'
        attname  = 'Forr_rofl_16O'
@@ -2904,6 +2897,7 @@ module seq_flds_mod
        call metadata_set(attname, longname, stdname, units)
        call seq_flds_add(r2x_fluxes,'Forr_rofl_18O')
        call seq_flds_add(x2o_fluxes,'Foxx_rofl_18O')
+       call seq_flds_add(r2o_liq_fluxes,'Forr_rofl_18O')
        longname = 'H2_18O Water flux due to liq runoff '
        stdname  = 'H2_18O_water_flux_into_sea_water'
        attname  = 'Forr_rofl_18O'
@@ -2912,6 +2906,7 @@ module seq_flds_mod
        call metadata_set(attname, longname, stdname, units)
        call seq_flds_add(r2x_fluxes,'Forr_rofl_HDO')
        call seq_flds_add(x2o_fluxes,'Foxx_rofl_HDO')
+       call seq_flds_add(r2o_liq_fluxes,'Forr_rofl_HDO')
        longname = 'HDO Water flux due to liq runoff '
        stdname  = 'HDO_water_flux_into_sea_water'
        attname  = 'Forr_rofl_HDO'
@@ -2921,6 +2916,7 @@ module seq_flds_mod
 
        call seq_flds_add(r2x_fluxes,'Forr_rofi_16O')
        call seq_flds_add(x2o_fluxes,'Foxx_rofi_16O')
+       call seq_flds_add(r2o_ice_fluxes,'Forr_rofi_16O')
        longname = 'H2_16O Water flux due to ice runoff '
        stdname  = 'H2_16O_water_flux_into_sea_water'
        attname  = 'Forr_rofi_16O'
@@ -2929,6 +2925,7 @@ module seq_flds_mod
        call metadata_set(attname, longname, stdname, units)
        call seq_flds_add(r2x_fluxes,'Forr_rofi_18O')
        call seq_flds_add(x2o_fluxes,'Foxx_rofi_18O')
+       call seq_flds_add(r2o_ice_fluxes,'Forr_rofi_18O')
        longname = 'H2_18O Water flux due to ice runoff '
        stdname  = 'H2_18O_water_flux_into_sea_water'
        attname  = 'Forr_rofi_18O'
@@ -2937,6 +2934,7 @@ module seq_flds_mod
        call metadata_set(attname, longname, stdname, units)
        call seq_flds_add(r2x_fluxes,'Forr_rofi_HDO')
        call seq_flds_add(x2o_fluxes,'Foxx_rofi_HDO')
+       call seq_flds_add(r2o_ice_fluxes,'Forr_rofi_HDO')
        longname = 'HDO Water flux due to ice runoff '
        stdname  = 'HDO_water_flux_into_sea_water'
        attname  = 'Forr_rofi_HDO'

--- a/driver_cpl/shr/seq_flds_mod.F90
+++ b/driver_cpl/shr/seq_flds_mod.F90
@@ -211,6 +211,8 @@ module seq_flds_mod
    character(CXX) :: seq_flds_r2x_fluxes
    character(CXX) :: seq_flds_x2r_states
    character(CXX) :: seq_flds_x2r_fluxes
+   character(CXX) :: seq_flds_r2o_liq_fluxes
+   character(CXX) :: seq_flds_r2o_ice_fluxes
 
    !----------------------------------------------------------------------------
    ! combined state/flux fields
@@ -321,6 +323,8 @@ module seq_flds_mod
      character(CXX) :: w2x_fluxes = ''
      character(CXX) :: x2w_states = ''
      character(CXX) :: x2w_fluxes = ''
+     character(CXX) :: r2o_liq_fluxes = ''
+     character(CXX) :: r2o_ice_fluxes = ''
 
      character(CXX) :: stringtmp  = ''
 
@@ -2464,6 +2468,10 @@ module seq_flds_mod
 
      endif
 
+     ! Runoff to ocean fluxes
+     call seq_flds_add(r2o_liq_fluxes,'Forr_rofl')
+     call seq_flds_add(r2o_ice_fluxes,'Forr_rofi')
+
      if (flds_wiso) then
         call seq_flds_add(o2x_states, "So_roce_16O")
         call seq_flds_add(x2i_states, "So_roce_16O")
@@ -2838,7 +2846,14 @@ module seq_flds_mod
        call metadata_set(attname, longname, stdname, units)
 
        !Iso-Runoff
-       ! l2x, x2r
+       ! r2o, l2x, x2r
+       call seq_flds_add(r2o_liq_fluxes,'Forr_rofl_16O')
+       call seq_flds_add(r2o_liq_fluxes,'Forr_rofl_18O')
+       call seq_flds_add(r2o_liq_fluxes,'Forr_rofl_HDO')
+       call seq_flds_add(r2o_ice_fluxes,'Forr_rofi_16O')
+       call seq_flds_add(r2o_ice_fluxes,'Forr_rofi_18O')
+       call seq_flds_add(r2o_ice_fluxes,'Forr_rofi_HDO')
+
        units    = 'kg m-2 s-1'
        call seq_flds_add(l2x_fluxes,'Flrl_rofi_16O')
        call seq_flds_add(x2r_fluxes,'Flrl_rofi_16O')
@@ -3162,6 +3177,8 @@ module seq_flds_mod
      seq_flds_x2r_fluxes = trim(x2r_fluxes)
      seq_flds_w2x_fluxes = trim(w2x_fluxes)
      seq_flds_x2w_fluxes = trim(x2w_fluxes)
+     seq_flds_r2o_liq_fluxes = trim(r2o_liq_fluxes)
+     seq_flds_r2o_ice_fluxes = trim(r2o_ice_fluxes)
 
      if (seq_comm_iamroot(ID)) then
         write(logunit,"(A)") subname//': seq_flds_a2x_states= ',trim(seq_flds_a2x_states)


### PR DESCRIPTION
Added a couple of new fields to track which r2o fluxes are needed

Test suite: no full test suite run, just verified previously failing ERS_D test now passes (and previously working ERS_D test continues to work)
Test baseline: n/a
Test namelist changes: none 
Test status: bit for bit

Fixes #685 

User interface changes?: none

Code review: 

When water isotopes were added to the coupler, the runoff -> ocean fields
changed -- this is fine in coupled and ocean / ice cases, but the new isotope
fields should not be used in ocean-only compsets. To get around this, I
introduced two new module variables (seq_flds_r2o_liq_fluxes and _ice_fluxes)
in seq_flds_mod.F90 that always contain 'Forr_rofl' and 'Forr_rofi',
respectively, and can also include the isotope fluxes if flds_wiso is .true.

The call to seq_map_map uses these new variables as the fldlist arguments in
calls from prep_ocn_calc_r2x_ox(), so that we don't run into the issue of
trying to map non-existent fields when water isotopes are not enabled.