### PR TITLE
mv buildlib.pio to python, add smarts

### DIFF
--- a/cime_config/acme/machines/buildlib.pio
+++ b/cime_config/acme/machines/buildlib.pio
@@ -87,26 +87,22 @@ def _main_func(description):
             netcdf4_string = "D_NETCDF4P"
         else:
             globs_to_copy = (os.path.join("src","clib","libpioc.*"),
-                             os.path.join("src","flib","libpiof.*"))
+                             os.path.join("src","flib","libpiof.*"),
+                             os.path.join("src","clib","*.h"),
+                             os.path.join("src","flib","*.mod"))
             for glob_to_copy in globs_to_copy:
                 installed_file_time = 0
                 for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
-                    installed_file = os.path.join(bldroot,"lib",os.path.basename(item))
+                    if item.endswith(".a") or item.endswith(".so"):
+                        installdir = "lib"
+                    else:
+                        installdir = "include"
+                    installed_file = os.path.join(bldroot,installdir,os.path.basename(item))
                     item_time = os.path.getmtime(item)
                     if os.path.isfile(installed_file):
                         installed_file_time = os.path.getmtime(installed_file)
                     if item_time  > installed_file_time:
-                        logger.info("Installing pio version 2")
-                        shutil.copy(item, "%s/lib"%bldroot)
-            for glob_to_copy in (os.path.join("src","clib","*.h"),
-                                 os.path.join("src","flib","*.mod")):
-                for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
-                    installed_file = os.path.join(bldroot,"include",os.path.basename(item))
-                    item_time = os.path.getmtime(item)
-                    if os.path.isfile(installed_file):
-                        installed_file_time = os.path.getmtime(installed_file)
-                    if item_time > installed_file_time:
-                        shutil.copy(item, "%s/include"%bldroot)
+                        shutil.copy(item, installed_file)
             expect_string = "NetCDF_C_LIBRARY-ADVANCED"
             pnetcdf_string = "PnetCDF_C_LIBRARY-ADVANCED"
             netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"

--- a/cime_config/acme/machines/buildlib.pio
+++ b/cime_config/acme/machines/buildlib.pio
@@ -1,52 +1,145 @@
-#! /bin/csh -fx
+#!/usr/bin/env python
+import shutil, glob, re
+from Tools.standard_script_setup import *
+from CIME.utils import run_cmd_no_fail, expect
+from CIME.case import Case
 
-cd $CASEROOT
+logger = logging.getLogger(__name__)
 
-set CIMEROOT  = `./xmlquery  CIMEROOT	-value `
-set CASETOOLS = `./xmlquery  CASETOOLS	-value `
-set GMAKE     = `./xmlquery  GMAKE	-value `
-set GMAKE_J   = `./xmlquery  GMAKE_J	-value `
-set BLDROOT = $1
-# directory in which pio is built
-setenv PIO_VERSION  `./xmlquery PIO_VERSION -value`
-set PIOVERSION="pio$PIO_VERSION"
-set pio_dir="$BLDROOT/$PIOVERSION"
-if (! -e $pio_dir) then
-  mkdir -p $pio_dir
-endif
-cd $pio_dir
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n%s [--debug]
+OR
+%s --verbose
+OR
+%s --help
+OR
+%s --test
 
-# ----------------------------------------------------------------------
-# Set options to cmake
-# ----------------------------------------------------------------------
-# Note that some other generic CMAKE options are set in the Makefile
-#set cmake_opts=" -D USER_CMAKE_MODULE_PATH=$CIMEROOT/externals/CMake"
-#set cmake_opts="$cmake_opts -D GENF90_PATH=$CIMEROOT/externals/genf90"
-set cmake_opts=" -D GENF90_PATH=$CIMEROOT/externals/genf90"
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Run \033[0m
+    > %s
+""" % ((os.path.basename(args[0]), ) * 5),
 
-# ----------------------------------------------------------------------
-# create the pio makefile by running cmake (done via a rule
-# in the system-level makefile)
-# ----------------------------------------------------------------------
-$GMAKE  $pio_dir/Makefile MODEL=$PIOVERSION USER_CMAKE_OPTS="$cmake_opts" \
-       PIO_LIBDIR=$pio_dir -f $CASETOOLS/Makefile || exit 1
+description=description,
 
-# ----------------------------------------------------------------------
-# create the pio library (or libraries), using the makefile
-# created by cmake
-# ----------------------------------------------------------------------
-$GMAKE -j $GMAKE_J || exit 2
-if ( -d "$pio_dir/src" ) then
-  cp -p $pio_dir/src/clib/libpioc.* $BLDROOT/lib
-  cp -p $pio_dir/src/flib/libpiof.* $BLDROOT/lib
-  cp -p $pio_dir/src/clib/*.h $pio_dir/src/flib/*.mod $BLDROOT/include
-else
-  if( -d "$pio_dir/pio" ) then
-    cd pio
-  endif
-  pwd
-  cp -p lib*.a $BLDROOT/lib
-  cp -p *.h *.mod $BLDROOT/include
-endif
-exit 0
+formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
 
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("buildroot",
+                        help="build path root")
+
+    parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
+                        help="Case directory to build")
+
+    args = parser.parse_args(args[1:])
+
+    CIME.utils.handle_standard_logging_options(args)
+
+    return args.buildroot, args.caseroot
+
+def _main_func(description):
+###############################################################################
+    if ("--test" in sys.argv):
+        test_results = doctest.testmod(verbose=True)
+        sys.exit(1 if test_results.failed > 0 else 0)
+
+    bldroot, caseroot = parse_command_line(sys.argv, description)
+    with Case(caseroot, read_only=False) as case:
+        pio_version = case.get_value("PIO_VERSION")
+        pio_model = "pio%s"% pio_version
+        pio_dir = os.path.join(bldroot, pio_model)
+        if not os.path.isdir(pio_dir):
+            os.makedirs(pio_dir)
+        os.chdir(pio_dir)
+        casetools = case.get_value("CASETOOLS")
+        cmake_opts = "\" -D GENF90_PATH=$CIMEROOT/externals/genf90\""
+        gmake_opts = "%s/Makefile CASEROOT=%s MODEL=%s USER_CMAKE_OPTS=%s PIO_LIBDIR=%s CASETOOLS=%s PIO_VERSION=%s -f %s/Makefile"\
+            %(pio_dir,caseroot,pio_model, cmake_opts, pio_dir, casetools, pio_version, casetools)
+        # These are needed to satisfy the make command but are not used in the pio cmake build
+        gmake_opts += " EXEROOT=\"\" BUILD_THREADED=\"\" LIBROOT=\"\" SHAREDLIBROOT=\"\" COMPILER=\"\" NINST_VALUE=\"\" MPILIB=\"\" "
+
+        gmake_cmd = case.get_value("GMAKE")
+        # This runs the pio cmake command from the cime case Makefile
+        cmd = "%s %s"%(gmake_cmd, gmake_opts)
+        output = run_cmd_no_fail(cmd, from_dir=pio_dir)
+        # This runs the pio make command from the cmake generated Makefile
+        output += run_cmd_no_fail("%s -j %s"%(gmake_cmd, case.get_value("GMAKE_J")), from_dir=pio_dir)
+        logger.info(output)
+        if pio_version == 1:
+            installed_lib = os.path.join(bldroot,"lib","libpio.a")
+            installed_lib_time = 0
+            if os.path.isfile(installed_lib):
+                installed_lib_time = os.path.getmtime(installed_lib)
+            newlib = os.path.join(pio_dir,"pio","libpio.a")
+            newlib_time = os.path.getmtime(newlib)
+            if newlib_time > installed_lib_time:
+                logger.info("Installing pio version 1")
+                shutil.copy(newlib, installed_lib)
+                for glob_to_copy in ("*.h", "*.mod"):
+                    for item in glob.glob(os.path.join(pio_dir,"pio",glob_to_copy)):
+                        shutil.copy(item, "%s/include"%bldroot)
+            expect_string = "D_NETCDF;"
+            pnetcdf_string = "D_PNETCDF"
+            netcdf4_string = "D_NETCDF4P"
+        else:
+            globs_to_copy = (os.path.join("src","clib","libpioc.*"),
+                             os.path.join("src","flib","libpiof.*"))
+            for glob_to_copy in globs_to_copy:
+                installed_file_time = 0
+                for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
+                    installed_file = os.path.join(bldroot,"lib",os.path.basename(item))
+                    item_time = os.path.getmtime(item)
+                    if os.path.isfile(installed_file):
+                        installed_file_time = os.path.getmtime(installed_file)
+                    if item_time  > installed_file_time:
+                        logger.info("Installing pio version 2")
+                        shutil.copy(item, "%s/lib"%bldroot)
+            for glob_to_copy in (os.path.join("src","clib","*.h"),
+                                 os.path.join("src","flib","*.mod")):
+                for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
+                    installed_file = os.path.join(bldroot,"include",os.path.basename(item))
+                    item_time = os.path.getmtime(item)
+                    if os.path.isfile(installed_file):
+                        installed_file_time = os.path.getmtime(installed_file)
+                    if item_time > installed_file_time:
+                        shutil.copy(item, "%s/include"%bldroot)
+            expect_string = "NetCDF_C_LIBRARY-ADVANCED"
+            pnetcdf_string = "PnetCDF_C_LIBRARY-ADVANCED"
+            netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
+
+
+        # make sure case pio_typename valid_values is set correctly
+        expect_string_found = False
+        pnetcdf_found = False
+        netcdf4_parallel_found = False
+
+        cache_file = open(os.path.join(pio_dir,"CMakeCache.txt"), "r")
+        for line in cache_file:
+            if re.search(expect_string, line):
+                expect_string_found = True
+            if re.search(pnetcdf_string, line):
+                pnetcdf_found = True
+            if re.search(netcdf4_string, line):
+                netcdf4_parallel_found = True
+
+        expect(expect_string_found, "CIME models require NETCDF in PIO build")
+        valid_values = "netcdf"
+        if pnetcdf_found:
+            valid_values += ",pnetcdf"
+        if netcdf4_parallel_found:
+            valid_values += ",netcdf4p,netcdf4c"
+        logger.warn("Updating valid_values for PIO_TYPENAME: %s", valid_values)
+        case.set_valid_values("PIO_TYPENAME",valid_values)
+        # nothing means use the general default
+        valid_values += ",nothing"
+        for comp in ("ATM","CPL","OCN","WAV","GLC","ICE","ROF","LND"):
+            case.set_valid_values("%s_PIO_TYPENAME"%comp,valid_values)
+
+
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/cime_config/cesm/machines/buildlib.pio
+++ b/cime_config/cesm/machines/buildlib.pio
@@ -87,26 +87,22 @@ def _main_func(description):
             netcdf4_string = "D_NETCDF4P"
         else:
             globs_to_copy = (os.path.join("src","clib","libpioc.*"),
-                             os.path.join("src","flib","libpiof.*"))
+                             os.path.join("src","flib","libpiof.*"),
+                             os.path.join("src","clib","*.h"),
+                             os.path.join("src","flib","*.mod"))
             for glob_to_copy in globs_to_copy:
                 installed_file_time = 0
                 for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
-                    installed_file = os.path.join(bldroot,"lib",os.path.basename(item))
+                    if item.endswith(".a") or item.endswith(".so"):
+                        installdir = "lib"
+                    else:
+                        installdir = "include"
+                    installed_file = os.path.join(bldroot,installdir,os.path.basename(item))
                     item_time = os.path.getmtime(item)
                     if os.path.isfile(installed_file):
                         installed_file_time = os.path.getmtime(installed_file)
                     if item_time  > installed_file_time:
-                        logger.info("Installing pio version 2")
-                        shutil.copy(item, "%s/lib"%bldroot)
-            for glob_to_copy in (os.path.join("src","clib","*.h"),
-                                 os.path.join("src","flib","*.mod")):
-                for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
-                    installed_file = os.path.join(bldroot,"include",os.path.basename(item))
-                    item_time = os.path.getmtime(item)
-                    if os.path.isfile(installed_file):
-                        installed_file_time = os.path.getmtime(installed_file)
-                    if item_time > installed_file_time:
-                        shutil.copy(item, "%s/include"%bldroot)
+                        shutil.copy(item, installed_file)
             expect_string = "NetCDF_C_LIBRARY-ADVANCED"
             pnetcdf_string = "PnetCDF_C_LIBRARY-ADVANCED"
             netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"

--- a/cime_config/cesm/machines/buildlib.pio
+++ b/cime_config/cesm/machines/buildlib.pio
@@ -1,52 +1,145 @@
-#! /bin/csh -fx
+#!/usr/bin/env python
+import shutil, glob, re
+from Tools.standard_script_setup import *
+from CIME.utils import run_cmd_no_fail, expect
+from CIME.case import Case
 
-cd $CASEROOT
+logger = logging.getLogger(__name__)
 
-set CIMEROOT  = `./xmlquery  CIMEROOT	-value `
-set CASETOOLS = `./xmlquery  CASETOOLS	-value `
-set GMAKE     = `./xmlquery  GMAKE	-value `
-set GMAKE_J   = `./xmlquery  GMAKE_J	-value `
-set BLDROOT = $1
-# directory in which pio is built
-setenv PIO_VERSION  `./xmlquery PIO_VERSION -value`
-set PIOVERSION="pio$PIO_VERSION"
-set pio_dir="$BLDROOT/$PIOVERSION"
-if (! -e $pio_dir) then
-  mkdir -p $pio_dir
-endif
-cd $pio_dir
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n%s [--debug]
+OR
+%s --verbose
+OR
+%s --help
+OR
+%s --test
 
-# ----------------------------------------------------------------------
-# Set options to cmake
-# ----------------------------------------------------------------------
-# Note that some other generic CMAKE options are set in the Makefile
-#set cmake_opts=" -D USER_CMAKE_MODULE_PATH=$CIMEROOT/externals/CMake"
-#set cmake_opts="$cmake_opts -D GENF90_PATH=$CIMEROOT/externals/genf90"
-set cmake_opts=" -D GENF90_PATH=$CIMEROOT/externals/genf90"
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Run \033[0m
+    > %s
+""" % ((os.path.basename(args[0]), ) * 5),
 
-# ----------------------------------------------------------------------
-# create the pio makefile by running cmake (done via a rule
-# in the system-level makefile)
-# ----------------------------------------------------------------------
-$GMAKE  $pio_dir/Makefile MODEL=$PIOVERSION USER_CMAKE_OPTS="$cmake_opts" \
-       PIO_LIBDIR=$pio_dir -f $CASETOOLS/Makefile || exit 1
+description=description,
 
-# ----------------------------------------------------------------------
-# create the pio library (or libraries), using the makefile
-# created by cmake
-# ----------------------------------------------------------------------
-$GMAKE -j $GMAKE_J || exit 2
-if ( -d "$pio_dir/src" ) then
-  cp -p $pio_dir/src/clib/libpioc.* $BLDROOT/lib
-  cp -p $pio_dir/src/flib/libpiof.* $BLDROOT/lib
-  cp -p $pio_dir/src/clib/*.h $pio_dir/src/flib/*.mod $BLDROOT/include
-else
-  if( -d "$pio_dir/pio" ) then
-    cd pio
-  endif
-  pwd
-  cp -p lib*.a $BLDROOT/lib
-  cp -p *.h *.mod $BLDROOT/include
-endif
-exit 0
+formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
 
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("buildroot",
+                        help="build path root")
+
+    parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
+                        help="Case directory to build")
+
+    args = parser.parse_args(args[1:])
+
+    CIME.utils.handle_standard_logging_options(args)
+
+    return args.buildroot, args.caseroot
+
+def _main_func(description):
+###############################################################################
+    if ("--test" in sys.argv):
+        test_results = doctest.testmod(verbose=True)
+        sys.exit(1 if test_results.failed > 0 else 0)
+
+    bldroot, caseroot = parse_command_line(sys.argv, description)
+    with Case(caseroot, read_only=False) as case:
+        pio_version = case.get_value("PIO_VERSION")
+        pio_model = "pio%s"% pio_version
+        pio_dir = os.path.join(bldroot, pio_model)
+        if not os.path.isdir(pio_dir):
+            os.makedirs(pio_dir)
+        os.chdir(pio_dir)
+        casetools = case.get_value("CASETOOLS")
+        cmake_opts = "\" -D GENF90_PATH=$CIMEROOT/externals/genf90\""
+        gmake_opts = "%s/Makefile CASEROOT=%s MODEL=%s USER_CMAKE_OPTS=%s PIO_LIBDIR=%s CASETOOLS=%s PIO_VERSION=%s -f %s/Makefile"\
+            %(pio_dir,caseroot,pio_model, cmake_opts, pio_dir, casetools, pio_version, casetools)
+        # These are needed to satisfy the make command but are not used in the pio cmake build
+        gmake_opts += " EXEROOT=\"\" BUILD_THREADED=\"\" LIBROOT=\"\" SHAREDLIBROOT=\"\" COMPILER=\"\" NINST_VALUE=\"\" MPILIB=\"\" "
+
+        gmake_cmd = case.get_value("GMAKE")
+        # This runs the pio cmake command from the cime case Makefile
+        cmd = "%s %s"%(gmake_cmd, gmake_opts)
+        output = run_cmd_no_fail(cmd, from_dir=pio_dir)
+        # This runs the pio make command from the cmake generated Makefile
+        output += run_cmd_no_fail("%s -j %s"%(gmake_cmd, case.get_value("GMAKE_J")), from_dir=pio_dir)
+        logger.info(output)
+        if pio_version == 1:
+            installed_lib = os.path.join(bldroot,"lib","libpio.a")
+            installed_lib_time = 0
+            if os.path.isfile(installed_lib):
+                installed_lib_time = os.path.getmtime(installed_lib)
+            newlib = os.path.join(pio_dir,"pio","libpio.a")
+            newlib_time = os.path.getmtime(newlib)
+            if newlib_time > installed_lib_time:
+                logger.info("Installing pio version 1")
+                shutil.copy(newlib, installed_lib)
+                for glob_to_copy in ("*.h", "*.mod"):
+                    for item in glob.glob(os.path.join(pio_dir,"pio",glob_to_copy)):
+                        shutil.copy(item, "%s/include"%bldroot)
+            expect_string = "D_NETCDF;"
+            pnetcdf_string = "D_PNETCDF"
+            netcdf4_string = "D_NETCDF4P"
+        else:
+            globs_to_copy = (os.path.join("src","clib","libpioc.*"),
+                             os.path.join("src","flib","libpiof.*"))
+            for glob_to_copy in globs_to_copy:
+                installed_file_time = 0
+                for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
+                    installed_file = os.path.join(bldroot,"lib",os.path.basename(item))
+                    item_time = os.path.getmtime(item)
+                    if os.path.isfile(installed_file):
+                        installed_file_time = os.path.getmtime(installed_file)
+                    if item_time  > installed_file_time:
+                        logger.info("Installing pio version 2")
+                        shutil.copy(item, "%s/lib"%bldroot)
+            for glob_to_copy in (os.path.join("src","clib","*.h"),
+                                 os.path.join("src","flib","*.mod")):
+                for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
+                    installed_file = os.path.join(bldroot,"include",os.path.basename(item))
+                    item_time = os.path.getmtime(item)
+                    if os.path.isfile(installed_file):
+                        installed_file_time = os.path.getmtime(installed_file)
+                    if item_time > installed_file_time:
+                        shutil.copy(item, "%s/include"%bldroot)
+            expect_string = "NetCDF_C_LIBRARY-ADVANCED"
+            pnetcdf_string = "PnetCDF_C_LIBRARY-ADVANCED"
+            netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
+
+
+        # make sure case pio_typename valid_values is set correctly
+        expect_string_found = False
+        pnetcdf_found = False
+        netcdf4_parallel_found = False
+
+        cache_file = open(os.path.join(pio_dir,"CMakeCache.txt"), "r")
+        for line in cache_file:
+            if re.search(expect_string, line):
+                expect_string_found = True
+            if re.search(pnetcdf_string, line):
+                pnetcdf_found = True
+            if re.search(netcdf4_string, line):
+                netcdf4_parallel_found = True
+
+        expect(expect_string_found, "CIME models require NETCDF in PIO build")
+        valid_values = "netcdf"
+        if pnetcdf_found:
+            valid_values += ",pnetcdf"
+        if netcdf4_parallel_found:
+            valid_values += ",netcdf4p,netcdf4c"
+        logger.warn("Updating valid_values for PIO_TYPENAME: %s", valid_values)
+        case.set_valid_values("PIO_TYPENAME",valid_values)
+        # nothing means use the general default
+        valid_values += ",nothing"
+        for comp in ("ATM","CPL","OCN","WAV","GLC","ICE","ROF","LND"):
+            case.set_valid_values("%s_PIO_TYPENAME"%comp,valid_values)
+
+
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -140,6 +140,27 @@ class EntryID(GenericXML):
     def _get_group (self, node):
         return self._get_node_element_info(node, "group")
 
+    def set_valid_values(self, vid, new_valid_values):
+        node = self.get_optional_node("entry", {"id":vid})
+        if node is None:
+            return None
+        vv_node = self.get_optional_node("valid_values", root=node)
+        if vv_node is None:
+            vv_node = ET.Element("valid_values")
+            vv_node.text = new_valid_values
+            self.add_child(vv_node)
+        else:
+            logger.debug("Replacing valid_values %s for %s"%(vv_node.text, vid))
+            vv_node.text = new_valid_values
+        logger.debug("Adding valid_values %s for %s"%(new_valid_values, vid))
+
+        current_value = node.get("value")
+        valid_values_list = new_valid_values.split(',')
+        if current_value is not None and current_value not in valid_values_list:
+            logger.warn("WARNING: Current setting for %s not in new valid values. Updating setting to \"%s\""%(vid, valid_values_list[0]))
+            self._set_value(node, valid_values_list[0])
+        return new_valid_values
+
     def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False):
         """
         Set the value of an entry-id field to value

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -151,7 +151,7 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
 
     expect(not (sharedlib_only and model_only),
            "Contradiction: both sharedlib_only and model_only")
-
+    logger.info("Building case in directory %s"%caseroot)
     logger.info("sharedlib_only is %s" % sharedlib_only)
     logger.info("model_only is %s" % model_only)
 

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -317,10 +317,6 @@ class Case(object):
 
     def set_value(self, item, value, subgroup=None, ignore_type=False):
         """
-        If a file has not been defined, set an id/value pair in the
-        case dictionary, this will be used later. Note that in
-        create_newcase, when this is called and are setting the
-        command line options none of these files have been defined
         If a file has been defined, and the variable is in the file,
         then that value will be set in the file object and the file
         name is returned
@@ -330,6 +326,20 @@ class Case(object):
         result = None
         for env_file in self._env_entryid_files:
             result = env_file.set_value(item, value, subgroup, ignore_type)
+            if (result is not None):
+                logger.debug("Will rewrite file %s %s",env_file.filename, item)
+                self._env_files_that_need_rewrite.add(env_file)
+                return result
+
+    def set_valid_values(self, item, valid_values):
+        """
+        Update or create a valid_values entry for item and populate it
+        """
+        if item == "CASEROOT":
+            self._caseroot = value
+        result = None
+        for env_file in self._env_entryid_files:
+            result = env_file.set_valid_values(item, valid_values)
             if (result is not None):
                 logger.debug("Will rewrite file %s %s",env_file.filename, item)
                 self._env_files_that_need_rewrite.add(env_file)


### PR DESCRIPTION
Fix issues with assigning a PIO_TYPENAME which is not supported by the pio build

Test suite: scripts_regression_tests with pio_version 1 and 2
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 

