### PR TITLE
fix indentation error

### DIFF
--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -204,8 +204,8 @@ class EnvMachSpecific(EnvBase):
 
                             val = self.get_resolved_value(val)
                             expect("$" not in val, "Not safe to leave unresolved items in env var value: '%s'" % val)
-
-                            result.append( (child.get("name"), val) )
+                        # intentional unindent, result is appended even if val is None
+                        result.append( (child.get("name"), val) )
 
         return result
 


### PR DESCRIPTION
Fix Indentation error in env_mach_specific causing module to load incorrectly

Test suite: scripts_regression_tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 

