### PR TITLE
Erp test fix

### DIFF
--- a/utils/python/CIME/SystemTests/erp.py
+++ b/utils/python/CIME/SystemTests/erp.py
@@ -72,11 +72,11 @@ class ERP(SystemTestsCommon):
                         self._case.set_value("NTASKS_%s"%comp, ntasks/2)
                         self._case.set_value("ROOTPE_%s"%comp, rootpe/2)
 
-            # Note, some components, like CESM-CICE, have
-            # decomposition information in env_build.xml
-            # case_setup(self._case, test_mode=True, reset=True)that
-            # needs to be regenerated for the above new tasks and thread counts
-            case_setup(self._case, test_mode=True, reset=True)
+                # Note, some components, like CESM-CICE, have
+                # decomposition information in env_build.xml
+                # case_setup(self._case, test_mode=True, reset=True)that
+                # needs to be regenerated for the above new tasks and thread counts
+                case_setup(self._case, test_mode=True, reset=True)
 
             # Now rebuild the system, given updated information in env_build.xml
 

--- a/utils/python/CIME/SystemTests/erp.py
+++ b/utils/python/CIME/SystemTests/erp.py
@@ -53,8 +53,8 @@ class ERP(SystemTestsCommon):
         # Build two executables, one using the original tasks and threads (ERP1) and
         # one using the modified tasks and threads (ERP2)
         # The reason we currently need two executables that CESM-CICE has a compile time decomposition
-        # For cases where ERP works, changing this decomposition will not effect answers, but it will
-        # effect the executable that is used
+        # For cases where ERP works, changing this decomposition will not affect answers, but it will
+        # affect the executable that is used
         self._case.set_value("SMP_BUILD","0")
         for bld in range(1,3):
             logging.warn("Starting bld %s"%bld)

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -5,7 +5,7 @@ Library for case.setup.
 from CIME.XML.standard_module_setup import *
 
 from CIME.check_lockedfiles import check_lockedfiles
-from CIME.preview_namelists import create_dirs
+from CIME.preview_namelists import create_dirs, create_namelists
 from CIME.XML.env_mach_pes  import EnvMachPes
 from CIME.XML.compilers     import Compilers
 from CIME.utils             import append_status, parse_test_name, get_cime_root

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -261,6 +261,10 @@ def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, r
                 run_cmd_no_fail("./testcase.setup -caseroot %s" % caseroot)
                 logger.info("Finished testcase.setup")
 
+        # some tests need namelists created here (ERP)
+        if test_mode:
+            create_namelists(case)
+
         msg = "case.setup complete"
         append_status(msg, caseroot=caseroot, sfile="CaseStatus")
 


### PR DESCRIPTION
Tow build Test cases need create_namelist to run as a part of case.setup reset so that the second case builds correctly

Test suite: ERP_Ln9.f09_f09.F2000_DEV.yellowstone_intel.cam-outfrq9s, scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
