### PR TITLE
Add indentation in cs.status output

### DIFF
--- a/scripts/Tools/cs_status
+++ b/scripts/Tools/cs_status
@@ -46,7 +46,7 @@ def cs_status(test_paths):
         test_name = ts.get_name()
         summary = ts.get_overall_test_status()
         print "%s (Overall: %s), details:" % (test_name, summary)
-        ts.phase_statuses_dump(sys.stdout)
+        ts.phase_statuses_dump(sys.stdout, prefix='  ')
 
 ###############################################################################
 def _main_func(description):

--- a/utils/python/CIME/test_status.py
+++ b/utils/python/CIME/test_status.py
@@ -201,18 +201,19 @@ class TestStatus(object):
     def get_comment(self, phase):
         return self._phase_statuses[phase][1] if phase in self._phase_statuses else None
 
-    def phase_statuses_dump(self, fd):
+    def phase_statuses_dump(self, fd, prefix=''):
         """
         Args:
             fd: file open for writing
+            prefix: string printed at the start of each line
         """
         if self._phase_statuses:
             for phase, data in self._phase_statuses.iteritems():
                 status, comments = data
                 if not comments:
-                    fd.write("%s %s %s\n" % (status, self._test_name, phase))
+                    fd.write("%s%s %s %s\n" % (prefix, status, self._test_name, phase))
                 else:
-                    fd.write("%s %s %s %s\n" % (status, self._test_name, phase, comments))
+                    fd.write("%s%s %s %s %s\n" % (prefix, status, self._test_name, phase, comments))
 
     def flush(self):
         if self._phase_statuses and not self._no_io:


### PR DESCRIPTION
Indents cs.status output to look like this:

```
ERS_Ld3.f45_g37_rx1.A.yellowstone_intel (Overall: PEND), details:
  PASS ERS_Ld3.f45_g37_rx1.A.yellowstone_intel CREATE_NEWCASE
  PASS ERS_Ld3.f45_g37_rx1.A.yellowstone_intel XML
  PASS ERS_Ld3.f45_g37_rx1.A.yellowstone_intel SETUP
  PEND ERS_Ld3.f45_g37_rx1.A.yellowstone_intel SHAREDLIB_BUILD
```

Test suite: Ran one test, checked TestStatus and cs.status output
  scripts_regression_tests running now
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: #710

User interface changes?: Adds indentation in cs.status output

Code review: @fischer-ncar 

@cacraigucar 