### PR TITLE
change lt_archive queue to caldera, add sleep in scripts_regression_t…

### DIFF
--- a/cime_config/cesm/machines/config_batch.xml
+++ b/cime_config/cesm/machines/config_batch.xml
@@ -378,7 +378,8 @@
 
   <batch_system MACH="yellowstone" type="lsf" version="9.1">
     <queues>
-      <queue walltimemax="24:00" jobmin="1" jobmax="1" jobname="case.lt_archive">hpss</queue>
+      <!-- the hpss queue that should be used for lt_archive jobs on yellowstone does not have modules installed and so rejects our python job -->
+      <queue walltimemax="24:00" jobmin="1" jobmax="1" jobname="case.lt_archive">caldera</queue>
       <queue walltimemax="24:00" jobmin="1" jobmax="8" >caldera</queue>
       <queue walltimemax="12:00" jobmin="9" jobmax="16384" default="true">regular</queue>
       <queue walltimemax="12:00" jobmin="16385" jobmax="65536">capability</queue>

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -463,6 +463,7 @@ class TestCreateTestCommon(unittest.TestCase):
         else:
             for file_to_clean in files_to_clean:
                 if (os.path.isdir(file_to_clean)):
+                    time.sleep(5) # Kinda hacky
                     shutil.rmtree(file_to_clean)
                 else:
                     os.remove(file_to_clean)


### PR DESCRIPTION
The hpss queue on yellowstone does not support modules and has too old a python version installed.  
Test suite:  case.submit --job case.lt_archive 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #720 

User interface changes?: 

Code review: 
