### PR TITLE
trim include directories list so that each is only added once

### DIFF
--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -8,8 +8,7 @@ from CIME.check_lockedfiles import check_lockedfiles
 from CIME.preview_namelists import create_dirs, create_namelists
 from CIME.XML.env_mach_pes  import EnvMachPes
 from CIME.XML.compilers     import Compilers
-from CIME.utils             import append_status, parse_test_name, get_cime_root
-from CIME.user_mod_support  import apply_user_mods
+from CIME.utils             import get_cime_root, append_status
 from CIME.test_status       import *
 
 import shutil, time, glob
@@ -77,7 +76,7 @@ def _build_usernl_files(case, model, comp):
                     shutil.copy(model_nl, nlfile)
 
 ###############################################################################
-def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, reset=False):
+def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 ###############################################################################
     os.chdir(caseroot)
     msg = "case.setup starting"
@@ -236,15 +235,16 @@ def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, r
                 run_cmd_no_fail("%s/../components/cism/cime_config/cism.template %s" % (cimeroot, caseroot))
 
         _build_usernl_files(case, "drv", "cpl")
-
-        user_mods_path = case.get_value("USER_MODS_FULLPATH")
-        if user_mods_path is not None:
-            apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
-        elif case.get_value("TEST"):
-            test_mods = parse_test_name(casebaseid)[6]
-            if test_mods is not None:
-                user_mods_path = os.path.join(case.get_value("TESTS_MODS_DIR"), test_mods)
-                apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
+# only do this at create_newcase time, leaving the code in place in case
+# we decide to add a cmd line argument to support this in case.setup
+#        user_mods_path = case.get_value("USER_MODS_FULLPATH")
+#        if user_mods_path is not None:
+#            apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
+#        elif case.get_value("TEST"):
+#            test_mods = parse_test_name(casebaseid)[6]
+#            if test_mods is not None:
+#                user_mods_path = os.path.join(case.get_value("TESTS_MODS_DIR"), test_mods)
+#                apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
 
 
         # Create needed directories for case
@@ -285,11 +285,11 @@ def case_setup(case, clean=False, test_mode=False, reset=False):
         test_name = casebaseid if casebaseid is not None else case.get_value("CASE")
         with TestStatus(test_dir=caseroot, test_name=test_name) as ts:
             try:
-                _case_setup_impl(case, caseroot, casebaseid, clean=clean, test_mode=test_mode, reset=reset)
+                _case_setup_impl(case, caseroot, clean=clean, test_mode=test_mode, reset=reset)
             except:
                 ts.set_status(SETUP_PHASE, TEST_FAIL_STATUS)
                 raise
             else:
                 ts.set_status(SETUP_PHASE, TEST_PASS_STATUS)
     else:
-        _case_setup_impl(case, caseroot, casebaseid, clean=clean, test_mode=test_mode, reset=reset)
+        _case_setup_impl(case, caseroot, clean=clean, test_mode=test_mode, reset=reset)

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -8,7 +8,8 @@ from CIME.check_lockedfiles import check_lockedfiles
 from CIME.preview_namelists import create_dirs, create_namelists
 from CIME.XML.env_mach_pes  import EnvMachPes
 from CIME.XML.compilers     import Compilers
-from CIME.utils             import get_cime_root, append_status
+from CIME.utils             import append_status, parse_test_name, get_cime_root
+from CIME.user_mod_support  import apply_user_mods
 from CIME.test_status       import *
 
 import shutil, time, glob
@@ -76,7 +77,7 @@ def _build_usernl_files(case, model, comp):
                     shutil.copy(model_nl, nlfile)
 
 ###############################################################################
-def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
+def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, reset=False):
 ###############################################################################
     os.chdir(caseroot)
     msg = "case.setup starting"
@@ -235,16 +236,15 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 run_cmd_no_fail("%s/../components/cism/cime_config/cism.template %s" % (cimeroot, caseroot))
 
         _build_usernl_files(case, "drv", "cpl")
-# only do this at create_newcase time, leaving the code in place in case
-# we decide to add a cmd line argument to support this in case.setup
-#        user_mods_path = case.get_value("USER_MODS_FULLPATH")
-#        if user_mods_path is not None:
-#            apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
-#        elif case.get_value("TEST"):
-#            test_mods = parse_test_name(casebaseid)[6]
-#            if test_mods is not None:
-#                user_mods_path = os.path.join(case.get_value("TESTS_MODS_DIR"), test_mods)
-#                apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
+
+        user_mods_path = case.get_value("USER_MODS_FULLPATH")
+        if user_mods_path is not None:
+            apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
+        elif case.get_value("TEST"):
+            test_mods = parse_test_name(casebaseid)[6]
+            if test_mods is not None:
+                user_mods_path = os.path.join(case.get_value("TESTS_MODS_DIR"), test_mods)
+                apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
 
 
         # Create needed directories for case
@@ -285,11 +285,11 @@ def case_setup(case, clean=False, test_mode=False, reset=False):
         test_name = casebaseid if casebaseid is not None else case.get_value("CASE")
         with TestStatus(test_dir=caseroot, test_name=test_name) as ts:
             try:
-                _case_setup_impl(case, caseroot, clean=clean, test_mode=test_mode, reset=reset)
+                _case_setup_impl(case, caseroot, casebaseid, clean=clean, test_mode=test_mode, reset=reset)
             except:
                 ts.set_status(SETUP_PHASE, TEST_FAIL_STATUS)
                 raise
             else:
                 ts.set_status(SETUP_PHASE, TEST_PASS_STATUS)
     else:
-        _case_setup_impl(case, caseroot, clean=clean, test_mode=test_mode, reset=reset)
+        _case_setup_impl(case, caseroot, casebaseid, clean=clean, test_mode=test_mode, reset=reset)

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -105,30 +105,6 @@ def build_include_dirs_list(user_mods_path, include_dirs=None):
            "Expected full directory path, got '%s'"%user_mods_path)
     expect(os.path.isdir(user_mods_path),
            "Directory not found %s"%user_mods_path)
-    logger.info("Adding user mods directory %s"%user_mods_path)
-    include_dirs.append(os.path.normpath(user_mods_path))
-    include_file = os.path.join(include_dirs[-1],"include_user_mods")
-    if os.path.isfile(include_file):
-        with open(include_file, "r") as fd:
-            for newpath in fd:
-                newpath = newpath.rstrip()
-                if len(newpath) > 0 and not newpath.startswith("#"):
-                    if not os.path.isabs(newpath):
-                        newpath = os.path.join(user_mods_path, newpath)
-                    if os.path.isabs(newpath):
-                        build_include_dirs_list(newpath, include_dirs)
-                    else:
-                        logger.warn("Could not resolve path '%s' in file '%s'"%newpath,include_file)
-
-    return list(set(include_dirs))
-
-    include_dirs = [] if include_dirs is None else include_dirs
-    if user_mods_path is None or user_mods_path == 'UNSET':
-        return include_dirs
-    expect(os.path.isabs(user_mods_path),
-           "Expected full directory path, got '%s'"%user_mods_path)
-    expect(os.path.isdir(user_mods_path),
-           "Directory not found %s"%user_mods_path)
     norm_path = os.path.normpath(user_mods_path)
 
     for dir_ in include_dirs:

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -72,24 +72,13 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
             run_cmd_no_fail(shell_command_file)
 
 def update_user_nl_file(case_user_nl, contents):
-    update_file = True
     if os.path.isfile(case_user_nl):
         with open(case_user_nl, "r") as fd:
             old_contents = fd.read()
-
-        oc = set(old_contents.splitlines())
-        nc = set(contents.splitlines())
-        if not nc.issubset(oc):
-            contents = contents + old_contents
-            update_file = True
-        else:
-            update_file = False
-    if update_file:
+        contents = contents + old_contents
         logger.info("Pre-pending file %s"%(case_user_nl))
         with open(case_user_nl, "w") as fd:
             fd.write(contents)
-
-
 
 def build_include_dirs_list(user_mods_path, include_dirs=None):
     '''

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -22,6 +22,7 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
             os.remove(shell_command_file)
 
     include_dirs = build_include_dirs_list(user_mods_path)
+    logger.warn("include_dirs are %s"%include_dirs)
     for include_dir in include_dirs:
         # write user_nl_xxx file in caseroot
         for user_nl in glob.iglob(os.path.join(include_dir,"user_nl_*")):
@@ -101,18 +102,20 @@ def build_include_dirs_list(user_mods_path, include_dirs=None):
            "Expected full directory path, got '%s'"%user_mods_path)
     expect(os.path.isdir(user_mods_path),
            "Directory not found %s"%user_mods_path)
-    logger.info("Adding user mods directory %s"%user_mods_path)
-    include_dirs.append(os.path.normpath(user_mods_path))
-    include_file = os.path.join(include_dirs[-1],"include_user_mods")
-    if os.path.isfile(include_file):
-        with open(include_file, "r") as fd:
-            for newpath in fd:
-                newpath = newpath.rstrip()
-                if len(newpath) > 0 and not newpath.startswith("#"):
-                    if not os.path.isabs(newpath):
-                        newpath = os.path.join(user_mods_path, newpath)
-                    if os.path.isabs(newpath):
-                        build_include_dirs_list(newpath, include_dirs)
-                    else:
-                        logger.warn("Could not resolve path '%s' in file '%s'"%newpath,include_file)
+    norm_path = os.path.normpath(user_mods_path)
+    if norm_path not in include_dirs:
+        logger.info("Adding user mods directory %s"%norm_path)
+        include_dirs.append(norm_path)
+        include_file = os.path.join(include_dirs[-1],"include_user_mods")
+        if os.path.isfile(include_file):
+            with open(include_file, "r") as fd:
+                for newpath in fd:
+                    newpath = newpath.rstrip()
+                    if len(newpath) > 0 and not newpath.startswith("#"):
+                        if not os.path.isabs(newpath):
+                            newpath = os.path.join(user_mods_path, newpath)
+                        if os.path.isabs(newpath):
+                            build_include_dirs_list(newpath, include_dirs)
+                        else:
+                            logger.warn("Could not resolve path '%s' in file '%s'"%newpath,include_file)
     return include_dirs

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -72,13 +72,24 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
             run_cmd_no_fail(shell_command_file)
 
 def update_user_nl_file(case_user_nl, contents):
+    update_file = True
     if os.path.isfile(case_user_nl):
         with open(case_user_nl, "r") as fd:
             old_contents = fd.read()
-        contents = contents + old_contents
+
+        oc = set(old_contents.splitlines())
+        nc = set(contents.splitlines())
+        if not nc.issubset(oc):
+            contents = contents + old_contents
+            update_file = True
+        else:
+            update_file = False
+    if update_file:
         logger.info("Pre-pending file %s"%(case_user_nl))
         with open(case_user_nl, "w") as fd:
             fd.write(contents)
+
+
 
 def build_include_dirs_list(user_mods_path, include_dirs=None):
     '''


### PR DESCRIPTION
Include directories are only listed once if repeated in chain.

Test suite: scripts_regression_tests, SMS.T62_g16.C.yellowstone_intel.pop-cice_ecosys_dust_flux_driver
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #719 

User interface changes?: 

Code review: 
