### PR TITLE
Don't assume . is in PATH.

### DIFF
--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -464,7 +464,7 @@ class TestScheduler(object):
         # A little subtle. If namelists_only, the RUN phase, when the namelists would normally
         # be handled, is not going to happen, so we have to do it here.
         if self._namelists_only:
-            run_cmd("case.cmpgen_namelists", from_dir=test_dir)
+            run_cmd_no_fail("./case.cmpgen_namelists", from_dir=test_dir)
 
         return rv
 


### PR DESCRIPTION
Also, fail the phase if the cmpgen command fails.

This will fix the broken test on melvin.

Test suite: by hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?: None

Code review: jedwards

