### PR TITLE
Fix eri and erp tests

### DIFF
--- a/cime_config/config_tests.xml
+++ b/cime_config/config_tests.xml
@@ -177,7 +177,6 @@ LII    CLM initial condition interpolation test
     <HIST_OPTION>ndays</HIST_OPTION>
     <HIST_N>1</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <BUILD_THREADED>TRUE</BUILD_THREADED>
   </test>
 
   <test NAME="ERI">
@@ -186,7 +185,6 @@ LII    CLM initial condition interpolation test
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>22</STOP_N>
     <DOUT_S>FALSE</DOUT_S>
-    <BUILD_THREADED>TRUE</BUILD_THREADED>
   </test>
 
   <test NAME="ERP">

--- a/utils/python/CIME/SystemTests/erp.py
+++ b/utils/python/CIME/SystemTests/erp.py
@@ -61,7 +61,9 @@ class ERP(SystemTestsCommon):
 
             if (bld == 2):
                 # halve the number of tasks and threads
-                for comp in ['ATM','CPL','OCN','WAV','GLC','ICE','ROF','LND']:
+                for comp in self._case.get_values("COMP_CLASSES"):
+                    if comp == "DRV":
+                        comp = "CPL"
                     ntasks    = self._case.get_value("NTASKS_%s"%comp)
                     nthreads  = self._case.get_value("NTHRDS_%s"%comp)
                     rootpe    = self._case.get_value("ROOTPE_%s"%comp)


### PR DESCRIPTION
1. Remove BUILD_THREADED for ERI and DAE tests: These tests shouldn't
   need to build in threaded mode, and setting BUILD_THREADED to true
   makes these tests fail on machines/compilers that don't support
   threading (e.g. hobart-nag).

2. Ensure that ERP halves task and thread counts for *all* components -
   previously, ESP was omitted, leading to some strange PE layouts.

Test suite: scripts_regression_tests on yellowstone - all pass except:
   test_create_test_rebless_namelist (__main__.N_TestCreateTest) ... FAIL
   which is also failing on master, according to CDash

   Also ran a bunch of ERI and ERP tests from CLM on hobart; these all
   pass now (whereas previously they all failed):
   ERI_D_Ld9_P24x1.f10_f10.ICLM45BGC.hobart_nag.clm-reduceOutput
   ERI_D_Ld9_P24x1.f10_f10.ICLM45.hobart_nag.clm-SNICARFRC
   ERI_D_Ld9_P24x1.f10_f10.ICRUCLM50BGC.hobart_nag.clm-reduceOutput
   ERI_D_Ld9_P24x1.T31_g37.I1850CLM45.hobart_nag.clm-reduceOutput
   ERP_D_Ld5_P24x1.f10_f10.I1850CLM45BGC.hobart_nag.clm-ciso
   ERP_D_Ld5_P24x1.f10_f10.I1850CLM45.hobart_nag.clm-o3
   ERP_D_Ld5_P24x1.f10_f10.ICLM45BGC.hobart_nag.clm-reduceOutput
   ERP_D_P24x1.f10_f10.IHISTCLM45BGC.hobart_nag.clm-decStart

Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #687
Fixes #723

User interface changes?: no

Code review: 
