### PR TITLE
backout change to xmlchange (needed by external components)

### DIFF
--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -24,7 +24,7 @@ logger = logging.getLogger("xmlchange")
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n%s [<changeargs>] [--verbose][--id id][--val value][--noecho][--append][--force]
+        usage="""\n%s [<changeargs>] [--verbose][--file file][--id id][--val value][--noecho][--append][--warn][--force]
 OR
 %s --help
 OR
@@ -51,6 +51,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-loglevel",
                         help="ignored, backward compatibility only")
 
+    parser.add_argument("-file", "--file",
+                        help="xml file to edit")
+
     parser.add_argument("-id", "--id",
                         help="the xml entry id")
 
@@ -69,6 +72,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-append","--append", action="store_true",
                         help="append to the existing value")
 
+    parser.add_argument("-warn","--warn", action="store_true",
+                        help="not implemented")
+
     parser.add_argument("-subgroup","--subgroup",
                         help="apply to this subgroup only")
 
@@ -84,7 +90,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
         delimiter = re.escape(args.delimiter)
         listofsettings = re.split(r'(?<!\\)'+ delimiter , args.listofsettings)
 
-    return args.caseroot, listofsettings, args.id, args.val, args.subgroup, args.append, args.noecho, args.force , args.dryrun
+    return args.caseroot, listofsettings, args.file, args.id, args.val, args.subgroup, args.append, args.noecho, args.warn, args.force , args.dryrun
 
 def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=None,
               append=None, noecho=False, force=False , dryrun=False):
@@ -132,8 +138,8 @@ def _main_func(description):
     if ("--test" in sys.argv):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
-
-    caseroot, listofsettings, xmlid, xmlval, subgroup, append, noecho, force , dry = parse_command_line(sys.argv, description)
+    # pylint: disable=unused-variable
+    caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup, append, noecho, warn, force , dry = parse_command_line(sys.argv, description)
 
     xmlchange(caseroot, listofsettings, xmlid, xmlval, subgroup, append, noecho, force , dry)
 


### PR DESCRIPTION
The --file option is ignored in xmlchange, but still used by some external components. 

Test suite: SMS_Ld5.T31_g37_gl20.B1850C5L45BGCRG2.yellowstone_intel.allactive-defaultio SETUP 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Code review: 

