### PR TITLE
Copy user_nl_foo from the case directory to the multi-instance version

### DIFF
--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -884,16 +884,7 @@ class Case(object):
                 user_mods_path = self.get_value('USER_MODS_DIR')
                 user_mods_path = os.path.join(user_mods_path, user_mods_dir)
             self.set_value("USER_MODS_FULLPATH",user_mods_path)
-            ninst_vals = {}
-            for i in xrange(1,len(self._component_classes)):
-                comp_class = self._component_classes[i]
-                comp_name  = self._components[i-1]
-                if comp_class == "DRV":
-                    continue
-                ninst_comp = self.get_value("NINST_%s"%comp_class)
-                if ninst_comp > 1:
-                    ninst_vals[comp_name] = ninst_comp
-            apply_user_mods(self._caseroot, user_mods_path, ninst_vals)
+            apply_user_mods(self._caseroot, user_mods_path)
 
     def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None):
 

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -8,8 +8,7 @@ from CIME.check_lockedfiles import check_lockedfiles
 from CIME.preview_namelists import create_dirs, create_namelists
 from CIME.XML.env_mach_pes  import EnvMachPes
 from CIME.XML.compilers     import Compilers
-from CIME.utils             import append_status, parse_test_name, get_cime_root
-from CIME.user_mod_support  import apply_user_mods
+from CIME.utils             import append_status, get_cime_root
 from CIME.test_status       import *
 
 import shutil, time, glob
@@ -84,7 +83,7 @@ def _build_usernl_files(case, model, comp):
                     shutil.copy(model_nl, nlfile)
 
 ###############################################################################
-def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, reset=False):
+def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 ###############################################################################
     os.chdir(caseroot)
     msg = "case.setup starting"
@@ -165,19 +164,17 @@ def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, r
 
         # Check ninst.
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.
-        # Save ninst in a dict to use later in apply_user_mods
-        ninst = dict()
         for comp in models:
             if comp == "DRV":
                 continue
             comp_model = case.get_value("COMP_%s" % comp)
-            ninst[comp_model]  = case.get_value("NINST_%s" % comp)
+            ninst  = case.get_value("NINST_%s" % comp)
             ntasks = case.get_value("NTASKS_%s" % comp)
-            if ninst[comp_model] > ntasks:
+            if ninst > ntasks:
                 if ntasks == 1:
-                    case.set_value("NTASKS_%s" % comp, ninst[comp_model])
+                    case.set_value("NTASKS_%s" % comp, ninst)
                 else:
-                    expect(False, "NINST_%s value %d greater than NTASKS_%s %d" % (comp, ninst[comp_model], comp, ntasks))
+                    expect(False, "NINST_%s value %d greater than NTASKS_%s %d" % (comp, ninst, comp, ntasks))
 
         if os.path.exists("case.run"):
             logger.info("Machine/Decomp/Pes configuration has already been done ...skipping")
@@ -244,16 +241,6 @@ def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, r
 
         _build_usernl_files(case, "drv", "cpl")
 
-        user_mods_path = case.get_value("USER_MODS_FULLPATH")
-        if user_mods_path is not None:
-            apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
-        elif case.get_value("TEST"):
-            test_mods = parse_test_name(casebaseid)[6]
-            if test_mods is not None:
-                user_mods_path = os.path.join(case.get_value("TESTS_MODS_DIR"), test_mods)
-                apply_user_mods(caseroot, user_mods_path=user_mods_path, ninst=ninst)
-
-
         # Create needed directories for case
         create_dirs(case)
         case.load_env()
@@ -292,11 +279,11 @@ def case_setup(case, clean=False, test_mode=False, reset=False):
         test_name = casebaseid if casebaseid is not None else case.get_value("CASE")
         with TestStatus(test_dir=caseroot, test_name=test_name) as ts:
             try:
-                _case_setup_impl(case, caseroot, casebaseid, clean=clean, test_mode=test_mode, reset=reset)
+                _case_setup_impl(case, caseroot, clean=clean, test_mode=test_mode, reset=reset)
             except:
                 ts.set_status(SETUP_PHASE, TEST_FAIL_STATUS)
                 raise
             else:
                 ts.set_status(SETUP_PHASE, TEST_PASS_STATUS)
     else:
-        _case_setup_impl(case, caseroot, casebaseid, clean=clean, test_mode=test_mode, reset=reset)
+        _case_setup_impl(case, caseroot, clean=clean, test_mode=test_mode, reset=reset)

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -66,14 +66,21 @@ def _build_usernl_files(case, model, comp):
         ninst = case.get_value("NINST_%s" % model)
         nlfile = "user_nl_%s" % comp
         model_nl = os.path.join(model_dir, nlfile)
-        if os.path.exists(model_nl):
-            if ninst > 1:
-                for inst_counter in xrange(1, ninst+1):
-                    case_nlfile = "%s_%04d" % (nlfile, inst_counter)
-                    if not os.path.exists(case_nlfile):
-                        shutil.copy(model_nl, case_nlfile)
-            else:
-                if not os.path.exists(nlfile):
+        if ninst > 1:
+            for inst_counter in xrange(1, ninst+1):
+                inst_nlfile = "%s_%04d" % (nlfile, inst_counter)
+                if not os.path.exists(inst_nlfile):
+                    # If there is a user_nl_foo in the case directory, copy it
+                    # to user_nl_foo_INST; otherwise, copy the original
+                    # user_nl_foo from model_dir
+                    if os.path.exists(nlfile):
+                        shutil.copy(nlfile, inst_nlfile)
+                    elif os.path.exists(model_nl):
+                        shutil.copy(model_nl, inst_nlfile)
+        else:
+            # ninst = 1
+            if not os.path.exists(nlfile):
+                if os.path.exists(model_nl):
                     shutil.copy(model_nl, nlfile)
 
 ###############################################################################

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -167,7 +167,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         for comp in models:
             if comp == "DRV":
                 continue
-            comp_model = case.get_value("COMP_%s" % comp)
             ninst  = case.get_value("NINST_%s" % comp)
             ntasks = case.get_value("NTASKS_%s" % comp)
             if ninst > ntasks:

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -31,7 +31,6 @@ def apply_user_mods(caseroot, user_mods_path):
             if len(newcontents) == 0:
                 continue
             case_user_nl = user_nl.replace(include_dir, caseroot)
-            comp = case_user_nl.split('_')[-1]
             update_user_nl_file(case_user_nl, newcontents)
 
         # update SourceMods in caseroot

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -8,7 +8,7 @@ import shutil, glob
 
 logger = logging.getLogger(__name__)
 
-def apply_user_mods(caseroot, user_mods_path, ninst=None):
+def apply_user_mods(caseroot, user_mods_path):
     '''
     Recursivlely apply user_mods to caseroot - this includes updating user_nl_xxx,
     updating SourceMods and creating case shell_commands and xmlchange_cmds files
@@ -32,13 +32,7 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
                 continue
             case_user_nl = user_nl.replace(include_dir, caseroot)
             comp = case_user_nl.split('_')[-1]
-            if ninst is not None and comp in ninst.keys() and ninst[comp] > 1:
-                for comp_inst in xrange(1, ninst[comp]+1):
-                    contents = newcontents
-                    case_user_nl_inst = case_user_nl + "_%4.4d"%comp_inst
-                    update_user_nl_file(case_user_nl_inst, contents)
-            else:
-                update_user_nl_file(case_user_nl, newcontents)
+            update_user_nl_file(case_user_nl, newcontents)
 
         # update SourceMods in caseroot
         for root, _, files in os.walk(include_dir,followlinks=True,topdown=False):
@@ -72,22 +66,13 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
             run_cmd_no_fail(shell_command_file)
 
 def update_user_nl_file(case_user_nl, contents):
-    update_file = True
     if os.path.isfile(case_user_nl):
         with open(case_user_nl, "r") as fd:
             old_contents = fd.read()
-
-        oc = set(old_contents.splitlines())
-        nc = set(contents.splitlines())
-        if not nc.issubset(oc):
-            contents = contents + old_contents
-            update_file = True
-        else:
-            update_file = False
-    if update_file:
-        logger.info("Pre-pending file %s"%(case_user_nl))
-        with open(case_user_nl, "w") as fd:
-            fd.write(contents)
+        contents = contents + old_contents
+    logger.info("Pre-pending file %s"%(case_user_nl))
+    with open(case_user_nl, "w") as fd:
+        fd.write(contents)
 
 
 


### PR DESCRIPTION
Changes how user_nl files are handled in multi-instance cases and tests

(1) When case.setup is run, then for any component foo, if there is a
    file user_nl_foo in the case directory, but no file
    user_nl_foo_NNNN, where NNNN <= NINST_FOO, then user_nl_foo is
    copied to user_nl_foo_NNNN. This means that anything added to
    user_nl_foo, either by user_mods / testmods or manually by the user,
    is copied to any multi-instance user_nl_foo file, if that given
    multi-instance user_nl_foo file doesn't already exist.

(2) Remove handling of multi-instance in apply_user_mods: this is now
    handled by (1).

(3) Get rid of user_mods / testmods handling in case_setup, just keeping
    it in create_newcase. It was originally needed in case_setup to
    handle multi-instance cases, but with the reworked handling of
    multi-instance user_nl files, this is no longer needed.

(4) Remove code that checks for already-applied user_nl contents: this
    was needed because user_mods / testmods were applied repeatedly by
    case.setup; since they are now only applied by create_newcase, this
    is no longer needed.

Test suite: scripts_regression_tests.py on yellowstone
   All pass except test_create_test_rebless_namelist
      (which is also failing on master)
   Also many other manual tests - see below
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Other tests:

For user cases (not tests):

- for ninst = 1, make sure user_nl_ files get copied from the source
  tree

- for ninst = 2, when there is no user_nl_foo in the case dir, make sure
  it gets copied from the source tree

- for ninst = 2, if there is a user_nl_foo in the case dir and also a
  user_nl_foo_0002, user_nl_foo_0002 should be maintained

- for ninst = 2, if there is a user_nl_foo in the case dir but no
  user_nl_foo_0002, user_nl_foo should be copied to user_nl_foo_0002.

- and some other manipulations of NINST and rerunning of case.setup

For tests:

- Make sure user_nl files are set up correctly for an _N2 test with a
  testmods dir

- Make sure user_nl files are set up correctly for a NCK test.

- Checked CLM_BLDNML_OPTS in
  ERP_P60x2_Lm36.f10_f10.ICRUCLM50BGCCROP.yellowstone_intel.clm-clm50cropIrrigMonth_interp
  - ensured the append wasn't repeatedly applied

- Ran NCK_D.f10_f10.ICLM45BGC.yellowstone_intel.clm-default from clm4_5_12_r198

Fixes: #734

User interface changes?: YES: For multi-instance cases, when case.setup
is run, then for any component foo, if there is a file user_nl_foo in
the case directory, but no file user_nl_foo_NNNN, where NNNN <=
NINST_FOO, then user_nl_foo is copied to user_nl_foo_NNNN. This means
that anything added to user_nl_foo, either by user_mods / testmods or
manually by the user, is copied to any multi-instance user_nl_foo file,
if that given multi-instance user_nl_foo file doesn't already exist.

Code review: @jedwards4b
