### PR TITLE
Pea test fix

### DIFF
--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -193,12 +193,16 @@ ifdef NETCDF_PATH
     LIB_NETCDF:=$(NETCDF_PATH)/lib
   endif
 endif
-ifdef PNETCDF_PATH
-  ifndef $(INC_PNETCDF)
-    INC_PNETCDF:=$(PNETCDF_PATH)/include
-  endif
-  ifndef LIB_PNETCDF
-    LIB_PNETCDF:=$(PNETCDF_PATH)/lib
+ifeq ($(MPILIB),mpi-serial)
+  undefine PNETCDF_PATH
+else
+  ifdef PNETCDF_PATH
+    ifndef $(INC_PNETCDF)
+      INC_PNETCDF:=$(PNETCDF_PATH)/include
+    endif
+    ifndef LIB_PNETCDF
+      LIB_PNETCDF:=$(PNETCDF_PATH)/lib
+    endif
   endif
 endif
 # Set PETSc info if it is being used

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -193,15 +193,18 @@ ifdef NETCDF_PATH
     LIB_NETCDF:=$(NETCDF_PATH)/lib
   endif
 endif
-ifdef PNETCDF_PATH
-  ifndef $(INC_PNETCDF)
-    INC_PNETCDF:=$(PNETCDF_PATH)/include
-  endif
-  ifndef LIB_PNETCDF
-    LIB_PNETCDF:=$(PNETCDF_PATH)/lib
+ifeq ($(MPILIB),mpi-serial)
+  undefine PNETCDF_PATH
+else
+  ifdef PNETCDF_PATH
+    ifndef $(INC_PNETCDF)
+      INC_PNETCDF:=$(PNETCDF_PATH)/include
+    endif
+    ifndef LIB_PNETCDF
+      LIB_PNETCDF:=$(PNETCDF_PATH)/lib
+    endif
   endif
 endif
-
 ifeq ($(strip $(USE_TRILINOS)), TRUE)
   ifdef TRILINOS_PATH
     ifndef INC_TRILINOS

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -136,6 +136,8 @@ def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, r
         append_status(msg, caseroot=caseroot, sfile="CaseStatus")
 
     if not clean:
+        case.load_env()
+
         models = case.get_values("COMP_CLASSES")
 
         mach, compiler, debug, mpilib = \
@@ -249,7 +251,6 @@ def _case_setup_impl(case, caseroot, casebaseid, clean=False, test_mode=False, r
 
         # Create needed directories for case
         create_dirs(case)
-        case.load_env()
 
         logger.info("If an old case build already exists, might want to run \'case.build --clean\' before building")
 


### PR DESCRIPTION
The pea test on yellowstone was finding PNETCDF_PATH in the environment and so 
pio was building with it and the model was failing in the link step.  Force PNETCDF_PATH
unset in Makefile

Test suite: scripts_regression_tests, PEA_P1_Ld3.f45_g37_rx1.A.yellowstone_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Code review: 

