### PR TITLE
Fix regression namelist regression test

### DIFF
--- a/scripts/Tools/case.cmpgen_namelists
+++ b/scripts/Tools/case.cmpgen_namelists
@@ -66,7 +66,7 @@ def _main_func(description):
     with Case(caseroot, read_only=True) as case:
         success = case_cmpgen_namelists(case, compare, generate, compare_name, generate_name)
 
-    sys.exit(0 if success else 1)
+    sys.exit(0 if success else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -527,16 +527,16 @@ class N_TestCreateTest(TestCreateTestCommon):
 
         # Basic namelist compare should now fail
         test_id = "%s-%s" % (self._baseline_name, CIME.utils.get_timestamp())
-        self.simple_test(True, "%s -n -t %s" % (comparg, test_id))
+        self.simple_test(False, "%s -n -t %s" % (comparg, test_id))
         casedir = os.path.join(self._testroot,
                                "%s.C.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_P1.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), test_id))
-        run_cmd_assert_result(self, "./case.cmpgen_namelists", from_dir=casedir, expected_stat=1)
+        run_cmd_assert_result(self, "./case.cmpgen_namelists", from_dir=casedir, expected_stat=100)
 
         # preview namelists should work
         run_cmd_assert_result(self, "./preview_namelists", from_dir=casedir)
 
         # This should still fail
-        run_cmd_assert_result(self, "./case.cmpgen_namelists", from_dir=casedir, expected_stat=1)
+        run_cmd_assert_result(self, "./case.cmpgen_namelists", from_dir=casedir, expected_stat=100)
 
         # Regen
         self.simple_test(True, "%s -n -t %s-%s" % (genarg, self._baseline_name, CIME.utils.get_timestamp()))


### PR DESCRIPTION
1) case.cmpgen_namelists: make better use of return code
to differentiate between fatal errors and namelist diffs.
1.a) reoganize expcetion handling to allow fatal errors to escape
but catch all non-fatal errors

2) Restore some smarts to test_scheduler so that it will report
NLFAIL tests as NLFAIL even though it is no longer directly responsible for
doing the namelist comparisons

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?: Return code changes for case.cmpgen_namelists. create_test will report test status more accurately.

Code review: jedwards

