### PR TITLE
Rework output format for compare_test_results

### DIFF
--- a/scripts/Tools/compare_test_results
+++ b/scripts/Tools/compare_test_results
@@ -3,14 +3,19 @@
 """Analyze results from a test root area, comparing non-BFB changes.
 
 Purpose is, instead of re-running tests in compare mode, which is very slow,
-allow for very fast analsis of diffs.
+allow for very fast analysis of diffs.
 
 Outputs results for each test to stdout (one line per test); possible status
-codes are: PASS, FAIL, SKIP.
+codes are: PASS, FAIL, SKIP. (A SKIP denotes a test that did not make it to the
+run phase or a test for which the run phase did not pass: we skip baseline
+comparisons in this case.)
 
 In addition, creates files named compare.log.BASELINE_NAME.TIMESTAMP in each
 test directory, which contain more detailed output. Also creates
 *.cprnc.out.BASELINE_NAME.TIMESTAMP files in each run directory.
+
+Returns a 0 exit status if all tests are bit-for-bit, and a non-zero exit status
+(TESTS_FAILED_ERR_CODE) if any tests differed from the baseline.
 
 You may need to load modules for cprnc to work.
 
@@ -95,8 +100,8 @@ def _main_func(description):
     baseline_name, baseline_root, test_root, compiler, test_id, compare_tests = \
         parse_command_line(sys.argv, description)
 
-    compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id, compare_tests)
-    sys.exit(0)
+    success = compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id, compare_tests)
+    sys.exit(0 if success else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################
 

--- a/scripts/Tools/compare_test_results
+++ b/scripts/Tools/compare_test_results
@@ -1,11 +1,19 @@
 #!/usr/bin/env python
 
-"""
-Analyze results from a test root area, comparing non-BFB
-changes. Purpose is, instead of re-running tests
-in compare mode, which is very slow, allow for very fast analsis of diffs.
+"""Analyze results from a test root area, comparing non-BFB changes.
+
+Purpose is, instead of re-running tests in compare mode, which is very slow,
+allow for very fast analsis of diffs.
+
+Outputs results for each test to stdout (one line per test); possible status
+codes are: PASS, FAIL, SKIP.
+
+In addition, creates files named compare.log.BASELINE_NAME.TIMESTAMP in each
+test directory, which contain more detailed output. Also creates
+*.cprnc.out.BASELINE_NAME.TIMESTAMP files in each run directory.
 
 You may need to load modules for cprnc to work.
+
 """
 
 from standard_script_setup import *

--- a/scripts/Tools/compare_test_results
+++ b/scripts/Tools/compare_test_results
@@ -87,8 +87,8 @@ def _main_func(description):
     baseline_name, baseline_root, test_root, compiler, test_id, compare_tests = \
         parse_command_line(sys.argv, description)
 
-    success = compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id, compare_tests)
-    sys.exit(0 if success else 1)
+    compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id, compare_tests)
+    sys.exit(0)
 
 ###############################################################################
 

--- a/tools/cprnc/summarize_cprnc_diffs
+++ b/tools/cprnc/summarize_cprnc_diffs
@@ -16,9 +16,13 @@ use List::Util qw(max sum);
 #----------------------------------------------------------------------
 
 my %opts;
+# set defaults
+$opts{'output_suffix'} = '';
+# set up options
 GetOptions(
            "basedir=s"       => \$opts{'basedir'},
            "testid=s"        => \$opts{'testid'},
+           "output_suffix=s" => \$opts{'output_suffix'},
            "narrow"          => \$opts{'narrow'},
            "h|help"          => \$opts{'help'},
 )  or usage();
@@ -53,9 +57,12 @@ if (!$opts{'testid'}) {
 #    FILLDIFF  => ' '                  [may or may not be present]
 #    DIMSIZEDIFF => ' '                [may or may not be present]
 my ($summary_hash) =
-   process_cprnc_output($opts{'basedir'}, $opts{'testid'});
+   process_cprnc_output($opts{'basedir'}, $opts{'testid'}, $opts{'output_suffix'});
 
 my $outbase="cprnc.summary.$opts{'testid'}";
+if ($opts{'output_suffix'}) {
+   $outbase = "$outbase.$opts{'output_suffix'}";
+}
 
 # set widths of output strings
 my $widths_hash;
@@ -93,9 +100,11 @@ SYNOPSIS
     The script finds all directories in basedir whose name ends with the given
     testid; these are the test directories of interest. It then examines the
     'run' subdirectory of each test directory of interest, looking for files of
-    the form *.base.cprnc.out. (Thus, note that it only looks at output for
-    baseline comparisons - NOT output from the test itself, such as cprnc output
-    files from the exact restart test.)
+    the form *.nc.cprnc.out. Or, if the -output_suffix argument is given, then
+    it looks for files of the form *.nc.cprnc.out.SUFFIX. (With this naming
+    convention [i.e., looking for files of the form *.nc.cprnc.out], note that
+    it only looks at output for baseline comparisons - NOT output from the test
+    itself, such as cprnc output files from the exact restart test.)
 
     Summaries of cprnc differences (normalized RMS differences, FILLDIFFs and DIMSIZEDIFFs)
     are placed in three output files beginning with the name 'cprnc.summary', in
@@ -105,10 +114,13 @@ SYNOPSIS
 
 
 OPTIONS
-    -narrow              Use generally-narrower output field widths to aid readability,
-                         at the expense of truncated strings
+    -output_suffix <suffix>  If provided, look for files of the form *.nc.cprnc.out.SUFFIX
+                             rather than just *.nc.cprnc.out
 
-    -help [or -h]        Display this help
+    -narrow                  Use generally-narrower output field widths to aid readability,
+                             at the expense of truncated strings
+
+    -help [or -h]            Display this help
 
 EOF
 }
@@ -119,10 +131,11 @@ EOF
 # Inputs:
 #  - basedir
 #  - testid
+#  - output_suffix
 # Output: hash reference
 # Dies with an error if no cprnc output files are found
 sub process_cprnc_output {
-   my ($basedir, $testid) = @_;
+   my ($basedir, $testid, $output_suffix) = @_;
 
    my %diffs;
    my $num_files = 0;
@@ -132,7 +145,13 @@ sub process_cprnc_output {
    foreach my $test_dir (@test_dirs) {
       my $test_dir_base = basename($test_dir);
 
-      my @cprnc_files = glob "${test_dir}/run/*.nc.cprnc.out";
+      my @cprnc_files;
+      if ($output_suffix) {
+         @cprnc_files = glob "${test_dir}/run/*.nc.cprnc.out.${output_suffix}";
+      }
+      else {
+         @cprnc_files = glob "${test_dir}/run/*.nc.cprnc.out";
+      }
 
       foreach my $cprnc_file (@cprnc_files) {
          my $cprnc_file_base = basename($cprnc_file);

--- a/utils/python/CIME/compare_test_results.py
+++ b/utils/python/CIME/compare_test_results.py
@@ -62,9 +62,5 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                         broken_compares.append((test_name, reason))
 
     # Make sure user knows that some tests were not compareed
-    success = True
     for broken_compare, reason in broken_compares:
         logging.warning("COMPARE FAILED FOR TEST: %s, reason %s" % (broken_compare, reason))
-        success = False
-
-    return success

--- a/utils/python/CIME/compare_test_results.py
+++ b/utils/python/CIME/compare_test_results.py
@@ -46,7 +46,9 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
         test_name = ts.get_name()
         if (compare_tests in [[], None] or CIME.utils.match_any(test_name, compare_tests)):
             CIME.utils.append_status(
-                msg = "Comparing against baseline with compare_test_results: %s"%(baseline_name),
+                msg = ("Comparing against baseline with compare_test_results:\n" +
+                       "Baseline: %s\n"%(baseline_name) +
+                       "In baseline_root: %s"%(baseline_root)),
                 caseroot = test_dir,
                 sfile = logfile_name)
 

--- a/utils/python/CIME/compare_test_results.py
+++ b/utils/python/CIME/compare_test_results.py
@@ -16,11 +16,8 @@ def compare_history(testcase_dir_for_test, baseline_name, baseline_root, log_id)
         outfile_suffix = "%s.%s"%(baseline_name, log_id)
         result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
                                             outfile_suffix=outfile_suffix)
-        if result:
-            return True, None
-        else:
-            logging.info(comments)
-            return False, "Diff'd"
+
+        return result, comments
 
 ###############################################################################
 def compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, compare_tests=None):

--- a/utils/python/CIME/compare_test_results.py
+++ b/utils/python/CIME/compare_test_results.py
@@ -9,11 +9,13 @@ from CIME.case import Case
 import os, glob
 
 ###############################################################################
-def compare_history(testcase_dir_for_test, baseline_name, baseline_root):
+def compare_history(testcase_dir_for_test, baseline_name, baseline_root, log_id):
 ###############################################################################
     with Case(testcase_dir_for_test) as case:
         baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
-        result, comments = compare_baseline(case, baseline_dir=baseline_full_dir)
+        outfile_suffix = "%s.%s"%(baseline_name, log_id)
+        result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
+                                            outfile_suffix=outfile_suffix)
         if result:
             return True, None
         else:
@@ -28,7 +30,8 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
     codes are: PASS, FAIL, SKIP
 
     In addition, creates files named compare.log.BASELINE_NAME.TIMESTAMP in each
-    test directory, which contain more detailed output
+    test directory, which contain more detailed output. Also creates
+    *.cprnc.out.BASELINE_NAME.TIMESTAMP files in each run directory.
     """
 ###############################################################################
     test_id_glob = "*%s*%s*" % (compiler, baseline_name) if test_id is None else "*%s" % test_id
@@ -68,7 +71,7 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
 
             if do_compare:
                 # Compare hist files
-                success, detailed_comments = compare_history(test_dir, baseline_name, baseline_root)
+                success, detailed_comments = compare_history(test_dir, baseline_name, baseline_root, log_id)
                 if success:
                     compare_result = TEST_PASS_STATUS
                 else:

--- a/utils/python/CIME/compare_test_results.py
+++ b/utils/python/CIME/compare_test_results.py
@@ -24,11 +24,17 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
     """Compares with baselines for all matching tests
 
     Outputs results for each test to stdout (one line per test); possible status
-    codes are: PASS, FAIL, SKIP
+    codes are: PASS, FAIL, SKIP. (A SKIP denotes a test that did not make it to
+    the run phase or a test for which the run phase did not pass: we skip
+    baseline comparisons in this case.)
 
     In addition, creates files named compare.log.BASELINE_NAME.TIMESTAMP in each
     test directory, which contain more detailed output. Also creates
     *.cprnc.out.BASELINE_NAME.TIMESTAMP files in each run directory.
+
+    Returns True if all tests generated either PASS or SKIP results, False if
+    there was at least one FAIL result.
+
     """
 ###############################################################################
     test_id_glob = "*%s*%s*" % (compiler, baseline_name) if test_id is None else "*%s" % test_id
@@ -39,6 +45,8 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
     # earlier files that may exist.
     log_id = CIME.utils.get_timestamp()
     logfile_name = "compare.log.%s.%s"%(baseline_name, log_id)
+
+    all_pass_or_skip = True
 
     for test_status_file in test_status_files:
         test_dir = os.path.dirname(test_status_file)
@@ -61,7 +69,7 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                 do_compare = False
             elif (run_result != TEST_PASS_STATUS):
                 compare_result = "SKIP"
-                compare_comment = "Test did not pass"
+                compare_comment = "Run phase did not pass"
                 do_compare = False
             else:
                 do_compare = True
@@ -73,6 +81,7 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                     compare_result = TEST_PASS_STATUS
                 else:
                     compare_result = TEST_FAIL_STATUS
+                    all_pass_or_skip = False
 
             brief_result = "%s %s %s"%(compare_result, test_name, BASELINE_PHASE)
             if compare_comment:
@@ -90,5 +99,5 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                     caseroot = test_dir,
                     sfile = logfile_name)
 
-
+    return all_pass_or_skip
 

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -884,12 +884,12 @@ class Q_TestBlessTestResults(TestCreateTestCommon):
         test_id = "%s-%s" % (self._baseline_name, CIME.utils.get_timestamp())
         self.simple_test(False, "%s -t %s" % (comparg, test_id))
 
-        # compare_test_results should detect the fail
+        # compare_test_results should run to completion
         cpr_cmd = "%s/compare_test_results -b %s -t %s 2>&1" % (TOOLS_DIR, self._baseline_name, test_id)
-        output = run_cmd_assert_result(self, cpr_cmd, expected_stat=1)
+        output = run_cmd_no_fail(cpr_cmd)
 
         # use regex
-        expected_pattern = re.compile(r'COMPARE FAILED FOR TEST: %s[^\s]* reason Diff' % self._test_name)
+        expected_pattern = re.compile(r'FAIL %s[^\s]* BASELINE' % self._test_name)
         the_match = expected_pattern.search(output)
         self.assertNotEqual(the_match, None,
                             msg="Cmd '%s' failed to display failed test in output:\n%s" % (cpr_cmd, output))

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -884,9 +884,9 @@ class Q_TestBlessTestResults(TestCreateTestCommon):
         test_id = "%s-%s" % (self._baseline_name, CIME.utils.get_timestamp())
         self.simple_test(False, "%s -t %s" % (comparg, test_id))
 
-        # compare_test_results should run to completion
+        # compare_test_results should detect the fail
         cpr_cmd = "%s/compare_test_results -b %s -t %s 2>&1" % (TOOLS_DIR, self._baseline_name, test_id)
-        output = run_cmd_no_fail(cpr_cmd)
+        output = run_cmd_assert_result(self, cpr_cmd, expected_stat=CIME.utils.TESTS_FAILED_ERR_CODE)
 
         # use regex
         expected_pattern = re.compile(r'FAIL %s[^\s]* BASELINE' % self._test_name)


### PR DESCRIPTION
Simplifies output sent to stdout from compare_test_results, for easier
parsing. Now each test outputs a single line to stdout, with a status
code of PASS, FAIL or SKIP. SKIP is given for tests that either didn't
have a RUN phase, or whose RUN phase didn't pass. The output format
essentially matches the BASELINE line in TestStatus - e.g.

FAIL SMS.f10_f10.ICLM45.yellowstone_intel.clm-default BASELINE [comment]

In addition, in each test compared, a new file is put in the test (i.e.,
case) directory: compare.log.BASELINE_NAME.TIMESTAMP. This file contains
extra details, similar to what is put in TestStatus.log during the main
run of the test suite. Also, in each run directory, cprnc output files
are created with names like *.nc.cprnc.out.BASELINE_NAME.TIMESTAMP. Note
that the suffix is added to prevent files from stomping on existing
files.

I have changed the return code from compare_test_results so that a
non-zero return code is only generated if the script exits
abnormally. In particular, it exits with a 0 return code if the script
succeeded but differences were found. Personally, I prefer if non-zero
return codes are reserved for cases where there was some real
failure. I can change this back if others prefer, although I don't love
the old behavior where (I think) a 1 return code was generated either
when differences were found or when the script exited abnormally: I feel
it's important to distinguish abnormal exits.

Test suite: scripts_regression_tests.py on yellowstone
   Also some manual testing
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #429

User interface changes?:
- Significant change in output format and return code from
  compare_test_results
- New -output_suffix argument to summarize_cprnc_diffs

Code review: 
