### PR TITLE
Switch to CISM2 by default

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -42,12 +42,12 @@
 
   <compset>
     <alias>B1850Ws</alias>
-    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD</lname>
+    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850</alias>
-    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <compset>
@@ -244,7 +244,7 @@
 
   <compset>
     <alias>BC5L45BGCRG</alias>
-    <lname>2000_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM1_SWAV</lname>
+    <lname>2000_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM2_SWAV</lname>
   </compset>
 
   <compset>
@@ -253,10 +253,17 @@
   </compset>
 
   <compset>
-    <alias>B1850C5L45BGCRG2</alias>
+    <alias>B1850C5L45BGCRG</alias>
     <lname>1850_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM2_SWAV</lname>
   </compset>
 
+  <!-- Include one CISM1 compset, mainly for testing purposes, to make sure that
+       CISM1 can operate in a fully-coupled configuration. Main point is to
+       check the PE layout. -->
+  <compset>
+    <alias>B1850C5L45BGCRG1</alias>
+    <lname>1850_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM1_SWAV</lname>
+  </compset>
 
   <!-- Prognostic wave -->
 
@@ -283,7 +290,7 @@
        Used for spinup and testing of CISM couplings -->
 
   <compset>
-     <alias>J1850G2</alias>
+     <alias>J1850G</alias>
      <lname>1850_DATM%CRU_CLM50%BGC_CICE_POP2_MOSART_CISM2_SWAV</lname>
   </compset>
 

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -334,7 +334,7 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850C5L45BGCRG2" testmods="allactive/defaultio">
+  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850C5L45BGCRG" testmods="allactive/defaultio">
     <machines>
       <machine name="yellowstone" compiler="intel" category="prealpha"/>
       <machine name="yellowstone" compiler="intel" category="prebeta"/>
@@ -342,6 +342,16 @@
     <options>
       <option name="wallclock"> 00:20 </option>
     </options>
+  </test>
+  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850C5L45BGCRG1" testmods="allactive/defaultio">
+    <machines>
+      <machine name="yellowstone" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">0:20</option>
+          <option name="comment">Include a fully-coupled test with CISM1, mainly to make sure the PE layout works</option>
+        </options>
+      </machine>
+    </machines>
   </test>
   <test name="SMS_Ld5" grid="T31_g37_gl20" compset="BC5L45BGCRG" testmods="allactive/defaultio">
     <machines>
@@ -359,7 +369,7 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="f09_g16_gl4" compset="J1850G2" testmods="allactive/defaultio">
+  <test name="SMS_Ld5" grid="f09_g16_gl4" compset="J1850G" testmods="allactive/defaultio">
     <machines>
       <machine name="yellowstone" compiler="gnu" category="prebeta"/>
     </machines>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -3260,9 +3260,6 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>never</default_value>
-    <values>
-      <value compset="CISM\d">nyears</value>
-    </values>
     <group>run_drv_history</group>
     <file>env_run.xml</file>
     <desc>Sets driver snapshot history file frequency (like REST_OPTION)</desc>
@@ -3272,9 +3269,6 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>-999</default_value>
-    <values>
-      <value compset="CISM\d">1</value>
-    </values>
     <group>run_drv_history</group>
     <file>env_run.xml</file>
     <desc>Sets driver snapshot history file frequency (like REST_N)


### PR DESCRIPTION
Changes allactive compsets that use CISM to use CISM2 rather than CISM1
by default. CISM1 is now denoted with G1 (in contrast to the earlier
behavior, where G meant CISM1 and G2 meant CISM2).

Also, an unrelated change: no longer set HIST_OPTION / HIST_N to 1 year
for compsets with CISM. This was needed until 6-12 months ago because
CISM's history frequency keyed off of the coupler's history frequency,
but it is no longer needed now that CISM has its own history frequency.

Test suite:
  SMS_Ld5.T31_g37_gl20.B1850C5L45BGCRG1.yellowstone_gnu.allactive-defaultio
  ERS_Ld7.f19_g16.B1850.yellowstone_intel.allactive-defaultio
Test baseline: N/A
Test namelist changes: YES - tests that now use CISM2 rather than CISM1
  will have namelist differences
Test status: climate changing for configurations that now use CISM2
  rather than CISM1

  Specifically: will change answers for B1850Ws, B1850, BC5L45BGCRG (now
  use CISM2 rather than CISM1); will BFAIL for B1850C5L45BGCRG,
  B1850C5L45BGCRG1, J1850G (these compsets didn't exist before)

Fixes: none

User interface changes?: compsets that use CISM now use CISM2 rather
than CISM1 by default

Code review: 
