### PR TITLE
user_mods ran through xmlchange in the wrong order

### DIFF
--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -63,8 +63,17 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
             case_shell_commands = shell_commands_file.replace(include_dir, caseroot)
             with open(shell_commands_file,"r") as fd:
                 new_shell_commands = fd.read().replace("xmlchange","xmlchange --force")
-            with open(case_shell_commands, "a") as fd:
+            # prepend new_shell_commands to case_shell_commands file
+            old_shell_commands = None
+            if os.path.isfile(case_shell_commands):
+                with open(case_shell_commands, "r") as fd:
+                    old_shell_commands = fd.read()
+                    fd.close()
+            with open(case_shell_commands, "w") as fd:
                 fd.write(new_shell_commands)
+                if old_shell_commands is not None:
+                    fd.write(old_shell_commands)
+                fd.close()
 
     for shell_command_file in case_shell_command_files:
         if os.path.isfile(shell_command_file):


### PR DESCRIPTION
Reverse the order that `xmlchange` commands are called

Test suite: none, just tested by hand
Test baseline: n/a
Test namelist changes: none
Test status: should be bit-for-bit unless there is a test dependency that is currently being mishandled

Fixes #756

User interface changes?: None

Code review: (assigning to Jim and Bill because they seem more familiar than me with python in general and the cime scripts in particular)

If test A depends on test B, and both run xmlchange on the same variable, then
the expected behavior is that the value set by test A would overwrite the value
set by test B. Unfortunately, that was not the case... the value from test B
would overwrite test A. This commit fixes that.