### PR TITLE
Another possible fix to #756

### DIFF
--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -66,6 +66,11 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
                               glob.glob(os.path.join(include_dir,"xmlchange_cmnds"))
         for shell_commands_file in shell_command_files:
             case_shell_commands = shell_commands_file.replace(include_dir, caseroot)
+            # add commands from both shell_commands and xmlchange_cmnds to
+            # the same file (caseroot/shell_commands)
+            # Note that use of xmlchange_cmnds has been deprecated and will soon
+            # be removed altogether, so new tests should rely on shell_commands
+            case_shell_commands = case_shell_commands.replace("xmlchange_cmnds","shell_commands")
             with open(shell_commands_file,"r") as fd:
                 new_shell_commands = fd.read().replace("xmlchange","xmlchange --force")
             with open(case_shell_commands, "a") as fd:

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -56,6 +56,8 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
                             expect(False, "Could not write file %s in caseroot %s"
                                    %(case_source_mods,caseroot))
 
+    include_dirs.reverse()
+    for include_dir in include_dirs:
         # create xmlchange_cmnds and shell_commands in caseroot
         shell_command_files = glob.glob(os.path.join(include_dir,"shell_commands")) +\
                               glob.glob(os.path.join(include_dir,"xmlchange_cmnds"))

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -68,9 +68,13 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
             case_shell_commands = shell_commands_file.replace(include_dir, caseroot)
             # add commands from both shell_commands and xmlchange_cmnds to
             # the same file (caseroot/shell_commands)
+            case_shell_commands = case_shell_commands.replace("xmlchange_cmnds","shell_commands")
             # Note that use of xmlchange_cmnds has been deprecated and will soon
             # be removed altogether, so new tests should rely on shell_commands
-            case_shell_commands = case_shell_commands.replace("xmlchange_cmnds","shell_commands")
+            if shell_commands_file.endswith("xmlchange_cmnds"):
+                logger.warn("xmlchange_cmnds is deprecated and will be removed " +\
+                            "in a future release; please rename this file " +\
+                            "shell_commands")
             with open(shell_commands_file,"r") as fd:
                 new_shell_commands = fd.read().replace("xmlchange","xmlchange --force")
             with open(case_shell_commands, "a") as fd:

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -56,6 +56,9 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
                             expect(False, "Could not write file %s in caseroot %s"
                                    %(case_source_mods,caseroot))
 
+    # Reverse include_dirs to make sure xmlchange commands are called in the
+    # correct order; it may be desireable to reverse include_dirs above the
+    # previous loop and then append user_nl changes rather than prepend them.
     include_dirs.reverse()
     for include_dir in include_dirs:
         # create xmlchange_cmnds and shell_commands in caseroot

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -73,8 +73,8 @@ def apply_user_mods(caseroot, user_mods_path, ninst=None):
             # be removed altogether, so new tests should rely on shell_commands
             if shell_commands_file.endswith("xmlchange_cmnds"):
                 logger.warn("xmlchange_cmnds is deprecated and will be removed " +\
-                            "in a future release; please rename this file " +\
-                            "shell_commands")
+                            "in a future release; please rename %s shell_commands" %\
+                            shell_commands_file)
             with open(shell_commands_file,"r") as fd:
                 new_shell_commands = fd.read().replace("xmlchange","xmlchange --force")
             with open(case_shell_commands, "a") as fd:


### PR DESCRIPTION
Reverse the order that xmlchange commands are called (pick this PR or #757 not both)

Test suite: none, just tested by hand
Test baseline: n/a
Test namelist changes: none
Test status: should be bit-for-bit unless there is a test dependency that is currently being mishandled

Fixes #756

User interface changes?: None

Code review: (assigning to Jim and Bill because they seem more familiar than me with python in general and the cime scripts in particular)


If test A depends on test B, and both change the same XML variable, expected
behavior is for test A's value to take precedence.