### PR TITLE
Ensure all of CIME is using the GMAKE case setting

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -288,7 +288,7 @@
 >
     <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
     <SUPPORTED_BY>jnjohnson at lbl dot gov</SUPPORTED_BY>
-<!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
+    <GMAKE>make</GMAKE>
     <GMAKE_J>4</GMAKE_J>
     <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>2</PES_PER_NODE>
@@ -310,7 +310,7 @@
     <!-- cmake -DCMAKE_Fortran_COMPILER=/opt/local/bin/mpif90-mpich-gcc48 -DHDF5_DIR=/opt/local -DNetcdf_INCLUDE_DIR=/opt/local/include .. -->>
     <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
     <SUPPORTED_BY>jayesh at mcs dot anl dot gov</SUPPORTED_BY>
-<!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
+    <GMAKE>make</GMAKE>
     <GMAKE_J>4</GMAKE_J>
     <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>2</PES_PER_NODE>
@@ -339,7 +339,7 @@
     <SAVE_TIMING_DIR>/sems-data-store/ACME/timings</SAVE_TIMING_DIR>
     <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build/cprnc</CCSM_CPRNC>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
-<!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
+    <GMAKE>make</GMAKE>
     <GMAKE_J>32</GMAKE_J>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>64</PES_PER_NODE>
@@ -393,7 +393,7 @@
     <SAVE_TIMING_DIR>/sems-data-store/ACME/timings</SAVE_TIMING_DIR>
     <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build/cprnc</CCSM_CPRNC>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
-<!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
+    <GMAKE>make</GMAKE>
     <GMAKE_J>32</GMAKE_J>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>64</PES_PER_NODE>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -775,7 +775,7 @@
     <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build/cprnc</CCSM_CPRNC>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
-<!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
+    <GMAKE>make</GMAKE>
     <GMAKE_J>32</GMAKE_J>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>32</PES_PER_NODE>

--- a/utils/python/CIME/SystemTests/homme.py
+++ b/utils/python/CIME/SystemTests/homme.py
@@ -28,12 +28,13 @@ class HOMME(SystemTestsCommon):
             basegen  = self._case.get_value("BASEGEN_CASE")
             basecmp  = self._case.get_value("BASECMP_CASE")
             generate = self._case.get_value("GENERATE_BASELINE")
+            gmake    = self._case.get_value("GMAKE")
 
             basename = basegen if generate else basecmp
             cmake_cmd = "cmake -C %s/components/homme/cmake/machineFiles/%s.cmake -DUSE_NUM_PROCS=%s %s/components/homme -DHOMME_BASELINE_DIR=%s/%s >& homme.bldlog" % (srcroot, mach, procs, srcroot, baseline, basename)
 
             run_cmd_no_fail(cmake_cmd, from_dir=exeroot)
-            run_cmd_no_fail("make -j8 >> homme.bldlog 2>&1", from_dir=exeroot)
+            run_cmd_no_fail("%s -j8 >> homme.bldlog 2>&1" % gmake, from_dir=exeroot)
 
             post_build(self._case, [os.path.join(exeroot, "homme.bldlog")])
 
@@ -45,6 +46,7 @@ class HOMME(SystemTestsCommon):
         compare  = self._case.get_value("COMPARE_BASELINE")
         generate = self._case.get_value("GENERATE_BASELINE")
         basegen  = self._case.get_value("BASEGEN_CASE")
+        gmake    = self._case.get_value("GMAKE")
 
         log = os.path.join(rundir, "homme.log")
         if os.path.exists(log):
@@ -52,11 +54,11 @@ class HOMME(SystemTestsCommon):
 
         if generate:
             full_baseline_dir = os.path.join(baseline, basegen, "tests", "baseline")
-            run_cmd_no_fail("make -j 4 baseline >& %s" % log, from_dir=exeroot)
+            run_cmd_no_fail("%s -j 4 baseline >& %s" % (gmake, log), from_dir=exeroot)
             if os.path.isdir(full_baseline_dir):
                 shutil.rmtree(full_baseline_dir)
             shutil.copytree(os.path.join(exeroot, "tests", "baseline"), full_baseline_dir)
         elif compare:
-            run_cmd_no_fail("make -j 4 check >& %s" % log, from_dir=exeroot)
+            run_cmd_no_fail("%s -j 4 check >& %s" % (gmake, log), from_dir=exeroot)
         else:
-            run_cmd_no_fail("make -j 4 baseline >& %s" % log, from_dir=exeroot)
+            run_cmd_no_fail("%s -j 4 baseline >& %s" % (gmake, log), from_dir=exeroot)


### PR DESCRIPTION
... versus hardcoded usage of gmake or make. It appears that only
the homme test case was using a hardcoded make. I did several rounds
of grepping and am reasonably confident I caught them all.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #618

User interface changes?: None

Code review: jedwards