### PR TITLE
minor bug fix to restart pattern match for datm suffix

### DIFF
--- a/cime_config/acme/config_archive.xml
+++ b/cime_config/acme/config_archive.xml
@@ -12,7 +12,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="datm" compclass="atm">
-    <rest_file_extension>\.r\..*</rest_file_extension>
+    <rest_file_extension>\.r.*</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.atm</rpointer_file>

--- a/cime_config/cesm/config_archive.xml
+++ b/cime_config/cesm/config_archive.xml
@@ -12,7 +12,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="datm" compclass="atm">
-    <rest_file_extension>\.r\..*</rest_file_extension>
+    <rest_file_extension>\.r.*</rest_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.atm</rpointer_file>


### PR DESCRIPTION

Test suite: A compset, 5 day run with 1 day interim restarts saved
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes [CIME Github issue #] #744

User interface changes?: none

Code review: 