### PR TITLE
build exe in correct location

### DIFF
--- a/driver_cpl/cime_config/buildexe
+++ b/driver_cpl/cime_config/buildexe
@@ -20,10 +20,10 @@ logger = logging.getLogger(__name__)
 def _main_func():
 ###############################################################################
 
-    caseroot, bldroot, libroot = parse_input(sys.argv)
+    caseroot, libroot, _ = parse_input(sys.argv)
 
     logger.info("Building a single executable version of target coupled model")
-    os.chdir(bldroot)
+
     with Case(caseroot) as case:
         casetools = case.get_value("CASETOOLS")
         cimeroot  = case.get_value("CIMEROOT")
@@ -48,7 +48,7 @@ def _main_func():
     rc, out, err = run_cmd(cmd)
     expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
     logger.info(out)
-    os.chdir(caseroot)
+
 ###############################################################################
 
 if __name__ == "__main__":

--- a/driver_cpl/cime_config/buildexe
+++ b/driver_cpl/cime_config/buildexe
@@ -20,10 +20,10 @@ logger = logging.getLogger(__name__)
 def _main_func():
 ###############################################################################
 
-    caseroot, libroot, _ = parse_input(sys.argv)
+    caseroot, bldroot, libroot = parse_input(sys.argv)
 
     logger.info("Building a single executable version of target coupled model")
-
+    os.chdir(bldroot)
     with Case(caseroot) as case:
         casetools = case.get_value("CASETOOLS")
         cimeroot  = case.get_value("CIMEROOT")
@@ -48,6 +48,7 @@ def _main_func():
     rc, out, err = run_cmd(cmd)
     expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
     logger.info(out)
+    os.chdir(caseroot)
 ###############################################################################
 
 if __name__ == "__main__":

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -94,8 +94,9 @@ def build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
 
     config_dir = os.path.join(cimeroot, "driver_cpl", "cime_config")
     f = open(file_build, "w")
+    bldroot = os.path.join(exeroot, "cpl", "obj")
     stat = run_cmd("%s/buildexe %s %s %s" %
-                   (config_dir, caseroot, bldroot, libroot),
+                   (config_dir, caseroot, libroot, bldroot),
                    from_dir=bldroot, verbose=True, arg_stdout=f,
                    arg_stderr=subprocess.STDOUT)[0]
     f.close()

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -59,7 +59,7 @@ def build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
         # thread_bad_results captures error output from thread (expected to be empty)
         # logs is a list of log files to be compressed and added to the case logs/bld directory
         t = threading.Thread(target=_build_model_thread,
-            args=(config_dir, model, caseroot, bldroot, libroot, incroot, file_build,
+            args=(config_dir, model, caseroot, libroot, bldroot, incroot, file_build,
                   thread_bad_results, smp, compiler))
         t.start()
 
@@ -80,7 +80,7 @@ def build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
             logger.debug("Now build aquap ocn component")
             # thread_bad_results captures error output from thread (expected to be empty)
             # logs is a list of log files to be compressed and added to the case logs/bld directory
-            _build_model_thread(config_dir, comp, caseroot, bldroot, libroot, incroot, file_build,
+            _build_model_thread(config_dir, comp, caseroot, libroot, bldroot, incroot, file_build,
                                 thread_bad_results, smp, compiler)
             logs.append(file_build)
     expect(not thread_bad_results, "\n".join(thread_bad_results))
@@ -474,7 +474,7 @@ def build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid,
         # thread_bad_results captures error output from thread (expected to be empty)
         # logs is a list of log files to be compressed and added to the case logs/bld directory
         thread_bad_results = []
-        _build_model_thread(config_lnd_dir, "lnd", caseroot, bldroot, libroot, incroot,
+        _build_model_thread(config_lnd_dir, "lnd", caseroot, libroot, bldroot, incroot,
                             file_build, thread_bad_results, smp, compiler)
         logs.append(file_build)
         expect(not thread_bad_results, "\n".join(thread_bad_results))
@@ -482,7 +482,7 @@ def build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid,
     return logs
 
 ###############################################################################
-def _build_model_thread(config_dir, compclass, caseroot, bldroot, libroot, incroot, file_build,
+def _build_model_thread(config_dir, compclass, caseroot, libroot, bldroot, incroot, file_build,
                         thread_bad_results, smp, compiler):
 ###############################################################################
     with open(file_build, "w") as fd:

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -487,7 +487,7 @@ def _build_model_thread(config_dir, compclass, caseroot, bldroot, libroot, incro
 ###############################################################################
     with open(file_build, "w") as fd:
         stat = run_cmd("MODEL=%s SMP=%s %s/buildlib %s %s %s " %
-                       (compclass, stringify_bool(smp), config_dir, caseroot, bldroot, libroot),
+                       (compclass, stringify_bool(smp), config_dir, caseroot, libroot, bldroot),
                        from_dir=bldroot, verbose=True, arg_stdout=fd,
                        arg_stderr=subprocess.STDOUT)[0]
     analyze_build_log(compclass, file_build, compiler)

--- a/utils/python/CIME/buildlib.py
+++ b/utils/python/CIME/buildlib.py
@@ -24,12 +24,11 @@ def parse_input(argv):
     parser.add_argument("caseroot", default=os.getcwd(),
                         help="Case directory")
 
-    # JGF: This doesn't appear to be used anywhere
-    parser.add_argument("bldroot",
-                        help="root for building library")
-
     parser.add_argument("libroot",
                         help="root for creating the library")
+
+    parser.add_argument("bldroot",
+                        help="root for building library")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Corrects a problem which caused the driver coupler code to get built in the esp directory

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #753 

User interface changes?: 

Code review: 

