### PR TITLE
only put caseroot file in bld and run dirs

### DIFF
--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -34,8 +34,11 @@ def create_dirs(case):
                 os.makedirs(dir_to_make)
             except OSError as e:
                 expect(False, "Could not make directory '%s', error: %s" % (dir_to_make, e))
-            with open(os.path.join(dir_to_make,"CASEROOT"),"w+") as fd:
-                fd.write(caseroot+"\n")
+
+    # As a convenience write the location of the case directory in the bld and run directories
+    for dir_ in (exeroot, rundir):
+        with open(os.path.join(dir_,"CASEROOT"),"w+") as fd:
+            fd.write(caseroot+"\n")
 
 def create_namelists(case):
 


### PR DESCRIPTION
The CASEROOT file was being created in too many places and this was having unintended side effects.  Only create CASEROOT in bld and run directories.

Test suite: scripts_regression_tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 

