### PR TITLE
detect netcdf4 correctly in pio1

### DIFF
--- a/cime_config/buildlib.pio
+++ b/cime_config/buildlib.pio
@@ -95,7 +95,7 @@ def _main_func(description):
                         shutil.copy2(item, "%s/include"%installpath)
             expect_string = "D_NETCDF;"
             pnetcdf_string = "D_PNETCDF"
-            netcdf4_string = "D_NETCDF4P"
+            netcdf4_string = "D_NETCDF4"
         else:
             globs_to_copy = (os.path.join("src","clib","libpioc.*"),
                              os.path.join("src","flib","libpiof.*"),


### PR DESCRIPTION
Fix issue in detecting netcdf4 build in pio1. 

Test suite: tested by hand, create a case, xmlchange pio_typename=netcdf4p build the case, xmlquery pio_typename 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #768 

User interface changes?: 

Code review: 

