### PR TITLE
Cori port2a

### DIFF
--- a/cime_config/cesm/machines/config_batch.xml
+++ b/cime_config/cesm/machines/config_batch.xml
@@ -366,7 +366,7 @@
      </directives>
      <queues>
        <queue walltimemax="06:00:00" jobmin="1" jobmax="45440">regular</queue>
-       <queue walltimemax="00:30:00" jobmin="1" jobmax="3072" default="true">debug</queue>
+     <!--  <queue walltimemax="00:30:00" jobmin="1" jobmax="3072" default="true">debug</queue> -->
      </queues>
    </batch_system>
 

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -395,7 +395,7 @@
       <env name="OMP_STACKSIZE">256M</env>
     </environment_variables>
   </machine>
-  <machine MACH="corip2">
+  <machine MACH="cori-knl">
     <DESC>NERSC XC* KNL, os is CNL, 68 pes/node, batch system is Slurm</DESC>
     <COMPILERS>intel,gnu,cray</COMPILERS>
     <MPILIBS>mpt,mpi-serial</MPILIBS>

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -5,7 +5,7 @@ All interaction with and between the module files in XML/ takes place
 through the Case module.
 """
 from copy   import deepcopy
-import glob, os, shutil, traceback
+import glob, os, shutil, traceback, math
 from CIME.XML.standard_module_setup import *
 
 from CIME.utils                     import expect, get_cime_root, append_status
@@ -110,10 +110,10 @@ class Case(object):
         """
         env_mach_pes = self.get_env("mach_pes")
         comp_classes = self.get_values("COMP_CLASSES")
-        total_tasks = self.get_value("TOTALPES")
+        total_tasks = env_mach_pes.get_total_tasks(comp_classes)
         self.thread_count = env_mach_pes.get_max_thread_count(comp_classes)
         self.tasks_per_node = env_mach_pes.get_tasks_per_node(total_tasks, self.thread_count)
-        
+        logger.warn("total_tasks %s thread_count %s"%(total_tasks, self.thread_count))
         self.num_nodes = env_mach_pes.get_total_nodes(total_tasks, self.thread_count)
         self.tasks_per_numa = int(math.ceil(self.tasks_per_node / 2.0))
         smt_factor = self.get_value("MAX_TASKS_PER_NODE")/self.get_value("PES_PER_NODE")

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -792,6 +792,8 @@ def transform_vars(text, case=None, subgroup=None, check_members=None, default=N
     directive_re = re.compile(r"{{ (\w+) }}", flags=re.M)
     # loop through directive text, replacing each string enclosed with
     # template characters with the necessary values.
+    if check_members is None and case is not None:
+        check_members = case
     while directive_re.search(text):
         m = directive_re.search(text)
         variable = m.groups()[0]


### PR DESCRIPTION
Port to corip1, make it easier to understand what fields are available for batch and mpirun commands.  Fix issue with erio test. 

Test suite:  scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Code review: 
