### PR TITLE
fix erio test,and a minor format change for cray compiler

### DIFF
--- a/share/csm_share/shr/shr_strdata_mod.F90
+++ b/share/csm_share/shr/shr_strdata_mod.F90
@@ -1184,7 +1184,7 @@ subroutine shr_strdata_readnml(SDAT,file,rc,mpicom)
          read (nUnit, nml=shr_strdata_nml, iostat=rCode)
          if (rCode /= 0) then
             write(logunit,F01) 'ERROR: reading input namelist shr_strdata_input from file, &
-                 '//trim(file)//' iostat=',rCode
+                 &'//trim(file)//' iostat=',rCode
             call shr_sys_abort(subName//": namelist read error "//trim(file))
          end if
       end if


### PR DESCRIPTION
Fix issues with erio test.  Minor formating change for cray compiler

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 

