### PR TITLE
Cleanup ESMF output in model.log

### DIFF
--- a/share/esmf_wrf_timemgr/ESMF_TimeMod.F90
+++ b/share/esmf_wrf_timemgr/ESMF_TimeMod.F90
@@ -836,7 +836,7 @@ recursive subroutine ESMF_TimeGet(time, YY, MM, DD, D, Dl, H, M, S, MS, &
 !$$$here...  add negative sign for YR<0
 !$$$here...  add Sn, Sd ??
       write(TimeFormatString,FMT="(A,I4.4,A,I4.4,A)") &
-           "(I", yearWidth, ".", yearWidth, "'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2,':',I2.2)"
+           "(I", yearWidth, ".", yearWidth, ",'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2,':',I2.2)"
       write(TimeString,FMT=TimeFormatString) year,month,dayofmonth,hour,minute,second
 
       end subroutine ESMFold_TimeGetString


### PR DESCRIPTION
Cleanup the ESMF output in acme/cesm log

Each MPI rank on Mira is printing messages of the form

"cime/share/esmf_wrf_timemgr/ESMF_TimeMod.F90", line 840: 1525-076 A
comma was expected after the I edit descriptor in a format
specification.  The program will recover by assuming a comma."

This can extend to 50K such lines in a 68K line cesm.log file.
The issue is format specification
- (I0004.0004'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2,':',I2.2)
which should be
- (I0004.0004,'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2,':',I2.2)
to avoid the warning message.

Fix provided by Azamat Mametjanov

[BFB] - Bit-For-Bit