### PR TITLE
In compare_test_results: print the comment from comparison if it's brief

### DIFF
--- a/utils/python/CIME/compare_test_results.py
+++ b/utils/python/CIME/compare_test_results.py
@@ -83,6 +83,12 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                     compare_result = TEST_FAIL_STATUS
                     all_pass_or_skip = False
 
+                # Following the logic in SystemTestsCommon._compare_baseline:
+                # We'll print the comment if it's a brief one-liner; otherwise
+                # the comment will only appear in the log file
+                if "\n" not in detailed_comments:
+                    compare_comment = detailed_comments
+
             brief_result = "%s %s %s"%(compare_result, test_name, BASELINE_PHASE)
             if compare_comment:
                 brief_result += " %s"%(compare_comment)


### PR DESCRIPTION
In compare_test_results: print the comment from comparison if it's a brief one-liner

This matches the behavior of an in-test baseline comparison

Test suite: scripts_regression_tests.py Q_TestBlessTestResults on yellowstone
   Also manual test of compare_test_results
Test baseline: N/A
Test namelist changes: N/A
Test status: N/A

Fixes: None

User interface changes?: Minor changes to output of compare_test_results

Code review: