### PR TITLE
Allow modification of vmag with gustiness

### DIFF
--- a/driver_cpl/bld/build-namelist
+++ b/driver_cpl/bld/build-namelist
@@ -412,6 +412,7 @@ if (defined $xmlvars{'CPL_EPBAL'}) {
     add_default($nl, 'flux_epbal', 'val'=>"off");
 }
 add_default($nl, 'flux_diurnal');
+add_default($nl, 'gust_fac');
 
 add_default($nl, 'info_debug');
 add_default($nl, 'cpl_decomp');

--- a/driver_cpl/bld/namelist_files/namelist_defaults_drv.xml
+++ b/driver_cpl/bld/namelist_files/namelist_defaults_drv.xml
@@ -108,6 +108,7 @@
 <wall_time_limit>-1.0</wall_time_limit>
 <force_stop_at>month</force_stop_at>
 <flux_diurnal>.false.</flux_diurnal>
+<gust_fac>0.0D0</gust_fac>
 
 <run_barriers COMP_RUN_BARRIERS="TRUE">.true.</run_barriers>
 <run_barriers COMP_RUN_BARRIERS="FALSE">.false.</run_barriers>

--- a/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
+++ b/driver_cpl/bld/namelist_files/namelist_definition_drv.xml
@@ -487,6 +487,15 @@ default: false
 </entry>
 
 <entry
+id="gust_fac"
+type="real"
+category="control"
+group="seq_infodata_inparm">
+wind gustiness factor
+default: 0.0D0
+</entry>
+
+<entry
 id="atm_gnam"
 type="char*64"
 category="mapping"

--- a/driver_cpl/shr/seq_infodata_mod.F90
+++ b/driver_cpl/shr/seq_infodata_mod.F90
@@ -107,6 +107,7 @@ MODULE seq_infodata_mod
       character(SHR_KIND_CL)  :: flux_epbal      ! selects E,P,R adjustment technique
       logical                 :: flux_albav      ! T => no diurnal cycle in ocn albedos
       logical                 :: flux_diurnal    ! T => diurnal cycle in atm/ocn fluxes
+      real(SHR_KIND_R8)       :: gust_fac        ! wind gustiness factor
       real(SHR_KIND_R8)       :: wall_time_limit ! force stop time limit (hours)
       character(SHR_KIND_CS)  :: force_stop_at   ! when to force a stop (month, day, etc)
       character(SHR_KIND_CL)  :: atm_gnam        ! atm grid
@@ -336,6 +337,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
     character(SHR_KIND_CL) :: flux_epbal         ! selects E,P,R adjustment technique
     logical                :: flux_albav         ! T => no diurnal cycle in ocn albedos
     logical                :: flux_diurnal       ! T => diurnal cycle in atm/ocn fluxes
+    real(SHR_KIND_R8)      :: gust_fac           ! wind gustiness factor
     real(SHR_KIND_R8)      :: wall_time_limit    ! force stop time limit (hours)
     character(SHR_KIND_CS) :: force_stop_at      ! when to force a stop (month, day, etc)
     character(SHR_KIND_CL) :: atm_gnam           ! atm grid
@@ -397,7 +399,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
          brnch_retain_casename, info_debug, bfbflag,       &
          restart_pfile, restart_file, run_barriers,        &
          single_column, scmlat, force_stop_at,             &
-         scmlon, logFilePostFix, outPathRoot, flux_diurnal,&
+         scmlon, logFilePostFix, outPathRoot, flux_diurnal, gust_fac,&
          perpetual, perpetual_ymd, flux_epbal, flux_albav, &
          orb_iyear_align, orb_mode, wall_time_limit,       &
          orb_iyear, orb_obliq, orb_eccen, orb_mvelp,       &
@@ -473,6 +475,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        flux_epbal            = 'off'
        flux_albav            = .false.
        flux_diurnal          = .false.
+       gust_fac              = huge(1.0_SHR_KIND_R8)
        wall_time_limit       = -1.0
        force_stop_at         = 'month'
        atm_gnam              = 'undefined'
@@ -576,6 +579,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        infodata%flux_epbal            = flux_epbal
        infodata%flux_albav            = flux_albav
        infodata%flux_diurnal          = flux_diurnal
+       infodata%gust_fac              = gust_fac
        infodata%wall_time_limit       = wall_time_limit
        infodata%force_stop_at         = force_stop_at
        infodata%atm_gnam              = atm_gnam
@@ -866,7 +870,7 @@ SUBROUTINE seq_infodata_GetData_explicit( infodata, case_name, case_desc, timing
            shr_map_dopole, vect_map, aoflux_grid, flux_epbalfact,             &
            nextsw_cday, precip_fact, flux_epbal, flux_albav, glcrun_alarm,    &
            glc_g2lupdate, atm_aero, run_barriers, esmf_map_flag,              &
-           do_budgets, do_histinit, drv_threading, flux_diurnal,              &
+           do_budgets, do_histinit, drv_threading, flux_diurnal, gust_fac,    &
            budget_inst, budget_daily, budget_month, wall_time_limit,          &
            budget_ann, budget_ltann, budget_ltend , force_stop_at,            &
            histaux_a2x    , histaux_a2x3hr, histaux_a2x3hrp , histaux_l2x1yr, &
@@ -934,6 +938,7 @@ SUBROUTINE seq_infodata_GetData_explicit( infodata, case_name, case_desc, timing
    character(len=*)    ,optional, intent(OUT) :: flux_epbal    ! selects E,P,R adjustment technique
    logical             ,optional, intent(OUT) :: flux_albav    ! T => no diurnal cycle in ocn albedos
    logical             ,optional, intent(OUT) :: flux_diurnal  ! T => diurnal cycle in atm/ocn flux
+   real(SHR_KIND_R8)   ,optional, intent(OUT) :: gust_fac      ! wind gustiness factor
    real(SHR_KIND_R8)   ,optional, intent(OUT) :: wall_time_limit ! force stop wall time (hours)
    character(len=*)    ,optional, intent(OUT) :: force_stop_at ! force stop at next (month, day, etc)
    character(len=*)    ,optional, intent(OUT) :: atm_gnam      ! atm grid
@@ -1096,6 +1101,7 @@ SUBROUTINE seq_infodata_GetData_explicit( infodata, case_name, case_desc, timing
     if ( present(flux_epbal)     ) flux_epbal     = infodata%flux_epbal
     if ( present(flux_albav)     ) flux_albav     = infodata%flux_albav
     if ( present(flux_diurnal)   ) flux_diurnal   = infodata%flux_diurnal
+    if ( present(gust_fac)       ) gust_fac       = infodata%gust_fac
     if ( present(wall_time_limit)) wall_time_limit= infodata%wall_time_limit
     if ( present(force_stop_at)  ) force_stop_at  = infodata%force_stop_at
     if ( present(atm_gnam)       ) atm_gnam       = infodata%atm_gnam
@@ -1346,7 +1352,7 @@ SUBROUTINE seq_infodata_PutData_explicit( infodata, case_name, case_desc, timing
            shr_map_dopole, vect_map, aoflux_grid, run_barriers,               &
            nextsw_cday, precip_fact, flux_epbal, flux_albav, glcrun_alarm,    &
            glc_g2lupdate, atm_aero, esmf_map_flag, wall_time_limit,           &
-           do_budgets, do_histinit, drv_threading, flux_diurnal,              &
+           do_budgets, do_histinit, drv_threading, flux_diurnal, gust_fac,    &
            budget_inst, budget_daily, budget_month, force_stop_at,            &
            budget_ann, budget_ltann, budget_ltend ,                           &
            histaux_a2x    , histaux_a2x3hr, histaux_a2x3hrp , histaux_l2x1yr, &
@@ -1413,6 +1419,7 @@ SUBROUTINE seq_infodata_PutData_explicit( infodata, case_name, case_desc, timing
    character(len=*)    ,optional, intent(IN) :: flux_epbal    ! selects E,P,R adjustment technique
    logical             ,optional, intent(IN) :: flux_albav    ! T => no diurnal cycle in ocn albedos
    logical             ,optional, intent(IN) :: flux_diurnal  ! T => diurnal cycle in atm/ocn flux
+   real(SHR_KIND_R8)   ,optional, intent(IN) :: gust_fac      ! wind gustiness factor
    real(SHR_KIND_R8)   ,optional, intent(IN) :: wall_time_limit ! force stop wall time (hours)
    character(len=*)    ,optional, intent(IN) :: force_stop_at ! force a stop at next (month, day, etc)
    character(len=*)    ,optional, intent(IN) :: atm_gnam   ! atm grid
@@ -1574,6 +1581,7 @@ SUBROUTINE seq_infodata_PutData_explicit( infodata, case_name, case_desc, timing
     if ( present(flux_epbal)     ) infodata%flux_epbal     = flux_epbal
     if ( present(flux_albav)     ) infodata%flux_albav     = flux_albav
     if ( present(flux_diurnal)   ) infodata%flux_diurnal   = flux_diurnal
+    if ( present(gust_fac)       ) infodata%gust_fac       = gust_fac
     if ( present(wall_time_limit)) infodata%wall_time_limit= wall_time_limit
     if ( present(force_stop_at)  ) infodata%force_stop_at  = force_stop_at
     if ( present(atm_gnam)       ) infodata%atm_gnam       = atm_gnam
@@ -1847,6 +1855,7 @@ subroutine seq_infodata_bcast(infodata,mpicom)
     call shr_mpi_bcast(infodata%flux_epbal,            mpicom)
     call shr_mpi_bcast(infodata%flux_albav,            mpicom)
     call shr_mpi_bcast(infodata%flux_diurnal,          mpicom)
+    call shr_mpi_bcast(infodata%gust_fac,              mpicom)
     call shr_mpi_bcast(infodata%wall_time_limit,       mpicom)
     call shr_mpi_bcast(infodata%force_stop_at,         mpicom)
     call shr_mpi_bcast(infodata%atm_gnam,              mpicom)
@@ -2488,6 +2497,7 @@ SUBROUTINE seq_infodata_print( infodata )
        write(logunit,F0A) subname,'flux_epbal               = ', trim(infodata%flux_epbal)
        write(logunit,F0L) subname,'flux_albav               = ', infodata%flux_albav
        write(logunit,F0L) subname,'flux_diurnal             = ', infodata%flux_diurnal
+       write(logunit,F0R) subname,'gust_fac                 = ', infodata%gust_fac
        write(logunit,F0R) subname,'wall_time_limit          = ', infodata%wall_time_limit
        write(logunit,F0A) subname,'force_stop_at            = ', trim(infodata%force_stop_at)
        write(logunit,F0A) subname,'atm_gridname             = ', trim(infodata%atm_gnam)

--- a/share/csm_share/shr/shr_flux_mod.F90
+++ b/share/csm_share/shr/shr_flux_mod.F90
@@ -278,11 +278,12 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
     
         !--- compute some needed quantities ---
 
-        vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
+        ! old version
+        !vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
 
-        ! ACME version
         !--- vmag+ugust (convective gustiness) Limit to a max precip 6 cm/day = 0.00069444 mm/s.
-        !vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) + ugust(min(prec_gust(n),6.94444e-4_R8)
+        !--- reverts to original formula if gust_fac=0 
+        vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) +  ugust(min(prec_gust(n),6.94444e-4_R8)))
 
 
         thvbot = thbot(n) * (1.0_R8 + loc_zvir * qbot(n)) ! virtual temp (K)

--- a/share/csm_share/shr/shr_flux_mod.F90
+++ b/share/csm_share/shr/shr_flux_mod.F90
@@ -119,7 +119,7 @@ end subroutine shr_flux_adjust_constants
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   & 
+SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_fac, &
            &               qbot  ,s16O  ,sHDO  ,s18O  ,rbot  ,   & 
            &               tbot  ,us    ,vs    ,   &
            &               ts    ,mask  ,sen   ,lat   ,lwup  ,   &
@@ -156,6 +156,8 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
    real(R8)   ,intent(in) :: us   (nMax) ! ocn u-velocity        (m/s)
    real(R8)   ,intent(in) :: vs   (nMax) ! ocn v-velocity        (m/s)
    real(R8)   ,intent(in) :: ts   (nMax) ! ocn temperature       (K)
+   real(R8)   ,intent(in) :: prec_gust (nMax) ! atm precip for convective gustiness (kg/m^3)
+   real(R8)   ,intent(in) :: gust_fac    ! wind gustiness factor
 
    !--- output arguments -------------------------------
    real(R8),intent(out)  ::  sen  (nMax) ! heat flux: sensible    (W/m^2)
@@ -222,14 +224,22 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
    real(R8)    :: cdn    ! function: neutral drag coeff at 10m
    real(R8)    :: psimhu ! function: unstable part of psimh
    real(R8)    :: psixhu ! function: unstable part of psimx
+   real(R8)    :: ugust  ! function: gustiness as a function of convective rainfall
    real(R8)    :: Umps   ! dummy arg ~ wind velocity (m/s)
    real(R8)    :: Tk     ! dummy arg ~ temperature (K)
    real(R8)    :: xd     ! dummy arg ~ ?
+   real(R8)    :: gprec  ! dummy arg ~ ?
  
    qsat(Tk)   = 640380.0_R8 / exp(5107.4_R8/Tk)
    cdn(Umps)  =   0.0027_R8 / Umps + 0.000142_R8 + 0.0000764_R8 * Umps
    psimhu(xd) = log((1.0_R8+xd*(2.0_R8+xd))*(1.0_R8+xd*xd)/8.0_R8) - 2.0_R8*atan(xd) + 1.571_R8
    psixhu(xd) = 2.0_R8 * log((1.0_R8 + xd*xd)/2.0_R8)
+
+   ! Convective gustiness appropriate for input precipitation.
+   ! Following Redelsperger et al. (2000, J. Clim)
+   ! Ug = log(1.0+6.69R-0.476R^2)
+   ! Coefficients X by 8640 for mm/s (from cam) -> cm/day (for above forumla)
+   ugust(gprec) = gust_fac*log(1._R8+57801.6_R8*gprec-3.55332096e7_R8*(gprec**2.0_R8))
  
    !--- formats ----------------------------------------
    character(*),parameter :: subName = '(shr_flux_atmOcn) '
@@ -267,7 +277,14 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
      if (mask(n) /= 0) then
     
         !--- compute some needed quantities ---
+
         vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
+
+        ! ACME version
+        !--- vmag+ugust (convective gustiness) Limit to a max precip 6 cm/day = 0.00069444 mm/s.
+        !vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) + ugust(min(prec_gust(n),6.94444e-4_R8)
+
+
         thvbot = thbot(n) * (1.0_R8 + loc_zvir * qbot(n)) ! virtual temp (K)
         ssq    = 0.98_R8 * qsat(ts(n)) / rbot(n)   ! sea surf hum (kg/kg)
         delt   = thbot(n) - ts(n)                  ! pot temp diff (K)


### PR DESCRIPTION
Use an input gust_fac and other functions to adjust vmag in the ocean/atmosphere surface flux
calculation to account for gustiness in storms.

gust_fac is input in drv_in and is default 0.0 which turns off the effect.

Originially implemented in ACME by Balwinder Singh.