### PR TITLE
Changes to build/run on cori-haswell.

### DIFF
--- a/cime_config/acme/allactive/config_pes.xml
+++ b/cime_config/acme/allactive/config_pes.xml
@@ -77,7 +77,7 @@
     </mach>
   </grid>
   <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">
-    <mach name="corip1">
+    <mach name="cori-haswell">
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>
@@ -1072,7 +1072,7 @@
     </mach>
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
-    <mach name='corip1'>
+    <mach name='cori-haswell'>
       <pes pesize="any" compset="any">
 	<comment>none</comment>
 	<ntasks>

--- a/cime_config/acme/allactive/config_pesall.xml
+++ b/cime_config/acme/allactive/config_pesall.xml
@@ -297,7 +297,7 @@
     </mach>
   </grid>
   <grid name="a%ne120np4">
-    <mach name="titan|stampede|bluewaters|edison|eos|corip1">
+    <mach name="titan|stampede|bluewaters|edison|eos|cori-haswell">
       <pes compset="CAM.+CLM.+DOCN." pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -5290,7 +5290,7 @@
     </mach>
   </grid>
   <grid name="any">
-    <mach name="corip1">
+    <mach name="cori-haswell">
       <pes compset="CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -5438,7 +5438,7 @@
     </mach>
   </grid>
   <grid name="a%ne120np4_l%ne120np4_oi%oRRS15to5_r%r0.+_m%oRRS15to5_g%null_w%null">
-    <mach name="titan|edison|corip1">
+    <mach name="titan|edison|cori-haswell">
       <pes compset="CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -5475,7 +5475,7 @@
     </mach>
   </grid>
   <grid name="a%ne120np4_l%ne120np4_oi%oRRS18to6_r%r0.+_m%oRRS18to6_g%null_w%null">
-    <mach name="titan|edison|corip1">
+    <mach name="titan|edison|cori-haswell">
       <pes compset="CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
         <comment>none</comment>
         <ntasks>
@@ -5623,7 +5623,7 @@
     </mach>
   </grid>
   <grid name="any">
-    <mach name="edison|corip1">
+    <mach name="edison|cori-haswell">
       <pes compset="any" pesize="T">
         <comment>none</comment>
         <ntasks>

--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -127,7 +127,6 @@
      <directives>
        <directive> --job-name={{ job_id }}</directive>
        <directive> --nodes={{ num_nodes }}</directive>
-       <directive> --ntasks-per-node={{ tasks_per_node }}</directive>
        <directive> --output={{ output_error_path }}   </directive>
        <directive> --exclusive                        </directive>
        <directive> --time={{ job_wallclock_time }}</directive>
@@ -164,14 +163,9 @@
     <!-- edison is SLURM as of Jan-4-2016 -->
     <batch_system MACH="edison" type="slurm" version="x.y">
       <queues>
-        <queue walltimemax="36:00:00" jobmin="1" jobmax="130181" default="true">regular</queue>
-	<queue walltimemax="00:30:00" jobmin="1" jobmax="12288">debug</queue>
+        <queue walltimemax="01:30:00" jobmin="1" jobmax="100" default="true">regular</queue>
+	<queue walltimemax="00:30:00" jobmin="1" jobmax="100">debug</queue>
       </queues>
-      <walltimes>
-        <walltime default="true">01:15:00</walltime>
-        <walltime ccsm_estcost="1">01:50:00</walltime>
-        <walltime ccsm_estcost="3">05:00:00</walltime>
-      </walltimes>
     </batch_system>
 
     <!-- eos is PBS -->
@@ -190,17 +184,24 @@
     </walltimes>
    </batch_system>
 
-    <batch_system MACH="corip1" type="slurm" version="x.y">
+    <batch_system MACH="cori-haswell" type="slurm" version="x.y">
+      <directives>
+        <directive>--constraint=haswell</directive>
+      </directives>
       <queues>
-        <queue walltimemax="24:00:00" jobmin="1" jobmax="16384" default="true">regular</queue>
-        <queue walltimemax="12:00:00" jobmin="16385" jobmax="45440">regular</queue>
-	<queue walltimemax="00:30:00" jobmin="1" jobmax="4096">debug</queue>
+        <queue walltimemax="01:00:00" jobmin="1" jobmax="100" default="true">regular</queue>
+	<queue walltimemax="00:30:00" jobmin="1" jobmax="100">debug</queue>
       </queues>
-      <walltimes>
-        <walltime default="true">01:15:00</walltime>
-        <walltime ccsm_estcost="1">01:50:00</walltime>
-        <walltime ccsm_estcost="3">05:00:00</walltime>
-      </walltimes>
+    </batch_system>
+
+    <batch_system MACH="cori-knl" type="slurm" version="x.y">
+      <directives>
+        <directive>--constraint=knl</directive>
+      </directives>
+      <queues>
+        <queue walltimemax="01:00:00" jobmin="1" jobmax="100" default="true">regular</queue>
+	<queue walltimemax="00:30:00" jobmin="1" jobmax="100">debug</queue>
+      </queues>
     </batch_system>
 
     <batch_system MACH="mira" type="cobalt">
@@ -223,6 +224,7 @@
 
    <batch_system MACH="constance" type="slurm" version="x.y">
     <directives>
+       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
        <directive>--mail-type=END</directive>
        <directive>--mail-user=email@pnnl.gov</directive>
        <directive>--output=slurm.out</directive>
@@ -234,6 +236,9 @@
    </batch_system>
 
   <batch_system MACH="skybridge" type="slurm" version="x.y">
+    <directives>
+       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
+    </directives>
     <queues>
       <queue jobmin="1" jobmax="480" default="true">ec</queue>
     </queues>
@@ -244,6 +249,9 @@
     </walltimes>
   </batch_system>
   <batch_system MACH="redsky" type="slurm" version="x.y">
+    <directives>
+       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
+    </directives>
     <queues>
       <queue jobmin="1" jobmax="480" default="true">ec</queue>
     </queues>
@@ -362,29 +370,25 @@
    <batch_system MACH="lawrencium-lr2" type="slurm" version="x.y">
      <directives>
        <directive>--partition=lr2</directive>
+       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
        <directive>--account={{ project }}</directive>
        <directive>--exclusive</directive>
      </directives>
     <queues>
-      <queue walltimemin="0" walltimemax="72:00:00" jobmin="0" jobmax="64" default="true">lr_normal</queue>
+      <queue walltimemin="0" walltimemax="01:00:00" jobmin="0" jobmax="64" default="true">lr_normal</queue>
     </queues>
-    <walltimes>
-      <walltime default="true">00:59:00</walltime>
-    </walltimes>
    </batch_system>
 
    <batch_system MACH="lawrencium-lr3" type="slurm" version="x.y">
      <directives>
        <directive>--partition=lr3</directive>
+       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
        <directive>--account={{ project }}</directive>
        <directive>--exclusive</directive>
      </directives>
     <queues>
-      <queue walltimemin="0" walltimemax="72:00:00" jobmin="0" jobmax="64" default="true">lr_normal</queue>
+      <queue walltimemin="0" walltimemax="01:00:00" jobmin="0" jobmax="64" default="true">lr_normal</queue>
     </queues>
-    <walltimes>
-      <walltime default="true">00:59:00</walltime>
-    </walltimes>
    </batch_system>
 
   <batch_jobs>

--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -563,18 +563,54 @@ for mct, etc.
   <ALBANY_PATH>/global/project/projectdirs/acme/software/AlbanyTrilinos_09232015/Albany/build/install</ALBANY_PATH>
 </compiler>
 
-<compiler COMPILER="intel" MACH="corip1">
-  <ADD_FFLAGS DEBUG="FALSE"> -O2 -no-opt-dynamic-align </ADD_FFLAGS>
+<compiler COMPILER="intel" MACH="cori-haswell">
+  <ADD_FFLAGS> -xCORE-AVX2 </ADD_FFLAGS>
+  <ADD_CFLAGS> -xCORE-AVX2 </ADD_CFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O2 -qno-opt-dynamic-align </ADD_FFLAGS>
   <ADD_CFLAGS DEBUG="FALSE"> -O2  </ADD_CFLAGS>
+  <ADD_CFLAGS compile_threaded="true"> -qopenmp </ADD_CFLAGS>
+  <ADD_FFLAGS compile_threaded="true"> -qopenmp </ADD_FFLAGS>
+  <ADD_FFLAGS_NOOPT compile_threaded="true"> -qopenmp </ADD_FFLAGS_NOOPT>
+  <ADD_LDFLAGS compile_threaded="true"> -qopenmp </ADD_LDFLAGS>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <ADD_SLIBS> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </ADD_SLIBS>
   <ADD_SLIBS> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </ADD_SLIBS>
+  <!--ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS-->
   <ADD_GPTL_CPPDEFS> -DHAVE_PAPI </ADD_GPTL_CPPDEFS>
+  <ADD_CPPDEFS> -DHAVE_SLASHPROC </ADD_CPPDEFS>
   <MPIFC> ftn </MPIFC>
   <MPICC> cc </MPICC>
   <MPICXX> CC </MPICXX>
+  <SFC> ifort </SFC>
+  <SCC> icc </SCC>
+  <SCXX> icpc </SCXX>
   <PETSC_PATH>$(PETSC_DIR)</PETSC_PATH>
-  <ALBANY_PATH>/global/project/projectdirs/acme/software/AlbanyTrilinos/Albany/build/install</ALBANY_PATH>
+</compiler>
+
+<compiler COMPILER="intel" MACH="cori-knl">
+  <ADD_FFLAGS> -xMIC-AVX512 </ADD_FFLAGS>
+  <ADD_CFLAGS> -xMIC-AVX512 </ADD_CFLAGS>
+  <ADD_FFLAGS DEBUG="FALSE"> -O2 -qno-opt-dynamic-align</ADD_FFLAGS>
+  <ADD_CFLAGS DEBUG="FALSE"> -O2  </ADD_CFLAGS>
+  <ADD_CFLAGS compile_threaded="true"> -qopenmp </ADD_CFLAGS>
+  <ADD_FFLAGS compile_threaded="true"> -qopenmp </ADD_FFLAGS>
+  <ADD_FFLAGS_NOOPT compile_threaded="true"> -qopenmp </ADD_FFLAGS_NOOPT>
+  <ADD_LDFLAGS compile_threaded="true"> -qopenmp </ADD_LDFLAGS>
+  <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
+  <ADD_SLIBS> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </ADD_SLIBS>
+  <ADD_SLIBS> ${MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group ${MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </ADD_SLIBS>
+  <!--ADD_SLIBS> -mkl -lpthread -lm </ADD_SLIBS-->
+
+  <ADD_GPTL_CPPDEFS> -DHAVE_PAPI </ADD_GPTL_CPPDEFS>
+  <ADD_CPPDEFS>  -DHAVE_SLASHPROC </ADD_CPPDEFS>
+  <!--ADD_CPPDEFS>  -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY  </ADD_CPPDEFS> -->
+  <MPIFC> ftn </MPIFC>
+  <MPICC> cc </MPICC>
+  <MPICXX> CC </MPICXX>
+  <SFC> ifort </SFC>
+  <SCC> icc </SCC>
+  <SCXX> icpc </SCXX>
+  <PETSC_PATH>$(PETSC_DIR)</PETSC_PATH>
 </compiler>
 
 <compiler COMPILER="intel" MACH="eos">

--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -167,8 +167,8 @@
 
 </machine>
 
-<machine MACH="corip1">
-    <DESC>NERSC XC40 Haswell, os is CNL, 32 pes/node, batch system is SLURM</DESC>
+<machine MACH="cori-haswell">
+    <DESC>Cori. XC40 Cray system at NERSC. Haswell partition. os is CNL, 32 pes/node, batch system is SLURM</DESC>
     <NODENAME_REGEX>cori</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
@@ -197,24 +197,28 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n {{ num_tasks }}</arg>
-	<arg name="thread_count" > -c {{ thread_count }}</arg>
+        <!--NOTE: hard-coding -c 2 for now, which is only correct when using full node with no hyper-threading.  need updates from cime5.2 to fix.  (ndk) -->
+	<arg name="thread_count" > -c 2 </arg>
+	<arg name="binding" > --cpu_bind=cores</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
-      <init_path lang="perl">/opt/modules/default/init/perl.pm</init_path>
-      <init_path lang="python">/opt/modules/default/init/python.py</init_path>
+      <init_path lang="perl">/opt/modules/default/init/perl</init_path>
+      <init_path lang="python">/opt/modules/default/init/python</init_path>
       <init_path lang="sh">/opt/modules/default/init/sh</init_path>
       <init_path lang="csh">/opt/modules/default/init/csh</init_path>
       <cmd_path lang="perl">/opt/modules/default/bin/modulecmd perl</cmd_path>
       <cmd_path lang="python">/opt/modules/default/bin/modulecmd python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
+
       <modules>
 	<command name="rm">PrgEnv-intel</command>
 	<command name="rm">PrgEnv-cray</command>
 	<command name="rm">PrgEnv-gnu</command>
 	<command name="rm">intel</command>
 	<command name="rm">cce</command>
+        <command name="rm">gcc</command>
 	<command name="rm">cray-parallel-netcdf</command>
 	<command name="rm">cray-parallel-hdf5</command>
 	<command name="rm">pmi</command>
@@ -227,19 +231,25 @@
 	<command name="rm">craype-sandybridge</command>
 	<command name="rm">craype-ivybridge</command>
 	<command name="rm">craype</command>
+        <command name="rm">papi</command>
+        <command name="rm">cmake</command>
+        <command name="rm">cray-petsc</command>
+        <command name="rm">esmf</command>
+      </modules>
+
+      <modules>
+	<command name="rm">craype</command>
+	<command name="load">craype/2.5.5</command>
+	<command name="load">craype-haswell</command>
+
+	<command name="load">cray-mpich/7.4.0</command>
       </modules>
 
       <modules compiler="intel">
 	<command name="load">PrgEnv-intel</command>
-	<command name="switch">intel intel/17.0.0.042</command>
-	<command name="rm">cray-libsci</command>
-	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
-      </modules>
-      <modules compiler="intel" mpilib="!mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel2016-mpi-O</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpi-serial" >
-        <command name="load">esmf/6.3.0rp1-defio-intel2016-mpiuni-O</command>
+	<command name="rm">intel</command>
+	<!--command name="load">intel/16.0.3.210</command-->
+	<command name="load">intel/17.0.0.098</command>
       </modules>
 
       <modules compiler="cray">
@@ -250,16 +260,145 @@
 	<command name="load">PrgEnv-gnu</command>
 	<command name="switch">gcc gcc/5.3.0</command>
       </modules>
+
+      <modules compiler="!intel">
+	<command name="rm">cray-libsci</command>
+	<command name="load">cray-libsci/16.06.1</command>
+      </modules>
+
+      <modules mpilib="mpi-serial">
+	<command name="load">cray-hdf5/1.8.16</command>
+	<command name="load">cray-netcdf/4.4.0</command>
+      </modules>
+      <modules mpilib="!mpi-serial">
+	<command name="load">cray-netcdf-hdf5parallel/4.4.0</command>
+	<command name="load">cray-hdf5-parallel/1.8.16</command>
+	<command name="load">cray-parallel-netcdf/1.7.0</command>
+      </modules>
+
       <modules>
+	<command name="load">cmake/3.3.2</command>
+	<command name="load">pmi/5.0.10-1.0000.11050.0.0.ari</command>
 	<command name="load">papi/5.4.3.2</command>
-	<command name="swap">craype craype/2.5.5</command>
+	<command name="load">cray-petsc/3.7.0.0</command>
+      </modules>
+    </module_system>
+
+    <environment_variables>
+
+      <env name="MPICH_ENV_DISPLAY">1</env>
+      <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="MPICH_CPUMASK_DISPLAY">1</env>
+
+      <env name="OMP_STACKSIZE">128M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
+
+    <!-- Where to put commands such as these? -->
+    <!-- module list >& software_environment.txt -->
+    <!-- env >>&  software_environment.txt -->
+    <!-- limit coredumpsize unlimited -->
+    <!-- limit stacksize unlimited -->
+    </environment_variables>
+</machine>
+
+<!-- Think of this as a stub entry.  Will have access and can test soon.  ndk -->
+<machine MACH="cori-knl">
+    <DESC>Cori. XC40 Cray system at NERSC. KNL partition. os is CNL, 68 pes/node (for now only use 64), batch system is SLURM</DESC>
+    <NODENAME_REGEX>cori-knl-haswell-is-default</NODENAME_REGEX>
+    <TESTS>acme_developer</TESTS>
+    <COMPILERS>intel,gnu,cray</COMPILERS>
+    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <CESMSCRATCHROOT>$ENV{SCRATCH}/acme_scratch</CESMSCRATCHROOT>
+    <RUNDIR>$CESMSCRATCHROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CESMSCRATCHROOT/$CASE/bld</EXEROOT>
+    <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CESMSCRATCHROOT/archive/$CASE</DOUT_S_ROOT>
+    <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
+    <CCSM_BASELINE>/project/projectdirs/acme/baselines</CCSM_BASELINE>
+    <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.cori/cprnc</CCSM_CPRNC>
+    <SAVE_TIMING_DIR>/project/projectdirs/$PROJECT</SAVE_TIMING_DIR>
+    <OS>CNL</OS>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>acme</SUPPORTED_BY>
+    <GMAKE_J>8</GMAKE_J>
+    <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
+    <PES_PER_NODE>64</PES_PER_NODE>
+    <PROJECT>acme</PROJECT>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+	<arg name="label"> --label</arg>
+	<arg name="num_tasks" > -n {{ num_tasks }}</arg>
+        <!--NOTE: hard-coding -c 4 for now, which is only correct when using full node with no hyper-threading.  need updates from cime5.2 to fix.  (ndk) -->
+	<arg name="thread_count" > -c 2 </arg>
+	<arg name="binding" > --cpu_bind=cores</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/opt/modules/default/init/perl</init_path>
+      <init_path lang="python">/opt/modules/default/init/python</init_path>
+      <init_path lang="sh">/opt/modules/default/init/sh</init_path>
+      <init_path lang="csh">/opt/modules/default/init/csh</init_path>
+      <cmd_path lang="perl">/opt/modules/default/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="python">/opt/modules/default/bin/modulecmd python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+	<command name="rm">PrgEnv-intel</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">intel</command>
+	<command name="rm">cce</command>
+        <command name="rm">gcc</command>
+	<command name="rm">cray-parallel-netcdf</command>
+	<command name="rm">cray-parallel-hdf5</command>
+	<command name="rm">pmi</command>
+	<command name="rm">cray-libsci</command>
+	<command name="rm">cray-mpich2</command>
+	<command name="rm">cray-mpich</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">cray-hdf5</command>
+	<command name="rm">cray-netcdf-hdf5parallel</command>
+	<command name="rm">craype-sandybridge</command>
+	<command name="rm">craype-ivybridge</command>
+	<command name="rm">craype</command>
+	<command name="rm">cray-libsci</command>
+        <command name="rm">papi</command>
+        <command name="rm">cmake</command>
+        <command name="rm">cray-petsc</command>
+        <command name="rm">esmf</command>
+      </modules>
+
+      <modules>
+	<command name="rm">craype</command>
+	<command name="load">craype/2.5.5</command>
+	<command name="load">craype-mic-knl</command>
+
+	<command name="load">cray-mpich/7.4.0</command>
+      </modules>
+
+      <modules compiler="intel">
+	<command name="load">PrgEnv-intel</command>
+	<!--command name="switch">intel intel/16.0.3.210</command-->
+	<command name="switch">intel intel/17.0.0.098</command>
+      </modules>
+
+      <modules compiler="cray">
+	<command name="load">PrgEnv-cray</command>
+	<command name="switch">cce cce/8.5.0</command>
+      </modules>
+      <modules compiler="gnu">
+	<command name="load">PrgEnv-gnu</command>
+	<command name="switch">gcc gcc/5.3.0</command>
       </modules>
       <modules compiler="!intel">
 	<command name="switch">cray-libsci/16.06.1</command>
       </modules>
-      <modules>
-	<command name="load">cray-mpich/7.4.0</command>
-      </modules>
+
       <modules mpilib="mpi-serial">
 	<command name="load">cray-hdf5/1.8.16</command>
 	<command name="load">cray-netcdf/4.4.0</command>
@@ -271,8 +410,29 @@
       </modules>
       <modules>
 	<command name="load">cmake/3.3.2</command>
+	<command name="load">pmi/5.0.10-1.0000.11050.0.0.ari</command>
+	<command name="load">papi/5.4.3.2</command>
+	<command name="load">cray-petsc/3.7.0.0</command>
       </modules>
     </module_system>
+
+    <environment_variables>
+
+      <env name="MPICH_ENV_DISPLAY">1</env>
+      <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="MPICH_CPUMASK_DISPLAY">1</env>
+
+      <env name="OMP_STACKSIZE">128M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
+
+   <!-- Where to put commands such as these? -->
+   <!-- module list >& software_environment.txt -->
+   <!-- env >>&  software_environment.txt -->
+   <!-- limit coredumpsize unlimited -->
+   <!-- limit stacksize unlimited -->
+
+    </environment_variables>
 </machine>
 
 
@@ -285,7 +445,8 @@
     <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
     <RUNDIR>$ENV{HOME}/projects/acme/scratch/$CASE/run</RUNDIR>
     <EXEROOT>$ENV{HOME}/projects/acme/scratch/$CASE/bld</EXEROOT>
-    <DIN_LOC_ROOT>$ENV{HOME}/projects/acme/cesm-inputdata</DIN_LOC_ROOT>    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/projects/acme/ptclm-data</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT>$ENV{HOME}/projects/acme/cesm-inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/projects/acme/ptclm-data</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$ENV{HOME}/projects/acme/scratch/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
     <CESMSCRATCHROOT>$ENV{HOME}/projects/acme/scratch</CESMSCRATCHROOT>


### PR DESCRIPTION
Changes to add cori-haswell and cori-knl.  Adds temporary hack for the -c flag to srun until we get changes from cime5.2.  Removes a slurm batch option from the default. Similar change has been made onto ESMCI/cime master.

Test suite: passed cime_developers
Test baseline: 
Test namelist changes: 
Test status: BFB

Fixes

User interface changes?: no

Code review: 

Stubs got cori-knl.