### PR TITLE
changes need for getting ww3 to have branch capabilities

### DIFF
--- a/cime_config/cesm/config_archive.xml
+++ b/cime_config/cesm/config_archive.xml
@@ -123,7 +123,7 @@
   </comp_archive_spec>
 
   <comp_archive_spec compname="ww3" compclass="wav">
-    <rest_file_extension>\.\..*</rest_file_extension>
+    <rest_file_extension>\.r.*</rest_file_extension>
     <hist_file_extension>\.hi.*</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>

--- a/cime_config/cesm/config_files.xml
+++ b/cime_config/cesm/config_files.xml
@@ -308,7 +308,7 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="ww"  >$SRCROOT/components/ww3/cime_config/config_component.xml</value>
+      <value component="ww3" >$SRCROOT/components/ww3/cime_config/config_component.xml</value>
       <value component="dwav">$CIMEROOT/components/data_comps/dwav/cime_config/config_component.xml</value>
       <value component="swav">$CIMEROOT/components/stub_comps/swav/cime_config/config_component.xml</value>
       <value component="xwav">$CIMEROOT/components/xcpl_comps/xwav/cime_config/config_component.xml</value>

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -451,7 +451,8 @@ class Case(object):
                 continue
             else:
                 element_component = element.split('%')[0].lower()
-                element_component = re.sub(r'[0-9]*',"",element_component)
+                if "ww" not in element_component:
+                    element_component = re.sub(r'[0-9]*',"",element_component)
                 components.append(element_component)
         return components
 


### PR DESCRIPTION
Bugfixes/changes needed to to implement branch capabilities for ww3

Note: the change to case.py is ww specific and is due to the fact that ww3 rather than ww is present in all compsets using ww3. So at this point, removing the specific integer from ww would need changes to other components. In addition, ww3 is not developed at NCAR, and is from that perspective a "fixed" component - so keeping the reference to ww3 rather than ww is actually reasonable.

Test suite: scripts_regression_tests (yellowstone)
Test baseline: NA
Test namelist changes: none
Test status: NA

Fixes [CIME Github issue #] None

User interface changes?: None

Code review: 

