### PR TITLE
Update support for stampede.  Change ERR_N3 tests to NCK_N3 tests.

### DIFF
--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -32,7 +32,7 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="ERR_N3" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
+  <test name="NCK_N3" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
       <machine name="yellowstone" compiler="intel" category="prealpha"/>
@@ -311,8 +311,8 @@
   </test>
   <test name="PFS" grid="ne30_g16" compset="B1850" testmods="allactive/default">
     <machines>
-      <machine name="yellowstone" compiler="intel " category="prealpha"/>
-      <machine name="yellowstone" compiler="intel " category="prebeta"/>
+      <machine name="yellowstone" compiler="intel" category="prealpha"/>
+      <machine name="yellowstone" compiler="intel" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20 </option>

--- a/cime_config/cesm/machines/config_batch.xml
+++ b/cime_config/cesm/machines/config_batch.xml
@@ -131,7 +131,6 @@
 
    <batch_system type="slurm" version="x.y">
      <batch_query>squeue</batch_query>
-     <batch_submit>sbatch</batch_submit>
      <batch_directive>#SBATCH</batch_directive>
      <jobid_pattern>(\d+)$</jobid_pattern>
      <depend_string> --dependency=afterok:jobid</depend_string>
@@ -242,11 +241,12 @@
 
    <!-- hera is SLURM -->
    <batch_system MACH="hera" type="slurm">
-   <batch_directive>#MSUB</batch_directive>
-   <directives>
-     <directive>-A ees</directive>
-     <directive>-l gres=lscratchd</directive>
-   </directives>
+     <batch_submit>sbatch</batch_submit>
+     <batch_directive>#MSUB</batch_directive>
+     <directives>
+       <directive>-A ees</directive>
+       <directive>-l gres=lscratchd</directive>
+     </directives>
    </batch_system>
 
 
@@ -274,6 +274,7 @@
   </batch_system>
 
   <batch_system MACH="olympus" type="slurm">
+    <batch_submit>sbatch</batch_submit>
     <queues>
       <queue walltimemin="0" walltimemax="00:59:00" jobmin="0" jobmax="9999" default="true">queue</queue>
     </queues>
@@ -310,6 +311,7 @@
   </batch_system>
 
   <batch_system MACH="skybridge" type="slurm" version="x.y">
+    <batch_submit>sbatch</batch_submit>
     <queues>
       <queue jobmin="1" jobmax="480" default="true">ec</queue>
     </queues>
@@ -341,23 +343,26 @@
   </batch_system>
 
   <!-- sierra is SLURM -->
-   <batch_system MACH="sierra" type="slurm">
-   <batch_directive>#MSUB</batch_directive>
-   <directives>
-     <directive> </directive>
-     <directive>-A ees </directive>
-     <directive>-l nodes={{ num_nodes }}</directive>
-     <directive>-l gres=lscratchd</directive>
-   </directives>
-   </batch_system>
+  <batch_system MACH="sierra" type="slurm">
+    <batch_submit>sbatch</batch_submit>
+    <batch_directive>#MSUB</batch_directive>
+    <directives>
+      <directive> </directive>
+      <directive>-A ees </directive>
+      <directive>-l nodes={{ num_nodes }}</directive>
+      <directive>-l gres=lscratchd</directive>
+    </directives>
+  </batch_system>
 
    <batch_system MACH="eastwind" type="slurm" version="x.y">
+     <batch_submit>sbatch</batch_submit>
      <queues>
        <queue jobmin="1" jobmax="9999" default="true">batch</queue>
      </queues>
    </batch_system>
 
    <batch_system MACH="corip1" type="slurm" version="x.y">
+     <batch_submit>sbatch</batch_submit>
      <directives>
        <directive>-C haswell </directive>
      </directives>
@@ -368,6 +373,7 @@
    </batch_system>
 
    <batch_system MACH="edison" type="slurm" version="x.y">
+     <batch_submit>sbatch</batch_submit>
      <queues>
        <queue walltimemax="36:00:00" jobmin="1" jobmax="130181" >regular</queue>
        <queue walltimemax="00:30:00" jobmin="1" jobmax="12288" default="true">debug</queue>
@@ -375,6 +381,7 @@
    </batch_system>
 
    <batch_system MACH="stampede" type="slurm" version="x.y">
+     <batch_submit>ssh stampede.tacc.utexas.edu cd $CASEROOT ; sbatch</batch_submit>
      <queues>
        <queue walltimemax="48:00:00" jobmin="1" jobmax="4096" >normal</queue>
        <queue walltimemax="02:00:00" jobmin="1" jobmax="256" default="true">development</queue>
@@ -382,6 +389,7 @@
    </batch_system>
 
    <batch_system MACH="rosa" type="slurm" version="x.y">
+     <batch_submit>sbatch</batch_submit>
      <queues>
        <queue default="true">default</queue>
      </queues>
@@ -395,6 +403,7 @@
   </batch_system>
 
   <batch_system type="slurm" MACH="constance" version="x.y">
+     <batch_submit>sbatch</batch_submit>
   </batch_system>
 
   <batch_system MACH="yellowstone" type="lsf" version="9.1">

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -1400,20 +1400,10 @@
     <PES_PER_NODE>16</PES_PER_NODE>
 
     <mpirun mpilib="impi">
-      <executable>srun</executable>
-      <arguments>
-	<arg name="label"> --label</arg>
-	<arg name="num_tasks" > -n $TOTALPES</arg>
-     	<arg name="thread_count" > -c $ENV{OMP_NUM_THREADS}</arg>
-      </arguments>
+      <executable>ibrun</executable>
     </mpirun>
     <mpirun mpilib="mvapich2">
-      <executable>srun</executable>
-      <arguments>
-	<arg name="label"> --label</arg>
-	<arg name="num_tasks" > -n $TOTALPES</arg>
-     	<arg name="thread_count" > -c $ENV{OMP_NUM_THREADS}</arg>
-      </arguments>
+      <executable>ibrun</executable>
     </mpirun>
     <mpirun mpilib="mpi-serial">
       <executable></executable>


### PR DESCRIPTION
Final update for stampede support.  Change ERR_N3 test to NCK_N3 test.
Removed extra spaces from testlist_allactive.xml which was causing test to be skipped.

Test suite:  Ran prealpha intel test on yellowstone with --no-build to test testlist_allactive.xml
                   Ran ERS_Ld3.f45_g37_rx1.A on stampede and edison to test slurm.
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #821 

User interface changes?: 

Code review: 

Removed blank spaces from testlist_allactive.xml.

Test suite: Ran intel prealpha tests on yellowstone with --no-rebuild to
            test testlist_allactive.xml.
            Ran ERS_Ld3.f45_g37_rx1.A and stampede and edison.
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes #821

User interface changes?:

Code review: