### PR TITLE
remove cvmixlib creation now done in pop

### DIFF
--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -333,10 +333,6 @@ else
   endif
 endif
 
-ifeq ($(COMP_OCN), pop)
-  INCLDIR += -I$(EXEROOT)/ocn/cvmix
-endif
-
 ifndef MCT_LIBDIR
   MCT_LIBDIR=$(INSTALL_SHAREDPATH)/lib
 endif
@@ -649,9 +645,6 @@ ifeq ($(ULIBDEP),$(null))
      ULIBDEP += $(LIBROOT)/libice.a
      ULIBDEP += $(LNDLIBDIR)/$(LNDLIB)
      ULIBDEP += $(LIBROOT)/libocn.a
-     ifeq ($(COMP_OCN), pop)
-       ULIBDEP += $(LIBROOT)/libcvmix.a
-     endif
      ULIBDEP += $(LIBROOT)/librof.a
      ULIBDEP += $(LIBROOT)/libglc.a
      ULIBDEP += $(LIBROOT)/libwav.a
@@ -717,9 +710,6 @@ $(EXEC_SE): $(OBJS) $(ULIBDEP) $(CSMSHARELIB) $(MCTLIBS) $(PIOLIB) $(GPTLLIB)
 $(COMPLIB): $(OBJS)
 	$(AR) -r $(COMPLIB) $(OBJS)
 
-$(LIBROOT)/libcvmix.a:
-	$(MAKE) -f $(CIMEROOT)/../components/pop/source/cvmix/Makefile SRC_DIR=$(CIMEROOT)/../components/pop/source/cvmix FC=$(SFC) FCFLAGS="$(FFLAGS) $(FREEFLAGS)" LIB_DIR=$(LIBROOT)
-
 .c.o:
 	$(CC) -c $(INCLDIR) $(INCS) $(CFLAGS)  $<
 .F.o:
@@ -744,7 +734,7 @@ cleancpl:
 	cd $(EXEROOT)/cpl/obj;  $(RM) -f *.o *.mod
 
 cleanocn:
-	$(RM) -f $(LIBROOT)/libocn.a $(LIBROOT)/libcvmix.a
+	$(RM) -f $(LIBROOT)/libocn.a
 	cd $(EXEROOT)/ocn/obj ; $(RM) -f *.o *.mod
 
 cleanwav:


### PR DESCRIPTION
Sorry the branch is misnamed.  This mod proposed by Mike Levy removes the building/linking of a CVMIX library.  The CVMIX files will now be compiled along with the rest of POP.  There will be a new POP tag with the required pop/cime_config changes.  Didn't see any ACME conflicts.

Test suite: aux_pop
Test baseline: cesm2_0_alpha04b
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing] BFB

Fixes [CIME Github issue #]

User interface changes?: 

Code review: Jim will review the changes before tagging.

