### PR TITLE
the comma was causing debug to be set incorrectly

### DIFF
--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -1054,7 +1054,7 @@ class Case(object):
     def load_env(self):
         if not self._is_env_loaded:
             compiler = self.get_value("COMPILER")
-            debug=self.get_value("DEBUG"),
+            debug=self.get_value("DEBUG")
             mpilib=self.get_value("MPILIB")
             env_module = self.get_env("mach_specific")
             env_module.load_env(compiler=compiler,debug=debug, mpilib=mpilib)


### PR DESCRIPTION
Because of the comma the variable debug was being set to (False,) instead of False
and then was not interpreted correctly causing the attribute to be ignored.  

Test suite: Individual tests on yellowstone
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #843 

User interface changes?: 

Code review: 

