### PR TITLE
Module load error message

### DIFF
--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -244,7 +244,9 @@ class EnvMachSpecific(EnvBase):
     def _load_module_modules(self, modules_to_load):
         for cmd in self._get_module_commands(modules_to_load, "python"):
             logger.debug("module command is %s"%cmd)
-            py_module_code = run_cmd_no_fail(cmd)
+            stat, py_module_code, errout = run_cmd(cmd)
+            expect(stat==0 and len(errout) == 0, 
+                   "module command %s failed with message:\n%s"%(cmd,errout))
             exec(py_module_code)
 
     def _load_soft_modules(self, modules_to_load):

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1290,7 +1290,7 @@ class MakefileTester(object):
     _makefile_template = """
 include Macros
 query:
-/techo '$({})' > query.out
+\techo '$({})' > query.out
 """
 
     def __init__(self, parent, make_string):


### PR DESCRIPTION
module system does not always set non-zero status on error, also check the error message itself
Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #841 

User interface changes?: 

Code review: 
