### PR TITLE
Buildnml without run cmd

### DIFF
--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -196,13 +196,12 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     nmlgen.write_output_file(namelist_file, data_list_path, groups=['datm_nml','shr_strdata_nml'])
 
 ###############################################################################
-def _main_func():
+def buildnml(caseroot):
 ###############################################################################
 
     # Build the component namelist and required stream txt files
 
     compname = "datm"
-    caseroot = _parse_input(sys.argv)
 
     with Case(caseroot) as case:
         cimeroot = case.get_value("CIMEROOT")
@@ -285,4 +284,5 @@ def _main_func():
 ###############################################################################
 
 if __name__ == "__main__":
-    _main_func()
+    caseroot = _parse_input(sys.argv)
+    buildnml(caseroot)

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -196,93 +196,93 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     nmlgen.write_output_file(namelist_file, data_list_path, groups=['datm_nml','shr_strdata_nml'])
 
 ###############################################################################
-def buildnml(caseroot):
+def buildnml(case, caseroot, compname):
 ###############################################################################
 
     # Build the component namelist and required stream txt files
+    if compname != "datm":
+        raise AttributeError
 
-    compname = "datm"
+    cimeroot = case.get_value("CIMEROOT")
+    rundir = case.get_value("RUNDIR")
+    ninst = case.get_value("NINST_ATM")
+    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    with Case(caseroot) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        rundir = case.get_value("RUNDIR")
-        ninst = case.get_value("NINST_ATM")
-        din_loc_root = case.get_value("DIN_LOC_ROOT")
-
-        if not os.path.isdir(din_loc_root):
-            os.makedirs(din_loc_root)
-            logger.info("Created input root directory %s" %din_loc_root)
+    if not os.path.isdir(din_loc_root):
+        os.makedirs(din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
         # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
-        user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
-        expect (os.path.isdir(user_xml_dir),
-                "user_xml_dir %s does not exist " %user_xml_dir)
+    user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
+    expect (os.path.isdir(user_xml_dir),
+            "user_xml_dir %s does not exist " %user_xml_dir)
 
         # NOTE: User definition *replaces* existing definition.
-        namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
-        definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_datm.xml")]
-        user_definition = os.path.join(user_xml_dir, "namelist_definition_datm.xml")
-        if os.path.isfile(user_definition):
-            definition_file = [user_definition]
+    namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
+    definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_datm.xml")]
+    user_definition = os.path.join(user_xml_dir, "namelist_definition_datm.xml")
+    if os.path.isfile(user_definition):
+        definition_file = [user_definition]
 
-        # Checkout if definition file exists
-        for file_ in definition_file:
-            expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
+    # Checkout if definition file exists
+    for file_ in definition_file:
+        expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-        confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-        if not os.path.isdir(confdir):
-            os.makedirs(confdir)
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
-        # Loop over instances
+    # Loop over instances
+    inst_string = ""
+    inst_counter = 1
+    while (inst_counter <= ninst):
+
+        # determine instance string
         inst_string = ""
-        inst_counter = 1
-        while (inst_counter <= ninst):
+        if ninst > 1:
+            inst_string = '_' + '%04d' % inst_counter
 
-            # determine instance string
-            inst_string = ""
-            if ninst > 1:
-                inst_string = '_' + '%04d' % inst_counter
+        # If multi-instance case does not have restart file, use
+        # single-case restart for each instance
+        rpointer = "rpointer." + compname
+        if (os.path.isfile(os.path.join(rundir,rpointer)) and
+            (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
+            shutil.copy(os.path.join(rundir, rpointer),
+                        os.path.join(rundir, rpointer + inst_string))
 
-            # If multi-instance case does not have restart file, use
-            # single-case restart for each instance
-            rpointer = "rpointer." + compname
-            if (os.path.isfile(os.path.join(rundir,rpointer)) and
-                (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-                shutil.copy(os.path.join(rundir, rpointer),
-                            os.path.join(rundir, rpointer + inst_string))
+        inst_string_label = inst_string
+        if not inst_string_label:
+            inst_string_label = "\"\""
 
-            inst_string_label = inst_string
-            if not inst_string_label:
-                inst_string_label = "\"\""
+        # create namelist output infile using user_nl_file as input
+        user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
+        expect(os.path.isfile(user_nl_file),
+               "Missing required user_nl_file %s " %(user_nl_file))
+        infile = os.path.join(confdir, "namelist_infile")
+        create_namelist_infile(case, user_nl_file, infile)
+        namelist_infile = [infile]
 
-            # create namelist output infile using user_nl_file as input
-            user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
-            expect(os.path.isfile(user_nl_file),
-                   "Missing required user_nl_file %s " %(user_nl_file))
-            infile = os.path.join(confdir, "namelist_infile")
-            create_namelist_infile(case, user_nl_file, infile)
-            namelist_infile = [infile]
+        # create namelist and stream file(s) data component
+        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
 
-            # create namelist and stream file(s) data component
-            _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        # copy namelist files and stream text files, to rundir
+        if os.path.isdir(rundir):
+            filename = compname + "_in"
+            file_src  = os.path.join(confdir, filename)
+            file_dest = os.path.join(rundir, filename)
+            if inst_string:
+                file_dest += inst_string
+            shutil.copy(file_src,file_dest)
 
-            # copy namelist files and stream text files, to rundir
-            if os.path.isdir(rundir):
-                filename = compname + "_in"
-                file_src  = os.path.join(confdir, filename)
-                file_dest = os.path.join(rundir, filename)
-                if inst_string:
-                    file_dest += inst_string
-                shutil.copy(file_src,file_dest)
+            for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
+                shutil.copy(txtfile, rundir)
 
-                for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                    shutil.copy(txtfile, rundir)
-
-            # increment instance counter
-            inst_counter = inst_counter + 1
+        # increment instance counter
+        inst_counter = inst_counter + 1
 
 ###############################################################################
 
 if __name__ == "__main__":
     caseroot = _parse_input(sys.argv)
-    buildnml(caseroot)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "datm")

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -18,32 +18,9 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
 from CIME.utils import expect
-from CIME.utils import handle_standard_logging_options
-from CIME.utils import setup_standard_logging_options
-from CIME.buildnml import create_namelist_infile
+from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
-
-###############################################################################
-def _parse_input(argv):
-###############################################################################
-
-    if "--test" in argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
-    parser = argparse.ArgumentParser()
-
-    setup_standard_logging_options(parser)
-
-    parser.add_argument("caseroot",
-                        help="case directory")
-
-    args = parser.parse_args()
-
-    handle_standard_logging_options(args)
-
-    return args.caseroot
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
@@ -60,7 +37,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Get a bunch of information from the case.
     #----------------------------------------------------
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
     atm_domain_file = case.get_value("ATM_DOMAIN_FILE")
     atm_domain_path = case.get_value("ATM_DOMAIN_PATH")
     datm_mode = case.get_value("DATM_MODE")
@@ -121,7 +97,11 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     # Construct the list of streams.
     #----------------------------------------------------
     streams = nmlgen.get_streams()
-
+    #
+    # This disable is required because nmlgen.get_streams
+    # may return a string or a list.  See issue #877 in ESMCI/cime
+    #
+    #pylint: disable=no-member
     if datm_presaero == "pt1_pt1":
         streams.append("presaero.%s.%s" % (datm_presaero, atm_grid))
     elif datm_presaero != "none":
@@ -281,8 +261,11 @@ def buildnml(case, caseroot, compname):
         inst_counter = inst_counter + 1
 
 ###############################################################################
-
-if __name__ == "__main__":
-    caseroot = _parse_input(sys.argv)
+def _main_func():
+    caseroot = parse_input(sys.argv)
     with Case(caseroot) as case:
         buildnml(case, caseroot, "datm")
+
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -18,32 +18,9 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
 from CIME.utils import expect
-from CIME.utils import handle_standard_logging_options
-from CIME.utils import setup_standard_logging_options
-from CIME.buildnml import create_namelist_infile
+from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
-
-###############################################################################
-def _parse_input(argv):
-###############################################################################
-
-    if "--test" in argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
-    parser = argparse.ArgumentParser()
-
-    setup_standard_logging_options(parser)
-
-    parser.add_argument("caseroot",
-                        help="case directory")
-
-    args = parser.parse_args()
-
-    handle_standard_logging_options(args)
-
-    return args.caseroot
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
@@ -60,7 +37,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Get a bunch of information from the case.
     #----------------------------------------------------
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
     ice_domain_file = case.get_value("ICE_DOMAIN_FILE")
     ice_domain_path = case.get_value("ICE_DOMAIN_PATH")
     dice_mode = case.get_value("DICE_MODE")
@@ -236,9 +212,11 @@ def buildnml(case, caseroot, compname):
         inst_counter = inst_counter + 1
 
 ###############################################################################
-
-if __name__ == "__main__":
+def _main_func():
     # Build the component namelist and required stream txt files
-    caseroot = _parse_input(sys.argv)
+    caseroot = parse_input(sys.argv)
     with Case(caseroot) as case:
         buildnml(case, caseroot, "dice")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -154,94 +154,91 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     namelist_file = os.path.join(confdir, "dice_in")
     nmlgen.write_output_file(namelist_file, data_list_path, groups=['dice_nml','shr_strdata_nml'])
 
-###############################################################################
-def _main_func():
-###############################################################################
+def buildnml(case, caseroot, compname):
+    if compname != "dice":
+        raise AttributeError
 
-    # Build the component namelist and required stream txt files
+    cimeroot = case.get_value("CIMEROOT")
+    rundir = case.get_value("RUNDIR")
+    ninst = case.get_value("NINST_ICE")
+    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    compname = "dice"
-    caseroot = _parse_input(sys.argv)
+    if not os.path.isdir(din_loc_root):
+        os.makedirs(din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
-    with Case(caseroot) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        rundir = case.get_value("RUNDIR")
-        ninst = case.get_value("NINST_ICE")
-        din_loc_root = case.get_value("DIN_LOC_ROOT")
+    # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
+    user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
+    expect (os.path.isdir(user_xml_dir),
+            "user_xml_dir %s does not exist " %user_xml_dir)
 
-        if not os.path.isdir(din_loc_root):
-            os.makedirs(din_loc_root)
-            logger.info("Created input root directory %s" %din_loc_root)
+    # NOTE: User definition *replaces* existing definition.
+    namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
+    definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_dice.xml")]
+    user_definition = os.path.join(user_xml_dir, "namelist_definition_dice.xml")
+    if os.path.isfile(user_definition):
+        definition_file = [user_definition]
 
-        # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
-        user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
-        expect (os.path.isdir(user_xml_dir),
-                "user_xml_dir %s does not exist " %user_xml_dir)
+    # Checkout if definition file exists
+    for file_ in definition_file:
+        expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-        # NOTE: User definition *replaces* existing definition.
-        namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
-        definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_dice.xml")]
-        user_definition = os.path.join(user_xml_dir, "namelist_definition_dice.xml")
-        if os.path.isfile(user_definition):
-            definition_file = [user_definition]
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
-        # Checkout if definition file exists
-        for file_ in definition_file:
-            expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
+    # Loop over instances
+    inst_string = ""
+    inst_counter = 1
+    while (inst_counter <= ninst):
 
-        confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-        if not os.path.isdir(confdir):
-            os.makedirs(confdir)
-
-        # Loop over instances
+        # determine instance string
         inst_string = ""
-        inst_counter = 1
-        while (inst_counter <= ninst):
+        if ninst > 1:
+            inst_string = '_' + '%04d' % inst_counter
 
-            # determine instance string
-            inst_string = ""
-            if ninst > 1:
-                inst_string = '_' + '%04d' % inst_counter
+        # If multi-instance case does not have restart file, use
+        # single-case restart for each instance
+        rpointer = "rpointer." + compname
+        if (os.path.isfile(os.path.join(rundir,rpointer)) and
+            (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
+            shutil.copy(os.path.join(rundir, rpointer),
+                        os.path.join(rundir, rpointer + inst_string))
 
-            # If multi-instance case does not have restart file, use
-            # single-case restart for each instance
-            rpointer = "rpointer." + compname
-            if (os.path.isfile(os.path.join(rundir,rpointer)) and
-                (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-                shutil.copy(os.path.join(rundir, rpointer),
-                            os.path.join(rundir, rpointer + inst_string))
+        inst_string_label = inst_string
+        if not inst_string_label:
+            inst_string_label = "\"\""
 
-            inst_string_label = inst_string
-            if not inst_string_label:
-                inst_string_label = "\"\""
+        # create namelist output infile using user_nl_file as input
+        user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
+        expect(os.path.isfile(user_nl_file),
+               "Missing required user_nl_file %s " %(user_nl_file))
+        infile = os.path.join(confdir, "namelist_infile")
+        create_namelist_infile(case, user_nl_file, infile)
+        namelist_infile = [infile]
 
-            # create namelist output infile using user_nl_file as input
-            user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
-            expect(os.path.isfile(user_nl_file),
-                   "Missing required user_nl_file %s " %(user_nl_file))
-            infile = os.path.join(confdir, "namelist_infile")
-            create_namelist_infile(case, user_nl_file, infile)
-            namelist_infile = [infile]
+        # create namelist and stream file(s) data component
+        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
 
-            # create namelist and stream file(s) data component
-            _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        # copy namelist files and stream text files, to rundir
+        if os.path.isdir(rundir):
+            filename = compname + "_in"
+            file_src  = os.path.join(confdir, filename)
+            file_dest = os.path.join(rundir, filename)
+            if inst_string:
+                file_dest += inst_string
+            shutil.copy(file_src,file_dest)
 
-            # copy namelist files and stream text files, to rundir
-            if os.path.isdir(rundir):
-                filename = compname + "_in"
-                file_src  = os.path.join(confdir, filename)
-                file_dest = os.path.join(rundir, filename)
-                if inst_string:
-                    file_dest += inst_string
-                shutil.copy(file_src,file_dest)
+            for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
+                shutil.copy(txtfile, rundir)
 
-                for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                    shutil.copy(txtfile, rundir)
-
-            # increment instance counter
-            inst_counter = inst_counter + 1
+        # increment instance counter
+        inst_counter = inst_counter + 1
 
 ###############################################################################
 
 if __name__ == "__main__":
-    _main_func()
+    # Build the component namelist and required stream txt files
+    caseroot = _parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "dice")

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -156,93 +156,95 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     nmlgen.write_output_file(namelist_file, data_list_path, groups=['dlnd_nml','shr_strdata_nml'])
 
 ###############################################################################
-def _main_func():
+def buildnml(case, caseroot, compname):
 ###############################################################################
 
     # Build the component namelist and required stream txt files
 
-    compname = "dlnd"
-    caseroot = _parse_input(sys.argv)
+    if compname != "dlnd":
+        raise AttributeError
 
-    with Case(caseroot) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        rundir = case.get_value("RUNDIR")
-        ninst = case.get_value("NINST_LND")
-        din_loc_root = case.get_value("DIN_LOC_ROOT")
+    cimeroot = case.get_value("CIMEROOT")
+    rundir = case.get_value("RUNDIR")
+    ninst = case.get_value("NINST_LND")
+    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-        if not os.path.isdir(din_loc_root):
-            os.makedirs(din_loc_root)
-            logger.info("Created input root directory %s" %din_loc_root)
+    if not os.path.isdir(din_loc_root):
+        os.makedirs(din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
-        # determine directory for user modified namelist_definitions.xml
-        user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
-        expect (os.path.isdir(user_xml_dir),
-                "user_xml_dir %s does not exist " %user_xml_dir)
+    # determine directory for user modified namelist_definitions.xml
+    user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
+    expect (os.path.isdir(user_xml_dir),
+            "user_xml_dir %s does not exist " %user_xml_dir)
 
-        # NOTE: User definition *replaces* existing definition.
-        namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
-        definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_dlnd.xml")]
-        user_definition = os.path.join(user_xml_dir, "namelist_definition_dlnd.xml")
-        if os.path.isfile(user_definition):
-            definition_file = [user_definition]
+    # NOTE: User definition *replaces* existing definition.
+    namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
+    definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_dlnd.xml")]
+    user_definition = os.path.join(user_xml_dir, "namelist_definition_dlnd.xml")
+    if os.path.isfile(user_definition):
+        definition_file = [user_definition]
 
-        # Checkout if definition file exists
-        for file_ in definition_file:
-            expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
+    # Checkout if definition file exists
+    for file_ in definition_file:
+        expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-        confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-        if not os.path.isdir(confdir):
-            os.makedirs(confdir)
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
-        # Loop over instances
+    # Loop over instances
+    inst_string = ""
+    inst_counter = 1
+    while (inst_counter <= ninst):
+
+        # determine instance string
         inst_string = ""
-        inst_counter = 1
-        while (inst_counter <= ninst):
+        if ninst > 1:
+            inst_string = '_' + '%04d' % inst_counter
 
-            # determine instance string
-            inst_string = ""
-            if ninst > 1:
-                inst_string = '_' + '%04d' % inst_counter
+        # If multi-instance case does not have restart file, use
+        # single-case restart for each instance
+        rpointer = "rpointer." + compname
+        if (os.path.isfile(os.path.join(rundir,rpointer)) and
+            (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
+            shutil.copy(os.path.join(rundir, rpointer),
+                        os.path.join(rundir, rpointer + inst_string))
 
-            # If multi-instance case does not have restart file, use
-            # single-case restart for each instance
-            rpointer = "rpointer." + compname
-            if (os.path.isfile(os.path.join(rundir,rpointer)) and
-                (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-                shutil.copy(os.path.join(rundir, rpointer),
-                            os.path.join(rundir, rpointer + inst_string))
+        inst_string_label = inst_string
+        if not inst_string_label:
+            inst_string_label = "\"\""
 
-            inst_string_label = inst_string
-            if not inst_string_label:
-                inst_string_label = "\"\""
+        # create namelist output infile using user_nl_file as input
+        user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
+        expect(os.path.isfile(user_nl_file),
+               "Missing required user_nl_file %s " %(user_nl_file))
+        infile = os.path.join(confdir, "namelist_infile")
+        create_namelist_infile(case, user_nl_file, infile)
+        namelist_infile = [infile]
 
-            # create namelist output infile using user_nl_file as input
-            user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
-            expect(os.path.isfile(user_nl_file),
-                   "Missing required user_nl_file %s " %(user_nl_file))
-            infile = os.path.join(confdir, "namelist_infile")
-            create_namelist_infile(case, user_nl_file, infile)
-            namelist_infile = [infile]
+        # create namelist and stream file(s) data component
+        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
 
-            # create namelist and stream file(s) data component
-            _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        # copy namelist files and stream text files, to rundir
+        if os.path.isdir(rundir):
+            filename = compname + "_in"
+            file_src  = os.path.join(confdir, filename)
+            file_dest = os.path.join(rundir, filename)
+            if inst_string:
+                file_dest += inst_string
+            shutil.copy(file_src,file_dest)
 
-            # copy namelist files and stream text files, to rundir
-            if os.path.isdir(rundir):
-                filename = compname + "_in"
-                file_src  = os.path.join(confdir, filename)
-                file_dest = os.path.join(rundir, filename)
-                if inst_string:
-                    file_dest += inst_string
-                shutil.copy(file_src,file_dest)
+            for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
+                shutil.copy(txtfile, rundir)
 
-                for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                    shutil.copy(txtfile, rundir)
-
-            # increment instance counter
-            inst_counter = inst_counter + 1
+        # increment instance counter
+        inst_counter = inst_counter + 1
 
 ###############################################################################
 
 if __name__ == "__main__":
-    _main_func()
+    # Build the component namelist and required stream txt files
+    caseroot = _parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "dlnd")

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -18,32 +18,9 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
 from CIME.utils import expect
-from CIME.utils import handle_standard_logging_options
-from CIME.utils import setup_standard_logging_options
-from CIME.buildnml import create_namelist_infile
+from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
-
-###############################################################################
-def _parse_input(argv):
-###############################################################################
-
-    if "--test" in argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
-    parser = argparse.ArgumentParser()
-
-    setup_standard_logging_options(parser)
-
-    parser.add_argument("caseroot",
-                        help="case directory")
-
-    args = parser.parse_args()
-
-    handle_standard_logging_options(args)
-
-    return args.caseroot
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
@@ -60,7 +37,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Get a bunch of information from the case.
     #----------------------------------------------------
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
     lnd_domain_file = case.get_value("LND_DOMAIN_FILE")
     lnd_domain_path = case.get_value("LND_DOMAIN_PATH")
     dlnd_mode = case.get_value("DLND_MODE")
@@ -242,9 +218,11 @@ def buildnml(case, caseroot, compname):
         inst_counter = inst_counter + 1
 
 ###############################################################################
-
-if __name__ == "__main__":
+def _main_func():
     # Build the component namelist and required stream txt files
-    caseroot = _parse_input(sys.argv)
+    caseroot = parse_input(sys.argv)
     with Case(caseroot) as case:
         buildnml(case, caseroot, "dlnd")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -155,93 +155,93 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     nmlgen.write_output_file(namelist_file, data_list_path, groups=['docn_nml','shr_strdata_nml'])
 
 ###############################################################################
-def _main_func():
+def buildnml(case, caseroot, compname):
 ###############################################################################
 
     # Build the component namelist and required stream txt files
+    if compname != "docn":
+        raise AttributeError
 
-    compname = "docn"
-    caseroot = _parse_input(sys.argv)
+    cimeroot = case.get_value("CIMEROOT")
+    rundir = case.get_value("RUNDIR")
+    ninst = case.get_value("NINST_OCN")
+    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    with Case(caseroot) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        rundir = case.get_value("RUNDIR")
-        ninst = case.get_value("NINST_OCN")
-        din_loc_root = case.get_value("DIN_LOC_ROOT")
+    if not os.path.isdir(din_loc_root):
+        os.makedirs(din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
-        if not os.path.isdir(din_loc_root):
-            os.makedirs(din_loc_root)
-            logger.info("Created input root directory %s" %din_loc_root)
+    # determine directory for user modified namelist_definitions.xml
+    user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
+    expect (os.path.isdir(user_xml_dir),
+            "user_xml_dir %s does not exist " %user_xml_dir)
 
-        # determine directory for user modified namelist_definitions.xml
-        user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
-        expect (os.path.isdir(user_xml_dir),
-                "user_xml_dir %s does not exist " %user_xml_dir)
+    # NOTE: User definition *replaces* existing definition.
+    namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
+    definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_docn.xml")]
+    user_definition = os.path.join(user_xml_dir, "namelist_definition_docn.xml")
+    if os.path.isfile(user_definition):
+        definition_file = [user_definition]
 
-        # NOTE: User definition *replaces* existing definition.
-        namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
-        definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_docn.xml")]
-        user_definition = os.path.join(user_xml_dir, "namelist_definition_docn.xml")
-        if os.path.isfile(user_definition):
-            definition_file = [user_definition]
+    # Checkout if definition file exists
+    for file_ in definition_file:
+        expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-        # Checkout if definition file exists
-        for file_ in definition_file:
-            expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
-        confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-        if not os.path.isdir(confdir):
-            os.makedirs(confdir)
+    # Loop over instances
+    inst_string = ""
+    inst_counter = 1
+    while (inst_counter <= ninst):
 
-        # Loop over instances
+        # determine instance string
         inst_string = ""
-        inst_counter = 1
-        while (inst_counter <= ninst):
+        if ninst > 1:
+            inst_string = '_' + '%04d' % inst_counter
 
-            # determine instance string
-            inst_string = ""
-            if ninst > 1:
-                inst_string = '_' + '%04d' % inst_counter
+        # If multi-instance case does not have restart file, use
+        # single-case restart for each instance
+        rpointer = "rpointer." + compname
+        if (os.path.isfile(os.path.join(rundir,rpointer)) and
+            (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
+            shutil.copy(os.path.join(rundir, rpointer),
+                        os.path.join(rundir, rpointer + inst_string))
 
-            # If multi-instance case does not have restart file, use
-            # single-case restart for each instance
-            rpointer = "rpointer." + compname
-            if (os.path.isfile(os.path.join(rundir,rpointer)) and
-                (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-                shutil.copy(os.path.join(rundir, rpointer),
-                            os.path.join(rundir, rpointer + inst_string))
+        inst_string_label = inst_string
+        if not inst_string_label:
+            inst_string_label = "\"\""
 
-            inst_string_label = inst_string
-            if not inst_string_label:
-                inst_string_label = "\"\""
+        # create namelist output infile using user_nl_file as input
+        user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
+        expect(os.path.isfile(user_nl_file),
+               "Missing required user_nl_file %s " %(user_nl_file))
+        infile = os.path.join(confdir, "namelist_infile")
+        create_namelist_infile(case, user_nl_file, infile)
+        namelist_infile = [infile]
 
-            # create namelist output infile using user_nl_file as input
-            user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
-            expect(os.path.isfile(user_nl_file),
-                   "Missing required user_nl_file %s " %(user_nl_file))
-            infile = os.path.join(confdir, "namelist_infile")
-            create_namelist_infile(case, user_nl_file, infile)
-            namelist_infile = [infile]
+        # create namelist and stream file(s) data component
+        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
 
-            # create namelist and stream file(s) data component
-            _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        # copy namelist files and stream text files, to rundir
+        if os.path.isdir(rundir):
+            filename = compname + "_in"
+            file_src  = os.path.join(confdir, filename)
+            file_dest = os.path.join(rundir, filename)
+            if inst_string:
+                file_dest += inst_string
+            shutil.copy(file_src,file_dest)
 
-            # copy namelist files and stream text files, to rundir
-            if os.path.isdir(rundir):
-                filename = compname + "_in"
-                file_src  = os.path.join(confdir, filename)
-                file_dest = os.path.join(rundir, filename)
-                if inst_string:
-                    file_dest += inst_string
-                shutil.copy(file_src,file_dest)
+            for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
+                shutil.copy(txtfile, rundir)
 
-                for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                    shutil.copy(txtfile, rundir)
-
-            # increment instance counter
-            inst_counter = inst_counter + 1
+        # increment instance counter
+        inst_counter = inst_counter + 1
 
 ###############################################################################
-
 if __name__ == "__main__":
-    _main_func()
+    # Build the component namelist and required stream txt files
+    caseroot = _parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "docn")

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -18,32 +18,9 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
 from CIME.utils import expect
-from CIME.utils import handle_standard_logging_options
-from CIME.utils import setup_standard_logging_options
-from CIME.buildnml import create_namelist_infile
+from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
-
-###############################################################################
-def _parse_input(argv):
-###############################################################################
-
-    if "--test" in argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
-    parser = argparse.ArgumentParser()
-
-    setup_standard_logging_options(parser)
-
-    parser.add_argument("caseroot",
-                        help="case directory")
-
-    args = parser.parse_args()
-
-    handle_standard_logging_options(args)
-
-    return args.caseroot
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
@@ -60,7 +37,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Get a bunch of information from the case.
     #----------------------------------------------------
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
     ocn_domain_file = case.get_value("OCN_DOMAIN_FILE")
     ocn_domain_path = case.get_value("OCN_DOMAIN_PATH")
     docn_mode = case.get_value("DOCN_MODE")
@@ -240,8 +216,11 @@ def buildnml(case, caseroot, compname):
         inst_counter = inst_counter + 1
 
 ###############################################################################
-if __name__ == "__main__":
+def _main_func():
     # Build the component namelist and required stream txt files
-    caseroot = _parse_input(sys.argv)
+    caseroot = parse_input(sys.argv)
     with Case(caseroot) as case:
         buildnml(case, caseroot, "docn")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob, re
+import os, shutil, sys, glob
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -18,32 +18,9 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
 from CIME.utils import expect
-from CIME.utils import handle_standard_logging_options
-from CIME.utils import setup_standard_logging_options
-from CIME.buildnml import create_namelist_infile
+from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
-
-###############################################################################
-def _parse_input(argv):
-###############################################################################
-
-    if "--test" in argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
-    parser = argparse.ArgumentParser()
-
-    setup_standard_logging_options(parser)
-
-    parser.add_argument("caseroot",
-                        help="case directory")
-
-    args = parser.parse_args()
-
-    handle_standard_logging_options(args)
-
-    return args.caseroot
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
@@ -60,7 +37,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Get a bunch of information from the case.
     #----------------------------------------------------
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
     rof_domain_file = case.get_value("ROF_DOMAIN_FILE")
     rof_domain_path = case.get_value("ROF_DOMAIN_PATH")
     drof_mode = case.get_value("DROF_MODE")
@@ -238,9 +214,11 @@ def buildnml(case, caseroot, compname):
         inst_counter = inst_counter + 1
 
 ###############################################################################
-
-if __name__ == "__main__":
+def _main_func():
     # Build the component namelist and required stream txt files
-    caseroot = _parse_input(sys.argv)
+    caseroot = parse_input(sys.argv)
     with Case(caseroot) as case:
         buildnml(case, caseroot, "drof")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -118,7 +118,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
         inst_stream = stream + inst_string
         logger.info("DROF stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "drof.streams.txt." + inst_stream)
-        user_stream_path = os.path.join(case.get_case_root(), 
+        user_stream_path = os.path.join(case.get_case_root(),
                                         "user_drof.streams.txt." + inst_stream)
 
         # Use the user's stream file, or create one if necessary.
@@ -153,93 +153,94 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     nmlgen.write_output_file(namelist_file, data_list_path, groups=['drof_nml','shr_strdata_nml'])
 
 ###############################################################################
-def _main_func():
+def buildnml(case, caseroot, compname):
 ###############################################################################
 
     # Build the component namelist and required stream txt files
+    if compname != "drof":
+        raise AttributeError
 
-    compname = "drof"
-    caseroot = _parse_input(sys.argv)
+    cimeroot = case.get_value("CIMEROOT")
+    rundir = case.get_value("RUNDIR")
+    ninst = case.get_value("NINST_ROF")
+    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    with Case(caseroot) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        rundir = case.get_value("RUNDIR")
-        ninst = case.get_value("NINST_ROF")
-        din_loc_root = case.get_value("DIN_LOC_ROOT")
+    if not os.path.isdir(din_loc_root):
+        os.makedirs(din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
-        if not os.path.isdir(din_loc_root):
-            os.makedirs(din_loc_root)
-            logger.info("Created input root directory %s" %din_loc_root)
+    # determine directory for user modified namelist_definitions.xml
+    user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
+    expect (os.path.isdir(user_xml_dir),
+            "user_xml_dir %s does not exist " %user_xml_dir)
 
-        # determine directory for user modified namelist_definitions.xml
-        user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
-        expect (os.path.isdir(user_xml_dir),
-                "user_xml_dir %s does not exist " %user_xml_dir)
+    # NOTE: User definition *replaces* existing definition.
+    namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
+    definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_drof.xml")]
+    user_definition = os.path.join(user_xml_dir, "namelist_definition_drof.xml")
+    if os.path.isfile(user_definition):
+        definition_file = [user_definition]
 
-        # NOTE: User definition *replaces* existing definition.
-        namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
-        definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_drof.xml")]
-        user_definition = os.path.join(user_xml_dir, "namelist_definition_drof.xml")
-        if os.path.isfile(user_definition):
-            definition_file = [user_definition]
+    # Checkout if definition file exists
+    for file_ in definition_file:
+        expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-        # Checkout if definition file exists
-        for file_ in definition_file:
-            expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
-        confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-        if not os.path.isdir(confdir):
-            os.makedirs(confdir)
+    # Loop over instances
+    inst_string = ""
+    inst_counter = 1
+    while (inst_counter <= ninst):
 
-        # Loop over instances
+        # determine instance string
         inst_string = ""
-        inst_counter = 1
-        while (inst_counter <= ninst):
+        if ninst > 1:
+            inst_string = '_' + '%04d' % inst_counter
 
-            # determine instance string
-            inst_string = ""
-            if ninst > 1:
-                inst_string = '_' + '%04d' % inst_counter
+        # If multi-instance case does not have restart file, use
+        # single-case restart for each instance
+        rpointer = "rpointer." + compname
+        if (os.path.isfile(os.path.join(rundir,rpointer)) and
+            (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
+            shutil.copy(os.path.join(rundir, rpointer),
+                        os.path.join(rundir, rpointer + inst_string))
 
-            # If multi-instance case does not have restart file, use
-            # single-case restart for each instance
-            rpointer = "rpointer." + compname
-            if (os.path.isfile(os.path.join(rundir,rpointer)) and
-                (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-                shutil.copy(os.path.join(rundir, rpointer),
-                            os.path.join(rundir, rpointer + inst_string))
+        inst_string_label = inst_string
+        if not inst_string_label:
+            inst_string_label = "\"\""
 
-            inst_string_label = inst_string
-            if not inst_string_label:
-                inst_string_label = "\"\""
+        # create namelist output infile using user_nl_file as input
+        user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
+        expect(os.path.isfile(user_nl_file),
+               "Missing required user_nl_file %s " %(user_nl_file))
+        infile = os.path.join(confdir, "namelist_infile")
+        create_namelist_infile(case, user_nl_file, infile)
+        namelist_infile = [infile]
 
-            # create namelist output infile using user_nl_file as input
-            user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
-            expect(os.path.isfile(user_nl_file),
-                   "Missing required user_nl_file %s " %(user_nl_file))
-            infile = os.path.join(confdir, "namelist_infile")
-            create_namelist_infile(case, user_nl_file, infile)
-            namelist_infile = [infile]
+        # create namelist and stream file(s) data component
+        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
 
-            # create namelist and stream file(s) data component
-            _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        # copy namelist files and stream text files, to rundir
+        if os.path.isdir(rundir):
+            filename = compname + "_in"
+            file_src  = os.path.join(confdir, filename)
+            file_dest = os.path.join(rundir, filename)
+            if inst_string:
+                file_dest += inst_string
+            shutil.copy(file_src,file_dest)
 
-            # copy namelist files and stream text files, to rundir
-            if os.path.isdir(rundir):
-                filename = compname + "_in"
-                file_src  = os.path.join(confdir, filename)
-                file_dest = os.path.join(rundir, filename)
-                if inst_string:
-                    file_dest += inst_string
-                shutil.copy(file_src,file_dest)
+            for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
+                shutil.copy(txtfile, rundir)
 
-                for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                    shutil.copy(txtfile, rundir)
-
-            # increment instance counter
-            inst_counter = inst_counter + 1
+        # increment instance counter
+        inst_counter = inst_counter + 1
 
 ###############################################################################
 
 if __name__ == "__main__":
-    _main_func()
+    # Build the component namelist and required stream txt files
+    caseroot = _parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "drof")

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -150,93 +150,95 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     nmlgen.write_output_file(namelist_file, data_list_path)
 
 ###############################################################################
-def _main_func():
+def buildnml(case, caseroot, compname):
 ###############################################################################
 
     # Build the component namelist and required stream txt files
 
-    compname = "dwav"
-    caseroot = _parse_input(sys.argv)
+    if compname != "dwav":
+        raise AttributeError
 
-    with Case(caseroot) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        rundir = case.get_value("RUNDIR")
-        ninst = case.get_value("NINST_WAV")
-        din_loc_root = case.get_value("DIN_LOC_ROOT")
+    cimeroot = case.get_value("CIMEROOT")
+    rundir = case.get_value("RUNDIR")
+    ninst = case.get_value("NINST_WAV")
+    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-        if not os.path.isdir(din_loc_root):
-            os.makedirs(din_loc_root)
-            logger.info("Created input root directory %s" %din_loc_root)
+    if not os.path.isdir(din_loc_root):
+        os.makedirs(din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
-        # determine directory for user modified namelist_definitions.xml
-        user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
-        expect (os.path.isdir(user_xml_dir),
-                "user_xml_dir %s does not exist " %user_xml_dir)
+    # determine directory for user modified namelist_definitions.xml
+    user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
+    expect (os.path.isdir(user_xml_dir),
+            "user_xml_dir %s does not exist " %user_xml_dir)
 
         # NOTE: User definition *replaces* existing definition.
-        namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
-        definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_dwav.xml")]
-        user_definition = os.path.join(user_xml_dir, "namelist_definition_dwav.xml")
-        if os.path.isfile(user_definition):
-            definition_file = [user_definition]
+    namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
+    definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_dwav.xml")]
+    user_definition = os.path.join(user_xml_dir, "namelist_definition_dwav.xml")
+    if os.path.isfile(user_definition):
+        definition_file = [user_definition]
 
-        # Checkout if definition file exists
-        for file_ in definition_file:
-            expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
+    # Checkout if definition file exists
+    for file_ in definition_file:
+        expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-        confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-        if not os.path.isdir(confdir):
-            os.makedirs(confdir)
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
-        # Loop over instances
+    # Loop over instances
+    inst_string = ""
+    inst_counter = 1
+    while (inst_counter <= ninst):
+
+        # determine instance string
         inst_string = ""
-        inst_counter = 1
-        while (inst_counter <= ninst):
+        if ninst > 1:
+            inst_string = '_' + '%04d' % inst_counter
 
-            # determine instance string
-            inst_string = ""
-            if ninst > 1:
-                inst_string = '_' + '%04d' % inst_counter
+        # If multi-instance case does not have restart file, use
+        # single-case restart for each instance
+        rpointer = "rpointer." + compname
+        if (os.path.isfile(os.path.join(rundir,rpointer)) and
+            (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
+            shutil.copy(os.path.join(rundir, rpointer),
+                        os.path.join(rundir, rpointer + inst_string))
 
-            # If multi-instance case does not have restart file, use
-            # single-case restart for each instance
-            rpointer = "rpointer." + compname
-            if (os.path.isfile(os.path.join(rundir,rpointer)) and
-                (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-                shutil.copy(os.path.join(rundir, rpointer),
-                            os.path.join(rundir, rpointer + inst_string))
+        inst_string_label = inst_string
+        if not inst_string_label:
+            inst_string_label = "\"\""
 
-            inst_string_label = inst_string
-            if not inst_string_label:
-                inst_string_label = "\"\""
+        # create namelist output infile using user_nl_file as input
+        user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
+        expect(os.path.isfile(user_nl_file),
+               "Missing required user_nl_file %s " %(user_nl_file))
+        infile = os.path.join(confdir, "namelist_infile")
+        create_namelist_infile(case, user_nl_file, infile)
+        namelist_infile = [infile]
 
-            # create namelist output infile using user_nl_file as input
-            user_nl_file = os.path.join(caseroot, "user_nl_" + compname + inst_string)
-            expect(os.path.isfile(user_nl_file),
-                   "Missing required user_nl_file %s " %(user_nl_file))
-            infile = os.path.join(confdir, "namelist_infile")
-            create_namelist_infile(case, user_nl_file, infile)
-            namelist_infile = [infile]
+        # create namelist and stream file(s) data component
+        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
 
-            # create namelist and stream file(s) data component
-            _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        # copy namelist files and stream text files, to rundir
+        if os.path.isdir(rundir):
+            filename = compname + "_in"
+            file_src  = os.path.join(confdir, filename)
+            file_dest = os.path.join(rundir, filename)
+            if inst_string:
+                file_dest += inst_string
+            shutil.copy(file_src,file_dest)
 
-            # copy namelist files and stream text files, to rundir
-            if os.path.isdir(rundir):
-                filename = compname + "_in"
-                file_src  = os.path.join(confdir, filename)
-                file_dest = os.path.join(rundir, filename)
-                if inst_string:
-                    file_dest += inst_string
-                shutil.copy(file_src,file_dest)
+            for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
+                shutil.copy(txtfile, rundir)
 
-                for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                    shutil.copy(txtfile, rundir)
-
-            # increment instance counter
-            inst_counter = inst_counter + 1
+        # increment instance counter
+        inst_counter = inst_counter + 1
 
 ###############################################################################
 
 if __name__ == "__main__":
-    _main_func()
+    # Build the component namelist and required stream txt files
+    caseroot = _parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "dwav")

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -21,32 +21,9 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
 from CIME.utils import expect
-from CIME.utils import handle_standard_logging_options
-from CIME.utils import setup_standard_logging_options
-from CIME.buildnml import create_namelist_infile
+from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
-
-###############################################################################
-def _parse_input(argv):
-###############################################################################
-
-    if "--test" in argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
-    parser = argparse.ArgumentParser()
-
-    setup_standard_logging_options(parser)
-
-    parser.add_argument("caseroot",
-                        help="case directory")
-
-    args = parser.parse_args()
-
-    handle_standard_logging_options(args)
-
-    return args.caseroot
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
@@ -63,7 +40,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Get a bunch of information from the case.
     #----------------------------------------------------
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
     wav_domain_file = case.get_value("WAV_DOMAIN_FILE")
     wav_domain_path = case.get_value("WAV_DOMAIN_PATH")
     dwav_mode = case.get_value("DWAV_MODE")
@@ -146,7 +122,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Finally, write out all the namelists.
     #----------------------------------------------------
-    namelist_file = os.path.join(confdir, COMPONENT+"_in")
+    namelist_file = os.path.join(confdir, "dwav_in")
     nmlgen.write_output_file(namelist_file, data_list_path)
 
 ###############################################################################
@@ -236,9 +212,11 @@ def buildnml(case, caseroot, compname):
         inst_counter = inst_counter + 1
 
 ###############################################################################
-
-if __name__ == "__main__":
+def _main_func():
     # Build the component namelist and required stream txt files
-    caseroot = _parse_input(sys.argv)
+    caseroot = parse_input(sys.argv)
     with Case(caseroot) as case:
         buildnml(case, caseroot, "dwav")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/xcpl_comps/xatm/cime_config/buildnml
+++ b/components/xcpl_comps/xatm/cime_config/buildnml
@@ -10,6 +10,18 @@ _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *
-from CIME.buildnml import build_xcpl_nml
+from CIME.buildnml import build_xcpl_nml, parse_input
+from CIME.case import Case
 
-build_xcpl_nml(sys.argv, 'atm')
+def buildnml(case, caseroot, compname):
+    if compname != "xatm":
+        raise AttributeError
+    build_xcpl_nml(case, caseroot, compname)
+
+def _main_func():
+    caseroot = parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "xatm")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/xcpl_comps/xglc/cime_config/buildnml
+++ b/components/xcpl_comps/xglc/cime_config/buildnml
@@ -10,6 +10,18 @@ _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *
-from CIME.buildnml import build_xcpl_nml
+from CIME.buildnml import build_xcpl_nml, parse_input
+from CIME.case import Case
 
-build_xcpl_nml(sys.argv, 'glc')
+def buildnml(case, caseroot, compname):
+    if compname != "xglc":
+        raise AttributeError
+    build_xcpl_nml(case, caseroot, compname)
+
+def _main_func():
+    caseroot = parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "xglc")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/xcpl_comps/xice/cime_config/buildnml
+++ b/components/xcpl_comps/xice/cime_config/buildnml
@@ -10,6 +10,18 @@ _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *
-from CIME.buildnml import build_xcpl_nml
+from CIME.buildnml import build_xcpl_nml, parse_input
+from CIME.case import Case
 
-build_xcpl_nml(sys.argv, 'ice')
+def buildnml(case, caseroot, compname):
+    if compname != "xice":
+        raise AttributeError
+    build_xcpl_nml(case, caseroot, compname)
+
+def _main_func():
+    caseroot = parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "xice")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/xcpl_comps/xlnd/cime_config/buildnml
+++ b/components/xcpl_comps/xlnd/cime_config/buildnml
@@ -10,6 +10,18 @@ _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *
-from CIME.buildnml import build_xcpl_nml
+from CIME.buildnml import build_xcpl_nml, parse_input
+from CIME.case import Case
 
-build_xcpl_nml(sys.argv, 'lnd')
+def buildnml(case, caseroot, compname):
+    if compname != "xlnd":
+        raise AttributeError
+    build_xcpl_nml(case, caseroot, compname)
+
+def _main_func():
+    caseroot = parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "xlnd")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/xcpl_comps/xocn/cime_config/buildnml
+++ b/components/xcpl_comps/xocn/cime_config/buildnml
@@ -10,6 +10,18 @@ _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *
-from CIME.buildnml import build_xcpl_nml
+from CIME.buildnml import build_xcpl_nml, parse_input
+from CIME.case import Case
 
-build_xcpl_nml(sys.argv, 'ocn')
+def buildnml(case, caseroot, compname):
+    if compname != "xocn":
+        raise AttributeError
+    build_xcpl_nml(case, caseroot, compname)
+
+def _main_func():
+    caseroot = parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "xocn")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/xcpl_comps/xrof/cime_config/buildnml
+++ b/components/xcpl_comps/xrof/cime_config/buildnml
@@ -10,6 +10,18 @@ _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *
-from CIME.buildnml import build_xcpl_nml
+from CIME.buildnml import build_xcpl_nml, parse_input
+from CIME.case import Case
 
-build_xcpl_nml(sys.argv, 'rof')
+def buildnml(case, caseroot, compname):
+    if compname != "xrof":
+        raise AttributeError
+    build_xcpl_nml(case, caseroot, compname)
+
+def _main_func():
+    caseroot = parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "xrof")
+
+if __name__ == "__main__":
+    _main_func()

--- a/components/xcpl_comps/xwav/cime_config/buildnml
+++ b/components/xcpl_comps/xwav/cime_config/buildnml
@@ -10,6 +10,18 @@ _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *
-from CIME.buildnml import build_xcpl_nml
+from CIME.buildnml import build_xcpl_nml, parse_input
+from CIME.case import Case
 
-build_xcpl_nml(sys.argv, 'wav')
+def buildnml(case, caseroot, compname):
+    if compname != "xwav":
+        raise AttributeError
+    build_xcpl_nml(case, caseroot, compname)
+
+def _main_func():
+    caseroot = parse_input(sys.argv)
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "xwav")
+
+if __name__ == "__main__":
+    _main_func()

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -15,32 +15,11 @@ sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect, handle_standard_logging_options, setup_standard_logging_options
+from CIME.utils import expect
 from CIME.utils import run_cmd_no_fail, get_model
-from CIME.buildnml import create_namelist_infile
+from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
-
-###############################################################################
-def _parse_input(argv):
-###############################################################################
-
-    if "--test" in argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
-    parser = argparse.ArgumentParser()
-
-    setup_standard_logging_options(parser)
-
-    parser.add_argument("caseroot",
-                        help="Case diretory")
-
-    args = parser.parse_args()
-
-    handle_standard_logging_options(args)
-
-    return args.caseroot
 
 ###############################################################################
 def _create_drv_namelists(case, infiles, definition_file, confdir):
@@ -318,9 +297,11 @@ def buildnml(case, caseroot, component):
         shutil.copy(filename, rundir)
 
 ###############################################################################
-
-if __name__ == "__main__":
-    caseroot = _parse_input(sys.argv)
+def _main_func():
+    caseroot = parse_input(sys.argv)
 
     with Case(caseroot) as case:
         buildnml(case, caseroot, "drv")
+
+if __name__ == "__main__":
+    _main_func()

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -261,64 +261,66 @@ def _create_component_modelio_namelists(case):
                 inst_index = inst_index + 1
 
 ###############################################################################
-def _main_func():
+def buildnml(case, caseroot, component):
 ###############################################################################
+    if component != "drv":
+        raise AttributeError
+    cimeroot = case.get_value("CIMEROOT")
 
-    caseroot = _parse_input(sys.argv)
-    with Case(caseroot) as case:
-        cimeroot = case.get_value("CIMEROOT")
+    confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
-        confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
-        if not os.path.isdir(confdir):
-            os.makedirs(confdir)
+    # NOTE: User definition *replaces* existing definition.
+    # TODO: Append instead of replace?
+    user_xml_dir = os.path.join(caseroot, "SourceMods", "src.drv")
+    expect (os.path.isdir(user_xml_dir),
+            "user_xml_dir %s does not exist " %user_xml_dir)
+    namelist_xml_dir = os.path.join(cimeroot, "driver_cpl", "cime_config")
+    definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_drv.xml")]
+    user_definition = os.path.join(user_xml_dir, "namelist_definition_drv.xml")
+    if os.path.isfile(user_definition):
+        definition_file = [user_definition]
 
-        # NOTE: User definition *replaces* existing definition.
-        # TODO: Append instead of replace?
-        user_xml_dir = os.path.join(caseroot, "SourceMods", "src.drv")
-        expect (os.path.isdir(user_xml_dir),
-                "user_xml_dir %s does not exist " %user_xml_dir)
-        namelist_xml_dir = os.path.join(cimeroot, "driver_cpl", "cime_config")
-        definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_drv.xml")]
-        user_definition = os.path.join(user_xml_dir, "namelist_definition_drv.xml")
-        if os.path.isfile(user_definition):
-            definition_file = [user_definition]
+    # create cplconf/namelist
+    infile_text = ""
+    if case.get_value('COMP_ATM') == 'cam':
+        # cam is actually changing the driver namelist settings
+        cam_config_opts = case.get_value("CAM_CONFIG_OPTS")
+        if "adiabatic" in cam_config_opts:
+            infile_text = "atm_adiabatic = .true."
+        if "ideal" in cam_config_opts:
+            infile_text = "atm_ideal_phys = .true."
+        if "aquaplanet" in cam_config_opts:
+            infile_text = "aqua_planet = .true. \n aqua_planet_sst = 1"
+    user_nl_file = os.path.join(caseroot, "user_nl_cpl")
+    namelist_infile = os.path.join(confdir, "namelist_infile")
+    create_namelist_infile(case, user_nl_file, namelist_infile, infile_text)
+    infile = [namelist_infile]
 
-        # create cplconf/namelist
-        infile_text = ""
-        if case.get_value('COMP_ATM') == 'cam':
-            # cam is actually changing the driver namelist settings
-            cam_config_opts = case.get_value("CAM_CONFIG_OPTS")
-            if "adiabatic" in cam_config_opts:
-                infile_text = "atm_adiabatic = .true."
-            if "ideal" in cam_config_opts:
-                infile_text = "atm_ideal_phys = .true."
-            if "aquaplanet" in cam_config_opts:
-                infile_text = "aqua_planet = .true. \n aqua_planet_sst = 1"
-        user_nl_file = os.path.join(caseroot, "user_nl_cpl")
-        namelist_infile = os.path.join(confdir, "namelist_infile")
-        create_namelist_infile(case, user_nl_file, namelist_infile, infile_text)
-        infile = [namelist_infile]
+    # create the files drv_in, drv_flds_in and seq_maps.rc
+    _create_drv_namelists(case, infile, definition_file, confdir)
 
-        # create the files drv_in, drv_flds_in and seq_maps.rc
-        _create_drv_namelists(case, infile, definition_file, confdir)
+    # create the files comp_modelio.nml where comp = [atm, lnd...]
+    _create_component_modelio_namelists(case)
 
-        # create the files comp_modelio.nml where comp = [atm, lnd...]
-        _create_component_modelio_namelists(case)
+    # copy drv_in, drv_flds_in, seq_maps.rc and all *modio* fiels to rundir
+    rundir = case.get_value("RUNDIR")
 
-        # copy drv_in, drv_flds_in, seq_maps.rc and all *modio* fiels to rundir
-        rundir = case.get_value("RUNDIR")
+    shutil.copy(os.path.join(confdir,"drv_in"), rundir)
+    drv_flds_in = os.path.join(caseroot, "CaseDocs", "drv_flds_in")
+    if os.path.isfile(drv_flds_in):
+        shutil.copy(drv_flds_in, rundir)
 
-        shutil.copy(os.path.join(confdir,"drv_in"), rundir)
-        drv_flds_in = os.path.join(caseroot, "CaseDocs", "drv_flds_in")
-        if os.path.isfile(drv_flds_in):
-            shutil.copy(drv_flds_in, rundir)
+    shutil.copy(os.path.join(confdir,"seq_maps.rc"), rundir)
 
-        shutil.copy(os.path.join(confdir,"seq_maps.rc"), rundir)
-
-        for filename in glob.glob(os.path.join(confdir, "*modelio*")):
-            shutil.copy(filename, rundir)
+    for filename in glob.glob(os.path.join(confdir, "*modelio*")):
+        shutil.copy(filename, rundir)
 
 ###############################################################################
 
 if __name__ == "__main__":
-    _main_func()
+    caseroot = _parse_input(sys.argv)
+
+    with Case(caseroot) as case:
+        buildnml(case, caseroot, "drv")

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -10,6 +10,7 @@ from standard_script_setup import *
 
 from CIME.preview_namelists import create_namelists
 from CIME.case              import Case
+from CIME.utils             import expect
 
 import argparse, doctest
 
@@ -54,6 +55,8 @@ def _main_func(description):
         sys.exit(1 if test_results.failed > 0 else 0)
 
     caseroot = parse_command_line(sys.argv, description)
+    expect(os.path.isfile(os.path.join(caseroot, "CaseStatus")),
+           "case.setup must be run prior to running preview_namelists")
     with Case(caseroot, read_only=False) as case:
         create_namelists(case)
 

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -35,15 +35,15 @@ class Machines(GenericXML):
 
         # Append the contents of $HOME/.cime/config_machines.xml if it exists
         # This could cause problems if node matchs are repeated when only one is expected
-        infile = os.path.join(os.environ.get("HOME"),".cime","config_machines.xml")
-        logger.debug("Infile: %s" , infile)
-        if os.path.exists(infile):
-            GenericXML.read(self, infile)
+        local_infile = os.path.join(os.environ.get("HOME"),".cime","config_machines.xml")
+        logger.debug("Infile: %s" , local_infile)
+        if os.path.exists(local_infile):
+            GenericXML.read(self, local_infile)
 
         if machine is None:
             machine = self.probe_machine_name()
 
-        expect(machine is not None, "Could not initialize machine object")
+        expect(machine is not None, "Could not initialize machine object from %s or %s"%(infile, local_infile))
         self.set_machine(machine)
 
     def get_machines_dir(self):

--- a/utils/python/CIME/buildnml.py
+++ b/utils/python/CIME/buildnml.py
@@ -6,7 +6,6 @@ These are used by components/<model_type>/<component>/cime_config/buildnml
 
 from CIME.XML.standard_module_setup import *
 from CIME.utils import expect, handle_standard_logging_options, setup_standard_logging_options
-from CIME.case import Case
 import sys, os, argparse, doctest
 
 logger = logging.getLogger(__name__)
@@ -33,22 +32,22 @@ def parse_input(argv):
     return args.caseroot
 
 ###############################################################################
-def build_xcpl_nml(argv, compclass):
+#pylint: disable=unused-argument
+def build_xcpl_nml(case, caseroot, compname):
 ###############################################################################
-
-    caseroot = parse_input(argv)
-
-    compname = "x" + compclass
-
-    caseroot = parse_input(argv)
-
-    with Case(caseroot) as case:
-        rundir = case.get_value("RUNDIR")
-        ninst  = case.get_value("NINST_%s" % compclass.upper())
-        nx     = case.get_value("%s_NX" % compclass.upper())
-        ny     = case.get_value("%s_NY" % compclass.upper())
-        if compname == "xrof":
-            flood_mode = case.get_value('XROF_FLOOD_MODE')
+    compclasses = case.get_values("COMP_CLASSES")
+    compclass = None
+    for compclass in compclasses:
+        if case.get_value("COMP_%s"%compclass) == compname:
+            break
+    expect(compclass is not None,
+           "Could not identify compclass for compname %s"%compname)
+    rundir = case.get_value("RUNDIR")
+    ninst  = case.get_value("NINST_%s" % compclass.upper())
+    nx     = case.get_value("%s_NX" % compclass.upper())
+    ny     = case.get_value("%s_NY" % compclass.upper())
+    if compname == "xrof":
+        flood_mode = case.get_value('XROF_FLOOD_MODE')
 
     extras = []
     dtype = 1

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -4,7 +4,7 @@ API for preview namelist
 
 from CIME.XML.standard_module_setup import *
 
-import glob, shutil
+import glob, shutil, imp
 logger = logging.getLogger(__name__)
 
 def create_dirs(case):
@@ -60,8 +60,12 @@ def create_namelists(case):
         model_str = model.lower()
         config_file = case.get_value("CONFIG_%s_FILE" % model_str.upper())
         config_dir = os.path.dirname(config_file)
-        cmd = os.path.join(config_dir, "buildnml")
-        run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=True)
+        try:
+            mod = imp.load_source("buildnml",config_file)
+            buildnml.buildnml(caseroot)
+        except:
+            cmd = os.path.join(config_dir, "buildnml")
+            run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=True)
 
     # refresh case xml object from file
     case.read_xml()

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -60,13 +60,20 @@ def create_namelists(case):
         model_str = model.lower()
         config_file = case.get_value("CONFIG_%s_FILE" % model_str.upper())
         config_dir = os.path.dirname(config_file)
+        if model_str == "drv":
+            compname = "drv"
+        else:
+            compname = case.get_value("COMP_%s" % model_str.upper())
         try:
             mod = imp.load_source("buildnml",
                                   os.path.join(config_dir, "buildnml"))
-            mod.buildnml(caseroot)
-        except:
+            logger.info("Calling %s buildnml"%compname)
+            mod.buildnml(case, caseroot, compname)
+        except AttributeError:
             cmd = os.path.join(config_dir, "buildnml")
             run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=True)
+        except:
+            raise
 
     # refresh case xml object from file
     case.read_xml()

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -61,8 +61,9 @@ def create_namelists(case):
         config_file = case.get_value("CONFIG_%s_FILE" % model_str.upper())
         config_dir = os.path.dirname(config_file)
         try:
-            mod = imp.load_source("buildnml",config_file)
-            buildnml.buildnml(caseroot)
+            mod = imp.load_source("buildnml",
+                                  os.path.join(config_dir, "buildnml"))
+            mod.buildnml(caseroot)
         except:
             cmd = os.path.join(config_dir, "buildnml")
             run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=True)

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1889,6 +1889,8 @@ def _main_func():
                                         from_dir=cimeroot).splitlines())
         #TODO - get rid of this
         list_of_directories_to_ignore = ("xmlconvertors", "pointclm", "point_clm", "tools", "machines", "apidocs", "unit_test")
+        testnames = []
+        cnt = 0
         for file_ in files_to_test:
             # Dont test template files
             test_this = True
@@ -1898,7 +1900,14 @@ def _main_func():
                     break
             if test_this:
                 pylint_test = make_pylint_test(file_, cimeroot)
-                setattr(B_CheckCode, 'test_pylint_%s'%os.path.basename(file_), pylint_test)
+                testname = "test_pylint_%s"%(os.path.basename(file_))
+                # if two files have the same name this will generate
+                # different test names so that both are tested
+                if testname in testnames:
+                    testname += "_%s"%cnt
+                    cnt = cnt + 1
+                testnames.append(testname)
+                setattr(B_CheckCode, testname, pylint_test)
 
     unittest.main(verbosity=2, catchbreak=True)
 


### PR DESCRIPTION
Attempts to call buildnml scripts as modules before using run_cmd to call them.  This results in a
20% speedup in performance of buildnml on an A case.  

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #845 

User interface changes?: 

Code review: 
