### PR TITLE
Buildnml fix

### DIFF
--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -64,13 +64,20 @@ def create_namelists(case):
             compname = "drv"
         else:
             compname = case.get_value("COMP_%s" % model_str.upper())
+        cmd = os.path.join(config_dir, "buildnml")
         try:
-            mod = imp.load_source("buildnml",
-                                  os.path.join(config_dir, "buildnml"))
+            mod = imp.load_source("buildnml", cmd)
             logger.info("Calling %s buildnml"%compname)
             mod.buildnml(case, caseroot, compname)
-        except (AttributeError, SyntaxError):
-            cmd = os.path.join(config_dir, "buildnml")
+
+        except SyntaxError as detail:
+            with open(cmd, 'r') as f:
+                first_line = f.readline()
+            if 'python' in first_line:
+                expect(False, detail)
+            else:
+                run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=True)
+        except AttributeError:
             run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=True)
         except:
             raise

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -69,7 +69,7 @@ def create_namelists(case):
                                   os.path.join(config_dir, "buildnml"))
             logger.info("Calling %s buildnml"%compname)
             mod.buildnml(case, caseroot, compname)
-        except AttributeError:
+        except (AttributeError, SyntaxError):
             cmd = os.path.join(config_dir, "buildnml")
             run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=True)
         except:


### PR DESCRIPTION
If buildnml is in perl a SyntaxError exception will be raised when you try to load it
as a module, trap and use run_cmd instead.   On the other hand if a SyntaxError is
raised and the code is python raise that error. 

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 

