### PR TITLE
prevent division by 0

### DIFF
--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -116,7 +116,7 @@ class Case(object):
         logger.debug("total_tasks %s thread_count %s"%(total_tasks, self.thread_count))
         self.num_nodes = env_mach_pes.get_total_nodes(total_tasks, self.thread_count)
         self.tasks_per_numa = int(math.ceil(self.tasks_per_node / 2.0))
-        smt_factor = self.get_value("MAX_TASKS_PER_NODE")/self.get_value("PES_PER_NODE")
+        smt_factor = max(1,int(self.get_value("MAX_TASKS_PER_NODE")/self.get_value("PES_PER_NODE")))
 
         self.cores_per_task = ((self.get_value("MAX_TASKS_PER_NODE")/smt_factor) \
                                / self.tasks_per_node) * 2
@@ -974,7 +974,7 @@ class Case(object):
         # copy user_ files
         cloneroot = self._caseroot
         files = glob.glob(cloneroot + '/user_*')
-        
+
         for item in files:
             shutil.copy(item, newcaseroot)
 


### PR DESCRIPTION
If MAX_TASKS_PER_NODE < PES_PER_NODE a division by 0 may occur in the computation of cores per task.  This prevents that.  
./create_newcase -case <caseroot> -mach yellowstone -res ne30_ne30 -project P93300642 -compset FC5
cd <caseroot>
./xmlchange MAX_TASKS_PER_NODE=15
./xmlchange ATM_NTASKS=15

Test suite: scripts_regression_tests, 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #883 

User interface changes?: 

Code review: 

