### PR TITLE
Make bless_test_results more robust by providing full path to create_test run_cmd

### DIFF
--- a/scripts/Tools/compare_test_results
+++ b/scripts/Tools/compare_test_results
@@ -66,6 +66,12 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
+    parser.add_argument("-n", "--namelists-only", action="store_true",
+                        help="Only analyze namelists.")
+
+    parser.add_argument("--hist-only", action="store_true",
+                        help="Only analyze history files.")
+
     parser.add_argument("-b", "--baseline-name", default=default_baseline_name,
                         help="Name of baselines to use, corresponds to branch used.")
 
@@ -88,7 +94,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.handle_standard_logging_options(args)
 
-    return args.baseline_name, args.baseline_root, args.test_root, args.compiler, args.test_id, args.compare_tests
+    return args.baseline_name, args.baseline_root, args.test_root, args.compiler, args.test_id, args.compare_tests, args.namelists_only, args.hist_only
 
 ###############################################################################
 def _main_func(description):
@@ -97,10 +103,10 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    baseline_name, baseline_root, test_root, compiler, test_id, compare_tests = \
+    baseline_name, baseline_root, test_root, compiler, test_id, compare_tests, namelists_only, hist_only = \
         parse_command_line(sys.argv, description)
 
-    success = compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id, compare_tests)
+    success = compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id, compare_tests, namelists_only, hist_only)
     sys.exit(0 if success else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/utils/python/CIME/bless_test_results.py
+++ b/utils/python/CIME/bless_test_results.py
@@ -1,6 +1,6 @@
 import CIME.compare_namelists, CIME.simple_compare
 from CIME.test_scheduler import NAMELIST_PHASE
-from CIME.utils import run_cmd, expect
+from CIME.utils import run_cmd, expect, get_scripts_root
 from CIME.test_status import *
 from CIME.hist_utils import generate_baseline, compare_baseline
 from CIME.case import Case
@@ -18,7 +18,7 @@ def bless_namelists(test_name, report_only, force, baseline_name, baseline_root)
     print "Test '%s' had a namelist diff" % test_name
     if (not report_only and
         (force or raw_input("Update namelists (y/n)? ").upper() in ["Y", "YES"])):
-        stat, _, err = run_cmd("create_test -n -g %s -b %s --baseline-root %s" % (test_name, baseline_name, baseline_root))
+        stat, _, err = run_cmd("%s/create_test -n -g %s -b %s --baseline-root %s" % (get_scripts_root, test_name, baseline_name, baseline_root))
         if stat != 0:
             return False, "Namelist regen failed: '%s'" % err
         else:

--- a/utils/python/CIME/bless_test_results.py
+++ b/utils/python/CIME/bless_test_results.py
@@ -18,7 +18,7 @@ def bless_namelists(test_name, report_only, force, baseline_name, baseline_root)
     print "Test '%s' had a namelist diff" % test_name
     if (not report_only and
         (force or raw_input("Update namelists (y/n)? ").upper() in ["Y", "YES"])):
-        stat, _, err = run_cmd("%s/create_test -n -g %s -b %s --baseline-root %s" % (get_scripts_root, test_name, baseline_name, baseline_root))
+        stat, _, err = run_cmd("%s/create_test -n -g %s -b %s --baseline-root %s -o" % (get_scripts_root(), test_name, baseline_name, baseline_root))
         if stat != 0:
             return False, "Namelist regen failed: '%s'" % err
         else:

--- a/utils/python/CIME/case_cmpgen_namelists.py
+++ b/utils/python/CIME/case_cmpgen_namelists.py
@@ -14,10 +14,10 @@ import os, shutil, traceback, stat, glob
 
 logger = logging.getLogger(__name__)
 
-def _do_full_nl_comp(case, test, compare_name):
+def _do_full_nl_comp(case, test, compare_name, baseline_root=None):
     test_dir       = case.get_value("CASEROOT")
     casedoc_dir    = os.path.join(test_dir, "CaseDocs")
-    baseline_root  = case.get_value("BASELINE_ROOT")
+    baseline_root  = case.get_value("BASELINE_ROOT") if baseline_root is None else baseline_root
 
     all_match         = True
     baseline_dir      = os.path.join(baseline_root, compare_name, test)
@@ -52,10 +52,10 @@ def _do_full_nl_comp(case, test, compare_name):
     logging.info(comments)
     return all_match, comments
 
-def _do_full_nl_gen(case, test, generate_name):
+def _do_full_nl_gen(case, test, generate_name, baseline_root=None):
     test_dir       = case.get_value("CASEROOT")
     casedoc_dir    = os.path.join(test_dir, "CaseDocs")
-    baseline_root  = case.get_value("BASELINE_ROOT")
+    baseline_root  = case.get_value("BASELINE_ROOT") if baseline_root is None else baseline_root
 
     baseline_dir      = os.path.join(baseline_root, generate_name, test)
     baseline_casedocs = os.path.join(baseline_dir, "CaseDocs")
@@ -79,7 +79,7 @@ def _do_full_nl_gen(case, test, generate_name):
         shutil.copy2(item, baseline_dir)
         os.chmod(preexisting_baseline, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
 
-def case_cmpgen_namelists(case, compare=False, generate=False, compare_name=None, generate_name=None):
+def case_cmpgen_namelists(case, compare=False, generate=False, compare_name=None, generate_name=None, baseline_root=None, logfile_name="TestStatus.log"):
     expect(case.get_value("TEST"), "Only makes sense to run this for a test case")
 
     caseroot, casebaseid = case.get_value("CASEROOT"), case.get_value("CASEBASEID")
@@ -117,9 +117,9 @@ def case_cmpgen_namelists(case, compare=False, generate=False, compare_name=None
             success = True
             output = ""
             if compare:
-                success, output = _do_full_nl_comp(case, test_name, compare_name)
+                success, output = _do_full_nl_comp(case, test_name, compare_name, baseline_root)
             if generate:
-                _do_full_nl_gen(case, test_name, generate_name)
+                _do_full_nl_gen(case, test_name, generate_name, baseline_root)
         except:
             ts.set_status(NAMELIST_PHASE, TEST_FAIL_STATUS)
             success = False
@@ -128,7 +128,7 @@ def case_cmpgen_namelists(case, compare=False, generate=False, compare_name=None
             logging.warning(warn)
         finally:
             ts.set_status(NAMELIST_PHASE, TEST_PASS_STATUS if success else TEST_FAIL_STATUS)
-            append_status(output, caseroot=caseroot, sfile="TestStatus.log")
+            append_status(output, caseroot=caseroot, sfile=logfile_name)
 
         return success
 

--- a/utils/python/CIME/compare_test_results.py
+++ b/utils/python/CIME/compare_test_results.py
@@ -1,26 +1,33 @@
-from __future__ import print_function
-
 import CIME.compare_namelists, CIME.simple_compare
 from CIME.utils import expect
 from CIME.test_status import *
 from CIME.hist_utils import compare_baseline
+from CIME.case_cmpgen_namelists import case_cmpgen_namelists
 from CIME.case import Case
 
-import os, glob
+import os, glob, logging
 
 ###############################################################################
-def compare_history(testcase_dir_for_test, baseline_name, baseline_root, log_id):
+def compare_namelists(case, baseline_name, baseline_root, logfile_name):
 ###############################################################################
-    with Case(testcase_dir_for_test) as case:
-        baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
-        outfile_suffix = "%s.%s"%(baseline_name, log_id)
-        result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
-                                            outfile_suffix=outfile_suffix)
-
-        return result, comments
+    log_lvl = logging.getLogger().getEffectiveLevel()
+    logging.disable(logging.CRITICAL)
+    success = case_cmpgen_namelists(case, compare=True, compare_name=baseline_name, baseline_root=baseline_root, logfile_name=logfile_name)
+    logging.getLogger().setLevel(log_lvl)
+    return success
 
 ###############################################################################
-def compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, compare_tests=None):
+def compare_history(case, baseline_name, baseline_root, log_id):
+###############################################################################
+    baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
+    outfile_suffix = "%s.%s" % (baseline_name, log_id)
+    result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
+                                        outfile_suffix=outfile_suffix)
+
+    return result, comments
+
+###############################################################################
+def compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, compare_tests=None, namelists_only=False, hist_only=False):
     """Compares with baselines for all matching tests
 
     Outputs results for each test to stdout (one line per test); possible status
@@ -44,7 +51,7 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
     # ID to use in the log file names, to avoid file name collisions with
     # earlier files that may exist.
     log_id = CIME.utils.get_timestamp()
-    logfile_name = "compare.log.%s.%s"%(baseline_name, log_id)
+    logfile_name = "compare.log.%s.%s" % (baseline_name.replace("/", "_"), log_id)
 
     all_pass_or_skip = True
 
@@ -60,39 +67,74 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                 caseroot = test_dir,
                 sfile = logfile_name)
 
-            run_result = ts.get_status(RUN_PHASE)
-            compare_comment = ""
-            detailed_comments = ""
-            if (run_result is None):
-                compare_result = "SKIP"
-                compare_comment = "Test did not make it to run phase"
-                do_compare = False
-            elif (run_result != TEST_PASS_STATUS):
-                compare_result = "SKIP"
-                compare_comment = "Run phase did not pass"
-                do_compare = False
-            else:
-                do_compare = True
-
-            if do_compare:
-                # Compare hist files
-                success, detailed_comments = compare_history(test_dir, baseline_name, baseline_root, log_id)
-                if success:
-                    compare_result = TEST_PASS_STATUS
+            if (not hist_only):
+                nl_compare_result = None
+                nl_compare_comment = ""
+                nl_result = ts.get_status(SETUP_PHASE)
+                if (nl_result is None):
+                    nl_compare_result = "SKIP"
+                    nl_compare_comment = "Test did not make it to setup phase"
+                    nl_do_compare = False
                 else:
-                    compare_result = TEST_FAIL_STATUS
-                    all_pass_or_skip = False
+                    nl_do_compare = True
+            else:
+                nl_do_compare = False
 
-                # Following the logic in SystemTestsCommon._compare_baseline:
-                # We'll print the comment if it's a brief one-liner; otherwise
-                # the comment will only appear in the log file
-                if "\n" not in detailed_comments:
-                    compare_comment = detailed_comments
+            detailed_comments = ""
+            if (not namelists_only):
+                compare_result = None
+                compare_comment = ""
+                run_result = ts.get_status(RUN_PHASE)
+                if (run_result is None):
+                    compare_result = "SKIP"
+                    compare_comment = "Test did not make it to run phase"
+                    do_compare = False
+                elif (run_result != TEST_PASS_STATUS):
+                    compare_result = "SKIP"
+                    compare_comment = "Run phase did not pass"
+                    do_compare = False
+                else:
+                    do_compare = True
+            else:
+                do_compare = False
 
-            brief_result = "%s %s %s"%(compare_result, test_name, BASELINE_PHASE)
-            if compare_comment:
-                brief_result += " %s"%(compare_comment)
-            print(brief_result)
+            if nl_do_compare or do_compare:
+                with Case(test_dir) as case:
+                    if nl_do_compare:
+                        nl_success = compare_namelists(case, baseline_name, baseline_root, logfile_name)
+                        if nl_success:
+                            nl_compare_result = TEST_PASS_STATUS
+                            nl_compare_comment = ""
+                        else:
+                            nl_compare_result = TEST_FAIL_STATUS
+                            nl_compare_comment = "See %s/%s" % (test_dir, logfile_name)
+                            all_pass_or_skip = False
+
+                    if do_compare:
+                        success, detailed_comments = compare_history(case, baseline_name, baseline_root, log_id)
+                        if success:
+                            compare_result = TEST_PASS_STATUS
+                        else:
+                            compare_result = TEST_FAIL_STATUS
+                            all_pass_or_skip = False
+
+                        # Following the logic in SystemTestsCommon._compare_baseline:
+                        # We'll print the comment if it's a brief one-liner; otherwise
+                        # the comment will only appear in the log file
+                        if "\n" not in detailed_comments:
+                            compare_comment = detailed_comments
+
+            brief_result = ""
+            if not hist_only:
+                brief_result += "%s %s %s %s\n" % (nl_compare_result, test_name, NAMELIST_PHASE, nl_compare_comment)
+
+            if not namelists_only:
+                brief_result += "%s %s %s" % (compare_result, test_name, BASELINE_PHASE)
+                if compare_comment:
+                    brief_result += " %s" % compare_comment
+                brief_result += "\n"
+
+            print brief_result,
 
             CIME.utils.append_status(
                 msg = brief_result,
@@ -106,4 +148,3 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                     sfile = logfile_name)
 
     return all_pass_or_skip
-


### PR DESCRIPTION
compare_test_result output for a case with both NL and baseline diffs:
FAIL TESTRUNPASS_P1.f19_g16_rx1.A.sandia-srn-sems_gnu NLCOMP See /home/jgfouca/acme/scratch/TESTRUNPASS_P1.f19_g16_rx1.A.sandia-srn-sems_gnu.C.20161206_130940_yfq5ct/compare.log.foucar.20161206_131733
FAIL TESTRUNPASS_P1.f19_g16_rx1.A.sandia-srn-sems_gnu BASELINE


Test suite: scripts_regression_tests.py --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #882

User interface changes?: No

Code review: jedwards

