### PR TITLE
Replace strncpy and snprintf where applied to non-null-term. strings

### DIFF
--- a/share/timing/ChangeLog
+++ b/share/timing/ChangeLog
@@ -1,3 +1,8 @@
+timing_161207: Replaced strncpy and snprintf where applied to 
+               non-null-terminated strings, to avoid memory issues
+               when strncpy and snprintf implementations use strlen
+               to check validity of passed in string length parameter.
+               [Patrick Worley and Gautam Bisht]
 timing_160320: Added routines t_set_prefixf and t_unset_prefixf.
                Setting the prefix adds this to the beginning of all subsequent 
                timer event names (defined in t_startf/t_stopf).

--- a/share/timing/ChangeLog
+++ b/share/timing/ChangeLog
@@ -1,7 +1,8 @@
 timing_161207: Replaced strncpy and snprintf where applied to 
                non-null-terminated strings, to avoid memory issues
-               when strncpy and snprintf implementations use strlen
+               when strncpy and snprintf implementations use strnlen
                to check validity of passed in string length parameter.
+               (Why this causes problems is still a mystery.)
                [Patrick Worley and Gautam Bisht]
 timing_160320: Added routines t_set_prefixf and t_unset_prefixf.
                Setting the prefix adds this to the beginning of all subsequent 

--- a/share/timing/f_wrappers.c
+++ b/share/timing/f_wrappers.c
@@ -237,12 +237,17 @@ int gptlpr (int *procid)
 int gptlpr_file (char *file, int nc1)
 {
   char *locfile;
+  int c;
   int ret;
 
   if ( ! (locfile = (char *) malloc (nc1+1)))
     return GPTLerror ("gptlpr_file: malloc error\n");
 
-  snprintf (locfile, nc1+1, "%s", file);
+  //pw  snprintf (locfile, nc1+1, "%s", file);
+  for (c = 0; c < nc1; c++) {
+    locfile[c] = file[c];
+  }
+  locfile[c] = '\0';
 
   ret = GPTLpr_file (locfile);
   free (locfile);
@@ -269,6 +274,7 @@ int gptlpr_summary (int *fcomm)
 int gptlpr_summary_file (int *fcomm, char *file, int nc1)
 {
   char *locfile;
+  int c;
   int ret;
 
 #ifdef HAVE_MPI
@@ -286,7 +292,11 @@ int gptlpr_summary_file (int *fcomm, char *file, int nc1)
   if ( ! (locfile = (char *) malloc (nc1+1)))
     return GPTLerror ("gptlpr_summary_file: malloc error\n");
 
-  snprintf (locfile, nc1+1, "%s", file);
+  //pw  snprintf (locfile, nc1+1, "%s", file);
+  for (c = 0; c < nc1; c++) {
+    locfile[c] = file[c];
+  }
+  locfile[c] = '\0';
 
   ret = GPTLpr_summary_file (ccomm, locfile);
   free (locfile);

--- a/share/timing/gptl.c
+++ b/share/timing/gptl.c
@@ -946,6 +946,7 @@ int GPTLstartf (const char *name, const int namelen)    /* timer name and length
 {
   Timer *ptr;        /* linked list pointer */
   int t;             /* thread index (of this thread) */
+  int c;             /* character index */
   int numchars;      /* number of characters to copy */
   unsigned int indx; /* hash table index */
   char strname[MAX_CHARS+1]; /* null terminated version of name */
@@ -1029,7 +1030,10 @@ int GPTLstartf (const char *name, const int namelen)    /* timer name and length
     memset (ptr, 0, sizeof (Timer));
 
     numchars = MIN (namelen, MAX_CHARS);
-    strncpy (ptr->name, name, numchars);
+    //pw    strncpy (ptr->name, name, numchars);
+    for (c = 0; c < numchars; c++) {
+      ptr->name[c] = name[c];
+    }
     ptr->name[numchars] = '\0';
 
     if (update_ll_hash (ptr, t, indx) != 0)
@@ -1074,6 +1078,7 @@ int GPTLstartf_handle (const char *name,  /* timer name */
 {
   Timer *ptr;                            /* linked list pointer */
   int t;                                 /* thread index (of this thread) */
+  int c;                                 /* character index */
   int numchars;                          /* number of characters to copy */
   unsigned int indx = (unsigned int) -1; /* hash table index: init to bad value */
   char strname[MAX_CHARS+1];             /* null terminated version of name */
@@ -1161,7 +1166,10 @@ int GPTLstartf_handle (const char *name,  /* timer name */
     memset (ptr, 0, sizeof (Timer));
 
     numchars = MIN (namelen, MAX_CHARS);
-    strncpy (ptr->name, name, numchars);
+    //pw    strncpy (ptr->name, name, numchars);
+    for (c = 0; c < numchars; c++) {
+      ptr->name[c] = name[c];
+    }
     ptr->name[numchars] = '\0';
 
     if (update_ll_hash (ptr, t, indx) != 0)
@@ -1666,6 +1674,7 @@ int GPTLstopf (const char *name, const int namelen) /* timer name and length */
   unsigned int indx;         /* index into hash table */
   long usr = 0;              /* user time (returned from get_cpustamp) */
   long sys = 0;              /* system time (returned from get_cpustamp) */
+  int c;                     /* character index */
   int numchars;              /* number of characters to copy */
   char strname[MAX_CHARS+1]; /* null terminated version of name */
   double tpa = 0.0;          /* time stamp */
@@ -1713,7 +1722,10 @@ int GPTLstopf (const char *name, const int namelen) /* timer name and length */
 
   if ( ! (ptr = getentryf (hashtable[t], name, namelen, &indx))){
     numchars = MIN (namelen, MAX_CHARS);
-    strncpy (strname, name, numchars);
+    //pw    strncpy (strname, name, numchars);
+    for (c = 0; c < numchars; c++) {
+      strname[c] = name[c];
+    }
     strname[numchars] = '\0';
     return GPTLerror ("%s thread %d: timer for %s had not been started.\n", thisfunc, t, strname);
   }
@@ -1786,6 +1798,7 @@ int GPTLstopf_handle (const char *name,     /* timer name */
   unsigned int indx;         /* index into hash table */
   long usr = 0;              /* user time (returned from get_cpustamp) */
   long sys = 0;              /* system time (returned from get_cpustamp) */
+  int c;                     /* character index */
   int numchars;              /* number of characters to copy */
   char strname[MAX_CHARS+1]; /* null terminated version of name */
   double tpa = 0.0;          /* time stamp */
@@ -1841,7 +1854,10 @@ int GPTLstopf_handle (const char *name,     /* timer name */
   } else {
     if ( ! (ptr = getentryf (hashtable[t], name, namelen, &indx))){
       numchars = MIN (namelen, MAX_CHARS);
-      strncpy (strname, name, numchars);
+      //pw      strncpy (strname, name, numchars);
+      for (c = 0; c < numchars; c++) {
+        strname[c] = name[c];
+      }
       strname[numchars] = '\0';
       return GPTLerror ("%s thread %d: timer for %s had not been started.\n", thisfunc, t, strname);
     }


### PR DESCRIPTION
[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. ]

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #851 

User interface changes?: no

Code review: 

Valgrind is complaining when strncpy or snprintf are used with
non-null-terminated strings. 

To eliminate the issue, strncpy and snprintf are replaced with
equivalent character-by-character copy loops in the
instances in which the input string is non-null-terminated.

While this resolves #851 , the clean-up to t_drvstartf/t_drvstops suggested by @bishtgautam should still be implemented.

This is BFB in limited testing using an ACME B case, and should be BFB if not buggy.