### PR TITLE
force compilers version 2 for regression testing

### DIFF
--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config_build>
+<config_compilers version="2.0">
 <!--
 ===========================
 This file defines compiler flags for building CIME.  General flags are listed first
@@ -1622,4 +1622,4 @@ for mct, etc.
   <TRILINOS_PATH><env>TRILINOS_PATH</env></TRILINOS_PATH>
 </compiler>
 
-</config_build>
+</config_compilers>

--- a/utils/python/CIME/XML/compilers.py
+++ b/utils/python/CIME/XML/compilers.py
@@ -138,7 +138,7 @@ class Compilers(GenericXML):
 
         return value
 
-    def write_macros_file(self, macros_file="Macros", output_format="make", xml=None):
+    def write_macros_file(self, macros_file="Macros.make", output_format="make", xml=None):
         if self._version == "1.0":
             # Parse the xml settings into the $macros hash structure
             # put conditional settings in the _COND_ portion of the hash
@@ -149,7 +149,7 @@ class Compilers(GenericXML):
             for compiler_node in reversed(self.compiler_nodes):
                 _add_to_macros(compiler_node, macros)
             write_macros_file_v1(macros, self.compiler, self.os,
-                                        self.machine, macros_file="Macros",
+                                        self.machine, macros_file="Macros.make",
                                         output_format=output_format)
         else:
             if output_format == "make":

--- a/utils/python/CIME/XML/compilers.py
+++ b/utils/python/CIME/XML/compilers.py
@@ -15,10 +15,11 @@ logger = logging.getLogger(__name__)
 
 class Compilers(GenericXML):
 
-    def __init__(self, machobj, infile=None, compiler=None, mpilib=None, files=None):
+    def __init__(self, machobj, infile=None, compiler=None, mpilib=None, files=None, version=None):
         """
         initialize an object
         """
+
         if infile is None:
             if files is None:
                 files = Files()
@@ -27,7 +28,11 @@ class Compilers(GenericXML):
 
         GenericXML.__init__(self, infile, schema)
         self._machobj = machobj
-        self._version = self.get_version()
+        if version is not None:
+            # this is used in scripts_regression_tests to force version 2, it should not be used otherwise
+            self._version = version
+        else:
+            self._version = self.get_version()
 
         self.machine  = machobj.get_machine_name()
         self.os = machobj.get_value("OS")
@@ -144,8 +149,8 @@ class Compilers(GenericXML):
             for compiler_node in reversed(self.compiler_nodes):
                 _add_to_macros(compiler_node, macros)
             write_macros_file_v1(macros, self.compiler, self.os,
-                                        self.machine, macros_file,
-                                        output_format)
+                                        self.machine, macros_file="Macros",
+                                        output_format=output_format)
         else:
             if output_format == "make":
                 format_ = "Makefile"
@@ -153,7 +158,7 @@ class Compilers(GenericXML):
                 format_ = "CMake"
             else:
                 format_ = output_format
-            
+
             if isinstance(macros_file, basestring):
                 with open(macros_file, "w") as macros:
                     self._write_macros_file_v2(format_, macros)

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1503,19 +1503,19 @@ class G_TestMacrosBasic(unittest.TestCase):
     def test_script_is_callable(self):
         """The test script can be called on valid output without dying."""
         # This is really more a smoke test of this script than anything else.
-        maker = Compilers(MockMachines("mymachine", "SomeOS"))
+        maker = Compilers(MockMachines("mymachine", "SomeOS"), version="2.0")
         test_xml = _wrap_config_build_xml("<compiler><SUPPORTS_CXX>FALSE</SUPPORTS_CXX></compiler>")
         get_macros(maker, test_xml, "Makefile")
 
     def test_script_rejects_bad_xml(self):
         """The macro writer rejects input that's not valid XML."""
-        maker = Compilers(MockMachines("mymachine", "SomeOS"))
+        maker = Compilers(MockMachines("mymachine", "SomeOS"), version="2.0")
         with self.assertRaises(ParseError):
             get_macros(maker, "This is not valid XML.", "Makefile")
 
     def test_script_rejects_bad_build_system(self):
         """The macro writer rejects a bad build system string."""
-        maker = Compilers(MockMachines("mymachine", "SomeOS"))
+        maker = Compilers(MockMachines("mymachine", "SomeOS"), version="2.0")
         bad_string = "argle-bargle."
         with self.assertRaisesRegexp(
                 SystemExit,
@@ -1539,7 +1539,7 @@ class H_TestMakeMacros(unittest.TestCase):
     test_machine = "mymachine"
 
     def setUp(self):
-        self._maker = Compilers(MockMachines(self.test_machine, self.test_os))
+        self._maker = Compilers(MockMachines(self.test_machine, self.test_os), version="2.0")
 
     def xml_to_tester(self, xml_string):
         """Helper that directly converts an XML string to a MakefileTester."""


### PR DESCRIPTION
Fix for scripts_regression_tests when config_compilers.xml is in version 1
The tests must be forced to version 2. 

Test suite: scripts_regression_tests for both acme and cesm
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes current red lights on master cdash 

User interface changes?: 

Code review: 

