### PR TITLE
Fix for Depends with multiple spaces between filenames

### DIFF
--- a/tools/utils/find_circular_dependency.py
+++ b/tools/utils/find_circular_dependency.py
@@ -61,7 +61,7 @@ def findCircularDep(filename):
       lmatch = objline.match(line.strip())
       if (lmatch is not None):
         obj = lmatch.group(1)
-        deps = [ x.split(".")[0].lower() for x in lmatch.group(2).strip().split(" ") if x.split(".")[1] == "mod" ]
+        deps = [ x.split(".")[0].lower() for x in lmatch.group(2).strip().split(" ") if "." in x and x.split(".")[1] == "mod" ]
         depends[obj.strip().lower()] = deps
       # End if
     # End for


### PR DESCRIPTION
Some Depends files end up with funny spacing and the script was sensitive to that. This commit fixes at least one such problem.

Test suite: NA
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes [CIME Github issue #] NA

User interface changes?: None

Code review: 

