### PR TITLE
Mvertens/python namelists

### DIFF
--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -518,55 +518,55 @@
 
     <domain name="1x1_numaIA">
       <nx>1</nx> <ny>1</ny>
-      <file grid="lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-numaIA_navy.110106.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-numaIA_navy.110106.nc</file>
       <desc>1x1 Numa Iowa -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_brazil">
       <nx>1</nx> <ny>1</ny>
-      <file grid="lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-brazil_navy.090715.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-brazil_navy.090715.nc</file>
       <desc>1x1 Brazil -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_smallvilleIA">
       <nx>1</nx> <ny>1</ny>
-      <file grid="lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-smallvilleIA_test.110106.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-smallvilleIA_test.110106.nc</file>
       <desc>1x1 Smallville Iowa Crop Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_camdenNJ">
       <nx>1</nx> <ny>1</ny>
-      <file grid="lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-camdenNJ_navy.111004.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-camdenNJ_navy.111004.nc</file>
       <desc>1x1 Camden New Jersey -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_mexicocityMEX">
       <nx>1</nx> <ny>1</ny>
-      <file grid="lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc</file>
       <desc>1x1 Mexico City Mexico -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_vancouverCAN">
       <nx>1</nx> <ny>1</ny>
-      <file grid="lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>
       <desc>1x1 Vancouver Canada -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_tropicAtl">
       <nx>1</nx> <ny>1</ny>
-      <file grid="lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-tropicAtl_test.111004.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-tropicAtl_test.111004.nc</file>
       <desc>1x1 Tropical Atlantic Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_urbanc_alpha">
       <nx>1</nx> <ny>1</ny>
-      <file grid="lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-urbanc_alpha_test.110201.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-urbanc_alpha_test.110201.nc</file>
       <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="5x5_amazon">
       <nx>1</nx> <ny>1</ny>
-      <file grid="lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.5x5pt-amazon_navy.090715.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.5x5pt-amazon_navy.090715.nc</file>
       <desc>5x5 Amazon regional case -- only valid for DATM/CLM compset</desc>
     </domain>
 
@@ -1201,39 +1201,50 @@
     </gridmap>
 
     <gridmap rof_grid="rx1" ocn_grid="gx3v7" >
-      <map name="ROF2OCN_RMAPNAME">cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="gx1v6" >
-      <map name="ROF2OCN_RMAPNAME">cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tx1v1" >
-      <map name="ROF2OCN_RMAPNAME">cpl/cpl6/map_rx1_to_tx1v1_e1000r300_090318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tx1v1_e1000r300_090318.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tx1v1_e1000r300_090318.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tx0.1v2" >
-      <map name="ROF2OCN_RMAPNAME">cpl/cpl6/map_rx1_to_tx0.1v2_e1000r200_090624.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tx0.1v2_e1000r200_090624.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tx0.1v2_e1000r200_090624.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="oQU120" >
-      <map name="ROF2OCN_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_oQU120_nn.160527.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_oQU120_nn.160527.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_oQU120_nn.160527.nc</map>
     </gridmap>
 
     <gridmap rof_grid="r05" ocn_grid="gx3v7" >
-      <map name="ROF2OCN_RMAPNAME">cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="gx1v6" >
-      <map name="ROF2OCN_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_151109.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_151109.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_151109.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="gx1v7" >
-      <map name="ROF2OCN_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_151109b.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_151109b.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_151109b.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tx1v1" >
-      <map name="ROF2OCN_RMAPNAME">cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tx0.1v2" >
-      <map name="ROF2OCN_RMAPNAME">cpl/cpl6/map_r05_to_tx0.1v2_r500e1000_080620.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tx0.1v2_r500e1000_080620.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_tx0.1v2_r500e1000_080620.nc</map>
     </gridmap>
 
     <gridmap rof_grid="r01" ocn_grid="gx1v6" >
-      <map name="ROF2OCN_RMAPNAME">cpl/cpl6/map_r01_to_gx1v6_120711.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r01_to_gx1v6_120711.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r01_to_gx1v6_120711.nc</map>
     </gridmap>
 
     <!--- river flooding variables -->

--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -154,13 +154,6 @@
       <mask>usgs</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42" not_compset="_POP">
-      <grid name="atm">T42</grid>
-      <grid name="lnd">T42</grid>
-      <grid name="ocnice">T42</grid>
-      <mask>usgs</mask>
-    </model_grid>
-
     <model_grid alias="T85_T85" not_compset="_POP">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>

--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -661,6 +661,13 @@
       <desc>T31 is Gaussian grid:</desc>
     </domain>
 
+    <domain name="T42">
+      <nx>128</nx> <ny>64</ny>
+      <file grid="atm|lnd" mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.T42_USGS.111004.nc</file>
+      <file grid="ocnice"  mask="usgs">$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.64x128_USGS_070807.nc</file>
+      <desc>T42 is Gaussian grid:</desc>
+    </domain>
+
     <domain name="ne16np4">
       <nx>13826</nx> <ny>1</ny>
       <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.lnd.ne16np4_gx3v7.120406.nc</file>

--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -154,6 +154,13 @@
       <mask>usgs</mask>
     </model_grid>
 
+    <model_grid alias="T42_T42" not_compset="_POP">
+      <grid name="atm">T42</grid>
+      <grid name="lnd">T42</grid>
+      <grid name="ocnice">T42</grid>
+      <mask>usgs</mask>
+    </model_grid>
+
     <model_grid alias="T85_T85" not_compset="_POP">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -61,10 +61,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.debug("DATM mode is %s", datm_mode)
-    logger.debug("DATM grid is %s", atm_grid)
-    logger.debug("DATM presaero mode is %s", datm_presaero)
-    logger.debug("DATM topo mode is %s", datm_topo)
+    logger.info("DATM mode is %s", datm_mode)
+    logger.info("DATM grid is %s", atm_grid)
+    logger.info("DATM presaero mode is %s", datm_presaero)
+    logger.info("DATM topo mode is %s", datm_topo)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -140,7 +140,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             config = {'ispresaerostream': 'FALSE'}
 
         inst_stream = stream + inst_string
-        logger.debug("DATM stream is %s", inst_stream)
+        logger.info("DATM stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "datm.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(), "user_datm.streams.txt." + inst_stream)
 
@@ -190,7 +190,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
         # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -61,10 +61,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.info("DATM mode is %s", datm_mode)
-    logger.info("DATM grid is %s", atm_grid)
-    logger.info("DATM presaero mode is %s", datm_presaero)
-    logger.info("DATM topo mode is %s", datm_topo)
+    logger.debug("DATM mode is %s", datm_mode)
+    logger.debug("DATM grid is %s", atm_grid)
+    logger.debug("DATM presaero mode is %s", datm_presaero)
+    logger.debug("DATM topo mode is %s", datm_topo)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -140,7 +140,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             config = {'ispresaerostream': 'FALSE'}
 
         inst_stream = stream + inst_string
-        logger.info("DATM stream is %s", inst_stream)
+        logger.debug("DATM stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "datm.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(), "user_datm.streams.txt." + inst_stream)
 
@@ -190,7 +190,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.info("Created input root directory %s" %din_loc_root)
+        logger.debug("Created input root directory %s" %din_loc_root)
 
         # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -147,6 +147,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             shutil.copyfile(user_stream_path, stream_path)
+            config['stream'] = stream
+            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 

--- a/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -2508,7 +2508,7 @@
     </desc>
     <values>
       <value>1</value>
-      <value stream="CPLHISTForcingForOcnIce">-1</value>
+      <value datm_mode="CPLHISTForcingForOcnIce">-1</value>
     </values>
   </entry>
 

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -54,8 +54,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.info("DICE mode is %s", dice_mode)
-    logger.info("DICE grid is %s", ice_grid)
+    logger.debug("DICE mode is %s", dice_mode)
+    logger.debug("DICE grid is %s", ice_grid)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -94,7 +94,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.info("DICE stream is %s", inst_stream)
+        logger.debug("DICE stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "dice.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_dice.streams.txt." + inst_stream)
@@ -141,7 +141,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.info("Created input root directory %s" %din_loc_root)
+        logger.debug("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -54,8 +54,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.debug("DICE mode is %s", dice_mode)
-    logger.debug("DICE grid is %s", ice_grid)
+    logger.info("DICE mode is %s", dice_mode)
+    logger.info("DICE grid is %s", ice_grid)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -94,7 +94,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.debug("DICE stream is %s", inst_stream)
+        logger.info("DICE stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "dice.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_dice.streams.txt." + inst_stream)
@@ -141,7 +141,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -102,6 +102,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             shutil.copyfile(user_stream_path, stream_path)
+            config['stream'] = stream
+            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -55,9 +55,9 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.debug("DLND mode is %s", dlnd_mode)
-    logger.debug("DLND grid is %s", lnd_grid)
-    logger.debug("DLND glc_nec is %s", glc_nec)
+    logger.info("DLND mode is %s", dlnd_mode)
+    logger.info("DLND grid is %s", lnd_grid)
+    logger.info("DLND glc_nec is %s", glc_nec)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -95,7 +95,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.debug("DLND stream is %s", inst_stream)
+        logger.info("DLND stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "dlnd.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_dlnd.streams.txt." + inst_stream)
@@ -147,7 +147,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -55,9 +55,9 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.info("DLND mode is %s", dlnd_mode)
-    logger.info("DLND grid is %s", lnd_grid)
-    logger.info("DLND glc_nec is %s", glc_nec)
+    logger.debug("DLND mode is %s", dlnd_mode)
+    logger.debug("DLND grid is %s", lnd_grid)
+    logger.debug("DLND glc_nec is %s", glc_nec)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -95,7 +95,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.info("DLND stream is %s", inst_stream)
+        logger.debug("DLND stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "dlnd.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_dlnd.streams.txt." + inst_stream)
@@ -147,7 +147,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.info("Created input root directory %s" %din_loc_root)
+        logger.debug("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -103,6 +103,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             shutil.copyfile(user_stream_path, stream_path)
+            config['stream'] = stream
+            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -54,8 +54,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.info("DOCN mode is %s", docn_mode)
-    logger.info("DOCN grid is %s", ocn_grid)
+    logger.debug("DOCN mode is %s", docn_mode)
+    logger.debug("DOCN grid is %s", ocn_grid)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -94,7 +94,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.info("DOCN stream is %s", inst_stream)
+        logger.debug("DOCN stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "docn.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_docn.streams.txt." + inst_stream)
@@ -145,7 +145,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.info("Created input root directory %s" %din_loc_root)
+        logger.debug("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -54,8 +54,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.debug("DOCN mode is %s", docn_mode)
-    logger.debug("DOCN grid is %s", ocn_grid)
+    logger.info("DOCN mode is %s", docn_mode)
+    logger.info("DOCN grid is %s", ocn_grid)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -94,7 +94,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.debug("DOCN stream is %s", inst_stream)
+        logger.info("DOCN stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "docn.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_docn.streams.txt." + inst_stream)
@@ -145,7 +145,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -102,6 +102,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             shutil.copyfile(user_stream_path, stream_path)
+            config['stream'] = stream
+            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -53,8 +53,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.debug("DROF mode is %s", drof_mode)
-    logger.debug("DROF grid is %s", rof_grid)
+    logger.info("DROF mode is %s", drof_mode)
+    logger.info("DROF grid is %s", rof_grid)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -92,7 +92,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.debug("DROF stream is %s", inst_stream)
+        logger.info("DROF stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "drof.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_drof.streams.txt." + inst_stream)
@@ -143,7 +143,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -53,8 +53,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.info("DROF mode is %s", drof_mode)
-    logger.info("DROF grid is %s", rof_grid)
+    logger.debug("DROF mode is %s", drof_mode)
+    logger.debug("DROF grid is %s", rof_grid)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -92,7 +92,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.info("DROF stream is %s", inst_stream)
+        logger.debug("DROF stream is %s", inst_stream)
         stream_path = os.path.join(confdir, "drof.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_drof.streams.txt." + inst_stream)
@@ -143,7 +143,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.info("Created input root directory %s" %din_loc_root)
+        logger.debug("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -100,6 +100,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             shutil.copyfile(user_stream_path, stream_path)
+            config['stream'] = stream
+            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -56,8 +56,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.debug("DWAV mode is %s", dwav_mode)
-    logger.debug("DWAV grid is %s", wav_grid)
+    logger.info("DWAV mode is %s", dwav_mode)
+    logger.info("DWAV grid is %s", wav_grid)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -95,7 +95,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.debug("DWAV stream is %s", inst_stream)
+        logger.info("DWAV stream is %s", inst_stream)
         stream_path = os.path.join(confdir,
                                    "dwav.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
@@ -141,7 +141,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+        logger.info("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -56,8 +56,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Log some settings.
     #----------------------------------------------------
-    logger.info("DWAV mode is %s", dwav_mode)
-    logger.info("DWAV grid is %s", wav_grid)
+    logger.debug("DWAV mode is %s", dwav_mode)
+    logger.debug("DWAV grid is %s", wav_grid)
 
     #----------------------------------------------------
     # Clear out old data.
@@ -95,7 +95,7 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
             continue
 
         inst_stream = stream + inst_string
-        logger.info("DWAV stream is %s", inst_stream)
+        logger.debug("DWAV stream is %s", inst_stream)
         stream_path = os.path.join(confdir,
                                    "dwav.streams.txt." + inst_stream)
         user_stream_path = os.path.join(case.get_case_root(),
@@ -141,7 +141,7 @@ def buildnml(case, caseroot, compname):
 
     if not os.path.isdir(din_loc_root):
         os.makedirs(din_loc_root)
-        logger.info("Created input root directory %s" %din_loc_root)
+        logger.debug("Created input root directory %s" %din_loc_root)
 
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -104,6 +104,8 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             shutil.copyfile(user_stream_path, stream_path)
+            config['stream'] = stream
+            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 

--- a/driver_cpl/cime_config/namelist_definition_drv.xml
+++ b/driver_cpl/cime_config/namelist_definition_drv.xml
@@ -2406,7 +2406,7 @@
     <group>ccsm_pes</group>
     <desc>
       the number of threads per mpi task for the lnd component.
-      set by NTHRDS_LND in env_configure.xml.
+      set by NTHRDS_ROF in env_configure.xml.
     </desc>
     <values>
       <value>$NTHRDS_ROF</value>

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -95,6 +95,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=None,
               append=None, noecho=False, force=False , dryrun=False):
     with Case(caseroot, read_only=False) as case:
+
         if len(listofsettings):
             logger.debug("List of attributes to change: %s" , listofsettings)
 
@@ -114,8 +115,7 @@ def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=N
                     xmlval = convert_to_type(xmlval, type_str, xmlid)
 
                 if not dryrun :
-                    newval = case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
-                    expect(newval is not None,"No variable \"%s\" found"%xmlid)
+                    case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
                 else :
                     logger.warning("'%s' = '%s'" , xmlid , xmlval )
         else:
@@ -125,8 +125,7 @@ def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=N
             type_str = case.get_type_info(xmlid)
             if not force:
                 xmlval = convert_to_type(xmlval, type_str, xmlid)
-            newval = case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
-            expect(newval is not None,"No variable \"%s\" found"%xmlid)
+            case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
 
     if not noecho:
         argstr = ""

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -95,7 +95,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=None,
               append=None, noecho=False, force=False , dryrun=False):
     with Case(caseroot, read_only=False) as case:
-
         if len(listofsettings):
             logger.debug("List of attributes to change: %s" , listofsettings)
 
@@ -115,7 +114,8 @@ def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=N
                     xmlval = convert_to_type(xmlval, type_str, xmlid)
 
                 if not dryrun :
-                    case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
+                    newval = case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
+                    expect(newval is not None,"No variable \"%s\" found"%xmlid)
                 else :
                     logger.warning("'%s' = '%s'" , xmlid , xmlval )
         else:
@@ -125,7 +125,8 @@ def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=N
             type_str = case.get_type_info(xmlid)
             if not force:
                 xmlval = convert_to_type(xmlval, type_str, xmlid)
-            case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
+            newval = case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
+            expect(newval is not None,"No variable \"%s\" found"%xmlid)
 
     if not noecho:
         argstr = ""

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -232,7 +232,7 @@ class GenericXML(object):
             elif var in os.environ:
                 # this is a list of suppressed warnings (things normally expected to be resolved in env)
                 if var not in ("USER",):
-                    logging.warn("Resolved from env: " + var)
+                    logging.debug("Resolved from env: " + var)
                 item_data = item_data.replace(m.group(), os.environ[var])
         if math_re.search(item_data):
             try:

--- a/utils/python/CIME/XML/grids.py
+++ b/utils/python/CIME/XML/grids.py
@@ -399,13 +399,8 @@ class Grids(GenericXML):
                 if grid1_value != grid2_value and grid1_value != 'null' and grid2_value != 'null':
                     map_ = gridmaps[node.text]
                     if map_ == 'idmap':
-                        if node.text in ("ROF2OCN_LIQ_RMAPNAME" , "ROF2OCN_ICE_RMAPNAME") and \
-                                "ROF2OCN_RMAPNAME" in gridmaps and gridmaps["ROF2OCN_RMAPNAME"] != "idmap":
-                            map_ = gridmaps["ROF2OCN_RMAPNAME"]
-                            gridmaps[node.text] = map_
-                        else:
-                            logger.warning("Warning: missing non-idmap %s for %s, %s and %s %s "
-                                           %(node.text, grid1_name, grid1_value, grid2_name, grid2_value))
+                        logger.warning("Warning: missing non-idmap %s for %s, %s and %s %s "
+                                       %(node.text, grid1_name, grid1_value, grid2_name, grid2_value))
 
         return gridmaps
 

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -296,6 +296,8 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
                                 lid, caseroot, cimeroot, compiler))
 
     if not sharedlib_only:
+        # in case component build scripts updated the xml files, update the case object
+        case.read_xml()
         post_build(case, logs)
 
     t3 = time.time()

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -409,6 +409,7 @@ ERROR MPILIB is mpi-serial and USE_ESMF_LIB IS TRUE
 
     case.flush()
     if not model_only:
+        logger.info("Generating component namelists as part of build")
         create_namelists(case)
 
     return sharedpath

--- a/utils/python/CIME/case_run.py
+++ b/utils/python/CIME/case_run.py
@@ -60,6 +60,8 @@ def pre_run_check(case):
     os.makedirs(os.path.join(rundir, "timing", "checkpoints"))
 
     # This needs to be done everytime the LID changes in order for log files to be set up correctly
+    # The following also needs to be called in case a user changes a user_nl_xxx file OR an env_run.xml
+    # variable while the job is in the queue
     create_namelists(case)
 
     # document process

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -235,7 +235,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         # loop over models
         for model in models:
             comp = case.get_value("COMP_%s" % model)
-            logger.info("Building %s usernl files"%model)
+            logger.debug("Building %s usernl files"%model)
             _build_usernl_files(case, model, comp)
             if comp == "cism":
                 run_cmd_no_fail("%s/../components/cism/cime_config/cism.template %s" % (cimeroot, caseroot))
@@ -254,10 +254,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 logger.info("Starting testcase.setup")
                 run_cmd_no_fail("./testcase.setup -caseroot %s" % caseroot)
                 logger.info("Finished testcase.setup")
-
-        # some tests need namelists created here (ERP)
-        if test_mode:
-            create_namelists(case)
 
         msg = "case.setup complete"
         append_status(msg, caseroot=caseroot, sfile="CaseStatus")

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -255,6 +255,11 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 run_cmd_no_fail("./testcase.setup -caseroot %s" % caseroot)
                 logger.info("Finished testcase.setup")
 
+        # Some tests need namelists created here (ERP) - so do this if are in test mode
+        if test_mode:
+            logger.info("Generating component namelists as part of setup")
+            create_namelists(case)
+
         msg = "case.setup complete"
         append_status(msg, caseroot=caseroot, sfile="CaseStatus")
 

--- a/utils/python/CIME/case_submit.py
+++ b/utils/python/CIME/case_submit.py
@@ -66,6 +66,7 @@ def submit(case, job=None, resubmit=False, no_batch=False):
 def check_case(case, caseroot):
     check_lockedfiles(caseroot)
     create_namelists(case) # Must be called before check_all_input_data
+    logger.info("Checking that inputdata is available as part of case submission")
     check_all_input_data(case)
     # Now that we have baselines, do baseline operations
     if case.get_value("TEST"):

--- a/utils/python/CIME/compare_namelists.py
+++ b/utils/python/CIME/compare_namelists.py
@@ -161,6 +161,9 @@ def _parse_namelists(namelist_lines, filename):
                 logger.debug("    Adding list entries: %s" % ", ".join(tokens))
 
             elif (compress_item_re.match(value) is not None):
+                # the following ensure that the following to namelist settings trigger a match
+                # nmlvalue = 1,1,1 versus nmlvalue = 3*1
+
                 repeat, value = compress_item_re.match(value).groups()
                 rv[current_namelist][name] = list(value) * int(repeat)
 

--- a/utils/python/CIME/compare_namelists.py
+++ b/utils/python/CIME/compare_namelists.py
@@ -72,6 +72,7 @@ def _parse_namelists(namelist_lines, filename):
     rcline_re = re.compile(r"^([^&\s':]+)\s*:\s*(.+)$")
     dict_re = re.compile(r"^'(\S+)\s*->\s*(\S+)'")
     comma_re = re.compile(r'\s*,\s*')
+    compress_item_re = re.compile(r'([0-9]+)[*](.+)$')
 
     rv = OrderedDict()
     current_namelist = None
@@ -158,6 +159,10 @@ def _parse_namelists(namelist_lines, filename):
                 rv[current_namelist][name] = tokens
 
                 logger.debug("    Adding list entries: %s" % ", ".join(tokens))
+
+            elif (compress_item_re.match(value) is not None):
+                repeat, value = compress_item_re.match(value).groups()
+                rv[current_namelist][name] = list(value) * int(repeat)
 
             else:
                 rv[current_namelist][name] = value

--- a/utils/python/CIME/namelist.py
+++ b/utils/python/CIME/namelist.py
@@ -973,7 +973,7 @@ class Namelist(object):
                     merged_val = merge_literal_lists(other_val, self_val)
                 self.set_variable_value(group_name, variable_name, merged_val)
 
-    def write(self, out_file, groups=None, append=False, format_='nml'):
+    def write(self, out_file, groups=None, append=False, format_='nml', sorted_groups=True):
         """Write a Fortran namelist to a file.
 
         As with `parse`, the `out_file` argument can be either a file name, or a
@@ -994,12 +994,12 @@ class Namelist(object):
             logger.debug("Writing namelist to: %s", out_file)
             flag = 'a' if append else 'w'
             with open(out_file, flag) as file_obj:
-                self._write(file_obj, groups, format_)
+                self._write(file_obj, groups, format_, sorted_groups=sorted_groups)
         else:
             logger.debug("Writing namelist to file object")
-            self._write(out_file, groups, format_)
+            self._write(out_file, groups, format_, sorted_groups=sorted_groups)
 
-    def _write(self, out_file, groups, format_):
+    def _write(self, out_file, groups, format_, sorted_groups):
         """Unwrapped version of `write` assuming that a file object is input."""
         if groups is None:
             groups = self._groups.keys()
@@ -1007,7 +1007,11 @@ class Namelist(object):
             equals = ' ='
         elif format_ == 'rc':
             equals = ':'
-        for group_name in sorted(group.lower() for group in groups):
+        if (sorted_groups):
+            group_names = sorted(group.lower() for group in groups)
+        else:
+            group_names = groups
+        for group_name in group_names:
             if format_ == 'nml':
                 out_file.write("&%s\n" % group_name)
             group = self._groups[group_name]

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -582,7 +582,7 @@ class NamelistGenerator(object):
                         input_data_list.write("%s = %s\n" %
                                               (variable_name, file_path))
 
-    def write_output_file(self, namelist_file, data_list_path=None, groups=None):
+    def write_output_file(self, namelist_file, data_list_path=None, groups=None, sorted_groups=True):
         """Write out the namelists and input data files.
 
         The `namelist_file` and `modelio_file` are the locations to which the
@@ -601,7 +601,7 @@ class NamelistGenerator(object):
             groups.remove("seq_maps")
 
         # write namelist file
-        self._namelist.write(namelist_file, groups=groups)
+        self._namelist.write(namelist_file, groups=groups, sorted_groups=sorted_groups)
 
         if data_list_path is not None:
             # append to input_data_list file

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -530,6 +530,7 @@ class NamelistGenerator(object):
                 if literal == '':
                     continue
                 file_path = character_literal_to_string(literal)
+                # NOTE - these are hard-coded here and a better way is to make these extensible
                 if file_path == 'UNSET' or file_path == 'idmap':
                     continue
                 if file_path == 'null':
@@ -565,6 +566,9 @@ class NamelistGenerator(object):
                                                                  variable_name)
                     for literal in literals:
                         file_path = character_literal_to_string(literal)
+                        # NOTE - these are hard-coded here and a better way is to make these extensible
+                        if file_path == 'UNSET' or file_path == 'idmap':
+                            continue
                         if input_pathname == 'abs':
                             # No further mangling needed for absolute paths.
                             pass
@@ -579,8 +583,7 @@ class NamelistGenerator(object):
                                    "Bad input_pathname value: %s." %
                                    input_pathname)
                         # Write to the input data list.
-                        input_data_list.write("%s = %s\n" %
-                                              (variable_name, file_path))
+                        input_data_list.write("%s = %s\n" % (variable_name, file_path))
 
     def write_output_file(self, namelist_file, data_list_path=None, groups=None, sorted_groups=True):
         """Write out the namelists and input data files.

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -54,9 +54,12 @@ def create_namelists(case):
     # Load modules
     case.load_env()
 
-    # Create namelists
+    # Create namelists - must have DRV last in the list below
+    # Note - DRV must be last in the loop below so that in generating its namelist, 
+    # it can use xml vars potentially set by other component's buildnml scripts
     models = case.get_values("COMP_CLASSES")
-    for model in models:
+    models_reverse = models[::-1]
+    for model in models_reverse:
         model_str = model.lower()
         config_file = case.get_value("CONFIG_%s_FILE" % model_str.upper())
         config_dir = os.path.dirname(config_file)

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -42,7 +42,9 @@ def create_dirs(case):
             fd.write(caseroot+"\n")
 
 def create_namelists(case):
-
+    """
+    Create component namelists 
+    """
     case.flush()
 
     casebuild = case.get_value("CASEBUILD")
@@ -53,6 +55,8 @@ def create_namelists(case):
 
     # Load modules
     case.load_env()
+
+    logger.info("Creating component namelists")
 
     # Create namelists - must have DRV last in the list below
     # Note - DRV must be last in the loop below so that in generating its namelist, 
@@ -68,9 +72,9 @@ def create_namelists(case):
         else:
             compname = case.get_value("COMP_%s" % model_str.upper())
         cmd = os.path.join(config_dir, "buildnml")
+        logger.info("   Calling %s buildnml"%compname)
         try:
             mod = imp.load_source("buildnml", cmd)
-            logger.info("Calling %s buildnml"%compname)
             mod.buildnml(case, caseroot, compname)
 
         except SyntaxError as detail:
@@ -79,11 +83,13 @@ def create_namelists(case):
             if 'python' in first_line:
                 expect(False, detail)
             else:
-                run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=True)
+                run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=False)
         except AttributeError:
-            run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=True)
+            run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=False)
         except:
             raise
+
+    logger.info("Finished creating component namelists")
 
     # refresh case xml object from file
     case.read_xml()

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -289,8 +289,8 @@ class TestScheduler(object):
                 # succeeded was the submission.
                 if phase != RUN_PHASE or self._no_batch:
                     self._log_output(test,
-                                     "%s PASSED for test '%s'.\nCommand: %s\nOutput: %s\n\nErrput: %s" %
-                                     (phase, test, cmd, output, errput))
+                                     "%s PASSED for test '%s'.\nCommand: %s\nOutput: %s" %
+                                     (phase, test, cmd, output))
                 break
 
         return rc == 0

--- a/utils/python/CIME/user_mod_support.py
+++ b/utils/python/CIME/user_mod_support.py
@@ -83,7 +83,7 @@ def update_user_nl_file(case_user_nl, contents):
         with open(case_user_nl, "r") as fd:
             old_contents = fd.read()
         contents = contents + old_contents
-    logger.info("Pre-pending file %s"%(case_user_nl))
+    logger.debug("Pre-pending file %s"%(case_user_nl))
     with open(case_user_nl, "w") as fd:
         fd.write(contents)
 

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -770,6 +770,7 @@ def append_status(msg, caseroot='.', sfile="CaseStatus"):
         ctime = time.strftime("%Y-%m-%d %H:%M:%S: ")
     with open(os.path.join(caseroot,sfile), "a") as fd:
         fd.write(ctime + msg + "\n")
+        fd.write("\n ---------------------------------------------------\n\n")
 
 def does_file_have_string(filepath, text):
     """


### PR DESCRIPTION
Fixes for upcoming pythonization of buildnml for cesm components
  - addition to build.py to read the xml files back in (this is needed for the upcoming
    pythonization of buildnml for cesm components
  - addition of new regular expression to compare_namelists.py 
  - addition of new optional argument to namelist.py write routine that permits 
    namelist to be written out in unsorted order 
 
Simplification of default scripts  output
  - Replaced logger.info with loger.debug for all data components.
    This makes the output much easier to read 
    The namelist generation output across components is very different
    depending on the component, so capturing this only on debug really cleans up
    the amount of output normally shown
  - preview_namelists now by default has verbosity=False
    this again makes the output (particularly for the tests) much easier to parse
  - preview_namelists was modified so that DRV is last in the loop over components
    NOTE - DRV must be last in that loop below so that in generating its namelist, 
    it can use xml vars potentially set by other component's buildnml scripts

Fixes to cesm/config_grids.xml and grids.py

Fixed a typo in namelist_definition_drv.xml
  
Testing: Also ran the following cesm tests successfully:
ERP_Ln9.f09_f09.F2000_DEV.yellowstone_intel.cam-outfrq9s_clm5 - compared with cesm2_0_alpha05a
ERS_Ld7.f19_g16.B1850.yellowstone_intel.allactive-defaultio - compared with cesm2_0_alpha05a
ERS_Ld5_Mmpi-serial.1x1_mexicocityMEX.I1PTCLM45.yellowstone_intel.clm-default

Test suite: scripts_regression test 
ERP_Ln9.f09_f09.F2000_DEV.yellowstone_intel.cam-outfrq9s_clm5 - compared with cesm2_0_alpha05a
ERS_Ld7.f19_g16.B1850.yellowstone_intel.allactive-defaultio - compared with cesm2_0_alpha05a
ERS_Ld5_Mmpi-serial.1x1_mexicocityMEX.I1PTCLM45.yellowstone_intel.clm-default
Test baseline: 
Test namelist changes: none
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Code review: parts were reviewed by jedwards
