### PR TITLE
runoff src mask = 1 globally

### DIFF
--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/src/map_mod.F90
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/src/map_mod.F90
@@ -428,13 +428,8 @@ SUBROUTINE map_gridRead(map, rfilename, ofilename, gridtype, lmake_rSCRIP)
 
          map%area_a(n) = 0.5 * 0.5 * cos(lat*DEGtoRAD) * DEGtoRAD * DEGtoRAD
 
-         if (abs(rdirc) < 0.5) then
-            map%mask_a(n) = 1
-            map%frac_a(n) = 1.0_r8
-         else
-            map%mask_a(n) = 0
-            map%frac_a(n) = 0.0_r8
-         endif
+         map%mask_a(n) = 1
+         map%frac_a(n) = 1.0_r8
       enddo
 
       close(fid)


### PR DESCRIPTION
To save computation, the runoff to ocean map originally only considered coastal points as potential sources, but we now potentially have runoff coming from the interior of continents so we don't want that mask any more.

Test suite: none
Test baseline: none
Test namelist changes: none
Test status: changes the runoff to ocean mask generated by the mapping tools

I don't believe this was every formally reported via issues

User interface changes?: none

Code review: @jtruesdal stood over my shoulder while I removed 4 lines of code and reformatted the whitespace of two more.

--- 

We don't want to limit the possible source points for the runoff to ocean
mapping file, so mask_a = 1 everywhere.