### PR TITLE
Clone fix

### DIFF
--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -628,12 +628,12 @@ class Case(object):
             for component_class in self._component_classes:
                 if component_class == "DRV":
                     component_class = "CPL"
-                string = "NTASKS_" + component_class
-                pes_ntasks[string] = opti_tasks
-                string = "NTHRDS_" + component_class
-                pes_nthrds[string] = opti_thrds
-                string = "ROOTPE_" + component_class
-                pes_rootpe[string] = 0
+                string_ = "NTASKS_" + component_class
+                pes_ntasks[string_] = opti_tasks
+                string_ = "NTHRDS_" + component_class
+                pes_nthrds[string_] = opti_thrds
+                string_ = "ROOTPE_" + component_class
+                pes_rootpe[string_] = 0
         else:
             pesobj = Pes(self._pesfile)
 

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -5,7 +5,7 @@ All interaction with and between the module files in XML/ takes place
 through the Case module.
 """
 from copy   import deepcopy
-import glob, os, shutil, traceback, math
+import glob, os, shutil, traceback, math, string
 from CIME.XML.standard_module_setup import *
 
 from CIME.utils                     import expect, get_cime_root, append_status
@@ -908,6 +908,21 @@ class Case(object):
         newcase = self.copy(newcasename, newcaseroot, newsrcroot=srcroot)
         newcase.set_value("CIMEROOT", newcase_cimeroot)
 
+        # if we are cloning to a different user modify the output directory
+        olduser = self.get_value("USER")
+        newuser = os.environ.get("USER")
+        if olduser != newuser:
+            outputroot = self.get_value("CIME_OUTPUT_ROOT")
+            outputroot = string.replace(outputroot, olduser, newuser)
+            # try to make the new output directory and raise an exception
+            # on any error other than directory already exists.
+            try:
+                os.makedirs(outputroot)
+            except OSError:
+                if not os.path.isdir(outputroot):
+                    raise
+            newcase.set_value("CIME_OUTPUT_ROOT", outputroot)
+            newcase.set_value("USER", newuser)
         # determine if will use clone executable or not
         if keepexe:
             orig_exeroot = self.get_value("EXEROOT")

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -206,6 +206,7 @@ class J_TestCreateNewcase(unittest.TestCase):
             contents = fd.read()
             self.assertTrue("a different cpl test option" in contents, msg="User_mods contents of user_nl_cpl missing")
             self.assertTrue("a cpl namelist option" in contents, msg="User_mods contents of user_nl_cpl missing")
+        self._do_teardown.append(testdir)
 
     def test_c_create_clone_keepexe(self):
         testdir = os.path.join(self._testroot, 'test_create_clone_keepexe')
@@ -217,7 +218,6 @@ class J_TestCreateNewcase(unittest.TestCase):
         run_cmd_assert_result(self, "%s/create_clone --clone %s --case %s --keepexe" %
                               (SCRIPT_DIR, prevtestdir, testdir),from_dir=SCRIPT_DIR)
 
-        self._do_teardown.append(prevtestdir)
         self._do_teardown.append(testdir)
 
     def test_d_create_clone_new_user(self):
@@ -237,7 +237,6 @@ class J_TestCreateNewcase(unittest.TestCase):
         run_cmd_assert_result(self, "%s/create_clone --clone %s --case %s" %
                               (SCRIPT_DIR, prevtestdir, testdir),from_dir=SCRIPT_DIR)
 
-        self._do_teardown.append(prevtestdir)
         self._do_teardown.append(testdir)
         self._do_teardown.append(self._testroot)
 


### PR DESCRIPTION
Fixes an issue with create_clone when cloning from one user to another, adds two tests
to scripts_regression_tests to try to assure this works.   (It's not possible to write a test which
actually invokes two user accounts)

Test suite:  scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #917 

User interface changes?: 

Code review: 
