### PR TITLE
Give a meaningful error message when query_testlists can't find anything

### DIFF
--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -157,6 +157,10 @@ def _main_func(description):
         xml_compiler = args.xml_compiler,
         xml_testlist = args.xml_testlist)
 
+    expect(test_data, "No tests found with the following options (where 'None' means no subsetting on that attribute):\n"
+           "\tMachine = %s\n\tCategory = %s\n\tCompiler = %s\n\tTestlist = %s"%
+           (args.xml_machine, args.xml_category, args.xml_compiler, args.xml_testlist))
+
     if args.count:
         count_test_data(test_data)
     elif args.list_type:


### PR DESCRIPTION
This is particularly needed to avoid a cryptic traceback when no tests
are found, when you don't specify --count or --list

Test suite: ./scripts_regression_tests.py A_RunUnitTests S_TestManageAndQuery
   And manual testing of query_testlists
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes: None

User interface changes?: No

Code review: 