### PR TITLE
Fix hdf5 serial version on skybridge

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -788,7 +788,7 @@
       <command name="load">libraries/intel-mkl-15.0.2.164</command>
       <command name="load" mpilib="!mpi-serial">sems-hdf5/1.8.12/parallel</command>
       <command name="load" mpilib="!mpi-serial">sems-netcdf/4.3.2/parallel</command>
-      <command name="load" mpilib="mpi-serial">sems-hdf5/1.8.11/base</command>
+      <command name="load" mpilib="mpi-serial">sems-hdf5/1.8.12/base</command>
       <command name="load" mpilib="mpi-serial">sems-netcdf/4.3.2/base</command>
     </modules>
   </module_system>
@@ -856,7 +856,7 @@
       <command name="load">libraries/intel-mkl-15.0.2.164</command>
       <command name="load" mpilib="!mpi-serial">sems-hdf5/1.8.12/parallel</command>
       <command name="load" mpilib="!mpi-serial">sems-netcdf/4.3.2/parallel</command>
-      <command name="load" mpilib="mpi-serial">sems-hdf5/1.8.11/base</command>
+      <command name="load" mpilib="mpi-serial">sems-hdf5/1.8.12/base</command>
       <command name="load" mpilib="mpi-serial">sems-netcdf/4.3.2/base</command>
     </modules>
   </module_system>


### PR DESCRIPTION
Fixes K_TestCimeCase.test_cime_case_mpi_serial on skybridge

Test suite: K_TestCimeCase.test_cime_case_mpi_serial on skybridge
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: None

Code review: None

