### PR TITLE
check_input_data: Use umask before svn export

### DIFF
--- a/utils/python/CIME/check_input_data.py
+++ b/utils/python/CIME/check_input_data.py
@@ -45,14 +45,14 @@ def download_if_in_repo(svn_loc, input_data_root, rel_path):
         logging.warning("FAIL: SVN repo '%s' does not have file '%s'\nReason:%s\n%s\n" % (svn_loc, full_url, out, err))
         return False
     else:
+        # Use umask to make sure files are group read/writable. As long as parent directories
+        # have +s, then everything should work.
         stat, output, errput = \
-            run_cmd("svn --non-interactive --trust-server-cert export %s %s" % (full_url, full_path))
+            run_cmd("umask 002 && svn --non-interactive --trust-server-cert export %s %s" % (full_url, full_path))
         if (stat != 0):
             logging.warning("svn export failed with output: %s and errput %s\n" % (output, errput))
             return False
         else:
-            # Make sure it is group r/w
-            os.chmod(full_path, 0664)
             logging.info("SUCCESS\n")
             return True
 


### PR DESCRIPTION
Will ensure all files and directories that get created will have
permissions that allow for collaboration between users.

Test suite: code_checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: None

Code review: jedwards

