### PR TITLE
Refactor xml compvars 

### DIFF
--- a/cime_config/acme/config_files.xml
+++ b/cime_config/acme/config_files.xml
@@ -194,7 +194,7 @@
   <!-- File names for all component specific configuration variables -->
   <!-- =============================================================== -->
 
-  <entry id="CONFIG_DRV_FILE">
+  <entry id="CONFIG_CPL_FILE">
     <type>char</type>
     <default_value>$CIMEROOT/driver_cpl/cime_config/config_component.xml</default_value>
     <group>case_last</group>

--- a/cime_config/cesm/config_files.xml
+++ b/cime_config/cesm/config_files.xml
@@ -194,7 +194,7 @@
   <!-- File names for all component specific configuration variables -->
   <!-- =============================================================== -->
 
-  <entry id="CONFIG_DRV_FILE">
+  <entry id="CONFIG_CPL_FILE">
     <type>char</type>
     <default_value>$CIMEROOT/driver_cpl/cime_config/config_component.xml</default_value>
     <group>case_last</group>

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -46,6 +46,7 @@ def _create_drv_namelists(case, infiles, definition_file, confdir):
     config['timer_level'] = 'pos' if case.get_value('TIMER_LEVEL') >= 1 else 'neg'
     config['bfbflag'] = 'on' if case.get_value('BFBFLAG') else 'off'
     config['continue_run'] = '.true.' if case.get_value('CONTINUE_RUN') else '.false.'
+
     if case.get_value('RUN_TYPE') == 'startup':
         config['run_type'] = 'startup'
     elif case.get_value('RUN_TYPE') == 'hybrid':

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -1901,28 +1901,75 @@
     <desc>number of tasks for each component</desc>
   </entry>
 
-  <entry id="NTHRDS_ATM">
+  <entry id="NTHRDS">
     <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_atm</group>
+    <values>
+      <value component="ATM">1</value>
+      <value component="CPL">1</value>
+      <value component="OCN">1</value>
+      <value component="WAV">1</value>
+      <value component="GLC">1</value>
+      <value component="ICE">1</value>
+      <value component="ROF">1</value>
+      <value component="LND">1</value>
+      <value component="ESP">1</value>
+    </values>
+    <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>number of atmosphere threads</desc>
+    <desc>number of threads for each task in each component</desc>
   </entry>
 
-  <entry id="ROOTPE_ATM">
+  <entry id="ROOTPE">
     <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_atm</group>
+    <values>
+      <value component="ATM">0</value>
+      <value component="CPL">0</value>
+      <value component="OCN">0</value>
+      <value component="WAV">0</value>
+      <value component="GLC">0</value>
+      <value component="ICE">0</value>
+      <value component="ROF">0</value>
+      <value component="LND">0</value>
+      <value component="ESP">0</value>
+    </values>
+    <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>root atm mpi task</desc>
+    <desc>ROOTPE (mpi task in MPI_COMM_WORLD) for each component</desc>
   </entry>
 
-  <entry id="NINST_ATM">
+  <entry id="NINST">
     <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_atm</group>
+    <values>
+      <value component="ATM">1</value>
+      <value component="OCN">1</value>
+      <value component="WAV">1</value>
+      <value component="GLC">1</value>
+      <value component="ICE">1</value>
+      <value component="ROF">1</value>
+      <value component="LND">1</value>
+      <value component="ESP">1</value>
+    </values>
+    <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of atmosphere instances</desc>
+    <desc>Number of instances for each component</desc>
+  </entry>
+
+  <entry id="PSTRID">
+    <type>integer</type>
+    <values>
+      <value component="ATM">1</value>
+      <value component="CPL">1</value>
+      <value component="OCN">1</value>
+      <value component="WAV">1</value>
+      <value component="GLC">1</value>
+      <value component="ICE">1</value>
+      <value component="ROF">1</value>
+      <value component="LND">1</value>
+      <value component="ESP">1</value>
+    </values>
+    <group>mach_pes</group>
+    <file>env_mach_pes.xml</file>
+    <desc>Number of instances for each component</desc>
   </entry>
 
   <entry id="NINST_ATM_LAYOUT">
@@ -1934,30 +1981,6 @@
     <desc>Layout of atmosphere instances</desc>
   </entry>
 
-  <entry id="NTHRDS_LND">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_lnd</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of land mpi threads</desc>
-  </entry>
-
-  <entry id="ROOTPE_LND">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_lnd</group>
-    <file>env_mach_pes.xml</file>
-    <desc>root lnd mpi task</desc>
-  </entry>
-
-  <entry id="NINST_LND">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_lnd</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Number of land instances</desc>
-  </entry>
-
   <entry id="NINST_LND_LAYOUT">
     <type>char</type>
     <valid_values>sequential,concurrent</valid_values>
@@ -1965,30 +1988,6 @@
     <group>mach_pes_lnd</group>
     <file>env_mach_pes.xml</file>
     <desc>Layout of land instances</desc>
-  </entry>
-
-  <entry id="NTHRDS_ICE">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_ice</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of ice mpi threads</desc>
-  </entry>
-
-  <entry id="ROOTPE_ICE">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_ice</group>
-    <file>env_mach_pes.xml</file>
-    <desc>root ice mpi task</desc>
-  </entry>
-
-  <entry id="NINST_ICE">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_ice</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Number of sea ice instances</desc>
   </entry>
 
   <entry id="NINST_ICE_LAYOUT">
@@ -2000,30 +1999,6 @@
     <desc>Layout of sea ice instances</desc>
   </entry>
 
-  <entry id="NTHRDS_OCN">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_ocn</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of ocean mpi threads</desc>
-  </entry>
-
-  <entry id="ROOTPE_OCN">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_ocn</group>
-    <file>env_mach_pes.xml</file>
-    <desc>root ocn mpi task</desc>
-  </entry>
-
-  <entry id="NINST_OCN">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_ocn</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Number of ocean instances</desc>
-  </entry>
-
   <entry id="NINST_OCN_LAYOUT">
     <type>char</type>
     <valid_values>sequential,concurrent</valid_values>
@@ -2031,49 +2006,6 @@
     <group>mach_pes_ocn</group>
     <file>env_mach_pes.xml</file>
     <desc>Layout of ocean instances</desc>
-  </entry>
-
-  <entry id="NTHRDS_CPL">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_cpl</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of coupler mpi threads</desc>
-  </entry>
-
-  <entry id="ROOTPE_CPL">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_cpl</group>
-    <file>env_mach_pes.xml</file>
-    <desc>root cpl mpi task</desc>
-  </entry>
-
-  <entry id="NTHRDS_GLC">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <values>
-      <value compset="_CISM1">1</value>
-    </values>
-    <group>mach_pes_glc</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of glc mpi threads</desc>
-  </entry>
-
-  <entry id="ROOTPE_GLC">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_glc</group>
-    <file>env_mach_pes.xml</file>
-    <desc>root glc mpi task</desc>
-  </entry>
-
-  <entry id="NINST_GLC">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_glc</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Number of glacier instances</desc>
   </entry>
 
   <entry id="NINST_GLC_LAYOUT">
@@ -2085,61 +2017,12 @@
     <desc>Layout of glacier instances</desc>
   </entry>
 
-  <entry id="NTHRDS_ROF">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_rof</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of river runoff threads</desc>
-  </entry>
-
-  <entry id="ROOTPE_ROF">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_rof</group>
-    <file>env_mach_pes.xml</file>
-    <desc>root rof mpi task</desc>
-  </entry>
-
-  <entry id="NINST_ROF">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_rof</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Number of river runoff instances</desc>
-  </entry>
-
   <entry id="NINST_ROF_LAYOUT">
     <type>char</type>
     <default_value>concurrent</default_value>
     <group>mach_pes_rof</group>
     <file>env_mach_pes.xml</file>
     <desc>Layout of river runoff instances</desc>
-  </entry>
-
-
-  <entry id="NTHRDS_WAV">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_wav</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of wav mpi threads</desc>
-  </entry>
-
-  <entry id="ROOTPE_WAV">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_wav</group>
-    <file>env_mach_pes.xml</file>
-    <desc>root wav mpi task</desc>
-  </entry>
-
-  <entry id="NINST_WAV">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_wav</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Number of wave instances</desc>
   </entry>
 
   <entry id="NINST_WAV_LAYOUT">
@@ -2151,30 +2034,6 @@
     <desc>Layout of wave instances</desc>
   </entry>
 
-  <entry id="NTHRDS_ESP">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_esp</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of external processing tool mpi threads</desc>
-  </entry>
-
-  <entry id="ROOTPE_ESP">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_esp</group>
-    <file>env_mach_pes.xml</file>
-    <desc>root ocn mpi task</desc>
-  </entry>
-
-  <entry id="NINST_ESP">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_esp</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Number of external processing tool instances</desc>
-  </entry>
-
   <entry id="NINST_ESP_LAYOUT">
     <type>char</type>
     <valid_values>sequential,concurrent</valid_values>
@@ -2182,83 +2041,6 @@
     <group>mach_pes_esp</group>
     <file>env_mach_pes.xml</file>
     <desc>Layout of external processing tool instances</desc>
-  </entry>
-
-  <entry id="PSTRID_ATM">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_stride</group>
-    <file>env_mach_pes.xml</file>
-    <desc>stride of mpi tasks for atm comp - currently should always be set to 1</desc>
-  </entry>
-
-  <entry id="PSTRID_LND">
-    <type>integer</type>
-    <valid_values>1</valid_values>
-    <default_value>1</default_value>
-    <group>mach_pes_stride</group>
-    <file>env_mach_pes.xml</file>
-    <desc>stride of mpi tasks for lnd comp - currently should always be set to 1</desc>
-  </entry>
-
-  <entry id="PSTRID_ICE">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_stride</group>
-    <file>env_mach_pes.xml</file>
-    <desc>stride of mpi tasks for ice comp - currently should always be set to 1</desc>
-  </entry>
-
-  <entry id="PSTRID_OCN">
-    <type>integer</type>
-    <valid_values>1</valid_values>
-    <default_value>1</default_value>
-    <group>mach_pes_stride</group>
-    <file>env_mach_pes.xml</file>
-    <desc>stride of mpi tasks for ocn comp - currently should always be set to 1</desc>
-  </entry>
-
-  <entry id="PSTRID_CPL">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_stride</group>
-    <file>env_mach_pes.xml</file>
-    <desc>stride of mpi tasks for cpl comp - currently should always be set to 1</desc>
-  </entry>
-
-  <entry id="PSTRID_GLC">
-    <type>integer</type>
-    <valid_values>1</valid_values>
-    <default_value>1</default_value>
-    <group>mach_pes_stride</group>
-    <file>env_mach_pes.xml</file>
-    <desc>stride of mpi tasks for glc comp - currently should always be set to 1</desc>
-  </entry>
-
-  <entry id="PSTRID_ROF">
-    <type>integer</type>
-    <default_value>1</default_value>
-    <group>mach_pes_stride</group>
-    <file>env_mach_pes.xml</file>
-    <desc>stride of mpi tasks for rof comp - currently should always be set to 1</desc>
-  </entry>
-
-  <entry id="PSTRID_WAV">
-    <type>integer</type>
-    <valid_values>1</valid_values>
-    <default_value>1</default_value>
-    <group>mach_pes_stride</group>
-    <file>env_mach_pes.xml</file>
-    <desc>stride of mpi tasks for wav comp - currently should always be set to 1</desc>
-  </entry>
-
-  <entry id="PSTRID_ESP">
-    <type>integer</type>
-    <valid_values>1</valid_values>
-    <default_value>1</default_value>
-    <group>mach_pes_stride</group>
-    <file>env_mach_pes.xml</file>
-    <desc>stride of mpi tasks for esp comp - currently should always be set to 1</desc>
   </entry>
 
   <entry id="TOTALPES">

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2045,38 +2045,6 @@
     <desc>TRUE implies perform asynchronous i/o</desc>
   </entry>
 
-  <entry id="PIO_STRIDE">
-    <type>integer</type>
-    <default_value>-1</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>mpi task stride between io tasks</desc>
-  </entry>
-
-  <entry id="PIO_ROOT">
-    <type>integer</type>
-    <default_value>-1</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio root processor</desc>
-  </entry>
-
-  <entry id="PIO_NUMTASKS">
-    <type>integer</type>
-    <default_value>-1</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="PIO_REARRANGER">
-    <type>integer</type>
-    <default_value>2</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
-  </entry>
-
   <entry id="PIO_REARR_COMM_TYPE">
     <type>char</type>
     <valid_values>p2p,coll,default</valid_values>
@@ -2158,7 +2126,6 @@
     <file>env_run.xml</file>
     <desc>pio io type</desc>
     <values>
-      <value>pnetcdf</value>
       <value component="ATM">default</value>
       <value component="CPL">default</value>
       <value component="OCN">default</value>
@@ -2170,6 +2137,25 @@
       <value component="ESP">default</value>
     </values>
   </entry>
+
+  <entry id="PIO_STRIDE">
+    <type>integer</type>
+    <group>run_pio</group>
+    <file>env_run.xml</file>
+    <desc>stride in compute comm of io tasks for each component</desc>
+    <values>
+      <value component="ATM"></value>
+      <value component="CPL"></value>
+      <value component="OCN"></value>
+      <value component="WAV"></value>
+      <value component="GLC"></value>
+      <value component="ICE"></value>
+      <value component="ROF"></value>
+      <value component="LND"></value>
+      <value component="ESP"></value>
+    </values>
+  </entry>
+
 
   <entry id="PIO_DEBUG_LEVEL">
     <type>integer</type>
@@ -2195,13 +2181,6 @@
     <desc>pio buffer size limit for pnetcdf output</desc>
   </entry>
 
-  <entry id="OCN_PIO_STRIDE">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio stride</desc>
-  </entry>
 
   <entry id="OCN_PIO_REARRANGER">
     <type>integer</type>
@@ -2225,14 +2204,6 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="LND_PIO_STRIDE">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio stride</desc>
   </entry>
 
   <entry id="LND_PIO_REARRANGER">
@@ -2259,14 +2230,6 @@
     <desc>pio number of io tasks</desc>
   </entry>
 
-  <entry id="ROF_PIO_STRIDE">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio stride</desc>
-  </entry>
-
   <entry id="ROF_PIO_REARRANGER">
     <type>integer</type>
     <default_value>-99</default_value>
@@ -2289,14 +2252,6 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="ICE_PIO_STRIDE">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio stride</desc>
   </entry>
 
   <entry id="ICE_PIO_REARRANGER">
@@ -2323,14 +2278,6 @@
     <desc>pio number of io tasks</desc>
   </entry>
 
-  <entry id="ATM_PIO_STRIDE">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio stride</desc>
-  </entry>
-
   <entry id="ATM_PIO_REARRANGER">
     <type>integer</type>
     <default_value>-99</default_value>
@@ -2353,14 +2300,6 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio number of io tasks, -99 value means inherit whatever the driver uses</desc>
-  </entry>
-
-  <entry id="CPL_PIO_STRIDE">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio stride</desc>
   </entry>
 
   <entry id="CPL_PIO_REARRANGER">
@@ -2387,14 +2326,6 @@
     <desc>pio number of io tasks</desc>
   </entry>
 
-  <entry id="GLC_PIO_STRIDE">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio stride</desc>
-  </entry>
-
   <entry id="GLC_PIO_REARRANGER">
     <type>integer</type>
     <default_value>-99</default_value>
@@ -2417,14 +2348,6 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="WAV_PIO_STRIDE">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio stride</desc>
   </entry>
 
   <entry id="WAV_PIO_REARRANGER">

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -1954,6 +1954,24 @@
     <desc>Number of instances for each component</desc>
   </entry>
 
+  <entry id="NINST_LAYOUT">
+    <type>char</type>
+    <valid_values>sequential,concurrent</valid_values>
+    <values>
+      <value component="ATM">concurrent</value>
+      <value component="OCN">concurrent</value>
+      <value component="WAV">concurrent</value>
+      <value component="GLC">concurrent</value>
+      <value component="ICE">concurrent</value>
+      <value component="ROF">concurrent</value>
+      <value component="LND">concurrent</value>
+      <value component="ESP">concurrent</value>
+    </values>
+    <group>mach_pes</group>
+    <file>env_mach_pes.xml</file>
+    <desc>Layout of component instances for each component</desc>
+  </entry>
+
   <entry id="PSTRID">
     <type>integer</type>
     <values>
@@ -1972,76 +1990,6 @@
     <desc>Number of instances for each component</desc>
   </entry>
 
-  <entry id="NINST_ATM_LAYOUT">
-    <type>char</type>
-    <valid_values>sequential,concurrent</valid_values>
-    <default_value>concurrent</default_value>
-    <group>mach_pes_atm</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Layout of atmosphere instances</desc>
-  </entry>
-
-  <entry id="NINST_LND_LAYOUT">
-    <type>char</type>
-    <valid_values>sequential,concurrent</valid_values>
-    <default_value>concurrent</default_value>
-    <group>mach_pes_lnd</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Layout of land instances</desc>
-  </entry>
-
-  <entry id="NINST_ICE_LAYOUT">
-    <type>char</type>
-    <valid_values>sequential,concurrent</valid_values>
-    <default_value>concurrent</default_value>
-    <group>mach_pes_ice</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Layout of sea ice instances</desc>
-  </entry>
-
-  <entry id="NINST_OCN_LAYOUT">
-    <type>char</type>
-    <valid_values>sequential,concurrent</valid_values>
-    <default_value>concurrent</default_value>
-    <group>mach_pes_ocn</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Layout of ocean instances</desc>
-  </entry>
-
-  <entry id="NINST_GLC_LAYOUT">
-    <type>char</type>
-    <valid_values>sequential,concurrent</valid_values>
-    <default_value>concurrent</default_value>
-    <group>mach_pes_glc</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Layout of glacier instances</desc>
-  </entry>
-
-  <entry id="NINST_ROF_LAYOUT">
-    <type>char</type>
-    <default_value>concurrent</default_value>
-    <group>mach_pes_rof</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Layout of river runoff instances</desc>
-  </entry>
-
-  <entry id="NINST_WAV_LAYOUT">
-    <type>char</type>
-    <valid_values>sequential,concurrent</valid_values>
-    <default_value>concurrent</default_value>
-    <group>mach_pes_wav</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Layout of wave instances</desc>
-  </entry>
-
-  <entry id="NINST_ESP_LAYOUT">
-    <type>char</type>
-    <valid_values>sequential,concurrent</valid_values>
-    <default_value>concurrent</default_value>
-    <group>mach_pes_esp</group>
-    <file>env_mach_pes.xml</file>
-    <desc>Layout of external processing tool instances</desc>
-  </entry>
 
   <entry id="TOTALPES">
     <type>integer</type>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2959,6 +2959,7 @@
    <file>env_batch.xml</file>
    <desc>The machine queue in which to submit the job.  Default determined in config_machines.xml can be overwritten by testing</desc>
  </entry>
+
  <entry id="JOB_WALLCLOCK_TIME">
    <type>char</type>
    <valid_values></valid_values>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -11,7 +11,7 @@
 
   <entry id="COMP_CLASSES">
     <type>char</type>
-    <default_value>DRV,ATM,LND,ICE,OCN,ROF,GLC,WAV,ESP</default_value>
+    <default_value>CPL,ATM,LND,ICE,OCN,ROF,GLC,WAV,ESP</default_value>
     <file>env_case.xml</file>
     <group>case_comp</group>
     <desc>List of component classes supported by this driver</desc>

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2206,10 +2206,21 @@
   <entry id="PIO_TYPENAME">
     <type>char</type>
     <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,default</valid_values>
-    <default_value>pnetcdf</default_value>
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio io type</desc>
+    <values>
+      <value>pnetcdf</value>
+      <value component="ATM">default</value>
+      <value component="CPL">default</value>
+      <value component="OCN">default</value>
+      <value component="WAV">default</value>
+      <value component="GLC">default</value>
+      <value component="ICE">default</value>
+      <value component="ROF">default</value>
+      <value component="LND">default</value>
+      <value component="ESP">default</value>
+    </values>
   </entry>
 
   <entry id="PIO_DEBUG_LEVEL">
@@ -2268,15 +2279,6 @@
     <desc>pio number of io tasks</desc>
   </entry>
 
-  <entry id="OCN_PIO_TYPENAME">
-    <type>char</type>
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
-    <default_value>nothing</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio io type</desc>
-  </entry>
-
   <entry id="LND_PIO_STRIDE">
     <type>integer</type>
     <default_value>-99</default_value>
@@ -2307,15 +2309,6 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="LND_PIO_TYPENAME">
-    <type>char</type>
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
-    <default_value>nothing</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio io type</desc>
   </entry>
 
   <entry id="ROF_PIO_STRIDE">
@@ -2350,15 +2343,6 @@
     <desc>pio number of io tasks</desc>
   </entry>
 
-  <entry id="ROF_PIO_TYPENAME">
-    <type>char</type>
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
-    <default_value>nothing</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio io type</desc>
-  </entry>
-
   <entry id="ICE_PIO_STRIDE">
     <type>integer</type>
     <default_value>-99</default_value>
@@ -2389,15 +2373,6 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="ICE_PIO_TYPENAME">
-    <type>char</type>
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
-    <default_value>nothing</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio io type</desc>
   </entry>
 
   <entry id="ATM_PIO_STRIDE">
@@ -2432,15 +2407,6 @@
     <desc>pio number of io tasks, -99 value means inherit whatever the driver uses</desc>
   </entry>
 
-  <entry id="ATM_PIO_TYPENAME">
-    <type>char</type>
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
-    <default_value>nothing</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio io type</desc>
-  </entry>
-
   <entry id="CPL_PIO_STRIDE">
     <type>integer</type>
     <default_value>-99</default_value>
@@ -2471,15 +2437,6 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="CPL_PIO_TYPENAME">
-    <type>char</type>
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
-    <default_value>nothing</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio io type</desc>
   </entry>
 
   <entry id="GLC_PIO_STRIDE">
@@ -2514,15 +2471,6 @@
     <desc>pio number of io tasks</desc>
   </entry>
 
-  <entry id="GLC_PIO_TYPENAME">
-    <type>char</type>
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
-    <default_value>nothing</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio io type</desc>
-  </entry>
-
   <entry id="WAV_PIO_STRIDE">
     <type>integer</type>
     <default_value>-99</default_value>
@@ -2553,15 +2501,6 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="WAV_PIO_TYPENAME">
-    <type>char</type>
-    <valid_values>nothing,netcdf,pnetcdf,netcdf4p,netcdf4c</valid_values>
-    <default_value>nothing</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio io type</desc>
   </entry>
 
   <!-- ===================================================================== -->

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2119,43 +2119,6 @@
     <desc>pio rearranger communiation options (io2comp) : TRUE implies enable isend</desc>
   </entry>
 
-  <entry id="PIO_TYPENAME">
-    <type>char</type>
-    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,default</valid_values>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio io type</desc>
-    <values>
-      <value component="ATM">default</value>
-      <value component="CPL">default</value>
-      <value component="OCN">default</value>
-      <value component="WAV">default</value>
-      <value component="GLC">default</value>
-      <value component="ICE">default</value>
-      <value component="ROF">default</value>
-      <value component="LND">default</value>
-      <value component="ESP">default</value>
-    </values>
-  </entry>
-
-  <entry id="PIO_STRIDE">
-    <type>integer</type>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>stride in compute comm of io tasks for each component</desc>
-    <values>
-      <value component="ATM"></value>
-      <value component="CPL"></value>
-      <value component="OCN"></value>
-      <value component="WAV"></value>
-      <value component="GLC"></value>
-      <value component="ICE"></value>
-      <value component="ROF"></value>
-      <value component="LND"></value>
-      <value component="ESP"></value>
-    </values>
-  </entry>
-
 
   <entry id="PIO_DEBUG_LEVEL">
     <type>integer</type>
@@ -2181,197 +2144,103 @@
     <desc>pio buffer size limit for pnetcdf output</desc>
   </entry>
 
+  <entry id="PIO_TYPENAME">
+    <type>char</type>
+    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,default</valid_values>
+    <group>run_pio</group>
+    <file>env_run.xml</file>
+    <desc>pio io type</desc>
+    <values>
+      <value component="ATM">default</value>
+      <value component="CPL">default</value>
+      <value component="OCN">default</value>
+      <value component="WAV">default</value>
+      <value component="GLC">default</value>
+      <value component="ICE">default</value>
+      <value component="ROF">default</value>
+      <value component="LND">default</value>
+      <value component="ESP">default</value>
+    </values>
+  </entry>
 
-  <entry id="OCN_PIO_REARRANGER">
+  <entry id="PIO_STRIDE">
     <type>integer</type>
-    <default_value>-99</default_value>
+    <group>run_pio</group>
+    <file>env_run.xml</file>
+    <desc>
+     stride in compute comm of io tasks for each component, if this value is -99 it will
+     be computed based on PIO_NUMTASKS and number of compute tasks
+    </desc>
+    <values>
+      <value component="ATM"></value>
+      <value component="CPL"></value>
+      <value component="OCN"></value>
+      <value component="WAV"></value>
+      <value component="GLC"></value>
+      <value component="ICE"></value>
+      <value component="ROF"></value>
+      <value component="LND"></value>
+      <value component="ESP"></value>
+    </values>
+  </entry>
+
+  <entry id="PIO_REARRANGER">
+    <type>integer</type>
+    <valid_values>1,2</valid_values>
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio rearranger choice box=1, subset=2 </desc>
+    <values>
+      <value>$PIO_VERSION</value>
+      <value component="ATM"></value>
+      <value component="CPL"></value>
+      <value component="OCN"></value>
+      <value component="WAV"></value>
+      <value component="GLC"></value>
+      <value component="ICE"></value>
+      <value component="ROF"></value>
+      <value component="LND"></value>
+      <value component="ESP"></value>
+    </values>
   </entry>
 
-  <entry id="OCN_PIO_ROOT">
+  <entry id="PIO_ROOT">
     <type>integer</type>
-    <default_value>0</default_value>
     <group>run_pio</group>
     <file>env_run.xml</file>
-    <desc>pio root processor</desc>
+    <desc>pio root processor relative to component root</desc>
+    <values>
+      <value component="ATM">1</value>
+      <value component="CPL">1</value>
+      <value component="OCN">1</value>
+      <value component="WAV">1</value>
+      <value component="GLC">1</value>
+      <value component="ICE">1</value>
+      <value component="ROF">1</value>
+      <value component="LND">1</value>
+      <value component="ESP">1</value>
+    </values>
   </entry>
 
-  <entry id="OCN_PIO_NUMTASKS">
+  <entry id="PIO_NUMTASKS">
     <type>integer</type>
-    <default_value>-99</default_value>
     <group>run_pio</group>
     <file>env_run.xml</file>
-    <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="LND_PIO_REARRANGER">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
-  </entry>
-
-  <entry id="LND_PIO_ROOT">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio root processor</desc>
-  </entry>
-
-  <entry id="LND_PIO_NUMTASKS">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="ROF_PIO_REARRANGER">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
-  </entry>
-
-  <entry id="ROF_PIO_ROOT">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio root processor</desc>
-  </entry>
-
-  <entry id="ROF_PIO_NUMTASKS">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="ICE_PIO_REARRANGER">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
-  </entry>
-
-  <entry id="ICE_PIO_ROOT">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio root processor</desc>
-  </entry>
-
-  <entry id="ICE_PIO_NUMTASKS">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="ATM_PIO_REARRANGER">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
-  </entry>
-
-  <entry id="ATM_PIO_ROOT">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio root processor</desc>
-  </entry>
-
-  <entry id="ATM_PIO_NUMTASKS">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio number of io tasks, -99 value means inherit whatever the driver uses</desc>
-  </entry>
-
-  <entry id="CPL_PIO_REARRANGER">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
-  </entry>
-
-  <entry id="CPL_PIO_ROOT">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio root processor</desc>
-  </entry>
-
-  <entry id="CPL_PIO_NUMTASKS">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="GLC_PIO_REARRANGER">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
-  </entry>
-
-  <entry id="GLC_PIO_ROOT">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio root processor</desc>
-  </entry>
-
-  <entry id="GLC_PIO_NUMTASKS">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio number of io tasks</desc>
-  </entry>
-
-  <entry id="WAV_PIO_REARRANGER">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio rearranger choice box=1, subset=2 </desc>
-  </entry>
-
-  <entry id="WAV_PIO_ROOT">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio root processor</desc>
-  </entry>
-
-  <entry id="WAV_PIO_NUMTASKS">
-    <type>integer</type>
-    <default_value>-99</default_value>
-    <group>run_pio</group>
-    <file>env_run.xml</file>
-    <desc>pio number of io tasks</desc>
+    <desc>
+      pio number of io tasks, if this value is -99 it will be computed based on PIO_STRIDE and
+      number of tasks
+    </desc>
+    <values>
+      <value component="ATM">-99</value>
+      <value component="CPL">-99</value>
+      <value component="OCN">-99</value>
+      <value component="WAV">-99</value>
+      <value component="GLC">-99</value>
+      <value component="ICE">-99</value>
+      <value component="ROF">-99</value>
+      <value component="LND">-99</value>
+      <value component="ESP">-99</value>
+    </values>
   </entry>
 
   <!-- ===================================================================== -->

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -1883,12 +1883,22 @@
   <!-- definitions pelayout -->
   <!-- ===================================================================== -->
 
-  <entry id="NTASKS_ATM">
+  <entry id="NTASKS">
     <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_atm</group>
+    <values>
+      <value component="ATM"> 0</value>
+      <value component="CPL"> 0</value>
+      <value component="OCN"> 0</value>
+      <value component="WAV"> 0</value>
+      <value component="GLC"> 0</value>
+      <value component="ICE"> 0</value>
+      <value component="ROF"> 0</value>
+      <value component="LND"> 0</value>
+      <value component="ESP"> 0</value>
+    </values>
+    <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>number of atmosphere tasks</desc>
+    <desc>number of tasks for each component</desc>
   </entry>
 
   <entry id="NTHRDS_ATM">
@@ -1924,14 +1934,6 @@
     <desc>Layout of atmosphere instances</desc>
   </entry>
 
-  <entry id="NTASKS_LND">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_lnd</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of land mpi tasks</desc>
-  </entry>
-
   <entry id="NTHRDS_LND">
     <type>integer</type>
     <default_value>0</default_value>
@@ -1963,14 +1965,6 @@
     <group>mach_pes_lnd</group>
     <file>env_mach_pes.xml</file>
     <desc>Layout of land instances</desc>
-  </entry>
-
-  <entry id="NTASKS_ICE">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_ice</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of ice mpi tasks</desc>
   </entry>
 
   <entry id="NTHRDS_ICE">
@@ -2006,14 +2000,6 @@
     <desc>Layout of sea ice instances</desc>
   </entry>
 
-  <entry id="NTASKS_OCN">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_ocn</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of ocean mpi tasks</desc>
-  </entry>
-
   <entry id="NTHRDS_OCN">
     <type>integer</type>
     <default_value>0</default_value>
@@ -2047,14 +2033,6 @@
     <desc>Layout of ocean instances</desc>
   </entry>
 
-  <entry id="NTASKS_CPL">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_cpl</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of coupler mpi tasks</desc>
-  </entry>
-
   <entry id="NTHRDS_CPL">
     <type>integer</type>
     <default_value>0</default_value>
@@ -2069,17 +2047,6 @@
     <group>mach_pes_cpl</group>
     <file>env_mach_pes.xml</file>
     <desc>root cpl mpi task</desc>
-  </entry>
-
-  <entry id="NTASKS_GLC">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <values>
-      <value compset="_CISM1">1</value>
-    </values>
-    <group>mach_pes_glc</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of glc mpi tasks</desc>
   </entry>
 
   <entry id="NTHRDS_GLC">
@@ -2118,14 +2085,6 @@
     <desc>Layout of glacier instances</desc>
   </entry>
 
-  <entry id="NTASKS_ROF">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_rof</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of river runoff tasks</desc>
-  </entry>
-
   <entry id="NTHRDS_ROF">
     <type>integer</type>
     <default_value>0</default_value>
@@ -2158,13 +2117,6 @@
     <desc>Layout of river runoff instances</desc>
   </entry>
 
-  <entry id="NTASKS_WAV">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_wav</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of wav mpi tasks</desc>
-  </entry>
 
   <entry id="NTHRDS_WAV">
     <type>integer</type>
@@ -2197,14 +2149,6 @@
     <group>mach_pes_wav</group>
     <file>env_mach_pes.xml</file>
     <desc>Layout of wave instances</desc>
-  </entry>
-
-  <entry id="NTASKS_ESP">
-    <type>integer</type>
-    <default_value>0</default_value>
-    <group>mach_pes_esp</group>
-    <file>env_mach_pes.xml</file>
-    <desc>number of external processing tool mpi tasks</desc>
   </entry>
 
   <entry id="NTHRDS_ESP">

--- a/driver_cpl/cime_config/namelist_definition_drv.xml
+++ b/driver_cpl/cime_config/namelist_definition_drv.xml
@@ -2788,68 +2788,6 @@
     </values>
   </entry>
 
-  <entry id="pio_stride" modify_via_xml="PIO_STRIDE">
-    <type>integer</type>
-    <category>pio</category>
-    <group>pio_default_inparm</group>
-    <desc>
-      stride of tasks in pio used generically, component based value takes precedent.
-    </desc>
-    <values>
-      <value>$PIO_STRIDE</value>
-    </values>
-  </entry>
-
-  <entry id="pio_root" modify_via_xml="PIO_ROOT">
-    <type>integer</type>
-    <category>pio</category>
-    <group>pio_default_inparm</group>
-    <desc>
-      io task root in pio used generically, component based value takes precedent.
-    </desc>
-    <values>
-      <value>$PIO_ROOT</value>
-    </values>
-  </entry>
-
-  <entry id="pio_rearranger" modify_via_xml="PIO_REARRANGER">
-    <type>integer</type>
-    <category>pio</category>
-    <group>pio_default_inparm</group>
-    <desc>
-      Rearranger method for pio 1=box, 2=subset.
-    </desc>
-    <values>
-      <value>$PIO_REARRANGER</value>
-    </values>
-  </entry>
-
-  <entry id="pio_numiotasks" modify_via_xml="PIO_NUMTASKS">
-    <type>integer</type>
-    <category>pio</category>
-    <group>pio_default_inparm</group>
-    <desc>
-      number of io tasks in pio used generically, component based value takes precedent.
-    </desc>
-    <values>
-      <value>$PIO_NUMTASKS</value>
-    </values>
-  </entry>
-
-  <entry id="pio_typename" modify_via_xml="PIO_TYPENAME">
-    <type>char</type>
-    <category>pio</category>
-    <group>pio_default_inparm</group>
-    <valid_values>netcdf,pnetcdf,netcdf4p,netcdf4c,default</valid_values>
-    <desc>
-      io type in pio used generically, component based value takes precedent.
-      valid values: netcdf, pnetcdf, netcdf4p, netcdf4c, default
-    </desc>
-    <values>
-      <value>$PIO_TYPENAME</value>
-    </values>
-  </entry>
-
   <entry id="pio_debug_level" modify_via_xml="PIO_DEBUG_LEVEL">
     <type>integer</type>
     <category>pio</category>

--- a/driver_cpl/cime_config/namelist_definition_modelio.xml
+++ b/driver_cpl/cime_config/namelist_definition_modelio.xml
@@ -64,7 +64,7 @@
     </values>
   </entry>
 
-  <entry id="pio_root" modify_via_xml="PIO_STRIDE">
+  <entry id="pio_root" modify_via_xml="PIO_ROOT">
     <type>integer</type>
     <category>pio</category>
     <group>pio_inparm</group>

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -43,10 +43,9 @@ OR
                         help="Assume shared libs already built")
 
     files = Files()
-    config_file = files.get_value("CONFIG_DRV_FILE")
+    config_file = files.get_value("CONFIG_CPL_FILE")
     component = Component(config_file)
     comps = [x.lower() for x in component.get_valid_model_components()]
-    comps = [x.replace('drv', 'cpl') for x in comps]
     libs  = ["csmshare", "mct", "pio", "gptl"]
     allobjs = comps + libs
 

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -95,6 +95,8 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=None,
               append=None, noecho=False, force=False , dryrun=False):
     with Case(caseroot, read_only=False) as case:
+        env_mach_pes = case.get_env("mach_pes")
+        env_mach_pes.set_components(case.get_values("COMP_CLASSES"))
         if len(listofsettings):
             logger.debug("List of attributes to change: %s" , listofsettings)
 
@@ -126,6 +128,7 @@ def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=N
             if not force:
                 xmlval = convert_to_type(xmlval, type_str, xmlid)
             newval = case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
+
             expect(newval is not None,"No variable \"%s\" found"%xmlid)
 
     if not noecho:

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -106,7 +106,6 @@ def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=N
                 pair = setting.split("=",1)
                 expect(len(pair) == 2 , "Expecting a key value pair in the form of key=value. Got %s" % (pair) )
                 (xmlid, xmlval) = pair
-
                 type_str = case.get_type_info(xmlid)
                 if(append is True):
                     value = case.get_value(xmlid, resolved=False,

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -95,6 +95,19 @@ def parse_command_line(args):
         args.value, args.no_resolve, args.raw, args.description, args.group, args.full, \
         args.type, args.valid_values
 
+
+def get_value_as_string(case, var):
+    thistype = case.get_record_fields(var, "type")
+    value = None
+    if thistype:
+        value = convert_to_string(
+            case.get_value(var, resolved=resolved, subgroup=group),
+            thistype[0])
+    else:
+        value = case.get_value(var, resolved=resolved, subgroup=group)
+    return value
+
+
 def xmlquery(case, variables, subgroup=None, fileonly=False,
              resolved=True, raw=False, description=False, group=False,
              full=False, dtype=False, valid_values=False):
@@ -103,7 +116,7 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
 
     """
     results = {}
-
+    comp_classes = case.get_values("COMP_CLASSES")
     for var in variables:
         if subgroup is not None:
             groups = [subgroup]
@@ -117,14 +130,17 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
             if not var in results[group]:
                 results[group][var] = {}
             expect(group, "No group found for var %s"% var)
-            thistype = case.get_record_fields(var, "type")
-            if thistype:
-                results[group][var]['value'] = convert_to_string(
-                    case.get_value(var, resolved=resolved, subgroup=group),
-                    thistype[0])
-            else:
-                results[group][var]['value'] = \
-                    case.get_value(var, resolved=resolved, subgroup=group)
+            value = get_value_as_string(case, var)
+            if value is None:
+                value = []
+                for comp in comp_classes:
+                    if comp == "DRV":
+                        comp = "CPL"
+
+                    value.append(comp + ":" + "%s"%get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group))
+
+            results[group][var]['value'] = value
+
             if raw:
                 results[group][var]['raw'] = case.get_record_fields(var, "raw")
             if description or full:
@@ -135,8 +151,6 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
                 results[group][var]['type'] = case.get_record_fields(var, "type")
             if valid_values or full:
                 results[group][var]['valid_values'] = case.get_record_fields(var, "valid_values")
-
-
 
     return results
 

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -96,7 +96,7 @@ def parse_command_line(args):
         args.type, args.valid_values
 
 
-def get_value_as_string(case, var):
+def get_value_as_string(case, var, attribute=None, resolved=False, subgroup=None):
     thistype = case.get_record_fields(var, "type")
     value = None
     if thistype:
@@ -123,21 +123,23 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
         else:
             groups = case.get_record_fields(var, "group")
 
-
+        expect(groups, " No results found for variable %s"%var)
         for group in groups:
             if not group in results:
                 results[group] = {}
             if not var in results[group]:
                 results[group][var] = {}
             expect(group, "No group found for var %s"% var)
-            value = get_value_as_string(case, var)
+            value = get_value_as_string(case, var, resolved=resolved, subgroup=group)
             if value is None:
                 value = []
                 for comp in comp_classes:
                     if comp == "DRV":
                         comp = "CPL"
-
-                    value.append(comp + ":" + "%s"%get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group))
+                    nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group))
+                    if nextval is not None:
+                        value.append(comp + ":" + "%s"%nextval)
+            expect(value is not None, " No results found for variable %s"%var)
 
             results[group][var]['value'] = value
 

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -97,10 +97,10 @@ def parse_command_line(args):
 
 
 def get_value_as_string(case, var, attribute=None, resolved=False, subgroup=None):
-    thistype = case.get_record_fields(var, "type")
+    thistype = case.get_type_info(var)
     value = case.get_value(var, attribute=attribute, resolved=resolved, subgroup=subgroup)
     if value is not None and thistype:
-        value = convert_to_string(value, thistype[0], var)
+        value = convert_to_string(value, thistype, var)
     return value
 
 
@@ -126,15 +126,18 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
             if not var in results[group]:
                 results[group][var] = {}
             expect(group, "No group found for var %s"% var)
-            value = get_value_as_string(case, var, resolved=resolved)
+            value = get_value_as_string(case, var, resolved=resolved, subgroup=subgroup)
             if value is None:
-                value = []
-                for comp in comp_classes:
-                    if comp == "DRV":
-                        comp = "CPL"
-                    nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group)
-                    if nextval is not None:
-                        value.append(comp + ":" + "%s"%nextval)
+                vid, comp, iscompvar = case.check_if_comp_var(var)
+                if iscompvar:
+                    value = []
+                    for comp in comp_classes:
+                        nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group)
+                        if nextval is not None:
+                            value.append(comp + ":" + "%s"%nextval)
+                else:
+                    value = get_value_as_string(case, var, resolved=resolved, subgroup=group)
+
             expect(value is not None, " No results found for variable %s"%var)
 
             results[group][var]['value'] = value
@@ -146,7 +149,7 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
             if fileonly or full:
                 results[group][var]['file'] = case.get_record_fields(var, "file")
             if dtype or full:
-                results[group][var]['type'] = case.get_record_fields(var, "type")
+                results[group][var]['type'] = case.get_type_info(var)
             if valid_values or full:
                 results[group][var]['valid_values'] = case.get_record_fields(var, "valid_values")
 

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -98,13 +98,9 @@ def parse_command_line(args):
 
 def get_value_as_string(case, var, attribute=None, resolved=False, subgroup=None):
     thistype = case.get_record_fields(var, "type")
-    value = None
-    if thistype:
-        value = convert_to_string(
-            case.get_value(var, resolved=resolved, subgroup=group),
-            thistype[0])
-    else:
-        value = case.get_value(var, resolved=resolved, subgroup=group)
+    value = case.get_value(var, attribute=attribute, resolved=resolved, subgroup=subgroup)
+    if value is not None and thistype:
+        value = convert_to_string(value, thistype[0], var)
     return value
 
 
@@ -130,13 +126,13 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
             if not var in results[group]:
                 results[group][var] = {}
             expect(group, "No group found for var %s"% var)
-            value = get_value_as_string(case, var, resolved=resolved, subgroup=group)
+            value = get_value_as_string(case, var, resolved=resolved)
             if value is None:
                 value = []
                 for comp in comp_classes:
                     if comp == "DRV":
                         comp = "CPL"
-                    nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group))
+                    nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group)
                     if nextval is not None:
                         value.append(comp + ":" + "%s"%nextval)
             expect(value is not None, " No results found for variable %s"%var)

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -128,7 +128,7 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
             expect(group, "No group found for var %s"% var)
             value = get_value_as_string(case, var, resolved=resolved, subgroup=subgroup)
             if value is None:
-                vid, comp, iscompvar = case.check_if_comp_var(var)
+                var, comp, iscompvar = case.check_if_comp_var(var)
                 if iscompvar:
                     value = []
                     for comp in comp_classes:

--- a/scripts/manage_case
+++ b/scripts/manage_case
@@ -76,7 +76,7 @@ def query_component(name):
     # Determine the valid component classes (e.g. atm) for the driver/cpl
     # These are then stored in comps_array
     files = Files()
-    infile = files.get_value("CONFIG_DRV_FILE")
+    infile = files.get_value("CONFIG_CPL_FILE")
     config_drv = Component(infile)
     components = config_drv.get_valid_model_components()
 

--- a/scripts/manage_pes
+++ b/scripts/manage_pes
@@ -335,11 +335,9 @@ class ManagePes(object):
             logger.info("grid: %s  machine: %s  compset:%s  "
                         "pesize: %s\n",
                         gridname, machname, compsetname, pesizename)
-            drv_config_file = Files().get_value("CONFIG_DRV_FILE")
+            drv_config_file = Files().get_value("CONFIG_CPL_FILE")
             drv_comps = [x.lower() for x in
                         Component(drv_config_file).get_valid_model_components()]
-            if "drv" in drv_comps:
-                drv_comps[drv_comps.index("drv")] = "cpl"
 
             logger.info("                   " +
                         (len(drv_comps)*' {:10}').format(*drv_comps))

--- a/utils/python/CIME/SystemTests/erp.py
+++ b/utils/python/CIME/SystemTests/erp.py
@@ -62,8 +62,6 @@ class ERP(SystemTestsCommon):
             if (bld == 2):
                 # halve the number of tasks and threads
                 for comp in self._case.get_values("COMP_CLASSES"):
-                    if comp == "DRV":
-                        comp = "CPL"
                     ntasks    = self._case.get_value("NTASKS_%s"%comp)
                     nthreads  = self._case.get_value("NTHRDS_%s"%comp)
                     rootpe    = self._case.get_value("ROOTPE_%s"%comp)

--- a/utils/python/CIME/SystemTests/nck.py
+++ b/utils/python/CIME/SystemTests/nck.py
@@ -32,7 +32,7 @@ class NCK(SystemTestsCompareTwo):
         # original NTASKS was odd. (e.g., for NTASKS originally 15, we want to
         # use NTASKS = int(15/2) * 2 = 14 tasks for case two.)
         self._comp_classes = self._case.get_values("COMP_CLASSES")
-        self._comp_classes.remove("DRV")
+        self._comp_classes.remove("CPL")
         for comp in self._comp_classes:
             ntasks = self._case.get_value("NTASKS_%s"%comp)
             if ( ntasks > 1 ):

--- a/utils/python/CIME/SystemTests/pea.py
+++ b/utils/python/CIME/SystemTests/pea.py
@@ -24,8 +24,6 @@ class PEA(SystemTestsCompareTwo):
 
     def _common_setup(self):
         for comp in self._case.get_values("COMP_CLASSES"):
-            if comp == "DRV":
-                comp = "CPL"
             self._case.set_value("NTASKS_%s"%comp, 1)
             self._case.set_value("NTHRDS_%s"%comp, 1)
             self._case.set_value("ROOTPE_%s"%comp, 0)

--- a/utils/python/CIME/SystemTests/seq.py
+++ b/utils/python/CIME/SystemTests/seq.py
@@ -40,18 +40,16 @@ class SEQ(SystemTestsCommon):
 
         comp_classes = self._case.get_values("COMP_CLASSES")
         for comp in comp_classes:
-            if comp != "DRV":
-                any_changes |= self._case.get_value("ROOTPE_%s" % comp) != 0
+            any_changes |= self._case.get_value("ROOTPE_%s" % comp) != 0
         if any_changes:
             for comp in comp_classes:
-                if comp != "DRV":
-                    self._case.set_value("ROOTPE_%s"%comp, 0)
+                self._case.set_value("ROOTPE_%s"%comp, 0)
         else:
             rootpe = 2
             for comp in comp_classes:
                 # here we set the cpl to have the first 2 tasks
                 # and each component to have a different ROOTPE
-                if comp == "DRV":
+                if comp == "CPL":
                     self._case.set_value("NTASKS_CPL", 2)
                 else:
                     ntasks = self._case.get_value("NTASKS_%s"%comp)

--- a/utils/python/CIME/XML/component.py
+++ b/utils/python/CIME/XML/component.py
@@ -20,7 +20,7 @@ class Component(EntryID):
         # not checking schema on external components yet
         cimeroot = get_cime_root()
         if  cimeroot in os.path.abspath(infile):
-            schema = files.get_schema("CONFIG_DRV_FILE")
+            schema = files.get_schema("CONFIG_CPL_FILE")
 
         EntryID.__init__(self, infile, schema=schema)
 
@@ -31,7 +31,7 @@ class Component(EntryID):
     def get_valid_model_components(self):
         """
         return a list of all possible valid generic (e.g. atm, clm, ...) model components
-        from the entries in the model CONFIG_DRV_FILE
+        from the entries in the model CONFIG_CPL_FILE
         """
         components = []
         comps_node = self.get_node("entry", {"id":"COMP_CLASSES"})

--- a/utils/python/CIME/XML/component.py
+++ b/utils/python/CIME/XML/component.py
@@ -51,6 +51,9 @@ class Component(EntryID):
             return
         # use the default_value if present
         val_node = self.get_optional_node("default_value", root=node)
+        if val_node is None:
+            logger.debug("No default_value for %s"%node.get("id"))
+            return val_node
         value = val_node.text
         if value is not None and len(value) > 0 and value != "UNSET":
             match_values.append(value)

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -185,24 +185,24 @@ class EntryID(GenericXML):
         return new_valid_values
 
     def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False):
-        """
+       """
         Set the value of an entry-id field to value
         Returns the value or None if not found
         subgroup is ignored in the general routine and applied in specific methods
         """
-        expect(subgroup is None, "Subgroup not supported")
-        valid_values = self._get_valid_values(node)
-        if ignore_type:
-            expect(type(value) is str, "Value must be type string if ignore_type is true")
-            str_value = value
-        else:
-            type_str = self._get_type_info(node)
-            str_value = convert_to_string(value, type_str, vid)
-        if valid_values is not None and not str_value.startswith('$'):
-            expect(str_value in valid_values, "Did not find %s in valid values:%s"%(value, valid_values))
-        node.set("value", str_value)
+       expect(subgroup is None, "Subgroup not supported")
+       valid_values = self._get_valid_values(node)
+       if ignore_type:
+           expect(type(value) is str, "Value must be type string if ignore_type is true")
+           str_value = value
+       else:
+           type_str = self._get_type_info(node)
+           str_value = convert_to_string(value, type_str, vid)
+       if valid_values is not None and not str_value.startswith('$'):
+           expect(str_value in valid_values, "Did not find %s in valid values:%s"%(value, valid_values))
+       node.set("value", str_value)
 
-        return value
+       return value
 
     def set_value(self, vid, value, subgroup=None, ignore_type=False):
         """
@@ -358,7 +358,9 @@ class EntryID(GenericXML):
         if dnode is not None:
             node.remove(dnode)
         vnode = node.find(".//values")
-        if vnode is not None:
+        vid = node.get("id")
+        _, _, iscompvar = self.check_if_comp_var(vid)
+        if vnode is not None and not iscompvar:
             node.remove(vnode)
         return node
 

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -117,10 +117,10 @@ class EntryID(GenericXML):
         return val
 
     def get_type_info(self, vid):
-        val = self.get_node_element_info(vid, "type")
-        if val is None:
-            return "char"
-        return val
+        vid, _, _ = self.check_if_comp_var(vid, None)
+        node = self.get_optional_node("entry", {"id":vid})
+        return self._get_type_info(node)
+
 
     def _get_default(self, node):
         return self._get_node_element_info(node, "default_value")

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -250,6 +250,8 @@ class EntryID(GenericXML):
         val = self._get_value(node, attribute=attribute, resolved=resolved, subgroup=subgroup)
         # Return value as right type if we were able to fully resolve
         # otherwise, we have to leave as string.
+        if val is None:
+            return val
         if "$" in val:
             return val
         else:

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -82,11 +82,10 @@ class EntryID(GenericXML):
                             score = -1
                             break
                     else:
-                        if attribute not in attributes or \
-                                not re.search(vnode.get(attribute),
-                                              attributes[attribute]):
-                                score = -1
-                                break
+                        if attribute not in attributes or not \
+                                re.search(vnode.get(attribute),attributes[attribute]):
+                            score = -1
+                            break
 
             # Add valid matches to the list.
             if score >= 0:
@@ -111,6 +110,8 @@ class EntryID(GenericXML):
         return self.get_element_text(element_name, root=node)
 
     def _get_type_info(self, node):
+        if node is None:
+            return None
         val = self._get_node_element_info(node, "type")
         if val is None:
             return "char"
@@ -120,6 +121,11 @@ class EntryID(GenericXML):
         vid, _, _ = self.check_if_comp_var(vid, None)
         node = self.get_optional_node("entry", {"id":vid})
         return self._get_type_info(node)
+
+    # pylint: disable=unused-argument
+    def check_if_comp_var(self, vid, comp=None):
+        # handled in classes
+        return vid, None, False
 
 
     def _get_default(self, node):

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -340,7 +340,7 @@ class EntryID(GenericXML):
             # expression match to a dictionary value in attributes matching a
             # value attribute in node
             value = srcobj.get_default_value(src_node, attributes)
-            if value is not None:
+            if value is not None and len(value):
                 self._set_value(node,value)
             logger.debug ("Adding to group " + gname)
 

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -338,8 +338,8 @@ class EntryID(GenericXML):
             # expression match to a dictionary value in attributes matching a
             # value attribute in node
             value = srcobj.get_default_value(src_node, attributes)
-
-            self._set_value(node,value)
+            if value is not None:
+                self._set_value(node,value)
             logger.debug ("Adding to group " + gname)
 
         return nodelist
@@ -353,7 +353,8 @@ class EntryID(GenericXML):
         gnode = node.find(".//group")
         node.remove(gnode)
         dnode = node.find(".//default_value")
-        node.remove(dnode)
+        if dnode is not None:
+            node.remove(dnode)
         vnode = node.find(".//values")
         if vnode is not None:
             node.remove(vnode)

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -70,22 +70,23 @@ class EntryID(GenericXML):
         for vnode in nodes:
             # For each node in the list start a score.
             score = 0
-            for attribute in vnode.keys():
-                # For each attribute, add to the score.
-                score += 1
-                # If some attribute is specified that we don't know about,
-                # or the values don't match, it's not a match we want.
-                if exact_match:
-                    if attribute not in attributes or \
-                            attributes[attribute] != vnode.get(attribute):
-                        score = -1
-                        break
-                else:
-                    if attribute not in attributes or \
-                            not re.search(vnode.get(attribute),
-                                          attributes[attribute]):
-                        score = -1
-                        break
+            if attributes:
+                for attribute in vnode.keys():
+                    # For each attribute, add to the score.
+                    score += 1
+                    # If some attribute is specified that we don't know about,
+                    # or the values don't match, it's not a match we want.
+                    if exact_match:
+                        if attribute not in attributes or \
+                                attributes[attribute] != vnode.get(attribute):
+                            score = -1
+                            break
+                    else:
+                        if attribute not in attributes or \
+                                not re.search(vnode.get(attribute),
+                                              attributes[attribute]):
+                                score = -1
+                                break
 
             # Add valid matches to the list.
             if score >= 0:
@@ -185,24 +186,24 @@ class EntryID(GenericXML):
         return new_valid_values
 
     def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False):
-       """
+        """
         Set the value of an entry-id field to value
         Returns the value or None if not found
         subgroup is ignored in the general routine and applied in specific methods
         """
-       expect(subgroup is None, "Subgroup not supported")
-       valid_values = self._get_valid_values(node)
-       if ignore_type:
-           expect(type(value) is str, "Value must be type string if ignore_type is true")
-           str_value = value
-       else:
-           type_str = self._get_type_info(node)
-           str_value = convert_to_string(value, type_str, vid)
-       if valid_values is not None and not str_value.startswith('$'):
-           expect(str_value in valid_values, "Did not find %s in valid values:%s"%(value, valid_values))
-       node.set("value", str_value)
+        expect(subgroup is None, "Subgroup not supported")
+        valid_values = self._get_valid_values(node)
+        if ignore_type:
+            expect(type(value) is str, "Value must be type string if ignore_type is true")
+            str_value = value
+        else:
+            type_str = self._get_type_info(node)
+            str_value = convert_to_string(value, type_str, vid)
+        if valid_values is not None and not str_value.startswith('$'):
+            expect(str_value in valid_values, "Did not find %s in valid values:%s"%(value, valid_values))
+        node.set("value", str_value)
 
-       return value
+        return value
 
     def set_value(self, vid, value, subgroup=None, ignore_type=False):
         """
@@ -348,21 +349,9 @@ class EntryID(GenericXML):
 
     def cleanupnode(self, node):
         """
-        Remove the <group>, <file>, <values> and <value> childnodes from node
+        in env_base.py, not expected to get here
         """
-        fnode = node.find(".//file")
-        node.remove(fnode)
-        gnode = node.find(".//group")
-        node.remove(gnode)
-        dnode = node.find(".//default_value")
-        if dnode is not None:
-            node.remove(dnode)
-        vnode = node.find(".//values")
-        vid = node.get("id")
-        _, _, iscompvar = self.check_if_comp_var(vid)
-        if vnode is not None and not iscompvar:
-            node.remove(vnode)
-        return node
+        expect(False, " Not expected to be here %s"%node.get("id"))
 
     def compare_xml(self, other):
         xmldiffs = {}

--- a/utils/python/CIME/XML/env_base.py
+++ b/utils/python/CIME/XML/env_base.py
@@ -28,20 +28,17 @@ class EnvBase(EntryID):
 
     def set_components(self, components):
         if hasattr(self, '_components'):
-            if 'DRV' in components:
-                index = components.index("DRV")
-                components[index] = "CPL"
             # pylint: disable=attribute-defined-outside-init
             self._components = components
 
     def check_if_comp_var(self, vid, attribute=None):
+        # pylint: disable=no-member
         if not hasattr(self, "_component_value_list") or\
                 (self.get_nodes("entry", {"id" : vid}) and \
                      not vid in self._component_value_list):
             return vid, None, False
 
         comp = None
-        # pylint: disable=no-member
         if vid in self._component_value_list:
             if attribute is not None:
                 if "component" in attribute:
@@ -67,10 +64,14 @@ class EnvBase(EntryID):
         """
         value = None
         vid, comp, iscompvar = self.check_if_comp_var(vid, attribute)
+        logger.debug( "vid %s comp %s iscompvar %s"%(vid, comp, iscompvar))
         if iscompvar:
             if comp is None:
-                logger.debug("Not enough info to get value for %s"%vid)
-                return value
+                if subgroup is not None:
+                    comp = subgroup
+                else:
+                    logger.debug("Not enough info to get value for %s"%vid)
+                    return value
             if attribute is None:
                 attribute = {"component" : comp}
             else:

--- a/utils/python/CIME/XML/env_base.py
+++ b/utils/python/CIME/XML/env_base.py
@@ -5,7 +5,7 @@ from CIME.XML.standard_module_setup import *
 
 from CIME.XML.entry_id import EntryID
 from CIME.XML.headers import Headers
-
+from CIME.utils import convert_to_type, convert_to_string
 logger = logging.getLogger(__name__)
 
 class EnvBase(EntryID):
@@ -24,3 +24,87 @@ class EnvBase(EntryID):
             headerobj = Headers()
             headernode = headerobj.get_header_node(os.path.basename(fullpath))
             self.root.append(headernode)
+
+
+    def set_components(self, components):
+        if hasattr(self, '_components'):
+            if 'DRV' in components:
+                index = components.index("DRV")
+                components[index] = "CPL"
+            self._components = components
+
+    def check_if_comp_var(self, vid, attribute=None):
+        if not hasattr(self, "_component_value_list"):
+            return vid, None, False
+        comp = None
+        if vid in self._component_value_list:
+            if attribute is not None:
+                if "component" in attribute:
+                    comp = attribute["component"]
+            return vid, comp, True
+        return self.comp_var_split(vid)
+
+        parts = vid.split("_", 1)
+        if len(parts) == 2 and parts[1] in self._component_value_list:
+            return parts[1], parts[0], True
+        return vid, None, False
+
+    def get_value(self, vid, attribute=None, resolved=True, subgroup=None):
+        """
+        Get a value for entry with id attribute vid.
+        or from the values field if the attribute argument is provided
+        and matches
+        """
+        value = None
+        vid, comp, iscompvar = self.check_if_comp_var(vid, attribute)
+        if iscompvar:
+            if comp is None:
+                logger.debug("Not enough info to get value for %s"%vid)
+                return value
+            if attribute is None:
+                attribute = {"component" : comp}
+            else:
+                attribute["component"] = comp
+            node = self.get_optional_node("entry", {"id":vid})
+            if node is not None:
+                type_str = self._get_type_info(node)
+                value = convert_to_type(self.get_element_text("value", attribute, root=node), type_str, vid)
+                return value
+        return EntryID.get_value(self, vid, attribute=attribute, resolved=resolved, subgroup=subgroup)
+
+    def set_value(self, vid, value, subgroup=None, ignore_type=False):
+        """
+        Set the value of an entry-id field to value
+        Returns the value or None if not found
+        subgroup is ignored in the general routine and applied in specific methods
+        """
+        vid, comp, iscompvar = self.check_if_comp_var(vid, None)
+        val = None
+        node = self.get_optional_node("entry", {"id":vid})
+        if node is not None:
+            if iscompvar and comp is None:
+                for comp in self._components:
+                    val = self._set_value(node, value, vid, subgroup, ignore_type, component=comp)
+            else:
+                val = self._set_value(node, value, vid, subgroup, ignore_type, component=comp)
+        return val
+
+    def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False, component=None):
+        if vid is None:
+            vid = node.get("id")
+        vid, _, iscompvar = self.check_if_comp_var(vid, None)
+
+        if iscompvar:
+            attribute = {"component":component}
+            type_str = self._get_type_info(node)
+            # special case - no NINST defined for coupler component
+            if vid == "NINST" and component == "CPL":
+                return None
+            val = self.set_element_text("value", convert_to_string(value, type_str, vid), attribute, root=node)
+            return val
+        val = EntryID._set_value(self, node, value, vid, subgroup, ignore_type)
+        return val
+
+    def get_nodes_by_id(self, varid):
+        varid, _, _ = self.check_if_comp_var(varid, None)
+        return EntryID.get_nodes_by_id(self, varid)

--- a/utils/python/CIME/XML/env_base.py
+++ b/utils/python/CIME/XML/env_base.py
@@ -1,8 +1,8 @@
 """
 Base class for env files .  This class inherits from EntryID.py
 """
+import string
 from CIME.XML.standard_module_setup import *
-
 from CIME.XML.entry_id import EntryID
 from CIME.XML.headers import Headers
 from CIME.utils import convert_to_type, convert_to_string
@@ -42,11 +42,16 @@ class EnvBase(EntryID):
                 if "component" in attribute:
                     comp = attribute["component"]
             return vid, comp, True
-        return self.comp_var_split(vid)
 
-        parts = vid.split("_", 1)
-        if len(parts) == 2 and parts[1] in self._component_value_list:
-            return parts[1], parts[0], True
+        for comp in self._components:
+            if "_"+comp in vid:
+                vid = string.replace(vid, '_'+comp, '', 1)
+                break
+            elif comp+"_" in vid:
+                vid = string.replace(vid, comp+'_', '', 1)
+                break
+        if vid in self._component_value_list:
+            return vid, comp, True
         return vid, None, False
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None):

--- a/utils/python/CIME/XML/env_base.py
+++ b/utils/python/CIME/XML/env_base.py
@@ -73,7 +73,11 @@ class EnvBase(EntryID):
             node = self.get_optional_node("entry", {"id":vid})
             if node is not None:
                 type_str = self._get_type_info(node)
-                value = convert_to_type(self.get_element_text("value", attribute, root=node), type_str, vid)
+                val = self.get_element_text("value", attribute, root=node)
+                if val.startswith("$"):
+                    value = val
+                else:
+                    value = convert_to_type(val,type_str, vid)
                 return value
         return EntryID.get_value(self, vid, attribute=attribute, resolved=resolved, subgroup=subgroup)
 

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -70,12 +70,13 @@ class EnvBatch(EnvBase):
 
         value = None
         if subgroup is None:
-            node = self.get_optional_node(item, attribute)
-            if node is not None:
+            nodes = self.get_nodes(item, attribute)
+            if len(nodes) == 1:
+                node = nodes[0]
                 value = node.text
                 if resolved:
                     value = self.get_resolved_value(value)
-            else:
+            elif not nodes:
                 value = EnvBase.get_value(self,item,attribute,resolved)
         else:
             job_node = self.get_optional_node("job", {"name":subgroup})
@@ -89,7 +90,7 @@ class EnvBatch(EnvBase):
 
                     # Return value as right type if we were able to fully resolve
                     # otherwise, we have to leave as string.
-                    if "$" not in value:
+                    if value is not None and "$" not in value:
                         type_str = self._get_type_info(node)
                         value = convert_to_type(value, type_str, item)
         return value

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -15,24 +15,19 @@ class EnvMachPes(EnvBase):
         initialize an object interface to file env_mach_pes.xml in the case directory
         """
         EnvBase.__init__(self, case_root, infile)
-        self._component_value_list = ["NTASKS", "NTHRDS", "NINST", "ROOTPE", "PSTRID"]
+        self._component_value_list = ["NTASKS", "NTHRDS", "NINST",
+                                      "ROOTPE", "PSTRID", "NINST_LAYOUT"]
         self._components = []
-
-    def comp_var_split(self, vid):
-        parts = vid.split("_")
-        if len(parts) == 2 and parts[0] in self._component_value_list:
-            return parts[0], parts[1], True
-        return vid, None, False
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
 
-        if "NTASKS" in vid or "ROOTPE" in vid and pes_per_node is None:
-            pes_per_node = self.get_value("PES_PER_NODE")
-            if "NTASKS" in vid and value < 0:
+        if "NTASKS" in vid or "ROOTPE" in vid:
+            if pes_per_node is None:
+                pes_per_node = self.get_value("PES_PER_NODE")
+            if value is not None and value < 0:
                 value = -1*value*pes_per_node
-            if "ROOTPE" in vid and value < 0:
-                value = -1*value*pes_per_node
+
         return value
 
     def get_max_thread_count(self, comp_classes):

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -160,7 +160,7 @@ class EnvMachPes(EnvBase):
 
 
     def get_nodes_by_id(self, varid):
-        varid, _ = self.check_if_comp_var(varid, attribute)
+        varid, _ = self.check_if_comp_var(varid, None)
         return EnvBase.get_nodes_by_id(self, varid)
 
 

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -3,7 +3,6 @@ Interface to the env_mach_pes.xml file.  This class inherits from EntryID
 """
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_base import EnvBase
-from CIME.utils import convert_to_type, convert_to_string
 import math
 
 logger = logging.getLogger(__name__)

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -88,26 +88,6 @@ class EnvMachPes(EnvBase):
         num_nodes = int(math.ceil(float(total_tasks) / tasks_per_node))
         return num_nodes
 
-    def cleanupnode(self, node):
-        """
-        Remove the <group>, <file>, <values> and <value> childnodes from node
-        """
-        fnode = node.find(".//file")
-        node.remove(fnode)
-        gnode = node.find(".//group")
-        node.remove(gnode)
-        dnode = node.find(".//default_value")
-        if dnode is not None:
-            node.remove(dnode)
-        if node.get("id") not in self._component_value_list:
-            vnode = node.find(".//values")
-            if vnode is not None:
-                node.remove(vnode)
-        return node
 
-
-    def get_nodes_by_id(self, varid):
-        varid, _, _ = self.check_if_comp_var(varid, None)
-        return EnvBase.get_nodes_by_id(self, varid)
 
 

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -33,8 +33,6 @@ class EnvMachPes(EnvBase):
         ''' Find the maximum number of openmp threads for any component in the case '''
         max_threads = 1
         for comp in comp_classes:
-            if comp == "DRV":
-                comp = "CPL"
             threads = self.get_value("NTHRDS_%s"%comp)
             expect(threads is not None, "Error no thread count found for component class %s"%comp)
             if threads > max_threads:
@@ -63,8 +61,6 @@ class EnvMachPes(EnvBase):
     def get_total_tasks(self, comp_classes):
         total_tasks = 0
         for comp in comp_classes:
-            if comp == "DRV":
-                comp = "CPL"
             ntasks = self.get_value("NTASKS_%s"%comp)
             rootpe = self.get_value("ROOTPE_%s"%comp)
             pstrid = self.get_value("PSTRID_%s"%comp)

--- a/utils/python/CIME/XML/env_run.py
+++ b/utils/python/CIME/XML/env_run.py
@@ -15,7 +15,7 @@ class EnvRun(EnvBase):
         """
         EnvBase.__init__(self, case_root, infile)
         self._components = []
-        self._component_value_list = ["PIO_TYPENAME"]
+        self._component_value_list = ["PIO_TYPENAME", "PIO_STRIDE"]
 
 
 

--- a/utils/python/CIME/XML/env_run.py
+++ b/utils/python/CIME/XML/env_run.py
@@ -15,7 +15,8 @@ class EnvRun(EnvBase):
         """
         EnvBase.__init__(self, case_root, infile)
         self._components = []
-        self._component_value_list = ["PIO_TYPENAME", "PIO_STRIDE"]
+        self._component_value_list = ["PIO_TYPENAME", "PIO_STRIDE", "PIO_REARRANGER",
+                                      "PIO_NUMTASKS", "PIO_ROOT"]
 
 
 

--- a/utils/python/CIME/XML/env_run.py
+++ b/utils/python/CIME/XML/env_run.py
@@ -17,11 +17,5 @@ class EnvRun(EnvBase):
         self._components = []
         self._component_value_list = ["PIO_TYPENAME"]
 
-    def comp_var_split(self, vid):
-        parts = vid.split("_", 1)
-        if len(parts) == 2 and parts[1] in self._component_value_list:
-            return parts[1], parts[0], True
-        return vid, None, False
-
 
 

--- a/utils/python/CIME/XML/env_run.py
+++ b/utils/python/CIME/XML/env_run.py
@@ -14,3 +14,14 @@ class EnvRun(EnvBase):
         initialize an object interface to file env_run.xml in the case directory
         """
         EnvBase.__init__(self, case_root, infile)
+        self._components = []
+        self._component_value_list = ["PIO_TYPENAME"]
+
+    def comp_var_split(self, vid):
+        parts = vid.split("_", 1)
+        if len(parts) == 2 and parts[1] in self._component_value_list:
+            return parts[1], parts[0], True
+        return vid, None, False
+
+
+

--- a/utils/python/CIME/XML/pes.py
+++ b/utils/python/CIME/XML/pes.py
@@ -89,7 +89,7 @@ class Pes(GenericXML):
         logger.info("Pes setting: pesize match  is %s " %pesize_choice)
         logger.info("Pes other settings: %s"%other_settings)
         if mpilib == "mpi-serial":
-           for i in iter(pes_ntasks):
-               pes_ntasks[i] = 1
-               pes_rootpe[i] = 1
+            for i in iter(pes_ntasks):
+                pes_ntasks[i] = 1
+                pes_rootpe[i] = 1
         return pes_ntasks, pes_nthrds, pes_rootpe, other_settings

--- a/utils/python/CIME/XML/pes.py
+++ b/utils/python/CIME/XML/pes.py
@@ -16,7 +16,7 @@ class Pes(GenericXML):
         logger.debug("DEBUG: infile is %s"%infile)
         GenericXML.__init__(self, infile)
 
-    def find_pes_layout(self, grid, compset, machine, pesize_opts='M'):
+    def find_pes_layout(self, grid, compset, machine, pesize_opts='M', mpilib=None):
         pe_select = None
         grid_match = None
         mach_match = None
@@ -88,4 +88,8 @@ class Pes(GenericXML):
         logger.info("Pes setting: compset_match is %s " %compset_choice)
         logger.info("Pes setting: pesize match  is %s " %pesize_choice)
         logger.info("Pes other settings: %s"%other_settings)
+        if mpilib == "mpi-serial":
+           for i in iter(pes_ntasks):
+               pes_ntasks[i] = 1
+               pes_rootpe[i] = 1
         return pes_ntasks, pes_nthrds, pes_rootpe, other_settings

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -184,8 +184,7 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
 
     complist = []
     for comp_class in comp_classes:
-        if comp_class == "DRV":
-            comp_class = "CPL"
+        if comp_class == "CPL":
             ninst = 1
             config_dir = None
         else:
@@ -193,7 +192,11 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
             config_dir = os.path.dirname(case.get_value("CONFIG_%s_FILE"%comp_class))
 
         comp = case.get_value("COMP_%s"%comp_class)
+        if ninst is None:
+            import pdb
+            pdb.set_trace()
         thrds =  case.get_value("NTHRDS_%s"%comp_class)
+        expect(ninst is not None,"Failed to get ninst for comp_class %s"%comp_class)
         complist.append((comp_class.lower(), comp, thrds, ninst, config_dir ))
         os.environ["COMP_%s"%comp_class] = comp
 

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -192,9 +192,6 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
             config_dir = os.path.dirname(case.get_value("CONFIG_%s_FILE"%comp_class))
 
         comp = case.get_value("COMP_%s"%comp_class)
-        if ninst is None:
-            import pdb
-            pdb.set_trace()
         thrds =  case.get_value("NTHRDS_%s"%comp_class)
         expect(ninst is not None,"Failed to get ninst for comp_class %s"%comp_class)
         complist.append((comp_class.lower(), comp, thrds, ninst, config_dir ))

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -333,10 +333,7 @@ class Case(object):
             if result is not None:
                 return result
         env_batch = self.get_env("batch")
-        result = env_batch.get_type_info(item)
-
-        return result
-        logging.debug("Not able to retreive type for item '%s'" % item)
+        return env_batch.get_type_info(item)
 
     def get_resolved_value(self, item, recurse=0):
         num_unresolved = item.count("$") if item else 0

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -618,7 +618,7 @@ class Case(object):
         self.schedule_rewrite(env_mach_specific_obj)
 
         #--------------------------------------------
-        # pe payout
+        # pe layout
         #--------------------------------------------
         match1 = re.match('([0-9]+)x([0-9]+)', "" if pecount is None else pecount)
         match2 = re.match('([0-9]+)', "" if pecount is None else pecount)
@@ -647,7 +647,7 @@ class Case(object):
             pesobj = Pes(self._pesfile)
 
             pes_ntasks, pes_nthrds, pes_rootpe, other = pesobj.find_pes_layout(self._gridname, self._compsetname,
-                                                                    machine_name, pesize_opts=pecount)
+                                                                    machine_name, pesize_opts=pecount, mpilib=mpilib)
 
         mach_pes_obj = self.get_env("mach_pes")
         totaltasks = {}

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -655,18 +655,18 @@ class Case(object):
         # we can get rid of this code when all of the perl is removed
         for key, value in other.items():
             self.set_value(key, value)
-        pes_per_node = self.get_value("PES_PER_NODE")
         for key, value in pes_ntasks.items():
             totaltasks[key[-3:]] = int(value)
-            mach_pes_obj.set_value(key,int(value), pes_per_node=pes_per_node)
+            mach_pes_obj.set_value(key,int(value))
         for key, value in pes_rootpe.items():
             totaltasks[key[-3:]] += int(value)
-            mach_pes_obj.set_value(key,int(value), pes_per_node=pes_per_node)
+            mach_pes_obj.set_value(key,int(value))
         for key, value in pes_nthrds.items():
             totaltasks[key[-3:]] *= int(value)
-            mach_pes_obj.set_value(key,int(value), pes_per_node=pes_per_node)
+            mach_pes_obj.set_value(key,int(value))
 
         maxval = 1
+        pes_per_node = self.get_value("PES_PER_NODE")
         if mpilib != "mpi-serial":
             for key, val in totaltasks.items():
                 if val < 0:

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -102,6 +102,10 @@ class Case(object):
         if self.get_value("CASEROOT") is not None:
             self.initialize_derived_attributes()
 
+    def set_comp_classes(self, comp_classes):
+        for env_file in self._env_entryid_files:
+            env_file.set_components(comp_classes)
+
     def initialize_derived_attributes(self):
         """
         These are derived variables which can be used in the config_* files
@@ -109,6 +113,8 @@ class Case(object):
         """
         env_mach_pes = self.get_env("mach_pes")
         comp_classes = self.get_values("COMP_CLASSES")
+        self.set_comp_classes(comp_classes)
+
         total_tasks = env_mach_pes.get_total_tasks(comp_classes)
         self.thread_count = env_mach_pes.get_max_thread_count(comp_classes)
         self.tasks_per_node = env_mach_pes.get_tasks_per_node(total_tasks, self.thread_count)
@@ -321,7 +327,7 @@ class Case(object):
         logging.debug("Not able to retreive type for item '%s'" % item)
 
     def get_resolved_value(self, item, recurse=0):
-        num_unresolved = item.count("$")
+        num_unresolved = item.count("$") if item else 0
         recurse_limit = 10
         if (num_unresolved > 0 and recurse < recurse_limit ):
             for env_file in self._env_entryid_files:
@@ -495,7 +501,7 @@ class Case(object):
         self._component_classes =drv_comp.get_valid_model_components()
         if len(self._component_classes) > len(self._components):
             self._components.append('sesp')
-
+        self.set_comp_classes(self._component_classes)
         for i in xrange(1,len(self._component_classes)):
             comp_class = self._component_classes[i]
             comp_name  = self._components[i-1]

--- a/utils/python/CIME/case_run.py
+++ b/utils/python/CIME/case_run.py
@@ -89,11 +89,6 @@ def run_model(case):
     cmd = case.get_resolved_value(cmd)
     logger.info("run command is %s " %cmd)
 
-    with open("runtime_environment.txt", 'w') as fd:
-        fd.write("run command is: %s"%cmd)
-    run_cmd_no_fail("echo -e '\n' >> runtime_environment.txt && \
-                         env >> runtime_environment.txt")
-
     rundir = case.get_value("RUNDIR")
     run_cmd_no_fail(cmd, from_dir=rundir)
     logger.info("%s MODEL EXECUTION HAS FINISHED" %(time.strftime("%Y-%m-%d %H:%M:%S")))

--- a/utils/python/CIME/case_run.py
+++ b/utils/python/CIME/case_run.py
@@ -89,6 +89,11 @@ def run_model(case):
     cmd = case.get_resolved_value(cmd)
     logger.info("run command is %s " %cmd)
 
+    with open("runtime_environment.txt", 'w') as fd:
+        fd.write("run command is: %s"%cmd)
+    run_cmd_no_fail("echo -e '\n' >> runtime_environment.txt && \
+                         env >> runtime_environment.txt")
+
     rundir = case.get_value("RUNDIR")
     run_cmd_no_fail(cmd, from_dir=rundir)
     logger.info("%s MODEL EXECUTION HAS FINISHED" %(time.strftime("%Y-%m-%d %H:%M:%S")))

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -53,7 +53,12 @@ def _build_usernl_files(case, model, comp):
     Create user_nl_xxx files, expects cwd is caseroot
     """
     model = model.upper()
-    model_file = case.get_value("CONFIG_%s_FILE" % model)
+    if model == "DRV":
+        model_file = case.get_value("CONFIG_CPL_FILE")
+    else:
+        model_file = case.get_value("CONFIG_%s_FILE" % model)
+    expect(model_file is not None,
+           "Could not locate CONFIG_%s_FILE in config_files.xml"%model)
     model_dir = os.path.dirname(model_file)
 
     expect(os.path.isdir(model_dir),
@@ -153,7 +158,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         # Check ninst.
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.
         for comp in models:
-            if comp == "DRV":
+            if comp == "CPL":
                 continue
             ninst  = case.get_value("NINST_%s" % comp)
             ntasks = case.get_value("NTASKS_%s" % comp)

--- a/utils/python/CIME/get_timing.py
+++ b/utils/python/CIME/get_timing.py
@@ -103,7 +103,6 @@ class _TimingParser:
 
     def getTiming(self):
         components=self.case.get_values("COMP_CLASSES")
-        components[components.index("DRV")]="CPL"
         for s in components:
             self.models[s] = _GetTimingInfo(s)
         atm = self.models['ATM']

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -23,7 +23,7 @@ def create_dirs(case):
     dirs_to_make = []
     models = case.get_values("COMP_CLASSES")
     for model in models:
-        dirname = "cpl" if model == "DRV" else model.lower()
+        dirname = model.lower()
         dirs_to_make.append(os.path.join(exeroot, dirname, "obj"))
 
     dirs_to_make.extend([exeroot, libroot, incroot, rundir, docdir])
@@ -43,7 +43,7 @@ def create_dirs(case):
 
 def create_namelists(case):
     """
-    Create component namelists 
+    Create component namelists
     """
     case.flush()
 
@@ -58,8 +58,8 @@ def create_namelists(case):
 
     logger.info("Creating component namelists")
 
-    # Create namelists - must have DRV last in the list below
-    # Note - DRV must be last in the loop below so that in generating its namelist, 
+    # Create namelists - must have cpl last in the list below
+    # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
     models = case.get_values("COMP_CLASSES")
     models += [models.pop(0)]
@@ -67,7 +67,7 @@ def create_namelists(case):
         model_str = model.lower()
         config_file = case.get_value("CONFIG_%s_FILE" % model_str.upper())
         config_dir = os.path.dirname(config_file)
-        if model_str == "drv":
+        if model_str == "cpl":
             compname = "drv"
         else:
             compname = case.get_value("COMP_%s" % model_str.upper())

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -362,7 +362,7 @@ class TestScheduler(object):
         # Determine list of component classes that this coupler/driver knows how
         # to deal with. This list follows the same order as compset longnames follow.
         files = Files()
-        drv_config_file = files.get_value("CONFIG_DRV_FILE")
+        drv_config_file = files.get_value("CONFIG_CPL_FILE")
         drv_comp = Component(drv_config_file)
         envtest.add_elements_by_group(files, {}, "env_test.xml")
         envtest.add_elements_by_group(drv_comp, {}, "env_test.xml")

--- a/utils/python/CIME/test_status.py
+++ b/utils/python/CIME/test_status.py
@@ -175,7 +175,8 @@ class TestStatus(object):
 
             if previous_core_phase in self._phase_statuses:
                 expect(self._phase_statuses[previous_core_phase][0] == TEST_PASS_STATUS,
-                       "Cannot move past core phase '%s', it didn't pass" % previous_core_phase)
+                       "Cannot move past core phase '%s', it didn't pass: %s" \
+                           % (previous_core_phase,self._phase_statuses[previous_core_phase][0]))
 
         reran_phase = (phase in self._phase_statuses and self._phase_statuses[phase][0] != TEST_PEND_STATUS and phase in CORE_PHASES)
         if reran_phase:

--- a/utils/python/CIME/test_status.py
+++ b/utils/python/CIME/test_status.py
@@ -175,8 +175,8 @@ class TestStatus(object):
 
             if previous_core_phase in self._phase_statuses:
                 expect(self._phase_statuses[previous_core_phase][0] == TEST_PASS_STATUS,
-                       "Cannot move past core phase '%s', it didn't pass: %s" \
-                           % (previous_core_phase,self._phase_statuses[previous_core_phase][0]))
+                       "Cannot move past core phase '%s', it didn't pass: " \
+                           % (previous_core_phase))
 
         reran_phase = (phase in self._phase_statuses and self._phase_statuses[phase][0] != TEST_PEND_STATUS and phase in CORE_PHASES)
         if reran_phase:

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -852,8 +852,6 @@ def get_build_threaded(case):
         return True
     comp_classes = case.get_values("COMP_CLASSES")
     for comp_class in comp_classes:
-        if comp_class == "DRV":
-            comp_class = "CPL"
         if case.get_value("NTHRDS_%s"%comp_class) > 1:
             return True
     return False


### PR DESCRIPTION
In this PR I have combined various variables of the form XXX_COMPCLASS into variable XXX with values for each compclass.  xmlquery can use XXX_COMPCLASS or XXX --subgroup COMPCLASS
or simply XXX to get values for each compclass.  I also removed DRV from the comp classes and replaced it with CPL which cleans up a lot of code

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #890 
Addresses #848 

User interface changes?: 

Code review: 
