### PR TITLE
Fix cmake srt

### DIFF
--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -912,7 +912,7 @@
 
   <entry id="TIMER_DETAIL">
     <type>integer</type>
-    <default_value>0</default_value>
+    <default_value>2</default_value>
     <group>run_flags</group>
     <file>env_run.xml</file>
     <desc>timer detail FIXME - add documentation</desc>

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -22,7 +22,6 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.utils import expect
 import textwrap
-from textwrap import dedent
 import sys
 
 logger = logging.getLogger("xmlquery")

--- a/utils/python/tests/CMakeLists.txt
+++ b/utils/python/tests/CMakeLists.txt
@@ -1,15 +1,46 @@
 cmake_minimum_required(VERSION 2.8)
 
+    MACRO(STRING_UNQUOTE var str)
+
+	# ';' and '\' are tricky, need to be encoded.
+	# '\' => '#B'
+	# '#' => '#H'
+	# ';' => '#S'
+	STRING(REGEX REPLACE "#" "#H" _ret "${str}")
+	STRING(REGEX REPLACE "\\\\" "#B" _ret "${_ret}")
+	STRING(REGEX REPLACE ";" "#S" _ret "${_ret}")
+
+	IF(_ret MATCHES "^[ \t\r\n]+")
+	    STRING(REGEX REPLACE "^[ \t\r\n]+" "" _ret "${_ret}")
+	ENDIF(_ret MATCHES "^[ \t\r\n]+")
+	IF(_ret MATCHES "^\"")
+	    # Double quote
+	    STRING(REGEX REPLACE "\"\(.*\)\"[ \t\r\n]*$" "\\1" _ret "${_ret}")
+	ELSEIF(_ret MATCHES "^'")
+	    # Single quote
+	    STRING(REGEX REPLACE "'\(.*\)'[ \t\r\n]*$" "\\1" _ret "${_ret}")
+	ELSE(_ret MATCHES "^\"")
+	    SET(_ret "")
+	ENDIF(_ret MATCHES "^\"")
+
+	# Unencoding
+	STRING(REGEX REPLACE "#B" "\\\\" _ret "${_ret}")
+	STRING(REGEX REPLACE "#H" "#" _ret "${_ret}")
+	STRING(REGEX REPLACE "#S" "\\\\;" ${var} "${_ret}")
+    ENDMACRO(STRING_UNQUOTE var str)
+
 include(CTest)
 
 execute_process(COMMAND "python" "list_tests" OUTPUT_VARIABLE STR_TESTS
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 OUTPUT_STRIP_TRAILING_WHITESPACE
                 ERROR_STRIP_TRAILING_WHITESPACE)
-
-separate_arguments(TEST_LIST UNIX_COMMAND ${STR_TESTS})
+separate_arguments(TEST_LIST UNIX_COMMAND ${STR_TESTS} )
 
 foreach(ATEST ${TEST_LIST})
-    add_test(NAME ${ATEST} COMMAND "python" "-m" "unittest" "-v" ${ATEST}
+    # this assignment prevents quotes being added to testname in add_test
+    set(fulltest "${ATEST}")
+    add_test(NAME ${ATEST} COMMAND ./scripts_regression_tests.py ${fulltest}
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach(ATEST)
+

--- a/utils/python/tests/CMakeLists.txt
+++ b/utils/python/tests/CMakeLists.txt
@@ -1,34 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 
-    MACRO(STRING_UNQUOTE var str)
-
-	# ';' and '\' are tricky, need to be encoded.
-	# '\' => '#B'
-	# '#' => '#H'
-	# ';' => '#S'
-	STRING(REGEX REPLACE "#" "#H" _ret "${str}")
-	STRING(REGEX REPLACE "\\\\" "#B" _ret "${_ret}")
-	STRING(REGEX REPLACE ";" "#S" _ret "${_ret}")
-
-	IF(_ret MATCHES "^[ \t\r\n]+")
-	    STRING(REGEX REPLACE "^[ \t\r\n]+" "" _ret "${_ret}")
-	ENDIF(_ret MATCHES "^[ \t\r\n]+")
-	IF(_ret MATCHES "^\"")
-	    # Double quote
-	    STRING(REGEX REPLACE "\"\(.*\)\"[ \t\r\n]*$" "\\1" _ret "${_ret}")
-	ELSEIF(_ret MATCHES "^'")
-	    # Single quote
-	    STRING(REGEX REPLACE "'\(.*\)'[ \t\r\n]*$" "\\1" _ret "${_ret}")
-	ELSE(_ret MATCHES "^\"")
-	    SET(_ret "")
-	ENDIF(_ret MATCHES "^\"")
-
-	# Unencoding
-	STRING(REGEX REPLACE "#B" "\\\\" _ret "${_ret}")
-	STRING(REGEX REPLACE "#H" "#" _ret "${_ret}")
-	STRING(REGEX REPLACE "#S" "\\\\;" ${var} "${_ret}")
-    ENDMACRO(STRING_UNQUOTE var str)
-
 include(CTest)
 
 execute_process(COMMAND "python" "list_tests" OUTPUT_VARIABLE STR_TESTS

--- a/utils/python/tests/CMakeLists.txt
+++ b/utils/python/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ execute_process(COMMAND "python" "list_tests" OUTPUT_VARIABLE STR_TESTS
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 OUTPUT_STRIP_TRAILING_WHITESPACE
                 ERROR_STRIP_TRAILING_WHITESPACE)
-separate_arguments(TEST_LIST UNIX_COMMAND ${STR_TESTS} )
+separate_arguments(TEST_LIST UNIX_COMMAND ${STR_TESTS})
 
 foreach(ATEST ${TEST_LIST})
     # this assignment prevents quotes being added to testname in add_test
@@ -14,4 +14,3 @@ foreach(ATEST ${TEST_LIST})
     add_test(NAME ${ATEST} COMMAND ./scripts_regression_tests.py ${fulltest}
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach(ATEST)
-

--- a/utils/python/tests/list_tests
+++ b/utils/python/tests/list_tests
@@ -16,9 +16,9 @@ def list_tests_from():
                     print atest
                 for btest in atest._tests:
                     btestname = btest.__str__().split()
-                    test_classes.append(btestname[1][1:-1])
+                    test_classes.append(btestname[1][1:-1].split('.')[1])
             # add this explicitly, not captured by the above
-            test_classes.append("scripts_regression_tests.B_CheckCode")
+            test_classes.append("B_CheckCode")
             for ctest in sorted(list(set(test_classes))):
                 print ctest
 


### PR DESCRIPTION
The cmake invocation of python unittests was calling unittest.main directory thus skipping the setup code in scripts_regression_tests.py.  Fixed by calling scripts_regression_tests.py 

Test suite: scripts_regression_tests.py using ctest
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #937 
Fixes #938

User interface changes?: 

Code review: 
