### PR TITLE
Alpha05b fixes

### DIFF
--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -1020,6 +1020,8 @@ using a fortran linker.
   <SLIBS>
     <append> -llapack -lblas </append>
   </SLIBS>
+  <SCC MPILIB="mpi-serial">pgcc</SCC>
+  <SFC MPILIB="mpi-serial">pgfortran</SFC>
 </compiler>
 
 </config_compilers>

--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -290,7 +290,7 @@ using a fortran linker.
     <append MODEL="cism"> -mismatch_all </append>
   </FFLAGS>
   <FFLAGS_NOOPT>
-    <base> <var>FFLAGS</var> </base>
+    <base>-Wp,-macro=no_com -convert=BIG_ENDIAN -indirect <env>CIMEROOT</env>/cime_config/cesm/machines/nag_mpi_argument.txt</base>
     <append DEBUG="FALSE"> -ieee=full     </append>
     <!-- Hack! If DEBUG="TRUE", put runtime checks in FFLAGS, but not into     -->
     <!-- FFLAGS_NOOPT, allowing strict checks to be removed from files by      -->

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -20,7 +20,7 @@ If this tool is missing any feature that you need, please go to github and creat
 from standard_script_setup import *
 
 from CIME.case import Case
-from CIME.utils import expect
+from CIME.utils import expect, convert_to_string
 import textwrap
 import sys
 
@@ -118,7 +118,9 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
                 results[group][var] = {}
             expect(group, "No group found for var %s"% var)
 
-            results[group][var]['value'] = case.get_value(var, resolved=resolved, subgroup=group)
+            results[group][var]['value'] = convert_to_string(
+                case.get_value(var, resolved=resolved, subgroup=group),
+                case.get_record_fields(var, "type")[0])
             if raw:
                 results[group][var]['raw'] = case.get_record_fields(var, "raw")
             if description or full:

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -117,10 +117,14 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
             if not var in results[group]:
                 results[group][var] = {}
             expect(group, "No group found for var %s"% var)
-
-            results[group][var]['value'] = convert_to_string(
-                case.get_value(var, resolved=resolved, subgroup=group),
-                case.get_record_fields(var, "type")[0])
+            thistype = case.get_record_fields(var, "type")
+            if thistype:
+                results[group][var]['value'] = convert_to_string(
+                    case.get_value(var, resolved=resolved, subgroup=group),
+                    thistype[0])
+            else:
+                results[group][var]['value'] = \
+                    case.get_value(var, resolved=resolved, subgroup=group)
             if raw:
                 results[group][var]['raw'] = case.get_record_fields(var, "raw")
             if description or full:

--- a/utils/python/tests/CMakeLists.txt
+++ b/utils/python/tests/CMakeLists.txt
@@ -11,6 +11,6 @@ separate_arguments(TEST_LIST UNIX_COMMAND ${STR_TESTS})
 foreach(ATEST ${TEST_LIST})
     # this assignment prevents quotes being added to testname in add_test
     set(fulltest "${ATEST}")
-    add_test(NAME ${ATEST} COMMAND ./scripts_regression_tests.py ${fulltest}
+    add_test(NAME ${ATEST} COMMAND ./scripts_regression_tests.py -v ${fulltest}
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach(ATEST)

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1098,7 +1098,7 @@ class K_TestCimeCase(TestCreateTestCommon):
 
             build_complete = run_cmd_no_fail("./xmlquery BUILD_COMPLETE -value",
                                              from_dir=casedir)
-            self.assertEqual(build_complete, "True",
+            self.assertEqual(build_complete, "TRUE",
                             msg="Build complete had wrong value '%s'" %
                             build_complete)
 


### PR DESCRIPTION
There is a little bit of a logic mess in the cime master that I’ve had to untangle:  The old xmlquery would return “true" and “false" when a logical variable was the argument.   The current master xmlquery is returning “True" and “False" - which is how python translates logicals with “%s” but not how cime translates internally.   So in my latest sandbox I’ve changed xmlquery to use convert_to_string and it returns “TRUE" and “FALSE" which makes it consistant with what cime does internally.   But ths lead to a few places where tests of “true” == “TRUE”  were failing.

Also fixes nag and pgi compiler issues.

Test suite: scripts_regression_tests.py using ctest, cesm component tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
