### PR TITLE
removed clm40 compsets from allactive compsets and tests

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -14,7 +14,7 @@
     Where for the CAM specific compsets below the following is supported
     TIME = Time period (e.g. 2000, HIST, RCP8...)
     ATM  = [CAM40, CAM50, CAM60]
-    LND  = [CLM40, CLM45, CLM50, SLND]
+    LND  = [CLM45, CLM50, SLND]
     ICE  = [CICE, DICE, SICE]
     OCN  = [DOCN, ,AQUAP, SOCN]
     ROF  = [RTM, MOSART, SROF]
@@ -60,40 +60,93 @@
     <lname>1850_CAM60%WTSM_CLM50%BGC_CICE_POP2%ECO_MOSART_SGLC_WW3</lname>
   </compset>
 
+  <!-- 
+       Other B water isotope compsets that are only relevant for clm water isotope branches
+       where only clm40 is supported
+  -->
 
+  <compset>
+    <alias>Bi1850C5</alias>
+    <lname>1850_CAM50%WISOall_CLM40%SP-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV</lname>
+  </compset>
 
+  <compset>
+    <alias>Bi1850C5CN</alias>
+    <lname>1850_CAM50%WISOall_CLM40%CN-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV</lname>
+  </compset>
 
+  <compset>
+    <alias>BiHISTC5CN</alias>
+    <lname>HIST_CAM50_CLM40%CN-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV</lname>
+  </compset>
 
+  <compset>
+    <alias>BiHISTC5CN5</alias>
+    <lname>HIST_CAM5_CLM50%CN-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV</lname>
+  </compset>
+
+  <!-- No longer supported B compsets with CLM40 -->
+
+  <!-- <compset> -->
+  <!--   <alias>B1850C5L40SPR</alias> -->
+  <!--   <lname>1850_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>B1850C4L40CNR</alias> -->
+  <!--   <lname>1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>B1850C5L40CNR</alias> -->
+  <!--   <lname>1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>B1850C4RCO2L40CNR</alias> -->
+  <!--   <lname>1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>B1850C4L40CNRBDRD</alias> -->
+  <!--   <lname>1850_CAM40_CLM40%CN_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BDRD</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>BHISTC5L40CNRWs</alias> -->
+  <!--   <lname>HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>BHISTC5L40CNR</alias> -->
+  <!--   <lname>HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_WW3</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>BRCP26C4L40CNR</alias> -->
+  <!--   <lname>RCP2_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>BRCP45C4L40CNRBDRD</alias> -->
+  <!--   <lname>RCP4_CAM40_CLM40%CN_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BDRD</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>BRCP85C4L40CNRBPRP</alias> -->
+  <!--   <lname>RCP8_CAM40_CLM40%CN_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BPRP</lname> -->
+  <!-- </compset> -->
+
+  <!-- <compset> -->
+  <!--   <alias>BHISTC4L40CNRBDRD</alias> -->
+  <!--   <lname>HIST_CAM40_CLM40%CN_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BDRD</lname> -->
+  <!-- </compset> -->
 
   <!-- Other B compsets -->
 
   <compset>
     <alias>BC5L45BGC</alias>
     <lname>2000_CAM50_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>B1850C5L40SPR</alias>
-    <lname>1850_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>Bi1850C5</alias>
-    <lname>1850_CAM50%WISOall_CLM40%SP-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV</lname>
-  </compset>
-  <compset>
-    <alias>B1850C4L40CNR</alias>
-    <lname>1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>B1850C5L40CNR</alias>
-    <lname>1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>Bi1850C5CN</alias>
-    <lname>1850_CAM50%WISOall_CLM40%CN-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -104,37 +157,6 @@
   <compset>
     <alias>B1850C5L45BGC</alias>
     <lname>1850_CAM50_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-
-  <compset>
-    <alias>B1850C4RCO2L40CNR</alias>
-    <lname>1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-
-  <compset>
-    <alias>B1850C4L40CNRBDRD</alias>
-    <lname>1850_CAM40_CLM40%CN_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BDRD</lname>
-  </compset>
-
-  <compset>
-    <alias>BHISTC5L40CNRWs</alias>
-    <lname>HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>BiHISTC5CN</alias>
-    <lname>HIST_CAM50_CLM40%CN-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV</lname>
-  </compset>
-  <compset>
-    <alias>BiHISTC5CN5</alias>
-    <lname>HIST_CAM5_CLM50%CN-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>BHISTC5L40CNR</alias>
-    <lname>HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_WW3</lname>
   </compset>
 
   <compset>
@@ -158,21 +180,6 @@
   </compset>
 
   <compset>
-    <alias>BRCP26C4L40CNR</alias>
-    <lname>RCP2_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>BRCP45C4L40CNRBDRD</alias>
-    <lname>RCP4_CAM40_CLM40%CN_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BDRD</lname>
-  </compset>
-
-  <compset>
-    <alias>BRCP85C4L40CNRBPRP</alias>
-    <lname>RCP8_CAM40_CLM40%CN_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BPRP</lname>
-  </compset>
-
-  <compset>
     <alias>BRCP85C5L45BGCR</alias>
     <lname>RCP8_CAM50_CLM45%BGC_CICE_POP2_RTM_SGLC_SWAV</lname>
   </compset>
@@ -183,6 +190,7 @@
   </compset>
 
   <!-- Climate Simulation Lab compsets for Keith Lindsay -->
+
   <compset>
     <alias>B1850C4L45BGCRBPRP</alias>
     <lname>1850_CAM40_CLM45%BGC_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BPRP</lname>
@@ -197,12 +205,6 @@
     <alias>B1850C5L45BGCRBPRP</alias>
     <lname>1850_CAM50_CLM45%BGC_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BPRP</lname>
   </compset>
-
-  <compset>
-    <alias>BHISTC4L40CNRBDRD</alias>
-    <lname>HIST_CAM40_CLM40%CN_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BDRD</lname>
-  </compset>
-
 
   <!-- BG compsets -->
 
@@ -260,10 +262,10 @@
 
   <entries>
 
- <entry id="RUN_TYPE">
-      <values>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"	compset="1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"	   >hybrid</value>
-      </values>
+  <entry id="RUN_TYPE">
+    <values>
+      <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"	compset="1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"	   >hybrid</value>
+    </values>
     </entry>
     <entry id="RUN_REFCASE">
       <values>
@@ -275,187 +277,6 @@
 	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"   compset="1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"			   >0041-01-01</value>
       </values>
     </entry>
-<!-- Reference cases from older cesm versions are no longer valid
-    <entry id="RUN_TYPE">
-      <values>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCCM_CLM40%CN"			   >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCSC_CLM40%CN"			   >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="5505_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="5505_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP2_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP4_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP8_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP2_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP4_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP8_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_CISM1_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40%FCHM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM40%CHEM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP8_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP8_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP6_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP6_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP4_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP4_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP2_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP2_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%T31_l%T31_oi%gx3v7_r%r05_m%gx3v7"		compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%ne30np4_l%ne30np4_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="2013_CAM40%WCBC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_w%ww3a"         compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_WW3"        >hybrid</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_w%ww3a"         compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_DWAV"       >hybrid</value>
-      </values>
-    </entry>
-
-    <entry id="RUN_REFCASE">
-      <values>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCCM_CLM40%CN"			   >b40.1850.track1.2deg.wcm.007</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCSC_CLM40%CN"			   >b40.1850.track1.2deg.wcm.007</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40.1850.track1.2deg.003</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV"	   >b40_1850_c02c_76jpf</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40_1850_2d_r07c5cn_160jp</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.1850.track1.2deg.003</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40.1850.track1.2deg.003</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV"	   >b40_1850_c02c_76jpf</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50%WISOall_CLM40%CN-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV"   >b.ie12.Bi1850C5CN.f19_g16.KFoff.01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40_1850_2d_r07c5cn_160jp</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.1850.track1.2deg.wcm.007</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="5505_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.20th.track1.2deg.wcm.007</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="5505_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.20th.track1.2deg.wcm.007</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP2_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.1955-2005.2deg.wcm.002</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP4_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.1955-2005.2deg.wcm.002</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP8_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.1955-2005.2deg.wcm.002</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP2_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.1955-2005.2deg.wcm.002</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP4_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.1955-2005.2deg.wcm.002</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP8_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.1955-2005.2deg.wcm.002</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40_1850_1d_b08c5cn_138j</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40.1850.track1.1deg.006</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_CISM1_SWAV"	   >bg40.1850.track1.1deg.006b</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.1850.track1.1deg.006</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40%FCHM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >trk1_1deg_chm_1850_b55.01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40.1850.track1.1deg.006</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM40%CHEM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >trk1_1deg_chm_1850_b55.01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40_1850_1d_b08c5cn_138j</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP8_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40.20th.track1.1deg.008</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP8_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b.e10.BHISTC5CN.f09_g16.001</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP6_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40.20th.track1.1deg.008</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP6_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b.e10.BHISTC5CN.f09_g16.001</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP4_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40.20th.track1.1deg.008</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP4_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b.e10.BHISTC5CN.f09_g16.001</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP2_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40.20th.track1.1deg.008</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP2_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b.e10.BHISTC5CN.f09_g16.001</value>
-	<value grid="a%T31_l%T31_oi%gx3v7_r%r05_m%gx3v7"		compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b40.t31x3.037c</value>
-	<value grid="a%ne30np4_l%ne30np4_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >b.e11.B1850C5CN.ne30_g16.tuning.004</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="2013_CAM40%WCBC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >b40.rcp4_5.2deg.wcm.carma.bc0tg.002</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_w%ww3a"         compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_WW3"        >b40_1850_c02c_76jpf</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_w%ww3a"         compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_DWAV"       >b40_1850_c02c_76jpf</value>
-      </values>
-    </entry>
-
-    <entry id="RUN_REFDATE">
-      <values>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCCM_CLM40%CN"			   >0156-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCCM_CLM40%CN"			   >0156-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCSC_CLM40%CN"			   >0156-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0501-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV"	   >0221-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50%WISOall_CLM40%CN-WISO_CICE%WISO_POP2%ISO_RTM%WISO_SGLC_SWAV"	   >0561-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0070-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >0501-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0501-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV"	   >0221-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0070-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >0156-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="5505_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >1955-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="5505_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >1955-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP2_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >2005-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP4_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >2005-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP8_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >2005-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP2_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >2005-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP4_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >2005-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP8_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >2005-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0320-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0863-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_CISM1_SWAV"	   >0863-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >0863-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40%FCHM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >0086-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0863-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM40%CHEM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >0086-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0320-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP8_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >2005-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP8_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >2006-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP6_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >2005-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP6_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >2006-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP4_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >2005-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP4_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >2006-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP2_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >2005-01-01</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP2_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >2006-01-01</value>
-	<value grid="a%T31_l%T31_oi%gx3v7_r%r05_m%gx3v7"		compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0507-01-01</value>
-	<value grid="a%ne30np4_l%ne30np4_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >0026-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="2013_CAM40%WCBC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >2013-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_w%ww3a"         compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_WW3"        >0221-01-01</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_w%ww3a"         compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_DWAV"       >0221-01-01</value>
-      </values>
-    </entry>
-
-    <entry id="RUN_REFDIR">
-      <values>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCCM_CLM40%CN"			   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCCM_CLM40%CN"			   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%WCSC_CLM40%CN"			   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="HIST_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="5505_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="5505_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP2_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP4_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP8_CAM40%WCCM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP2_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP4_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="RCP8_CAM40%WCSC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_CISM1_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40%RCO2_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM40%FCHM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM40%CHEM_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="HIST_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP8_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP8_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP6_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP6_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP4_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP4_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP2_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6"	compset="RCP2_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%T31_l%T31_oi%gx3v7_r%r05_m%gx3v7"		compset="1850_CAM40_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%ne30np4_l%ne30np4_oi%gx1v6_r%r05_m%gx1v6"	compset="1850_CAM50_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"	   >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05"		compset="2013_CAM40%WCBC_CLM40%CN_CICE_POP2_RTM_SGLC_SWAV"  >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_w%ww3a"         compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_WW3"        >ccsm4_init</value>
-	<value grid="a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_w%ww3a"         compset="HIST_CAM50_CLM40%SP_CICE_POP2_RTM_SGLC_DWAV"       >ccsm4_init</value>
-      </values>
-    </entry>
--->
     <entry id="RUN_STARTDATE">
       <values>
 	<value compset="1850_"     >0001-01-01</value>

--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -83,14 +83,14 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="ERS" grid="f09_g16" compset="BRCP45C4L40CNRBDRD" testmods="allactive/defaultio">
-    <machines>
-      <machine name="yellowstone" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:00 </option>
-    </options>
-  </test>
+  <!-- <test name="ERS" grid="f09_g16" compset="BRCP45C4L40CNRBDRD" testmods="allactive/defaultio"> -->
+  <!--   <machines> -->
+  <!--     <machine name="yellowstone" compiler="intel" category="prebeta"/> -->
+  <!--   </machines> -->
+  <!--   <options> -->
+  <!--     <option name="wallclock"> 01:00 </option> -->
+  <!--   </options> -->
+  <!-- </test> -->
   <test name="ERS" grid="f09_g16" compset="BRCP85C5L45BGCR" testmods="allactive/defaultio">
     <machines>
       <machine name="yellowstone" compiler="intel" category="prebeta"/>
@@ -167,14 +167,14 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="ERS_Ld7" grid="f19_g16" compset="B1850C4RCO2L40CNRWs" testmods="allactive/defaultio">
-    <machines>
-      <machine name="bluewaters" compiler="pgi" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
-    </options>
-  </test>
+  <!-- <test name="ERS_Ld7" grid="f19_g16" compset="B1850C4RCO2L40CNRWs" testmods="allactive/defaultio"> -->
+  <!--   <machines> -->
+  <!--     <machine name="bluewaters" compiler="pgi" category="prebeta"/> -->
+  <!--   </machines> -->
+  <!--   <options> -->
+  <!--     <option name="wallclock"> 00:20 </option> -->
+  <!--   </options> -->
+  <!-- </test> -->
   <test name="ERS_Ld7" grid="f09_g16" compset="BHISTC5L45BGCR" testmods="allactive/defaultio">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>
@@ -191,16 +191,16 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="ERS_N3_Ld7" grid="f19_g16" compset="BHISTC5L40CNR" testmods="allactive/defaultio">
-    <machines>
-      <machine name="edison" compiler="intel" category="prebeta"/>
-      <machine name="yellowstone" compiler="gnu" category="prealpha"/>
-      <machine name="yellowstone" compiler="gnu" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
-    </options>
-  </test>
+  <!-- <test name="ERS_N3_Ld7" grid="f19_g16" compset="BHISTC5L40CNR" testmods="allactive/defaultio"> -->
+  <!--   <machines> -->
+  <!--     <machine name="edison" compiler="intel" category="prebeta"/> -->
+  <!--     <machine name="yellowstone" compiler="gnu" category="prealpha"/> -->
+  <!--     <machine name="yellowstone" compiler="gnu" category="prebeta"/> -->
+  <!--   </machines> -->
+  <!--   <options> -->
+  <!--     <option name="wallclock"> 00:20 </option> -->
+  <!--   </options> -->
+  <!-- </test> -->
   <test name="ERS_N3_Ld7" grid="f19_g16" compset="BHISTC5L45BGCR" testmods="allactive/defaultio">
     <machines>
       <machine name="hobart" compiler="intel" category="prebeta"/>
@@ -209,14 +209,14 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="ERS_Ld7" grid="f09_g16" compset="BRCP26C4L40CNR" testmods="allactive/defaultio">
-    <machines>
-      <machine name="janus" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
-    </options>
-  </test>
+  <!-- <test name="ERS_Ld7" grid="f09_g16" compset="BRCP26C4L40CNR" testmods="allactive/defaultio"> -->
+  <!--   <machines> -->
+  <!--     <machine name="janus" compiler="intel" category="prebeta"/> -->
+  <!--   </machines> -->
+  <!--   <options> -->
+  <!--     <option name="wallclock"> 00:20 </option> -->
+  <!--   </options> -->
+  <!-- </test> -->
   <test name="ERS_Ld7" grid="f09_g16" compset="BRCP85C5L45BGCR" testmods="allactive/defaultio">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
@@ -267,14 +267,14 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="PET" grid="f19_g16" compset="B1850C5L40SPRWs" testmods="allactive/defaultio">
-    <machines>
-      <machine name="bluewaters" compiler="pgi" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
-    </options>
-  </test>
+  <!-- <test name="PET" grid="f19_g16" compset="B1850C5L40SPRWs" testmods="allactive/defaultio"> -->
+  <!--   <machines> -->
+  <!--     <machine name="bluewaters" compiler="pgi" category="prebeta"/> -->
+  <!--   </machines> -->
+  <!--   <options> -->
+  <!--     <option name="wallclock"> 00:20 </option> -->
+  <!--   </options> -->
+  <!-- </test> -->
   <test name="PFS" grid="f09_g16" compset="B1850" testmods="allactive/default">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>
@@ -345,14 +345,14 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="f09_g16" compset="BRCP85C4L40CNRBPRP" testmods="allactive/defaultio">
-    <machines>
-      <machine name="edison" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
-    </options>
-  </test>
+  <!-- <test name="SMS_Ld5" grid="f09_g16" compset="BRCP85C4L40CNRBPRP" testmods="allactive/defaultio"> -->
+  <!--   <machines> -->
+  <!--     <machine name="edison" compiler="intel" category="prebeta"/> -->
+  <!--   </machines> -->
+  <!--   <options> -->
+  <!--     <option name="wallclock"> 00:20 </option> -->
+  <!--   </options> -->
+  <!-- </test> -->
   <test name="SMS_Ld5" grid="f09_g16_gl4" compset="J1850G" testmods="allactive/defaultio">
     <machines>
       <machine name="yellowstone" compiler="gnu" category="prebeta"/>

--- a/cime_config/config_headers.xml
+++ b/cime_config/config_headers.xml
@@ -31,9 +31,8 @@
   <file name ="env_mach_specific.xml">
     <header>
     These variables control the machine dependent environment including
-	the paths to compilers and libraries external to cime such as netcdf, 
-	environment variables for use in the running job should also be set
-	here.
+    the paths to compilers and libraries external to cime such as netcdf, 
+    environment variables for use in the running job should also be set	here.
     </header>
   </file>
 
@@ -49,30 +48,16 @@
   <file name="env_mach_pes.xml">
     <header>
     These variables CANNOT be modified once case_setup has been
-    invoked without first invoking case_setup -clean.
+    invoked without first invoking case_setup -reset
 
-    component task/thread settings
-    if the user wants to change the values below after ./case_setup, run
-    ./case_setup -clean
-    ./case_setup
-    to reset the pes for the run
+    NTASKS: the total number of MPI tasks, a negative value indicates nodes rather than tasks.
+    NTHRDS: the number of OpenMP threads per MPI task.
+    ROOTPE: the global mpi task of the component root task, if negative, indicates nodes rather than tasks.
+    PSTRID: the stride of MPI tasks across the global set of pes (for now set to 1)
+    NINST : the number of component instances (will be spread evenly across NTASKS)
 
-    NTASKS are the total number of MPI tasks, a negative value in this field
-                 indicates nodes rather than tasks.
-    NTHRDS are the number of OpenMP threads per MPI task
-    ROOTPE is the global mpi task associated with the root task
-    of that component, a negative value in this field indicates nodes rather than tasks.           PSTRID is the stride of MPI tasks across the global
-    set of pes (for now this is set to 1)
-    NINST is the number of instances of the component (will be spread
-    evenly across NTASKS)
-
-    for example, for a setting with
-    NTASKS = 8
-    NTHRDS = 2
-    ROOTPE = 32
-    NINST  = 2
-    the MPI tasks would be placed starting on global pe 32
-    and each pe would be threaded 2-ways for this component.
+    for example, for NTASKS = 8, NTHRDS = 2, ROOTPE = 32, NINST  = 2
+    the MPI tasks would be placed starting on global pe 32 and each pe would be threaded 2-ways
     These tasks will be divided amongst both instances (4 tasks each).
 
     Note: PEs that support threading never have an MPI task associated
@@ -82,28 +67,14 @@
     to determine how those mpi tasks should be placed across the machine.
 
     The following values should not be set by the user since they'll be
-    overwritten by scripts.
-    TOTALPES
-    CCSM_PCOST
-    CCSM_ESTCOST
-    PES_LEVEL
-    MAX_TASKS_PER_NODE
-    PES_PER_NODE
-    CCSM_TCOST
-    CCSM_ESTCOST
-
-    The user can copy env_mach_pes.xml from another run, but they'll need to
-    do the following
-    ./case_setup -clean
-    ./case_setup
-    ./CASE.build
+    overwritten by scripts: TOTALPES, MAX_TASKS_PER_NODE, PES_PER_NODE
     </header>
   </file>
 
   <file name="env_archive.xml">
     <header>
-    These are the variables specific to the short term
-    archiver. For a detailed listing of the env_archive.xml file, run
+    These are the variables specific to the short term archiver. 
+    For a detailed listing of the env_archive.xml file, run
     ./st_archive -help
     To validate the env_archive.xml file using xmllint, run
     xmllint -schema Tools/archive.xsd env_archive.xml

--- a/utils/python/CIME/case_run.py
+++ b/utils/python/CIME/case_run.py
@@ -69,7 +69,7 @@ def pre_run_check(case):
                   sfile="CaseStatus")
 
     logger.info("-------------------------------------------------------------------------")
-    logger.info(" - To prestage required restarts, untar a restart.tar file into %s" %(rundir))
+    logger.info(" - Prestage required restarts into %s" %(rundir))
     logger.info(" - Case input data directory (DIN_LOC_ROOT) is %s " %(din_loc_root))
     logger.info(" - Checking for required input datasets in DIN_LOC_ROOT")
     logger.info("-------------------------------------------------------------------------")


### PR DESCRIPTION
Removed clm40 compsets and associated tests

clm40 will no longer be supported in cesm2 - and this is the first step to remove all active compsets 
that reference clm40.
Also cleaned up comments in config_headers.xml for env_mach_pes.xml.

Test suite: None
Test baseline: None
Test namelist changes: None
Test status: bit for bit

Fixes: None

User interface changes?: None 

Code review: 
