### PR TITLE
Fix bug in setting up tprof namelist vals.

### DIFF
--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -140,8 +140,8 @@ def _create_drv_namelists(case, infiles, definition_file, confdir):
         tprofn = int(stopn / tprof_total)
         if tprofn < 1:
             tprofn = 1
-        nmlgen.set_value('tprof_option', value="tprofoption")
-        nmlgen.set_value('tprof_n'     , value="tprofn")
+        nmlgen.set_value('tprof_option', value=tprofoption)
+        nmlgen.set_value('tprof_n'     , value=tprofn)
 
     #--------------------------------
     # Write output files


### PR DESCRIPTION
Variable names were mistakely being treated as string.

Test suite: by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: None

Code review: jedwards
