### PR TITLE
Comp classes cleanup

### DIFF
--- a/utils/python/CIME/XML/env_archive.py
+++ b/utils/python/CIME/XML/env_archive.py
@@ -1,5 +1,5 @@
 """
-Interface to the env_archive.xml file.  This class inherits from EnvBase
+Interface to the env_archive.xml file.  This class inherits from GenericXML
 """
 from CIME.XML.standard_module_setup import *
 

--- a/utils/python/CIME/XML/env_base.py
+++ b/utils/python/CIME/XML/env_base.py
@@ -26,7 +26,7 @@ class EnvBase(EntryID):
             self.root.append(headernode)
 
     def set_components(self, components):
-        if hasattr(self, "_components"):
+        if hasattr(self, '_components'):
             # pylint: disable=attribute-defined-outside-init
             self._components = components
 

--- a/utils/python/CIME/XML/env_base.py
+++ b/utils/python/CIME/XML/env_base.py
@@ -25,9 +25,8 @@ class EnvBase(EntryID):
             headernode = headerobj.get_header_node(os.path.basename(fullpath))
             self.root.append(headernode)
 
-
     def set_components(self, components):
-        if hasattr(self, '_components'):
+        if hasattr(self, "_components"):
             # pylint: disable=attribute-defined-outside-init
             self._components = components
 
@@ -99,6 +98,7 @@ class EnvBase(EntryID):
         node = self.get_optional_node("entry", {"id":vid})
         if node is not None:
             if iscompvar and comp is None:
+                # pylint: disable=no-member
                 for comp in self._components:
                     val = self._set_value(node, value, vid, subgroup, ignore_type, component=comp)
             else:

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -338,7 +338,7 @@ class EnvBatch(EnvBase):
             depid[job] = self.submit_single_job(case, job, jobid, no_batch=no_batch)
             if self.batchtype == "cobalt":
                 break
-
+            return sorted(list(depid.values()))
     def submit_single_job(self, case, job, depid=None, no_batch=False):
         logger.warn("Submit job %s"%job)
         caseroot = case.get_value("CASEROOT")

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -21,11 +21,11 @@ class EnvBatch(EnvBase):
         """
         initialize an object interface to file env_batch.xml in the case directory
         """
-        EnvBase.__init__(self, case_root, infile)
         self.prereq_jobid = None
         self.batchtype = None
         # This arbitrary setting should always be overwritten
         self._default_walltime = "00:20:00"
+        EnvBase.__init__(self, case_root, infile)
 
     def set_value(self, item, value, subgroup=None, ignore_type=False):
         """

--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -338,7 +338,8 @@ class EnvBatch(EnvBase):
             depid[job] = self.submit_single_job(case, job, jobid, no_batch=no_batch)
             if self.batchtype == "cobalt":
                 break
-            return sorted(list(depid.values()))
+        return sorted(list(depid.values()))
+
     def submit_single_job(self, case, job, depid=None, no_batch=False):
         logger.warn("Submit job %s"%job)
         caseroot = case.get_value("CASEROOT")

--- a/utils/python/CIME/XML/env_build.py
+++ b/utils/python/CIME/XML/env_build.py
@@ -14,9 +14,3 @@ class EnvBuild(EnvBase):
         initialize an object interface to file env_build.xml in the case directory
         """
         EnvBase.__init__(self, case_root, infile)
-
-
-
-
-
-

--- a/utils/python/CIME/XML/env_build.py
+++ b/utils/python/CIME/XML/env_build.py
@@ -8,10 +8,15 @@ from CIME.XML.env_base import EnvBase
 logger = logging.getLogger(__name__)
 
 class EnvBuild(EnvBase):
-
-    def __init__(self, case_root=None, infile="env_build.xml"):
+    # pylint: disable=unused-argument
+    def __init__(self, case_root=None, infile="env_build.xml",components=None):
         """
         initialize an object interface to file env_build.xml in the case directory
         """
         EnvBase.__init__(self, case_root, infile)
+
+
+
+
+
 

--- a/utils/python/CIME/XML/env_case.py
+++ b/utils/python/CIME/XML/env_case.py
@@ -8,8 +8,8 @@ from CIME.XML.env_base import EnvBase
 logger = logging.getLogger(__name__)
 
 class EnvCase(EnvBase):
-
-    def __init__(self, case_root=None, infile="env_case.xml"):
+    # pylint: disable=unused-argument
+    def __init__(self, case_root=None, infile="env_case.xml", components=None):
         """
         initialize an object interface to file env_case.xml in the case directory
         """

--- a/utils/python/CIME/XML/env_mach_pes.py
+++ b/utils/python/CIME/XML/env_mach_pes.py
@@ -9,14 +9,14 @@ logger = logging.getLogger(__name__)
 
 class EnvMachPes(EnvBase):
 
-    def __init__(self, case_root=None, infile="env_mach_pes.xml"):
+    def __init__(self, case_root=None, infile="env_mach_pes.xml", components=None):
         """
         initialize an object interface to file env_mach_pes.xml in the case directory
         """
-        EnvBase.__init__(self, case_root, infile)
+        self._components = components
         self._component_value_list = ["NTASKS", "NTHRDS", "NINST",
                                       "ROOTPE", "PSTRID", "NINST_LAYOUT"]
-        self._components = []
+        EnvBase.__init__(self, case_root, infile)
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)

--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 # Is not of type EntryID but can use functions from EntryID (e.g
 # get_type) otherwise need to implement own functions and make GenericXML parent class
 class EnvMachSpecific(EnvBase):
-
-    def __init__(self, caseroot, infile="env_mach_specific.xml"):
+    # pylint: disable=unused-argument
+    def __init__(self, caseroot, infile="env_mach_specific.xml",components=None):
         """
         initialize an object interface to file env_mach_specific.xml in the case directory
         """

--- a/utils/python/CIME/XML/env_run.py
+++ b/utils/python/CIME/XML/env_run.py
@@ -9,14 +9,14 @@ logger = logging.getLogger(__name__)
 
 class EnvRun(EnvBase):
 
-    def __init__(self, case_root=None, infile="env_run.xml"):
+    def __init__(self, case_root=None, infile="env_run.xml", components=None):
         """
         initialize an object interface to file env_run.xml in the case directory
         """
-        EnvBase.__init__(self, case_root, infile)
-        self._components = []
+        self._components = components
         self._component_value_list = ["PIO_TYPENAME", "PIO_STRIDE", "PIO_REARRANGER",
                                       "PIO_NUMTASKS", "PIO_ROOT"]
+        EnvBase.__init__(self, case_root, infile)
 
 
 

--- a/utils/python/CIME/XML/env_test.py
+++ b/utils/python/CIME/XML/env_test.py
@@ -9,8 +9,8 @@ from CIME.utils import convert_to_type
 logger = logging.getLogger(__name__)
 
 class EnvTest(EnvBase):
-
-    def __init__(self, case_root=None, infile="env_test.xml"):
+    # pylint: disable=unused-argument
+    def __init__(self, case_root=None, infile="env_test.xml", components=None):
         """
         initialize an object interface to file env_test.xml in the case directory
         """

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -190,8 +190,6 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
         else:
             ninst = case.get_value("NINST_%s"%comp_class)
             config_dir = os.path.dirname(case.get_value("CONFIG_%s_FILE"%comp_class))
-        import pdb
-        pdb.set_trace()
         comp = case.get_value("COMP_%s"%comp_class)
         thrds =  case.get_value("NTHRDS_%s"%comp_class)
         expect(ninst is not None,"Failed to get ninst for comp_class %s"%comp_class)

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -190,7 +190,8 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
         else:
             ninst = case.get_value("NINST_%s"%comp_class)
             config_dir = os.path.dirname(case.get_value("CONFIG_%s_FILE"%comp_class))
-
+        import pdb
+        pdb.set_trace()
         comp = case.get_value("COMP_%s"%comp_class)
         thrds =  case.get_value("NTHRDS_%s"%comp_class)
         expect(ninst is not None,"Failed to get ninst for comp_class %s"%comp_class)

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -26,8 +26,7 @@ def _check_pelayouts_require_rebuild(case, models):
     if os.path.exists(locked_pes):
         # Look to see if $comp_PE_CHANGE_REQUIRES_REBUILD is defined
         # for any component
-        env_mach_pes_locked = EnvMachPes(infile=locked_pes)
-        env_mach_pes_locked.set_components(case.get_values("COMP_CLASSES"))
+        env_mach_pes_locked = EnvMachPes(infile=locked_pes, components=case.get_values("COMP_CLASSES"))
         for comp in models:
             if case.get_value("%s_PE_CHANGE_REQUIRES_REBUILD" % comp):
                 # Changing these values in env_mach_pes.xml will force

--- a/utils/python/CIME/case_submit.py
+++ b/utils/python/CIME/case_submit.py
@@ -7,7 +7,7 @@ jobs.
 """
 import socket
 from CIME.XML.standard_module_setup import *
-from CIME.utils                     import expect
+from CIME.utils                     import expect, append_status
 from CIME.preview_namelists         import create_namelists
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.check_input_data          import check_all_input_data
@@ -62,7 +62,9 @@ def submit(case, job=None, resubmit=False, no_batch=False):
     case.flush()
 
     logger.warn("submit_jobs %s"%job)
-    case.submit_jobs(no_batch=no_batch, job=job)
+    job_ids = case.submit_jobs(no_batch=no_batch, job=job)
+    msg = "Submitted jobs %s"%job_ids
+    append_status(msg, caseroot=caseroot, sfile="CaseStatus")
 
 def check_case(case, caseroot):
     check_lockedfiles(caseroot)


### PR DESCRIPTION
Some of the env_ objects need to know their comp classes, this cleans up the code
that sets comp classes for those objects.  Also adds case_submit output to CaseStatus file.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #961 

User interface changes?: 

Code review: 
