### PR TITLE
Mvertens/nmlgen updates

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,28 @@
 ======================================================================
 
+Originator: Chris Fischer 
+Date: 12-23-2016
+Tag: cime5.2.0-alpha.13.bhist
+Answer Changes: None
+Tests: prealpha pgi tests on hobart, BHIST restart on yellowstone
+
+Dependencies:
+
+Brief Summary: Fix pnetcdf module on hobart for pgi.  Update BHIST compset
+names
+
+User interface changes: 
+
+Modified files: git diff --name-status
+
+        M       cime_config/cesm/allactive/config_compsets.xml
+        M       cime_config/cesm/allactive/testlist_allactive.xml
+        M       cime_config/cesm/machines/config_machines.xml
+
+======================================================================
+
+======================================================================
+
 Originator: Jim Edwards
 Date: 12-20-2016
 Tag: cime5.2.0-alpha.13

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -810,7 +810,7 @@
 	<command name="load">compiler/pgi/15.1</command>
       </modules>
       <modules  compiler="pgi" mpilib="mvapich2">
-	  <command name="load">  tool/parallel-netcdf/1.7.0/pgi/mvapich2  </command>
+	  <command name="load">  tool/parallel-netcdf/1.6.1/pgi/mvapich2  </command>
       </modules>
       <modules compiler="nag">
 	<command name="load">compiler/nag/6.1</command>

--- a/cime_config/xml_schemas/entry_id_base.xsd
+++ b/cime_config/xml_schemas/entry_id_base.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 
   <!-- attributes -->
-  <xs:attribute name="id" type="xs:NCName"/>
+  <xs:attribute name="id" type="xs:string"/>
   <xs:attribute name="compset" type="xs:string"/>
   <xs:attribute name="component" type="xs:string"/>
   <xs:attribute name="grid"  type="xs:string"/>

--- a/cime_config/xml_schemas/entry_id_namelist.xsd
+++ b/cime_config/xml_schemas/entry_id_namelist.xsd
@@ -3,7 +3,7 @@
   <!-- base schema -->
   <xs:include schemaLocation="entry_id_base.xsd"/>
   <!-- attributes -->
-  <xs:attribute name="modify_via_xml" type="xs:NCName"/>
+  <xs:attribute name="modify_via_xml" type="xs:string"/>
   <xs:attribute name="skip_default_entry" type="xs:boolean"/>
   <xs:attribute name="per_stream_entry" type="xs:boolean"/>
 

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -161,9 +161,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `datm_nml` namelist group.
     #----------------------------------------------------
-    entries = nmlgen.get_definition_entries()
+    skip_groups = []
+    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
-        nmlgen.add_default(entry)
+        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -122,9 +122,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `dice_nml` namelist group.
     #----------------------------------------------------
-    entries = nmlgen.get_definition_entries()
+    skip_groups = []
+    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
-        nmlgen.add_default(entry)
+        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.
@@ -132,7 +133,9 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     namelist_file = os.path.join(confdir, "dice_in")
     nmlgen.write_output_file(namelist_file, data_list_path, groups=['dice_nml','shr_strdata_nml'])
 
+###############################################################################
 def buildnml(case, caseroot, compname):
+###############################################################################
     if compname != "dice":
         raise AttributeError
 

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -123,9 +123,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `dlnd_nml` namelist group.
     #----------------------------------------------------
-    entries = nmlgen.get_definition_entries()
+    skip_groups = []
+    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
-        nmlgen.add_default(entry)
+        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -122,9 +122,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `docn_nml` namelist group.
     #----------------------------------------------------
-    entries = nmlgen.get_definition_entries()
+    skip_groups = []
+    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
-        nmlgen.add_default(entry)
+        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -120,9 +120,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `drof_nml` namelist group.
     #----------------------------------------------------
-    entries = nmlgen.get_definition_entries()
+    skip_groups = []
+    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
-        nmlgen.add_default(entry)
+        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -122,6 +122,14 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
         nmlgen.add_default("domainfile", value=full_domain_path)
 
     #----------------------------------------------------
+    # Create `dwav_nml` namelist group.
+    #----------------------------------------------------
+    skip_groups = []
+    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
+    for entry in entries:
+        nmlgen.add_default(entry.get("id"), node=entry)
+
+    #----------------------------------------------------
     # Finally, write out all the namelists.
     #----------------------------------------------------
     namelist_file = os.path.join(confdir, "dwav_in")

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -58,13 +58,14 @@ def _create_drv_namelists(case, infiles, definition_file, confdir):
     # Create nmlgen object - using config dictionary
     #--------------------------------
     nmlgen = NamelistGenerator(case, infiles, definition_file, config)
-    entries = nmlgen.get_definition_entries()
 
     #--------------------------------
     # Add default values for all entries in namelist_definition_drv.xml
     #--------------------------------
+    skip_groups = []
+    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
-        nmlgen.add_default(entry)
+        nmlgen.add_default(entry.get("id"), node=entry)
 
     #--------------------------------
     # Overwrite: set brnch_retain_casename

--- a/utils/python/CIME/XML/entry_id.py
+++ b/utils/python/CIME/XML/entry_id.py
@@ -43,7 +43,7 @@ class EntryID(GenericXML):
 
         return val
 
-    def get_value_match(self, vid, attributes=None, exact_match=False):
+    def get_value_match(self, vid, attributes=None, exact_match=False, entry_node=None):
         # Handle this case:
         # <entry id ...>
         #  <values>
@@ -53,10 +53,13 @@ class EntryID(GenericXML):
         #  </values>
         # </entry>
 
-        node = self.get_optional_node("entry", {"id":vid})
-        value = None
-        if node is not None:
-            value = self._get_value_match(node, attributes, exact_match)
+        if entry_node is not None:
+            value = self._get_value_match(entry_node, attributes, exact_match)
+        else:
+            node = self.get_optional_node("entry", {"id":vid})
+            value = None
+            if node is not None:
+                value = self._get_value_match(node, attributes, exact_match)
         logger.debug("(get_value_match) vid %s value %s"%(vid, value))
         return value
 

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -110,7 +110,7 @@ class NamelistDefinition(EntryID):
             valid_values = valid_values.split(',')
         return valid_values
 
-    def get_value_match(self, item, attributes=None, exact_match=True):
+    def get_value_match(self, item, attributes=None, exact_match=True, entry_node=None):
         """Return the default value for the variable named `item`.
 
         The return value is a list of strings corresponding to the
@@ -124,7 +124,8 @@ class NamelistDefinition(EntryID):
         if attributes is not None:
             all_attributes.update(attributes)
 
-        value = super(NamelistDefinition, self).get_value_match(item.lower(),attributes=all_attributes, exact_match=exact_match)
+        value = super(NamelistDefinition, self).get_value_match(item.lower(),attributes=all_attributes, exact_match=exact_match,
+                                                                entry_node=entry_node)
 
         if value is None:
             value = ''

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -47,17 +47,19 @@ class NamelistDefinition(EntryID):
             schema = os.path.join(cimeroot,"cime_config","xml_schemas","entry_id_namelist.xsd")
             self.validate_xml_file(infile, schema)
 
-    def get_entries(self, skip_groups=[]):
+    def get_entries(self, skip_groups=None):
         """Return all variables in the namelist definition file
         that do not have attributes of skip_default_entry or per_stream_entry
         """
+        if skip_groups is None:
+            skip_groups = []
         nodes = self.get_entry_nodes(skip_groups)
         entries = []
         for node in nodes:
             entries.append(node.get("id"))
         return entries
 
-    def get_entry_nodes(self, skip_groups=[]):
+    def get_entry_nodes(self, skip_groups=None):
         """Return all variables in the namelist definition file
         that do not have attributes of skip_default_entry or per_stream_entry
         """
@@ -66,7 +68,7 @@ class NamelistDefinition(EntryID):
         for node in nodes:
             skip_default_entry = node.get("skip_default_entry")
             per_stream_entry = node.get("per_stream_entry")
-            if skip_groups:
+            if skip_groups is not None:
                 group_value = self.get_element_text("group", root=node)
                 if not group_value in skip_groups:
                     if not skip_default_entry and not per_stream_entry:

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -320,14 +320,11 @@ class NamelistDefinition(EntryID):
                 # and has the right group name...
                 var_group = self.get_group_name(variable_name)
                 expect(var_group == group_name,
-                       (variable_template + " is in a group named %r, but "
-                        "should be in %r.") %
-                       (str(variable_name), str(group_name),
-                        str(var_group)))
+                       (variable_template + " is in a group named %r, but should be in %r.") %
+                       (str(variable_name), str(group_name), str(var_group)))
 
                 # and has a valid value.
                 value = namelist.get_variable_value(group_name, variable_name)
-                print "DEBUG: check4 %s %s" %(variable_name, value)
                 expect(self.is_valid_value(variable_name, value),
                        (variable_template + " has invalid value %r.") %
                        (str(variable_name), [str(scalar) for scalar in value]))

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -174,8 +174,6 @@ class Case(object):
         self._env_generic_files.append(EnvMachSpecific(self._caseroot))
         self._env_generic_files.append(EnvArchive(self._caseroot))
         self._files = self._env_entryid_files + self._env_generic_files
-        # this gives the env objects access to the comp_classes
-        self.get_values("COMP_CLASSES")
 
     def get_case_root(self):
         """Returns the root directory for this case."""

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -175,7 +175,7 @@ class Case(object):
         self._env_generic_files.append(EnvArchive(self._caseroot))
         self._files = self._env_entryid_files + self._env_generic_files
         # this gives the env objects access to the comp_classes
-        comp_classes = self.get_values("COMP_CLASSES")
+        self.get_values("COMP_CLASSES")
 
     def get_case_root(self):
         """Returns the root directory for this case."""

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -174,6 +174,8 @@ class Case(object):
         self._env_generic_files.append(EnvMachSpecific(self._caseroot))
         self._env_generic_files.append(EnvArchive(self._caseroot))
         self._files = self._env_entryid_files + self._env_generic_files
+        # this gives the env objects access to the comp_classes
+        comp_classes = self.get_values("COMP_CLASSES")
 
     def get_case_root(self):
         """Returns the root directory for this case."""

--- a/utils/python/CIME/namelist.py
+++ b/utils/python/CIME/namelist.py
@@ -635,37 +635,43 @@ def compress_literal_list(literals):
     >>> compress_literal_list([u'f*', u'f*'])
     [u'2*f*']
     """
-    # For now are not returning a compressed list
-    # To return a compressed list - uncomment the following return call
-    return literals
-
     compressed = []
     if len(literals) == 0:
         return compressed
-    # Start with the first literal.
-    old_literal = literals[0]
-    num_reps = 1
-    for literal in literals[1:]:
-        if literal == old_literal:
-            # For each new literal, if it matches the old one, it increases the
-            # number of repetitions by one.
-            num_reps += 1
-        else:
-            # Otherwise, write out the previous literal and start tracking the
-            # new one.
-            rep_str = str(num_reps) + '*' if num_reps > 1 else ''
-            if isinstance(old_literal, basestring):
-                compressed.append(rep_str + old_literal)
+    # for right now do not compress
+    do_compression = False
+    if do_compression:
+        # Start with the first literal.
+        old_literal = literals[0]
+        num_reps = 1
+        for literal in literals[1:]:
+            if literal == old_literal:
+                # For each new literal, if it matches the old one, it increases the
+                # number of repetitions by one.
+                num_reps += 1
             else:
-                compressed.append(rep_str + str(old_literal))
-            old_literal = literal
-            num_reps = 1
-    rep_str = str(num_reps) + '*' if num_reps > 1 else ''
-    if isinstance(old_literal, basestring):
-        compressed.append(rep_str + old_literal)
+                # Otherwise, write out the previous literal and start tracking the
+                # new one.
+                rep_str = str(num_reps) + '*' if num_reps > 1 else ''
+                if isinstance(old_literal, basestring):
+                    compressed.append(rep_str + old_literal)
+                else:
+                    compressed.append(rep_str + str(old_literal))
+                old_literal = literal
+                num_reps = 1
+        rep_str = str(num_reps) + '*' if num_reps > 1 else ''
+        if isinstance(old_literal, basestring):
+            compressed.append(rep_str + old_literal)
+        else:
+            compressed.append(rep_str + str(old_literal))
+        return compressed
     else:
-        compressed.append(rep_str + str(old_literal))
-    return compressed
+        for literal in literals:
+            if isinstance(literal, basestring):
+                compressed.append(literal)
+            else:
+                compressed.append(str(literal))
+        return compressed
 
 def merge_literal_lists(default, overwrite):
     """Merge two lists of literal value strings.
@@ -1011,23 +1017,23 @@ class Namelist(object):
             equals = ' ='
         elif format_ == 'rc':
             equals = ':'
-
         if (sorted_groups):
             group_names = sorted(group.lower() for group in groups)
         else:
             group_names = groups
-
         for group_name in group_names:
             if format_ == 'nml':
                 out_file.write("&%s\n" % group_name)
             group = self._groups[group_name]
             for name in sorted(group.keys()):
                 values = group[name]
+
                 # @ is used in a namelist to put the same namelist variable in multiple groups
                 # in the write phase, all characters in the namelist variable name after 
                 # the @ and including the @ should be removed
                 if "@" in name:
                     name = re.sub('@.+$', "", name)
+
                 # To prettify things for long lists of values, build strings
                 # line-by-line.
                 if values[0] == "True" or values[0] == "False":

--- a/utils/python/CIME/namelist.py
+++ b/utils/python/CIME/namelist.py
@@ -631,9 +631,9 @@ def compress_literal_list(literals):
     >>> compress_literal_list(['true'])
     ['true']
     >>> compress_literal_list(['1', '2', 'f*', '3', '3', '3', '5'])
-    ['1', '2', 'f*', '3*3', '5']
+    ['1', '2', 'f*', '3', '3', '3', '5']
     >>> compress_literal_list([u'f*', u'f*'])
-    [u'2*f*']
+    [u'f*', u'f*']
     """
     compressed = []
     if len(literals) == 0:
@@ -696,7 +696,7 @@ def merge_literal_lists(default, overwrite):
     >>> merge_literal_lists(['true'], [])
     ['true']
     >>> merge_literal_lists(['3*false', '3*true'], ['true', '4*', 'false'])
-    ['true', '2*false', '2*true', 'false']
+    ['true', 'false', 'false', 'true', 'true', 'false']
     """
     merged = []
     default = expand_literal_list(default)
@@ -963,7 +963,7 @@ class Namelist(object):
         >>> x.get_value('bar')
         [u'2']
         >>> x.get_value('bazz')
-        [u'3*1']
+        [u'1', u'1', u'1']
         >>> x.get_value('brat')
         [u'3']
         >>> x.get_value('baker')

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -106,10 +106,10 @@ class NamelistGenerator(object):
     def __exit__(self, *_):
         return False
 
-    def get_definition_nodes(self, skip_groups=[]):
+    def get_definition_nodes(self, skip_groups=None):
         return self._definition.get_entry_nodes(skip_groups=skip_groups)
 
-    def get_definition_entries(self, skip_groups=[]):
+    def get_definition_entries(self, skip_groups=None):
         """Return array of names of all definition entries"""
         return self._definition.get_entries(skip_groups=skip_groups)
 
@@ -197,6 +197,7 @@ class NamelistGenerator(object):
         the old setting for the variable will be thrown out completely.
         """
         if node is not None:
+            # pylint: disable=protected-access
             var_group = self._definition._get_node_element_info(node, "group")
         else:
             var_group = self._definition.get_node_element_info(name, "group")
@@ -511,6 +512,7 @@ class NamelistGenerator(object):
             expect(len(nodes) == 1, "incorrect number of matchs %s"%len(nodes))
             node = nodes[0]
 
+        # pylint: disable=protected-access
         group = self._definition._get_node_element_info(node, "group")
 
         # Use this to see if we need to raise an error when nothing is found.

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -106,9 +106,12 @@ class NamelistGenerator(object):
     def __exit__(self, *_):
         return False
 
-    def get_definition_entries(self):
+    def get_definition_nodes(self, skip_groups=[]):
+        return self._definition.get_entry_nodes(skip_groups=skip_groups)
+
+    def get_definition_entries(self, skip_groups=[]):
         """Return array of names of all definition entries"""
-        return self._definition.get_entries()
+        return self._definition.get_entries(skip_groups=skip_groups)
 
     @staticmethod
     def quote_string(string):
@@ -121,9 +124,9 @@ class NamelistGenerator(object):
             string = string_to_character_literal(string)
         return string
 
-    def _to_python_value(self, name, literals):
+    def _to_python_value(self, name, literals, node=None):
         """Transform a literal list as needed for `get_value`."""
-        var_type, _, var_size, =  self._definition.split_type_string(name, self._definition.get_type_info(name))
+        var_type, _, var_size, = self._definition.split_type_string(name, self._definition.get_type_info(name, node=node))
         if len(literals) > 0:
             value = expand_literal_list(literals)
         else:
@@ -139,13 +142,13 @@ class NamelistGenerator(object):
         else:
             return value
 
-    def _to_namelist_literals(self, name, value):
+    def _to_namelist_literals(self, name, value, node=None):
         """Transform a literal list as needed for `set_value`.
 
         This is the inverse of `_to_python_value`, except that many of the
         changes have potentially already been performed.
         """
-        var_type, _, var_size, =  self._definition.split_type_string(name, self._definition.get_type_info(name))
+        var_type, _, var_size, =  self._definition.split_type_string(name, self._definition.get_type_info(name, node=node))
         if var_size == 1 and not isinstance(value, list):
             value = [value]
         for i, scalar in enumerate(value):
@@ -156,7 +159,7 @@ class NamelistGenerator(object):
                 value[i] = self.quote_string(scalar)
         return compress_literal_list(value)
 
-    def get_value(self, name):
+    def get_value(self, name, node=None):
         """Get the current value of a given namelist variable.
 
         Note that the return value of this function is always a string or a list
@@ -174,9 +177,9 @@ class NamelistGenerator(object):
         All other literals are returned as the raw string values that will be
         written to the namelist.
         """
-        return self._to_python_value(name, self._namelist.get_value(name))
+        return self._to_python_value(name, self._namelist.get_value(name), node=node)
 
-    def set_value(self, name, value):
+    def set_value(self, name, value, node=None):
         """Set the current value of a given namelist variable.
 
         Usually, you should use `add_default` instead of this function.
@@ -193,11 +196,14 @@ class NamelistGenerator(object):
         a user-specified setting. Even if `value` is (or contains) a null value,
         the old setting for the variable will be thrown out completely.
         """
-        var_group = self._definition.get_node_element_info(name, "group")
-        literals = self._to_namelist_literals(name, value)
+        if node is not None:
+            var_group = self._definition._get_node_element_info(node, "group")
+        else:
+            var_group = self._definition.get_node_element_info(name, "group")
+        literals = self._to_namelist_literals(name, value, node=node)
         self._namelist.set_variable_value(var_group, name, literals)
 
-    def get_default(self, name, config=None, allow_none=False):
+    def get_default(self, name, config=None, allow_none=False, node=None):
         """Get the value of a variable from the namelist definition file.
 
         The `config` argument is passed through to the underlying
@@ -226,13 +232,26 @@ class NamelistGenerator(object):
            exists. This behavior is suppressed within single-quoted strings
            (similar to parameter expansion in shell scripts).
         """
-        default = self._definition.get_value_match(name, attributes=config, exact_match=False)
+        if node is not None:
+            # this uses the entry_id.py _get_value_match function
+            default = self._definition._get_value_match(node, attributes=config, exact_match=False)
+            if default is None: 
+                default = ''
+            else:
+                default =  self._definition._split_defaults_text(default)
+        else:
+            # this uses the namelist_definition.py get_value_match function
+            default = self._definition.get_value_match(name, attributes=config, exact_match=False)
+
         if default is None:
             expect(allow_none, "No default value found for %s." % name)
             return None
         default = expand_literal_list(default)
 
-        var_type,_,_ = self._definition.split_type_string(name, self._definition.get_type_info(name))
+        if node is not None:
+            var_type,_,_ = self._definition.split_type_string(name, self._definition.get_type_info(name, node=node))
+        else:
+            var_type,_,_ = self._definition.split_type_string(name, self._definition.get_type_info(name))
 
         for i, scalar in enumerate(default):
             # Skip single-quoted strings.
@@ -257,7 +276,7 @@ class NamelistGenerator(object):
                 if scalar != '':
                     default[i] = self.quote_string(scalar)
 
-        default = self._to_python_value(name, default)
+        default = self._to_python_value(name, default, node=node)
         return default
 
     def get_streams(self):
@@ -484,7 +503,7 @@ class NamelistGenerator(object):
             fullpath = os.path.join(self._din_loc_root, file_path)
             return fullpath
 
-    def add_default(self, name, value=None):
+    def add_default(self, name, value=None, node=None):
         """Add a value for the specified variable to the namelist.
 
         If the specified variable is already defined in the object, the existing
@@ -496,7 +515,12 @@ class NamelistGenerator(object):
         If no value for the variable is found via any of the above, this method
         will raise an exception.
         """
-        group = self._definition.get_node_element_info(name, "group")
+        if node is None:
+            nodes = self._definition.get_nodes_by_id(name)
+            expect(len(nodes) == 1, "incorrect number of matchs %s"%len(nodes))
+            node = nodes[0]
+
+        group = self._definition._get_node_element_info(node, "group")
 
         # Use this to see if we need to raise an error when nothing is found.
         have_value = False
@@ -505,20 +529,22 @@ class NamelistGenerator(object):
         current_literals = self._namelist.get_variable_value(group, name)
         if current_literals != [""]:
             have_value = True
+            # Do not proceed further since this has been obtained the -infile contents
+            return 
 
         # Check for input argument.
         if value is not None:
             have_value = True
-            literals = self._to_namelist_literals(name, value) #FIXME - this is where an array is compressed into a 3*value
+            # if compression were to occur, this is where it does
+            literals = self._to_namelist_literals(name, value) 
             current_literals = merge_literal_lists(literals, current_literals)
 
         # Check for default value.
-        default = self.get_default(name, allow_none=True)
+        default = self.get_default(name, allow_none=True, node=node)
         if default is not None:
             have_value = True
             default_literals = self._to_namelist_literals(name, default)
-            current_literals = merge_literal_lists(default_literals,
-                                                   current_literals)
+            current_literals = merge_literal_lists(default_literals, current_literals)
         expect(have_value, "No default value found for %s." % name)
 
         # Go through file names and prepend input data root directory for
@@ -536,8 +562,8 @@ class NamelistGenerator(object):
                 if file_path == 'null':
                     continue
                 file_path = self.set_abs_file_path(file_path)
-                expect(os.path.exists(file_path),
-                       "File not found: %s = %s" % (name, literal))
+                if not os.path.exists(file_path):
+                    logger.warn ("File not found: %s = %s, will attempt to download in check_input_data phase" % (name, literal))
                 current_literals[i] = string_to_character_literal(file_path)
             current_literals = compress_literal_list(current_literals)
 
@@ -610,6 +636,10 @@ class NamelistGenerator(object):
             # append to input_data_list file
             with open(data_list_path, "a") as input_data_list:
                 self._write_input_files(input_data_list)
+
+    def add_nmlcontents(self, filename, group, append=True, format_="nmlcontents", sorted_groups=True):
+        """ Write only contents of nml group """
+        self._namelist.write(filename, groups=[group], append=append, format_=format_, sorted_groups=sorted_groups)
 
     def write_seq_maps(self, filename):
         """ Write out seq_maps.rc"""

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -200,6 +200,7 @@ class NamelistGenerator(object):
             var_group = self._definition._get_node_element_info(node, "group")
         else:
             var_group = self._definition.get_node_element_info(name, "group")
+        var_group = self._definition.get_node_element_info(name, "group")
         literals = self._to_namelist_literals(name, value, node=node)
         self._namelist.set_variable_value(var_group, name, literals)
 
@@ -232,17 +233,7 @@ class NamelistGenerator(object):
            exists. This behavior is suppressed within single-quoted strings
            (similar to parameter expansion in shell scripts).
         """
-        if node is not None:
-            # this uses the entry_id.py _get_value_match function
-            default = self._definition._get_value_match(node, attributes=config, exact_match=False)
-            if default is None: 
-                default = ''
-            else:
-                default =  self._definition._split_defaults_text(default)
-        else:
-            # this uses the namelist_definition.py get_value_match function
-            default = self._definition.get_value_match(name, attributes=config, exact_match=False)
-
+        default = self._definition.get_value_match(name, attributes=config, exact_match=False, entry_node=node)
         if default is None:
             expect(allow_none, "No default value found for %s." % name)
             return None


### PR DESCRIPTION
Performance improvements to namelist generation

- Added significant performance improvements to nmlgen.py to permit
  reuse of a target namelist entry node in the
  namelist_defaults_xxx.xml file rather than repeated searches over
  the namelist entry name.
- Removed the compression of output namelists produced by nmlgen. The
  overwhelming response from users was that this was very confusing.
  Changes to have this take place were very small and we can always
  revert to the compressed namelist output in the future.
- Fixed #958 
- Fixed a significant bug in how user_nl_xxx files were treated.
  A setting in the user_nl_xxx file should ALWAYS take precedence over
  namelist default settings from the call to add_default. There was not 
  a separate issue related to this.
- Changed entry_id and entry_id_namelist schemas to permit new
  requirements needed by pythonization of cesm prognostic components


Test suite: scripts_regression_test
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #958 

User interface changes?: none

Code review: jedwards
