### PR TITLE
Mvertens/nmlgen update2

### DIFF
--- a/cime_config/cesm/allactive/testlist_allactive.xml
+++ b/cime_config/cesm/allactive/testlist_allactive.xml
@@ -32,7 +32,7 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="NCK_N3" grid="f19_g16" compset="B1850" testmods="allactive/defaultio">
+  <test name="NCK" grid="f19_g16" compset="B1850Ws" testmods="allactive/defaultio">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
       <machine name="yellowstone" compiler="intel" category="prealpha"/>

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -182,7 +182,6 @@ def buildnml(case, caseroot, compname):
     cimeroot = case.get_value("CIMEROOT")
     rundir = case.get_value("RUNDIR")
     ninst = case.get_value("NINST_ATM")
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
     # Determine configuration directory
     confdir = os.path.join(caseroot,"Buildconf",compname + "conf")

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -87,8 +87,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     #----------------------------------------------------
     # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
+    entries = nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -147,7 +147,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 
     # set variables that are not per-stream
     if datm_mode == 'CPLHISTForcingForOcnIce':
-        nmlgen.add_default("domainfile", 'null')
+        nmlgen.add_default("domainfile", value='null')
         if atm_domain_file != "UNSET":
             if case.get_value('ATM_DOMAIN_FILE') != 'UNSET':
                 case.set_value('ATM_DOMAIN_FILE', 'UNSET')

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -85,9 +85,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     config['datm_presaero'] = datm_presaero
 
     #----------------------------------------------------
-    # Obtain entry nodes and initialize the defaults
+    # Initialize namelist defaults 
     #----------------------------------------------------
-    entries = nmlgen.init_defaults(infile, config)
+    nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -149,20 +149,11 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
         nmlgen.add_default("domainfile", value='null')
         if atm_domain_file != "UNSET":
             if case.get_value('ATM_DOMAIN_FILE') != 'UNSET':
-                case.set_value('ATM_DOMAIN_FILE', 'UNSET')
+                case.add_default('ATM_DOMAIN_FILE', value='UNSET', ignore_abs_path=True)
                 case.flush()
     else:
-        if atm_domain_file != "UNSET":
-            full_domain_path = os.path.join(atm_domain_path, atm_domain_file)
-            nmlgen.add_default("domainfile", value=full_domain_path)
-
-    nmlgen.add_default("vectors")
-
-    #----------------------------------------------------
-    # Create `datm_nml` namelist group.
-    #----------------------------------------------------
-    for entry in entries:
-        nmlgen.add_default(entry.get("id"), node=entry)
+        full_domain_path = os.path.join(atm_domain_path, atm_domain_file)
+        nmlgen.add_default("domainfile", value=full_domain_path)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/datm/cime_config/buildnml
+++ b/components/data_comps/datm/cime_config/buildnml
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
-def _create_namelists(case, confdir, inst_string, infile, definition_file):
+def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 ####################################################################################
     """Write out the namelist for this component.
 
@@ -85,9 +85,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     config['datm_presaero'] = datm_presaero
 
     #----------------------------------------------------
-    # Construct the namelist generator.
+    # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    nmlgen = NamelistGenerator(case, infile, definition_file, config)
+    skip_groups = []
+    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -161,8 +162,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `datm_nml` namelist group.
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
         nmlgen.add_default(entry.get("id"), node=entry)
 
@@ -185,34 +184,35 @@ def buildnml(case, caseroot, compname):
     ninst = case.get_value("NINST_ATM")
     din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    if not os.path.isdir(din_loc_root):
-        os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+    # Determine configuration directory
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
-        # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
+    #----------------------------------------------------
+    # Construct the namelist generator 
+    #----------------------------------------------------
+    # Determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
     expect (os.path.isdir(user_xml_dir),
             "user_xml_dir %s does not exist " %user_xml_dir)
 
-        # NOTE: User definition *replaces* existing definition.
+    # NOTE: User definition *replaces* existing definition.
     namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
     definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_datm.xml")]
     user_definition = os.path.join(user_xml_dir, "namelist_definition_datm.xml")
     if os.path.isfile(user_definition):
         definition_file = [user_definition]
-
-    # Checkout if definition file exists
     for file_ in definition_file:
         expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-    if not os.path.isdir(confdir):
-        os.makedirs(confdir)
-
+    # Create the namelist generator object - independent of instance
+    nmlgen = NamelistGenerator(case, definition_file)
+    
+    #----------------------------------------------------
     # Loop over instances
-    inst_string = ""
-    inst_counter = 1
-    while (inst_counter <= ninst):
+    #----------------------------------------------------
+    for inst_counter in range(1, ninst+1):
 
         # determine instance string
         inst_string = ""
@@ -240,7 +240,7 @@ def buildnml(case, caseroot, compname):
         namelist_infile = [infile]
 
         # create namelist and stream file(s) data component
-        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        _create_namelists(case, confdir, inst_string, namelist_infile, nmlgen)
 
         # copy namelist files and stream text files, to rundir
         if os.path.isdir(rundir):
@@ -253,9 +253,6 @@ def buildnml(case, caseroot, compname):
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
                 shutil.copy(txtfile, rundir)
-
-        # increment instance counter
-        inst_counter = inst_counter + 1
 
 ###############################################################################
 def _main_func():

--- a/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -1747,7 +1747,7 @@
     </values>
   </entry>
 
-  <entry id="domainfile">
+  <entry id="domainfile" skip_default_entry="true">
     <type>char</type>
     <category>streams</category>
     <input_pathname>abs</input_pathname>
@@ -1999,7 +1999,7 @@
     </values>
   </entry>
 
-  <entry id="vectors" skip_default_entry="true">
+  <entry id="vectors">
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
-def _create_namelists(case, confdir, inst_string, infile, definition_file):
+def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 ####################################################################################
     """Write out the namelist for this component.
 
@@ -74,9 +74,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     config['sstice_stream'] = sstice_stream
 
     #----------------------------------------------------
-    # Construct the namelist generator.
+    # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    nmlgen = NamelistGenerator(case, infile, definition_file, config)
+    skip_groups = []
+    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -122,8 +123,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `dice_nml` namelist group.
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
         nmlgen.add_default(entry.get("id"), node=entry)
 
@@ -144,10 +143,14 @@ def buildnml(case, caseroot, compname):
     ninst = case.get_value("NINST_ICE")
     din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    if not os.path.isdir(din_loc_root):
-        os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+    # Determine configuration directory
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
+    #----------------------------------------------------
+    # Construct the namelist generator 
+    #----------------------------------------------------
     # determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
     expect (os.path.isdir(user_xml_dir),
@@ -159,19 +162,16 @@ def buildnml(case, caseroot, compname):
     user_definition = os.path.join(user_xml_dir, "namelist_definition_dice.xml")
     if os.path.isfile(user_definition):
         definition_file = [user_definition]
-
-    # Checkout if definition file exists
     for file_ in definition_file:
         expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-    if not os.path.isdir(confdir):
-        os.makedirs(confdir)
-
+    # Create the namelist generator object - independent of instance
+    nmlgen = NamelistGenerator(case, definition_file)
+    
+    #----------------------------------------------------
     # Loop over instances
-    inst_string = ""
-    inst_counter = 1
-    while (inst_counter <= ninst):
+    #----------------------------------------------------
+    for inst_counter in range(1, ninst+1):
 
         # determine instance string
         inst_string = ""
@@ -199,7 +199,7 @@ def buildnml(case, caseroot, compname):
         namelist_infile = [infile]
 
         # create namelist and stream file(s) data component
-        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        _create_namelists(case, confdir, inst_string, namelist_infile, nmlgen)
 
         # copy namelist files and stream text files, to rundir
         if os.path.isdir(rundir):
@@ -212,9 +212,6 @@ def buildnml(case, caseroot, compname):
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
                 shutil.copy(txtfile, rundir)
-
-        # increment instance counter
-        inst_counter = inst_counter + 1
 
 ###############################################################################
 def _main_func():

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -76,8 +76,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     #----------------------------------------------------
     # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
+    entries = nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -141,7 +140,6 @@ def buildnml(case, caseroot, compname):
     cimeroot = case.get_value("CIMEROOT")
     rundir = case.get_value("RUNDIR")
     ninst = case.get_value("NINST_ICE")
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
     # Determine configuration directory
     confdir = os.path.join(caseroot,"Buildconf",compname + "conf")

--- a/components/data_comps/dice/cime_config/buildnml
+++ b/components/data_comps/dice/cime_config/buildnml
@@ -74,9 +74,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     config['sstice_stream'] = sstice_stream
 
     #----------------------------------------------------
-    # Obtain entry nodes and initialize the defaults
+    # Initialize namelist defaults 
     #----------------------------------------------------
-    entries = nmlgen.init_defaults(infile, config)
+    nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -117,13 +117,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     if ice_domain_file != "UNSET":
         full_domain_path = os.path.join(ice_domain_path, ice_domain_file)
         nmlgen.add_default("domainfile", value=full_domain_path)
-    nmlgen.add_default("vectors")
-
-    #----------------------------------------------------
-    # Create `dice_nml` namelist group.
-    #----------------------------------------------------
-    for entry in entries:
-        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/dice/cime_config/namelist_definition_dice.xml
+++ b/components/data_comps/dice/cime_config/namelist_definition_dice.xml
@@ -541,7 +541,7 @@
     </values>
   </entry>
 
-  <entry id="vectors" skip_default_entry="true">
+  <entry id="vectors">
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -75,10 +75,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     config['dlnd_mode'] = dlnd_mode
 
     #----------------------------------------------------
-    # Obtain entry nodes and initialize the defaults
+    # Initialize namelist defaults 
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
+    nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -119,13 +118,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     if lnd_domain_file != "UNSET":
         full_domain_path = os.path.join(lnd_domain_path, lnd_domain_file)
         nmlgen.add_default("domainfile", value=full_domain_path)
-    nmlgen.add_default("vectors")
-
-    #----------------------------------------------------
-    # Create `dlnd_nml` namelist group.
-    #----------------------------------------------------
-    for entry in entries:
-        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
-def _create_namelists(case, confdir, inst_string, infile, definition_file):
+def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 ####################################################################################
     """Write out the namelist for this component.
 
@@ -75,9 +75,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     config['dlnd_mode'] = dlnd_mode
 
     #----------------------------------------------------
-    # Construct the namelist generator.
+    # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    nmlgen = NamelistGenerator(case, infile, definition_file, config)
+    skip_groups = []
+    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -123,8 +124,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `dlnd_nml` namelist group.
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
         nmlgen.add_default(entry.get("id"), node=entry)
 
@@ -148,10 +147,13 @@ def buildnml(case, caseroot, compname):
     ninst = case.get_value("NINST_LND")
     din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    if not os.path.isdir(din_loc_root):
-        os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
+    #----------------------------------------------------
+    # Construct the namelist generator 
+    #----------------------------------------------------
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
     expect (os.path.isdir(user_xml_dir),
@@ -163,19 +165,16 @@ def buildnml(case, caseroot, compname):
     user_definition = os.path.join(user_xml_dir, "namelist_definition_dlnd.xml")
     if os.path.isfile(user_definition):
         definition_file = [user_definition]
-
-    # Checkout if definition file exists
     for file_ in definition_file:
         expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-    if not os.path.isdir(confdir):
-        os.makedirs(confdir)
+    # Create the namelist generator object - independent of instance
+    nmlgen = NamelistGenerator(case, definition_file)
 
+    #----------------------------------------------------
     # Loop over instances
-    inst_string = ""
-    inst_counter = 1
-    while (inst_counter <= ninst):
+    #----------------------------------------------------
+    for inst_counter in range(1, ninst+1):
 
         # determine instance string
         inst_string = ""
@@ -203,7 +202,7 @@ def buildnml(case, caseroot, compname):
         namelist_infile = [infile]
 
         # create namelist and stream file(s) data component
-        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        _create_namelists(case, confdir, inst_string, namelist_infile, nmlgen)
 
         # copy namelist files and stream text files, to rundir
         if os.path.isdir(rundir):
@@ -216,9 +215,6 @@ def buildnml(case, caseroot, compname):
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
                 shutil.copy(txtfile, rundir)
-
-        # increment instance counter
-        inst_counter = inst_counter + 1
 
 ###############################################################################
 def _main_func():

--- a/components/data_comps/dlnd/cime_config/buildnml
+++ b/components/data_comps/dlnd/cime_config/buildnml
@@ -145,7 +145,6 @@ def buildnml(case, caseroot, compname):
     cimeroot = case.get_value("CIMEROOT")
     rundir = case.get_value("RUNDIR")
     ninst = case.get_value("NINST_LND")
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
     confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
     if not os.path.isdir(confdir):

--- a/components/data_comps/dlnd/cime_config/namelist_definition_dlnd.xml
+++ b/components/data_comps/dlnd/cime_config/namelist_definition_dlnd.xml
@@ -217,7 +217,7 @@
     </values>
   </entry>
 
-  <entry id="domainfile">
+  <entry id="domainfile" skip_default_entry="true">
     <type>char</type>
     <category>streams</category>
     <input_pathname>abs</input_pathname>

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
-def _create_namelists(case, confdir, inst_string, infile, definition_file):
+def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 ####################################################################################
     """Write out the namelist for this component.
 
@@ -74,9 +74,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     config['sstice_stream'] = sstice_stream
 
     #----------------------------------------------------
-    # Construct the namelist generator.
+    # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    nmlgen = NamelistGenerator(case, infile, definition_file, config)
+    skip_groups = []
+    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -122,8 +123,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `docn_nml` namelist group.
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
         nmlgen.add_default(entry.get("id"), node=entry)
 
@@ -146,10 +145,14 @@ def buildnml(case, caseroot, compname):
     ninst = case.get_value("NINST_OCN")
     din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    if not os.path.isdir(din_loc_root):
-        os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+    # Determine configuration directory
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
+    #----------------------------------------------------
+    # Construct the namelist generator 
+    #----------------------------------------------------
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
     expect (os.path.isdir(user_xml_dir),
@@ -161,19 +164,16 @@ def buildnml(case, caseroot, compname):
     user_definition = os.path.join(user_xml_dir, "namelist_definition_docn.xml")
     if os.path.isfile(user_definition):
         definition_file = [user_definition]
-
-    # Checkout if definition file exists
     for file_ in definition_file:
         expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-    if not os.path.isdir(confdir):
-        os.makedirs(confdir)
+    # Create the namelist generator object - independent of instance
+    nmlgen = NamelistGenerator(case, definition_file)
 
+    #----------------------------------------------------
     # Loop over instances
-    inst_string = ""
-    inst_counter = 1
-    while (inst_counter <= ninst):
+    #----------------------------------------------------
+    for inst_counter in range(1, ninst+1):
 
         # determine instance string
         inst_string = ""
@@ -201,7 +201,7 @@ def buildnml(case, caseroot, compname):
         namelist_infile = [infile]
 
         # create namelist and stream file(s) data component
-        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        _create_namelists(case, confdir, inst_string, namelist_infile, nmlgen)
 
         # copy namelist files and stream text files, to rundir
         if os.path.isdir(rundir):
@@ -214,9 +214,6 @@ def buildnml(case, caseroot, compname):
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
                 shutil.copy(txtfile, rundir)
-
-        # increment instance counter
-        inst_counter = inst_counter + 1
 
 ###############################################################################
 def _main_func():

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -76,8 +76,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     #----------------------------------------------------
     # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
+    entries = nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -143,7 +142,6 @@ def buildnml(case, caseroot, compname):
     cimeroot = case.get_value("CIMEROOT")
     rundir = case.get_value("RUNDIR")
     ninst = case.get_value("NINST_OCN")
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
     # Determine configuration directory
     confdir = os.path.join(caseroot,"Buildconf",compname + "conf")

--- a/components/data_comps/docn/cime_config/buildnml
+++ b/components/data_comps/docn/cime_config/buildnml
@@ -74,9 +74,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     config['sstice_stream'] = sstice_stream
 
     #----------------------------------------------------
-    # Obtain entry nodes and initialize the defaults
+    # Initialize namelist defaults 
     #----------------------------------------------------
-    entries = nmlgen.init_defaults(infile, config)
+    nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -117,13 +117,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     if ocn_domain_file != "UNSET":
         full_domain_path = os.path.join(ocn_domain_path, ocn_domain_file)
         nmlgen.add_default("domainfile", value=full_domain_path)
-    nmlgen.add_default("vectors")
-
-    #----------------------------------------------------
-    # Create `docn_nml` namelist group.
-    #----------------------------------------------------
-    for entry in entries:
-        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -318,7 +318,7 @@
     </values>
   </entry>
 
-  <entry id="domainfile">
+  <entry id="domainfile" skip_default_entry="true">
     <type>char</type>
     <category>streams</category>
     <input_pathname>abs</input_pathname>
@@ -525,7 +525,7 @@
     </values>
   </entry>
 
-  <entry id="vectors" skip_default_entry="true">
+  <entry id="vectors">
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -74,8 +74,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     #----------------------------------------------------
     # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
+    entries = nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -141,7 +140,6 @@ def buildnml(case, caseroot, compname):
     cimeroot = case.get_value("CIMEROOT")
     rundir = case.get_value("RUNDIR")
     ninst = case.get_value("NINST_ROF")
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
     # Determine configuration directory
     confdir = os.path.join(caseroot,"Buildconf",compname + "conf")

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
-def _create_namelists(case, confdir, inst_string, infile, definition_file):
+def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 ####################################################################################
     """Write out the namelist for this component.
 
@@ -72,9 +72,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     config['drof_mode'] = drof_mode
 
     #----------------------------------------------------
-    # Construct the namelist generator.
+    # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    nmlgen = NamelistGenerator(case, infile, definition_file, config)
+    skip_groups = []
+    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -120,8 +121,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `drof_nml` namelist group.
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
         nmlgen.add_default(entry.get("id"), node=entry)
 
@@ -144,10 +143,14 @@ def buildnml(case, caseroot, compname):
     ninst = case.get_value("NINST_ROF")
     din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    if not os.path.isdir(din_loc_root):
-        os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+    # Determine configuration directory
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
+    #----------------------------------------------------
+    # Construct the namelist generator 
+    #----------------------------------------------------
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
     expect (os.path.isdir(user_xml_dir),
@@ -159,19 +162,16 @@ def buildnml(case, caseroot, compname):
     user_definition = os.path.join(user_xml_dir, "namelist_definition_drof.xml")
     if os.path.isfile(user_definition):
         definition_file = [user_definition]
-
-    # Checkout if definition file exists
     for file_ in definition_file:
         expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-    if not os.path.isdir(confdir):
-        os.makedirs(confdir)
-
+    # Create the namelist generator object - independent of instance
+    nmlgen = NamelistGenerator(case, definition_file)
+    
+    #----------------------------------------------------
     # Loop over instances
-    inst_string = ""
-    inst_counter = 1
-    while (inst_counter <= ninst):
+    #----------------------------------------------------
+    for inst_counter in range(1, ninst+1):
 
         # determine instance string
         inst_string = ""
@@ -199,7 +199,7 @@ def buildnml(case, caseroot, compname):
         namelist_infile = [infile]
 
         # create namelist and stream file(s) data component
-        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        _create_namelists(case, confdir, inst_string, namelist_infile, nmlgen)
 
         # copy namelist files and stream text files, to rundir
         if os.path.isdir(rundir):
@@ -212,9 +212,6 @@ def buildnml(case, caseroot, compname):
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
                 shutil.copy(txtfile, rundir)
-
-        # increment instance counter
-        inst_counter = inst_counter + 1
 
 ###############################################################################
 def _main_func():

--- a/components/data_comps/drof/cime_config/buildnml
+++ b/components/data_comps/drof/cime_config/buildnml
@@ -72,9 +72,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     config['drof_mode'] = drof_mode
 
     #----------------------------------------------------
-    # Obtain entry nodes and initialize the defaults
+    # Initialize namelist defaults 
     #----------------------------------------------------
-    entries = nmlgen.init_defaults(infile, config)
+    nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -115,13 +115,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     if rof_domain_file != "UNSET":
         full_domain_path = os.path.join(rof_domain_path, rof_domain_file)
         nmlgen.add_default("domainfile", value=full_domain_path)
-    nmlgen.add_default("vectors")
-
-    #----------------------------------------------------
-    # Create `drof_nml` namelist group.
-    #----------------------------------------------------
-    for entry in entries:
-        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -449,7 +449,7 @@
     </values>
   </entry>
 
-  <entry id="vectors" skip_default_entry="true">
+  <entry id="vectors">
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
-def _create_namelists(case, confdir, inst_string, infile, definition_file):
+def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 ####################################################################################
     """Write out the namelist for this component.
 
@@ -75,9 +75,10 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     config['dwav_mode'] = dwav_mode
 
     #----------------------------------------------------
-    # Construct the namelist generator.
+    # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    nmlgen = NamelistGenerator(case, infile, definition_file, config)
+    skip_groups = []
+    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -124,8 +125,6 @@ def _create_namelists(case, confdir, inst_string, infile, definition_file):
     #----------------------------------------------------
     # Create `dwav_nml` namelist group.
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
     for entry in entries:
         nmlgen.add_default(entry.get("id"), node=entry)
 
@@ -149,34 +148,35 @@ def buildnml(case, caseroot, compname):
     ninst = case.get_value("NINST_WAV")
     din_loc_root = case.get_value("DIN_LOC_ROOT")
 
-    if not os.path.isdir(din_loc_root):
-        os.makedirs(din_loc_root)
-        logger.debug("Created input root directory %s" %din_loc_root)
+    # Determine configuration directory
+    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
+    if not os.path.isdir(confdir):
+        os.makedirs(confdir)
 
+    #----------------------------------------------------
+    # Construct the namelist generator 
+    #----------------------------------------------------
     # determine directory for user modified namelist_definitions.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
     expect (os.path.isdir(user_xml_dir),
             "user_xml_dir %s does not exist " %user_xml_dir)
 
-        # NOTE: User definition *replaces* existing definition.
+    # NOTE: User definition *replaces* existing definition.
     namelist_xml_dir = os.path.join(cimeroot, "components", "data_comps", compname, "cime_config")
     definition_file = [os.path.join(namelist_xml_dir, "namelist_definition_dwav.xml")]
     user_definition = os.path.join(user_xml_dir, "namelist_definition_dwav.xml")
     if os.path.isfile(user_definition):
         definition_file = [user_definition]
-
-    # Checkout if definition file exists
     for file_ in definition_file:
         expect(os.path.isfile(file_), "Namelist XML file %s not found!" % file_)
 
-    confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
-    if not os.path.isdir(confdir):
-        os.makedirs(confdir)
-
+    # Create the namelist generator object - independent of instance
+    nmlgen = NamelistGenerator(case, definition_file)
+    
+    #----------------------------------------------------
     # Loop over instances
-    inst_string = ""
-    inst_counter = 1
-    while (inst_counter <= ninst):
+    #----------------------------------------------------
+    for inst_counter in range(1, ninst+1):
 
         # determine instance string
         inst_string = ""
@@ -204,7 +204,7 @@ def buildnml(case, caseroot, compname):
         namelist_infile = [infile]
 
         # create namelist and stream file(s) data component
-        _create_namelists(case, confdir, inst_string, namelist_infile, definition_file)
+        _create_namelists(case, confdir, inst_string, namelist_infile, nmlgen)
 
         # copy namelist files and stream text files, to rundir
         if os.path.isdir(rundir):
@@ -217,9 +217,6 @@ def buildnml(case, caseroot, compname):
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
                 shutil.copy(txtfile, rundir)
-
-        # increment instance counter
-        inst_counter = inst_counter + 1
 
 ###############################################################################
 def _main_func():

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -75,9 +75,9 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     config['dwav_mode'] = dwav_mode
 
     #----------------------------------------------------
-    # Obtain entry nodes and initialize the defaults
+    # Initialize namelist defaults 
     #----------------------------------------------------
-    entries = nmlgen.init_defaults(infile, config)
+    nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -114,18 +114,12 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     #----------------------------------------------------
     nmlgen.create_shr_strdata_nml()
     nmlgen.add_default("decomp", "1d")
-    nmlgen.add_default("force_prognostic_true", ".false.")
-    nmlgen.add_default("restfilm", "undefined")
-    nmlgen.add_default("restfils", "undefined")
+    nmlgen.add_default("force_prognostic_true", value=".false.")
+    nmlgen.add_default("restfilm", value="undefined")
+    nmlgen.add_default("restfils", value="undefined")
     if wav_domain_file != "UNSET":
         full_domain_path = os.path.join(wav_domain_path, wav_domain_file)
         nmlgen.add_default("domainfile", value=full_domain_path)
-
-    #----------------------------------------------------
-    # Create `dwav_nml` namelist group.
-    #----------------------------------------------------
-    for entry in entries:
-        nmlgen.add_default(entry.get("id"), node=entry)
 
     #----------------------------------------------------
     # Finally, write out all the namelists.

--- a/components/data_comps/dwav/cime_config/buildnml
+++ b/components/data_comps/dwav/cime_config/buildnml
@@ -77,8 +77,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     #----------------------------------------------------
     # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
+    entries = nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Construct the list of streams.
@@ -146,7 +145,6 @@ def buildnml(case, caseroot, compname):
     cimeroot = case.get_value("CIMEROOT")
     rundir = case.get_value("RUNDIR")
     ninst = case.get_value("NINST_WAV")
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
 
     # Determine configuration directory
     confdir = os.path.join(caseroot,"Buildconf",compname + "conf")

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -55,15 +55,9 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
         config['run_type'] = 'branch'
 
     #----------------------------------------------------
-    # Obtain entry nodes and initialize the defaults
+    # Initialize namelist defaults 
     #----------------------------------------------------
-    entries = nmlgen.init_defaults(infile, config)
-
-    #----------------------------------------------------
-    # Add default entries
-    #----------------------------------------------------
-    for entry in entries:
-        nmlgen.add_default(entry.get("id"), node=entry)
+    nmlgen.init_defaults(infile, config)
 
     #--------------------------------
     # Overwrite: set brnch_retain_casename
@@ -71,7 +65,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
     start_type = nmlgen.get_value('start_type')
     if start_type != 'startup':
         if case.get_value('CASE') == case.get_value('RUN_REFCASE'):
-            nmlgen.set_value('brnch_retain_casename' , value='.true.')
+            nmlgen.add_default('brnch_retain_casename' , value='.true.')
 
     #--------------------------------
     # Overwrite: set component coupling frequencies
@@ -110,7 +104,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
     # Overwrite: set start_ymd
     #--------------------------------
     run_startdate = "".join(str(x) for x in case.get_value('RUN_STARTDATE').split('-'))
-    nmlgen.set_value('start_ymd', value=run_startdate)
+    nmlgen.add_default('start_ymd', value=run_startdate)
 
     #--------------------------------
     # Overwrite: set tprof_option and tprof_n - if tprof_total is > 0
@@ -139,8 +133,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
         tprofn = int(stopn / tprof_total)
         if tprofn < 1:
             tprofn = 1
-        nmlgen.set_value('tprof_option', value=tprofoption)
-        nmlgen.set_value('tprof_n'     , value=tprofn)
+        nmlgen.add_default('tprof_option', value=tprofoption)
+        nmlgen.add_default('tprof_n'     , value=tprofn)
 
     #--------------------------------
     # (1) Write output namelist file drv_in and  input dataset list.
@@ -181,7 +175,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
         definition_file = [os.path.join(cimeroot, "driver_cpl", "bld",
                                         "namelist_files", "namelist_definition_drv_flds.xml")]
         nmlgen = NamelistGenerator(case, definition_file)
-        entries = nmlgen.init_defaults(infiles, config)
+        entries = nmlgen.init_defaults(infiles, config, skip_adding_entries=True)
         drv_flds_in = os.path.join(caseroot, "CaseDocs", "drv_flds_in")
         nmlgen.write_output_file(drv_flds_in)
 
@@ -201,7 +195,7 @@ def _create_component_modelio_namelists(case):
         with NamelistGenerator(case, definition_file) as nmlgen:
             config = {}
             config['component'] = model
-            entries = nmlgen.init_defaults(infiles, config)
+            entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
 
             if model == 'cpl':
                 inst_count = 1
@@ -220,20 +214,20 @@ def _create_component_modelio_namelists(case):
 
                 # set default values
                 for entry in entries:
-                    nmlgen.add_default(entry.get("id"), node=entry)
+                    nmlgen.add_default(entry.get("id"))
 
                 # overwrite defaults
                 moddiri = case.get_value('EXEROOT') + "/" + model
-                nmlgen.set_value('diri',    value=moddiri)
+                nmlgen.set_value('diri', moddiri)
 
                 moddiro = case.get_value('RUNDIR')
-                nmlgen.set_value('diro',    value=moddiro)
+                nmlgen.set_value('diro', moddiro)
 
                 if inst_count > 1:
                     logfile = model + "_" + inst_string + ".log." + str(lid)
                 else:
                     logfile = model + ".log." + str(lid)
-                nmlgen.set_value('logfile', value=logfile)
+                nmlgen.set_value('logfile', logfile)
 
                 # Write output file
                 if inst_count > 1:

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -57,8 +57,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
     #----------------------------------------------------
     # Obtain entry nodes and initialize the defaults
     #----------------------------------------------------
-    skip_groups = []
-    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
+    entries = nmlgen.init_defaults(infile, config)
 
     #----------------------------------------------------
     # Add default entries
@@ -181,7 +180,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
         config = {}
         definition_file = [os.path.join(cimeroot, "driver_cpl", "bld",
                                         "namelist_files", "namelist_definition_drv_flds.xml")]
-        nmlgen = NamelistGenerator(case, infiles, definition_file, config)
+        nmlgen = NamelistGenerator(case, definition_file)
+        entries = nmlgen.init_defaults(infiles, config)
         drv_flds_in = os.path.join(caseroot, "CaseDocs", "drv_flds_in")
         nmlgen.write_output_file(drv_flds_in)
 
@@ -201,8 +201,7 @@ def _create_component_modelio_namelists(case):
         with NamelistGenerator(case, definition_file) as nmlgen:
             config = {}
             config['component'] = model
-            skip_groups = []
-            entries = nmlgen.init_defaults(infiles, config, skip_groups=skip_groups)
+            entries = nmlgen.init_defaults(infiles, config)
 
             if model == 'cpl':
                 inst_count = 1

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -22,7 +22,7 @@ from CIME.buildnml import create_namelist_infile, parse_input
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def _create_drv_namelists(case, infiles, definition_file, confdir):
+def _create_drv_namelists(case, infile, confdir, nmlgen):
 ###############################################################################
 
     #--------------------------------
@@ -54,16 +54,15 @@ def _create_drv_namelists(case, infiles, definition_file, confdir):
     elif case.get_value('RUN_TYPE') == 'branch':
         config['run_type'] = 'branch'
 
-    #--------------------------------
-    # Create nmlgen object - using config dictionary
-    #--------------------------------
-    nmlgen = NamelistGenerator(case, infiles, definition_file, config)
-
-    #--------------------------------
-    # Add default values for all entries in namelist_definition_drv.xml
-    #--------------------------------
+    #----------------------------------------------------
+    # Obtain entry nodes and initialize the defaults
+    #----------------------------------------------------
     skip_groups = []
-    entries = nmlgen.get_definition_nodes(skip_groups=skip_groups)
+    entries = nmlgen.init_defaults(infile, config, skip_groups=skip_groups)
+
+    #----------------------------------------------------
+    # Add default entries
+    #----------------------------------------------------
     for entry in entries:
         nmlgen.add_default(entry.get("id"), node=entry)
 
@@ -145,20 +144,23 @@ def _create_drv_namelists(case, infiles, definition_file, confdir):
         nmlgen.set_value('tprof_n'     , value=tprofn)
 
     #--------------------------------
-    # Write output files
-    #--------------------------------
     # (1) Write output namelist file drv_in and  input dataset list.
+    #--------------------------------
     data_list_path = os.path.join(case.get_case_root(), "Buildconf", "cpl.input_data_list")
     if os.path.exists(data_list_path):
         os.remove(data_list_path)
     namelist_file = os.path.join(confdir, "drv_in")
     nmlgen.write_output_file(namelist_file, data_list_path )
 
+    #--------------------------------
     # (2) Write out seq_map.rc file
+    #--------------------------------
     seq_maps_file = os.path.join(confdir, "seq_maps.rc")
     nmlgen.write_seq_maps(seq_maps_file)
 
+    #--------------------------------
     # (3) Construct and write out drv_flds_in
+    #--------------------------------
     # In thte following, all values come simply from the infiles - no default values need to be added
     # FIXME - do want to add the possibility that will use a user definition file for drv_flds_in
 
@@ -196,9 +198,12 @@ def _create_component_modelio_namelists(case):
 
     models = ["cpl", "atm", "lnd", "ice", "ocn", "glc", "rof", "wav", "esp"]
     for model in models:
-        config = {}
-        config['component'] = model
-        with NamelistGenerator(case, infiles, definition_file, config) as nmlgen:
+        with NamelistGenerator(case, definition_file) as nmlgen:
+            config = {}
+            config['component'] = model
+            skip_groups = []
+            entries = nmlgen.init_defaults(infiles, config, skip_groups=skip_groups)
+
             if model == 'cpl':
                 inst_count = 1
             else:
@@ -215,9 +220,8 @@ def _create_component_modelio_namelists(case):
                     inst_string = "0" + str(inst_string)
 
                 # set default values
-                entries = nmlgen.get_definition_entries()
                 for entry in entries:
-                    nmlgen.add_default(entry)
+                    nmlgen.add_default(entry.get("id"), node=entry)
 
                 # overwrite defaults
                 moddiri = case.get_value('EXEROOT') + "/" + model
@@ -263,6 +267,9 @@ def buildnml(case, caseroot, component):
     if os.path.isfile(user_definition):
         definition_file = [user_definition]
 
+    # Create the namelist generator object - independent of instance
+    nmlgen = NamelistGenerator(case, definition_file)
+
     # create cplconf/namelist
     infile_text = ""
     if case.get_value('COMP_ATM') == 'cam':
@@ -280,7 +287,7 @@ def buildnml(case, caseroot, component):
     infile = [namelist_infile]
 
     # create the files drv_in, drv_flds_in and seq_maps.rc
-    _create_drv_namelists(case, infile, definition_file, confdir)
+    _create_drv_namelists(case, infile, confdir, nmlgen)
 
     # create the files comp_modelio.nml where comp = [atm, lnd...]
     _create_component_modelio_namelists(case)

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -104,7 +104,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
     # Overwrite: set start_ymd
     #--------------------------------
     run_startdate = "".join(str(x) for x in case.get_value('RUN_STARTDATE').split('-'))
-    nmlgen.add_default('start_ymd', value=run_startdate)
+    nmlgen.set_value('start_ymd', value=run_startdate)
 
     #--------------------------------
     # Overwrite: set tprof_option and tprof_n - if tprof_total is > 0

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -65,7 +65,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
     start_type = nmlgen.get_value('start_type')
     if start_type != 'startup':
         if case.get_value('CASE') == case.get_value('RUN_REFCASE'):
-            nmlgen.add_default('brnch_retain_casename' , value='.true.')
+            nmlgen.set_value('brnch_retain_casename' , value='.true.')
 
     #--------------------------------
     # Overwrite: set component coupling frequencies
@@ -133,8 +133,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
         tprofn = int(stopn / tprof_total)
         if tprofn < 1:
             tprofn = 1
-        nmlgen.add_default('tprof_option', value=tprofoption)
-        nmlgen.add_default('tprof_n'     , value=tprofn)
+        nmlgen.set_value('tprof_option', value=tprofoption)
+        nmlgen.set_value('tprof_n'     , value=tprofn)
 
     #--------------------------------
     # (1) Write output namelist file drv_in and  input dataset list.

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -175,7 +175,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
         definition_file = [os.path.join(cimeroot, "driver_cpl", "bld",
                                         "namelist_files", "namelist_definition_drv_flds.xml")]
         nmlgen = NamelistGenerator(case, definition_file)
-        entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
+        skip_entry_loop = True
+        entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=skip_entry_loop)
         drv_flds_in = os.path.join(caseroot, "CaseDocs", "drv_flds_in")
         nmlgen.write_output_file(drv_flds_in)
 

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -175,7 +175,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
         definition_file = [os.path.join(cimeroot, "driver_cpl", "bld",
                                         "namelist_files", "namelist_definition_drv_flds.xml")]
         nmlgen = NamelistGenerator(case, definition_file)
-        entries = nmlgen.init_defaults(infiles, config, skip_adding_entries=True)
+        entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
         drv_flds_in = os.path.join(caseroot, "CaseDocs", "drv_flds_in")
         nmlgen.write_output_file(drv_flds_in)
 

--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -55,7 +55,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
         config['run_type'] = 'branch'
 
     #----------------------------------------------------
-    # Initialize namelist defaults 
+    # Initialize namelist defaults
     #----------------------------------------------------
     nmlgen.init_defaults(infile, config)
 
@@ -176,7 +176,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen):
                                         "namelist_files", "namelist_definition_drv_flds.xml")]
         nmlgen = NamelistGenerator(case, definition_file)
         skip_entry_loop = True
-        entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=skip_entry_loop)
+        nmlgen.init_defaults(infiles, config, skip_entry_loop=skip_entry_loop)
         drv_flds_in = os.path.join(caseroot, "CaseDocs", "drv_flds_in")
         nmlgen.write_output_file(drv_flds_in)
 

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2786,6 +2786,22 @@
       introduced to coordinate this value among multiple components.</desc>
   </entry>
 
+  <entry id="CO2_TYPE_COSTANT_VALUE">
+    <type>real</type>
+    <valid_values></valid_values>
+    <default_value>284.7</default_value>
+    <values>
+      <value compset="^2000">367.0</value>
+      <value compset="^4804">367.0</value>
+    </values>
+    <group>run_co2</group>
+    <file>env_run.xml</file>
+    <desc>
+      Mechanism for setting the CO2 value in ppmv for CLM if
+      CLM_CO2_TYPE is constant POP if OCN_CO2_TYPE is constant.
+    </desc>
+  </entry>
+
   <entry id="FLDS_WISO">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -141,7 +141,7 @@ class NamelistDefinition(EntryID):
         raise TypeError, \
             "NamelistDefinition does not support `set_value`."
 
-    def get_value_match(self, item, attributes=None, exact_match=True):
+    def get_value_match(self, item, attributes=None, exact_match=True, entry_node=None):
         """Return the default value for the variable named `item`.
 
         The return value is a list of strings corresponding to the
@@ -155,7 +155,8 @@ class NamelistDefinition(EntryID):
         if attributes is not None:
             all_attributes.update(attributes)
 
-        entry_node = self._nodes[item]
+        if entry_node is None:
+            entry_node = self._nodes[item]
         value = super(NamelistDefinition, self).get_value_match(item.lower(),attributes=all_attributes, exact_match=exact_match,
                                                                 entry_node=entry_node)
         if value is None:
@@ -394,9 +395,6 @@ class NamelistDefinition(EntryID):
             input_pathname = self._get_node_element_info(node, "input_pathname")
         return(input_pathname)
 
-    def get_group(self, name):
-        return self._group_names[name]
-
     def get_default_value(self, item, attribute=None):
         """Return the default value for the variable named `item`.
 
@@ -411,5 +409,5 @@ class NamelistDefinition(EntryID):
         if attribute is not None:
             all_attributes.update(attribute)
 
-        value = self.get_value_match(item.lower(), all_attributes, True)
+        value = self.get_value_match(item.lower(), all_attributes, True, )
         return self._split_defaults_text(value)

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -46,13 +46,15 @@ class NamelistDefinition(EntryID):
         self._valid_values = {}
         self._entry_types = {}
         self._group_names = {}
+        self._nodes = {}
         for node in self.get_nodes("entry"):
             name = node.get("id")
             self._entry_nodes.append(node)
             self._entry_ids.append(name)
-            self._entry_types[name] = self.get_type_info(node)
-            self._valid_values[name] = self.get_valid_values(node)
-            self._group_names[name] = self.get_group_name(node) 
+            self._nodes[name] = node
+            self._entry_types[name] = self._get_type(node)
+            self._valid_values[name] = self._get_valid_values(node)
+            self._group_names[name] = self._get_group_name(node) 
 
         # if the file is invalid we may not be able to check the version
         # but we need to do it this way until we remove the version 1 files
@@ -61,21 +63,21 @@ class NamelistDefinition(EntryID):
             schema = os.path.join(cimeroot,"cime_config","xml_schemas","entry_id_namelist.xsd")
             self.validate_xml_file(infile, schema)
 
-    def get_group_name(self, node=None):
+    def _get_group_name(self, node=None):
         if self.get_version() == "1.0":
             group = node.get('group')
         elif self.get_version() == "2.0":
             group = self.get_element_text("group", root=node)
         return(group)
 
-    def get_type_info(self, node):
+    def _get_type(self, node):
         if self.get_version() == "1.0":
             type_info = node.get('type')
         elif self.get_version() == "2.0":
             type_info = self._get_type_info(node)
         return(type_info)
 
-    def get_valid_values(self, node):
+    def _get_valid_values(self, node):
         # The "valid_values" attribute is not required, and an empty string has
         # the same effect as not specifying it.
         # Returns a list from a comma seperated string in xml
@@ -89,6 +91,9 @@ class NamelistDefinition(EntryID):
         if valid_values is not None:
             valid_values = valid_values.split(',')
         return valid_values
+
+    def get_group(self, name):
+        return self._group_names[name]
 
     def add_attributes(self, attributes):
         self._attributes = attributes        
@@ -112,7 +117,7 @@ class NamelistDefinition(EntryID):
         raise TypeError, \
             "NamelistDefinition does not support `set_value`."
 
-    def get_value_match(self, item, attributes=None, exact_match=True, entry_node=None):
+    def get_value_match(self, item, attributes=None, exact_match=True):
         """Return the default value for the variable named `item`.
 
         The return value is a list of strings corresponding to the
@@ -126,9 +131,9 @@ class NamelistDefinition(EntryID):
         if attributes is not None:
             all_attributes.update(attributes)
 
+        entry_node = self._nodes[item]
         value = super(NamelistDefinition, self).get_value_match(item.lower(),attributes=all_attributes, exact_match=exact_match,
                                                                 entry_node=entry_node)
-
         if value is None:
             value = ''
         else:
@@ -357,10 +362,8 @@ class NamelistDefinition(EntryID):
             groups[group_name][variable_lc] = dict_[variable_name]
         return Namelist(groups)
 
-    def get_input_pathname(self, name, node=None):
-        if node is None:
-            node = self.get_optional_node("entry", attributes={'id': name})
-            
+    def get_input_pathname(self, name):
+        node = self._nodes[name]
         if self.get_version() == "1.0":
             input_pathname = node.get('input_pathname')
         elif self.get_version() == "2.0":

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -112,24 +112,6 @@ class NamelistDefinition(EntryID):
         raise TypeError, \
             "NamelistDefinition does not support `set_value`."
 
-    #pylint:disable=arguments-differ
-    def get_valid_values(self, name, node=None):
-        # The "valid_values" attribute is not required, and an empty string has
-        # the same effect as not specifying it.
-        # Returns a list from a comma seperated string in xml
-        valid_values = ''
-        if node is None:
-            node = self.get_optional_node("entry", attributes={'id': name})
-        if self.get_version() == "1.0":
-            valid_values = node.get('valid_values')
-        elif self.get_version() == "2.0":
-            valid_values = self._get_node_element_info(node, "valid_values")
-        if valid_values == '':
-            valid_values = None
-        if valid_values is not None:
-            valid_values = valid_values.split(',')
-        return valid_values
-
     def get_value_match(self, item, attributes=None, exact_match=True, entry_node=None):
         """Return the default value for the variable named `item`.
 
@@ -375,11 +357,10 @@ class NamelistDefinition(EntryID):
             groups[group_name][variable_lc] = dict_[variable_name]
         return Namelist(groups)
 
-    #pylint:disable=arguments-differ
     def get_input_pathname(self, name, node=None):
         if node is None:
             node = self.get_optional_node("entry", attributes={'id': name})
-
+            
         if self.get_version() == "1.0":
             input_pathname = node.get('input_pathname')
         elif self.get_version() == "2.0":

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -52,7 +52,7 @@ class NamelistDefinition(EntryID):
             self._entry_ids.append(name)
             self._entry_types[name] = self.get_type_info(node)
             self._valid_values[name] = self.get_valid_values(node)
-            self._group_names[name] = self.get_element_text("group", root=node)
+            self._group_names[name] = self.get_group_name(node) 
 
         # if the file is invalid we may not be able to check the version
         # but we need to do it this way until we remove the version 1 files
@@ -60,6 +60,13 @@ class NamelistDefinition(EntryID):
             cimeroot = get_cime_root()
             schema = os.path.join(cimeroot,"cime_config","xml_schemas","entry_id_namelist.xsd")
             self.validate_xml_file(infile, schema)
+
+    def get_group_name(self, node=None):
+        if self.get_version() == "1.0":
+            group = node.get('group')
+        elif self.get_version() == "2.0":
+            group = self.get_element_text("group", root=node)
+        return(group)
 
     def get_type_info(self, node):
         if self.get_version() == "1.0":

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -409,5 +409,5 @@ class NamelistDefinition(EntryID):
         if attribute is not None:
             all_attributes.update(attribute)
 
-        value = self.get_value_match(item.lower(), all_attributes, True, )
+        value = self.get_value_match(item.lower(), all_attributes, True)
         return self._split_defaults_text(value)

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -40,6 +40,7 @@ class NamelistDefinition(EntryID):
         """Construct a `NamelistDefinition` from an XML file."""
         super(NamelistDefinition, self).__init__(infile)
 
+        self._attributes = {}
         self._entry_nodes = []
         self._entry_ids = []
         self._valid_values = {}
@@ -49,8 +50,8 @@ class NamelistDefinition(EntryID):
             name = node.get("id")
             self._entry_nodes.append(node)
             self._entry_ids.append(name)
-            self._entry_types[name] = self.get_type_info(name, node)
-            self._valid_values[name] = self.get_valid_values(name, node)
+            self._entry_types[name] = self.get_type_info(node)
+            self._valid_values[name] = self.get_valid_values(node)
             self._group_names[name] = self.get_element_text("group", root=node)
 
         # if the file is invalid we may not be able to check the version
@@ -60,14 +61,14 @@ class NamelistDefinition(EntryID):
             schema = os.path.join(cimeroot,"cime_config","xml_schemas","entry_id_namelist.xsd")
             self.validate_xml_file(infile, schema)
 
-    def get_type_info(self, name, node):
+    def get_type_info(self, node):
         if self.get_version() == "1.0":
             type_info = node.get('type')
         elif self.get_version() == "2.0":
             type_info = self._get_type_info(node)
         return(type_info)
 
-    def get_valid_values(self, name, node):
+    def get_valid_values(self, node):
         # The "valid_values" attribute is not required, and an empty string has
         # the same effect as not specifying it.
         # Returns a list from a comma seperated string in xml
@@ -236,7 +237,7 @@ class NamelistDefinition(EntryID):
             canonical_value = [int(scalar) for scalar in canonical_value]
         return canonical_value
 
-    def is_valid_value(self, name, value, node=None):
+    def is_valid_value(self, name, value):
         """Determine whether a value is valid for the named variable.
 
         The `value` argument must be a list of strings formatted as they would

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -76,15 +76,6 @@ class NamelistGenerator(object):
         # Create definition object - this will validate the xml schema in the definition file
         self._definition = NamelistDefinition(definition_files[0])
 
-        # Array of all entry nodes
-        self._entry_nodes = []
-
-        # Array of all entry id names
-        self._entry_ids = []
-
-        # Determine values for the above arrays and dictionaries
-        self._init_data()
-
         # Determine array of _stream_variables from definition object
         # This is only applicable to data models
         self._streams_namelists = {"streams": []}
@@ -102,15 +93,12 @@ class NamelistGenerator(object):
     def __exit__(self, *_):
         return False
 
-    def _init_data(self):
-        self._entry_nodes, self._entry_ids = self._definition.get_entry_nodes()
-
     def init_defaults(self, infiles, config, skip_groups=None ):
         """Return array of names of all definition nodes"""
 
         # Determine the array of entry nodes that will be acted upon 
         entry_nodes = []
-        for node in self._entry_nodes:
+        for node in self._definition.get_entry_nodes():
             skip_default_entry = node.get("skip_default_entry")
             per_stream_entry = node.get("per_stream_entry")
             name = node.get("id")
@@ -639,7 +627,7 @@ class NamelistGenerator(object):
         `data_list_path` argument is the location of the `*.input_data_list`
         file, which will have the input data files added to it.
         """
-        self._definition.validate(self._namelist, entry_ids=self._entry_ids)
+        self._definition.validate(self._namelist)
         if groups is None:
             groups = self._namelist.get_group_names()
 

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -76,6 +76,18 @@ class NamelistGenerator(object):
         # Create definition object.
         self._definition = NamelistDefinition(definition_files[0], attributes=config)
 
+        # Array of entry id names
+        self._entry_ids = []
+
+        # Dictionary associating a group name with each entry id
+        self._entry_group_names = {}
+
+        # Dictionary associating valid_values with each entry id 
+        self._entry_valid_values = {}
+
+        # Dictionary associating a type with each entry id 
+        self._entry_types = {}
+
         # Determine array of _stream_variables from definition object
         # This is only applicable to data models
         self._streams_namelists = {"streams": []}
@@ -106,12 +118,19 @@ class NamelistGenerator(object):
     def __exit__(self, *_):
         return False
 
-    def get_definition_nodes(self, skip_groups=None):
-        return self._definition.get_entry_nodes(skip_groups=skip_groups)
+    def get_definition_nodes(self, skip_groups=[]):
+        entry_nodes, ids, group_names, valid_values, entry_types = self._definition.get_entry_nodes(skip_groups=skip_groups)
+        self._entry_ids = ids
+        self._entry_group_names = group_names
+        self._entry_valid_values = valid_values
+        self._entry_types = entry_types
+        return entry_nodes
 
     def get_definition_entries(self, skip_groups=None):
         """Return array of names of all definition entries"""
-        return self._definition.get_entries(skip_groups=skip_groups)
+        entry_ids = self._definition.get_entries(skip_groups=skip_groups)
+        self._entry_ids = entry_ids
+        return entry_ids
 
     @staticmethod
     def quote_string(string):
@@ -612,7 +631,10 @@ class NamelistGenerator(object):
         `data_list_path` argument is the location of the `*.input_data_list`
         file, which will have the input data files added to it.
         """
-        self._definition.validate(self._namelist)
+        self._definition.validate(self._namelist, entry_ids=self._entry_ids, 
+                                  entry_group_names=self._entry_group_names, 
+                                  entry_valid_values=self._entry_valid_values, 
+                                  entry_types=self._entry_types)
         if groups is None:
             groups = self._namelist.get_group_names()
 

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -94,22 +94,12 @@ class NamelistGenerator(object):
         return False
 
     def init_defaults(self, infiles, config, skip_groups=None, skip_entry_loop=None ):
-        """Return array of names of all definition nodes"""
+        """Return array of names of all definition nodes
+        """
+        self._definition.set_nodes(skip_groups=skip_groups)
 
         # Determine the array of entry nodes that will be acted upon 
-        entry_nodes = []
-        for node in self._definition.get_entry_nodes():
-            skip_default_entry = node.get("skip_default_entry")
-            per_stream_entry = node.get("per_stream_entry")
-            name = node.get("id")
-            if skip_groups:
-                group_name = self._definition.get_group(name)
-                if not group_name in skip_groups:
-                    if not skip_default_entry and not per_stream_entry:
-                        entry_nodes.append(node)
-            else:
-                if not skip_default_entry and not per_stream_entry:
-                    entry_nodes.append(node)
+        entry_nodes = self._definition.set_nodes(skip_groups=skip_groups)
 
         # Add attributes to definition object 
         self._definition.add_attributes(config)
@@ -600,7 +590,11 @@ class NamelistGenerator(object):
                             continue
                         if input_pathname == 'abs':
                             # No further mangling needed for absolute paths.
-                            pass
+                            # At this point, there are overwrites that should be ignored
+                            if not os.path.isabs(file_path):
+                                continue
+                            else:
+                                pass
                         elif input_pathname.startswith('rel:'):
                             # The part past "rel" is the name of a variable that
                             # this variable specifies its path relative to.

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -510,7 +510,7 @@ class NamelistGenerator(object):
             fullpath = os.path.join(self._din_loc_root, file_path)
             return fullpath
 
-    def add_default(self, name, value=None):
+    def add_default(self, name, value=None, ignore_abs_path=None):
         """Add a value for the specified variable to the namelist.
 
         If the specified variable is already defined in the object, the existing
@@ -552,23 +552,24 @@ class NamelistGenerator(object):
 
         # Go through file names and prepend input data root directory for
         # absolute pathnames.
-        var_input_pathname = self._definition.get_input_pathname(name)
-        if var_input_pathname == 'abs':
-            current_literals = expand_literal_list(current_literals)
-            for i, literal in enumerate(current_literals):
-                if literal == '':
-                    continue
-                file_path = character_literal_to_string(literal)
-                # NOTE - these are hard-coded here and a better way is to make these extensible
-                if file_path == 'UNSET' or file_path == 'idmap':
-                    continue
-                if file_path == 'null':
-                    continue
-                file_path = self.set_abs_file_path(file_path)
-                if not os.path.exists(file_path):
-                    logger.warn ("File not found: %s = %s, will attempt to download in check_input_data phase" % (name, literal))
-                current_literals[i] = string_to_character_literal(file_path)
-            current_literals = compress_literal_list(current_literals)
+        if ignore_abs_path is None:
+            var_input_pathname = self._definition.get_input_pathname(name)
+            if var_input_pathname == 'abs':
+                current_literals = expand_literal_list(current_literals)
+                for i, literal in enumerate(current_literals):
+                    if literal == '':
+                        continue
+                    file_path = character_literal_to_string(literal)
+                    # NOTE - these are hard-coded here and a better way is to make these extensible
+                    if file_path == 'UNSET' or file_path == 'idmap':
+                        continue
+                    if file_path == 'null':
+                        continue
+                    file_path = self.set_abs_file_path(file_path)
+                    if not os.path.exists(file_path):
+                        logger.warn ("File not found: %s = %s, will attempt to download in check_input_data phase" % (name, literal))
+                    current_literals[i] = string_to_character_literal(file_path)
+                current_literals = compress_literal_list(current_literals)
 
         # Set the new value.
         self._namelist.set_variable_value(group, name, current_literals)

--- a/utils/python/CIME/nmlgen.py
+++ b/utils/python/CIME/nmlgen.py
@@ -178,7 +178,7 @@ class NamelistGenerator(object):
                 value[i] = self.quote_string(scalar)
         return compress_literal_list(value)
 
-    def get_value(self, name, node=None):
+    def get_value(self, name):
         """Get the current value of a given namelist variable.
 
         Note that the return value of this function is always a string or a list


### PR DESCRIPTION
More performance updates for namelist generation

The performance slowdown of the current namelist generation, particularly for multi-instance namelist generation has largely been addressed by removing xml node queries with simple dictionary access in namelist_definition.py. This has also had an impact on improving the performance of the single instance namelist generation. As an example, the time to create a pop namelist with the new namelist generator is now decreased by an order of magnitude.

The interfaces to nmlgen are different - but currently this only effects cime code.
- the instantiation of nmlgen is now done outside of the instance loop
`nmlgen = NamelistGenerator(case, definition_file)`
- the generation of namelist defaults for all entry ids whose group elements are not part of an optional skip_groups argument or do not have the entry attribute skip_default_entry="true" is done in one call within the multi instance loop (this is needed since infile is dependent on the particular instance)
`nmlgen.init_defaults(infile, config,skip_groups=skip_groups)
`
If skip_groups is empty it is not added in the call in any of the CIME buildnml scripts.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit-for-bit

Fixes None

User interface changes?: interfaces to nmlgen

Code review: 
