### PR TITLE
Pio namelist fix

### DIFF
--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -978,7 +978,9 @@ using a fortran linker.
   <FFLAGS>
     <append> -vec-report </append>
   </FFLAGS>
-
+  <CMAKE_OPTS>
+    <append DEBUG="TRUE"> -DPIO_ENABLE_LOGGING=ON </append>
+  </CMAKE_OPTS>
 </compiler>
 
 <compiler MACH="yellowstone" COMPILER="gnu">

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -956,6 +956,7 @@
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">256M</env>
+      <env name="MPI_TYPE_DEPTH">16</env>
     </environment_variables>
   </machine>
 

--- a/share/csm_share/shr/shr_pio_mod.F90
+++ b/share/csm_share/shr/shr_pio_mod.F90
@@ -531,7 +531,7 @@ contains
        if(pio_root == -99) pio_root = pio_default_root
        if(pio_rearranger == -99) pio_rearranger = pio_default_rearranger
        if(pio_numiotasks == -99) then
-          pio_numiotasks = min(pio_default_numiotasks,npes/pio_stride)
+          pio_numiotasks = npes/pio_stride
        endif
     endif
 

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -799,6 +799,7 @@ class Case(object):
         compset = self.get_value("COMPSET")
         mpilib = self.get_value("MPILIB")
         defaults = pioobj.get_defaults(grid=grid,compset=compset,mach=mach,compiler=compiler, mpilib=mpilib)
+        
         for vid, value in defaults.items():
             self.set_value(vid,value)
 

--- a/utils/python/CIME/case_run.py
+++ b/utils/python/CIME/case_run.py
@@ -177,9 +177,9 @@ def resubmit_check(case):
         submit(case, job=job, resubmit=True)
 
 ###############################################################################
-def do_data_assimilation(da_script, cycle, data_assimilation_cycles, lid):
+def do_data_assimilation(da_script, caseroot, cycle, lid):
 ###############################################################################
-    cmd = da_script + " 1> da.log.%s %d %d 2>&1" %(lid, cycle, data_assimilation_cycles)
+    cmd = da_script + " 1> da.log.%s %d %d 2>&1" %(lid, caseroot, cycle)
     logger.debug("running %s" %da_script)
     run_cmd_no_fail(cmd)
     # disposeLog(case, 'da', lid)  THIS IS UNDEFINED!
@@ -218,7 +218,7 @@ def case_run(case):
             get_timing(case, lid)     # Run the getTiming script
 
         if data_assimilation:
-            do_data_assimilation(data_assimilation_script, cycle, data_assimilation_cycles, lid)
+            do_data_assimilation(data_assimilation_script, case.get_value("CASEROOT"), cycle, lid)
 
         save_postrun_provenance(case)
 

--- a/utils/python/CIME/preview_namelists.py
+++ b/utils/python/CIME/preview_namelists.py
@@ -72,6 +72,7 @@ def create_namelists(case):
         else:
             compname = case.get_value("COMP_%s" % model_str.upper())
         cmd = os.path.join(config_dir, "buildnml")
+        do_run_cmd = False
         try:
             with open(cmd, 'r') as f:
                 first_line = f.readline()
@@ -81,24 +82,22 @@ def create_namelists(case):
                 mod.buildnml(case, caseroot, compname)
             else:
                 raise SyntaxError
-
         except SyntaxError as detail:
             if 'python' in first_line:
                 expect(False, detail)
             else:
-                logger.info("   Running %s buildnml"%compname)
-                run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=False)
-                # refresh case xml object from file
-                case.read_xml()
+                do_run_cmd = True
         except AttributeError:
-            logger.info("   Running %s buildnml"%compname)
-            run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=False)
-            # refresh case xml object from file
-            case.read_xml()
+            do_run_cmd = True
         except:
             raise
 
-
+        if do_run_cmd:
+            logger.info("   Running %s buildnml"%compname)
+            case.flush()
+            run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=False)
+            # refresh case xml object from file
+            case.read_xml()            
     logger.info("Finished creating component namelists")
 
 


### PR DESCRIPTION
The pio_numtasks wasn't being set correctly.  After each external call to a component buildnml we must update the case object to assure that changes made by the external are captured.

Test suite: scripts_regression_tests, GECO case in cesm
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Code review: 
