### PR TITLE
Add SharedArea context manager

### DIFF
--- a/utils/python/CIME/check_input_data.py
+++ b/utils/python/CIME/check_input_data.py
@@ -3,7 +3,7 @@ API for checking input for testcase
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import get_model
+from CIME.utils import get_model, SharedArea
 
 import fnmatch, glob, shutil
 
@@ -47,14 +47,15 @@ def download_if_in_repo(svn_loc, input_data_root, rel_path):
     else:
         # Use umask to make sure files are group read/writable. As long as parent directories
         # have +s, then everything should work.
-        stat, output, errput = \
-            run_cmd("umask 002 && svn --non-interactive --trust-server-cert export %s %s" % (full_url, full_path))
-        if (stat != 0):
-            logging.warning("svn export failed with output: %s and errput %s\n" % (output, errput))
-            return False
-        else:
-            logging.info("SUCCESS\n")
-            return True
+        with SharedArea():
+            stat, output, errput = \
+                run_cmd("svn --non-interactive --trust-server-cert export %s %s" % (full_url, full_path))
+            if (stat != 0):
+                logging.warning("svn export failed with output: %s and errput %s\n" % (output, errput))
+                return False
+            else:
+                logging.info("SUCCESS\n")
+                return True
 
 ###############################################################################
 def check_all_input_data(case):

--- a/utils/python/CIME/provenance.py
+++ b/utils/python/CIME/provenance.py
@@ -5,7 +5,7 @@ Library for saving build/run provenance.
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import touch, gzip_existing_file
+from CIME.utils import touch, gzip_existing_file, SharedArea
 
 import tarfile, getpass, signal, glob, shutil
 
@@ -81,11 +81,12 @@ def save_build_provenance_cesm(case, lid=None): # pylint: disable=unused-argumen
         fd.write("CESM version is %s\n"%version)
 
 def save_build_provenance(case, lid=None):
-    model = case.get_value("MODEL")
-    if model == "acme":
-        save_build_provenance_acme(case, lid=lid)
-    elif model == "cesm":
-        save_build_provenance_cesm(case, lid=lid)
+    with SharedArea():
+        model = case.get_value("MODEL")
+        if model == "acme":
+            save_build_provenance_acme(case, lid=lid)
+        elif model == "cesm":
+            save_build_provenance_cesm(case, lid=lid)
 
 def save_prerun_provenance_acme(case, lid=None):
     if not case.get_value("SAVE_TIMING"):
@@ -191,11 +192,12 @@ def save_prerun_provenance_cesm(case, lid=None): # pylint: disable=unused-argume
     pass
 
 def save_prerun_provenance(case, lid=None):
-    model = case.get_value("MODEL")
-    if model == "acme":
-        save_prerun_provenance_acme(case, lid=lid)
-    elif model == "cesm":
-        save_prerun_provenance_cesm(case, lid=lid)
+    with SharedArea():
+        model = case.get_value("MODEL")
+        if model == "acme":
+            save_prerun_provenance_acme(case, lid=lid)
+        elif model == "cesm":
+            save_prerun_provenance_cesm(case, lid=lid)
 
 def save_postrun_provenance_cesm(case, lid=None):
     save_timing = case.get_value("SAVE_TIMING")
@@ -271,8 +273,9 @@ def save_postrun_provenance_acme(case, lid):
                 gzip_existing_file(os.path.join(root, filename))
 
 def save_postrun_provenance(case, lid=None):
-    model = case.get_value("MODEL")
-    if model == "acme":
-        save_postrun_provenance_acme(case, lid=lid)
-    elif model == "cesm":
-        save_postrun_provenance_cesm(case, lid=lid)
+    with SharedArea():
+        model = case.get_value("MODEL")
+        if model == "acme":
+            save_postrun_provenance_acme(case, lid=lid)
+        elif model == "cesm":
+            save_postrun_provenance_cesm(case, lid=lid)

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -985,3 +985,18 @@ def analyze_build_log(comp, log, compiler):
 
     if warncnt > 0:
         logger.info("Component %s build complete with %s warnings"%(comp,warncnt))
+
+class SharedArea(object):
+    """
+    Enable 0002 umask within this manager
+    """
+
+    def __init__(self, new_perms=0o002):
+        self._orig_umask = None
+        self._new_perms  = new_perms
+
+    def __enter__(self):
+        self._orig_umask = os.umask(self._new_perms)
+
+    def __exit__(self, *_):
+        os.umask(self._orig_umask)


### PR DESCRIPTION
Makes it very easy to temporary loosen umask when making
files in shared areas.

Test suite: code_checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Ensures loose permissions in perf/provenance archives

Code review: @jedwards4b 
