### PR TITLE
explicitly set rof grid to null for this single column cases

### DIFF
--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -65,46 +65,55 @@
     <model_grid alias="1x1_numaIA" compset="DATM.+CLM">
       <grid name="atm">1x1_numaIA</grid>
       <grid name="lnd">1x1_numaIA</grid>
+      <grid name="rof">null</grid>
     </model_grid>
 
     <model_grid alias="1x1_brazil" compset="DATM.+CLM">
       <grid name="atm">1x1_brazil</grid>
       <grid name="lnd">1x1_brazil</grid>
+      <grid name="rof">null</grid>
     </model_grid>
 
     <model_grid alias="1x1_smallvilleIA" compset="DATM.+CLM">
       <grid name="atm">1x1_smallvilleIA</grid>
       <grid name="lnd">1x1_smallvilleIA</grid>
+      <grid name="rof">null</grid>
     </model_grid>
 
     <model_grid alias="1x1_camdenNJ" compset="DATM.+CLM">
       <grid name="atm">1x1_camdenNJ</grid>
       <grid name="lnd">1x1_camdenNJ</grid>
+      <grid name="rof">null</grid>
     </model_grid>
 
     <model_grid alias="1x1_mexicocityMEX" compset="DATM.+CLM">
       <grid name="atm">1x1_mexicocityMEX</grid>
       <grid name="lnd">1x1_mexicocityMEX</grid>
+      <grid name="rof">null</grid>
     </model_grid>
 
     <model_grid alias="1x1_vancouverCAN" compset="DATM.+CLM">
       <grid name="atm">1x1_vancouverCAN</grid>
       <grid name="lnd">1x1_vancouverCAN</grid>
+      <grid name="rof">null</grid>
     </model_grid>
 
     <model_grid alias="1x1_tropicAtl" compset="DATM.+CLM">
       <grid name="atm">1x1_tropicAtl</grid>
       <grid name="lnd">1x1_tropicAtl</grid>
+      <grid name="rof">null</grid>
     </model_grid>
 
     <model_grid alias="1x1_urbanc_alpha" compset="DATM.+CLM">
       <grid name="atm">1x1_urbanc_alpha</grid>
       <grid name="lnd">1x1_urbanc_alpha</grid>
+      <grid name="rof">null</grid>
     </model_grid>
 
     <model_grid alias="5x5_amazon" compset="DATM.+CLM">
       <grid name="atm">5x5_amazon</grid>
       <grid name="lnd">5x5_amazon</grid>
+      <grid name="rof">null</grid>
     </model_grid>
 
     <model_grid alias="hcru_hcru" compset="DATM.+CLM">


### PR DESCRIPTION
explicitly set rof grid to null for these single column clm cases.

Test suite: cesm ERI_D_Ld9.1x1_camdenNJ.ICLM45CNTEST.yellowstone_intel.clm-default
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes
User interface changes?: 

Code review: 
