### PR TITLE
Significant refactor of code_checker and related tests

### DIFF
--- a/scripts/Tools/case_diff
+++ b/scripts/Tools/case_diff
@@ -6,9 +6,9 @@ directory trees.
 """
 
 from standard_script_setup import *
-from CIME.utils import expect, run_cmd
+from CIME.utils import run_cmd
 
-import argparse, sys, os, doctest, glob
+import argparse, sys, os, doctest
 
 IGNORE = [".git", "bin", "bakefiles", "SNTools.project"]
 
@@ -49,7 +49,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     return args.case1, args.case2, args.show_binary, args.skip_list
 
 ###############################################################################
-def recursive_diff(dir1, dir2, show_binary=False, skip_list=[]):
+def recursive_diff(dir1, dir2, show_binary=False, skip_list=()):
 ###############################################################################
     """
     Starting at dir1, dir2 respectively, compare their contents

--- a/scripts/Tools/code_checker
+++ b/scripts/Tools/code_checker
@@ -7,11 +7,9 @@ and follow the PEP8 standard.
 
 from standard_script_setup import *
 
-from CIME.utils import run_cmd, run_cmd_no_fail, expect
-from CIME.utils import get_python_libs_root, get_cime_root
+from CIME.code_checker import check_code, expect
 
 import argparse, sys, os, doctest
-from multiprocessing.dummy import Pool as ThreadPool
 from distutils.spawn import find_executable
 
 logger = logging.getLogger(__name__)
@@ -42,10 +40,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    parser.add_argument("--dir", default=get_python_libs_root(),
-                        help="The root directory containing python files to check.")
-
-    parser.add_argument("-j", "--num-procs", type=int, default=8,
+    parser.add_argument("-j", "--num-procs", type=int, default=10,
                         help="The number of files to check in parallel")
 
     parser.add_argument("files", nargs="*",
@@ -55,66 +50,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.handle_standard_logging_options(args)
 
-    return args.dir, args.num_procs, args.files
-
-###############################################################################
-def run_pylint(on_file):
-###############################################################################
-    pylint = find_executable("pylint")
-
-    cmd_options = " --disable=I,C,R,logging-not-lazy,wildcard-import,unused-wildcard-import,fixme,broad-except,bare-except,eval-used,exec-used,global-statement"
-    cimeroot = get_cime_root()
-
-    if "scripts/Tools" in on_file:
-        cmd_options +=",relative-import"
-
-    # add init-hook option
-    cmd_options += " --init-hook='sys.path.extend((\"%s\",\"%s\"))'"%\
-        (os.path.join(cimeroot,"utils","python"),
-         os.path.join(cimeroot,"scripts","Tools"))
-
-    cmd = "%s %s %s" % (pylint, cmd_options, on_file)
-    logger.debug("pylint command is %s"%cmd)
-    stat, out, err = run_cmd(cmd, verbose=False, from_dir=cimeroot)
-    if stat != 0:
-        logger.info("File %s has pylint problems, please fix\n    Use command: %s" % (on_file, cmd))
-        logger.info(out + "\n" + err)
-        return False
-    else:
-        logger.info("File %s has no pylint problems" % on_file)
-        return True
-
-###############################################################################
-def matches(file_path, file_ends):
-###############################################################################
-    for file_end in file_ends:
-        if file_path.endswith(file_end):
-            return True
-
-    return False
-
-###############################################################################
-def check_code(dir_to_check, num_procs, files):
-###############################################################################
-    """
-    Check all python files in the given directory
-
-    Returns True if all files had no problems
-    """
-    # Get list of files to check
-    if '/' in files:
-        files_to_check = files
-    else:
-        files_to_check = run_cmd_no_fail('git ls-files --full-name %s' % dir_to_check, verbose=False).splitlines()
-        if files:
-            files_to_check = [item for item in files_to_check if matches(item, files)]
-        else:
-            files_to_check = [item for item in files_to_check if item.endswith(".py")]
-
-
-    pool = ThreadPool(num_procs)
-    results = pool.map(run_pylint, files_to_check)
-    return False not in results
+    return args.num_procs, args.files
 
 ###############################################################################
 def _main_func(description):
@@ -126,9 +62,14 @@ def _main_func(description):
     pylint = find_executable("pylint")
     expect(pylint is not None, "pylint not found")
 
-    dir_to_check, num_procs, files = parse_command_line(sys.argv, description)
+    num_procs, files = parse_command_line(sys.argv, description)
 
-    sys.exit(0 if check_code(dir_to_check, num_procs, files) else 1)
+    results = check_code(files, num_procs=num_procs, interactive=True)
+    for result in results.itervalues():
+        if result != "":
+            sys.exit(1)
+
+    sys.exit(0)
 
 ###############################################################################
 

--- a/utils/python/CIME/code_checker.py
+++ b/utils/python/CIME/code_checker.py
@@ -1,0 +1,109 @@
+"""
+Libraries for checking python code with pylint
+"""
+
+from CIME.XML.standard_module_setup import *
+
+from CIME.utils import run_cmd, run_cmd_no_fail, expect, get_cime_root, is_python_executable
+
+from multiprocessing.dummy import Pool as ThreadPool
+from distutils.spawn import find_executable
+
+logger = logging.getLogger(__name__)
+
+###############################################################################
+def _run_pylint(on_file, interactive):
+###############################################################################
+    pylint = find_executable("pylint")
+
+    cmd_options = " --disable=I,C,R,logging-not-lazy,wildcard-import,unused-wildcard-import,fixme,broad-except,bare-except,eval-used,exec-used,global-statement"
+    cimeroot = get_cime_root()
+
+    if "scripts/Tools" in on_file:
+        cmd_options +=",relative-import"
+
+    # add init-hook option
+    cmd_options += " --init-hook='sys.path.extend((\"%s\",\"%s\"))'"%\
+        (os.path.join(cimeroot,"utils","python"),
+         os.path.join(cimeroot,"scripts","Tools"))
+
+    cmd = "%s %s %s" % (pylint, cmd_options, on_file)
+    logger.debug("pylint command is %s"%cmd)
+    stat, out, err = run_cmd(cmd, verbose=False, from_dir=cimeroot)
+    if stat != 0:
+        if interactive:
+            logger.info("File %s has pylint problems, please fix\n    Use command: %s" % (on_file, cmd))
+            logger.info(out + "\n" + err)
+        return (on_file, out + "\n" + err)
+    else:
+        if interactive:
+            logger.info("File %s has no pylint problems" % on_file)
+        return (on_file, "")
+
+###############################################################################
+def _matches(file_path, file_ends):
+###############################################################################
+    for file_end in file_ends:
+        if file_path.endswith(file_end):
+            return True
+
+    return False
+
+###############################################################################
+def _should_pylint_skip(filepath):
+###############################################################################
+    # TODO - get rid of this
+    list_of_directories_to_ignore = ("xmlconvertors", "pointclm", "point_clm", "tools", "machines", "apidocs", "unit_test")
+    for dir_to_skip in list_of_directories_to_ignore:
+        if dir_to_skip in filepath:
+            return True
+
+    return False
+
+###############################################################################
+def get_all_checkable_files():
+###############################################################################
+    cimeroot = get_cime_root()
+    all_git_files = run_cmd_no_fail("git ls-files --full-name %s" % cimeroot, verbose=False).splitlines()
+    files_to_test = [item for item in all_git_files
+                     if ((item.endswith(".py") or is_python_executable(os.path.join(cimeroot, item))) and not _should_pylint_skip(item))]
+    return files_to_test
+
+###############################################################################
+def check_code(files, num_procs=10, interactive=False):
+###############################################################################
+    """
+    Check all python files in the given directory
+
+    Returns True if all files had no problems
+    """
+    # Get list of files to check, we look to see if user-provided file argument
+    # is a valid file, if not, we search the repo for a file with similar name.
+    repo_files = run_cmd_no_fail('git ls-files --full-name %s' % get_cime_root(), verbose=False).splitlines()
+    files_to_check = []
+    if files:
+        for filearg in files:
+            if os.path.exists(filearg):
+                files_to_check.append(os.path.abspath(filearg))
+            else:
+                found = False
+                for repo_file in repo_files:
+                    if repo_file.endswith(filearg):
+                        found = True
+                        files_to_check.append(repo_file) # could have multiple matches
+
+                if not found:
+                    logger.warning("Could not find file matching argument '%s'" % filearg)
+    else:
+        # Check every python file
+        files_to_check = get_all_checkable_files()
+
+    expect(len(files_to_check) > 0, "No matching files found")
+
+    # No point in using more threads than files
+    if len(files_to_check) < num_procs:
+        num_procs = len(files_to_check)
+
+    pool = ThreadPool(num_procs)
+    results = pool.map(lambda x : _run_pylint(x, interactive), files_to_check)
+    return dict(results)

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -986,6 +986,12 @@ def analyze_build_log(comp, log, compiler):
     if warncnt > 0:
         logger.info("Component %s build complete with %s warnings"%(comp,warncnt))
 
+def is_python_executable(filepath):
+    with open(filepath, "r") as f:
+        first_line = f.readline()
+
+    return first_line.startswith("#!") and "python" in first_line
+
 class SharedArea(object):
     """
     Enable 0002 umask within this manager


### PR DESCRIPTION
1) Convert code_checker to follow the usual pattern of the executable
   being a thin wrapper around a python library, giving access to this
   functionality via python library.
2) The library now returns a dict mapping the full file name to a string
   representing error output from pylint. Empty string implies success.
3) Be smarter about handling user-specified file arguments. We check first
   to see if the file exists as provided, if not, then we search the repo
   for a matching file.
4) Be a little more flexible when looking for python executables to check.
5) Change scripts_regression_tests.B_CheckCode to run all the pylint tests
   in parallel. Reduces total time required for this test from 6 minutes to
   about 40 seconds. The downside is that the first pylint test appears to
   take a very long time.
6) Use file paths to make test names unique instead of counter.
7) You now get a full repo check, same as B_CheckCode, when running code_checker
   with no arguments.

Test suite: B_CodeChecker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Minor changes to code_checker UI

Code review: @jedwards4b 
