### PR TITLE
Mfdeakin sandia/separate net cdf c fortran

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,40 @@
 ======================================================================
 
 Originator: Jim Edwards
+Date: 12-20-2016
+Tag: cime5.2.0-alpha.13
+Answer Changes: None
+Tests: scripts_regression_tests, cesm2_0_alpha05b
+Dependencies:
+
+Brief Summary: fix nag and pgi compiler issues, refactor xmlquery tool,
+	fix issues with dlnd buildnml
+
+User interface changes: xmlquery options were changed
+
+Modified files:
+	M       cime_config/cesm/machines/config_compilers.xml
+	M       components/data_comps/dlnd/cime_config/namelist_definition_dlnd.xml
+	M       driver_cpl/cime_config/config_component.xml
+	M       scripts/Tools/xmlquery
+	M       utils/python/CIME/XML/entry_id.py
+	M       utils/python/CIME/XML/env_batch.py
+	M       utils/python/CIME/XML/env_mach_specific.py
+	M       utils/python/CIME/XML/generic_xml.py
+	M       utils/python/CIME/buildnml.py
+	M       utils/python/CIME/case.py
+	M       utils/python/CIME/case_submit.py
+	M       utils/python/CIME/preview_namelists.py
+	M       utils/python/tests/CMakeLists.txt
+	M       utils/python/tests/list_tests
+	M       utils/python/tests/scripts_regression_tests.py
+
+
+======================================================================
+
+======================================================================
+
+Originator: Jim Edwards
 Date: 12-16-2016
 Tag: cime5.2.0-alpha.12
 Answer Changes: None
@@ -9,13 +43,13 @@ Dependencies:
 
 Brief Summary: Fix for cori-haswell, critical namelist bug fix for datm
 
-User interface changes: 
+User interface changes:
 	M       cime_config/cesm/machines/config_compilers.xml
 	M       cime_config/cesm/machines/config_machines.xml
 	M       components/data_comps/datm/cime_config/namelist_definition_datm.xml
 	M       utils/python/CIME/check_input_data.py
 	M       utils/python/tests/scripts_regression_tests.py
-	
+
 
 Modified files: git diff --name-status
 

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -354,7 +354,7 @@ INCLDIR += -I$(INSTALL_SHAREDPATH)/include -I$(INSTALL_SHAREDPATH)/$(COMP_INTERF
 
 ifeq ($(NETCDF_SEPARATE), false)
   INCLDIR += -I$(INC_NETCDF)
-else
+else ifeq ($(NETCDF_SEPARATE), true)
   INCLDIR += -I$(INC_NETCDF_C) -I$(INC_NETCDF_FORTRAN)
 endif
 ifdef MOD_NETCDF
@@ -384,7 +384,7 @@ ifeq ($(MODEL),driver)
   ifeq ($(strip $(COMPILER)),nag)
      ifeq ($(NETCDF_SEPARATE), false)
        SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF)
-     else
+     else ifeq ($(NETCDF_SEPARATE), true)
        SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF_C)
        SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF_FORTRAN)
      endif
@@ -438,7 +438,7 @@ CONFIG_ARGS +=  CC="$(CC)" FC="$(FC)" MPICC="$(MPICC)" \
 
 ifeq ($(NETCDF_SEPARATE), false)
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_PATH)
-else 
+else ifeq ($(NETCDF_SEPARATE), true)
   # The mct library needs the NetCDF_C library
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_C_PATH)
 endif
@@ -493,7 +493,7 @@ endif
 ifndef SLIBS
   ifeq ($(NETCDF_SEPARATE), false)
     SLIBS := -L$(LIB_NETCDF) -lnetcdf
-  else
+  else ifeq ($(NETCDF_SEPARATE), true)
     SLIBS := -L$(LIB_NETCDF_C) -L$(LIB_NETCDF_FORTRAN) -lnetcdf
   endif
 endif
@@ -615,7 +615,7 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
 # Allow for separate installations of the NetCDF C and Fortran libraries
 ifeq ($(NETCDF_SEPARATE), false)
   CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_PATH)
-else
+else ifeq ($(NETCDF_SEPARATE), true)
   # NETCDF_Fortran_DIR points to the separate
   # installation of Fortran NetCDF for PIO
   CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_C_PATH) \
@@ -717,7 +717,7 @@ test_fc: test_fc.o
 ifeq ($(NETCDF_SEPARATE), false)
 test_nc: test_nc.o
 	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
-else
+else ifeq ($(NETCDF_SEPARATE), true)
 test_nc: test_nc.o
 	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF_C) -lnetcdf $(LDFLAGS)
 endif

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -186,21 +186,26 @@ ifndef AR
 endif
 
 ifdef NETCDF_PATH
+  NETCDF_SEPARATE:=false
   ifndef INC_NETCDF
     INC_NETCDF:=$(NETCDF_PATH)/include
   endif
   ifndef LIB_NETCDF
     LIB_NETCDF:=$(NETCDF_PATH)/lib
   endif
-endif
-
-ifdef NETCDFF_PATH
-  ifndef INC_NETCDFF
-    INC_NETCDFF:=$(NETCDFF_PATH)/include
+else ifdef NETCDF_C_PATH
+  ifndef NETCDF_FORTRAN_PATH
+    $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
   endif
-  ifndef LIB_NETCDFF
-    LIB_NETCDFF:=$(NETCDFF_PATH)/lib
+  NETCDF_SEPARATE:=true
+  ifndef INC_NETCDF_C
+    INC_NETCDF_C:=$(NETCDF_C_PATH)/include
   endif
+  ifndef LIB_NETCDF_FORTRAN
+    LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
+  endif
+else ifdef NETCDF_FORTRAN_PATH
+  $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
 endif
 
 ifeq ($(MPILIB),mpi-serial)
@@ -337,11 +342,12 @@ endif
 #===============================================================================
 INCLDIR += -I$(INSTALL_SHAREDPATH)/include -I$(INSTALL_SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/include
 
-ifdef INC_NETCDF
-  INCLDIR += -I$(INC_NETCDF)
-endif
-ifdef INC_NETCDFF
-  INCLDIR += -I$(INC_NETCDFF)
+ifdef NETCDF_SEPARATE
+  ifeq ($NETCDF_SEPARATE, false)
+    INCLDIR += -I$(INC_NETCDF)
+  else
+    INCLDIR += -I$(INC_NETCDF_C) -I$(INC_NETCDF_FORTRAN)
+  endif
 endif
 ifdef MOD_NETCDF
   INCLDIR += -I$(MOD_NETCDF)
@@ -368,7 +374,12 @@ ifeq ($(MODEL),driver)
 # nagfor requires the weird "-Wl,-Wl,," syntax.
 # If done in config_compilers.xml, we break MCT.
   ifeq ($(strip $(COMPILER)),nag)
-     SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_PATH)/lib
+     ifeq ($NETCDF_SEPARATE, false)
+       SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF)
+     else
+       SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF_C)
+       SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF_FORTRAN)
+     endif
   endif
 else
   ifeq ($(strip $(COMPILER)),nag)
@@ -415,7 +426,16 @@ CXXFLAGS := $(CFLAGS)
 CONFIG_ARGS +=  CC="$(CC)" FC="$(FC)" MPICC="$(MPICC)" \
                 MPIFC="$(MPIFC)" FCFLAGS="$(FFLAGS) $(FREEFLAGS) $(INCLDIR)" \
                 CPPDEFS="$(CPPDEFS)" CFLAGS="$(CFLAGS) -I.. $(INCLDIR)" \
-                NETCDF_PATH=$(NETCDF_PATH) LDFLAGS="$(LDFLAGS)"
+                LDFLAGS="$(LDFLAGS)"
+
+ifdef NETCDF_PATH
+  CONFIG_ARGS += NETCDF_PATH=$(NETCDF_PATH)
+else ifdef NETCDF_C_PATH
+  CONFIG_ARGS += NETCDF_PATH=$(NETCDF_C_PATH)
+else
+  $(error No NETCDF Path defined)
+endif
+
 ifeq ($(COMPILER),nag)
   CONFIG_ARGS += LIBS="$(SLIBS)"
 endif
@@ -430,24 +450,24 @@ COSP_LIBDIR:=$(EXEROOT)/atm/obj/cosp
 endif
 
 ifeq ($(MODEL),cam)
-   # These RRTMG files take an extraordinarily long time to compile with optimization.
-   # Until mods are made to read the data from files, just remove optimization from
-   # their compilation.
-rrtmg_lw_k_g.o: rrtmg_lw_k_g.f90
+  # These RRTMG files take an extraordinarily long time to compile with optimization.
+  # Until mods are made to read the data from files, just remove optimization from
+  # their compilation.
+  rrtmg_lw_k_g.o: rrtmg_lw_k_g.f90
 	$(FC) -c $(FPPFLAGS) $(INCLDIR) $(INCS) $(FREEFLAGS) $(FFLAGS_NOOPT) $<
-rrtmg_sw_k_g.o: rrtmg_sw_k_g.f90
+  rrtmg_sw_k_g.o: rrtmg_sw_k_g.f90
 	$(FC) -c $(FPPFLAGS) $(INCLDIR) $(INCS) $(FREEFLAGS) $(FFLAGS_NOOPT) $<
 
 
-ifdef COSP_LIBDIR
-INCLDIR+=-I$(COSP_LIBDIR) -I$(COSP_LIBDIR)/../
-$(COSP_LIBDIR)/libcosp.a: cam_abortutils.o
-	$(MAKE) -C $(COSP_LIBDIR) F90='$(FC)' F90FLAGS='$(INCLDIR) $(INCS) $(FREEFLAGS) $(FFLAGS) $(FC_AUTO_R8)' \
-	F90FLAGS_noauto='$(INCLDIR) $(INCS) $(FREEFLAGS) $(FFLAGS)' \
-	F90FLAGS_fixed='$(INCLDIR) $(INCS) $(FIXEDFLAGS) $(FFLAGS) $(FC_AUTO_R8)'
+  ifdef COSP_LIBDIR
+    INCLDIR+=-I$(COSP_LIBDIR) -I$(COSP_LIBDIR)/../
+    $(COSP_LIBDIR)/libcosp.a: cam_abortutils.o
+    $(MAKE) -C $(COSP_LIBDIR) F90='$(FC)' F90FLAGS='$(INCLDIR) $(INCS) $(FREEFLAGS) $(FFLAGS) $(FC_AUTO_R8)' \
+    F90FLAGS_noauto='$(INCLDIR) $(INCS) $(FREEFLAGS) $(FFLAGS)' \
+    F90FLAGS_fixed='$(INCLDIR) $(INCS) $(FIXEDFLAGS) $(FFLAGS) $(FC_AUTO_R8)'
 
-cospsimulator_intr.o: $(COSP_LIBDIR)/libcosp.a
-endif
+    cospsimulator_intr.o: $(COSP_LIBDIR)/libcosp.a
+  endif
 
 endif
 
@@ -463,7 +483,11 @@ endif
 
 # System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)
 ifndef SLIBS
-   SLIBS := -L$(LIB_NETCDF) -lnetcdf
+  ifeq ($NETCDF_SEPARATE, false)
+    SLIBS := -L$(LIB_NETCDF) -lnetcdf
+  else
+    SLIBS := -L$(LIB_NETCDF_C) -L$(LIB_NETCDF_FORTRAN) -lnetcdf
+  endif
 endif
 ifdef LIB_PNETCDF
    SLIBS += -L$(LIB_PNETCDF) -lpnetcdf
@@ -575,14 +599,16 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
               -D CMAKE_C_FLAGS:STRING="$(CFLAGS) $(INCLDIR)" \
               -D CMAKE_CXX_FLAGS:STRING="$(CXXFLAGS) $(INCLDIR)" \
               -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-              -D NETCDF_DIR:STRING=$(NETCDF_PATH) \
               -D GPTL_PATH:STRING=$(INSTALL_SHAREDPATH) \
               -D PIO_ENABLE_TESTS:BOOL=OFF \
               -D USER_CMAKE_MODULE_PATH:STRING=$(CIMEROOT)/externals/CMake
 
 # Allow for separate installations of the NetCDF C and Fortran libraries
-ifdef NETCDFF_PATH
-	CMAKE_OPTS += -D NETCDF_Fortran_DIR:PATH="$(NETCDFF_PATH)"
+ifeq ($NETCDF_SEPARATE, false)
+  CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_PATH)
+else
+  CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_C_PATH) \
+                -D NETCDF_Fortran_DIR:PATH=$(NETCDF_FORTRAN_PATH)
 endif
 
 ifdef PNETCDF_PATH
@@ -677,8 +703,13 @@ db_flags:
 
 test_fc: test_fc.o
 	$(LD) -o $@ test_fc.o $(LDFLAGS)
+ifeq ($NETCDF_SEPARATE, false)
 test_nc: test_nc.o
 	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
+else
+test_nc: test_nc.o
+	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
+endif
 test_mpi: test_mpi.o
 	$(LD) -o $@ test_mpi.o $(LDFLAGS)
 test_esmf: test_esmf.o

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -185,36 +185,38 @@ ifndef AR
    AR := ar
 endif
 
-ifdef NETCDF_C_PATH
-  ifndef NETCDF_FORTRAN_PATH
-    $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
+# To prevent breaking cleaning and building components which don't require NetCDF directly
+ifeq ($(if $(or $(filter pio, $(subst /,  , $(MAKECMDGOALS))), $(filter exec_se, $(subst /,  , $(MAKECMDGOALS)))), true, false), true)
+  ifdef NETCDF_C_PATH
+    ifndef NETCDF_FORTRAN_PATH
+      $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
+    endif
+    NETCDF_SEPARATE:=true
+    ifndef INC_NETCDF_C
+      INC_NETCDF_C:=$(NETCDF_C_PATH)/include
+    endif
+    ifndef INC_NETCDF_FORTRAN
+      INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
+    endif
+    ifndef LIB_NETCDF_C
+      LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
+    endif
+    ifndef LIB_NETCDF_FORTRAN
+      LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
+    endif
+  else ifdef NETCDF_FORTRAN_PATH
+    $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
+  else ifdef NETCDF_PATH
+    NETCDF_SEPARATE:=false
+    ifndef INC_NETCDF
+      INC_NETCDF:=$(NETCDF_PATH)/include
+    endif
+    ifndef LIB_NETCDF
+      LIB_NETCDF:=$(NETCDF_PATH)/lib
+    endif
+  else
+    $(error No NetCDF Specified, required for PIO and ACME)
   endif
-  NETCDF_SEPARATE:=true
-  ifndef INC_NETCDF_C
-    INC_NETCDF_C:=$(NETCDF_C_PATH)/include
-  endif
-  ifndef INC_NETCDF_FORTRAN
-    INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
-  endif
-  ifndef LIB_NETCDF_C
-    LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
-  endif
-  ifndef LIB_NETCDF_FORTRAN
-    LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
-  endif
-else ifdef NETCDF_FORTRAN_PATH
-  $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
-else ifdef NETCDF_PATH
-  NETCDF_SEPARATE:=false
-  ifndef INC_NETCDF
-    INC_NETCDF:=$(NETCDF_PATH)/include
-  endif
-  ifndef LIB_NETCDF
-    LIB_NETCDF:=$(NETCDF_PATH)/lib
-  endif
-else
-  # Not certain if safe to assume this, but it seems like it should be
-  $(error "No NetCDF Specified")
 endif
 
 ifeq ($(MPILIB),mpi-serial)

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -186,7 +186,8 @@ ifndef AR
 endif
 
 # To prevent breaking cleaning and building components which don't require NetCDF directly
-ifeq ($(if $(or $(filter pio, $(subst /,  , $(MAKECMDGOALS))), $(filter exec_se, $(subst /,  , $(MAKECMDGOALS)))), true, false), true)
+# NetCDF is only required for building the coupled model and the PIO library
+ifeq ($(if $(or $(findstring PIO, $(MODEL)), $(findstring CIME_MODEL, $(MODEL))), true, false), true)
   ifdef NETCDF_C_PATH
     ifndef NETCDF_FORTRAN_PATH
       $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
@@ -492,9 +493,9 @@ endif
 # System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)
 ifndef SLIBS
   ifeq ($(NETCDF_SEPARATE), false)
-    SLIBS := -L$(LIB_NETCDF) -lnetcdf
+    SLIBS := -L$(LIB_NETCDF) -lnetcdff -lnetcdf
   else ifeq ($(NETCDF_SEPARATE), true)
-    SLIBS := -L$(LIB_NETCDF_C) -L$(LIB_NETCDF_FORTRAN) -lnetcdf
+    SLIBS := -L$(LIB_NETCDF_FORTRAN) -L$(LIB_NETCDF_C) -lnetcdff -lnetcdf
   endif
 endif
 
@@ -716,10 +717,10 @@ test_fc: test_fc.o
 	$(LD) -o $@ test_fc.o $(LDFLAGS)
 ifeq ($(NETCDF_SEPARATE), false)
 test_nc: test_nc.o
-	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
+	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdff -lnetcdf $(LDFLAGS)
 else ifeq ($(NETCDF_SEPARATE), true)
 test_nc: test_nc.o
-	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF_C) -lnetcdf $(LDFLAGS)
+	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF_FORTRAN) -L$(LIB_NETCDF_C) -lnetcdff -lnetcdf $(LDFLAGS)
 endif
 test_mpi: test_mpi.o
 	$(LD) -o $@ test_mpi.o $(LDFLAGS)

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -187,7 +187,7 @@ endif
 
 # To prevent breaking cleaning and building components which don't require NetCDF directly
 # NetCDF is only required for building the coupled model and the PIO library
-ifeq ($(if $(or $(findstring PIO, $(MODEL)), $(findstring CIME_MODEL, $(MODEL))), true, false), true)
+ifeq ($(if $(or $(findstring PIO, $(MODEL)), $(findstring acme, $(MODEL))), true, false), true)
   ifdef NETCDF_C_PATH
     ifndef NETCDF_FORTRAN_PATH
       $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -186,7 +186,6 @@ ifndef AR
 endif
 
 ifdef NETCDF_C_PATH
-  $(info "NetCDF Split Directory in $(NETCDF_FORTRAN_PATH)   $(NETCDF_C_PATH)")
   ifndef NETCDF_FORTRAN_PATH
     $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
   endif
@@ -207,7 +206,6 @@ else ifdef NETCDF_FORTRAN_PATH
   $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
 else ifdef NETCDF_PATH
   NETCDF_SEPARATE:=false
-  $(info "NetCDF Single Directory in $(NETCDF_PATH)")
   ifndef INC_NETCDF
     INC_NETCDF:=$(NETCDF_PATH)/include
   endif
@@ -352,12 +350,10 @@ endif
 #===============================================================================
 INCLDIR += -I$(INSTALL_SHAREDPATH)/include -I$(INSTALL_SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/include
 
-ifdef NETCDF_SEPARATE
-  ifeq ($NETCDF_SEPARATE, false)
-    INCLDIR += -I$(INC_NETCDF)
-  else
-    INCLDIR += -I$(INC_NETCDF_C) -I$(INC_NETCDF_FORTRAN)
-  endif
+ifeq ($NETCDF_SEPARATE, false)
+  INCLDIR += -I$(INC_NETCDF)
+else
+  INCLDIR += -I$(INC_NETCDF_C) -I$(INC_NETCDF_FORTRAN)
 endif
 ifdef MOD_NETCDF
   INCLDIR += -I$(MOD_NETCDF)

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -350,7 +350,7 @@ endif
 #===============================================================================
 INCLDIR += -I$(INSTALL_SHAREDPATH)/include -I$(INSTALL_SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/include
 
-ifeq ($NETCDF_SEPARATE, false)
+ifeq ($(NETCDF_SEPARATE), false)
   INCLDIR += -I$(INC_NETCDF)
 else
   INCLDIR += -I$(INC_NETCDF_C) -I$(INC_NETCDF_FORTRAN)
@@ -380,7 +380,7 @@ ifeq ($(MODEL),driver)
 # nagfor requires the weird "-Wl,-Wl,," syntax.
 # If done in config_compilers.xml, we break MCT.
   ifeq ($(strip $(COMPILER)),nag)
-     ifeq ($NETCDF_SEPARATE, false)
+     ifeq ($(NETCDF_SEPARATE), false)
        SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF)
      else
        SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF_C)
@@ -434,7 +434,7 @@ CONFIG_ARGS +=  CC="$(CC)" FC="$(FC)" MPICC="$(MPICC)" \
                 CPPDEFS="$(CPPDEFS)" CFLAGS="$(CFLAGS) -I.. $(INCLDIR)" \
                 LDFLAGS="$(LDFLAGS)"
 
-ifeq ($NETCDF_SEPARATE, false)
+ifeq ($(NETCDF_SEPARATE), false)
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_PATH)
 else 
   # The mct library needs the NetCDF_C library
@@ -489,7 +489,7 @@ endif
 
 # System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)
 ifndef SLIBS
-  ifeq ($NETCDF_SEPARATE, false)
+  ifeq ($(NETCDF_SEPARATE), false)
     SLIBS := -L$(LIB_NETCDF) -lnetcdf
   else
     SLIBS := -L$(LIB_NETCDF_C) -L$(LIB_NETCDF_FORTRAN) -lnetcdf
@@ -611,7 +611,7 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
               -D USER_CMAKE_MODULE_PATH:STRING=$(CIMEROOT)/externals/CMake
 
 # Allow for separate installations of the NetCDF C and Fortran libraries
-ifeq ($NETCDF_SEPARATE, false)
+ifeq ($(NETCDF_SEPARATE), false)
   CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_PATH)
 else
   # NETCDF_Fortran_DIR points to the separate
@@ -712,7 +712,7 @@ db_flags:
 
 test_fc: test_fc.o
 	$(LD) -o $@ test_fc.o $(LDFLAGS)
-ifeq ($NETCDF_SEPARATE, false)
+ifeq ($(NETCDF_SEPARATE), false)
 test_nc: test_nc.o
 	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
 else

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -185,15 +185,8 @@ ifndef AR
    AR := ar
 endif
 
-ifdef NETCDF_PATH
-  NETCDF_SEPARATE:=false
-  ifndef INC_NETCDF
-    INC_NETCDF:=$(NETCDF_PATH)/include
-  endif
-  ifndef LIB_NETCDF
-    LIB_NETCDF:=$(NETCDF_PATH)/lib
-  endif
-else ifdef NETCDF_C_PATH
+ifdef NETCDF_C_PATH
+  $(info "NetCDF Split Directory in $(NETCDF_FORTRAN_PATH)   $(NETCDF_C_PATH)")
   ifndef NETCDF_FORTRAN_PATH
     $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
   endif
@@ -212,6 +205,18 @@ else ifdef NETCDF_C_PATH
   endif
 else ifdef NETCDF_FORTRAN_PATH
   $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
+else ifdef NETCDF_PATH
+  NETCDF_SEPARATE:=false
+  $(info "NetCDF Single Directory in $(NETCDF_PATH)")
+  ifndef INC_NETCDF
+    INC_NETCDF:=$(NETCDF_PATH)/include
+  endif
+  ifndef LIB_NETCDF
+    LIB_NETCDF:=$(NETCDF_PATH)/lib
+  endif
+else
+  # Not certain if safe to assume this, but it seems like it should be
+  $(error "No NetCDF Specified")
 endif
 
 ifeq ($(MPILIB),mpi-serial)
@@ -433,13 +438,11 @@ CONFIG_ARGS +=  CC="$(CC)" FC="$(FC)" MPICC="$(MPICC)" \
                 CPPDEFS="$(CPPDEFS)" CFLAGS="$(CFLAGS) -I.. $(INCLDIR)" \
                 LDFLAGS="$(LDFLAGS)"
 
-ifdef NETCDF_PATH
+ifeq ($NETCDF_SEPARATE, false)
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_PATH)
-else ifeq ($NETCDF_SEPARATE, true)
+else 
   # The mct library needs the NetCDF_C library
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_C_PATH)
-else
-  $(error No NETCDF Path defined)
 endif
 
 ifeq ($(COMPILER),nag)

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -201,8 +201,14 @@ else ifdef NETCDF_C_PATH
   ifndef INC_NETCDF_C
     INC_NETCDF_C:=$(NETCDF_C_PATH)/include
   endif
-  ifndef LIB_NETCDF_FORTRAN
+  ifndef INC_NETCDF_FORTRAN
+    INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
+  endif
+  ifndef LIB_NETCDF_C
     LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
+  endif
+  ifndef LIB_NETCDF_FORTRAN
+    LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
   endif
 else ifdef NETCDF_FORTRAN_PATH
   $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
@@ -288,7 +294,6 @@ ifdef CPRE
 else
   FPPDEFS := $(CPPDEFS)
 endif
-
 
 #===============================================================================
 # Set config args for pio and mct to blank and then enable serial
@@ -430,7 +435,8 @@ CONFIG_ARGS +=  CC="$(CC)" FC="$(FC)" MPICC="$(MPICC)" \
 
 ifdef NETCDF_PATH
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_PATH)
-else ifdef NETCDF_C_PATH
+else ifeq ($NETCDF_SEPARATE, true)
+  # The mct library needs the NetCDF_C library
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_C_PATH)
 else
   $(error No NETCDF Path defined)
@@ -453,9 +459,10 @@ ifeq ($(MODEL),cam)
   # These RRTMG files take an extraordinarily long time to compile with optimization.
   # Until mods are made to read the data from files, just remove optimization from
   # their compilation.
-  rrtmg_lw_k_g.o: rrtmg_lw_k_g.f90
+rrtmg_lw_k_g.o: rrtmg_lw_k_g.f90
 	$(FC) -c $(FPPFLAGS) $(INCLDIR) $(INCS) $(FREEFLAGS) $(FFLAGS_NOOPT) $<
-  rrtmg_sw_k_g.o: rrtmg_sw_k_g.f90
+
+rrtmg_sw_k_g.o: rrtmg_sw_k_g.f90
 	$(FC) -c $(FPPFLAGS) $(INCLDIR) $(INCS) $(FREEFLAGS) $(FFLAGS_NOOPT) $<
 
 
@@ -489,6 +496,7 @@ ifndef SLIBS
     SLIBS := -L$(LIB_NETCDF_C) -L$(LIB_NETCDF_FORTRAN) -lnetcdf
   endif
 endif
+
 ifdef LIB_PNETCDF
    SLIBS += -L$(LIB_PNETCDF) -lpnetcdf
 endif
@@ -607,6 +615,8 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
 ifeq ($NETCDF_SEPARATE, false)
   CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_PATH)
 else
+  # NETCDF_Fortran_DIR points to the separate
+  # installation of Fortran NetCDF for PIO
   CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_C_PATH) \
                 -D NETCDF_Fortran_DIR:PATH=$(NETCDF_FORTRAN_PATH)
 endif
@@ -708,7 +718,7 @@ test_nc: test_nc.o
 	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
 else
 test_nc: test_nc.o
-	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
+	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF_C) -lnetcdf $(LDFLAGS)
 endif
 test_mpi: test_mpi.o
 	$(LD) -o $@ test_mpi.o $(LDFLAGS)

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -193,6 +193,16 @@ ifdef NETCDF_PATH
     LIB_NETCDF:=$(NETCDF_PATH)/lib
   endif
 endif
+
+ifdef NETCDFF_PATH
+  ifndef INC_NETCDFF
+    INC_NETCDFF:=$(NETCDFF_PATH)/include
+  endif
+  ifndef LIB_NETCDFF
+    LIB_NETCDFF:=$(NETCDFF_PATH)/lib
+  endif
+endif
+
 ifeq ($(MPILIB),mpi-serial)
   undefine PNETCDF_PATH
 else
@@ -329,6 +339,9 @@ INCLDIR += -I$(INSTALL_SHAREDPATH)/include -I$(INSTALL_SHAREDPATH)/$(COMP_INTERF
 
 ifdef INC_NETCDF
   INCLDIR += -I$(INC_NETCDF)
+endif
+ifdef INC_NETCDFF
+  INCLDIR += -I$(INC_NETCDFF)
 endif
 ifdef MOD_NETCDF
   INCLDIR += -I$(MOD_NETCDF)
@@ -566,6 +579,11 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
               -D GPTL_PATH:STRING=$(INSTALL_SHAREDPATH) \
               -D PIO_ENABLE_TESTS:BOOL=OFF \
               -D USER_CMAKE_MODULE_PATH:STRING=$(CIMEROOT)/externals/CMake
+
+# Allow for separate installations of the NetCDF C and Fortran libraries
+ifdef NETCDFF_PATH
+	CMAKE_OPTS += -D NETCDF_Fortran_DIR:PATH="$(NETCDFF_PATH)"
+endif
 
 ifdef PNETCDF_PATH
 	CMAKE_OPTS += -D PNETCDF_DIR:STRING="$(PNETCDF_PATH)"

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -187,7 +187,7 @@ endif
 
 # To prevent breaking cleaning and building components which don't require NetCDF directly
 # NetCDF is only required for building the coupled model and the PIO library
-ifeq ($(if $(or $(findstring PIO, $(MODEL)), $(findstring acme, $(MODEL))), true, false), true)
+ifneq ($(or $(findstring pio, $(MODEL)), $(findstring driver, $(MODEL)), $(findstring acme, $(MODEL))),)
   ifdef NETCDF_C_PATH
     ifndef NETCDF_FORTRAN_PATH
       $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")

--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -1424,13 +1424,12 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <NETCDF_C_PATH><env>NETCDFROOT</env></NETCDF_C_PATH>
-  <NETCDF_FORTRAN_PATH><env>NETCDFROOT</env></NETCDF_FORTRAN_PATH>
+  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
   <!-- Don't rely on nf-config, as it's not available with all NetCDF modules on Skybridge -->
   <SLIBS>
-    <append> -L<var>NETCDF_FORTRAN_PATH</var>/lib -lnetcdff -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
+    <append> -L<var>NETCDF_PATH</var>/lib -lnetcdff -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
     <append MPILIB="mpich"> -mkl=cluster </append>
     <append MPILIB="mpich2"> -mkl=cluster </append>
     <append MPILIB="mpt"> -mkl=cluster </append>

--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -1424,10 +1424,13 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
+  <!-- <NETCDF_C_PATH><env>NETCDFROOT</env></NETCDF_C_PATH> -->
+  <!-- <NETCDF_FORTRAN_PATH><env>NETCDFROOT</env></NETCDF_FORTRAN_PATH> -->
   <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
   <SLIBS>
+    <!-- <append> <var>NETCDF_FORTRAN_PATH</var>/lib -L/projects/ccsm/BLAS-intel -lblas_LINUX</append> -->
     <append> <shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
     <append MPILIB="mpich"> -mkl=cluster </append>
     <append MPILIB="mpich2"> -mkl=cluster </append>

--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -1424,14 +1424,13 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <!-- <NETCDF_C_PATH><env>NETCDFROOT</env></NETCDF_C_PATH> -->
-  <!-- <NETCDF_FORTRAN_PATH><env>NETCDFROOT</env></NETCDF_FORTRAN_PATH> -->
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
+  <NETCDF_C_PATH><env>NETCDFROOT</env></NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH><env>NETCDFROOT</env></NETCDF_FORTRAN_PATH>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <!-- Don't rely on nf-config, as it's not available with all NetCDF modules on Skybridge -->
   <SLIBS>
-    <!-- <append> <var>NETCDF_FORTRAN_PATH</var>/lib -L/projects/ccsm/BLAS-intel -lblas_LINUX</append> -->
-    <append> <shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
+    <append> -L<var>NETCDF_FORTRAN_PATH</var>/lib -lnetcdff -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
     <append MPILIB="mpich"> -mkl=cluster </append>
     <append MPILIB="mpich2"> -mkl=cluster </append>
     <append MPILIB="mpt"> -mkl=cluster </append>

--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -1429,7 +1429,7 @@ for mct, etc.
   <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
   <!-- Don't rely on nf-config, as it's not available with all NetCDF modules on Skybridge -->
   <SLIBS>
-    <append> -L<var>NETCDF_PATH</var>/lib -lnetcdff -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
+    <append> -L<var>NETCDF_PATH</var>/lib -lnetcdff -lnetcdf -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
     <append MPILIB="mpich"> -mkl=cluster </append>
     <append MPILIB="mpich2"> -mkl=cluster </append>
     <append MPILIB="mpt"> -mkl=cluster </append>

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -187,7 +187,7 @@ endif
 
 # To prevent breaking cleaning and building components which don't require NetCDF directly
 # NetCDF is only required for building the coupled model and the PIO library
-ifeq ($(if $(or $(findstring PIO, $(MODEL)), $(findstring cesm, $(MODEL))), true, false), true)
+ifneq ($(or $(findstring pio, $(MODEL)), $(findstring driver, $(MODEL)), $(findstring cesm, $(MODEL))),)
   ifdef NETCDF_C_PATH
     ifndef NETCDF_FORTRAN_PATH
       $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -185,36 +185,38 @@ ifndef AR
    AR := ar
 endif
 
-ifdef NETCDF_C_PATH
-  ifndef NETCDF_FORTRAN_PATH
-    $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
+# To prevent breaking cleaning and building components which don't require NetCDF directly
+ifeq ($(if $(or $(filter pio, $(subst /,  , $(MAKECMDGOALS))), $(filter exec_se, $(subst /,  , $(MAKECMDGOALS)))), true, false), true)
+  ifdef NETCDF_C_PATH
+    ifndef NETCDF_FORTRAN_PATH
+      $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
+    endif
+    NETCDF_SEPARATE:=true
+    ifndef INC_NETCDF_C
+      INC_NETCDF_C:=$(NETCDF_C_PATH)/include
+    endif
+    ifndef INC_NETCDF_FORTRAN
+      INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
+    endif
+    ifndef LIB_NETCDF_C
+      LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
+    endif
+    ifndef LIB_NETCDF_FORTRAN
+      LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
+    endif
+  else ifdef NETCDF_FORTRAN_PATH
+    $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
+  else ifdef NETCDF_PATH
+    NETCDF_SEPARATE:=false
+    ifndef INC_NETCDF
+      INC_NETCDF:=$(NETCDF_PATH)/include
+    endif
+    ifndef LIB_NETCDF
+      LIB_NETCDF:=$(NETCDF_PATH)/lib
+    endif
+  else
+    $(error No NetCDF Specified, required for PIO and CESM)
   endif
-  NETCDF_SEPARATE:=true
-  ifndef INC_NETCDF_C
-    INC_NETCDF_C:=$(NETCDF_C_PATH)/include
-  endif
-  ifndef INC_NETCDF_FORTRAN
-    INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
-  endif
-  ifndef LIB_NETCDF_C
-    LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
-  endif
-  ifndef LIB_NETCDF_FORTRAN
-    LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
-  endif
-else ifdef NETCDF_FORTRAN_PATH
-  $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
-else ifdef NETCDF_PATH
-  NETCDF_SEPARATE:=false
-  ifndef INC_NETCDF
-    INC_NETCDF:=$(NETCDF_PATH)/include
-  endif
-  ifndef LIB_NETCDF
-    LIB_NETCDF:=$(NETCDF_PATH)/lib
-  endif
-else
-  # Not certain if safe to assume this, but it seems like it should be
-  $(error "No NetCDF Specified")
 endif
 
 ifeq ($(MPILIB),mpi-serial)

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -323,7 +323,7 @@ INCLDIR += -I$(INSTALL_SHAREDPATH)/include -I$(CSM_SHR_INCLUDE)
 
 ifeq ($(NETCDF_SEPARATE), false)
   INCLDIR += -I$(INC_NETCDF)
-else
+else ifeq ($(NETCDF_SEPARATE), true)
   INCLDIR += -I$(INC_NETCDF_C) -I$(INC_NETCDF_FORTRAN)
 endif
 ifdef MOD_NETCDF
@@ -347,7 +347,7 @@ ifeq ($(MODEL),driver)
   ifeq ($(strip $(COMPILER)),nag)
     ifeq ($(NETCDF_SEPARATE), false)
       SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_PATH)/lib
-    else
+    else ifeq ($(NETCDF_SEPARATE), true)
       SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_C_PATH)/lib
       SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_FORTRAN_PATH)/lib
     endif
@@ -399,7 +399,7 @@ CONFIG_ARGS +=  CC="$(CC)" FC="$(FC)" MPICC="$(MPICC)" \
 
 ifeq ($(NETCDF_SEPARATE), false)
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_PATH)
-else
+else ifeq ($(NETCDF_SEPARATE), true)
   # The mct library needs the NetCDF_C library
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_C_PATH)
 endif
@@ -453,7 +453,7 @@ endif
 ifndef SLIBS
   ifeq ($(NETCDF_SEPARATE), false)
     SLIBS := -L$(LIB_NETCDF) -lnetcdf
-  else
+  else ifeq ($(NETCDF_SEPARATE), true)
     SLIBS := -L$(LIB_NETCDF_C) -L$(LIB_NETCDF_FORTRAN) -lnetcdf
   endif
 endif
@@ -563,7 +563,7 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
 # Allow for separate installations of the NetCDF C and Fortran libraries
 ifeq ($(NETCDF_SEPARATE), false)
   CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_PATH)
-else
+else ifeq ($(NETCDF_SEPARATE), true)
   CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_C_PATH) \
                 -D NETCDF_Fortran_DIR:PATH=$(NETCDF_FORTRAN_PATH)
 endif
@@ -671,7 +671,7 @@ test_fc: test_fc.o
 ifeq ($(NETCDF_SEPARATE), false)
 test_nc: test_nc.o
 	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
-else
+else ifeq ($(NETCDF_SEPARATE), true)
 test_nc: test_nc.o
 	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF_C) -lnetcdf $(LDFLAGS)
 endif

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -187,7 +187,7 @@ endif
 
 # To prevent breaking cleaning and building components which don't require NetCDF directly
 # NetCDF is only required for building the coupled model and the PIO library
-ifeq ($(if $(or $(findstring PIO, $(MODEL)), $(findstring CIME_MODEL, $(MODEL))), true, false), true)
+ifeq ($(if $(or $(findstring PIO, $(MODEL)), $(findstring cesm, $(MODEL))), true, false), true)
   ifdef NETCDF_C_PATH
     ifndef NETCDF_FORTRAN_PATH
       $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -186,7 +186,8 @@ ifndef AR
 endif
 
 # To prevent breaking cleaning and building components which don't require NetCDF directly
-ifeq ($(if $(or $(filter pio, $(subst /,  , $(MAKECMDGOALS))), $(filter exec_se, $(subst /,  , $(MAKECMDGOALS)))), true, false), true)
+# NetCDF is only required for building the coupled model and the PIO library
+ifeq ($(if $(or $(findstring PIO, $(MODEL)), $(findstring CIME_MODEL, $(MODEL))), true, false), true)
   ifdef NETCDF_C_PATH
     ifndef NETCDF_FORTRAN_PATH
       $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
@@ -452,9 +453,9 @@ endif
 # System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)
 ifndef SLIBS
   ifeq ($(NETCDF_SEPARATE), false)
-    SLIBS := -L$(LIB_NETCDF) -lnetcdf
+    SLIBS := -L$(LIB_NETCDF) -lnetcdff -lnetcdf
   else ifeq ($(NETCDF_SEPARATE), true)
-    SLIBS := -L$(LIB_NETCDF_C) -L$(LIB_NETCDF_FORTRAN) -lnetcdf
+    SLIBS := -L$(LIB_NETCDF_FORTRAN) -L$(LIB_NETCDF_C) -lnetcdff -lnetcdf
   endif
 endif
 ifdef LIB_PNETCDF
@@ -670,10 +671,10 @@ test_fc: test_fc.o
 	$(LD) -o $@ test_fc.o $(LDFLAGS)
 ifeq ($(NETCDF_SEPARATE), false)
 test_nc: test_nc.o
-	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
+	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdff -lnetcdf $(LDFLAGS)
 else ifeq ($(NETCDF_SEPARATE), true)
 test_nc: test_nc.o
-	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF_C) -lnetcdf $(LDFLAGS)
+	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF_FORTRAN) -L$(LIB_NETCDF_C) -lnetcdff -lnetcdf $(LDFLAGS)
 endif
 test_mpi: test_mpi.o
 	$(LD) -o $@ test_mpi.o $(LDFLAGS)

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -185,14 +185,40 @@ ifndef AR
    AR := ar
 endif
 
-ifdef NETCDF_PATH
+ifdef NETCDF_C_PATH
+  $(info "NetCDF Split Directory in $(NETCDF_FORTRAN_PATH)   $(NETCDF_C_PATH)")
+  ifndef NETCDF_FORTRAN_PATH
+    $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
+  endif
+  NETCDF_SEPARATE:=true
+  ifndef INC_NETCDF_C
+    INC_NETCDF_C:=$(NETCDF_C_PATH)/include
+  endif
+  ifndef INC_NETCDF_FORTRAN
+    INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
+  endif
+  ifndef LIB_NETCDF_C
+    LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
+  endif
+  ifndef LIB_NETCDF_FORTRAN
+    LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
+  endif
+else ifdef NETCDF_FORTRAN_PATH
+  $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
+else ifdef NETCDF_PATH
+  NETCDF_SEPARATE:=false
+  $(info "NetCDF Single Directory in $(NETCDF_PATH)")
   ifndef INC_NETCDF
     INC_NETCDF:=$(NETCDF_PATH)/include
   endif
   ifndef LIB_NETCDF
     LIB_NETCDF:=$(NETCDF_PATH)/lib
   endif
+else
+  # Not certain if safe to assume this, but it seems like it should be
+  $(error "No NetCDF Specified")
 endif
+
 ifeq ($(MPILIB),mpi-serial)
   undefine PNETCDF_PATH
 else
@@ -295,8 +321,10 @@ VPATH+=$(CSM_SHR_INCLUDE)
 #===============================================================================
 INCLDIR += -I$(INSTALL_SHAREDPATH)/include -I$(CSM_SHR_INCLUDE)
 
-ifdef INC_NETCDF
+ifeq ($NETCDF_SEPARATE, false)
   INCLDIR += -I$(INC_NETCDF)
+else
+  INCLDIR += -I$(INC_NETCDF_C) -I$(INC_NETCDF_FORTRAN)
 endif
 ifdef MOD_NETCDF
   INCLDIR += -I$(MOD_NETCDF)
@@ -317,7 +345,12 @@ ifeq ($(MODEL),driver)
 # nagfor requires the weird "-Wl,-Wl,," syntax.
 # If done in config_compilers.xml, we break MCT.
   ifeq ($(strip $(COMPILER)),nag)
-     SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_PATH)/lib
+    ifeq ($NETCDF_SEPARATE, false)
+      SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_PATH)/lib
+    else
+      SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_C_PATH)/lib
+      SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_FORTRAN_PATH)/lib
+    endif
   endif
 else
   ifeq ($(strip $(COMPILER)),nag)
@@ -362,8 +395,15 @@ CXXFLAGS := $(CFLAGS)
 
 CONFIG_ARGS +=  CC="$(CC)" FC="$(FC)" MPICC="$(MPICC)" \
 		MPIFC="$(MPIFC)" FCFLAGS="$(FFLAGS) $(FREEFLAGS) $(INCLDIR)" \
-		CPPDEFS="$(CPPDEFS)" CFLAGS="$(CFLAGS) -I.. $(INCLDIR)" \
-		NETCDF_PATH=$(NETCDF_PATH) LDFLAGS="$(LDFLAGS)"
+		CPPDEFS="$(CPPDEFS)" CFLAGS="$(CFLAGS) -I.. $(INCLDIR)"
+
+ifeq ($NETCDF_SEPARATE, false)
+  CONFIG_ARGS += NETCDF_PATH=$(NETCDF_PATH)
+else
+  # The mct library needs the NetCDF_C library
+  CONFIG_ARGS += NETCDF_PATH=$(NETCDF_C_PATH)
+endif
+
 ifeq ($(COMPILER),nag)
   CONFIG_ARGS += LIBS="$(SLIBS)"
 endif
@@ -411,7 +451,11 @@ endif
 
 # System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)
 ifndef SLIBS
-   SLIBS := -L$(LIB_NETCDF) -lnetcdf
+  ifeq ($NETCDF_SEPARATE, false)
+    SLIBS := -L$(LIB_NETCDF) -lnetcdf
+  else
+    SLIBS := -L$(LIB_NETCDF_C) -L$(LIB_NETCDF_FORTRAN) -lnetcdf
+  endif
 endif
 ifdef LIB_PNETCDF
    SLIBS += -L$(LIB_PNETCDF) -lpnetcdf
@@ -512,10 +556,17 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
 	      -D CMAKE_C_FLAGS:STRING="$(CFLAGS) $(INCLDIR)" \
 	      -D CMAKE_CXX_FLAGS:STRING="$(CXXFLAGS) $(INCLDIR)" \
 	      -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-	      -D NETCDF_DIR:STRING=$(NETCDF_PATH) \
 	      -D GPTL_PATH:STRING=$(INSTALL_SHAREDPATH) \
 	      -D PIO_ENABLE_TESTS:BOOL=OFF \
 	      -D USER_CMAKE_MODULE_PATH:STRING=$(CIMEROOT)/externals/CMake
+
+# Allow for separate installations of the NetCDF C and Fortran libraries
+ifeq ($NETCDF_SEPARATE, false)
+  CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_PATH)
+else
+  CMAKE_OPTS += -D NETCDF_DIR:PATH=$(NETCDF_C_PATH) \
+                -D NETCDF_Fortran_DIR:PATH=$(NETCDF_FORTRAN_PATH)
+endif
 
 ifdef PNETCDF_PATH
 	CMAKE_OPTS += -D PNETCDF_DIR:STRING="$(PNETCDF_PATH)"
@@ -617,8 +668,13 @@ db_flags:
 
 test_fc: test_fc.o
 	$(LD) -o $@ test_fc.o $(LDFLAGS)
+ifeq ($NETCDF_SEPARATE, false)
 test_nc: test_nc.o
 	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF) -lnetcdf $(LDFLAGS)
+else
+test_nc: test_nc.o
+	$(LD) -o $@ test_nc.o -L$(LIB_NETCDF_C) -lnetcdf $(LDFLAGS)
+endif
 test_mpi: test_mpi.o
 	$(LD) -o $@ test_mpi.o $(LDFLAGS)
 test_esmf: test_esmf.o

--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -871,7 +871,7 @@ using a fortran linker.
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
   <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
   <SLIBS>
-    <append> <shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
+    <append> -L<var>NETCDF_PATH</var>/lib -lnetcdff -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
   </SLIBS>
 </compiler>
 

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -1428,13 +1428,16 @@
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>               <!-- complete path to a short term archiving directory -->
     <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>           <!-- complete path to a long term archiving directory -->
     <BASELINE_ROOT>/projects/ccsm/ccsm_baselines</BASELINE_ROOT>
-    <CCSM_CPRNC>/projects/ccsm/cprnc/build/cprnc</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
+    <CCSM_CPRNC>/projects/ccsm/cprnc/build/cprnc_wrap</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
+    <SAVE_TIMING_DIR>/projects/ccsm/timings</SAVE_TIMING_DIR>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
-    <GMAKE_J>4</GMAKE_J>
+    <GMAKE_J>8</GMAKE_J>
     <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
+    <PES_PER_NODE>16</PES_PER_NODE>
     <PIO_BUFFER_SIZE_LIMIT>1</PIO_BUFFER_SIZE_LIMIT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
@@ -1442,6 +1445,39 @@
 	<arg name="tasks_per_node"> -npernode $PES_PER_NODE</arg>
       </arguments>
     </mpirun>
+    <mpirun mpilib="mpi-serial">
+      <executable></executable>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+      <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
+      <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
+      <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
+      <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
+      <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="load">sems-env</command>
+        <command name="load">sems-git</command>
+        <command name="load">sems-python/2.7.9</command>
+        <command name="load">gnu/4.9.2</command>
+        <command name="load">intel/intel-15.0.3.187</command>
+        <command name="load" mpilib="!mpi-serial">openmpi-intel/1.8</command>
+        <command name="load">libraries/intel-mkl-15.0.2.164</command>
+        <command name="load">libraries/intel-mkl-15.0.2.164</command>
+        <command name="load" mpilib="!mpi-serial">sems-hdf5/1.8.12/parallel</command>
+        <command name="load" mpilib="!mpi-serial">sems-netcdf/4.3.2/parallel</command>
+        <command name="load" mpilib="mpi-serial">sems-hdf5/1.8.12/base</command>
+        <command name="load" mpilib="mpi-serial">sems-netcdf/4.3.2/base</command>
+      </modules>
+    </module_system>
+    <environment_variables>
+      <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
+      <env name="PNETCDFROOT" mpilib="!mpi-serial">$ENV{SEMS_NETCDF_ROOT}</env>
+      <env name="OMP_STACKSIZE">64M</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="stampede">

--- a/cime_config/xml_schemas/config_compilers_v2.xsd
+++ b/cime_config/xml_schemas/config_compilers_v2.xsd
@@ -167,6 +167,8 @@
       <xs:element name="MPICXX" type="systemPath"/>
       <xs:element name="MPIFC" type="systemPath"/>
       <xs:element name="NETCDF_PATH" type="systemPath"/>
+      <xs:element name="NETCDF_C_PATH" type="systemPath"/>
+      <xs:element name="NETCDF_FORTRAN_PATH" type="systemPath"/>
       <xs:element name="PAPI_INC" type="systemPath"/>
       <xs:element name="PAPI_LIB" type="systemPath"/>
       <xs:element name="PETSC_PATH" type="systemPath"/>


### PR DESCRIPTION
Adds support for separate NetCDF C and Fortran library installations.

Test suite: scripts_regression_tests
Test baseline: NA
Test namelist changes: NA
Test status: Pass

Fixes #907 

User interface changes?: To use separate NetCDF C and Fortran libraries, specify NETCDF_C_PATH and NETCDF_FORTRAN_PATH in config_compilers.xml before creating the case.

Code review: 
