### PR TITLE
new CESM2 defaults - 1hr pop cpl, Robert Filtering, grid files for  EBM, mushy ice

### DIFF
--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -1218,20 +1218,20 @@
     </gridmap>
 
     <gridmap rof_grid="rx1" ocn_grid="gx3v7" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx3v7_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx3v7_e1000r500_161214.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="gx1v6" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v6_nn_ac_161213.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v6_e1000r300_161212.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tx1v1" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tx1v1_e1000r300_090318.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tx1v1_e1000r300_090318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_tx1v1_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_tx1v1_e1000r300_161214.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tx0.1v2" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tx0.1v2_e1000r200_090624.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tx0.1v2_e1000r200_090624.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_tx0.1v2_e1000r200_090624.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_tx0.1v2_e1000r200_090624.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="oQU120" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_oQU120_nn.160527.nc</map>
@@ -1239,20 +1239,20 @@
     </gridmap>
 
     <gridmap rof_grid="r05" ocn_grid="gx3v7" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx3v7_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx3v7_e1000r500_161214.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="gx1v6" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_151109.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_151109.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_161212.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="gx1v7" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_151109b.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_151109b.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_nn_ac_161213.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_161213.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tx1v1" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx1v1_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx1v1_e1000r500_161214.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tx0.1v2" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tx0.1v2_r500e1000_080620.nc</map>

--- a/driver_cpl/bld/testdir/env_run.xml
+++ b/driver_cpl/bld/testdir/env_run.xml
@@ -994,7 +994,7 @@
     This is used to set the driver namelist ice_cpl_dt, equal to basedt/ICE_NCPL
     where basedt is equal to NCPL_BASE_PERIOD in seconds.</desc>
     </entry>
-    <entry id="OCN_NCPL" value="1">
+    <entry id="OCN_NCPL" value="24">
       <type>integer</type>
       <desc>Number of ocn coupling intervals per NCPL_BASE_PERIOD.
     Thisn is used to set the driver namelist ocn_cpl_dt, equal to basedt/OCN_NCPL

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2406,12 +2406,12 @@
     <valid_values>CESM1_ORIG,CESM1_ORIG_TIGHT,CESM1_MOD,CESM1_MOD_TIGHT,RASM_OPTION1,RASM_OPTION2</valid_values>
     <default_value>CESM1_MOD_TIGHT</default_value>
     <values>
-      <value compset="_DATM.*_DOCN%SOM"          >CESM1_MOD</value>
-      <value compset="_POP2"                     >CESM1_MOD</value>
-      <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN">CESM1_MOD</value>
-      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">CESM1_MOD</value>
-      <value compset="_SOCN"                     >CESM1_MOD</value>
-      <value compset="_MPAS"                     >CESM1_MOD</value>
+      <value compset="_DATM.*_DOCN%SOM"          >RASM_OPTION1</value>
+      <value compset="_POP2"                     >RASM_OPTION1</value>
+      <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN">RASM_OPTION1</value>
+      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">RASM_OPTION1</value>
+      <value compset="_SOCN"                     >RASM_OPTION1</value>
+      <value compset="_MPAS"                     >RASM_OPTION1</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -2548,15 +2548,15 @@
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
     <values>
-      <value compset="_POP2">1</value>
-      <value compset="_POP2" grid="oi%tx0.1v2">4</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
-      <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
-      <value compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
-      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">1</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
-      <value compset="_SATM.*_SLND.*_SICE.*_SOCN">1</value>
-      <value compset="_DLND.*_CISM\d">1</value>
+      <value compset="_POP2">24</value>
+      <value compset="_POP2" grid="oi%tx0.1v2">24</value>
+      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">24</value>
+      <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">24</value>
+      <value compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">24</value>
+      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">24</value>
+      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">24</value>
+      <value compset="_SATM.*_SLND.*_SICE.*_SOCN">24</value>
+      <value compset="_DLND.*_CISM\d">24</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>

--- a/driver_cpl/cime_config/namelist_definition_drv.xml
+++ b/driver_cpl/cime_config/namelist_definition_drv.xml
@@ -568,10 +568,10 @@
     <valid_values>minus1p8,linear_salt,mushy</valid_values>
     <desc>
       Freezing point calculation for salt water.
-      Default: minus1p8
+      Default: mushy
     </desc>
     <values>
-      <value>minus1p8</value>
+      <value>mushy</value>
     </values>
   </entry>
 

--- a/driver_cpl/shr/seq_infodata_mod.F90
+++ b/driver_cpl/shr/seq_infodata_mod.F90
@@ -477,7 +477,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        wv_sat_transition_start = 20.0
        wv_sat_use_tables     = .false.
        wv_sat_table_spacing  = 1.0
-       tfreeze_option        = 'minus1p8'
+       tfreeze_option        = 'mushy'
        flux_epbal            = 'off'
        flux_albav            = .false.
        flux_diurnal          = .false.


### PR DESCRIPTION
New defaults for ICE an OCN which match the current state of CESM2 development.  
   1hr Ocean coupling using Robert Filtering and RASM1 coupling order
   Separate LIQ and ICE runoff files for EBM (With EBM on LIQROF is no longer spread over many ocn pts.)
   Mushy Ice algorithm is now the default for providing ice temperatures.  Previously set to -1.8

Test suite: cime regression 
Test baseline: 
Test namelist changes: NA
Test status: climate changing - new ICE and POP defaults for CESM

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 
