### PR TITLE
added cime_model attribute to all value entries that had compset attr…

### DIFF
--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -366,7 +366,8 @@
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
     <default_value>never</default_value>
     <values>
-      <value compset="_DATM.+_CLM">ndays</value>
+      <value cime_model="acme" compset="_DATM.+_CLM">ndays</value>
+      <value cime_model="cesm" compset="_DATM.+_CLM">ndays</value>
     </values>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
@@ -2406,12 +2407,19 @@
     <valid_values>CESM1_ORIG,CESM1_ORIG_TIGHT,CESM1_MOD,CESM1_MOD_TIGHT,RASM_OPTION1,RASM_OPTION2</valid_values>
     <default_value>CESM1_MOD_TIGHT</default_value>
     <values>
-      <value compset="_DATM.*_DOCN%SOM"          >RASM_OPTION1</value>
-      <value compset="_POP2"                     >RASM_OPTION1</value>
-      <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN">RASM_OPTION1</value>
-      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">RASM_OPTION1</value>
-      <value compset="_SOCN"                     >RASM_OPTION1</value>
-      <value compset="_MPAS"                     >RASM_OPTION1</value>
+      <value cime_model="acme" compset="_DATM.*_DOCN%SOM">CESM1_MOD</value>
+      <value cime_model="acme" compset="_POP2">CESM1_MOD</value>
+      <value cime_model="acme" compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN">CESM1_MOD</value>
+      <value cime_model="acme" compset="_XATM.*_XLND.*_XICE.*_XOCN">CESM1_MOD</value>
+      <value cime_model="acme" compset="_SOCN">CESM1_MOD</value>
+      <value cime_model="acme" compset="_MPAS">CESM1_MOD</value>
+
+      <value cime_model="cesm" compset="_DATM.*_DOCN%SOM">RASM_OPTION1</value>
+      <value cime_model="cesm" compset="_POP2">RASM_OPTION1</value>
+      <value cime_model="cesm" compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN">RASM_OPTION1</value>
+      <value cime_model="cesm" compset="_XATM.*_XLND.*_XICE.*_XOCN">RASM_OPTION1</value>
+      <value cime_model="cesm" compset="_SOCN">RASM_OPTION1</value>
+      <value cime_model="cesm" compset="_MPAS">RASM_OPTION1</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -2447,13 +2455,21 @@
     <valid_values>none,CO2A,CO2B,CO2C,CO2_DMSA</valid_values>
     <default_value>none</default_value>
     <values>
-      <value compset="_CAM\d+"  >CO2A</value>
-      <value compset="_DATM"    >none</value>
-      <value compset="_DATM%S1850.+POP\d">CO2A</value>
-      <value compset="_BGC%BPRP">CO2C</value>
-      <value compset="_BGC%BDRD">CO2C</value>
-      <value compset="HIST.*_DATM%(QIA|CRU)">CO2A</value>
-      <value compset="RCP.*_DATM%(QIA|CRU)" >CO2A</value>
+      <value cime_model="acme" compset="_CAM\d+">CO2A</value>
+      <value cime_model="acme" compset="_DATM">none</value>
+      <value cime_model="acme" compset="_DATM%S1850.+POP\d">CO2A</value>
+      <value cime_model="acme" compset="_BGC%BPRP">CO2C</value>
+      <value cime_model="acme" compset="_BGC%BDRD">CO2C</value>
+      <value cime_model="acme" compset="HIST.*_DATM%(QIA|CRU)">CO2A</value>
+      <value cime_model="acme" compset="RCP.*_DATM%(QIA|CRU)">CO2A</value>
+
+      <value cime_model="cesm" compset="_CAM\d+">CO2A</value>
+      <value cime_model="cesm" compset="_DATM">none</value>
+      <value cime_model="cesm" compset="_DATM%S1850.+POP\d">CO2A</value>
+      <value cime_model="cesm" compset="_BGC%BPRP">CO2C</value>
+      <value cime_model="cesm" compset="_BGC%BDRD">CO2C</value>
+      <value cime_model="cesm" compset="HIST.*_DATM%(QIA|CRU)">CO2A</value>
+      <value cime_model="cesm" compset="RCP.*_DATM%(QIA|CRU)">CO2A</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -2470,8 +2486,11 @@
     <file>env_run.xml</file>
     <default_value>day</default_value>
     <values>
-      <value compset="_DLND.*_CISM\d">year</value>
-      <value compset="_MPAS"       >hour</value>
+      <value cime_model="acme" compset="_DLND.*_CISM\d">year</value>
+      <value cime_model="acme" compset="_MPAS">hour</value>
+
+      <value cime_model="cesm" compset="_DLND.*_CISM\d">year</value>
+      <value cime_model="cesm" compset="_MPAS">hour</value>
     </values>
     <desc>Base period associated with NCPL coupling frequency.
     This xml variable is only used to set the driver namelist variables,
@@ -2482,34 +2501,63 @@
     <type>integer</type>
     <default_value>48</default_value>
     <values>
-      <value compset="_CAM.*">48</value>
-      <value compset="_CAM\d+%WCBC">144</value>
-      <value compset="_CAM\d+%WCMX">288</value>
-      <value compset="_CAM\d+%WCXI">288</value>
-      <value compset="_CAM%ADIAB">48</value>
-      <value compset="_CAM%IDEAL">48</value>
-      <value compset="_DATM%COPYALL_NPS">72</value>
-      <value compset="_DATM.*_CLM">48</value>
-      <value compset="_DATM.*_DICE.*_POP2">4</value>
-      <value compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
-      <value compset="_DATM.*_CICE.*_DOCN">24</value>
-      <value compset="_DATM.*_DOCN%US20">24</value>
-      <value compset="_DATM%S1850.+POP\d">48</value>
-      <value compset="_MPAS">1</value>
-      <value compset=".+" grid="a%0.23x0.31">96</value>
-      <value compset=".+" grid="a%ne60np4">96</value>
-      <value compset=".+" grid="a%ne120np4">96</value>
-      <value compset=".+" grid="a%ne240np4">96</value>
-      <value compset=".+" grid="a%T42">72</value>
-      <value compset=".+" grid="a%T85">144</value>
-      <value compset=".+" grid="a%T341">288</value>
-      <value compset=".+" grid="1x1">48</value>
-      <value compset=".+" grid="1x1_urbanc">48</value>
-      <value compset=".+" grid="1x1_mexico">24</value>
-      <value compset=".+" grid="1x1_vancou">24</value>
-      <value compset="_DLND.*_CISM\d">1</value>
-      <value compset="_DATM.*_DICE.*_POP2.*_WW3">4</value>
-      <value compset="_DATM.*_DICE.*_POP2.*_DWAV">4</value>
+      <value cime_model="acme" compset="_CAM.*">48</value>
+      <value cime_model="acme" compset="_CAM\d+%WCBC">144</value>
+      <value cime_model="acme" compset="_CAM\d+%WCMX">288</value>
+      <value cime_model="acme" compset="_CAM\d+%WCXI">288</value>
+      <value cime_model="acme" compset="_CAM%ADIAB">48</value>
+      <value cime_model="acme" compset="_CAM%IDEAL">48</value>
+      <value cime_model="acme" compset="_DATM%COPYALL_NPS">72</value>
+      <value cime_model="acme" compset="_DATM.*_CLM">48</value>
+      <value cime_model="acme" compset="_DATM.*_DICE.*_POP2">4</value>
+      <value cime_model="acme" compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
+      <value cime_model="acme" compset="_DATM.*_CICE.*_DOCN">24</value>
+      <value cime_model="acme" compset="_DATM.*_DOCN%US20">24</value>
+      <value cime_model="acme" compset="_DATM%S1850.+POP\d">48</value>
+      <value cime_model="acme" compset="_MPAS">1</value>
+      <value cime_model="acme" compset=".+" grid="a%0.23x0.31">96</value>
+      <value cime_model="acme" compset=".+" grid="a%ne60np4">96</value>
+      <value cime_model="acme" compset=".+" grid="a%ne120np4">96</value>
+      <value cime_model="acme" compset=".+" grid="a%ne240np4">96</value>
+      <value cime_model="acme" compset=".+" grid="a%T42">72</value>
+      <value cime_model="acme" compset=".+" grid="a%T85">144</value>
+      <value cime_model="acme" compset=".+" grid="a%T341">288</value>
+      <value cime_model="acme" compset=".+" grid="1x1">48</value>
+      <value cime_model="acme" compset=".+" grid="1x1_urbanc">48</value>
+      <value cime_model="acme" compset=".+" grid="1x1_mexico">24</value>
+      <value cime_model="acme" compset=".+" grid="1x1_vancou">24</value>
+      <value cime_model="acme" compset="_DLND.*_CISM\d">1</value>
+      <value cime_model="acme" compset="_DATM.*_DICE.*_POP2.*_WW3">4</value>
+      <value cime_model="acme" compset="_DATM.*_DICE.*_POP2.*_DWAV">4</value>
+
+      <value cime_model="cesm" compset="_CAM.*">48</value>
+      <value cime_model="cesm" compset="_CAM\d+%WCBC">144</value>
+      <value cime_model="cesm" compset="_CAM\d+%WCMX">288</value>
+      <value cime_model="cesm" compset="_CAM\d+%WCXI">288</value>
+      <value cime_model="cesm" compset="_CAM%ADIAB">48</value>
+      <value cime_model="cesm" compset="_CAM%IDEAL">48</value>
+      <value cime_model="cesm" compset="_DATM%COPYALL_NPS">72</value>
+      <value cime_model="cesm" compset="_DATM.*_CLM">48</value>
+      <value cime_model="cesm" compset="_DATM.*_DICE.*_POP2">4</value>
+      <value cime_model="cesm" compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
+      <value cime_model="cesm" compset="_DATM.*_CICE.*_DOCN">24</value>
+      <value cime_model="cesm" compset="_DATM.*_DOCN%US20">24</value>
+      <value cime_model="cesm" compset="_DATM%S1850.+POP\d">48</value>
+      <value cime_model="cesm" compset="_MPAS">1</value>
+      <value cime_model="cesm" compset=".+" grid="a%0.23x0.31">96</value>
+      <value cime_model="cesm" compset=".+" grid="a%ne60np4">96</value>
+      <value cime_model="cesm" compset=".+" grid="a%ne120np4">96</value>
+      <value cime_model="cesm" compset=".+" grid="a%ne240np4">96</value>
+      <value cime_model="cesm" compset=".+" grid="a%T42">72</value>
+      <value cime_model="cesm" compset=".+" grid="a%T85">144</value>
+      <value cime_model="cesm" compset=".+" grid="a%T341">288</value>
+      <value cime_model="cesm" compset=".+" grid="1x1">48</value>
+      <value cime_model="cesm" compset=".+" grid="1x1_urbanc">48</value>
+      <value cime_model="cesm" compset=".+" grid="1x1_mexico">24</value>
+      <value cime_model="cesm" compset=".+" grid="1x1_vancou">24</value>
+      <value cime_model="cesm" compset="_DLND.*_CISM\d">1</value>
+      <value cime_model="cesm" compset="_DATM.*_DICE.*_POP2.*_WW3">4</value>
+      <value cime_model="cesm" compset="_DATM.*_DICE.*_POP2.*_DWAV">4</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -2522,7 +2570,8 @@
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
     <values>
-      <value compset="_DLND.*_CISM\d">1</value>
+      <value cime_model="acme" compset="_DLND.*_CISM\d">1</value>
+      <value cime_model="cesm" compset="_DLND.*_CISM\d">1</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -2535,7 +2584,8 @@
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
     <values>
-      <value compset="_DLND.*_CISM\d">1</value>
+      <value cime_model="acme" compset="_DLND.*_CISM\d">1</value>
+      <value cime_model="cesm" compset="_DLND.*_CISM\d">1</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -2548,15 +2598,25 @@
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
     <values>
-      <value compset="_POP2">24</value>
-      <value compset="_POP2" grid="oi%tx0.1v2">24</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">24</value>
-      <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">24</value>
-      <value compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">24</value>
-      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">24</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">24</value>
-      <value compset="_SATM.*_SLND.*_SICE.*_SOCN">24</value>
-      <value compset="_DLND.*_CISM\d">24</value>
+      <value cime_model="acme" compset="_POP2">1</value>
+      <value cime_model="acme" compset="_POP2" grid="oi%tx0.1v2">4</value>
+      <value cime_model="acme" compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
+      <value cime_model="acme" compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
+      <value cime_model="acme" compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
+      <value cime_model="acme" compset="_XATM.*_XLND.*_XICE.*_XOCN">1</value>
+      <value cime_model="acme" compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
+      <value cime_model="acme" compset="_SATM.*_SLND.*_SICE.*_SOCN">1</value>
+      <value cime_model="acme" compset="_DLND.*_CISM\d">1</value>
+
+      <value cime_model="cesm" compset="_POP2">24</value>
+      <value cime_model="cesm" compset="_POP2" grid="oi%tx0.1v2">24</value>
+      <value cime_model="cesm" compset="_DATM.*_CLM4.*_SICE.*_SOCN">24</value>
+      <value cime_model="cesm" compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">24</value>
+      <value cime_model="cesm" compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">24</value>
+      <value cime_model="cesm" compset="_XATM.*_XLND.*_XICE.*_XOCN">24</value>
+      <value cime_model="cesm" compset="_DATM.*_CLM4.*_SICE.*_SOCN">24</value>
+      <value cime_model="cesm" compset="_SATM.*_SLND.*_SICE.*_SOCN">24</value>
+      <value cime_model="cesm" compset="_DLND.*_CISM\d">24</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -2569,7 +2629,8 @@
     <type>integer</type>
     <default_value>1</default_value>
     <values>
-      <value compset="_DLND.*_CISM\d">1</value>
+      <value cime_model="acme" compset="_DLND.*_CISM\d">1</value>
+      <value cime_model="cesm" compset="_DLND.*_CISM\d">1</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -2580,12 +2641,19 @@
     <type>integer</type>
     <default_value>8</default_value>
     <values>
-      <value compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
-      <value compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
-      <value compset="_DATM.*_SLND.*_DICE.*_DOCN">$ATM_NCPL</value>
-      <value compset="_DATM%S1850.+POP\d">8</value>
-      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>
-      <value compset="_DLND.*_CISM\d">1</value>
+      <value cime_model="acme" compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
+      <value cime_model="acme" compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
+      <value cime_model="acme" compset="_DATM.*_SLND.*_DICE.*_DOCN">$ATM_NCPL</value>
+      <value cime_model="acme" compset="_DATM%S1850.+POP\d">8</value>
+      <value cime_model="acme" compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>
+      <value cime_model="acme" compset="_DLND.*_CISM\d">1</value>
+
+      <value cime_model="cesm" compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
+      <value cime_model="cesm" compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
+      <value cime_model="cesm" compset="_DATM.*_SLND.*_DICE.*_DOCN">$ATM_NCPL</value>
+      <value cime_model="cesm" compset="_DATM%S1850.+POP\d">8</value>
+      <value cime_model="cesm" compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>
+      <value cime_model="cesm" compset="_DLND.*_CISM\d">1</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -2612,9 +2680,13 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values>
-      <value compset="DATM.+POP\d">TRUE</value>
-      <value compset="DATM.+DOCN%IAF">TRUE</value>
-      <value compset="DATM%S1850.+POP\d">FALSE</value>
+      <value cime_model="acme" compset="DATM.+POP\d">TRUE</value>
+      <value cime_model="acme" compset="DATM.+DOCN%IAF">TRUE</value>
+      <value cime_model="acme" compset="DATM%S1850.+POP\d">FALSE</value>
+
+      <value cime_model="cesm" compset="DATM.+POP\d">TRUE</value>
+      <value cime_model="cesm" compset="DATM.+DOCN%IAF">TRUE</value>
+      <value cime_model="cesm" compset="DATM%S1850.+POP\d">FALSE</value>
     </values>
     <group>run_component_cpl</group>
     <file>env_run.xml</file>
@@ -2639,8 +2711,11 @@
     <valid_values>off,ocn</valid_values>
     <default_value>off</default_value>
     <values>
-      <value compset="DATM.+POP\d">ocn</value>
-      <value compset="DATM%S1850.+POP\d">off</value>
+      <value cime_model="acme" compset="DATM.+POP\d">ocn</value>
+      <value cime_model="acme" compset="DATM%S1850.+POP\d">off</value>
+
+      <value cime_model="cesm" compset="DATM.+POP\d">ocn</value>
+      <value cime_model="cesm" compset="DATM%S1850.+POP\d">off</value>
     </values>
     <group>run_component_cpl</group>
     <file>env_run.xml</file>
@@ -2692,7 +2767,8 @@
     <valid_values></valid_values>
     <default_value>never</default_value>
     <values>
-      <value compset="_DOCN%IAF">nmonths</value>
+      <value cime_model="acme" compset="_DOCN%IAF">nmonths</value>
+      <value cime_model="cesm" compset="_DOCN%IAF">nmonths</value>
     </values>
     <group>run_drv_history</group>
     <file>env_run.xml</file>
@@ -2704,7 +2780,8 @@
     <valid_values></valid_values>
     <default_value>-999</default_value>
     <values>
-      <value compset="_DOCN%IAF">1</value>
+      <value cime_model="acme" compset="_DOCN%IAF">1</value>
+      <value cime_model="cesm" compset="_DOCN%IAF">1</value>
     </values>
     <group>run_drv_history</group>
     <file>env_run.xml</file>
@@ -2725,9 +2802,13 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values>
-      <value compset="DATM.*_POP\d">TRUE</value>
-      <value compset="CAM.*_POP\d">TRUE</value>
-      <value compset="CAM.*_DOCN%SOM">TRUE</value>
+      <value cime_model="acme" compset="DATM.*_POP\d">TRUE</value>
+      <value cime_model="acme" compset="CAM.*_POP\d">TRUE</value>
+      <value cime_model="acme" compset="CAM.*_DOCN%SOM">TRUE</value>
+
+      <value cime_model="cesm" compset="DATM.*_POP\d">TRUE</value>
+      <value cime_model="cesm" compset="CAM.*_POP\d">TRUE</value>
+      <value cime_model="cesm" compset="CAM.*_DOCN%SOM">TRUE</value>
     </values>
     <group>run_budgets</group>
     <file>env_run.xml</file>
@@ -2739,46 +2820,75 @@
     <valid_values></valid_values>
     <default_value>379.000</default_value>
     <values>
-      <value compset="^1850"                     >284.7</value>
-      <value compset="^HIST.+BGC%BPRP"           >284.7</value>
-      <value compset="^HIST_CAM4%FCHM"           >0.000001</value>
-      <value compset="^2000"                     >367.0</value>
-      <value compset="^1850.+DATM%NYF"           >379.000</value>
-      <value compset="^1850.+DATM%NYF.*_POP2%ECO">284.7</value>
-      <value compset="^2000.+DATM%NYF"           >379.000</value>
-      <value compset="^2000.+DATM%IAF"           >379.000</value>
-      <value compset="^HIST.+DATM"               >367.0</value>
-      <value compset="^4804.+DATM"               >367.0</value>
-      <value compset="^RCP2.+DATM"               >367.0</value>
-      <value compset="^RCP4.+DATM"               >367.0</value>
-      <value compset="^RCP6.+DATM"               >367.0</value>
-      <value compset="^RCP8.+DATM"               >367.0</value>
-      <value compset="^2000.+XATM"               >379.000</value>
-      <value compset="^HIST.+CAM"                >0.000001</value>
-      <value compset="^5505.+CAM"                >0.000001</value>
-      <value compset="^RCP2.+CAM"                >0.000001</value>
-      <value compset="^RCP4.+CAM"                >0.000001</value>
-      <value compset="^RCP6.+CAM"                >0.000001</value>
-      <value compset="^RCP8.+CAM"                >0.000001</value>
-      <value compset="^2013.+CAM"                >0.000001</value>
-      <value compset="^SDYN.+CAM"                >0.000001</value>
-      <value compset="^AMIP.+CAM"                >0.000001</value>
-      <value compset="^AR95"                     >368.9</value>
-      <value compset="^AR97"                     >368.9</value>
-      <value compset="^2003"                     >367.0</value>
+      <value cime_model="acme" compset="^1850">284.7</value>
+      <value cime_model="acme" compset="^HIST.+BGC%BPRP">284.7</value>
+      <value cime_model="acme" compset="^HIST_CAM4%FCHM">0.000001</value>
+      <value cime_model="acme" compset="^2000">367.0</value>
+      <value cime_model="acme" compset="^1850.+DATM%NYF">379.000</value>
+      <value cime_model="acme" compset="^1850.+DATM%NYF.*_POP2%ECO">284.7</value>
+      <value cime_model="acme" compset="^2000.+DATM%NYF">379.000</value>
+      <value cime_model="acme" compset="^2000.+DATM%IAF">379.000</value>
+      <value cime_model="acme" compset="^HIST.+DATM">367.0</value>
+      <value cime_model="acme" compset="^4804.+DATM">367.0</value>
+      <value cime_model="acme" compset="^RCP2.+DATM">367.0</value>
+      <value cime_model="acme" compset="^RCP4.+DATM">367.0</value>
+      <value cime_model="acme" compset="^RCP6.+DATM">367.0</value>
+      <value cime_model="acme" compset="^RCP8.+DATM">367.0</value>
+      <value cime_model="acme" compset="^2000.+XATM">379.000</value>
+      <value cime_model="acme" compset="^HIST.+CAM">0.000001</value>
+      <value cime_model="acme" compset="^5505.+CAM">0.000001</value>
+      <value cime_model="acme" compset="^RCP2.+CAM">0.000001</value>
+      <value cime_model="acme" compset="^RCP4.+CAM">0.000001</value>
+      <value cime_model="acme" compset="^RCP6.+CAM">0.000001</value>
+      <value cime_model="acme" compset="^RCP8.+CAM">0.000001</value>
+      <value cime_model="acme" compset="^2013.+CAM">0.000001</value>
+      <value cime_model="acme" compset="^SDYN.+CAM">0.000001</value>
+      <value cime_model="acme" compset="^AMIP.+CAM">0.000001</value>
+      <value cime_model="acme" compset="^AR95">368.9</value>
+      <value cime_model="acme" compset="^AR97">368.9</value>
+      <value cime_model="acme" compset="^2003">367.0</value>
+
+      <value cime_model="cesm" compset="^1850">284.7</value>
+      <value cime_model="cesm" compset="^HIST.+BGC%BPRP">284.7</value>
+      <value cime_model="cesm" compset="^HIST_CAM4%FCHM">0.000001</value>
+      <value cime_model="cesm" compset="^2000">367.0</value>
+      <value cime_model="cesm" compset="^1850.+DATM%NYF">379.000</value>
+      <value cime_model="cesm" compset="^1850.+DATM%NYF.*_POP2%ECO">284.7</value>
+      <value cime_model="cesm" compset="^2000.+DATM%NYF">379.000</value>
+      <value cime_model="cesm" compset="^2000.+DATM%IAF">379.000</value>
+      <value cime_model="cesm" compset="^HIST.+DATM">367.0</value>
+      <value cime_model="cesm" compset="^4804.+DATM">367.0</value>
+      <value cime_model="cesm" compset="^RCP2.+DATM">367.0</value>
+      <value cime_model="cesm" compset="^RCP4.+DATM">367.0</value>
+      <value cime_model="cesm" compset="^RCP6.+DATM">367.0</value>
+      <value cime_model="cesm" compset="^RCP8.+DATM">367.0</value>
+      <value cime_model="cesm" compset="^2000.+XATM">379.000</value>
+      <value cime_model="cesm" compset="^HIST.+CAM">0.000001</value>
+      <value cime_model="cesm" compset="^5505.+CAM">0.000001</value>
+      <value cime_model="cesm" compset="^RCP2.+CAM">0.000001</value>
+      <value cime_model="cesm" compset="^RCP4.+CAM">0.000001</value>
+      <value cime_model="cesm" compset="^RCP6.+CAM">0.000001</value>
+      <value cime_model="cesm" compset="^RCP8.+CAM">0.000001</value>
+      <value cime_model="cesm" compset="^2013.+CAM">0.000001</value>
+      <value cime_model="cesm" compset="^SDYN.+CAM">0.000001</value>
+      <value cime_model="cesm" compset="^AMIP.+CAM">0.000001</value>
+      <value cime_model="cesm" compset="^AR95">368.9</value>
+      <value cime_model="cesm" compset="^AR97">368.9</value>
+      <value cime_model="cesm" compset="^2003">367.0</value>
+
       <!-- Override values based on CAM (WACCM) chemistry -->
-      <value compset="CAM[456]0%W"               >0.000001</value>
-      <value compset="CAM[456]0%SVBS"            >0.000001</value>
-      <value compset="CAM[456]0%TMOZ"            >0.000001</value>
+      <value cime_model="cesm" compset="CAM[456]0%W">0.000001</value>
+      <value cime_model="cesm" compset="CAM[456]0%SVBS">0.000001</value>
+      <value cime_model="cesm" compset="CAM[456]0%TMOZ">0.000001</value>
       <!-- Mariana's fix to allow isotopes to get the proper CO2 value -->
-      <value compset="CAM..%WISOall"             >284.7</value>
-      <value compset="^2000.+CAM[45]%WCSC"       >368.9</value>
-      <value compset="^2000.+CAM[45]%MOZM"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%MMOS"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%TMOZ"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%SMA3"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%SMA7"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%SSOA"       >0.000001</value>
+      <value cime_model="cesm" compset="CAM..%WISOall">284.7</value>
+      <value cime_model="cesm" compset="^2000.+CAM[45]%WCSC">368.9</value>
+      <value cime_model="cesm" compset="^2000.+CAM[45]%MOZM">0.000001</value>
+      <value cime_model="cesm" compset="^2000.+CAM[45]%MMOS">0.000001</value>
+      <value cime_model="cesm" compset="^2000.+CAM[45]%TMOZ">0.000001</value>
+      <value cime_model="cesm" compset="^2000.+CAM[45]%SMA3">0.000001</value>
+      <value cime_model="cesm" compset="^2000.+CAM[45]%SMA7">0.000001</value>
+      <value cime_model="cesm" compset="^2000.+CAM[45]%SSOA">0.000001</value>
     </values>
     <group>run_co2</group>
     <file>env_run.xml</file>
@@ -2791,8 +2901,8 @@
     <valid_values></valid_values>
     <default_value>284.7</default_value>
     <values>
-      <value compset="^2000">367.0</value>
-      <value compset="^4804">367.0</value>
+      <value cime_model="cesm" compset="^2000">367.0</value>
+      <value cime_model="cesm" compset="^4804">367.0</value>
     </values>
     <group>run_co2</group>
     <file>env_run.xml</file>
@@ -2807,8 +2917,8 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values>
-      <value compset="%WISO">TRUE</value>
-      <value compset="%ISO">TRUE</value>
+      <value cime_model="cesm" compset="%WISO">TRUE</value>
+      <value cime_model="cesm" compset="%ISO">TRUE</value>
     </values>
     <group>run_flags</group>
     <file>env_run.xml</file>
@@ -2867,7 +2977,8 @@
     <valid_values>0,1,3,5,10,36</valid_values>
     <default_value>10</default_value>
     <values>
-      <value compset="_SGLC">0</value>
+      <value cime_model="acme" compset="_SGLC">0</value>
+      <value cime_model="cesm" compset="_SGLC">0</value>
     </values>
     <group>run_glc</group>
     <file>env_run.xml</file>
@@ -2922,11 +3033,17 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values>
-      <value compset="_CLM45.+CISM\d">TRUE</value>
-      <value compset="_CLM50.+CISM\d">TRUE</value>
+      <value cime_model="acme" compset="_CLM45.+CISM\d">TRUE</value>
+      <value cime_model="acme" compset="_CLM50.+CISM\d">TRUE</value>
       <!-- Turn on two-way coupling for TG compsets - even though there are no
            feedbacks for a TG compset, this will give us additional diagnostics -->
-      <value compset="_DLND.+CISM\d">TRUE</value>
+      <value cime_model="acme" compset="_DLND.+CISM\d">TRUE</value>
+
+      <value cime_model="cesm" compset="_CLM45.+CISM\d">TRUE</value>
+      <value cime_model="cesm" compset="_CLM50.+CISM\d">TRUE</value>
+      <!-- Turn on two-way coupling for TG compsets - even though there are no
+           feedbacks for a TG compset, this will give us additional diagnostics -->
+      <value cime_model="cesm" compset="_DLND.+CISM\d">TRUE</value>
     </values>
     <group>run_glc</group>
     <file>env_run.xml</file>
@@ -3012,34 +3129,34 @@
  </entry>
 
   <description>
-    <desc compset="BGC%BPRP">BGC CO2=prog, rad CO2=prog:</desc>
-    <desc compset="BGC%BDRD">BGC CO2=diag, rad CO2=diag:</desc>
-    <desc compset="POP2%ECO">ECO in POP:</desc>
-    <desc compset="_TEST" >--DO NOT USE FOR LONG SIMULATIONS:</desc>
-    <desc compset="1850_">pre-industrial:</desc>
-    <desc compset="2000_">present day:</desc>
-    <desc compset="HIST_">Historical 1850 to 2000 transient:</desc>
-    <desc compset="AMIP_">AMIP for stand-alone cam:</desc>
-    <desc compset="C2R[68]_">CCMI REFC2 1950 to 2100 transient:</desc>
-    <desc compset="C2R4_">CCMI REFC2 2004 to 2100 transient:</desc>
-    <desc compset="4804_">1948 to 2004 transient:</desc>
-    <desc compset="FRC1_">CCMI REFC1 Free running, 1950 to 2010 transient:</desc>
-    <desc compset="SDC1_">CCMI REFC1 Specified dynamics, 1975 to 2010 transient:</desc>
-    <desc compset="C2R8_">RCP8.5 future scenario:</desc>
-    <desc compset="C2R6_">RCP6.0 future scenario:</desc>
-    <desc compset="C2R4_">RCP4.5 future scenario:</desc>
-    <desc compset="5505_">1955 to 2005 transient:</desc>
-    <desc compset="RCP8_">RCP8.5 future scenario:</desc>
-    <desc compset="RCP6_">RCP6.0 future scenario:</desc>
-    <desc compset="RCP4_">RCP4.5 future scenario:</desc>
-    <desc compset="RCP2_">RCP2.6 future scenario:</desc>
-    <desc compset="2013_">RCP4.5 based scenario from 2013 (control for WACCM/CARMA nuclear winter study):</desc>
-    <desc compset="9205_CAM">1992 to 2005 transient:</desc>
-    <desc compset="SDYN_CAM">prescribed meteorology: for stand-alone cam</desc>
-    <desc compset="AR95_CAM">ARM95 IOP: for stand-alone cam</desc>
-    <desc compset="AR97_CAM">ARM97 IOP: for stand-alone cam</desc>
-    <desc compset="HIST_CLM4[05]%CN">CLM transient land use:</desc>
-    <desc compset="PIPD">
+    <desc cime_model="acme" compset="BGC%BPRP">BGC CO2=prog, rad CO2=prog:</desc>
+    <desc cime_model="acme" compset="BGC%BDRD">BGC CO2=diag, rad CO2=diag:</desc>
+    <desc cime_model="acme" compset="POP2%ECO">ECO in POP:</desc>
+    <desc cime_model="acme" compset="_TEST" >--DO NOT USE FOR LONG SIMULATIONS:</desc>
+    <desc cime_model="acme" compset="1850_">pre-industrial:</desc>
+    <desc cime_model="acme" compset="2000_">present day:</desc>
+    <desc cime_model="acme" compset="HIST_">Historical 1850 to 2000 transient:</desc>
+    <desc cime_model="acme" compset="AMIP_">AMIP for stand-alone cam:</desc>
+    <desc cime_model="acme" compset="C2R[68]_">CCMI REFC2 1950 to 2100 transient:</desc>
+    <desc cime_model="acme" compset="C2R4_">CCMI REFC2 2004 to 2100 transient:</desc>
+    <desc cime_model="acme" compset="4804_">1948 to 2004 transient:</desc>
+    <desc cime_model="acme" compset="FRC1_">CCMI REFC1 Free running, 1950 to 2010 transient:</desc>
+    <desc cime_model="acme" compset="SDC1_">CCMI REFC1 Specified dynamics, 1975 to 2010 transient:</desc>
+    <desc cime_model="acme" compset="C2R8_">RCP8.5 future scenario:</desc>
+    <desc cime_model="acme" compset="C2R6_">RCP6.0 future scenario:</desc>
+    <desc cime_model="acme" compset="C2R4_">RCP4.5 future scenario:</desc>
+    <desc cime_model="acme" compset="5505_">1955 to 2005 transient:</desc>
+    <desc cime_model="acme" compset="RCP8_">RCP8.5 future scenario:</desc>
+    <desc cime_model="acme" compset="RCP6_">RCP6.0 future scenario:</desc>
+    <desc cime_model="acme" compset="RCP4_">RCP4.5 future scenario:</desc>
+    <desc cime_model="acme" compset="RCP2_">RCP2.6 future scenario:</desc>
+    <desc cime_model="acme" compset="2013_">RCP4.5 based scenario from 2013 (control for WACCM/CARMA nuclear winter study):</desc>
+    <desc cime_model="acme" compset="9205_CAM">1992 to 2005 transient:</desc>
+    <desc cime_model="acme" compset="SDYN_CAM">prescribed meteorology: for stand-alone cam</desc>
+    <desc cime_model="acme" compset="AR95_CAM">ARM95 IOP: for stand-alone cam</desc>
+    <desc cime_model="acme" compset="AR97_CAM">ARM97 IOP: for stand-alone cam</desc>
+    <desc cime_model="acme" compset="HIST_CLM4[05]%CN">CLM transient land use:</desc>
+    <desc cime_model="acme" compset="PIPD">
       pre-industrial (1850) to present day:
       -----------------------------WARNING ------------------------------------------------
       "PIPD" compsets use complete forcing data from observed sources
@@ -3047,7 +3164,49 @@
       (land-use, SST, sea ice, CO2, CH4, N2O) to present day and IPCC RCP4.5 scenario data.
       -------------------------------------------------------------------------------------
     </desc>
-    <desc compset="CAM4.*_BGC%B">
+    <desc cime_model="acme" compset="CAM4.*_BGC%B">
+      -----------------------------WARNING ------------------------------------------------
+      This compset is not spun-up! In later versions of the model, spun-up initial
+      conditions will be provided and this warning will be removed.
+      -------------------------------------------------------------------------------------
+    </desc>
+
+    <desc cime_model="cesm" compset="BGC%BPRP">BGC CO2=prog, rad CO2=prog:</desc>
+    <desc cime_model="cesm" compset="BGC%BDRD">BGC CO2=diag, rad CO2=diag:</desc>
+    <desc cime_model="cesm" compset="POP2%ECO">ECO in POP:</desc>
+    <desc cime_model="cesm" compset="_TEST" >--DO NOT USE FOR LONG SIMULATIONS:</desc>
+    <desc cime_model="cesm" compset="1850_">pre-industrial:</desc>
+    <desc cime_model="cesm" compset="2000_">present day:</desc>
+    <desc cime_model="cesm" compset="HIST_">Historical 1850 to 2000 transient:</desc>
+    <desc cime_model="cesm" compset="AMIP_">AMIP for stand-alone cam:</desc>
+    <desc cime_model="cesm" compset="C2R[68]_">CCMI REFC2 1950 to 2100 transient:</desc>
+    <desc cime_model="cesm" compset="C2R4_">CCMI REFC2 2004 to 2100 transient:</desc>
+    <desc cime_model="cesm" compset="4804_">1948 to 2004 transient:</desc>
+    <desc cime_model="cesm" compset="FRC1_">CCMI REFC1 Free running, 1950 to 2010 transient:</desc>
+    <desc cime_model="cesm" compset="SDC1_">CCMI REFC1 Specified dynamics, 1975 to 2010 transient:</desc>
+    <desc cime_model="cesm" compset="C2R8_">RCP8.5 future scenario:</desc>
+    <desc cime_model="cesm" compset="C2R6_">RCP6.0 future scenario:</desc>
+    <desc cime_model="cesm" compset="C2R4_">RCP4.5 future scenario:</desc>
+    <desc cime_model="cesm" compset="5505_">1955 to 2005 transient:</desc>
+    <desc cime_model="cesm" compset="RCP8_">RCP8.5 future scenario:</desc>
+    <desc cime_model="cesm" compset="RCP6_">RCP6.0 future scenario:</desc>
+    <desc cime_model="cesm" compset="RCP4_">RCP4.5 future scenario:</desc>
+    <desc cime_model="cesm" compset="RCP2_">RCP2.6 future scenario:</desc>
+    <desc cime_model="cesm" compset="2013_">RCP4.5 based scenario from 2013 (control for WACCM/CARMA nuclear winter study):</desc>
+    <desc cime_model="cesm" compset="9205_CAM">1992 to 2005 transient:</desc>
+    <desc cime_model="cesm" compset="SDYN_CAM">prescribed meteorology: for stand-alone cam</desc>
+    <desc cime_model="cesm" compset="AR95_CAM">ARM95 IOP: for stand-alone cam</desc>
+    <desc cime_model="cesm" compset="AR97_CAM">ARM97 IOP: for stand-alone cam</desc>
+    <desc cime_model="cesm" compset="HIST_CLM4[05]%CN">CLM transient land use:</desc>
+    <desc cime_model="cesm" compset="PIPD">
+      pre-industrial (1850) to present day:
+      -----------------------------WARNING ------------------------------------------------
+      "PIPD" compsets use complete forcing data from observed sources
+      up to the year 2005. Following this period they are a combination of observed sources
+      (land-use, SST, sea ice, CO2, CH4, N2O) to present day and IPCC RCP4.5 scenario data.
+      -------------------------------------------------------------------------------------
+    </desc>
+    <desc cime_model="cesm" compset="CAM4.*_BGC%B">
       -----------------------------WARNING ------------------------------------------------
       This compset is not spun-up! In later versions of the model, spun-up initial
       conditions will be provided and this warning will be removed.

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -90,6 +90,7 @@ class Case(object):
         self._components = []
         self._component_classes = []
         self._is_env_loaded = False
+        self._cime_model = get_model()
 
         self.thread_count = None
         self.tasks_per_node = None
@@ -485,12 +486,14 @@ class Case(object):
             env_file.set_components(comp_classes)
 
     def _get_component_config_data(self):
-        # attributes used for multi valued defaults ($attlist is a hash reference)
-        attlist = {"compset":self._compsetname, "grid":self._gridname}
+        # attributes used for multi valued defaults 
+        # attlist is a dictionary used to determine the value element that has the most matches
+        attlist = {"compset":self._compsetname, "grid":self._gridname, "cime_model":self._cime_model}
 
         # Determine list of component classes that this coupler/driver knows how
         # to deal with. This list follows the same order as compset longnames follow.
         files = Files()
+
         # Add the group and elements for the config_files.xml
         for env_file in self._env_entryid_files:
             env_file.add_elements_by_group(files, attlist)
@@ -498,6 +501,7 @@ class Case(object):
         drv_comp = Component(drv_config_file)
         for env_file in self._env_entryid_files:
             env_file.add_elements_by_group(drv_comp, attributes=attlist)
+
         # Add the group and elements for env_batch
         env_batch = self.get_env("batch")
         env_batch.add_elements_by_group(drv_comp, attributes=attlist)

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1141,6 +1141,12 @@ class K_TestCimeCase(TestCreateTestCommon):
                             msg="Build complete had wrong value '%s'" %
                             build_complete)
 
+            model_specific_val = case.get_value("CPL_SEQ_OPTION")
+            if CIME.utils.get_model() == 'cesm':
+                self.assertEqual(model_specific_val, "RASM_OPTION1")
+            else:
+                self.assertEqual(model_specific_val, "CESM1_MOD")
+
             # Test some test properties
             self.assertEqual(case.get_value("TESTCASE"), "TESTRUNPASS")
 


### PR DESCRIPTION
add cime_model attribute to driver_cpl config_component.xml

Value tags in driver_cpl/cime_config/ config_component.xml has compset attributes that are not always the same for cesm and acme. This became particularly true in the recent PR where cesm coupling frequencies were changed and this effected the acme defaults incorrectly.
To mitigate this in the future, all value elements in config_component.xml also need a cime_model attribute so that cesm developments can be independent of acme developments.

Test suite: scripts_regression_tests
Test baseline: none
Test namelist changes: none
Test status: bit for bit

Fixes #983

User interface changes?: None

Code review: 
