### PR TITLE
Reduce redundant case setups

### DIFF
--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -33,7 +33,6 @@ class SystemTestsCommon(object):
         self._test_status = TestStatus(test_dir=caseroot, test_name=self._casebaseid)
         self._init_environment(caseroot)
         self._init_locked_files(caseroot, expected)
-        self._init_case_setup()
 
     def _init_environment(self, caseroot):
         """
@@ -59,16 +58,19 @@ class SystemTestsCommon(object):
             shutil.copy(os.path.join(caseroot,"env_run.xml"),
                         os.path.join(lockedfiles, "env_run.orig.xml"))
 
-    def _init_case_setup(self):
+    def _resetup_case(self, phase):
         """
-        Do initial case setup needed in __init__
+        Re-setup this case. This is necessary if user is re-running an already-run
+        phase.
         """
-        if self._case.get_value("IS_FIRST_RUN"):
+        # We never want to re-setup if we're doing the resubmitted run
+        phase_status = self._test_status.get_status(phase)
+        if self._case.get_value("IS_FIRST_RUN") and phase_status != TEST_PEND_STATUS:
+
+            logging.warning("Resetting case due to detected re-run of phase %s" % phase)
             self._case.set_initial_test_values()
 
-        case_setup(self._case, reset=True, test_mode=True)
-        self._case.set_value("TEST",True)
-        self._case.flush()
+            case_setup(self._case, reset=True, test_mode=True, no_status=True)
 
     def build(self, sharedlib_only=False, model_only=False):
         """
@@ -80,6 +82,7 @@ class SystemTestsCommon(object):
         for phase_name, phase_bool in [(SHAREDLIB_BUILD_PHASE, not model_only),
                                        (MODEL_BUILD_PHASE, not sharedlib_only)]:
             if phase_bool:
+                self._resetup_case(phase_name)
                 with self._test_status:
                     self._test_status.set_status(phase_name, TEST_PEND_STATUS)
 
@@ -132,6 +135,7 @@ class SystemTestsCommon(object):
         try:
             expect(self._test_status.get_status(MODEL_BUILD_PHASE) == TEST_PASS_STATUS,
                    "Model was not built!")
+            self._resetup_case(RUN_PHASE)
             with self._test_status:
                 self._test_status.set_status(RUN_PHASE, TEST_PEND_STATUS)
 

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -799,7 +799,7 @@ class Case(object):
         compset = self.get_value("COMPSET")
         mpilib = self.get_value("MPILIB")
         defaults = pioobj.get_defaults(grid=grid,compset=compset,mach=mach,compiler=compiler, mpilib=mpilib)
-        
+
         for vid, value in defaults.items():
             self.set_value(vid,value)
 

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -270,10 +270,10 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                          env >> software_environment.txt")
 
 ###############################################################################
-def case_setup(case, clean=False, test_mode=False, reset=False):
+def case_setup(case, clean=False, test_mode=False, reset=False, no_status=False):
 ###############################################################################
     caseroot, casebaseid = case.get_value("CASEROOT"), case.get_value("CASEBASEID")
-    if case.get_value("TEST"):
+    if case.get_value("TEST") and not no_status:
         test_name = casebaseid if casebaseid is not None else case.get_value("CASE")
         with TestStatus(test_dir=caseroot, test_name=test_name) as ts:
             try:

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -462,6 +462,7 @@ class TestScheduler(object):
                            os.path.join(self._output_root,
                                         "sharedlibroot.%s"%self._test_id))
             envtest.set_initial_values(case)
+            case.set_value("TEST", True)
             if self._save_timing:
                 case.set_value("SAVE_TIMING", True)
 

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1107,6 +1107,20 @@ class Z_FullSystemTest(TestCreateTestCommon):
             self.assertIs(type(test_time), int, msg="get time did not return int for %s" % test_status)
             self.assertTrue(test_time > 0, msg="test time was zero for %s" % test_status)
 
+        # Test that re-running works
+        tests = update_acme_tests.get_test_suite("cime_developer")
+        for test in tests:
+            if test.startswith("ERI"):
+                # TODO: these need to all work in the future but currently do not support re-run
+                pass
+            else:
+                casedir = os.path.join(TEST_ROOT, "%s.%s" % (test, self._baseline_name))
+                run_cmd_assert_result(self, "./case.submit", from_dir=casedir)
+
+        if (self._hasbatch):
+            run_cmd_assert_result(self, "%s/wait_for_tests *%s/TestStatus" % (TOOLS_DIR, self._baseline_name),
+                                  from_dir=self._testroot)
+
 ###############################################################################
 class K_TestCimeCase(TestCreateTestCommon):
 ###############################################################################


### PR DESCRIPTION
1) SystemTestsCommon no longer calls case.setup in it's constructor.
   We will now only re-setup the case if it appears that we are re-running
   a phase that had already been run before.
2) Add tests to Z_FullSystemTest to test re-running cases. Currently ERI does
   not work when re-running either with or without the case.setup changes above.
3) If SystemTestsCommon does have to call case.setup, this call should not impact
   the TestStatus file.

Reduces the number of case.setup calls in an SMS case from 4 to 1.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #692 

User interface changes?: None

Code review: @jedwards4b @billsacks 
