### PR TITLE
Add support for --machine to scripts_regression_tests

### DIFF
--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -41,7 +41,10 @@ class Machines(GenericXML):
             GenericXML.read(self, local_infile)
 
         if machine is None:
-            machine = self.probe_machine_name()
+            if "CIME_MACHINE" in os.environ:
+                machine = os.environ["CIME_MACHINE"]
+            else:
+                machine = self.probe_machine_name()
 
         expect(machine is not None, "Could not initialize machine object from %s or %s" % (infile, local_infile))
         self.set_machine(machine)

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -28,7 +28,7 @@ MACHINE     = Machines()
 FAST_ONLY   = False
 NO_BATCH    = False
 NO_CMAKE    = False
-TEST_ROOT = None
+TEST_ROOT   = None
 
 os.environ["CIME_GLOBAL_WALLTIME"] = "0:05:00"
 
@@ -1887,7 +1887,9 @@ def write_provenance_info():
     curr_commit = get_current_commit(repo=LIB_DIR)
     logging.info("\nTesting commit %s" % curr_commit)
     cime_model = CIME.utils.get_model()
-    logging.info("Using cime_model = %s\n" % cime_model)
+    logging.info("Using cime_model = %s" % cime_model)
+    logging.info("Testing machine = %s" % MACHINE.get_machine_name())
+    logging.info("Test root: %s\n" % TEST_ROOT)
 
 def _main_func():
     global MACHINE
@@ -1910,7 +1912,8 @@ def _main_func():
     if "--machine" in sys.argv:
         midx = sys.argv.index("--machine")
         mach_name = sys.argv[midx + 1]
-        MACHINES = Machines(machine=mach_name)
+        MACHINE = Machines(machine=mach_name)
+        os.environ["CIME_MACHINE"] = mach_name
         del sys.argv[midx + 1]
         del sys.argv[midx]
 

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1890,6 +1890,7 @@ def write_provenance_info():
     logging.info("Using cime_model = %s\n" % cime_model)
 
 def _main_func():
+    global MACHINE
 
     if "--fast" in sys.argv:
         sys.argv.remove("--fast")
@@ -1906,6 +1907,13 @@ def _main_func():
         global NO_CMAKE
         NO_CMAKE = True
 
+    if "--machine" in sys.argv:
+        midx = sys.argv.index("--machine")
+        mach_name = sys.argv[midx + 1]
+        MACHINES = Machines(machine=mach_name)
+        del sys.argv[midx + 1]
+        del sys.argv[midx]
+
     if "--test-root" in sys.argv:
         global TEST_ROOT
         trindex = sys.argv.index("--test-root")
@@ -1915,6 +1923,7 @@ def _main_func():
     else:
         TEST_ROOT = os.path.join(MACHINE.get_value("CIME_OUTPUT_ROOT"),
                                  "scripts_regression_test.%s"% CIME.utils.get_timestamp())
+
 
     args = lambda: None # just something to set attrs on
     for log_param in ["debug", "silent", "verbose"]:


### PR DESCRIPTION
In order to avoid having to add --machine arguments in 50 spots, add concept of CIME_MACHINE environment variable.

Test suite: scripts_regression_tests.py --machine sandia-srn-sems
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #829 

User interface changes?: Adds --machine option to scripts_regression_tests

Code review: @jedwards4b 
