### PR TITLE
NETCDF include path is needed by all components

### DIFF
--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -185,7 +185,7 @@ ifndef AR
    AR := ar
 endif
 
-ifdef NETCDF_C_PATH 
+ifdef NETCDF_C_PATH
   ifndef NETCDF_FORTRAN_PATH
     $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
   endif
@@ -217,7 +217,7 @@ else
   ifneq ($(MAKECMDGOALS), db_files)
   ifneq ($(MAKECMDGOALS), db_flags)
   ifeq (,$(findstring clean,$(MAKECMDGOALS)))
-      $(error No NetCDF Specified, required for PIO and CESM)
+      $(error NETCDF not found: Define NETCDF_PATH or NETCDF_C_PATH and NETCDF_FORTRAN_PATH)
   endif
   endif
   endif

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -217,7 +217,7 @@ else
   ifneq ($(MAKECMDGOALS), db_files)
   ifneq ($(MAKECMDGOALS), db_flags)
   ifeq (,$(findstring clean,$(MAKECMDGOALS)))
-      $(error NETCDF not found: Define NETCDF_PATH or NETCDF_C_PATH and NETCDF_FORTRAN_PATH)
+      $(error NETCDF not found: Define NETCDF_PATH or NETCDF_C_PATH and NETCDF_FORTRAN_PATH in config_machines.xml or config_compilers.xml)
   endif
   endif
   endif

--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -185,40 +185,44 @@ ifndef AR
    AR := ar
 endif
 
-# To prevent breaking cleaning and building components which don't require NetCDF directly
-# NetCDF is only required for building the coupled model and the PIO library
-ifneq ($(or $(findstring pio, $(MODEL)), $(findstring driver, $(MODEL)), $(findstring acme, $(MODEL))),)
-  ifdef NETCDF_C_PATH
-    ifndef NETCDF_FORTRAN_PATH
-      $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
-    endif
-    NETCDF_SEPARATE:=true
-    ifndef INC_NETCDF_C
-      INC_NETCDF_C:=$(NETCDF_C_PATH)/include
-    endif
-    ifndef INC_NETCDF_FORTRAN
-      INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
-    endif
-    ifndef LIB_NETCDF_C
-      LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
-    endif
-    ifndef LIB_NETCDF_FORTRAN
-      LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
-    endif
-  else ifdef NETCDF_FORTRAN_PATH
-    $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
-  else ifdef NETCDF_PATH
-    NETCDF_SEPARATE:=false
-    ifndef INC_NETCDF
-      INC_NETCDF:=$(NETCDF_PATH)/include
-    endif
-    ifndef LIB_NETCDF
-      LIB_NETCDF:=$(NETCDF_PATH)/lib
-    endif
-  else
-    $(error No NetCDF Specified, required for PIO and ACME)
+ifdef NETCDF_C_PATH 
+  ifndef NETCDF_FORTRAN_PATH
+    $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
+  endif
+  NETCDF_SEPARATE:=true
+  ifndef INC_NETCDF_C
+    INC_NETCDF_C:=$(NETCDF_C_PATH)/include
+  endif
+  ifndef INC_NETCDF_FORTRAN
+    INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
+  endif
+  ifndef LIB_NETCDF_C
+    LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
+  endif
+  ifndef LIB_NETCDF_FORTRAN
+    LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
+  endif
+ else ifdef NETCDF_FORTRAN_PATH
+  $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
+ else ifdef NETCDF_PATH
+  NETCDF_SEPARATE:=false
+  ifndef INC_NETCDF
+    INC_NETCDF:=$(NETCDF_PATH)/include
+  endif
+  ifndef LIB_NETCDF
+    LIB_NETCDF:=$(NETCDF_PATH)/lib
+  endif
+else
+  # No Netcdf is an error unless target is clean or DEP
+  ifneq ($(MAKECMDGOALS), db_files)
+  ifneq ($(MAKECMDGOALS), db_flags)
+  ifeq (,$(findstring clean,$(MAKECMDGOALS)))
+      $(error No NetCDF Specified, required for PIO and CESM)
+  endif
+  endif
   endif
 endif
+
 
 ifeq ($(MPILIB),mpi-serial)
   undefine PNETCDF_PATH

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -217,7 +217,7 @@ else
   ifneq ($(MAKECMDGOALS), db_files)
   ifneq ($(MAKECMDGOALS), db_flags)
   ifeq (,$(findstring clean,$(MAKECMDGOALS)))
-      $(error NETCDF not found: Define NETCDF_PATH or NETCDF_C_PATH and NETCDF_FORTRAN_PATH)
+      $(error NETCDF not found: Define NETCDF_PATH or NETCDF_C_PATH and NETCDF_FORTRAN_PATH in config_machines.xml or config_compilers.xml)
   endif
   endif
   endif

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -184,41 +184,45 @@ endif
 ifndef AR
    AR := ar
 endif
-
-# To prevent breaking cleaning and building components which don't require NetCDF directly
-# NetCDF is only required for building the coupled model and the PIO library
-ifneq ($(or $(findstring pio, $(MODEL)), $(findstring driver, $(MODEL)), $(findstring cesm, $(MODEL))),)
-  ifdef NETCDF_C_PATH
-    ifndef NETCDF_FORTRAN_PATH
-      $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
-    endif
-    NETCDF_SEPARATE:=true
-    ifndef INC_NETCDF_C
-      INC_NETCDF_C:=$(NETCDF_C_PATH)/include
-    endif
-    ifndef INC_NETCDF_FORTRAN
-      INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
-    endif
-    ifndef LIB_NETCDF_C
-      LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
-    endif
-    ifndef LIB_NETCDF_FORTRAN
-      LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
-    endif
-  else ifdef NETCDF_FORTRAN_PATH
-    $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
-  else ifdef NETCDF_PATH
-    NETCDF_SEPARATE:=false
-    ifndef INC_NETCDF
-      INC_NETCDF:=$(NETCDF_PATH)/include
-    endif
-    ifndef LIB_NETCDF
-      LIB_NETCDF:=$(NETCDF_PATH)/lib
-    endif
-  else
-    $(error No NetCDF Specified, required for PIO and CESM)
+ 
+ifdef NETCDF_C_PATH 
+  ifndef NETCDF_FORTRAN_PATH
+    $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
+  endif
+  NETCDF_SEPARATE:=true
+  ifndef INC_NETCDF_C
+    INC_NETCDF_C:=$(NETCDF_C_PATH)/include
+  endif
+  ifndef INC_NETCDF_FORTRAN
+    INC_NETCDF_FORTRAN:=$(NETCDF_FORTRAN_PATH)/include
+  endif
+  ifndef LIB_NETCDF_C
+    LIB_NETCDF_C:=$(NETCDF_C_PATH)/lib
+  endif
+  ifndef LIB_NETCDF_FORTRAN
+    LIB_NETCDF_FORTRAN:=$(NETCDF_C_PATH)/lib
+  endif
+ else ifdef NETCDF_FORTRAN_PATH
+  $(error "NETCDF_FORTRAN_PATH specified without NETCDF_C_PATH")
+ else ifdef NETCDF_PATH
+  NETCDF_SEPARATE:=false
+  ifndef INC_NETCDF
+    INC_NETCDF:=$(NETCDF_PATH)/include
+  endif
+  ifndef LIB_NETCDF
+    LIB_NETCDF:=$(NETCDF_PATH)/lib
+  endif
+else
+  # No Netcdf is an error unless target is clean or DEP
+  ifneq ($(MAKECMDGOALS), db_files)
+  ifneq ($(MAKECMDGOALS), db_flags)
+  ifeq (,$(findstring clean,$(MAKECMDGOALS)))
+      $(error No NetCDF Specified, required for PIO and CESM)
+  endif
+  endif
   endif
 endif
+
 
 ifeq ($(MPILIB),mpi-serial)
   undefine PNETCDF_PATH

--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -184,8 +184,8 @@ endif
 ifndef AR
    AR := ar
 endif
- 
-ifdef NETCDF_C_PATH 
+
+ifdef NETCDF_C_PATH
   ifndef NETCDF_FORTRAN_PATH
     $(error "NETCDF_C_PATH specified without NETCDF_FORTRAN_PATH")
   endif
@@ -217,7 +217,7 @@ else
   ifneq ($(MAKECMDGOALS), db_files)
   ifneq ($(MAKECMDGOALS), db_flags)
   ifeq (,$(findstring clean,$(MAKECMDGOALS)))
-      $(error No NetCDF Specified, required for PIO and CESM)
+      $(error NETCDF not found: Define NETCDF_PATH or NETCDF_C_PATH and NETCDF_FORTRAN_PATH)
   endif
   endif
   endif


### PR DESCRIPTION
Makes the netcdf include path available during all components build.   Avoids an error with path not found during make clean operations

Test suite: scripts_regression_tests, cesm prealpha tests on hobart
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #990 

User interface changes?: 

Code review: 
