### PR TITLE
Add run_environment.txt output for all runs of CIME.

### DIFF
--- a/utils/python/CIME/XML/env_mach_specific.py
+++ b/utils/python/CIME/XML/env_mach_specific.py
@@ -119,6 +119,15 @@ class EnvMachSpecific(EnvBase):
         else:
             expect(False, "Unhandled module system '%s'" % module_system)
 
+    def save_all_env_info(self, filename):
+        """
+        Get a string representation of all current environment info and
+        save it to file.
+        """
+        with open(filename, "w") as f:
+            f.write(self.list_modules())
+        run_cmd_no_fail("echo -e '\n' >> %s && env >> %s" % (filename, filename))
+
     def make_env_mach_specific_file(self, compiler, debug, mpilib, shell):
         modules_to_load = self._get_modules_for_case(compiler, debug, mpilib)
         envs_to_set = self._get_envs_for_case(compiler, debug, mpilib)

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -264,10 +264,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         env_module = case.get_env("mach_specific")
         env_module.make_env_mach_specific_file(compiler, debug, mpilib, "sh")
         env_module.make_env_mach_specific_file(compiler, debug, mpilib, "csh")
-        with open("software_environment.txt", "w") as f:
-            f.write(env_module.list_modules())
-        run_cmd_no_fail("echo -e '\n' >> software_environment.txt && \
-                         env >> software_environment.txt")
+        env_module.save_all_env_info("software_environment.txt")
 
 ###############################################################################
 def case_setup(case, clean=False, test_mode=False, reset=False, no_status=False):

--- a/utils/python/CIME/provenance.py
+++ b/utils/python/CIME/provenance.py
@@ -193,6 +193,10 @@ def save_prerun_provenance_cesm(case, lid=None): # pylint: disable=unused-argume
 
 def save_prerun_provenance(case, lid=None):
     with SharedArea():
+        # Always save env
+        lid = os.environ["LID"] if lid is None else lid
+        env_module = case.get_env("mach_specific")
+        env_module.save_all_env_info(os.path.join(case.get_value("CASEROOT"), "logs", "run_environment.txt.%s" % lid))
         model = case.get_value("MODEL")
         if model == "acme":
             save_prerun_provenance_acme(case, lid=lid)
@@ -253,6 +257,7 @@ def save_postrun_provenance_acme(case, lid):
     elif mach in ["edison", "cori-haswell", "cori-knl"]:
         globs_to_copy.append("%s" % case.get_value("CASE"))
 
+    globs_to_copy.append("logs/run_environment.txt.%s" % lid)
     globs_to_copy.append("logs/acme.log.%s.gz" % lid)
     globs_to_copy.append("logs/cpl.log.%s.gz" % lid)
     globs_to_copy.append("timing/*.%s" % lid)


### PR DESCRIPTION
Sometimes this can be useful when compute nodes have significantly
different environemnts from login nodes.

Adds code to store this data in $casedir/logs and copies this data
when saving timings to SAVE_TIMING_DIR.

Test suite: scripts_regression_tests --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #940 

User interface changes?: Addition of run_environment.txt.$lid file

Code review: @jedwards4b @amametjanov @worleyph 
