### PR TITLE
Always print jobid unless --silent

### DIFF
--- a/utils/python/CIME/XML/env_batch.py
+++ b/utils/python/CIME/XML/env_batch.py
@@ -386,7 +386,7 @@ class EnvBatch(EnvBase):
         logger.info("Submitting job script %s"%submitcmd)
         output = run_cmd_no_fail(submitcmd)
         jobid = self.get_job_id(output)
-        logger.debug("Submitted job id is %s"%jobid)
+        logger.info("Submitted job id is %s"%jobid)
         return jobid
 
     def get_batch_system_type(self):


### PR DESCRIPTION
People on ACME would like to always see the job id.

Test suite: code_checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Print job-id as info

Code review: jedwards
