### PR TITLE
Add overrides for pes

### DIFF
--- a/cime_config/acme/allactive/config_pes.xml
+++ b/cime_config/acme/allactive/config_pes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<config_pes>
+<config_pes version="2.0">
 
   <grid name="any">
     <mach name="any">

--- a/cime_config/acme/config_files.xml
+++ b/cime_config/acme/config_files.xml
@@ -108,6 +108,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of all pe-layouts for primary component (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/config_pes.xsd</schema>
   </entry>
 
   <entry id="SYSTEM_TESTS_DIR">

--- a/cime_config/cesm/allactive/config_pes.xml
+++ b/cime_config/cesm/allactive/config_pes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<config_pes>
+<config_pes version="2.0">
 
   <grid name="any">
     <mach name="any">
@@ -1792,6 +1792,30 @@
         </pes>
      </mach>
   </grid>
-
-
+  <overrides>
+    <grid name="any" >
+      <mach name="any" >
+        <pes pesize="any" compset="SPCAM[SM]">
+          <nthrds>
+            <nthrds_atm>1</nthrds_atm>
+            <nthrds_lnd>1</nthrds_lnd>
+            <nthrds_rof>1</nthrds_rof>
+            <nthrds_ice>1</nthrds_ice>
+            <nthrds_ocn>1</nthrds_ocn>
+            <nthrds_glc>1</nthrds_glc>
+            <nthrds_wav>1</nthrds_wav>
+            <nthrds_cpl>1</nthrds_cpl>
+          </nthrds>
+        </pes>
+        <pes pesize="any" compset="CISM1">
+          <ntasks>
+            <ntasks_glc>1</ntasks_glc>
+          </ntasks>
+          <nthrds>
+            <nthrds_glc>1</nthrds_glc>
+          </nthrds>
+        </pes>
+      </mach>
+    </grid>
+  </overrides>
 </config_pes>

--- a/cime_config/cesm/config_files.xml
+++ b/cime_config/cesm/config_files.xml
@@ -106,6 +106,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of all pe-layouts for primary component (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/config_pes.xsd</schema>
   </entry>
 
   <entry id="SYSTEM_TESTS_DIR">

--- a/cime_config/xml_schemas/config_pes.xsd
+++ b/cime_config/xml_schemas/config_pes.xsd
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+<!-- attributes -->
+<xs:attribute name="name"  type="xs:string"/>
+<xs:attribute name="pesize"  type="xs:NCName"/>
+<xs:attribute name="compset"  type="xs:string"/>
+
+<!-- simple elements -->
+<xs:element name="comment" type="xs:string"/>
+<xs:element name="PES_PER_NODE" type="xs:integer"/>
+<xs:element name="MAX_TASKS_PER_NODE" type="xs:integer"/>
+<xs:element name="ntasks_atm" type="xs:integer"/>
+<xs:element name="ntasks_lnd" type="xs:integer"/>
+<xs:element name="ntasks_rof" type="xs:integer"/>
+<xs:element name="ntasks_ice" type="xs:integer"/>
+<xs:element name="ntasks_cpl" type="xs:integer"/>
+<xs:element name="ntasks_glc" type="xs:integer"/>
+<xs:element name="ntasks_ocn" type="xs:integer"/>
+<xs:element name="ntasks_wav" type="xs:integer"/>
+<xs:element name="nthrds_atm" type="xs:integer"/>
+<xs:element name="nthrds_lnd" type="xs:integer"/>
+<xs:element name="nthrds_cpl" type="xs:integer"/>
+<xs:element name="nthrds_glc" type="xs:integer"/>
+<xs:element name="nthrds_ice" type="xs:integer"/>
+<xs:element name="nthrds_ocn" type="xs:integer"/>
+<xs:element name="nthrds_rof" type="xs:integer"/>
+<xs:element name="nthrds_wav" type="xs:integer"/>
+<xs:element name="rootpe_atm" type="xs:integer"/>
+<xs:element name="rootpe_lnd" type="xs:integer"/>
+<xs:element name="rootpe_cpl" type="xs:integer"/>
+<xs:element name="rootpe_glc" type="xs:integer"/>
+<xs:element name="rootpe_ice" type="xs:integer"/>
+<xs:element name="rootpe_ocn" type="xs:integer"/>
+<xs:element name="rootpe_rof" type="xs:integer"/>
+<xs:element name="rootpe_wav" type="xs:integer"/>
+
+<!-- complex elements -->
+
+  <xs:element name="config_pes">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="grid"/>
+        <xs:element ref="overrides" minOccurs="0"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="overrides">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="grid"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="grid">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="mach"/>
+      </xs:sequence>
+      <xs:attribute ref="name" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="mach">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="pes"/>
+      </xs:sequence>
+      <xs:attribute ref="name" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="pes">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element minOccurs="0" ref="PES_PER_NODE"/>
+        <xs:element minOccurs="0" ref="MAX_TASKS_PER_NODE"/>
+        <xs:element minOccurs="0" ref="comment"/>
+        <xs:element minOccurs="0" ref="ntasks"/>
+        <xs:element minOccurs="0" ref="nthrds"/>
+        <xs:element minOccurs="0" ref="rootpe"/>
+      </xs:choice>
+      <xs:attribute ref="compset" use="required"/>
+      <xs:attribute ref="pesize" use="required" />
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="ntasks">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+	<xs:element ref="ntasks_atm"/>
+	<xs:element ref="ntasks_lnd"/>
+	<xs:element ref="ntasks_rof"/>
+	<xs:element ref="ntasks_ice"/>
+	<xs:element ref="ntasks_cpl"/>
+	<xs:element ref="ntasks_glc"/>
+	<xs:element ref="ntasks_ocn"/>
+	<xs:element ref="ntasks_wav"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="nthrds">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+	<xs:element ref="nthrds_atm"/>
+	<xs:element ref="nthrds_lnd"/>
+	<xs:element ref="nthrds_cpl"/>
+	<xs:element ref="nthrds_glc"/>
+	<xs:element ref="nthrds_ice"/>
+	<xs:element ref="nthrds_ocn"/>
+	<xs:element ref="nthrds_rof"/>
+	<xs:element ref="nthrds_wav"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="rootpe">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="rootpe_atm"/>
+        <xs:element ref="rootpe_lnd"/>
+	<xs:element ref="rootpe_cpl"/>
+	<xs:element ref="rootpe_glc"/>
+	<xs:element ref="rootpe_ice"/>
+	<xs:element ref="rootpe_ocn"/>
+	<xs:element ref="rootpe_rof"/>
+	<xs:element ref="rootpe_wav"/>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/utils/python/CIME/XML/machines.py
+++ b/utils/python/CIME/XML/machines.py
@@ -28,7 +28,7 @@ class Machines(GenericXML):
                 files = Files()
             infile = files.get_value("MACHINES_SPEC_FILE", resolved=False)
             schema = files.get_schema("MACHINES_SPEC_FILE")
-            logger.warn("Verifying using schema %s"%schema)
+            logger.debug("Verifying using schema %s"%schema)
             infile = files.get_resolved_value(infile)
 
         self.machines_dir = os.path.dirname(infile)

--- a/utils/python/CIME/XML/pes.py
+++ b/utils/python/CIME/XML/pes.py
@@ -17,11 +17,6 @@ class Pes(GenericXML):
         GenericXML.__init__(self, infile)
 
     def find_pes_layout(self, grid, compset, machine, pesize_opts='M', mpilib=None):
-        pe_select = None
-        grid_match = None
-        mach_match = None
-        compset_match = None
-        pesize_match = None
         opes_ntasks = {}
         opes_nthrds = {}
         opes_rootpe = {}
@@ -32,7 +27,7 @@ class Pes(GenericXML):
         overrides = self.get_optional_node("overrides")
         if overrides is not None:
             o_grid_nodes = self.get_nodes("grid", root = overrides)
-            opes_ntasks, opes_nthrds, opes_rootpe, oother_settings = self._find_matches(o_grid_nodes, grid, compset, machine, pesize_opts, mpilib, True)
+            opes_ntasks, opes_nthrds, opes_rootpe, oother_settings = self._find_matches(o_grid_nodes, grid, compset, machine, pesize_opts, True)
         # Get all the nodes
         grid_nodes = self.get_nodes("grid")
         if o_grid_nodes:
@@ -42,23 +37,25 @@ class Pes(GenericXML):
             grid_nodes = list(gn_set)
 
 
-        pes_ntasks, pes_nthrds, pes_rootpe, other_settings = self._find_matches(grid_nodes, grid, compset, machine, pesize_opts, mpilib, False)
+        pes_ntasks, pes_nthrds, pes_rootpe, other_settings = self._find_matches(grid_nodes, grid, compset, machine, pesize_opts, False)
         pes_ntasks.update(opes_ntasks)
         pes_nthrds.update(opes_nthrds)
         pes_rootpe.update(opes_rootpe)
-        other_settings.update(other_settings)
+        other_settings.update(oother_settings)
 
         if mpilib == "mpi-serial":
             for i in iter(pes_ntasks):
                 pes_ntasks[i] = 1
+            for i in iter(pes_rootpe):
                 pes_rootpe[i] = 0
 
         logger.info("Pes setting: grid          is %s " %grid)
         logger.info("Pes setting: compset       is %s " %compset)
+        logger.info("Pes setting: tasks       is %s " %pes_ntasks)
         logger.info("Pes other settings: %s"%other_settings)
         return pes_ntasks, pes_nthrds, pes_rootpe, other_settings
 
-    def _find_matches(self, grid_nodes, grid, compset, machine, pesize_opts, mpilib, override=False):
+    def _find_matches(self, grid_nodes, grid, compset, machine, pesize_opts, override=False):
         grid_choice = None
         mach_choice = None
         compset_choice = None

--- a/utils/python/CIME/XML/pes.py
+++ b/utils/python/CIME/XML/pes.py
@@ -22,15 +22,50 @@ class Pes(GenericXML):
         mach_match = None
         compset_match = None
         pesize_match = None
+        opes_ntasks = {}
+        opes_nthrds = {}
+        opes_rootpe = {}
+        oother_settings = {}
+        other_settings = {}
+        o_grid_nodes = []
+        # Get any override nodes
+        overrides = self.get_optional_node("overrides")
+        if overrides is not None:
+            o_grid_nodes = self.get_nodes("grid", root = overrides)
+            opes_ntasks, opes_nthrds, opes_rootpe, oother_settings = self._find_matches(o_grid_nodes, grid, compset, machine, pesize_opts, mpilib, True)
+        # Get all the nodes
+        grid_nodes = self.get_nodes("grid")
+        if o_grid_nodes:
+            gn_set = set(grid_nodes)
+            ogn_set = set(o_grid_nodes)
+            gn_set.difference_update(ogn_set)
+            grid_nodes = list(gn_set)
+
+
+        pes_ntasks, pes_nthrds, pes_rootpe, other_settings = self._find_matches(grid_nodes, grid, compset, machine, pesize_opts, mpilib, False)
+        pes_ntasks.update(opes_ntasks)
+        pes_nthrds.update(opes_nthrds)
+        pes_rootpe.update(opes_rootpe)
+        other_settings.update(other_settings)
+
+        if mpilib == "mpi-serial":
+            for i in iter(pes_ntasks):
+                pes_ntasks[i] = 1
+                pes_rootpe[i] = 0
+
+        logger.info("Pes setting: grid          is %s " %grid)
+        logger.info("Pes setting: compset       is %s " %compset)
+        logger.info("Pes other settings: %s"%other_settings)
+        return pes_ntasks, pes_nthrds, pes_rootpe, other_settings
+
+    def _find_matches(self, grid_nodes, grid, compset, machine, pesize_opts, mpilib, override=False):
         grid_choice = None
         mach_choice = None
         compset_choice = None
         pesize_choice = None
-        other_settings = {}
         max_points = -1
-
-        # Get all the nodes
-        grid_nodes = self.get_nodes("grid")
+        pes_ntasks, pes_nthrds, pes_rootpe, other_settings = {}, {}, {}, {}
+        pe_select = []
         for grid_node in grid_nodes:
             grid_match = grid_node.get("name")
             if grid_match == "any" or  re.search(grid_match,grid):
@@ -49,47 +84,57 @@ class Pes(GenericXML):
 
                                 points = int(grid_match!="any")*4+int(mach_match!="any")*3+\
                                     int(compset_match!="any")*2+int(pesize_match!="any")
-                                if points > max_points:
-                                    pe_select = pes_node
-                                    max_points = points
-                                    mach_choice = mach_match
-                                    grid_choice = grid_match
-                                    compset_choice = compset_match
-                                    pesize_choice = pesize_match
-                                elif points == max_points:
-                                    logger.warn("mach_choice %s mach_match %s"%(mach_choice, mach_match))
-                                    logger.warn("grid_choice %s grid_match %s"%(grid_choice, grid_match))
-                                    logger.warn("compset_choice %s compset_match %s"%(compset_choice, compset_match))
-                                    logger.warn("pesize_choice %s pesize_match %s"%(pesize_choice, pesize_match))
-                                    logger.warn("points = %d"%points)
-                                    expect(False, "We dont expect to be here" )
+                                if override and points > 0:
+                                    for node in pes_node:
+                                        vid = node.tag
+                                        logger.info("vid is %s"%vid)
+                                        if "ntasks" in vid:
+                                            for child in node:
+                                                pes_ntasks[child.tag.upper()] = child.text
+                                        elif "nthrds" in vid:
+                                            for child in node:
+                                                pes_nthrds[child.tag.upper()] = child.text
+                                        elif "rootpe" in vid:
+                                            for child in node:
+                                                pes_rootpe[child.tag.upper()] = child.text
+                                    # if the value is already upper case its something else we are trying to set
+                                        elif vid == node.tag:
+                                            other_settings[vid] = node.text
 
-        pes_ntasks, pes_nthrds, pes_rootpe, other_settings = {}, {}, {}, {}
-        for node in pe_select:
-            vid = node.tag
-            logger.debug("vid is %s"%vid)
-            if "ntasks" in vid:
-                for child in node:
-                    pes_ntasks[child.tag.upper()] = child.text
-            elif "nthrds" in vid:
-                for child in node:
-                    pes_nthrds[child.tag.upper()] = child.text
-            elif "rootpe" in vid:
-                for child in node:
-                    pes_rootpe[child.tag.upper()] = child.text
+                                else:
+                                    if points > max_points:
+                                        pe_select = pes_node
+                                        max_points = points
+                                        mach_choice = mach_match
+                                        grid_choice = grid_match
+                                        compset_choice = compset_match
+                                        pesize_choice = pesize_match
+                                    elif points == max_points:
+                                        logger.warn("mach_choice %s mach_match %s"%(mach_choice, mach_match))
+                                        logger.warn("grid_choice %s grid_match %s"%(grid_choice, grid_match))
+                                        logger.warn("compset_choice %s compset_match %s"%(compset_choice, compset_match))
+                                        logger.warn("pesize_choice %s pesize_match %s"%(pesize_choice, pesize_match))
+                                        logger.warn("points = %d"%points)
+                                        expect(False, "We dont expect to be here" )
+        if not override:
+            for node in pe_select:
+                vid = node.tag
+                logger.debug("vid is %s"%vid)
+                if "ntasks" in vid:
+                    for child in node:
+                        pes_ntasks[child.tag.upper()] = child.text
+                elif "nthrds" in vid:
+                    for child in node:
+                        pes_nthrds[child.tag.upper()] = child.text
+                elif "rootpe" in vid:
+                    for child in node:
+                        pes_rootpe[child.tag.upper()] = child.text
             # if the value is already upper case its something else we are trying to set
-            elif vid == node.tag:
-                other_settings[vid] = node.text
+                elif vid == node.tag:
+                    other_settings[vid] = node.text
+            logger.info("Pes setting: grid match    is %s " %grid_choice )
+            logger.info("Pes setting: machine match is %s " %mach_choice)
+            logger.info("Pes setting: compset_match is %s " %compset_choice)
+            logger.info("Pes setting: pesize match  is %s " %pesize_choice)
 
-        logger.info("Pes setting: grid          is %s " %grid)
-        logger.info("Pes setting: compset       is %s " %compset)
-        logger.info("Pes setting: grid match    is %s " %grid_choice )
-        logger.info("Pes setting: machine match is %s " %mach_choice)
-        logger.info("Pes setting: compset_match is %s " %compset_choice)
-        logger.info("Pes setting: pesize match  is %s " %pesize_choice)
-        logger.info("Pes other settings: %s"%other_settings)
-        if mpilib == "mpi-serial":
-            for i in iter(pes_ntasks):
-                pes_ntasks[i] = 1
-                pes_rootpe[i] = 1
         return pes_ntasks, pes_nthrds, pes_rootpe, other_settings

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -486,7 +486,7 @@ class Case(object):
             env_file.set_components(comp_classes)
 
     def _get_component_config_data(self):
-        # attributes used for multi valued defaults 
+        # attributes used for multi valued defaults
         # attlist is a dictionary used to determine the value element that has the most matches
         attlist = {"compset":self._compsetname, "grid":self._gridname, "cime_model":self._cime_model}
 
@@ -669,13 +669,11 @@ class Case(object):
 
             pes_ntasks, pes_nthrds, pes_rootpe, other = pesobj.find_pes_layout(self._gridname, self._compsetname,
                                                                     machine_name, pesize_opts=pecount, mpilib=mpilib)
-
         mach_pes_obj = self.get_env("mach_pes")
         totaltasks = {}
-        # Since other items may include PES_PER_NODE we need to do this first
-        # we can get rid of this code when all of the perl is removed
-        for key, value in other.items():
-            self.set_value(key, value)
+        if other is not None:
+            for key, value in other.items():
+                self.set_value(key, value)
         for key, value in pes_ntasks.items():
             totaltasks[key[-3:]] = int(value)
             mach_pes_obj.set_value(key,int(value))

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -97,7 +97,6 @@ class Case(object):
         self.num_nodes = None
         self.tasks_per_numa = None
         self.cores_per_task = None
-
         # check if case has been configured and if so initialize derived
         if self.get_value("CASEROOT") is not None:
             self.initialize_derived_attributes()
@@ -121,6 +120,7 @@ class Case(object):
         env_mach_pes = self.get_env("mach_pes")
         comp_classes = self.get_values("COMP_CLASSES")
         total_tasks = env_mach_pes.get_total_tasks(comp_classes)
+
         self.thread_count = env_mach_pes.get_max_thread_count(comp_classes)
         self.tasks_per_node = env_mach_pes.get_tasks_per_node(total_tasks, self.thread_count)
         logger.debug("total_tasks %s thread_count %s"%(total_tasks, self.thread_count))
@@ -686,12 +686,11 @@ class Case(object):
 
         maxval = 1
         pes_per_node = self.get_value("PES_PER_NODE")
-        if mpilib != "mpi-serial":
-            for key, val in totaltasks.items():
-                if val < 0:
-                    val = -1*val*pes_per_node
-                if val > maxval:
-                    maxval = val
+        for key, val in totaltasks.items():
+            if val < 0:
+                val = -1*val*pes_per_node
+            if val > maxval:
+                maxval = val
 
         # Make sure that every component has been accounted for
         # set, nthrds and ntasks to 1 otherwise. Also set the ninst values here.
@@ -707,11 +706,7 @@ class Case(object):
             if compclass not in pes_nthrds.keys():
                 mach_pes_obj.set_value(compclass,1)
 
-        # FIXME - this is a short term fix for dealing with the restriction that
-        # CISM1 cannot run on multiple cores
-        if "CISM1" in self._compsetname:
-            mach_pes_obj.set_value("NTASKS_GLC",1)
-            mach_pes_obj.set_value("NTHRDS_GLC",1)
+
 
         #--------------------------------------------
         # batch system


### PR DESCRIPTION
Add overrides section to the config_pes.xml file to allow altering pe layout definitions for certain cases.    Add schema for config_pes.xml and test file when opening

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1002  (these fields should not have been in config_compsets.xml but the support to
                      put them into config_pes.xml was incomplete) 

User interface changes?: 

Code review: 
