### PR TITLE
Fix race condition in Z_FullSystemTests test re-runs

### DIFF
--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1115,6 +1115,16 @@ class Z_FullSystemTest(TestCreateTestCommon):
                 pass
             else:
                 casedir = os.path.join(TEST_ROOT, "%s.%s" % (test, self._baseline_name))
+
+                # Subtle issue: The run phases of these tests will be in the PASS state until
+                # the submitted case.test script is run, which could take a while if the system is
+                # busy. This potentially leaves a window where the wait_for_tests command below will
+                # not wait for the re-submitted jobs to run because it sees the original PASS.
+                # The code below forces things back to PEND to avoid this race condition.
+                if self._hasbatch:
+                    with TestStatus(test_dir=casedir) as ts:
+                        ts.set_status(RUN_PHASE, TEST_PEND_STATUS)
+
                 run_cmd_assert_result(self, "./case.submit", from_dir=casedir)
 
         if (self._hasbatch):

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1110,7 +1110,7 @@ class Z_FullSystemTest(TestCreateTestCommon):
         # Test that re-running works
         tests = update_acme_tests.get_test_suite("cime_developer")
         for test in tests:
-            if test.startswith("ERI"):
+            if test.startswith("ERI") or test.startswith("ERS") or test.startswith("ERR"):
                 # TODO: these need to all work in the future but currently do not support re-run
                 pass
             else:


### PR DESCRIPTION
Fix is to manually set TestStatus files back to PEND
for the run_phase before resubmission.

Test suite: scripts_regression_tests.py Z_FullSystemTests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1014

User interface changes?: None

Code review: @jedwards4b 
