### PR TITLE
create_test: Add --force-procs and --force-threads options

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -211,6 +211,12 @@ OR
     parser.add_argument("--wait", action="store_true",
                         help="On batch systems, wait for submitted jobs to complete")
 
+    parser.add_argument("--force-procs", type=int, default=None,
+                        help="For all tests to run with this number of processors")
+
+    parser.add_argument("--force-threads", type=int, default=None,
+                        help="For all tests to run with this number of threads")
+
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
@@ -335,7 +341,7 @@ OR
         args.test_root, args.baseline_root, args.clean, baseline_cmp_name, baseline_gen_name, \
         args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.walltime, \
         args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue, \
-        args.allow_baseline_overwrite, args.output_root, args.wait
+        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads
 
 ###############################################################################
 def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost_map, wall_time, test_root):
@@ -440,7 +446,8 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
 # pragma pylint: disable=protected-access
 def create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                 baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, project, test_id, parallel_jobs,
-                walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite, output_root, wait):
+                walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite, output_root, wait,
+                force_procs, force_threads):
 ###############################################################################
     impl = TestScheduler(test_names, test_data=test_data,
                          no_run=no_run, no_build=no_build, no_setup=no_setup, no_batch=no_batch,
@@ -452,7 +459,7 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
                          project=project, parallel_jobs=parallel_jobs, walltime=walltime,
                          proc_pool=proc_pool, use_existing=use_existing, save_timing=save_timing,
                          queue=queue, allow_baseline_overwrite=allow_baseline_overwrite,
-                         output_root=output_root)
+                         output_root=output_root, force_procs=force_procs, force_threads=force_threads)
 
     success = impl.run_tests(wait=wait)
 
@@ -493,13 +500,13 @@ def _main_func(description):
     test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, \
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \
-    save_timing, queue, allow_baseline_overwrite, output_root, wait \
+    save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads \
         = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                          baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only,
                          project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, save_timing,
-                         queue, allow_baseline_overwrite, output_root, wait))
+                         queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads))
 
 ###############################################################################
 

--- a/utils/python/CIME/XML/pes.py
+++ b/utils/python/CIME/XML/pes.py
@@ -87,13 +87,13 @@ class Pes(GenericXML):
                                         logger.info("vid is %s"%vid)
                                         if "ntasks" in vid:
                                             for child in node:
-                                                pes_ntasks[child.tag.upper()] = child.text
+                                                pes_ntasks[child.tag.upper()] = int(child.text)
                                         elif "nthrds" in vid:
                                             for child in node:
-                                                pes_nthrds[child.tag.upper()] = child.text
+                                                pes_nthrds[child.tag.upper()] = int(child.text)
                                         elif "rootpe" in vid:
                                             for child in node:
-                                                pes_rootpe[child.tag.upper()] = child.text
+                                                pes_rootpe[child.tag.upper()] = int(child.text)
                                     # if the value is already upper case its something else we are trying to set
                                         elif vid == node.tag:
                                             other_settings[vid] = node.text
@@ -119,13 +119,13 @@ class Pes(GenericXML):
                 logger.debug("vid is %s"%vid)
                 if "ntasks" in vid:
                     for child in node:
-                        pes_ntasks[child.tag.upper()] = child.text
+                        pes_ntasks[child.tag.upper()] = int(child.text)
                 elif "nthrds" in vid:
                     for child in node:
-                        pes_nthrds[child.tag.upper()] = child.text
+                        pes_nthrds[child.tag.upper()] = int(child.text)
                 elif "rootpe" in vid:
                     for child in node:
-                        pes_rootpe[child.tag.upper()] = child.text
+                        pes_rootpe[child.tag.upper()] = int(child.text)
             # if the value is already upper case its something else we are trying to set
                 elif vid == node.tag:
                     other_settings[vid] = node.text

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -44,14 +44,18 @@ class TestScheduler(object):
                  project=None, parallel_jobs=None,
                  walltime=None, proc_pool=None,
                  use_existing=False, save_timing=False, queue=None,
-                 allow_baseline_overwrite=False, output_root=None):
+                 allow_baseline_overwrite=False, output_root=None,
+                 force_procs=None, force_threads=None):
     ###########################################################################
-        self._cime_root  = CIME.utils.get_cime_root()
-        self._cime_model = CIME.utils.get_model()
+        self._cime_root     = CIME.utils.get_cime_root()
+        self._cime_model    = CIME.utils.get_model()
+        self._save_timing   = save_timing
+        self._queue         = queue
+        self._test_data     = {} if test_data is None else test_data # Format:  {test_name -> {data_name -> data}}
+        self._force_procs   = force_procs
+        self._force_threads = force_threads
+
         self._allow_baseline_overwrite  = allow_baseline_overwrite
-        self._save_timing = save_timing
-        self._queue       = queue
-        self._test_data   = {} if test_data is None else test_data # Format:  {test_name -> {data_name -> data}}
 
         self._machobj = Machines(machine=machine_name)
 
@@ -311,6 +315,13 @@ class TestScheduler(object):
             create_newcase_cmd += " --project %s " % self._project
         if self._output_root is not None:
             create_newcase_cmd += " --output-root %s " % self._output_root
+
+        if self._force_procs or self._force_threads:
+            pecount_str = "M" if self._force_procs is None else str(self._force_procs)
+            if self._force_threads is not None:
+                pecount_str += "x%d" % self._force_threads
+
+            create_newcase_cmd += " --pecount %s" % pecount_str
 
         if test_mods is not None:
             files = Files()

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1182,6 +1182,21 @@ class K_TestCimeCase(TestCreateTestCommon):
             # Serial cases should be using 1 task
             self.assertEqual(case.get_value("TOTALPES"), 1)
 
+    ###########################################################################
+    def test_cime_case_force_pecount(self):
+    ###########################################################################
+        run_cmd_assert_result(self, "%s/create_test TESTRUNPASS_Mmpi-serial.f19_g16_rx1.A -t %s --no-build --test-root %s --output-root %s --force-procs 16 --force-threads 8"
+                              % (SCRIPT_DIR, self._baseline_name, self._testroot, self._testroot))
+
+        casedir = os.path.join(self._testroot,
+                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_Mmpi-serial.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
+        self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
+
+        with Case(casedir, read_only=True) as case:
+            self.assertEqual(case.get_value("NTASKS_CPL"), 16)
+
+            self.assertEqual(case.get_value("NTHRDS_CPL"), 8)
+
 ###############################################################################
 class X_TestSingleSubmit(TestCreateTestCommon):
 ###############################################################################


### PR DESCRIPTION
Allows user to force procs and threads withouth having to change test names.

Also, refactors case.py handling of pecount to allow for user to force threads
without having to change procs.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #897 

User interface changes?: Yes, adds pecount force options to create_test

Code review: @jedwards4b 
