### PR TITLE
add cime-output-root option to create_clone

### DIFF
--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -36,6 +36,10 @@ def parse_command_line(args):
 			"default: user-specified environment variable PROJECT or ACCOUNT"
 			"or read from ~/.cesm_proj or ~/.ccsm_proj")
 
+    parser.add_argument("--cime-output-root",
+                        help="Specify the root output directory"
+			"default: setting in case, create_clone will fail if this directory is not writable")
+
     args = parser.parse_args()
 
     CIME.utils.handle_standard_logging_options(args)
@@ -48,20 +52,21 @@ def parse_command_line(args):
         expect(False,
                "Must specify -clone as an input argument")
 
-    return args.case, args.clone, args.keepexe, args.mach_dir, args.project
+    return args.case, args.clone, args.keepexe, args.mach_dir, args.project, \
+        args.cime_output_root
 
 ##############################################################################
 def _main_func():
 ###############################################################################
 
-    case, clone, keepexe, mach_dir, project = parse_command_line(sys.argv)
+    case, clone, keepexe, mach_dir, project, cime_output_root = parse_command_line(sys.argv)
 
     cloneroot = os.path.abspath(clone)
     expect(os.path.isdir(cloneroot),
            "Missing cloneroot directory %s " % cloneroot)
 
     with Case(cloneroot, read_only=False) as clone:
-        clone.create_clone(case, keepexe, mach_dir, project)
+        clone.create_clone(case, keepexe, mach_dir, project, cime_output_root)
 
 ###############################################################################
 

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -927,7 +927,12 @@ class Case(object):
             self.set_value("USER_MODS_FULLPATH",user_mods_path)
             apply_user_mods(self._caseroot, user_mods_path)
 
-    def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None):
+    def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
+        if cime_output_root is None:
+            cime_output_root = self.get_value("CIME_OUTPUT_ROOT")
+        expect(os.access(cime_output_root, os.W_OK), "Directory %s is not writable"
+               "by this user.  Use the --cime-output-root flag to provide a writable "
+               "scratch directory"%cime_output_root)
 
         newcaseroot = os.path.abspath(newcase)
         expect(not os.path.isdir(newcaseroot),
@@ -947,6 +952,7 @@ class Case(object):
         srcroot = os.path.join(newcase_cimeroot,"..")
         newcase = self.copy(newcasename, newcaseroot, newsrcroot=srcroot)
         newcase.set_value("CIMEROOT", newcase_cimeroot)
+        newcase.set_value("CIME_OUTPUT_ROOT", cime_output_root)
 
         # if we are cloning to a different user modify the output directory
         olduser = self.get_value("USER")

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -242,9 +242,12 @@ class J_TestCreateNewcase(unittest.TestCase):
         fakeoutputroot = string.replace(cls._testroot, os.environ.get("USER"), "this_is_not_a_user")
         run_cmd_assert_result(self, "./xmlchange CIME_OUTPUT_ROOT=%s"%fakeoutputroot,
                               from_dir=prevtestdir)
-
-        run_cmd_assert_result(self, "%s/create_clone --clone %s --case %s" %
-                              (SCRIPT_DIR, prevtestdir, testdir),from_dir=SCRIPT_DIR)
+        # this test should fail
+        run_cmd_assert_result(self, "%s/create_clone --clone %s --case %s " %
+                              (SCRIPT_DIR, prevtestdir, testdir),from_dir=SCRIPT_DIR, expected_stat=1)
+        #this test should pass
+        run_cmd_assert_result(self, "%s/create_clone --clone %s --case %s --cime-output-root %s" %
+                              (SCRIPT_DIR, prevtestdir, testdir, cls._testroot),from_dir=SCRIPT_DIR)
 
         cls._do_teardown.append(testdir)
 


### PR DESCRIPTION
Add --cime-output-root option to create_clone and throw an error if this directory does not exist or is not writable.   Expand testing for this in scripts_regression_tests.py

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1020 

User interface changes?: 

Code review: 
