### PR TITLE
Refactor implementation of forcing procs/threads in create_test

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -186,7 +186,6 @@
       <arguments>
         <arg name="label"> --label</arg>
         <arg name="num_tasks"> -n $TOTALPES</arg>
-        <arg name="thread_count"> -c {{ cores_per_task }}</arg>
         <arg name="binding"> --cpu_bind=cores</arg>
       </arguments>
     </mpirun>
@@ -298,7 +297,6 @@
       <arguments>
         <arg name="label"> --label</arg>
         <arg name="num_tasks"> -n $TOTALPES</arg>
-        <arg name="thread_count"> -c {{ cores_per_task }}</arg>
         <arg name="binding"> --cpu_bind=cores</arg>
       </arguments>
     </mpirun>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -386,7 +386,6 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-	<arg name="thread_count" > -c {{ cores_per_task }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -491,7 +490,6 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-	<arg name="thread_count" > -c {{ cores_per_task }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -1967,6 +1967,14 @@
     <desc>total number of tasks and threads (setup automatically - DO NOT EDIT)</desc>
   </entry>
 
+  <entry id="TOTAL_CORES">
+    <type>integer</type>
+    <default_value>1</default_value>
+    <group>mach_pes_last</group>
+    <file>env_mach_pes.xml</file>
+    <desc>total number of cores used (setup automatically - DO NOT EDIT)</desc>
+  </entry>
+
   <entry id="MAX_TASKS_PER_NODE">
     <type>integer</type>
     <default_value>0</default_value>

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -119,16 +119,19 @@ class Case(object):
         """
         env_mach_pes = self.get_env("mach_pes")
         comp_classes = self.get_values("COMP_CLASSES")
-        total_tasks = env_mach_pes.get_total_tasks(comp_classes)
+        total_tasks  = env_mach_pes.get_total_tasks(comp_classes)
+        pes_per_node = self.get_value("PES_PER_NODE")
 
         self.thread_count = env_mach_pes.get_max_thread_count(comp_classes)
         self.tasks_per_node = env_mach_pes.get_tasks_per_node(total_tasks, self.thread_count)
         logger.debug("total_tasks %s thread_count %s"%(total_tasks, self.thread_count))
         self.num_nodes = env_mach_pes.get_total_nodes(total_tasks, self.thread_count)
         self.tasks_per_numa = int(math.ceil(self.tasks_per_node / 2.0))
-        smt_factor = max(1,int(self.get_value("MAX_TASKS_PER_NODE")/self.get_value("PES_PER_NODE")))
+        smt_factor = max(1,int(self.get_value("MAX_TASKS_PER_NODE") / pes_per_node))
 
-        self.cores_per_task = self.thread_count / smt_factor
+        threads_per_node = self.tasks_per_node * self.thread_count
+        threads_per_core = 1 if (threads_per_node < pes_per_node) else smt_factor
+        self.cores_per_task = self.thread_count / threads_per_core
 
         return total_tasks
 

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -130,7 +130,7 @@ class Case(object):
         smt_factor = max(1,int(self.get_value("MAX_TASKS_PER_NODE") / pes_per_node))
 
         threads_per_node = self.tasks_per_node * self.thread_count
-        threads_per_core = 1 if (threads_per_node < pes_per_node) else smt_factor
+        threads_per_core = 1 if (threads_per_node <= pes_per_node) else smt_factor
         self.cores_per_task = self.thread_count / threads_per_core
 
         return total_tasks

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -128,12 +128,9 @@ class Case(object):
         self.tasks_per_numa = int(math.ceil(self.tasks_per_node / 2.0))
         smt_factor = max(1,int(self.get_value("MAX_TASKS_PER_NODE")/self.get_value("PES_PER_NODE")))
 
-        self.cores_per_task = ((self.get_value("MAX_TASKS_PER_NODE")/smt_factor) \
-                               / self.tasks_per_node) * 2
+        self.cores_per_task = self.thread_count / smt_factor
 
         return total_tasks
-
-
 
     # Define __enter__ and __exit__ so that we can use this as a context manager
     # and force a flush on exit.
@@ -774,7 +771,9 @@ class Case(object):
             self.set_value("TIMER_LEVEL", 4)
         if test:
             self.set_value("TEST",True)
+
         total_tasks = self.initialize_derived_attributes()
+
         # Make sure that parallel IO is not specified if total_tasks==1
         if total_tasks == 1:
             for compclass in self._component_classes:
@@ -783,6 +782,8 @@ class Case(object):
                 if pio_typename in ("pnetcdf", "netcdf4p"):
                     self.set_value(key, "netcdf")
 
+        # Set TOTAL_CORES
+        self.set_value("TOTAL_CORES", total_tasks * self.cores_per_task )
 
     def get_compset_var_settings(self):
         compset_obj = Compsets(infile=self.get_value("COMPSETS_SPEC_FILE"))

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -190,6 +190,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                    "it is not possible to run with OpenMP if using the NAG Fortran compiler")
             cost_pes = env_mach_pes.get_cost_pes(pestot, thread_count, machine=case.get_value("MACH"))
             case.set_value("COST_PES", cost_pes)
+            case.set_value("TOTAL_CORES", pestot * thread_count)
 
             # create batch files
             logger.info("Creating batch script case.run")
@@ -207,6 +208,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 elif job != "case.test":
                     logger.info("Writing %s script from input template %s" % (job, input_batch_script))
                     env_batch.make_batch_script(input_batch_script, job, case, pestot, tasks_per_node, num_nodes, thread_count)
+
             # Make sure pio settings are consistant
             for comp in models:
                 pio_stride = case.get_value("PIO_STRIDE_%s"%comp)

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -190,7 +190,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                    "it is not possible to run with OpenMP if using the NAG Fortran compiler")
             cost_pes = env_mach_pes.get_cost_pes(pestot, thread_count, machine=case.get_value("MACH"))
             case.set_value("COST_PES", cost_pes)
-            case.set_value("TOTAL_CORES", pestot * thread_count)
 
             # create batch files
             logger.info("Creating batch script case.run")

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1207,7 +1207,8 @@ class K_TestCimeCase(TestCreateTestCommon):
 
             self.assertEqual(case.get_value("NTHRDS_CPL"), 8)
 
-            self.assertEqual(case.get_value("TOTAL_CORES"), 128)
+            expected_cores = 16 * case.cores_per_task
+            self.assertEqual(case.get_value("TOTAL_CORES"), expected_cores)
 
 ###############################################################################
 class X_TestSingleSubmit(TestCreateTestCommon):

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1207,6 +1207,8 @@ class K_TestCimeCase(TestCreateTestCommon):
 
             self.assertEqual(case.get_value("NTHRDS_CPL"), 8)
 
+            self.assertEqual(case.get_value("TOTAL_CORES"), 128)
+
 ###############################################################################
 class X_TestSingleSubmit(TestCreateTestCommon):
 ###############################################################################

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1199,7 +1199,7 @@ class K_TestCimeCase(TestCreateTestCommon):
                               % (SCRIPT_DIR, self._baseline_name, self._testroot, self._testroot))
 
         casedir = os.path.join(self._testroot,
-                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_Mmpi-serial.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
+                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_Mmpi-serial_P16x8.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
         self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
 
         with Case(casedir, read_only=True) as case:


### PR DESCRIPTION
Dynamically re-write test names to reflect these choices.

Add new TOTAL_CORES entry id in order to better support test_schedulers
scheduling.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1017 

User interface changes?: Auto test-renaming in create_test

Code review: @jedwards4b 
