### PR TITLE
Science support field

### DIFF
--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -47,6 +47,7 @@
   <compset>
     <alias>B1850</alias>
     <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <science_support grid="f09_g16"/>
   </compset>
 
   <compset>

--- a/cime_config/cesm/allactive/config_compsets.xml
+++ b/cime_config/cesm/allactive/config_compsets.xml
@@ -11,7 +11,7 @@
 
     The notation for the compset longname is
     TIME_ATM[%phys]_LND[%phys]_ICE[%phys]_OCN[%phys]_ROF[%phys]_GLC[%phys]_WAV[%phys][_ESP%phys][_BGC%phys]
-    Where for the CAM specific compsets below the following is supported
+    Where for the specific compsets below the following is supported
     TIME = Time period (e.g. 2000, HIST, RCP8...)
     ATM  = [CAM40, CAM50, CAM60]
     LND  = [CLM45, CLM50, SLND]
@@ -25,8 +25,7 @@
 
     The OPTIONAL %phys attributes specify submodes of the given system
     For example DOCN%DOM is the data ocean model for DOCN
-    ALL the possible %phys choices for each component are listed
-    with the -list command for create_newcase
+    ALL the possible %phys choices for each component are listed.
     ALL data models must have a %phys option that corresponds to the data  model mode
 
     Each compset node is associated with the following elements

--- a/cime_config/cesm/config_files.xml
+++ b/cime_config/cesm/config_files.xml
@@ -153,6 +153,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of all system tests for primary component (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/testlist.xsd</schema>
   </entry>
 
   <entry id="TESTS_MODS_DIR">

--- a/cime_config/xml_schemas/config_compsets.xsd
+++ b/cime_config/xml_schemas/config_compsets.xsd
@@ -10,6 +10,7 @@
   <xs:element name="help" type="xs:string"/>
   <xs:element name="alias" type="xs:NCName"/>
   <xs:element name="lname" type="xs:string"/>
+  <xs:element name="science_support"/>
 
   <!-- complex elements -->
 
@@ -30,6 +31,7 @@
       <xs:sequence>
         <xs:element ref="alias"/>
         <xs:element ref="lname"/>
+	<xs:element ref="science_support" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute ref="grid"/>
     </xs:complexType>

--- a/cime_config/xml_schemas/config_pes.xsd
+++ b/cime_config/xml_schemas/config_pes.xsd
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 <!-- attributes -->
+<xs:attribute name="version"  type="xs:decimal"/>
 <xs:attribute name="name"  type="xs:string"/>
 <xs:attribute name="pesize"  type="xs:NCName"/>
 <xs:attribute name="compset"  type="xs:string"/>
@@ -42,6 +43,7 @@
         <xs:element maxOccurs="unbounded" ref="grid"/>
         <xs:element ref="overrides" minOccurs="0"/>
       </xs:sequence>
+      <xs:attribute ref="version" use="required"/>
     </xs:complexType>
   </xs:element>
 

--- a/cime_config/xml_schemas/testlist.xsd
+++ b/cime_config/xml_schemas/testlist.xsd
@@ -19,7 +19,7 @@
       <xs:attribute name="compset" use="required" type="xs:NCName"/>
       <xs:attribute name="grid" use="required" type="xs:NCName"/>
       <xs:attribute name="name" use="required" type="xs:NCName"/>
-      <xs:attribute name="testmods" use="required"/>
+      <xs:attribute name="testmods" />
     </xs:complexType>
   </xs:element>
 

--- a/driver_cpl/cime_config/config_component.xml
+++ b/driver_cpl/cime_config/config_component.xml
@@ -2426,16 +2426,6 @@
     <desc>level of debug output, 0=minimum, 1=normal, 2=more, 3=too much</desc>
   </entry>
 
-  <entry id="SCIENCE_SUPPORT">
-    <type>char</type>
-    <valid_values>on, off</valid_values>
-    <default_value>off</default_value>
-    <group>case_def</group>
-    <file>env_case.xml</file>
-    <desc>If set to off, this component set/ grid specification is not scientifically supported.
-    If set to on, this component set/ grid specification is scientifically supported</desc>
-  </entry>
-
   <entry id="CLM_USE_PETSC">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -2,16 +2,26 @@
 
 from Tools.standard_script_setup import *
 from shutil import copyfile
-from CIME.utils         import expect
+from CIME.utils         import expect, get_model
 from CIME.case          import Case
 
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def parse_command_line(args, cimeroot):
+def parse_command_line(args, cimeroot, description):
 ###############################################################################
+    help_str = \
+"""
+%s --case [CASE] --compset [COMPSET] --res [GRID] [--machine ...] [--compiler ...]
+OR
+%s --help
+"""
+    model = get_model()
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(usage=help_str,
+                                     description=description,
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
 
     CIME.utils.setup_standard_logging_options(parser)
 
@@ -87,6 +97,11 @@ def parse_command_line(args, cimeroot):
     parser.add_argument("--output-root",
                         help="Alternative path for the directory where case output is written")
 
+    if model == "cesm":
+        parser.add_argument("--run-unsupported", action="store_true",
+                            help="Force the creation of a case not tested or supported by CESM developers")
+
+
     # hidden argument indicating called from create_test
     parser.add_argument("--test", "-test", action="store_true",
                         help="Used to indicate that create_newcase was called from create_test"
@@ -124,14 +139,19 @@ def parse_command_line(args, cimeroot):
         expect(args.gridfile is not None,
                "User grid specification file must be set if the user grid is requested")
 
+    run_unsupported = False
+    if model == "cesm":
+        run_unsupported = args.run_unsupported
+
+
     return args.case, args.compset, args.res, args.mach, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.user_compset, args.pesfile, \
         args.user_grid, args.gridfile, args.srcroot, args.test, args.ninst, \
-        args.walltime, args.queue, args.output_root
+        args.walltime, args.queue, args.output_root, run_unsupported
 
 ###############################################################################
-def _main_func():
+def _main_func(description):
 ###############################################################################
     cimeroot  = os.path.abspath(CIME.utils.get_cime_root())
 
@@ -139,7 +159,7 @@ def _main_func():
         mpilib, project, pecount,  \
         user_mods_dir, user_compset, pesfile, \
         user_grid, gridfile, srcroot, test, ninst, walltime, queue, \
-        output_root = parse_command_line(sys.argv, cimeroot)
+        output_root, run_unsupported = parse_command_line(sys.argv, cimeroot, description)
 
     caseroot = os.path.abspath(caseroot)
 
@@ -156,10 +176,11 @@ def _main_func():
 
         # Configure the Case
         case.configure(compset, grid, machine_name=machine, project=project,
-                          pecount=pecount, compiler=compiler, mpilib=mpilib,
-                          user_compset=user_compset, pesfile=pesfile,
-                          user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
-                          walltime=walltime, queue=queue, output_root=output_root)
+                       pecount=pecount, compiler=compiler, mpilib=mpilib,
+                       user_compset=user_compset, pesfile=pesfile,
+                       user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
+                       walltime=walltime, queue=queue, output_root=output_root,
+                       run_unsupported=run_unsupported)
 
         case.create_caseroot()
 
@@ -177,4 +198,4 @@ def _main_func():
 ###############################################################################
 
 if __name__ == "__main__":
-    _main_func()
+    _main_func(__doc__)

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -15,7 +15,7 @@ def parse_command_line(args, cimeroot, description):
 %s --case [CASE] --compset [COMPSET] --res [GRID] [--machine ...] [--compiler ...]
 OR
 %s --help
-"""
+""" % ((os.path.basename(args[0]), ) * 2)
     model = get_model()
 
     parser = argparse.ArgumentParser(usage=help_str,

--- a/utils/python/CIME/XML/compsets.py
+++ b/utils/python/CIME/XML/compsets.py
@@ -20,17 +20,22 @@ class Compsets(GenericXML):
         self.groups={}
 
     def get_compset_match(self, name):
+        """
+        science support is used in cesm to determine if this compset and grid
+        is scientifically supported.   science_support is returned as an array of grids for this compset
+        """
         nodes = self.get_nodes("compset")
         alias = None
         lname = None
-        science_support = False
+        science_support = []
         for node in nodes:
             alias = self.get_element_text("alias",root=node)
             lname = self.get_element_text("lname",root=node)
             if alias == name or lname == name:
-                science_support = self.get_element_text("science_support", root=node)
-                if science_support == None:
-                    science_support = False
+                science_support_nodes = self.get_nodes("science_support", root=node)
+                for node in science_support_nodes:
+                    science_support.append(node.get("grid"))
+
                 logger.debug("Found node match with alias: %s and lname: %s" % (alias, lname))
                 return (lname, alias, science_support)
         return (None, None, False)

--- a/utils/python/CIME/XML/compsets.py
+++ b/utils/python/CIME/XML/compsets.py
@@ -21,12 +21,19 @@ class Compsets(GenericXML):
 
     def get_compset_match(self, name):
         nodes = self.get_nodes("compset")
+        alias = None
+        lname = None
+        science_support = False
         for node in nodes:
-            alias = self.get_node("alias",root=node)
-            lname = self.get_node("lname",root=node)
-            if alias.text == name or lname.text == name:
-                logger.debug("Found node match with alias: %s and lname: %s" % (alias.text, lname.text))
-                return lname.text
+            alias = self.get_element_text("alias",root=node)
+            lname = self.get_element_text("lname",root=node)
+            if alias == name or lname == name:
+                science_support = self.get_element_text("science_support", root=node)
+                if science_support == None:
+                    science_support = False
+                logger.debug("Found node match with alias: %s and lname: %s" % (alias, lname))
+                return (lname, alias, science_support)
+        return (None, None, False)
 
     def get_compset_var_settings(self, compset, grid):
         '''

--- a/utils/python/CIME/XML/testlist.py
+++ b/utils/python/CIME/XML/testlist.py
@@ -37,18 +37,23 @@ Currently supported options are:
 from CIME.XML.standard_module_setup import *
 
 from CIME.XML.generic_xml import GenericXML
+from CIME.XML.files import Files
 
 logger = logging.getLogger(__name__)
 
 class Testlist(GenericXML):
 
-    def __init__(self,infile):
+    def __init__(self,infile, files=None):
         """
         initialize an object
         """
-        GenericXML.__init__(self,infile)
+        schema = None
+        if files is None:
+            files = Files()
+        schema = files.get_schema("TESTS_SPEC_FILE")
+        GenericXML.__init__(self, infile, schema=schema)
 
-    def _get_testsv1(self, machine=None, category=None, compiler=None):
+    def _get_testsv1(self, machine=None, category=None, compiler=None, compset=None, grid=None):
         tests = []
 
         machatts = {}
@@ -70,6 +75,7 @@ class Testlist(GenericXML):
                     logger.debug("      machnodes %d"%len(machnodes))
                     for mach in machnodes:
                         thistest = {}
+                        save_this = True
                         if machine is None or (machine is not None and mach.text == machine):
                             thistest["compiler"] = mach.get("compiler")
                             thistest["category"] = mach.get("testtype")
@@ -79,12 +85,24 @@ class Testlist(GenericXML):
                             thistest["compset"] = cnode.get("name")
                             if ("testmods" in mach.attrib):
                                 thistest["testmods"] = mach.get("testmods")
-                            tests.append(thistest)
+                            if compset is not None and compset != thistest["compset"]:
+                                save_this = False
+                            if grid is not None and grid != thistest["grid"]:
+                                save_this = False
+                            if save_this:
+                                tests.append(thistest)
         return tests
 
-    def _get_testsv2(self, machine=None, category=None, compiler=None):
+    def _get_testsv2(self, machine=None, category=None, compiler=None, compset=None, grid=None):
         tests = []
-        testnodes = self.get_nodes("test")
+        attributes = {}
+        if compset is not None:
+            attributes['compset'] = compset
+        if grid is not None:
+            attributes['grid'] = grid
+
+        testnodes = self.get_nodes("test", attributes=attributes)
+
         machatts = {}
         if machine is not None:
             machatts["name"]      = machine
@@ -131,11 +149,11 @@ class Testlist(GenericXML):
 
         return tests
 
-    def get_tests(self, machine=None, category=None, compiler=None):
+    def get_tests(self, machine=None, category=None, compiler=None, compset=None, grid=None):
         if self.get_version() == 1.0:
-            return self._get_testsv1(machine, category, compiler)
+            return self._get_testsv1(machine, category, compiler, compset, grid)
         elif self.get_version() >= 2.0:
-            return self._get_testsv2(machine, category, compiler)
+            return self._get_testsv2(machine, category, compiler, compset, grid)
         else:
             logger.critical("Did not recognize testlist file version %s for file %s"
                              % (self.get_version(), self.filename))

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -1109,7 +1109,7 @@ class Case(object):
         tests = Testlist(tests_spec_file, files)
         testlist = tests.get_tests(compset=compset_alias, grid=grid_name)
         if len(testlist) > 0:
-            logger.info("\nThis compset and grid combination is not scientifically_supported, however it is used in %d tests.\n"%(len(testlist)))
+            logger.info("\nThis compset and grid combination is not scientifically supported, however it is used in %d tests.\n"%(len(testlist)))
         else:
-            expect(False, "\nThis compset and grid combination is unsupported in CESM."
+            expect(False, "\nThis compset and grid combination is unsupported in CESM.  "
                    "If you wish to use it anyway you must supply the --run-unsupported option to create_newcase.")

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -409,7 +409,7 @@ class Case(object):
         either a longname or an alias.  This will also set the
         compsets and pes specfication files.
         """
-        science_support = False
+        science_support = {}
         compset_alias = None
         components = files.get_components("COMPSETS_SPEC_FILE")
         logger.debug(" Possible components for COMPSETS_SPEC_FILE are %s" % components)
@@ -454,8 +454,8 @@ class Case(object):
         else:
             expect(False,
                    "Could not find a compset match for either alias or longname in %s" %(compset_name))
-        expect(not science_support, "science_support not expected to be true here")
-        return False
+
+        return None, science_support
 
     def get_compset_components(self):
         #If are doing a create_clone then, self._compsetname is not set yet
@@ -741,8 +741,8 @@ class Case(object):
         logger.info(" Components in compset are: %s " %self._components)
 
         if not test and not run_unsupported and self._cime_model == "cesm":
-            if science_support:
-                logger.info("\nThis is a CESM scientifically supported compset.\n")
+            if grid_name in science_support:
+                logger.info("\nThis is a CESM scientifically supported compset at this resolution.\n")
             else:
                 self._check_testlists(compset_alias, grid_name, files)
 
@@ -1098,6 +1098,9 @@ class Case(object):
             self._is_env_loaded = True
 
     def _check_testlists(self, compset_alias, grid_name, files):
+        """
+        CESM only: check the testlist file for tests of this compset grid combination
+        """
         if "TESTS_SPEC_FILE" in self.lookups:
             tests_spec_file = self.get_resolved_value(self.lookups["TESTS_SPEC_FILE"])
         else:

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -14,6 +14,7 @@ from CIME.utils                     import get_build_threaded, get_current_commi
 from CIME.XML.machines              import Machines
 from CIME.XML.pes                   import Pes
 from CIME.XML.files                 import Files
+from CIME.XML.testlist                 import Testlist
 from CIME.XML.component             import Component
 from CIME.XML.compsets              import Compsets
 from CIME.XML.grids                 import Grids
@@ -82,6 +83,8 @@ class Case(object):
         # table and then remove the entry.
         self.lookups = {}
         self.set_lookup_value('CIMEROOT',os.path.abspath(get_cime_root()))
+        self._cime_model = get_model()
+        self.set_lookup_value('MODEL', self._cime_model)
         self._compsetname = None
         self._gridname = None
         self._compsetsfile = None
@@ -90,7 +93,7 @@ class Case(object):
         self._components = []
         self._component_classes = []
         self._is_env_loaded = False
-        self._cime_model = get_model()
+
 
         self.thread_count = None
         self.tasks_per_node = None
@@ -406,7 +409,8 @@ class Case(object):
         either a longname or an alias.  This will also set the
         compsets and pes specfication files.
         """
-
+        science_support = False
+        compset_alias = None
         components = files.get_components("COMPSETS_SPEC_FILE")
         logger.debug(" Possible components for COMPSETS_SPEC_FILE are %s" % components)
 
@@ -420,7 +424,7 @@ class Case(object):
             # If the file exists, read it and see if there is a match for the compset alias or longname
             if (os.path.isfile(compsets_filename)):
                 compsets = Compsets(compsets_filename)
-                match = compsets.get_compset_match(name=compset_name)
+                match, compset_alias, science_support = compsets.get_compset_match(name=compset_name)
                 pesfile = files.get_value("PES_SPEC_FILE"     , {"component":component})
                 if match is not None:
                     self._pesfile = pesfile
@@ -439,7 +443,7 @@ class Case(object):
                     logger.info("Compset longname is %s " %(match))
                     logger.info("Compset specification file is %s" %(compsets_filename))
                     logger.info("Pes     specification file is %s" %(pesfile))
-                    return
+                    return compset_alias, science_support
 
         if user_compset is True:
             #Do not error out for user_compset
@@ -450,7 +454,8 @@ class Case(object):
         else:
             expect(False,
                    "Could not find a compset match for either alias or longname in %s" %(compset_name))
-
+        expect(not science_support, "science_support not expected to be true here")
+        return False
 
     def get_compset_components(self):
         #If are doing a create_clone then, self._compsetname is not set yet
@@ -550,13 +555,13 @@ class Case(object):
                   project=None, pecount=None, compiler=None, mpilib=None,
                   user_compset=False, pesfile=None,
                   user_grid=False, gridfile=None, ninst=1, test=False,
-                  walltime=None, queue=None, output_root=None):
+                  walltime=None, queue=None, output_root=None, run_unsupported=False):
 
         #--------------------------------------------
         # compset, pesfile, and compset components
         #--------------------------------------------
         files = Files()
-        self._set_compset_and_pesfile(compset_name, files, user_compset=user_compset, pesfile=pesfile)
+        compset_alias, science_support = self._set_compset_and_pesfile(compset_name, files, user_compset=user_compset, pesfile=pesfile)
 
         self._components = self.get_compset_components()
         #FIXME - if --user-compset is True then need to determine that
@@ -734,6 +739,13 @@ class Case(object):
         logger.info(" Compset is: %s " %self._compsetname)
         logger.info(" Grid is: %s " %self._gridname )
         logger.info(" Components in compset are: %s " %self._components)
+
+        if not test and not run_unsupported and self._cime_model == "cesm":
+            if science_support:
+                logger.info("\nThis is a CESM scientifically supported compset.\n")
+            else:
+                self._check_testlists(compset_alias, grid_name, files)
+
 
         # Set project id
         if project is None:
@@ -1084,3 +1096,17 @@ class Case(object):
             env_module = self.get_env("mach_specific")
             env_module.load_env(compiler=compiler,debug=debug, mpilib=mpilib)
             self._is_env_loaded = True
+
+    def _check_testlists(self, compset_alias, grid_name, files):
+        if "TESTS_SPEC_FILE" in self.lookups:
+            tests_spec_file = self.get_resolved_value(self.lookups["TESTS_SPEC_FILE"])
+        else:
+            tests_spec_file = self.get_value("TESTS_SPEC_FILE")
+
+        tests = Testlist(tests_spec_file, files)
+        testlist = tests.get_tests(compset=compset_alias, grid=grid_name)
+        if len(testlist) > 0:
+            logger.info("\nThis compset and grid combination is not scientifically_supported, however it is used in %d tests.\n"%(len(testlist)))
+        else:
+            expect(False, "\nThis compset and grid combination is unsupported in CESM."
+                   "If you wish to use it anyway you must supply the --run-unsupported option to create_newcase.")

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -508,6 +508,7 @@ def get_timestamp(timestamp_format="%Y%m%d_%H%M%S", utc_time=False):
 def get_project(machobj=None):
     """
     Hierarchy for choosing PROJECT:
+    0. Command line flag to create_newcase or create_test
     1. Environment variable PROJECT
     2  Environment variable ACCOUNT  (this is for backward compatibility)
     3. File $HOME/.cime/config       (this is new)


### PR DESCRIPTION
Add a science_support field to the config_compsets.xml file.  This is implemented for CESM only and should not affect non cesm models in any way.  

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #533 

User interface changes?:   Added --use-unsupported flag to create_newcase for cesm only.

Code review: 
