### PR TITLE
fix drv namelist issue

### DIFF
--- a/driver_cpl/cime_config/buildnml
+++ b/driver_cpl/cime_config/buildnml
@@ -172,7 +172,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
 
     if len(infiles) != 0:
         config = {}
-        definition_file = files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv_flds"})
+        definition_file = [files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv_flds"})]
 
         nmlgen = NamelistGenerator(case, definition_file, files=files)
         skip_entry_loop = True

--- a/utils/python/CIME/XML/namelist_definition.py
+++ b/utils/python/CIME/XML/namelist_definition.py
@@ -45,10 +45,8 @@ class NamelistDefinition(EntryID):
         schema = None
         if files is None:
             files = Files()
-            cimeroot = get_cime_root()
-            schema = os.path.join(cimeroot,"cime_config","xml_schemas","entry_id_namelist.xsd")
-            self.validate_xml_file(infile, schema)
-
+        schema = files.get_schema("NAMELIST_DEFINITION_FILE")
+        expect(os.path.isfile(infile), "File %s does not exist"%infile)
         super(NamelistDefinition, self).__init__(infile, schema=schema)
 
         self._attributes = {}
@@ -58,10 +56,6 @@ class NamelistDefinition(EntryID):
         self._entry_types = {}
         self._group_names = {}
         self._nodes = {}
-
-
-
-
 
     def set_nodes(self, skip_groups=None):
         """


### PR DESCRIPTION
Namellsts are expected to be lists, namelist gen should always be passed an existing file, throw an error if its not 
Test suite: SMS_Ld7.f09_g16.B1850.yellowstone_intel.allactive-defaultio
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
