### PR TITLE
Lock env_mach.xml file

### DIFF
--- a/cime_config/acme/machines/config_batch.xml
+++ b/cime_config/acme/machines/config_batch.xml
@@ -39,13 +39,13 @@
      <batch_directive></batch_directive>
      <jobid_pattern>(\d+)</jobid_pattern>
      <depend_string> --dependencies</depend_string>
-     <walltime_format>%H:%M:%S</walltime_format>
+     <walltime_format>%H:%M:%s</walltime_format>
      <submit_args>
        <arg flag="--cwd" name="CASEROOT"/>
        <arg flag="-A" name="PROJECT"/>
        <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
        <!-- space is required here so that variable is resolved correctly -->
-       <arg flag="-n" name=" $TOTALPES/$PES_PER_NODE"/>
+       <arg flag="-n" name=" $TOTALPES / $PES_PER_NODE"/>
        <arg flag="-q" name="JOB_QUEUE"/>
        <arg flag="--mode script"/>
      </submit_args>
@@ -72,43 +72,43 @@
     <batch_redirect>&lt;</batch_redirect>
     <batch_directive>#BSUB</batch_directive>
     <jobid_pattern>&lt;(\d+)&gt;</jobid_pattern>
-    <depend_string> -w "done(jobid)"</depend_string>
+    <depend_string> -w 'done(jobid)'</depend_string>
     <walltime_format>%H:%M</walltime_format>
+    <submit_args>
+      <arg flag="-q" name="$JOB_QUEUE"/>
+      <arg flag="-W" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-P" name="$PROJECT"/>
+    </submit_args>
     <directives>
-      <directive                       > -n {{ totaltasks }} </directive>
-      <directive                       > -R "span[ptile={{ ptile }}]"</directive>
-      <directive                       > -q {{ job_queue }} </directive>
+      <directive                       > -n {{ total_tasks }} </directive>
+      <directive                       > -R "span[ptile={{ tasks_per_node }}]"</directive>
       <directive                       > -N  </directive>
       <directive default="poe"         > -a {{ poe }} </directive>
-      <directive                       > -x {{ queue_exclusive }} </directive>
-      <directive default="acme.stdout" > -o {{ acme_stdout }}.%J  </directive>
-      <directive default="acme.stderr" > -e {{ acme_stderr }}.%J  </directive>
+      <directive default="acme.stdout" > -o {{ output_error_path }}.%J  </directive>
+      <directive default="acme.stderr" > -e {{ output_error_path }}.%J  </directive>
       <directive                       > -J {{ job_id }} </directive>
-      <directive                       > -W {{ job_wallclock_time }} </directive>
-      <directive                       > -P {{ account }}  </directive>
     </directives>
   </batch_system>
 
   <batch_system type="pbs" >
-    <batch_query args="-u $USER" >qselect</batch_query>
+    <batch_query args="-f" >qstat</batch_query>
     <batch_submit>qsub </batch_submit>
     <batch_directive>#PBS</batch_directive>
-    <jobid_pattern>^(\d+)</jobid_pattern>
+    <jobid_pattern>^(\S+)$</jobid_pattern>
     <depend_string> -W depend=afterok:jobid</depend_string>
     <walltime_format>%H:%M:%S</walltime_format>
     <submit_args>
-      <arg flag="-q" name="JOB_QUEUE"/>
-      <arg flag="-l walltime=" name="JOB_WALLCLOCK_TIME"/>
-      <arg flag="-A" name="PROJECT"/>
+      <arg flag="-q" name="$JOB_QUEUE"/>
+      <arg flag="-l walltime=" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-A" name="$PROJECT"/>
     </submit_args>
     <directives>
-      <directive> -V </directive>
       <directive> -N {{ job_id }}</directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
       <!-- <directive> -j oe {{ output_error_path }} </directive> -->
       <directive> -j oe </directive>
       <directive default="ae"  > -m {{ mail_options }} </directive>
-      <directive default="/bin/bash" > -S {{ shell }} </directive>
+      <directive> -V </directive>
     </directives>
   </batch_system>
 
@@ -119,11 +119,13 @@
     <jobid_pattern>(\d+)$</jobid_pattern>
     <depend_string> -W depend=afterok:jobid</depend_string>
     <walltime_format>%H:%M:%S</walltime_format>
+    <submit_args>
+      <arg flag="-l walltime=" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-A" name="$PROJECT"/>
+    </submit_args>
     <directives>
       <directive> -N {{ job_id }}</directive>
-      <directive> -l walltime={{ job_wallclock_time }}</directive>
       <directive> -j oe </directive>
-      <directive> -A {{ project }} </directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
       <directive default="ae"  > -m {{ mail_options }} </directive>
       <directive default="/bin/bash" > -S {{ shell }}</directive>
@@ -131,20 +133,23 @@
   </batch_system>
 
    <batch_system type="slurm" >
-     <batch_query args="-o '%i' -h -u $USER">squeue </batch_query>
+     <batch_query>squeue</batch_query>
      <batch_submit>sbatch</batch_submit>
      <batch_directive>#SBATCH</batch_directive>
      <jobid_pattern>(\d+)$</jobid_pattern>
      <depend_string> --dependency=afterok:jobid</depend_string>
     <walltime_format>%H:%M:%S</walltime_format>
+     <submit_args>
+       <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
+       <arg flag="-p" name="$JOB_QUEUE"/>
+       <arg flag="--account" name="$PROJECT"/>
+     </submit_args>
      <directives>
        <directive> --job-name={{ job_id }}</directive>
        <directive> --nodes={{ num_nodes }}</directive>
+       <directive> --ntasks-per-node={{ tasks_per_node }}</directive>
        <directive> --output={{ output_error_path }}   </directive>
        <directive> --exclusive                        </directive>
-       <directive> --time={{ job_wallclock_time }}</directive>
-       <directive> --partition={{ job_queue }}</directive>
-       <directive> --account={{ project }}</directive>
      </directives>
    </batch_system>
 

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 from Tools.standard_script_setup import *
-from shutil import copyfile
 from CIME.utils         import expect, get_model
 from CIME.case          import Case
+from CIME.check_lockedfiles import lock_file
 
 logger = logging.getLogger(__name__)
 
@@ -191,9 +191,8 @@ def _main_func(description):
                 user_mods_dir = os.path.abspath(user_mods_dir)
             case.apply_user_mods(user_mods_dir)
 
-    # Copy env_case.xml into LockedFiles
-    copyfile(os.path.join(caseroot,"env_case.xml"),
-             os.path.join(caseroot,"LockedFiles","env_case.xml"))
+    # Lock env_case.xml
+    lock_file("env_case.xml", caseroot)
 
 ###############################################################################
 

--- a/utils/python/CIME/SystemTests/seq.py
+++ b/utils/python/CIME/SystemTests/seq.py
@@ -4,6 +4,7 @@ CIME smoke test  This class inherits from SystemTestsCommon
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case_setup import case_setup
+from CIME.check_lockedfiles import *
 import shutil
 
 logger = logging.getLogger(__name__)
@@ -31,12 +32,11 @@ class SEQ(SystemTestsCommon):
         shutil.move("%s/%s.exe"%(exeroot,cime_model),
                     "%s/%s.exe.SEQ1"%(exeroot,cime_model))
         any_changes = False
-        machpes1 = os.path.join("LockedFiles","env_mach_pes.SEQ1.xml")
-        if ( os.path.isfile(machpes1) ):
-            shutil.copy(machpes1,"env_mach_pes.xml")
+        machpes1 = "env_mach_pes.SEQ1.xml"
+        if is_locked(machpes1):
+            restore(machpes1, newname="env_mach_pes.xml")
         else:
-            logging.info("Copying env_mach_pes.xml to %s"%(machpes1))
-            shutil.copy("env_mach_pes.xml", machpes1)
+            lock_file("env_mach_pes.xml", newname=machpes1)
 
         comp_classes = self._case.get_values("COMP_CLASSES")
         for comp in comp_classes:
@@ -63,9 +63,7 @@ class SEQ(SystemTestsCommon):
         self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
         shutil.move("%s/%s.exe"%(exeroot,cime_model),
                     "%s/%s.exe.SEQ2"%(exeroot,cime_model))
-        machpes2 = os.path.join("LockedFiles","env_mach_pes.SEQ2.xml")
-        logging.info("Copying env_mach_pes.xml to %s"%(machpes2))
-        shutil.copy("env_mach_pes.xml", machpes2)
+        lock_file("env_mach_pes.xml", newname="env_mach_pes.SEQ2.xml")
 
     def run_phase(self):
         # Move to config_tests.xml once that's ready.
@@ -87,12 +85,10 @@ class SEQ(SystemTestsCommon):
 
         shutil.copy("%s/%s.exe.SEQ1"%(exeroot,cime_model),
                     "%s/%s.exe"%(exeroot,cime_model))
-        shutil.copy(os.path.join("LockedFiles", "env_mach_pes.SEQ1.xml"), "env_mach_pes.xml")
-        shutil.copy("env_mach_pes.xml", os.path.join("LockedFiles", "env_mach_pes.xml"))
+        restore("env_mach_pes.SEQ1.xml", newname="env_mach_pes.xml")
         self.run_indv()
 
-        shutil.copy(os.path.join("LockedFiles", "env_mach_pes.SEQ2.xml"), "env_mach_pes.xml")
-        shutil.copy("env_mach_pes.xml", os.path.join("LockedFiles", "env_mach_pes.xml"))
+        restore("env_mach_pes.SEQ2.xml", newname="env_mach_pes.xml")
 
         os.remove("%s/%s.exe"%(exeroot,cime_model))
         shutil.copy("%s/%s.exe.SEQ1"%(exeroot,cime_model),

--- a/utils/python/CIME/SystemTests/system_tests_common.py
+++ b/utils/python/CIME/SystemTests/system_tests_common.py
@@ -8,6 +8,7 @@ from CIME.case_setup import case_setup
 from CIME.case_run import case_run
 from CIME.case_st_archive import case_st_archive
 from CIME.test_status import *
+from CIME.check_lockedfiles import *
 from CIME.hist_utils import *
 
 import CIME.build as build
@@ -20,7 +21,7 @@ class SystemTestsCommon(object):
 
     def __init__(self, case, expected=None):
         """
-        initialize a CIME system test object, if the file LockedFiles/env_run.orig.xml
+        initialize a CIME system test object, if the locked env_run.orig.xml
         does not exist copy the current env_run.xml file.  If it does exist restore values
         changed in a previous run of the test.
         """
@@ -43,20 +44,14 @@ class SystemTestsCommon(object):
 
     def _init_locked_files(self, caseroot, expected):
         """
-        If the file LockedFiles/env_run.orig.xml does not exist, copy the current
+        If the locked env_run.orig.xml does not exist, copy the current
         env_run.xml file. If it does exist, restore values changed in a previous
         run of the test.
         """
-        if os.path.isfile(os.path.join(caseroot, "LockedFiles", "env_run.orig.xml")):
+        if is_locked("env_run.orig.xml"):
             self.compare_env_run(expected=expected)
         elif os.path.isfile(os.path.join(caseroot, "env_run.xml")):
-            lockedfiles = os.path.join(caseroot, "LockedFiles")
-            try:
-                os.stat(lockedfiles)
-            except:
-                os.mkdir(lockedfiles)
-            shutil.copy(os.path.join(caseroot,"env_run.xml"),
-                        os.path.join(lockedfiles, "env_run.orig.xml"))
+            lock_file("env_run.xml", caseroot=caseroot, newname="env_run.orig.xml")
 
     def _resetup_case(self, phase):
         """
@@ -307,12 +302,13 @@ class SystemTestsCommon(object):
                     self._test_status.set_status(MEMLEAK_PHASE, TEST_FAIL_STATUS, comments=comment)
 
     def compare_env_run(self, expected=None):
+        # JGF implement in check_lockedfiles?
         f1obj = EnvRun(self._caseroot, "env_run.xml")
-        f2obj = EnvRun(self._caseroot, os.path.join("LockedFiles", "env_run.orig.xml"))
+        f2obj = EnvRun(self._caseroot, os.path.join(LOCKED_DIR, "env_run.orig.xml"))
         diffs = f1obj.compare_xml(f2obj)
         for key in diffs.keys():
             if expected is not None and key in expected:
-                logging.warn("  Resetting %s for test"%key)
+                logging.warn("  Resetting %s for test" % key)
                 f1obj.set_value(key, f2obj.get_value(key, resolved=False))
             else:
                 print "Found difference in %s: case: %s original value %s" %\

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -11,6 +11,7 @@ from CIME.XML.standard_module_setup import *
 from CIME.utils                     import expect, get_cime_root, append_status
 from CIME.utils                     import convert_to_type, get_model, get_project
 from CIME.utils                     import get_build_threaded, get_current_commit
+from CIME.check_lockedfiles         import LOCKED_DIR, lock_file
 from CIME.XML.machines              import Machines
 from CIME.XML.pes                   import Pes
 from CIME.XML.files                 import Files
@@ -907,13 +908,13 @@ class Case(object):
 
         # Create relevant directories in $self._caseroot
         if clone:
-            newdirs = ("LockedFiles", "Tools")
+            newdirs = (LOCKED_DIR, "Tools")
         else:
-            newdirs = ("SourceMods", "LockedFiles", "Buildconf", "Tools")
+            newdirs = ("SourceMods", LOCKED_DIR, "Buildconf", "Tools")
         for newdir in newdirs:
             os.makedirs(newdir)
-        # Open a new README.case file in $self._caseroot
 
+        # Open a new README.case file in $self._caseroot
         append_status(" ".join(sys.argv), caseroot=self._caseroot, sfile="README.case")
         append_status("Compset longname is %s"%self.get_value("COMPSET"),
                       caseroot=self._caseroot, sfile="README.case")
@@ -1022,8 +1023,8 @@ class Case(object):
         for casesub in ("SourceMods", "Buildconf"):
             shutil.copytree(os.path.join(cloneroot, casesub), os.path.join(newcaseroot, casesub))
 
-        # copy env_case.xml to LockedFiles
-        shutil.copy(os.path.join(newcaseroot,"env_case.xml"), os.path.join(newcaseroot,"LockedFiles"))
+        # lock env_case.xml in new case
+        lock_file("env_case.xml", newcaseroot)
 
         # Update README.case
         fclone   = open(cloneroot + "/README.case", "r")

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -98,8 +98,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 os.remove("case.testdriver")
                 logger.info("Successfully cleaned test script case.testdriver")
 
-        unlock_file("env_batch.xml")
-
         logger.info("Successfully cleaned batch script case.run")
 
         msg = "case.setup clean complete"
@@ -178,9 +176,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 elif job != "case.test":
                     logger.info("Writing %s script from input template %s" % (job, input_batch_script))
                     env_batch.make_batch_script(input_batch_script, job, case, pestot, tasks_per_node, num_nodes, thread_count)
-
-            # Lock env_batch
-            lock_file("env_batch.xml")
 
             # Make sure pio settings are consistant
             for comp in models:

--- a/utils/python/CIME/case_setup.py
+++ b/utils/python/CIME/case_setup.py
@@ -4,7 +4,7 @@ Library for case.setup.
 
 from CIME.XML.standard_module_setup import *
 
-from CIME.check_lockedfiles import check_lockedfiles
+from CIME.check_lockedfiles import *
 from CIME.preview_namelists import create_dirs, create_namelists
 from CIME.XML.env_mach_pes  import EnvMachPes
 from CIME.XML.machines      import Machines
@@ -15,36 +15,6 @@ from CIME.test_status       import *
 import shutil
 
 logger = logging.getLogger(__name__)
-
-###############################################################################
-def _check_pelayouts_require_rebuild(case, models):
-###############################################################################
-    """
-    Create if we require a rebuild, expects cwd is caseroot
-    """
-    locked_pes = "LockedFiles/env_mach_pes.xml"
-    if os.path.exists(locked_pes):
-        # Look to see if $comp_PE_CHANGE_REQUIRES_REBUILD is defined
-        # for any component
-        env_mach_pes_locked = EnvMachPes(infile=locked_pes, components=case.get_values("COMP_CLASSES"))
-        for comp in models:
-            if case.get_value("%s_PE_CHANGE_REQUIRES_REBUILD" % comp):
-                # Changing these values in env_mach_pes.xml will force
-                # you to clean the corresponding component
-                old_tasks   = env_mach_pes_locked.get_value("NTASKS_%s" % comp)
-                old_threads = env_mach_pes_locked.get_value("NTHRDS_%s" % comp)
-                old_inst    = env_mach_pes_locked.get_value("NINST_%s" % comp)
-
-                new_tasks   = case.get_value("NTASKS_%s" % comp)
-                new_threads = case.get_value("NTHRDS_%s" % comp)
-                new_inst    = case.get_value("NINST_%s" % comp)
-
-                if old_tasks != new_tasks or old_threads != new_threads or old_inst != new_inst:
-                    logger.warn("%s pe change requires clean build %s %s" % (comp, old_tasks, new_tasks))
-                    cleanflag = comp.lower()
-                    run_cmd_no_fail("./case.build --clean %s" % cleanflag)
-
-        os.remove(locked_pes)
 
 ###############################################################################
 def _build_usernl_files(case, model, comp):
@@ -128,6 +98,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 os.remove("case.testdriver")
                 logger.info("Successfully cleaned test script case.testdriver")
 
+        unlock_file("env_batch.xml")
+
         logger.info("Successfully cleaned batch script case.run")
 
         msg = "case.setup clean complete"
@@ -171,10 +143,9 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         if os.path.exists("case.run"):
             logger.info("Machine/Decomp/Pes configuration has already been done ...skipping")
         else:
-            _check_pelayouts_require_rebuild(case, models)
+            check_pelayouts_require_rebuild(case, models)
 
-            if os.path.exists("LockedFiles/env_build.xml"):
-                os.remove("LockedFiles/env_build.xml")
+            unlock_file("env_build.xml")
 
             case.flush()
             check_lockedfiles()
@@ -208,6 +179,9 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                     logger.info("Writing %s script from input template %s" % (job, input_batch_script))
                     env_batch.make_batch_script(input_batch_script, job, case, pestot, tasks_per_node, num_nodes, thread_count)
 
+            # Lock env_batch
+            lock_file("env_batch.xml")
+
             # Make sure pio settings are consistant
             for comp in models:
                 pio_stride = case.get_value("PIO_STRIDE_%s"%comp)
@@ -225,7 +199,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             logger.info("Locking file env_mach_pes.xml")
             case.flush()
             logger.debug("at copy TOTALPES = %s"%case.get_value("TOTALPES"))
-            shutil.copy("env_mach_pes.xml", "LockedFiles")
+            lock_file("env_mach_pes.xml")
 
         # Create user_nl files for the required number of instances
         if not os.path.exists("user_nl_cpl"):

--- a/utils/python/CIME/check_lockedfiles.py
+++ b/utils/python/CIME/check_lockedfiles.py
@@ -6,8 +6,73 @@ from CIME.XML.standard_module_setup import *
 from CIME.XML.env_build import EnvBuild
 from CIME.XML.env_case import EnvCase
 from CIME.XML.env_mach_pes import EnvMachPes
+from CIME.XML.env_batch import EnvBatch
+from CIME.utils import run_cmd_no_fail
 
-import glob
+import glob, shutil
+
+LOCKED_DIR = "LockedFiles"
+
+def lock_file(filename, caseroot=None, newname=None):
+    expect("/" not in filename, "Please just provide basename of locked file")
+    caseroot = os.getcwd() if caseroot is None else caseroot
+    newname = filename if newname is None else newname
+    fulllockdir = os.path.join(caseroot, LOCKED_DIR)
+    if not os.path.exists(fulllockdir):
+        os.mkdir(fulllockdir)
+    shutil.copyfile(os.path.join(caseroot, filename), os.path.join(fulllockdir, newname))
+
+def unlock_file(filename, caseroot=None):
+    expect("/" not in filename, "Please just provide basename of locked file")
+    caseroot = os.getcwd() if caseroot is None else caseroot
+    locked_path = os.path.join(caseroot, LOCKED_DIR, filename)
+    if os.path.exists(locked_path):
+        os.remove(locked_path)
+
+def is_locked(filename, caseroot=None):
+    expect("/" not in filename, "Please just provide basename of locked file")
+    caseroot = os.getcwd() if caseroot is None else caseroot
+    return os.path.exists(os.path.join(caseroot, LOCKED_DIR, filename))
+
+def restore(filename, caseroot=None, newname=None):
+    """
+    Restore the locked version of filename into main case dir
+    """
+    expect("/" not in filename, "Please just provide basename of locked file")
+    caseroot = os.getcwd() if caseroot is None else caseroot
+    newname = filename if newname is None else newname
+    shutil.copyfile(os.path.join(caseroot, LOCKED_DIR, newname), os.path.join(caseroot, filename))
+    # relock the restored file if names diffs
+    if newname != filename:
+        lock_file(newname, caseroot)
+
+def check_pelayouts_require_rebuild(case, models):
+    """
+    Create if we require a rebuild, expects cwd is caseroot
+    """
+    locked_pes = os.path.join(LOCKED_DIR, "env_mach_pes.xml")
+    if os.path.exists(locked_pes):
+        # Look to see if $comp_PE_CHANGE_REQUIRES_REBUILD is defined
+        # for any component
+        env_mach_pes_locked = EnvMachPes(infile=locked_pes, components=case.get_values("COMP_CLASSES"))
+        for comp in models:
+            if case.get_value("%s_PE_CHANGE_REQUIRES_REBUILD" % comp):
+                # Changing these values in env_mach_pes.xml will force
+                # you to clean the corresponding component
+                old_tasks   = env_mach_pes_locked.get_value("NTASKS_%s" % comp)
+                old_threads = env_mach_pes_locked.get_value("NTHRDS_%s" % comp)
+                old_inst    = env_mach_pes_locked.get_value("NINST_%s" % comp)
+
+                new_tasks   = case.get_value("NTASKS_%s" % comp)
+                new_threads = case.get_value("NTHRDS_%s" % comp)
+                new_inst    = case.get_value("NINST_%s" % comp)
+
+                if old_tasks != new_tasks or old_threads != new_threads or old_inst != new_inst:
+                    logging.warn("%s pe change requires clean build %s %s" % (comp, old_tasks, new_tasks))
+                    cleanflag = comp.lower()
+                    run_cmd_no_fail("./case.build --clean %s" % cleanflag)
+
+        unlock_file("env_mach_pes.xml", case.get_value("CASEROOT"))
 
 def check_lockedfiles(caseroot=None):
     """
@@ -32,6 +97,12 @@ def check_lockedfiles(caseroot=None):
             elif objname == "env_case":
                 f1obj = EnvCase(caseroot, cfile)
                 f2obj = EnvCase(caseroot, lfile)
+            elif objname == "env_batch":
+                f1obj = EnvBatch(caseroot, cfile)
+                f2obj = EnvBatch(caseroot, lfile)
+            else:
+                logging.warn("Locked XML file '%s' is not current being handled" % fpart)
+                continue
 
             diffs = f1obj.compare_xml(f2obj)
             if diffs:
@@ -39,6 +110,7 @@ def check_lockedfiles(caseroot=None):
                 for key in diffs.keys():
                     print("  found difference in %s : case %s locked %s" %
                           (key, repr(diffs[key][0]), repr(diffs[key][1])))
+
                 if objname == "env_mach_pes":
                     expect(False, "Invoke case.setup --reset ")
                 elif objname == "env_case":
@@ -55,6 +127,7 @@ def check_lockedfiles(caseroot=None):
                     else:
                         f1obj.set_value("BUILD_STATUS", 1)
                         f1obj.write()
+                elif objname == "env_batch":
+                    expect(False, "Batch configuration has changed, please run case.setup --reset")
                 else:
-                    # JGF : Error?
-                    pass
+                    expect(False, "'%s' diff was not handled" % objname)

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -21,6 +21,7 @@ from CIME.XML.component import Component
 from CIME.XML.tests import Tests
 from CIME.case import Case
 from CIME.wait_for_tests import wait_for_tests
+from CIME.check_lockedfiles import lock_file
 import CIME.test_utils
 
 logger = logging.getLogger(__name__)
@@ -495,11 +496,7 @@ class TestScheduler(object):
                     expect(False, "Could not parse option '%s' " %opt)
 
         envtest.write()
-        lockedfiles = os.path.join(test_dir, "LockedFiles")
-        if not os.path.exists(lockedfiles):
-            os.mkdir(lockedfiles)
-        shutil.copy(os.path.join(test_dir,"env_run.xml"),
-                    os.path.join(lockedfiles, "env_run.orig.xml"))
+        lock_file("env_run.xml", caseroot=test_dir, newname="env_run.orig.xml")
 
         with Case(test_dir, read_only=False) as case:
             if self._output_root is None:


### PR DESCRIPTION
If user changes walltime or queue, this will not affect the batch
directives in case.run or case.test unless the user cleans and
re-runs case.setup. We've gotten complaints from users that their
WALLTIME changes are not taking affect. We've updated the ACME
config_batch settings to have these params be args to submit instead
of directives.

This branch also does some work to encapsulate the lockfile
concept better inside check_lockedfiles.py.

Test suite: scripts_regression_tests.py and by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?: env_batch.xml is now locked by case.setup

Code review: @jedwards4b 
