### PR TITLE
made the input namelist variable tfreeze_option either acme or cesm s…

### DIFF
--- a/driver_cpl/cime_config/config_component_acme.xml
+++ b/driver_cpl/cime_config/config_component_acme.xml
@@ -463,6 +463,15 @@
       compsets.</desc>
   </entry>
 
+  <entry id="TFREEZE_SALTWATER_OPTION">
+    <type>char</type>
+    <valid_values>minus1p8,linear_salt,mushy</valid_values>
+    <default_value>minus1p8</default_value>
+    <group>run_physics</group>
+    <file>env_run.xml</file>
+    <desc>Freezing point calculation for salt water.</desc>
+  </entry>
+
   <description>
     <desc compset="BGC%BPRP">BGC CO2=prog, rad CO2=prog:</desc>
     <desc compset="BGC%BDRD">BGC CO2=diag, rad CO2=diag:</desc>

--- a/driver_cpl/cime_config/config_component_cesm.xml
+++ b/driver_cpl/cime_config/config_component_cesm.xml
@@ -463,6 +463,15 @@
       compsets.</desc>
   </entry>
 
+  <entry id="TFREEZE_SALTWATER_OPTION">
+    <type>char</type>
+    <valid_values>minus1p8,linear_salt,mushy</valid_values>
+    <default_value>mushy</default_value>
+    <group>run_physics</group>
+    <file>env_run.xml</file>
+    <desc>Freezing point calculation for salt water.</desc>
+  </entry>
+
   <description>
     <desc compset="BGC%BPRP">BGC CO2=prog, rad CO2=prog:</desc>
     <desc compset="BGC%BDRD">BGC CO2=diag, rad CO2=diag:</desc>

--- a/driver_cpl/cime_config/namelist_definition_drv.xml
+++ b/driver_cpl/cime_config/namelist_definition_drv.xml
@@ -561,17 +561,13 @@
     </values>
   </entry>
 
-  <entry id="tfreeze_option">
+  <entry id="tfreeze_option" modify_via_xml="TFREEZE_SALTWATER_OPTION">
     <type>char</type>
     <category>control</category>
     <group>seq_infodata_inparm</group>
-    <valid_values>minus1p8,linear_salt,mushy</valid_values>
-    <desc>
-      Freezing point calculation for salt water.
-      Default: minus1p8
-    </desc>
+    <desc>Freezing point calculation for salt water.</desc>
     <values>
-      <value>minus1p8</value>
+      <value>$TFREEZE_SALTWATER_OPTION</value>
     </values>
   </entry>
 


### PR DESCRIPTION
made input driver namelist variable tfreeze_option either acme or cesm settable 

To make a default namelist setting in the driver either acme or cesm model dependent you have to currently bring that namelist variable into config_component_[cesm/acme].xml - since the model name is actually itself a namelist input. tfreeze_option is the freezing point calculation for salt water and in cesm it is used by both cice and pop. It is not clear if acme uses this variable - but if it does it is important to keep its default driver namelist input separate from that in cesm. CESM wanted to change this default setting and these changes permit this new default setting to occur indepedent from any change that ACME would want.

Test suite: Verified manually that the new namelist in cesm is different from before and in acme it is the same
Test baseline: 
Test namelist changes: 
Test status: bit for bit for acme, should not be climate changing for cesm

Fixes 
User interface changes?: None
Code review: 
