### PR TITLE
updating pop defaults for cesm

### DIFF
--- a/cime_config/cesm/config_grids.xml
+++ b/cime_config/cesm/config_grids.xml
@@ -1221,16 +1221,16 @@
     </gridmap>
 
     <gridmap rof_grid="rx1" ocn_grid="gx3v7" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx3v7_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx3v7_e1000r500_161214.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="gx1v6" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v6_nn_ac_161213.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v6_e1000r300_161212.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tx1v1" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tx1v1_e1000r300_090318.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tx1v1_e1000r300_090318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_tx1v1_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_tx1v1_e1000r300_161214.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tx0.1v2" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tx0.1v2_e1000r200_090624.nc</map>
@@ -1242,20 +1242,20 @@
     </gridmap>
 
     <gridmap rof_grid="r05" ocn_grid="gx3v7" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx3v7_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx3v7_e1000r500_161214.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="gx1v6" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_151109.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_151109.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_161212.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="gx1v7" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_151109b.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_151109b.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_nn_ac_161213.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_e1000r300_161213.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tx1v1" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_tx1v1_e1000r500_080505.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx1v1_nn_ac_161214.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx1v1_e1000r500_161214.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="tx0.1v2" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_tx0.1v2_r500e1000_080620.nc</map>

--- a/driver_cpl/cime_config/config_component_cesm.xml
+++ b/driver_cpl/cime_config/config_component_cesm.xml
@@ -163,6 +163,8 @@
     <values>
       <value compset="_POP2">1</value>
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
+      <value compset="_POP2" grid="oi%gx1v6">24</value>
+      <value compset="_POP2" grid="oi%gx1v7">24</value>
       <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
       <value compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
@@ -275,6 +277,8 @@
     <values>
       <value compset="_DATM.*_DOCN%SOM"          >CESM1_MOD</value>
       <value compset="_POP2"                     >CESM1_MOD</value>
+      <value compset="_POP2" grid="oi%gx1v6"     >RASM_OPTION1</value>
+      <value compset="_POP2" grid="oi%gx1v7"     >RASM_OPTION1</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN">CESM1_MOD</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">CESM1_MOD</value>
       <value compset="_SOCN"                     >CESM1_MOD</value>


### PR DESCRIPTION
Updating CESM defaults.  Changed map defaults for EBM and set coupling frequency to one hour/robert filtering for the ocean. Only grids gx1v6 and gx1v7 have the 1hr coupling interval for now.  As other resolutions are tested they will be updated.  

Test suite: Ran cime regression tests and pylint check.  When running my CESM pop tests I had one error in an ERR test that I traced to a recent cime mod.  Forwarded to Jim Edwards and he has a fix and PR in hand.
Test baseline: 
Test namelist changes: 
Test status: [climate changing]  New pop defaults, Estuary parameterization, and new maps give a different climate.

Fixes [CIME Github issue #]

User interface changes?: 

Code review: Mariana worked with me to create these cime mods.  Jim is handling ERR fix via a different PR.
