### PR TITLE
Config compilers conformity

### DIFF
--- a/cime_config/acme/machines/config_compilers.xml
+++ b/cime_config/acme/machines/config_compilers.xml
@@ -756,10 +756,10 @@ for mct, etc.
   <MPICXX> CC </MPICXX>
   <MPIFC> ftn </MPIFC>
   <MPI_LIB_NAME> mpich </MPI_LIB_NAME>
-  <MPI_PATH> <env>MPICH_DIR</env></MPI_PATH>
-  <NETCDF_PATH><env>NETCDF_DIR</env></NETCDF_PATH>
+  <MPI_PATH> $ENV{MPICH_DIR}</MPI_PATH>
+  <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PARALLEL_NETCDF_DIR</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PARALLEL_NETCDF_DIR}</PNETCDF_PATH>
   <SCC> cc </SCC>
   <SCXX> CC </SCXX>
   <SFC> ftn </SFC>
@@ -809,8 +809,8 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append> <shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -lblas -llapack</append>
   </SLIBS>
@@ -819,9 +819,9 @@ for mct, etc.
 <compiler MACH="blues" COMPILER="gnu">
   <MPI_LIB_NAME MPILIB="mvapich">mpi</MPI_LIB_NAME>
   <MPI_PATH MPILIB="mvapich">/soft/mvapich2/2.2b_psm/gnu-5.2/</MPI_PATH>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nc-config --flibs</shell> -llapack -lblas</append>
   </SLIBS>
@@ -830,12 +830,12 @@ for mct, etc.
 <compiler MACH="blues" COMPILER="intel">
   <MPI_LIB_NAME MPILIB="mvapich">mpi</MPI_LIB_NAME>
   <MPI_PATH MPILIB="mvapich">/soft/mvapich2/2.2b_psm/intel-15.0</MPI_PATH>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nc-config --flibs</shell> -llapack -lblas </append>
-    <append> -Wl,-rpath -Wl,<env>NETCDFROOT</env>/lib </append>
+    <append> -Wl,-rpath -Wl,$ENV{NETCDFROOT}/lib </append>
     <append MPILIB="mpich"> -mkl=cluster </append>
     <append MPILIB="mpich2"> -mkl=cluster </append>
     <append MPILIB="mpt"> -mkl=cluster </append>
@@ -851,9 +851,9 @@ for mct, etc.
   <MPI_LIB_NAME MPILIB="mpich">mpich</MPI_LIB_NAME>
   <MPI_PATH MPILIB="openmpi">/soft/openmpi/1.8.2/intel-13.1</MPI_PATH>
   <MPI_PATH MPILIB="mpich">/soft/mpich2/1.4.1-intel-13.1</MPI_PATH>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nc-config --flibs</shell> -llapack -lblas</append>
     <append MPILIB="mpich"> -mkl=cluster </append>
@@ -869,9 +869,9 @@ for mct, etc.
 <compiler MACH="blues" COMPILER="nag">
   <MPI_LIB_NAME MPILIB="mpich"> mpi </MPI_LIB_NAME>
   <MPI_PATH MPILIB="mpich">/home/robl/soft/mpich-3.1.4-nag-6.0</MPI_PATH>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nc-config --flibs</shell> -llapack -lblas</append>
   </SLIBS>
@@ -883,12 +883,12 @@ for mct, etc.
   <MPI_LIB_NAME MPILIB="mpich">mpich</MPI_LIB_NAME>
   <MPI_PATH MPILIB="openmpi">/soft/openmpi/1.8.2/pgi-13.9</MPI_PATH>
   <MPI_PATH MPILIB="mpich">/soft/mpich2/1.4.1-pgi-13.9/</MPI_PATH>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>gpfs </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nc-config --flibs</shell> -llapack -lblas</append>
-    <append> -rpath <env>NETCDFROOT</env>/lib </append>
+    <append> -rpath $ENV{NETCDFROOT}/lib </append>
   </SLIBS>
 </compiler>
 
@@ -897,9 +897,9 @@ for mct, etc.
     <!-- these flags enable nano timers -->
     <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
   </CPPDEFS>
-  <NETCDF_PATH><env>NETCDF</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDF}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDF</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF}</PNETCDF_PATH>
 </compiler>
 
 <compiler MACH="cascade" COMPILER="intel">
@@ -912,11 +912,11 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_LIB</env>/..</NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_LIB}/..</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
-    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi -L<env>MKL_PATH</env> -lmkl_rt </base>
+    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi -L$ENV{MKL_PATH} -lmkl_rt </base>
     <append MPILIB="mpich"> -mkl=cluster </append>
     <append MPILIB="mpich2"> -mkl=cluster </append>
     <append MPILIB="mpt"> -mkl=cluster </append>
@@ -943,12 +943,12 @@ for mct, etc.
   <LDFLAGS>
     <append compile_threaded="true">  </append>
   </LDFLAGS>
-  <MPI_PATH MPILIB="mvapich2"> <env>MPI_LIB</env></MPI_PATH>
-  <NETCDF_PATH><env>NETCDF_ROOT</env></NETCDF_PATH>
+  <MPI_PATH MPILIB="mvapich2"> $ENV{MPI_LIB}</MPI_PATH>
+  <NETCDF_PATH>$ENV{NETCDF_ROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
-    <append> -L<env>NETCDF_ROOT</env>/lib -lnetcdf -lnetcdff -L<env>MKL_PATH</env> -lmkl_rt</append>
+    <append> -L$ENV{NETCDF_ROOT}/lib -lnetcdf -lnetcdff -L$ENV{MKL_PATH} -lmkl_rt</append>
   </SLIBS>
 </compiler>
 
@@ -958,7 +958,7 @@ for mct, etc.
     <append> -DMPASLI_EXTERNAL_INTERFACE_DISABLE_MANGLING </append>
   </CPPDEFS>
   <CXX_LIBS>
-    <base> -llapack -lblas -L<env>IBM_MAIN_DIR</env>/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L<env>IBM_MAIN_DIR</env>/xlsmp/bg/3.1/bglib64 -lxlsmp </base>
+    <base> -llapack -lblas -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </base>
   </CXX_LIBS>
   <CXX_LINKER>CXX</CXX_LINKER>
   <LDFLAGS>
@@ -976,7 +976,7 @@ for mct, etc.
   <SFC> mpixlf2003_r </SFC>
   <SLIBS>
     <append>-L<var>NETCDF_PATH</var>/lib -lnetcdff -lnetcdf -L/soft/libraries/hdf5/1.8.10/cnk-xl/current/lib -lhdf5 -lhdf5_hl -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
-    <append compile_threaded="true"> -L<env>IBM_MAIN_DIR</env>/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L<env>IBM_MAIN_DIR</env>/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
+    <append compile_threaded="true"> -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
   </SLIBS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
@@ -995,11 +995,11 @@ for mct, etc.
     <append DEBUG="FALSE"> -O2 </append>
     <append DEBUG="TRUE"> -g -traceback  -O0 -fpe0 -check  all -check noarg_temp_created -ftrapuv </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_HOME</env></NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
-    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi -L<env>MKL_PATH</env> -lmkl_rt</base>
+    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi -L$ENV{MKL_PATH} -lmkl_rt</base>
   </SLIBS>
 </compiler>
 
@@ -1017,11 +1017,11 @@ for mct, etc.
     <append DEBUG="FALSE"> -O2 </append>
     <append DEBUG="TRUE">-C -Mbounds -traceback -Mchkfpstk -Mchkstk -Mdalign  -Mdepchk  -Mextend -Miomutex -Mrecursive  -Ktrap=fp -O0 -g -byteswapio -Meh_frame</append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_HOME</env></NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
-    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi -L<env>MPI_LIB</env> -lmpich</base>
+    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi -L$ENV{MPI_LIB} -lmpich</base>
   </SLIBS>
 </compiler>
 
@@ -1044,10 +1044,10 @@ for mct, etc.
   <MPICC> cc </MPICC>
   <MPICXX> CC </MPICXX>
   <MPIFC> ftn </MPIFC>
-  <PETSC_PATH><env>PETSC_DIR</env></PETSC_PATH>
+  <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
   <SLIBS>
-    <append> -L<env>NETCDF_DIR</env> -lnetcdff -Wl,--as-needed,-L<env>NETCDF_DIR</env>/lib -lnetcdff -lnetcdf </append>
-    <append> <env>MKLROOT</env>/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group <env>MKLROOT</env>/lib/intel64/libmkl_intel_lp64.a <env>MKLROOT</env>/lib/intel64/libmkl_core.a <env>MKLROOT</env>/lib/intel64/libmkl_sequential.a -Wl,--end-group <env>MKLROOT</env>/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </append>
+    <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
+    <append> $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </append>
   </SLIBS>
 </compiler>
 
@@ -1070,10 +1070,10 @@ for mct, etc.
   <MPICC> cc </MPICC>
   <MPICXX> CC </MPICXX>
   <MPIFC> ftn </MPIFC>
-  <PETSC_PATH><env>PETSC_DIR</env></PETSC_PATH>
+  <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
   <SLIBS>
-    <append> -L<env>NETCDF_DIR</env> -lnetcdff -Wl,--as-needed,-L<env>NETCDF_DIR</env>/lib -lnetcdff -lnetcdf </append>
-    <append> <env>MKLROOT</env>/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group <env>MKLROOT</env>/lib/intel64/libmkl_intel_lp64.a <env>MKLROOT</env>/lib/intel64/libmkl_core.a <env>MKLROOT</env>/lib/intel64/libmkl_sequential.a -Wl,--end-group <env>MKLROOT</env>/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </append>
+    <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
+    <append> $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </append>
   </SLIBS>
 </compiler>
 
@@ -1090,7 +1090,7 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_HOME</env></NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
     <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi </base>
@@ -1114,10 +1114,10 @@ for mct, etc.
   <MPICC> cc </MPICC>
   <MPICXX> CC </MPICXX>
   <MPIFC> ftn </MPIFC>
-  <PETSC_PATH><env>PETSC_DIR</env></PETSC_PATH>
+  <PETSC_PATH>$ENV{PETSC_DIR}</PETSC_PATH>
   <SLIBS>
-    <append> -L<env>NETCDF_DIR</env> -lnetcdff -Wl,--as-needed,-L<env>NETCDF_DIR</env>/lib -lnetcdff -lnetcdf </append>
-    <append> <env>MKLROOT</env>/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group <env>MKLROOT</env>/lib/intel64/libmkl_intel_lp64.a <env>MKLROOT</env>/lib/intel64/libmkl_core.a <env>MKLROOT</env>/lib/intel64/libmkl_sequential.a -Wl,--end-group <env>MKLROOT</env>/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </append>
+    <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
+    <append> $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </append>
   </SLIBS>
 </compiler>
 
@@ -1138,8 +1138,8 @@ for mct, etc.
   <MPICXX> CC </MPICXX>
   <MPIFC> ftn </MPIFC>
   <SLIBS>
-    <append> -L<env>NETCDF_DIR</env> -lnetcdff -Wl,--as-needed,-L<env>NETCDF_DIR</env>/lib -lnetcdff -lnetcdf </append>
-    <append> <env>MKLROOT</env>/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group <env>MKLROOT</env>/lib/intel64/libmkl_intel_lp64.a <env>MKLROOT</env>/lib/intel64/libmkl_core.a <env>MKLROOT</env>/lib/intel64/libmkl_sequential.a -Wl,--end-group <env>MKLROOT</env>/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </append>
+    <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
+    <append> $ENV{MKLROOT}/lib/intel64/libmkl_scalapack_lp64.a -Wl,--start-group $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a -Wl,--end-group $ENV{MKLROOT}/lib/intel64/libmkl_blacs_intelmpi_lp64.a -lpthread -lm </append>
   </SLIBS>
 </compiler>
 
@@ -1167,7 +1167,7 @@ for mct, etc.
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
   <CXX_LIBS>
-    <base> -lmpichf90_pgi <env>PGI_PATH</env>/linux86-64/<env>PGI_VERSION</env>/lib/f90main.o </base>
+    <base> -lmpichf90_pgi $ENV{PGI_PATH}/linux86-64/$ENV{PGI_VERSION}/lib/f90main.o </base>
   </CXX_LIBS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
@@ -1195,8 +1195,8 @@ for mct, etc.
 </compiler>
 
 <compiler MACH="linux-generic" COMPILER="gnu">
-  <NETCDF_PATH> <env>NETCDF_PATH</env></NETCDF_PATH>
-  <PNETCDF_PATH> <env>PNETCDF_PATH</env></PNETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_PATH}</NETCDF_PATH>
+  <PNETCDF_PATH> $ENV{PNETCDF_PATH}</PNETCDF_PATH>
   <SLIBS>
     <append> <shell><var>NETCDF_PATH</var>/bin/nc-config --flibs</shell> </append>
   </SLIBS>
@@ -1206,7 +1206,7 @@ for mct, etc.
   <LDFLAGS>
     <append>-framework Accelerate</append>
   </LDFLAGS>
-  <NETCDF_PATH> <env>NETCDF_PATH</env></NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_PATH}</NETCDF_PATH>
   <SLIBS>
     <append>-L<var>NETCDF_PATH</var>/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
@@ -1226,8 +1226,8 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append> <shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -lblas -llapack</append>
   </SLIBS>
@@ -1247,8 +1247,8 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append> <shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -lblas -llapack</append>
   </SLIBS>
@@ -1260,7 +1260,7 @@ for mct, etc.
     <append> -DMPASLI_EXTERNAL_INTERFACE_DISABLE_MANGLING </append>
   </CPPDEFS>
   <CXX_LIBS>
-    <base> -llapack -lblas -L<env>IBM_MAIN_DIR</env>/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L<env>IBM_MAIN_DIR</env>/xlsmp/bg/3.1/bglib64 -lxlsmp </base>
+    <base> -llapack -lblas -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </base>
   </CXX_LIBS>
   <CXX_LINKER>CXX</CXX_LINKER>
   <HDF5_PATH>/soft/libraries/hdf5/1.8.14/cnk-xl/current/ </HDF5_PATH>
@@ -1279,13 +1279,13 @@ for mct, etc.
   <SFC> mpixlf2003_r </SFC>
   <SLIBS>
     <append>-L<var>NETCDF_PATH</var>/lib -lnetcdff -lnetcdf -L/soft/libraries/hdf5/1.8.14/cnk-xl/current/lib -lhdf5_hl -lhdf5 -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
-    <append compile_threaded="true"> -L<env>IBM_MAIN_DIR</env>/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L<env>IBM_MAIN_DIR</env>/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
+    <append compile_threaded="true"> -L$ENV{IBM_MAIN_DIR}/xlf/bg/14.1/bglib64 -lxlfmath -lxlf90_r -lxlopt -lxl -L$ENV{IBM_MAIN_DIR}/xlsmp/bg/3.1/bglib64 -lxlsmp </append>
   </SLIBS>
   <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
 </compiler>
 
 <compiler MACH="mustang" COMPILER="gnu">
-  <ALBANY_PATH><env>ALBANY_PATH</env></ALBANY_PATH>
+  <ALBANY_PATH>$ENV{ALBANY_PATH}</ALBANY_PATH>
   <CXX_LIBS>
     <base>-lstdc++ -lmpi_cxx</base>
   </CXX_LIBS>
@@ -1298,7 +1298,7 @@ for mct, etc.
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -llapack -lblas</append>
   </SLIBS>
-  <TRILINOS_PATH><env>TRILINOS_PATH</env></TRILINOS_PATH>
+  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 <compiler MACH="mustang" COMPILER="intel">
@@ -1318,7 +1318,7 @@ for mct, etc.
     <append MPILIB="impi"> -mkl=cluster </append>
     <append MPILIB="mpi-serial"> -mkl </append>
   </SLIBS>
-  <TRILINOS_PATH><env>TRILINOS_PATH</env></TRILINOS_PATH>
+  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 <compiler MACH="mustang" COMPILER="pgi">
@@ -1331,7 +1331,7 @@ for mct, etc.
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -llapack -lblas</append>
   </SLIBS>
-  <TRILINOS_PATH><env>TRILINOS_PATH</env></TRILINOS_PATH>
+  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 <compiler MACH="oic2" COMPILER="gnu">
@@ -1379,7 +1379,7 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_LIB</env>/..</NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_LIB}/..</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
     <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi </base>
@@ -1399,7 +1399,7 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_LIB</env>/..</NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_LIB}/..</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
     <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi </base>
@@ -1418,9 +1418,9 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
     <append> <shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
     <append MPILIB="mpich"> -mkl=cluster </append>
@@ -1445,9 +1445,9 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <!-- Don't rely on nf-config, as it's not available with all NetCDF modules on Skybridge -->
   <SLIBS>
     <append> -L<var>NETCDF_PATH</var>/lib -lnetcdff -lnetcdf -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
@@ -1474,7 +1474,7 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF</env></NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
     <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lpmi </base>
@@ -1501,7 +1501,7 @@ for mct, etc.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_LIB</env>/..</NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_LIB}/..</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
     <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi </base>
@@ -1541,7 +1541,7 @@ for mct, etc.
     <base> --host=Linux </base>
   </CONFIG_ARGS>
   <CXX_LIBS>
-    <base> -lfmpich -lmpichf90_pgi <env>PGI_PATH</env>/linux86-64/<env>PGI_VERSION</env>/lib/f90main.o /opt/gcc/default/snos/lib64/libstdc++.a  </base>
+    <base> -lfmpich -lmpichf90_pgi $ENV{PGI_PATH}/linux86-64/$ENV{PGI_VERSION}/lib/f90main.o /opt/gcc/default/snos/lib64/libstdc++.a  </base>
   </CXX_LIBS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
@@ -1565,7 +1565,7 @@ for mct, etc.
     <base> --host=Linux </base>
   </CONFIG_ARGS>
   <CXX_LIBS>
-    <base> -lfmpich -lmpichf90_pgi <env>PGI_PATH</env>/linux86-64/<env>PGI_VERSION</env>/lib/f90main.o </base>
+    <base> -lfmpich -lmpichf90_pgi $ENV{PGI_PATH}/linux86-64/$ENV{PGI_VERSION}/lib/f90main.o </base>
   </CXX_LIBS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
@@ -1595,7 +1595,7 @@ for mct, etc.
 </compiler>
 
 <compiler MACH="wolf" COMPILER="gnu">
-  <ALBANY_PATH><env>ALBANY_PATH</env></ALBANY_PATH>
+  <ALBANY_PATH>$ENV{ALBANY_PATH}</ALBANY_PATH>
   <CXX_LIBS>
     <base>-lstdc++ -lmpi_cxx</base>
   </CXX_LIBS>
@@ -1608,7 +1608,7 @@ for mct, etc.
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -llapack -lblas</append>
   </SLIBS>
-  <TRILINOS_PATH><env>TRILINOS_PATH</env></TRILINOS_PATH>
+  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 <compiler MACH="wolf" COMPILER="intel">
@@ -1628,7 +1628,7 @@ for mct, etc.
     <append MPILIB="impi"> -mkl=cluster </append>
     <append MPILIB="mpi-serial"> -mkl </append>
   </SLIBS>
-  <TRILINOS_PATH><env>TRILINOS_PATH</env></TRILINOS_PATH>
+  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 <compiler MACH="wolf" COMPILER="pgi">
@@ -1641,7 +1641,7 @@ for mct, etc.
   <SLIBS>
     <append><shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -llapack -lblas</append>
   </SLIBS>
-  <TRILINOS_PATH><env>TRILINOS_PATH</env></TRILINOS_PATH>
+  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 </config_compilers>

--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -275,7 +275,7 @@ using a fortran linker.
   <FFLAGS>
     <!-- The indirect flag below is to deal with MPI functions that violate    -->
     <!-- the Fortran standard, by adding a large set of arguments from a file. -->
-    <base>-Wp,-macro=no_com -convert=BIG_ENDIAN -indirect <env>CIMEROOT</env>/cime_config/cesm/machines/nag_mpi_argument.txt</base>
+    <base>-Wp,-macro=no_com -convert=BIG_ENDIAN -indirect $ENV{CIMEROOT}/cime_config/cesm/machines/nag_mpi_argument.txt</base>
     <!-- DEBUG vs. non-DEBUG runs.                                             -->
     <append DEBUG="FALSE"> -ieee=full -O2 </append>
     <!-- The "-gline" option is nice, but it doesn't work with OpenMP.         -->
@@ -290,7 +290,7 @@ using a fortran linker.
     <append MODEL="cism"> -mismatch_all </append>
   </FFLAGS>
   <FFLAGS_NOOPT>
-    <base>-Wp,-macro=no_com -convert=BIG_ENDIAN -indirect <env>CIMEROOT</env>/cime_config/cesm/machines/nag_mpi_argument.txt</base>
+    <base>-Wp,-macro=no_com -convert=BIG_ENDIAN -indirect $ENV{CIMEROOT}/cime_config/cesm/machines/nag_mpi_argument.txt</base>
     <append DEBUG="FALSE"> -ieee=full     </append>
     <!-- Hack! If DEBUG="TRUE", put runtime checks in FFLAGS, but not into     -->
     <!-- FFLAGS_NOOPT, allowing strict checks to be removed from files by      -->
@@ -444,9 +444,9 @@ using a fortran linker.
   <MPICC> cc </MPICC>
   <MPICXX> CC </MPICXX>
   <MPIFC> ftn </MPIFC>
-  <NETCDF_PATH><env>NETCDF_DIR</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PARALLEL_NETCDF_DIR</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PARALLEL_NETCDF_DIR}</PNETCDF_PATH>
   <SCC> cc </SCC>
   <SCXX> CC </SCXX>
   <SFC> ftn </SFC>
@@ -480,7 +480,7 @@ using a fortran linker.
     <append> -nofma </append>
   </CFLAGS>
   <CXX_LIBS>
-    <base> -lmpichf90_pgi <env>PGI_PATH</env>/linux86-64/<env>PGI_VERSION</env>/lib/f90main.o </base>
+    <base> -lmpichf90_pgi $ENV{PGI_PATH}/linux86-64/$ENV{PGI_VERSION}/lib/f90main.o </base>
   </CXX_LIBS>
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
@@ -502,10 +502,10 @@ using a fortran linker.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_HOME</env></NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
-    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi -L<env>MKL_PATH</env> -lmkl_rt</base>
+    <base> -L${NETCDF_PATH}/lib -lnetcdf -lnetcdff -lpmi -L$ENV{MKL_PATH} -lmkl_rt</base>
   </SLIBS>
 </compiler>
 
@@ -522,10 +522,10 @@ using a fortran linker.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_HOME</env></NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
-    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi </base>
+    <base> -L${NETCDF_PATH}/lib -lnetcdf -lnetcdff -lpmi </base>
   </SLIBS>
 </compiler>
 
@@ -586,10 +586,10 @@ using a fortran linker.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_HOME</env></NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
-    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi </base>
+    <base> -L${NETCDF_PATH}/lib -lnetcdf -lnetcdff -lpmi </base>
   </SLIBS>
 </compiler>
 
@@ -611,10 +611,10 @@ using a fortran linker.
   <LDFLAGS>
     <append compile_threaded="false"> -nomp </append>
   </LDFLAGS>
-  <NETCDF_PATH> <env>NETCDF_HOME</env></NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_HOME}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
-    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi </base>
+    <base> -L${NETCDF_PATH}/lib -lnetcdf -lnetcdff -lpmi </base>
   </SLIBS>
 </compiler>
 
@@ -632,7 +632,7 @@ using a fortran linker.
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
   <SLIBS>
-    <append> -L<env>NETCDF_DIR</env> -lnetcdff -Wl,--as-needed,-L<env>NETCDF_DIR</env>/lib -lnetcdff -lnetcdf </append>
+    <append> -L$ENV{NETCDF_DIR} -lnetcdff -Wl,--as-needed,-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf </append>
   </SLIBS>
 </compiler>
 
@@ -650,7 +650,7 @@ using a fortran linker.
   <MPI_PATH>/usr/local/tools/mvapich2-pgi-1.7/</MPI_PATH>
   <NETCDF_PATH>/usr/local/tools/netcdf-pgi-4.1.3</NETCDF_PATH>
   <SLIBS>
-    <append><shell>/usr/local/tools/netcdf-pgi-4.1.3/bin/nc-config --flibs</shell></append>
+    <append>$SHELL{/usr/local/tools/netcdf-pgi-4.1.3/bin/nc-config --flibs}</append>
   </SLIBS>
 </compiler>
 
@@ -660,9 +660,9 @@ using a fortran linker.
   </CPPDEFS>
   <LAPACK_LIBDIR> /usr/lib64 </LAPACK_LIBDIR>
   <MPI_LIB_NAME MPILIB="mvapich2"> mpich</MPI_LIB_NAME>
-  <NETCDF_PATH><env>NETCDF_PATH</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDF_PATH}</NETCDF_PATH>
   <SLIBS>
-    <append><shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell></append>
+    <append>$SHELL{${NETCDF_PATH}/bin/nf-config --flibs}</append>
   </SLIBS>
 </compiler>
 
@@ -676,10 +676,10 @@ using a fortran linker.
   </FFLAGS>
   <LDFLAGS>
     <append> -lquadmath </append>
-    <append> -Wl,-rpath,<var>NETCDF_PATH</var>/lib </append>
-    <append> -Wl,-rpath,<env>COMPILER_PATH</env>/lib/intel64 </append>
-    <append> -Wl,-rpath,<env>COMPILER_PATH</env>/mkl/lib/intel64 </append>
-    <append> -Wl,-rpath,<env>MPI_PATH</env>/lib</append>
+    <append> -Wl,-rpath,${NETCDF_PATH}/lib </append>
+    <append> -Wl,-rpath,$ENV{COMPILER_PATH}/lib/intel64 </append>
+    <append> -Wl,-rpath,$ENV{COMPILER_PATH}/mkl/lib/intel64 </append>
+    <append> -Wl,-rpath,$ENV{MPI_PATH}/lib</append>
     <append> -lifcore</append>
   </LDFLAGS>
   <PFUNIT_PATH>/home/santos/pFUnit/pFUnit_Intel_3_0</PFUNIT_PATH>
@@ -708,9 +708,9 @@ using a fortran linker.
   </FFLAGS>
   <LDFLAGS>
     <append> -lgomp </append>
-    <append> -Wl,-R<var>NETCDF_PATH</var>/lib</append>
-    <append> -Wl,-R<env>COMPILER_PATH</env>/lib</append>
-    <append> -Wl,-R<env>COMPILER_PATH</env>/libso</append>
+    <append> -Wl,-R${NETCDF_PATH}/lib</append>
+    <append> -Wl,-R$ENV{COMPILER_PATH}/lib</append>
+    <append> -Wl,-R$ENV{COMPILER_PATH}/libso</append>
   </LDFLAGS>
 </compiler>
 
@@ -741,10 +741,10 @@ using a fortran linker.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
-    <append> <shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -lblas -llapack</append>
+    <append> $SHELL{${NETCDF_PATH}/bin/nf-config --flibs} -lblas -llapack</append>
   </SLIBS>
 </compiler>
 
@@ -755,7 +755,7 @@ using a fortran linker.
   <FFLAGS>
     <append>-qfloat=nomaf</append>
   </FFLAGS>
-  <HDF5_PATH><env>HDF5</env></HDF5_PATH>
+  <HDF5_PATH>$ENV{HDF5}</HDF5_PATH>
   <!-- This LD is a workaround for darshan initialization on mira (Darshan does -->
   <!-- not run if f90 or higher is used for linking -->
   <LD> /home/pkcoff/mpich-sandboxes/master/install-production/bin/mpixlf77_r </LD>
@@ -768,7 +768,7 @@ using a fortran linker.
   <SCC> /home/pkcoff/mpich-sandboxes/master/install-production/bin/mpixlc_r </SCC>
   <SFC> /home/pkcoff/mpich-sandboxes/master/install-production/bin/mpixlf2003_r </SFC>
   <SLIBS>
-    <append>-L<var>NETCDF_PATH</var>/lib -lnetcdff -lnetcdf -L<env>HDF5</env>/lib -lhdf5_hl -lhdf5 -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
+    <append>-L${NETCDF_PATH}/lib -lnetcdff -lnetcdf -L$ENV{HDF5}/lib -lhdf5_hl -lhdf5 -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
   </SLIBS>
 </compiler>
 
@@ -785,10 +785,10 @@ using a fortran linker.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
   </FFLAGS>
-  <NETCDF_PATH> <env>NETCDF_LIB</env>/..</NETCDF_PATH>
+  <NETCDF_PATH> $ENV{NETCDF_LIB}/..</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
-    <base> -L<var>NETCDF_PATH</var>/lib -lnetcdf -lnetcdff -lpmi </base>
+    <base> -L${NETCDF_PATH}/lib -lnetcdf -lnetcdff -lpmi </base>
   </SLIBS>
 </compiler>
 
@@ -798,10 +798,10 @@ using a fortran linker.
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
-  <MPI_PATH><env>MPI_ROOT</env></MPI_PATH>
+  <MPI_PATH>$ENV{MPI_ROOT}</MPI_PATH>
   <NETCDF_PATH>/nasa/netcdf/4.1.3/intel/mpt</NETCDF_PATH>
   <SLIBS>
-    <append>-L<env>NETCDF_DIR</env>/lib -lnetcdff -lnetcdf</append>
+    <append>-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
 </compiler>
 
@@ -811,10 +811,10 @@ using a fortran linker.
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
-  <MPI_PATH><env>MPI_ROOT</env></MPI_PATH>
+  <MPI_PATH>$ENV{MPI_ROOT}</MPI_PATH>
   <NETCDF_PATH>/nasa/netcdf/4.1.3/intel/mpt</NETCDF_PATH>
   <SLIBS>
-    <append>-L<env>NETCDF_DIR</env>/lib -lnetcdff -lnetcdf</append>
+    <append>-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
 </compiler>
 
@@ -824,10 +824,10 @@ using a fortran linker.
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
-  <MPI_PATH><env>MPI_ROOT</env></MPI_PATH>
+  <MPI_PATH>$ENV{MPI_ROOT}</MPI_PATH>
   <NETCDF_PATH>/nasa/netcdf/4.1.3/intel/mpt</NETCDF_PATH>
   <SLIBS>
-    <append>-L<env>NETCDF_DIR</env>/lib -lnetcdff -lnetcdf</append>
+    <append>-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
 </compiler>
 
@@ -837,10 +837,10 @@ using a fortran linker.
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
-  <MPI_PATH><env>MPI_ROOT</env></MPI_PATH>
+  <MPI_PATH>$ENV{MPI_ROOT}</MPI_PATH>
   <NETCDF_PATH>/nasa/netcdf/4.1.3/intel/mpt</NETCDF_PATH>
   <SLIBS>
-    <append>-L<env>NETCDF_DIR</env>/lib -lnetcdff -lnetcdf</append>
+    <append>-L$ENV{NETCDF_DIR}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
 </compiler>
 
@@ -852,7 +852,7 @@ using a fortran linker.
   <MPI_PATH>/usr/local/tools/mvapich2-pgi-1.7/</MPI_PATH>
   <NETCDF_PATH>/usr/local/tools/netcdf-pgi-4.1.3</NETCDF_PATH>
   <SLIBS>
-    <append><shell>/usr/local/tools/netcdf-pgi-4.1.3/bin/nc-config --flibs</shell></append>
+    <append>$SHELL{/usr/local/tools/netcdf-pgi-4.1.3/bin/nc-config --flibs}</append>
   </SLIBS>
 </compiler>
 
@@ -867,11 +867,11 @@ using a fortran linker.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2  </append>
   </FFLAGS>
-  <NETCDF_PATH><env>NETCDFROOT</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDFROOT}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDFROOT</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDFROOT}</PNETCDF_PATH>
   <SLIBS>
-    <append> -L<var>NETCDF_PATH</var>/lib -lnetcdff -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
+    <append> -L${NETCDF_PATH}/lib -lnetcdff -L/projects/ccsm/BLAS-intel -lblas_LINUX</append>
   </SLIBS>
 </compiler>
 
@@ -879,9 +879,9 @@ using a fortran linker.
   <CPPDEFS>
     <append> -DHAVE_NANOTIME </append>
   </CPPDEFS>
-  <NETCDF_PATH><env>TACC_NETCDF_DIR</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{TACC_NETCDF_DIR}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>TACC_PNETCDF_DIR</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{TACC_PNETCDF_DIR}</PNETCDF_PATH>
 </compiler>
 
 <compiler MACH="stampede" COMPILER="intel">
@@ -893,12 +893,12 @@ using a fortran linker.
     <append MPILIB="mpi-serial"> -mcmodel medium </append>
   </FFLAGS>
   <LDFLAGS>
-    <append>-L<env>TACC_HDF5_LIB</env> -lhdf5</append>
+    <append>-L$ENV{TACC_HDF5_LIB} -lhdf5</append>
   </LDFLAGS>
   <SLIBS>
-    <append><shell><var>NETCDF_PATH</var>/bin/nf-config --flibs</shell> -L<env>TACC_HDF5_LIB</env> -lhdf5</append>
+    <append>$SHELL{${NETCDF_PATH}/bin/nf-config --flibs} -L$ENV{TACC_HDF5_LIB} -lhdf5</append>
   </SLIBS>
-  <TRILINOS_PATH><env>TRILINOS_PATH</env></TRILINOS_PATH>
+  <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 <compiler MACH="theta">
@@ -931,7 +931,7 @@ using a fortran linker.
   <SCC> mpixlc_r </SCC>
   <SFC> mpixlf2003_r </SFC>
   <SLIBS>
-    <append>-L<var>NETCDF_PATH</var>/lib -lnetcdff -lnetcdf -L/soft/libraries/hdf5/1.8.10/cnk-xl/current/lib -lhdf5_hl -lhdf5 -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
+    <append>-L${NETCDF_PATH}/lib -lnetcdff -lnetcdf -L/soft/libraries/hdf5/1.8.10/cnk-xl/current/lib -lhdf5_hl -lhdf5 -L/soft/libraries/alcf/current/xl/ZLIB/lib -lz -L/soft/libraries/alcf/current/xl/LAPACK/lib -llapack -L/soft/libraries/alcf/current/xl/BLAS/lib -lblas -L/bgsys/drivers/ppcfloor/comm/sys/lib </append>
   </SLIBS>
 </compiler>
 
@@ -948,7 +948,7 @@ using a fortran linker.
   <NETCDF_PATH> USERDEFINED_MUST_EDIT_THIS</NETCDF_PATH>
   <PNETCDF_PATH/>
   <SLIBS>
-    <append># USERDEFINED <shell><var>NETCDF_PATH</var>/bin/nc-config --flibs</shell></append>
+    <append># USERDEFINED $SHELL{${NETCDF_PATH}/bin/nc-config --flibs}</append>
   </SLIBS>
 </compiler>
 
@@ -957,9 +957,9 @@ using a fortran linker.
     <!-- these flags enable nano timers -->
     <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
   </CPPDEFS>
-  <NETCDF_PATH><env>NETCDF</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDF}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDF</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF}</PNETCDF_PATH>
 </compiler>
 
 <compiler MACH="cheyenne">
@@ -967,9 +967,9 @@ using a fortran linker.
     <!-- these flags enable nano timers -->
     <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
   </CPPDEFS>
-  <NETCDF_PATH><env>NETCDF</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDF}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDF</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF}</PNETCDF_PATH>
 </compiler>
 <compiler MACH="cheyenne" COMPILER="intel">
   <CFLAGS>
@@ -988,9 +988,9 @@ using a fortran linker.
     <!-- these flags enable nano timers -->
     <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
   </CPPDEFS>
-  <NETCDF_PATH><env>NETCDF</env></NETCDF_PATH>
+  <NETCDF_PATH>$ENV{NETCDF}</NETCDF_PATH>
   <PIO_FILESYSTEM_HINTS>gpfs</PIO_FILESYSTEM_HINTS>
-  <PNETCDF_PATH><env>PNETCDF</env></PNETCDF_PATH>
+  <PNETCDF_PATH>$ENV{PNETCDF}</PNETCDF_PATH>
 </compiler>
 <compiler MACH="laramie" COMPILER="intel">
   <CFLAGS>
@@ -1023,16 +1023,16 @@ using a fortran linker.
   <MPICXX MPILIB="mpich2">mpiicpc</MPICXX>
   <PAPI_INC MPILIB="mpich2"> /glade/apps/opt/papi/5.3.0/intel/12.1.5/include/</PAPI_INC>
   <PAPI_LIB MPILIB="mpich2">/glade/apps/opt/papi/5.3.0/intel/12.1.5/lib64 </PAPI_LIB>
-  <PFUNIT_PATH><env>CESMDATAROOT</env>/tools/pFUnit/pFUnit3.1_Intel15.0.1_MPI</PFUNIT_PATH>
+  <PFUNIT_PATH>$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.1_Intel15.0.1_MPI</PFUNIT_PATH>
   <!-- Needed due to the way that netcdf is loaded on yellowstone -->
   <SCC MPILIB="mpi-serial">icc</SCC>
   <SFC MPILIB="mpi-serial">ifort</SFC>
-  <SCC MPILIB="mpich2"><var>MPICC</var></SCC>
-  <SFC MPILIB="mpich2"><var>MPIFC</var></SFC>
+  <SCC MPILIB="mpich2">${MPICC}</SCC>
+  <SFC MPILIB="mpich2">${MPIFC}</SFC>
   <SLIBS>
-    <append MPILIB="mpich2"> -Wl,-rpath <var>PAPI_LIB</var> -L<var>PAPI_LIB</var> -lpapi</append>
+    <append MPILIB="mpich2"> -Wl,-rpath ${PAPI_LIB} -L${PAPI_LIB} -lpapi</append>
   </SLIBS>
-  <TRILINOS_PATH MPILIB="mpich2"><env>TRILINOS_PATH</env></TRILINOS_PATH>
+  <TRILINOS_PATH MPILIB="mpich2">$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
 <compiler MACH="yellowstone" COMPILER="pgi">

--- a/utils/python/CIME/XML/compilerblock.py
+++ b/utils/python/CIME/XML/compilerblock.py
@@ -118,7 +118,6 @@ class CompilerBlock(object):
         if output is None:
             output = ""
         logger.debug("Initial output=%s"%output)
-        #Brackets are manditory in this file
         reference_re = re.compile(r'\${?(\w+)}?')
         env_ref_re   = re.compile(r'\$ENV\{(\w+)\}')
         shell_ref_re = re.compile(r'\$SHELL\{([^}]+)\}')

--- a/utils/python/CIME/XML/compilers.py
+++ b/utils/python/CIME/XML/compilers.py
@@ -208,9 +208,9 @@ class Compilers(GenericXML):
                 if value_lists[var_name].depends <= vars_written
             ]
             expect(len(ready_variables) > 0,
-                   "The config_build XML has bad <var> references. "
+                   "The file %s has bad <var> references. "
                    "Check for circular references or variables that "
-                   "are in a <var> tag but not actually defined.")
+                   "are in a <var> tag but not actually defined."%self.filename)
             big_normal_tree = None
             big_append_tree = None
             for var_name in ready_variables:

--- a/utils/python/tests/scripts_regression_tests.py
+++ b/utils/python/tests/scripts_regression_tests.py
@@ -1832,7 +1832,7 @@ class H_TestMakeMacros(unittest.TestCase):
         # This is a special case of the next test, which also checks circular
         # references.
         xml1 = """<MPI_LIB_NAME><var>MPI_LIB_NAME</var></MPI_LIB_NAME>"""
-        err_msg = "The config_build XML has bad <var> references."
+        err_msg = ".* has bad <var> references."
         with self.assertRaisesRegexp(SystemExit, err_msg):
             self.xml_to_tester("<compiler>"+xml1+"</compiler>")
 
@@ -1840,7 +1840,7 @@ class H_TestMakeMacros(unittest.TestCase):
         """Test that cyclical <var> references are rejected."""
         xml1 = """<MPI_LIB_NAME><var>MPI_PATH</var></MPI_LIB_NAME>"""
         xml2 = """<MPI_PATH><var>MPI_LIB_NAME</var></MPI_PATH>"""
-        err_msg = "The config_build XML has bad <var> references."
+        err_msg = ".* has bad <var> references."
         with self.assertRaisesRegexp(SystemExit, err_msg):
             self.xml_to_tester("<compiler>"+xml1+xml2+"</compiler>")
 
@@ -1849,7 +1849,7 @@ class H_TestMakeMacros(unittest.TestCase):
         xml1 = """<compiler><MPI_LIB_NAME>something</MPI_LIB_NAME></compiler>"""
         xml2 = """<compiler MACH="{}"><MPI_LIB_NAME><var>MPI_PATH</var></MPI_LIB_NAME></compiler>""".format(self.test_machine)
         xml3 = """<compiler><MPI_PATH><var>MPI_LIB_NAME</var></MPI_PATH></compiler>"""
-        err_msg = "The config_build XML has bad <var> references."
+        err_msg = ".* has bad <var> references."
         with self.assertRaisesRegexp(SystemExit, err_msg):
             self.xml_to_tester(xml1+xml2+xml3)
 


### PR DESCRIPTION
Add support for $ENV{} $SHELL{} and ${} in config_compilers.xml to conform to usage in other
xml files.  

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1078 

User interface changes?: 

Code review: 
