### PR TITLE
add back the mask grid dropped in v2 but used by components

### DIFF
--- a/utils/python/CIME/XML/grids.py
+++ b/utils/python/CIME/XML/grids.py
@@ -35,6 +35,8 @@ class Grids(GenericXML):
                 gn = node.get("name")
                 if gn not in gridnames:
                     gridnames.append(gn)
+            if "mask" not in gridnames:
+                gridnames.append("mask")
         else:
             expect(False,"Did not recognize config_grids.xml file version")
 
@@ -215,7 +217,7 @@ class Grids(GenericXML):
         """ determine domains dictionary for config_grids.xml v2 schema"""
         # use component_grids to create grids dictionary
         # TODO: this should be in XML, not here
-        grids = [("atm", "a%"), ("lnd", "l%"), ("ocn", "o%"), \
+        grids = [("atm", "a%"), ("lnd", "l%"), ("ocn", "o%"), ("mask", "m%"),\
                  ("ice", "i%"), ("rof", "r%"), ("glc", "g%"), ("wav", "w%")]
         domains = {}
         mask_name = None


### PR DESCRIPTION
The mask field was dropped from the grid longname in v2 of this file, but some components use it
so put it back 

Test suite: scripts_regression_tests.py (one expected failure fixed by #1081)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1079 

User interface changes?: 

Code review: 
