### PR TITLE
Add ESMF_TimeIntervalProdI8 routine

### DIFF
--- a/share/esmf_wrf_timemgr/ESMF_TimeIntervalMod.F90
+++ b/share/esmf_wrf_timemgr/ESMF_TimeIntervalMod.F90
@@ -103,6 +103,7 @@ module ESMF_TimeIntervalMod
 
       public operator(*)
       private ESMF_TimeIntervalProdI
+      private ESMF_TimeIntervalProdI8
 
 ! Inherited and overloaded from ESMF_BaseTime
 
@@ -147,6 +148,7 @@ module ESMF_TimeIntervalMod
 
 ! !PRIVATE MEMBER FUNCTIONS:
       module procedure ESMF_TimeIntervalProdI
+      module procedure ESMF_TimeIntervalProdI8
 
 ! !DESCRIPTION:
 !     This interface overloads the * operator for the {\tt ESMF\_TimeInterval}
@@ -1113,6 +1115,56 @@ module ESMF_TimeIntervalMod
       CALL normalize_timeint( ESMF_TimeIntervalProdI )
 
       end function ESMF_TimeIntervalProdI
+
+
+!------------------------------------------------------------------------------
+!BOP
+! !IROUTINE:   ESMF_TimeIntervalProdI8 - Multiply a time interval by an integer
+
+! !INTERFACE:
+      function ESMF_TimeIntervalProdI8(timeinterval, multiplier)
+
+! !RETURN VALUE:
+      type(ESMF_TimeInterval) :: ESMF_TimeIntervalProdI8
+
+! !ARGUMENTS:
+      type(ESMF_TimeInterval), intent(in) :: timeinterval
+      integer(kind=ESMF_KIND_I8), intent(in) :: multiplier
+! !LOCAL:
+      integer    :: rc
+
+! !DESCRIPTION:
+!     Multiply a {\tt ESMF\_TimeInterval} by an integer, return product as a
+!     {\tt ESMF\_TimeInterval}
+!
+!     The arguments are:
+!     \begin{description}
+!     \item[timeinterval]
+!          The multiplicand
+!     \item[mutliplier]
+!          Integer multiplier
+!     \end{description}
+!
+! !REQUIREMENTS:
+!     TMG1.5.7, TMG7.2
+!EOP
+      CALL timeintchecknormalized( timeinterval, 'ESMF_TimeIntervalProdI arg1', &
+                                   relative_interval=.true. )
+
+      CALL ESMF_TimeIntervalSet( ESMF_TimeIntervalProdI8, rc=rc )
+!$$$move this into overloaded operator(*) in BaseTime
+      ESMF_TimeIntervalProdI8%basetime%S  = &
+        timeinterval%basetime%S * multiplier
+      ESMF_TimeIntervalProdI8%basetime%Sn = &
+        timeinterval%basetime%Sn * multiplier
+      ! Don't multiply Sd
+      ESMF_TimeIntervalProdI8%basetime%Sd = timeinterval%basetime%Sd
+      ESMF_TimeIntervalProdI8%MM = timeinterval%MM * multiplier
+      ESMF_TimeIntervalProdI8%YR = timeinterval%YR * multiplier
+      CALL normalize_timeint( ESMF_TimeIntervalProdI8 )
+
+      end function ESMF_TimeIntervalProdI8
+
 
 !------------------------------------------------------------------------------
 !


### PR DESCRIPTION
This PR adds a new routine, ESMF_TimeIntervalProdI8, for multiplying an ESMF_TimeInterval by an 8-byte integer.

To complement the existing routine ESMF_TimeIntervalProdI that implements the `*` operator for multiplying an ESMF_TimeInterval by a 4-byte integer, this PR adds a new routine, ESMF_TimeIntervalProdI8, that multiplies an ESMF_TimeInterval by an 8-byte integer. This new routine is accessed through the '*' operator in the same way as the existing ESMF_TimeIntervalProdI routine. This routine is useful when multiplying small intervals (e.g., 1 second) by large integers (e.g., the number of seconds in 1000 years).

Test suite: scripts_regression_tests.py passes with two errors related to ACME; according to @jedwards4b these failures are not problematic.
Test baseline: 
Test namelist changes: 
Test status: bit-for-bit -- only a new routine has been added

User interface changes: The `operator(*)` interface for multiplying an `ESMF_TimeInterval` by an integer now supports multiplication by either 4-byte or 8-byte integers.

Code review: 
