### PR TITLE
Tie timers to xml

### DIFF
--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -249,11 +249,10 @@
 	<command name="load">ncarcompilers/0.3.5</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">netcdf/4.4.1</command>
+	<command name="load">netcdf/4.4.1.1</command>
       </modules>
       <modules mpilib="mpt">
-	<command name="load">netcdf/4.4.1</command>
-<!--	<command name="load">netcdf-mpi/4.4.1</command> -->
+	<command name="load">netcdf-mpi/4.4.1.1</command>
 	<command name="load">pnetcdf/1.8.0</command>
       </modules>
     </module_system>

--- a/driver_cpl/cime_config/namelist_definition_drv.xml
+++ b/driver_cpl/cime_config/namelist_definition_drv.xml
@@ -2615,7 +2615,7 @@
     </values>
   </entry>
 
-  <entry id="profile_depth_limit" modify_via_xml="TIMER_LEVEL">>
+  <entry id="profile_depth_limit" modify_via_xml="TIMER_LEVEL">
     <type>integer</type>
     <category>performance</category>
     <group>prof_inparm</group>

--- a/driver_cpl/cime_config/namelist_definition_drv.xml
+++ b/driver_cpl/cime_config/namelist_definition_drv.xml
@@ -2615,15 +2615,14 @@
     </values>
   </entry>
 
-  <entry id="profile_depth_limit">
+  <entry id="profile_depth_limit" modify_via_xml="TIMER_LEVEL">>
     <type>integer</type>
     <category>performance</category>
     <group>prof_inparm</group>
     <desc>
     </desc>
     <values>
-      <value timer_level='pos'>$TIMER_LEVEL</value>
-      <value timer_level='neg'>20</value>
+      <value>$TIMER_LEVEL</value>
     </values>
   </entry>
 
@@ -2638,15 +2637,14 @@
     </values>
   </entry>
 
-  <entry id="profile_detail_limit">
+  <entry id="profile_detail_limit"   modify_via_xml="TIMER_DETAIL">
     <type>integer</type>
     <category>performance</category>
     <group>prof_inparm</group>
     <desc>
     </desc>
     <values>
-      <value timer_level='neg'>$TIMER_LEVEL</value>
-      <value timer_level='pos'>0</value>
+      <value>$TIMER_DETAIL</value>
     </values>
   </entry>
 

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -144,7 +144,7 @@ OR
         run_unsupported = args.run_unsupported
 
 
-    return args.case, args.compset, args.res, args.mach, args.compiler,\
+    return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.user_compset, args.pesfile, \
         args.user_grid, args.gridfile, args.srcroot, args.test, args.ninst, \

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -12,7 +12,7 @@ def parse_command_line(args, cimeroot, description):
 ###############################################################################
     help_str = \
 """
-%s --case [CASE] --compset [COMPSET] --res [GRID] [--mach ...] [--compiler ...]
+%s --case [CASE] --compset [COMPSET] --res [GRID] [--machine ...] [--compiler ...]
 OR
 %s --help
 """ % ((os.path.basename(args[0]), ) * 2)
@@ -38,7 +38,7 @@ OR
                         help="(required) Specify a model grid resolution. "
                         "To see list of current compsets, use the utility manage_case in this directory")
 
-    parser.add_argument("--mach", "-mach",
+    parser.add_argument("--machine", "-mach",
                         help="Specify a machine. default: match NODENAME_REGEX in config_machines.xml "
                         "To see list of current  machines, use the utility manage_case in this directory"
                         )


### PR DESCRIPTION
The settings for timers in xml TIMER_LEVEL and TIMER_DETAIL were a bit disconnected from their counterparts in namelist, this is an attempt to straighten out the problems.  Unrelated update netcdf on cheyenne.   

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1096 
Fixes #1084 
Fixes #770

User interface changes?:  create_newcase --mach is now --machine to match create_test 

Code review: 
