### PR TITLE
only count tests in prealpha prebeta or aux_* categories

### DIFF
--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -1121,4 +1121,5 @@ class Case(object):
             logger.info("\nThis compset and grid combination is not scientifically supported, however it is used in %d tests.\n"%(testcnt))
         else:
             expect(False, "\nThis compset and grid combination is unsupported in CESM.  "
-                   "If you wish to use it anyway you must supply the --run-unsupported option to create_newcase.")
+                   "If you wish to use it anyway you must supply the --run-unsupported option to create_newcase.",
+                   error_prefix="STOP: ")

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -1113,8 +1113,12 @@ class Case(object):
 
         tests = Testlist(tests_spec_file, files)
         testlist = tests.get_tests(compset=compset_alias, grid=grid_name)
-        if len(testlist) > 0:
-            logger.info("\nThis compset and grid combination is not scientifically supported, however it is used in %d tests.\n"%(len(testlist)))
+        testcnt = 0
+        for test in testlist:
+            if test["category"] == "prealpha" or test["category"] == "prebeta" or "aux_" in test["category"]:
+                testcnt += 1
+        if testcnt > 0:
+            logger.info("\nThis compset and grid combination is not scientifically supported, however it is used in %d tests.\n"%(testcnt))
         else:
             expect(False, "\nThis compset and grid combination is unsupported in CESM.  "
                    "If you wish to use it anyway you must supply the --run-unsupported option to create_newcase.")

--- a/utils/python/CIME/case.py
+++ b/utils/python/CIME/case.py
@@ -1120,6 +1120,6 @@ class Case(object):
         if testcnt > 0:
             logger.info("\nThis compset and grid combination is not scientifically supported, however it is used in %d tests.\n"%(testcnt))
         else:
-            expect(False, "\nThis compset and grid combination is unsupported in CESM.  "
-                   "If you wish to use it anyway you must supply the --run-unsupported option to create_newcase.",
+            expect(False, "\nThis compset and grid combination is untested in CESM.  "
+                   "Override this warning with the --run-unsupported option to create_newcase.",
                    error_prefix="STOP: ")

--- a/utils/python/CIME/utils.py
+++ b/utils/python/CIME/utils.py
@@ -8,7 +8,7 @@ import logging, gzip, sys, os, time, re, shutil, glob, string, random
 TESTS_FAILED_ERR_CODE = 100
 logger = logging.getLogger(__name__)
 
-def expect(condition, error_msg, exc_type=SystemExit):
+def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR: "):
     """
     Similar to assert except doesn't generate an ugly stacktrace. Useful for
     checking user error, not programming error.
@@ -23,7 +23,7 @@ def expect(condition, error_msg, exc_type=SystemExit):
         if logger.isEnabledFor(logging.DEBUG):
             import pdb
             pdb.set_trace()
-        raise exc_type("ERROR: %s" % error_msg)
+        raise exc_type("%s %s" % (error_prefix,error_msg))
 
 def id_generator(size=6, chars=string.ascii_lowercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))


### PR DESCRIPTION
Limits the test count to prealpha, prebeta and aux_* test categories.  If you want to test a
compset but don't want it listed as tested call it something that doesn't match any of these prefixes. 

Test suite: hand tested 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1093 

User interface changes?: 

Code review: 
