### PR TITLE
Jgfouca/fixes to recent new tests

### DIFF
--- a/cime_config/acme/allactive/config_pesall.xml
+++ b/cime_config/acme/allactive/config_pesall.xml
@@ -407,6 +407,7 @@
       </pes>
     </mach>
   </grid>
+
   <grid name="a%ne30np4">
     <mach name="melvin">
       <pes compset="any" pesize="any">
@@ -479,6 +480,44 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%4x5">
+    <mach name="melvin">
+      <pes compset="2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_DESP" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>64</ntasks_atm>
+          <ntasks_lnd>64</ntasks_lnd>
+          <ntasks_rof>64</ntasks_rof>
+          <ntasks_ice>64</ntasks_ice>
+          <ntasks_ocn>64</ntasks_ocn>
+          <ntasks_glc>64</ntasks_glc>
+          <ntasks_wav>64</ntasks_wav>
+          <ntasks_cpl>64</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
   <grid name="a%ne30np4">
     <mach name="edison">
       <pes compset="any" pesize="any">

--- a/cime_config/acme/config_files.xml
+++ b/cime_config/acme/config_files.xml
@@ -363,6 +363,7 @@
     <default_value>$CIMEROOT/components/stub_comps/sesp/cime_config/config_component.xml</default_value>
     <values>
       <value component="sesp">$CIMEROOT/components/stub_comps/sesp/cime_config/config_component.xml</value>
+      <value component="desp">$CIMEROOT/components/data_comps/desp/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/utils/python/CIME/SystemTests/dae.py
+++ b/utils/python/CIME/SystemTests/dae.py
@@ -66,8 +66,8 @@ class DAE(SystemTestsCompareTwo):
         self._activate_case2()
         case_root = self._get_caseroot2()
         da_files = glob.glob(os.path.join(case_root, 'da.log.*'))
-        for file in da_files:
-            os.remove(file)
+        for file_ in da_files:
+            os.remove(file_)
         # End for
         self._activate_case1()
         SystemTestsCompareTwo.run_phase(self)

--- a/utils/python/update_acme_tests.py
+++ b/utils/python/update_acme_tests.py
@@ -48,8 +48,8 @@ _TEST_SUITES = {
                              "ERR.f45_g37_rx1.A",
                              "ERP.f45_g37_rx1.A",
                              "SMS_D_Ln9.f19_g16_rx1.A",
-                             "DAE.f19_f19.A",
-                             "PRE.f19_f19.ADESP")
+                             "DAE.f19_f19.A")
+#                             "PRE.f19_f19.ADESP")
                             ),
 
     #


### PR DESCRIPTION
Disable PRE.f19_f19.ADESP test, it's far too expensive.
ACME config XML needed desp config component file.
Fix minor pylint error.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Removes PRE test from cime_developer

Code review: @jedwards4b @gold2718 
