### PR TITLE
Update to bless_test_results

### DIFF
--- a/scripts/Tools/bless_test_results
+++ b/scripts/Tools/bless_test_results
@@ -70,6 +70,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-c", "--compiler", default=default_compiler,
                         help="Compiler of run you want to bless")
 
+    parser.add_argument("-p", "--no-skip-pass", action="store_true",
+                        help="Normally, if namelist or baseline phase exists and shows PASS, we assume no bless is needed. "
+                        "This option forces the bless to happen regardless.")
+
     parser.add_argument("--report-only", action="store_true",
                         help="Only report what files will be overwritten and why. Caution is a good thing when updating baselines")
 
@@ -94,7 +98,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     expect(not (args.namelists_only and args.hist_only),
            "Makes no sense to use --namelists-only and --hist-only simultaneously")
 
-    return args.baseline_name, args.baseline_root, args.test_root, args.compiler, args.test_id, args.namelists_only, args.hist_only, args.report_only, args.force, args.bless_tests
+    return args.baseline_name, args.baseline_root, args.test_root, args.compiler, args.test_id, args.namelists_only, args.hist_only, args.report_only, args.force, args.bless_tests, args.no_skip_pass
 
 ###############################################################################
 def _main_func(description):
@@ -103,10 +107,12 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    baseline_name, baseline_root, test_root, compiler, test_id, namelists_only, hist_only, report_only, force, bless_tests = \
+    baseline_name, baseline_root, test_root, compiler, test_id, namelists_only, hist_only, report_only, force, bless_tests, no_skip_pass = \
         parse_command_line(sys.argv, description)
 
-    success = bless_test_results(baseline_name, baseline_root, test_root, compiler, test_id, namelists_only, hist_only, report_only, force, bless_tests)
+    success = bless_test_results(baseline_name, baseline_root, test_root, compiler,
+                                 test_id=test_id, namelists_only=namelists_only, hist_only=hist_only,
+                                 report_only=report_only, force=force, bless_tests=bless_tests, no_skip_pass=no_skip_pass)
     sys.exit(0 if success else 1)
 
 ###############################################################################

--- a/utils/python/CIME/bless_test_results.py
+++ b/utils/python/CIME/bless_test_results.py
@@ -15,7 +15,7 @@ def bless_namelists(test_name, report_only, force, baseline_name, baseline_root)
     # re-run create_test.
 
     # Update namelist files
-    print "Test '%s' had a namelist diff" % test_name
+    print "Test '%s' had namelist diff" % test_name
     if (not report_only and
         (force or raw_input("Update namelists (y/n)? ").upper() in ["Y", "YES"])):
         create_test_gen_args = " -g %s " % baseline_name if get_model() == "cesm" else " -g -b %s " % baseline_name
@@ -54,7 +54,7 @@ def bless_history(test_name, testcase_dir_for_test, baseline_name, baseline_root
                 return True, None
 
 ###############################################################################
-def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, namelists_only=False, hist_only=False, report_only=False, force=False, bless_tests=None):
+def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, namelists_only=False, hist_only=False, report_only=False, force=False, bless_tests=None, no_skip_pass=False):
 ###############################################################################
     test_id_glob = "*%s*%s*" % (compiler, baseline_name) if test_id is None else "*%s" % test_id
     test_status_files = glob.glob("%s/%s/%s" % (test_root, test_id_glob, TEST_STATUS_FILENAME))
@@ -68,36 +68,35 @@ def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_i
         if (bless_tests in [[], None] or CIME.utils.match_any(test_name, bless_tests)):
             overall_result = ts.get_overall_test_status()
 
-            # Compute namelists status, False implies it diffed
+            # See if we need to bless namelist
             if (not hist_only):
-                if (ts.get_status(NAMELIST_PHASE) is not None):
-                    nl_no_bless = ts.get_status(NAMELIST_PHASE) == TEST_PASS_STATUS
+                if no_skip_pass:
+                    nl_bless = True
                 else:
-                    logging.warning("Test '%s' did not make it to namelist phase" % test_name)
-                    broken_blesses.append((test_name, "no namelist phase"))
-                    nl_no_bless = True
+                    nl_bless = ts.get_status(NAMELIST_PHASE) != TEST_PASS_STATUS
             else:
-                nl_no_bless = True
+                nl_bless = False
 
-            # Compute hist status, False implies it diffed
+            # See if we need to bless baselines
             if (not namelists_only):
                 run_result = ts.get_status(RUN_PHASE)
                 if (run_result is None):
                     broken_blesses.append((test_name, "no run phase"))
                     logging.warning("Test '%s' did not make it to run phase" % test_name)
-                    hist_no_bless = True
+                    hist_bless = False
                 elif (run_result != TEST_PASS_STATUS):
                     broken_blesses.append((test_name, "test did not pass"))
                     logging.warning("Test '%s' did not pass, not safe to bless" % test_name)
-                    hist_no_bless = True
+                    hist_bless = False
+                elif no_skip_pass:
+                    hist_bless = True
                 else:
-                    hist_no_bless = False
-
+                    hist_bless = ts.get_status(BASELINE_PHASE) != TEST_PASS_STATUS
             else:
-                hist_no_bless = True
+                hist_bless = False
 
             # Now, do the bless
-            if ( (nl_no_bless and hist_no_bless) or (nl_no_bless and namelists_only) or (hist_no_bless and hist_only) ):
+            if not nl_bless and not hist_bless:
                 print "Nothing to bless for test:", test_name, " overall status:", overall_result
             else:
 
@@ -108,13 +107,13 @@ def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_i
                     time.sleep(2)
 
                 # Bless namelists
-                if (not nl_no_bless):
+                if nl_bless:
                     success, reason = bless_namelists(test_name, report_only, force, baseline_name, baseline_root)
                     if not success:
                         broken_blesses.append((test_name, reason))
 
                 # Bless hist files
-                if (not hist_no_bless):
+                if hist_bless:
                     success, reason = bless_history(test_name, test_dir, baseline_name, baseline_root, compiler, report_only, force)
                     if (not success):
                         broken_blesses.append((test_name, reason))


### PR DESCRIPTION
There's no need to abort the namelist bless if there's not a namelist
phase, just do the bless.

Both namelist and baseline blessing should take into account the state
of the corresponding phase. If the corresponding phase is PASS, we can
assume there's no need to bless unless the user passes a special new
-p option.

Test suite: scripts_regression_tests Q_TestBlessTestResults, code_checker, by hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #750 

User interface changes?: changes in bless_test_results behavior, adds -p

Code review: @billsacks @jedwards4b 
