### PR TITLE
Fix config_archive.xml and case_st_archive.py

### DIFF
--- a/cime_config/cesm/config_archive.xml
+++ b/cime_config/cesm/config_archive.xml
@@ -43,7 +43,7 @@
   <comp_archive_spec compname="rtm" compclass="rof">
     <rest_file_extension>\.r.*</rest_file_extension>
     <hist_file_extension>\.h.*.nc$</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
+    <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.rof</rpointer_file>
       <rpointer_content>$CASE.rtm$NINST_STRING.r.$DATENAME.nc</rpointer_content>
@@ -53,7 +53,7 @@
   <comp_archive_spec compname="mosart" compclass="rof">
     <rest_file_extension>\.r.*</rest_file_extension>
     <hist_file_extension>\.h.*.nc$</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
+    <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.rof</rpointer_file>
       <rpointer_content>$CASE.mosart$NINST_STRING.r.$DATENAME.nc</rpointer_content>
@@ -124,7 +124,7 @@
 
   <comp_archive_spec compname="ww3" compclass="wav">
     <rest_file_extension>\.r.*</rest_file_extension>
-    <hist_file_extension>\.hi.*</hist_file_extension>
+    <hist_file_extension>\.hi\..*\.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.wav</rpointer_file>
@@ -141,16 +141,18 @@
     </rpointer>
   </comp_archive_spec>
 
-  <comp_archive_spec compname="dart" compclass="esp">
+  <comp_archive_spec compclass="esp" compname="dart">
     <rest_file_extension>inflate_restart.*</rest_file_extension>
-    <hist_file_extension>True_State.*</hist_file_extension>
-    <hist_file_extension>Prior_Diag.*</hist_file_extension>
-    <hist_file_extension>Posterior_Diag.*</hist_file_extension>
-    <hist_file_extension>obs_seq.*</hist_file_extension>
+    <hist_file_extension>\.True_State.*</hist_file_extension>
+    <hist_file_extension>\.Prior_Diag.*</hist_file_extension>
+    <hist_file_extension>\.Posterior_Diag.*</hist_file_extension>
+    <hist_file_extension>\..+\.posterior*</hist_file_extension>
+    <hist_file_extension>\..+\.prior*</hist_file_extension>
+    <hist_file_extension>\..+$_obs_seq.*</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.unset</rpointer_file>
-      <rpointer_content >unset</rpointer_content>
+      <rpointer_content>unset</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 

--- a/utils/python/CIME/SystemTests/err.py
+++ b/utils/python/CIME/SystemTests/err.py
@@ -29,6 +29,13 @@ class ERR(ERS):
             rundir = self._case.get_value("RUNDIR")
             logger.info("staging files from archive %s" % dout_s_root)
             for item in glob.glob(os.path.join(dout_s_root, "*", "hist", "*base")):
+                # NOTE - this loop doesn't do anything because the
+                # _ers_first_phase has already copied the history files in the
+                # rundir adding the .base suffix before the short term archiver runs.
+                # The pattern matching in the env_archive.xml looks for history 
+                # files that match ".nc$" in the rundir in order to copy them
+                # to the DOUT_S_ROOT location so the files with the .base
+                # suffix are never copied. 
                 shutil.copy(item, rundir)
 
             self._ers_second_phase()

--- a/utils/python/CIME/case_st_archive.py
+++ b/utils/python/CIME/case_st_archive.py
@@ -147,10 +147,13 @@ def _archive_history_files(case, archive, archive_entry,
     rundir = case.get_value("RUNDIR")
     for suffix in archive.get_hist_file_extensions(archive_entry):
         for i in range(ninst):
-            if ninst_string:
-                newsuffix = casename + '.' + compname + ".*" + ninst_string[i] + suffix
+            if compname == 'dart':
+                newsuffix = casename + suffix
             else:
-                newsuffix = casename + '.' + compname + ".*" + suffix
+                if ninst_string:
+                    newsuffix = casename + '.' + compname + ".*" + ninst_string[i] + suffix
+                else:
+                    newsuffix = casename + '.' + compname + ".*" + suffix
             logger.debug("short term archiving suffix is %s " %newsuffix)
             pfile = re.compile(newsuffix)
             histfiles = [f for f in os.listdir(rundir) if pfile.search(f)]
@@ -194,7 +197,7 @@ def get_histfiles_for_restarts(case, archive, archive_entry, restfile):
                 if matchobj:
                     histfile = matchobj.group(1).strip()
                     histfile = os.path.basename(histfile)
-                    # append histfile to the list ONLY if it exists in rundir before the archviving
+                    # append histfile to the list ONLY if it exists in rundir before the archiving
                     if os.path.isfile(os.path.join(rundir,histfile)): 
                         histfiles.append(histfile)
     return histfiles


### PR DESCRIPTION
Add fix to config_archive.xml for DART, mosart, rtm
and ww3 element values for filename pattern matching.
Update case_st_archive.py to correctly archive DART v1 files.

Test suite: ERR.f19_g16.B1850.yellowstone_intel.allactive-defaultio
NOTE - this PR did not test with DART data because we didn't have
any available at the time. I'll work with Kevin Raeder to test later
but wanted to get these other changes checked in today for mosart and rtm.

Fixes [Github issue #]: #1129 and #1124

User interface changes: None

Input data changes: None

Code review:
