### PR TITLE
Unit test cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,11 @@ include(ExternalProject)
 set(CIME_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 
 project(cime_tests Fortran C)
+
+# We rely on pio for cmake utilities like findnetcdf.cmake, so that we don't
+# need to duplicate this cmake code
 list(APPEND CMAKE_MODULE_PATH "${CIME_ROOT}/externals/pio2/cmake")
+
 list(APPEND CMAKE_MODULE_PATH ${CIME_CMAKE_MODULE_DIRECTORY})
 include(CIME_utils)
 find_package(NetCDF)

--- a/README.unit_testing
+++ b/README.unit_testing
@@ -1,10 +1,17 @@
-# To run all CIME unit tests on caldera, run the following command:
+# To run all CIME unit tests on caldera, run the following commands:
 # (Note that this must be done from an interactive caldera session, not from yellowstone)
 # Note also that this requires module load all-python-libs
+#
+# The creation of a temporary directory ensures that you are doing a completely
+# clean build of the unit tests. (The use of the --clean flag to run_tests.py
+# cleans most, but not all of the files created by the unit test build.) For
+# rerunning the tests after an incremental change, you can instead use an
+# existing build directory.
 #
 # We would encourage you to port these tests to other platforms.
 # The test requires an install of pFunit available from
 # https://sourceforge.net/projects/pfunit/
 #
 
-tools/unit_testing/run_tests.py --test-spec-dir=. --compiler=intel --mpilib=mpich2 --use-openmp --mpirun-command=mpirun.lsf
+tempdir=`mktemp -d --tmpdir=. unit_tests.XXXXXXXX`
+tools/unit_testing/run_tests.py --test-spec-dir=. --compiler=intel --mpilib=mpich2 --use-openmp --mpirun-command=mpirun.lsf --build-dir $tempdir

--- a/tools/unit_testing/Examples/circle_area/tests/CTest/CMakeLists.txt
+++ b/tools/unit_testing/Examples/circle_area/tests/CTest/CMakeLists.txt
@@ -12,4 +12,4 @@ add_test(circle_area CTest_circle_exe)
 
 # Tell CTest how to figure out that "STOP 1" fails for the current
 # compiler.
-#define_Fortran_stop_failure(circle_area)
+define_Fortran_stop_failure(circle_area)

--- a/tools/unit_testing/Examples/circle_area/tests/README
+++ b/tools/unit_testing/Examples/circle_area/tests/README
@@ -1,0 +1,2 @@
+NOTE (2-15-17): The CTest_circle_exe test is currently failing for an unknown
+reason, but the pFunittest_circle_area_exe test should pass.

--- a/tools/unit_testing/run_tests.py
+++ b/tools/unit_testing/run_tests.py
@@ -36,7 +36,7 @@ builds and runs the tests defined via CMake."""
     parser.add_argument("--build-dir", default=".",
                         help="""Directory where tests are built and run. Will be created if it does not exist."""
                         )
-    parser.add_argument("--build-type", default="CIME_DEBUG",
+    parser.add_argument("--build-type", default="CESM_DEBUG",
                         help="""Value defined for CMAKE_BUILD_TYPE."""
                         )
 


### PR DESCRIPTION
Cleans up some minor outstanding issues from PR #1135, including:

1. Brings back a commented-out line in the circle_area CMakeLists.txt,
   and adds a README documenting the expected failure of one of the
   circle_area tests.

    Jim Edwards commented out this line, but I think it should not have
    been commented out. This test is currently failing with and without
    this line. I'm guessing he commented it out thinking it would make the
    test pass, but it doesn't.

2. Changes --build-type default back to CESM_DEBUG rather than
   CIME_DEBUG

    I started down the path of changing things to consistently use CIME_DEBUG, but
    then wasn't sure that was the right thing to do: Some cmake-related code seems
    to expect CESM or ACME there - e.g., in machine_setup.py: write_cmake_macros. I
    wasn't sure what the right thing to do was, so I decided it was safest for now
    to maintain this as CESM_DEBUG.

3. Change README.unit_testing to suggest creating a temporary
   directory for the unit test build.

    The main motivation is to isolate these files that otherwise get put
    in the current directory:

        .env_mach_specific.csh
        .env_mach_specific.sh
        Depends.intel
        Macros.cmake
        env_mach_specific.xml

Test suite: Fortran unit tests according to instructions in README.unit_testing
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #1144 

User interface changes?: none

Code review: @jedwards4b 
