### PR TITLE
gitignore: add  buildnmlc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore python bytecode files
 *.pyc
+buildnmlc
 
 # Ignore emacs backup files
 *~


### PR DESCRIPTION
buildnmlc  files are being auto-generated by python,
and git has been marking them as new files. Now they
will be ignored by git.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]: none made; discussed in slack

User interface changes?: No

Code review: 
