### PR TITLE
Build unit tests in debug mode, and enable parallel builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ ExternalProject_add(mct_project
   SOURCE_DIR ${MCT_ROOT}
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/mct
   CONFIGURE_COMMAND ${MCT_ROOT}/configure --enable-debugging --prefix=${CMAKE_CURRENT_BINARY_DIR} CFLAGS=${CFLAGS} FCFLAGS=${FFLAGS} SRCDIR=${MCT_ROOT} DEBUG="-g"
-  BUILD_COMMAND make
+  BUILD_COMMAND $(MAKE)
   # Leave things in <BINARY_DIR> rather than "installing", because we have
   # no need to move things around inside of the CMake binary directory.
   INSTALL_COMMAND :

--- a/README.unit_testing
+++ b/README.unit_testing
@@ -1,4 +1,4 @@
-# To run all CIME unit tests on caldera, run the following commands:
+# To run all CIME unit tests on caldera, run the following command:
 # (Note that this must be done from an interactive caldera session, not from yellowstone)
 # Note also that this requires module load all-python-libs
 #
@@ -13,5 +13,4 @@
 # https://sourceforge.net/projects/pfunit/
 #
 
-tempdir=`mktemp -d --tmpdir=. unit_tests.XXXXXXXX`
-tools/unit_testing/run_tests.py --test-spec-dir=. --compiler=intel --mpilib=mpich2 --use-openmp --mpirun-command=mpirun.lsf --build-dir $tempdir
+tools/unit_testing/run_tests.py --test-spec-dir=. --compiler=intel --mpilib=mpich2 --use-openmp --mpirun-command=mpirun.lsf --build-dir `mktemp -d --tmpdir=. unit_tests.XXXXXXXX`

--- a/tools/unit_testing/Examples/circle_area/tests/README
+++ b/tools/unit_testing/Examples/circle_area/tests/README
@@ -1,2 +1,0 @@
-NOTE (2-15-17): The CTest_circle_exe test is currently failing for an unknown
-reason, but the pFunittest_circle_area_exe test should pass.

--- a/tools/unit_testing/Examples/circle_area/tests/pFUnit/CMakeLists.txt
+++ b/tools/unit_testing/Examples/circle_area/tests/pFUnit/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(sources_needed circle.F90)
 extract_sources("${sources_needed}" "${circle_area_sources}" test_sources)
 
-create_pFUnit_test(circle_area pFunittest_circle_area_exe "test_circle.pf" ${test_sources})
+create_pFUnit_test(pFunit_circle_area pFunittest_circle_area_exe "test_circle.pf" ${test_sources})
 

--- a/tools/unit_testing/run_tests.py
+++ b/tools/unit_testing/run_tests.py
@@ -36,9 +36,11 @@ builds and runs the tests defined via CMake."""
     parser.add_argument("--build-dir", default=".",
                         help="""Directory where tests are built and run. Will be created if it does not exist."""
                         )
-    parser.add_argument("--build-type", default="CESM_DEBUG",
-                        help="""Value defined for CMAKE_BUILD_TYPE."""
-                        )
+
+    parser.add_argument("--build-optimized", action="store_true",
+                        help="""By default, tests are built with debug flags.
+                        If this option is provided, then tests are instead built
+                        in optimized mode.""")
 
     parser.add_argument("--machine",
                         help="The machine to create build information for.")
@@ -129,18 +131,19 @@ override the command provided by Machines."""
     if args.make_j < 1:
         raise Exception("--make-j must be >= 1")
 
-    return output, args.build_dir, args.build_type, args.clean,\
+    return output, args.build_dir, args.build_optimized, args.clean,\
         args.cmake_args, args.compiler, args.enable_genf90, args.machine, args.machines_dir,\
         args.make_j, args.mpilib, args.mpirun_command, args.test_spec_dir, args.ctest_args,\
         args.use_openmp, args.xml_test_list, args.verbose
 
 
-def cmake_stage(name, test_spec_dir, build_type, mpirun_command, output, cmake_args=None, clean=False, verbose=False, enable_genf90=True, color=True):
+def cmake_stage(name, test_spec_dir, build_optimized, mpirun_command, output, cmake_args=None, clean=False, verbose=False, enable_genf90=True, color=True):
     """Run cmake in the current working directory.
 
     Arguments:
     name - Name for output messages.
     test_spec_dir - Test specification directory to run CMake on.
+    build_optimized (logical) - If True, we'll build in optimized rather than debug mode
     """
     # Clear CMake cache.
     if clean:
@@ -153,6 +156,13 @@ def cmake_stage(name, test_spec_dir, build_type, mpirun_command, output, cmake_a
     if not os.path.isfile("CMakeCache.txt"):
 
         output.print_header("Running cmake for "+name+".")
+
+        # This build_type only has limited uses, and should probably be removed,
+        # but for now it's still needed
+        if build_optimized:
+            build_type = "CESM"
+        else:
+            build_type = "CESM_DEBUG"
 
         cmake_command = [
             "cmake",
@@ -204,7 +214,7 @@ def make_stage(name, output, make_j, clean=False, verbose=True):
 
 
 def _main():
-    output, build_dir, build_type, clean,\
+    output, build_dir, build_optimized, clean,\
         cmake_args, compiler, enable_genf90, machine, machines_dir,\
         make_j, mpilib, mpirun_command, test_spec_dir, ctest_args,\
         use_openmp, xml_test_list, verbose \
@@ -262,7 +272,7 @@ def _main():
     if compiler is None:
         compiler = machobj.get_default_compiler()
 
-    debug = False
+    debug = not build_optimized
     os_ = machobj.get_value("OS")
 
     # Create the environment, and the Macros.cmake file
@@ -305,7 +315,7 @@ def _main():
 
             if not os.path.islink("Macros.cmake"):
                 os.symlink(os.path.join(build_dir,"Macros.cmake"), "Macros.cmake")
-            cmake_stage(name, directory, build_type, mpirun_command, output, verbose=verbose,
+            cmake_stage(name, directory, build_optimized, mpirun_command, output, verbose=verbose,
                         enable_genf90=enable_genf90, cmake_args=cmake_args)
             make_stage(name, output, make_j, clean=clean, verbose=verbose)
 


### PR DESCRIPTION
1. Build unit tests in debug mode by default

   Add a `--build-optimized` flag to `run_tests.py` allowing the user to
   control this behavior.

   I have made sure that the shr_infnan test is treated properly in
   either debug (doesn't run) or optimized (runs).

2. Enable parallel builds of the unit tests, controlled by --make-j
   argument

   This cuts the unit test build time by more than half

3. Get circle_area CTest-based test passing

4. Change recommended unit testing command to be shell independent

Test suite: scripts_regression_tests
    Initially submitted with multiple cores; set N_TestUnitTest failed due to #1156 .
    Reran just set N_TestUnitTest with a single core; now passed

    Also ran Fortran unit tests in optimized & debug mode using
    instructions in README.unit_testing
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #1143 

User interface changes?: none

Code review: @jedwards4b 
