### PR TITLE
Get timing correction and misc cesm changes

### DIFF
--- a/cime_config/cesm/machines/config_compilers.xml
+++ b/cime_config/cesm/machines/config_compilers.xml
@@ -214,7 +214,7 @@ using a fortran linker.
   </CFLAGS>
   <CPPDEFS>
     <!-- http://software.intel.com/en-us/articles/intel-composer-xe/ -->
-    <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL</append>
+    <append> -DFORTRANUNDERSCORE -DCPRINTEL</append>
   </CPPDEFS>
   <CXX_LDFLAGS>
     <base> -cxxlib </base>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -238,7 +238,7 @@
 	<command name="load">ncarenv/1.0</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/16.0.3</command>
+	<command name="load">intel/17.0.1</command>
 	<command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">
@@ -1666,7 +1666,7 @@
 	<command name="load">git</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/15.0.3</command>
+	<command name="load">intel/16.0.3</command>
 	<command name="load">mkl/11.1.2</command>
 	<command name="load">trilinos/11.10.2</command>
 	<command name="load">esmf</command>
@@ -1684,17 +1684,17 @@
 	<command name="load"> esmf-6.3.0rp1-ncdfio-uni-O</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/15.10</command>
+	<command name="load">pgi/16.5</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">gnu/5.2.0</command>
+	<command name="load">gnu/6.1.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">netcdf/4.3.3.1</command>
+	<command name="load">netcdf/4.4.1</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">netcdf-mpi/4.3.3.1</command>
-	<command name="load">pnetcdf/1.6.1</command>
+	<command name="load">netcdf-mpi/4.4.1</command>
+	<command name="load">pnetcdf/1.7.0</command>
       </modules>
       <modules>
 	<command name="load">ncarcompilers/1.0</command>

--- a/driver_cpl/cime_config/config_component_cesm.xml
+++ b/driver_cpl/cime_config/config_component_cesm.xml
@@ -69,7 +69,7 @@
     <valid_values>none,CO2A,CO2B,CO2C,CO2_DMSA</valid_values>
     <default_value>none</default_value>
     <values>
-      <value compset="_CAM\d+"  >CO2A</value>
+      <value compset="_CAM"  >CO2A</value>
       <value compset="_DATM"    >none</value>
       <value compset="_DATM%S1850.+POP\d">CO2A</value>
       <value compset="_BGC%BPRP">CO2C</value>

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -445,11 +445,11 @@ def build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid,
         if lib == "pio":
             my_file = "PYTHONPATH=%s:%s:$PYTHONPATH %s"%(os.path.join(cimeroot,"scripts","Tools"),
                                                           os.path.join(cimeroot,"utils","python"), my_file)
+        logger.info("Building %s with output to file %s"%(lib,file_build))
         with open(file_build, "w") as fd:
             stat = run_cmd("%s %s %s %s 2>&1" %
                            (my_file, full_lib_path, os.path.join(exeroot,sharedpath), caseroot),
-                           from_dir=exeroot,
-                           verbose=True, arg_stdout=fd)[0]
+                           from_dir=exeroot,arg_stdout=fd)[0]
 
         analyze_build_log(lib, file_build, compiler)
         expect(stat == 0, "ERROR: buildlib.%s failed, cat %s" % (lib, file_build))
@@ -493,14 +493,15 @@ def build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid,
 def _build_model_thread(config_dir, compclass, caseroot, libroot, bldroot, incroot, file_build,
                         thread_bad_results, smp, compiler):
 ###############################################################################
+    logger.info("Building %s with output to %s"%(compclass, file_build))
     with open(file_build, "w") as fd:
         stat = run_cmd("MODEL=%s SMP=%s %s/buildlib %s %s %s " %
                        (compclass, stringify_bool(smp), config_dir, caseroot, libroot, bldroot),
-                       from_dir=bldroot, verbose=True, arg_stdout=fd,
+                       from_dir=bldroot,  arg_stdout=fd,
                        arg_stderr=subprocess.STDOUT)[0]
     analyze_build_log(compclass, file_build, compiler)
     if (stat != 0):
-        thread_bad_results.append("ERROR: %s.buildlib failed, see %s" % (compclass, file_build))
+        thread_bad_results.append("ERROR: %s.buildlib failed, cat %s" % (compclass, file_build))
 
     for mod_file in glob.glob(os.path.join(bldroot, "*_[Cc][Oo][Mm][Pp]_*.mod")):
         shutil.copy(mod_file, incroot)

--- a/utils/python/CIME/case_cmpgen_namelists.py
+++ b/utils/python/CIME/case_cmpgen_namelists.py
@@ -93,7 +93,7 @@ def case_cmpgen_namelists(case, compare=False, generate=False, compare_name=None
         generate = case.get_value("GENERATE_BASELINE")
 
     if not compare and not generate:
-        logging.info("Nothing to do")
+        logging.debug("No namelists compares requested")
         return True
 
     # create namelists for case if they haven't been already

--- a/utils/python/CIME/check_input_data.py
+++ b/utils/python/CIME/check_input_data.py
@@ -135,7 +135,7 @@ def check_input_data(case, svn_loc=None, input_data_root=None, data_list_dir="Bu
 
     no_files_missing = True
     for data_list_file in data_list_files:
-        logging.info("Loading input file: '%s'" % data_list_file)
+        logging.info("Loading input file list: '%s'" % data_list_file)
         with open(data_list_file, "r") as fd:
             lines = fd.readlines()
 
@@ -160,7 +160,7 @@ def check_input_data(case, svn_loc=None, input_data_root=None, data_list_dir="Bu
                                 logging.warning("    Cannot download file since it lives outside of the input_data_root '%s'" % input_data_root)
                             no_files_missing = False
                         else:
-                            logging.info("  Found input file: '%s'" % full_path)
+                            logging.debug("  Found input file: '%s'" % full_path)
 
                     else:
                         # There are some special values of rel_path that
@@ -186,10 +186,9 @@ def check_input_data(case, svn_loc=None, input_data_root=None, data_list_dir="Bu
                             else:
                                 no_files_missing = False
                         else:
-                            logging.info("  Already had input file: '%s'" % full_path)
+                            logging.debug("  Already had input file: '%s'" % full_path)
 
                 else:
                     model = os.path.basename(data_list_file).split('.')[0]
                     logging.warning("Model %s no file specified for %s"%(model,description))
-
     return no_files_missing

--- a/utils/python/CIME/check_input_data.py
+++ b/utils/python/CIME/check_input_data.py
@@ -191,4 +191,5 @@ def check_input_data(case, svn_loc=None, input_data_root=None, data_list_dir="Bu
                 else:
                     model = os.path.basename(data_list_file).split('.')[0]
                     logging.warning("Model %s no file specified for %s"%(model,description))
+
     return no_files_missing

--- a/utils/python/CIME/get_timing.py
+++ b/utils/python/CIME/get_timing.py
@@ -132,7 +132,7 @@ class _TimingParser:
         cost_pes = self.case.get_value("COST_PES")
         totalpes = self.case.get_value("TOTALPES")
         pes_per_node = self.case.get_value("PES_PER_NODE")
-        smt_factor = max(1,int(self.get_value("MAX_TASKS_PER_NODE") / pes_per_node))
+        smt_factor = max(1,int(self.case.get_value("MAX_TASKS_PER_NODE") / pes_per_node))
 
         if cost_pes > 0:
             pecost = cost_pes
@@ -246,14 +246,15 @@ class _TimingParser:
                    " instances (stride) \n")
         self.write("  ---------        ------     -------   ------   "
                    "------  ---------  ------  \n")
-
+        maxthrds = 0
         for k in ['CPL', 'GLC', 'WAV', 'LND', 'ROF', 'ICE', 'ATM', 'OCN']:
             m = self.models[k]
             self.write("  %s = %-8s   %-6u      %-6u   %-6u x %-6u  "
                        "%-6u (%-6u) \n"
                        % (m.name.lower(), m.comp, (m.ntasks*m.nthrds *smt_factor), m.rootpe,
                           m.ntasks, m.nthrds, m.ninst, m.pstrid))
-
+            if m.nthrds > maxthrds:
+                maxthrds = m.nthrds
         nmax  = self.gettime(' CPL:INIT ')[1]
         tmax  = self.gettime(' CPL:RUN_LOOP ')[1]
         wtmax = self.gettime(' CPL:TPROF_WRITE ')[1]
@@ -296,7 +297,7 @@ class _TimingParser:
             tmaxr = adays*86400.0/(tmax*365.0)
 
         self.write("\n")
-        self.write("  total pes active           : %s \n" % totalpes)
+        self.write("  total pes active           : %s \n" % (totalpes*maxthrds*smt_factor ))
         self.write("  pes per node               : %s \n" % pes_per_node)
         self.write("  pe count for cost estimate : %s \n" % pecost)
         self.write("\n")

--- a/utils/python/CIME/get_timing.py
+++ b/utils/python/CIME/get_timing.py
@@ -132,6 +132,7 @@ class _TimingParser:
         cost_pes = self.case.get_value("COST_PES")
         totalpes = self.case.get_value("TOTALPES")
         pes_per_node = self.case.get_value("PES_PER_NODE")
+        smt_factor = max(1,int(self.get_value("MAX_TASKS_PER_NODE") / pes_per_node))
 
         if cost_pes > 0:
             pecost = cost_pes
@@ -250,7 +251,7 @@ class _TimingParser:
             m = self.models[k]
             self.write("  %s = %-8s   %-6u      %-6u   %-6u x %-6u  "
                        "%-6u (%-6u) \n"
-                       % (m.name.lower(), m.comp, m.ntasks, m.rootpe,
+                       % (m.name.lower(), m.comp, (m.ntasks*m.nthrds *smt_factor), m.rootpe,
                           m.ntasks, m.nthrds, m.ninst, m.pstrid))
 
         nmax  = self.gettime(' CPL:INIT ')[1]


### PR DESCRIPTION
Corrects some of the output from get_timing to account for threads and smt.   
Updates for cheyenne and yellowstone systems and for intel support for double double
Reduce default output from check_input_data

Test suite: scripts_regression_tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit 

Fixes 

User interface changes?: 

Code review: in progress
