### PR TITLE
Conditionally use undefine in Makefile for backward compatibility

### DIFF
--- a/cime_config/acme/machines/Makefile
+++ b/cime_config/acme/machines/Makefile
@@ -225,7 +225,9 @@ endif
 
 
 ifeq ($(MPILIB),mpi-serial)
-  undefine PNETCDF_PATH
+	ifdef PNETCDF_PATH
+		undefine PNETCDF_PATH
+	endif
 else
   ifdef PNETCDF_PATH
     ifndef $(INC_PNETCDF)


### PR DESCRIPTION
The Makefile undefine directive was included in make 3.82 . Many
machines (e.g. blues, compute001,..) still use make 3.81 . This
fix uses the "undefine" directive only if the variable is already
defined (On machines that use make 3.81 we are careful not to
define the variable, PNETCDF_PATH, when building with mpi-serial).

Test suite: A simple X case
Test baseline: 
Test namelist changes: None
Test status: bit for bit

Fixes #1033

User interface changes?: None

Code review: @jedwards4b 
