### PR TITLE
Fixing mpi-serial builds on compute001

### DIFF
--- a/cime_config/acme/machines/config_machines.xml
+++ b/cime_config/acme/machines/config_machines.xml
@@ -657,13 +657,18 @@
       <cmd_path lang="csh">source /software/common/adm/packages/softenv-1.6.2/etc/softenv-aliases.csh ; soft</cmd_path>
       <cmd_path lang="sh">source /software/common/adm/packages/softenv-1.6.2/etc/softenv-aliases.sh ; soft</cmd_path>
       <modules compiler="gnu">
-	<command name="add">+gcc-6.2.0</command>
-	<command name="add">+szip-2.1-gcc-6.2.0</command>
-	<command name="add" mpilib="!mpi-serial">+mpich-3.2-gcc-6.2.0</command>
-	<command name="add">+hdf5-1.8.16-gcc-6.2.0-mpich-3.2-parallel</command>
-	<command name="add">+netcdf-4.3.3.1c-4.2cxx-4.4.2f-parallel-gcc6.2.0-mpich3.2</command>
-	<command name="add" mpilib="!mpi-serial">+pnetcdf-1.6.1-gcc-6.2.0-mpich-3.2</command>
-	<command name="add">+cmake-2.8.12</command>
+        <command name="add">+gcc-6.2.0</command>
+        <command name="add">+szip-2.1-gcc-6.2.0</command>
+        <command name="add">+cmake-2.8.12</command>
+      </modules>
+      <modules compiler="gnu" mpilib="mpi-serial">
+        <command name="add">+netcdf-4.4.1c-4.2cxx-4.4.4f-serial-gcc6.2.0</command>
+      </modules>
+      <modules compiler="gnu" mpilib="!mpi-serial">
+        <command name="add">+hdf5-1.8.16-gcc-6.2.0-mpich-3.2-parallel</command>
+        <command name="add">+netcdf-4.3.3.1c-4.2cxx-4.4.2f-parallel-gcc6.2.0-mpich3.2</command>
+        <command name="add">+mpich-3.2-gcc-6.2.0</command>
+        <command name="add">+pnetcdf-1.6.1-gcc-6.2.0-mpich-3.2</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
We now only include netcdf-parallel and hdf5 for non-mpi-serial
builds and include netcdf-serial for mpi-serial builds. Without
the fix builds on compute001 with mpi-serial fails due to missing
MPI function (MPI_File*) references (Note that these functions
are not required by ACME+mpi-serial or Netcdf-serial).

Test suite: X case with and without mpi-serial
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #667

User interface changes?: None

Code review: @sarich 
