### PR TITLE
changes to get pop namelists working with user_nl_pop changes

### DIFF
--- a/utils/python/CIME/namelist.py
+++ b/utils/python/CIME/namelist.py
@@ -1401,7 +1401,17 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         while self._curr() not in separators:
             self._advance()
         text = self._text[old_pos:self._pos]
-        if not is_valid_fortran_name(text):
+
+        # @ is used in a namelist to put the same namelist variable in multiple groups
+        # in the write phase, all characters in the namelist variable name after 
+        # the @ and including the @ should be removed
+        if "%" in text:
+            text_check = re.sub('%.+$', "", text)
+        elif "@" in text:
+            text_check = re.sub('@.+$', "", text)
+        else:
+            text_check = text
+        if not is_valid_fortran_name(text_check):
             raise _NamelistParseError("%r is not a valid variable name at %s" %
                                       (str(text), self._line_col_string()))
         return text.lower()


### PR DESCRIPTION
changes to get pop namelists working with user_nl_pop changes

POP has the "feature" that multiple namelist groups often have the same variable name. To distinguish the various names in user_nl_pop settings, an @ symbol is appended to the variable to specify its group. Then this variable is stripped when the namelist is written out. These changes are minimal but permit POP requirements to be met for its namelist.

Test suite: scripts_regression_tests
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

User interface changes?: None

Code review: mvertens
