### PR TITLE
revert intel compiler change on yellowstone

### DIFF
--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -1684,10 +1684,10 @@
 	<command name="load"> esmf-6.3.0rp1-ncdfio-uni-O</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/16.5</command>
+	<command name="load">pgi/15.10</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">gnu/6.1.0</command>
+	<command name="load">gnu/5.2.0</command>
       </modules>
       <modules mpilib="mpi-serial">
 	<command name="load">netcdf/4.3.3.1</command>

--- a/cime_config/cesm/machines/config_machines.xml
+++ b/cime_config/cesm/machines/config_machines.xml
@@ -1666,7 +1666,7 @@
 	<command name="load">git</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/16.0.3</command>
+	<command name="load">intel/15.0.3</command>
 	<command name="load">mkl/11.1.2</command>
 	<command name="load">trilinos/11.10.2</command>
 	<command name="load">esmf</command>
@@ -1690,11 +1690,11 @@
 	<command name="load">gnu/6.1.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">netcdf/4.4.1</command>
+	<command name="load">netcdf/4.3.3.1</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">netcdf-mpi/4.4.1</command>
-	<command name="load">pnetcdf/1.7.0</command>
+	<command name="load">netcdf-mpi/4.3.3.1</command>
+	<command name="load">pnetcdf/1.6.1</command>
       </modules>
       <modules>
 	<command name="load">ncarcompilers/1.0</command>


### PR DESCRIPTION
Backout the compiler update on yellowstone

Test suite:  cesm testing of clm revealed a problem in the intel compiler, confirmed this change reverts the problem 

Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
