### PR TITLE
make sure pio1 finds netcdf4

### DIFF
--- a/cime_config/cesm/machines/Makefile
+++ b/cime_config/cesm/machines/Makefile
@@ -342,33 +342,6 @@ ifdef INC_TRILINOS
   INCLDIR += -I$(INC_TRILINOS)
 endif
 
-ifeq ($(MODEL),driver)
-  INCLDIR += -I$(EXEROOT)/atm/obj -I$(EXEROOT)/ice/obj -I$(EXEROOT)/ocn/obj -I$(EXEROOT)/glc/obj -I$(EXEROOT)/rof/obj -I$(EXEROOT)/wav/obj -I$(EXEROOT)/esp/obj
-# nagfor and gcc have incompatible LDFLAGS.
-# nagfor requires the weird "-Wl,-Wl,," syntax.
-# If done in config_compilers.xml, we break MCT.
-  ifeq ($(strip $(COMPILER)),nag)
-    ifeq ($(NETCDF_SEPARATE), false)
-      SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_PATH)/lib
-    else ifeq ($(NETCDF_SEPARATE), true)
-      SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_C_PATH)/lib
-      SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_FORTRAN_PATH)/lib
-    endif
-  endif
-else
-  ifeq ($(strip $(COMPILER)),nag)
-    ifeq ($(DEBUG), TRUE)
-      ifeq ($(strip $(MACH)),hobart)
-       # GCC needs to be able to link to
-       # nagfor runtime to get autoconf
-       # tests to work.
-	 CFLAGS += -Wl,--as-needed,--allow-shlib-undefined
-	 SLIBS += -L$(COMPILER_PATH)/lib/NAG_Fortran -lf60rts
-       endif
-    endif
-  endif
-endif
-
 ifndef MCT_LIBDIR
   MCT_LIBDIR=$(INSTALL_SHAREDPATH)/lib
 endif
@@ -453,13 +426,41 @@ endif
 
 
 # System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)
-ifndef SLIBS
-  ifeq ($(NETCDF_SEPARATE), false)
-    SLIBS := -L$(LIB_NETCDF) -lnetcdff -lnetcdf
-  else ifeq ($(NETCDF_SEPARATE), true)
-    SLIBS := -L$(LIB_NETCDF_FORTRAN) -L$(LIB_NETCDF_C) -lnetcdff -lnetcdf
+
+ifeq ($(NETCDF_SEPARATE), false)
+  SLIBS += -L$(LIB_NETCDF) -lnetcdff -lnetcdf
+else ifeq ($(NETCDF_SEPARATE), true)
+  SLIBS += -L$(LIB_NETCDF_FORTRAN) -L$(LIB_NETCDF_C) -lnetcdff -lnetcdf
+endif
+
+
+ifeq ($(MODEL),driver)
+  INCLDIR += -I$(EXEROOT)/atm/obj -I$(EXEROOT)/ice/obj -I$(EXEROOT)/ocn/obj -I$(EXEROOT)/glc/obj -I$(EXEROOT)/rof/obj -I$(EXEROOT)/wav/obj -I$(EXEROOT)/esp/obj
+# nagfor and gcc have incompatible LDFLAGS.
+# nagfor requires the weird "-Wl,-Wl,," syntax.
+# If done in config_compilers.xml, we break MCT.
+  ifeq ($(strip $(COMPILER)),nag)
+    ifeq ($(NETCDF_SEPARATE), false)
+      SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_PATH)/lib
+    else ifeq ($(NETCDF_SEPARATE), true)
+      SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_C_PATH)/lib
+      SLIBS += -Wl,-Wl,,-rpath=$(NETCDF_FORTRAN_PATH)/lib
+    endif
+  endif
+else
+  ifeq ($(strip $(COMPILER)),nag)
+    ifeq ($(DEBUG), TRUE)
+      ifeq ($(strip $(MACH)),hobart)
+       # GCC needs to be able to link to
+       # nagfor runtime to get autoconf
+       # tests to work.
+	 CFLAGS += -Wl,--as-needed,--allow-shlib-undefined
+	 SLIBS += -L$(COMPILER_PATH)/lib/NAG_Fortran -lf60rts
+       endif
+    endif
   endif
 endif
+
 ifdef LIB_PNETCDF
    SLIBS += -L$(LIB_PNETCDF) -lpnetcdf
 endif

--- a/externals/pio1/pio/CMakeLists.txt
+++ b/externals/pio1/pio/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 # Netcdf is required
 
 #SET (NETCDF_FIND_COMPONENTS F90)
-FIND_PACKAGE(NetCDF "4.3.3" COMPONENTS Fortran)
+FIND_PACKAGE(NetCDF "4.3.3" COMPONENTS C Fortran)
 IF (${NetCDF_Fortran_FOUND})
   MESSAGE("Building PIO with netcdf support ")
   SET(pio_include_dirs_ ${pio_include_dirs_} ${NetCDF_Fortran_INCLUDE_DIR})
@@ -39,8 +39,6 @@ IF (${NetCDF_Fortran_FOUND})
 ELSE()
   MESSAGE("Building PIO without netcdf support ${NetCDF_C_FOUND} ${NetCDF_Fortran_FOUND}")
 ENDIF ()
-#    SET(bld_PIO_DEFINITIONS ${bld_PIO_DEFINITIONS} -D_NETCDF4)
-
 
 
 # PNetcdf is optional but used by default
@@ -78,6 +76,9 @@ ENDIF()
 IF(NetCDF_Fortran_FOUND)
   SET(pio_include_dirs_ ${pio_include_dirs_} ${NetCDF_Fortran_INCLUDE_DIR})
   SET(bld_PIO_DEFINITIONS ${bld_PIO_DEFINITIONS} -D_NETCDF ${NetCDF_Fortran_DEFINITIONS})
+  if (${NetCDF_C_HAS_PARALLEL})
+    SET(bld_PIO_DEFINITIONS ${bld_PIO_DEFINITIONS} -D_NETCDF4)
+  ENDIF()
 ELSE()
   SET(bld_PIO_DEFINITIONS ${bld_PIO_DEFINITIONS} -D_NONETCDF)
 ENDIF()


### PR DESCRIPTION
The pio1 interface to netcdf4 parallel option was commented out, this fixes it.  Tested on
yellowstone and with nag on hobart

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Code review: 
