### PR TITLE
add --mpilib option to create_test

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -54,7 +54,7 @@ OR
     parser.add_argument("--mpilib", "-mpilib",
                         help="Specify the mpilib. "
                         "To see list of supported mpilibs for each machine, use the utility manage_case in this directory. "
-                        "The default is mpi-serial, but will be replaced by default mpi library for the target machine.")
+                        "The default is the first listing in MPILIBS in config_machines.xml")
 
     parser.add_argument("--project", "-project",
                         help="Specify a project id")

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -122,6 +122,11 @@ OR
                         "NODENAME_REGEX field in config_machines.xml. This option is highly "
                         "unsafe and should only be used if you know what you're doing.")
 
+    parser.add_argument("--mpilib",
+                        help="Specify the mpilib. "
+                        "To see list of supported mpilibs for each machine, use the utility manage_case in this directory. "
+                        "The default is the first listing in MPILIBS in config_machines.xml")
+
     if model == "cesm":
         parser.add_argument("-c", "--compare",
                             help="While testing, compare baselines"
@@ -342,7 +347,7 @@ OR
         args.test_root, args.baseline_root, args.clean, baseline_cmp_name, baseline_gen_name, \
         args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.walltime, \
         args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue, \
-        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads
+        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib
 
 ###############################################################################
 def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost_map, wall_time, test_root):
@@ -448,7 +453,7 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
 def create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                 baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, project, test_id, parallel_jobs,
                 walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite, output_root, wait,
-                force_procs, force_threads):
+                force_procs, force_threads, mpilib):
 ###############################################################################
     impl = TestScheduler(test_names, test_data=test_data,
                          no_run=no_run, no_build=no_build, no_setup=no_setup, no_batch=no_batch,
@@ -460,7 +465,7 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
                          project=project, parallel_jobs=parallel_jobs, walltime=walltime,
                          proc_pool=proc_pool, use_existing=use_existing, save_timing=save_timing,
                          queue=queue, allow_baseline_overwrite=allow_baseline_overwrite,
-                         output_root=output_root, force_procs=force_procs, force_threads=force_threads)
+                         output_root=output_root, force_procs=force_procs, force_threads=force_threads, mpilib=mpilib)
 
     success = impl.run_tests(wait=wait)
 
@@ -501,13 +506,13 @@ def _main_func(description):
     test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, \
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \
-    save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads \
+    save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib \
         = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                          baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only,
                          project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, save_timing,
-                         queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads))
+                         queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib))
 
 ###############################################################################
 

--- a/utils/python/CIME/build.py
+++ b/utils/python/CIME/build.py
@@ -95,9 +95,10 @@ def build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
     bldroot = os.path.join(exeroot, "cpl", "obj")
     if not os.path.isdir(bldroot):
         os.makedirs(bldroot)
+    logger.info("Building %s with output to %s"%(cime_model, file_build))
     stat = run_cmd("%s/buildexe %s %s %s" %
                    (config_dir, caseroot, libroot, bldroot),
-                   from_dir=bldroot, verbose=True, arg_stdout=f,
+                   from_dir=bldroot, verbose=False, arg_stdout=f,
                    arg_stderr=subprocess.STDOUT)[0]
     f.close()
     analyze_build_log("%s exe"%cime_model, file_build, compiler)

--- a/utils/python/CIME/test_scheduler.py
+++ b/utils/python/CIME/test_scheduler.py
@@ -87,14 +87,14 @@ class TestScheduler(object):
                  walltime=None, proc_pool=None,
                  use_existing=False, save_timing=False, queue=None,
                  allow_baseline_overwrite=False, output_root=None,
-                 force_procs=None, force_threads=None):
+                 force_procs=None, force_threads=None, mpilib=None):
     ###########################################################################
         self._cime_root     = CIME.utils.get_cime_root()
         self._cime_model    = CIME.utils.get_model()
         self._save_timing   = save_timing
         self._queue         = queue
         self._test_data     = {} if test_data is None else test_data # Format:  {test_name -> {data_name -> data}}
-
+        self._mpilib = mpilib  # allow override of default mpilib
         self._allow_baseline_overwrite  = allow_baseline_overwrite
 
         self._machobj = Machines(machine=machine_name)
@@ -374,7 +374,7 @@ class TestScheduler(object):
                 self._log_output(test, "Missing testmod file '%s'" % test_mod_file)
                 return False
             create_newcase_cmd += " --user-mods-dir %s" % test_mod_file
-
+        mpilib = None
         if case_opts is not None:
             for case_opt in case_opts: # pylint: disable=not-an-iterable
                 if case_opt.startswith('M'):
@@ -388,6 +388,12 @@ class TestScheduler(object):
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]
                     create_newcase_cmd += " --pecount %s"%pesize
+
+        # create_test mpilib option overrides default but not explicitly set case_opt mpilib
+        if mpilib is None and self._mpilib is not None:
+            create_newcase_cmd += " --mpilib %s" % self._mpilib
+            logger.debug (" MPILIB set to %s" % self._mpilib)
+
 
         if self._queue is not None:
             create_newcase_cmd += " --queue=%s" % self._queue


### PR DESCRIPTION
Add an mpilib option to create_test, this option will override the default but not any mpilib
explicitly added in an _M testname modifier. 
Test suite: scripts_regression_tests & create_test cime_developer --mpilib mpi-serial
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1083 

User interface changes?: adds --mpilib optional argument to create_test

Code review: 
