### PR TITLE
Add S-case test to cime_developers

### DIFF
--- a/utils/python/update_acme_tests.py
+++ b/utils/python/update_acme_tests.py
@@ -47,7 +47,8 @@ _TEST_SUITES = {
                              "ERR.f45_g37_rx1.A",
                              "ERP.f45_g37_rx1.A",
                              "SMS_D_Ln9.f19_g16_rx1.A",
-                             "DAE.f19_f19.A")
+                             "DAE.f19_f19.A",
+                             "SMS.T42_T42.S")
 #                             "PRE.f19_f19.ADESP")
                             ),
 


### PR DESCRIPTION
S-cases were supported but not tested, so adding 1 test:  SMS.T42_T42.S

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes: #1179 

User interface changes?: No

Code review: 
