### PR TITLE
add dart to all cesm archive rules, add components element

### DIFF
--- a/cime_config/acme/config_files.xml
+++ b/cime_config/acme/config_files.xml
@@ -120,6 +120,30 @@
     <desc>file containing specification of all pe-layouts for primary component (for documentation only - DO NOT EDIT)</desc>
     <schema>$CIMEROOT/cime_config/xml_schemas/config_pes.xsd</schema>
   </entry>
+  <entry id="ARCHIVE_SPEC_FILE">
+    <type>char</type>
+    <values>
+      <value>$CIMEROOT/cime_config/acme/config_archive.xml</value>
+      <value component="cpl"      >$CIMEROOT/driver_cpl/cime_config/config_archive.xml</value>
+      <!-- data model components -->
+      <value component="drof">$CIMEROOT/components/data_comps/drof/cime_config/config_archive.xml</value>
+      <value component="datm">$CIMEROOT/components/data_comps/datm/cime_config/config_archive.xml</value>
+      <value component="dice">$CIMEROOT/components/data_comps/dice/cime_config/config_archive.xml</value>
+      <value component="dlnd">$CIMEROOT/components/data_comps/dlnd/cime_config/config_archive.xml</value>
+      <value component="docn">$CIMEROOT/components/data_comps/docn/cime_config/config_archive.xml</value>
+      <value component="dwav">$CIMEROOT/components/data_comps/dwav/cime_config/config_archive.xml</value>
+      <!-- external model components -->
+<!--      <value component="cam"      >$SRCROOT/components/cam/cime_config/config_archive.xml</value>
+      <value component="cism"     >$SRCROOT/components/cism/cime_config/config_archive.xml</value>
+      <value component="clm"      >$SRCROOT/components/clm/cime_config/config_archive.xml</value>
+      <value component="cice"     >$SRCROOT/components/cice/cime_config/config_archive.xml</value>
+      <value component="pop"      >$SRCROOT/components/pop/cime_config/config_archive.xml</value> -->
+    </values>
+    <group>case_last</group>
+    <file>env_case.xml</file>
+    <desc>file containing specification of archive files for each component (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/cime_config/xml_schemas/config_archive.xsd</schema>
+  </entry>
 
   <entry id="SYSTEM_TESTS_DIR">
     <type>char</type>

--- a/cime_config/config_headers.xml
+++ b/cime_config/config_headers.xml
@@ -76,8 +76,8 @@
       These are the variables specific to the short term archiver.
       See  ./case.st_archive --help for details on running the short term archiver script.
       To validate the env_archive.xml file using xmllint, run
-      xmllint -schema $SRCROOT/cime/cime_config/xml_schemas/config_archive.xsd env_archive.xml
-      from the case root. (Currently broken - see issue #1185)
+      xmllint -schema $SRCROOT/cime/cime_config/xml_schemas/env_archive.xsd env_archive.xml
+      from the case root. 
     </header>
   </file>
 

--- a/cime_config/config_headers.xml
+++ b/cime_config/config_headers.xml
@@ -31,7 +31,7 @@
   <file name ="env_mach_specific.xml">
     <header>
     These variables control the machine dependent environment including
-    the paths to compilers and libraries external to cime such as netcdf, 
+    the paths to compilers and libraries external to cime such as netcdf,
     environment variables for use in the running job should also be set	here.
     </header>
   </file>
@@ -73,12 +73,11 @@
 
   <file name="env_archive.xml">
     <header>
-    These are the variables specific to the short term archiver. 
-    For a detailed listing of the env_archive.xml file, run
-    ./st_archive -help
-    To validate the env_archive.xml file using xmllint, run
-    xmllint -schema Tools/archive.xsd env_archive.xml
-    from the case root.
+      These are the variables specific to the short term archiver.
+      See  ./case.st_archive --help for details on running the short term archiver script.
+      To validate the env_archive.xml file using xmllint, run
+      xmllint -schema $SRCROOT/cime/cime_config/xml_schemas/config_archive.xsd env_archive.xml
+      from the case root. (Currently broken - see issue #1185)
     </header>
   </file>
 

--- a/cime_config/xml_schemas/entry_id.xsd
+++ b/cime_config/xml_schemas/entry_id.xsd
@@ -2,6 +2,9 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
   <xs:include schemaLocation="entry_id_base.xsd"/>
   <xs:element name="type" type="xs:NCName"/>
+  <xs:element name="group" type="xs:NCName"/>
+  <xs:element name="file" type="xs:NCName"/>
+
 <!-- complex elements -->
   <xs:element name="entry">
     <xs:complexType>

--- a/cime_config/xml_schemas/entry_id_base.xsd
+++ b/cime_config/xml_schemas/entry_id_base.xsd
@@ -12,11 +12,10 @@
   <!-- simple elements -->
   <xs:element name="help" type="xs:string"/>
   <xs:element name="default_value" type="xs:string"/>
-  <xs:element name="file" type="xs:NCName"/>
-  <xs:element name="group" type="xs:NCName"/>
   <xs:element name="valid_values" type="xs:string"/>
   <xs:element name="schema" type="xs:string"/>
   <xs:element name="category" type="xs:string"/>
+  <xs:element name="header" type="xs:string"/>
 
   <!-- complex elements -->
   <xs:element name="value">

--- a/cime_config/xml_schemas/entry_id_namelist.xsd
+++ b/cime_config/xml_schemas/entry_id_namelist.xsd
@@ -10,6 +10,8 @@
   <!-- simple elements -->
   <xs:element name="type" type="xs:string"/>
   <xs:element name="input_pathname" type="xs:NCName"/>
+  <xs:element name="group" type="xs:NCName"/>
+  <xs:element name="file" type="xs:NCName"/>
 
 <!-- complex elements -->
   <xs:element name="entry">

--- a/cime_config/xml_schemas/env_archive.xsd
+++ b/cime_config/xml_schemas/env_archive.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:include schemaLocation="config_archive.xsd"/>
+  <xs:attribute name="id" type="xs:string"/>
+
+  <xs:element name="header" type="xs:string"/>
+<!-- complex elements -->
+  <xs:element name="file">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="header" />
+	<xs:element ref="components" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute ref="id"/>
+      <xs:attribute ref="version"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/cime_config/xml_schemas/env_entry_id.xsd
+++ b/cime_config/xml_schemas/env_entry_id.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:include schemaLocation="entry_id_base.xsd"/>
+
+  <xs:attribute name="value" type="xs:string"/>
+
+  <xs:element name="type" type="xs:NCName"/>
+<!-- complex elements -->
+
+
+  <xs:element name="entry">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+	<xs:element ref="type"/>
+	<xs:element ref="valid_values"/>
+	<xs:element ref="default_value"/>
+	<xs:element ref="file"/>
+	<xs:element ref="values"/>
+	<xs:element ref="desc"/>
+	<xs:element ref="schema" minOccurs="0"/>
+      </xs:choice>
+      <xs:attribute ref="id" use="required"/>
+      <xs:attribute ref="value" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="group">
+    <xs:complexType>
+      <xs:choice>
+	<xs:element ref="entry" maxOccurs="unbounded"/>
+      </xs:choice>
+      <xs:attribute ref="id" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="file">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="header" />
+	<xs:element ref="group" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute ref="id"/>
+      <xs:attribute ref="version"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/utils/python/CIME/XML/archive.py
+++ b/utils/python/CIME/XML/archive.py
@@ -6,7 +6,7 @@ Interface to the archive.xml file.  This class inherits from GenericXML.py
 from CIME.XML.standard_module_setup import *
 from CIME.XML.generic_xml import GenericXML
 from CIME.XML.files import Files
-from CIME.utils import expect
+from CIME.utils import expect, get_model
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +26,16 @@ class Archive(GenericXML):
         if files is None:
             files = Files()
 
+        components_node = ET.Element("components")
+        components_node.set("version", "2.0")
+
+
+        model = get_model()
         if 'cpl' not in components:
             components.append('cpl')
+        if 'dart' not in components and model == 'cesm':
+            components.append('dart')
+
         for comp in components:
             infile = files.get_value("ARCHIVE_SPEC_FILE", {"component":comp})
 
@@ -45,5 +53,6 @@ class Archive(GenericXML):
                 logger.debug("No archive specs found for component %s"%comp)
             else:
                 logger.debug("adding archive spec for %s"%comp)
-                env_archive.add_child(specs)
+                components_node.append(specs)
+        env_archive.add_child(components_node)
 

--- a/utils/python/CIME/XML/env_archive.py
+++ b/utils/python/CIME/XML/env_archive.py
@@ -26,9 +26,8 @@ class EnvArchive(GenericXML):
         else:
             fullpath = os.path.join(case_root, infile)
 
-        # Initialize self
-        # If env_archive.xml file does not exists in case directory read default from config
-        GenericXML.__init__(self, fullpath)
+        schema = os.path.join(get_cime_root(), "cime_config", "xml_schemas", "env_archive.xsd")
+        GenericXML.__init__(self, fullpath, schema=schema)
 
         # The following creates the CASEROOT/env_archive.xml contents in self.root
         if not os.path.isfile(fullpath):

--- a/utils/python/CIME/XML/env_base.py
+++ b/utils/python/CIME/XML/env_base.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class EnvBase(EntryID):
 
-    def __init__(self, case_root, infile):
+    def __init__(self, case_root, infile, schema=None):
         if case_root is None:
             case_root = os.getcwd()
 
@@ -19,7 +19,7 @@ class EnvBase(EntryID):
         else:
             fullpath = os.path.join(case_root, infile)
 
-        EntryID.__init__(self, fullpath)
+        EntryID.__init__(self, fullpath, schema=schema)
         if not os.path.isfile(fullpath):
             headerobj = Headers()
             headernode = headerobj.get_header_node(os.path.basename(fullpath))

--- a/utils/python/CIME/XML/env_build.py
+++ b/utils/python/CIME/XML/env_build.py
@@ -13,4 +13,5 @@ class EnvBuild(EnvBase):
         """
         initialize an object interface to file env_build.xml in the case directory
         """
-        EnvBase.__init__(self, case_root, infile)
+        schema = os.path.join(get_cime_root(), "cime_config", "xml_schemas", "env_entry_id.xsd")
+        EnvBase.__init__(self, case_root, infile, schema=schema)

--- a/utils/python/CIME/XML/env_case.py
+++ b/utils/python/CIME/XML/env_case.py
@@ -13,4 +13,5 @@ class EnvCase(EnvBase):
         """
         initialize an object interface to file env_case.xml in the case directory
         """
-        EnvBase.__init__(self, case_root, infile)
+        schema = os.path.join(get_cime_root(), "cime_config", "xml_schemas", "env_entry_id.xsd")
+        EnvBase.__init__(self, case_root, infile, schema=schema)

--- a/utils/python/CIME/XML/env_run.py
+++ b/utils/python/CIME/XML/env_run.py
@@ -16,7 +16,8 @@ class EnvRun(EnvBase):
         self._components = components
         self._component_value_list = ["PIO_TYPENAME", "PIO_STRIDE", "PIO_REARRANGER",
                                       "PIO_NUMTASKS", "PIO_ROOT"]
-        EnvBase.__init__(self, case_root, infile)
+        schema = os.path.join(get_cime_root(), "cime_config", "xml_schemas", "env_entry_id.xsd")
+        EnvBase.__init__(self, case_root, infile, schema=schema)
 
 
 

--- a/utils/python/CIME/XML/generic_xml.py
+++ b/utils/python/CIME/XML/generic_xml.py
@@ -5,7 +5,6 @@ be used by other XML interface modules and not directly.
 from CIME.XML.standard_module_setup import *
 from distutils.spawn import find_executable
 from xml.dom import minidom
-from CIME.utils import expect, get_cime_root
 
 import getpass
 
@@ -41,6 +40,7 @@ class GenericXML(object):
             root = ET.Element("xml")
             self.root = ET.SubElement(root, "file")
             self.root.set("id", os.path.basename(infile))
+            self.root.set("version", "2.0")
             self.tree = ET.ElementTree(root)
 
     def read(self, infile, schema=None):

--- a/utils/python/CIME/XML/standard_module_setup.py
+++ b/utils/python/CIME/XML/standard_module_setup.py
@@ -8,4 +8,4 @@ import xml.etree.ElementTree as ET
 import re
 LIB_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(LIB_DIR)
-from CIME.utils import expect, run_cmd, run_cmd_no_fail
+from CIME.utils import expect, run_cmd, run_cmd_no_fail, get_cime_root


### PR DESCRIPTION
Adds the dart component to all cesm cases.  Since it's external and not a component this is the
safest way to assure that it's available. 

Test suite: scripts_regression_tests.py several tests of create_newcase with comparison of env_archive.xml to previous versions.  ERR.f09_g16.B1850 using cesm2_0_alpha06d
A, B, and F compsets were created and the env_archive.xml file was checked for correctness
several rounds of introducing errors to env_run.xml, env_case.xml, env_build.xml and env_archive.xml were conducted assuring that the schema check was working.
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: mvertens
