### PR TITLE
case.build will now remake key directories.

### DIFF
--- a/config/acme/config_files.xml
+++ b/config/acme/config_files.xml
@@ -124,7 +124,7 @@
     <type>char</type>
     <values>
       <value>$CIMEROOT/config/acme/config_archive.xml</value>
-      <value component="cpl"      >$CIMEROOT/drivers/mct/cime_config/config_archive.xml</value>
+      <value component="cpl"      >$CIMEROOT/src/drivers/mct/cime_config/config_archive.xml</value>
       <!-- data model components -->
       <value component="drof">$CIMEROOT/src/components/data_comps/drof/cime_config/config_archive.xml</value>
       <value component="datm">$CIMEROOT/src/components/data_comps/datm/cime_config/config_archive.xml</value>
@@ -133,11 +133,11 @@
       <value component="docn">$CIMEROOT/src/components/data_comps/docn/cime_config/config_archive.xml</value>
       <value component="dwav">$CIMEROOT/src/components/data_comps/dwav/cime_config/config_archive.xml</value>
       <!-- external model components -->
-<!--      <value component="cam"      >$SRCROOT/components/cam/cime_config/config_archive.xml</value>
+      <value component="cam"      >$SRCROOT/components/cam/cime_config/config_archive.xml</value>
       <value component="cism"     >$SRCROOT/components/cism/cime_config/config_archive.xml</value>
       <value component="clm"      >$SRCROOT/components/clm/cime_config/config_archive.xml</value>
       <value component="cice"     >$SRCROOT/components/cice/cime_config/config_archive.xml</value>
-      <value component="pop"      >$SRCROOT/components/pop/cime_config/config_archive.xml</value> -->
+      <value component="pop"      >$SRCROOT/components/pop/cime_config/config_archive.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/config/acme/config_files.xml
+++ b/config/acme/config_files.xml
@@ -144,30 +144,6 @@
     <desc>file containing specification of archive files for each component (for documentation only - DO NOT EDIT)</desc>
     <schema>$CIMEROOT/config/xml_schemas/config_archive.xsd</schema>
   </entry>
-  <entry id="ARCHIVE_SPEC_FILE">
-    <type>char</type>
-    <values>
-      <value>$CIMEROOT/cime_config/acme/config_archive.xml</value>
-      <value component="cpl"      >$CIMEROOT/driver_cpl/cime_config/config_archive.xml</value>
-      <!-- data model components -->
-      <value component="drof">$CIMEROOT/components/data_comps/drof/cime_config/config_archive.xml</value>
-      <value component="datm">$CIMEROOT/components/data_comps/datm/cime_config/config_archive.xml</value>
-      <value component="dice">$CIMEROOT/components/data_comps/dice/cime_config/config_archive.xml</value>
-      <value component="dlnd">$CIMEROOT/components/data_comps/dlnd/cime_config/config_archive.xml</value>
-      <value component="docn">$CIMEROOT/components/data_comps/docn/cime_config/config_archive.xml</value>
-      <value component="dwav">$CIMEROOT/components/data_comps/dwav/cime_config/config_archive.xml</value>
-      <!-- external model components -->
-<!--      <value component="cam"      >$SRCROOT/components/cam/cime_config/config_archive.xml</value>
-      <value component="cism"     >$SRCROOT/components/cism/cime_config/config_archive.xml</value>
-      <value component="clm"      >$SRCROOT/components/clm/cime_config/config_archive.xml</value>
-      <value component="cice"     >$SRCROOT/components/cice/cime_config/config_archive.xml</value>
-      <value component="pop"      >$SRCROOT/components/pop/cime_config/config_archive.xml</value> -->
-    </values>
-    <group>case_last</group>
-    <file>env_case.xml</file>
-    <desc>file containing specification of archive files for each component (for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/cime_config/xml_schemas/config_archive.xsd</schema>
-  </entry>
 
   <entry id="SYSTEM_TESTS_DIR">
     <type>char</type>

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -69,9 +69,3 @@ def _main_func(description):
 
 if __name__ == "__main__":
     _main_func(__doc__)
-
-
-
-
-
-

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -4,7 +4,7 @@ functions for building CIME models
 from CIME.XML.standard_module_setup  import *
 from CIME.utils                 import get_model, append_status, analyze_build_log, stringify_bool
 from CIME.provenance            import save_build_provenance
-from CIME.preview_namelists     import create_namelists
+from CIME.preview_namelists     import create_namelists, create_dirs
 from CIME.check_lockedfiles     import check_lockedfiles, lock_file, unlock_file
 import glob, shutil, time, threading, gzip, subprocess
 
@@ -406,6 +406,9 @@ ERROR MPILIB is mpi-serial and USE_ESMF_LIB IS TRUE
 """)
 
     case.set_value("BUILD_COMPLETE", False)
+
+    # User may have rm -rf their build directory
+    create_dirs(case)
 
     case.flush()
     if not model_only:

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -12,12 +12,11 @@ def create_dirs(case):
     Make necessary directories for case
     """
     # Get data from XML
-    exeroot = case.get_value("EXEROOT")
-    libroot = case.get_value("LIBROOT")
-    incroot = case.get_value("INCROOT")
-    rundir = case.get_value("RUNDIR")
+    exeroot  = case.get_value("EXEROOT")
+    libroot  = case.get_value("LIBROOT")
+    incroot  = case.get_value("INCROOT")
+    rundir   = case.get_value("RUNDIR")
     caseroot = case.get_value("CASEROOT")
-
 
     docdir = os.path.join(caseroot, "CaseDocs")
     dirs_to_make = []
@@ -76,7 +75,7 @@ def create_namelists(case):
         try:
             with open(cmd, 'r') as f:
                 first_line = f.readline()
-            if "python" in first_line:    
+            if "python" in first_line:
                 logger.info("   Calling %s buildnml"%compname)
                 mod = imp.load_source("buildnml", cmd)
                 mod.buildnml(case, caseroot, compname)
@@ -97,9 +96,9 @@ def create_namelists(case):
             case.flush()
             run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=False)
             # refresh case xml object from file
-            case.read_xml()            
-    logger.info("Finished creating component namelists")
+            case.read_xml()
 
+    logger.info("Finished creating component namelists")
 
     # Save namelists to docdir
     if (not os.path.isdir(docdir)):
@@ -109,7 +108,6 @@ def create_namelists(case):
                 fd.write(" CESM Resolved Namelist Files\n   For documentation only DO NOT MODIFY\n")
         except (OSError, IOError) as e:
             expect(False, "Failed to write %s/README: %s" % (docdir, e))
-
 
     for cpglob in ["*_in_[0-9]*", "*modelio*", "*_in",
                    "*streams*txt*", "*stxt", "*maps.rc", "*cism.config*"]:

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -46,6 +46,8 @@ def create_namelists(case):
     """
     case.flush()
 
+    create_dirs(case)
+
     casebuild = case.get_value("CASEBUILD")
     caseroot = case.get_value("CASEROOT")
     rundir = case.get_value("RUNDIR")

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -201,12 +201,13 @@ class N_TestUnitTest(unittest.TestCase):
 
         machine           = MACHINE.get_machine_name()
         compiler          = MACHINE.get_default_compiler()
-        test_dir = os.path.join(cls._testroot,"driver_f90_tests")
-        cls._testdirs.append(test_dir)
-        os.makedirs(test_dir)
         if (machine != "yellowstone" or compiler != "intel"):
             #TODO: get rid of this restriction
             self.skipTest("Skipping TestUnitTest - only supported on yellowstone with intel")
+
+        test_dir = os.path.join(cls._testroot,"driver_f90_tests")
+        cls._testdirs.append(test_dir)
+        os.makedirs(test_dir)
         test_spec_dir = CIME.utils.get_cime_root()
         unit_test_tool = os.path.abspath(os.path.join(test_spec_dir,"tools","unit_testing","run_tests.py"))
 
@@ -226,10 +227,9 @@ class N_TestUnitTest(unittest.TestCase):
                 teardown_root = False
             elif do_teardown:
                 shutil.rmtree(tfile)
-        if teardown_root:
+
+        if teardown_root and do_teardown:
             shutil.rmtree(cls._testroot)
-
-
 
 ###############################################################################
 class J_TestCreateNewcase(unittest.TestCase):


### PR DESCRIPTION
Allows user to rm -rf their build area and rebuild without having
to re-run case.setup.

Also:
1) Fix merge error that duplicated ARCHIVE_SPEC_FILE
2) Whitespace improvement around in several places
3) Fix bug in N_TestUnitTest that was sometimes causing it
   to try to remove directory that didn't exist.

Test suite: scripts_regression_tests.py --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1035 #1189 

User interface changes?: case.build behavior slightly different

Code review: @agsalin @jedwards4b 
