### PR TITLE
Big refactor of CaseStatus management

### DIFF
--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -7,8 +7,8 @@ Script to build a case.
 from standard_script_setup import *
 
 import CIME.build as build
-from CIME.case           import Case
-from CIME.utils           import  append_status, find_system_test
+from CIME.case            import Case
+from CIME.utils           import find_system_test
 from CIME.XML.files       import Files
 from CIME.XML.component   import Component
 from CIME.test_status     import *
@@ -94,20 +94,10 @@ def _main_func(description):
                     ts.set_status(phase_to_fail, TEST_FAIL_STATUS, comments="failed to initialize")
                 raise
 
-            append_status("case.testbuild starting ",
-                          caseroot=caseroot,sfile="CaseStatus")
             success = test.build(sharedlib_only=sharedlib_only, model_only=model_only)
-            if success:
-                append_status("case.testbuild complete",
-                              caseroot=caseroot,sfile="CaseStatus")
         else:
-            append_status("case.build starting",
-                          caseroot=caseroot,sfile="CaseStatus")
             success = build.case_build(caseroot, case=case, sharedlib_only=sharedlib_only,
-                             model_only=model_only)
-            if success:
-                append_status("case.build complete",
-                              caseroot=caseroot,sfile="CaseStatus")
+                                       model_only=model_only)
 
     sys.exit(0 if success else 1)
 

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -12,7 +12,7 @@
 
 from standard_script_setup import *
 
-from CIME.utils import expect, convert_to_type, append_status
+from CIME.utils import expect, convert_to_type, append_case_status
 from CIME.case import Case
 
 import re
@@ -135,7 +135,7 @@ def xmlchange(caseroot, listofsettings=None, xmlid=None, xmlval=None, subgroup=N
         for arg in sys.argv:
             argstr += "%s "%arg
         msg = "<command> %s </command>" % (argstr)
-        append_status(msg, caseroot=caseroot, sfile="CaseStatus")
+        append_case_status("xmlchange", "success", msg=msg, caseroot=caseroot)
 
 def _main_func(description):
     if ("--test" in sys.argv):

--- a/scripts/lib/CIME/SystemTests/homme.py
+++ b/scripts/lib/CIME/SystemTests/homme.py
@@ -4,7 +4,7 @@ CIME HOMME test. This class inherits from SystemTestsCommon
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.build import post_build
-from CIME.utils import append_status
+from CIME.utils import append_testlog
 import shutil
 
 logger = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ class HOMME(SystemTestsCommon):
         # Add homme.log output to TestStatus.log so that it can
         # appear on the dashboard. Otherwise, the TestStatus.log
         # is pretty useless for this test.
-        append_status(open(log, "r").read(), sfile="TestStatus.log")
+        append_testlog(open(log, "r").read())
 
     # Homme is a bit of an oddball test since it's not really running the ACME model
     # We need to override some methods to make the core infrastructure work.

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -3,7 +3,7 @@ Base class for CIME system tests
 """
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_run import EnvRun
-from CIME.utils import append_status
+from CIME.utils import append_testlog
 from CIME.case_setup import case_setup
 from CIME.case_run import case_run
 from CIME.case_st_archive import case_st_archive
@@ -89,7 +89,7 @@ class SystemTestsCommon(object):
                     success = False
                     excmsg = "Exception during build:\n%s\n%s" % (sys.exc_info()[1], traceback.format_exc())
                     logger.warning(excmsg)
-                    append_status(excmsg, sfile="TestStatus.log")
+                    append_testlog(excmsg)
 
                 time_taken = time.time() - start_time
                 with self._test_status:
@@ -150,7 +150,7 @@ class SystemTestsCommon(object):
             success = False
             excmsg = "Exception during run:\n%s\n%s" % (sys.exc_info()[1], traceback.format_exc())
             logger.warning(excmsg)
-            append_status(excmsg, sfile="TestStatus.log")
+            append_testlog(excmsg)
 
         # Writing the run status should be the very last thing due to wait_for_tests
         time_taken = time.time() - start_time
@@ -225,7 +225,7 @@ class SystemTestsCommon(object):
 
     def _component_compare_copy(self, suffix):
         comments = copy(self._case, suffix)
-        append_status(comments, sfile="TestStatus.log")
+        append_testlog(comments)
 
     def _component_compare_test(self, suffix1, suffix2):
         """
@@ -233,7 +233,7 @@ class SystemTestsCommon(object):
         run case needs indirection based on success.
         """
         success, comments = compare_test(self._case, suffix1, suffix2)
-        append_status(comments, sfile="TestStatus.log")
+        append_testlog(comments)
         status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
         with self._test_status:
             self._test_status.set_status("%s_%s_%s" % (COMPARE_PHASE, suffix1, suffix2), status)
@@ -300,7 +300,7 @@ class SystemTestsCommon(object):
                     self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS)
                 else:
                     comment = "memleak detected, memory went from %f to %f in %d days" % (originalmem, finalmem, finaldate-originaldate)
-                    append_status(comment, sfile="TestStatus.log")
+                    append_testlog(comment)
                     self._test_status.set_status(MEMLEAK_PHASE, TEST_FAIL_STATUS, comments=comment)
 
     def compare_env_run(self, expected=None):
@@ -339,7 +339,7 @@ class SystemTestsCommon(object):
         with self._test_status:
             # compare baseline
             success, comments = compare_baseline(self._case)
-            append_status(comments, sfile="TestStatus.log")
+            append_testlog(comments)
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             ts_comments = comments if "\n" not in comments else None
             self._test_status.set_status(BASELINE_PHASE, status, comments=ts_comments)
@@ -361,7 +361,7 @@ class SystemTestsCommon(object):
                 else:
                     comment = "Error: Memory usage increase > 10% from baseline"
                     self._test_status.set_status(MEMCOMP_PHASE, TEST_FAIL_STATUS, comments=comment)
-                    append_status(comment, sfile="TestStatus.log")
+                    append_testlog(comment)
 
             # compare throughput to baseline
             current = self._get_throughput(newestcpllogfile)
@@ -374,7 +374,7 @@ class SystemTestsCommon(object):
                 else:
                     comment = "Error: Computation time increase > 25% from baseline"
                     self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
-                    append_status(comment, sfile="TestStatus.log")
+                    append_testlog(comment)
 
     def _generate_baseline(self):
         """
@@ -383,7 +383,7 @@ class SystemTestsCommon(object):
         with self._test_status:
             # generate baseline
             success, comments = generate_baseline(self._case)
-            append_status(comments, sfile="TestStatus.log")
+            append_testlog(comments)
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             self._test_status.set_status("%s" % GENERATE_PHASE, status)
             basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -2,7 +2,7 @@
 functions for building CIME models
 """
 from CIME.XML.standard_module_setup  import *
-from CIME.utils                 import get_model, append_status, analyze_build_log, stringify_bool
+from CIME.utils                 import get_model, analyze_build_log, stringify_bool, run_and_log_case_status
 from CIME.provenance            import save_build_provenance
 from CIME.preview_namelists     import create_namelists, create_dirs
 from CIME.check_lockedfiles     import check_lockedfiles, lock_file, unlock_file
@@ -11,8 +11,8 @@ import glob, shutil, time, threading, gzip, subprocess
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
-                lid, caseroot, cimeroot, compiler):
+def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
+                 lid, caseroot, cimeroot, compiler):
 ###############################################################################
     logs = []
 
@@ -112,40 +112,262 @@ def build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
     return logs
 
 ###############################################################################
-def post_build(case, logs):
+def _build_checks(case, build_threaded, comp_interface, use_esmf_lib,
+                  debug, compiler, mpilib, complist, ninst_build, smp_value,
+                  model_only):
+###############################################################################
+    """
+    check if a build needs to be done and warn if a clean is warrented first
+    returns the relative sharedpath directory for sharedlibraries
+    """
+    ninst_value  = case.get_value("NINST_VALUE")
+    smp_build    = case.get_value("SMP_BUILD")
+    build_status = case.get_value("BUILD_STATUS")
+
+    smpstr = ""
+    inststr = ""
+    for model, _, nthrds, ninst, _ in complist:
+        if nthrds > 1:
+            build_threaded = True
+        if build_threaded:
+            smpstr += "%s1"%model[0]
+        else:
+            smpstr += "%s0"%model[0]
+        inststr += "%s%d"%(model[0],ninst)
+
+    if build_threaded:
+        os.environ["SMP"] = "TRUE"
+    else:
+        os.environ["SMP"] = "FALSE"
+    case.set_value("SMP_VALUE", smpstr)
+    os.environ["SMP_VALUE"] = smpstr
+    case.set_value("NINST_VALUE", inststr)
+    os.environ["NINST_VALUE"] = inststr
+
+
+    debugdir = "debug" if debug else "nodebug"
+    threaddir = "threads" if (os.environ["SMP"] == "TRUE" or build_threaded) else "nothreads"
+    sharedpath = os.path.join(compiler, mpilib, debugdir, threaddir)
+
+    logger.debug("compiler=%s mpilib=%s debugdir=%s threaddir=%s"%
+                 (compiler,mpilib,debugdir,threaddir))
+
+    expect( ninst_build == ninst_value or ninst_build == "0",
+            """
+ERROR, NINST VALUES HAVE CHANGED
+  NINST_BUILD = %s
+  NINST_VALUE = %s
+  A manual clean of your obj directories is strongly recommended
+  You should execute the following:
+    ./case.build --clean
+  Then rerun the build script interactively
+  ---- OR ----
+  You can override this error message at your own risk by executing:
+    ./xmlchange -file env_build.xml -id NINST_BUILD -val 0
+  Then rerun the build script interactively
+""" % (ninst_build, ninst_value))
+
+    expect( smp_build == smpstr or smp_build == "0",
+            """
+ERROR, SMP VALUES HAVE CHANGED
+  SMP_BUILD = %s
+  SMP_VALUE = %s
+  smpstr = %s
+  A manual clean of your obj directories is strongly recommended
+  You should execute the following:
+    ./case.build --clean
+  Then rerun the build script interactively
+  ---- OR ----
+  You can override this error message at your own risk by executing:
+    ./xmlchange -file env_build.xml -id SMP_BUILD -val 0
+  Then rerun the build script interactively
+""" % (smp_build, smp_value, smpstr))
+
+    expect(build_status == 0,
+           """
+ERROR env_build HAS CHANGED
+  A manual clean of your obj directories is required
+  You should execute the following:
+    ./case.build --clean-all
+""")
+
+    expect(comp_interface != "ESMF" or use_esmf_lib,
+           """
+ERROR COMP_INTERFACE IS ESMF BUT USE_ESMF_LIB IS NOT TRUE
+  SET USE_ESMF_LIB to TRUE with:
+    ./xmlchange -file env_build.xml -id USE_ESMF_LIB -value TRUE
+""")
+
+    expect(mpilib != "mpi-serial" or not use_esmf_lib,
+           """
+ERROR MPILIB is mpi-serial and USE_ESMF_LIB IS TRUE
+  MPILIB can only be used with an ESMF library built with mpiuni on
+  Set USE_ESMF_LIB to FALSE with
+    ./xmlchange -file env_build.xml -id USE_ESMF_LIB -val FALSE
+  ---- OR ----
+  Make sure the ESMF_LIBDIR used was built with mipuni (or change it to one that was)
+  And comment out this if block in Tools/models_buildexe
+""")
+
+    case.set_value("BUILD_COMPLETE", False)
+
+    # User may have rm -rf their build directory
+    create_dirs(case)
+
+    case.flush()
+    if not model_only:
+        logger.info("Generating component namelists as part of build")
+        create_namelists(case)
+
+    return sharedpath
+
+###############################################################################
+def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid, compiler):
 ###############################################################################
 
-    logdir = case.get_value("LOGDIR")
+    shared_lib = os.path.join(exeroot, sharedpath, "lib")
+    shared_inc = os.path.join(exeroot, sharedpath, "include")
+    for shared_item in [shared_lib, shared_inc]:
+        if (not os.path.exists(shared_item)):
+            os.makedirs(shared_item)
+    mpilib = case.get_value("MPILIB")
+    libs = ["gptl", "mct", "pio", "csm_share"]
+    if mpilib == "mpi-serial":
+        libs.insert(0, mpilib)
+    logs = []
+    sharedlibroot = case.get_value("SHAREDLIBROOT")
+    for lib in libs:
+        if lib == "csm_share":
+            # csm_share adds its own dir name
+            full_lib_path = os.path.join(sharedlibroot, sharedpath)
+        elif lib == "mpi-serial":
+            full_lib_path = os.path.join(sharedlibroot, sharedpath, "mct", lib)
+        else:
+            full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
+        # pio build creates its own directory
+        if (lib != "pio" and not os.path.exists(full_lib_path)):
+            os.makedirs(full_lib_path)
 
-    #zip build logs to CASEROOT/logs
-    if logdir:
-        bldlogdir = os.path.join(logdir, "bld")
-        if not os.path.exists(bldlogdir):
-            os.makedirs(bldlogdir)
+        file_build = os.path.join(exeroot, "%s.bldlog.%s" % (lib, lid))
+        my_file = os.path.join(cimeroot, "src", "build_scripts", "buildlib.%s" % lib)
+        if lib == "pio":
+            my_file = "PYTHONPATH=%s:%s:$PYTHONPATH %s"%(os.path.join(cimeroot,"scripts","Tools"),
+                                                          os.path.join(cimeroot,"scripts","lib"), my_file)
+        logger.info("Building %s with output to file %s"%(lib,file_build))
+        with open(file_build, "w") as fd:
+            stat = run_cmd("%s %s %s %s 2>&1" %
+                           (my_file, full_lib_path, os.path.join(exeroot,sharedpath), caseroot),
+                           from_dir=exeroot,arg_stdout=fd)[0]
 
-    for log in logs:
-        logger.debug("Copying build log %s to %s"%(log,bldlogdir))
-        with open(log, 'rb') as f_in:
-            with gzip.open("%s.gz"%log, 'wb') as f_out:
-                shutil.copyfileobj(f_in, f_out)
-        if "sharedlibroot" not in log:
-            shutil.copy("%s.gz"%log,os.path.join(bldlogdir,"%s.gz"%os.path.basename(log)))
+        analyze_build_log(lib, file_build, compiler)
+        expect(stat == 0, "ERROR: buildlib.%s failed, cat %s" % (lib, file_build))
+        logs.append(file_build)
+        if lib == "pio":
+            bldlog = open(file_build, "r")
+            for line in bldlog:
+                if re.search("Current setting for", line):
+                    logger.warn(line)
 
-    # Set XML to indicate build complete
-    case.set_value("BUILD_COMPLETE", True)
-    case.set_value("BUILD_STATUS", 0)
-    if "SMP_VALUE" in os.environ:
-        case.set_value("SMP_BUILD", os.environ["SMP_VALUE"])
+
+    # clm not a shared lib for ACME
+    if get_model() != "acme":
+        comp_lnd = case.get_value("COMP_LND")
+        clm_config_opts = case.get_value("CLM_CONFIG_OPTS")
+        if comp_lnd == "clm" and not "clm4_0" in clm_config_opts:
+            logging.info("         - Building clm4_5/clm5_0 Library ")
+            esmfdir = "esmf" if case.get_value("USE_ESMF_LIB") else "noesmf"
+            bldroot = os.path.join(sharedlibroot, sharedpath, case.get_value("COMP_INTERFACE"), esmfdir, "clm","obj" )
+            libroot = os.path.join(exeroot, sharedpath, case.get_value("COMP_INTERFACE"), esmfdir, "lib")
+            incroot = os.path.join(exeroot, sharedpath, case.get_value("COMP_INTERFACE"), esmfdir, "include")
+            file_build = os.path.join(exeroot, "lnd.bldlog.%s" %  lid)
+            config_lnd_dir = os.path.dirname(case.get_value("CONFIG_LND_FILE"))
+
+            for ndir in [bldroot, libroot, incroot]:
+                if (not os.path.isdir(ndir)):
+                    os.makedirs(ndir)
+
+            smp = "SMP" in os.environ and os.environ["SMP"] == "TRUE"
+            # thread_bad_results captures error output from thread (expected to be empty)
+            # logs is a list of log files to be compressed and added to the case logs/bld directory
+            thread_bad_results = []
+            _build_model_thread(config_lnd_dir, "lnd", caseroot, libroot, bldroot, incroot,
+                                file_build, thread_bad_results, smp, compiler)
+            logs.append(file_build)
+            expect(not thread_bad_results, "\n".join(thread_bad_results))
+
+    return logs
+
+###############################################################################
+def _build_model_thread(config_dir, compclass, caseroot, libroot, bldroot, incroot, file_build,
+                        thread_bad_results, smp, compiler):
+###############################################################################
+    logger.info("Building %s with output to %s"%(compclass, file_build))
+    with open(file_build, "w") as fd:
+        stat = run_cmd("MODEL=%s SMP=%s %s/buildlib %s %s %s " %
+                       (compclass, stringify_bool(smp), config_dir, caseroot, libroot, bldroot),
+                       from_dir=bldroot,  arg_stdout=fd,
+                       arg_stderr=subprocess.STDOUT)[0]
+    analyze_build_log(compclass, file_build, compiler)
+    if (stat != 0):
+        thread_bad_results.append("ERROR: %s.buildlib failed, cat %s" % (compclass, file_build))
+
+    for mod_file in glob.glob(os.path.join(bldroot, "*_[Cc][Oo][Mm][Pp]_*.mod")):
+        shutil.copy(mod_file, incroot)
+
+
+###############################################################################
+def _clean_impl(case, cleanlist, clean_all):
+###############################################################################
+    caseroot = case.get_value("CASEROOT")
+    if clean_all:
+        # If cleanlist is empty just remove the bld directory
+        exeroot = case.get_value("EXEROOT")
+        expect(exeroot is not None,"No EXEROOT defined in case")
+        if os.path.isdir(exeroot):
+            logging.info("cleaning directory %s" %exeroot)
+            shutil.rmtree(exeroot)
+        # if clean_all is True also remove the sharedlibpath
+        sharedlibroot = case.get_value("SHAREDLIBROOT")
+        expect(sharedlibroot is not None,"No SHAREDLIBROOT defined in case")
+        if sharedlibroot != exeroot and os.path.isdir(sharedlibroot):
+            logging.warn("cleaning directory %s" %sharedlibroot)
+            shutil.rmtree(sharedlibroot)
+    else:
+        expect(cleanlist is not None and len(cleanlist) > 0,"Empty cleanlist not expected")
+        debug           = case.get_value("DEBUG")
+        use_esmf_lib    = case.get_value("USE_ESMF_LIB")
+        build_threaded  = case.get_value("BUILD_THREADED")
+        gmake           = case.get_value("GMAKE")
+        caseroot        = case.get_value("CASEROOT")
+        casetools       = case.get_value("CASETOOLS")
+        clm_config_opts = case.get_value("CLM_CONFIG_OPTS")
+
+        os.environ["DEBUG"]           = stringify_bool(debug)
+        os.environ["USE_ESMF_LIB"]    = stringify_bool(use_esmf_lib)
+        os.environ["BUILD_THREADED"]  = stringify_bool(build_threaded)
+        os.environ["CASEROOT"]        = caseroot
+        os.environ["COMP_INTERFACE"]  = case.get_value("COMP_INTERFACE")
+        os.environ["PIO_VERSION"]     = str(case.get_value("PIO_VERSION"))
+        os.environ["CLM_CONFIG_OPTS"] = clm_config_opts  if clm_config_opts is not None else ""
+
+        cmd = gmake + " -f " + os.path.join(casetools, "Makefile")
+        for item in cleanlist:
+            tcmd = cmd + " clean" + item
+            logger.info("calling %s "%(tcmd))
+            run_cmd_no_fail(tcmd)
+
+    # unlink Locked files directory
+    unlock_file("env_build.xml")
+
+    # reset following values in xml files
+    case.set_value("SMP_BUILD",str(0))
+    case.set_value("NINST_BUILD",str(0))
+    case.set_value("BUILD_STATUS",str(0))
+    case.set_value("BUILD_COMPLETE","FALSE")
     case.flush()
 
-    lock_file("env_build.xml")
-
-    # must ensure there's an lid
-    lid = os.environ["LID"] if "LID" in os.environ else run_cmd_no_fail("date +%y%m%d-%H%M%S")
-    save_build_provenance(case, lid=lid)
-
 ###############################################################################
-def case_build(caseroot, case, sharedlib_only=False, model_only=False):
+def _case_build_impl(caseroot, case, sharedlib_only, model_only):
 ###############################################################################
 
     t1 = time.time()
@@ -280,19 +502,19 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
     # Load modules
     case.load_env()
 
-    sharedpath = build_checks(case, build_threaded, comp_interface,
-                              use_esmf_lib, debug, compiler, mpilib,
-                              complist, ninst_build, smp_value, model_only)
+    sharedpath = _build_checks(case, build_threaded, comp_interface,
+                               use_esmf_lib, debug, compiler, mpilib,
+                               complist, ninst_build, smp_value, model_only)
 
     t2 = time.time()
     logs = []
 
     if not model_only:
-        logs = build_libraries(case, exeroot, sharedpath, caseroot,
+        logs = _build_libraries(case, exeroot, sharedpath, caseroot,
                                cimeroot, libroot, lid, compiler)
 
     if not sharedlib_only:
-        logs.extend(build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
+        logs.extend(_build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
                                 lid, caseroot, cimeroot, compiler))
 
     if not sharedlib_only:
@@ -308,264 +530,46 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False):
     return True
 
 ###############################################################################
-def build_checks(case, build_threaded, comp_interface, use_esmf_lib,
-                 debug, compiler, mpilib, complist, ninst_build, smp_value,
-                 model_only):
+def post_build(case, logs):
 ###############################################################################
-    """
-    check if a build needs to be done and warn if a clean is warrented first
-    returns the relative sharedpath directory for sharedlibraries
-    """
-    ninst_value  = case.get_value("NINST_VALUE")
-    smp_build    = case.get_value("SMP_BUILD")
-    build_status = case.get_value("BUILD_STATUS")
 
-    smpstr = ""
-    inststr = ""
-    for model, _, nthrds, ninst, _ in complist:
-        if nthrds > 1:
-            build_threaded = True
-        if build_threaded:
-            smpstr += "%s1"%model[0]
-        else:
-            smpstr += "%s0"%model[0]
-        inststr += "%s%d"%(model[0],ninst)
+    logdir = case.get_value("LOGDIR")
 
-    if build_threaded:
-        os.environ["SMP"] = "TRUE"
-    else:
-        os.environ["SMP"] = "FALSE"
-    case.set_value("SMP_VALUE", smpstr)
-    os.environ["SMP_VALUE"] = smpstr
-    case.set_value("NINST_VALUE", inststr)
-    os.environ["NINST_VALUE"] = inststr
+    #zip build logs to CASEROOT/logs
+    if logdir:
+        bldlogdir = os.path.join(logdir, "bld")
+        if not os.path.exists(bldlogdir):
+            os.makedirs(bldlogdir)
 
+    for log in logs:
+        logger.debug("Copying build log %s to %s"%(log,bldlogdir))
+        with open(log, 'rb') as f_in:
+            with gzip.open("%s.gz"%log, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        if "sharedlibroot" not in log:
+            shutil.copy("%s.gz"%log,os.path.join(bldlogdir,"%s.gz"%os.path.basename(log)))
 
-    debugdir = "debug" if debug else "nodebug"
-    threaddir = "threads" if (os.environ["SMP"] == "TRUE" or build_threaded) else "nothreads"
-    sharedpath = os.path.join(compiler, mpilib, debugdir, threaddir)
-
-    logger.debug("compiler=%s mpilib=%s debugdir=%s threaddir=%s"%
-                 (compiler,mpilib,debugdir,threaddir))
-
-    expect( ninst_build == ninst_value or ninst_build == "0",
-            """
-ERROR, NINST VALUES HAVE CHANGED
-  NINST_BUILD = %s
-  NINST_VALUE = %s
-  A manual clean of your obj directories is strongly recommended
-  You should execute the following:
-    ./case.build --clean
-  Then rerun the build script interactively
-  ---- OR ----
-  You can override this error message at your own risk by executing:
-    ./xmlchange -file env_build.xml -id NINST_BUILD -val 0
-  Then rerun the build script interactively
-""" % (ninst_build, ninst_value))
-
-    expect( smp_build == smpstr or smp_build == "0",
-            """
-ERROR, SMP VALUES HAVE CHANGED
-  SMP_BUILD = %s
-  SMP_VALUE = %s
-  smpstr = %s
-  A manual clean of your obj directories is strongly recommended
-  You should execute the following:
-    ./case.build --clean
-  Then rerun the build script interactively
-  ---- OR ----
-  You can override this error message at your own risk by executing:
-    ./xmlchange -file env_build.xml -id SMP_BUILD -val 0
-  Then rerun the build script interactively
-""" % (smp_build, smp_value, smpstr))
-
-    expect(build_status == 0,
-           """
-ERROR env_build HAS CHANGED
-  A manual clean of your obj directories is required
-  You should execute the following:
-    ./case.build --clean-all
-""")
-
-    expect(comp_interface != "ESMF" or use_esmf_lib,
-           """
-ERROR COMP_INTERFACE IS ESMF BUT USE_ESMF_LIB IS NOT TRUE
-  SET USE_ESMF_LIB to TRUE with:
-    ./xmlchange -file env_build.xml -id USE_ESMF_LIB -value TRUE
-""")
-
-    expect(mpilib != "mpi-serial" or not use_esmf_lib,
-           """
-ERROR MPILIB is mpi-serial and USE_ESMF_LIB IS TRUE
-  MPILIB can only be used with an ESMF library built with mpiuni on
-  Set USE_ESMF_LIB to FALSE with
-    ./xmlchange -file env_build.xml -id USE_ESMF_LIB -val FALSE
-  ---- OR ----
-  Make sure the ESMF_LIBDIR used was built with mipuni (or change it to one that was)
-  And comment out this if block in Tools/models_buildexe
-""")
-
-    case.set_value("BUILD_COMPLETE", False)
-
-    # User may have rm -rf their build directory
-    create_dirs(case)
-
+    # Set XML to indicate build complete
+    case.set_value("BUILD_COMPLETE", True)
+    case.set_value("BUILD_STATUS", 0)
+    if "SMP_VALUE" in os.environ:
+        case.set_value("SMP_BUILD", os.environ["SMP_VALUE"])
     case.flush()
-    if not model_only:
-        logger.info("Generating component namelists as part of build")
-        create_namelists(case)
 
-    return sharedpath
+    lock_file("env_build.xml")
 
-###############################################################################
-def build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid, compiler):
-###############################################################################
-
-    shared_lib = os.path.join(exeroot, sharedpath, "lib")
-    shared_inc = os.path.join(exeroot, sharedpath, "include")
-    for shared_item in [shared_lib, shared_inc]:
-        if (not os.path.exists(shared_item)):
-            os.makedirs(shared_item)
-    mpilib = case.get_value("MPILIB")
-    libs = ["gptl", "mct", "pio", "csm_share"]
-    if mpilib == "mpi-serial":
-        libs.insert(0, mpilib)
-    logs = []
-    sharedlibroot = case.get_value("SHAREDLIBROOT")
-    for lib in libs:
-        if lib == "csm_share":
-            # csm_share adds its own dir name
-            full_lib_path = os.path.join(sharedlibroot, sharedpath)
-        elif lib == "mpi-serial":
-            full_lib_path = os.path.join(sharedlibroot, sharedpath, "mct", lib)
-        else:
-            full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
-        # pio build creates its own directory
-        if (lib != "pio" and not os.path.exists(full_lib_path)):
-            os.makedirs(full_lib_path)
-
-        file_build = os.path.join(exeroot, "%s.bldlog.%s" % (lib, lid))
-        my_file = os.path.join(cimeroot, "src", "build_scripts", "buildlib.%s" % lib)
-        if lib == "pio":
-            my_file = "PYTHONPATH=%s:%s:$PYTHONPATH %s"%(os.path.join(cimeroot,"scripts","Tools"),
-                                                          os.path.join(cimeroot,"scripts","lib"), my_file)
-        logger.info("Building %s with output to file %s"%(lib,file_build))
-        with open(file_build, "w") as fd:
-            stat = run_cmd("%s %s %s %s 2>&1" %
-                           (my_file, full_lib_path, os.path.join(exeroot,sharedpath), caseroot),
-                           from_dir=exeroot,arg_stdout=fd)[0]
-
-        analyze_build_log(lib, file_build, compiler)
-        expect(stat == 0, "ERROR: buildlib.%s failed, cat %s" % (lib, file_build))
-        logs.append(file_build)
-        if lib == "pio":
-            bldlog = open(file_build, "r")
-            for line in bldlog:
-                if re.search("Current setting for", line):
-                    logger.warn(line)
-
-
-    # clm not a shared lib for ACME
-    if get_model() != "acme":
-        comp_lnd = case.get_value("COMP_LND")
-        clm_config_opts = case.get_value("CLM_CONFIG_OPTS")
-        if comp_lnd == "clm" and not "clm4_0" in clm_config_opts:
-            logging.info("         - Building clm4_5/clm5_0 Library ")
-            esmfdir = "esmf" if case.get_value("USE_ESMF_LIB") else "noesmf"
-            bldroot = os.path.join(sharedlibroot, sharedpath, case.get_value("COMP_INTERFACE"), esmfdir, "clm","obj" )
-            libroot = os.path.join(exeroot, sharedpath, case.get_value("COMP_INTERFACE"), esmfdir, "lib")
-            incroot = os.path.join(exeroot, sharedpath, case.get_value("COMP_INTERFACE"), esmfdir, "include")
-            file_build = os.path.join(exeroot, "lnd.bldlog.%s" %  lid)
-            config_lnd_dir = os.path.dirname(case.get_value("CONFIG_LND_FILE"))
-
-            for ndir in [bldroot, libroot, incroot]:
-                if (not os.path.isdir(ndir)):
-                    os.makedirs(ndir)
-
-            smp = "SMP" in os.environ and os.environ["SMP"] == "TRUE"
-            # thread_bad_results captures error output from thread (expected to be empty)
-            # logs is a list of log files to be compressed and added to the case logs/bld directory
-            thread_bad_results = []
-            _build_model_thread(config_lnd_dir, "lnd", caseroot, libroot, bldroot, incroot,
-                                file_build, thread_bad_results, smp, compiler)
-            logs.append(file_build)
-            expect(not thread_bad_results, "\n".join(thread_bad_results))
-
-    return logs
+    # must ensure there's an lid
+    lid = os.environ["LID"] if "LID" in os.environ else run_cmd_no_fail("date +%y%m%d-%H%M%S")
+    save_build_provenance(case, lid=lid)
 
 ###############################################################################
-def _build_model_thread(config_dir, compclass, caseroot, libroot, bldroot, incroot, file_build,
-                        thread_bad_results, smp, compiler):
+def case_build(caseroot, case, sharedlib_only=False, model_only=False):
 ###############################################################################
-    logger.info("Building %s with output to %s"%(compclass, file_build))
-    with open(file_build, "w") as fd:
-        stat = run_cmd("MODEL=%s SMP=%s %s/buildlib %s %s %s " %
-                       (compclass, stringify_bool(smp), config_dir, caseroot, libroot, bldroot),
-                       from_dir=bldroot,  arg_stdout=fd,
-                       arg_stderr=subprocess.STDOUT)[0]
-    analyze_build_log(compclass, file_build, compiler)
-    if (stat != 0):
-        thread_bad_results.append("ERROR: %s.buildlib failed, cat %s" % (compclass, file_build))
-
-    for mod_file in glob.glob(os.path.join(bldroot, "*_[Cc][Oo][Mm][Pp]_*.mod")):
-        shutil.copy(mod_file, incroot)
-
+    functor = lambda: _case_build_impl(caseroot, case, sharedlib_only, model_only)
+    return run_and_log_case_status(functor, "case.build", caseroot=caseroot)
 
 ###############################################################################
 def clean(case, cleanlist=None, clean_all=False):
 ###############################################################################
-    caseroot = case.get_value("CASEROOT")
-    if clean_all:
-        # If cleanlist is empty just remove the bld directory
-        exeroot = case.get_value("EXEROOT")
-        expect(exeroot is not None,"No EXEROOT defined in case")
-        if os.path.isdir(exeroot):
-            logging.info("cleaning directory %s" %exeroot)
-            shutil.rmtree(exeroot)
-        # if clean_all is True also remove the sharedlibpath
-        sharedlibroot = case.get_value("SHAREDLIBROOT")
-        expect(sharedlibroot is not None,"No SHAREDLIBROOT defined in case")
-        if sharedlibroot != exeroot and os.path.isdir(sharedlibroot):
-            logging.warn("cleaning directory %s" %sharedlibroot)
-            shutil.rmtree(sharedlibroot)
-    else:
-        expect(cleanlist is not None and len(cleanlist) > 0,"Empty cleanlist not expected")
-        debug           = case.get_value("DEBUG")
-        use_esmf_lib    = case.get_value("USE_ESMF_LIB")
-        build_threaded  = case.get_value("BUILD_THREADED")
-        gmake           = case.get_value("GMAKE")
-        caseroot        = case.get_value("CASEROOT")
-        casetools       = case.get_value("CASETOOLS")
-        clm_config_opts = case.get_value("CLM_CONFIG_OPTS")
-
-        os.environ["DEBUG"]           = stringify_bool(debug)
-        os.environ["USE_ESMF_LIB"]    = stringify_bool(use_esmf_lib)
-        os.environ["BUILD_THREADED"]  = stringify_bool(build_threaded)
-        os.environ["CASEROOT"]        = caseroot
-        os.environ["COMP_INTERFACE"]  = case.get_value("COMP_INTERFACE")
-        os.environ["PIO_VERSION"]     = str(case.get_value("PIO_VERSION"))
-        os.environ["CLM_CONFIG_OPTS"] = clm_config_opts  if clm_config_opts is not None else ""
-
-        cmd = gmake + " -f " + os.path.join(casetools, "Makefile")
-        for item in cleanlist:
-            tcmd = cmd + " clean" + item
-            logger.info("calling %s "%(tcmd))
-            run_cmd_no_fail(tcmd)
-
-    # unlink Locked files directory
-    unlock_file("env_build.xml")
-
-    # reset following values in xml files
-    case.set_value("SMP_BUILD",str(0))
-    case.set_value("NINST_BUILD",str(0))
-    case.set_value("BUILD_STATUS",str(0))
-    case.set_value("BUILD_COMPLETE","FALSE")
-    case.flush()
-
-    # append call of to CaseStatus
-    if cleanlist:
-        msg = "clean %s "%" ".join(cleanlist)
-    elif clean_all:
-        msg = "clean_all"
-
-    append_status(msg, caseroot=caseroot, sfile="CaseStatus")
+    functor = lambda: _clean_impl(case, cleanlist, clean_all)
+    return run_and_log_case_status(functor, "build.clean", caseroot=case.get_value("CASEROOT"))

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -942,21 +942,21 @@ class Case(object):
             os.makedirs(newdir)
 
         # Open a new README.case file in $self._caseroot
-        append_status(" ".join(sys.argv), caseroot=self._caseroot, sfile="README.case")
+        append_status(" ".join(sys.argv), "README.case", caseroot=self._caseroot)
         append_status("Compset longname is %s"%self.get_value("COMPSET"),
-                      caseroot=self._caseroot, sfile="README.case")
+                      "README.case", caseroot=self._caseroot)
         append_status("Compset specification file is %s" %
                       (self.get_value("COMPSETS_SPEC_FILE")),
-                      caseroot=self._caseroot, sfile="README.case")
+                      "README.case", caseroot=self._caseroot)
         append_status("Pes     specification file is %s" %
                       (self.get_value("PES_SPEC_FILE")),
-                      caseroot=self._caseroot, sfile="README.case")
+                      "README.case", caseroot=self._caseroot)
         for component_class in self._component_classes:
             if component_class == "CPL":
                 continue
             comp_grid = "%s_GRID"%component_class
             append_status("%s is %s"%(comp_grid,self.get_value(comp_grid)),
-                          caseroot=self._caseroot, sfile="README.case")
+                          "README.case", caseroot=self._caseroot)
         if not clone:
             self._create_caseroot_sourcemods()
         self._create_caseroot_tools()

--- a/scripts/lib/CIME/case_cmpgen_namelists.py
+++ b/scripts/lib/CIME/case_cmpgen_namelists.py
@@ -129,7 +129,7 @@ def case_cmpgen_namelists(case, compare=False, generate=False, compare_name=None
             logging.warning(warn)
         finally:
             ts.set_status(NAMELIST_PHASE, TEST_PASS_STATUS if success else TEST_FAIL_STATUS)
-            append_status(output, caseroot=caseroot, sfile=logfile_name)
+            append_status(output, logfile_name, caseroot=caseroot)
 
         return success
 

--- a/scripts/lib/CIME/case_lt_archive.py
+++ b/scripts/lib/CIME/case_lt_archive.py
@@ -1,5 +1,5 @@
 from CIME.XML.standard_module_setup import *
-from CIME.utils                     import expect, does_file_have_string, append_status
+from CIME.utils                     import expect, does_file_have_string, run_and_log_case_status
 from CIME.XML.lt_archive            import LTArchive
 
 import time
@@ -7,15 +7,12 @@ import time
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def case_lt_archive(case):
+def _case_lt_archive_impl(case):
 ###############################################################################
     caseroot = case.get_value("CASEROOT")
 
     # max number of threads needed by scripts
     os.environ["maxthrds"] = "1"
-
-    # document start
-    append_status("lt_archive starting",caseroot=caseroot,sfile="CaseStatus")
 
     # determine status of run and short term archiving
     runComplete = does_file_have_string(os.path.join(caseroot, "CaseStatus"),
@@ -37,12 +34,15 @@ def case_lt_archive(case):
             + lt_archive_args + "ltArchiveStatus." + lid + " 2>&1"
         run_cmd_no_fail(cmd, from_dir=caseroot)
     else:
-        logger.warn("runComplete %s staComplete %s"%(runComplete, staComplete))
+        logger.warn("runComplete %s staComplete %s" % (runComplete, staComplete))
         expect(False,
                "lt_archive: run or st_archive is not yet complete or was not successful."
                "Unable to perform long term archive...")
 
-    # document completion
-    append_status("lt_archive completed" ,caseroot=caseroot, sfile="CaseStatus")
-
     return True
+
+###############################################################################
+def case_lt_archive(case):
+###############################################################################
+    functor = lambda: _case_lt_archive_impl(case)
+    return run_and_log_case_status(functor, "lt_archiving", caseroot=case.get_value("CASEROOT"))

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -7,7 +7,7 @@ import shutil, glob, re, os
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
 from CIME.XML.env_archive           import EnvArchive
-from CIME.utils                     import append_status
+from CIME.utils                     import run_and_log_case_status
 from os.path                        import isdir, join
 
 logger = logging.getLogger(__name__)
@@ -379,21 +379,15 @@ def case_st_archive(case):
 
     logger.info("st_archive starting")
 
-    # do short-term archiving
-    append_status("st_archiving starting", caseroot=caseroot, sfile="CaseStatus")
-
     archive = EnvArchive(infile=os.path.join(caseroot, 'env_archive.xml'))
+    functor = lambda: _archive_process(case, archive)
+    run_and_log_case_status(functor, "st_archive", caseroot=caseroot)
 
-    _archive_process(case, archive)
-
-    append_status("st_archiving completed", caseroot=caseroot, sfile="CaseStatus")
     logger.info("st_archive completed")
 
     # resubmit case if appropriate
     resubmit = case.get_value("RESUBMIT")
     if resubmit > 0:
-        append_status("resubmitting from st_archive",
-                      caseroot=caseroot, sfile="CaseStatus")
         logger.info("resubmitting from st_archive, resubmit=%d"%resubmit)
         if case.get_value("MACH") == "mira":
             expect(os.path.isfile(".original_host"), "ERROR alcf host file not found")

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -7,7 +7,7 @@ jobs.
 """
 import socket
 from CIME.XML.standard_module_setup import *
-from CIME.utils                     import expect, append_status
+from CIME.utils                     import expect, append_testlog, run_and_log_case_status
 from CIME.preview_namelists         import create_namelists
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.check_input_data          import check_all_input_data
@@ -64,12 +64,12 @@ def _submit(case, job=None, resubmit=False, no_batch=False, batch_args=None):
 
     logger.warn("submit_jobs %s" % job)
     job_ids = case.submit_jobs(no_batch=no_batch, job=job, batch_args=batch_args)
-    msg = "Submitted jobs %s" % job_ids
-    append_status(msg, caseroot=caseroot, sfile="CaseStatus")
+    logger.info("Submitted job ids %s" % job_ids)
 
 def submit(case, job=None, resubmit=False, no_batch=False, batch_args=None):
     try:
-        _submit(case, job=job, resubmit=resubmit, no_batch=no_batch, batch_args=batch_args)
+        functor = lambda: _submit(case, job, resubmit, no_batch, batch_args)
+        run_and_log_case_status(functor, "case.submit", caseroot=case.get_value("CASEROOT"))
     except:
         # If something failed in the batch system, make sure to mark
         # the test as failed if we are running a test.
@@ -79,7 +79,7 @@ def submit(case, job=None, resubmit=False, no_batch=False, batch_args=None):
             with TestStatus(test_dir=caseroot, test_name=casebaseid, lock=True) as ts:
                 ts.set_status(RUN_PHASE, TEST_FAIL_STATUS, comments="batch system failure")
 
-            append_status("Batch submission failed, TestStatus file changed to read-only", caseroot=caseroot, sfile="TestStatus.log")
+            append_testlog("Batch submission failed, TestStatus file changed to read-only", caseroot=caseroot)
 
         raise
 

--- a/scripts/lib/CIME/case_test.py
+++ b/scripts/lib/CIME/case_test.py
@@ -3,7 +3,7 @@ Run a testcase.
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect, find_system_test, append_status, find_proc_id
+from CIME.utils import expect, find_system_test, append_testlog, find_proc_id
 from CIME.SystemTests.system_tests_common import *
 
 import sys, signal
@@ -61,7 +61,7 @@ def case_test(case, testname=None):
         caseroot = case.get_value("CASEROOT")
         with TestStatus(test_dir=caseroot) as ts:
             ts.set_status(RUN_PHASE, TEST_FAIL_STATUS, comments="failed to initialize")
-        append_status(str(sys.exc_info()[1]), sfile="TestStatus.log")
+        append_testlog(str(sys.exc_info()[1]))
         raise
 
     success = test.run()

--- a/scripts/lib/CIME/compare_test_results.py
+++ b/scripts/lib/CIME/compare_test_results.py
@@ -1,5 +1,5 @@
 import CIME.compare_namelists, CIME.simple_compare
-from CIME.utils import expect, get_model
+from CIME.utils import expect, get_model, append_status
 from CIME.test_status import *
 from CIME.hist_utils import compare_baseline
 from CIME.case_cmpgen_namelists import case_cmpgen_namelists
@@ -67,12 +67,12 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
         ts = TestStatus(test_dir=test_dir)
         test_name = ts.get_name()
         if (compare_tests in [[], None] or CIME.utils.match_any(test_name, compare_tests)):
-            CIME.utils.append_status(
-                msg = ("Comparing against baseline with compare_test_results:\n" +
-                       "Baseline: %s\n"%(baseline_name) +
-                       "In baseline_root: %s"%(baseline_root)),
-                caseroot = test_dir,
-                sfile = logfile_name)
+            append_status(
+                "Comparing against baseline with compare_test_results:\n" +
+                "Baseline: %s\n"%(baseline_name) +
+                "In baseline_root: %s"%(baseline_root),
+                logfile_name,
+                caseroot=test_dir)
 
             if (not hist_only):
                 nl_compare_result = None
@@ -143,15 +143,9 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
 
             print brief_result,
 
-            CIME.utils.append_status(
-                msg = brief_result,
-                caseroot = test_dir,
-                sfile = logfile_name)
+            append_status(brief_result, logfile_name, caseroot=test_dir)
 
             if detailed_comments:
-                CIME.utils.append_status(
-                    msg = "Detailed comments:\n" + detailed_comments,
-                    caseroot = test_dir,
-                    sfile = logfile_name)
+                append_status("Detailed comments:\n" + detailed_comments, logfile_name, caseroot=test_dir)
 
     return all_pass_or_skip

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -13,7 +13,7 @@ from CIME.XML.standard_module_setup import *
 import CIME.compare_namelists
 import CIME.utils
 from update_acme_tests import get_recommended_test_time
-from CIME.utils import append_status, TESTS_FAILED_ERR_CODE, parse_test_name, get_full_test_name
+from CIME.utils import append_status, append_testlog, TESTS_FAILED_ERR_CODE, parse_test_name, get_full_test_name
 from CIME.test_status import *
 from CIME.XML.machines import Machines
 from CIME.XML.env_test import EnvTest
@@ -237,7 +237,7 @@ class TestScheduler(object):
             # Note: making this directory could cause create_newcase to fail
             # if this is run before.
             os.makedirs(test_dir)
-        append_status(output,caseroot=test_dir,sfile="TestStatus.log")
+        append_testlog(output, caseroot=test_dir)
 
     ###########################################################################
     def _get_case_id(self, test):
@@ -655,7 +655,7 @@ class TestScheduler(object):
             self._update_test_status_file(test, test_phase, status)
 
         if test_phase == XML_PHASE:
-            append_status("Case Created using: "+" ".join(sys.argv), caseroot=self._get_test_dir(test), sfile="README.case")
+            append_status("Case Created using: "+" ".join(sys.argv), "README.case", caseroot=self._get_test_dir(test))
 
         # On batch systems, we want to immediately submit to the queue, because
         # it's very cheap to submit and will get us a better spot in line

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -775,17 +775,26 @@ def compute_total_time(job_cost_map, proc_pool):
 
     return current_time
 
-def append_status(msg, caseroot='.', sfile="CaseStatus"):
+def append_status(msg, sfile, caseroot='.'):
     """
     Append msg to sfile in caseroot
     """
-    ctime = ""
-    # Don't put the time stamp in TestStatus
-    if sfile != "TestStatus":
-        ctime = time.strftime("%Y-%m-%d %H:%M:%S: ")
-    with open(os.path.join(caseroot,sfile), "a") as fd:
+    ctime = time.strftime("%Y-%m-%d %H:%M:%S: ")
+    with open(os.path.join(caseroot, sfile), "a") as fd:
         fd.write(ctime + msg + "\n")
         fd.write("\n ---------------------------------------------------\n\n")
+
+def append_testlog(msg, caseroot='.'):
+    """
+    Add to TestStatus.log file
+    """
+    append_status(msg, "TestStatus.log", caseroot)
+
+def append_case_status(phase, status, msg=None, caseroot='.'):
+    """
+    Update CaseStatus file
+    """
+    append_status("%s %s%s" % (phase, status, " %s" % msg if msg else ""), "CaseStatus", caseroot)
 
 def does_file_have_string(filepath, text):
     """
@@ -1036,6 +1045,17 @@ def stringify_bool(val):
     val = False if val is None else val
     expect(type(val) is bool, "Wrong type for val '%s'" % repr(val))
     return "TRUE" if val else "FALSE"
+
+def run_and_log_case_status(func, phase, caseroot='.'):
+    append_case_status(phase, "starting", caseroot=caseroot)
+    try:
+        return func()
+    except:
+        e = sys.exc_info()[0]
+        append_case_status(phase, "error", msg=("\n%s" % e), caseroot=caseroot)
+        raise
+    else:
+        append_case_status(phase, "success", caseroot=caseroot)
 
 class SharedArea(object):
     """

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1048,14 +1048,17 @@ def stringify_bool(val):
 
 def run_and_log_case_status(func, phase, caseroot='.'):
     append_case_status(phase, "starting", caseroot=caseroot)
+    rv = None
     try:
-        return func()
+        rv = func()
     except:
         e = sys.exc_info()[0]
         append_case_status(phase, "error", msg=("\n%s" % e), caseroot=caseroot)
         raise
     else:
         append_case_status(phase, "success", caseroot=caseroot)
+
+    return rv
 
 class SharedArea(object):
     """

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -761,9 +761,9 @@ class O_TestTestScheduler(TestCreateTestCommon):
                 self.assertEqual(ts.get_status(CIME.test_scheduler.RUN_PHASE), TEST_PASS_STATUS)
             else:
                 self.assertTrue(test_name in [pass_test, mem_pass_test])
-                self.assertEqual(ts.get_status(CIME.test_scheduler.RUN_PHASE), TEST_PASS_STATUS)
+                self.assertEqual(ts.get_status(CIME.test_scheduler.RUN_PHASE), TEST_PASS_STATUS, msg=test_name)
                 if (test_name == mem_pass_test):
-                    self.assertEqual(ts.get_status(MEMLEAK_PHASE), TEST_PASS_STATUS)
+                    self.assertEqual(ts.get_status(MEMLEAK_PHASE), TEST_PASS_STATUS, msg=test_name)
 
     ###########################################################################
     def test_c_use_existing(self):


### PR DESCRIPTION
Write a special handler in utils.py in order to be able to
easily encapsulate the concept that a function needs to log
its status to CaseStatus and be robust in the face of exceptions.

Rearrange and rename some functions in build.py in order to make
it more clear what is the public API and what are internal functions.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1038 

User interface changes?: CaseStatus will look slightly different

Code review: @jedwards4b @bertinia 
