### PR TITLE
cdf64 only valid for serial netcdf, fix seq test

### DIFF
--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -179,18 +179,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
 
             # Make sure pio settings are consistant
             if adjust_pio:
-                for comp in models:
-                    pio_stride = case.get_value("PIO_STRIDE_%s"%comp)
-                    pio_numtasks = case.get_value("PIO_NUMTASKS_%s"%comp)
-                    ntasks = case.get_value("NTASKS_%s"%comp)
-                    new_stride = min(ntasks, tasks_per_node)
-                    new_numtasks = max(1, ntasks//new_stride)
-                    if pio_stride != new_stride:
-                        logger.info("Resetting  PIO_STRIDE_%s to %s"%(comp, new_stride))
-                        case.set_value("PIO_STRIDE_%s"%comp, new_stride)
-                    if pio_numtasks != new_numtasks:
-                        logger.info("Resetting  PIO_NUMTASKS_%s to %s"%(comp, new_numtasks))
-                        case.set_value("PIO_NUMTASKS_%s"%comp, new_numtasks)
+                adjust_pio_layout(case, tasks_per_node)
 
             # Make a copy of env_mach_pes.xml in order to be able
             # to check that it does not change once case.setup is invoked
@@ -238,6 +227,24 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
         env_module.make_env_mach_specific_file(compiler, debug, mpilib, "sh")
         env_module.make_env_mach_specific_file(compiler, debug, mpilib, "csh")
         env_module.save_all_env_info("software_environment.txt")
+
+
+def adjust_pio_layout(case, new_pio_stride):
+
+    models = case.get_values("COMP_CLASSES")
+    for comp in models:
+        pio_stride = case.get_value("PIO_STRIDE_%s"%comp)
+        pio_numtasks = case.get_value("PIO_NUMTASKS_%s"%comp)
+        ntasks = case.get_value("NTASKS_%s"%comp)
+        new_stride = min(ntasks, new_pio_stride)
+        new_numtasks = max(1, ntasks//new_stride)
+        if pio_stride != new_stride:
+            logger.info("Resetting  PIO_STRIDE_%s to %s"%(comp, new_stride))
+            case.set_value("PIO_STRIDE_%s"%comp, new_stride)
+            if pio_numtasks != new_numtasks:
+                logger.info("Resetting  PIO_NUMTASKS_%s to %s"%(comp, new_numtasks))
+                case.set_value("PIO_NUMTASKS_%s"%comp, new_numtasks)
+
 
 ###############################################################################
 def case_setup(case, clean=False, test_mode=False, reset=False, no_status=False, adjust_pio=True):

--- a/src/drivers/mct/main/seq_io_mod.F90
+++ b/src/drivers/mct/main/seq_io_mod.F90
@@ -184,7 +184,9 @@ subroutine seq_io_wopen(filename,clobber,cdf64,file_ind)
        if (exists) then
           if (lclobber) then
              nmode = pio_clobber
-             if (lcdf64) nmode = ior(nmode,PIO_64BIT_OFFSET)
+             !lcdf64 only applies to classic NETCDF files.
+             if (lcdf64 .and. cpl_pio_iotype == PIO_IOTYPE_NETCDF) &
+                  nmode = ior(nmode,PIO_64BIT_OFFSET)
              rcode = pio_createfile(cpl_io_subsystem, cpl_io_file(lfile_ind), cpl_pio_iotype, trim(filename), nmode)
              if(iam==0) write(logunit,*) subname,' create file ',trim(filename)
              rcode = pio_put_att(cpl_io_file(lfile_ind),pio_global,"file_version",version)
@@ -203,7 +205,9 @@ subroutine seq_io_wopen(filename,clobber,cdf64,file_ind)
           endif
        else
           nmode = pio_noclobber
-          if (lcdf64) nmode = ior(nmode,PIO_64BIT_OFFSET)
+          !lcdf64 only applies to classic NETCDF files.
+          if (lcdf64 .and. cpl_pio_iotype == PIO_IOTYPE_NETCDF) &
+               nmode = ior(nmode,PIO_64BIT_OFFSET)
           rcode = pio_createfile(cpl_io_subsystem, cpl_io_file(lfile_ind), cpl_pio_iotype, trim(filename), nmode)
           if(iam==0) write(logunit,*) subname,' create file ',trim(filename)
           rcode = pio_put_att(cpl_io_file(lfile_ind),pio_global,"file_version",version)


### PR DESCRIPTION
The cdf64 parameter is only needed for serial netcdf io.  The seq test was not
implemented as intended, each component should be on it's own set of tasks.  

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Partially Fixes #1114 

User interface changes?: 

Code review: 
