### PR TITLE
Fix bug in ERP namelist comparison.

### DIFF
--- a/scripts/lib/CIME/SystemTests/pem.py
+++ b/scripts/lib/CIME/SystemTests/pem.py
@@ -30,4 +30,4 @@ class PEM(SystemTestsCompareTwo):
             ntasks = self._case.get_value("NTASKS_%s"%comp)
             if ( ntasks > 1 ):
                 self._case.set_value("NTASKS_%s"%comp, int(ntasks/2))
-        case_setup(self._case, clean=False, test_mode=False, reset=True)
+        case_setup(self._case, reset=True)

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -65,7 +65,7 @@ class SystemTestsCommon(object):
             logging.warning("Resetting case due to detected re-run of phase %s" % phase)
             self._case.set_initial_test_values()
 
-            case_setup(self._case, reset=True, test_mode=True, no_status=True)
+            case_setup(self._case, reset=True, test_mode=True)
 
     def build(self, sharedlib_only=False, model_only=False):
         """

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1062,7 +1062,7 @@ class Case(object):
         clonename = self.get_value("CASE")
         logger.info(" Successfully created new case %s from clone case %s " %(newcasename, clonename))
 
-        case_setup(newcase, clean=False, test_mode=False)
+        case_setup(newcase)
 
         return newcase
 

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -232,13 +232,13 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
         env_module.save_all_env_info("software_environment.txt")
 
 ###############################################################################
-def case_setup(case, clean=False, test_mode=False, reset=False, no_status=False, adjust_pio=True):
+def case_setup(case, clean=False, test_mode=False, reset=False, adjust_pio=True):
 ###############################################################################
     caseroot, casebaseid = case.get_value("CASEROOT"), case.get_value("CASEBASEID")
     phase = "setup.clean" if clean else "case.setup"
     functor = lambda: _case_setup_impl(case, caseroot, clean, test_mode, reset, adjust_pio)
 
-    if case.get_value("TEST") and not no_status:
+    if case.get_value("TEST") and not test_mode:
         test_name = casebaseid if casebaseid is not None else case.get_value("CASE")
         with TestStatus(test_dir=caseroot, test_name=test_name) as ts:
             try:
@@ -247,6 +247,9 @@ def case_setup(case, clean=False, test_mode=False, reset=False, no_status=False,
                 ts.set_status(SETUP_PHASE, TEST_FAIL_STATUS)
                 raise
             else:
-                ts.set_status(SETUP_PHASE, TEST_PASS_STATUS)
+                if clean:
+                    ts.set_status(SETUP_PHASE, TEST_PEND_STATUS)
+                else:
+                    ts.set_status(SETUP_PHASE, TEST_PASS_STATUS)
     else:
         run_and_log_case_status(functor, phase, caseroot=caseroot)

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -11,7 +11,6 @@ from CIME.utils                     import expect, append_testlog, run_and_log_c
 from CIME.preview_namelists         import create_namelists
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.check_input_data          import check_all_input_data
-from CIME.case_cmpgen_namelists     import case_cmpgen_namelists
 from CIME.test_status               import *
 
 logger = logging.getLogger(__name__)

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -88,9 +88,6 @@ def check_case(case, caseroot):
     create_namelists(case) # Must be called before check_all_input_data
     logger.info("Checking that inputdata is available as part of case submission")
     check_all_input_data(case)
-    # Now that we have baselines, do baseline operations
-    if case.get_value("TEST"):
-        case_cmpgen_namelists(case)
 
     expect(case.get_value("BUILD_COMPLETE"), "Build complete is "
            "not True please rebuild the model by calling case.build")

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -175,8 +175,8 @@ class TestScheduler(object):
                     if os.path.isdir(test_baseline):
                         existing_baselines.append(test_baseline)
                 expect(allow_baseline_overwrite or len(existing_baselines) == 0,
-                           "Baseline directories already exists %s\n"\
-                           "Use --allow_baseline_overwrite to avoid this error"%existing_baselines)
+                       "Baseline directories already exists %s\n" \
+                       "Use -o to avoid this error" % existing_baselines)
         else:
             self._baseline_root = None
 
@@ -536,12 +536,9 @@ class TestScheduler(object):
         test_dir  = self._get_test_dir(test)
         rv = self._shell_cmd_for_phase(test, "./case.setup", SETUP_PHASE, from_dir=test_dir)
 
-        # A little subtle. If namelists_only, the RUN phase, when the namelists would normally
-        # be handled, is not going to happen, so we have to do it here.
-        if self._namelists_only:
-            # It's OK for this command to fail with baseline diffs but not catastrophically
-            cmdstat, output, errput = run_cmd("./case.cmpgen_namelists", from_dir=test_dir)
-            expect(cmdstat in [0, TESTS_FAILED_ERR_CODE], "Fatal error in case.cmpgen_namelists: %s" % (output + "\n" + errput))
+        # It's OK for this command to fail with baseline diffs but not catastrophically
+        cmdstat, output, errput = run_cmd("./case.cmpgen_namelists", from_dir=test_dir)
+        expect(cmdstat in [0, TESTS_FAILED_ERR_CODE], "Fatal error in case.cmpgen_namelists: %s" % (output + "\n" + errput))
 
         return rv
 


### PR DESCRIPTION
The following pattern was broken...
% ./create_test -o -g ERP.f45_g37_rx1.A.melvin_gnu -b jimtest
% ./create_test -c -n ERP.f45_g37_rx1.A.melvin_gnu -b jimtest

In the first command, the cmpgen_namelists used to occur during the RUN
phase and therefore occurs after the ERP build phase which impacts
the contents of the namelist files. In the second command, the cmpgen_namelists
occurs after the setup phase and therefore will not match the first.

With this change, we have essentially re-introduced all the namelist
creations that I tried to remove a few months ago in order to
improve performance. The SETUP phase is back up to 15 seconds on melvin.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1102 

User interface changes?: Namelists in baselines are relative to post-SETUP phase

Code review: @jedwards4b 
