### PR TITLE
Refactor env_batch

### DIFF
--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -129,7 +129,6 @@ def get_value_as_string(case, var, attribute=None, resolved=False, subgroup=None
         value = convert_to_string(value, thistype, var)
     return value
 
-
 def xmlquery(case, variables, subgroup=None, fileonly=False,
              resolved=True, raw=False, description=False, group=False,
              full=False, dtype=False, valid_values=False):
@@ -151,6 +150,7 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
                 results[group] = {}
             if not var in results[group]:
                 results[group][var] = {}
+
             expect(group, "No group found for var %s"% var)
             value = get_value_as_string(case, var, resolved=resolved, subgroup=subgroup)
             if value is None:

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -130,7 +130,6 @@ class EntryID(GenericXML):
         # handled in classes
         return vid, None, False
 
-
     def _get_default(self, node):
         return self._get_node_element_info(node, "default_value")
 
@@ -151,7 +150,6 @@ class EntryID(GenericXML):
                 result.append(group.get("id"))
 
         return result
-
 
     def get_valid_values(self, vid):
         node = self.get_optional_node("entry", {"id":vid})
@@ -174,7 +172,6 @@ class EntryID(GenericXML):
 
     def get_nodes_by_id(self, vid):
         return self.get_nodes("entry", {"id":vid})
-
 
     def _set_valid_values(self, node, new_valid_values):
         old_vv = self._get_valid_values(node)
@@ -254,7 +251,8 @@ class EntryID(GenericXML):
         or from the values field if the attribute argument is provided
         and matches
         """
-        node = self.get_optional_node("entry", {"id":vid})
+        root = self.root if subgroup is None else self.get_optional_node("group", {"id":subgroup})
+        node = self.get_optional_node("entry", {"id":vid}, root=root)
         if node is None:
             return
         val = self._get_value(node, attribute=attribute, resolved=resolved, subgroup=subgroup)

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -218,7 +218,8 @@ class EntryID(GenericXML):
         subgroup is ignored in the general routine and applied in specific methods
         """
         val = None
-        node = self.get_optional_node("entry", {"id":vid})
+        root = self.root if subgroup is None else self.get_optional_node("group", {"id":subgroup})
+        node = self.get_optional_node("entry", {"id":vid}, root=root)
         if node is not None:
             val = self._set_value(node, value, vid, subgroup, ignore_type)
         return val

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -95,7 +95,8 @@ class EnvBase(EntryID):
         """
         vid, comp, iscompvar = self.check_if_comp_var(vid, None)
         val = None
-        node = self.get_optional_node("entry", {"id":vid})
+        root = self.root if subgroup is None else self.get_optional_node("group", {"id":subgroup})
+        node = self.get_optional_node("entry", {"id":vid}, root=root)
         if node is not None:
             if iscompvar and comp is None:
                 # pylint: disable=no-member
@@ -104,6 +105,7 @@ class EnvBase(EntryID):
             else:
                 val = self._set_value(node, value, vid, subgroup, ignore_type, component=comp)
         return val
+
     # pylint: disable=arguments-differ
     def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False, component=None):
         if vid is None:

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -1,5 +1,5 @@
 """
-Base class for env files .  This class inherits from EntryID.py
+Base class for env files.  This class inherits from EntryID.py
 """
 import string
 from CIME.XML.standard_module_setup import *

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -54,7 +54,11 @@ class EnvBatch(EnvBase):
                 self._set_value(node, value, vid=item, ignore_type=ignore_type)
                 val = value
         else:
-            val = self.set_value(item, value, subgroup=subgroup, ignore_type=ignore_type)
+            group = self.get_optional_node("group", {"id":subgroup})
+            if group:
+                node = self.get_optional_node("entry", {"id":item}, root=group)
+                if node:
+                    val = self._set_value(node, value, vid=item, ignore_type=ignore_type)
 
         return val
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -6,7 +6,6 @@ import time
 import re
 import math
 from CIME.XML.standard_module_setup import *
-from CIME.utils import convert_to_type
 from CIME.XML.env_base import EnvBase
 from CIME.utils import transform_vars, get_cime_root
 from copy import deepcopy
@@ -48,18 +47,14 @@ class EnvBatch(EnvBase):
 
                 value = time.strftime(walltime_format, t)
 
-        # allow the user to set all instances of item if subgroup is not provided
+        # allow the user to set item for all jobs if subgroup is not provided
         if subgroup is None:
             nodes = self.get_nodes("entry", {"id":item})
             for node in nodes:
                 self._set_value(node, value, vid=item, ignore_type=ignore_type)
                 val = value
         else:
-            nodes = self.get_nodes("job", {"name":subgroup})
-            for node in nodes:
-                vnode = self.get_optional_node("entry", {"id":item}, root=node)
-                if vnode is not None:
-                    val = self._set_value(vnode, value, vid=item, ignore_type=ignore_type)
+            val = self.set_value(item, value, subgroup=subgroup, ignore_type=ignore_type)
 
         return val
 
@@ -79,20 +74,8 @@ class EnvBatch(EnvBase):
             elif not nodes:
                 value = EnvBase.get_value(self,item,attribute,resolved)
         else:
-            job_node = self.get_optional_node("job", {"name":subgroup})
-            if job_node is not None:
-                node = self.get_optional_node("entry", {"id":item}, root=job_node)
-                if node is not None:
-                    value = node.get("value")
+            value = EnvBase.get_value(self, item, attribute=attribute, resolved=resolved, subgroup=subgroup)
 
-                    if resolved:
-                        value = self.get_resolved_value(value)
-
-                    # Return value as right type if we were able to fully resolve
-                    # otherwise, we have to leave as string.
-                    if value is not None and "$" not in value:
-                        type_str = self._get_type_info(node)
-                        value = convert_to_type(value, type_str, item)
         return value
 
     def get_type_info(self, vid):
@@ -108,36 +91,41 @@ class EnvBatch(EnvBase):
         return type_info
 
     def get_jobs(self):
-        jobs = []
-        for node in self.get_nodes("job"):
-            name = node.get("name")
-            jobs.append(name)
-        return jobs
+        groups = self.get_nodes("group")
+        results = []
+        for group in groups:
+            if group.get("id") not in ["job_submission", "config_batch"]:
+                results.append(group.get("id"))
 
-    def create_job_groups(self, bjobs):
-        # only the job_submission group is repeated
-        group = self.get_node("group", {"id":"job_submission"})
-        # look to see if any jobs are already defined
-        cjobs = self.get_jobs()
+        return results
+
+    def create_job_groups(self, batch_jobs):
+        # Subtle: in order to support dynamic batch jobs, we need to remove the
+        # job_submission group and replace with job-based groups
+
+        orig_group = self.get_optional_node("group", {"id":"job_submission"})
+        expect(orig_group, "Looks like job groups have already been created")
+
         childnodes = []
-
-        expect(len(cjobs)==0," Looks like job groups have already been created")
-
-        for child in reversed(group):
+        for child in reversed(orig_group):
             childnodes.append(deepcopy(child))
-            group.remove(child)
+            orig_group.remove(child)
 
-        for name,jdict in bjobs:
-            newjob = ET.Element("job")
-            newjob.set("name",name)
+        self.root.remove(orig_group)
+
+        for name, jdict in batch_jobs:
+            new_job_group = ET.Element("group")
+            new_job_group.set("id", name)
             for field in jdict.keys():
                 val = jdict[field]
-                node = ET.SubElement(newjob, "entry", {"id":field,"value":val})
+                node = ET.SubElement(new_job_group, "entry", {"id":field,"value":val})
                 tnode = ET.SubElement(node, "type")
                 tnode.text = "char"
+
             for child in childnodes:
-                newjob.append(deepcopy(child))
-            group.append(newjob)
+                new_job_group.append(deepcopy(child))
+
+            self.root.append(new_job_group)
 
     def cleanupnode(self, node):
         if node.get("id") == "batch_system":
@@ -190,14 +178,14 @@ class EnvBatch(EnvBase):
             fd.write(output_text)
         os.chmod(job, os.stat(job).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
-    def set_job_defaults(self, bjobs, pesize=None, walltime=None, force_queue=None):
+    def set_job_defaults(self, batch_jobs, pesize=None, walltime=None, force_queue=None):
         if self.batchtype is None:
             self.batchtype = self.get_batch_system_type()
 
         if self.batchtype == 'none':
             return
 
-        for job, jsect in bjobs:
+        for job, jsect in batch_jobs:
             task_count = jsect["task_count"]
             if task_count is None or task_count == "default":
                 task_count = pesize
@@ -216,8 +204,8 @@ class EnvBatch(EnvBase):
                     self.get_default_queue()
                 walltime = self._default_walltime
 
-            self.set_value( "JOB_WALLCLOCK_TIME", walltime , subgroup=job)
-            logger.debug("Job %s queue %s walltime %s"%(job, queue, walltime))
+            self.set_value("JOB_WALLCLOCK_TIME", walltime, subgroup=job)
+            logger.debug("Job %s queue %s walltime %s" % (job, queue, walltime))
 
     def get_batch_directives(self, case, job, raw=False):
         """
@@ -264,7 +252,7 @@ class EnvBatch(EnvBase):
             else:
                 if name.startswith("$"):
                     name = name[1:]
-                val = case.get_value(name,subgroup=job)
+                val = case.get_value(name, subgroup=job)
                 if val is None:
                     val = case.get_resolved_value(name)
 
@@ -295,7 +283,7 @@ class EnvBatch(EnvBase):
             startindex = alljobs.index(job)
 
         for index, job in enumerate(alljobs):
-            logger.debug( "Index %d job %s startindex %d"%(index, job, startindex))
+            logger.debug( "Index %d job %s startindex %d" % (index, job, startindex))
             if index < startindex:
                 continue
             try:
@@ -456,9 +444,3 @@ class EnvBatch(EnvBase):
         else:
             nodes =  EnvBase.get_nodes(self, nodename, attributes, root, xpath)
         return nodes
-
-    def get_groups(self, root):
-        groups = EnvBase.get_groups(self, root)
-        if len(groups) == 1 and groups[0] == "job_submission":
-            groups = self.get_jobs()
-        return groups

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -16,7 +16,6 @@ class GenericXML(object):
         """
         Initialize an object
         """
-
         logger.debug("Initializing %s" , infile)
         self.tree = None
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -4,7 +4,7 @@ Wrapper around all env XML for a case.
 All interaction with and between the module files in XML/ takes place
 through the Case module.
 """
-from copy   import deepcopy
+from copy import deepcopy
 import glob, os, shutil, math, string
 from CIME.XML.standard_module_setup import *
 
@@ -15,14 +15,13 @@ from CIME.check_lockedfiles         import LOCKED_DIR, lock_file
 from CIME.XML.machines              import Machines
 from CIME.XML.pes                   import Pes
 from CIME.XML.files                 import Files
-from CIME.XML.testlist                 import Testlist
+from CIME.XML.testlist              import Testlist
 from CIME.XML.component             import Component
 from CIME.XML.compsets              import Compsets
 from CIME.XML.grids                 import Grids
 from CIME.XML.batch                 import Batch
 from CIME.XML.pio                   import PIO
 from CIME.XML.archive               import Archive
-
 from CIME.XML.env_test              import EnvTest
 from CIME.XML.env_mach_specific     import EnvMachSpecific
 from CIME.XML.env_case              import EnvCase
@@ -171,10 +170,10 @@ class Case(object):
         self._env_entryid_files.append(EnvRun(self._caseroot, components=components))
         self._env_entryid_files.append(EnvBuild(self._caseroot, components=components))
         self._env_entryid_files.append(EnvMachPes(self._caseroot, components=components))
+        self._env_entryid_files.append(EnvBatch(self._caseroot))
         if os.path.isfile(os.path.join(self._caseroot,"env_test.xml")):
             self._env_entryid_files.append(EnvTest(self._caseroot, components=components))
         self._env_generic_files = []
-        self._env_generic_files.append(EnvBatch(self._caseroot))
         self._env_generic_files.append(EnvMachSpecific(self._caseroot))
         self._env_generic_files.append(EnvArchive(self._caseroot))
         self._files = self._env_entryid_files + self._env_generic_files
@@ -279,12 +278,7 @@ class Case(object):
         # Return empty result
         return result
 
-
     def get_record_fields(self, variable, field):
-
-        """
-
-        """
         # Empty result
         result = []
 
@@ -333,8 +327,8 @@ class Case(object):
             result = env_file.get_type_info(item)
             if result is not None:
                 return result
-        env_batch = self.get_env("batch")
-        return env_batch.get_type_info(item)
+
+        return result
 
     def get_resolved_value(self, item, recurse=0):
         num_unresolved = item.count("$") if item else 0
@@ -345,22 +339,7 @@ class Case(object):
             if ("$" not in item):
                 return item
             else:
-                item = self.get_resolved_value(item,recurse=recurse+1)
-
-        if recurse >= 2*recurse_limit:
-            logging.warning("Not able to fully resolve item '%s'" % item)
-        elif recurse >= recurse_limit:
-            #try env_batch first
-            env_batch = self.get_env("batch")
-            item = env_batch.get_resolved_value(item)
-            logger.debug("item is %s, checking env_batch"%item)
-            if item is not None:
-                if ("$" not in item):
-                    return item
-                else:
-                    item = self.get_resolved_value(item,recurse=recurse+1)
-            else:
-                logging.warning("Not able to fully resolve item '%s'" % item)
+                item = self.get_resolved_value(item, recurse=recurse+1)
 
         return item
 
@@ -373,9 +352,7 @@ class Case(object):
         if item == "CASEROOT":
             self._caseroot = value
         result = None
-        files = self._env_entryid_files
-        files.append(self.get_env('batch'))
-        for env_file in files:
+        for env_file in self._env_entryid_files:
             result = env_file.set_value(item, value, subgroup, ignore_type)
             if (result is not None):
                 logger.debug("Will rewrite file %s %s",env_file.filename, item)
@@ -515,10 +492,6 @@ class Case(object):
         drv_comp_model_specific = Component(drv_config_file_model_specific)
         for env_file in self._env_entryid_files:
             env_file.add_elements_by_group(drv_comp_model_specific, attributes=attlist)
-
-        # Add the group and elements for env_batch
-        env_batch = self.get_env("batch")
-        env_batch.add_elements_by_group(drv_comp, attributes=attlist)
 
         # loop over all elements of both component_classes and components - and get config_component_file for
         # for each component
@@ -679,7 +652,6 @@ class Case(object):
 
         mach_pes_obj = self.get_env("mach_pes")
 
-
         if other is not None:
             for key, value in other.items():
                 self.set_value(key, value)
@@ -729,7 +701,6 @@ class Case(object):
         batch = Batch(batch_system=batch_system_type, machine=machine_name)
         bjobs = batch.get_batch_jobs()
 
-
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
         env_batch.create_job_groups(bjobs)
         env_batch.set_job_defaults(bjobs, pesize=maxval, walltime=walltime, force_queue=queue)
@@ -759,8 +730,6 @@ class Case(object):
                 logger.info("\nThis is a CESM scientifically supported compset at this resolution.\n")
             else:
                 self._check_testlists(compset_alias, grid_name, files)
-
-
 
         # Set project id
         if project is None:


### PR DESCRIPTION
In places all over the code, env_batch was treated like a standard
env*.xml file, but it's format was not compatible due to the way
jobs were being handled. This required special code all over the place
to handle and it also rendered xmlquery useless when querying for
stuff in env_batch.

This branch fixes that by re-doing the way jobs are expressed in env_batch.xml
by treating them as groups instead of sub elements of the useless job_submission
group.

This also fixes a bug entry_id.get_value where it was throwing an error
complaining of too many matches even though the user provided a subgroup
that would have limited it to a single match.

Test suite: scripts_regression_tests (melvin and skybridge)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1116 

User interface changes?: env_batch.xml now looks different

Code review: @jedwards4b 
