### PR TITLE
update compare_xml to find more differences

### DIFF
--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -366,11 +366,22 @@ class EntryID(GenericXML):
         f1nodes = self.get_nodes("entry")
         for node in f1nodes:
             vid = node.get("id")
-            f2val = other.get_value(vid, resolved=False)
-            if f2val is not None:
+            f2match = other.get_optional_node("entry", attributes={"id":vid})
+            if f2match is not None:
                 f1val = self.get_value(vid, resolved=False)
-                if f2val != f1val:
-                    xmldiffs[vid] = [f1val, f2val]
+                if f1val is not None:
+                    f2val = other.get_value(vid, resolved=False)
+                    if f1val != f2val:
+                        xmldiffs[vid] = [f1val, f2val]
+                else:
+                    f1val = ET.tostring(node, method="text")
+                    f2val = ET.tostring(f2match, method="text")
+                    if f2val != f1val:
+                       f1value_nodes = self.get_nodes("value", root=node)
+                       for valnode in f1value_nodes:
+                           f2valnode = other.get_node("value", root=f2match, attributes=valnode.attrib)
+                           if f2valnode.text != valnode.text:
+                               xmldiffs["%s:%s"%(vid,valnode.attrib)] = [valnode.text, f2valnode.text]
 
         return xmldiffs
 

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -377,11 +377,11 @@ class EntryID(GenericXML):
                     f1val = ET.tostring(node, method="text")
                     f2val = ET.tostring(f2match, method="text")
                     if f2val != f1val:
-                       f1value_nodes = self.get_nodes("value", root=node)
-                       for valnode in f1value_nodes:
-                           f2valnode = other.get_node("value", root=f2match, attributes=valnode.attrib)
-                           if f2valnode.text != valnode.text:
-                               xmldiffs["%s:%s"%(vid,valnode.attrib)] = [valnode.text, f2valnode.text]
+                        f1value_nodes = self.get_nodes("value", root=node)
+                        for valnode in f1value_nodes:
+                            f2valnode = other.get_node("value", root=f2match, attributes=valnode.attrib)
+                            if f2valnode.text != valnode.text:
+                                xmldiffs["%s:%s"%(vid,valnode.attrib)] = [valnode.text, f2valnode.text]
 
         return xmldiffs
 


### PR DESCRIPTION
The <values> subnode of entry id nodes was not being checked with compare_xml and so
changes to the pelayout were not being trapped by check_lockedfiles

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1205 

User interface changes?: 

Code review: 
