### PR TITLE
fix issue with compset not printing to timing file

### DIFF
--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -122,9 +122,7 @@ class _TimingParser:
         ncpl_base_period = self.case.get_value("NCPL_BASE_PERIOD")
         atm_ncpl = self.case.get_value("ATM_NCPL")
         ocn_ncpl = self.case.get_value("OCN_NCPL")
-        ccsm_compset = self.case.get_value("CCSM_COMPSET")
-        if ccsm_compset is None:
-            ccsm_compset = ""
+        compset = self.case.get_value("COMPSET")
         grid = self.case.get_value("GRID")
         run_type = self.case.get_value("RUN_TYPE")
         stop_option = self.case.get_value("STOP_OPTION")
@@ -232,7 +230,7 @@ class _TimingParser:
         self.write("  Curr Date   : %s\n" % now)
 
         self.write("  grid        : %s\n" % grid)
-        self.write("  compset     : %s\n" % ccsm_compset)
+        self.write("  compset     : %s\n" % compset)
         self.write("  run_type    : %s, continue_run = %s "
                    "(inittype = %s)\n" %
                    (run_type, str(continue_run).upper(), inittype))


### PR DESCRIPTION
Get_timing was using the old CCSM_COMPSET name instead of just COMPSET

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1191 

User interface changes?: 

Code review: 
