### PR TITLE
copy rather than follow links in create_clone

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1016,8 +1016,10 @@ class Case(object):
             shutil.copy(item, newcaseroot)
 
         # copy SourceMod and Buildconf files
+        # if symlinks exist, copy rather than follow links
         for casesub in ("SourceMods", "Buildconf"):
-            shutil.copytree(os.path.join(cloneroot, casesub), os.path.join(newcaseroot, casesub))
+            shutil.copytree(os.path.join(cloneroot, casesub), os.path.join(newcaseroot, casesub)
+                            , symlinks=True)
 
         # lock env_case.xml in new case
         lock_file("env_case.xml", newcaseroot)


### PR DESCRIPTION
Copy rather than follow links when copying BuildConf and SourceMods directories in create_clone

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1175 

User interface changes?:  

Code review: 
