### PR TITLE
remove hardcoded compclasses

### DIFF
--- a/scripts/lib/CIME/SystemTests/ncr.py
+++ b/scripts/lib/CIME/SystemTests/ncr.py
@@ -37,7 +37,9 @@ class NCR(SystemTestsCommon):
             logging.warn("Starting bld %s"%bld)
             machpes = "env_mach_pes.NCR%s.xml" % bld
             ntasks_sum = 0
-            for comp in ['ATM','OCN','WAV','GLC','ICE','ROF','LND']:
+            for comp in self._case.get_values("COMP_CLASSES"):
+                if comp == "CPL":
+                    continue
                 self._case.set_value("NINST_%s"%comp,str(bld))
                 ntasks      = self._case.get_value("NTASKS_%s"%comp)
                 if(bld == 1):

--- a/scripts/lib/CIME/SystemTests/pem.py
+++ b/scripts/lib/CIME/SystemTests/pem.py
@@ -26,7 +26,7 @@ class PEM(SystemTestsCompareTwo):
         pass
 
     def _case_two_setup(self):
-        for comp in ['ATM','CPL','OCN','WAV','GLC','ICE','ROF','LND']:
+        for comp in self._case.get_values("COMP_CLASSES"):
             ntasks = self._case.get_value("NTASKS_%s"%comp)
             if ( ntasks > 1 ):
                 self._case.set_value("NTASKS_%s"%comp, int(ntasks/2))

--- a/scripts/lib/CIME/SystemTests/pet.py
+++ b/scripts/lib/CIME/SystemTests/pet.py
@@ -14,8 +14,6 @@ logger = logging.getLogger(__name__)
 
 class PET(SystemTestsCompareTwo):
 
-    _COMPONENT_LIST = ('ATM','CPL','OCN','WAV','GLC','ICE','ROF','LND')
-
     def __init__(self, case):
         """
         initialize a test object
@@ -28,7 +26,7 @@ class PET(SystemTestsCompareTwo):
 
     def _case_one_setup(self):
         # first make sure that all components have threaded settings
-        for comp in self._COMPONENT_LIST:
+        for comp in self._case.get_values("COMP_CLASSES"):
             if self._case.get_value("NTHRDS_%s"%comp) <= 1:
                 self._case.set_value("NTHRDS_%s"%comp, 2)
 
@@ -37,7 +35,7 @@ class PET(SystemTestsCompareTwo):
 
     def _case_two_setup(self):
         #Do a run with all threads set to 1
-        for comp in self._COMPONENT_LIST:
+        for comp in self._case.get_values("COMP_CLASSES"):
             self._case.set_value("NTHRDS_%s"%comp, 1)
 
         # The need for this is subtle. On batch systems, the entire PET test runs

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -245,7 +245,7 @@ class _TimingParser:
         self.write("  ---------        ------     -------   ------   "
                    "------  ---------  ------  \n")
         maxthrds = 0
-        for k in ['CPL', 'GLC', 'WAV', 'LND', 'ROF', 'ICE', 'ATM', 'OCN']:
+        for k in self._case.get_values("COMP_CLASSES"):
             m = self.models[k]
             self.write("  %s = %-8s   %-6u      %-6u   %-6u x %-6u  "
                        "%-6u (%-6u) \n"
@@ -333,7 +333,7 @@ class _TimingParser:
 
         self.write("    TOT Run Time:  %10.3f seconds   %10.3f seconds/mday   "
                    "%10.2f myears/wday \n" % (tmax, tmax/adays, tmaxr))
-        for k in ['LND', 'ROF', 'ICE', 'ATM', 'OCN', 'GLC', 'WAV', 'CPL']:
+        for k in self._case.get_values("COMP_CLASSES"):
             m = self.models[k]
             self.write("    %s Run Time:  %10.3f seconds   "
                        "%10.3f seconds/mday   %10.2f myears/wday \n"

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -245,7 +245,7 @@ class _TimingParser:
         self.write("  ---------        ------     -------   ------   "
                    "------  ---------  ------  \n")
         maxthrds = 0
-        for k in self._case.get_values("COMP_CLASSES"):
+        for k in self.case.get_values("COMP_CLASSES"):
             m = self.models[k]
             self.write("  %s = %-8s   %-6u      %-6u   %-6u x %-6u  "
                        "%-6u (%-6u) \n"
@@ -333,7 +333,7 @@ class _TimingParser:
 
         self.write("    TOT Run Time:  %10.3f seconds   %10.3f seconds/mday   "
                    "%10.2f myears/wday \n" % (tmax, tmax/adays, tmaxr))
-        for k in self._case.get_values("COMP_CLASSES"):
+        for k in self.case.get_values("COMP_CLASSES"):
             m = self.models[k]
             self.write("    %s Run Time:  %10.3f seconds   "
                        "%10.3f seconds/mday   %10.2f myears/wday \n"


### PR DESCRIPTION
Removes some lingering hardcoded lists of COMP_CLASSES and uses get_values instead
Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1170 

User interface changes?: 

Code review: 
