### PR TITLE
additional include path needed for cmake check_function_exists

### DIFF
--- a/config/acme/machines/Makefile
+++ b/config/acme/machines/Makefile
@@ -614,7 +614,7 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
               -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
               -D GPTL_PATH:STRING=$(INSTALL_SHAREDPATH) \
               -D PIO_ENABLE_TESTS:BOOL=OFF \
-              -D USER_CMAKE_MODULE_PATH:STRING=$(CIMEROOT)/src/externals/CMake
+	      -D USER_CMAKE_MODULE_PATH:LIST="$(CIMEROOT)/src/externals/CMake;$(CIMEROOT)/src/externals/pio2/cmake" \
 
 # Allow for separate installations of the NetCDF C and Fortran libraries
 ifeq ($(NETCDF_SEPARATE), false)

--- a/config/cesm/machines/Makefile
+++ b/config/cesm/machines/Makefile
@@ -562,7 +562,7 @@ CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(INCLDIR)" \
 	      -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
 	      -D GPTL_PATH:STRING=$(INSTALL_SHAREDPATH) \
 	      -D PIO_ENABLE_TESTS:BOOL=OFF \
-	      -D USER_CMAKE_MODULE_PATH:STRING=$(CIMEROOT)/src/externals/CMake
+	      -D USER_CMAKE_MODULE_PATH:LIST="$(CIMEROOT)/src/externals/CMake;$(CIMEROOT)/src/externals/pio2/cmake" \
 
 # Allow for separate installations of the NetCDF C and Fortran libraries
 ifeq ($(NETCDF_SEPARATE), false)

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -63,9 +63,7 @@ def _main_func(description):
             os.makedirs(pio_dir)
         os.chdir(pio_dir)
         casetools = case.get_value("CASETOOLS")
-        cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/genf90\
-                        -D CMAKE_MODULE_PATH=%s\" "%\
-            os.path.join(CIME.utils.get_cime_root(), "src", "externals","pio2","cmake")
+        cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/genf90\ \""
         gmake_opts = "%s/Makefile CASEROOT=%s MODEL=%s USER_CMAKE_OPTS=%s "\
             "PIO_LIBDIR=%s CASETOOLS=%s PIO_VERSION=%s MPILIB=%s "\
             "SHAREDLIBROOT=%s EXEROOT=%s COMPILER=%s BUILD_THREADED=%s "\

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -63,7 +63,7 @@ def _main_func(description):
             os.makedirs(pio_dir)
         os.chdir(pio_dir)
         casetools = case.get_value("CASETOOLS")
-        cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/genf90\ \""
+        cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/genf90 \""
         gmake_opts = "%s/Makefile CASEROOT=%s MODEL=%s USER_CMAKE_OPTS=%s "\
             "PIO_LIBDIR=%s CASETOOLS=%s PIO_VERSION=%s MPILIB=%s "\
             "SHAREDLIBROOT=%s EXEROOT=%s COMPILER=%s BUILD_THREADED=%s "\

--- a/src/externals/pio2/cmake/LibCheck.cmake
+++ b/src/externals/pio2/cmake/LibCheck.cmake
@@ -1,5 +1,5 @@
 include (CMakeParseArguments)
-
+include (CheckFunctionExists)
 #==============================================================================
 #
 #  FUNCTIONS TO HELP WITH Check* MODULES
@@ -14,17 +14,17 @@ include (CMakeParseArguments)
 #                          HINTS <path> <path> ...
 #                          DEFINITIONS <definition1> <definition> ...
 #                          COMMENT <string_comment>)
-#                         
+#
 function (check_macro VARIABLE)
 
     # Parse the input arguments
     set (oneValueArgs COMMENT NAME)
     set (multiValueArgs HINTS DEFINITIONS)
-    cmake_parse_arguments (${VARIABLE} "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})    
-    
+    cmake_parse_arguments (${VARIABLE} "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
     # If the return variable is defined, already, don't continue
     if (NOT DEFINED ${VARIABLE})
-        
+
         message (STATUS "Checking ${${VARIABLE}_COMMENT}")
         find_file (${VARIABLE}_TRY_FILE
                    NAMES ${${VARIABLE}_NAME}
@@ -40,17 +40,17 @@ function (check_macro VARIABLE)
             else ()
                 message (STATUS "Checking ${${VARIABLE}_COMMENT} - no")
             endif ()
-            
+
             set (${VARIABLE} ${COMPILE_RESULT}
                  CACHE BOOL "${${VARIABLE}_COMMENT}")
-                 
+
         else ()
             message (STATUS "Checking ${${VARIABLE}_COMMENT} - failed")
         endif ()
-     
+
         unset (${VARIABLE}_TRY_FILE CACHE)
     endif ()
-            
+
 endfunction ()
 
 #______________________________________________________________________________
@@ -60,17 +60,17 @@ endfunction ()
 #                         NAME <try_version_file>
 #                         HINTS <path> <path> ...
 #                         DEFINITIONS <definition1> <definition> ...)
-#  
+#
 function (check_version PKG)
 
     # Parse the input arguments
     set (oneValueArgs NAME MACRO_REGEX)
     set (multiValueArgs HINTS)
-    cmake_parse_arguments (${PKG} "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})    
+    cmake_parse_arguments (${PKG} "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     # If the return variable is defined, already, don't continue
     if (NOT DEFINED ${PKG}_VERSION)
-        
+
         message (STATUS "Checking ${PKG} version")
         find_file (${PKG}_VERSION_HEADER
                    NAMES ${${PKG}_NAME}
@@ -96,9 +96,9 @@ function (check_version PKG)
         else ()
             message (STATUS "Checking ${PKG} version - failed")
         endif ()
-        
+
         unset (${PKG}_VERSION_HEADER CACHE)
-     
+
     endif ()
 
 endfunction ()


### PR DESCRIPTION
standard cmake module check_function_exists was not being found when scripts_regression_tests.py was run from cron.  

Test suite: scripts_regression_tests.py (also ran tests with pio2 as default)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes cmake build issues introduced in PR #1202 

User interface changes?: 

Code review: 
