### PR TITLE
remove a misleading print statement from tests

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -313,10 +313,8 @@ class SystemTestsCommon(object):
                 logging.warn("  Resetting %s for test" % key)
                 f1obj.set_value(key, f2obj.get_value(key, resolved=False))
             else:
-                print "Found difference in %s: case: %s original value %s" %\
+                print "WARNING: Found difference in test %s: case: %s original value %s" %\
                     (key, diffs[key][0], diffs[key][1])
-                print " Use option --force to run the test with this"\
-                    " value or --reset to reset to original"
                 return False
         return True
 


### PR DESCRIPTION
One line change to remove this statement from testcases:

-                print " Use option --force to run the test with this"\
-                    " value or --reset to reset to original"

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
