### PR TITLE
no longer need this code

### DIFF
--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -287,15 +287,6 @@ def buildnml(case, caseroot, component):
 
     # create cplconf/namelist
     infile_text = ""
-    if case.get_value('COMP_ATM') == 'cam':
-        # cam is actually changing the driver namelist settings
-        cam_config_opts = case.get_value("CAM_CONFIG_OPTS")
-        if "adiabatic" in cam_config_opts:
-            infile_text = "atm_adiabatic = .true."
-        if "ideal" in cam_config_opts:
-            infile_text = "atm_ideal_phys = .true."
-        if "aquaplanet" in cam_config_opts:
-            infile_text = "aqua_planet = .true. \n aqua_planet_sst = 1"
     user_nl_file = os.path.join(caseroot, "user_nl_cpl")
     namelist_infile = os.path.join(confdir, "namelist_infile")
     create_namelist_infile(case, user_nl_file, namelist_infile, infile_text)

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -287,6 +287,12 @@ def buildnml(case, caseroot, component):
 
     # create cplconf/namelist
     infile_text = ""
+    if case.get_value('COMP_ATM') == 'cam':		
+        # cam is actually changing the driver namelist settings		
+        cam_config_opts = case.get_value("CAM_CONFIG_OPTS")		
+        if "aquaplanet" in cam_config_opts:		
+            infile_text = "aqua_planet = .true. \n aqua_planet_sst = 1"
+
     user_nl_file = os.path.join(caseroot, "user_nl_cpl")
     namelist_infile = os.path.join(confdir, "namelist_infile")
     create_namelist_infile(case, user_nl_file, namelist_infile, infile_text)


### PR DESCRIPTION
Driver code no longer needs to do this for cam 

Test suite: scripts_regression_tests.py + ERP_D_Ln9.T42z30_T42.FDABIP04.hobart_nag.cam-outfrq9s 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1222 

User interface changes?: 

Code review: @gold2718 
