### PR TITLE
need to set RTM to NULL in both cases in order to have this work with…

### DIFF
--- a/scripts/lib/CIME/SystemTests/ssp.py
+++ b/scripts/lib/CIME/SystemTests/ssp.py
@@ -52,6 +52,7 @@ class SSP(SystemTestsCommon):
         logger.info("  short term archiving is on ")
 
         clone.set_value("CLM_ACCELERATED_SPINUP", "on")
+        clone.set_value("RTM_MODE", "NULL")
         clone.set_value("STOP_N",stop_n1)
         clone.flush()
 
@@ -83,6 +84,7 @@ class SSP(SystemTestsCommon):
         self._case.set_value("RUN_TYPE", "hybrid")
         self._case.set_value("GET_REFCASE", False)
         self._case.set_value("RUN_REFCASE", "%s.ref1" % orig_casevar)
+        self._case.set_value("RTM_MODE", "NULL")
 
         self._case.set_value("RUN_REFDATE", refdate)
         self._case.set_value("STOP_N", stop_n2)


### PR DESCRIPTION
Fix needed for upcoming pythonization of rtm and mosart buildnml

RTM is being used incorrectly in the ssp test - and this fix ensures that both phases of NULL.
This enables the new RTM and MOSART pythonized buildnml scripts to pass the SSP test.

Only ran the ran SSP_Ld10.f19_g16.I1850CLM45BGC.yellowstone_pgi.clm-default test. Verified that the test passed and the only differences with respect to the baseline were the RTM fields.

Test suite: None
Test baseline: 
Test namelist changes: 
Test status: bit for bit - except for any test using ssp.py

Fixes

User interface changes?: None

Code review: 
