### PR TITLE
suppress futurewarning here

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -4,7 +4,7 @@ Warning: you cannot use CIME Classes in this module as it causes circular depend
 """
 import logging, gzip, sys, os, time, re, shutil, glob, string, random
 import stat as statlib
-
+import warnings
 # Return this error code if the scripts worked but tests failed
 TESTS_FAILED_ERR_CODE = 100
 logger = logging.getLogger(__name__)
@@ -20,7 +20,9 @@ def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR:"):
         ...
     SystemExit: ERROR: error2
     """
-    if (not condition):
+    # Without this line we get a futurewarning on the use of condition below
+    warnings.filterwarnings("ignore")
+    if not condition:
         if logger.isEnabledFor(logging.DEBUG):
             import pdb
             pdb.set_trace()


### PR DESCRIPTION
Supress a future warning on the use of condition in expect subroutine.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: Removes a distracting warning

Code review: 
