### PR TITLE
Mvertens/phys cycle

### DIFF
--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -65,18 +65,21 @@ class DAE(SystemTestsCompareTwo):
         # Clean up any da.log files in case this is a re-run.
         self._activate_case2()
         case_root = self._get_caseroot2()
-        da_files = glob.glob(os.path.join(case_root, 'da.log.*'))
+        rundir2 = self._case.get_value("RUNDIR")
+        da_files = glob.glob(os.path.join(rundir2, 'da.log.*'))
         for file_ in da_files:
             os.remove(file_)
         # End for
+
         # CONTINUE_RUN ends up TRUE, set it back in case this is a re-run.
         self._case.set_value("CONTINUE_RUN", False)
         # Start normal run here
         self._activate_case1()
         SystemTestsCompareTwo.run_phase(self)
+
         # Do some checks on the data assimilation 'output' from case2
         self._activate_case2()
-        da_files = glob.glob(os.path.join(case_root, 'da.log.*'))
+        da_files = glob.glob(os.path.join(rundir2, 'da.log.*'))
         if da_files is None:
             logger = logging.getLogger(__name__)
             logger.warning("No DA files in %s", os.path.join(case_root, 'da.log.*'))

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -200,6 +200,8 @@ def case_run(case):
     data_assimilation_cycles = case.get_value("DATA_ASSIMILATION_CYCLES")
     data_assimilation_script = case.get_value("DATA_ASSIMILATION_SCRIPT")
 
+    caseroot = case.get_value("CASEROOT")
+
     # set up the LID
     lid = new_lid()
 
@@ -212,7 +214,7 @@ def case_run(case):
             lid = new_lid()
 
         if prerun_script != "UNSET":
-            do_external(prerun_script, case.get_value("CASEROOT"), cycle, lid, prefix="prerun")
+            do_external(prerun_script, caseroot, cycle, lid, prefix="prerun")
 
         run_model(case, lid)
         save_logs(case, lid)       # Copy log files back to caseroot
@@ -221,11 +223,10 @@ def case_run(case):
 
 
         if data_assimilation:
-            do_external(data_assimilation_script, case.get_value("CASEROOT"), cycle, lid, 
-                        prefix="data_assimilation")
+            do_external(data_assimilation_script, caseroot, cycle, lid, prefix="data_assimilation")
 
         if postrun_script != "UNSET":
-            do_external(postrun_script, case.get_value("CASEROOT"), cycle, lid, prefix="postrun")
+            do_external(postrun_script, caseroot, cycle, lid, prefix="postrun")
 
         save_postrun_provenance(case)
 

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -175,12 +175,13 @@ def resubmit_check(case):
         submit(case, job=job, resubmit=True)
 
 ###############################################################################
-def do_data_assimilation(da_script, caseroot, cycle, lid):
+def do_external(script_name, caseroot, cycle, lid):
 ###############################################################################
-    cmd = da_script + " 1> da.log.%s %s %d 2>&1" %(lid, caseroot, cycle)
-    logger.debug("running %s" %da_script)
+    cmd = script_name + " 1> external.log.%s %d %d 2>&1" %(lid, caseroot, cycle)
+    logger.debug("running %s" %script_name)
     run_cmd_no_fail(cmd)
     # disposeLog(case, 'da', lid)  THIS IS UNDEFINED!
+
 
 ###############################################################################
 def case_run(case):
@@ -192,6 +193,9 @@ def case_run(case):
            "As a result, short-term archiving will not be called automatically."
            "Please submit your run using the submit script like so:"
            " ./case.submit")
+
+    prerun_script = case.get_value("PRERUN_SCRIPT")
+    postrun_script = case.get_value("POSTRUN_SCRIPT")
 
     data_assimilation = case.get_value("DATA_ASSIMILATION")
     data_assimilation_cycles = case.get_value("DATA_ASSIMILATION_CYCLES")
@@ -208,13 +212,19 @@ def case_run(case):
             case.set_value("CONTINUE_RUN", "TRUE")
             lid = new_lid()
 
+        if prerun_script is not None:
+            do_external(prerun_script, case.get_value("CASEROOT"), cycle, lid)
+
         run_model(case, lid)
         save_logs(case, lid)       # Copy log files back to caseroot
         if case.get_value("CHECK_TIMING") or case.get_value("SAVE_TIMING"):
             get_timing(case, lid)     # Run the getTiming script
 
         if data_assimilation:
-            do_data_assimilation(data_assimilation_script, case.get_value("CASEROOT"), cycle, lid)
+            do_external(data_assimilation_script, case.get_value("CASEROOT"), cycle, lid)
+
+        if postrun_script is not None:
+            do_external(postrun_script, case.get_value("CASEROOT"), cycle, lid)
 
         save_postrun_provenance(case)
 

--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -147,11 +147,11 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 
     # set variables that are not per-stream
     if datm_mode == 'CPLHISTForcingForOcnIce':
-        nmlgen.add_default("domainfile", value='null')
         if atm_domain_file != "UNSET":
             if case.get_value('ATM_DOMAIN_FILE') != 'UNSET':
-                case.add_default('ATM_DOMAIN_FILE', value='UNSET', ignore_abs_path=True)
-                case.flush()
+                nmlgen.add_default("domainfile", value=atm_domain_file, ignore_abs_path=True)
+        else:
+            nmlgen.add_default("domainfile", value='null')
     else:
         full_domain_path = os.path.join(atm_domain_path, atm_domain_file)
         nmlgen.add_default("domainfile", value=full_domain_path)

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2504,6 +2504,25 @@
       Albany.</desc>
   </entry>
 
+  <!-- Prerun/postrun custom script options -->
+
+  <entry id="PRERUN_SCRIPT">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <group>external_tools</group>
+    <file>env_run.xml</file>
+    <desc>External script to be run before model completion</desc>
+  </entry>
+  <entry id="POSTRUN_SCRIPT">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <group>external_tools</group>
+    <file>env_run.xml</file>
+    <desc>External script to be run after model completion</desc>
+  </entry>
+
   <!-- Data Assimilation type stuff -->
 
   <entry id="DATA_ASSIMILATION">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2508,14 +2508,14 @@
 
   <entry id="PRERUN_SCRIPT">
     <type>char</type>
-    <default_value>UNSET</default_value>
+    <default_value></default_value>
     <group>external_tools</group>
     <file>env_run.xml</file>
     <desc>External script to be run before model completion</desc>
   </entry>
   <entry id="POSTRUN_SCRIPT">
     <type>char</type>
-    <default_value>UNSET</default_value>
+    <default_value></default_value>
     <group>external_tools</group>
     <file>env_run.xml</file>
     <desc>External script to be run after model completion</desc>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2508,16 +2508,14 @@
 
   <entry id="PRERUN_SCRIPT">
     <type>char</type>
-    <valid_values></valid_values>
-    <default_value></default_value>
+    <default_value>UNSET</default_value>
     <group>external_tools</group>
     <file>env_run.xml</file>
     <desc>External script to be run before model completion</desc>
   </entry>
   <entry id="POSTRUN_SCRIPT">
     <type>char</type>
-    <valid_values></valid_values>
-    <default_value></default_value>
+    <default_value>UNSET</default_value>
     <group>external_tools</group>
     <file>env_run.xml</file>
     <desc>External script to be run after model completion</desc>


### PR DESCRIPTION
New hooks for runnning external scripts for pre-run and post-run 

CESM POP needs new pre-run and post-run hooks to carry out the lengthy spinup of its ecosystem module. This addition provides additional hooks other than data assimilation to carry this out.
However, it is general enough to be leveraged by other future pre-run and post-run scripts should those be needed.

In addition, all log files for either data assimilation OR the new pre-run and post-run hooks are now output in $RUNDIR rather than $CASEROOT

Test suite: scripts_regression_test AND PRE.f19_f19.ADESP.yellowstone_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit, roundoff

Fixes: None

User interface changes?: None

Code review: 
