### PR TITLE
Index in namelist

### DIFF
--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -307,7 +307,7 @@ class NamelistDefinition(EntryID):
 
         # Check size of input array.
         if len(expand_literal_list(value)) > size:
-            expect(False, "Value index exceeds variable size for variable %s"%name)
+            expect(False, "Value index exceeds variable size for variable %s, allowed array length is %s value array size is %s"%(name, size, len(expand_literal_list(value))))
         return True
 
     def _expect_variable_in_definition(self, name, variable_template):

--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -346,7 +346,7 @@ class NamelistDefinition(EntryID):
                 qualified_variable_name = get_fortran_name_only(variable_name)
                 self._expect_variable_in_definition(qualified_variable_name, variable_template)
 
-                # Check if can actuax1lly change this variable via filename change
+                # Check if can actually change this variable via filename change
                 if filename is not None:
                     self._user_modifiable_in_variable_definition(qualified_variable_name)
 

--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -307,7 +307,7 @@ class NamelistDefinition(EntryID):
 
         # Check size of input array.
         if len(expand_literal_list(value)) > size:
-            return False
+            expect(False, "Value index exceeds variable size for variable %s"%name)
         return True
 
     def _expect_variable_in_definition(self, name, variable_template):

--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -14,7 +14,7 @@ import re
 
 from CIME.namelist import fortran_namelist_base_value, \
     is_valid_fortran_namelist_literal, character_literal_to_string, \
-    expand_literal_list, Namelist, get_variable_name
+    expand_literal_list, Namelist, get_fortran_name_only
 
 from CIME.XML.standard_module_setup import *
 from CIME.XML.entry_id import EntryID
@@ -342,21 +342,22 @@ class NamelistDefinition(EntryID):
         for group_name in namelist.get_group_names():
             for variable_name in namelist.get_variable_names(group_name):
                 # Check that the variable is defined...
-                self._expect_variable_in_definition(variable_name, variable_template)
+                qualified_variable_name = get_fortran_name_only(variable_name)
+                self._expect_variable_in_definition(qualified_variable_name, variable_template)
 
                 # Check if can actuax1lly change this variable via filename change
                 if filename is not None:
-                    self._user_modifiable_in_variable_definition(variable_name)
+                    self._user_modifiable_in_variable_definition(qualified_variable_name)
 
                 # and has the right group name...
-                var_group = self.get_group(variable_name)
+                var_group = self.get_group(qualified_variable_name)
                 expect(var_group == group_name,
                        (variable_template + " is in a group named %r, but should be in %r.") %
                        (str(variable_name), str(group_name), str(var_group)))
 
                 # and has a valid value.
                 value = namelist.get_variable_value(group_name, variable_name)
-                expect(self.is_valid_value(variable_name, value),
+                expect(self.is_valid_value(qualified_variable_name, value),
                        (variable_template + " has invalid value %r.") %
                        (str(variable_name), [str(scalar) for scalar in value]))
 
@@ -379,8 +380,9 @@ class NamelistDefinition(EntryID):
         groups = {}
         for variable_name in dict_:
             variable_lc = variable_name.lower()
-            self._expect_variable_in_definition(get_variable_name(variable_lc), variable_template)
-            group_name = self.get_group(variable_lc)
+            qualified_varname = get_fortran_name_only(variable_lc)
+            self._expect_variable_in_definition(qualified_varname, variable_template)
+            group_name = self.get_group(qualified_varname)
             expect (group_name is not None, "No group found for var %s"%variable_lc)
             if group_name not in groups:
                 groups[group_name] = {}

--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -11,6 +11,7 @@ This module contains only one class, `NamelistDefinition`, inheriting from
 # pylint:disable=wildcard-import,unused-wildcard-import
 
 import re
+import collections
 
 from CIME.namelist import fortran_namelist_base_value, \
     is_valid_fortran_namelist_literal, character_literal_to_string, \
@@ -385,7 +386,7 @@ class NamelistDefinition(EntryID):
             group_name = self.get_group(qualified_varname)
             expect (group_name is not None, "No group found for var %s"%variable_lc)
             if group_name not in groups:
-                groups[group_name] = {}
+                groups[group_name] = collections.OrderedDict()
             groups[group_name][variable_lc] = dict_[variable_name]
         return Namelist(groups)
 

--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -14,7 +14,7 @@ import re
 
 from CIME.namelist import fortran_namelist_base_value, \
     is_valid_fortran_namelist_literal, character_literal_to_string, \
-    expand_literal_list, Namelist
+    expand_literal_list, Namelist, get_variable_name
 
 from CIME.XML.standard_module_setup import *
 from CIME.XML.entry_id import EntryID
@@ -344,7 +344,7 @@ class NamelistDefinition(EntryID):
                 # Check that the variable is defined...
                 self._expect_variable_in_definition(variable_name, variable_template)
 
-                # Check if can actually change this variable via filename change
+                # Check if can actuax1lly change this variable via filename change
                 if filename is not None:
                     self._user_modifiable_in_variable_definition(variable_name)
 
@@ -379,7 +379,7 @@ class NamelistDefinition(EntryID):
         groups = {}
         for variable_name in dict_:
             variable_lc = variable_name.lower()
-            self._expect_variable_in_definition(variable_lc, variable_template)
+            self._expect_variable_in_definition(get_variable_name(variable_lc), variable_template)
             group_name = self.get_group(variable_lc)
             expect (group_name is not None, "No group found for var %s"%variable_lc)
             if group_name not in groups:

--- a/scripts/lib/CIME/buildnml.py
+++ b/scripts/lib/CIME/buildnml.py
@@ -118,6 +118,5 @@ def create_namelist_infile(case, user_nl_file, namelist_infile, infile_text=""):
             lines_output.append(line)
 
     lines_output.append("/ \n")
-
     with open(namelist_infile, "w") as file_infile:
         file_infile.write("\n".join(lines_output))

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1018,6 +1018,9 @@ class Namelist(object):
         [u'3']
         >>> x.get_variable_value('brack', 'bar')
         [u'4']
+        >>> x.set_variable_value('foo', 'red(2:6:2)', [u'2', u'4', u'6'], var_size=12)
+        >>> x.get_variable_value('foo', 'red')
+        ['', u'2', '', u'4', '', u'6']
         """
         group_name = group_name.lower()
 
@@ -1033,8 +1036,8 @@ class Namelist(object):
         if variable_name in self._groups[group_name]:
             tlen = len(self._groups[group_name][variable_name])
         else:
-            tlen = 0
-            self._groups[group_name][variable_name] = []
+            tlen = 1
+            self._groups[group_name][variable_name] = ['']
 
         if minindex > tlen:
             self._groups[group_name][variable_name].extend(['']*(minindex-tlen-1))
@@ -1043,7 +1046,10 @@ class Namelist(object):
             if i < tlen:
                 self._groups[group_name][variable_name][i] = value.pop(0)
             else:
+                if tlen < i:
+                    self._groups[group_name][variable_name].extend(['']*(i-tlen))
                 self._groups[group_name][variable_name].append(value.pop(0))
+            tlen = len(self._groups[group_name][variable_name])
             if len(value) == 0:
                 break
 

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -635,8 +635,7 @@ def expand_literal_list(literals, nindex=None):
             num, _, value = literal.partition('*')
             expanded += int(num) * [value]
         elif nindex is not None:
-            for i in range(0,nindex-1):
-                expanded.append('')
+            expanded = ['']*(nindex-1)
             expanded.append(literal)
         else:
             expanded.append(literal)

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -122,12 +122,6 @@ FORTRAN_NAME_REGEX = re.compile(r"""(^[a-z][a-z0-9_]{0,62})                     
                                   \))?\s*$"""                                           # end optional index expression
                                 , re.IGNORECASE | re.VERBOSE)
 
-
-
-
-
-
-
 FORTRAN_LITERAL_REGEXES = {}
 # Integer literals.
 _int_re_string = r"(\+|-)?[0-9]+"

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1993,17 +1993,17 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> x = _NamelistParser("&group /")
         >>> x._parse_namelist_group()
         >>> x._settings
-        {u'group': {}}
+        OrderedDict([(u'group', {})])
         >>> x._curr()
         u'/'
         >>> x = _NamelistParser("&group\n foo='bar','bazz'\n,, foo2=2*5\n /")
         >>> x._parse_namelist_group()
         >>> x._settings
-        {u'group': {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'5', u'5']}}
+        OrderedDict([(u'group', {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'5', u'5']})])
         >>> x = _NamelistParser("&group\n foo='bar','bazz'\n,, foo2=2*5\n /", groupless=True)
         >>> x._parse_namelist_group()
         >>> x._settings
-        {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'5', u'5']}
+        OrderedDict([(u'foo', [u"'bar'", u"'bazz'", u'']), (u'foo2', [u'5', u'5'])])
         >>> x._curr()
         u'/'
         >>> x = _NamelistParser("&group /&group /")
@@ -2016,15 +2016,15 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> x = _NamelistParser("&group foo='bar', foo='bazz' /")
         >>> x._parse_namelist_group()
         >>> x._settings
-        {u'group': {u'foo': [u"'bazz'"]}}
+        OrderedDict([(u'group', {u'foo': [u"'bazz'"]})])
         >>> x = _NamelistParser("&group foo='bar', foo= /")
         >>> x._parse_namelist_group()
         >>> x._settings
-        {u'group': {u'foo': [u"'bar'"]}}
+        OrderedDict([(u'group', {u'foo': [u"'bar'"]})])
         >>> x = _NamelistParser("&group foo='bar', foo= /", groupless=True)
         >>> x._parse_namelist_group()
         >>> x._settings
-        {u'foo': [u"'bar'"]}
+        OrderedDict([(u'foo', [u"'bar'"])])
         """
         group_name = self._parse_namelist_group_name()
         if not self._groupless:
@@ -2056,33 +2056,33 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         first by namelist group name, then by variable name.
 
         >>> _NamelistParser("").parse_namelist()
-        {}
+        OrderedDict()
         >>> _NamelistParser(" \n!Comment").parse_namelist()
-        {}
+        OrderedDict()
         >>> _NamelistParser(" &group /").parse_namelist()
-        {u'group': {}}
+        OrderedDict([(u'group', {})])
         >>> _NamelistParser("! Comment \n &group /! Comment\n ").parse_namelist()
-        {u'group': {}}
+        OrderedDict([(u'group', {})])
         >>> _NamelistParser("! Comment \n &group /! Comment ").parse_namelist()
-        {u'group': {}}
+        OrderedDict([(u'group', {})])
         >>> _NamelistParser("&group1\n foo='bar','bazz'\n,, foo2=2*5\n / &group2 /").parse_namelist()
-        {u'group1': {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'5', u'5']}, u'group2': {}}
+        OrderedDict([(u'group1', {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'5', u'5']}), (u'group2', {})])
         >>> _NamelistParser("!blah \n foo='bar','bazz'\n,, foo2=2*5\n ", groupless=True).parse_namelist()
-        {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'2*5']}
+        OrderedDict([(u'foo', [u"'bar'", u"'bazz'", u'']), (u'foo2', [u'2*5'])])
         >>> _NamelistParser("!blah \n foo='bar','bazz'\n,, foo2=2*5,6\n ", groupless=True).parse_namelist()
-        {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'2*5', u'6']}
+        OrderedDict([(u'foo', [u"'bar'", u"'bazz'", u'']), (u'foo2', [u'2*5', u'6'])])
         >>> _NamelistParser("!blah \n foo='bar'", groupless=True).parse_namelist()
-        {u'foo': [u"'bar'"]}
+        OrderedDict([(u'foo', [u"'bar'"])])
         >>> _NamelistParser("foo='bar', foo='bazz'", groupless=True).parse_namelist()
-        {u'foo': [u"'bazz'"]}
+        OrderedDict([(u'foo', [u"'bazz'"])])
         >>> _NamelistParser("foo='bar', foo=", groupless=True).parse_namelist()
-        {u'foo': [u"'bar'"]}
+        OrderedDict([(u'foo', [u"'bar'"])])
         >>> _NamelistParser("foo='bar', foo(3)='bazz'", groupless=True).parse_namelist()
-        {u'foo': [u"'bar'"], u'foo(3)': [u"'bazz'"]}
+        OrderedDict([(u'foo', [u"'bar'"]), (u'foo(3)', [u"'bazz'"])])
         >>> _NamelistParser("foo(2)='bar'", groupless=True).parse_namelist()
-        {u'foo(2)': [u"'bar'"]}
+        OrderedDict([(u'foo(2)', [u"'bar'"])])
         >>> _NamelistParser("foo(2)='bar', foo(3)='bazz'", groupless=True).parse_namelist()
-        {u'foo(2)': [u"'bar'"], u'foo(3)': [u"'bazz'"]}
+        OrderedDict([(u'foo(2)', [u"'bar'"]), (u'foo(3)', [u"'bazz'"])])
         """
         # Return empty dictionary for empty files.
         if self._len == 0:

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1465,6 +1465,7 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
                 self._nameindex[vname].append(nindex)
             else:
                 self._nameindex[vname] = [nindex]
+
         return text.lower()
 
     def _parse_character_literal(self):

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -245,8 +245,6 @@ def get_fortran_variable_indices(varname, varlen=1, allow_any_len=False):
         if m.group(8) is not None:
             step = int(m.group(8))
 
-    expect(step > 0 and minindex <= maxindex,"Bad array index values, negative indexing not allowed in %s"%varname)
-
     if allow_any_len and maxindex == minindex:
         maxindex = -1
 
@@ -1991,7 +1989,7 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
             values.append(literal)
         (minindex, maxindex, step) = get_fortran_variable_indices(name,allow_any_len=True)
         if (minindex > 1 or maxindex > minindex or step > 1) and maxindex > 0:
-            arraylen =1 + ((maxindex - minindex)/step)
+            arraylen =max(0,1 + ((maxindex - minindex)/step))
             expect(len(values) <= arraylen, "Too many values for array %s"%(name))
 
         return name, values

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -901,7 +901,7 @@ class Namelist(object):
         >>> parse(text='&foo bar=1 / &bazz /').get_value('Bar')
         [u'1']
         >>> parse(text='&foo bar(2)=1 / &bazz /').get_value('Bar')
-        [u'1']
+        ['', u'1']
         >>> parse(text='&foo / &bazz /').get_value('bar')
         [u'']
         """
@@ -1896,11 +1896,11 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> x = _NamelistParser("&group\n foo='bar','bazz'\n,, foo2=2*5\n /")
         >>> x._parse_namelist_group()
         >>> x._settings
-        {u'group': {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'2*5']}}
+        {u'group': {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'5', u'5']}}
         >>> x = _NamelistParser("&group\n foo='bar','bazz'\n,, foo2=2*5\n /", groupless=True)
         >>> x._parse_namelist_group()
         >>> x._settings
-        {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'2*5']}
+        {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'5', u'5']}
         >>> x._curr()
         u'/'
         >>> x = _NamelistParser("&group /&group /")
@@ -1966,7 +1966,7 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> _NamelistParser("! Comment \n &group /! Comment ").parse_namelist()
         {u'group': {}}
         >>> _NamelistParser("&group1\n foo='bar','bazz'\n,, foo2=2*5\n / &group2 /").parse_namelist()
-        {u'group1': {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'2*5']}, u'group2': {}}
+        {u'group1': {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'5', u'5']}, u'group2': {}}
         >>> _NamelistParser("!blah \n foo='bar','bazz'\n,, foo2=2*5\n ", groupless=True).parse_namelist()
         {u'foo': [u"'bar'", u"'bazz'", u''], u'foo2': [u'5', u'5']}
         >>> _NamelistParser("!blah \n foo='bar','bazz'\n,, foo2=2*5,6\n ", groupless=True).parse_namelist()

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -112,7 +112,7 @@ logger = logging.getLogger(__name__)
 
 # Fortran syntax regular expressions.
 # Variable names.
-FORTRAN_NAME_REGEX = re.compile(r"^[a-z][a-z0-9_]{0,62}(\((\d+)\))?$", re.IGNORECASE)
+FORTRAN_NAME_REGEX = re.compile(r"^[a-z][a-z0-9_]{0,62}(\(([+-]?\d+)\))?$", re.IGNORECASE)
 FORTRAN_LITERAL_REGEXES = {}
 # Integer literals.
 _int_re_string = r"(\+|-)?[0-9]+"
@@ -1459,6 +1459,10 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
 
         nindex = fortran_name_index(text_check)
         if nindex is not None:
+            if nindex <= 0 or nindex > self._len:
+                raise _NamelistParseError("index value of %s is not supported in variable %s"%
+                                           (nindex, str(text)))
+
             text = text_check[:text.find('(')]
             vname = text.lower()
             if vname in self._nameindex:

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -839,6 +839,9 @@ class Namelist(object):
                     self._groups[group_lc][variable_lc] = \
                                         groups[group_name][variable_name]
 
+    def clean_groups(self):
+        self._groups = {}
+
     def get_group_names(self):
         """Return a list of all groups in the namelist.
 

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1949,6 +1949,10 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         (u'foo', [u'2'])
         >>> _NamelistParser("foo=1,2")._parse_name_and_values(allow_eof_end=True)
         (u'foo', [u'1', u'2'])
+        >>> _NamelistParser("foo(1:2)=1,2,3 ")._parse_name_and_values(allow_eof_end=True)
+        Traceback (most recent call last):
+        ...
+        SystemExit: ERROR: Too many values for array foo(1:2)
         >>> _NamelistParser("foo=1,")._parse_name_and_values(allow_eof_end=True)
         (u'foo', [u'1', u''])
         """
@@ -1976,6 +1980,10 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
                 break
             # and if it really is a literal, add it.
             values.append(literal)
+        (minindex, maxindex, step) = get_fortran_variable_indices(name)
+        if minindex > 1 or maxindex > minindex or step > 1:
+            expect(len(values) <= 1 + ((maxindex - minindex)/step), "Too many values for array %s"%(name))
+
         return name, values
 
     def _parse_namelist_group(self):

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -248,6 +248,8 @@ def get_fortran_variable_indices(varname, varlen=1, allow_any_len=False):
     if allow_any_len and maxindex == minindex:
         maxindex = -1
 
+    expect(step != 0,"Step size 0 not allowed")
+
     return (minindex, maxindex, step)
 
 def fortran_namelist_base_value(string):
@@ -1017,10 +1019,10 @@ class Namelist(object):
         if minindex > tlen:
             self._groups[group_name][variable_name].extend(['']*(minindex-tlen-1))
 
-        for i in range(minindex-1, maxindex+step, step):
-            while len(self._groups[group_name][variable_name]) < i+1:
+        for i in range(minindex, maxindex+2*step, step):
+            while len(self._groups[group_name][variable_name]) < i:
                 self._groups[group_name][variable_name].append('')
-            self._groups[group_name][variable_name][i] = value.pop(0)
+            self._groups[group_name][variable_name][i-1] = value.pop(0)
             if len(value) == 0:
                 break
 

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1553,7 +1553,7 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
             text_check = text
 
         if not is_valid_fortran_name(text_check):
-            if re.search(".*\(.*\,.*\)", text_check):
+            if re.search(r".*\(.*\,.*\)", text_check):
                 err_str = "Multiple dimensions not supported in CIME namelist variables %r" % str(text)
             else:
                 err_str = "%r is not a valid variable name" % str(text)

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -530,14 +530,8 @@ class NamelistGenerator(object):
 
         # Use this to see if we need to raise an error when nothing is found.
         have_value = False
-
         # Check for existing value.
         current_literals = self._namelist.get_variable_value(group, name)
-#     I may have broken something here???
-#        if current_literals != [""]:
-#            have_value = True
-            # Do not proceed further since this has been obtained the -infile contents
-#            return
 
         # Check for input argument.
         if value is not None:

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -211,7 +211,8 @@ class NamelistGenerator(object):
         """
         var_group = self._definition.get_group(name)
         literals = self._to_namelist_literals(name, value)
-        self._namelist.set_variable_value(var_group, name, literals)
+        _, _, var_size, = self._definition.split_type_string(name)
+        self._namelist.set_variable_value(var_group, name, literals, var_size)
 
     def get_default(self, name, config=None, allow_none=False):
         """Get the value of a variable from the namelist definition file.
@@ -550,7 +551,8 @@ class NamelistGenerator(object):
 
         # Go through file names and prepend input data root directory for
         # absolute pathnames.
-        if ignore_abs_path is None:
+        var_type, _, var_size = self._definition.split_type_string(name)
+        if var_type == "char" and ignore_abs_path is None:
             var_input_pathname = self._definition.get_input_pathname(name)
             if var_input_pathname == 'abs':
                 current_literals = expand_literal_list(current_literals)
@@ -570,7 +572,7 @@ class NamelistGenerator(object):
                 current_literals = compress_literal_list(current_literals)
 
         # Set the new value.
-        self._namelist.set_variable_value(group, name, current_literals)
+        self._namelist.set_variable_value(group, name, current_literals, var_size)
 
     def create_shr_strdata_nml(self):
         """Set defaults for `shr_strdata_nml` variables other than the variable domainfile """

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -85,7 +85,7 @@ class NamelistGenerator(object):
 
         # Create namelist object.
         self._namelist = Namelist()
-      
+
     # Define __enter__ and __exit__ so that we can use this as a context manager
     def __enter__(self):
         return self
@@ -284,6 +284,13 @@ class NamelistGenerator(object):
     def clean_streams(self):
         for variable in self._streams_variables:
             self._streams_namelists[variable] = []
+        self._streams_namelists["streams"] = []
+
+    def new_instance(self):
+        """ Clean the object just enough to introduce a new instance """
+        self.clean_streams()
+        self._namelist.clean_groups()
+
 
     def _sub_fields(self, varnames):
         """Substitute indicators with given values in a list of fields.

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -96,6 +96,9 @@ class NamelistGenerator(object):
     def init_defaults(self, infiles, config, skip_groups=None, skip_entry_loop=None ):
         """Return array of names of all definition nodes
         """
+        # first clean out any settings left over from previous calls
+        self.new_instance()
+
         self._definition.set_nodes(skip_groups=skip_groups)
 
         # Determine the array of entry nodes that will be acted upon
@@ -561,7 +564,7 @@ class NamelistGenerator(object):
                         continue
                     file_path = character_literal_to_string(literal)
                     # NOTE - these are hard-coded here and a better way is to make these extensible
-                    if file_path == 'UNSET' or file_path == 'idmap' or file_path == 'unknown_gridcpl_file':
+                    if file_path == 'UNSET' or file_path == 'idmap':
                         continue
                     if file_path == 'null':
                         continue

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -274,6 +274,7 @@ class NamelistGenerator(object):
                     default[i] = self.quote_string(scalar)
 
         default = self._to_python_value(name, default)
+
         return default
 
     def get_streams(self):
@@ -407,6 +408,7 @@ class NamelistGenerator(object):
         `stream_path` - Path to write the stream file to.
         `data_list_path` - Path of file to append input data information to.
         """
+
         # Stream-specific configuration.
         config = config.copy()
         config["stream"] = stream
@@ -520,10 +522,11 @@ class NamelistGenerator(object):
 
         # Check for existing value.
         current_literals = self._namelist.get_variable_value(group, name)
-        if current_literals != [""]:
-            have_value = True
+#     I may have broken something here???
+#        if current_literals != [""]:
+#            have_value = True
             # Do not proceed further since this has been obtained the -infile contents
-            return
+#            return
 
         # Check for input argument.
         if value is not None:

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -561,7 +561,7 @@ class NamelistGenerator(object):
                         continue
                     file_path = character_literal_to_string(literal)
                     # NOTE - these are hard-coded here and a better way is to make these extensible
-                    if file_path == 'UNSET' or file_path == 'idmap':
+                    if file_path == 'UNSET' or file_path == 'idmap' or file_path == 'unknown_gridcpl_file':
                         continue
                     if file_path == 'null':
                         continue

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -552,7 +552,7 @@ class NamelistGenerator(object):
         # Go through file names and prepend input data root directory for
         # absolute pathnames.
         var_type, _, var_size = self._definition.split_type_string(name)
-        if var_type == "char" and ignore_abs_path is None:
+        if var_type == "character" and ignore_abs_path is None:
             var_input_pathname = self._definition.get_input_pathname(name)
             if var_input_pathname == 'abs':
                 current_literals = expand_literal_list(current_literals)

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -85,7 +85,7 @@ class NamelistGenerator(object):
 
         # Create namelist object.
         self._namelist = Namelist()
-
+      
     # Define __enter__ and __exit__ so that we can use this as a context manager
     def __enter__(self):
         return self
@@ -280,6 +280,10 @@ class NamelistGenerator(object):
     def get_streams(self):
         """Get a list of all streams used for the current data model  mode."""
         return self.get_default("streamslist")
+
+    def clean_streams(self):
+        for variable in self._streams_variables:
+            self._streams_namelists[variable] = []
 
     def _sub_fields(self, varnames):
         """Substitute indicators with given values in a list of fields.

--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -203,7 +203,7 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-
+        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -203,7 +203,6 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/desp/cime_config/buildnml
+++ b/src/components/data_comps/desp/cime_config/buildnml
@@ -122,7 +122,6 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/desp/cime_config/buildnml
+++ b/src/components/data_comps/desp/cime_config/buildnml
@@ -65,7 +65,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     config['desp_mode'] = desp_mode
 
     #----------------------------------------------------
-    # Initialize namelist defaults 
+    # Initialize namelist defaults
     #----------------------------------------------------
     nmlgen.init_defaults(infile, config)
 
@@ -99,7 +99,7 @@ def buildnml(case, caseroot, compname):
         os.makedirs(confdir)
 
     #----------------------------------------------------
-    # Construct the namelist generator 
+    # Construct the namelist generator
     #----------------------------------------------------
     # Determine directory for user modified namelist_definitions.xml and namelist_defaults.xml
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src." + compname)
@@ -117,12 +117,12 @@ def buildnml(case, caseroot, compname):
 
     # Create the namelist generator object - independent of instance
     nmlgen = NamelistGenerator(case, definition_file)
-    
+
     #----------------------------------------------------
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-
+        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/dice/cime_config/buildnml
+++ b/src/components/data_comps/dice/cime_config/buildnml
@@ -164,7 +164,7 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-
+        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/dice/cime_config/buildnml
+++ b/src/components/data_comps/dice/cime_config/buildnml
@@ -164,7 +164,6 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/dlnd/cime_config/buildnml
+++ b/src/components/data_comps/dlnd/cime_config/buildnml
@@ -90,6 +90,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     # shr_strdata_nml group and input data list.
     #----------------------------------------------------
     for stream in streams:
+        nmlgen.clean_streams()
 
         # Ignore null values.
         if stream is None or stream in ("NULL", ""):
@@ -108,7 +109,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
             nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
-
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.
     #----------------------------------------------------

--- a/src/components/data_comps/dlnd/cime_config/buildnml
+++ b/src/components/data_comps/dlnd/cime_config/buildnml
@@ -84,14 +84,11 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     # Construct the list of streams.
     #----------------------------------------------------
     streams = nmlgen.get_streams()
-
     #----------------------------------------------------
     # For each stream, create stream text file and update
     # shr_strdata_nml group and input data list.
     #----------------------------------------------------
     for stream in streams:
-        nmlgen.clean_streams()
-
         # Ignore null values.
         if stream is None or stream in ("NULL", ""):
             continue
@@ -162,12 +159,11 @@ def buildnml(case, caseroot, compname):
 
     # Create the namelist generator object - independent of instance
     nmlgen = NamelistGenerator(case, definition_file, files=files)
-
     #----------------------------------------------------
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-
+        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/dlnd/cime_config/buildnml
+++ b/src/components/data_comps/dlnd/cime_config/buildnml
@@ -163,7 +163,6 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -166,7 +166,7 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-
+        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -166,7 +166,6 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/drof/cime_config/buildnml
+++ b/src/components/data_comps/drof/cime_config/buildnml
@@ -164,7 +164,7 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-
+        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/drof/cime_config/buildnml
+++ b/src/components/data_comps/drof/cime_config/buildnml
@@ -164,7 +164,6 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/dwav/cime_config/buildnml
+++ b/src/components/data_comps/dwav/cime_config/buildnml
@@ -170,7 +170,7 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-
+        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:

--- a/src/components/data_comps/dwav/cime_config/buildnml
+++ b/src/components/data_comps/dwav/cime_config/buildnml
@@ -170,7 +170,6 @@ def buildnml(case, caseroot, compname):
     # Loop over instances
     #----------------------------------------------------
     for inst_counter in range(1, ninst+1):
-        nmlgen.new_instance()
         # determine instance string
         inst_string = ""
         if ninst > 1:


### PR DESCRIPTION
Adds support for namelist entries of the form foo(3) = 'a'

Test suite: scripts_regression_tests.py, --namelist-only tests for cesm prealpha and aux_clm45
  Note there are some expected failures here due to bugs found in the process.  One bug was that
  for multi-instance cases all namelists were using the 0001 stream file and they each should have 
  a separate file.  Another bug was that only changes in user_nl_d***_0001 were being used in all
  instances (user_nl_d***_000n where n>1 was being ignored)
Test baseline: cesm2_0_alpha06g
Test namelist changes: 
Test status: bit for bit

Fixes #1248
Fixes #1274 

User interface changes?: 

Code review: @jgfouca @mvertens 