### PR TITLE
Enable PIO rearranger options for PIO2

### DIFF
--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -196,7 +196,6 @@ contains
              call shr_pio_read_component_namelist(nlfilename , comp_comm(i), pio_comp_settings(i)%pio_stride, &
                   pio_comp_settings(i)%pio_root, pio_comp_settings(i)%pio_numiotasks, &
                   pio_comp_settings(i)%pio_iotype, pio_comp_settings(i)%pio_rearranger)
-#ifdef PIO1
              call pio_init(comp_comm_iam(i), comp_comm(i), pio_comp_settings(i)%pio_numiotasks, 0, &
                   pio_comp_settings(i)%pio_stride, &
                   pio_comp_settings(i)%pio_rearranger, iosystems(i), &
@@ -207,14 +206,6 @@ contains
                 write(shr_log_unit,*) io_compname(i),' : pio_root = ',pio_comp_settings(i)%pio_root
                 write(shr_log_unit,*) io_compname(i),' : pio_iotype = ',pio_comp_settings(i)%pio_iotype
              end if
-#else
-             call pio_init(comp_comm_iam(i), comp_comm(i), pio_comp_settings(i)%pio_numiotasks, 0, &
-                  pio_comp_settings(i)%pio_stride, &
-                  pio_comp_settings(i)%pio_rearranger, iosystems(i), &
-                  base=pio_comp_settings(i)%pio_root)
-#endif
-
-
           end if
        end do
     end if
@@ -447,13 +438,11 @@ contains
     call shr_mpi_bcast(pio_async_interface, Comm)
     call shr_mpi_bcast(pio_rearranger, Comm)
 
-#ifdef PIO1
      call shr_pio_rearr_opts_set(Comm, pio_rearr_comm_type, pio_rearr_comm_fcd, &
            pio_rearr_comm_max_pend_req_comp2io, pio_rearr_comm_enable_hs_comp2io, &
            pio_rearr_comm_enable_isend_comp2io, &
            pio_rearr_comm_max_pend_req_io2comp, pio_rearr_comm_enable_hs_io2comp, &
            pio_rearr_comm_enable_isend_io2comp, pio_numiotasks)
-#endif
 
   end subroutine shr_pio_read_default_namelist
 
@@ -645,7 +634,7 @@ contains
     end if
 
   end subroutine shr_pio_namelist_set
-#ifdef PIO1
+
   ! This subroutine sets the global PIO rearranger options
   ! The input args that represent the rearranger options are valid only
   ! on the root proc of comm
@@ -818,7 +807,6 @@ contains
       pio_rearr_opts%comm_fc_opts_io2comp%enable_isend = .true.
     end if
   end subroutine
-#endif
 !===============================================================================
 
 end module shr_pio_mod


### PR DESCRIPTION
The PIO rearranger options, set via env_run.xml, was only
available (set) with PIO1. Now enabling it for PIO2.

Test suite: X case with PIO2
Test baseline: 
Test namelist changes: None
Test status: bit for bit

Fixes #1224

User interface changes?: None

Code review: @jedwards4b 
