### PR TITLE
Index in namelist2

### DIFF
--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -14,7 +14,7 @@ import re
 
 from CIME.namelist import fortran_namelist_base_value, \
     is_valid_fortran_namelist_literal, character_literal_to_string, \
-    expand_literal_list, Namelist
+    expand_literal_list, Namelist, get_fortran_name_only
 
 from CIME.XML.standard_module_setup import *
 from CIME.XML.entry_id import EntryID
@@ -118,7 +118,7 @@ class NamelistDefinition(EntryID):
         return valid_values
 
     def get_group(self, name):
-        return self._group_names[name]
+        return self._group_names[get_fortran_name_only(name)]
 
     def add_attributes(self, attributes):
         self._attributes = attributes
@@ -342,11 +342,12 @@ class NamelistDefinition(EntryID):
         for group_name in namelist.get_group_names():
             for variable_name in namelist.get_variable_names(group_name):
                 # Check that the variable is defined...
-                self._expect_variable_in_definition(variable_name, variable_template)
+                varname = get_fortran_name_only(variable_name)
+                self._expect_variable_in_definition(varname, variable_template)
 
                 # Check if can actually change this variable via filename change
                 if filename is not None:
-                    self._user_modifiable_in_variable_definition(variable_name)
+                    self._user_modifiable_in_variable_definition(varname)
 
                 # and has the right group name...
                 var_group = self.get_group(variable_name)
@@ -356,7 +357,7 @@ class NamelistDefinition(EntryID):
 
                 # and has a valid value.
                 value = namelist.get_variable_value(group_name, variable_name)
-                expect(self.is_valid_value(variable_name, value),
+                expect(self.is_valid_value(varname, value),
                        (variable_template + " has invalid value %r.") %
                        (str(variable_name), [str(scalar) for scalar in value]))
 
@@ -379,7 +380,7 @@ class NamelistDefinition(EntryID):
         groups = {}
         for variable_name in dict_:
             variable_lc = variable_name.lower()
-            self._expect_variable_in_definition(variable_lc, variable_template)
+            self._expect_variable_in_definition(get_fortran_name_only(variable_lc), variable_template)
             group_name = self.get_group(variable_lc)
             expect (group_name is not None, "No group found for var %s"%variable_lc)
             if group_name not in groups:

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -173,7 +173,22 @@ def is_valid_fortran_name(string):
     return FORTRAN_NAME_REGEX.search(string) is not None
 
 def get_fortran_name_only(varname):
-    
+    """ remove array section if any and return only the variable name 
+    >>> get_fortran_name_only('foo')
+    'foo'
+    >>> get_fortran_name_only('foo(3)')
+    'foo'
+    >>> get_fortran_name_only('foo(::)')
+    'foo'
+    >>> get_fortran_name_only('foo(1::)')
+    'foo'
+    >>> get_fortran_name_only('foo(:+2:)')
+    'foo'
+    >>> get_fortran_name_only('foo(::-3)')
+    'foo'
+    >>> get_fortran_name_only('foo(::)')
+    'foo'
+    """
     m = FORTRAN_NAME_REGEX.search(varname)
     if m is not None:
         return m.group(1)

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -112,7 +112,8 @@ logger = logging.getLogger(__name__)
 
 # Fortran syntax regular expressions.
 # Variable names.
-FORTRAN_NAME_REGEX = re.compile(r"^[a-z][a-z0-9_]{0,62}$", re.IGNORECASE)
+FORTRAN_NAME_REGEX = re.compile(r"(^[a-z][a-z0-9_]{0,62})(\(([+-]?\d*:?){3}\))?$", re.IGNORECASE)
+
 FORTRAN_LITERAL_REGEXES = {}
 # Integer literals.
 _int_re_string = r"(\+|-)?[0-9]+"

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -172,6 +172,13 @@ def is_valid_fortran_name(string):
     """
     return FORTRAN_NAME_REGEX.search(string) is not None
 
+def get_fortran_name_only(varname):
+    
+    m = FORTRAN_NAME_REGEX.search(varname)
+    if m is not None:
+        return m.group(1)
+
+
 
 def fortran_namelist_base_value(string):
     r"""Strip off whitespace and repetition syntax from a namelist value.


### PR DESCRIPTION
Handle array sections in user_nl input.   This version does not try to merge variables, however it does check for valid values.   Values out of bounds such as assigning dtlimit(0) when dtlimit array starts at 1 in the fortran are not trapped and will result in a runtime error. 
This PR supersedes #1259 

Test suite: scripts_regression_tests.py and hand testing of various inputs 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1248 

User interface changes?: 

Code review: 
