### PR TITLE
code_checker needs to work outside of ESMCI/CIME

### DIFF
--- a/scripts/lib/CIME/code_checker.py
+++ b/scripts/lib/CIME/code_checker.py
@@ -65,7 +65,8 @@ def _should_pylint_skip(filepath):
 def get_all_checkable_files():
 ###############################################################################
     cimeroot = get_cime_root()
-    all_git_files = run_cmd_no_fail("git ls-files --full-name %s" % cimeroot, verbose=False).splitlines()
+    all_git_files = run_cmd_no_fail("git ls-files", from_dir=cimeroot, verbose=False).splitlines()
+
     files_to_test = [item for item in all_git_files
                      if ((item.endswith(".py") or is_python_executable(os.path.join(cimeroot, item))) and not _should_pylint_skip(item))]
     return files_to_test


### PR DESCRIPTION
It doesn't work when run from ACME without this change

Test suite: B_CheckCode
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: None

Code review: @jedwards4b 
