### PR TITLE
make sure pio_typename is valid

### DIFF
--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -44,12 +44,6 @@
   <entry id="PIO_TYPENAME">
     <values>
       <value>pnetcdf</value>
-      <value mach="userdefined">netcdf</value>
-      <value mach="eastwind">netcdf</value>
-      <value mach="constance">netcdf</value>
-      <value mach="pleiades.*">netcdf</value>
-      <value mach="hobart" compiler="pgi">netcdf</value>
-      <value mach="hobart" compiler="nag">netcdf</value>
       <value mpilib="mpi-serial">netcdf</value>
     </values>
   </entry>

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -140,11 +140,20 @@ def _main_func(description):
         if netcdf4_parallel_found:
             valid_values += ",netcdf4p,netcdf4c"
         logger.warn("Updating valid_values for PIO_TYPENAME: %s", valid_values)
+
         case.set_valid_values("PIO_TYPENAME",valid_values)
         # nothing means use the general default
         valid_values += ",nothing"
-        for comp in ("ATM","CPL","OCN","WAV","GLC","ICE","ROF","LND"):
-            case.set_valid_values("%s_PIO_TYPENAME"%comp,valid_values)
+        
+        for comp in case.get_values("COMP_CLASSES"):
+            comp_pio_typename = "%s_PIO_TYPENAME"%comp
+            case.set_valid_values(comp_pio_typename,valid_values)
+            current_value = case.get_value(comp_pio_typename)
+            if current_value not in valid_values:
+                logger.warn("Resetting PIO_TYPENAME to netcdf for component %s"%comp)
+                case.set_value(comp_pio_typename,"netcdf")
+
+
 
 if (__name__ == "__main__"):
     _main_func(__doc__)


### PR DESCRIPTION
Make sure that the pio_typename value is a valid value for the build and reset to 
netcdf if it is not.   

Test suite: ERP.f19_f19.A.hobart_intel, ERP.f19_f19.A.hobart_gnu
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1272 

User interface changes?: 

Code review: 
