### PR TITLE
Add logging options to ESMF_Initialize

### DIFF
--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -935,6 +935,23 @@
     this to work.</desc>
   </entry>
 
+  <entry id="ESMF_LOGFILE_KIND">
+    <type>char</type>
+    <valid_values>ESMF_LOGKIND_SINGLE,ESMF_LOGKIND_MULTI,ESMF_LOGKIND_NONE</valid_values>
+    <default_value>ESMF_LOGKIND_NONE</default_value>
+    <group>run_cesm</group>
+    <file>env_run.xml</file>
+    <desc>
+      Determines what ESMF log files (if any) are generated when
+          USE_ESMF_LIB is TRUE. 
+      ESMF_LOGKIND_SINGLE: Use a single log file, combining messages from
+          all of the PETs. Not supported on some platforms.
+      ESMF_LOGKIND_MULTI: Use multiple log files — one per PET.
+      ESMF_LOGKIND_NONE: Do not issue messages to a log file.
+      By default, no ESMF log files are generated.
+    </desc>
+  </entry>
+
   <entry id="COMP_RUN_BARRIERS">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -946,7 +946,7 @@
           USE_ESMF_LIB is TRUE. 
       ESMF_LOGKIND_SINGLE: Use a single log file, combining messages from
           all of the PETs. Not supported on some platforms.
-      ESMF_LOGKIND_MULTI: Use multiple log files — one per PET.
+      ESMF_LOGKIND_MULTI: Use multiple log files -- one per PET.
       ESMF_LOGKIND_NONE: Do not issue messages to a log file.
       By default, no ESMF log files are generated.
     </desc>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -2602,6 +2602,24 @@
     </values>
   </entry>
 
+  <entry id="esmf_logging" modify_via_xml="ESMF_LOGFILE_KIND">
+    <type>char</type>
+    <category>ccsm_pes</category>
+    <group>ccsm_pes</group>
+    <desc>
+      Determines what ESMF log files (if any) are generated when
+          USE_ESMF_LIB is TRUE. 
+      ESMF_LOGKIND_SINGLE: Use a single log file, combining messages from
+          all of the PETs. Not supported on some platforms.
+      ESMF_LOGKIND_MULTI: Use multiple log files — one per PET.
+      ESMF_LOGKIND_NONE: Do not issue messages to a log file.
+      By default, no ESMF log files are generated.
+    </desc>
+    <values>
+      <value>$ESMF_LOGFILE_KIND</value>
+    </values>
+  </entry>
+
   <!-- =========================== -->
   <!-- group prof_inparm           -->
   <!--  in perf_mod.F90            -->

--- a/src/drivers/mct/main/cesm_driver.F90
+++ b/src/drivers/mct/main/cesm_driver.F90
@@ -20,8 +20,9 @@ program cesm_driver
    !----------------------------------------------------------------------------
    ! share code & libs
    !----------------------------------------------------------------------------
-   use perf_mod
-   use ESMF
+   use perf_mod,      only : t_startf, t_adj_detailf, t_stopf
+   use ESMF,          only : ESMF_Initialize, ESMF_Finalize
+   use seq_comm_mct,  only : esmf_logfile_kind
    use cesm_comp_mod, only : cesm_pre_init1
    use cesm_comp_mod, only : cesm_pre_init2
    use cesm_comp_mod, only : cesm_init
@@ -40,7 +41,7 @@ program cesm_driver
    ! because it is needed for the time manager, even if the ESMF_INTERFACE
    ! is not used.
    !--------------------------------------------------------------------------
-   call ESMF_Initialize()
+   call ESMF_Initialize(logkindflag=esmf_logfile_kind)
 
    !--------------------------------------------------------------------------
    ! Read in the configuration information and initialize the time manager.

--- a/src/share/esmf_wrf_timemgr/ESMF_Stubs.F90
+++ b/src/share/esmf_wrf_timemgr/ESMF_Stubs.F90
@@ -11,39 +11,47 @@ MODULE ESMF_Stubs
 ! Bogus typedefs
    TYPE ESMF_Grid
       INTEGER :: dummy
-   END TYPE
+   END TYPE ESMF_Grid
 
    TYPE ESMF_GridComp
       INTEGER :: dummy
-   END TYPE
+   END TYPE ESMF_GridComp
 
    TYPE ESMF_State
       INTEGER :: dummy
-   END TYPE
+   END TYPE ESMF_State
 
    TYPE ESMF_VM
       INTEGER :: dummy
-   END TYPE
+   END TYPE ESMF_VM
 
    TYPE ESMF_END_FLAG
       INTEGER :: dummy
-   END TYPE
-   TYPE(ESMF_END_FLAG), PARAMETER ::  &
-      ESMF_END_ABORT   = ESMF_END_FLAG(1), &
-      ESMF_END_NORMAL  = ESMF_END_FLAG(2), &
+   END TYPE ESMF_END_FLAG
+   TYPE(ESMF_END_FLAG), PARAMETER ::                &
+      ESMF_END_ABORT   = ESMF_END_FLAG(1),          &
+      ESMF_END_NORMAL  = ESMF_END_FLAG(2),          &
       ESMF_END_KEEPMPI = ESMF_END_FLAG(3)
 
    TYPE ESMF_MsgType
       INTEGER :: mtype
-   END TYPE
-   TYPE(ESMF_MsgType), PARAMETER  ::      &
-      ESMF_LOG_INFO  =   ESMF_MsgType(1), &
-      ESMF_LOG_WARNING = ESMF_MsgType(2), &
+   END TYPE ESMF_MsgType
+   TYPE(ESMF_MsgType), PARAMETER  ::                &
+      ESMF_LOG_INFO  =   ESMF_MsgType(1),           &
+      ESMF_LOG_WARNING = ESMF_MsgType(2),           &
       ESMF_LOG_ERROR =   ESMF_MsgType(3)
 
    TYPE ESMF_LOG
       INTEGER :: dummy
-   END TYPE
+   END TYPE ESMF_LOG
+
+   TYPE ESMF_LogKind_Flag
+      INTEGER :: dummy
+   END TYPE ESMF_LogKind_Flag
+   TYPE(ESMF_LogKind_Flag), PARAMETER ::            &
+        ESMF_LOGKIND_NONE = ESMF_LogKind_Flag(1),   &
+        ESMF_LOGKIND_SINGLE = ESMF_LogKind_Flag(2), &
+        ESMF_LOGKIND_MULTI = ESMF_LogKind_Flag(3)
 
    LOGICAL, private, save :: initialized = .false.
 
@@ -52,17 +60,20 @@ MODULE ESMF_Stubs
    PUBLIC ESMF_LogWrite, ESMF_LOG, ESMF_MsgType, ESMF_END_FLAG
    PUBLIC ESMF_LOG_INFO, ESMF_LOG_WARNING, ESMF_LOG_ERROR
    PUBLIC ESMF_END_ABORT, ESMF_END_NORMAL, ESMF_END_KEEPMPI
+   PUBLIC ESMF_LogKind_Flag
+   PUBLIC ESMF_LOGKIND_NONE, ESMF_LOGKIND_SINGLE, ESMF_LOGKIND_MULTI
 
 CONTAINS
 
 
 ! NOOP
-   SUBROUTINE ESMF_Initialize( vm, defaultCalendar, rc )
+   SUBROUTINE ESMF_Initialize( vm, defaultCalendar, logkindflag, rc )
       USE ESMF_BaseMod
       USE ESMF_CalendarMod
 !     USE ESMF_TimeMod,     only: defaultCal
       TYPE(ESMF_VM),           INTENT(IN   ), OPTIONAL :: vm
       TYPE(ESMF_CalKind_Flag), INTENT(IN   ), OPTIONAL :: defaultCalendar
+      TYPE(ESMF_LogKind_Flag), INTENT(IN   ), OPTIONAL :: logkindflag
       INTEGER,                 INTENT(  OUT), OPTIONAL :: rc
 
       TYPE(ESMF_CalKind_Flag) :: defaultCalType


### PR DESCRIPTION
Added log kind flag to ESMF_Initialize call to allow control over ESMF PET log files when the ESMF library is used. The flag determines what ESMF log files (if any) are generated when USE_ESMF_LIB is TRUE. 

- ESMF_LOGKIND_SINGLE: Use a single log file, combining messages from all of the PETs. Not supported on some platforms.
- ESMF_LOGKIND_MULTI: Use multiple log files -- one per PET.
- ESMF_LOGKIND_NONE: Do not issue messages to a log file.
- By default, no ESMF log files are generated.

Test suite: ./scripts_regression_test.py + hand testing:
```
./create_newcase --case /glade/scratch/goldy/esmfTest --compset A --res ne16_ne16 --run-unsupported
./xmlchange USE_ESMF_LIB=TRUE,DOUT_S=FALSE,STOP_OPTION=nsteps,STOP_N=3
```
Run test with each ESMF log kind option
Test baseline: NA
Test namelist changes: New driver namelist variable: `esmf_logging`
Test status: bit for bit

Fixes #1245 

User interface changes?: New run time XML variable: `ESMF_LOGFILE_KIND`

Code review: 
