### PR TITLE
Allow a custom input root through create_test.

### DIFF
--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -41,8 +41,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--svn-loc", default=SVN_LOCS[get_model()],
                         help="The input data repository from which to download data.")
 
-    parser.add_argument("-i", "--input-data-root", default=MACHINE.get_value("DIN_LOC_ROOT"),
-                        help="The root directory where input data goes")
+    parser.add_argument("-i", "--input-data-root", default=None,
+                        help="The root directory where input data goes. "
+                        "Default value will come from DIN_LOC_ROOT from case which itself "
+                        "defaults to '%s'" % MACHINE.get_value("DIN_LOC_ROOT"))
 
     parser.add_argument("--data-list-dir", default="Buildconf",
                         help="Where to find list of input files")

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -222,6 +222,9 @@ OR
     parser.add_argument("--force-threads", type=int, default=None,
                         help="For all tests to run with this number of threads")
 
+    parser.add_argument("-i", "--input-dir",
+                        help="Use a non-default location for input files")
+
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
@@ -343,11 +346,14 @@ OR
             elif args.generate:
                 baseline_gen_name = baseline_name
 
+    if args.input_dir is not None:
+        args.input_dir = os.path.abspath(args.input_dir)
+
     return test_names, test_extra_data, args.compiler, mach_obj.get_machine_name(), args.no_run, args.no_build, args.no_setup, args.no_batch,\
         args.test_root, args.baseline_root, args.clean, baseline_cmp_name, baseline_gen_name, \
         args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.walltime, \
         args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue, \
-        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib
+        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib, args.input_dir
 
 ###############################################################################
 def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost_map, wall_time, test_root):
@@ -453,7 +459,7 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
 def create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                 baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, project, test_id, parallel_jobs,
                 walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite, output_root, wait,
-                force_procs, force_threads, mpilib):
+                force_procs, force_threads, mpilib, input_dir):
 ###############################################################################
     impl = TestScheduler(test_names, test_data=test_data,
                          no_run=no_run, no_build=no_build, no_setup=no_setup, no_batch=no_batch,
@@ -465,7 +471,8 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
                          project=project, parallel_jobs=parallel_jobs, walltime=walltime,
                          proc_pool=proc_pool, use_existing=use_existing, save_timing=save_timing,
                          queue=queue, allow_baseline_overwrite=allow_baseline_overwrite,
-                         output_root=output_root, force_procs=force_procs, force_threads=force_threads, mpilib=mpilib)
+                         output_root=output_root, force_procs=force_procs, force_threads=force_threads,
+                         mpilib=mpilib, input_dir=input_dir)
 
     success = impl.run_tests(wait=wait)
 
@@ -506,13 +513,13 @@ def _main_func(description):
     test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, \
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \
-    save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib \
+    save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir \
         = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                          baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only,
                          project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, save_timing,
-                         queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib))
+                         queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir))
 
 ###############################################################################
 

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -87,16 +87,19 @@ class TestScheduler(object):
                  walltime=None, proc_pool=None,
                  use_existing=False, save_timing=False, queue=None,
                  allow_baseline_overwrite=False, output_root=None,
-                 force_procs=None, force_threads=None, mpilib=None):
+                 force_procs=None, force_threads=None, mpilib=None,
+                 input_dir=None):
     ###########################################################################
-        self._cime_root     = CIME.utils.get_cime_root()
-        self._cime_model    = CIME.utils.get_model()
-        self._save_timing   = save_timing
-        self._queue         = queue
-        self._test_data     = {} if test_data is None else test_data # Format:  {test_name -> {data_name -> data}}
-        self._mpilib = mpilib  # allow override of default mpilib
-        self._allow_baseline_overwrite  = allow_baseline_overwrite
+        self._cime_root       = CIME.utils.get_cime_root()
+        self._cime_model      = CIME.utils.get_model()
+        self._save_timing     = save_timing
+        self._queue           = queue
+        self._test_data       = {} if test_data is None else test_data # Format:  {test_name -> {data_name -> data}}
+        self._mpilib          = mpilib  # allow override of default mpilib
         self._completed_tests = 0
+        self._input_dir       = input_dir
+
+        self._allow_baseline_overwrite = allow_baseline_overwrite
 
         self._machobj = Machines(machine=machine_name)
 
@@ -530,6 +533,9 @@ class TestScheduler(object):
             envtest.set_initial_values(case)
             case.set_value("TEST", True)
             case.set_value("SAVE_TIMING", self._save_timing)
+
+            if self._input_dir is not None:
+                case.set_value("DIN_LOC_ROOT", self._input_dir)
 
         return True
 


### PR DESCRIPTION
Also, change check_input_data so that it supports custom input roots.

Test suite: by-hand, code-checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1282 (sort of)

User interface changes?: Add --input-dir argument to create_test

Code review: @jedwards4b 
