### PR TITLE
avoid a problem with pio_typename in clone with keepexe

### DIFF
--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -25,7 +25,7 @@ def parse_command_line(args):
                         "is assumed to be under then current working directory ")
 
     parser.add_argument("--keepexe", "-keepexe", action="store_true",
-                        help="Sets EXEROOT to point to original build")
+                        help="Sets EXEROOT to point to original build, it is highly recommended that the original case be built before cloning if using the --keepexe flag")
 
     parser.add_argument("--mach-dir", "-mach_dir",
                         help="Specify the locations of the Machines directory, other than the default"

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -144,6 +144,12 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         else:
             self._activate_case1()
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+            # pio_typename may be changed during the build if the default is not a 
+            # valid value for this build, update case2 to reflect this change
+            for comp in self._case1.get_values("COMP_CLASSES"):
+                comp_pio_typename = "%s_PIO_TYPENAME"%comp
+                self._case2.set_value(comp_pio_typename, self._case1.get_value(comp_pio_typename))
+
             # The following is needed when _case_two_setup has a case_setup call
             # despite sharing the build (e.g., to change NTHRDS)
             self._case2.set_value("BUILD_COMPLETE",True)

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -198,18 +198,22 @@ class EntryID(GenericXML):
         subgroup is ignored in the general routine and applied in specific methods
         """
         expect(subgroup is None, "Subgroup not supported")
+        str_value = self.get_valid_value_string(node, value, vid, ignore_type)
+        node.set("value", str_value)
+        return value
+
+    def get_valid_value_string(self, node, value,vid=None,  ignore_type=False):
         valid_values = self._get_valid_values(node)
         if ignore_type:
             expect(type(value) is str, "Value must be type string if ignore_type is true")
             str_value = value
-        else:
-            type_str = self._get_type_info(node)
-            str_value = convert_to_string(value, type_str, vid)
+            return str_value
+        type_str = self._get_type_info(node)
+        str_value = convert_to_string(value, type_str, vid)
+
         if valid_values is not None and not str_value.startswith('$'):
             expect(str_value in valid_values, "Did not find %s in valid values for %s: %s" % (value, vid, valid_values))
-        node.set("value", str_value)
-
-        return value
+        return str_value
 
     def set_value(self, vid, value, subgroup=None, ignore_type=False):
         """

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -114,10 +114,10 @@ class EnvBase(EntryID):
 
         if iscompvar:
             attribute = {"component":component}
-            type_str = self._get_type_info(node)
-            val = self.set_element_text("value", convert_to_string(value, type_str, vid), attribute, root=node)
-            return val
-        val = EntryID._set_value(self, node, value, vid, subgroup, ignore_type)
+            str_value = self.get_valid_value_string(node, value, vid, ignore_type)
+            val = self.set_element_text("value", str_value, attribute, root=node)
+        else:
+            val = EntryID._set_value(self, node, value, vid, subgroup, ignore_type)
         return val
 
     def get_nodes_by_id(self, varid):

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1009,7 +1009,7 @@ class Case(object):
             newcase.set_value("BUILD_COMPLETE","TRUE")
             orig_bld_complete = self.get_value("BUILD_COMPLETE")
             if not orig_bld_complete:
-                logger.warn("\nWARNING: Creating a clone before building the original case may cause PIO_TYPENAME to be invalid in the clone")
+                logger.warn("\nWARNING: Creating a clone with --keepexe before building the original case may cause PIO_TYPENAME to be invalid in the clone")
                 logger.warn("Avoid this message by building case one before you clone.\n")
         else:
             newcase.set_value("BUILD_COMPLETE","FALSE")

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1007,6 +1007,10 @@ class Case(object):
             orig_exeroot = self.get_value("EXEROOT")
             newcase.set_value("EXEROOT", orig_exeroot)
             newcase.set_value("BUILD_COMPLETE","TRUE")
+            orig_bld_complete = self.get_value("BUILD_COMPLETE")
+            if not orig_bld_complete:
+                logger.warn("\nWARNING: Creating a clone before building the original case may cause PIO_TYPENAME to be invalid in the clone")
+                logger.warn("Avoid this message by building case one before you clone.\n")
         else:
             newcase.set_value("BUILD_COMPLETE","FALSE")
 


### PR DESCRIPTION
Print a warning if create_clone is run before case1 is built.   Add code to system_tests_compare_two to update pio_typename in case2 after case1 build is complete.  

Test suite: scripts_regression_tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1304 

User interface changes?: 

Code review: 
