### PR TITLE
Fix atm grid match for T31 atm2wav map

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1483,7 +1483,7 @@
       <map name="ICE2WAV_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ww3a_splice_170214.nc</map>
     </gridmap>
 
-    <gridmap atm_grid="48x96" wav_grid="ww3a">
+    <gridmap atm_grid="T31" wav_grid="ww3a">
       <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/T31/map_T31_TO_ww3a_bilin_131104.nc</map>
     </gridmap>
 


### PR DESCRIPTION
This is needed in order to run a fully-coupled T31 run with ww3.

Test suite: Manual test
   Created a B compset with ww3 at T31 resolution, checked ATM2WAV_SMAPNAME
Test baseline: N/A
Test namelist changes: Changes atm2wav_smapname
Test status: bit for bit

Fixes #1319 

User interface changes?: none

Code review: 
