### PR TITLE
More-robust way of getting path to create_test

### DIFF
--- a/scripts/Tools/cime_bisect
+++ b/scripts/Tools/cime_bisect
@@ -88,7 +88,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def cime_bisect(testargs, good, bad, testroot, compiler, project, baseline_name, check_namelists, check_throughput, check_memory, all_commits):
 ###############################################################################
-    create_test = os.path.join(CIME.utils.get_scripts_location_within_cime(), "create_test")
+    create_test = os.path.join(CIME.utils.get_scripts_root(), "create_test")
     expect(os.path.exists(create_test), "Please run the root of a CIME repo")
     wait_for_tests = os.path.join(CIME.utils.get_scripts_location_within_cime(), "Tools", "wait_for_tests")
 


### PR DESCRIPTION
Test suite: by-hand, ACME side
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: None

Code review: None
