### PR TITLE
Refactor BUILD_THREADED to match documentation.

### DIFF
--- a/scripts/lib/CIME/SystemTests/erp.py
+++ b/scripts/lib/CIME/SystemTests/erp.py
@@ -67,7 +67,6 @@ class ERP(SystemTestsCommon):
                     nthreads  = self._case.get_value("NTHRDS_%s"%comp)
                     rootpe    = self._case.get_value("ROOTPE_%s"%comp)
                     if ( nthreads > 1 ):
-                        self._case.set_value("BUILD_THREADED", True)
                         self._case.set_value("NTHRDS_%s"%comp, nthreads/2)
                     if ( ntasks > 1 ):
                         self._case.set_value("NTASKS_%s"%comp, ntasks/2)

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -335,7 +335,7 @@ def _clean_impl(case, cleanlist, clean_all):
         expect(cleanlist is not None and len(cleanlist) > 0,"Empty cleanlist not expected")
         debug           = case.get_value("DEBUG")
         use_esmf_lib    = case.get_value("USE_ESMF_LIB")
-        build_threaded  = case.get_value("BUILD_THREADED")
+        build_threaded  = case.get_build_threaded()
         gmake           = case.get_value("GMAKE")
         caseroot        = case.get_value("CASEROOT")
         casetools       = case.get_value("CASETOOLS")
@@ -394,7 +394,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only):
     # needs to be unset before building again.
     if "MODEL" in os.environ.keys():
         del os.environ["MODEL"]
-    build_threaded      = case.get_value("BUILD_THREADED")
+    build_threaded      = case.get_build_threaded()
     casetools           = case.get_value("CASETOOLS")
     exeroot             = case.get_value("EXEROOT")
     incroot             = case.get_value("INCROOT")

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -10,7 +10,7 @@ from CIME.XML.standard_module_setup import *
 
 from CIME.utils                     import expect, get_cime_root, append_status
 from CIME.utils                     import convert_to_type, get_model, get_project
-from CIME.utils                     import get_build_threaded, get_current_commit
+from CIME.utils                     import get_current_commit
 from CIME.check_lockedfiles         import LOCKED_DIR, lock_file
 from CIME.XML.machines              import Machines
 from CIME.XML.pes                   import Pes
@@ -142,7 +142,7 @@ class Case(object):
         mpi_attribs = {
             "compiler" : self.get_value("COMPILER"),
             "mpilib"   : self.get_value("MPILIB"),
-            "threaded" : get_build_threaded(self)
+            "threaded" : self.get_build_threaded()
             }
 
         executable = env_mach_spec.get_mpirun(self, mpi_attribs, job="case.run", exe_only=True)[0]
@@ -1072,7 +1072,7 @@ class Case(object):
         mpi_attribs = {
             "compiler" : self.get_value("COMPILER"),
             "mpilib"   : self.get_value("MPILIB"),
-            "threaded" : get_build_threaded(self)
+            "threaded" : self.get_build_threaded()
             }
 
         executable, args = env_mach_specific.get_mpirun(self, mpi_attribs, job=job)
@@ -1118,6 +1118,13 @@ class Case(object):
             env_module = self.get_env("mach_specific")
             env_module.load_env(compiler=compiler,debug=debug, mpilib=mpilib)
             self._is_env_loaded = True
+
+    def get_build_threaded(self):
+        """
+        Returns True if current settings require a threaded build/run.
+        """
+        force_threaded = self.get_value("BUILD_THREADED")
+        return bool(force_threaded) or self.thread_count > 1
 
     def _check_testlists(self, compset_alias, grid_name, files):
         """

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -147,10 +147,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
             logger.debug("at update TOTALPES = %s"%pestot)
             case.set_value("TOTALPES", pestot)
             thread_count = env_mach_pes.get_max_thread_count(models)
-            if thread_count > 1:
-                case.set_value("BUILD_THREADED", True)
-
-            expect(not (case.get_value("BUILD_THREADED")  and compiler == "nag"),
+            build_threaded = case.get_build_threaded()
+            expect(not (build_threaded and compiler == "nag"),
                    "it is not possible to run with OpenMP if using the NAG Fortran compiler")
             cost_pes = env_mach_pes.get_cost_pes(pestot, thread_count, machine=case.get_value("MACH"))
             case.set_value("COST_PES", cost_pes)

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -973,17 +973,6 @@ def wait_for_unlocked(filepath):
             if file_object:
                 file_object.close()
 
-def get_build_threaded(case):
-    """Returns True if current settings require a threaded build/run."""
-    force_threaded = case.get_value("BUILD_THREADED")
-    if force_threaded:
-        return True
-    comp_classes = case.get_values("COMP_CLASSES")
-    for comp_class in comp_classes:
-        if case.get_value("NTHRDS_%s"%comp_class) > 1:
-            return True
-    return False
-
 def gunzip_existing_file(filepath):
     with gzip.open(filepath, "rb") as fd:
         return fd.read()

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1246,7 +1246,7 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case(self):
     ###########################################################################
-        run_cmd_assert_result(self, "%s/create_test cime_test_only -t %s --no-build --test-root %s --output-root %s"
+        run_cmd_assert_result(self, "%s/create_test TESTRUNPASS_P1.f19_g16_rx1.A -t %s --no-build --test-root %s --output-root %s"
                               % (SCRIPT_DIR, self._baseline_name, TEST_ROOT, TEST_ROOT))
 
         casedir = os.path.join(self._testroot,
@@ -1281,6 +1281,45 @@ class K_TestCimeCase(TestCreateTestCommon):
 
             # Test some test properties
             self.assertEqual(case.get_value("TESTCASE"), "TESTRUNPASS")
+
+    ###########################################################################
+    def test_cime_case_build_threaded_1(self):
+    ###########################################################################
+        run_cmd_assert_result(self, "%s/create_test TESTRUNPASS_P1x1.f19_g16_rx1.A -t %s --no-build --test-root %s --output-root %s"
+                              % (SCRIPT_DIR, self._baseline_name, TEST_ROOT, TEST_ROOT))
+
+        casedir = os.path.join(self._testroot,
+                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_P1x1.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
+        self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
+
+        with Case(casedir, read_only=False) as case:
+            build_threaded = case.get_value("BUILD_THREADED")
+            self.assertFalse(build_threaded)
+
+            build_threaded = case.get_build_threaded()
+            self.assertFalse(build_threaded)
+
+            case.set_value("BUILD_THREADED", True)
+
+            build_threaded = case.get_build_threaded()
+            self.assertTrue(build_threaded)
+
+    ###########################################################################
+    def test_cime_case_build_threaded_2(self):
+    ###########################################################################
+        run_cmd_assert_result(self, "%s/create_test TESTRUNPASS_P1x2.f19_g16_rx1.A -t %s --no-build --test-root %s --output-root %s"
+                              % (SCRIPT_DIR, self._baseline_name, TEST_ROOT, TEST_ROOT))
+
+        casedir = os.path.join(self._testroot,
+                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_P1x2.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
+        self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
+
+        with Case(casedir, read_only=False) as case:
+            build_threaded = case.get_value("BUILD_THREADED")
+            self.assertFalse(build_threaded)
+
+            build_threaded = case.get_build_threaded()
+            self.assertTrue(build_threaded)
 
     ###########################################################################
     def test_cime_case_mpi_serial(self):


### PR DESCRIPTION
Documentation (and CIME2 behavior) states that BUILD_THREADED is
supposed to represent an override to force the model to be built
with threads even if nthrds is one for all components.

Until this PR, we had been using BUILD_THREADED as a marker to
indicate that we found a component with nthrds > 1. This is not
useful because we already had case.thread_count for that.

This PR restores BUILD_THREADED to its original behavior and adds
some tests to enforce.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: BUILD_THREADED behaves differently

Code review: @jedwards4b 
