### PR TITLE
Add more checks for gnu in debug mode

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -109,7 +109,7 @@ using a fortran linker.
   <CFLAGS>
     <base> -mcmodel=medium -std=gnu99 </base>
     <append compile_threaded="true"> -fopenmp </append>
-    <append DEBUG="TRUE"> -g -Wall </append>
+    <append DEBUG="TRUE"> -g -Wall -ffpe-trap=invalid,zero,overflow -fcheck=bounds </append>
     <append DEBUG="FALSE"> -O </append>
   </CFLAGS>
   <CMAKE_OPTS>


### PR DESCRIPTION
This adds gnu flags that are roughly equivalent to what we check for
intel (or at least what we checked as of a few months ago - I haven't
checked recently).

Test suite: 
   Ran all gnu debug tests that I could find in CESM test suites - all
   on yellowstone. However, I did not run
   SMS_D.T62_s11.G.yellowstone_gnu.pop-cice, which is currently
   failing. Note that these tests exercise A, I and TG compsets, so do
   not exercise CAM, POP or CICE.

   - aux_clm45 gnu debug tests: all pass and bfb (ran from clm4_5_15_r233)
   - aux_glc gnu debug tests: all pass, did not compare baselines (ran
     from clm4_5_15_r233)
   - two tests from the prealpha / prebeta test suite: pass and bfb (ran
     from cesm2_0_alpha06h):
     - SMS_D.f09_g16_gl10.TG1.yellowstone_gnu
     - ERI_D.T31_g37_rx1.A.yellowstone_gnu

Test baseline: See above
Test namelist changes: none
Test status: bit for bit for tested configurations (A, I, TG compsets)

Fixes #857 

User interface changes?: No

Code review: 
