### PR TITLE
fixes for cheyenne issues

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -963,6 +963,12 @@ using a fortran linker.
   <PNETCDF_PATH>$ENV{PNETCDF}</PNETCDF_PATH>
 </compiler>
 
+<compiler MACH="cheyenne" COMPILER="gnu">
+  <CPPDEFS>
+    <append MODEL="pio1"> -DNO_MPIMOD </append>
+  </CPPDEFS>
+</compiler>
+
 <compiler MACH="cheyenne">
   <CPPDEFS>
     <!-- these flags enable nano timers -->
@@ -982,6 +988,8 @@ using a fortran linker.
   <CMAKE_OPTS>
     <append DEBUG="TRUE"> -DPIO_ENABLE_LOGGING=ON </append>
   </CMAKE_OPTS>
+  <!-- Bug in the intel/17.0.1 compiler requires this, remove this line when compiler is updated -->
+  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
 </compiler>
 
 <compiler MACH="laramie">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -251,13 +251,8 @@
       <modules mpilib="mpi-serial">
 	<command name="load">netcdf/4.4.1.1</command>
       </modules>
-      <modules mpilib="mpt" compiler="intel">
+      <modules mpilib="mpt">
 	<command name="load">netcdf-mpi/4.4.1.1</command>
-      </modules>
-      <modules mpilib="mpt" compiler="gnu">
-	<command name="load">netcdf/4.4.1.1</command>
-      </modules>
-      <modules mpilib="mpt" >
 	<command name="load">pnetcdf/1.8.0</command>
       </modules>
     </module_system>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -251,8 +251,13 @@
       <modules mpilib="mpi-serial">
 	<command name="load">netcdf/4.4.1.1</command>
       </modules>
-      <modules mpilib="mpt">
+      <modules mpilib="mpt" compiler="intel">
 	<command name="load">netcdf-mpi/4.4.1.1</command>
+      </modules>
+      <modules mpilib="mpt" compiler="gnu">
+	<command name="load">netcdf/4.4.1.1</command>
+      </modules>
+      <modules mpilib="mpt" >
 	<command name="load">pnetcdf/1.8.0</command>
       </modules>
     </module_system>

--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -109,13 +109,13 @@
     </values>
   </entry>
   -->
-  <entry id="LND_PIO_REARRANGER">
+<!--  <entry id="LND_PIO_REARRANGER">
     <values>
       <value compset="_CLM40" >2</value>
       <value compset="_CLM45" >1</value>
       <value compset="_CLM50" >1</value>
     </values>
-  </entry>
+  </entry> -->
 
   <!--- uncomment and fill in relevant sections
   <entry id="LND_PIO_STRIDE">

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -75,12 +75,14 @@ def create_namelists(case):
 
         cmd = os.path.join(config_dir, "buildnml")
         do_run_cmd = False
+        # This code will try to import and run each buildnml as a subroutine
+        # if that fails it will run it as a program in a seperate shell
         try:
             with open(cmd, 'r') as f:
                 first_line = f.readline()
             if "python" in first_line:
-                logger.info("   Calling %s buildnml"%compname)
                 mod = imp.load_source("buildnml", cmd)
+                logger.info("   Calling %s buildnml"%compname)
                 mod.buildnml(case, caseroot, compname)
             else:
                 raise SyntaxError

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -943,7 +943,7 @@
     <file>env_run.xml</file>
     <desc>
       Determines what ESMF log files (if any) are generated when
-          USE_ESMF_LIB is TRUE. 
+          USE_ESMF_LIB is TRUE.
       ESMF_LOGKIND_SINGLE: Use a single log file, combining messages from
           all of the PETs. Not supported on some platforms.
       ESMF_LOGKIND_MULTI: Use multiple log files -- one per PET.

--- a/src/share/util/mct_mod.F90
+++ b/src/share/util/mct_mod.F90
@@ -98,7 +98,6 @@ module mct_mod
    use m_GlobalSegMap       ,only: mct_gsMap_gstorage     => GlobalStorage
    use m_GlobalSegMap       ,only: mct_gsMap_ngseg        => ngseg
    use m_GlobalSegMap       ,only: mct_gsMap_nlseg        => nlseg
-   use m_GlobalSegMap       ,only: mct_gsMap_OP           => OrderedPoints
    use m_GlobalSegMap       ,only: mct_gsMap_maxnlseg     => max_nlseg
    use m_GlobalSegMap       ,only: mct_gsMap_activepes    => active_pes
    use m_GlobalSegMap       ,only: mct_gsMap_copy         => copy
@@ -1292,4 +1291,3 @@ end function mct_myindex
 !===============================================================================
 
 end module mct_mod
-


### PR DESCRIPTION
Fixes issue with gnu compiler on cheyenne, workaround for intel 17 compiler issue.
minor interface cleanup 

Test suite: scripts_regression_tests.py + cime_developer with gnu compiler on cheyenne
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #781 

User interface changes?: 

Code review: 
