### PR TITLE
User compset

### DIFF
--- a/scripts/lib/CIME/XML/compsets.py
+++ b/scripts/lib/CIME/XML/compsets.py
@@ -38,7 +38,7 @@ class Compsets(GenericXML):
 
                 logger.debug("Found node match with alias: %s and lname: %s" % (alias, lname))
                 return (lname, alias, science_support)
-        return (None, None, False)
+        return (None, None, [False])
 
     def get_compset_var_settings(self, compset, grid):
         '''
@@ -85,4 +85,3 @@ class Compsets(GenericXML):
         for v in compsets_text.iteritems():
             label, definition = v
             logger.info("   %20s : %s" %(label, definition))
-

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -403,7 +403,7 @@ class Case(object):
         either a longname or an alias.  This will also set the
         compsets and pes specfication files.
         """
-        science_support = {}
+        science_support = []
         compset_alias = None
         components = files.get_components("COMPSETS_SPEC_FILE")
         logger.debug(" Possible components for COMPSETS_SPEC_FILE are %s" % components)

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -26,7 +26,6 @@ def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR:"):
         if logger.isEnabledFor(logging.DEBUG):
             import pdb
             pdb.set_trace()
-        logger.error("%s %s", error_prefix,error_msg, exc_info=True)
         raise exc_type("%s %s"%(error_prefix,error_msg))
 
 def id_generator(size=6, chars=string.ascii_lowercase + string.digits):

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -248,8 +248,11 @@ class J_TestCreateNewcase(unittest.TestCase):
             shutil.rmtree(testdir)
 
         cls._testdirs.append(testdir)
-
-        run_cmd_assert_result(self, "%s/create_newcase --case %s --compset X --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
+        if CIME.utils.get_model() == "cesm":
+            pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
+            run_cmd_assert_result(self, "%s/create_newcase --case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --user-compset --run-unsupported --pesfile %s --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, pesfile, cls._testroot), from_dir=SCRIPT_DIR)
+        else:
+            run_cmd_assert_result(self, "%s/create_newcase --case %s --compset X --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
         run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
         run_cmd_assert_result(self, "./case.build", from_dir=testdir)
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -248,11 +248,27 @@ class J_TestCreateNewcase(unittest.TestCase):
             shutil.rmtree(testdir)
 
         cls._testdirs.append(testdir)
+        run_cmd_assert_result(self, "%s/create_newcase --case %s --compset X --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
+        run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
+        run_cmd_assert_result(self, "./case.build", from_dir=testdir)
+
+        cls._do_teardown.append(testdir)
+
+    def test_f_createnewcase_with_user_compset(self):
+        cls = self.__class__
+
+        testdir = os.path.join(cls._testroot, 'testcreatenewcase_with_user_compset')
+        if os.path.exists(testdir):
+            shutil.rmtree(testdir)
+
+        cls._testdirs.append(testdir)
+
+        pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
+        args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --user-compset --pesfile %s --res f19_g16 --output-root %s" % (testdir, pesfile, cls._testroot)
         if CIME.utils.get_model() == "cesm":
-            pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
-            run_cmd_assert_result(self, "%s/create_newcase --case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --user-compset --run-unsupported --pesfile %s --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, pesfile, cls._testroot), from_dir=SCRIPT_DIR)
-        else:
-            run_cmd_assert_result(self, "%s/create_newcase --case %s --compset X --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
+            args += " --run-unsupported"
+
+        run_cmd_assert_result(self, "%s/create_newcase %s"%(SCRIPT_DIR, args), from_dir=SCRIPT_DIR)
         run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
         run_cmd_assert_result(self, "./case.build", from_dir=testdir)
 


### PR DESCRIPTION
Fixes an issue with --user-compset flag, modifies test to include this
Test suite: scripts_regression_tests.py user-compset tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1315 

User interface changes?: 

Code review: 
