### PR TITLE
add support for user_mods in compset definition

### DIFF
--- a/config/xml_schemas/config_compsets.xsd
+++ b/config/xml_schemas/config_compsets.xsd
@@ -11,6 +11,7 @@
   <xs:element name="alias" type="xs:NCName"/>
   <xs:element name="lname" type="xs:string"/>
   <xs:element name="science_support"/>
+  <xs:element name="user_mods" type="xs:string"/>
 
   <!-- complex elements -->
 
@@ -32,6 +33,7 @@
         <xs:element ref="alias"/>
         <xs:element ref="lname"/>
 	<xs:element ref="science_support" minOccurs="0" maxOccurs="unbounded"/>
+	<xs:element ref="user_mods" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute ref="grid"/>
     </xs:complexType>

--- a/scripts/lib/CIME/XML/compsets.py
+++ b/scripts/lib/CIME/XML/compsets.py
@@ -36,8 +36,10 @@ class Compsets(GenericXML):
                 for node in science_support_nodes:
                     science_support.append(node.get("grid"))
 
+                user_mods = self.get_optional_node("user_mods", root=node)
+
                 logger.debug("Found node match with alias: %s and lname: %s" % (alias, lname))
-                return (lname, alias, science_support)
+                return (lname, alias, science_support, user_mods)
         return (None, None, [False])
 
     def get_compset_var_settings(self, compset, grid):

--- a/scripts/lib/CIME/XML/compsets.py
+++ b/scripts/lib/CIME/XML/compsets.py
@@ -27,7 +27,9 @@ class Compsets(GenericXML):
         nodes = self.get_nodes("compset")
         alias = None
         lname = None
+
         science_support = []
+
         for node in nodes:
             alias = self.get_element_text("alias",root=node)
             lname = self.get_element_text("lname",root=node)
@@ -40,7 +42,7 @@ class Compsets(GenericXML):
 
                 logger.debug("Found node match with alias: %s and lname: %s" % (alias, lname))
                 return (lname, alias, science_support, user_mods)
-        return (None, None, [False])
+        return (None, None, [False], None)
 
     def get_compset_var_settings(self, compset, grid):
         '''

--- a/scripts/lib/CIME/XML/compsets.py
+++ b/scripts/lib/CIME/XML/compsets.py
@@ -38,7 +38,11 @@ class Compsets(GenericXML):
                 for node in science_support_nodes:
                     science_support.append(node.get("grid"))
 
-                user_mods = self.get_optional_node("user_mods", root=node)
+                user_mods_node = self.get_optional_node("user_mods", root=node)
+                if user_mods_node is not None:
+                    user_mods = user_mods_node.text
+                else:
+                    user_mods = None
 
                 logger.debug("Found node match with alias: %s and lname: %s" % (alias, lname))
                 return (lname, alias, science_support, user_mods)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -958,8 +958,10 @@ class Case(object):
         User mods can be specified on the create_newcase command line (usually when called from create test)
         or they can be in the compset definition, or both.
         """
-        
-        for user_mods in (user_mods_dir, self._user_mods):
+
+        # This looping order will lead to the specified user_mods_dir taking
+        # precedence over self._user_mods, if there are any conflicts.
+        for user_mods in (self._user_mods, user_mods_dir):
             if user_mods is not None:
                 if os.path.isabs(user_mods):
                     user_mods_path = user_mods

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -95,7 +95,9 @@ class Case(object):
         self._components = []
         self._component_classes = []
         self._is_env_loaded = False
-
+        # these are user_mods as defined in the compset
+        # Command Line user_mods are handeled seperately
+        self._user_mods = None
         self.thread_count = None
         self.total_tasks = None
         self.tasks_per_node = None
@@ -419,7 +421,7 @@ class Case(object):
             # If the file exists, read it and see if there is a match for the compset alias or longname
             if (os.path.isfile(compsets_filename)):
                 compsets = Compsets(compsets_filename)
-                match, compset_alias, science_support = compsets.get_compset_match(name=compset_name)
+                match, compset_alias, science_support, self._user_mods = compsets.get_compset_match(name=compset_name)
                 pesfile = files.get_value("PES_SPEC_FILE"     , {"component":component})
                 if match is not None:
                     self._pesfile = pesfile
@@ -952,14 +954,22 @@ class Case(object):
         self._create_caseroot_tools()
 
     def apply_user_mods(self, user_mods_dir=None):
-        if user_mods_dir is not None:
-            if os.path.isabs(user_mods_dir):
-                user_mods_path = user_mods_dir
-            else:
-                user_mods_path = self.get_value('USER_MODS_DIR')
-                user_mods_path = os.path.join(user_mods_path, user_mods_dir)
-            self.set_value("USER_MODS_FULLPATH",user_mods_path)
-            apply_user_mods(self._caseroot, user_mods_path)
+        """
+        User mods can be specified on the create_newcase command line (usually when called from create test)
+        or they can be in the compset definition, or both.
+        """
+        
+        for user_mods in (user_mods_dir, self._user_mods):
+            if user_mods is not None:
+                if os.path.isabs(user_mods):
+                    user_mods_path = user_mods
+                else:
+                    user_mods_path = self.get_value('USER_MODS_DIR')
+                    user_mods_path = os.path.join(user_mods_path, user_mods)
+                CIME.user_mod_support.apply_user_mods(self._caseroot, user_mods_path)
+
+
+
 
     def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
         if cime_output_root is None:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -966,7 +966,7 @@ class Case(object):
                 else:
                     user_mods_path = self.get_value('USER_MODS_DIR')
                     user_mods_path = os.path.join(user_mods_path, user_mods)
-                CIME.user_mod_support.apply_user_mods(self._caseroot, user_mods_path)
+                apply_user_mods(self._caseroot, user_mods_path)
 
 
 

--- a/scripts/lib/CIME/tests/test_user_mod_support.py
+++ b/scripts/lib/CIME/tests/test_user_mod_support.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+
+import unittest
+import shutil
+import tempfile
+import os
+from CIME.user_mod_support import apply_user_mods
+
+# ========================================================================
+# Define some parameters
+# ========================================================================
+
+_SOURCEMODS = os.path.join("SourceMods", "src.drv")
+
+class TestUserModSupport(unittest.TestCase):
+
+    # ========================================================================
+    # Test helper functions
+    # ========================================================================
+
+    def setUp(self):
+        self._caseroot = tempfile.mkdtemp()
+        self._caseroot_sourcemods = os.path.join(self._caseroot, _SOURCEMODS)
+        os.makedirs(self._caseroot_sourcemods)
+        self._user_mods_parent_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self._caseroot, ignore_errors=True)
+        shutil.rmtree(self._user_mods_parent_dir, ignore_errors=True)
+
+    def createUserMod(self, name, include_dirs=None):
+        """Create a user_mods directory with the given name.
+
+        This directory is created within self._user_mods_parent_dir
+
+        For name='foo', it will contain:
+
+        - A user_nl_cpl file with contents:
+          foo
+
+        - A shell_commands file with contents:
+          echo foo >> /PATH/TO/CASEROOT/shell_commands_result
+
+        - A file in _SOURCEMODS named myfile.F90 with contents:
+          foo
+
+        If include_dirs is given, it should be a list of strings, giving names
+        of other user_mods directories to include. e.g., if include_dirs is
+        ['foo1', 'foo2'], then this will create a file 'include_user_mods' that
+        contains paths to the 'foo1' and 'foo2' user_mods directories, one per
+        line.
+        """
+
+        mod_dir = os.path.join(self._user_mods_parent_dir, name)
+        os.makedirs(mod_dir)
+        mod_dir_sourcemods = os.path.join(mod_dir, _SOURCEMODS)
+        os.makedirs(mod_dir_sourcemods)
+
+        with open(os.path.join(mod_dir, "user_nl_cpl"), "w") as user_nl_cpl:
+            user_nl_cpl.write(name + "\n")
+        with open(os.path.join(mod_dir, "shell_commands"), "w") as shell_commands:
+            command = "echo %s >> %s/shell_commands_result\n"%(name,
+                                                               self._caseroot)
+            shell_commands.write(command)
+        with open(os.path.join(mod_dir_sourcemods, "myfile.F90"), "w") as f90_file:
+            f90_file.write(name + "\n")
+
+        if include_dirs:
+            with open(os.path.join(mod_dir, "include_user_mods"), "w") as include_user_mods:
+                for one_include in include_dirs:
+                    include_user_mods.write(os.path.join(self._user_mods_parent_dir, one_include) + "\n")
+
+    def assertResults(self, expected_user_nl_cpl,
+                      expected_shell_commands_result,
+                      expected_sourcemod,
+                      msg = ""):
+        """Asserts that the contents of the files in self._caseroot match expectations
+
+        If msg is provided, it is printed for some failing assertions
+        """
+
+        path_to_user_nl_cpl = os.path.join(self._caseroot, "user_nl_cpl")
+        self.assertTrue(os.path.isfile(path_to_user_nl_cpl),
+                        msg = msg + ": user_nl_cpl does not exist")
+        with open(path_to_user_nl_cpl, "r") as user_nl_cpl:
+            contents = user_nl_cpl.read()
+            self.assertEqual(expected_user_nl_cpl, contents)
+
+        path_to_shell_commands_result = os.path.join(self._caseroot, "shell_commands_result")
+        self.assertTrue(os.path.isfile(path_to_shell_commands_result),
+                        msg = msg + ": shell_commands_result does not exist")
+        with open(path_to_shell_commands_result, "r") as shell_commands_result:
+            contents = shell_commands_result.read()
+            self.assertEqual(expected_shell_commands_result, contents)
+
+        path_to_sourcemod = os.path.join(self._caseroot_sourcemods, "myfile.F90")
+        self.assertTrue(os.path.isfile(path_to_sourcemod),
+                        msg = msg + ": sourcemod file does not exist")
+        with open(path_to_sourcemod, "r") as sourcemod:
+            contents = sourcemod.read()
+            self.assertEqual(expected_sourcemod, contents)
+
+    # ========================================================================
+    # Begin actual tests
+    # ========================================================================
+
+    def test_basic(self):
+        self.createUserMod("foo")
+        apply_user_mods(self._caseroot,
+                        os.path.join(self._user_mods_parent_dir, "foo"))
+        self.assertResults(expected_user_nl_cpl = "foo\n",
+                           expected_shell_commands_result = "foo\n",
+                           expected_sourcemod = "foo\n",
+                           msg = "test_basic")
+
+    def test_two_applications(self):
+        """If apply_user_mods is called twice, the second should appear after the first so that it takes precedence."""
+
+        self.createUserMod("foo1")
+        self.createUserMod("foo2")
+        apply_user_mods(self._caseroot,
+                        os.path.join(self._user_mods_parent_dir, "foo1"))
+        apply_user_mods(self._caseroot,
+                        os.path.join(self._user_mods_parent_dir, "foo2"))
+        self.assertResults(expected_user_nl_cpl = "foo1\nfoo2\n",
+                           expected_shell_commands_result = "foo1\nfoo2\n",
+                           expected_sourcemod = "foo2\n",
+                           msg = "test_two_applications")
+
+    def test_include(self):
+        """If there is an included mod, the main one should appear after the included one so that it takes precedence."""
+
+        self.createUserMod("base")
+        self.createUserMod("derived", include_dirs=["base"])
+
+        apply_user_mods(self._caseroot,
+                        os.path.join(self._user_mods_parent_dir, "derived"))
+
+        self.assertResults(expected_user_nl_cpl = "base\nderived\n",
+                           expected_shell_commands_result = "base\nderived\n",
+                           expected_sourcemod = "derived\n",
+                           msg = "test_include")
+
+    def test_duplicate_includes(self):
+        """Test multiple includes, where both include the same base mod.
+
+        The base mod should only be included once.
+        """
+
+        self.createUserMod("base")
+        self.createUserMod("derived1", include_dirs=["base"])
+        self.createUserMod("derived2", include_dirs=["base"])
+        self.createUserMod("derived_combo",
+                           include_dirs = ["derived1", "derived2"])
+
+        apply_user_mods(self._caseroot,
+                        os.path.join(self._user_mods_parent_dir, "derived_combo"))
+
+        # NOTE(wjs, 2017-04-15) The ordering of derived1 vs. derived2 is not
+        # critical here: If this aspect of the behavior changes, the
+        # expected_contents can be changed to match the new behavior in this
+        # respect.
+        expected_contents = """base
+derived2
+derived1
+derived_combo
+"""
+        self.assertResults(expected_user_nl_cpl = expected_contents,
+                           expected_shell_commands_result = expected_contents,
+                           expected_sourcemod = "derived_combo\n",
+                           msg = "test_duplicate_includes")


### PR DESCRIPTION
Allows for the specification of user_mods in the compset definition.   If both compset definition and
command line argument (--user-mods-dir) are specified then both are applied with command line applied first and compset second.  

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Code review: 
