### PR TITLE
Update domain_b in nnsm map

### DIFF
--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/src/main.F90
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/src/main.F90
@@ -208,6 +208,7 @@ if (step3) then
    !--- create new map datatype to hold result of matrix-matrix multiply ---
    call map_dup(map_orig,map_new)
    map_new%title  = trim(title)
+   map_new%domain_b = trim(map_smooth%domain_b)
    call map_matMatMult(map_orig,map_new,map_smooth) ! mult(A,B,S): B=S*A
    call mapsort_sort(map_new)
    call map_check(map_new)


### PR DESCRIPTION
Previously, the generated maps were

1. nn: runoff -> ocean
2. smooth: ocean -> ocean
3. nnsm: runoff -> ocean

The metadata from nn was copied to nnsm, and then the title attribute was
overwritten. Now the maps are

1. nn: runoff -> ocean (coastal)
2. smooth: ocean (coastal) -> ocean (global)
3. nnsm: runoff -> ocean (global)

So the domain_b attribute differs between nn and nnsm and also needs to be
overwritten (it should map domain_b from the smooth map).


Test suite: N/A
Test baseline:  N/A
Test namelist changes: N/A
Test status: bit-for-bit

Fixes: none filed, just noticed this bug while generating a new set of maps

User interface changes?:  N/A

Code review: added one line, verified metadata changed as expected. Sorry, I wish I had caught this before #1280 was accepted (but I was waiting for that to go through before re-generating maps).

