### PR TITLE
Fixes for PRE test

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -158,6 +158,8 @@ LAR    long term archive test
 
 DAE    data assimilation test: non answer changing
 
+PRE    pause-resume test: by default a BFB test of pause-resume cycling
+
 ======================================================================
     Other component-specific tests
 ======================================================================

--- a/scripts/lib/CIME/SystemTests/nck.py
+++ b/scripts/lib/CIME/SystemTests/nck.py
@@ -46,7 +46,11 @@ class NCK(SystemTestsCompareTwo):
 
     def _case_two_setup(self):
         for comp in self._comp_classes:
-            self._case.set_value("NINST_%s"%comp, 2)
+            if (comp == "ESP"):
+                self._case.set_value("NINST_%s"%comp, 1)
+            else:
+                self._case.set_value("NINST_%s"%comp, 2)
+
             ntasks = self._case.get_value("NTASKS_%s"%comp)
             self._case.set_value("NTASKS_%s"%comp, ntasks*2)
 

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -2,6 +2,7 @@
 Implementation of the CIME pause/resume test: Tests having driver
 'pause' (write cpl restart file) and 'resume' (read cpl restart file)
 without changing restart file. Compare to non-pause/resume run.
+Test can also be run with other component combinations.
 
 """
 
@@ -19,8 +20,9 @@ class PRE(SystemTestsCompareTwo):
 ###############################################################################
     """
     Implementation of the CIME pause/resume test: Tests having driver
-    'pause' (write cpl restart file) and 'resume' (read cpl restart file)
-    without changing restart file. Compare to non-pause/resume run.
+    'pause' (write cpl and/or other restart file(s)) and 'resume'
+    (read cpl and/or other restart file(s)) without changing restart
+    file. Compare to non-pause/resume run.
     """
 
     ###########################################################################
@@ -31,26 +33,35 @@ class PRE(SystemTestsCompareTwo):
                                        run_two_suffix='pr',
                                        run_one_description='no pause/resume',
                                        run_two_description='pause/resume')
+        self._stopopt  = 'ndays'
+        self._stopn    = 5
+        self._pausediv = 5 # Number of pause cycles per run
 
     ###########################################################################
     def _case_one_setup(self):
     ###########################################################################
         case_setup(self._case, test_mode=True, reset=True)
+        self._stopopt = self._case.get_value("STOP_OPTION")
+        self._stopn = self._case.get_value("STOP_N")
 
     ###########################################################################
     def _case_two_setup(self):
     ###########################################################################
         # Set up a pause/resume run
-        stopopt = self._case.get_value("STOP_OPTION")
-        stopn = self._case.get_value("STOP_N")
-        expect((stopn % 5) == 0, "ERROR: PRE test requires that STOP_N be divisible by five")
-        pausen = stopn / 5
-        expect(pausen > 0, "ERROR: pause_n (%d) must be > 0, stop_n is %d"%(pausen, stopn))
-        self._case.set_value("PAUSE_OPTION", stopopt)
+        self._case.set_value("STOP_OPTION", self._stopopt)
+        self._case.set_value("STOP_N", self._stopn)
+        if self._stopn > 3:
+            pausen = 2
+        else:
+            pausen = 1
+        # End if
+
+        self._case.set_value("PAUSE_OPTION", self._stopopt)
         self._case.set_value("PAUSE_N", pausen)
+        comps = [ x.lower() for x in self._case.get_values("COMP_CLASSES") ]
         pcl = self._case.get_value("PAUSE_COMPONENT_LIST")
-        expect(pcl == "cpl", 
-               "ERROR: PRE test expected PAUSE_COMPONENT_LIST = 'cpl', found '%s'"%pcl)
+        expect(pcl == "all" or set(pcl.split(':')).issubset(comps), 
+               "PRE ERROR: Invalid PAUSE_COMPONENT_LIST, '%s'"%pcl)
 
         self._case.flush()
 
@@ -65,37 +76,35 @@ class PRE(SystemTestsCompareTwo):
         self._activate_case2()
         rundir2 = self._case.get_value("RUNDIR")
         should_match = (self._case.get_value("DESP_MODE") == "NOCHANGE")
+        compare_ok = True
         pause_comps = self._case.get_value("PAUSE_COMPONENT_LIST")
         expect((pause_comps != 'none'), "Pause/Resume (PRE) test has no pause components")
         if pause_comps == 'all':
             pause_comps = self._case.get_values("COMP_CLASSES")
         else:
             pause_comps = pause_comps.split(':')
-        # End if
+
         for comp in pause_comps:
-            restart_files_1 = glob.glob(os.path.join(rundir1, '*.%s.r.*'%comp))
-            if len(restart_files_1) != 1:
-                logger.error("Wrong number of case1 %s restart files, %d", comp, len(restart_files_1))
-            # End if
-            restart_files_2 = glob.glob(os.path.join(rundir2, '*.%s.r.*'%comp))
-            if len(restart_files_2) != 5:
-                logger.error("Wrong number of case2 %s restart files, %d", comp, len(restart_files_2))
-            # End if
+            comp_name = self._case.get_value('COMP_%s'%comp.upper())
+            rname = '*.%s.r.*'%comp_name
+            restart_files_1 = glob.glob(os.path.join(rundir1, rname))
+            expect((len(restart_files_1) > 0), "No case1 restart files for %s"%comp)
+            restart_files_2 = glob.glob(os.path.join(rundir2, rname))
+            expect((len(restart_files_2) > len(restart_files_1)),
+                   "No pause (restart) files found in case2 for %s"%comp)
             # Do cprnc of restart files.
-            rfile1 = restart_files_1[0]
+            rfile1 = restart_files_1[len(restart_files_1) - 1]
             # rfile2 has to match rfile1 (same time string)
             parts = os.path.basename(rfile1).split(".")
             glob_str = "*.%s"%".".join(parts[len(parts)-4:])
             restart_files_2 = glob.glob(os.path.join(rundir2, glob_str))
-            if len(restart_files_2) < 1:
-                logger.error("Missing case2 restart file, %s", glob_str)
-            # End if
-            if len(restart_files_2) > 1:
-                logger.error("Multiple case2 restart files, %s", glob_str)
-            # End if
+            expect((len(restart_files_2) == 1),
+                   "Missing case2 restart file, %s", glob_str)
             rfile2 = restart_files_2[0]
             ok, out = cprnc(comp, rfile1, rfile2, self._case, rundir2)
-            logger.warning("CPRNC result: %s, file = %s"%(ok, out))
-            expect((should_match == ok),
-                   "%s restart files%s match"%(comp, " do not" if should_match else ""))
-        # End for
+            logger.warning("CPRNC result for %s: %s"%(os.path.basename(rfile1), "PASS" if (ok == should_match) else "FAIL"))
+            compare_ok = compare_ok and (should_match == ok)
+
+        expect(compare_ok,
+               "Not all restart files %s"%("matched" if should_match else "failed to match"))
+

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -50,6 +50,7 @@ class PRE(SystemTestsCompareTwo):
         # Set up a pause/resume run
         self._case.set_value("STOP_OPTION", self._stopopt)
         self._case.set_value("STOP_N", self._stopn)
+        self._case.set_value("ESP_RUN_ON_PAUSE", "TRUE")
         if self._stopn > 3:
             pausen = 2
         else:

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -33,9 +33,8 @@ class PRE(SystemTestsCompareTwo):
                                        run_two_suffix='pr',
                                        run_one_description='no pause/resume',
                                        run_two_description='pause/resume')
-        self._stopopt  = 'ndays'
-        self._stopn    = 5
-        self._pausediv = 5 # Number of pause cycles per run
+        self._stopopt  = ''
+        self._stopn    = 0
 
     ###########################################################################
     def _case_one_setup(self):

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -102,7 +102,7 @@ class PRE(SystemTestsCompareTwo):
             expect((len(restart_files_2) == 1),
                    "Missing case2 restart file, %s", glob_str)
             rfile2 = restart_files_2[0]
-            ok, out = cprnc(comp, rfile1, rfile2, self._case, rundir2)
+            ok, out = cprnc(comp, rfile1, rfile2, self._case, rundir2) # pylint: disable=unused-variable
             logger.warning("CPRNC result for %s: %s"%(os.path.basename(rfile1), "PASS" if (ok == should_match) else "FAIL"))
             compare_ok = compare_ok and (should_match == ok)
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -700,7 +700,12 @@ class Case(object):
             if compclass == "CPL":
                 continue
             key = "NINST_%s"%compclass
-            mach_pes_obj.set_value(key, ninst)
+            # ESP models are currently limited to 1 instance
+            if compclass == "ESP":
+                mach_pes_obj.set_value(key, 1)
+            else:
+                mach_pes_obj.set_value(key, ninst)
+
             key = "NTASKS_%s"%compclass
             if key not in pes_ntasks.keys():
                 mach_pes_obj.set_value(key,1)

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -127,6 +127,9 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
                 continue
             ninst  = case.get_value("NINST_%s" % comp)
             ntasks = case.get_value("NTASKS_%s" % comp)
+            # ESP models are currently limited to 1 instance
+            expect((comp != "ESP") or (ninst == 1),
+                   "ESP components may only have one instance")
             if ninst > ntasks:
                 if ntasks == 1:
                     case.set_value("NTASKS_%s" % comp, ninst)

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -573,6 +573,25 @@ def get_timestamp(timestamp_format="%Y%m%d_%H%M%S", utc_time=False):
         time_tuple = time.localtime()
     return time.strftime(timestamp_format, time_tuple)
 
+def get_time_in_seconds(time, unit):
+    """
+    Convert a time from 'unit' to seconds
+    """
+    if 'nyear' in unit:
+        dmult = 365 * 24 * 3600
+    elif 'nmonth' in unit:
+        dmult = 30 * 24 * 3600
+    elif 'nday' in unit:
+        dmult = 24 * 3600
+    elif 'nhour' in unit:
+        dmult = 3600
+    elif 'nminute' in unit:
+        dmult = 60
+    else:
+        dmult = 1
+
+    return dmult * time
+
 def get_project(machobj=None):
     """
     Hierarchy for choosing PROJECT:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -573,25 +573,6 @@ def get_timestamp(timestamp_format="%Y%m%d_%H%M%S", utc_time=False):
         time_tuple = time.localtime()
     return time.strftime(timestamp_format, time_tuple)
 
-def get_time_in_seconds(time, unit):
-    """
-    Convert a time from 'unit' to seconds
-    """
-    if 'nyear' in unit:
-        dmult = 365 * 24 * 3600
-    elif 'nmonth' in unit:
-        dmult = 30 * 24 * 3600
-    elif 'nday' in unit:
-        dmult = 24 * 3600
-    elif 'nhour' in unit:
-        dmult = 3600
-    elif 'nminute' in unit:
-        dmult = 60
-    else:
-        dmult = 1
-
-    return dmult * time
-
 def get_project(machobj=None):
     """
     Hierarchy for choosing PROJECT:
@@ -806,6 +787,25 @@ def convert_to_babylonian_time(seconds):
     seconds %= 60
 
     return "%02d:%02d:%02d" % (hours, minutes, seconds)
+
+def get_time_in_seconds(timeval, unit):
+    """
+    Convert a time from 'unit' to seconds
+    """
+    if 'nyear' in unit:
+        dmult = 365 * 24 * 3600
+    elif 'nmonth' in unit:
+        dmult = 30 * 24 * 3600
+    elif 'nday' in unit:
+        dmult = 24 * 3600
+    elif 'nhour' in unit:
+        dmult = 3600
+    elif 'nminute' in unit:
+        dmult = 60
+    else:
+        dmult = 1
+
+    return dmult * timeval
 
 def compute_total_time(job_cost_map, proc_pool):
     """

--- a/scripts/lib/update_acme_tests.py
+++ b/scripts/lib/update_acme_tests.py
@@ -48,8 +48,8 @@ _TEST_SUITES = {
                              "ERP.f45_g37_rx1.A",
                              "SMS_D_Ln9.f19_g16_rx1.A",
                              "DAE.f19_f19.A",
-                             "SMS.T42_T42.S")
-#                             "PRE.f19_f19.ADESP")
+                             "SMS.T42_T42.S",
+                             "PRE.f19_f19.ADESP")
                             ),
 
     #

--- a/scripts/lib/update_acme_tests.py
+++ b/scripts/lib/update_acme_tests.py
@@ -49,7 +49,7 @@ _TEST_SUITES = {
                              "SMS_D_Ln9.f19_g16_rx1.A",
                              "DAE.f19_f19.A",
                              "SMS.T42_T42.S",
-                             "PRE.f19_f19.ADESP")
+                             "PRE.f45_g37_rx1.ADESP")
                             ),
 
     #

--- a/src/drivers/mct/cime_config/buildexe
+++ b/src/drivers/mct/cime_config/buildexe
@@ -31,7 +31,11 @@ def _main_func():
         gmake     = case.get_value("GMAKE")
         gmake_j   = case.get_value("GMAKE_J")
         model     = case.get_value("MODEL")
+        num_esp   = case.get_value("NUM_COMP_INST_ESP")
         os.environ["PIO_VERSION"] = str(case.get_value("PIO_VERSION"))
+
+    expect((num_esp is None) or (int(num_esp) == 1), "ESP component restricted to one instance")
+        
 
     with open('Filepath', 'w') as out:
         out.write(os.path.join(caseroot, "SourceMods", "src.drv") + "\n")

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -23,6 +23,20 @@ from CIME.XML.files import Files
 logger = logging.getLogger(__name__)
 
 ###############################################################################
+def _get_time_in_seconds(time, unit):
+###############################################################################
+    if 'nyear' in unit:
+        dmult = 365 * 24 * 3600
+    elif 'nmonth' in unit:
+        dmult = 30 * 24 * 3600
+    elif 'nday' in unit:
+        dmult = 24 * 3600
+    else:
+        dmult = 1
+
+    return dmult * time
+
+###############################################################################
 def _create_drv_namelists(case, infile, confdir, nmlgen, files):
 ###############################################################################
 
@@ -93,6 +107,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         expect(False, "basedt invalid overflow for NCPL_BASE_PERIOD %s " %ncpl_base_period)
 
     comps = case.get_values("COMP_CLASSES")
+    mindt = basedt
     for comp in comps:
         ncpl = case.get_value(comp.upper() + '_NCPL')
         if ncpl is not None:
@@ -101,6 +116,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             if totaldt != basedt:
                 expect(False, " %s ncpl doesn't divide base dt evenly" %comp)
             nmlgen.set_value(comp.lower() + '_cpl_dt', value=cpl_dt)
+            mindt = min(mindt, cpl_dt)
 #        elif comp.lower() is not 'cpl':
 
     #--------------------------------
@@ -142,6 +158,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     # Set up the pause_component_list if pause is active
     pauseo = case.get_value('PAUSE_OPTION')
     if pauseo != 'never' and pauseo != 'none':
+        pausen = case.get_value('PAUSE_N')
         pcl = nmlgen.get_default('pause_component_list')
         nmlgen.add_default('pause_component_list', pcl)
         # Check to make sure pause_component_list is valid
@@ -154,6 +171,13 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
                        "Invalid PAUSE_COMPONENT_LIST, %s is not a valid component type"%comp)
             # End for
         # End if
+        # Set esp interval
+        if 'nstep' in pauseo:
+            esp_time = mindt
+        else:
+            esp_time = _get_time_in_seconds(pausen, pauseo)
+
+        nmlgen.set_value('esp_cpl_dt', value=esp_time)
     # End if pause is active
 
     #--------------------------------

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -16,29 +16,11 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
 from CIME.utils import expect
-from CIME.utils import run_cmd_no_fail, get_model
+from CIME.utils import run_cmd_no_fail, get_model, get_time_in_seconds
 from CIME.buildnml import create_namelist_infile, parse_input
 from CIME.XML.files import Files
 
 logger = logging.getLogger(__name__)
-
-###############################################################################
-def _get_time_in_seconds(time, unit):
-###############################################################################
-    if 'nyear' in unit:
-        dmult = 365 * 24 * 3600
-    elif 'nmonth' in unit:
-        dmult = 30 * 24 * 3600
-    elif 'nday' in unit:
-        dmult = 24 * 3600
-    elif 'nhour' in unit:
-        dmult = 3600
-    elif 'nminute' in unit:
-        dmult = 60
-    else:
-        dmult = 1
-
-    return dmult * time
 
 ###############################################################################
 def _create_drv_namelists(case, infile, confdir, nmlgen, files):
@@ -179,7 +161,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         if 'nstep' in pauseo:
             esp_time = mindt
         else:
-            esp_time = _get_time_in_seconds(pausen, pauseo)
+            esp_time = get_time_in_seconds(pausen, pauseo)
 
         nmlgen.set_value('esp_cpl_dt', value=esp_time)
     # End if pause is active

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -31,6 +31,10 @@ def _get_time_in_seconds(time, unit):
         dmult = 30 * 24 * 3600
     elif 'nday' in unit:
         dmult = 24 * 3600
+    elif 'nhour' in unit:
+        dmult = 3600
+    elif 'nminute' in unit:
+        dmult = 60
     else:
         dmult = 1
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -418,6 +418,23 @@
     </desc>
   </entry>
 
+  <entry id="ESP_RUN_ON_PAUSE">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_begin_stop_restart</group>
+    <file>env_run.xml</file>
+    <desc>
+      ESP component runs after driver 'pause cycle'
+      If any component 'pauses' (see PAUSE_OPTION, PAUSE_N and
+      PAUSE_COMPONENT_LIST XML variables), the ESP component (if
+      present) will be run to process the component 'pause' (restart)
+      files and set any required 'resume' signals.
+      If true, esp_cpl_dt and esp_cpl_offset settings are ignored.
+      default: false
+    </desc>
+  </entry>
+
   <entry id="CONTINUE_RUN">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="http://www.cgd.ucar.edu/~cam/namelist/namelist_definition.xsl"?>
+<?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>
 
 <entry_id version="2.0">
 
@@ -352,7 +352,7 @@
     </values>
   </entry>
 
-  <entry id="brnch_retain_casename" modify_via_xml="REFCASE">
+  <entry id="brnch_retain_casename" modify_via_xml="RUN_REFCASE">
     <type>logical</type>
     <category>expdef</category>
     <group>seq_infodata_inparm</group>
@@ -1497,6 +1497,23 @@
     </values>
   </entry>
 
+  <entry id="esp_cpl_dt" skip_default_entry="true">
+    <type>integer</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      esp run interval in seconds
+      esp_cpl_dt is the number of times the esp is run per NCPL_BASE_PERIOD
+      NCPL_BASE_PERIOD is set in env_run.xml and is the base period
+      associated with NCPL coupling frequency, nad has valid values: hour,day,year,decade
+      default value set by buildnml to be the pause interval if pause is active
+      otherwise, it is set to the shortest component coupling time
+    </desc>
+    <values>
+      <value>-999</value>
+    </values>
+  </entry>
+
   <entry id="atm_cpl_offset">
     <type>integer</type>
     <category>time</category>
@@ -1566,6 +1583,36 @@
     </desc>
     <values>
       <value>0</value>
+    </values>
+  </entry>
+
+  <entry id="esp_cpl_offset">
+    <type>integer</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      esp coupling interval offset in seconds default: 0
+    </desc>
+    <values>
+      <value>0</value>
+    </values>
+  </entry>
+
+  <entry id="esp_run_on_pause" modify_via_xml="ESP_RUN_ON_PAUSE">
+    <type>logical</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      true => ESP component runs after driver 'pause cycle'
+      If any component 'pauses' (see PAUSE_OPTION, PAUSE_N and
+      PAUSE_COMPONENT_LIST XML variables), the ESP component (if
+      present) will be run to process the component 'pause' (restart)
+      files and set any required 'resume' signals.
+      If true, esp_cpl_dt and esp_cpl_offset settings are ignored.
+      default: true
+    </desc>
+    <values>
+      <value>.true.</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/main/seq_io_mod.F90
+++ b/src/drivers/mct/main/seq_io_mod.F90
@@ -37,7 +37,8 @@ module seq_io_mod
   use shr_kind_mod, only: r4 => shr_kind_r4, r8 => shr_kind_r8, in => shr_kind_in
   use shr_kind_mod, only: cl => shr_kind_cl, cs => shr_kind_cs
   use shr_sys_mod       ! system calls
-  use seq_comm_mct
+  use seq_comm_mct, only: logunit, CPLID, seq_comm_setptrs
+  use seq_comm_mct, only: seq_comm_namelen, seq_comm_name
   use seq_flds_mod, only : seq_flds_lookup
   use mct_mod           ! mct wrappers
   use pio
@@ -1545,7 +1546,7 @@ subroutine seq_io_write_time(filename,time_units,time_cal,time_val,nt,whead,wdat
     implicit none
     character(len=*),intent(in) :: filename ! file
     type(mct_gsMap), intent(in) :: gsmap
-    type(mct_aVect) ,intent(inout):: AV     ! data to be written
+    type(mct_aVect) ,intent(inout):: AV     ! data to be read
     character(len=*),intent(in) :: dname    ! name of data
     character(len=*),intent(in),optional :: pre      ! prefix name
 
@@ -1671,7 +1672,7 @@ subroutine seq_io_write_time(filename,time_units,time_cal,time_val,nt,whead,wdat
     implicit none
     character(len=*),intent(in) :: filename ! file
     type(mct_gsMap), intent(in) :: gsmap
-    type(mct_aVect) ,intent(inout):: AVS(:) ! data to be written
+    type(mct_aVect) ,intent(inout):: AVS(:) ! data to be read
     character(len=*),intent(in) :: dname    ! name of data
     character(len=*),intent(in),optional :: pre      ! prefix name
 

--- a/src/drivers/mct/main/seq_rest_mod.F90
+++ b/src/drivers/mct/main/seq_rest_mod.F90
@@ -40,16 +40,17 @@ module seq_rest_mod
         seq_comm_iamin, CPLID, GLOID, logunit, loglevel
 
    ! "infodata" gathers various control flags into one datatype
-   use seq_infodata_mod
+   use seq_infodata_mod, only: seq_infodata_type, seq_infodata_getData
 
    ! clock & alarm routines
-   use seq_timemgr_mod
+   use seq_timemgr_mod, only: seq_timemgr_type, seq_timemgr_EClockGetData
 
    ! diagnostic routines
    use seq_diag_mct, only: budg_datag
 
    ! lower level io routines
-   use seq_io_mod
+   use seq_io_mod, only: seq_io_read, seq_io_write, seq_io_enddef
+   use seq_io_mod, only: seq_io_wopen, seq_io_close
 
    ! prep modules - coupler communication between different components
    use prep_ocn_mod,    only: prep_ocn_get_x2oacc_ox
@@ -412,7 +413,6 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
          if (fk == 1) then
             whead = .true.
             wdata = .false.
-!!            call seq_io_redef(rest_file)
          elseif (fk == 2) then
             whead = .false.
             wdata = .true.

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -96,7 +96,6 @@ module seq_comm_mct
   !!! internal communications, and one is needed for the global space.
   !!! All instances of a component type also share a separate communicator
   !!! All instances of a component type share a communicator with the coupler
-  !!! Note that ESP models do not need coupler communicators
 
   integer, parameter, public :: num_inst_phys = num_inst_atm + num_inst_lnd + &
                                                 num_inst_ocn + num_inst_ice + &
@@ -105,7 +104,7 @@ module seq_comm_mct
   integer, parameter, public :: num_cpl_phys  = num_inst_atm + num_inst_lnd + &
                                                 num_inst_ocn + num_inst_ice + &
                                                 num_inst_glc + num_inst_rof + &
-                                                num_inst_wav
+                                                num_inst_wav + num_inst_esp
   integer, parameter :: ncomps = (1 + ncouplers + ncomptypes + nphysmod + num_inst_phys + num_cpl_phys)
 
   integer, public :: GLOID
@@ -127,7 +126,7 @@ module seq_comm_mct
   integer, public :: CPLALLGLCID
   integer, public :: CPLALLROFID
   integer, public :: CPLALLWAVID
-  integer, public, parameter :: CPLALLESPID = -1
+  integer, public :: CPLALLESPID
 
   integer, public :: ATMID(num_inst_atm)
   integer, public :: LNDID(num_inst_lnd)
@@ -166,7 +165,9 @@ module seq_comm_mct
     integer :: gloroot         ! the global task number of each comps root on all pes
     integer :: pethreads       ! max number of threads on my task
     integer :: cplpe           ! a common task in mpicom from the cpl group for join mpicoms
+                               ! cplpe is used to broadcast information from the coupler to the component
     integer :: cmppe           ! a common task in mpicom from the component group for join mpicoms
+                               ! cmppe is used to broadcast information from the component to the coupler
     logical :: set             ! has this datatype been set
     integer, pointer    :: petlist(:)  ! esmf pet list
     logical :: petlist_allocated ! whether the petlist pointer variable was allocated
@@ -394,7 +395,8 @@ contains
     num_inst_min = min(num_inst_min, num_inst_glc)
     num_inst_min = min(num_inst_min, num_inst_wav)
     num_inst_min = min(num_inst_min, num_inst_rof)
-    num_inst_min = min(num_inst_min, num_inst_esp)
+! ESP is currently limited to one instance, should not affect other comps
+!    num_inst_min = min(num_inst_min, num_inst_esp)
     num_inst_max = num_inst_atm
     num_inst_max = max(num_inst_max, num_inst_lnd)
     num_inst_max = max(num_inst_max, num_inst_ocn)
@@ -412,7 +414,10 @@ contains
     if (num_inst_glc /= num_inst_min .and. num_inst_glc /= num_inst_max) error_state = .true.
     if (num_inst_wav /= num_inst_min .and. num_inst_wav /= num_inst_max) error_state = .true.
     if (num_inst_rof /= num_inst_min .and. num_inst_rof /= num_inst_max) error_state = .true.
-    if (num_inst_esp /= num_inst_min .and. num_inst_esp /= num_inst_max) error_state = .true.
+    if (num_inst_esp /= 1) then
+       write(logunit,*) trim(subname),' ERROR: ESP restricted to one instance'
+       error_state = .true.
+    end if
 
     if (error_state) then
        write(logunit,*) trim(subname),' ERROR: num_inst inconsistent'
@@ -459,6 +464,8 @@ contains
     CPLALLROFID = count
     count = count + 1
     CPLALLWAVID = count
+    count = count + 1
+    CPLALLESPID = count
 
     do n = 1, num_inst_atm
        count = count + 1
@@ -841,6 +848,7 @@ contains
        call seq_comm_setcomm(ESPID(n), pelist, esp_nthreads, 'ESP', n, num_inst_esp)
     end do
     call seq_comm_jcommarr(ESPID,ALLESPID,'ALLESPID',1,1)
+    call seq_comm_joincomm(CPLID,ALLESPID,CPLALLESPID,'CPLALLESPID',1,1)
 
     !! Count the total number of threads
 
@@ -1155,36 +1163,6 @@ contains
        seq_comms(ID)%iam = -1
        seq_comms(ID)%iamroot = .false.
     endif
-
-! needs to be excluded until mpi_group_size is added to serial mpi in mct
-#if (1 == 0)
-    if (loglevel > 3) then
-       ! some debug code to prove the join is working ok
-       ! when joining mpicomms, the local rank may be quite different
-       !   from either the global or local ranks of the joining comms
-       call mpi_group_size(seq_comms(ID1)%mpigrp,nsize,ierr)
-       allocate(pe_t1(nsize),pe_t2(nsize))
-       do n = 1,nsize
-          pe_t1(n) = n-1
-          pe_t2(n) = -1
-       enddo
-       call mpi_group_translate_ranks(seq_comms(ID1)%mpigrp, nsize, pe_t1, mpigrp, pe_t2, ierr)
-       write(logunit,*) 'ID1      ranks ',pe_t1
-       write(logunit,*) 'ID1-JOIN ranks ',pe_t2
-       deallocate(pe_t1,pe_t2)
-
-       call mpi_group_size(seq_comms(ID2)%mpigrp,nsize,ierr)
-       allocate(pe_t1(nsize),pe_t2(nsize))
-       do n = 1,nsize
-          pe_t1(n) = n-1
-          pe_t2(n) = -1
-       enddo
-       call mpi_group_translate_ranks(seq_comms(ID2)%mpigrp, nsize, pe_t1, mpigrp, pe_t2, ierr)
-       write(logunit,*) 'ID2      ranks ',pe_t1
-       write(logunit,*) 'ID2-JOIN ranks ',pe_t2
-       deallocate(pe_t1,pe_t2)
-    endif
-#endif
 
     allocate(pe_t1(1),pe_t2(1))
     pe_t1(1) = 0


### PR DESCRIPTION
 New method for setting and detecting pause alarms in component models
 Refactor access to components which are paused
 Pause works with the driver and at least one active component (POP).
 Active component (POP) able to correctly process resume signal.
 PRE test refactored to be more flexible.
 Modify code and scripts to error if NINST_ESP > 1.
 Fixed NCK test to not set NINST_ESP > 1
 Added PRE test back to cime_developer.

Test suite: scripts_regression_tests.py on Yellowstone (CESM) and compute001 (ACME)
                   CESM prealpha on hobart_nag
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes #1112 

User interface changes?: NA

Code review: 
