### PR TITLE
Remove conditional pio1 code

### DIFF
--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -181,7 +181,6 @@ contains
     allocate(iosystems(total_comps))
 
     if(pio_async_interface) then
-#ifdef PIO1
        call pio_init(total_comps,mpi_comm_world, comp_comm, io_comm, iosystems)
        do i=1,total_comps
          ret =  pio_set_rearr_opts(iosystems(i), pio_rearr_opt_comm_type,&
@@ -194,10 +193,6 @@ contains
             write(shr_log_unit,*) "ERROR: Setting rearranger options failed"
          end if
        end do
-
-#else
-       call pio_init(total_comps,mpi_comm_world, comp_comm, io_comm, iosystems)
-#endif
        i=1
     else
        do i=1,total_comps


### PR DESCRIPTION
Getting rid of the conditional ("#ifdef PIO1") code since
we no longer pass rearranger options via pio_init(). 

This should have been part of PR #1354 .

Test suite: X
Test baseline: NA 
Test namelist changes: None
Test status: bit for bit

User interface changes?: None

Code review: @jedwards4b 
