### PR TITLE
Make Machines.get_value more likely to return values of the correct type

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -412,7 +412,7 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
         submit_cmd  = env_batch.get_value("batch_submit", subgroup=None)
         submit_args = env_batch.get_submit_args(case, "case.run")
 
-    tasks_per_node = int(mach.get_value("PES_PER_NODE"))
+    tasks_per_node = mach.get_value("PES_PER_NODE")
     num_nodes = int(math.ceil(float(proc_pool) / tasks_per_node))
     if wall_time is None:
         wall_time = compute_total_time(job_cost_map, proc_pool)

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -4,6 +4,7 @@ Interface to the config_machines.xml file.  This class inherits from GenericXML.
 from CIME.XML.standard_module_setup import *
 from CIME.XML.generic_xml import GenericXML
 from CIME.XML.files import Files
+from CIME.utils import convert_to_unknown_type
 
 import socket
 
@@ -190,6 +191,8 @@ class Machines(GenericXML):
                 value = self.get_resolved_value(value)
             elif name in os.environ:
                 value = os.environ[name]
+
+            value = convert_to_unknown_type(value)
 
         return value
 

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -150,7 +150,7 @@ class TestScheduler(object):
 
         if parallel_jobs is None:
             self._parallel_jobs = min(len(test_names),
-                                      int(self._machobj.get_value("MAX_TASKS_PER_NODE")))
+                                      self._machobj.get_value("MAX_TASKS_PER_NODE"))
         else:
             self._parallel_jobs = parallel_jobs
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -714,9 +714,9 @@ def convert_to_type(value, type_str, vid=""):
                 expect(False, "Entry %s was listed as type int but value '%s' is not valid int" % (vid, value))
 
         elif type_str == "logical":
-            expect(value in ["TRUE", "FALSE","true","false"],
+            expect(value.upper() in ["TRUE", "FALSE"],
                    "Entry %s was listed as type logical but had val '%s' instead of TRUE or FALSE" % (vid, value))
-            value = value == "TRUE" or value == "true"
+            value = value.upper() == "TRUE"
 
         elif type_str == "real":
             try:
@@ -726,6 +726,36 @@ def convert_to_type(value, type_str, vid=""):
 
         else:
             expect(False, "Unknown type '%s'" % type_str)
+
+    return value
+
+def convert_to_unknown_type(value):
+    """
+    Convert value to it's real type by probing conversions.
+    """
+    if value is not None:
+
+        # Attempt to convert to logical
+        if value.upper() in ["TRUE", "FALSE"]:
+            return value.upper() == "TRUE"
+
+        # Attempt to convert to integer
+        try:
+            value = int(eval(value))
+        except:
+            pass
+        else:
+            return value
+
+        # Attempt to convert to float
+        try:
+            value = float(value)
+        except:
+            pass
+        else:
+            return value
+
+        # Just treat as string
 
     return value
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1268,6 +1268,9 @@ class K_TestCimeCase(TestCreateTestCommon):
         run_cmd_assert_result(self, "%s/create_test TESTRUNPASS_P1.f19_g16_rx1.A -t %s --no-build --test-root %s --output-root %s"
                               % (SCRIPT_DIR, self._baseline_name, TEST_ROOT, TEST_ROOT))
 
+        self.assertEqual(type(MACHINE.get_value("MAX_TASKS_PER_NODE")), int)
+        self.assertTrue(type(MACHINE.get_value("PROJECT_REQUIRED")) in [type(None) , bool])
+
         casedir = os.path.join(self._testroot,
                                "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_P1.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
         self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)


### PR DESCRIPTION
This makes the behavior more similar to case.get_value, so we can hopefully avoid bugs like this in the future.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1358

User interface changes?: None

Code review: @jedwards4b 
