### PR TITLE
Force user to always go through case.submit

### DIFF
--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -245,6 +245,10 @@ def case_run(case):
            "Please submit your run using the submit script like so:"
            " ./case.submit")
 
+    # Forces user to use case.submit if they re-submit
+    if case.get_value("TESTCASE") is None:
+        case.set_value("RUN_WITH_SUBMIT", False)
+
     prerun_script = case.get_value("PRERUN_SCRIPT")
     postrun_script = case.get_value("POSTRUN_SCRIPT")
 

--- a/scripts/lib/CIME/case_test.py
+++ b/scripts/lib/CIME/case_test.py
@@ -66,4 +66,6 @@ def case_test(case, testname=None):
 
     success = test.run()
 
+    case.set_value("RUN_WITH_SUBMIT", False)
+
     return success


### PR DESCRIPTION
This was already the policy, but was not being enforced correctly.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #347 

User interface changes?: None

Code review: @jedwards4b 
