### PR TITLE
fix typo in cori-knl binding

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -491,7 +491,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
-	<arg name="binding"> -c 4 --cpu-bind=cores</arg>
+	<arg name="binding"> -c 4 --cpu_bind=cores</arg>
       </arguments>
     </mpirun>
     <module_system type="module">


### PR DESCRIPTION
Fix typo in cori-knl bind command

Test suite: by hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
