### PR TITLE
Fix Fortran unit tests

### DIFF
--- a/src/drivers/mct/unit_test/stubs/CMakeLists.txt
+++ b/src/drivers/mct/unit_test/stubs/CMakeLists.txt
@@ -1,4 +1,5 @@
 list(APPEND drv_sources
+  seq_timemgr_mod.F90
   vertical_gradient_calculator_constant.F90
   )
 

--- a/src/drivers/mct/unit_test/stubs/seq_timemgr_mod.F90
+++ b/src/drivers/mct/unit_test/stubs/seq_timemgr_mod.F90
@@ -1,0 +1,19 @@
+module seq_timemgr_mod
+
+  ! Stub for routines from seq_timemgr_mod that are needed by other modules built by the
+  ! unit tests.
+
+  implicit none
+  private
+
+  public :: seq_timemgr_pause_active
+
+contains
+
+  logical function seq_timemgr_pause_active()
+    ! Stub for seq_timemgr_pause_active - always returns .false.
+
+    seq_timemgr_pause_active = .false.
+  end function seq_timemgr_pause_active
+
+end module seq_timemgr_mod

--- a/src/share/unit_test_stubs/pio/pio.F90.in
+++ b/src/share/unit_test_stubs/pio/pio.F90.in
@@ -87,8 +87,9 @@ module pio
   integer,parameter,public :: PIO_rearr_comm_fc_1d_io2comp = 2
   integer,parameter,public :: PIO_rearr_comm_fc_2d_disable = 3
   integer, public, parameter :: PIO_REARR_COMM_UNLIMITED_PEND_REQ = -1
+  integer, public, parameter :: PIO_NOERR=0
 
-
+  public :: PIO_set_rearr_opts
   public :: PIO_def_dim
   public :: PIO_enddef
   public :: PIO_FILE_IS_OPEN
@@ -272,6 +273,18 @@ contains
     type (file_desc_t) :: file
     type (io_desc_t) :: iodesc
   end subroutine freedecomp_file
+
+  integer function PIO_set_rearr_opts(iosystem, comm_type, fcd,&
+                              enable_hs_c2i, enable_isend_c2i,&
+                              max_pend_req_c2i,&
+                              enable_hs_i2c, enable_isend_i2c,&
+                              max_pend_req_i2c) result(ierr)
+    type (iosystem_desc_t), intent(inout)  :: iosystem
+    integer, intent(in) :: comm_type, fcd
+    logical, intent(in) :: enable_hs_c2i, enable_hs_i2c
+    logical, intent(in) :: enable_isend_c2i, enable_isend_i2c
+    integer, intent(in) :: max_pend_req_c2i, max_pend_req_i2c
+  end function PIO_set_rearr_opts
 
   integer function get_att_desc_{TYPE} (File,varDesc,name,value) result(ierr)
     type (File_desc_t), intent(inout) , target :: File

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -428,6 +428,19 @@ contains
     pio_async_interface = .false.   ! pio tasks are a subset of component tasks
     pio_rearranger = PIO_REARR_SUBSET
 
+    pio_rearr_comm_type = 'p2p'
+    pio_rearr_comm_fcd = '2denable'
+    pio_rearr_comm_max_pend_req_comp2io = 0
+    pio_rearr_comm_enable_hs_comp2io = .true.
+    pio_rearr_comm_enable_isend_comp2io = .false.
+    pio_rearr_comm_max_pend_req_io2comp = 0
+    pio_rearr_comm_enable_hs_io2comp = .true.
+    pio_rearr_comm_enable_isend_io2comp = .false.
+
+
+
+
+
     if(iamroot) then
        unitn=shr_file_getunit()
        open( unitn, file=trim(nlfilename), status='old' , iostat=ierr)


### PR DESCRIPTION
Two changes to fix the Fortran unit tests that had gotten broken recently.

Changes are from myself and @jedwards4b 

Test suite: scripts_regression_tests on yellowstone
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #1376 

User interface changes?: no

Code review: 
