### PR TITLE
Get Fortran unit tests working on cheyenne

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -992,6 +992,7 @@ using a fortran linker.
   <CMAKE_OPTS>
     <append DEBUG="TRUE"> -DPIO_ENABLE_LOGGING=ON </append>
   </CMAKE_OPTS>
+  <PFUNIT_PATH>$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.2.8_cheyenne_Intel17.0.1_MPI_openMP</PFUNIT_PATH>
   <!-- Bug in the intel/17.0.1 compiler requires this, remove this line when compiler is updated -->
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
 </compiler>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -227,11 +227,6 @@
       <!-- The only place we can build and run the unit tests is on cheyenne's
            shared nodes. However, running mpi jobs on the shared nodes currently
            requires some workarounds; these workarounds are implemented here -->
-      <!-- It's possible that we also need to set:
-           LD_LIBRARY_PATH=/opt/sgi/mpt/mpt-2.15/lib:$LD_LIBRARY_PATH
-           but I can't figure out how to do that: setting it at the start of the
-           executable line causes PFUNIT_MPIRUN to become empty, for some reason.
-           -->
       <executable>/opt/sgi/mpt/mpt-2.15/bin/mpirun $ENV{UNIT_TEST_HOST} -np 1 </executable>
     </mpirun>
     <mpirun mpilib="mpi-serial">
@@ -274,6 +269,9 @@
       <env name="MPI_TYPE_DEPTH">16</env>
     </environment_variables>
     <environment_variables unit_testing="true">
+      <!-- It's possible that we also need to set:
+           LD_LIBRARY_PATH=/opt/sgi/mpt/mpt-2.15/lib:$LD_LIBRARY_PATH
+      -->
       <env name="MPI_USE_ARRAY">false</env>
     </environment_variables>
   </machine>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -223,6 +223,17 @@
 	<arg name="threadplacement"> omplace </arg>
       </arguments>
     </mpirun>
+    <mpirun mpilib="default" unit_testing="true">
+      <!-- The only place we can build and run the unit tests is on cheyenne's
+           shared nodes. However, running mpi jobs on the shared nodes currently
+           requires some workarounds; these workarounds are implemented here -->
+      <!-- It's possible that we also need to set:
+           LD_LIBRARY_PATH=/opt/sgi/mpt/mpt-2.15/lib:$LD_LIBRARY_PATH
+           but I can't figure out how to do that: setting it at the start of the
+           executable line causes PFUNIT_MPIRUN to become empty, for some reason.
+           -->
+      <executable>/opt/sgi/mpt/mpt-2.15/bin/mpirun $ENV{UNIT_TEST_HOST} -np 1 </executable>
+    </mpirun>
     <mpirun mpilib="mpi-serial">
       <executable></executable>
     </mpirun>
@@ -261,6 +272,9 @@
     <environment_variables>
       <env name="OMP_STACKSIZE">256M</env>
       <env name="MPI_TYPE_DEPTH">16</env>
+    </environment_variables>
+    <environment_variables unit_testing="true">
+      <env name="MPI_USE_ARRAY">false</env>
     </environment_variables>
   </machine>
 

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -188,6 +188,7 @@
       <xs:attribute ref="debug"/>
       <xs:attribute ref="mpilib"/>
       <xs:attribute ref="compiler"/>
+      <xs:attribute ref="unit_testing"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="env">

--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -23,7 +23,8 @@ from CIME.XML.env_mach_specific import EnvMachSpecific
 
 logger = logging.getLogger(__name__)
 
-def configure(machobj, output_dir, macros_format, compiler, mpilib, debug, sysos):
+def configure(machobj, output_dir, macros_format, compiler, mpilib, debug,
+              sysos, unit_testing=False):
     """Add Macros, Depends, and env_mach_specific files to a directory.
 
     Arguments:
@@ -34,6 +35,8 @@ def configure(machobj, output_dir, macros_format, compiler, mpilib, debug, sysos
     compiler - String containing the compiler vendor to configure for.
     mpilib - String containing the MPI implementation to configure for.
     debug - Boolean specifying whether debugging options are enabled.
+    unit_testing - Boolean specifying whether we're running unit tests (as
+                   opposed to a system run)
     """
     # Macros generation.
     suffixes = {'Makefile': 'make', 'CMake': 'cmake'}
@@ -44,7 +47,7 @@ def configure(machobj, output_dir, macros_format, compiler, mpilib, debug, sysos
 
     _copy_depends_files(machobj.get_machine_name(), machobj.machines_dir, output_dir, compiler)
     _generate_env_mach_specific(output_dir, machobj, compiler, mpilib,
-                                debug, sysos)
+                                debug, sysos, unit_testing)
 
 def _copy_depends_files(machine_name, machines_dir, output_dir, compiler):
     """
@@ -64,7 +67,8 @@ def _copy_depends_files(machine_name, machines_dir, output_dir, compiler):
                 shutil.copyfile(dfile, outputdfile)
 
 
-def _generate_env_mach_specific(output_dir, machobj, compiler, mpilib, debug, sysos):
+def _generate_env_mach_specific(output_dir, machobj, compiler, mpilib, debug,
+                                sysos, unit_testing):
     """
     env_mach_specific generation.
     """
@@ -72,7 +76,7 @@ def _generate_env_mach_specific(output_dir, machobj, compiler, mpilib, debug, sy
     if os.path.exists(ems_path):
         logger.warn("%s already exists, delete to replace"%ems_path)
         return
-    ems_file = EnvMachSpecific(output_dir)
+    ems_file = EnvMachSpecific(output_dir, unit_testing=unit_testing)
     ems_file.populate(machobj)
     ems_file.write()
     for shell in ('sh', 'csh'):

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -13,12 +13,14 @@ logger = logging.getLogger(__name__)
 # get_type) otherwise need to implement own functions and make GenericXML parent class
 class EnvMachSpecific(EnvBase):
     # pylint: disable=unused-argument
-    def __init__(self, caseroot, infile="env_mach_specific.xml",components=None):
+    def __init__(self, caseroot, infile="env_mach_specific.xml",
+                 components=None, unit_testing=False):
         """
         initialize an object interface to file env_mach_specific.xml in the case directory
         """
         fullpath = infile if os.path.isabs(infile) else os.path.join(caseroot, infile)
         EnvBase.__init__(self, caseroot, fullpath)
+        self._unit_testing = unit_testing
 
     def populate(self, machobj):
         """Add entries to the file using information from a Machines object."""
@@ -190,6 +192,10 @@ class EnvMachSpecific(EnvBase):
             return False
         elif ("debug" in attribs and
             not self._match("TRUE" if debug else "FALSE", attribs["debug"].upper())):
+            return False
+        elif ("unit_testing" in attribs and
+              not self._match("TRUE" if self._unit_testing else "FALSE",
+                              attribs["unit_testing"].upper())):
             return False
 
         return True

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -178,13 +178,19 @@ class N_TestUnitTest(unittest.TestCase):
         cls._testroot = os.path.join(TEST_ROOT, 'TestUnitTests')
         cls._testdirs = []
 
+    def _has_unit_test_support(self):
+        default_compiler = MACHINE.get_default_compiler()
+        compiler = Compilers(MACHINE, compiler=default_compiler)
+        pfunit_path = compiler.get_optional_compiler_node("PFUNIT_PATH")
+        if pfunit_path is None:
+            return False
+        else:
+            return True
+
     def test_a_unit_test(self):
         cls = self.__class__
-        machine           = MACHINE.get_machine_name()
-        compiler          = MACHINE.get_default_compiler()
-        if (machine != "yellowstone" or compiler != "intel"):
-            #TODO: get rid of this restriction
-            self.skipTest("Skipping TestUnitTest - only supported on yellowstone with intel")
+        if not self._has_unit_test_support():
+            self.skipTest("Skipping TestUnitTest - PFUNIT_PATH not found for the default compiler on this machine")
         test_dir = os.path.join(cls._testroot,"unit_tester_test")
         cls._testdirs.append(test_dir)
         os.makedirs(test_dir)
@@ -199,11 +205,8 @@ class N_TestUnitTest(unittest.TestCase):
         if (FAST_ONLY):
             self.skipTest("Skipping slow test")
 
-        machine           = MACHINE.get_machine_name()
-        compiler          = MACHINE.get_default_compiler()
-        if (machine != "yellowstone" or compiler != "intel"):
-            #TODO: get rid of this restriction
-            self.skipTest("Skipping TestUnitTest - only supported on yellowstone with intel")
+        if not self._has_unit_test_support():
+            self.skipTest("Skipping TestUnitTest - PFUNIT_PATH not found for the default compiler on this machine")
 
         test_dir = os.path.join(cls._testroot,"driver_f90_tests")
         cls._testdirs.append(test_dir)

--- a/src/externals/CMake/pFUnit_utils.cmake
+++ b/src/externals/CMake/pFUnit_utils.cmake
@@ -215,7 +215,8 @@ function(create_pFUnit_test test_name executable_name pf_file_list fortran_sourc
   endif()
 
   # Prefix command with an mpirun command
-  set (MY_COMMAND ${PFUNIT_MPIRUN} ${MY_COMMAND})
+  separate_arguments(PFUNIT_MPIRUN_LIST UNIX_COMMAND ${PFUNIT_MPIRUN})
+  set (MY_COMMAND ${PFUNIT_MPIRUN_LIST} ${MY_COMMAND})
 
   # Do the work
   add_pFUnit_executable(${executable_name} "${pf_file_list}"


### PR DESCRIPTION
Changes needed to get the cime Fortran unit tests building and running
on cheyenne.

Some of these changes just involved setting the appropriate variables
for cheyenne. However, I needed to make more extensive changes in order
to support setting certain environment variabes only if we're doing unit
testing.

Note that the cheyenne unit tests can be built and run from either the
login nodes or the share queue - e.g.

```
qsub -I -l select=1:ncpus=1:mpiprocs=1 -l walltime=06:00:00 -q share -A P93300601
```

But running on the share queue causes some of the system tests run with
scripts_regression_tests to fail - so for now running on the login nodes
seems like the best bet.

Getting this working was painful - specifically due to complications of
how we can (and can't) build and run mpi programs on cheyenne. I'm going
to take a stab at allowing non-mpi builds and runs of the unit tests in
a separate PR to make porting the unit tests easier. But I still think
it's worth bringing this PR to master first.

Test suite: scripts_regression_tests on both yellowstone and cheyenne
(latter run from the login node). One test failed on cheyenne: `FAIL:
test_run_restart (__main__.T_TestRunRestart)`. It looks like this was
fixed recently in cime, so I assume this failure was expected from the
version on which this branch is based.
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes: Partially addresses #1141

User interface changes?: none

Code review: 
