### PR TITLE
add illegal char : to check_name test

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -45,7 +45,7 @@ def check_name(fullname, additional_chars=None, fullpath=False):
     True
     """
 
-    chars = '<>/{}[\]~`@' # pylint: disable=anomalous-backslash-in-string
+    chars = '<>/{}[\]~`@:' # pylint: disable=anomalous-backslash-in-string
     if additional_chars is not None:
         chars += additional_chars
     if fullpath:


### PR DESCRIPTION
It needs to be illegal for both case names and test ids (for case names it was okay until the build and then gmake had problems)

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #433

User interface changes?:  do not allow ':' in testid or case name.   

Code review: 
