### PR TITLE
simplify netcdf lib args on hobart

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -667,7 +667,7 @@ using a fortran linker.
   <MPI_LIB_NAME MPILIB="mvapich2"> mpich</MPI_LIB_NAME>
   <NETCDF_PATH>$ENV{NETCDF_PATH}</NETCDF_PATH>
   <SLIBS>
-    <append>$SHELL{${NETCDF_PATH}/bin/nf-config --flibs}</append>
+    <append>-L$NETCDF_PATH/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
 </compiler>
 


### PR DESCRIPTION
Using nf-config is overly complicated and in this case unnecessary, remove it. 

Test suite: scripts_regression_tests + SMS.f19_g16.X for all supported compilers on hobart
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1344 

User interface changes?: 

Code review: 
