### PR TITLE
Add Support for '+=' in Namelists

### DIFF
--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -2098,6 +2098,10 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> x._parse_namelist_group()
         >>> x._settings
         OrderedDict([(u'group', {u'foo': [u"'bar'", u"'baz'"]})])
+        >>> x = _NamelistParser("&group foo+='bar' /")
+        >>> x._parse_namelist_group()
+        >>> x._settings
+        OrderedDict([(u'group', {u'foo': [u"'bar'"]})])
         """
         group_name = self._parse_namelist_group_name()
         if not self._groupless:

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -2094,6 +2094,10 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> x._parse_namelist_group()
         >>> x._settings
         OrderedDict([(u'foo', [u"'bar'", u"'baz'"])])
+        >>> x = _NamelistParser("&group foo+='bar' /", groupless=True)
+        >>> x._parse_namelist_group()
+        >>> x._settings
+        OrderedDict([(u'foo', [u"'bar'"])])
         >>> x = _NamelistParser("&group foo='bar', foo+='baz' /")
         >>> x._parse_namelist_group()
         >>> x._settings

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1538,6 +1538,8 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         Traceback (most recent call last):
             ...
         _NamelistParseError: Error in parsing namelist: '' is not a valid variable name
+        >>> _NamelistParser('foo+= ')._parse_variable_name()
+        u'foo'
         """
         old_pos = self._pos
         separators = (' ', '\n', '=', '+') if allow_equals else (' ', '\n')
@@ -2155,6 +2157,8 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         OrderedDict([(u'foo', [u"'bar'"])])
         >>> _NamelistParser("foo='bar', 'bazz'\n foo+='ban'", groupless=True).parse_namelist()
         OrderedDict([(u'foo', [u"'bar'", u"'bazz'", u"'ban'"])])
+        >>> _NamelistParser("foo+='bar'", groupless=True).parse_namelist()
+        OrderedDict([(u'foo', [u"'bar'"])])
         """
         # Return empty dictionary for empty files.
         if self._len == 0:

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -2094,6 +2094,10 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> x._parse_namelist_group()
         >>> x._settings
         OrderedDict([(u'foo', [u"'bar'", u"'baz'"])])
+        >>> x = _NamelistParser("&group foo='bar', foo+='baz' /")
+        >>> x._parse_namelist_group()
+        >>> x._settings
+        OrderedDict([(u'group', {u'foo': [u"'bar'", u"'baz'"]})])
         """
         group_name = self._parse_namelist_group_name()
         if not self._groupless:
@@ -2118,7 +2122,10 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
                 group = self._settings[group_name]
                 if name in group:
                     dsettings = group[name]
-                values = merge_literal_lists(dsettings, values)
+                    if addto:
+                        values = group[name] + values
+                if not addto:
+                    values = merge_literal_lists(dsettings, values)
                 group[name] = values
 
     def parse_namelist(self):

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -2090,6 +2090,10 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> x._parse_namelist_group()
         >>> x._settings
         OrderedDict([(u'foo', [u"'bar'"])])
+        >>> x = _NamelistParser("&group foo='bar', foo+='baz' /", groupless=True)
+        >>> x._parse_namelist_group()
+        >>> x._settings
+        OrderedDict([(u'foo', [u"'bar'", u"'baz'"])])
         """
         group_name = self._parse_namelist_group_name()
         if not self._groupless:


### PR DESCRIPTION
Namelists.pm had the ability to parse += in namelist files. This adds the
support for += into the python version.

Test suite: `scripts_regression_tests.py --fast` 
and
```
./create_newcase -case test_nml_0420 -compset A -res f45_g37
```
with the following in `user_nl_cpl`

```
cplflds_custom = 'foo','bar'
cplflds_custom += 'baz'
```

Test baseline: 
Test namelist changes:
Test status: bit for bit

Fixes #839

User interface changes?: Added support for '+=' to namelist parser.

Code review: @billsacks, @jgfouca 
