### PR TITLE
Errput may be empty string or None

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -259,7 +259,7 @@ def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
     if stat != 0:
         # If command produced no errput, put output in the exception since we
         # have nothing else to go on.
-        errput = output if errput == "" else errput
+        errput = output if not errput else errput
         expect(False, "Command: '%s' failed with error '%s'%s" %
                (cmd, errput, "" if from_dir is None else " from dir '%s'" % from_dir))
 


### PR DESCRIPTION
In either case, you want to inform the user using output
instead of errput. When user was adding combine_output=True,
errput was coming back as None, not "".

Test suite: scripts_regression_tests --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: None

Code review: @jedwards4b 
