### PR TITLE
Fix bug where LockedFiles weren't checked if there was a dot in filepath

### DIFF
--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -88,7 +88,7 @@ def check_lockedfiles(caseroot=None):
     for lfile in lockedfiles:
         fpart = os.path.basename(lfile)
         # ignore files used for tests such as env_mach_pes.ERP1.xml by looking for extra dots in the name
-        if lfile.count('.') > 1:
+        if fpart.count('.') > 1:
             continue
         cfile = os.path.join(caseroot, fpart)
         if os.path.isfile(cfile):


### PR DESCRIPTION
Fix bug where LockedFiles weren't checked if there was a dot in filepath.
The tests should only be skipped if the xml filename itself has more than one dot (for example, env_mach_pes.ERP1.xml), the directory name shouldn't matter.


Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status:

Fixes CIME Github issue #1322

User interface changes?: None

Code review: 
