### PR TITLE
Conforming command line

### DIFF
--- a/config/acme/machines/template.case.run
+++ b/config/acme/machines/template.case.run
@@ -55,9 +55,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    CIME.utils.parse_args_and.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/acme/machines/template.case.test
+++ b/config/acme/machines/template.case.test
@@ -50,9 +50,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/acme/machines/template.lt_archive
+++ b/config/acme/machines/template.lt_archive
@@ -49,9 +49,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/acme/machines/template.st_archive
+++ b/config/acme/machines/template.st_archive
@@ -48,9 +48,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -52,7 +52,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -52,9 +52,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -46,9 +46,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -46,7 +46,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/cesm/machines/template.lt_archive
+++ b/config/cesm/machines/template.lt_archive
@@ -47,7 +47,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/cesm/machines/template.lt_archive
+++ b/config/cesm/machines/template.lt_archive
@@ -47,9 +47,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/cesm/machines/template.st_archive
+++ b/config/cesm/machines/template.st_archive
@@ -47,7 +47,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/config/cesm/machines/template.st_archive
+++ b/config/cesm/machines/template.st_archive
@@ -47,9 +47,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)

--- a/scripts/Tools/acme_check_env
+++ b/scripts/Tools/acme_check_env
@@ -30,7 +30,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
 ###############################################################################
 def check_sh():

--- a/scripts/Tools/acme_check_env
+++ b/scripts/Tools/acme_check_env
@@ -30,9 +30,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
 ###############################################################################
 def check_sh():

--- a/scripts/Tools/bless_test_results
+++ b/scripts/Tools/bless_test_results
@@ -89,7 +89,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("bless_tests", nargs="*",
                         help="When blessing, limit the bless to tests matching these regex")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     expect(not (args.report_only and args.force),
            "Makes no sense to use -r and -f simultaneously")

--- a/scripts/Tools/bless_test_results
+++ b/scripts/Tools/bless_test_results
@@ -89,9 +89,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("bless_tests", nargs="*",
                         help="When blessing, limit the bless to tests matching these regex")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     expect(not (args.report_only and args.force),
            "Makes no sense to use -r and -f simultaneously")

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -56,7 +56,7 @@ OR
     parser.add_argument("--clean-all", action="store_true",
                         help="clean all objects including sharedlibobjects that may be used by other builds")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     cleanlist = args.clean if args.clean is None or len(args.clean) else comps
 

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -56,9 +56,7 @@ OR
     parser.add_argument("--clean-all", action="store_true",
                         help="clean all objects including sharedlibobjects that may be used by other builds")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     cleanlist = args.clean if args.clean is None or len(args.clean) else comps
 

--- a/scripts/Tools/case.cmpgen_namelists
+++ b/scripts/Tools/case.cmpgen_namelists
@@ -49,9 +49,7 @@ OR
                         help="Force generation to use baselines with this name. "
                         "Default will be to follow the case specification")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.caseroot, args.compare, args.generate, args.compare_name, args.generate_name
 

--- a/scripts/Tools/case.cmpgen_namelists
+++ b/scripts/Tools/case.cmpgen_namelists
@@ -49,7 +49,7 @@ OR
                         help="Force generation to use baselines with this name. "
                         "Default will be to follow the case specification")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.caseroot, args.compare, args.generate, args.compare_name, args.generate_name
 

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -45,9 +45,7 @@ OR
     parser.add_argument("-r", "--reset", action="store_true",
                         help="Does a clean followed by setup")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.caseroot, args.clean, args.test_mode, args.reset
 

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -45,7 +45,7 @@ OR
     parser.add_argument("-r", "--reset", action="store_true",
                         help="Does a clean followed by setup")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.caseroot, args.clean, args.test_mode, args.reset
 

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -48,11 +48,9 @@ OR
     parser.add_argument("-a", "--batch-args",
                         help="Used to pass additional arguments to batch system. ")
 
-    args = parser.parse_args(args[1:])
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     CIME.utils.expect(args.prereq is None, "--prereq not currently supported")
-
-    CIME.utils.handle_standard_logging_options(args)
 
     return args.caseroot, args.job, args.no_batch, args.resubmit, args.batch_args
 

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -48,7 +48,7 @@ OR
     parser.add_argument("-a", "--batch-args",
                         help="Used to pass additional arguments to batch system. ")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     CIME.utils.expect(args.prereq is None, "--prereq not currently supported")
 

--- a/scripts/Tools/case_diff
+++ b/scripts/Tools/case_diff
@@ -42,9 +42,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-b", "--show-binary", action="store_true",
                         help="Show binary diffs")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.case1, args.case2, args.show_binary, args.skip_list
 

--- a/scripts/Tools/case_diff
+++ b/scripts/Tools/case_diff
@@ -42,7 +42,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-b", "--show-binary", action="store_true",
                         help="Show binary diffs")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.case1, args.case2, args.show_binary, args.skip_list
 

--- a/scripts/Tools/check_case
+++ b/scripts/Tools/check_case
@@ -38,9 +38,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
 ###############################################################################
 def _main_func(description):
@@ -68,4 +66,3 @@ def _main_func(description):
 
 if __name__ == "__main__":
     _main_func(__doc__)
-

--- a/scripts/Tools/check_case
+++ b/scripts/Tools/check_case
@@ -38,7 +38,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
 ###############################################################################
 def _main_func(description):

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -52,9 +52,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--download", action="store_true",
                         help="Attempt to download missing input files")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.svn_loc, args.input_data_root, args.data_list_dir, args.download
 
@@ -78,4 +76,3 @@ def _main_func(description):
 
 if (__name__ == "__main__"):
     _main_func(__doc__)
-

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -52,7 +52,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--download", action="store_true",
                         help="Attempt to download missing input files")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.svn_loc, args.input_data_root, args.data_list_dir, args.download
 

--- a/scripts/Tools/check_lockedfiles
+++ b/scripts/Tools/check_lockedfiles
@@ -29,7 +29,7 @@ OR
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.caseroot
 

--- a/scripts/Tools/check_lockedfiles
+++ b/scripts/Tools/check_lockedfiles
@@ -29,9 +29,7 @@ OR
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.caseroot
 

--- a/scripts/Tools/cime_bisect
+++ b/scripts/Tools/cime_bisect
@@ -74,7 +74,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-a", "--all-commits", action="store_true",
                         help="Test all commits, not just merges")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if (args.test_root is None):
         args.test_root = os.path.join(_MACHINE.get_value("CIME_OUTPUT_ROOT"), "cime_bisect")

--- a/scripts/Tools/cime_bisect
+++ b/scripts/Tools/cime_bisect
@@ -74,9 +74,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-a", "--all-commits", action="store_true",
                         help="Test all commits, not just merges")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if (args.test_root is None):
         args.test_root = os.path.join(_MACHINE.get_value("CIME_OUTPUT_ROOT"), "cime_bisect")

--- a/scripts/Tools/code_checker
+++ b/scripts/Tools/code_checker
@@ -46,7 +46,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("files", nargs="*",
                         help="Restrict checking to specific files. Relative name is fine.")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.num_procs, args.files
 

--- a/scripts/Tools/code_checker
+++ b/scripts/Tools/code_checker
@@ -46,9 +46,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("files", nargs="*",
                         help="Restrict checking to specific files. Relative name is fine.")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.num_procs, args.files
 

--- a/scripts/Tools/compare_namelists
+++ b/scripts/Tools/compare_namelists
@@ -40,7 +40,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-c", "--case", action="store", dest="case", default=None,
                         help="The case base id (<TESTCASE>.<GRID>.<COMPSET>). Helps us normalize data.")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     # Normalize case
     if (args.case is not None):

--- a/scripts/Tools/compare_namelists
+++ b/scripts/Tools/compare_namelists
@@ -40,9 +40,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-c", "--case", action="store", dest="case", default=None,
                         help="The case base id (<TESTCASE>.<GRID>.<COMPSET>). Helps us normalize data.")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     # Normalize case
     if (args.case is not None):

--- a/scripts/Tools/compare_test_results
+++ b/scripts/Tools/compare_test_results
@@ -90,7 +90,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("compare_tests", nargs="*",
                         help="When comparing, limit the comparison to tests matching these regex")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.baseline_name, args.baseline_root, args.test_root, args.compiler, args.test_id, args.compare_tests, args.namelists_only, args.hist_only
 

--- a/scripts/Tools/compare_test_results
+++ b/scripts/Tools/compare_test_results
@@ -90,9 +90,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("compare_tests", nargs="*",
                         help="When comparing, limit the comparison to tests matching these regex")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.baseline_name, args.baseline_root, args.test_root, args.compiler, args.test_id, args.compare_tests, args.namelists_only, args.hist_only
 

--- a/scripts/Tools/component_compare_baseline
+++ b/scripts/Tools/component_compare_baseline
@@ -35,7 +35,7 @@ OR
     parser.add_argument("-b", "--baseline-dir",
                         help="Use custom baseline dir")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.caseroot, args.baseline_dir
 

--- a/scripts/Tools/component_compare_baseline
+++ b/scripts/Tools/component_compare_baseline
@@ -35,9 +35,7 @@ OR
     parser.add_argument("-b", "--baseline-dir",
                         help="Use custom baseline dir")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.caseroot, args.baseline_dir
 

--- a/scripts/Tools/component_compare_copy
+++ b/scripts/Tools/component_compare_copy
@@ -36,9 +36,7 @@ OR
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
                         help="Case directory")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.suffix, args.caseroot
 

--- a/scripts/Tools/component_compare_copy
+++ b/scripts/Tools/component_compare_copy
@@ -36,7 +36,7 @@ OR
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
                         help="Case directory")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.suffix, args.caseroot
 

--- a/scripts/Tools/component_compare_test
+++ b/scripts/Tools/component_compare_test
@@ -38,9 +38,7 @@ OR
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
                         help="Case directory")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.suffix1, args.suffix2, args.caseroot
 

--- a/scripts/Tools/component_compare_test
+++ b/scripts/Tools/component_compare_test
@@ -38,7 +38,7 @@ OR
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
                         help="Case directory")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.suffix1, args.suffix2, args.caseroot
 

--- a/scripts/Tools/component_generate_baseline
+++ b/scripts/Tools/component_generate_baseline
@@ -40,9 +40,7 @@ OR
                         "will raise an error. Specifying this option allows "
                         "existing baseline directories to be silently overwritten.")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.caseroot, args.baseline_dir, args.allow_baseline_overwrite
 

--- a/scripts/Tools/component_generate_baseline
+++ b/scripts/Tools/component_generate_baseline
@@ -40,7 +40,7 @@ OR
                         "will raise an error. Specifying this option allows "
                         "existing baseline directories to be silently overwritten.")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.caseroot, args.baseline_dir, args.allow_baseline_overwrite
 

--- a/scripts/Tools/getTiming
+++ b/scripts/Tools/getTiming
@@ -21,8 +21,8 @@ def parse_command_line(args, description):
                         default="999999-999999")
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to get timing for")
-    args = parser.parse_args(args[1:])
-    CIME.utils.handle_standard_logging_options(args)
+
+    args = CIME.utils.handle_standard_logging_options(args, parser)
     return args.caseroot, args.lid
 
 def __main_func(description):

--- a/scripts/Tools/getTiming
+++ b/scripts/Tools/getTiming
@@ -22,7 +22,7 @@ def parse_command_line(args, description):
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to get timing for")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
     return args.caseroot, args.lid
 
 def __main_func(description):

--- a/scripts/Tools/jenkins_generic_job
+++ b/scripts/Tools/jenkins_generic_job
@@ -84,9 +84,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="Number of tasks create_test should perform simultaneously. Default "
                         "will be min(num_cores, num_tests).")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     expect(not (args.submit_to_cdash and args.generate_baselines),
            "Does not make sense to use --generate-baselines and --submit-to-cdash together")

--- a/scripts/Tools/jenkins_generic_job
+++ b/scripts/Tools/jenkins_generic_job
@@ -84,7 +84,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="Number of tasks create_test should perform simultaneously. Default "
                         "will be min(num_cores, num_tests).")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     expect(not (args.submit_to_cdash and args.generate_baselines),
            "Does not make sense to use --generate-baselines and --submit-to-cdash together")

--- a/scripts/Tools/list_acme_tests
+++ b/scripts/Tools/list_acme_tests
@@ -43,9 +43,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("categories", nargs="*",
                         help="The test categories to list. Default will list all. Test categories: %s" % (", ".join(update_acme_tests.get_test_suites())))
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if (not args.categories):
         args.categories = update_acme_tests.get_test_suites()

--- a/scripts/Tools/list_acme_tests
+++ b/scripts/Tools/list_acme_tests
@@ -43,7 +43,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("categories", nargs="*",
                         help="The test categories to list. Default will list all. Test categories: %s" % (", ".join(update_acme_tests.get_test_suites())))
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if (not args.categories):
         args.categories = update_acme_tests.get_test_suites()

--- a/scripts/Tools/normalize_cases
+++ b/scripts/Tools/normalize_cases
@@ -38,9 +38,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     parser.add_argument("case2", help="Second case. This one will not be changed")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.case1, args.case2
 

--- a/scripts/Tools/normalize_cases
+++ b/scripts/Tools/normalize_cases
@@ -38,7 +38,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     parser.add_argument("case2", help="Second case. This one will not be changed")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.case1, args.case2
 

--- a/scripts/Tools/pelayout
+++ b/scripts/Tools/pelayout
@@ -68,7 +68,7 @@ def parse_command_line(args):
     parser.add_argument("-caseroot" , "--caseroot", default=os.getcwd(),
                         help="Case directory to reference")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if (args.no_header):
         args.header = None

--- a/scripts/Tools/pelayout
+++ b/scripts/Tools/pelayout
@@ -68,9 +68,7 @@ def parse_command_line(args):
     parser.add_argument("-caseroot" , "--caseroot", default=os.getcwd(),
                         help="Case directory to reference")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if (args.no_header):
         args.header = None

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -27,7 +27,7 @@ def parse_command_line(args, description):
     parser.add_argument('--test', action='store_true',
                         help="Run preview_namelist in test mode.")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args
 

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -27,9 +27,7 @@ def parse_command_line(args, description):
     parser.add_argument('--test', action='store_true',
                         help="Run preview_namelist in test mode.")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args
 

--- a/scripts/Tools/save_provenance
+++ b/scripts/Tools/save_provenance
@@ -42,7 +42,7 @@ OR
     parser.add_argument("-l", "--lid",
                         help="Force system to save provenance with this LID")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.mode, args.caseroot, args.lid
 

--- a/scripts/Tools/save_provenance
+++ b/scripts/Tools/save_provenance
@@ -42,9 +42,7 @@ OR
     parser.add_argument("-l", "--lid",
                         help="Force system to save provenance with this LID")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.mode, args.caseroot, args.lid
 

--- a/scripts/Tools/simple_compare
+++ b/scripts/Tools/simple_compare
@@ -40,7 +40,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-c", "--case", action="store", dest="case", default=None,
                         help="The case base id (<TESTCASE>.<GRID>.<COMPSET>). Helps us normalize data.")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     # Normalize case
     if (args.case is not None):

--- a/scripts/Tools/simple_compare
+++ b/scripts/Tools/simple_compare
@@ -40,9 +40,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-c", "--case", action="store", dest="case", default=None,
                         help="The case base id (<TESTCASE>.<GRID>.<COMPSET>). Helps us normalize data.")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     # Normalize case
     if (args.case is not None):

--- a/scripts/Tools/testreporter.py
+++ b/scripts/Tools/testreporter.py
@@ -43,7 +43,7 @@ def parse_command_line(args):
     parser.add_argument("--dumpxml",action="store_true", 
                         help="Dump XML test results to sceen.")
     args = parser.parse_args()
-    CIME.utils.handle_standard_logging_options(args)
+    CIME.utils.parse_args_and_handle_standard_logging_options(args)
 
 
     return args.testroot, args.testid, args.tagname, args.testtype, args.dryrun, args.dumpxml

--- a/scripts/Tools/update_acme_tests
+++ b/scripts/Tools/update_acme_tests
@@ -48,7 +48,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-p", "--platform",
                         help="Only add tests for a specific platform, format=machine,compiler. Useful for adding new platforms.")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     expect(os.path.isfile(args.test_list_path),
            "'%s' is not a valid file" % args.test_list_path)

--- a/scripts/Tools/update_acme_tests
+++ b/scripts/Tools/update_acme_tests
@@ -48,9 +48,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-p", "--platform",
                         help="Only add tests for a specific platform, format=machine,compiler. Useful for adding new platforms.")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     expect(os.path.isfile(args.test_list_path),
            "'%s' is not a valid file" % args.test_list_path)

--- a/scripts/Tools/wait_for_tests
+++ b/scripts/Tools/wait_for_tests
@@ -66,9 +66,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-g", "--cdash-build-group", default=CIME.wait_for_tests.CDASH_DEFAULT_BUILD_GROUP,
                         help="The build group to be used to display results on the CDash dashboard.")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.paths, args.no_wait, args.check_throughput, args.check_memory, args.ignore_namelist_diffs, args.ignore_memleak, args.cdash_build_name, args.cdash_project, args.cdash_build_group
 

--- a/scripts/Tools/wait_for_tests
+++ b/scripts/Tools/wait_for_tests
@@ -66,7 +66,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-g", "--cdash-build-group", default=CIME.wait_for_tests.CDASH_DEFAULT_BUILD_GROUP,
                         help="The build group to be used to display results on the CDash dashboard.")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.paths, args.no_wait, args.check_throughput, args.check_memory, args.ignore_namelist_diffs, args.ignore_memleak, args.cdash_build_name, args.cdash_project, args.cdash_build_group
 

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -78,7 +78,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-f","--force", action="store_true",
                         help="ignore typing checks and store value")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     listofsettings = []
     if( len(args.listofsettings )):

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -78,9 +78,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-f","--force", action="store_true",
                         help="ignore typing checks and store value")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     listofsettings = []
     if( len(args.listofsettings )):

--- a/scripts/Tools/xmlconvertors/config_pes_converter.py
+++ b/scripts/Tools/xmlconvertors/config_pes_converter.py
@@ -28,9 +28,7 @@ def parse_command_line(args):
     parser.add_argument("-cime2file", "--cime2file", help="location of config_grid.xml file in CIME2 repository")
     parser.add_argument("-cime5file", "--cime5file", help="location of config_grids.xml file in CIME5 repository")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.cime2file is None or args.cime5file is None:
         parser.print_help()
@@ -187,8 +185,8 @@ class PesTree(grid_xml_converter.DataTree):
             tempxml = StringIO.StringIO(t3)
             super(PesTree, self).__init__(tempxml)
             tempxml.close()
-        
-        
+
+
     def populate(self):
         xmlnodes = self.root.findall('grid')
         nodeclass = Cime5PesNode

--- a/scripts/Tools/xmlconvertors/grid_xml_converter.py
+++ b/scripts/Tools/xmlconvertors/grid_xml_converter.py
@@ -33,9 +33,7 @@ def parse_command_line(args):
     parser.add_argument("-cime2file", "--cime2file", help="location of config_grid.xml file in CIME2 repository")
     parser.add_argument("-cime5file", "--cime5file", help="location of config_grids.xml file in CIME5 repository")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.cime2file is None or args.cime5file is None:
         parser.print_help()

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -105,9 +105,7 @@ epilog=textwrap.dedent(__doc__))
     group.add_argument("--valid-values", default=False, action="store_true",
                         help="Print the valid values associated with this variable if defined")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if (len(sys.argv) == 1) :
         parser.print_help()

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -105,7 +105,7 @@ epilog=textwrap.dedent(__doc__))
     group.add_argument("--valid-values", default=False, action="store_true",
                         help="Print the valid values associated with this variable if defined")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if (len(sys.argv) == 1) :
         parser.print_help()

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -40,9 +40,7 @@ def parse_command_line(args):
                         help="Specify the root output directory"
 			"default: setting in case, create_clone will fail if this directory is not writable")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if args.case is None:
         expect(False,

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -40,7 +40,7 @@ def parse_command_line(args):
                         help="Specify the root output directory"
 			"default: setting in case, create_clone will fail if this directory is not writable")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.case is None:
         expect(False,

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -121,7 +121,7 @@ OR
     parser.add_argument("-i", "--input-dir",
                         help="Use a non-default location for input files")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.srcroot is not None:
         expect(os.path.isdir(args.srcroot),

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -121,9 +121,7 @@ OR
     parser.add_argument("-i", "--input-dir",
                         help="Use a non-default location for input files")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     if args.srcroot is not None:
         expect(os.path.isdir(args.srcroot),

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -226,9 +226,7 @@ OR
     parser.add_argument("-i", "--input-dir",
                         help="Use a non-default location for input files")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     # generate and compare flags may not point to the same directory
     if model == "cesm":

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -226,7 +226,7 @@ OR
     parser.add_argument("-i", "--input-dir",
                         help="Use a non-default location for input files")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     # generate and compare flags may not point to the same directory
     if model == "cesm":

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -127,8 +127,8 @@ override the command provided by Machines."""
         "--xml-test-list",
         help="""Path to an XML file listing directories to run tests from."""
         )
-    args = parser.parse_args()
-    CIME.utils.handle_standard_logging_options(args)
+
+    args = CIME.utils.handle_standard_logging_options(args, parser)
     output = Printer(color=args.color)
 
     if args.xml_test_list is None and args.test_spec_dir is None:

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -128,7 +128,7 @@ override the command provided by Machines."""
         help="""Path to an XML file listing directories to run tests from."""
         )
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
     output = Printer(color=args.color)
 
     if args.xml_test_list is None and args.test_spec_dir is None:

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -336,7 +336,7 @@ class EnvMachSpecific(EnvBase):
         best_num_matched = -1
         default_match = None
         best_num_matched_default = -1
-        args = {}
+        args = []
         for mpirun_node in mpirun_nodes:
             xml_attribs = mpirun_node.attrib
             all_match = True
@@ -388,7 +388,7 @@ class EnvMachSpecific(EnvBase):
                                                subgroup=job,
                                                check_members=check_members,
                                                default=arg_node.get("default"))
-                    args[arg_node.get("name")] = arg_value
+                    args.append(arg_value)
 
         exec_node = self.get_node("executable", root=the_match)
         expect(exec_node is not None,"No executable found")

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -30,9 +30,7 @@ def parse_input(argv):
     parser.add_argument("bldroot",
                         help="root for building library")
 
-    args = parser.parse_args()
-
-    handle_standard_logging_options(args)
+    args = handle_standard_logging_options(argv, parser)
 
     return args.caseroot, args.libroot, args.bldroot
 

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -3,7 +3,7 @@ common utilities for buildlib
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import handle_standard_logging_options, setup_standard_logging_options
+from CIME.utils import parse_args_and_handle_standard_logging_options, setup_standard_logging_options
 from CIME.case  import Case
 import sys, os, argparse, doctest
 
@@ -30,7 +30,7 @@ def parse_input(argv):
     parser.add_argument("bldroot",
                         help="root for building library")
 
-    args = handle_standard_logging_options(argv, parser)
+    args = parse_args_and_handle_standard_logging_options(argv, parser)
 
     return args.caseroot, args.libroot, args.bldroot
 

--- a/scripts/lib/CIME/buildnml.py
+++ b/scripts/lib/CIME/buildnml.py
@@ -5,7 +5,7 @@ These are used by components/<model_type>/<component>/cime_config/buildnml
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect, handle_standard_logging_options, setup_standard_logging_options
+from CIME.utils import expect, parse_args_and_handle_standard_logging_options, setup_standard_logging_options
 import sys, os, argparse, doctest
 
 logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ def parse_input(argv):
     parser.add_argument("caseroot", default=os.getcwd(),
                         help="Case directory")
 
-    args = handle_standard_logging_options(argv, parser)
+    args = parse_args_and_handle_standard_logging_options(argv, parser)
 
     return args.caseroot
 

--- a/scripts/lib/CIME/buildnml.py
+++ b/scripts/lib/CIME/buildnml.py
@@ -25,9 +25,7 @@ def parse_input(argv):
     parser.add_argument("caseroot", default=os.getcwd(),
                         help="Case directory")
 
-    args = parser.parse_args()
-
-    handle_standard_logging_options(args)
+    args = handle_standard_logging_options(argv, parser)
 
     return args.caseroot
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1129,7 +1129,7 @@ class Case(object):
             "unit_testing" : False
             }
 
-        executable, args = env_mach_specific.get_mpirun(self, mpi_attribs, job=job)
+        executable, mpi_arg_string = env_mach_specific.get_mpirun(self, mpi_attribs, job=job)
 
         # special case for aprun
         if  executable is not None and "aprun" in executable:
@@ -1140,10 +1140,10 @@ class Case(object):
         else:
             mpi_arg_string = " ".join(args.values())
 
-            if self.get_value("BATCH_SYSTEM") == "cobalt":
-                mpi_arg_string += " : "
+        if self.get_value("BATCH_SYSTEM") == "cobalt":
+            mpi_arg_string += " : "
 
-            return "%s %s %s" % (executable if executable is not None else "", mpi_arg_string, run_suffix)
+        return "%s %s %s" % (executable if executable is not None else "", mpi_arg_string, run_suffix)
 
     def set_model_version(self, model):
         version = "unknown"

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1132,8 +1132,8 @@ class Case(object):
         executable, mpi_arg_string = env_mach_specific.get_mpirun(self, mpi_attribs, job=job)
 
         # special case for aprun
-        if  executable is not None and "aprun" in executable:
-            aprun_args, num_nodes = get_aprun_cmd_for_case(self, run_exe)
+        if executable is not None and "aprun" in executable:
+            aprun_cmd, num_nodes = get_aprun_cmd_for_case(self, run_exe)
             expect(num_nodes == self.num_nodes, "Not using optimized num nodes")
             return executable + aprun_args + " " + run_misc_suffix
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1129,7 +1129,7 @@ class Case(object):
             "unit_testing" : False
             }
 
-        executable, mpi_arg_string = env_mach_specific.get_mpirun(self, mpi_attribs, job=job)
+        executable, mpi_arg_list = env_mach_specific.get_mpirun(self, mpi_attribs, job=job)
 
         # special case for aprun
         if executable is not None and "aprun" in executable:
@@ -1138,7 +1138,7 @@ class Case(object):
             return executable + aprun_args + " " + run_misc_suffix
 
         else:
-            mpi_arg_string = " ".join(args.values())
+            mpi_arg_string = " ".join(mpi_arg_list)
 
         if self.get_value("BATCH_SYSTEM") == "cobalt":
             mpi_arg_string += " : "

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1133,7 +1133,7 @@ class Case(object):
 
         # special case for aprun
         if executable is not None and "aprun" in executable:
-            aprun_cmd, num_nodes = get_aprun_cmd_for_case(self, run_exe)
+            aprun_args, num_nodes = get_aprun_cmd_for_case(self, run_exe)
             expect(num_nodes == self.num_nodes, "Not using optimized num nodes")
             return executable + aprun_args + " " + run_misc_suffix
 

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -155,7 +155,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             logger.debug("at update TOTALPES = %s"%pestot)
             case.set_value("TOTALPES", pestot)
             thread_count = env_mach_pes.get_max_thread_count(models)
-            build_threaded = case.get_build_threaded()
             cost_pes = env_mach_pes.get_cost_pes(pestot, thread_count, machine=case.get_value("MACH"))
             case.set_value("COST_PES", cost_pes)
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -637,7 +637,7 @@ class _LessThanFilter(logging.Filter):
         #non-zero return means we log this message
         return 1 if record.levelno < self.max_level else 0
 
-def handle_standard_logging_options(args):
+def handle_standard_logging_options(args, parser):
     """
     Guide to logging in CIME.
 
@@ -659,6 +659,11 @@ def handle_standard_logging_options(args):
     # Change warnings and above to go to stderr
     stderr_stream_handler = logging.StreamHandler(stream=sys.stderr)
     stderr_stream_handler.setLevel(logging.WARNING)
+
+    # scripts_regression_tests is the only thing that should pass a None argument in parser
+    if parser is not None:
+        _check_for_invalid_args(args[1:])
+        args = parser.parse_args(args[1:])
 
     # --verbose adds to the message format but does not impact the log level
     if args.verbose:
@@ -682,6 +687,8 @@ def handle_standard_logging_options(args):
         root_logger.setLevel(logging.WARN)
     else:
         root_logger.setLevel(logging.INFO)
+    return args
+
 
 def get_logging_options():
     """
@@ -1228,6 +1235,16 @@ def run_and_log_case_status(func, phase, caseroot='.'):
         append_case_status(phase, "success", caseroot=caseroot)
 
     return rv
+
+def _check_for_invalid_args(args):
+    for arg in args:
+        if arg.startswith("--"):
+            continue
+        if arg.startswith("-") and len(arg) > 2:
+            expect(False, "Invalid argument %s\n  Arguments should begin with -- or be single character (-s)\n  Use --help for a complete list of available options"%arg)
+
+
+
 
 class SharedArea(object):
     """

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1241,7 +1241,10 @@ def _check_for_invalid_args(args):
         if arg.startswith("--"):
             continue
         if arg.startswith("-") and len(arg) > 2:
-            expect(False, "Invalid argument %s\n  Arguments should begin with -- or be single character (-s)\n  Use --help for a complete list of available options"%arg)
+            if arg == "-value":
+                logger.warn("This argument is deprecated, please use -%s"%arg)
+            else:
+                expect(False, "Invalid argument %s\n  Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options"%arg)
 
 
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1246,9 +1246,6 @@ def _check_for_invalid_args(args):
             else:
                 expect(False, "Invalid argument %s\n  Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options"%arg)
 
-
-
-
 class SharedArea(object):
     """
     Enable 0002 umask within this manager

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -637,7 +637,7 @@ class _LessThanFilter(logging.Filter):
         #non-zero return means we log this message
         return 1 if record.levelno < self.max_level else 0
 
-def handle_standard_logging_options(args, parser=None):
+def parse_args_and_handle_standard_logging_options(args, parser=None):
     """
     Guide to logging in CIME.
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -637,7 +637,7 @@ class _LessThanFilter(logging.Filter):
         #non-zero return means we log this message
         return 1 if record.levelno < self.max_level else 0
 
-def handle_standard_logging_options(args, parser):
+def handle_standard_logging_options(args, parser=None):
     """
     Guide to logging in CIME.
 
@@ -1241,8 +1241,8 @@ def _check_for_invalid_args(args):
         if arg.startswith("--"):
             continue
         if arg.startswith("-") and len(arg) > 2:
-            if arg == "-value":
-                logger.warn("This argument is deprecated, please use -%s"%arg)
+            if arg == "-value" or arg == "-noecho":
+                logger.warn("This argument is depricated, please use -%s"%arg)
             else:
                 expect(False, "Invalid argument %s\n  Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options"%arg)
 

--- a/scripts/manage_case
+++ b/scripts/manage_case
@@ -140,7 +140,7 @@ def parse_command_line(args):
     parser.add_argument("--long", action="store_true",
                         help="Provide long output for queries")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args
 

--- a/scripts/manage_case
+++ b/scripts/manage_case
@@ -140,9 +140,7 @@ def parse_command_line(args):
     parser.add_argument("--long", action="store_true",
                         help="Provide long output for queries")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args
 

--- a/scripts/manage_pes
+++ b/scripts/manage_pes
@@ -99,7 +99,7 @@ def parse_command_line(args, description):
     parser.add_argument("-machine", "--machine", default=None,
                         help="can be a supported machine name")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
     CIME.utils.expect(args.add or args.query,
                       "Either --query or --add must be on command line")
 

--- a/scripts/manage_pes
+++ b/scripts/manage_pes
@@ -98,8 +98,8 @@ def parse_command_line(args, description):
                         help=queryhelp)
     parser.add_argument("-machine", "--machine", default=None,
                         help="can be a supported machine name")
-    args = parser.parse_args(args[1:])
-    CIME.utils.handle_standard_logging_options(args)
+
+    args = CIME.utils.handle_standard_logging_options(args, parser)
     CIME.utils.expect(args.add or args.query,
                       "Either --query or --add must be on command line")
 

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -45,7 +45,7 @@ def parse_command_line(description):
     parser.add_argument("--xml-testlist",
                         help="Use this testlist to lookup tests, default specified in config_files.xml")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.handle_standard_logging_options(description, parser)
 
     expect(not(args.count and args.list_type),
            "Cannot specify both --count and --list arguments.")

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -11,7 +11,7 @@ from CIME.utils import expect
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def parse_command_line(description):
+def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
         description=description)
@@ -45,7 +45,7 @@ def parse_command_line(description):
     parser.add_argument("--xml-testlist",
                         help="Use this testlist to lookup tests, default specified in config_files.xml")
 
-    args = CIME.utils.handle_standard_logging_options(description, parser)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     expect(not(args.count and args.list_type),
            "Cannot specify both --count and --list arguments.")
@@ -147,7 +147,7 @@ def list_test_data(test_data, list_type):
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    args = parse_command_line(description)
+    args = parse_command_line(sys.argv, description)
 
     test_data = get_tests_from_xml(
         xml_machine = args.xml_machine,

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -45,9 +45,7 @@ def parse_command_line(description):
     parser.add_argument("--xml-testlist",
                         help="Use this testlist to lookup tests, default specified in config_files.xml")
 
-    args = parser.parse_args()
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     expect(not(args.count and args.list_type),
            "Cannot specify both --count and --list arguments.")

--- a/scripts/query_testlists
+++ b/scripts/query_testlists
@@ -45,7 +45,7 @@ def parse_command_line(args, description):
     parser.add_argument("--xml-testlist",
                         help="Use this testlist to lookup tests, default specified in config_files.xml")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     expect(not(args.count and args.list_type),
            "Cannot specify both --count and --list arguments.")

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2217,7 +2217,7 @@ def _main_func():
         else:
             setattr(args, log_param, False)
 
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, None)
 
     write_provenance_info()
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2217,7 +2217,7 @@ def _main_func():
         else:
             setattr(args, log_param, False)
 
-    args = CIME.utils.handle_standard_logging_options(args, None)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, None)
 
     write_provenance_info()
 

--- a/src/build_scripts/buildlib.gptl
+++ b/src/build_scripts/buildlib.gptl
@@ -6,8 +6,8 @@
 
 cd $CASEROOT # CASEROOT is always assumed to be an environment variable
 
-set CIMEROOT	= `./xmlquery  CIMEROOT	-value `
-set GMAKE	= `./xmlquery  GMAKE	-value `
+set CIMEROOT	= `./xmlquery  CIMEROOT -value `
+set GMAKE	= `./xmlquery  GMAKE	--value `
 
 # NOTE- (mv, 2015-01-02) SHAREDPATH is an environment variable set in
 # the $CASE.build script

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -38,7 +38,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = CIME.utils.handle_standard_logging_options(args, parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     return args.buildroot, args.installpath, args.caseroot
 

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -38,9 +38,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
                         help="Case directory to build")
 
-    args = parser.parse_args(args[1:])
-
-    CIME.utils.handle_standard_logging_options(args)
+    args = CIME.utils.handle_standard_logging_options(args, parser)
 
     return args.buildroot, args.installpath, args.caseroot
 
@@ -144,7 +142,7 @@ def _main_func(description):
         case.set_valid_values("PIO_TYPENAME",valid_values)
         # nothing means use the general default
         valid_values += ",nothing"
-        
+
         for comp in case.get_values("COMP_CLASSES"):
             comp_pio_typename = "%s_PIO_TYPENAME"%comp
             case.set_valid_values(comp_pio_typename,valid_values)

--- a/tools/configure
+++ b/tools/configure
@@ -69,7 +69,7 @@ def parse_command_line(args):
 
     argcnt = len(args)
     args = parser.parse_args()
-    CIME.utils.handle_standard_logging_options(args)
+    CIME.utils.parse_args_and_handle_standard_logging_options(args)
 
     opts = {}
     if args.machines_dir is not None:


### PR DESCRIPTION
All command line arguments should conform.   I have allowed for one exception, the -value option to xmlquery.  

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #428 

User interface changes?:  YES, now accepting only conforming command line arguments 

Code review: 
