### PR TITLE
remove the cprnc.out files prior to running tests

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -197,6 +197,10 @@ class SystemTestsCommon(object):
         run_type    = self._case.get_value("RUN_TYPE")
         rest_option = self._case.get_value("REST_OPTION")
         rest_n      = self._case.get_value("REST_N")
+        rundir = self._case.get_value("RUNDIR")
+        # remove any cprnc output leftover from previous runs
+        for compout in glob.iglob(os.path.join(rundir,"*.cprnc.out")):
+            os.remove(compout)
         infostr     = "doing an %d %s %s test" % (stop_n, stop_option,run_type)
 
         if rest_option == "none" or rest_option == "never":


### PR DESCRIPTION
If an ERS test passes and then should fail on the second run, having the *.cprnc.out files still in 
place will cause it to pass.   Removing this file before each run solves the problem.

Test suite: scripts_regression_test,  ERS_Ln9.T62_g37.DTEST.yellowstone_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
