### PR TITLE
Use ESMF7 on yellowstone and cheyenne

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -995,6 +995,8 @@ using a fortran linker.
   <PFUNIT_PATH>$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.2.8_cheyenne_Intel17.0.1_MPI_openMP</PFUNIT_PATH>
   <!-- Bug in the intel/17.0.1 compiler requires this, remove this line when compiler is updated -->
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
+  <ESMF_LIBDIR DEBUG="FALSE">/glade/u/home/fvitt/esmf_7_0_0_intel17/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
+  <ESMF_LIBDIR DEBUG="TRUE" >/glade/u/home/fvitt/esmf_7_0_0_intel17/esmf/lib/libg/Linux.intel.64.mpi.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="laramie">

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -995,8 +995,6 @@ using a fortran linker.
   <PFUNIT_PATH>$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.2.8_cheyenne_Intel17.0.1_MPI_openMP</PFUNIT_PATH>
   <!-- Bug in the intel/17.0.1 compiler requires this, remove this line when compiler is updated -->
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
-  <ESMF_LIBDIR DEBUG="FALSE">/glade/u/home/fvitt/esmf_7_0_0_intel17/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
-  <ESMF_LIBDIR DEBUG="TRUE" >/glade/u/home/fvitt/esmf_7_0_0_intel17/esmf/lib/libg/Linux.intel.64.mpi.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="laramie">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -251,6 +251,23 @@
 	<command name="load">intel/17.0.1</command>
 	<command name="load">mkl</command>
       </modules>
+<!-- esmf_libs does not seem to be compatible with intel/17.0.1 on cheyenne
+      <modules compiler="intel">
+	<command name="load">esmf_libs</command>
+      </modules>
+      <modules compiler="intel" mpilib="!mpi-serial" debug="true">
+	<command name="load">esmf-7.0.0-defio-mpi-g</command>
+      </modules>
+      <modules compiler="intel" mpilib="!mpi-serial" debug="false">
+	<command name="load">esmf-7.0.0-defio-mpi-O</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial" debug="true">
+	<command name="load">esmf-7.0.0-ncdfio-uni-g</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial" debug="false">
+	<command name="load">esmf-7.0.0-ncdfio-uni-O</command>
+      </modules>
+ -->
       <modules compiler="gnu">
 	<command name="load">gnu/6.3.0</command>
       </modules>
@@ -1694,16 +1711,16 @@
 	<command name="load">esmf</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" debug="true">
-	<command name="load">esmf-6.3.0rp1-defio-mpi-g</command>
+	<command name="load">esmf-7.0.0-ncdfio-mpi-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" debug="false">
-	<command name="load">esmf-6.3.0rp1-defio-mpi-O</command>
+	<command name="load">esmf-7.0.0-defio-mpi-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" debug="true">
-	<command name="load">esmf-6.3.0rp1-ncdfio-uni-g</command>
+	<command name="load">esmf-7.0.0-ncdfio-uni-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" debug="false">
-	<command name="load"> esmf-6.3.0rp1-ncdfio-uni-O</command>
+	<command name="load">esmf-7.0.0-ncdfio-uni-O</command>
       </modules>
       <modules compiler="pgi">
 	<command name="load">pgi/15.10</command>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -250,9 +250,6 @@
       <modules compiler="intel">
 	<command name="load">intel/17.0.1</command>
 	<command name="load">mkl</command>
-      </modules>
-<!-- esmf_libs does not seem to be compatible with intel/17.0.1 on cheyenne
-      <modules compiler="intel">
 	<command name="load">esmf_libs</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" debug="true">
@@ -267,7 +264,6 @@
       <modules compiler="intel" mpilib="mpi-serial" debug="false">
 	<command name="load">esmf-7.0.0-ncdfio-uni-O</command>
       </modules>
- -->
       <modules compiler="gnu">
 	<command name="load">gnu/6.3.0</command>
       </modules>


### PR DESCRIPTION
        modified:   config/cesm/machines/config_compilers.xml
        modified:   config/cesm/machines/config_machines.xml

WACCMX compsets need ESMF7 lib on yellowstone and cheyenne

Test suite: waccmx
Test baseline: 
Test namelist changes: 
Test status: Bit-for-bit

User interface changes?: no

Code review: Jim Edwards
