### PR TITLE
handle case when executable is none (scripts_regression_tests)

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -149,7 +149,7 @@ class Case(object):
             }
 
         executable = env_mach_spec.get_mpirun(self, mpi_attribs, job="case.run", exe_only=True)[0]
-        if "aprun" in executable:
+        if executable is not None and "aprun" in executable:
             self.num_nodes = get_aprun_cmd_for_case(self, "acme.exe")[1]
             self.spare_nodes = env_mach_pes.get_spare_nodes(self.num_nodes)
             self.num_nodes += self.spare_nodes
@@ -1123,7 +1123,7 @@ class Case(object):
         executable, args = env_mach_specific.get_mpirun(self, mpi_attribs, job=job)
 
         # special case for aprun
-        if  "aprun" in executable:
+        if  executable is not None and "aprun" in executable:
             aprun_args, num_nodes = get_aprun_cmd_for_case(self, run_exe)
             expect(num_nodes == self.num_nodes, "Not using optimized num nodes")
             return executable + aprun_args + " " + run_misc_suffix


### PR DESCRIPTION
Handle the case when executable is None
Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1408

User interface changes?: 

Code review: 
