### PR TITLE
Fix big mistake in scripts_regression_tests

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2241,7 +2241,8 @@ def _main_func():
             print "All pass, removing directory:", TEST_ROOT
             if os.path.exists(TEST_ROOT):
                 shutil.rmtree(TEST_ROOT)
-            raise
+
+        raise
 
 if (__name__ == "__main__"):
     _main_func()


### PR DESCRIPTION
Indent error lead to cdash always showing OK :(

Test suite: by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1409 

User interface changes?: None

Code review: @jedwards4b 
