### PR TITLE
Adds support for data model to read multiple time slices at once

### DIFF
--- a/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -1970,6 +1970,23 @@
     </values>
   </entry>
 
+  <entry id="readmode" per_stream_entry="true">
+    <type>char(30)</type>
+    <category>streams</category>
+    <group>shr_strdata_nml</group>
+    <valid_values>single,full_file</valid_values>
+    <desc>
+      array (up to 30 elements) of reading mode associated with the array of
+      streams.  specifies the mode of reading temporal stream dataset.
+      valid options are "single" (read temporal dataset one at a time) or
+      "full_file" (read all entires of temporal dataset in a given netcdf file)
+      valid values: single,full_file
+    </desc>
+    <values>
+      <value>single</value>
+    </values>
+  </entry>
+
   <entry id="dtlimit" per_stream_entry="true">
     <type>real(30)</type>
     <category>streams</category>

--- a/src/components/data_comps/dice/cime_config/namelist_definition_dice.xml
+++ b/src/components/data_comps/dice/cime_config/namelist_definition_dice.xml
@@ -518,6 +518,23 @@
     </values>
   </entry>
 
+  <entry id="readmode" per_stream_entry="true">
+    <type>char(30)</type>
+    <category>streams</category>
+    <group>shr_strdata_nml</group>
+    <valid_values>single,full_file</valid_values>
+    <desc>
+      array (up to 30 elements) of reading mode associated with the array of
+      streams.  specifies the mode of reading temporal stream dataset.
+      valid options are "single" (read temporal dataset one at a time) or
+      "full_file" (read all entires of temporal dataset in a given netcdf file)
+      valid values: single,full_file
+    </desc>
+    <values>
+      <value>single</value>
+    </values>
+  </entry>
+
   <entry id="dtlimit" per_stream_entry="true">
     <type>real(30)</type>
     <category>streams</category>

--- a/src/components/data_comps/dlnd/cime_config/namelist_definition_dlnd.xml
+++ b/src/components/data_comps/dlnd/cime_config/namelist_definition_dlnd.xml
@@ -398,6 +398,23 @@
     </values>
   </entry>
 
+  <entry id="readmode" per_stream_entry="true">
+    <type>char(30)</type>
+    <category>streams</category>
+    <group>shr_strdata_nml</group>
+    <valid_values>single,full_file</valid_values>
+    <desc>
+      array (up to 30 elements) of reading mode associated with the array of
+      streams.  specifies the mode of reading temporal stream dataset.
+      valid options are "single" (read temporal dataset one at a time) or
+      "full_file" (read all entires of temporal dataset in a given netcdf file)
+      valid values: single,full_file
+    </desc>
+    <values>
+      <value>single</value>
+    </values>
+  </entry>
+
   <entry id="dtlimit" per_stream_entry="true">
     <type>real(30)</type>
     <category>streams</category>

--- a/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -502,6 +502,23 @@
     </values>
   </entry>
 
+  <entry id="readmode" per_stream_entry="true">
+    <type>char(30)</type>
+    <category>streams</category>
+    <group>shr_strdata_nml</group>
+    <valid_values>single,full_file</valid_values>
+    <desc>
+      array (up to 30 elements) of reading mode associated with the array of
+      streams.  specifies the mode of reading temporal stream dataset.
+      valid options are "single" (read temporal dataset one at a time) or
+      "full_file" (read all entires of temporal dataset in a given netcdf file)
+      valid values: single,full_file
+    </desc>
+    <values>
+      <value>single</value>
+    </values>
+  </entry>
+
   <entry id="dtlimit" per_stream_entry="true">
     <type>real(30)</type>
     <category>streams</category>

--- a/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -426,6 +426,23 @@
     </values>
   </entry>
 
+  <entry id="readmode" per_stream_entry="true">
+    <type>char(30)</type>
+    <category>streams</category>
+    <group>shr_strdata_nml</group>
+    <valid_values>single,full_file</valid_values>
+    <desc>
+      array (up to 30 elements) of reading mode associated with the array of
+      streams.  specifies the mode of reading temporal stream dataset.
+      valid options are "single" (read temporal dataset one at a time) or
+      "full_file" (read all entires of temporal dataset in a given netcdf file)
+      valid values: single,full_file
+    </desc>
+    <values>
+      <value>single</value>
+    </values>
+  </entry>
+
   <entry id="dtlimit"  per_stream_entry="true">
     <type>real(30)</type>
     <category>streams</category>

--- a/src/components/data_comps/dwav/cime_config/namelist_definition_dwav.xml
+++ b/src/components/data_comps/dwav/cime_config/namelist_definition_dwav.xml
@@ -378,6 +378,23 @@
     </values>
   </entry>
 
+  <entry id="readmode" per_stream_entry="true">
+    <type>char(30)</type>
+    <category>streams</category>
+    <group>shr_strdata_nml</group>
+    <valid_values>single,full_file</valid_values>
+    <desc>
+      array (up to 30 elements) of reading mode associated with the array of
+      streams.  specifies the mode of reading temporal stream dataset.
+      valid options are "single" (read temporal dataset one at a time) or
+      "full_file" (read all entires of temporal dataset in a given netcdf file)
+      valid values: single,full_file
+    </desc>
+    <values>
+      <value>single</value>
+    </values>
+  </entry>
+
   <entry id="dtlimit" per_stream_entry="true">
     <type>real(30)</type>
     <category>streams</category>

--- a/src/share/util/shr_dmodel_mod.F90
+++ b/src/share/util/shr_dmodel_mod.F90
@@ -1064,7 +1064,7 @@ subroutine shr_dmodel_readstrm_fullfile(stream, pio_subsystem, pio_iotype, &
         call mct_avect_clean(avFile)
         call mct_aVect_init(avFile,rlist=fldList,lsize=nx*ny*nz)
 
-        call mct_gsmap_OP(gsMap,my_task,gsmOP)
+        call mct_gsmap_orderedPoints(gsMap,my_task,gsmOP)
 
         allocate(count(3))
         allocate(compDOF(lsize*nz),stat=rcode)


### PR DESCRIPTION
A new namelist variable ("readmode") is added that determines how
a temporal stream dataset is read. At present, "readmode" can be set to:
  - single    : Default method of reading a single time slice at a time
  - full_file : Reads all time slices in a given netcdf file at once

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: new xml variable, readmode

Code review: 
