### PR TITLE
Xmlcq fileoption

### DIFF
--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -14,7 +14,6 @@ from standard_script_setup import *
 
 from CIME.utils import expect, convert_to_type, append_case_status
 from CIME.case import Case
-from CIME.XML.generic_xml import GenericXML
 
 import re
 
@@ -96,12 +95,7 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
     with Case(caseroot, read_only=False) as case:
 
         if xmlfile:
-            expect(os.path.isfile(xmlfile), "Could not find file %s"%xmlfile)
-            gfile = GenericXML(infile=xmlfile)
-            ftype = gfile.get_id()
-            if os.path.abspath(os.path.join(caseroot,ftype)) != os.path.abspath(xmlfile):
-                logger.warn("setting case file to %s"%xmlfile)
-                case.set_file(xmlfile, ftype)
+            case.set_file(xmlfile)
 
         env_mach_pes = case.get_env("mach_pes")
         env_mach_pes.set_components(case.get_values("COMP_CLASSES"))

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -93,12 +93,12 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
               append, noecho, force, dryrun):
 
     with Case(caseroot, read_only=False) as case:
-
         if xmlfile:
             case.set_file(xmlfile)
-        else:
-            env_mach_pes = case.get_env("mach_pes")
-            env_mach_pes.set_components(case.get_values("COMP_CLASSES"))
+
+        env_mach_pes = case.get_env("mach_pes")
+        env_mach_pes.set_components(case.get_values("COMP_CLASSES"))
+
         if len(listofsettings):
             logger.debug("List of attributes to change: %s" , listofsettings)
 

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -14,6 +14,7 @@ from standard_script_setup import *
 
 from CIME.utils import expect, convert_to_type, append_case_status
 from CIME.case import Case
+from CIME.XML.generic_xml import GenericXML
 
 import re
 
@@ -24,7 +25,7 @@ logger = logging.getLogger("xmlchange")
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n%s [<changeargs>] [--verbose][--file file][--id id][--val value][--noecho][--append][--warn][--force]
+        usage="""\n%s [<changeargs>] [--verbose][--file file][--id id][--val value][--noecho][--append][--force]
 OR
 %s --help
 OR
@@ -72,9 +73,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-append","--append", action="store_true",
                         help="append to the existing value")
 
-    parser.add_argument("-warn","--warn", action="store_true",
-                        help="not implemented")
-
     parser.add_argument("-subgroup","--subgroup",
                         help="apply to this subgroup only")
 
@@ -90,11 +88,21 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
         delimiter = re.escape(args.delimiter)
         listofsettings = re.split(r'(?<!\\)'+ delimiter , args.listofsettings)
 
-    return args.caseroot, listofsettings, args.file, args.id, args.val, args.subgroup, args.append, args.noecho, args.warn, args.force , args.dryrun
+    return args.caseroot, listofsettings, args.file, args.id, args.val, args.subgroup, args.append, args.noecho, args.force , args.dryrun
 
-def xmlchange(caseroot, listofsettings, xmlid, xmlval, subgroup,
+def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
               append, noecho, force, dryrun):
+
     with Case(caseroot, read_only=False) as case:
+
+        if xmlfile:
+            expect(os.path.isfile(xmlfile), "Could not find file %s"%xmlfile)
+            gfile = GenericXML(infile=xmlfile)
+            ftype = gfile.get_id()
+            if os.path.abspath(os.path.join(caseroot,ftype)) != os.path.abspath(xmlfile):
+                logger.warn("setting case file to %s"%xmlfile)
+                case.set_file(xmlfile, ftype)
+
         env_mach_pes = case.get_env("mach_pes")
         env_mach_pes.set_components(case.get_values("COMP_CLASSES"))
         if len(listofsettings):
@@ -142,9 +150,9 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
     # pylint: disable=unused-variable
-    caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup, append, noecho, warn, force , dry = parse_command_line(sys.argv, description)
+    caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup, append, noecho, force , dry = parse_command_line(sys.argv, description)
 
-    xmlchange(caseroot, listofsettings, xmlid, xmlval, subgroup, append, noecho, force, dry)
+    xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup, append, noecho, force, dry)
 
 if (__name__ == "__main__"):
     _main_func(__doc__)

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -93,11 +93,10 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
               append, noecho, force, dryrun):
 
     with Case(caseroot, read_only=False) as case:
+        comp_classes = case.get_values("COMP_CLASSES")
         if xmlfile:
             case.set_file(xmlfile)
-
-        env_mach_pes = case.get_env("mach_pes")
-        env_mach_pes.set_components(case.get_values("COMP_CLASSES"))
+        case.set_comp_classes(comp_classes)
 
         if len(listofsettings):
             logger.debug("List of attributes to change: %s" , listofsettings)

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -96,9 +96,9 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
 
         if xmlfile:
             case.set_file(xmlfile)
-
-        env_mach_pes = case.get_env("mach_pes")
-        env_mach_pes.set_components(case.get_values("COMP_CLASSES"))
+        else:
+            env_mach_pes = case.get_env("mach_pes")
+            env_mach_pes.set_components(case.get_values("COMP_CLASSES"))
         if len(listofsettings):
             logger.debug("List of attributes to change: %s" , listofsettings)
 
@@ -113,7 +113,7 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
                     value = case.get_value(xmlid, resolved=False,
                                            subgroup=subgroup)
                     xmlval = "%s %s" % (value, xmlval)
-                if not force:
+                if type_str is not None and not force:
                     xmlval = convert_to_type(xmlval, type_str, xmlid)
 
                 if not dryrun :

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -174,7 +174,11 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
                 else:
                     value = get_value_as_string(case, var, resolved=resolved, subgroup=group)
 
-            expect(value is not None, " No results found for variable %s"%var)
+            if value is None:
+                if xmlfile:
+                    expect(False, " No results found for variable %s in file %s"%(var, xmlfile))
+                else:
+                    expect(False, " No results found for variable %s"%var)
 
             results[group][var]['value'] = value
 

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -131,7 +131,7 @@ def get_value_as_string(case, var, attribute=None, resolved=False, subgroup=None
 
 def xmlquery(case, variables, subgroup=None, fileonly=False,
              resolved=True, raw=False, description=False, group=False,
-             full=False, dtype=False, valid_values=False):
+             full=False, dtype=False, valid_values=False, xmlfile=None):
     """
     Return list of attributes and their values, print formatted
 
@@ -143,8 +143,12 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
             groups = [subgroup]
         else:
             groups = case.get_record_fields(var, "group")
-
-        expect(groups, " No results found for variable %s"%var)
+        if xmlfile and not groups:
+            results['none'] = {}
+            results['none'][var] = {}
+            results['none'][var]['value'] = case.get_value(var, resolved=resolved)
+        else:
+            expect(groups, " No results found for variable %s"%var)
         for group in groups:
             if not group in results:
                 results[group] = {}
@@ -228,7 +232,7 @@ def _main_func():
         expect(variables, "No variables found")
         results = xmlquery(case, variables, subgroup, fileonly, resolved=not no_resolve,
                            raw=raw, description=description, group=group, full=full,
-                           dtype=dtype, valid_values=valid_values)
+                           dtype=dtype, valid_values=valid_values, xmlfile=xmlfile)
 
     if full or description:
         wrapper=textwrap.TextWrapper()

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -63,7 +63,7 @@ epilog=textwrap.dedent(__doc__))
                         help="variable name in env_*.xml file ( <entry_id id='variable_name'>value</entry_id> )")
 
     parser.add_argument("-file" , "--file",
-                        help="deprecated option, do not use")
+                        help="specify the file you want to query")
 
     parser.add_argument("-subgroup","--subgroup",
                         help="apply to this subgroup only")
@@ -120,7 +120,7 @@ epilog=textwrap.dedent(__doc__))
 
     return variables, args.subgroup, args.caseroot, args.listall, args.fileonly, \
         args.value, args.no_resolve, args.raw, args.description, args.group, args.full, \
-        args.type, args.valid_values, args.partial_match
+        args.type, args.valid_values, args.partial_match, args.file
 
 def get_value_as_string(case, var, attribute=None, resolved=False, subgroup=None):
     thistype = case.get_type_info(var)
@@ -189,10 +189,12 @@ def _main_func():
     # Initialize command line parser and get command line options
     variables, subgroup, caseroot, listall,  fileonly, \
         value, no_resolve, raw, description, group, full, dtype, \
-        valid_values, partial_match = parse_command_line(sys.argv)
+        valid_values, partial_match, xmlfile = parse_command_line(sys.argv)
 
     # Initialize case ; read in all xml files from caseroot
     with Case(caseroot) as case:
+        if xmlfile:
+            case.set_file(xmlfile)
         if listall or partial_match:
             all_variables = sorted(case.get_record_fields(None, "varid"))
             if partial_match:

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -138,15 +138,21 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
     """
     results = {}
     comp_classes = case.get_values("COMP_CLASSES")
+    if xmlfile:
+        case.set_file(xmlfile)
     for var in variables:
-        if subgroup is not None:
+        if xmlfile:
+            groups = ['none']
+        elif subgroup is not None:
             groups = [subgroup]
         else:
             groups = case.get_record_fields(var, "group")
-        if xmlfile and not groups:
+
+        if xmlfile:
+            value =  case.get_value(var, resolved=resolved)
             results['none'] = {}
             results['none'][var] = {}
-            results['none'][var]['value'] = case.get_value(var, resolved=resolved)
+            results['none'][var]['value']  = value
         else:
             expect(groups, " No results found for variable %s"%var)
         for group in groups:
@@ -197,8 +203,6 @@ def _main_func():
 
     # Initialize case ; read in all xml files from caseroot
     with Case(caseroot) as case:
-        if xmlfile:
-            case.set_file(xmlfile)
         if listall or partial_match:
             all_variables = sorted(case.get_record_fields(None, "varid"))
             if partial_match:

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # get_type) otherwise need to implement own functions and make GenericXML parent class
 class EnvMachSpecific(EnvBase):
     # pylint: disable=unused-argument
-    def __init__(self, caseroot, infile="env_mach_specific.xml",
+    def __init__(self, caseroot=None, infile="env_mach_specific.xml",
                  components=None, unit_testing=False):
         """
         initialize an object interface to file env_mach_specific.xml in the case directory

--- a/scripts/lib/CIME/XML/env_test.py
+++ b/scripts/lib/CIME/XML/env_test.py
@@ -103,3 +103,22 @@ class EnvTest(EnvBase):
         if dnode is not None:
             node.remove(dnode)
         return node
+
+    def set_value(self, vid, value, subgroup=None, ignore_type=False):
+        """
+        check if vid is in test section of file
+        """
+        newval = EnvBase.set_value(self, vid, value, subgroup, ignore_type)
+        if newval is None:
+            tnode = self.get_optional_node("test")
+            if tnode is not None:
+                newval = self.set_element_text(vid, value, root=tnode)
+        return newval
+
+    def get_value(self, vid, attribute=None, resolved=True, subgroup=None):
+        value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
+        if value is None:
+            tnode = self.get_optional_node("test")
+            if tnode is not None:
+                value = self.get_element_text(vid, root=tnode)
+        return value

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -294,4 +294,5 @@ class GenericXML(object):
             expect(False, "Could not write file %s, xml formatting error '%s'" % (self.filename, e))
         return xmlstr
 
-
+    def get_id(self):
+        return self.root.get("id")

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -373,10 +373,6 @@ class Case(object):
             self._caseroot = value
         result = None
 
-        env_test = self.get_env("test", allow_missing=True)
-        if env_test:
-            chkval = env_test.get_test_parameter(item)
-
         for env_file in self._env_entryid_files:
             result = env_file.set_value(item, value, subgroup, ignore_type)
             if (result is not None):
@@ -1201,7 +1197,11 @@ class Case(object):
                    error_prefix="STOP: ")
 
     def set_file(self, xmlfile):
+        """
+        force the case object to consider only xmlfile
+        """
         expect(os.path.isfile(xmlfile), "Could not find file %s"%xmlfile)
+
         gfile = GenericXML(infile=xmlfile)
         ftype = gfile.get_id()
 
@@ -1222,7 +1222,9 @@ class Case(object):
                 elif ftype == "env_test.xml":
                     new_env_file = EnvTest(infile=xmlfile)
             if new_env_file is not None:
-                self._env_entryid_files[idx] = new_env_file
+                self._env_entryid_files = []
+                self._env_generic_files = []
+                self._env_entryid_files.append(new_env_file)
                 break
         if new_env_file is None:
             for idx, env_file in enumerate(self._env_generic_files):
@@ -1234,7 +1236,9 @@ class Case(object):
                     else:
                         expect(False, "No match found for file type %s"%ftype)
                 if new_env_file is not None:
-                    self._env_generic_files[idx] = new_env_file
+                    self._env_entryid_files = []
+                    self._env_generic_files = []
+                    self._env_generic_files.append(new_env_file)
                     break
 
         self._files = self._env_entryid_files + self._env_generic_files

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -30,6 +30,7 @@ from CIME.XML.env_build             import EnvBuild
 from CIME.XML.env_run               import EnvRun
 from CIME.XML.env_archive           import EnvArchive
 from CIME.XML.env_batch             import EnvBatch
+from CIME.XML.generic_xml           import GenericXML
 from CIME.user_mod_support          import apply_user_mods
 from CIME.case_setup import case_setup
 from CIME.aprun import get_aprun_cmd_for_case
@@ -1199,7 +1200,12 @@ class Case(object):
                    "Override this warning with the --run-unsupported option to create_newcase.",
                    error_prefix="STOP: ")
 
-    def set_file(self, xmlfile, ftype):
+    def set_file(self, xmlfile):
+        expect(os.path.isfile(xmlfile), "Could not find file %s"%xmlfile)
+        gfile = GenericXML(infile=xmlfile)
+        ftype = gfile.get_id()
+
+        logger.warn("setting case file to %s"%xmlfile)
         new_env_file = None
         for idx, env_file in enumerate(self._env_entryid_files):
             if os.path.basename(env_file.filename) == ftype:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -283,7 +283,8 @@ class Case(object):
                 if resolved and type(result) is str:
                     result = self.get_resolved_value(result)
                     vtype = env_file.get_type_info(item)
-                    result = convert_to_type(result, vtype, item)
+                    if vtype is not None:
+                        result = convert_to_type(result, vtype, item)
                 return result
 
         for env_file in self._env_generic_files:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1208,7 +1208,7 @@ class Case(object):
 
         logger.warn("setting case file to %s"%xmlfile)
         new_env_file = None
-        for idx, env_file in enumerate(self._env_entryid_files):
+        for env_file in self._env_entryid_files:
             if os.path.basename(env_file.filename) == ftype:
                 if ftype == "env_run.xml":
                     new_env_file = EnvRun(infile=xmlfile)
@@ -1228,7 +1228,7 @@ class Case(object):
                 self._env_entryid_files.append(new_env_file)
                 break
         if new_env_file is None:
-            for idx, env_file in enumerate(self._env_generic_files):
+            for env_file in self._env_generic_files:
                 if os.path.basename(env_file.filename) == ftype:
                     if ftype == "env_archive.xml":
                         new_env_file = EnvArchive(infile=xmlfile)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -492,7 +492,7 @@ class Case(object):
                 else:
                     yield key, val
 
-    def _set_comp_classes(self, comp_classes):
+    def set_comp_classes(self, comp_classes):
         self._component_classes = comp_classes
         for env_file in self._env_entryid_files:
             env_file.set_components(comp_classes)
@@ -521,7 +521,7 @@ class Case(object):
 
         # loop over all elements of both component_classes and components - and get config_component_file for
         # for each component
-        self._set_comp_classes(drv_comp.get_valid_model_components())
+        self.set_comp_classes(drv_comp.get_valid_model_components())
 
         if len(self._component_classes) > len(self._components):
             self._components.append('sesp')


### PR DESCRIPTION
Add --file option to xmlquery and enable option in xmlchange.   Add code to allow changes in env_test.xml

Test suite: scripts_regression_tests.py hand tests of xmlchange and xmlquery
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1216 
FIxes #1416

User interface changes?:  new --file option in xmlquery

Code review: 
