### PR TITLE
nag needs a lib pointer

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -701,6 +701,10 @@ using a fortran linker.
   <LDFLAGS>
     <append> -lpthread</append>
   </LDFLAGS>
+  <PFUNIT_PATH>/home/santos/pFUnit/pFUnit_NAG_3_0</PFUNIT_PATH>
+  <SLIBS>
+    <append> -L/usr/local/nag/lib/NAG_Fortran </append>
+  </SLIBS>
 </compiler>
 
 <compiler MACH="hobart" COMPILER="pgi">

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -701,7 +701,6 @@ using a fortran linker.
   <LDFLAGS>
     <append> -lpthread</append>
   </LDFLAGS>
-  <PFUNIT_PATH>/home/santos/pFUnit/pFUnit_NAG_3_0</PFUNIT_PATH>
   <SLIBS>
     <append> -L/usr/local/nag/lib/NAG_Fortran </append>
   </SLIBS>


### PR DESCRIPTION
nag compliler needs an additional library flag when built with debug

Test suite: SMS_D_Ld3.f45_g37_rx1.A.hobart_nag
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
