### PR TITLE
remove debug print statement, fix netcdf4p support

### DIFF
--- a/src/externals/pio1/pio/CMakeLists.txt
+++ b/src/externals/pio1/pio/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 # Netcdf is required
 #SET (NETCDF_FIND_COMPONENTS F90)
-FIND_PACKAGE(NetCDF "4.3.3" COMPONENTS Fortran)
+FIND_PACKAGE(NetCDF "4.3.3" COMPONENTS C Fortran)
 IF (${NetCDF_Fortran_FOUND})
   MESSAGE("Building PIO with netcdf support ")
   SET(pio_include_dirs_ ${pio_include_dirs_} ${NetCDF_Fortran_INCLUDE_DIR})
@@ -189,5 +189,3 @@ endif()
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../testpio)
   ADD_SUBDIRECTORY(../testpio testpio)
 endif()
-
-

--- a/src/externals/pio1/pio/pionfput_mod.F90.in
+++ b/src/externals/pio1/pio/pionfput_mod.F90.in
@@ -125,7 +125,6 @@ contains
           ierr = nfmpi_begin_indep_data(File%fh)
 
           if(Ios%io_rank==0 .and. (ierr==NF_EINDEP .or. ierr==PIO_NOERR)) then
-             print *,__PIO_FILE__,__LINE__,index,count,trim(ival)
              ierr = nfmpi_put_vara (File%fh, varid, int(index,kind=PIO_OFFSET), &
                   int(count,kind=PIO_OFFSET), ival, int(count,kind=PIO_OFFSET), &
                   MPI_CHARACTER)


### PR DESCRIPTION
Fixes an issue with pio1 determining if netcdf4 is available and removes a debug print statement.

Test suite: hand tests ERS_D_Ld5.f09_g16.ICLM45ED.cheyenne_intel.clm-edTest
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?: 

Code review: @jayeshkrishna
