### PR TITLE
add missing term for NET WATER BUDGET tables

### DIFF
--- a/src/drivers/mct/main/seq_diag_mct.F90
+++ b/src/drivers/mct/main/seq_diag_mct.F90
@@ -78,6 +78,13 @@ module seq_diag_mct
    &  - (shr_const_ocn_ref_sal-shr_const_ice_ref_sal) / &
    &    (shr_const_ocn_ref_sal*shr_const_latice)
 
+   real(r8),parameter :: SFLXtoWFLX = & ! water flux implied by salt flux
+                                        ! WFLX (kg/m^2s) = -SFLX (kg/m^2s) 
+                                        !                  / ocn_ref_sal (psu) (34.7g/kg)
+					!		   / 1.e-3 kg/g
+        -1._r8/(shr_const_ocn_ref_sal*1.e-3_r8)
+
+
    !--- C for component ---
    !--- "r" is recieve in the coupler, "s" is send from the coupler
 
@@ -131,29 +138,30 @@ module seq_diag_mct
    integer(in),parameter :: f_wrain     =13     ! water: precip, liquid
    integer(in),parameter :: f_wsnow     =14     ! water: precip, frozen
    integer(in),parameter :: f_wevap     =15     ! water: evaporation
-   integer(in),parameter :: f_wroff     =16     ! water: runoff/flood
-   integer(in),parameter :: f_wioff     =17     ! water: frozen runoff
-   integer(in),parameter :: f_wfrz_16O  =18     ! water: freezing
-   integer(in),parameter :: f_wmelt_16O =19     ! water: melting
-   integer(in),parameter :: f_wrain_16O =20     ! water: precip, liquid
-   integer(in),parameter :: f_wsnow_16O =21     ! water: precip, frozen
-   integer(in),parameter :: f_wevap_16O =22     ! water: evaporation
-   integer(in),parameter :: f_wroff_16O =23     ! water: runoff/flood
-   integer(in),parameter :: f_wioff_16O =24     ! water: frozen runoff
-   integer(in),parameter :: f_wfrz_18O  =25     ! water: freezing
-   integer(in),parameter :: f_wmelt_18O =26     ! water: melting
-   integer(in),parameter :: f_wrain_18O =27     ! water: precip, liquid
-   integer(in),parameter :: f_wsnow_18O =28     ! water: precip, frozen
-   integer(in),parameter :: f_wevap_18O =29     ! water: evaporation
-   integer(in),parameter :: f_wroff_18O =30     ! water: runoff/flood
-   integer(in),parameter :: f_wioff_18O =31     ! water: frozen runoff
-   integer(in),parameter :: f_wfrz_HDO  =32     ! water: freezing
-   integer(in),parameter :: f_wmelt_HDO =33     ! water: melting
-   integer(in),parameter :: f_wrain_HDO =34     ! water: precip, liquid
-   integer(in),parameter :: f_wsnow_HDO =35     ! water: precip, frozen
-   integer(in),parameter :: f_wevap_HDO =36     ! water: evaporation
-   integer(in),parameter :: f_wroff_HDO =37     ! water: runoff/flood
-   integer(in),parameter :: f_wioff_HDO =38     ! water: frozen runoff
+   integer(in),parameter :: f_wsalt     =16     ! water: water equivalent of salt flux
+   integer(in),parameter :: f_wroff     =17     ! water: runoff/flood
+   integer(in),parameter :: f_wioff     =18     ! water: frozen runoff
+   integer(in),parameter :: f_wfrz_16O  =19     ! water: freezing
+   integer(in),parameter :: f_wmelt_16O =20     ! water: melting
+   integer(in),parameter :: f_wrain_16O =21     ! water: precip, liquid
+   integer(in),parameter :: f_wsnow_16O =22     ! water: precip, frozen
+   integer(in),parameter :: f_wevap_16O =23     ! water: evaporation
+   integer(in),parameter :: f_wroff_16O =24     ! water: runoff/flood
+   integer(in),parameter :: f_wioff_16O =25     ! water: frozen runoff
+   integer(in),parameter :: f_wfrz_18O  =26     ! water: freezing
+   integer(in),parameter :: f_wmelt_18O =27     ! water: melting
+   integer(in),parameter :: f_wrain_18O =28     ! water: precip, liquid
+   integer(in),parameter :: f_wsnow_18O =29     ! water: precip, frozen
+   integer(in),parameter :: f_wevap_18O =30     ! water: evaporation
+   integer(in),parameter :: f_wroff_18O =31     ! water: runoff/flood
+   integer(in),parameter :: f_wioff_18O =32     ! water: frozen runoff
+   integer(in),parameter :: f_wfrz_HDO  =33     ! water: freezing
+   integer(in),parameter :: f_wmelt_HDO =34     ! water: melting
+   integer(in),parameter :: f_wrain_HDO =35     ! water: precip, liquid
+   integer(in),parameter :: f_wsnow_HDO =36     ! water: precip, frozen
+   integer(in),parameter :: f_wevap_HDO =37     ! water: evaporation
+   integer(in),parameter :: f_wroff_HDO =38     ! water: runoff/flood
+   integer(in),parameter :: f_wioff_HDO =39     ! water: frozen runoff
 
    integer(in),parameter :: f_size     = f_wioff_HDO   ! Total array size of all elements
    integer(in),parameter :: f_a        = f_area        ! 1st index for area
@@ -173,13 +181,13 @@ module seq_diag_mct
 
       (/'        area','     hfreeze','       hmelt','      hnetsw','       hlwdn', &
         '       hlwup','     hlatvap','     hlatfus','      hiroff','        hsen', &
-        '     wfreeze','       wmelt','       wrain','       wsnow', &
-        '       wevap','     wrunoff','     wfrzrof', &
-        ' wfreeze_16O','   wmelt_16O','   wrain_16O','   wsnow_16O', &
-        '   wevap_16O',' wrunoff_16O',' wfrzrof_16O', &
-        ' wfreeze_18O','   wmelt_18O','   wrain_18O','   wsnow_18O', &
-        '   wevap_18O',' wrunoff_18O',' wfrzrof_18O', &
-        ' wfreeze_HDO','   wmelt_HDO','   wrain_HDO','   wsnow_HDO', &
+        '     wfreeze','       wmelt','       wrain','       wsnow',                &
+        '       wevap','    weqsaltf','     wrunoff','     wfrzrof',                &
+        ' wfreeze_16O','   wmelt_16O','   wrain_16O','   wsnow_16O',                &
+        '   wevap_16O',' wrunoff_16O',' wfrzrof_16O',                               &
+        ' wfreeze_18O','   wmelt_18O','   wrain_18O','   wsnow_18O',                &
+        '   wevap_18O',' wrunoff_18O',' wfrzrof_18O',                               &
+        ' wfreeze_HDO','   wmelt_HDO','   wrain_HDO','   wsnow_HDO',                &
         '   wevap_HDO',' wrunoff_HDO',' wfrzrof_HDO'/)
 
    !--- P for period ---
@@ -281,9 +289,11 @@ module seq_diag_mct
    integer :: index_x2o_Faxa_snow
    integer :: index_x2o_Fioi_melth
    integer :: index_x2o_Fioi_meltw
+   integer :: index_x2o_Fioi_salt
 
    integer :: index_i2x_Fioi_melth
    integer :: index_i2x_Fioi_meltw
+   integer :: index_i2x_Fioi_salt
    integer :: index_i2x_Faii_swnet
    integer :: index_i2x_Fioi_swpen
    integer :: index_i2x_Faii_lwup
@@ -1394,6 +1404,7 @@ subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, infodata, do_o2x, do_x2o, do_xa
       if (first_time) then
          index_x2o_Fioi_melth  = mct_aVect_indexRA(x2o_o,'Fioi_melth')
          index_x2o_Fioi_meltw  = mct_aVect_indexRA(x2o_o,'Fioi_meltw')
+         index_x2o_Fioi_salt   = mct_aVect_indexRA(x2o_o,'Fioi_salt')
          index_x2o_Foxx_swnet  = mct_aVect_indexRA(x2o_o,'Foxx_swnet')
          index_x2o_Faxa_lwdn   = mct_aVect_indexRA(x2o_o,'Faxa_lwdn')
          index_x2o_Faxa_rain   = mct_aVect_indexRA(x2o_o,'Faxa_rain')
@@ -1448,6 +1459,7 @@ subroutine seq_diag_ocn_mct( ocn, xao_o, frac_o, infodata, do_o2x, do_x2o, do_xa
          if = f_area  ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + do
          if = f_wmelt ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + (do+di)*x2o_o%rAttr(index_x2o_Fioi_meltw,n)
          if = f_hmelt ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + (do+di)*x2o_o%rAttr(index_x2o_Fioi_melth,n)
+         if = f_wsalt ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + (do+di)*x2o_o%rAttr(index_x2o_Fioi_salt,n) * SFLXtoWFLX
          if = f_hswnet; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + (do+di)*x2o_o%rAttr(index_x2o_Foxx_swnet,n)
          if = f_hlwdn ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + (do+di)*x2o_o%rAttr(index_x2o_Faxa_lwdn,n)
          if = f_wrain ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + (do+di)*x2o_o%rAttr(index_x2o_Faxa_rain,n)
@@ -1580,6 +1592,7 @@ subroutine seq_diag_ice_mct( ice, frac_i, infodata, do_i2x, do_x2i)
       index_i2x_Faii_lat    = mct_aVect_indexRA(i2x_i,'Faii_lat')
       index_i2x_Faii_sen    = mct_aVect_indexRA(i2x_i,'Faii_sen')
       index_i2x_Faii_evap   = mct_aVect_indexRA(i2x_i,'Faii_evap')
+      index_i2x_Fioi_salt   = mct_aVect_indexRA(i2x_i,'Fioi_salt')
 
       index_i2x_Fioi_meltw_16O   = mct_aVect_indexRA(i2x_i,'Fioi_meltw_16O',perrWith='quiet')
       if ( index_i2x_Fioi_meltw_16O /= 0 ) flds_wiso_ice = .true.
@@ -1604,6 +1617,7 @@ subroutine seq_diag_ice_mct( ice, frac_i, infodata, do_i2x, do_x2i)
          if = f_area  ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + di
          if = f_hmelt ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) - di*i2x_i%rAttr(index_i2x_Fioi_melth,n)
          if = f_wmelt ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) - di*i2x_i%rAttr(index_i2x_Fioi_meltw,n)
+         if = f_wsalt ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) - di*i2x_i%rAttr(index_i2x_Fioi_salt,n) * SFLXtoWFLX
          if = f_hswnet; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + di*i2x_i%rAttr(index_i2x_Faii_swnet,n) &
                                                                     - di*i2x_i%rAttr(index_i2x_Fioi_swpen,n)
          if = f_hlwup ; budg_dataL(if,ic,ip) = budg_dataL(if,ic,ip) + di*i2x_i%rAttr(index_i2x_Faii_lwup,n)
@@ -1968,19 +1982,6 @@ SUBROUTINE seq_diag_print_mct(EClock, stop_alarm, &
                                        -sum(dataGpr(f_h:f_h_end,icar,ip))+sum(dataGpr(f_h:f_h_end,icxs,ip))+ &
                                        sum(dataGpr(f_h:f_h_end,icxr,ip))-sum(dataGpr(f_h:f_h_end,icas,ip))
 
-      write(logunit,*) ' '
-      write(logunit,FAH) subname,trim(str)//' WATER BUDGET (kg/m2s*1e6): period = ',trim(pname(ip)),': date = ',cdate,sec
-      write(logunit,FA0) cname(icar),cname(icxs),cname(icxr),cname(icas),' *SUM*  '
-      do if = f_w, f_w_end
-         write(logunit,FA1)    fname(if),-dataGpr(if,icar,ip),dataGpr(if,icxs,ip), &
-                                         dataGpr(if,icxr,ip),-dataGpr(if,icas,ip), &
-                                         -dataGpr(if,icar,ip)+dataGpr(if,icxs,ip)+ &
-                                         dataGpr(if,icxr,ip)-dataGpr(if,icas,ip)
-      enddo
-      write(logunit,FA1)    '   *SUM*',-sum(dataGpr(f_w:f_w_end,icar,ip)),sum(dataGpr(f_w:f_w_end,icxs,ip)), &
-                                       sum(dataGpr(f_w:f_w_end,icxr,ip)),-sum(dataGpr(f_w:f_w_end,icas,ip)), &
-                                       -sum(dataGpr(f_w:f_w_end,icar,ip))+sum(dataGpr(f_w:f_w_end,icxs,ip))+ &
-                                       sum(dataGpr(f_w:f_w_end,icxr,ip))-sum(dataGpr(f_w:f_w_end,icas,ip))
       write(logunit,*) ' '
       write(logunit,FAH) subname,trim(str)//' WATER BUDGET (kg/m2s*1e6): period = ',trim(pname(ip)),': date = ',cdate,sec
       write(logunit,FA0) cname(icar),cname(icxs),cname(icxr),cname(icas),' *SUM*  '


### PR DESCRIPTION
Correct a budget diagnostic printed in the coupler log files.  The fresh water budget was missing a freshwater term associated the salt flux due to ice melt/growth.  This salt flux should be  represented as an additional  freshwater flux in the coupler water budget.

The complete equation for net surface forcing of the POP model is 

 PREC_F+EVAP_F+ROFF_F+IOFF_F+MELT_F+SALT_F*(sflux_factor/salinity_factor) + QFLUX/lh_fusion*1e4*s_scaling

The freshwater representation of the SALT_F term was missing from the coupler budget.  I've added that term and verified that the net ocean fresh water budget better represents the freshwater tendency calculated by the ocean component.  I doubled checked the net budget against the global salinity trend in a model run.  The new term in the table for the missing flux is weqsalt which stands for the fresh water equivalent of the salt flux. 

Test suite: cime regression tests and a coupled run where I backed out the freshwater flux from the salinity timeseries.
Test baseline: cime_master 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #1429 


Code review: Tony, Rob, and Mariana.
