### PR TITLE
Add --component Option to preview_namelist

### DIFF
--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -15,10 +15,10 @@ from CIME.utils             import expect
 import argparse, doctest
 
 ###############################################################################
-def parse_command_line(args):
+def parse_command_line(args, description):
 ###############################################################################
     cime_model = CIME.utils.get_model()
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=description)
     CIME.utils.setup_standard_logging_options(parser)
 
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
@@ -37,15 +37,14 @@ def parse_command_line(args):
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    args = parse_command_line(sys.argv)
+    args = parse_command_line(sys.argv, description)
     if args.test:
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot = args.caseroot
-    expect(os.path.isfile(os.path.join(caseroot, "CaseStatus")),
+    expect(os.path.isfile(os.path.join(args.caseroot, "CaseStatus")),
            "case.setup must be run prior to running preview_namelists")
-    with Case(caseroot, read_only=False) as case:
+    with Case(args.caseroot, read_only=False) as case:
         create_namelists(case, component=args.component)
 
 if (__name__ == "__main__"):

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -15,50 +15,38 @@ from CIME.utils             import expect
 import argparse, doctest
 
 ###############################################################################
-def parse_command_line(args, description):
+def parse_command_line(args):
 ###############################################################################
-    parser = argparse.ArgumentParser(
-        usage="""\n%s [--debug]
-OR
-%s --verbose
-OR
-%s --help
-OR
-%s --test
-
-\033[1mEXAMPLES:\033[0m
-    \033[1;32m# Run \033[0m
-    > %s
-""" % ((os.path.basename(args[0]), ) * 5),
-
-description=description,
-
-formatter_class=argparse.ArgumentDefaultsHelpFormatter
-)
-
+    cime_model = CIME.utils.get_model()
+    parser = argparse.ArgumentParser()
     CIME.utils.setup_standard_logging_options(parser)
 
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
                         help="Case directory to build")
+    parser.add_argument('--component',
+                        help="Specify component's namelist to build.")
+    parser.add_argument('--test', action='store_true',
+                        help="Run preview_namelist in test mode.")
 
-    args = parser.parse_args(args[1:])
+    args = parser.parse_args()
 
     CIME.utils.handle_standard_logging_options(args)
 
-    return args.caseroot
+    return args
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
+    args = parse_command_line(sys.argv)
+    if args.test:
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot = parse_command_line(sys.argv, description)
+    caseroot = args.caseroot
     expect(os.path.isfile(os.path.join(caseroot, "CaseStatus")),
            "case.setup must be run prior to running preview_namelists")
     with Case(caseroot, read_only=False) as case:
-        create_namelists(case)
+        create_namelists(case, component=args.component)
 
 if (__name__ == "__main__"):
     _main_func(__doc__)

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -40,7 +40,7 @@ def create_dirs(case):
         with open(os.path.join(dir_,"CASEROOT"),"w+") as fd:
             fd.write(caseroot+"\n")
 
-def create_namelists(case):
+def create_namelists(case, component=None):
     """
     Create component namelists
     """
@@ -73,36 +73,37 @@ def create_namelists(case):
         else:
             compname = case.get_value("COMP_%s" % model_str.upper())
 
-        cmd = os.path.join(config_dir, "buildnml")
-        do_run_cmd = False
-        # This code will try to import and run each buildnml as a subroutine
-        # if that fails it will run it as a program in a seperate shell
-        try:
-            with open(cmd, 'r') as f:
-                first_line = f.readline()
-            if "python" in first_line:
-                mod = imp.load_source("buildnml", cmd)
-                logger.info("   Calling %s buildnml"%compname)
-                mod.buildnml(case, caseroot, compname)
-            else:
-                raise SyntaxError
-        except SyntaxError as detail:
-            if 'python' in first_line:
-                expect(False, detail)
-            else:
+        if component is None or component == model_str:
+            cmd = os.path.join(config_dir, "buildnml")
+            do_run_cmd = False
+            # This code will try to import and run each buildnml as a subroutine
+            # if that fails it will run it as a program in a seperate shell
+            try:
+                with open(cmd, 'r') as f:
+                    first_line = f.readline()
+                if "python" in first_line:
+                    mod = imp.load_source("buildnml", cmd)
+                    logger.info("   Calling %s buildnml"%compname)
+                    mod.buildnml(case, caseroot, compname)
+                else:
+                    raise SyntaxError
+            except SyntaxError as detail:
+                if 'python' in first_line:
+                    expect(False, detail)
+                else:
+                    do_run_cmd = True
+            except AttributeError:
                 do_run_cmd = True
-        except AttributeError:
-            do_run_cmd = True
-        except:
-            raise
+            except:
+                raise
 
-        if do_run_cmd:
-            logger.info("   Running %s buildnml"%compname)
-            case.flush()
-            output = run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=False)
-            logger.info(output)
-            # refresh case xml object from file
-            case.read_xml()
+            if do_run_cmd:
+                logger.info("   Running %s buildnml"%compname)
+                case.flush()
+                output = run_cmd_no_fail("%s %s" % (cmd, caseroot), verbose=False)
+                logger.info(output)
+                # refresh case xml object from file
+                case.read_xml()
 
     logger.info("Finished creating component namelists")
 


### PR DESCRIPTION
Added an option to preview_namelist, which allows the user to specify
the component for which to run the preview_namelist script.

Test suite: scripts_regression_tests.py --fast
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #887

User interface changes?: added --component option to preview_namelist

Code review: @mnlevy1981, @jgfouca 