### PR TITLE
allow default value of PIO_STRIDE

### DIFF
--- a/scripts/lib/CIME/SystemTests/seq.py
+++ b/scripts/lib/CIME/SystemTests/seq.py
@@ -90,7 +90,7 @@ class SEQ(SystemTestsCommon):
 
         # update the pelayout settings for this run
         self._case.read_xml()
-        adjust_pio_layout(self._case, self._case.get_value("PES_PER_NODE"))
+        adjust_pio_layout(self._case)
 
         self.run_indv()
 
@@ -103,7 +103,7 @@ class SEQ(SystemTestsCommon):
         logger.info("doing a second %d %s test with rootpes set to zero" % (stop_n, stop_option))
         # update the pelayout settings for this run
         self._case.read_xml()
-        adjust_pio_layout(self._case, self._case.get_value("PES_PER_NODE"))
+        adjust_pio_layout(self._case)
 
         self.run_indv(suffix="seq")
         self._component_compare_test("base", "seq")

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -34,14 +34,15 @@ class EntryID(GenericXML):
 
         return value
 
-    def set_default_value(self, vid, val):
+    def set_default_value(self, vid, val, subgroup=None, ignore_type=False):
         node = self.get_optional_node("entry", {"id":vid})
         if node is not None:
-            val = self.set_element_text("default_value", val, root=node)
-            if val is None:
+            value = self.get_valid_value_string(node, val, vid, ignore_type)
+            value = self.set_element_text("default_value", value, root=node)
+            if value is None:
                 logger.warn("Called set_default_value on a node without default_value field")
 
-        return val
+        return value
 
     def get_value_match(self, vid, attributes=None, exact_match=False, entry_node=None):
         # Handle this case:

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -35,7 +35,9 @@ class EntryID(GenericXML):
         return value
 
     def set_default_value(self, vid, val, subgroup=None, ignore_type=False):
-        node = self.get_optional_node("entry", {"id":vid})
+        root = self.root if subgroup is None else self.get_optional_node("group", {"id":subgroup})
+        node = self.get_optional_node("entry", {"id":vid}, root=root)
+        value = None
         if node is not None:
             value = self.get_valid_value_string(node, val, vid, ignore_type)
             value = self.set_element_text("default_value", value, root=node)

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -106,6 +106,23 @@ class EnvBase(EntryID):
                 val = self._set_value(node, value, vid, subgroup, ignore_type, component=comp)
         return val
 
+    def set_default_value(self, vid, value, subgroup=None, ignore_type=False):
+        """
+        Set the default value of an compvvar entry-id field to value
+        Returns the value or None if not found
+        subgroup is ignored in the general routine and applied in specific methods
+        """
+        vid, _, iscompvar = self.check_if_comp_var(vid, None)
+        if not iscompvar:
+            logger.debug("Functionality for compvars only")
+            return None
+        val = None
+        root = self.root if subgroup is None else self.get_optional_node("group", {"id":subgroup})
+        node = self.get_optional_node("entry", {"id":vid}, root=root)
+        if node is not None:
+            val = self._set_value(node, value, vid, subgroup, ignore_type, component="default")
+
+
     # pylint: disable=arguments-differ
     def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False, component=None):
         if vid is None:

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -121,7 +121,7 @@ class EnvBase(EntryID):
         node = self.get_optional_node("entry", {"id":vid}, root=root)
         if node is not None:
             val = self._set_value(node, value, vid, subgroup, ignore_type, component="default")
-
+        return val
 
     # pylint: disable=arguments-differ
     def _set_value(self, node, value, vid=None, subgroup=None, ignore_type=False, component=None):

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -849,7 +849,6 @@ class Case(object):
         compset = self.get_value("COMPSET")
         mpilib = self.get_value("MPILIB")
         defaults = pioobj.get_defaults(grid=grid,compset=compset,mach=mach,compiler=compiler, mpilib=mpilib)
-        print "HERE defaults %s"%defaults
         env_run = self.get_env("run")
         for vid, value in defaults.items():
             self.set_value(vid, value)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -849,9 +849,12 @@ class Case(object):
         compset = self.get_value("COMPSET")
         mpilib = self.get_value("MPILIB")
         defaults = pioobj.get_defaults(grid=grid,compset=compset,mach=mach,compiler=compiler, mpilib=mpilib)
-
+        print "HERE defaults %s"%defaults
+        env_run = self.get_env("run")
         for vid, value in defaults.items():
-            self.set_value(vid,value)
+            self.set_value(vid, value)
+            # also update the default value if defined
+            env_run.set_default_value(vid,value)
 
     def _create_caseroot_tools(self):
         machines_dir = os.path.abspath(self.get_value("MACHDIR"))

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -162,9 +162,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
             case.set_value("COST_PES", cost_pes)
 
             # Make sure pio settings are consistent
-            tasks_per_node = env_mach_pes.get_tasks_per_node(pestot, thread_count)
             if adjust_pio:
-                adjust_pio_layout(case, tasks_per_node)
+                adjust_pio_layout(case)
 
             case.initialize_derived_attributes()
 
@@ -172,6 +171,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
             logger.info("Creating batch script case.run")
             env_batch = case.get_env("batch")
             num_nodes = case.num_nodes
+            tasks_per_node = env_mach_pes.get_tasks_per_node(pestot, thread_count)
+
             for job in env_batch.get_jobs():
                 input_batch_script  = os.path.join(case.get_value("MACHDIR"), env_batch.get_value('template', subgroup=job))
                 if job == "case.test" and testcase is not None and not test_mode:
@@ -232,8 +233,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
         env_module.make_env_mach_specific_file(compiler, debug, mpilib, "csh")
         env_module.save_all_env_info("software_environment.txt")
 
-def adjust_pio_layout(case, new_pio_stride):
-
+def adjust_pio_layout(case):
+    new_pio_stride = case.get_value("PIO_STRIDE", attribute={"component":"default"})
     models = case.get_values("COMP_CLASSES")
     for comp in models:
         pio_stride = case.get_value("PIO_STRIDE_%s"%comp)

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2228,6 +2228,7 @@
      be computed based on PIO_NUMTASKS and number of compute tasks
     </desc>
     <values>
+      <value component="default">$PES_PER_NODE</value>
       <value component="ATM"></value>
       <value component="CPL"></value>
       <value component="OCN"></value>


### PR DESCRIPTION
This provides a default value of PIO_STRIDE it can be adjusted from machine to machine in config_pio.xml and will be the stride used in adjust_pio_layout when a pe layout change is made.  

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1433 

User interface changes?: 

Code review: 
