### PR TITLE
create newcase script root option

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -97,6 +97,9 @@ OR
     parser.add_argument("--output-root",
                         help="Alternative path for the directory where case output is written")
 
+    parser.add_argument("--script-root", dest="script_root", default=None,
+                        help="Alternative path for the directory where the cime scripts are written")
+
     if model == "cesm":
         parser.add_argument("--run-unsupported", action="store_true",
                             help="Force the creation of a case not tested or supported by CESM developers")
@@ -160,20 +163,25 @@ OR
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.user_compset, args.pesfile, \
         args.user_grid, args.gridfile, args.srcroot, args.test, args.ninst, \
-        args.walltime, args.queue, args.output_root, run_unsupported, args.answer, args.input_dir
+        args.walltime, args.queue, args.output_root, args.script_root, \
+        run_unsupported, args.answer, args.input_dir
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
     cimeroot  = os.path.abspath(CIME.utils.get_cime_root())
 
-    caseroot, compset, grid, machine, compiler, \
+    casename, compset, grid, machine, compiler, \
         mpilib, project, pecount,  \
         user_mods_dir, user_compset, pesfile, \
         user_grid, gridfile, srcroot, test, ninst, walltime, queue, \
-        output_root, run_unsupported, answer, input_dir = parse_command_line(sys.argv, cimeroot, description)
+        output_root, script_root, run_unsupported, \
+        answer, input_dir = parse_command_line(sys.argv, cimeroot, description)
 
-    caseroot = os.path.abspath(caseroot)
+    if script_root is None:
+        caseroot = os.path.abspath(casename)
+    else:
+        caseroot = os.path.abspath(script_root)
 
     # create_test creates the caseroot before calling create_newcase
     # otherwise throw an error if this directory exists
@@ -182,7 +190,7 @@ def _main_func(description):
 
     with Case(caseroot, read_only=False) as case:
         # Set values for env_case.xml
-        case.set_lookup_value("CASE", os.path.basename(caseroot))
+        case.set_lookup_value("CASE", os.path.basename(casename))
         case.set_lookup_value("CASEROOT", caseroot)
         case.set_lookup_value("SRCROOT", srcroot)
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -254,6 +254,9 @@ class J_TestCreateNewcase(unittest.TestCase):
 
         cls._testdirs.append(testdir)
         run_cmd_assert_result(self, "%s/create_newcase --case CreateNewcaseTest --script-root %s --compset X --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
+        self.assertTrue(os.path.exists(testdir))
+        self.assertTrue(os.path.exists(os.path.join(testdir, "case.setup")))
+
         run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
         run_cmd_assert_result(self, "./case.build", from_dir=testdir)
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -253,7 +253,7 @@ class J_TestCreateNewcase(unittest.TestCase):
             shutil.rmtree(testdir)
 
         cls._testdirs.append(testdir)
-        run_cmd_assert_result(self, "%s/create_newcase --case %s --compset X --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
+        run_cmd_assert_result(self, "%s/create_newcase --case CreateNewcaseTest --script-root %s --compset X --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
         run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
         run_cmd_assert_result(self, "./case.build", from_dir=testdir)
 


### PR DESCRIPTION
Adds a --script-root option to create_newcase

This allows the user to use a specific directory for the CIME scripts and xml settings while having an unrelated case name.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: pass

Fixes #1353 

User interface changes?: 

Code review: 
