### PR TITLE
improve error message when config_files.xml is not found

### DIFF
--- a/scripts/lib/CIME/XML/files.py
+++ b/scripts/lib/CIME/XML/files.py
@@ -20,6 +20,7 @@ class Files(EntryID):
         """
         cimeroot = get_cime_root()
         infile = os.path.join(cimeroot, "config", get_model(), "config_files.xml")
+        expect(os.path.isfile(infile), "Could not find or open file %s"%infile)
         schema = os.path.join(cimeroot, "config", "xml_schemas", "entry_id.xsd")
         EntryID.__init__(self, infile, schema=schema)
 


### PR DESCRIPTION
If CIME_MODEL is set incorrectly the current error message from scripts_regression_tests.py is obscure, this error somewhat clarifies the problem.
Test suite:  hand testing 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Code review: 
