### PR TITLE
Pio default settings

### DIFF
--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -45,16 +45,11 @@ OR
     parser.add_argument("-r", "--reset", action="store_true",
                         help="Does a clean followed by setup")
 
-    parser.add_argument("--no-adjust-pio", action="store_true",
-                        help="Do NOT adjust pio settings for new pelayout."
-                                  "By default if the pelayout is changed the pio layout will be adjusted."
-                                  "This option overrides that feature and leaves the pio layout as currently set.")
-
     args = parser.parse_args(args[1:])
 
     CIME.utils.handle_standard_logging_options(args)
 
-    return args.caseroot, args.clean, args.test_mode, args.reset, not args.no_adjust_pio
+    return args.caseroot, args.clean, args.test_mode, args.reset
 
 ###############################################################################
 def _main_func(description):
@@ -63,9 +58,9 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, clean, test_mode, reset, adjust_pio = parse_command_line(sys.argv, description)
+    caseroot, clean, test_mode, reset = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        case_setup(case, clean=clean, test_mode=test_mode, reset=reset, adjust_pio=adjust_pio)
+        case_setup(case, clean=clean, test_mode=test_mode, reset=reset)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -17,7 +17,6 @@ import argparse, doctest
 ###############################################################################
 def parse_command_line(args, description):
 ###############################################################################
-    cime_model = CIME.utils.get_model()
     parser = argparse.ArgumentParser(description=description)
     CIME.utils.setup_standard_logging_options(parser)
 

--- a/scripts/lib/CIME/SystemTests/seq.py
+++ b/scripts/lib/CIME/SystemTests/seq.py
@@ -3,7 +3,7 @@ CIME smoke test  This class inherits from SystemTestsCommon
 """
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
-from CIME.case_setup import case_setup, adjust_pio_layout
+from CIME.case_setup import case_setup
 from CIME.check_lockedfiles import *
 import shutil
 
@@ -90,7 +90,6 @@ class SEQ(SystemTestsCommon):
 
         # update the pelayout settings for this run
         self._case.read_xml()
-        adjust_pio_layout(self._case, self._case.get_value("PES_PER_NODE"))
 
         self.run_indv()
 
@@ -103,7 +102,6 @@ class SEQ(SystemTestsCommon):
         logger.info("doing a second %d %s test with rootpes set to zero" % (stop_n, stop_option))
         # update the pelayout settings for this run
         self._case.read_xml()
-        adjust_pio_layout(self._case, self._case.get_value("PES_PER_NODE"))
 
         self.run_indv(suffix="seq")
         self._component_compare_test("base", "seq")

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -296,12 +296,9 @@ class EnvBatch(EnvBase):
                 continue
             try:
                 prereq = self.get_value('prereq', subgroup=job, resolved=False)
-                if prereq is None or job == firstjob:
+                if prereq is None or job == firstjob or (dry_run and prereq == "$BUILD_COMPLETE"):
                     prereq = True
                 else:
-                    if dry_run:
-                        # Assume build is complete
-                        prereq = prereq.replace("$BUILD_COMPLETE", "True")
                     prereq = case.get_resolved_value(prereq)
                     prereq = eval(prereq)
             except:

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -59,7 +59,7 @@ def _build_usernl_files(case, model, comp):
                     shutil.copy(model_nl, nlfile)
 
 ###############################################################################
-def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, adjust_pio=True):
+def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 ###############################################################################
     os.chdir(caseroot)
 
@@ -163,8 +163,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
 
             # Make sure pio settings are consistent
             tasks_per_node = env_mach_pes.get_tasks_per_node(pestot, thread_count)
-            if adjust_pio:
-                adjust_pio_layout(case, tasks_per_node)
 
             case.initialize_derived_attributes()
 
@@ -221,29 +219,12 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
         env_module.make_env_mach_specific_file(compiler, debug, mpilib, "csh")
         env_module.save_all_env_info("software_environment.txt")
 
-def adjust_pio_layout(case, new_pio_stride):
-
-    models = case.get_values("COMP_CLASSES")
-    for comp in models:
-        pio_stride = case.get_value("PIO_STRIDE_%s"%comp)
-        pio_numtasks = case.get_value("PIO_NUMTASKS_%s"%comp)
-        ntasks = case.get_value("NTASKS_%s"%comp)
-        new_stride = min(ntasks, new_pio_stride)
-        new_numtasks = max(1, ntasks//new_stride)
-        if pio_stride != new_stride:
-            logger.info("Resetting  PIO_STRIDE_%s to %s"%(comp, new_stride))
-            case.set_value("PIO_STRIDE_%s"%comp, new_stride)
-        if pio_numtasks != new_numtasks:
-            logger.info("Resetting  PIO_NUMTASKS_%s to %s"%(comp, new_numtasks))
-            case.set_value("PIO_NUMTASKS_%s"%comp, new_numtasks)
-
-
 ###############################################################################
-def case_setup(case, clean=False, test_mode=False, reset=False, adjust_pio=True):
+def case_setup(case, clean=False, test_mode=False, reset=False):
 ###############################################################################
     caseroot, casebaseid = case.get_value("CASEROOT"), case.get_value("CASEBASEID")
     phase = "setup.clean" if clean else "case.setup"
-    functor = lambda: _case_setup_impl(case, caseroot, clean, test_mode, reset, adjust_pio)
+    functor = lambda: _case_setup_impl(case, caseroot, clean, test_mode, reset)
 
     if case.get_value("TEST") and not test_mode:
         test_name = casebaseid if casebaseid is not None else case.get_value("CASE")

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -394,9 +394,9 @@ contains
 
     integer :: iam, ierr, npes, unitn
     logical :: iamroot
-    namelist /pio_default_inparm/ pio_stride, pio_root, pio_numiotasks, &
-          pio_typename, pio_async_interface, pio_debug_level, pio_blocksize, &
-          pio_buffer_size_limit, pio_rearranger, &
+    namelist /pio_default_inparm/  &
+          pio_async_interface, pio_debug_level, pio_blocksize, &
+          pio_buffer_size_limit, &
           pio_rearr_comm_type, pio_rearr_comm_fcd, &
           pio_rearr_comm_max_pend_req_comp2io, pio_rearr_comm_enable_hs_comp2io, &
           pio_rearr_comm_enable_isend_comp2io, &
@@ -436,10 +436,6 @@ contains
     pio_rearr_comm_max_pend_req_io2comp = 0
     pio_rearr_comm_enable_hs_io2comp = .true.
     pio_rearr_comm_enable_isend_io2comp = .false.
-
-
-
-
 
     if(iamroot) then
        unitn=shr_file_getunit()


### PR DESCRIPTION
remove scripts adjustment of pio settings - more trouble than its worth.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1433

User interface changes?: removed --no-adjust-pio flag from case.setup and never attempt to adjust pio settings.  

Code review:  @jayeshkrishna 
