### PR TITLE
fix erp test build

### DIFF
--- a/scripts/lib/CIME/SystemTests/erp.py
+++ b/scripts/lib/CIME/SystemTests/erp.py
@@ -56,9 +56,9 @@ class ERP(SystemTestsCommon):
         # The reason we currently need two executables that CESM-CICE has a compile time decomposition
         # For cases where ERP works, changing this decomposition will not affect answers, but it will
         # affect the executable that is used
-        self._case.set_value("SMP_BUILD","0")
         for bld in range(1,3):
             logging.warn("Starting bld %s"%bld)
+            self._case.set_value("BUILD_THREADED",True)
 
             if (bld == 2):
                 # halve the number of tasks and threads


### PR DESCRIPTION
Build threaded needs to be true for this test, recent refactor caused the method previously used
in erp.py to do this to no longer work

Test suite: ERP_Ln9.f09_f09.F1850_DONOTUSE.yellowstone_intel.cam-outfrq9s_clm5
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes: #1443 

User interface changes?: 

Code review: 
