### PR TITLE
Erp fix again

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -283,7 +283,6 @@ using a fortran linker.
     <!-- Runtime checks with OpenMP (in fact, all OpenMP cases) are WIP.       -->
     <append DEBUG="TRUE"> -C=all -g -time -f2003 -ieee=stop </append>
     <append DEBUG="TRUE" compile_threaded="false"> -gline </append>
-    <append compile_threaded="true"> -openmp </append>
     <!-- The SLAP library (which is part of the CISM build) has many instances of
        arguments being passed to different types. So disable argument type
        checking when building CISM. This can be removed once we remove SLAP from
@@ -298,7 +297,6 @@ using a fortran linker.
     <!-- having them use FFLAGS_NOOPT in Depends.nag                           -->
     <append DEBUG="TRUE"> -g -time -f2003 -ieee=stop </append>
     <append DEBUG="TRUE" compile_threaded="false"> -gline        </append>
-    <append compile_threaded="true"> -openmp </append>
   </FFLAGS_NOOPT>
   <FIXEDFLAGS>
     <base> -fixed </base>
@@ -307,9 +305,6 @@ using a fortran linker.
     <base> -free </base>
   </FREEFLAGS>
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
-  <LDFLAGS>
-    <append compile_threaded="true"> -openmp </append>
-  </LDFLAGS>
   <MPICC> mpicc </MPICC>
   <MPIFC> mpif90 </MPIFC>
   <SCC> gcc </SCC>

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -17,7 +17,6 @@ import argparse, doctest
 ###############################################################################
 def parse_command_line(args, description):
 ###############################################################################
-    cime_model = CIME.utils.get_model()
     parser = argparse.ArgumentParser(description=description)
     CIME.utils.setup_standard_logging_options(parser)
 

--- a/scripts/lib/CIME/SystemTests/erp.py
+++ b/scripts/lib/CIME/SystemTests/erp.py
@@ -31,6 +31,7 @@ class ERP(SystemTestsCommon):
         and tasks. This test will fail for components (e.g. pop) that do not reproduce exactly
         with different numbers of mpi tasks.
         """
+        self._case.set_value("BUILD_THREADED",True)
         if sharedlib_only:
             return self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
@@ -58,7 +59,6 @@ class ERP(SystemTestsCommon):
         # affect the executable that is used
         for bld in range(1,3):
             logging.warn("Starting bld %s"%bld)
-            self._case.set_value("BUILD_THREADED",True)
 
             if (bld == 2):
                 # halve the number of tasks and threads
@@ -79,7 +79,6 @@ class ERP(SystemTestsCommon):
                 case_setup(self._case, test_mode=True, reset=True)
 
             # Now rebuild the system, given updated information in env_build.xml
-
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
             shutil.move("%s/%s.exe"%(exeroot,cime_model),
                         "%s/%s.ERP%s.exe"%(exeroot,cime_model,bld))

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -156,8 +156,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
             case.set_value("TOTALPES", pestot)
             thread_count = env_mach_pes.get_max_thread_count(models)
             build_threaded = case.get_build_threaded()
-            expect(not (build_threaded and compiler == "nag"),
-                   "it is not possible to run with OpenMP if using the NAG Fortran compiler")
             cost_pes = env_mach_pes.get_cost_pes(pestot, thread_count, machine=case.get_value("MACH"))
             case.set_value("COST_PES", cost_pes)
 

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1006,7 +1006,6 @@ class Namelist(object):
         group_name = group_name.lower()
 
         minindex, maxindex, step = get_fortran_variable_indices(variable_name, var_size)
-        original_var = variable_name
         variable_name = get_fortran_name_only(variable_name.lower())
 
         expect(minindex > 0, "Indices < 1 not supported in CIME interface to fortran namelists... lower bound=%s"%minindex)


### PR DESCRIPTION
Needed to move build threaded flag to before shared lib build in erp test.  Test and fix issues with nag compiler.
Test suite:  scripts_regression_tests.py 
                   PASS ERP_Ln9.f09_f09.F1850_DONOTUSE.yellowstone_intel.cam-outfrq9s_clm5 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1443 

User interface changes?: 

Code review: mvertens
