### PR TITLE
New DOCN aquaplanet functionality

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -368,6 +368,13 @@
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="f09_f09_mnull" compset="_DOCN%SAQUAP|DOCN%DAQUAP" >
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">0.9x1.25</grid>
+      <mask>null</mask>
+    </model_grid>
+
     <model_grid alias="f09_f09_mg16" not_compset="_POP" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
@@ -504,6 +511,13 @@
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
       <mask>gx1v6</mask>
+    </model_grid>
+
+    <model_grid alias="f19_f19_mnull" compset="_DOCN%SAQUAP|DOCN%DAQUAP" >
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">1.9x2.5</grid>
+      <mask>null</mask>
     </model_grid>
 
     <model_grid alias="f19_f19_mg17" not_compset="_POP">

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -176,6 +176,13 @@
       <mask>usgs</mask>
     </model_grid>
 
+    <model_grid alias="T42_T42_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
+      <grid name="atm">T42</grid>
+      <grid name="lnd">T42</grid>
+      <grid name="ocnice">T42</grid>
+      <mask>null</mask>
+    </model_grid>
+
     <model_grid alias="T85_T85" not_compset="_POP">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>
@@ -368,7 +375,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_mnull" compset="_DOCN%SAQUAP|DOCN%DAQUAP" >
+    <model_grid alias="f09_f09_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
@@ -513,7 +520,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_mnull" compset="_DOCN%SAQUAP|DOCN%DAQUAP" >
+    <model_grid alias="f19_f19_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP" >
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
@@ -565,6 +572,13 @@
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="f02_f02_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
+      <grid name="atm">f02</grid>
+      <grid name="lnd">f02</grid>
+      <grid name="ocnice">f02</grid>
+      <mask>null</mask>
+    </model_grid>
+
     <model_grid alias="f02_f02_mg16" not_compset="_POP">
       <grid name="atm">0.23x0.31</grid>
       <grid name="lnd">0.23x0.31</grid>
@@ -607,11 +621,25 @@
       <mask>gx3v7</mask>
     </model_grid>
 
+    <model_grid alias="f45_f45_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
+      <grid name="atm">f45</grid>
+      <grid name="lnd">f45</grid>
+      <grid name="ocnice">f45</grid>
+      <mask>null</mask>
+    </model_grid>
+
     <model_grid alias="f10_f10" not_compset="_POP">
       <grid name="atm">10x15</grid>
       <grid name="lnd">10x15</grid>
       <grid name="ocnice">10x15</grid>
       <mask>usgs</mask>
+    </model_grid>
+
+    <model_grid alias="f10_f10_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
+      <grid name="atm">f10</grid>
+      <grid name="lnd">f10</grid>
+      <grid name="ocnice">f10</grid>
+      <mask>null</mask>
     </model_grid>
 
     <!--  spectral element grids -->
@@ -741,6 +769,13 @@
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="ne30_ne30_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">ne30np4</grid>
+      <mask>null</mask>
+    </model_grid>
+
     <model_grid alias="ne30_ne30_mg16" not_compset="_POP">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
@@ -781,6 +816,13 @@
       <grid name="lnd">ne120np4</grid>
       <grid name="ocnice">ne120np4</grid>
       <mask>gx1v6</mask>
+    </model_grid>
+
+    <model_grid alias="ne120_ne120_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
+      <grid name="atm">ne120np4</grid>
+      <grid name="lnd">ne120np4</grid>
+      <grid name="ocnice">ne120np4</grid>
+      <mask>null</mask>
     </model_grid>
 
     <model_grid alias="ne120_ne120_mg16" not_compset="_POP">

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -176,13 +176,6 @@
       <mask>usgs</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
-      <grid name="atm">T42</grid>
-      <grid name="lnd">T42</grid>
-      <grid name="ocnice">T42</grid>
-      <mask>null</mask>
-    </model_grid>
-
     <model_grid alias="T85_T85" not_compset="_POP">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>
@@ -375,13 +368,6 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP" >
-      <grid name="atm">0.9x1.25</grid>
-      <grid name="lnd">0.9x1.25</grid>
-      <grid name="ocnice">0.9x1.25</grid>
-      <mask>null</mask>
-    </model_grid>
-
     <model_grid alias="f09_f09_mg16" not_compset="_POP" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
@@ -520,13 +506,6 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP" >
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">1.9x2.5</grid>
-      <mask>null</mask>
-    </model_grid>
-
     <model_grid alias="f19_f19_mg17" not_compset="_POP">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
@@ -572,13 +551,6 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f02_f02_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
-      <grid name="atm">f02</grid>
-      <grid name="lnd">f02</grid>
-      <grid name="ocnice">f02</grid>
-      <mask>null</mask>
-    </model_grid>
-
     <model_grid alias="f02_f02_mg16" not_compset="_POP">
       <grid name="atm">0.23x0.31</grid>
       <grid name="lnd">0.23x0.31</grid>
@@ -621,25 +593,11 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="f45_f45_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
-      <grid name="atm">f45</grid>
-      <grid name="lnd">f45</grid>
-      <grid name="ocnice">f45</grid>
-      <mask>null</mask>
-    </model_grid>
-
     <model_grid alias="f10_f10" not_compset="_POP">
       <grid name="atm">10x15</grid>
       <grid name="lnd">10x15</grid>
       <grid name="ocnice">10x15</grid>
       <mask>usgs</mask>
-    </model_grid>
-
-    <model_grid alias="f10_f10_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
-      <grid name="atm">f10</grid>
-      <grid name="lnd">f10</grid>
-      <grid name="ocnice">f10</grid>
-      <mask>null</mask>
     </model_grid>
 
     <!--  spectral element grids -->
@@ -769,13 +727,6 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne30_ne30_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
-      <grid name="atm">ne30np4</grid>
-      <grid name="lnd">ne30np4</grid>
-      <grid name="ocnice">ne30np4</grid>
-      <mask>null</mask>
-    </model_grid>
-
     <model_grid alias="ne30_ne30_mg16" not_compset="_POP">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
@@ -816,13 +767,6 @@
       <grid name="lnd">ne120np4</grid>
       <grid name="ocnice">ne120np4</grid>
       <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="ne120_ne120_mnull" compset="_DOCN%SAQUAP|DOCN%AQUAP">
-      <grid name="atm">ne120np4</grid>
-      <grid name="lnd">ne120np4</grid>
-      <grid name="ocnice">ne120np4</grid>
-      <mask>null</mask>
     </model_grid>
 
     <model_grid alias="ne120_ne120_mg16" not_compset="_POP">

--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -109,10 +109,11 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 
     # For aquaplanet prescribed have no streams
-    match = re.match(r'^aquap\d+',docn_mode)
-    if match.group(0):
-        value = ['null']
-        nmlgen.set_value("streams",value)
+    match = re.match(r'^sst_aquap\d+',docn_mode)
+    if match is not None:
+        if match.group(0):
+            value = ['null']
+            nmlgen.set_value("streams",value)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -108,6 +108,11 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
         else:
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 
+    # For aquaplanet prescribed have no streams
+    if docn_mode == 'pres_aquap':
+        value = ['null']
+        nmlgen.set_value("streams",value)
+
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.
     #----------------------------------------------------

--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob
+import os, shutil, sys, glob, re
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -109,7 +109,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
             nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 
     # For aquaplanet prescribed have no streams
-    if docn_mode == 'pres_aquap':
+    match = re.match(r'^aquap\d+',docn_mode)
+    if match.group(0):
         value = ['null']
         nmlgen.set_value("streams",value)
 

--- a/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/src/components/data_comps/docn/cime_config/config_component.xml
@@ -15,7 +15,7 @@
 
   <entry id="DOCN_MODE">
     <type>char</type>
-    <valid_values>prescribed,pres_aquap,som,som_aquap,copyall,interannual,null</valid_values>
+    <valid_values>prescribed,aquap1,aquap2,aquap3,aquap4,aquap5,aquap6,aquap7,aquap8,aquap9,aquap10,som,som_aquap,copyall,interannual,null</valid_values>
     <default_value>prescribed</default_value>
     <values>
       <value compset="_DOCN%NULL">null</value>
@@ -24,9 +24,16 @@
       <value compset="_DOCN%US20">us20</value>
       <value compset="_DOCN%IAF">interannual</value>
       <value compset="_DOCN%COPY">copyall</value>
-      <value compset="_DOCN%DAQUAP">pres_aquap</value>
-      <value compset="_DOCN%SAQUAP">som_aquap</value>
-      <value compset="_DOCN%WW3">ww3</value>
+      <value compset="_DOCN%AQUAP1">aquap1</value>
+      <value compset="_DOCN%AQUAP2">aquap2</value>
+      <value compset="_DOCN%AQUAP3">aquap3</value>
+      <value compset="_DOCN%AQUAP4">aquap4</value>
+      <value compset="_DOCN%AQUAP5">aquap5</value>
+      <value compset="_DOCN%AQUAP6">aquap6</value>
+      <value compset="_DOCN%AQUAP7">aquap7</value>
+      <value compset="_DOCN%AQUAP8">aquap8</value>
+      <value compset="_DOCN%AQUAP9">aquap9</value>
+      <value compset="_DOCN%AQUAP10">aquap10</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>
@@ -215,6 +222,7 @@
     <desc compset="_DOCN%SOM" >docn slab ocean mode:</desc>
     <desc compset="_DOCN%DOM" >docn data mode:</desc>
     <desc compset="_DOCN%IAF" >docn interannual mode:</desc>
+    <desc compset="_DOCN%AQUAP">docn aquaplanet mode:</desc> 
   </description>
 
   <help>

--- a/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/src/components/data_comps/docn/cime_config/config_component.xml
@@ -15,25 +15,25 @@
 
   <entry id="DOCN_MODE">
     <type>char</type>
-    <valid_values>prescribed,aquap1,aquap2,aquap3,aquap4,aquap5,aquap6,aquap7,aquap8,aquap9,aquap10,som,som_aquap,copyall,interannual,null</valid_values>
+    <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,som,som_aquap,copyall,interannual,null</valid_values>
     <default_value>prescribed</default_value>
     <values>
       <value compset="_DOCN%NULL">null</value>
       <value compset="_DOCN%DOM" >prescribed</value>
       <value compset="_DOCN%SOM" >som</value>
-      <value compset="_DOCN%US20">us20</value>
+      <value compset="_DOCN%SOMAQP">som_aquap</value>
       <value compset="_DOCN%IAF">interannual</value>
+      <value compset="_DOCN%AQP1">sst_aquap1</value>
+      <value compset="_DOCN%AQP2">sst_aquap2</value>
+      <value compset="_DOCN%AQP3">sst_aquap3</value>
+      <value compset="_DOCN%AQP4">sst_aquap4</value>
+      <value compset="_DOCN%AQP5">sst_aquap5</value>
+      <value compset="_DOCN%AQP6">sst_aquap6</value>
+      <value compset="_DOCN%AQP7">sst_aquap7</value>
+      <value compset="_DOCN%AQP8">sst_aquap8</value>
+      <value compset="_DOCN%AQP9">sst_aquap9</value>
+      <value compset="_DOCN%AQP10">sst_aquap10</value>
       <value compset="_DOCN%COPY">copyall</value>
-      <value compset="_DOCN%AQUAP1">aquap1</value>
-      <value compset="_DOCN%AQUAP2">aquap2</value>
-      <value compset="_DOCN%AQUAP3">aquap3</value>
-      <value compset="_DOCN%AQUAP4">aquap4</value>
-      <value compset="_DOCN%AQUAP5">aquap5</value>
-      <value compset="_DOCN%AQUAP6">aquap6</value>
-      <value compset="_DOCN%AQUAP7">aquap7</value>
-      <value compset="_DOCN%AQUAP8">aquap8</value>
-      <value compset="_DOCN%AQUAP9">aquap9</value>
-      <value compset="_DOCN%AQUAP10">aquap10</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>
@@ -80,7 +80,8 @@
     <default_value>UNSET</default_value>
     <values>
       <value compset="_DOCN%SOM.*_TEST">pop_frc.1x1d.090130.nc</value>
-      <value compset="_DOCN%SAQUAP">/glade/u/home/benedict/ys/datain/cesm2_0_beta03.som.forcing/cam4.som.forcing.aquaplanet.QzaFix_h30Fix_TspunFix.fv19_CTL.nc</value>
+      <value compset="_DOCN%SOMAQP" grid="oi%1.9x2.5">default.som.forcing.aquaplanet.Qflux0_h30_sstQOBS.2degFV_c20170421.nc</value>
+      <value compset="_DOCN%SOMAQP" grid="oi%0.9x1.25">default.som.forcing.aquaplanet.Qflux0_h30_sstQOBS.1degFV_c20170421.nc</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>
@@ -218,11 +219,21 @@
   </entry>
 
   <description>
-    <desc compset="_DOCN%NULL">docn null mode:</desc>
-    <desc compset="_DOCN%SOM" >docn slab ocean mode:</desc>
-    <desc compset="_DOCN%DOM" >docn data mode:</desc>
-    <desc compset="_DOCN%IAF" >docn interannual mode:</desc>
-    <desc compset="_DOCN%AQUAP">docn aquaplanet mode:</desc> 
+    <desc compset="_DOCN%NULL">docn null mode</desc>
+    <desc compset="_DOCN%SOM" >docn slab ocean mode</desc>
+    <desc compset="_DOCN%SOMAQP">docn aquaplanet slab ocean mode</desc>
+    <desc compset="_DOCN%IAF" >docn interannual mode</desc>
+    <desc compset="_DOCN%SST_AQUAP">docn aquaplanet mode:</desc> 
+    <desc compset="_DOCN%AQP1">docn prescribed aquaplanet sst - option 1</desc>
+    <desc compset="_DOCN%AQP2">docn prescribed aquaplanet sst - option 2</desc>
+    <desc compset="_DOCN%AQP3">docn prescribed aquaplanet sst - option 3</desc>
+    <desc compset="_DOCN%AQP4">docn prescribed aquaplanet sst - option 4</desc>
+    <desc compset="_DOCN%AQP5">docn prescribed aquaplanet sst - option 5</desc>
+    <desc compset="_DOCN%AQP6">docn prescribed aquaplanet sst - option 6</desc>
+    <desc compset="_DOCN%AQP7">docn prescribed aquaplanet sst - option 7</desc>
+    <desc compset="_DOCN%AQP8">docn prescribed aquaplanet sst - option 8</desc>
+    <desc compset="_DOCN%AQP9">docn prescribed aquaplanet sst - option 9</desc>
+    <desc compset="_DOCN%AQP10">docn prescribed aquaplanet sst - option 10</desc>
   </description>
 
   <help>

--- a/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -301,6 +301,8 @@
       If DOCN_MODE is prescribed, datamode will be set to SSTDATA
       If DOCN_MODE is interannual, datamode will be set to IAF
       If DOCN_MODE is som , datamode will be set to SOM
+      If DOCN_MODE is sst_aqup[n], datamode will be set to SST_AQUAP
+      If DOCN_MODE is som_aqup[n], datamode will be set to SOM_AQUAP
       If DOCN_MODE is null, datamode will be set to NULL
 
       default: SSTDATA (prescribed setting for DOCN_MODE)'

--- a/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -45,10 +45,10 @@
     <group>streams_file</group>
     <desc>List of streams used for the given docn_mode.</desc>
     <values>
-      <value docn_mode="prescribed" >prescribed</value>
-      <value docn_mode="pres_aquap" >prescribed</value>
-      <value docn_mode="som"        >som</value>
-      <value docn_mode="som_aquap"  >som</value>
+      <value docn_mode="prescribed">prescribed</value>
+      <value docn_mode="aquap1">''</value>
+      <value docn_mode="som">som</value>
+      <value docn_mode="som_aquap">som</value>
       <value docn_mode="interannual">interannual</value>
     </values>
   </entry>
@@ -245,7 +245,7 @@
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>SSTDATA,SOM,IAF,NULL,COPYALL</valid_values>
+    <valid_values>SSTDATA,AQUAP1,SOM,IAF,NULL,COPYALL</valid_values>
     <desc>
       General method that operates on the data. This is generally
       implemented in the data models but is set in the strdata method for
@@ -299,7 +299,7 @@
     <values>
       <value docn_mode="null">NULL</value>
       <value docn_mode="prescribed" >SSTDATA</value>
-      <value docn_mode="pres_aquap" >SSTDATA</value>
+      <value docn_mode="aquap1"     >AQUAP1</value>
       <value docn_mode="som"        >SOM</value>
       <value docn_mode="som_aquap"  >SOM</value>
       <value docn_mode="interannual">IAF</value>

--- a/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -46,7 +46,16 @@
     <desc>List of streams used for the given docn_mode.</desc>
     <values>
       <value docn_mode="prescribed">prescribed</value>
-      <value docn_mode="aquap1">''</value>
+      <value docn_mode="sst_aquap1">''</value>
+      <value docn_mode="sst_aquap2">''</value>
+      <value docn_mode="sst_aquap3">''</value>
+      <value docn_mode="sst_aquap4">''</value>
+      <value docn_mode="sst_aquap5">''</value>
+      <value docn_mode="sst_aquap6">''</value>
+      <value docn_mode="sst_aquap7">''</value>
+      <value docn_mode="sst_aquap8">''</value>
+      <value docn_mode="sst_aquap9">''</value>
+      <value docn_mode="sst_aquap10">''</value>
       <value docn_mode="som">som</value>
       <value docn_mode="som_aquap">som</value>
       <value docn_mode="interannual">interannual</value>
@@ -245,7 +254,7 @@
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>SSTDATA,AQUAP1,SOM,IAF,NULL,COPYALL</valid_values>
+    <valid_values>SSTDATA,SST_AQUAP1,SST_AQUAP2,SST_AQUAP3,SST_AQUAP4,SST_AQUAP5,SST_AQUAP6,SST_AQUAP7,SST_AQUAP8,SST_AQUAP9,SST_AQUAP10,SOM,SOM_AQUAP,IAF,NULL,COPYALL</valid_values>
     <desc>
       General method that operates on the data. This is generally
       implemented in the data models but is set in the strdata method for
@@ -298,10 +307,19 @@
     </desc>
     <values>
       <value docn_mode="null">NULL</value>
-      <value docn_mode="prescribed" >SSTDATA</value>
-      <value docn_mode="aquap1"     >AQUAP1</value>
-      <value docn_mode="som"        >SOM</value>
-      <value docn_mode="som_aquap"  >SOM</value>
+      <value docn_mode="prescribed">SSTDATA</value>
+      <value docn_mode="sst_aquap1">SST_AQUAP1</value>
+      <value docn_mode="sst_aquap2">SST_AQUAP2</value>
+      <value docn_mode="sst_aquap3">SST_AQUAP3</value>
+      <value docn_mode="sst_aquap4">SST_AQUAP4</value>
+      <value docn_mode="sst_aquap5">SST_AQUAP5</value>
+      <value docn_mode="sst_aquap6">SST_AQUAP6</value>
+      <value docn_mode="sst_aquap7">SST_AQUAP7</value>
+      <value docn_mode="sst_aquap8">SST_AQUAP8</value>
+      <value docn_mode="sst_aquap9">SST_AQUAP9</value>
+      <value docn_mode="sst_aquap10">SST_AQUAP10</value>
+      <value docn_mode="som$">SOM</value>
+      <value docn_mode="som_aquap">SOM_AQUAP</value>
       <value docn_mode="interannual">IAF</value>
     </values>
   </entry>

--- a/src/components/data_comps/docn/docn_comp_mod.F90
+++ b/src/components/data_comps/docn/docn_comp_mod.F90
@@ -297,6 +297,7 @@ subroutine docn_comp_init( EClock, cdata, x2o, o2x, NLFilename )
 
     ocn_mode = trim(SDOCN%dataMode)
 
+    ! Special logic for aquaplanet
     if (ocn_mode(1:5) == 'AQUAP') then
        if (len_trim(ocn_mode) == 6) then
           read(ocn_mode(6:6),'(i)') aquap_option
@@ -610,16 +611,13 @@ subroutine docn_comp_run( EClock, cdata,  x2o, o2x)
    !--------------------
 
    call t_startf('docn_unpack')
-
-!  lsize = mct_avect_lsize(x2o)
-!  nflds_x2o = mct_avect_nRattr(x2o)
-
-!   do nf=1,nflds_x2o
-!   do n=1,lsize
-!     ?? = x2o%rAttr(nf,n)
-!   enddo
-!   enddo
-
+   !  lsize = mct_avect_lsize(x2o)
+   !  nflds_x2o = mct_avect_nRattr(x2o)
+   !   do nf=1,nflds_x2o
+   !   do n=1,lsize
+   !     ?? = x2o%rAttr(nf,n)
+   !   enddo
+   !   enddo
    call t_stopf('docn_unpack')
 
    !--------------------
@@ -683,7 +681,7 @@ subroutine docn_comp_run( EClock, cdata,  x2o, o2x)
    case('AQUAP')
       lsize = mct_avect_lsize(o2x)
       do n = 1,lsize
-         o2x%rAttr(kt,n) = 0.0_r8
+         o2x%rAttr(:,n) = 0.0_r8
       end do
       call prescribed_sst(xc, yc, lsize, aquap_option, o2x%rAttr(kt,:))
       do n = 1,lsize

--- a/src/components/data_comps/docn/docn_comp_mod.F90
+++ b/src/components/data_comps/docn/docn_comp_mod.F90
@@ -625,20 +625,6 @@ subroutine docn_comp_run( EClock, cdata,  x2o, o2x)
    call t_stopf('docn_run1')
 
    !--------------------
-   ! UNPACK
-   !--------------------
-
-   call t_startf('docn_unpack')
-   !  lsize = mct_avect_lsize(x2o)
-   !  nflds_x2o = mct_avect_nRattr(x2o)
-   !   do nf=1,nflds_x2o
-   !   do n=1,lsize
-   !     ?? = x2o%rAttr(nf,n)
-   !   enddo
-   !   enddo
-   call t_stopf('docn_unpack')
-
-   !--------------------
    ! ADVANCE OCN
    !--------------------
 

--- a/src/share/util/shr_strdata_mod.F90
+++ b/src/share/util/shr_strdata_mod.F90
@@ -1165,7 +1165,7 @@ subroutine shr_strdata_readnml(SDAT,file,rc,mpicom)
       call MPI_COMM_SIZE(mpicom,ntasks,rCode)
    endif
 
-!--master--task--
+   !--master--task--
    if (my_task == master_task) then
 
    !----------------------------------------------------------------------------
@@ -1241,15 +1241,21 @@ subroutine shr_strdata_readnml(SDAT,file,rc,mpicom)
    end do
 
    do n = 1,SDAT%nstreams
-      call shr_stream_parseInput(SDAT%streams(n),fileName,yearAlign,yearFirst,yearLast)
-      call shr_stream_init(SDAT%stream(n),fileName,yearFirst,yearLast,yearAlign, &
-                   trim(SDAT%taxMode(n)))
+      if (trim(SDAT%streams(n)) /= shr_strdata_nullstr) then
+
+         ! extract fileName (stream description text file), yearAlign, yearFirst, yearLast from SDAT%streams(n)
+         call shr_stream_parseInput(SDAT%streams(n), fileName, yearAlign, yearFirst, yearLast)
+
+         ! initialize stream datatype, read description text file
+         call shr_stream_init(SDAT%stream(n), fileName, yearFirst, yearLast, yearAlign, trim(SDAT%taxMode(n)))
+
+      end if
    enddo
 
-!   call shr_strdata_print(SDAT,trim(file)//' NML_ONLY')
+   !   call shr_strdata_print(SDAT,trim(file)//' NML_ONLY')
 
    endif   ! master_task
-!--master--task--
+   !--master--task--
 
    if (present(mpicom)) then
       call shr_strdata_bcastnml(SDAT,mpicom)


### PR DESCRIPTION
Creation of new aquaplanet capability in DOCN

Created new aquaplanet capability for both SOM and prescribed SST modes.
The prescribed modes are analytic and duplicate the capability in the CAM aquap (which is in fact part of CAM). This PR separates that out so that it is now in DOCN. As part of this, changes needed to be introduced so that no data was read if analytic data is present. 
In addition, aquaplanet capability has been introduced so that no changes in the domain files need to be made. This is done by overwriting the mask and fraction in aquaplanet mode with 1.

For the prescribed aquaplanet mode1, I have verified that the SST sent back to CAM is at most roundoff from that obtained with the current CAM aquap mode. However, the data ocean  areas used by CAM and sent to the coupler versus those sent by DOCN are different, and the flux correction calculation in the coupler introduces greater than roundoff differences in the solution due to differences in these areas.

Test suite: scripts_regression test
  also verified that the following tests are bfb with cesm2_0_alpha06j
     SMS_D_Ln9.f09_f09.FWAMIP.yellowstone_intel.cam-reduced_hist3s.C.aquaptest2/
     SMS_Ld1.f09_f09.FW1850.yellowstone_intel.cam-reduced_hist1d.C.aquaptest1/
Test baseline: cesm2_0_alpha06j
Test namelist changes: 
Test status: bit for bit (except for new prescribed aquaplanet mode)

Fixes: None
User interface changes?: None
Code review: 
