### PR TITLE
fix typo in parse_args

### DIFF
--- a/config/acme/machines/template.case.run
+++ b/config/acme/machines/template.case.run
@@ -55,7 +55,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
-    CIME.utils.parse_args_and.parse_args_and_handle_standard_logging_options(args, parser)
+    CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)


### PR DESCRIPTION
Fix typo introduced 
Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
