### PR TITLE
remove empty mpi-serial settings from config_machines.xml

### DIFF
--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -61,7 +61,7 @@
   <NODENAME_REGEX>edison</NODENAME_REGEX>
   <TESTS>acme_developer</TESTS>
   <COMPILERS>intel,gnu,cray</COMPILERS>
-  <MPILIBS>mpt</MPILIBS>
+  <MPILIBS>mpt,mpi-serial</MPILIBS>
   <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/edison</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -185,7 +185,7 @@
     <NODENAME_REGEX>cori</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt</MPILIBS>
+    <MPILIBS>mpt,mpi-serial</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -318,7 +318,7 @@
     <NODENAME_REGEX>cori-knl-haswell-is-default</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt</MPILIBS>
+    <MPILIBS>mpt,mpi-serial</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -453,7 +453,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>Darwin</OS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>openmpi,mpich</MPILIBS>
+    <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
     <RUNDIR>$ENV{HOME}/projects/acme/scratch/$CASE/run</RUNDIR>
     <EXEROOT>$ENV{HOME}/projects/acme/scratch/$CASE/bld</EXEROOT>
     <DIN_LOC_ROOT>$ENV{HOME}/projects/acme/cesm-inputdata</DIN_LOC_ROOT>    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/projects/acme/ptclm-data</DIN_LOC_ROOT_CLMFORC>
@@ -476,7 +476,7 @@
     <OS>LINUX</OS>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>openmpi,mpich</MPILIBS>
+    <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
     <RUNDIR>$ENV{HOME}/projects/acme/scratch/$CASE/run</RUNDIR>
     <EXEROOT>$ENV{HOME}/projects/acme/scratch/$CASE/bld</EXEROOT>
     <DIN_LOC_ROOT>$ENV{HOME}/projects/acme/cesm-inputdata</DIN_LOC_ROOT>
@@ -506,7 +506,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu,intel</COMPILERS>
-    <MPILIBS>openmpi</MPILIBS>
+    <MPILIBS>openmpi,mpi-serial</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -562,7 +562,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu,intel</COMPILERS>
-    <MPILIBS>openmpi</MPILIBS>
+    <MPILIBS>openmpi,mpi-serial</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -624,7 +624,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>mpich</MPILIBS>
+    <MPILIBS>mpich,mpi-serial</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -675,7 +675,7 @@
   <PROXY>wwwproxy.sandia.gov:80</PROXY>
   <TESTS>acme_integration</TESTS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi</MPILIBS>
+  <MPILIBS>openmpi,mpi-serial</MPILIBS>
   <OS>LINUX</OS>
   <CIME_OUTPUT_ROOT>/gscratch/$USER/acme_scratch/skybridge</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -751,7 +751,7 @@
   <PROXY>wwwproxy.sandia.gov:80</PROXY>
   <TESTS>acme_integration</TESTS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi</MPILIBS>
+  <MPILIBS>openmpi,mpi-serial</MPILIBS>
   <OS>LINUX</OS>
   <CIME_OUTPUT_ROOT>/gscratch/$USER/acme_scratch</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -826,7 +826,7 @@
          <NODENAME_REGEX>b.*.lcrc.anl.gov</NODENAME_REGEX>
          <TESTS>acme_integration</TESTS>
          <COMPILERS>gnu,pgi,intel,nag</COMPILERS>
-         <MPILIBS>mvapich,mpich,openmpi</MPILIBS>
+         <MPILIBS>mvapich,mpich,openmpi,mpi-serial</MPILIBS>
          <CIME_OUTPUT_ROOT>/lcrc/project/$PROJECT/$USER/acme_scratch</CIME_OUTPUT_ROOT>
 	 <SAVE_TIMING_DIR>/lcrc/project/$PROJECT</SAVE_TIMING_DIR>
 	 <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -898,7 +898,7 @@
          <NODENAME_REGEX>b.*.lcrc.anl.gov</NODENAME_REGEX>
          <TESTS>acme_integration</TESTS>
          <COMPILERS>intel,gnu,pgi</COMPILERS>
-         <MPILIBS>mvapich,openmpi</MPILIBS>
+         <MPILIBS>mvapich,openmpi,mpi-serial</MPILIBS>
          <CIME_OUTPUT_ROOT>/lcrc/group/acme/$USER/acme_scratch</CIME_OUTPUT_ROOT>
 	 <SAVE_TIMING_DIR>/lcrc/group/acme</SAVE_TIMING_DIR>
 	 <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -1028,9 +1028,9 @@
                <arg name="thread_count"> --envs OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
              </arguments>
          </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable>unsupported</executable>
-    </mpirun>
+	 <mpirun mpilib="mpi-serial">
+           <executable>unsupported</executable>
+	 </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
       <cmd_path lang="csh">soft</cmd_path>
@@ -1053,7 +1053,7 @@
 <machine MACH="sierra">
          <DESC>LLNL Linux Cluster, Linux (pgi), 12 pes/node, batch system is Moab</DESC>
          <COMPILERS>intel, pgi</COMPILERS>
-         <MPILIBS>mpich</MPILIBS>
+         <MPILIBS>mpich,mpi-serial</MPILIBS>
          <RUNDIR>/p/lscratche/$CCSMUSER/ACME/$CASE/run</RUNDIR>
          <EXEROOT>/p/lscratche/$CCSMUSER/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/p/lscratche/$USER</CIME_OUTPUT_ROOT>
@@ -1124,9 +1124,9 @@
                <arg name="thread_count"> --envs OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
              </arguments>
          </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable>unsupported</executable>
-    </mpirun>
+	 <mpirun mpilib="mpi-serial">
+           <executable>unsupported</executable>
+	 </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
       <cmd_path lang="csh">soft</cmd_path>
@@ -1192,7 +1192,7 @@
          <DESC>PNL Haswell cluster, OS is Linux, batch system is SLURM</DESC>
          <OS>LINUX</OS>
          <COMPILERS>intel,pgi</COMPILERS>
-         <MPILIBS>mpich</MPILIBS>
+         <MPILIBS>mpich,mpi-serial</MPILIBS>
 	 <NODENAME_REGEX>constance</NODENAME_REGEX>
          <RUNDIR>/pic/scratch/$CCSMUSER/csmruns/$CASE/run</RUNDIR>
          <EXEROOT>/pic/scratch/$CCSMUSER/csmruns/$CASE/bld</EXEROOT>
@@ -1216,6 +1216,7 @@
              <arg name="killonbadexit"> --kill-on-bad-exit</arg>
 	   </arguments>
 	 </mpirun>
+
 </machine>
 
 <machine MACH="oic2">
@@ -1223,7 +1224,7 @@
          <NODENAME_REGEX>oic2</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>gnu</COMPILERS>
-         <MPILIBS>mpich,openmpi</MPILIBS>
+         <MPILIBS>mpich,mpi-serial,openmpi</MPILIBS>
          <RUNDIR>/home/$USER/models/ACME/run/$CASE/run</RUNDIR>
          <EXEROOT>/home/$USER/models/ACME/run/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/home/$USER/models/ACME</CIME_OUTPUT_ROOT>
@@ -1268,7 +1269,7 @@
          <NODENAME_REGEX>oic5</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>gnu</COMPILERS>
-         <MPILIBS>mpich,openmpi</MPILIBS>
+         <MPILIBS>mpich,mpi-serial,openmpi</MPILIBS>
          <RUNDIR>/home/$USER/models/ACME/run/$CASE/run</RUNDIR>
          <EXEROOT>/home/$USER/models/ACME/run/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/home/$USER/models/ACME</CIME_OUTPUT_ROOT>
@@ -1299,7 +1300,7 @@
       <TESTS>acme_developer</TESTS>
       <OS>LINUX</OS>
       <COMPILERS>gnu,intel</COMPILERS>
-      <MPILIBS>openmpi</MPILIBS>
+      <MPILIBS>openmpi,mpi-serial</MPILIBS>
       <RUNDIR>/lustre/pfs1/cades-ccsi/scratch/$USER/$CASE/run</RUNDIR>
       <EXEROOT>/lustre/pfs1/cades-ccsi/scratch/$USER/$CASE/bld</EXEROOT>
       <DIN_LOC_ROOT>/lustre/pfs1/cades-ccsi/proj-shared/project_acme/ACME_inputdata</DIN_LOC_ROOT>
@@ -1345,7 +1346,7 @@
     <NODE_FAIL_REGEX>Received node event ec_node</NODE_FAIL_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>pgi,pgiacc,intel,cray</COMPILERS>
-    <MPILIBS>mpich</MPILIBS>
+    <MPILIBS>mpich,mpi-serial</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme_scratch/$PROJECT</CIME_OUTPUT_ROOT>
     <RUNDIR>$ENV{MEMBERWORK}/$PROJECT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1512,7 +1513,7 @@
          <NODENAME_REGEX>eos</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>intel</COMPILERS>
-         <MPILIBS>mpich</MPILIBS>
+         <MPILIBS>mpich,mpi-serial</MPILIBS>
          <CIME_OUTPUT_ROOT>$ENV{HOME}/acme_scratch/$PROJECT</CIME_OUTPUT_ROOT>
          <RUNDIR>$ENV{MEMBERWORK}/$PROJECT/$CASE/run</RUNDIR>
          <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1541,6 +1542,7 @@
              <arg name="numa_node" > -cc numa_node</arg>
            </arguments>
          </mpirun>
+
 	 <module_system type="module">
 	   <init_path lang="sh">$MODULESHOME/init/sh</init_path>
 	   <init_path lang="csh">$MODULESHOME/init/csh</init_path>
@@ -1590,7 +1592,7 @@
 	     <!-- This increases the stack size, which is necessary
 		  for CICE to run threaded on this machine -->
 	     <env name="OMP_STACKSIZE">64M</env>
-	     
+
 	   </environment_variables>
 	 </module_system>
 </machine>
@@ -1619,7 +1621,7 @@
 		<cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
 		<cmd_path lang="sh">module</cmd_path>
 		<cmd_path lang="csh">module</cmd_path>
-	
+
 		<modules>
 			<command name="purge"/>
 			<command name="use">/usr/projects/climate/SHARED_CLIMATE/modulefiles/all</command>
@@ -1662,6 +1664,7 @@
 			<arg name="num_tasks"> -n {{ num_tasks }}</arg>
 		</arguments>
 	</mpirun>
+
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
 	<PES_PER_NODE>32</PES_PER_NODE>
@@ -1675,7 +1678,7 @@
     <NODENAME_REGEX>wf-fe.*.lanl.gov</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
 	<COMPILERS>intel,gnu</COMPILERS>
-	<MPILIBS>openmpi,mvapich</MPILIBS>
+	<MPILIBS>openmpi,mvapich,mpi-serial</MPILIBS>
 	<OS>LINUX</OS>
 	<RUNDIR>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/run</RUNDIR>
 	<EXEROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/bld</EXEROOT>
@@ -1744,6 +1747,7 @@
 			<arg name="num_tasks"> -n $TOTALPES</arg>
 		</arguments>
 	</mpirun>
+
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
 	<PES_PER_NODE>16</PES_PER_NODE>
@@ -1757,7 +1761,7 @@
   <NODENAME_REGEX>.*yellowstone</NODENAME_REGEX>
   <OS>LINUX</OS>
   <COMPILERS>intel,pgi,gnu</COMPILERS>
-  <MPILIBS>mpich2,pempi</MPILIBS>
+  <MPILIBS>mpich2,pempi,mpi-serial</MPILIBS>
   <CIME_OUTPUT_ROOT>/glade/scratch/$USER</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1924,7 +1928,7 @@
   <DESC>Lawrencium LR3 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
   <OS>LINUX</OS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi</MPILIBS>
+  <MPILIBS>openmpi,mpi-serial</MPILIBS>
   <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1986,7 +1990,7 @@
   <DESC>Lawrencium LR2 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
   <OS>LINUX</OS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi</MPILIBS>
+  <MPILIBS>openmpi,mpi-serial</MPILIBS>
   <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>

--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -61,7 +61,7 @@
   <NODENAME_REGEX>edison</NODENAME_REGEX>
   <TESTS>acme_developer</TESTS>
   <COMPILERS>intel,gnu,cray</COMPILERS>
-  <MPILIBS>mpt,mpi-serial</MPILIBS>
+  <MPILIBS>mpt</MPILIBS>
   <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/edison</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -185,7 +185,7 @@
     <NODENAME_REGEX>cori</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <MPILIBS>mpt</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -318,7 +318,7 @@
     <NODENAME_REGEX>cori-knl-haswell-is-default</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <MPILIBS>mpt</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -453,7 +453,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>Darwin</OS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi,mpich</MPILIBS>
     <RUNDIR>$ENV{HOME}/projects/acme/scratch/$CASE/run</RUNDIR>
     <EXEROOT>$ENV{HOME}/projects/acme/scratch/$CASE/bld</EXEROOT>
     <DIN_LOC_ROOT>$ENV{HOME}/projects/acme/cesm-inputdata</DIN_LOC_ROOT>    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/projects/acme/ptclm-data</DIN_LOC_ROOT_CLMFORC>
@@ -476,7 +476,7 @@
     <OS>LINUX</OS>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi,mpich</MPILIBS>
     <RUNDIR>$ENV{HOME}/projects/acme/scratch/$CASE/run</RUNDIR>
     <EXEROOT>$ENV{HOME}/projects/acme/scratch/$CASE/bld</EXEROOT>
     <DIN_LOC_ROOT>$ENV{HOME}/projects/acme/cesm-inputdata</DIN_LOC_ROOT>
@@ -506,7 +506,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu,intel</COMPILERS>
-    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -562,7 +562,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu,intel</COMPILERS>
-    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -624,7 +624,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -675,7 +675,7 @@
   <PROXY>wwwproxy.sandia.gov:80</PROXY>
   <TESTS>acme_integration</TESTS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi,mpi-serial</MPILIBS>
+  <MPILIBS>openmpi</MPILIBS>
   <OS>LINUX</OS>
   <CIME_OUTPUT_ROOT>/gscratch/$USER/acme_scratch/skybridge</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -751,7 +751,7 @@
   <PROXY>wwwproxy.sandia.gov:80</PROXY>
   <TESTS>acme_integration</TESTS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi,mpi-serial</MPILIBS>
+  <MPILIBS>openmpi</MPILIBS>
   <OS>LINUX</OS>
   <CIME_OUTPUT_ROOT>/gscratch/$USER/acme_scratch</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -826,7 +826,7 @@
          <NODENAME_REGEX>b.*.lcrc.anl.gov</NODENAME_REGEX>
          <TESTS>acme_integration</TESTS>
          <COMPILERS>gnu,pgi,intel,nag</COMPILERS>
-         <MPILIBS>mvapich,mpich,openmpi,mpi-serial</MPILIBS>
+         <MPILIBS>mvapich,mpich,openmpi</MPILIBS>
          <CIME_OUTPUT_ROOT>/lcrc/project/$PROJECT/$USER/acme_scratch</CIME_OUTPUT_ROOT>
 	 <SAVE_TIMING_DIR>/lcrc/project/$PROJECT</SAVE_TIMING_DIR>
 	 <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -898,7 +898,7 @@
          <NODENAME_REGEX>b.*.lcrc.anl.gov</NODENAME_REGEX>
          <TESTS>acme_integration</TESTS>
          <COMPILERS>intel,gnu,pgi</COMPILERS>
-         <MPILIBS>mvapich,openmpi,mpi-serial</MPILIBS>
+         <MPILIBS>mvapich,openmpi</MPILIBS>
          <CIME_OUTPUT_ROOT>/lcrc/group/acme/$USER/acme_scratch</CIME_OUTPUT_ROOT>
 	 <SAVE_TIMING_DIR>/lcrc/group/acme</SAVE_TIMING_DIR>
 	 <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -1028,9 +1028,6 @@
                <arg name="thread_count"> --envs OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
              </arguments>
          </mpirun>
-	 <mpirun mpilib="mpi-serial">
-           <executable>unsupported</executable>
-	 </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
       <cmd_path lang="csh">soft</cmd_path>
@@ -1053,7 +1050,7 @@
 <machine MACH="sierra">
          <DESC>LLNL Linux Cluster, Linux (pgi), 12 pes/node, batch system is Moab</DESC>
          <COMPILERS>intel, pgi</COMPILERS>
-         <MPILIBS>mpich,mpi-serial</MPILIBS>
+         <MPILIBS>mpich</MPILIBS>
          <RUNDIR>/p/lscratche/$CCSMUSER/ACME/$CASE/run</RUNDIR>
          <EXEROOT>/p/lscratche/$CCSMUSER/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/p/lscratche/$USER</CIME_OUTPUT_ROOT>
@@ -1124,9 +1121,6 @@
                <arg name="thread_count"> --envs OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
              </arguments>
          </mpirun>
-	 <mpirun mpilib="mpi-serial">
-           <executable>unsupported</executable>
-	 </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
       <cmd_path lang="csh">soft</cmd_path>
@@ -1192,7 +1186,7 @@
          <DESC>PNL Haswell cluster, OS is Linux, batch system is SLURM</DESC>
          <OS>LINUX</OS>
          <COMPILERS>intel,pgi</COMPILERS>
-         <MPILIBS>mpich,mpi-serial</MPILIBS>
+         <MPILIBS>mpich</MPILIBS>
 	 <NODENAME_REGEX>constance</NODENAME_REGEX>
          <RUNDIR>/pic/scratch/$CCSMUSER/csmruns/$CASE/run</RUNDIR>
          <EXEROOT>/pic/scratch/$CCSMUSER/csmruns/$CASE/bld</EXEROOT>
@@ -1224,7 +1218,7 @@
          <NODENAME_REGEX>oic2</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>gnu</COMPILERS>
-         <MPILIBS>mpich,mpi-serial,openmpi</MPILIBS>
+         <MPILIBS>mpich,openmpi</MPILIBS>
          <RUNDIR>/home/$USER/models/ACME/run/$CASE/run</RUNDIR>
          <EXEROOT>/home/$USER/models/ACME/run/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/home/$USER/models/ACME</CIME_OUTPUT_ROOT>
@@ -1269,7 +1263,7 @@
          <NODENAME_REGEX>oic5</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>gnu</COMPILERS>
-         <MPILIBS>mpich,mpi-serial,openmpi</MPILIBS>
+         <MPILIBS>mpich,openmpi</MPILIBS>
          <RUNDIR>/home/$USER/models/ACME/run/$CASE/run</RUNDIR>
          <EXEROOT>/home/$USER/models/ACME/run/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/home/$USER/models/ACME</CIME_OUTPUT_ROOT>
@@ -1300,7 +1294,7 @@
       <TESTS>acme_developer</TESTS>
       <OS>LINUX</OS>
       <COMPILERS>gnu,intel</COMPILERS>
-      <MPILIBS>openmpi,mpi-serial</MPILIBS>
+      <MPILIBS>openmpi</MPILIBS>
       <RUNDIR>/lustre/pfs1/cades-ccsi/scratch/$USER/$CASE/run</RUNDIR>
       <EXEROOT>/lustre/pfs1/cades-ccsi/scratch/$USER/$CASE/bld</EXEROOT>
       <DIN_LOC_ROOT>/lustre/pfs1/cades-ccsi/proj-shared/project_acme/ACME_inputdata</DIN_LOC_ROOT>
@@ -1346,7 +1340,7 @@
     <NODE_FAIL_REGEX>Received node event ec_node</NODE_FAIL_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>pgi,pgiacc,intel,cray</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme_scratch/$PROJECT</CIME_OUTPUT_ROOT>
     <RUNDIR>$ENV{MEMBERWORK}/$PROJECT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1513,7 +1507,7 @@
          <NODENAME_REGEX>eos</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>intel</COMPILERS>
-         <MPILIBS>mpich,mpi-serial</MPILIBS>
+         <MPILIBS>mpich</MPILIBS>
          <CIME_OUTPUT_ROOT>$ENV{HOME}/acme_scratch/$PROJECT</CIME_OUTPUT_ROOT>
          <RUNDIR>$ENV{MEMBERWORK}/$PROJECT/$CASE/run</RUNDIR>
          <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1678,7 +1672,7 @@
     <NODENAME_REGEX>wf-fe.*.lanl.gov</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
 	<COMPILERS>intel,gnu</COMPILERS>
-	<MPILIBS>openmpi,mvapich,mpi-serial</MPILIBS>
+	<MPILIBS>openmpi,mvapich</MPILIBS>
 	<OS>LINUX</OS>
 	<RUNDIR>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/run</RUNDIR>
 	<EXEROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/bld</EXEROOT>
@@ -1761,7 +1755,7 @@
   <NODENAME_REGEX>.*yellowstone</NODENAME_REGEX>
   <OS>LINUX</OS>
   <COMPILERS>intel,pgi,gnu</COMPILERS>
-  <MPILIBS>mpich2,pempi,mpi-serial</MPILIBS>
+  <MPILIBS>mpich2,pempi</MPILIBS>
   <CIME_OUTPUT_ROOT>/glade/scratch/$USER</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1928,7 +1922,7 @@
   <DESC>Lawrencium LR3 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
   <OS>LINUX</OS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi,mpi-serial</MPILIBS>
+  <MPILIBS>openmpi</MPILIBS>
   <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1990,7 +1984,7 @@
   <DESC>Lawrencium LR2 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
   <OS>LINUX</OS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi,mpi-serial</MPILIBS>
+  <MPILIBS>openmpi</MPILIBS>
   <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>

--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -61,7 +61,7 @@
   <NODENAME_REGEX>edison</NODENAME_REGEX>
   <TESTS>acme_developer</TESTS>
   <COMPILERS>intel,gnu,cray</COMPILERS>
-  <MPILIBS>mpt,mpi-serial</MPILIBS>
+  <MPILIBS>mpt</MPILIBS>
   <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch/edison</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -185,7 +185,7 @@
     <NODENAME_REGEX>cori</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <MPILIBS>mpt</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -318,7 +318,7 @@
     <NODENAME_REGEX>cori-knl-haswell-is-default</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <MPILIBS>mpt</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}/acme_scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -453,7 +453,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>Darwin</OS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi,mpich</MPILIBS>
     <RUNDIR>$ENV{HOME}/projects/acme/scratch/$CASE/run</RUNDIR>
     <EXEROOT>$ENV{HOME}/projects/acme/scratch/$CASE/bld</EXEROOT>
     <DIN_LOC_ROOT>$ENV{HOME}/projects/acme/cesm-inputdata</DIN_LOC_ROOT>    <DIN_LOC_ROOT_CLMFORC>$ENV{HOME}/projects/acme/ptclm-data</DIN_LOC_ROOT_CLMFORC>
@@ -476,7 +476,7 @@
     <OS>LINUX</OS>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi,mpich</MPILIBS>
     <RUNDIR>$ENV{HOME}/projects/acme/scratch/$CASE/run</RUNDIR>
     <EXEROOT>$ENV{HOME}/projects/acme/scratch/$CASE/bld</EXEROOT>
     <DIN_LOC_ROOT>$ENV{HOME}/projects/acme/cesm-inputdata</DIN_LOC_ROOT>
@@ -506,7 +506,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu,intel</COMPILERS>
-    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -562,7 +562,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu,intel</COMPILERS>
-    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -624,7 +624,7 @@
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -675,7 +675,7 @@
   <PROXY>wwwproxy.sandia.gov:80</PROXY>
   <TESTS>acme_integration</TESTS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi,mpi-serial</MPILIBS>
+  <MPILIBS>openmpi</MPILIBS>
   <OS>LINUX</OS>
   <CIME_OUTPUT_ROOT>/gscratch/$USER/acme_scratch/skybridge</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -702,9 +702,6 @@
       <arg name="num_tasks"> --n $TOTALPES</arg>
       <arg name="tasks_per_node"> --npernode $PES_PER_NODE</arg>
     </arguments>
-  </mpirun>
-  <mpirun mpilib="mpi-serial">
-    <executable></executable>
   </mpirun>
   <module_system type="module">
     <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
@@ -754,7 +751,7 @@
   <PROXY>wwwproxy.sandia.gov:80</PROXY>
   <TESTS>acme_integration</TESTS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi,mpi-serial</MPILIBS>
+  <MPILIBS>openmpi</MPILIBS>
   <OS>LINUX</OS>
   <CIME_OUTPUT_ROOT>/gscratch/$USER/acme_scratch</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -781,9 +778,6 @@
       <arg name="num_tasks"> --n $TOTALPES</arg>
       <arg name="tasks_per_node"> --npernode $PES_PER_NODE</arg>
     </arguments>
-  </mpirun>
-  <mpirun mpilib="mpi-serial">
-    <executable></executable>
   </mpirun>
   <module_system type="module">
     <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
@@ -832,7 +826,7 @@
          <NODENAME_REGEX>b.*.lcrc.anl.gov</NODENAME_REGEX>
          <TESTS>acme_integration</TESTS>
          <COMPILERS>gnu,pgi,intel,nag</COMPILERS>
-         <MPILIBS>mvapich,mpich,openmpi,mpi-serial</MPILIBS>
+         <MPILIBS>mvapich,mpich,openmpi</MPILIBS>
          <CIME_OUTPUT_ROOT>/lcrc/project/$PROJECT/$USER/acme_scratch</CIME_OUTPUT_ROOT>
 	 <SAVE_TIMING_DIR>/lcrc/project/$PROJECT</SAVE_TIMING_DIR>
 	 <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -855,9 +849,6 @@
            <arguments>
              <arg name="num_tasks"> -n $TOTALPES </arg>
            </arguments>
-         </mpirun>
-         <mpirun mpilib="mpi-serial">
-             <executable></executable>
          </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/a_softenv.csh</init_path>
@@ -907,7 +898,7 @@
          <NODENAME_REGEX>b.*.lcrc.anl.gov</NODENAME_REGEX>
          <TESTS>acme_integration</TESTS>
          <COMPILERS>intel,gnu,pgi</COMPILERS>
-         <MPILIBS>mvapich,openmpi,mpi-serial</MPILIBS>
+         <MPILIBS>mvapich,openmpi</MPILIBS>
          <CIME_OUTPUT_ROOT>/lcrc/group/acme/$USER/acme_scratch</CIME_OUTPUT_ROOT>
 	 <SAVE_TIMING_DIR>/lcrc/group/acme</SAVE_TIMING_DIR>
 	 <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
@@ -937,9 +928,6 @@
            <arguments>
              <arg name="num_tasks"> -n $TOTALPES </arg>
            </arguments>
-         </mpirun>
-         <mpirun mpilib="mpi-serial">
-             <executable></executable>
          </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/a_softenv.csh</init_path>
@@ -1062,7 +1050,7 @@
 <machine MACH="sierra">
          <DESC>LLNL Linux Cluster, Linux (pgi), 12 pes/node, batch system is Moab</DESC>
          <COMPILERS>intel, pgi</COMPILERS>
-         <MPILIBS>mpich,mpi-serial</MPILIBS>
+         <MPILIBS>mpich</MPILIBS>
          <RUNDIR>/p/lscratche/$CCSMUSER/ACME/$CASE/run</RUNDIR>
          <EXEROOT>/p/lscratche/$CCSMUSER/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/p/lscratche/$USER</CIME_OUTPUT_ROOT>
@@ -1091,9 +1079,6 @@
 	   <arguments>
 	     <arg name="num_nodes"> -N {{ num_nodes }}</arg>
 	   </arguments>
-	 </mpirun>
-	 <mpirun mpilib="mpi-serial">
-           <executable></executable>
 	 </mpirun>
 </machine>
 
@@ -1201,7 +1186,7 @@
          <DESC>PNL Haswell cluster, OS is Linux, batch system is SLURM</DESC>
          <OS>LINUX</OS>
          <COMPILERS>intel,pgi</COMPILERS>
-         <MPILIBS>mpich,mpi-serial</MPILIBS>
+         <MPILIBS>mpich</MPILIBS>
 	 <NODENAME_REGEX>constance</NODENAME_REGEX>
          <RUNDIR>/pic/scratch/$CCSMUSER/csmruns/$CASE/run</RUNDIR>
          <EXEROOT>/pic/scratch/$CCSMUSER/csmruns/$CASE/bld</EXEROOT>
@@ -1225,10 +1210,6 @@
              <arg name="killonbadexit"> --kill-on-bad-exit</arg>
 	   </arguments>
 	 </mpirun>
-	 <mpirun mpilib="mpi-serial">
-           <executable></executable>
-	 </mpirun>
-
 </machine>
 
 <machine MACH="oic2">
@@ -1236,7 +1217,7 @@
          <NODENAME_REGEX>oic2</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>gnu</COMPILERS>
-         <MPILIBS>mpich,mpi-serial,openmpi</MPILIBS>
+         <MPILIBS>mpich,openmpi</MPILIBS>
          <RUNDIR>/home/$USER/models/ACME/run/$CASE/run</RUNDIR>
          <EXEROOT>/home/$USER/models/ACME/run/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/home/$USER/models/ACME</CIME_OUTPUT_ROOT>
@@ -1255,9 +1236,6 @@
 			<arg name="num_tasks"> -np $TOTALPES</arg>
 			<arg name="machine_file">--hostfile $ENV{PBS_NODEFILE}</arg>
 	      </arguments>
-         </mpirun>
-         <mpirun mpilib = "mpi-serial">
-              <executable> </executable>
          </mpirun>
 	 <module_system type="module">
 	   <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
@@ -1284,7 +1262,7 @@
          <NODENAME_REGEX>oic5</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>gnu</COMPILERS>
-         <MPILIBS>mpich,mpi-serial,openmpi</MPILIBS>
+         <MPILIBS>mpich,openmpi</MPILIBS>
          <RUNDIR>/home/$USER/models/ACME/run/$CASE/run</RUNDIR>
          <EXEROOT>/home/$USER/models/ACME/run/$CASE/bld</EXEROOT>
          <CIME_OUTPUT_ROOT>/home/$USER/models/ACME</CIME_OUTPUT_ROOT>
@@ -1304,9 +1282,6 @@
                         <arg name="machine_file">--hostfile $ENV{PBS_NODEFILE}</arg>
 	      </arguments>
          </mpirun>
-         <mpirun mpilib = "mpi-serial">
-              <executable> </executable>
-         </mpirun>
 </machine>
 
 <machine MACH="cades">
@@ -1318,7 +1293,7 @@
       <TESTS>acme_developer</TESTS>
       <OS>LINUX</OS>
       <COMPILERS>gnu,intel</COMPILERS>
-      <MPILIBS>openmpi,mpi-serial</MPILIBS>
+      <MPILIBS>openmpi</MPILIBS>
       <RUNDIR>/lustre/pfs1/cades-ccsi/scratch/$USER/$CASE/run</RUNDIR>
       <EXEROOT>/lustre/pfs1/cades-ccsi/scratch/$USER/$CASE/bld</EXEROOT>
       <DIN_LOC_ROOT>/lustre/pfs1/cades-ccsi/proj-shared/project_acme/ACME_inputdata</DIN_LOC_ROOT>
@@ -1338,9 +1313,6 @@
           <arg name="num_tasks"> -np $TOTALPES</arg>
           <arg name="machine_file">--hostfile $ENV{PBS_NODEFILE}</arg>
         </arguments>
-      </mpirun>
-        <mpirun mpilib = "mpi-serial">
-        <executable> </executable>
       </mpirun>
       <module_system type="module">
 	<init_path lang="sh">/usr/share/Modules/init/sh</init_path>
@@ -1367,7 +1339,7 @@
     <NODE_FAIL_REGEX>Received node event ec_node</NODE_FAIL_REGEX>
     <TESTS>acme_developer</TESTS>
     <COMPILERS>pgi,pgiacc,intel,cray</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme_scratch/$PROJECT</CIME_OUTPUT_ROOT>
     <RUNDIR>$ENV{MEMBERWORK}/$PROJECT/$CASE/run</RUNDIR>
     <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1534,7 +1506,7 @@
          <NODENAME_REGEX>eos</NODENAME_REGEX>
          <TESTS>acme_developer</TESTS>
          <COMPILERS>intel</COMPILERS>
-         <MPILIBS>mpich,mpi-serial</MPILIBS>
+         <MPILIBS>mpich</MPILIBS>
          <CIME_OUTPUT_ROOT>$ENV{HOME}/acme_scratch/$PROJECT</CIME_OUTPUT_ROOT>
          <RUNDIR>$ENV{MEMBERWORK}/$PROJECT/$CASE/run</RUNDIR>
          <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1562,9 +1534,6 @@
              <arg name="thread_count" > -d $OMP_NUM_THREADS</arg>
              <arg name="numa_node" > -cc numa_node</arg>
            </arguments>
-         </mpirun>
-         <mpirun mpilib="mpi-serial">
-           <executable></executable>
          </mpirun>
 	 <module_system type="module">
 	   <init_path lang="sh">$MODULESHOME/init/sh</init_path>
@@ -1687,9 +1656,6 @@
 			<arg name="num_tasks"> -n {{ num_tasks }}</arg>
 		</arguments>
 	</mpirun>
-	<mpirun mpilib="mpi-serial">
-		<executable></executable>
-	</mpirun>
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
 	<PES_PER_NODE>32</PES_PER_NODE>
@@ -1703,7 +1669,7 @@
     <NODENAME_REGEX>wf-fe.*.lanl.gov</NODENAME_REGEX>
     <TESTS>acme_developer</TESTS>
 	<COMPILERS>intel,gnu</COMPILERS>
-	<MPILIBS>openmpi,mvapich,mpi-serial</MPILIBS>
+	<MPILIBS>openmpi,mvapich</MPILIBS>
 	<OS>LINUX</OS>
 	<RUNDIR>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/run</RUNDIR>
 	<EXEROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/cases/$CASE/bld</EXEROOT>
@@ -1772,9 +1738,6 @@
 			<arg name="num_tasks"> -n $TOTALPES</arg>
 		</arguments>
 	</mpirun>
-	<mpirun mpilib="mpi-serial">
-		<executable></executable>
-	</mpirun>
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
 	<PES_PER_NODE>16</PES_PER_NODE>
@@ -1788,7 +1751,7 @@
   <NODENAME_REGEX>.*yellowstone</NODENAME_REGEX>
   <OS>LINUX</OS>
   <COMPILERS>intel,pgi,gnu</COMPILERS>
-  <MPILIBS>mpich2,pempi,mpi-serial</MPILIBS>
+  <MPILIBS>mpich2,pempi</MPILIBS>
   <CIME_OUTPUT_ROOT>/glade/scratch/$USER</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -1806,9 +1769,6 @@
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <mpirun >
     <executable>mpirun.lsf</executable>
-  </mpirun>
-  <mpirun mpilib="mpi-serial">
-    <executable></executable>
   </mpirun>
   <module_system type="module">
     <init_path lang="perl">/glade/apps/opt/lmod/lmod/init/perl</init_path>
@@ -1958,7 +1918,7 @@
   <DESC>Lawrencium LR3 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
   <OS>LINUX</OS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi,mpi-serial</MPILIBS>
+  <MPILIBS>openmpi</MPILIBS>
   <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
@@ -2020,7 +1980,7 @@
   <DESC>Lawrencium LR2 cluster at LBL, OS is Linux (intel), batch system is SLURM</DESC>
   <OS>LINUX</OS>
   <COMPILERS>intel</COMPILERS>
-  <MPILIBS>openmpi,mpi-serial</MPILIBS>
+  <MPILIBS>openmpi</MPILIBS>
   <CIME_OUTPUT_ROOT>/global/scratch/$ENV{USER}</CIME_OUTPUT_ROOT>
   <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
   <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>

--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -1028,6 +1028,9 @@
                <arg name="thread_count"> --envs OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
              </arguments>
          </mpirun>
+    <mpirun mpilib="mpi-serial">
+      <executable>unsupported</executable>
+    </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
       <cmd_path lang="csh">soft</cmd_path>
@@ -1121,6 +1124,9 @@
                <arg name="thread_count"> --envs OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
              </arguments>
          </mpirun>
+    <mpirun mpilib="mpi-serial">
+      <executable>unsupported</executable>
+    </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
       <cmd_path lang="csh">soft</cmd_path>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -55,7 +55,7 @@
     <NODENAME_REGEX>h2o</NODENAME_REGEX>
     <OS>CNL</OS>
     <COMPILERS>pgi,cray,gnu</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/scratch/sciteam/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>$ENV{CESMDATAROOT}/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -134,7 +134,7 @@
     <DESC>Brutus Linux Cluster ETH (pgi(9.0-1)/intel(10.1.018) with openi(1.4.1)/mvapich2(1.4rc2), 16 pes/node, batch system LSF, added by UB</DESC>
     <OS>LINUX</OS>
     <COMPILERS>pgi,intel</COMPILERS>
-    <MPILIBS>openmpi,mpich,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi,mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/cluster/work/uwis/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/cluster/work/uwis/ccsm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/cluster/work/uwis/ccsm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -158,9 +158,6 @@
       <executable>ompirun</executable>
       <arguments>
       </arguments>
-    </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
     </mpirun>
     <module_system type="module">
       <init_path lang="perl">/etc/profile.d/modules.perl</init_path>
@@ -227,9 +224,6 @@
            shared nodes. However, running mpi jobs on the shared nodes currently
            requires some workarounds; these workarounds are implemented here -->
       <executable>/opt/sgi/mpt/mpt-2.15/bin/mpirun $ENV{UNIT_TEST_HOST} -np 1 </executable>
-    </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
     </mpirun>
     <module_system type="module">
       <init_path lang="perl">/glade/u/apps/ch/opt/lmod/7.2.1/lmod/lmod/init/perl</init_path>
@@ -305,9 +299,6 @@
     <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>24</PES_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
       <arguments>
@@ -392,7 +383,7 @@
     <NODENAME_REGEX>cori</NODENAME_REGEX>
     <OS>CNL</OS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <MPILIBS>mpt</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/project/projectdirs/ccsm1/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/ccsm1/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -495,7 +486,7 @@
     <DESC>NERSC XC* KNL, os is CNL, 68 pes/node, batch system is Slurm</DESC>
     <OS>CNL</OS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <MPILIBS>mpt</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/project/projectdirs/ccsm1/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/ccsm1/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -742,7 +733,7 @@
     <NODENAME_REGEX>edison</NODENAME_REGEX>
     <OS>CNL</OS>
     <COMPILERS>intel,gnu,cray</COMPILERS>
-    <MPILIBS>mpt,mpi-serial</MPILIBS>
+    <MPILIBS>mpt</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{CSCRATCH}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/project/projectdirs/ccsm1/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/ccsm1/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -908,7 +899,7 @@
     <DESC>NOAA XE6, os is CNL, 24 pes/node, batch system is PBS</DESC>
     <OS>CNL</OS>
     <COMPILERS>pgi</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/lustre/fs/scratch/Julio.T.Bacmeister</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/lustre/fs/scratch/Julio.T.Bacmeister/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/lustre/fs/scratch/Julio.T.Bacmeister/inputdata</DIN_LOC_ROOT_CLMFORC>
@@ -929,9 +920,6 @@
 	<arg name="tasks_per_node" > -N $PES_PER_NODE</arg>
 	<arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
-    </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
     </mpirun>
     <module_system type="module">
       <init_path lang="perl">/opt/modules/default/init/perl.pm</init_path>
@@ -997,9 +985,6 @@
 	<arg name="threadplacement"> omplace </arg>
       </arguments>
     </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <module_system type="module">
       <init_path lang="perl">/picnic/u/apps/la/opt/lmod/6.5/gnu/4.8.5/lmod/lmod/init/perl</init_path>
       <init_path lang="python">/picnic/u/apps/la/opt/lmod/6.5/gnu/4.8.5/lmod/lmod/init/env_modules_python.py</init_path>
@@ -1044,7 +1029,7 @@
     <OS>LINUX</OS>
     <PROXY>sonproxy.sandia.gov:80</PROXY>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi</MPILIBS>
     <SAVE_TIMING_DIR>/sems-data-store/ACME/timings</SAVE_TIMING_DIR>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/sems-data-store/ACME/inputdata</DIN_LOC_ROOT>
@@ -1099,7 +1084,7 @@
     <OS>LINUX</OS>
     <PROXY>wwwproxy.sandia.gov:80</PROXY>
     <COMPILERS>gnu</COMPILERS>
-    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi</MPILIBS>
     <SAVE_TIMING_DIR>/sems-data-store/ACME/timings</SAVE_TIMING_DIR>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/acme/scratch</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/sems-data-store/ACME/inputdata</DIN_LOC_ROOT>
@@ -1215,9 +1200,6 @@
     <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>32</PES_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
@@ -1250,7 +1232,7 @@
     <DESC>NASA/AMES Linux Cluster, Linux (ia64), 2.5 GHz Haswell Intel Xeon E5-2680v3 processors, 24 pes/node (two 12-core processors) and 128 GB of memory/node, batch system is PBS</DESC>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/nobackup/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/nobackup/mjmills2/ccsmdata/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/nobackup/mjmills2/ccsmdata/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -1263,9 +1245,6 @@
     <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>24</PES_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
@@ -1302,7 +1281,7 @@
     <DESC>NASA/AMES Linux Cluster, Linux (ia64), Altix ICE, 2.93 GHz Westmere processors, 12 pes/node and 24 GB of memory, batch system is PBS</DESC>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/nobackup/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/nobackup/mjmills2/ccsmdata/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/nobackup/mjmills2/ccsmdata/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -1315,9 +1294,6 @@
     <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>12</PES_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
@@ -1354,7 +1330,7 @@
     <DESC>NASA/AMES Linux Cluster, Linux (ia64), Altix ICE, 2.6 GHz Sandy Bridge processors, 16 cores/node and 32 GB of memory, batch system is PBS</DESC>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/nobackup/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/nobackup/mjmills2/ccsmdata/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/nobackup/mjmills2/ccsmdata/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -1367,9 +1343,6 @@
     <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>16</PES_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
@@ -1406,7 +1379,7 @@
     <DESC>NASA/AMES Linux Cluster, Linux (ia64), Altix ICE, 2.8 GHz Ivy Bridge processors, 20 cores/node and 3.2 GB of memory per core, batch system is PBS</DESC>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/nobackup/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/nobackup/mjmills2/ccsmdata/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/nobackup/mjmills2/ccsmdata/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -1419,9 +1392,6 @@
     <MAX_TASKS_PER_NODE>20</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>20</PES_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
@@ -1458,7 +1428,7 @@
     <DESC>CSCS Cray XE6, os is CNL, 32 pes/node, batch system is SLURM</DESC>
     <OS>CNL</OS>
     <COMPILERS>pgi,cray,gnu</COMPILERS>
-    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>/scratch/rosa/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/project/s433/cesm_inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/project/s433/cesm_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
@@ -1491,7 +1461,7 @@
     <OS>LINUX</OS>
     <PROXY>wwwproxy.sandia.gov:80</PROXY>
     <COMPILERS>intel</COMPILERS>
-    <MPILIBS>openmpi,mpi-serial</MPILIBS>
+    <MPILIBS>openmpi</MPILIBS>
     <SAVE_TIMING_DIR>/projects/ccsm/timings</SAVE_TIMING_DIR>
     <CIME_OUTPUT_ROOT>/gscratch/$USER/acme_scratch/skybridge</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/projects/ccsm/inputdata</DIN_LOC_ROOT>
@@ -1513,9 +1483,6 @@
 	<arg name="num_tasks"> -np $TOTALPES</arg>
 	<arg name="tasks_per_node"> -npernode $PES_PER_NODE</arg>
       </arguments>
-    </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
     </mpirun>
     <module_system type="module">
       <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
@@ -1577,9 +1544,6 @@
     <mpirun mpilib="mvapich2">
       <executable>ibrun</executable>
     </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <module_system type="module">
       <init_path lang="perl">/opt/apps/lmod/lmod/init/perl</init_path>
       <init_path lang="python">/opt/apps/lmod/lmod/init/env_modules_python.py</init_path>
@@ -1640,9 +1604,6 @@
     <MAX_TASKS_PER_NODE>30</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>15</PES_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
-    <mpirun mpilib="mpi-serial">
-      <executable></executable>
-    </mpirun>
     <mpirun mpilib="default" unit_testing="true">
       <!-- For unit testing, avoid all of the extra stuff that we use before and
            after the mpirun command when launching cesm on yellowstone -->

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1163,6 +1163,9 @@
 	<arg name="thread_count"> --envs OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
+    <mpirun mpilib="mpi-serial">
+      <executable>unsupported</executable>
+    </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
       <init_path lang="sh">/etc/profile.d/00softenv.sh</init_path>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1163,9 +1163,6 @@
 	<arg name="thread_count"> --envs OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
-    <mpirun mpilib="mpi-serial">
-      <executable>unsupported</executable>
-    </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
       <init_path lang="sh">/etc/profile.d/00softenv.sh</init_path>

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -355,7 +355,7 @@ class EnvMachSpecific(EnvBase):
 
                     if xml_attrib == value:
                         matches += 1
-                    elif key == "mpilib" and xml_attrib == "default":
+                    elif key == "mpilib" and value != "mpi-serial" and xml_attrib == "default":
                         is_default = True
                     else:
                         all_match = False
@@ -373,6 +373,10 @@ class EnvMachSpecific(EnvBase):
                     if matches > best_num_matched:
                         best_match = mpirun_node
                         best_num_matched = matches
+
+        # if there are no special arguments required for mpi-serial it need not have an entry in config_machines.xml
+        if "mpilib" in attribs and attribs["mpilib"] == "mpi-serial" and best_match is None:
+            return "",[]
 
         expect(best_match is not None or default_match is not None,
                "Could not find a matching MPI for attributes: %s" % attribs)

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -399,7 +399,5 @@ class EnvMachSpecific(EnvBase):
         exec_node = self.get_node("executable", root=the_match)
         expect(exec_node is not None,"No executable found")
         executable = exec_node.text
-        expect("unsupported" not in executable, "%s is not supported for this machine"%attribs["mpilib"])
-        
-        
+
         return executable, args

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -399,5 +399,7 @@ class EnvMachSpecific(EnvBase):
         exec_node = self.get_node("executable", root=the_match)
         expect(exec_node is not None,"No executable found")
         executable = exec_node.text
-
+        expect("unsupported" not in executable, "%s is not supported for this machine"%attribs["mpilib"])
+        
+        
         return executable, args

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -256,7 +256,9 @@ class Machines(GenericXML):
         >>> machobj.is_valid_MPIlib("fake-mpi")
         False
         """
-        return mpilib == "mpi-serial" or self.get_field_from_list("MPILIBS", reqval=mpilib, attributes=attributes) is not None
+        model = CIME.utils.get_model()
+        return (model == "cesm" and mpilib == "mpi-serial") or \
+            self.get_field_from_list("MPILIBS", reqval=mpilib, attributes=attributes) is not None
 
     def has_batch_system(self):
         """

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -4,7 +4,7 @@ Interface to the config_machines.xml file.  This class inherits from GenericXML.
 from CIME.XML.standard_module_setup import *
 from CIME.XML.generic_xml import GenericXML
 from CIME.XML.files import Files
-from CIME.utils import convert_to_unknown_type
+from CIME.utils import convert_to_unknown_type, get_model
 
 import socket
 
@@ -256,7 +256,7 @@ class Machines(GenericXML):
         >>> machobj.is_valid_MPIlib("fake-mpi")
         False
         """
-        model = CIME.utils.get_model()
+        model = get_model()
         return (model == "cesm" and mpilib == "mpi-serial") or \
             self.get_field_from_list("MPILIBS", reqval=mpilib, attributes=attributes) is not None
 

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -4,7 +4,7 @@ Interface to the config_machines.xml file.  This class inherits from GenericXML.
 from CIME.XML.standard_module_setup import *
 from CIME.XML.generic_xml import GenericXML
 from CIME.XML.files import Files
-from CIME.utils import convert_to_unknown_type, get_model
+from CIME.utils import convert_to_unknown_type
 
 import socket
 
@@ -256,8 +256,7 @@ class Machines(GenericXML):
         >>> machobj.is_valid_MPIlib("fake-mpi")
         False
         """
-        model = get_model()
-        return (model == "cesm" and mpilib == "mpi-serial") or \
+        return mpilib == "mpi-serial" or \
             self.get_field_from_list("MPILIBS", reqval=mpilib, attributes=attributes) is not None
 
     def has_batch_system(self):


### PR DESCRIPTION
Remove the requirement to have mpilib mpi-serial explicitly listed in the config_machines.xml file since it is assumed supported on all systems.   Remove the empty executable field for that library.

Test suite: scripts_regression_tests.py, preview_run (thanks for this!), SMS_Mmpi-serial.f19_g17.X.hobart_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1220 

User interface changes?: no

Code review: 
