### PR TITLE
in _check_for_invalid_args ignore quoted strings

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1238,6 +1238,9 @@ def run_and_log_case_status(func, phase, caseroot='.'):
 
 def _check_for_invalid_args(args):
     for arg in args:
+        # if arg contains a space then it was originally quoted and we can ignore it here.
+        if " " in arg:
+            continue
         if arg.startswith("--"):
             continue
         if arg.startswith("-") and len(arg) > 2:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1239,9 +1239,7 @@ def run_and_log_case_status(func, phase, caseroot='.'):
 def _check_for_invalid_args(args):
     for arg in args:
         # if arg contains a space then it was originally quoted and we can ignore it here.
-        if " " in arg:
-            continue
-        if arg.startswith("--"):
+        if " " in arg or arg.startswith("--"):
             continue
         if arg.startswith("-") and len(arg) > 2:
             if arg == "-value" or arg == "-noecho":


### PR DESCRIPTION
If there is a space in an argument then it was quoted in the shell and should be ignored in this test.

Test suite: ./xmlchange --id CLM_BLDNML_OPTS      --val "-bgc bgc -crop -irrig=.true."
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1460 

User interface changes?: 

Code review: 
