### PR TITLE
Quick fix of utils.py invalid parser args

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -661,7 +661,7 @@ def parse_args_and_handle_standard_logging_options(args, parser=None):
     stderr_stream_handler.setLevel(logging.WARNING)
 
     # scripts_regression_tests is the only thing that should pass a None argument in parser
-    if parser is not None:
+    if parser is None:
         _check_for_invalid_args(args[1:])
         args = parser.parse_args(args[1:])
 


### PR DESCRIPTION
Removing word "not" from if test. This was causing error for buildnml of cice with "-id" arg with single dash. From comment on line above, it seems clear that the True/False was reversed from intended.