### PR TITLE
Fixes for zlev problem in #1459

### DIFF
--- a/config/xml_schemas/env_mach_specific.xsd
+++ b/config/xml_schemas/env_mach_specific.xsd
@@ -8,6 +8,8 @@
 <xs:attribute name="debug" type="xs:boolean"/>
 <xs:attribute name="mpilib" type="xs:string"/>
 <xs:attribute name="value" type="xs:string"/>
+<xs:attribute name="unit_testing" type="xs:boolean"/>
+
 <!-- simple elements -->
 <xs:element name="header" type="xs:string"/>
 <xs:element name="executable" type="xs:string"/>
@@ -75,6 +77,7 @@
         <xs:element maxOccurs="unbounded" ref="env"/>
       </xs:sequence>
       <xs:attribute name="debug" type="xs:boolean"/>
+      <xs:attribute ref="unit_testing"/>
       <xs:attribute name="mpilib"/>
     </xs:complexType>
   </xs:element>
@@ -87,13 +90,23 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="executable"/>
+	<xs:element ref="arguments" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="mpilib"/>
       <xs:attribute name="threaded" type="xs:boolean"/>
-      <xs:attribute name="unit_testing" type="xs:boolean"/>
+      <xs:attribute ref="unit_testing"/>
     </xs:complexType>
   </xs:element>
+
+  <xs:element name="arguments">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
   <xs:element name="entry">
     <xs:complexType>
       <xs:sequence>

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -58,7 +58,7 @@ class Grids(GenericXML):
 
         #mechanism to specify lnd levels
         levmatch = re.match(r"(.*_)([^_]+)z(\d+)(_[^m].*)$", name)
-o        if  levmatch:
+        if  levmatch:
             lndnlev = levmatch.group(3)
             name = levmatch.group(1)+levmatch.group(2)+levmatch.group(4)
 
@@ -238,7 +238,7 @@ o        if  levmatch:
             levmatch = re.match(r"([^_]+)z(\d+)(.*)$", grid_name)
             if  levmatch:
                 grid_name_nonlev = levmatch.group(1)+levmatch.group(3)
-            levmatch = re.match(r"(.*_)([^_]+)z(\d+)(_[^m].*)$", name)
+            levmatch = re.match(r"(.*_)([^_]+)z(\d+)(_[^m].*)$", grid_name)
             if  levmatch:
                 grid_name_nonlev = levmatch.group(1)+levmatch.group(2)+levmatch.group(4)
 

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -55,16 +55,12 @@ class Grids(GenericXML):
         if  levmatch:
             atmnlev = levmatch.group(2)
             name = levmatch.group(1)+levmatch.group(3)
-        else:
-            atmnlev = None
 
         #mechanism to specify lnd levels
         levmatch = re.match(r"(.*_)([^_]+)z(\d+)(.*)$", name)
         if  levmatch:
             lndnlev = levmatch.group(3)
             name = levmatch.group(1)+levmatch.group(2)+levmatch.group(4)
-        else:
-            lndnlev = None
 
         # determine component_grids dictionary and grid longname
         lname, component_grids = self._read_config_grids(name, compset, atmnlev, lndnlev)
@@ -207,14 +203,11 @@ class Grids(GenericXML):
             else:
                 lname = prefix[component_gridname]
             if model_grid[component_gridname] is not None:
-                if component_gridname == 'atm':
-                    if atmnlev is not None:
-                        lname += model_grid[component_gridname] + "z" + atmnlev
-                elif component_gridname == 'lnd':
-                    if lndnlev is not None:
-                        lname += model_grid[component_gridname] + "z" + lndnlev
-                else:
-                    lname += model_grid[component_gridname]
+                lname += model_grid[component_gridname]
+                if component_gridname == 'atm' and atmnlev is not None:
+                        lname += "z" + atmnlev
+                elif component_gridname == 'lnd' and lndnlev is not None:
+                        lname += "z" + lndnlev
             else:
                 lname += 'null'
         component_grids = self._get_component_grids_from_longname(lname)

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -205,9 +205,9 @@ class Grids(GenericXML):
             if model_grid[component_gridname] is not None:
                 lname += model_grid[component_gridname]
                 if component_gridname == 'atm' and atmnlev is not None:
-                        lname += "z" + atmnlev
+                    lname += "z" + atmnlev
                 elif component_gridname == 'lnd' and lndnlev is not None:
-                        lname += "z" + lndnlev
+                    lname += "z" + lndnlev
             else:
                 lname += 'null'
         component_grids = self._get_component_grids_from_longname(lname)

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -57,8 +57,8 @@ class Grids(GenericXML):
             name = levmatch.group(1)+levmatch.group(3)
 
         #mechanism to specify lnd levels
-        levmatch = re.match(r"(.*_)([^_]+)z(\d+)(.*)$", name)
-        if  levmatch:
+        levmatch = re.match(r"(.*_)([^_]+)z(\d+)(_[^m].*)$", name)
+o        if  levmatch:
             lndnlev = levmatch.group(3)
             name = levmatch.group(1)+levmatch.group(2)+levmatch.group(4)
 
@@ -205,9 +205,13 @@ class Grids(GenericXML):
             if model_grid[component_gridname] is not None:
                 lname += model_grid[component_gridname]
                 if component_gridname == 'atm' and atmnlev is not None:
-                    lname += "z" + atmnlev
+                    if re.search(r"a%null", lname) is None:
+                        lname += "z" + atmnlev
+
                 elif component_gridname == 'lnd' and lndnlev is not None:
-                    lname += "z" + lndnlev
+                    if re.search(r"l%null", lname) is None:
+                        lname += "z" + lndnlev
+
             else:
                 lname += 'null'
         component_grids = self._get_component_grids_from_longname(lname)
@@ -234,7 +238,7 @@ class Grids(GenericXML):
             levmatch = re.match(r"([^_]+)z(\d+)(.*)$", grid_name)
             if  levmatch:
                 grid_name_nonlev = levmatch.group(1)+levmatch.group(3)
-            levmatch = re.match(r"(.*_)([^_]+)z(\d+)(.*)$", grid_name)
+            levmatch = re.match(r"(.*_)([^_]+)z(\d+)(_[^m].*)$", name)
             if  levmatch:
                 grid_name_nonlev = levmatch.group(1)+levmatch.group(2)+levmatch.group(4)
 


### PR DESCRIPTION
The level specifier for atm and lnd grids was being ignored.
Test suite: scripts_regression_tests.py, SMS.ne30z60_ne30.F1850
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1459

User interface changes?: 

Code review: 
