### PR TITLE
Add new runoff -> gx1v6 maps

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1632,8 +1632,8 @@
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx3v7_nnsm_e1000r500_170413.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="gx1v6" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v6_nn_ac_161213.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v6_e1000r300_161212.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v6_nn_open_ocean_nnsm_e1000r300_marginal_sea_170503.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v6_nnsm_e1000r300_170503.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="gx1v7" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rx1/map_rx1_to_gx1v7_nn_open_ocean_nnsm_e1000r300_marginal_sea_170413.nc</map>
@@ -1657,8 +1657,8 @@
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx3v7_nnsm_e1000r500_170413.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="gx1v6" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_nn_ac_161214.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_e1000r300_161212.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_nn_open_ocean_nnsm_e1000r300_marginal_sea_170503.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v6_nnsm_e1000r300_170503.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="gx1v7" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_gx1v7_nn_open_ocean_nnsm_e1000r300_marginal_sea_170413.nc</map>

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/map_r05_to_gx1v6_nnsm_e1000r300.nml
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/map_r05_to_gx1v6_nnsm_e1000r300.nml
@@ -1,0 +1,16 @@
+&input_nml
+   gridtype     = 'rtm'
+   file_roff    = '/glade/p/cesm/cseg/inputdata/lnd/clm2/rtmdata/rdirc.05.061026'
+   file_ocn     = '/glade/p/cesm/cseg/mapping/grids/gx1v6_090205.nc'
+   file_ocn_coastal_mask = '/glade/p/cesm/cseg/mapping/grids/gx1v6_coast_170503.nc'
+   file_nn      = 'map_r05_to_gx1v6_coast_nearestdtos_170503.nc'
+   file_smooth  = 'map_gx1v6_coast_to_gx1v6_sm_e1000r300_170503.nc'
+   file_new     = 'map_r05_to_gx1v6_nnsm_e1000r300_170503.nc'
+   title        = 'runoff map: r05 -> gx1v6, nearest neighbor and smoothed'
+   eFold        = 1000000.0
+   rMax         =  300000.0
+   restrict_smooth_src_to_nn_dest = .true.
+   step1 = .true.
+   step2 = .true.
+   step3 = .true.
+/

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/map_rx1_to_gx1v6_nnsm_e1000r300.nml
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/map_rx1_to_gx1v6_nnsm_e1000r300.nml
@@ -1,0 +1,16 @@
+&input_nml
+   gridtype     = 'obs'
+   file_roff    = '/glade/p/cesm/cseg/inputdata/lnd/dlnd7/RX1/runoff.daitren.annual.090225.nc'
+   file_ocn     = '/glade/p/cesm/cseg/mapping/grids/gx1v6_090205.nc'
+   file_ocn_coastal_mask = '/glade/p/cesm/cseg/mapping/grids/gx1v6_coast_170503.nc'
+   file_nn      = 'map_rx1_to_gx1v6_coast_nearestdtos_170503.nc'
+   file_smooth  = 'map_gx1v6_coast_to_gx1v6_sm_e1000r300_170503a.nc'
+   file_new     = 'map_rx1_to_gx1v6_nnsm_e1000r300_170503.nc'
+   title        = 'runoff map: rx1 -> gx1v6, nearest neighbor and smoothed'
+   eFold        = 1000000.0
+   rMax         =  300000.0
+   restrict_smooth_src_to_nn_dest = .true.
+   step1 = .true.
+   step2 = .true.
+   step3 = .true.
+/


### PR DESCRIPTION
#1455 updated runoff maps for gx1v7 and gx3v7 grids, but some users may still be dependent on the gx1v6 grid and the old maps will trigger aborts if the Estuary Box Model is turned on in POP on the gx1v6 grid. This pull request provides new maps for that resolution to avoid errors, and also the namelists needed to generate these new maps with our runoff tool.

Test suite: Ran a B1850 compset out of cesm2_0_alpha06i, but using a branch that errors out if the EBM does not like where the runoff is coming in (a feature coming to the pop trunk soon); verified that the old default maps triggered this error, and that the new maps do not.
Test baseline:  N/A
Test namelist changes: N/A
Test status: changes answers when running with a gx1v6 resolution because runoff is mapped differently

Fixes: N/A

User interface changes: N/A

Code review: 
