### PR TITLE
Only warning for single dash

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1242,10 +1242,7 @@ def _check_for_invalid_args(args):
         if " " in arg or arg.startswith("--"):
             continue
         if arg.startswith("-") and len(arg) > 2:
-            if arg == "-value" or arg == "-noecho":
-                logger.warn("This argument is depricated, please use -%s"%arg)
-            else:
-                expect(False, "Invalid argument %s\n  Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options"%arg)
+            logger.warn("The %s argument is depricated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options"%arg)
 
 class SharedArea(object):
     """

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1242,7 +1242,7 @@ def _check_for_invalid_args(args):
         if " " in arg or arg.startswith("--"):
             continue
         if arg.startswith("-") and len(arg) > 2:
-            logger.warn("The %s argument is depricated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options"%arg)
+            print "WARNING: The %s argument is depricated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options\n"%arg
 
 class SharedArea(object):
     """

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1242,7 +1242,7 @@ def _check_for_invalid_args(args):
         if " " in arg or arg.startswith("--"):
             continue
         if arg.startswith("-") and len(arg) > 2:
-            print "WARNING: The %s argument is depricated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options\n"%arg
+            sys.stderr.write( "WARNING: The %s argument is depricated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options\n"%arg)
 
 class SharedArea(object):
     """

--- a/src/build_scripts/buildlib.gptl
+++ b/src/build_scripts/buildlib.gptl
@@ -6,7 +6,7 @@
 
 cd $CASEROOT # CASEROOT is always assumed to be an environment variable
 
-set CIMEROOT	= `./xmlquery  CIMEROOT -value `
+set CIMEROOT	= `./xmlquery  CIMEROOT --value `
 set GMAKE	= `./xmlquery  GMAKE	--value `
 
 # NOTE- (mv, 2015-01-02) SHAREDPATH is an environment variable set in


### PR DESCRIPTION
Do not error on using one dash with a multi-character option. Just print a warning to stderr and move on.  It will take time to remove single-dash usage in various buildnml and buildlib and other scripts.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes

User interface changes?:  Yes.  print a warning to stdout if single dash used with multi-char arg.

Code review: 
