### PR TITLE
Fix ACME config_machines.xml format

### DIFF
--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -542,8 +542,14 @@
         <command name="load">sems-env</command>
         <command name="load">sems-git</command>
         <command name="load">sems-python/2.7.9</command>
-        <command name="load" compiler="gnu">sems-gcc/5.3.0</command>
-        <command name="load" compiler="intel">sems-intel/16.0.3</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">sems-gcc/5.3.0</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">sems-intel/16.0.3</command>
+      </modules>
+      <modules>
         <command name="load">sems-openmpi/1.8.7</command>
         <command name="load">sems-cmake/2.8.12</command>
         <command name="load">sems-netcdf/4.3.2/parallel</command>
@@ -551,7 +557,9 @@
     </module_system>
     <environment_variables>
       <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
-      <env name="PNETCDFROOT" mpilib="!mpi-serial">$ENV{SEMS_NETCDF_ROOT}</env>
+    </environment_variables>
+    <environment_variables mpilib="!mpi-serial">
+      <env name="PNETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
     </environment_variables>
 </machine>
 
@@ -613,7 +621,9 @@
     </module_system>
     <environment_variables>
       <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
-      <env name="PNETCDFROOT" mpilib="!mpi-serial">$ENV{SEMS_NETCDF_ROOT}</env>
+    </environment_variables>
+    <environment_variables mpilib="!mpi-serial">
+      <env name="PNETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
     </environment_variables>
 </machine>
 
@@ -656,15 +666,25 @@
       <modules compiler="gnu">
 	<command name="add">+gcc-6.2.0</command>
 	<command name="add">+szip-2.1-gcc-6.2.0</command>
-	<command name="add" mpilib="!mpi-serial">+mpich-3.2-gcc-6.2.0</command>
+      </modules>
+      <modules mpilib="!mpi-serial">
+	<command name="add">+mpich-3.2-gcc-6.2.0</command>
+      </modules>
+      <modules>
 	<command name="add">+hdf5-1.8.16-gcc-6.2.0-mpich-3.2-parallel</command>
 	<command name="add">+netcdf-4.3.3.1c-4.2cxx-4.4.2f-parallel-gcc6.2.0-mpich3.2</command>
-	<command name="add" mpilib="!mpi-serial">+pnetcdf-1.6.1-gcc-6.2.0-mpich-3.2</command>
+      </modules>
+      <modules mpilib="!mpi-serial">
+	<command name="add">+pnetcdf-1.6.1-gcc-6.2.0-mpich-3.2</command>
+      </modules>
+      <modules>
 	<command name="add">+cmake-2.8.12</command>
       </modules>
     </module_system>
     <environment_variables>
       <env name="NETCDFROOT">$SHELL{dirname $(dirname $(which ncdump))}</env>
+    </environment_variables>
+    <environment_variables mpilib="!mpi-serial">
       <env name="PNETCDFROOT" mpilib="!mpi-serial">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
 </machine>
@@ -723,7 +743,11 @@
       <command name="load">sems-cmake</command>
       <command name="load">gnu/4.9.2</command>
       <command name="load">intel/intel-15.0.3.187</command>
-      <command name="load" mpilib="!mpi-serial">openmpi-intel/1.6</command>
+    </modules>
+    <modules mpilib="!mpi-serial">
+      <command name="load">openmpi-intel/1.6</command>
+    </modules>
+    <modules>
       <command name="load">libraries/intel-mkl-15.0.2.164</command>
       <!-- We want to use these modules but the segfault comes back if we do, maybe wait for new PIO? -->
       <!-- <command name="load" mpilib="!mpi-serial">sems-hdf5/1.8.12/parallel</command> -->
@@ -802,7 +826,11 @@
       <command name="load">sems-cmake</command>
       <command name="load">gnu/4.9.2</command>
       <command name="load">intel/intel-15.0.3.187</command>
-      <command name="load" mpilib="!mpi-serial">openmpi-intel/1.6</command>
+    </modules>
+    <modules mpilib="!mpi-serial">
+      <command name="load" >openmpi-intel/1.6</command>
+    </modules>
+    <modules>
       <command name="load">libraries/intel-mkl-15.0.2.164</command>
       <!-- We want to use these modules but the segfault comes back if we do, maybe wait for new PIO? -->
       <!-- <command name="load" mpilib="!mpi-serial">sems-hdf5/1.8.12/parallel</command> -->
@@ -988,16 +1016,16 @@
       </modules>
     </module_system>
     <environment_variables>
-      <env name="NETCDF_PATH">`which nc-config | xargs dirname | xargs dirname`</env>
-      <env name="PNETCDF_PATH" mpilib="!mpi-serial">`which pnetcdf_version | xargs dirname | xargs dirname`</env>
-    </environment_variables>
-    <environment_variables>
+      <env name="NETCDF_PATH">$SHELL{which nc-config | xargs dirname | xargs dirname}</env>
       <env name="OMP_STACKSIZE">256M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
       <env name="OMP_MAX_ACTIVE_LEVELS">1</env>
       <env name="KMP_HOT_TEAMS_MODE">1</env>
       <env name="KMP_HOT_TEAMS_MAX_LEVEL">1</env>
+    </environment_variables>
+    <environment_variables mpilib="!mpi-serial">
+      <env name="PNETCDF_PATH">$SHELL{which pnetcdf_version | xargs dirname | xargs dirname}</env>
     </environment_variables>
 </machine>
 
@@ -1502,14 +1530,6 @@
         <env name="MPICH_VERSION_DISPLAY">1</env>
         <env name="MPICH_CPUMASK_DISPLAY">1</env>
         <env name="MPSTKZ">128M</env>
-	<env name="NETCDFROOT" compiler="pgi">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
-	<env name="PNETCDFROOT" compiler="pgi" mpilib="!mpi-serial">/opt/cray/parallel-netcdf/1.7.0/PGI/15.3</env>
-	<env name="NETCDFROOT" compiler="pgiacc">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
-	<env name="PNETCDFROOT" compiler="pgiacc" mpilib="!mpi-serial">/opt/cray/parallel-netcdf/1.7.0/PGI/15.3</env>
-	<env name="NETCDFROOT" compiler="intel">/opt/cray/netcdf-hdf5parallel/4.4.1.1/INTEL/15.0/</env>
-	<env name="PNETCDFROOT" compiler="intel" mpilib="!mpi-serial">/opt/cray/parallel-netcdf/1.7.0/INTEL/15.0</env>
-	<env name="NETCDFROOT" compiler="cray">/opt/cray/netcdf-hdf5parallel/4.4.1.1/CRAY/8.3/</env>
-	<env name="PNETCDFROOT" compiler="cray" mpilib="!mpi-serial">/opt/cray/parallel-netcdf/1.7.0/CRAY/8.3</env>
         <env name="OMP_STACKSIZE">128M</env>
       </environment_variables>
 
@@ -1518,14 +1538,40 @@
         <!-- NOTE(wjs, 2015-03-12) The following line is needed for bit-for-bit reproducibility -->
         <env name="CRAY_CPU_TARGET">istanbul</env>
         <env name="CRAY_CUDA_MPS">1</env>
+	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
       </environment_variables>
-      <environment_variables compiler="pgi">
+
+      <environment_variables compiler="pgiacc" mpilib="!mpi-serial">
+	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/PGI/15.3</env>
+      </environment_variables>
+
+      <environment_variables compiler="pgi" >
         <!-- NOTE(wjs, 2015-03-12) The following line is needed for bit-for-bit reproducibility -->
         <env name="CRAY_CPU_TARGET">istanbul</env>
+	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/PGI/15.3/</env>
       </environment_variables>
+
+      <environment_variables compiler="pgi" mpilib="!mpi-serial">
+	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/PGI/15.3</env>
+      </environment_variables>
+
       <environment_variables compiler="intel">
         <env name="CRAYPE_LINK_TYPE">dynamic</env>
+	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/INTEL/15.0/</env>
       </environment_variables>
+
+      <environment_variables compiler="intel" mpilib="!mpi-serial">
+	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/INTEL/15.0</env>
+      </environment_variables>
+
+      <environment_variables compiler="cray">
+	<env name="NETCDFROOT">/opt/cray/netcdf-hdf5parallel/4.4.1.1/CRAY/8.3/</env>
+      </environment_variables>
+
+      <environment_variables compiler="cray" mpilib="!mpi-serial">
+	<env name="PNETCDFROOT">/opt/cray/parallel-netcdf/1.7.0/CRAY/8.3</env>
+      </environment_variables>
+
     </module_system>
 </machine>
 
@@ -1615,7 +1661,7 @@
 	     <!-- This increases the stack size, which is necessary
 		  for CICE to run threaded on this machine -->
 	     <env name="OMP_STACKSIZE">64M</env>
-	     
+
 	   </environment_variables>
 	 </module_system>
 </machine>
@@ -1644,7 +1690,7 @@
 		<cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
 		<cmd_path lang="sh">module</cmd_path>
 		<cmd_path lang="csh">module</cmd_path>
-	
+
 		<modules>
 			<command name="purge"/>
 			<command name="use">/usr/projects/climate/SHARED_CLIMATE/modulefiles/all</command>


### PR DESCRIPTION
So that it passes the XSD format.

Basically, individual module commands and environment variables do not
support attributes.

Test suite: cime_tiny
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: None

Code review: @jedwards4b 
