### PR TITLE
New CISM mapping files

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1629,66 +1629,66 @@
     <!-- ====================  -->
 
     <gridmap lnd_grid="0.9x1.25" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland4km_aave.161223.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland4km_blin.161223.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.9x1.25_aave.161223.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.9x1.25_aave.161223.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland4km_aave.170429.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland4km_blin.170429.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.9x1.25_aave.170429.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.9x1.25_aave.170429.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="1.9x2.5" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland4km_aave.161223.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland4km_blin.161223.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv1.9x2.5_aave.161223.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv1.9x2.5_aave.161223.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland4km_aave.170429.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland4km_blin.170429.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv1.9x2.5_aave.170429.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv1.9x2.5_aave.170429.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="T31" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland4km_aave.161223.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland4km_blin.161223.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_T31_aave.161223.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_T31_aave.161223.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland4km_aave.170429.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland4km_blin.170429.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_T31_aave.170429.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_T31_aave.170429.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="360x720cru" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland4km_aave.161223.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland4km_blin.161223.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_360x720_aave.161223.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_360x720_aave.161223.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland4km_aave.170429.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland4km_blin.170429.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_360x720_aave.170429.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_360x720_aave.170429.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="10x15" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland4km_aave.161223.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland4km_blin.161223.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv10x15_aave.161223.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv10x15_aave.161223.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland4km_aave.170429.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland4km_blin.170429.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv10x15_aave.170429.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv10x15_aave.170429.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="4x5" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland4km_aave.161223.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland4km_blin.161223.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv4x5_aave.161223.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv4x5_aave.161223.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland4km_aave.170429.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland4km_blin.170429.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv4x5_aave.170429.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv4x5_aave.170429.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne16np4" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland4km_aave.161223.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland4km_blin.161223.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne16np4_aave.161223.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne16np4_aave.161223.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland4km_aave.170429.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland4km_blin.170429.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne16np4_aave.170429.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne16np4_aave.170429.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne30np4" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland4km_aave.161223.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland4km_blin.161223.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30np4_aave.161223.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30np4_aave.161223.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland4km_aave.170429.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland4km_blin.170429.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30np4_aave.170429.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30np4_aave.170429.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne120np4" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland4km_aave.161223.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland4km_blin.161223.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne120np4_aave.161223.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne120np4_aave.161223.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland4km_aave.170429.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland4km_blin.170429.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne120np4_aave.170429.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne120np4_aave.170429.nc</map>
     </gridmap>
 
     <!-- ====================  -->
@@ -1837,27 +1837,33 @@
     <!-- ======================================================== -->
 
     <gridmap ocn_grid="gx1v6" glc_grid="gland4" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx1v6_nnsm_e1000r300_161227.nc</map>
+      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx1v6_nnsm_e1000r300_170501.nc</map>
     </gridmap>
     <gridmap ocn_grid="gx1v7" glc_grid="gland4" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx1v7_nnsm_e1000r300_170111.nc</map>
+      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx1v7_nnsm_e1000r300_170501.nc</map>
     </gridmap>
     <gridmap ocn_grid="gx3v7" glc_grid="gland4" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx3v7_nnsm_e1000r300_161227.nc</map>
+      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx3v7_nnsm_e1000r300_170501.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="gx1v6" glc_grid="gland5UM" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx1v6_nnsm_e1000r300_150512.nc</map>
+      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx1v6_nnsm_e1000r300_170501.nc</map>
+    </gridmap>
+    <gridmap ocn_grid="gx1v7" glc_grid="gland5UM" >
+      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx1v7_nnsm_e1000r300_170501.nc</map>
     </gridmap>
     <gridmap ocn_grid="gx3v7" glc_grid="gland5UM" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx3v7_nnsm_e1000r300_150514.nc</map>
+      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx3v7_nnsm_e1000r300_170501.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="gx1v6" glc_grid="gland20" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx1v6_nnsm_e1000r300_150512.nc</map>
+      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx1v6_nnsm_e1000r300_170501.nc</map>
+    </gridmap>
+    <gridmap ocn_grid="gx1v7" glc_grid="gland20" >
+      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx1v7_nnsm_e1000r300_170501.nc</map>
     </gridmap>
     <gridmap ocn_grid="gx3v7" glc_grid="gland20" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx3v7_nnsm_e1000r300_150514.nc</map>
+      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx3v7_nnsm_e1000r300_170501.nc</map>
     </gridmap>
 
   </gridmaps>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -146,14 +146,6 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="T31_g37_gl10" compset="_CISM">
-      <grid name="atm">T31</grid>
-      <grid name="lnd">T31</grid>
-      <grid name="ocnice">gx3v7</grid>
-      <grid name="glc">gland10</grid>
-      <mask>gx3v7</mask>
-    </model_grid>
-
     <model_grid alias="T31_g37_gl20" compset="_CISM">
       <grid name="atm">T31</grid>
       <grid name="lnd">T31</grid>
@@ -311,22 +303,6 @@
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v7</grid>
       <grid name="glc">gland4</grid>
-      <mask>gx1v7</mask>
-    </model_grid>
-
-    <model_grid alias="f09_g16_gl10" compset="_CISM">
-      <grid name="atm">0.9x1.25</grid>
-      <grid name="lnd">0.9x1.25</grid>
-      <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gland10</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="f09_g17_gl10" compset="_CISM">
-      <grid name="atm">0.9x1.25</grid>
-      <grid name="lnd">0.9x1.25</grid>
-      <grid name="ocnice">gx1v7</grid>
-      <grid name="glc">gland10</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
@@ -511,30 +487,6 @@
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
-      <mask>gx1v7</mask>
-    </model_grid>
-
-    <model_grid alias="f19_f19_gl10" compset="_CISM" not_compset="_POP">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">1.9x2.5</grid>
-      <grid name="glc">gland10</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="f19_f19_gl10_mg16" compset="_CISM" not_compset="_POP">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">1.9x2.5</grid>
-      <grid name="glc">gland10</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="f19_f19_gl10_mg17" compset="_CISM" not_compset="_POP">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">1.9x2.5</grid>
-      <grid name="glc">gland10</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
@@ -1146,16 +1098,6 @@
       <desc>20-km Greenland grid</desc>
     </domain>
 
-    <domain name="gland10">
-      <nx>151</nx> <ny>281</ny>
-      <desc>10-km Greenland grid</desc>
-    </domain>
-
-    <domain name="gland5">
-      <nx>301</nx> <ny>561</ny>
-      <desc>5-km Greenland grid (OLD VERSION: Generally use gland5UM instead)</desc>
-    </domain>
-
     <domain name="gland5UM">
       <nx>301</nx> <ny>561</ny>
       <desc>5-km Greenland grid (new version from U. Montana)</desc>
@@ -1750,76 +1692,7 @@
     </gridmap>
 
     <!-- ====================  -->
-    <!-- GLC: gland5           -->
-    <!-- Use same mapping files for gland5 and gland5UM, because they use the same grids -->
-    <!-- ====================  -->
-
-    <gridmap lnd_grid="0.9x1.25" glc_grid="gland5" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland5km_aave.150514.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland5km_blin.150514.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_fv0.9x1.25_aave.150514.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_fv0.9x1.25_aave.150514.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="1.9x2.5" glc_grid="gland5" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland5km_aave.150514.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland5km_blin.150514.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_fv1.9x2.5_aave.150514.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_fv1.9x2.5_aave.150514.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="T31" glc_grid="gland5" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland5km_aave.150514.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland5km_blin.150514.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_T31_aave.150514.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_T31_aave.150514.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="360x720cru" glc_grid="gland5" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland5km_aave.160329.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland5km_blin.160329.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_360x720_aave.160329.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_360x720_aave.160329.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="10x15" glc_grid="gland5" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland5km_aave.160329.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland5km_blin.160329.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_fv10x15_aave.160329.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_fv10x15_aave.160329.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="4x5" glc_grid="gland5" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland5km_aave.160329.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland5km_blin.160329.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_fv4x5_aave.160329.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_fv4x5_aave.160329.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="ne16np4" glc_grid="gland5" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland5km_aave.160329.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland5km_blin.160329.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_ne16np4_aave.160329.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_ne16np4_aave.160329.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="ne30np4" glc_grid="gland5" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland5km_aave.160329.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland5km_blin.160329.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_ne30np4_aave.160329.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_ne30np4_aave.160329.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="ne120np4" glc_grid="gland5" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland5km_aave.160329.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland5km_blin.160329.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_ne120np4_aave.160329.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_ne120np4_aave.160329.nc</map>
-    </gridmap>
-
-    <!-- ====================  -->
     <!-- GLC: gland5UM         -->
-    <!-- Use same mapping files for gland5 and gland5UM, because they use the same grids -->
     <!-- ====================  -->
 
     <gridmap lnd_grid="0.9x1.25" glc_grid="gland5UM" >
@@ -1883,31 +1756,6 @@
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland5km_blin.160329.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_ne120np4_aave.160329.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland5km/map_gland5km_TO_ne120np4_aave.160329.nc</map>
-    </gridmap>
-
-    <!-- ====================  -->
-    <!-- GLC: gland10          -->
-    <!-- ====================  -->
-
-    <gridmap lnd_grid="0.9x1.25" glc_grid="gland10" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland10km_aave.150514.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland10km_blin.150514.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland10km/map_gland10km_TO_fv0.9x1.25_aave.150514.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland10km/map_gland10km_TO_fv0.9x1.25_aave.150514.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="1.9x2.5" glc_grid="gland10" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland10km_aave.150514.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland10km_blin.150514.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland10km/map_gland10km_TO_fv1.9x2.5_aave.150514.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland10km/map_gland10km_TO_fv1.9x2.5_aave.150514.nc</map>
-    </gridmap>
-
-    <gridmap lnd_grid="T31" glc_grid="gland10" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland10km_aave.150514.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland10km_blin.150514.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland10km/map_gland10km_TO_T31_aave.150514.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland10km/map_gland10km_TO_T31_aave.150514.nc</map>
     </gridmap>
 
     <!-- ====================  -->
@@ -1998,28 +1846,11 @@
       <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx3v7_nnsm_e1000r300_161227.nc</map>
     </gridmap>
 
-    <gridmap ocn_grid="gx1v6" glc_grid="gland5" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx1v6_nnsm_e1000r300_150512.nc</map>
-    </gridmap>
-    <gridmap ocn_grid="gx1v7" glc_grid="gland5" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx1v7_nnsm_e1000r300_161012.nc</map>
-    </gridmap>
-    <gridmap ocn_grid="gx3v7" glc_grid="gland5" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx3v7_nnsm_e1000r300_150514.nc</map>
-    </gridmap>
-
     <gridmap ocn_grid="gx1v6" glc_grid="gland5UM" >
       <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx1v6_nnsm_e1000r300_150512.nc</map>
     </gridmap>
     <gridmap ocn_grid="gx3v7" glc_grid="gland5UM" >
       <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland5km/map_gland5km_to_gx3v7_nnsm_e1000r300_150514.nc</map>
-    </gridmap>
-
-    <gridmap ocn_grid="gx1v6" glc_grid="gland10" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland10km/map_gland10km_to_gx1v6_nnsm_e1000r300_150512.nc</map>
-    </gridmap>
-    <gridmap ocn_grid="gx3v7" glc_grid="gland10" >
-      <map name="GLC2OCN_RMAPNAME">cpl/gridmaps/gland10km/map_gland10km_to_gx3v7_nnsm_e1000r300_150514.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="gx1v6" glc_grid="gland20" >


### PR DESCRIPTION
This depends on cism2_1_33, which I have currently slated for cesm2_0_alpha06l (though I'm happy to move it to wherever is appropriate). So this cime merge should be timed to come into the same alpha tag as cism2_1_33.**

1. Removes unnecessary CISM grids (gland5: use gland5UM instead;
   gland10: use gland20 instead)

2. New lnd <-> glc mapping files for the gland4 grid, since we are now
   using a new, slightly expanded gland4 grid

3. All new glc -> ocn mapping files. These were needed for the gland4
   grid because of the new grid definition. For other resolutions, I
   regenerated these mapping files with the recently-fixed version of
   the runoff mapping tool.

This depends on cism2_1_33, because the gland4 mapping files need to
agree with the version of the gland4 grid used in CISM.

Test suite: aux_glc test suite on yellowstone and hobart, ran out of
            cesm2_0_alpha06g with cism at cism2_1_33

Also ran the following, without baseline comparisons (ran the g17
tests out of the latest CESM alpha sandbox with updated cism and
cime):

    SMS_D.f09_g16_gl4.B1850C5L45BGCRG.yellowstone_intel.cism-test_coupling
    SMS_D.f09_g17_gl4.B1850C5L45BGCRG.yellowstone_intel.cism-test_coupling
    SMS_D.T31_g37_gl4.B1850C5L45BGCRG.yellowstone_intel.cism-test_coupling
    SMS_D.T31_g37_gl20.B1850C5L45BGCRG.yellowstone_intel.cism-test_coupling
    SMS_D.f09_g16_gl5.B1850C5L45BGCRG1.yellowstone_intel.cism-test_coupling
    SMS_D.f09_g17_gl5.B1850C5L45BGCRG1.yellowstone_intel.cism-test_coupling
    SMS_D.T31_g37_gl5.B1850C5L45BGCRG1.yellowstone_intel.cism-test_coupling

Test baseline: cism2_1_32
Test namelist changes: Changes lnd <-> glc and glc -> ocn mapping files
                       in seq_maps.rc
Test status: roundoff
- For all CISM2 cases at gland4 resolution (the default resolution),
  there are roundoff-level changes in the glc -> lnd mapping files, and
  so roundoff-level changes in the tests
- There are a few CLM grid cells with greater-than-roundoff-level
  differences in x2l_Sg_icemask and related fields, although this
  doesn't matter in practice
- With 2-way CISM coupling (cases *without* %NOEVOLVE), I expect greater
  than roundoff-level changes in the runoff fields after remapping to
  the ocean, because we're using new mapping files for ALL GRIDS in this
  respect, to incorporate a fix to the runoff mapping tool.

Fixes #1262

User interface changes?: none

Code review: 

cc @mvertens 