### PR TITLE
Make alternative implementation for ERS

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -49,6 +49,13 @@ ERS    exact restart from startup (default 6 days + 5 days)
        if $IOP_ON is set then suffix is rest_iop
        compare component history files ".base" and ".rest" at day 11
 
+ERS2    exact restart from startup (default 6 days + 5 days)
+       do an 11 day initial test without making restarts     (suffix: base)
+       if $IOP_ON is set then suffix is base_iop
+       do an 11 day restart test stopping at day 6 with a restart, then resuming from restart at day 6 (suffix: rest)
+       if $IOP_ON is set then suffix is rest_iop
+       compare component history files ".base" and ".rest" at day 11
+
 ERP    pes counts hybrid (open-MP/MPI) restart bfb test from startup, default 6 days + 5 days (previousy PER)
        initial pes set up out of the box
        do an 11 day initial test - write a restart at day 6     (suffix base)
@@ -248,6 +255,19 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
   </test>
 
   <test NAME="ERS">
+    <DESC>exact restart from startup, default 6 days + 5 days</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <STOP_OPTION>ndays</STOP_OPTION>
+    <STOP_N>11</STOP_N>
+    <REST_N>$STOP_N / 2 + 1</REST_N>
+    <REST_OPTION>$STOP_OPTION</REST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+  </test>
+
+  <test NAME="ERS2">
     <DESC>exact restart from startup, default 6 days + 5 days</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <STOP_OPTION>ndays</STOP_OPTION>

--- a/scripts/lib/CIME/SystemTests/ers2.py
+++ b/scripts/lib/CIME/SystemTests/ers2.py
@@ -1,0 +1,60 @@
+"""
+CIME restart test 2  This class inherits from SystemTestsCommon
+"""
+from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.system_tests_common import SystemTestsCommon
+
+logger = logging.getLogger(__name__)
+
+class ERS2(SystemTestsCommon):
+
+    def __init__(self, case):
+        """
+        initialize an object interface to the ERS2 system test
+        """
+        SystemTestsCommon.__init__(self, case)
+
+    def _ers2_first_phase(self):
+        stop_n      = self._case.get_value("STOP_N")
+        stop_option = self._case.get_value("STOP_OPTION")
+        rest_n      = self._case.get_value("REST_N")
+
+        # Don't need restarts for first run
+        self._case.set_value("REST_OPTION","never")
+
+        expect(stop_n > 0, "Bad STOP_N: %d" % stop_n)
+        expect(stop_n > 2, "ERROR: stop_n value %d too short"%stop_n)
+
+        logger.info("doing an %s %s initial test with restart file at %s %s"
+                    %(str(stop_n), stop_option, str(rest_n), stop_option))
+        self.run_indv()
+
+    def _ers2_second_phase(self):
+        stop_n      = self._case.get_value("STOP_N")
+        stop_option = self._case.get_value("STOP_OPTION")
+
+        rest_n = stop_n/2 + 1
+        stop_new = rest_n
+
+        self._case.set_value("REST_OPTION",stop_option)
+        self._case.set_value("STOP_N", stop_new)
+        self._case.flush()
+        logger.info("doing first part %s %s restart test"
+                    %(str(stop_new), stop_option))
+        self.run_indv(suffix="intermediate")
+
+        stop_new = stop_n - rest_n
+        self._case.set_value("STOP_N", stop_new)
+        self._case.set_value("CONTINUE_RUN", True)
+        self._case.set_value("REST_OPTION","never")
+
+        logger.info("doing second part %s %s restart test"
+                    %(str(stop_new), stop_option))
+        self.run_indv(suffix="rest")
+
+        # Compare restart file
+        self._component_compare_test("base", "rest")
+
+    def run_phase(self):
+        self._ers2_first_phase()
+        self._ers2_second_phase()


### PR DESCRIPTION
Creatively named ERS2. First phase does no restarts. Second phase does two runs,
the first run makes a restart file and stops, second run resumes and then compares
to the first phase.

Test suite: ERS2 test, code checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1244 

User interface changes?: new ERS2 test type

Code review: @jedwards4b @mnlevy1981 
