### PR TITLE
Fix blues batchq settings

### DIFF
--- a/config/acme/machines/config_batch.xml
+++ b/config/acme/machines/config_batch.xml
@@ -159,7 +159,7 @@
       </directives>
       <queues>
 	<queue walltimemax="01:00:00" jobmin="1" jobmax="64" strict="true">shared</queue>
-	<queue walltimemax="03:00:00" jobmin="64" jobmax="4096" default="true">batch</queue>
+	<queue walltimemax="03:00:00" jobmin="1" jobmax="4096" default="true">batch</queue>
       </queues>
     </batch_system>
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -199,6 +199,7 @@ class EnvBatch(EnvBase):
             if force_queue:
                 if not self.queue_meets_spec(force_queue, task_count, walltime=walltime, job=job):
                     logger.warning("WARNING: User-requested queue '%s' does not meet requirements for job '%s'" % (force_queue, job))
+                queue = force_queue
             else:
                 queue = self.select_best_queue(task_count, walltime=walltime, job=job)
                 if queue is None and walltime is not None:


### PR DESCRIPTION
Fix "batch" queue job settings on blues so that long jobs with
less number of procs (> 1hr walltime + < 64 procs) fit into 
one of the queues.

Also a minor fix to make sure that the "--queue=" options works
with the create_newcase command.

Test suite: X case
Test baseline: 
Test namelist changes: None
Test status: bit for bit

Fixes #1483 

User interface changes?: None

Code review: @jgfouca 
