### PR TITLE
fix ccsm co2 ppmv for #863

### DIFF
--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -56,8 +56,6 @@ class Grids(GenericXML):
         if  levmatch:
             atmnlev = levmatch.group(2)
             name = levmatch.group(1)+levmatch.group(3)
-        else:
-            atmnlev = None
 
         #mechanism to specify lnd levels
         lndlevregex = re.compile(r"(.*_)([^_]+)z(\d+)(_[^m].*)$")
@@ -65,8 +63,6 @@ class Grids(GenericXML):
         if  levmatch:
             lndnlev = levmatch.group(3)
             name = levmatch.group(1)+levmatch.group(2)+levmatch.group(4)
-        else:
-            lndnlev = None
 
         # determine component_grids dictionary and grid longname
         lname, component_grids = self._read_config_grids(name, compset, atmnlev, lndnlev)
@@ -209,14 +205,15 @@ class Grids(GenericXML):
             else:
                 lname = prefix[component_gridname]
             if model_grid[component_gridname] is not None:
-                if component_gridname == 'atm':
-                    if atmnlev is not None:
-                        lname += model_grid[component_gridname] + "z" + atmnlev
-                elif component_gridname == 'lnd':
-                    if lndnlev is not None:
-                        lname += model_grid[component_gridname] + "z" + lndnlev
-                else:
-                    lname += model_grid[component_gridname]
+                lname += model_grid[component_gridname]
+                if component_gridname == 'atm' and atmnlev is not None:
+                    if not ("a%null" in lname):
+                        lname += "z" + atmnlev
+
+                elif component_gridname == 'lnd' and lndnlev is not None:
+                    if not ("l%null" in lname):
+                        lname += "z" + lndnlev
+
             else:
                 lname += 'null'
         component_grids = self._get_component_grids_from_longname(lname)
@@ -240,10 +237,10 @@ class Grids(GenericXML):
 
             # Determine grid name with no nlev suffix if there is one
             grid_name_nonlev = grid_name
-            levmatch = re.match(r"([^_]+)z(\d+)(.*)$", grid_name)
+            levmatch = re.match(atmlevregex, grid_name)
             if  levmatch:
                 grid_name_nonlev = levmatch.group(1)+levmatch.group(3)
-            levmatch = re.match(r"(.*_)([^_]+)z(\d+)(.*)$", grid_name)
+            levmatch = re.match(lndlevregex, grid_name)
             if  levmatch:
                 grid_name_nonlev = levmatch.group(1)+levmatch.group(2)+levmatch.group(4)
 

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -56,6 +56,8 @@ class Grids(GenericXML):
         if  levmatch:
             atmnlev = levmatch.group(2)
             name = levmatch.group(1)+levmatch.group(3)
+        else:
+            atmnlev = None
 
         #mechanism to specify lnd levels
         lndlevregex = re.compile(r"(.*_)([^_]+)z(\d+)(_[^m].*)$")
@@ -63,6 +65,8 @@ class Grids(GenericXML):
         if  levmatch:
             lndnlev = levmatch.group(3)
             name = levmatch.group(1)+levmatch.group(2)+levmatch.group(4)
+        else:
+            lndnlev = None
 
         # determine component_grids dictionary and grid longname
         lname, component_grids = self._read_config_grids(name, compset, atmnlev, lndnlev)
@@ -205,15 +209,14 @@ class Grids(GenericXML):
             else:
                 lname = prefix[component_gridname]
             if model_grid[component_gridname] is not None:
-                lname += model_grid[component_gridname]
-                if component_gridname == 'atm' and atmnlev is not None:
-                    if not ("a%null" in lname):
-                        lname += "z" + atmnlev
-
-                elif component_gridname == 'lnd' and lndnlev is not None:
-                    if not ("l%null" in lname):
-                        lname += "z" + lndnlev
-
+                if component_gridname == 'atm':
+                    if atmnlev is not None:
+                        lname += model_grid[component_gridname] + "z" + atmnlev
+                elif component_gridname == 'lnd':
+                    if lndnlev is not None:
+                        lname += model_grid[component_gridname] + "z" + lndnlev
+                else:
+                    lname += model_grid[component_gridname]
             else:
                 lname += 'null'
         component_grids = self._get_component_grids_from_longname(lname)
@@ -237,10 +240,10 @@ class Grids(GenericXML):
 
             # Determine grid name with no nlev suffix if there is one
             grid_name_nonlev = grid_name
-            levmatch = re.match(atmlevregex, grid_name)
+            levmatch = re.match(r"([^_]+)z(\d+)(.*)$", grid_name)
             if  levmatch:
                 grid_name_nonlev = levmatch.group(1)+levmatch.group(3)
-            levmatch = re.match(lndlevregex, grid_name)
+            levmatch = re.match(r"(.*_)([^_]+)z(\d+)(.*)$", grid_name)
             if  levmatch:
                 grid_name_nonlev = levmatch.group(1)+levmatch.group(2)+levmatch.group(4)
 

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -384,58 +384,6 @@
   <entry id="CCSM_CO2_PPMV">
     <type>real</type>
     <valid_values></valid_values>
-    <default_value>379.000</default_value>
-    <values>
-      <value compset="^1850"                     >284.7</value>
-      <value compset="^HIST.+BGC%BPRP"           >284.7</value>
-      <value compset="^HIST_CAM4%FCHM"           >0.000001</value>
-      <value compset="^2000"                     >367.0</value>
-      <value compset="^1850.+DATM%NYF"           >379.000</value>
-      <value compset="^1850.+DATM%NYF.*_POP2%ECO">284.7</value>
-      <value compset="^2000.+DATM%NYF"           >379.000</value>
-      <value compset="^2000.+DATM%IAF"           >379.000</value>
-      <value compset="^HIST.+DATM"               >367.0</value>
-      <value compset="^4804.+DATM"               >367.0</value>
-      <value compset="^RCP2.+DATM"               >367.0</value>
-      <value compset="^RCP4.+DATM"               >367.0</value>
-      <value compset="^RCP6.+DATM"               >367.0</value>
-      <value compset="^RCP8.+DATM"               >367.0</value>
-      <value compset="^2000.+XATM"               >379.000</value>
-      <value compset="^HIST.+CAM"                >0.000001</value>
-      <value compset="^5505.+CAM"                >0.000001</value>
-      <value compset="^RCP2.+CAM"                >0.000001</value>
-      <value compset="^RCP4.+CAM"                >0.000001</value>
-      <value compset="^RCP6.+CAM"                >0.000001</value>
-      <value compset="^RCP8.+CAM"                >0.000001</value>
-      <value compset="^2013.+CAM"                >0.000001</value>
-      <value compset="^SDYN.+CAM"                >0.000001</value>
-      <value compset="^AMIP.+CAM"                >0.000001</value>
-      <value compset="^AR95"                     >368.9</value>
-      <value compset="^AR97"                     >368.9</value>
-      <value compset="^2003"                     >367.0</value>
-      <!-- Override values based on CAM (WACCM) chemistry -->
-      <value compset="CAM[456]0%W"               >0.000001</value>
-      <value compset="CAM[456]0%SVBS"            >0.000001</value>
-      <value compset="CAM[456]0%TMOZ"            >0.000001</value>
-      <!-- Mariana's fix to allow isotopes to get the proper CO2 value -->
-      <value compset="CAM..%WISOall"             >284.7</value>
-      <value compset="^2000.+CAM[45]%WCSC"       >368.9</value>
-      <value compset="^2000.+CAM[45]%MOZM"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%MMOS"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%TMOZ"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%SMA3"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%SMA7"       >0.000001</value>
-      <value compset="^2000.+CAM[45]%SSOA"       >0.000001</value>
-    </values>
-    <group>run_co2</group>
-    <file>env_run.xml</file>
-    <desc>This set the namelist values of CO2 ppmv for CAM and CLM. This variables is
-      introduced to coordinate this value among multiple components.</desc>
-  </entry>
-
-  <entry id="CO2_TYPE_COSTANT_VALUE">
-    <type>real</type>
-    <valid_values></valid_values>
     <default_value>284.7</default_value>
     <values>
       <value compset="^2000">367.0</value>
@@ -444,8 +392,9 @@
     <group>run_co2</group>
     <file>env_run.xml</file>
     <desc>
-      Mechanism for setting the CO2 value in ppmv for CLM if
-      CLM_CO2_TYPE is constant POP if OCN_CO2_TYPE is constant.
+      Mechanism for setting the CO2 value in ppmv for 
+      CLM if CLM_CO2_TYPE is constant or for 
+      POP if OCN_CO2_TYPE is constant.
     </desc>
   </entry>
 

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -387,7 +387,6 @@
     <default_value>284.7</default_value>
     <values>
       <value compset="^2000">367.0</value>
-      <value compset="^4804">367.0</value>
     </values>
     <group>run_co2</group>
     <file>env_run.xml</file>

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -387,6 +387,7 @@
     <default_value>284.7</default_value>
     <values>
       <value compset="^2000">367.0</value>
+      <value compset="DATM.*POP2%ECO">284.7</value>
     </values>
     <group>run_co2</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Simplify settings in CCSM_CO2_PPMV in config_components_cesm.xml

Note that this PR ONLY effects CESM compsets.
I have decided to implement a compromise approach to remove the need to modify CLM and POP namelist generation scripts. This PR removes the CO2_TYPE_COSTANT_VALUE xml variable and simplifying the CCSM_CO2_PPVM variable in CIME to be the following:

  <entry id="CCSM_CO2_PPMV">
    <type>real</type>
    <valid_values></valid_values>
    <default_value>284.7</default_value>
    <values>
      <value compset="^2000">367.0</value>
      <value compset="^4804">367.0</value>
    </values>
    <group>run_co2</group>
    <file>env_run.xml</file>
    <desc>
      Mechanism for setting the CO2 value in ppmv for 
      CLM if CLM_CO2_TYPE is constant or for 
      POP if OCN_CO2_TYPE is constant.
    </desc>
  </entry>

This accomplishes the main goal of #893 but also provides backwards compatibility and does not require either a new CLM or POP tag and accomplish much of the cleanup that we wanted. I only drawback is keeping the old name of CCSM_CO2_PPMV - but the documentation for it now reflects what it is meant for. And this will not required any new CLM or POP tags. 

Test suite: scripts_regression_tests
Test baseline: The following namelists comparisons were also validated:
    SSP_Ld10.f19_g16.I1850CLM45BGC.yellowstone_pgi.clm-rtmColdSSP
    ERP_D.f10_f10.IHISTCLM50BGC.yellowstone_pgi.clm-decStart
    SMS_Lm1_D.f10_f10.ICLM45BGCCROP.yellowstone_intel.clm-snowlayers_3_monthly
    ERS_Ld5.T62_g16.GECO.yellowstone_intel.pop-ecosys_5day_tavg
Test namelist changes: None
Test status: bit for bit

Fixes #863 
User interface changes?: None
Code review: 
