### PR TITLE
Fix bug where file drv_flds_in wasn't being closed after being opened.

### DIFF
--- a/src/drivers/mct/shr/seq_drydep_mod.F90
+++ b/src/drivers/mct/shr/seq_drydep_mod.F90
@@ -566,10 +566,10 @@ CONTAINS
                    call shr_sys_abort( subName//'ERROR: encountered end-of-file on namelist read' )
                 endif
              end do
-             close( unitn )
           else
              write(s_logunit,*) 'seq_drydep_read:  no drydep_inparm namelist found in ',NLFilename
           endif
+          close( unitn )
           call shr_file_freeUnit( unitn )
        end if
     end if

--- a/src/drivers/mct/shr/shr_ndep_mod.F90
+++ b/src/drivers/mct/shr/shr_ndep_mod.F90
@@ -87,10 +87,10 @@ CONTAINS
                    call shr_sys_abort( subName//'ERROR: encountered end-of-file on namelist read' )
                 endif
              end do
-             close( unitn )
           else
              write(s_logunit,*) 'shr_ndep_readnl:  no ndep_inparm namelist found in ',NLFilename
           endif
+          close( unitn )
           call shr_file_freeUnit( unitn )
        end if
     end if


### PR DESCRIPTION
A file close() statement that goes along with an file open() statement, was inside an if statement.  
This was causing the file to be open multi times, without it being closed.  This was throwing an error
for pgi and gnu.  Intel and nag didn't catch this.

Test suite: ./create_test cime_developer
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #1489

User interface changes?:

Code review:
