### PR TITLE
Pesfile usage

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -76,7 +76,8 @@ OR
     parser.add_argument("--pesfile",
                         help="Only used and required for --user-compset argument."
                         "Full pathname of the pes specification file"
-                        "This argument is required if --user-compset is True")
+                        "This argument is required if --user-compset is True"
+                        "The file can follow either the config_pes.xml or the env_mach_pes.xml format")
 
     parser.add_argument("--user-grid", action="store_true",
                         help="If set, then the -grid argument is treated as a user specified grid."

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -34,7 +34,7 @@ class EnvMachPes(EnvBase):
         ''' Find the maximum number of openmp threads for any component in the case '''
         max_threads = 1
         for comp in comp_classes:
-            threads = self.get_value("NTHRDS_%s"%comp)
+            threads = self.get_value("NTHRDS",attribute={"component":comp})
             expect(threads is not None, "Error no thread count found for component class %s"%comp)
             if threads > max_threads:
                 max_threads = threads
@@ -44,6 +44,7 @@ class EnvMachPes(EnvBase):
         """
         figure out the value of COST_PES which is the pe value used to estimate model cost
         """
+        expect(totaltasks > 0,"totaltasks > 0 expected totaltasks = %s"%totaltasks)
         pespn = self.get_value("PES_PER_NODE")
         num_nodes, spare_nodes = self.get_total_nodes(totaltasks, max_thread_count)
         num_nodes += spare_nodes
@@ -57,14 +58,15 @@ class EnvMachPes(EnvBase):
     def get_total_tasks(self, comp_classes):
         total_tasks = 0
         for comp in comp_classes:
-            ntasks = self.get_value("NTASKS_%s"%comp)
-            rootpe = self.get_value("ROOTPE_%s"%comp)
-            pstrid = self.get_value("PSTRID_%s"%comp)
+            ntasks = self.get_value("NTASKS", attribute={"component":comp})
+            rootpe = self.get_value("ROOTPE", attribute={"component":comp})
+            pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):
+        expect(total_tasks > 0,"totaltasks > 0 expected totaltasks = %s"%total_tasks)
         tasks_per_node = min(self.get_value("MAX_TASKS_PER_NODE")/ max_thread_count,
                              self.get_value("PES_PER_NODE"), total_tasks)
         return tasks_per_node

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -295,4 +295,7 @@ class GenericXML(object):
         return xmlstr
 
     def get_id(self):
-        return self.root.get("id")
+        xmlid = self.root.get("id")
+        if xmlid is not None:
+            return xmlid
+        return self.root.tag

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -155,7 +155,6 @@ class Case(object):
             self.spare_nodes = env_mach_pes.get_spare_nodes(self.num_nodes)
             self.num_nodes += self.spare_nodes
         else:
-            import pdb
             self.num_nodes, self.spare_nodes = env_mach_pes.get_total_nodes(self.total_tasks, self.thread_count)
             self.num_nodes += self.spare_nodes
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -238,7 +238,6 @@ class Case(object):
         for env_file in self._env_files_that_need_rewrite:
             env_file.write()
         self._env_files_that_need_rewrite = set()
-        mach_pes = self.get_env("mach_pes")
 
     def get_values(self, item, attribute=None, resolved=True, subgroup=None):
         results = []

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -126,6 +126,8 @@ class Case(object):
         for variable substitution using the {{ var }} syntax
         """
         env_mach_pes  = self.get_env("mach_pes")
+        print "HERE %s"%env_mach_pes.get_value("TOTALPES")
+
         env_mach_spec = self.get_env('mach_specific')
         comp_classes  = self.get_values("COMP_CLASSES")
         pes_per_node  = self.get_value("PES_PER_NODE")
@@ -155,6 +157,7 @@ class Case(object):
             self.spare_nodes = env_mach_pes.get_spare_nodes(self.num_nodes)
             self.num_nodes += self.spare_nodes
         else:
+            import pdb
             self.num_nodes, self.spare_nodes = env_mach_pes.get_total_nodes(self.total_tasks, self.thread_count)
             self.num_nodes += self.spare_nodes
 
@@ -415,6 +418,9 @@ class Case(object):
         components = files.get_components("COMPSETS_SPEC_FILE")
         logger.debug(" Possible components for COMPSETS_SPEC_FILE are %s" % components)
 
+        if pesfile is not None:
+            self._pesfile = pesfile
+
         # Loop through all of the files listed in COMPSETS_SPEC_FILE and find the file
         # that has a match for either the alias or the longname in that order
         for component in components:
@@ -426,9 +432,11 @@ class Case(object):
             if (os.path.isfile(compsets_filename)):
                 compsets = Compsets(compsets_filename)
                 match, compset_alias, science_support, self._user_mods = compsets.get_compset_match(name=compset_name)
-                pesfile = files.get_value("PES_SPEC_FILE"     , {"component":component})
                 if match is not None:
-                    self._pesfile = pesfile
+                    if pesfile is None:
+                        self._pesfile = files.get_value("PES_SPEC_FILE"     , {"component":component})
+                        self.set_lookup_value("PES_SPEC_FILE"      ,
+                                              files.get_value("PES_SPEC_FILE"     , {"component":component}, resolved=False))
                     self._compsetsfile = compsets_filename
                     self._compsetname = match
                     tests_filename    = files.get_value("TESTS_SPEC_FILE"   , {"component":component}, resolved=False)
@@ -439,8 +447,6 @@ class Case(object):
                     self.set_lookup_value("TESTS_SPEC_FILE"    , tests_filename)
                     self.set_lookup_value("TESTS_MODS_DIR"     , tests_mods_dir)
                     self.set_lookup_value("USER_MODS_DIR"      , user_mods_dir)
-                    self.set_lookup_value("PES_SPEC_FILE"      ,
-                                   files.get_value("PES_SPEC_FILE"     , {"component":component}, resolved=False))
                     compset_info = "Compset longname is %s"%(match)
                     if self._user_mods is not None:
                         compset_info += " with user_mods directory %s"%(self._user_mods)
@@ -453,7 +459,7 @@ class Case(object):
             #Do not error out for user_compset
             logger.warn("Could not find a compset match for either alias or longname in %s" %(compset_name))
             self._compsetname = compset_name
-            self._pesfile = pesfile
+            logger.info("Pes     specification file is %s" %(pesfile))
             self.set_lookup_value("PES_SPEC_FILE", pesfile)
         else:
             expect(False,
@@ -552,6 +558,112 @@ class Case(object):
             if result is not None:
                 del self.lookups[key]
 
+    def _setup_mach_pes(self, pecount, ninst, machine_name, mpilib):
+        #--------------------------------------------
+        # pe layout
+        #--------------------------------------------
+        mach_pes_obj = None
+        # self._pesfile may already be env_mach_pes.xml if so we can just return
+        try:
+            mach_pes_obj = EnvMachPes(infile=self._pesfile, components=self._components)
+            for n, _file in enumerate(self._env_entryid_files):
+                if isinstance(_file, EnvMachPes):
+                    mach_pes_obj.filename = _file.filename
+                    self._env_entryid_files[n] = deepcopy(mach_pes_obj)
+            return mach_pes_obj.get_value('TOTALPES')
+        except SystemExit:
+            pesobj = Pes(self._pesfile)
+
+        match1 = re.match('(.+)x([0-9]+)', "" if pecount is None else pecount)
+        match2 = re.match('([0-9]+)', "" if pecount is None else pecount)
+
+        pes_ntasks = {}
+        pes_nthrds = {}
+        pes_rootpe = {}
+        other      = {}
+
+        force_tasks = None
+        force_thrds = None
+
+        if match1:
+            opti_tasks = match1.group(1)
+            if opti_tasks.isdigit():
+                force_tasks = int(opti_tasks)
+            else:
+                pes_ntasks = pesobj.find_pes_layout(self._gridname, self._compsetname, machine_name,
+                                                    pesize_opts=opti_tasks, mpilib=mpilib)[0]
+            force_thrds = int(match1.group(2))
+        elif match2:
+            force_tasks = int(match2.group(1))
+            pes_nthrds = pesobj.find_pes_layout(self._gridname, self._compsetname, machine_name, mpilib=mpilib)[1]
+        else:
+            pes_ntasks, pes_nthrds, pes_rootpe, other = pesobj.find_pes_layout(self._gridname, self._compsetname,
+                                                                               machine_name, pesize_opts=pecount, mpilib=mpilib)
+
+        if match1 or match2:
+            for component_class in self._component_classes:
+                if force_tasks is not None:
+                    string_ = "NTASKS_" + component_class
+                    pes_ntasks[string_] = force_tasks
+
+                if force_thrds is not None:
+                    string_ = "NTHRDS_" + component_class
+                    pes_nthrds[string_] = force_thrds
+
+                # Always default to zero rootpe if user forced procs and or threads
+                string_ = "ROOTPE_" + component_class
+                pes_rootpe[string_] = 0
+
+        mach_pes_obj = self.get_env("mach_pes")
+
+        if other is not None:
+            for key, value in other.items():
+                self.set_value(key, value)
+
+        totaltasks = []
+        for comp_class in self._component_classes:
+            ntasks_str, nthrds_str, rootpe_str = "NTASKS_%s" % comp_class, "NTHRDS_%s" % comp_class, "ROOTPE_%s" % comp_class
+
+            ntasks = pes_ntasks[ntasks_str] if ntasks_str in pes_ntasks else 1
+            nthrds = pes_nthrds[nthrds_str] if nthrds_str in pes_nthrds else 1
+            rootpe = pes_rootpe[rootpe_str] if rootpe_str in pes_rootpe else 0
+
+            totaltasks.append( (ntasks + rootpe) * nthrds )
+
+            mach_pes_obj.set_value(ntasks_str, ntasks)
+            mach_pes_obj.set_value(nthrds_str, nthrds)
+            mach_pes_obj.set_value(rootpe_str, rootpe)
+
+        pesize = 1
+        pes_per_node = self.get_value("PES_PER_NODE")
+        for val in totaltasks:
+            if val < 0:
+                val = -1*val*pes_per_node
+            if val > pesize:
+                pesize = val
+
+        # Make sure that every component has been accounted for
+        # set, nthrds and ntasks to 1 otherwise. Also set the ninst values here.
+        for compclass in self._component_classes:
+            if compclass == "CPL":
+                continue
+            key = "NINST_%s"%compclass
+            # ESP models are currently limited to 1 instance
+            if compclass == "ESP":
+                mach_pes_obj.set_value(key, 1)
+            else:
+                mach_pes_obj.set_value(key, ninst)
+
+            key = "NTASKS_%s"%compclass
+            if key not in pes_ntasks.keys():
+                mach_pes_obj.set_value(key,1)
+            key = "NTHRDS_%s"%compclass
+            if compclass not in pes_nthrds.keys():
+                mach_pes_obj.set_value(compclass,1)
+
+        return pesize
+
+
     def configure(self, compset_name, grid_name, machine_name=None,
                   project=None, pecount=None, compiler=None, mpilib=None,
                   user_compset=False, pesfile=None,
@@ -638,97 +750,7 @@ class Case(object):
         env_mach_specific_obj.populate(machobj)
         self.schedule_rewrite(env_mach_specific_obj)
 
-        #--------------------------------------------
-        # pe layout
-        #--------------------------------------------
-        match1 = re.match('(.+)x([0-9]+)', "" if pecount is None else pecount)
-        match2 = re.match('([0-9]+)', "" if pecount is None else pecount)
-
-        pes_ntasks = {}
-        pes_nthrds = {}
-        pes_rootpe = {}
-        other      = {}
-
-        pesobj = Pes(self._pesfile)
-
-        force_tasks = None
-        force_thrds = None
-
-        if match1:
-            opti_tasks = match1.group(1)
-            if opti_tasks.isdigit():
-                force_tasks = int(opti_tasks)
-            else:
-                pes_ntasks = pesobj.find_pes_layout(self._gridname, self._compsetname, machine_name,
-                                                    pesize_opts=opti_tasks, mpilib=mpilib)[0]
-            force_thrds = int(match1.group(2))
-        elif match2:
-            force_tasks = int(match2.group(1))
-            pes_nthrds = pesobj.find_pes_layout(self._gridname, self._compsetname, machine_name, mpilib=mpilib)[1]
-        else:
-            pes_ntasks, pes_nthrds, pes_rootpe, other = pesobj.find_pes_layout(self._gridname, self._compsetname,
-                                                                               machine_name, pesize_opts=pecount, mpilib=mpilib)
-
-        if match1 or match2:
-            for component_class in self._component_classes:
-                if force_tasks is not None:
-                    string_ = "NTASKS_" + component_class
-                    pes_ntasks[string_] = force_tasks
-
-                if force_thrds is not None:
-                    string_ = "NTHRDS_" + component_class
-                    pes_nthrds[string_] = force_thrds
-
-                # Always default to zero rootpe if user forced procs and or threads
-                string_ = "ROOTPE_" + component_class
-                pes_rootpe[string_] = 0
-
-        mach_pes_obj = self.get_env("mach_pes")
-
-        if other is not None:
-            for key, value in other.items():
-                self.set_value(key, value)
-
-        totaltasks = []
-        for comp_class in self._component_classes:
-            ntasks_str, nthrds_str, rootpe_str = "NTASKS_%s" % comp_class, "NTHRDS_%s" % comp_class, "ROOTPE_%s" % comp_class
-
-            ntasks = pes_ntasks[ntasks_str] if ntasks_str in pes_ntasks else 1
-            nthrds = pes_nthrds[nthrds_str] if nthrds_str in pes_nthrds else 1
-            rootpe = pes_rootpe[rootpe_str] if rootpe_str in pes_rootpe else 0
-
-            totaltasks.append( (ntasks + rootpe) * nthrds )
-
-            mach_pes_obj.set_value(ntasks_str, ntasks)
-            mach_pes_obj.set_value(nthrds_str, nthrds)
-            mach_pes_obj.set_value(rootpe_str, rootpe)
-
-        maxval = 1
-        pes_per_node = self.get_value("PES_PER_NODE")
-        for val in totaltasks:
-            if val < 0:
-                val = -1*val*pes_per_node
-            if val > maxval:
-                maxval = val
-
-        # Make sure that every component has been accounted for
-        # set, nthrds and ntasks to 1 otherwise. Also set the ninst values here.
-        for compclass in self._component_classes:
-            if compclass == "CPL":
-                continue
-            key = "NINST_%s"%compclass
-            # ESP models are currently limited to 1 instance
-            if compclass == "ESP":
-                mach_pes_obj.set_value(key, 1)
-            else:
-                mach_pes_obj.set_value(key, ninst)
-
-            key = "NTASKS_%s"%compclass
-            if key not in pes_ntasks.keys():
-                mach_pes_obj.set_value(key,1)
-            key = "NTHRDS_%s"%compclass
-            if compclass not in pes_nthrds.keys():
-                mach_pes_obj.set_value(compclass,1)
+        pesize = self._setup_mach_pes(pecount, ninst, machine_name, mpilib)
 
         #--------------------------------------------
         # batch system
@@ -741,7 +763,7 @@ class Case(object):
 
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
         env_batch.create_job_groups(bjobs)
-        env_batch.set_job_defaults(bjobs, pesize=maxval, walltime=walltime, force_queue=queue, allow_walltime_override=test)
+        env_batch.set_job_defaults(bjobs, pesize=pesize, walltime=walltime, force_queue=queue, allow_walltime_override=test)
         self.schedule_rewrite(env_batch)
 
         #--------------------------------------------

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -262,26 +262,6 @@ class J_TestCreateNewcase(unittest.TestCase):
 
         cls._do_teardown.append(testdir)
 
-    def test_f_createnewcase_with_user_compset(self):
-        cls = self.__class__
-
-        testdir = os.path.join(cls._testroot, 'testcreatenewcase_with_user_compset')
-        if os.path.exists(testdir):
-            shutil.rmtree(testdir)
-
-        cls._testdirs.append(testdir)
-
-        pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
-        args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --user-compset --pesfile %s --res f19_g16 --output-root %s" % (testdir, pesfile, cls._testroot)
-        if CIME.utils.get_model() == "cesm":
-            args += " --run-unsupported"
-
-        run_cmd_assert_result(self, "%s/create_newcase %s"%(SCRIPT_DIR, args), from_dir=SCRIPT_DIR)
-        run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
-        run_cmd_assert_result(self, "./case.build", from_dir=testdir)
-
-        cls._do_teardown.append(testdir)
-
     def test_b_user_mods(self):
         cls = self.__class__
 
@@ -380,6 +360,49 @@ class J_TestCreateNewcase(unittest.TestCase):
             run_cmd_no_fail(cmd, from_dir=casedir)
 
         cls._do_teardown.append(cls._testroot)
+
+    def test_f_createnewcase_with_user_compset(self):
+        cls = self.__class__
+
+        testdir = os.path.join(cls._testroot, 'testcreatenewcase_with_user_compset')
+        if os.path.exists(testdir):
+            shutil.rmtree(testdir)
+
+        cls._testdirs.append(testdir)
+
+        pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
+        args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --user-compset --pesfile %s --res f19_g16 --output-root %s" % (testdir, pesfile, cls._testroot)
+        if CIME.utils.get_model() == "cesm":
+            args += " --run-unsupported"
+
+        run_cmd_assert_result(self, "%s/create_newcase %s"%(SCRIPT_DIR, args), from_dir=SCRIPT_DIR)
+        run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
+        run_cmd_assert_result(self, "./case.build", from_dir=testdir)
+
+        cls._do_teardown.append(testdir)
+
+    def test_g_createnewcase_with_user_compset_and_env_mach_pes(self):
+        cls = self.__class__
+
+        testdir = os.path.join(cls._testroot, 'testcreatenewcase_with_user_compset_and_env_mach_pes')
+        if os.path.exists(testdir):
+            shutil.rmtree(testdir)
+        previous_testdir = cls._testdirs[-1]
+        cls._testdirs.append(testdir)
+
+        pesfile = os.path.join(previous_testdir,"env_mach_pes.xml")
+        args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --user-compset --pesfile %s --res f19_g16 --output-root %s" % (testdir, pesfile, cls._testroot)
+        if CIME.utils.get_model() == "cesm":
+            args += " --run-unsupported"
+
+        run_cmd_assert_result(self, "%s/create_newcase %s"%(SCRIPT_DIR, args), from_dir=SCRIPT_DIR)
+        run_cmd_assert_result(self, "diff env_mach_pes.xml %s"%(previous_testdir), from_dir=testdir)
+        # this line should cause the diff to fail (I assume no machine is going to default to 17 tasks)
+        run_cmd_assert_result(self, "./xmlchange NTASKS=17", from_dir=testdir)
+        run_cmd_assert_result(self, "diff env_mach_pes.xml %s"%(previous_testdir), from_dir=testdir,
+                              expected_stat=1)
+
+        cls._do_teardown.append(testdir)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Previously the user was only allowed to specify a file in the config_pes.xml format in the --pesfile argument to create_newcase.   This change allows the user to specify a file in either the config_pes.xml or the env_mach_pes.xml format.   Also add a test for this feature

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: --pesfile argument in create_newcase 

Code review: 
