### PR TITLE
Fixes building when certain path variables have a trailing /

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -235,7 +235,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
     if mpilib == "mpi-serial":
         libs.insert(0, mpilib)
     logs = []
-    sharedlibroot = case.get_value("SHAREDLIBROOT")
+    sharedlibroot = os.path.abspath(case.get_value("SHAREDLIBROOT"))
     for lib in libs:
         if lib == "csm_share":
             # csm_share adds its own dir name
@@ -320,16 +320,15 @@ def _build_model_thread(config_dir, compclass, caseroot, libroot, bldroot, incro
 ###############################################################################
 def _clean_impl(case, cleanlist, clean_all):
 ###############################################################################
-    caseroot = case.get_value("CASEROOT")
     if clean_all:
         # If cleanlist is empty just remove the bld directory
-        exeroot = case.get_value("EXEROOT")
+        exeroot = os.path.abspath(case.get_value("EXEROOT"))
         expect(exeroot is not None,"No EXEROOT defined in case")
         if os.path.isdir(exeroot):
             logging.info("cleaning directory %s" %exeroot)
             shutil.rmtree(exeroot)
         # if clean_all is True also remove the sharedlibpath
-        sharedlibroot = case.get_value("SHAREDLIBROOT")
+        sharedlibroot = os.path.abspath(case.get_value("SHAREDLIBROOT"))
         expect(sharedlibroot is not None,"No SHAREDLIBROOT defined in case")
         if sharedlibroot != exeroot and os.path.isdir(sharedlibroot):
             logging.warn("cleaning directory %s" %sharedlibroot)
@@ -340,7 +339,7 @@ def _clean_impl(case, cleanlist, clean_all):
         use_esmf_lib    = case.get_value("USE_ESMF_LIB")
         build_threaded  = case.get_build_threaded()
         gmake           = case.get_value("GMAKE")
-        caseroot        = case.get_value("CASEROOT")
+        caseroot        = os.path.abspath(case.get_value("CASEROOT"))
         casetools       = case.get_value("CASETOOLS")
         clm_config_opts = case.get_value("CLM_CONFIG_OPTS")
 
@@ -399,10 +398,10 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only):
         del os.environ["MODEL"]
     build_threaded      = case.get_build_threaded()
     casetools           = case.get_value("CASETOOLS")
-    exeroot             = case.get_value("EXEROOT")
-    incroot             = case.get_value("INCROOT")
-    libroot             = case.get_value("LIBROOT")
-    sharedlibroot       = case.get_value("SHAREDLIBROOT")
+    exeroot             = os.path.abspath(case.get_value("EXEROOT"))
+    incroot             = os.path.abspath(case.get_value("INCROOT"))
+    libroot             = os.path.abspath(case.get_value("LIBROOT"))
+    sharedlibroot       = os.path.abspath(case.get_value("SHAREDLIBROOT"))
 
     complist = []
     for comp_class in comp_classes:


### PR DESCRIPTION
An inelegant fix because I don't want to assume xmlchange is always being used

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: pass

Fixes #1486 

User interface changes?: 

Code review: 
