### PR TITLE
improve err by removing rundir files and recopying from sta rest dire…

### DIFF
--- a/scripts/lib/CIME/SystemTests/err.py
+++ b/scripts/lib/CIME/SystemTests/err.py
@@ -27,15 +27,15 @@ class ERR(ERS):
         else:
             dout_s_root = self._case.get_value("DOUT_S_ROOT")
             rundir = self._case.get_value("RUNDIR")
-            logger.info("staging files from archive %s" % dout_s_root)
-            for item in glob.glob(os.path.join(dout_s_root, "*", "hist", "*base")):
-                # NOTE - this loop doesn't do anything because the
-                # _ers_first_phase has already copied the history files in the
-                # rundir adding the .base suffix before the short term archiver runs.
-                # The pattern matching in the env_archive.xml looks for history 
-                # files that match ".nc$" in the rundir in order to copy them
-                # to the DOUT_S_ROOT location so the files with the .base
-                # suffix are never copied. 
+            case = self._case.get_value("CASE")
+            # First remove restart, history and rpointer files from the run directory
+            for item in glob.iglob(os.path.join(rundir, "%s.*"%case)):
+                if not item.endswith("base"):
+                    os.remove(item)
+            for item in glob.iglob(os.path.join(rundir, "rpointer.*")):
+                os.remove(item)
+            # Then replace them from the restart directory
+            for item in glob.iglob(os.path.join(dout_s_root,"rest","*","*")):
                 shutil.copy(item, rundir)
 
             self._ers_second_phase()


### PR DESCRIPTION
…ctory
Remove files from the run directory and replace them from the sta rest directory improving the
scope of the err test.

Test suite: scripts_regression_tests.py, ERR.f09_g16.B1850
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #416

User interface changes?: 

Code review: @jgfouca 
