### PR TITLE
Fix for SOM bug introduced in PR #1451

### DIFF
--- a/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/src/components/data_comps/docn/cime_config/config_component.xml
@@ -41,7 +41,7 @@
     driver. The atmosphere/ocean fluxes are computed in the
     coupler. Therefore, the data ocean model does not compute fluxes like
     the data ice model. DOCN has two distinct modes of operation. It can
-    arun as a pure data model, reading in ocean SSTs (normally
+    run as a pure data model, reading in ocean SSTs (normally
     climatological) from input datasets, performing time/spatial
     interpolations, and passing these to the coupler. Alternatively,
     DOCN can compute updated SSTs by running as a slab ocean model where
@@ -50,18 +50,14 @@
     from the driver.
     --- A setting of prescribed assumes the only field in the input stream is SST.
     It also assumes the SST is in Celsius and must be converted to Kelvin.
-    All other fields are set to zero except for ocean salinity, which
-    is set to a constant reference salinity value.
-    Normally the ice fraction data is found in the same data files that
-    provide SST data to the data ocean model. They are normally found in
-    the same file because the SST and ice fraction data are derived from
-    the same observational data sets and are consistent with each other.
-    to the data ocean model. They are normally found in the same file
-    because the SST and ice fraction data are derived from the same
-    observational data sets and are consistent with each other.
-    --- A setting of som (slab ocean model) mode is a prognostic mode.  This mode
-    computes a prognostic sea surface temperature and a freeze/melt
-    potential (surface Q-flux) used by the sea ice model.  This
+    All other fields are set to zero except for ocean salinity, which is set to a 
+    constant reference salinity value. Normally the ice fraction data is found in 
+    the same data files that provide SST data to the data ocean model. They are 
+    normally found in the same file because the SST and ice fraction data are derived 
+    from the same observational data sets and are consistent with each other.
+    --- Settings of som (slab ocean model) or  som_aquap (aquaplanet slab ocean) are 
+    prognostic modes which compute a prognostic sea surface temperature and a 
+    freeze/melt potential (surface Q-flux) used by the sea ice model.  This
     calculation requires an external SOM forcing data file that includes
     ocean mixed layer depths and bottom-of-the-slab Q-fluxes.
     Scientifically appropriate bottom-of-the-slab Q-fluxes are normally
@@ -71,7 +67,14 @@
     appropriate and is provided for testing and development purposes only.
     Users must create scientifically appropriate data for their particular
     application.  A tool is available to derive valid SOM forcing.
-    Default is prescribed.</desc>
+    --- A setting of sst_aquapN (where “N” is an integer index value) is a 
+    type of prescribed SST mode used specifically for an aquaplanet setup in 
+    which global SSTs correspond to an analytic form set by the index value.  
+    Currently, indices for 10 SST profiles are supported [e.g., index 3 corresponds
+    to the “QOBS” profile of Neale and Hoskins (2001, Atmos. Sci. Lett.)]. 
+    With source code modifications, it is possible for users to create their own 
+    analytic SST distributions and match them to indices 11 or greater.  
+    </desc>
   </entry>
 
   <entry id="DOCN_SOM_FILENAME">

--- a/src/components/data_comps/docn/docn_comp_mod.F90
+++ b/src/components/data_comps/docn/docn_comp_mod.F90
@@ -704,7 +704,7 @@ subroutine docn_comp_run( EClock, cdata,  x2o, o2x)
          o2x%rAttr(kswp ,n) = swp
       enddo
 
-   case('SOM','SOM_AQUAP')
+   case('SOM')
       lsize = mct_avect_lsize(o2x)
       do n = 1,SDOCN%nstreams
          call shr_dmodel_translateAV(SDOCN%avs(n),avstrm,avifld,avofld,rearr)
@@ -737,6 +737,43 @@ subroutine docn_comp_run( EClock, cdata,  x2o, o2x)
              !--- compute ice formed or melt potential ---
             o2x%rAttr(kq,n) = (tfreeze(n) - o2x%rAttr(kt,n))*(cpsw*rhosw*hn)/dt  ! ice formed q>0
             o2x%rAttr(kt,n) = max(tfreeze(n),o2x%rAttr(kt,n))                    ! reset temp
+            somtp(n) = o2x%rAttr(kt,n)                                        ! save temp
+         endif
+         enddo
+      endif   ! firstcall
+
+   case('SOM_AQUAP')
+      lsize = mct_avect_lsize(o2x)
+      do n = 1,SDOCN%nstreams
+         call shr_dmodel_translateAV(SDOCN%avs(n),avstrm,avifld,avofld,rearr)
+      enddo
+      if (firstcall) then
+         do n = 1,lsize
+            if (.not. read_restart) then
+               somtp(n) = o2x%rAttr(kt,n) + TkFrz
+            endif
+            o2x%rAttr(kt,n) = somtp(n)
+            o2x%rAttr(kq,n) = 0.0_R8
+         enddo
+      else   ! firstcall
+         tfreeze = shr_frz_freezetemp(o2x%rAttr(ks,:)) + TkFrz
+         do n = 1,lsize
+         if (imask(n) /= 0) then
+            !--- pull out h from av for resuse below ---
+            hn = avstrm%rAttr(kh,n)
+            !--- compute new temp ---
+            o2x%rAttr(kt,n) = somtp(n) + &
+               (x2o%rAttr(kswnet,n) + &  ! shortwave 
+                x2o%rAttr(klwup ,n) + &  ! longwave
+                x2o%rAttr(klwdn ,n) + &  ! longwave
+                x2o%rAttr(ksen  ,n) + &  ! sensible
+                x2o%rAttr(klat  ,n) + &  ! latent
+                x2o%rAttr(kmelth,n) - &  ! ice melt
+                avstrm%rAttr(kqbot ,n) - &  ! flux at bottom
+                (x2o%rAttr(ksnow,n)+x2o%rAttr(krofi,n))*latice) * &  ! latent by prec and roff
+                dt/(cpsw*rhosw*hn)
+             !--- compute ice formed or melt potential ---
+            o2x%rAttr(kq,n) = (tfreeze(n) - o2x%rAttr(kt,n))*(cpsw*rhosw*hn)/dt  ! ice formed q>0
             somtp(n) = o2x%rAttr(kt,n)                                        ! save temp
          endif
          enddo

--- a/src/components/data_comps/docn/docn_comp_mod.F90
+++ b/src/components/data_comps/docn/docn_comp_mod.F90
@@ -79,6 +79,7 @@ module docn_comp_mod
   integer(IN)   :: kt,ks,ku,kv,kdhdx,kdhdy,kq,kswp  ! field indices
   integer(IN)   :: kswnet,klwup,klwdn,ksen,klat,kmelth,ksnow,krofi
   integer(IN)   :: kh,kqbot
+  integer(IN)   :: index_lat, index_lon
 
   type(shr_strdata_type) :: SDOCN
   type(mct_rearr)        :: rearr
@@ -148,8 +149,6 @@ subroutine docn_comp_init( EClock, cdata, x2o, o2x, NLFilename )
     integer(IN)   :: nunit       ! unit number
     integer(IN)   :: kmask       ! field reference
     integer(IN)   :: kfrac       ! field reference
-    integer(IN)   :: klat        ! field reference
-    integer(IN)   :: klon        ! field reference
     logical       :: ocn_present    ! flag
     logical       :: ocn_prognostic ! flag
     logical       :: ocnrof_prognostic  ! flag
@@ -466,11 +465,11 @@ subroutine docn_comp_init( EClock, cdata, x2o, o2x, NLFilename )
     kmask = mct_aVect_indexRA(ggrid%data,'mask')
     imask(:) = nint(ggrid%data%rAttr(kmask,:))
 
-    klon = mct_aVect_indexRA(ggrid%data,'lon')
-    xc(:) = ggrid%data%rAttr(klon,:)
+    index_lon = mct_aVect_indexRA(ggrid%data,'lon')
+    xc(:) = ggrid%data%rAttr(index_lon,:)
 
-    klat = mct_aVect_indexRA(ggrid%data,'lat')
-    yc(:) = ggrid%data%rAttr(klat,:)
+    index_lat = mct_aVect_indexRA(ggrid%data,'lat')
+    yc(:) = ggrid%data%rAttr(index_lat,:)
 
     call t_stopf('docn_initmctavs')
 


### PR DESCRIPTION
This PR fixes the SOM bug introduced in PR#1451

Test suite: scripts_regression_tests and
- verified that the following two tests passed functionality and were bfb with d4dfbf1 (the CIME PR
before the aquaplanet SOM changes were introduced)
ERS_D_Ld5.f19_g16.ETEST.yellowstone_intel.cice-default
ERS_Ld5.f19_g16.ETEST.yellowstone_intel.cice-default
- verified that the following two tests passed functionality (the QSC4 compset is a new CAM compset that has aquaplanet SOM functionality)
ERS_D_Ld5.f09_f09.QSC4.yellowstone_intel
ERS_Ld5.f09_f09.QSC4.yellowstone_intel

Test baseline: `d4dbf1`
Test namelist changes: None
Test status: bit for bit
Fixes #1497
User interface changes?: None
Code review:
