### PR TITLE
Reset test case

### DIFF
--- a/config/acme/machines/template.case.test
+++ b/config/acme/machines/template.case.test
@@ -1,14 +1,10 @@
 #!/usr/bin/env python
-
-# Batch system directives
 {{ batchdirectives }}
-
 """
 This is the system test submit script for CIME. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
 batch directives. Use case.submit from the command line to run your case.
 """
-
 import os, sys
 os.chdir( '{{ caseroot }}')
 
@@ -50,12 +46,15 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
+    parser.add_argument("--reset", action="store_true",
+                        help="Reset the case to its original state as defined by config_tests.xml")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)
 
-    return args.caseroot, args.testname
+    return args.caseroot, args.testname, args.reset
 
 ###############################################################################
 def _main_func(description):
@@ -64,9 +63,9 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, testname = parse_command_line(sys.argv, description)
+    caseroot, testname, reset = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        success = case_test(case, testname)
+        success = case_test(case, testname, reset)
 
     sys.exit(0 if success else 1)
 

--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -46,12 +46,15 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
+    parser.add_argument("--reset", action="store_true",
+                        help="Reset the case to its original state as defined by config_tests.xml")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)
 
-    return args.caseroot, args.testname
+    return args.caseroot, args.testname, args.reset
 
 ###############################################################################
 def _main_func(description):
@@ -60,9 +63,9 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, testname = parse_command_line(sys.argv, description)
+    caseroot, testname, reset = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        success = case_test(case, testname)
+        success = case_test(case, testname, reset)
 
     sys.exit(0 if success else 1)
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -35,6 +35,9 @@ class SystemTestsCommon(object):
         self._init_environment(caseroot)
         self._init_locked_files(caseroot, expected)
 
+    def __del__(self):
+        self._case.set_value("RUN_WITH_SUBMIT", False)
+
     def _init_environment(self, caseroot):
         """
         Do initializations of environment variables that are needed in __init__

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -53,14 +53,14 @@ class SystemTestsCommon(object):
         elif os.path.isfile(os.path.join(caseroot, "env_run.xml")):
             lock_file("env_run.xml", caseroot=caseroot, newname="env_run.orig.xml")
 
-    def _resetup_case(self, phase):
+    def _resetup_case(self, phase, reset=False):
         """
         Re-setup this case. This is necessary if user is re-running an already-run
         phase.
         """
         # We never want to re-setup if we're doing the resubmitted run
         phase_status = self._test_status.get_status(phase)
-        if self._case.get_value("IS_FIRST_RUN") and phase_status != TEST_PEND_STATUS:
+        if reset or (self._case.get_value("IS_FIRST_RUN") and phase_status != TEST_PEND_STATUS):
 
             logging.warning("Resetting case due to detected re-run of phase %s" % phase)
             self._case.set_initial_test_values()

--- a/scripts/lib/CIME/case_test.py
+++ b/scripts/lib/CIME/case_test.py
@@ -60,14 +60,14 @@ def case_test(case, testname=None, reset=False):
     except:
         caseroot = case.get_value("CASEROOT")
         with TestStatus(test_dir=caseroot) as ts:
-            if reset:
-                logger.info("Reset test to initial conditions and exit")
-                ts._resetup_case(RUN_PHASE)
-                return True
             ts.set_status(RUN_PHASE, TEST_FAIL_STATUS, comments="failed to initialize")
         append_testlog(str(sys.exc_info()[1]))
         return False
 
+    if reset:
+        logger.info("Reset test to initial conditions and exit")
+        test._resetup_case(RUN_PHASE)
+        return True
     success = test.run()
 
     case.set_value("RUN_WITH_SUBMIT", False)

--- a/scripts/lib/CIME/case_test.py
+++ b/scripts/lib/CIME/case_test.py
@@ -42,7 +42,7 @@ def _set_up_signal_handlers():
         signum = getattr(signal, signame)
         signal.signal(signum, _signal_handler)
 
-def case_test(case, testname=None):
+def case_test(case, testname=None, reset=False):
     if testname is None:
         testname = case.get_value('TESTCASE')
 
@@ -60,6 +60,10 @@ def case_test(case, testname=None):
     except:
         caseroot = case.get_value("CASEROOT")
         with TestStatus(test_dir=caseroot) as ts:
+            if reset:
+                logger.info("Reset test to initial conditions and exit")
+                ts._resetup_case(RUN_PHASE)
+                return True
             ts.set_status(RUN_PHASE, TEST_FAIL_STATUS, comments="failed to initialize")
         append_testlog(str(sys.exc_info()[1]))
         return False


### PR DESCRIPTION
adds a case.test --reset option to manually reset a test to initial conditions, also adds a teardown method to system_tests_common.py which assures that RUN_WITH_SUBMIT flag is reset to False
whenever a test method exits. 

Test suite: scripts_regression_tests.py ERR.f09_g16.B1850.cheyenne_intel.allactive-defaultio
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #901 

User interface changes?: Add --reset option to case.test 

Code review: jgfouca
