### PR TITLE
make --file and --listall work together in xmlquery

### DIFF
--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -139,12 +139,12 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
     if xmlfile:
         case.set_file(xmlfile)
     for var in variables:
-        if xmlfile:
-            groups = ['none']
-        elif subgroup is not None:
+        if subgroup is not None:
             groups = [subgroup]
         else:
             groups = case.get_record_fields(var, "group")
+            if groups is None and xmlfile:
+                groups = ['none']
 
         if xmlfile:
             value =  case.get_value(var, resolved=resolved)
@@ -166,7 +166,11 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
                 if iscompvar:
                     value = []
                     for comp in comp_classes:
-                        nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group)
+                        try:
+                            nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group)
+                        except:
+                            nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=False, subgroup=group)
+
                         if nextval is not None:
                             value.append(comp + ":" + "%s"%nextval)
                 else:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1226,23 +1226,23 @@ class Case(object):
 
         gfile = GenericXML(infile=xmlfile)
         ftype = gfile.get_id()
-
+        components = self.get_value("COMP_CLASSES")
         logger.warn("setting case file to %s"%xmlfile)
         new_env_file = None
         for env_file in self._env_entryid_files:
             if os.path.basename(env_file.filename) == ftype:
                 if ftype == "env_run.xml":
-                    new_env_file = EnvRun(infile=xmlfile)
+                    new_env_file = EnvRun(infile=xmlfile, components=components)
                 elif ftype == "env_build.xml":
-                    new_env_file = EnvBuild(infile=xmlfile)
+                    new_env_file = EnvBuild(infile=xmlfile, components=components)
                 elif ftype == "env_case.xml":
-                    new_env_file = EnvCase(infile=xmlfile)
+                    new_env_file = EnvCase(infile=xmlfile, components=components)
                 elif ftype == "env_mach_pes.xml":
-                    new_env_file = EnvMachPes(infile=xmlfile)
+                    new_env_file = EnvMachPes(infile=xmlfile, components=components)
                 elif ftype == "env_batch.xml":
-                    new_env_file = EnvBatch(infile=xmlfile)
+                    new_env_file = EnvBatch(infile=xmlfile, components=components)
                 elif ftype == "env_test.xml":
-                    new_env_file = EnvTest(infile=xmlfile)
+                    new_env_file = EnvTest(infile=xmlfile, components=components)
             if new_env_file is not None:
                 self._env_entryid_files = []
                 self._env_generic_files = []


### PR DESCRIPTION
xmlquery options --file and --listall were not working together, now they are. 

Test suite: scripts_regression_tests.py, hand tests of xmlquery 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #848 

User interface changes?: xmlquery --file and --listall can now be used together

Code review: 
