### PR TITLE
define acceptable attributes so that all are not required to be presetn

### DIFF
--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -21,7 +21,7 @@ class EnvMachSpecific(EnvBase):
         fullpath = infile if os.path.isabs(infile) else os.path.join(caseroot, infile)
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_specific.xsd")
         EnvBase.__init__(self, caseroot, fullpath,schema=schema)
-
+        self._allowed_mpi_attributes = ("compiler", "mpilib", "threaded", "unit_testing")
         self._unit_testing = unit_testing
 
     def populate(self, machobj):
@@ -344,7 +344,9 @@ class EnvMachSpecific(EnvBase):
             all_match = True
             matches = 0
             is_default = False
+
             for key, value in attribs.iteritems():
+                expect(key in self._allowed_mpi_attributes, "Unexpected key %s in mpirun attributes"%key)
                 if key in xml_attribs:
                     if xml_attribs[key].lower() == "false":
                         xml_attrib = False
@@ -361,8 +363,7 @@ class EnvMachSpecific(EnvBase):
                         all_match = False
                         break
 
-            for key in xml_attribs:
-                expect(key in attribs, "Unhandled MPI property '%s'" % key)
+
 
             if all_match:
                 if is_default:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -146,7 +146,6 @@ class Case(object):
             "compiler" : self.get_value("COMPILER"),
             "mpilib"   : self.get_value("MPILIB"),
             "threaded" : self.get_build_threaded(),
-            "unit_testing" : False
             }
 
         executable = env_mach_spec.get_mpirun(self, mpi_attribs, job="case.run", exe_only=True)[0]


### PR DESCRIPTION
Define the list of expected attributes to the mpirun command so that the all do not need to 
be passed in.   
Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1345 

User interface changes?: 

Code review: 
