### PR TITLE
Add support for multiple coupler instances

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -47,6 +47,10 @@ OR
                         help="Specify a compiler. "
                         "To see list of supported compilers for each machine, use the utility query_config in this directory")
 
+    parser.add_argument("--ncouplers",default=1,
+                        help="Specify number of coupler instances. "
+                        "Set the number of coupler instances in the case.")
+
     parser.add_argument("--ninst",default=1,
                         help="Specify number of component instances"
                         "Set the number of component instances in the case.")
@@ -148,6 +152,9 @@ OR
         expect(args.gridfile is not None,
                "User grid specification file must be set if the user grid is requested")
 
+    expect(not (int(args.ncouplers) > 1 and int(args.ninst) > 1),
+           "Only one component instance per coupler is allowed when using multiple couplers")
+
     run_unsupported = False
     if model == "cesm":
         run_unsupported = args.run_unsupported
@@ -161,8 +168,8 @@ OR
     return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.user_compset, args.pesfile, \
-        args.user_grid, args.gridfile, args.srcroot, args.test, args.ninst, \
-        args.walltime, args.queue, args.output_root, args.script_root, \
+        args.user_grid, args.gridfile, args.srcroot, args.test, args.ncouplers, \
+        args.ninst, args.walltime, args.queue, args.output_root, args.script_root, \
         run_unsupported, args.answer, args.input_dir
 
 ###############################################################################
@@ -173,7 +180,7 @@ def _main_func(description):
     casename, compset, grid, machine, compiler, \
         mpilib, project, pecount,  \
         user_mods_dir, user_compset, pesfile, \
-        user_grid, gridfile, srcroot, test, ninst, walltime, queue, \
+        user_grid, gridfile, srcroot, test, ncouplers, ninst, walltime, queue, \
         output_root, script_root, run_unsupported, \
         answer, input_dir = parse_command_line(sys.argv, cimeroot, description)
 
@@ -197,7 +204,8 @@ def _main_func(description):
         case.configure(compset, grid, machine_name=machine, project=project,
                        pecount=pecount, compiler=compiler, mpilib=mpilib,
                        user_compset=user_compset, pesfile=pesfile,
-                       user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
+                       user_grid=user_grid, gridfile=gridfile, 
+                       ncouplers=ncouplers, ninst=ninst, test=test,
                        walltime=walltime, queue=queue, output_root=output_root,
                        run_unsupported=run_unsupported, answer=answer,
                        input_dir=input_dir)

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -63,6 +63,7 @@ class EnvMachPes(EnvBase):
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
+        total_tasks *= self.get_value("NINST_CPL")
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -405,11 +405,10 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only):
 
     complist = []
     for comp_class in comp_classes:
+        ninst = case.get_value("NINST_%s"%comp_class)
         if comp_class == "CPL":
-            ninst = 1
             config_dir = None
         else:
-            ninst = case.get_value("NINST_%s"%comp_class)
             config_dir = os.path.dirname(case.get_value("CONFIG_%s_FILE"%comp_class))
         comp = case.get_value("COMP_%s"%comp_class)
         thrds =  case.get_value("NTHRDS_%s"%comp_class)

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -34,11 +34,13 @@ def _build_usernl_files(case, model, comp):
     expect(os.path.isdir(model_dir),
            "cannot find cime_config directory %s for component %s" % (model_dir, comp))
 
+    ninst = case.get_value("NINST_CPL")
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
             shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")
     else:
-        ninst = case.get_value("NINST_%s" % model)
+        if ninst == 1:
+            ninst = case.get_value("NINST_%s" % model)
         nlfile = "user_nl_%s" % comp
         model_nl = os.path.join(model_dir, nlfile)
         if ninst > 1:

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -20,9 +20,9 @@ def _get_datenames(case):
     rundir = case.get_value('RUNDIR')
     expect(isdir(rundir), 'Cannot open directory %s ' % rundir)
     casename = case.get_value("CASE")
-    files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl.r*.nc')))
+    files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl*.r*.nc')))
     if not files:
-        expect(False, 'Cannot find a %s.cpl.r.*.nc file in directory %s ' % (casename, rundir))
+        expect(False, 'Cannot find a %s.cpl*.r.*.nc file in directory %s ' % (casename, rundir))
     datenames = []
     for filename in files:
         names = filename.split('.')
@@ -36,10 +36,7 @@ def _get_datenames(case):
 def _get_ninst_info(case, compclass):
 ###############################################################################
 
-    if compclass != 'cpl':
-        ninst = case.get_value('NINST_' + compclass.upper())
-    else:
-        ninst = 1
+    ninst = case.get_value('NINST_' + compclass.upper())
     ninst_strings = []
     if ninst is None:
         ninst = 1
@@ -212,7 +209,7 @@ def _archive_restarts(case, archive, archive_entry,
     rundir = case.get_value("RUNDIR")
     casename = case.get_value("CASE")
     archive_restdir = join(dout_s_root, 'rest', datename)
-    if not datename_is_last or case.get_value('DOUT_S_SAVE_INTERIM_RESTART_FILES') \
+    if datename_is_last or case.get_value('DOUT_S_SAVE_INTERIM_RESTART_FILES') \
        or case.get_value("TEST"):
         if not os.path.exists(archive_restdir):
             os.makedirs(archive_restdir)

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -102,6 +102,14 @@ class _TimingParser:
         return (0, 0, False)
 
     def getTiming(self):
+        ninst = self.case.get_value("NINST_CPL")
+        if ninst > 1:
+            for inst in range(ninst):
+                self._getTiming(inst+1)
+        else:
+            self._getTiming()
+
+    def _getTiming(self, inst=0):
         components=self.case.get_values("COMP_CLASSES")
         for s in components:
             self.models[s] = _GetTimingInfo(s)
@@ -156,11 +164,16 @@ class _TimingParser:
                 not continue_run:
             inittype = "TRUE"
 
-        binfilename = os.path.join(rundir, "timing", "model_timing_stats")
+        if inst > 0:
+            inst_label = '_%04d' % inst
+        else:
+            inst_label = ''
+
+        binfilename = os.path.join(rundir, "timing", "model_timing%s_stats" % inst_label)
         finfilename = os.path.join(self.caseroot, "timing",
-                                   "%s_timing_stats.%s" % (cime_model, self.lid))
+                                   "%s_timing%s_stats.%s" % (cime_model, inst_label, self.lid))
         foutfilename = os.path.join(self.caseroot, "timing",
-                                    "%s_timing.%s.%s" % (cime_model, caseid, self.lid))
+                                   "%s_timing%s.%s.%s.gz" % (cime_model, inst_label, caseid, self.lid))
 
         timingDir = os.path.join(self.caseroot, "timing")
         if not os.path.isdir(timingDir):
@@ -249,9 +262,13 @@ class _TimingParser:
         maxthrds = 0
         for k in self.case.get_values("COMP_CLASSES"):
             m = self.models[k]
+            if m.comp == "cpl":
+                comp_label = m.comp + inst_label
+            else:
+                comp_label = m.comp
             self.write("  %s = %-8s   %-6u      %-6u   %-6u x %-6u  "
                        "%-6u (%-6u) \n"
-                       % (m.name.lower(), m.comp, (m.ntasks*m.nthrds *smt_factor), m.rootpe,
+                       % (m.name.lower(), comp_label, (m.ntasks*m.nthrds *smt_factor), m.rootpe,
                           m.ntasks, m.nthrds, m.ninst, m.pstrid))
             if m.nthrds > maxthrds:
                 maxthrds = m.nthrds

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -255,20 +255,14 @@ def _create_component_modelio_namelists(case, files):
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
 
-            if model == 'cpl':
-                inst_count = 1
-            else:
-                inst_count = case.get_value("NINST_" + model.upper())
+            inst_count = case.get_value("NINST_" + model.upper())
 
+            inst_string = ""
             inst_index = 1
             while inst_index <= inst_count:
-                inst_string = inst_index
-                if inst_index <= 999:
-                    inst_string = "0" + str(inst_string)
-                if inst_index <=  99:
-                    inst_string = "0" + str(inst_string)
-                if inst_index <=  9:
-                    inst_string = "0" + str(inst_string)
+                # determine instance string
+                if inst_count > 1:
+                    inst_string = '_%04d' % inst_index
 
                 # set default values
                 for entry in entries:
@@ -281,17 +275,11 @@ def _create_component_modelio_namelists(case, files):
                 moddiro = case.get_value('RUNDIR')
                 nmlgen.set_value('diro', moddiro)
 
-                if inst_count > 1:
-                    logfile = model + "_" + inst_string + ".log." + str(lid)
-                else:
-                    logfile = model + ".log." + str(lid)
+                logfile = model + inst_string + ".log." + str(lid)
                 nmlgen.set_value('logfile', logfile)
 
                 # Write output file
-                if inst_count > 1:
-                    modelio_file = model + "_modelio.nml_" + str(inst_string)
-                else:
-                    modelio_file = model + "_modelio.nml"
+                modelio_file = model + "_modelio.nml" + inst_string
                 nmlgen.write_modelio_file(os.path.join(confdir, modelio_file))
 
                 inst_index = inst_index + 1

--- a/src/drivers/mct/cime_config/config_archive.xml
+++ b/src/drivers/mct/cime_config/config_archive.xml
@@ -4,8 +4,8 @@
     <hist_file_extension>\.h.*.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.cpl</rpointer_file>
-      <rpointer_content >$CASE.cpl.r.$DATENAME.nc</rpointer_content>
+      <rpointer_file>rpointer$NINST_STRING.cpl</rpointer_file>
+      <rpointer_content >$CASE.cpl$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1961,6 +1961,7 @@
   <entry id="NINST">
     <type>integer</type>
     <values>
+      <value component="CPL">1</value>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -41,6 +41,22 @@
   -->
 
   <!-- =========================== -->
+  <!-- group cesm_cpl              -->
+  <!-- =========================== -->
+
+  <entry id="cpl_ninst" modify_via_xml="NINST_CPL">
+    <type>integer</type>
+    <category>cesm_cpl</category>
+    <group>cesm_cpl</group>
+    <desc>
+      Number of CESM coupler instances.
+    </desc>
+    <values>
+      <value>$NINST_CPL</value>
+    </values>
+  </entry>
+
+  <!-- =========================== -->
   <!-- group seq_cplflds_inparm    -->
   <!-- =========================== -->
 

--- a/src/drivers/mct/main/cesm_comp_mod.F90
+++ b/src/drivers/mct/main/cesm_comp_mod.F90
@@ -26,10 +26,11 @@ module cesm_comp_mod
    use shr_sys_mod,       only: shr_sys_abort, shr_sys_flush
    use shr_const_mod,     only: shr_const_cday
    use shr_file_mod,      only: shr_file_setLogLevel, shr_file_setLogUnit
-   use shr_file_mod,      only: shr_file_setIO, shr_file_getUnit
+   use shr_file_mod,      only: shr_file_setIO, shr_file_getUnit, shr_file_freeUnit
    use shr_scam_mod,      only: shr_scam_checkSurface
    use shr_map_mod,       only: shr_map_setDopole
    use shr_mpi_mod,       only: shr_mpi_min, shr_mpi_max
+   use shr_mpi_mod,       only: shr_mpi_bcast, shr_mpi_commrank, shr_mpi_commsize
    use shr_mem_mod,       only: shr_mem_init, shr_mem_getusage
    use shr_cal_mod,       only: shr_cal_date2ymd, shr_cal_ymd2date, shr_cal_advdateInt
    use shr_orb_mod,       only: shr_orb_params
@@ -535,6 +536,9 @@ module cesm_comp_mod
    logical  :: iamin_CPLALLROFID     ! pe associated with CPLALLROFID
    logical  :: iamin_CPLALLWAVID     ! pe associated with CPLALLWAVID
 
+   ! suffix for log and timing files if multi coupler driver
+   character(len=seq_comm_namelen) :: cpl_inst_tag
+
    !----------------------------------------------------------------------------
    ! complist: list of comps on this pe
    !----------------------------------------------------------------------------
@@ -596,6 +600,7 @@ subroutine cesm_pre_init1()
    logical :: comp_iamin(num_inst_total)
    character(len=seq_comm_namelen) :: comp_name(num_inst_total)
    integer :: i, it
+   integer :: num_inst_cpl, cpl_id
 
    call mpi_init(ierr)
    call shr_mpi_chkerr(ierr,subname//' mpi_init')
@@ -604,6 +609,9 @@ subroutine cesm_pre_init1()
    comp_comm = MPI_COMM_NULL
    time_brun = mpi_wtime()
 
+   !--- Initialize multiple coupler instances, if requested ---
+   call cesm_cpl_init(Global_Comm, num_inst_cpl, cpl_id)
+
    call shr_pio_init1(num_inst_total,NLFileName, Global_Comm)
    !
    ! If pio_async_interface is true Global_Comm is MPI_COMM_NULL on the servernodes
@@ -611,7 +619,13 @@ subroutine cesm_pre_init1()
    !
    !   if (Global_Comm /= MPI_COMM_NULL) then
 
-   call seq_comm_init(Global_Comm, NLFileName)
+   if (num_inst_cpl > 1) then
+      call seq_comm_init(Global_Comm, NLFileName, Comm_ID=cpl_id)
+      write(cpl_inst_tag,'("_",i4.4)') cpl_id
+   else
+      call seq_comm_init(Global_Comm, NLFileName)
+      cpl_inst_tag = ''
+   end if
 
    !--- set task based threading counts ---
    call seq_comm_getinfo(GLOID,pethreads=pethreads_GLOID,iam=iam_GLOID)
@@ -758,10 +772,10 @@ subroutine cesm_pre_init1()
    !----------------------------------------------------------
 
    if (iamroot_CPLID) then
-      inquire(file='cpl_modelio.nml',exist=exists)
+      inquire(file='cpl_modelio.nml'//trim(cpl_inst_tag),exist=exists) 
       if (exists) then
          logunit = shr_file_getUnit()
-         call shr_file_setIO('cpl_modelio.nml',logunit)
+         call shr_file_setIO('cpl_modelio.nml'//trim(cpl_inst_tag),logunit)
          call shr_file_setLogUnit(logunit)
          loglevel = 1
          call shr_file_setLogLevel(loglevel)
@@ -782,6 +796,8 @@ subroutine cesm_pre_init1()
       write(logunit,'(2A)') subname,' USE_ESMF_LIB is NOT set, using esmf_wrf_timemgr'
 #endif
       write(logunit,'(2A)') subname,' MCT_INTERFACE is set'
+      if (num_inst_cpl > 1) &
+         write(logunit,'(2A,I0,A)') subname,' Driver is running with',num_inst_cpl,'instances'
    endif
 
    !
@@ -851,7 +867,12 @@ subroutine cesm_pre_init2()
    !| Initialize infodata
    !----------------------------------------------------------
 
-   call seq_infodata_init(infodata,nlfilename, GLOID, pioid)
+   if (len(cpl_inst_tag) > 0) then
+      call seq_infodata_init(infodata,nlfilename, GLOID, pioid, &
+                             cpl_tag=cpl_inst_tag)
+   else
+      call seq_infodata_init(infodata,nlfilename, GLOID, pioid)
+   end if
 
    !----------------------------------------------------------
    !| Initialize coupled fields (depends on infodata)
@@ -3577,7 +3598,7 @@ end subroutine cesm_init
          call seq_rest_write(EClock_d, seq_SyncClock, infodata,       &
               atm, lnd, ice, ocn, rof, glc, wav, esp,                 &
               fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-              fractions_rx, fractions_gx, fractions_wx)
+              fractions_rx, fractions_gx, fractions_wx, tag=trim(cpl_inst_tag))
 
          if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
          call t_drvstopf  ('CPL:RESTART',cplrun=.true.)
@@ -3856,7 +3877,8 @@ end subroutine cesm_init
          call mpi_barrier(mpicom_GLOID,ierr)
          call t_stopf("sync1_tprof")
 
-         write(timing_file,'(a,i8.8,a1,i5.5)') trim(tchkpt_dir)//"/model_timing_",ymd,"_",tod
+         write(timing_file,'(a,i8.8,a1,i5.5)') & 
+           trim(tchkpt_dir)//"/cesm_timing"//trim(cpl_inst_tag)//"_",ymd,"_",tod
          if (output_perf) then
             call t_prf(filename=trim(timing_file), mpicom=mpicom_GLOID, &
                        num_outpe=0, output_thispe=output_perf)
@@ -3969,10 +3991,11 @@ end subroutine cesm_init
 
    call t_set_prefixf("final:")
    if (output_perf) then
-      call t_prf(trim(timing_dir)//'/model_timing', mpicom=mpicom_GLOID, &
-                 output_thispe=output_perf)
+      call t_prf(trim(timing_dir)//'/model_timing'//trim(cpl_inst_tag), &
+                 mpicom=mpicom_GLOID, output_thispe=output_perf)
    else
-      call t_prf(trim(timing_dir)//'/model_timing', mpicom=mpicom_GLOID)
+      call t_prf(trim(timing_dir)//'/model_timing'//trim(cpl_inst_tag), &
+                 mpicom=mpicom_GLOID)
    endif
    call t_unset_prefixf()
 
@@ -4041,5 +4064,61 @@ subroutine cesm_comp_barriers(mpicom, timer)
      call t_drvstopf (trim(timer))
   endif
 end subroutine cesm_comp_barriers
+
+subroutine cesm_cpl_init(comm, ninst, id)
+
+  !-----------------------------------------------------------------------
+  !
+  ! Initialize multiple coupler instances, if requested
+  !
+  !-----------------------------------------------------------------------
+
+  implicit none
+
+  integer , intent(inout) :: comm
+  integer , intent(out)   :: ninst
+  integer , intent(out)   :: id      ! instance ID, starts from 1
+  !
+  ! Local variables
+  !
+  integer :: ierr, inst_comm, mype, nu, numpes !, pes
+  integer :: cpl_ninst
+
+  namelist /cesm_cpl/ cpl_ninst
+
+  call shr_mpi_commrank(comm, mype  , ' cesm_cpl_init')
+  call shr_mpi_commsize(comm, numpes, ' cesm_cpl_init')
+
+  ninst = 1
+  id    = 0
+
+  if (mype == 0) then
+    ! Read coupler namelist if it exists
+    cpl_ninst = 1
+    nu = shr_file_getUnit()
+    open(unit = nu, file = NLFileName, status = 'old', iostat = ierr)
+    rewind(unit = nu)
+    read(unit = nu, nml = cesm_cpl, iostat = ierr)
+    close(unit = nu)
+    call shr_file_freeUnit(nu)
+    ninst = max(cpl_ninst, 1)
+  end if
+
+  call shr_mpi_bcast(ninst, comm, 'cpl_ninst')
+
+  if (mod(numpes, ninst) /= 0) then
+    call shr_sys_abort(subname // &
+      ' : Total PE number must be a multiple of coupler instance number')
+  end if
+
+  if (ninst > 1) then
+    id = mype * ninst / numpes + 1
+    call mpi_comm_split(comm, id, 0, inst_comm, ierr)
+    if (ierr /= 0) &
+      call shr_sys_abort(subname // ' : Error in generating coupler instances')
+    comm = inst_comm
+  end if
+
+end subroutine cesm_cpl_init
 
 end module cesm_comp_mod

--- a/src/drivers/mct/main/seq_rest_mod.F90
+++ b/src/drivers/mct/main/seq_rest_mod.F90
@@ -285,7 +285,7 @@ end subroutine seq_rest_read
 subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
      atm, lnd, ice, ocn, rof, glc, wav, esp,                 &
      fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-     fractions_rx, fractions_gx, fractions_wx)
+     fractions_rx, fractions_gx, fractions_wx, tag)
 
    implicit none
 
@@ -307,6 +307,7 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
    type(mct_aVect)        , intent(inout) :: fractions_rx(:)   ! Fractions on rof grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_gx(:)   ! Fractions on glc grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_wx(:)   ! Fractions on wav grid/decomp
+   character(len=*), optional, intent(in) :: tag
 
    integer(IN)   :: n,n1,n2,n3,fk
    integer(IN)   :: curr_ymd         ! Current date YYYYMMDD
@@ -369,8 +370,13 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
 
    call seq_timemgr_EClockGetData( EClock_d, curr_ymd=curr_ymd, curr_tod=curr_tod)
    call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
-   write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-      trim(case_name), '.cpl.r.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+   if (present(tag)) then   
+      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
+         trim(case_name), '.cpl'//trim(tag)//'.r.',yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+   else
+      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
+         trim(case_name), '.cpl.r.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+   end if
 
    ! Write driver data to restart file
 

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -199,7 +199,7 @@ contains
   end function seq_comm_get_ncomps
 
 
-  subroutine seq_comm_init(Comm_in, nmlfile)
+  subroutine seq_comm_init(Comm_in, nmlfile, Comm_ID)
 
     !----------------------------------------------------------
     !
@@ -207,6 +207,7 @@ contains
     implicit none
     integer, intent(in) :: Comm_in
     character(len=*), intent(IN) :: nmlfile
+    integer, optional, intent(in) :: Comm_ID
     !
     ! Local variables
     !
@@ -754,8 +755,13 @@ contains
           pelist(3,1) = astr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', n, num_inst_atm)
-       call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', n, num_inst_atm)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', n, num_inst_atm)
+          call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', n, num_inst_atm)
+       end if
     end do
     call seq_comm_jcommarr(ATMID,ALLATMID,'ALLATMID',1,1)
     call seq_comm_joincomm(CPLID,ALLATMID,CPLALLATMID,'CPLALLATMID',1,1)
@@ -767,8 +773,13 @@ contains
           pelist(3,1) = lstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', n, num_inst_lnd)
-       call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', n, num_inst_lnd)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', n, num_inst_lnd)
+          call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', n, num_inst_lnd)
+       end if
     end do
     call seq_comm_jcommarr(LNDID,ALLLNDID,'ALLLNDID',1,1)
     call seq_comm_joincomm(CPLID,ALLLNDID,CPLALLLNDID,'CPLALLLNDID',1,1)
@@ -780,8 +791,13 @@ contains
           pelist(3,1) = ostr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', n, num_inst_ocn)
-       call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', n, num_inst_ocn)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', n, num_inst_ocn)
+          call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', n, num_inst_ocn)
+       end if
     end do
     call seq_comm_jcommarr(OCNID,ALLOCNID,'ALLOCNID',1,1)
     call seq_comm_joincomm(CPLID,ALLOCNID,CPLALLOCNID,'CPLALLOCNID',1,1)
@@ -793,8 +809,13 @@ contains
           pelist(3,1) = istr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', n, num_inst_ice)
-       call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', n, num_inst_ice)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', n, num_inst_ice)
+          call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', n, num_inst_ice)
+       end if
     end do
     call seq_comm_jcommarr(ICEID,ALLICEID,'ALLICEID',1,1)
     call seq_comm_joincomm(CPLID,ALLICEID,CPLALLICEID,'CPLALLICEID',1,1)
@@ -806,8 +827,13 @@ contains
           pelist(3,1) = gstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', n, num_inst_glc)
-       call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', n, num_inst_glc)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', n, num_inst_glc)
+          call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', n, num_inst_glc)
+       end if
     end do
     call seq_comm_jcommarr(GLCID,ALLGLCID,'ALLGLCID',1,1)
     call seq_comm_joincomm(CPLID,ALLGLCID,CPLALLGLCID,'CPLALLGLCID',1,1)
@@ -819,8 +845,13 @@ contains
           pelist(3,1) = rstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', n, num_inst_rof)
-       call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', n, num_inst_rof)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', n, num_inst_rof)
+          call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', n, num_inst_rof)
+       end if
     end do
     call seq_comm_jcommarr(ROFID,ALLROFID,'ALLROFID',1,1)
     call seq_comm_joincomm(CPLID,ALLROFID,CPLALLROFID,'CPLALLROFID',1,1)
@@ -832,8 +863,13 @@ contains
           pelist(3,1) = wstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', n, num_inst_wav)
-       call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', n, num_inst_wav)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', n, num_inst_wav)
+          call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', n, num_inst_wav)
+       end if
     end do
     call seq_comm_jcommarr(WAVID,ALLWAVID,'ALLWAVID',1,1)
     call seq_comm_joincomm(CPLID,ALLWAVID,CPLALLWAVID,'CPLALLWAVID',1,1)

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -18,6 +18,7 @@
 ! !REVISION HISTORY:
 !     2005-Nov-11 - E. Kluzek - creation of shr_inputinfo_mod
 !     2007-Nov-15 - T. Craig - refactor for ccsm4 system and move to seq_infodata_mod
+!     2016-Dec-08 - R. Montuoro - updated for multiple coupler instances
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
@@ -283,7 +284,7 @@ CONTAINS
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
+SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid, cpl_tag)
 
 ! !USES:
 
@@ -300,6 +301,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
    character(len=*),        intent(IN)    :: nmlfile   ! Name-list filename
    integer(SHR_KIND_IN),    intent(IN)    :: ID        ! seq_comm ID
    type(file_desc_T) :: pioid
+   character(len=*), optional, intent(IN) :: cpl_tag   ! cpl instance suffix
 !EOP
 
     !----- local -----
@@ -585,6 +587,20 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        infodata%brnch_retain_casename = brnch_retain_casename
        infodata%restart_pfile         = restart_pfile
        infodata%restart_file          = restart_file
+       if (present(cpl_tag)) then
+          if (len(cpl_tag) > 0) then
+             if (trim(restart_file) /= trim(sp_str)) then
+                write(logunit,*) trim(subname),' ERROR: restart_file can '//&
+                'only be read from restart pointer files when using multiple couplers '
+                call shr_sys_abort(subname//' ERROR: invalid settings for restart_file ')
+             end if
+          end if
+          infodata%restart_file       = restart_file
+          infodata%restart_pfile      = trim(restart_pfile) // trim(cpl_tag)
+       else
+          infodata%restart_pfile      = restart_pfile
+          infodata%restart_file       = restart_file
+       end if
        infodata%single_column         = single_column
        infodata%scmlat                = scmlat
        infodata%scmlon                = scmlon


### PR DESCRIPTION
These changes add a new feature: multiple concurrent instances of the 
coupler can be run by setting cpl_ninst in the new cesm_cpl namelist
included in drv_in. At this time, only 1 component instance per coupler
instance is supported.

Test suite: 
Test baseline: 
Test namelist changes: Added cesm_cpl namelist to drv_in
Test status: bit for bit

Fixes: Potential bug fixes added in script/lib/CIME/case.py
(1) Fix log output for pestle
(2) Fix call to set_value in "final cleanup of lookup tables"

User interface changes?: Add --ncouplers option to create_newcase

Code review: 