### PR TITLE
add ability to remove tabs in shr_string_lalign

### DIFF
--- a/src/share/test/unit/shr_string_test/test_shr_string.pf
+++ b/src/share/test/unit/shr_string_test/test_shr_string.pf
@@ -47,13 +47,34 @@ contains
 
   @Test
   subroutine test_shr_string_leftAlign_initialTabs()
-    ! Should remove initial spaces
+    ! Should remove initial tabs
     character(len=6) :: str
 
     str = char(9) // char(9) // 'foo '
     call shr_string_leftAlign(str)
     @assertEqual('foo   ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_initialTabs
+
+  @Test
+  subroutine test_shr_string_leftAlign_interiorTabs()
+    ! Should NOT remove interior tabs
+    character(len=6) :: str, expected
+
+    str = 'f' // char(9) // 'oo  '
+    expected = str
+    call shr_string_leftAlign(str)
+    @assertEqual(expected, str, whitespace=KEEP_ALL)
+  end subroutine test_shr_string_leftAlign_interiorTabs
+
+  @Test
+  subroutine test_shr_string_leftAlign_initialSpacesAndTabs()
+    ! Should remove an initial mix of spaces and tabs
+    character(len=8) :: str
+
+    str = ' ' // char(9) // ' ' // char(9) // ' ' // 'foo'
+    call shr_string_leftAlign(str)
+    @assertEqual('foo     ', str, whitespace=KEEP_ALL)
+  end subroutine test_shr_string_leftAlign_initialSpacesAndTabs
 
   ! ------------------------------------------------------------------------
   ! Tests of shr_string_listDiff

--- a/src/share/test/unit/shr_string_test/test_shr_string.pf
+++ b/src/share/test/unit/shr_string_test/test_shr_string.pf
@@ -12,6 +12,40 @@ module test_shr_string
 contains
 
   ! ------------------------------------------------------------------------
+  ! Tests of shr_string_leftAlign
+  ! ------------------------------------------------------------------------
+
+  @Test
+  subroutine test_shr_string_leftAlign_noInitialSpaces()
+    ! With no initial spaces, should have no effect
+    character(len=6) :: str
+
+    str = 'foo   '
+    call shr_string_leftAlign(str)
+    @assertEqual('foo   ', str, whitespace=KEEP_ALL)
+  end subroutine test_shr_string_leftAlign_noInitialSpaces
+
+  @Test
+  subroutine test_shr_string_leftAlign_initialSpaces()
+    ! Should remove initial spaces
+    character(len=6) :: str
+
+    str = '  foo '
+    call shr_string_leftAlign(str)
+    @assertEqual('foo   ', str, whitespace=KEEP_ALL)
+  end subroutine test_shr_string_leftAlign_initialSpaces
+
+  @Test
+  subroutine test_shr_string_leftAlign_interiorSpaces()
+    ! Should NOT remove interior spaces
+    character(len=6) :: str
+
+    str = 'f oo  '
+    call shr_string_leftAlign(str)
+    @assertEqual('f oo  ', str, whitespace=KEEP_ALL)
+  end subroutine test_shr_string_leftAlign_interiorSpaces
+
+  ! ------------------------------------------------------------------------
   ! Tests of shr_string_listDiff
   ! ------------------------------------------------------------------------
 

--- a/src/share/test/unit/shr_string_test/test_shr_string.pf
+++ b/src/share/test/unit/shr_string_test/test_shr_string.pf
@@ -45,6 +45,16 @@ contains
     @assertEqual('f oo  ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_interiorSpaces
 
+  @Test
+  subroutine test_shr_string_leftAlign_initialTabs()
+    ! Should remove initial spaces
+    character(len=6) :: str
+
+    str = char(9) // char(9) // 'foo '
+    call shr_string_leftAlign(str)
+    @assertEqual('foo   ', str, whitespace=KEEP_ALL)
+  end subroutine test_shr_string_leftAlign_initialTabs
+
   ! ------------------------------------------------------------------------
   ! Tests of shr_string_listDiff
   ! ------------------------------------------------------------------------

--- a/src/share/test/unit/shr_string_test/test_shr_string.pf
+++ b/src/share/test/unit/shr_string_test/test_shr_string.pf
@@ -8,11 +8,17 @@ module test_shr_string
   implicit none
 
   integer, parameter :: list_len = 256
+  character, parameter :: tab_char = char(9)
 
 contains
 
   ! ------------------------------------------------------------------------
   ! Tests of shr_string_leftAlign
+  !
+  ! NOTE(wjs, 2017-05-15) There is more duplication in these tests than is warranted by
+  ! the simplicity of the subroutine. This is a historical artifact of when this routine
+  ! handled spaces and tabs separately. Some of these tests could probably be removed in
+  ! the future.
   ! ------------------------------------------------------------------------
 
   @Test
@@ -50,7 +56,7 @@ contains
     ! Should remove initial tabs
     character(len=6) :: str
 
-    str = char(9) // char(9) // 'foo '
+    str = tab_char // tab_char // 'foo '
     call shr_string_leftAlign(str)
     @assertEqual('foo   ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_initialTabs
@@ -60,7 +66,7 @@ contains
     ! Should NOT remove interior tabs
     character(len=6) :: str, expected
 
-    str = 'f' // char(9) // 'oo  '
+    str = 'f' // tab_char // 'oo  '
     expected = str
     call shr_string_leftAlign(str)
     @assertEqual(expected, str, whitespace=KEEP_ALL)
@@ -71,10 +77,21 @@ contains
     ! Should remove an initial mix of spaces and tabs
     character(len=8) :: str
 
-    str = ' ' // char(9) // ' ' // char(9) // ' ' // 'foo'
+    str = ' ' // tab_char // ' ' // tab_char // ' ' // 'foo'
     call shr_string_leftAlign(str)
     @assertEqual('foo     ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_initialSpacesAndTabs
+
+  @Test
+  subroutine test_shr_string_leftAlign_allSpacesAndTabs()
+    ! If string is just a mix of spaces and tabs, the resulting string should be all
+    ! spaces
+    character(len=6) :: str
+
+    str = ' ' // tab_char // ' ' // tab_char // '  '
+    call shr_string_leftAlign(str)
+    @assertEqual('      ', str, whitespace=KEEP_ALL)
+  end subroutine test_shr_string_leftAlign_allSpacesAndTabs
 
   ! ------------------------------------------------------------------------
   ! Tests of shr_string_listDiff

--- a/src/share/util/shr_string_mod.F90
+++ b/src/share/util/shr_string_mod.F90
@@ -412,7 +412,7 @@ end function shr_string_endIndex
 ! !IROUTINE: shr_string_leftAlign -- remove leading white space
 !
 ! !DESCRIPTION:
-!    Remove leading white space
+!    Remove leading white space (spaces and tabs)
 !     \newline
 !     call shr\_string\_leftAlign(string)
 !

--- a/src/share/util/shr_string_mod.F90
+++ b/src/share/util/shr_string_mod.F90
@@ -412,7 +412,8 @@ end function shr_string_endIndex
 ! !IROUTINE: shr_string_leftAlign -- remove leading white space
 !
 ! !DESCRIPTION:
-!    Remove leading white space (spaces and tabs)
+!    Remove leading white space (spaces and tabs); if input str is entirely spaces and tabs,
+!    then the result has all tabs converted to spaces
 !     \newline
 !     call shr\_string\_leftAlign(string)
 !
@@ -433,8 +434,10 @@ subroutine shr_string_leftAlign(str,rc)
 !EOP
 
    !----- local ----
+   integer(SHR_KIND_IN) :: index_first_non_blank
    integer(SHR_KIND_IN) :: rCode ! return code
    integer(SHR_KIND_IN) :: t01 = 0 ! timer
+   character, parameter :: tab_char = char(9)
 
    !----- formats -----
    character(*),parameter :: subName =   "(shr_string_leftAlign) "
@@ -447,66 +450,19 @@ subroutine shr_string_leftAlign(str,rc)
    if (debug>1 .and. t01<1) call shr_timer_get(t01,subName)
    if (debug>1) call shr_timer_start(t01)
 
-   ! First remove tabs from the string
-   str = shr_string_remove_tabs(str, rc)
-
-   ! Now remove the leading white space
-   str = adjustL(str)
+   ! From https://software.intel.com/en-us/forums/archived-visual-fortran-read-only/topic/314044
+   index_first_non_blank = verify(str, ' '//tab_char)
+   if (index_first_non_blank == 0) then
+      str = ' '
+   else
+      str = str(index_first_non_blank:)
+   end if
 
    if (present(rc)) rc = 0
 
    if (debug>1) call shr_timer_stop (t01)
 
 end subroutine shr_string_leftAlign
-
-
-!===============================================================================
-!BOP ===========================================================================
-!
-! !IROUTINE: shr_string_remove_tabs -- remove all tabs from a string
-!
-! !DESCRIPTION:
-!    Remove all tabs from a string
-!
-! !REVISION HISTORY:
-!     2017-May- - M. Vertenstein
-!
-! !INTERFACE: ------------------------------------------------------------------
-
-function shr_string_remove_tabs(str_input,rc) result(str_output)
-
-   implicit none
-
-! !INPUT/OUTPUT PARAMETERS:
-
-   character(len=*)    ,intent(in)             :: str_input
-   integer(SHR_KIND_IN),intent(out)  ,optional :: rc   ! return code
-   character(len=len(str_input))               :: str_output
-!EOP
-
-   !----- local ----
-   integer(SHR_KIND_IN) :: rCode              ! return code
-   integer(SHR_KIND_IN) :: index, inlength, i ! temporaries
-
-   !----- formats -----
-   character(*),parameter :: subName =   "(shr_string_remove_tabs) "
-   character(*),parameter :: F00     = "('(shr_string_remove_tabs) ',4a)"
-
-   ! note that tab is achar(9)
-   index = 0
-   inlength = len(str_input)
-   str_output = ''
-   do i = 1, inlength
-      if (str_input(i:i) /= achar(9)) then
-         index = index + 1
-         str_output(index:index) = str_input(i:i)
-      end if
-   end do
-   str_output(index+1:inlength) = ''
-   
-   if (present(rc)) rc = 0
-
- end function shr_string_remove_tabs
 
 !===============================================================================
 !BOP ===========================================================================

--- a/src/share/util/shr_string_mod.F90
+++ b/src/share/util/shr_string_mod.F90
@@ -1,8 +1,4 @@
 !===============================================================================
-! SVN $Id: shr_string_mod.F90 62094 2014-07-23 15:43:17Z muszala $
-! SVN $URL: https://svn-ccsm-models.cgd.ucar.edu/csm_share/trunk_tags/share3_150116/shr/shr_string_mod.F90 $
-!===============================================================================
-!===============================================================================
 !BOP ===========================================================================
 !
 ! !MODULE: shr_string_mod -- string and list methods
@@ -445,29 +441,72 @@ subroutine shr_string_leftAlign(str,rc)
    character(*),parameter :: F00     = "('(shr_string_leftAlign) ',4a)"
 
 !-------------------------------------------------------------------------------
-! note:
-! * ?? this routine isn't needed, use the intrisic adjustL instead ??
+!
 !-------------------------------------------------------------------------------
 
    if (debug>1 .and. t01<1) call shr_timer_get(t01,subName)
    if (debug>1) call shr_timer_start(t01)
 
-!  -------------------------------------------------------------------
-!  --- I used this until I discovered the intrinsic function below - BK
-!  do while (len_trim(str) > 0 )
-!     if (str(1:1) /= ' ') exit
-!     str = str(2:len_trim(str))
-!  end do
-!  rCode = 0
-!  !! (len_trim(str) == 0 ) rCode = 1  ! ?? appropriate ??
-!  -------------------------------------------------------------------
+   ! First remove tabs from the string
+   str = shr_string_remove_tabs(str, rc)
 
+   ! Now remove the leading white space
    str = adjustL(str)
+
    if (present(rc)) rc = 0
 
    if (debug>1) call shr_timer_stop (t01)
 
 end subroutine shr_string_leftAlign
+
+
+!===============================================================================
+!BOP ===========================================================================
+!
+! !IROUTINE: shr_string_remove_tabs -- remove all tabs from a string
+!
+! !DESCRIPTION:
+!    Remove all tabs from a string
+!
+! !REVISION HISTORY:
+!     2017-May- - M. Vertenstein
+!
+! !INTERFACE: ------------------------------------------------------------------
+
+function shr_string_remove_tabs(str_input,rc) result(str_output)
+
+   implicit none
+
+! !INPUT/OUTPUT PARAMETERS:
+
+   character(len=*)    ,intent(in)             :: str_input
+   integer(SHR_KIND_IN),intent(out)  ,optional :: rc   ! return code
+   character(len=len(str_input))               :: str_output
+!EOP
+
+   !----- local ----
+   integer(SHR_KIND_IN) :: rCode              ! return code
+   integer(SHR_KIND_IN) :: index, inlength, i ! temporaries
+
+   !----- formats -----
+   character(*),parameter :: subName =   "(shr_string_remove_tabs) "
+   character(*),parameter :: F00     = "('(shr_string_remove_tabs) ',4a)"
+
+   ! note that tab is achar(9)
+   index = 0
+   inlength = len(str_input)
+   str_output = ''
+   do i = 1, inlength
+      if (str_input(i:i) /= achar(9)) then
+         index = index + 1
+         str_output(index:index) = str_input(i:i)
+      end if
+   end do
+   str_output(index+1:inlength) = ''
+   
+   if (present(rc)) rc = 0
+
+ end function shr_string_remove_tabs
 
 !===============================================================================
 !BOP ===========================================================================


### PR DESCRIPTION
Removal of tabs from strings in stream files

Test suite: scripts_regression_tests 
 also manual verification that if tabs were introduced in a streams text file 
    (e.g. datm.streams.txt.CORE2_NYF.GISS) 
 then the resulting data model behaved correctly
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #862 
User interface changes?: None 
Code review: 
