### PR TITLE
remove XROF_FLOOD_MODE from config_grids.xml

### DIFF
--- a/config/xml_schemas/config_compsets.xsd
+++ b/config/xml_schemas/config_compsets.xsd
@@ -11,7 +11,6 @@
   <xs:element name="alias" type="xs:NCName"/>
   <xs:element name="lname" type="xs:string"/>
   <xs:element name="science_support"/>
-  <xs:element name="user_mods" type="xs:string"/>
 
   <!-- complex elements -->
 
@@ -33,7 +32,6 @@
         <xs:element ref="alias"/>
         <xs:element ref="lname"/>
 	<xs:element ref="science_support" minOccurs="0" maxOccurs="unbounded"/>
-	<xs:element ref="user_mods" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute ref="grid"/>
     </xs:complexType>

--- a/scripts/lib/CIME/XML/compsets.py
+++ b/scripts/lib/CIME/XML/compsets.py
@@ -37,14 +37,9 @@ class Compsets(GenericXML):
                 science_support_nodes = self.get_nodes("science_support", root=node)
                 for node in science_support_nodes:
                     science_support.append(node.get("grid"))
-                user_mods_node = self.get_optional_node("user_mods", root=node)
-                if user_mods_node is not None:
-                    user_mods = user_mods_node.text
-                else:
-                    user_mods = None
                 logger.debug("Found node match with alias: {} and lname: {}".format(alias, lname))
-                return (lname, alias, science_support, user_mods)
-        return (None, None, [False], None)
+                return (lname, alias, science_support)
+        return (None, None, [False])
 
     def get_compset_var_settings(self, compset, grid):
         '''


### PR DESCRIPTION
Remove XROF_FLOOD_MODE variable from config_grids.xml, this is handled in xrof config_component.xml.   Added a check in grids.py that gridmap fields in the config_grids.xml file have exactly two grid attributes.

Test suite: scripts_regression_tests.py, create_newcase for f09_g17.B1850
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1532 
User interface changes?: 

Code review: 
