### PR TITLE
fix issue when one value is resolved and the other isnt

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -315,9 +315,12 @@ class SystemTestsCommon(object):
                     self._test_status.set_status(MEMLEAK_PHASE, TEST_FAIL_STATUS, comments=comment)
 
     def compare_env_run(self, expected=None):
-        # JGF implement in check_lockedfiles?
-        f1obj = EnvRun(self._caseroot, "env_run.xml")
-        f2obj = EnvRun(self._caseroot, os.path.join(LOCKED_DIR, "env_run.orig.xml"))
+        """
+        Compare env_run file to original and warn about differences
+        """
+        components = self._case.get_values("COMP_CLASSES")
+        f1obj = EnvRun(self._caseroot, "env_run.xml", components=components)
+        f2obj = EnvRun(self._caseroot, os.path.join(LOCKED_DIR, "env_run.orig.xml"), components=components)
         diffs = f1obj.compare_xml(f2obj)
         for key in diffs.keys():
             if expected is not None and key in expected:

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -383,9 +383,12 @@ class EntryID(GenericXML):
                     if f2val != f1val:
                         f1value_nodes = self.get_nodes("value", root=node)
                         for valnode in f1value_nodes:
-                            f2valnode = other.get_node("value", root=f2match, attributes=valnode.attrib)
-                            if f2valnode.text != valnode.text:
-                                xmldiffs["%s:%s"%(vid,valnode.attrib)] = [valnode.text, f2valnode.text]
+                            f2valnodes = other.get_nodes("value", root=f2match, attributes=valnode.attrib)
+                            for f2valnode in f2valnodes:
+                                if valnode.attrib is None and f2valnode.attrib is None or \
+                                   f2valnode.attrib == valnode.attrib:
+                                    if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
+                                        xmldiffs["%s:%s"%(vid,valnode.attrib)] = [valnode.text, f2valnode.text]
 
         return xmldiffs
 


### PR DESCRIPTION
Fix an issue where env_run.xml may have resolved values but LockedFiles/env_run.orig.xml does not.

Test suite: scripts_regression_tests.py, hand tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Code review: 
