### PR TITLE
convert stream tabs to spaces

### DIFF
--- a/src/share/test/unit/shr_string_test/test_shr_string.pf
+++ b/src/share/test/unit/shr_string_test/test_shr_string.pf
@@ -27,14 +27,14 @@ contains
   end subroutine test_shr_string_leftAlign_noInitialSpaces
 
   @Test
-  subroutine test_shr_string_leftAlign_initialSpaces()
-    ! Should remove initial spaces
-    character(len=6) :: str
+  subroutine test_shr_string_leftAlign_initialSpacesAndTabs()
+    ! Should remove an initial mix of spaces and tabs
+    character(len=8) :: str
 
-    str = '  foo '
+    str = ' ' // tab_char // ' ' // tab_char // ' ' // 'foo'
     call shr_string_leftAlign_and_convert_tabs(str)
-    @assertEqual('foo   ', str, whitespace=KEEP_ALL)
-  end subroutine test_shr_string_leftAlign_initialSpaces
+    @assertEqual('foo     ', str, whitespace=KEEP_ALL)
+  end subroutine test_shr_string_leftAlign_initialSpacesAndTabs
 
   @Test
   subroutine test_shr_string_leftAlign_interiorSpaces()
@@ -47,16 +47,6 @@ contains
   end subroutine test_shr_string_leftAlign_interiorSpaces
 
   @Test
-  subroutine test_shr_string_leftAlign_initialTabs()
-    ! Should remove initial tabs
-    character(len=6) :: str
-
-    str = tab_char // tab_char // 'foo '
-    call shr_string_leftAlign_and_convert_tabs(str)
-    @assertEqual('foo   ', str, whitespace=KEEP_ALL)
-  end subroutine test_shr_string_leftAlign_initialTabs
-
-  @Test
   subroutine test_shr_string_leftAlign_interiorTabs()
     ! Convert interior tabs to spaces
     character(len=6) :: str, expected
@@ -66,16 +56,6 @@ contains
     call shr_string_leftAlign_and_convert_tabs(str)
     @assertEqual(expected, str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_interiorTabs
-
-  @Test
-  subroutine test_shr_string_leftAlign_initialSpacesAndTabs()
-    ! Should remove an initial mix of spaces and tabs
-    character(len=8) :: str
-
-    str = ' ' // tab_char // ' ' // tab_char // ' ' // 'foo'
-    call shr_string_leftAlign_and_convert_tabs(str)
-    @assertEqual('foo     ', str, whitespace=KEEP_ALL)
-  end subroutine test_shr_string_leftAlign_initialSpacesAndTabs
 
   ! ------------------------------------------------------------------------
   ! Tests of shr_string_listDiff

--- a/src/share/test/unit/shr_string_test/test_shr_string.pf
+++ b/src/share/test/unit/shr_string_test/test_shr_string.pf
@@ -13,12 +13,7 @@ module test_shr_string
 contains
 
   ! ------------------------------------------------------------------------
-  ! Tests of shr_string_leftAlign_
-  !
-  ! NOTE(wjs, 2017-05-15) There is more duplication in these tests than is warranted by
-  ! the simplicity of the subroutine. This is a historical artifact of when this routine
-  ! handled spaces and tabs separately. Some of these tests could probably be removed in
-  ! the future.
+  ! Tests of shr_string_leftAlign_and_convert_tabs
   ! ------------------------------------------------------------------------
 
   @Test
@@ -81,17 +76,6 @@ contains
     call shr_string_leftAlign_and_convert_tabs(str)
     @assertEqual('foo     ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_initialSpacesAndTabs
-
-  @Test
-  subroutine test_shr_string_leftAlign_allSpacesAndTabs()
-    ! If string is just a mix of spaces and tabs, the resulting string should be all
-    ! spaces
-    character(len=6) :: str
-
-    str = ' ' // tab_char // ' ' // tab_char // '  '
-    call shr_string_leftAlign_and_convert_tabs(str)
-    @assertEqual('      ', str, whitespace=KEEP_ALL)
-  end subroutine test_shr_string_leftAlign_allSpacesAndTabs
 
   ! ------------------------------------------------------------------------
   ! Tests of shr_string_listDiff

--- a/src/share/test/unit/shr_string_test/test_shr_string.pf
+++ b/src/share/test/unit/shr_string_test/test_shr_string.pf
@@ -13,7 +13,7 @@ module test_shr_string
 contains
 
   ! ------------------------------------------------------------------------
-  ! Tests of shr_string_leftAlign
+  ! Tests of shr_string_leftAlign_
   !
   ! NOTE(wjs, 2017-05-15) There is more duplication in these tests than is warranted by
   ! the simplicity of the subroutine. This is a historical artifact of when this routine
@@ -27,7 +27,7 @@ contains
     character(len=6) :: str
 
     str = 'foo   '
-    call shr_string_leftAlign(str)
+    call shr_string_leftAlign_and_convert_tabs(str)
     @assertEqual('foo   ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_noInitialSpaces
 
@@ -37,7 +37,7 @@ contains
     character(len=6) :: str
 
     str = '  foo '
-    call shr_string_leftAlign(str)
+    call shr_string_leftAlign_and_convert_tabs(str)
     @assertEqual('foo   ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_initialSpaces
 
@@ -47,7 +47,7 @@ contains
     character(len=6) :: str
 
     str = 'f oo  '
-    call shr_string_leftAlign(str)
+    call shr_string_leftAlign_and_convert_tabs(str)
     @assertEqual('f oo  ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_interiorSpaces
 
@@ -57,18 +57,18 @@ contains
     character(len=6) :: str
 
     str = tab_char // tab_char // 'foo '
-    call shr_string_leftAlign(str)
+    call shr_string_leftAlign_and_convert_tabs(str)
     @assertEqual('foo   ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_initialTabs
 
   @Test
   subroutine test_shr_string_leftAlign_interiorTabs()
-    ! Should NOT remove interior tabs
+    ! Convert interior tabs to spaces
     character(len=6) :: str, expected
 
     str = 'f' // tab_char // 'oo  '
-    expected = str
-    call shr_string_leftAlign(str)
+    expected = 'f oo '
+    call shr_string_leftAlign_and_convert_tabs(str)
     @assertEqual(expected, str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_interiorTabs
 
@@ -78,7 +78,7 @@ contains
     character(len=8) :: str
 
     str = ' ' // tab_char // ' ' // tab_char // ' ' // 'foo'
-    call shr_string_leftAlign(str)
+    call shr_string_leftAlign_and_convert_tabs(str)
     @assertEqual('foo     ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_initialSpacesAndTabs
 
@@ -89,7 +89,7 @@ contains
     character(len=6) :: str
 
     str = ' ' // tab_char // ' ' // tab_char // '  '
-    call shr_string_leftAlign(str)
+    call shr_string_leftAlign_and_convert_tabs(str)
     @assertEqual('      ', str, whitespace=KEEP_ALL)
   end subroutine test_shr_string_leftAlign_allSpacesAndTabs
 

--- a/src/share/util/shr_stream_mod.F90
+++ b/src/share/util/shr_stream_mod.F90
@@ -1,7 +1,4 @@
 !===============================================================================
-! SVN $Id: shr_stream_mod.F90 65656 2014-11-21 18:33:26Z santos@ucar.edu $
-! SVN $URL: https://svn-ccsm-models.cgd.ucar.edu/csm_share/trunk_tags/share3_150116/shr/shr_stream_mod.F90 $
-!===============================================================================
 !BOP ===========================================================================
 !
 ! !MODULE: shr_stream_mod -- Data type and methods to manage input data streams.
@@ -262,7 +259,7 @@ subroutine shr_stream_init(strm,infoFile,yearFirst,yearLast,yearAlign,taxMode,rc
 
    !--- read data ---
    read(nUnit,'(a)',END=999) str
-   call shr_string_leftAlign(str)
+   call shr_string_leftalign_and_convert_tabs(str)
    strm%dataSource = str
    if (debug>0 .and. s_loglev>0) write(s_logunit,F00) '  * format = ', trim(strm%dataSource)
 
@@ -288,7 +285,7 @@ subroutine shr_stream_init(strm,infoFile,yearFirst,yearLast,yearAlign,taxMode,rc
    n=0
    do while (.true.)
       read(nUnit,'(a)',END=999) str
-      call shr_string_leftAlign(str)
+      call shr_string_leftalign_and_convert_tabs(str)
       n=n+1
       if (str(1:len_trim(endTag)) == trim(endTag)) exit
       fldNameFile  = ""
@@ -385,7 +382,7 @@ subroutine shr_stream_init(strm,infoFile,yearFirst,yearLast,yearAlign,taxMode,rc
 
    !--- read data ---
    read(nUnit,'(a)',END=999) str
-   call shr_string_leftAlign(str)
+   call shr_string_leftalign_and_convert_tabs(str)
    n = len_trim(str)
    if (n>0 .and. str(n:n) /= '/') str(n+1:n+2) = "/ " ! must have trailing slash
    if (n==0) str = "./ "                              ! null path => ./
@@ -418,7 +415,7 @@ subroutine shr_stream_init(strm,infoFile,yearFirst,yearLast,yearAlign,taxMode,rc
    !--- read data ---
    do while (.true.)
       read(nUnit,'(a)',END=999) str
-      call shr_string_leftAlign(str)
+      call shr_string_leftalign_and_convert_tabs(str)
       if (str(1:len_trim(endTag)) == trim(endTag)) exit
       tempFile%name = str
       call fileVec%push_back(tempFile)
@@ -461,7 +458,7 @@ subroutine shr_stream_init(strm,infoFile,yearFirst,yearLast,yearAlign,taxMode,rc
    n=0
    do while (.true.)
       read(nUnit,'(a)',END=999) str
-      call shr_string_leftAlign(str)
+      call shr_string_leftalign_and_convert_tabs(str)
       n=n+1
       if (str(1:len_trim(endTag)) == trim(endTag)) exit
       fldNameFile  = ""
@@ -580,7 +577,7 @@ subroutine shr_stream_init(strm,infoFile,yearFirst,yearLast,yearAlign,taxMode,rc
 
    !--- read data ---
    read(nUnit,'(a)',END=999) str
-   call shr_string_leftAlign(str)
+   call shr_string_leftalign_and_convert_tabs(str)
    n = len_trim(str)
    if (n>0 .and. str(n:n) /= '/') str(n+1:n+2) = "/ " ! must have trailing slash
    if (n==0) str = "./ "                              ! null path => ./
@@ -611,7 +608,7 @@ subroutine shr_stream_init(strm,infoFile,yearFirst,yearLast,yearAlign,taxMode,rc
 
    !--- read data ---
    read(nUnit,'(a)',END=999) str
-   call shr_string_leftAlign(str)
+   call shr_string_leftalign_and_convert_tabs(str)
    strm%domFileName = str
    if (debug>0 .and. s_loglev>0) write(s_logunit,F00) '  * ',trim(strm%domFileName)
 
@@ -1540,8 +1537,8 @@ subroutine shr_stream_readTCoord(strm,k,rc)
    if (ichar(units(n:n)) == 0 ) units(n:n) = ' '
    n = len_trim(calendar)
    if (ichar(calendar(n:n)) == 0 ) calendar(n:n) = ' '
-   call shr_string_leftalign(units)
-   call shr_string_leftalign(calendar)
+   call shr_string_leftalign_and_convert_tabs(units)
+   call shr_string_leftalign_and_convert_tabs(calendar)
    call shr_string_parseCFtunit(units,bunits,bdate,bsec)
    strm%calendar = trim(shr_cal_calendarName(trim(calendar)))
 
@@ -2008,7 +2005,7 @@ subroutine shr_stream_getCalendar(strm,k,calendar)
    endif
    n = len_trim(lcal)
    if (ichar(lcal(n:n)) == 0 ) lcal(n:n) = ' '
-   call shr_string_leftalign(lcal)
+   call shr_string_leftalign_and_convert_tabs(lcal)
    calendar = trim(shr_cal_calendarName(trim(lcal)))
    rCode = nf90_close(fid)
    if (rcode /= nf90_noerr) call shr_sys_abort(subname//' ERROR: nf90_close')

--- a/src/share/util/shr_string_mod.F90
+++ b/src/share/util/shr_string_mod.F90
@@ -506,7 +506,6 @@ function shr_string_convert_tabs(str_input,rc) result(str_output)
          str_output(i:i) = str_input(i:i)
       end if
    end do
-   str_output(i+1:inlength) = ''
    
    if (present(rc)) rc = 0
 

--- a/src/share/util/shr_string_mod.F90
+++ b/src/share/util/shr_string_mod.F90
@@ -41,7 +41,8 @@ module shr_string_mod
    public :: shr_string_getParentDir    ! For a pathname get the parent directory name
    public :: shr_string_lastIndex       ! Index of last substr in str
    public :: shr_string_endIndex        ! Index of end of substr in str
-   public :: shr_string_leftalign_and_convert_tabs ! remove leading white space
+   public :: shr_string_leftalign_and_convert_tabs ! remove leading white space and convert all tabs to spaces
+   public :: shr_string_convert_tabs    ! Convert all tabs to spaces
    public :: shr_string_alphanum        ! remove all non alpha-numeric characters
    public :: shr_string_betweenTags     ! get the substring between the two tags
    public :: shr_string_parseCFtunit    ! parse CF time units
@@ -409,11 +410,12 @@ end function shr_string_endIndex
 !===============================================================================
 !BOP ===========================================================================
 !
-! !IROUTINE: shr_string_leftalign_and_convert_tabs -- remove leading white space
+! !IROUTINE: shr_string_leftalign_and_convert_tabs -- remove leading white space and
+! convert tabs to spaces
 !
 ! !DESCRIPTION:
-!    Remove leading white space (spaces and tabs); if input str is entirely spaces and tabs,
-!    then the result has all tabs converted to spaces
+!    Remove leading white space (spaces and tabs) and convert tabs to spaces
+!    This even converts tabs in the middle or at the end of the string to spaces
 !     \newline
 !     call shr\_string\_leftalign_and_convert_tabs(string)
 !
@@ -465,10 +467,10 @@ end subroutine shr_string_leftalign_and_convert_tabs
 !===============================================================================
 !BOP ===========================================================================
 !
-! !IROUTINE: shr_string_remove_tabs -- remove all tabs from a string
+! !IROUTINE: shr_string_convert_tabs -- convert all tabs to spaces
 !
 ! !DESCRIPTION:
-!    Remove all tabs from a string
+!    Convert all tabs to spaces in the given string
 !
 ! !REVISION HISTORY:
 !     2017-May- - M. Vertenstein


### PR DESCRIPTION
Convert all tabs to spaces in data model stream txt files

Test suite: scripts_regression_tests
      also manual verification that if tabs were introduced in a streams text file
              (e.g. datm.streams.txt.CORE2_NYF.GISS)
      then the resulting data model behaved correctly
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #862
User interface changes?: None
Code review: billsacks
