### PR TITLE
Improve user compset error checking

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -295,7 +295,7 @@ class J_TestCreateNewcase(unittest.TestCase):
             primary = case._find_primary_component()
             self.assertEqual(primary, "wilma", msg="primary component test expected wilma but got %s"%primary)
             # this is a "E" compset
-            case._compsetname.replace("XOCN","DOCN%SOM")
+            case._compsetname = case._compsetname.replace("XOCN","DOCN%SOM")
             primary = case._find_primary_component()
             self.assertEqual(primary, "allactive", msg="primary component test expected allactive but got %s"%primary)
             # finally a "B" compset

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -261,6 +261,7 @@ class J_TestCreateNewcase(unittest.TestCase):
         run_cmd_assert_result(self, "./case.build", from_dir=testdir)
 
         with Case(testdir, read_only=True) as case:
+            case._compsetname = case.get_value("COMPSET")
             case.set_comp_classes(case.get_values("COMP_CLASSES"))
             primary = case._find_primary_component()
             self.assertEqual(primary, "drv", msg="primary component test expected drv but got %s"%primary)


### PR DESCRIPTION
I updated the previous PR before I had quite finished testing.  This fixes a test that will currently fail on master
Test suite: scripts_regression_tests.py  
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes

User interface changes?: 

Code review: 
