### PR TITLE
Multi component user mods

### DIFF
--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -401,6 +401,8 @@ class Grids(GenericXML):
                 gridname = grid[0]
                 other_gridname = other_grid[0]
                 gridvalue = component_grids[grid[1]]
+                if gridname == "atm_grid":
+                    atm_gridvalue = gridvalue
                 other_gridvalue = component_grids[other_grid[1]]
                 gridmap_nodes = self.get_nodes(nodename="gridmap",
                                                attributes={gridname:gridvalue, other_gridname:other_gridvalue})
@@ -428,7 +430,10 @@ class Grids(GenericXML):
                 if grid1_value != grid2_value and grid1_value != 'null' and grid2_value != 'null':
                     map_ = gridmaps[node.text]
                     if map_ == 'idmap':
-                        logger.warning("Warning: missing non-idmap %s for %s, %s and %s %s "
+                        if grid1_name == "ocn_grid" and grid1_value == atm_gridvalue:
+                            logger.debug('ocn_grid == atm_grid so this is not an idmap error')
+                        else:
+                            logger.warning("Warning: missing non-idmap %s for %s, %s and %s %s "
                                        %(node.text, grid1_name, grid1_value, grid2_name, grid2_value))
 
         return gridmaps

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -443,7 +443,7 @@ class Case(object):
                     user_mods_dir     = files.get_value("USER_MODS_DIR"     , {"component":component}, resolved=False)
                     self.set_lookup_value("COMPSETS_SPEC_FILE" ,
                                    files.get_value("COMPSETS_SPEC_FILE", {"component":component}, resolved=False))
-                    self._primary_component = component.upper()
+                    self._primary_component = component
                     self.set_lookup_value("TESTS_SPEC_FILE"    , tests_filename)
                     self.set_lookup_value("TESTS_MODS_DIR"     , tests_mods_dir)
                     self.set_lookup_value("USER_MODS_DIR"      , user_mods_dir)
@@ -1030,13 +1030,9 @@ class Case(object):
         for newdir in newdirs:
             os.makedirs(newdir)
 
-        user_mods = self.get_value("%s_USER_MODS"%(self._primary_component))
-
         # Open a new README.case file in $self._caseroot
         append_status(" ".join(sys.argv), "README.case", caseroot=self._caseroot)
         compset_info = "Compset longname is %s"%(self.get_value("COMPSET"))
-        if user_mods is not None:
-            compset_info += " with user_mods directory %s"%(user_mods)
         append_status(compset_info,
                       "README.case", caseroot=self._caseroot)
         append_status("Compset specification file is %s" %
@@ -1053,11 +1049,12 @@ class Case(object):
                           "README.case", caseroot=self._caseroot)
             append_status("%s is %s"%(comp_grid,self.get_value(comp_grid)),
                           "README.case", caseroot=self._caseroot)
-
-        if user_mods is not None:
-            note = "This compset includes user_mods %s"%user_mods
-            append_status(note, "README.case", caseroot=self._caseroot)
-            logger.info(note)
+            comp = self.get_value("COMP_%s"%component_class)
+            user_mods = self.get_value("%s_USER_MODS"%(comp.upper()))
+            if user_mods is not None:
+                note = "This component includes user_mods %s"%user_mods
+                append_status(note, "README.case", caseroot=self._caseroot)
+                logger.info(note)
         if not clone:
             self._create_caseroot_sourcemods()
         self._create_caseroot_tools()
@@ -1067,19 +1064,30 @@ class Case(object):
         User mods can be specified on the create_newcase command line (usually when called from create test)
         or they can be in the compset definition, or both.
         """
-
-        component_user_mods = self.get_value("%s_USER_MODS"%(self._primary_component))
+        all_user_mods = []
+        for comp in self._component_classes:
+            if comp == self._primary_component:
+                continue
+            component = self.get_value("COMP_%s"%comp)
+            comp_user_mods = self.get_value("%s_USER_MODS"%comp.upper())
+            if comp_user_mods is not None:
+                all_user_mods.append(comp_user_mods)
+        # get the primary last so that it takes precidence over other components
+        comp_user_mods = self.get_value("%s_USER_MODS"%(self._primary_component.upper()))
+        if comp_user_mods is not None:
+            all_user_mods.append(comp_user_mods)
+        if user_mods_dir is not None:
+            all_user_mods.append(user_mods_dir)
 
         # This looping order will lead to the specified user_mods_dir taking
         # precedence over self._user_mods, if there are any conflicts.
-        for user_mods in (component_user_mods, user_mods_dir):
-            if user_mods is not None:
-                if os.path.isabs(user_mods):
-                    user_mods_path = user_mods
-                else:
-                    user_mods_path = self.get_value('USER_MODS_DIR')
-                    user_mods_path = os.path.join(user_mods_path, user_mods)
-                apply_user_mods(self._caseroot, user_mods_path)
+        for user_mods in all_user_mods:
+            if os.path.isabs(user_mods):
+                user_mods_path = user_mods
+            else:
+                user_mods_path = self.get_value('USER_MODS_DIR')
+                user_mods_path = os.path.join(user_mods_path, user_mods)
+            apply_user_mods(self._caseroot, user_mods_path)
 
     def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
         if cime_output_root is None:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1049,7 +1049,7 @@ class Case(object):
                           "README.case", caseroot=self._caseroot)
             append_status("%s is %s"%(comp_grid,self.get_value(comp_grid)),
                           "README.case", caseroot=self._caseroot)
-            comp = self.get_value("COMP_%s"%component_class)
+            comp = str(self.get_value("COMP_%s"%component_class))
             user_mods = self.get_value("%s_USER_MODS"%(comp.upper()))
             if user_mods is not None:
                 note = "This component includes user_mods %s"%user_mods
@@ -1068,8 +1068,8 @@ class Case(object):
         for comp in self._component_classes:
             if comp == self._primary_component:
                 continue
-            component = self.get_value("COMP_%s"%comp)
-            comp_user_mods = self.get_value("%s_USER_MODS"%comp.upper())
+            component = str(self.get_value("COMP_%s"%comp))
+            comp_user_mods = self.get_value("%s_USER_MODS"%component.upper())
             if comp_user_mods is not None:
                 all_user_mods.append(comp_user_mods)
         # get the primary last so that it takes precidence over other components

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -412,7 +412,7 @@ class J_TestCreateNewcase(unittest.TestCase):
             shutil.rmtree(testdir)
 
         cls._testdirs.append(testdir)
-        run_cmd_assert_result(self, "%s/create_newcase --case CreateNewcaseTest --script-root %s --compset X --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
+        run_cmd_assert_result(self, "%s/create_newcase --case CreateNewcaseTest --script-root %s --compset X --res f19_g16 --output-root %s --handle-preexisting-dirs u" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
         self.assertTrue(os.path.exists(testdir))
         self.assertTrue(os.path.exists(os.path.join(testdir, "case.setup")))
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -260,49 +260,6 @@ class J_TestCreateNewcase(unittest.TestCase):
         run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
         run_cmd_assert_result(self, "./case.build", from_dir=testdir)
 
-        with Case(testdir, read_only=True) as case:
-            case._compsetname = case.get_value("COMPSET")
-            case.set_comp_classes(case.get_values("COMP_CLASSES"))
-            primary = case._find_primary_component()
-            self.assertEqual(primary, "drv", msg="primary component test expected drv but got %s"%primary)
-            # now we are going to corrupt the case so that we can do more primary_component testing
-            case.set_valid_values("COMP_GLC","%s,fred"%case.get_value("COMP_GLC"))
-            case.set_value("COMP_GLC","fred")
-            primary = case._find_primary_component()
-            self.assertEqual(primary, "fred", msg="primary component test expected fred but got %s"%primary)
-            case.set_valid_values("COMP_ICE","%s,wilma"%case.get_value("COMP_ICE"))
-            case.set_value("COMP_ICE","wilma")
-            primary = case._find_primary_component()
-            self.assertEqual(primary, "wilma", msg="primary component test expected wilma but got %s"%primary)
-
-            case.set_valid_values("COMP_OCN","%s,bambam,docn"%case.get_value("COMP_OCN"))
-            case.set_value("COMP_OCN","bambam")
-            primary = case._find_primary_component()
-            self.assertEqual(primary, "bambam", msg="primary component test expected bambam but got %s"%primary)
-
-            case.set_valid_values("COMP_LND","%s,barney"%case.get_value("COMP_LND"))
-            case.set_value("COMP_LND","barney")
-            primary = case._find_primary_component()
-            # This is a "J" compset
-            self.assertEqual(primary, "allactive", msg="primary component test expected allactive but got %s"%primary)
-            case.set_value("COMP_OCN","docn")
-            case.set_valid_values("COMP_LND","%s,barney"%case.get_value("COMP_LND"))
-            case.set_value("COMP_LND","barney")
-            primary = case._find_primary_component()
-            self.assertEqual(primary, "barney", msg="primary component test expected barney but got %s"%primary)
-            case.set_valid_values("COMP_ATM","%s,wilma"%case.get_value("COMP_ATM"))
-            case.set_value("COMP_ATM","wilma")
-            primary = case._find_primary_component()
-            self.assertEqual(primary, "wilma", msg="primary component test expected wilma but got %s"%primary)
-            # this is a "E" compset
-            case._compsetname = case._compsetname.replace("XOCN","DOCN%SOM")
-            primary = case._find_primary_component()
-            self.assertEqual(primary, "allactive", msg="primary component test expected allactive but got %s"%primary)
-            # finally a "B" compset
-            case.set_value("COMP_OCN","bambam")
-            primary = case._find_primary_component()
-            self.assertEqual(primary, "allactive", msg="primary component test expected allactive but got %s"%primary)
-
         cls._do_teardown.append(testdir)
 
     def test_b_user_mods(self):
@@ -446,6 +403,64 @@ class J_TestCreateNewcase(unittest.TestCase):
                               expected_stat=1)
 
         cls._do_teardown.append(testdir)
+
+    def test_h_primary_component(self):
+        cls = self.__class__
+
+        testdir = os.path.join(cls._testroot, 'testprimarycomponent')
+        if os.path.exists(testdir):
+            shutil.rmtree(testdir)
+
+        cls._testdirs.append(testdir)
+        run_cmd_assert_result(self, "%s/create_newcase --case CreateNewcaseTest --script-root %s --compset X --res f19_g16 --output-root %s" % (SCRIPT_DIR, testdir, cls._testroot), from_dir=SCRIPT_DIR)
+        self.assertTrue(os.path.exists(testdir))
+        self.assertTrue(os.path.exists(os.path.join(testdir, "case.setup")))
+
+        with Case(testdir, read_only=True) as case:
+            case._compsetname = case.get_value("COMPSET")
+            case.set_comp_classes(case.get_values("COMP_CLASSES"))
+            primary = case._find_primary_component()
+            self.assertEqual(primary, "drv", msg="primary component test expected drv but got %s"%primary)
+            # now we are going to corrupt the case so that we can do more primary_component testing
+            case.set_valid_values("COMP_GLC","%s,fred"%case.get_value("COMP_GLC"))
+            case.set_value("COMP_GLC","fred")
+            primary = case._find_primary_component()
+            self.assertEqual(primary, "fred", msg="primary component test expected fred but got %s"%primary)
+            case.set_valid_values("COMP_ICE","%s,wilma"%case.get_value("COMP_ICE"))
+            case.set_value("COMP_ICE","wilma")
+            primary = case._find_primary_component()
+            self.assertEqual(primary, "wilma", msg="primary component test expected wilma but got %s"%primary)
+
+            case.set_valid_values("COMP_OCN","%s,bambam,docn"%case.get_value("COMP_OCN"))
+            case.set_value("COMP_OCN","bambam")
+            primary = case._find_primary_component()
+            self.assertEqual(primary, "bambam", msg="primary component test expected bambam but got %s"%primary)
+
+            case.set_valid_values("COMP_LND","%s,barney"%case.get_value("COMP_LND"))
+            case.set_value("COMP_LND","barney")
+            primary = case._find_primary_component()
+            # This is a "J" compset
+            self.assertEqual(primary, "allactive", msg="primary component test expected allactive but got %s"%primary)
+            case.set_value("COMP_OCN","docn")
+            case.set_valid_values("COMP_LND","%s,barney"%case.get_value("COMP_LND"))
+            case.set_value("COMP_LND","barney")
+            primary = case._find_primary_component()
+            self.assertEqual(primary, "barney", msg="primary component test expected barney but got %s"%primary)
+            case.set_valid_values("COMP_ATM","%s,wilma"%case.get_value("COMP_ATM"))
+            case.set_value("COMP_ATM","wilma")
+            primary = case._find_primary_component()
+            self.assertEqual(primary, "wilma", msg="primary component test expected wilma but got %s"%primary)
+            # this is a "E" compset
+            case._compsetname = case._compsetname.replace("XOCN","DOCN%SOM")
+            primary = case._find_primary_component()
+            self.assertEqual(primary, "allactive", msg="primary component test expected allactive but got %s"%primary)
+            # finally a "B" compset
+            case.set_value("COMP_OCN","bambam")
+            primary = case._find_primary_component()
+            self.assertEqual(primary, "allactive", msg="primary component test expected allactive but got %s"%primary)
+
+        cls._do_teardown.append(testdir)
+
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Allows multiple component user_mods. but gives primary component precedent.  
Fixes warning issues for ocn grid non-idmap error if ocn is DOCN
Rearrange tests in scripts_regression_tests to avoid conflict between tests.

Test suite: scripts_regression_tests.py hand tests with F2000_DEV and contrived user_mods
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
