### PR TITLE
undo recent change to land domain

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -960,7 +960,7 @@
       <nx>288</nx>  <ny>192</ny>
       <file grid="atm|lnd" mask="gx1v6">domain.lnd.fv0.9x1.25_gx1v6.090309.nc</file>
       <file grid="ocnice"  mask="gx1v6">domain.ocn.0.9x1.25_gx1v6_090403.nc</file>
-      <file grid="atm|lnd" mask="gx1v7">domain.lnd.fv0.9x1.25_gx1v7.151008.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">domain.lnd.fv0.9x1.25_gx1v7.151020.nc</file>
       <file grid="ocnice"  mask="gx1v7">domain.ocn.fv0.9x1.25_gx1v7.151008.nc</file>
       <file grid="atm|lnd" mask="null">/glade/u/home/benedict/ys/datain/domain.aqua.fv0.9x1.25.nc</file>
       <file grid="ocnice"  mask="null">/glade/u/home/benedict/ys/datain/domain.aqua.fv0.9x1.25.nc</file>
@@ -1089,7 +1089,7 @@
 
     <domain name="gx1v7">
       <nx>320</nx>  <ny>384</ny>
-      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.ocn.gx1v7.151008.nc</file>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.ocn.gx1v7.151020.nc</file>
       <file grid="ocnice">$DIN_LOC_ROOT/share/domains/domain.ocn.gx1v7.151008.nc</file>
       <desc>gx1v7 is displaced Greenland pole 1-deg grid with Caspian as a land feature:</desc>
     </domain>


### PR DESCRIPTION
I should have changed a gx1v7 ocn file but I also incorrectly changed a land domain file

Test suite: ERI.f09_g17.B1850.cheyenne_intel.allactive-defaultio
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Code review: 
