### PR TITLE
Support for multiple couplers

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -500,6 +500,24 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
   </test>
 
+  <test NAME="MCC">
+    <DESC>multi-instance validation vs multi-coupler (default length)</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>none</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+    <NINST_CPL>1</NINST_CPL>
+    <NINST_ATM>1</NINST_ATM>
+    <NINST_OCN>1</NINST_OCN>
+    <NINST_WAV>1</NINST_WAV>
+    <NINST_GLC>1</NINST_GLC>
+    <NINST_ICE>1</NINST_ICE>
+    <NINST_ROF>1</NINST_ROF>
+    <NINST_LND>1</NINST_LND>
+  </test>
+
   <test NAME="NCK">
     <DESC>multi-instance validation vs single instance (default length)</DESC>
     <INFO_DBUG>1</INFO_DBUG>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -508,7 +508,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <NINST_CPL>1</NINST_CPL>
+    <COUPLER_COUNT>1</COUPLER_COUNT>
     <NINST_ATM>1</NINST_ATM>
     <NINST_OCN>1</NINST_OCN>
     <NINST_WAV>1</NINST_WAV>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -501,7 +501,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
   </test>
 
   <test NAME="MCC">
-    <DESC>multi-instance validation vs multi-coupler (default length)</DESC>
+    <DESC>multi-coupler validation vs single-instance (default length)</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -509,7 +509,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
     <MULTI_COUPLER>TRUE</MULTI_COUPLER>
-    <NINST_CPL>3</NINST_CPL>
   </test>
 
   <test NAME="NCK">

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -508,14 +508,8 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <NINST_CPL>1</NINST_CPL>
-    <NINST_ATM>1</NINST_ATM>
-    <NINST_OCN>1</NINST_OCN>
-    <NINST_WAV>1</NINST_WAV>
-    <NINST_GLC>1</NINST_GLC>
-    <NINST_ICE>1</NINST_ICE>
-    <NINST_ROF>1</NINST_ROF>
-    <NINST_LND>1</NINST_LND>
+    <MULTI_COUPLER>TRUE</MULTI_COUPLER>
+    <NINST_CPL>3</NINST_CPL>
   </test>
 
   <test NAME="NCK">

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -508,7 +508,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <COUPLER_COUNT>1</COUPLER_COUNT>
+    <NINST_CPL>1</NINST_CPL>
     <NINST_ATM>1</NINST_ATM>
     <NINST_OCN>1</NINST_OCN>
     <NINST_WAV>1</NINST_WAV>

--- a/config/xml_schemas/env_mach_pes.xsd
+++ b/config/xml_schemas/env_mach_pes.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
   <!-- attributes -->
   <xs:attribute name="id" type="xs:NCName"/>
-  <xs:attribute name="value" type="xs:integer"/>
+  <xs:attribute name="value" type="xs:string"/>
   <xs:attribute name="version" type="xs:decimal"/>
 
   <!-- simple elements -->

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -1,44 +1,42 @@
 .. _multi-instance:
 
-**TODO: Need to update PE elements and explain + and - values**
-
-
 Multi-instance component functionality
 ======================================
 
-The CIME coupling infrastructure is capable of running multiple component instances under one model executable. 
-One caveat: If N multiple instances of any one active component are used, the same number of multiple instances of ALL active components are required. 
-More details are discussed below.
+The CIME coupling infrastructure is capable of running multiple component instances (ensembles) under one model executable.  There are two modes of ensemble capability, single coupler in which all component instances are handled by a single coupler component or multi-coupler in which each instance includes a separate coupler component.  In the multi-coupler mode the entire model is duplicated for each instance while in the single coupler mode only active components need be duplicated.   In most cases the multi-coupler mode will give better performance and should be used.
 
-The primary motivation for this development was to be able to run an ensemble Kalman-Filter for data assimilation and parameter estimation (UQ, for example). 
-However, it also provides the ability to run a set of experiments within a single model executable where each instance can have a different namelist, and to have all the output go to one directory. 
+The primary motivation for this development was to be able to run an ensemble Kalman-Filter for data assimilation and parameter estimation (UQ, for example).
+However, it also provides the ability to run a set of experiments within a single model executable where each instance can have a different namelist, and to have all the output go to one directory.
 
 An F compset is used in the following example. Using the multiple-instance code involves the following steps:
 
 1. Create the case.
 ::
 
-   > create_newcase --case Fmulti --compset F --res ne30_g16 
+   > create_newcase --case Fmulti --compset F --res ne30_ne30_mg17
    > cd Fmulti
 
-2. Assume this is the out-of-the-box pe-layout: 
+2. Assume this is the out-of-the-box pe-layout:
 ::
 
-   NTASKS(ATM)=128, NTHRDS(ATM)=1, ROOTPE(ATM)=0, NINST(ATM)=1
-   NTASKS(LND)=128, NTHRDS(LND)=1, ROOTPE(LND)=0, NINST(LND)=1
-   NTASKS(ICE)=128, NTHRDS(ICE)=1, ROOTPE(ICE)=0, NINST(ICE)=1
-   NTASKS(OCN)=128, NTHRDS(OCN)=1, ROOTPE(OCN)=0, NINST(OCN)=1
-   NTASKS(GLC)=128, NTHRDS(GLC)=1, ROOTPE(GLC)=0, NINST(GLC)=1
-   NTASKS(WAV)=128, NTHRDS(WAV)=1, ROOTPE(WAV)=0, NINST(WAV)=1
-   NTASKS(CPL)=128, NTHRDS(CPL)=1, ROOTPE(CPL)=0
+   Comp  NTASKS  NTHRDS  ROOTPE
+   CPL :    144/     1;      0
+   ATM :    144/     1;      0
+   LND :    144/     1;      0
+   ICE :    144/     1;      0
+   OCN :    144/     1;      0
+   ROF :    144/     1;      0
+   GLC :    144/     1;      0
+   WAV :    144/     1;      0
+   ESP :      1/     1;      0
 
-The atm, lnd and rof are active components in this compset. The ocn is a prescribed data component, cice is a mixed prescribed/active component (ice-coverage is prescribed), and glc and wav are stub components.
+The atm, lnd and rof are active components in this compset. The ocn is a prescribed data component, cice is a mixed prescribed/active component (ice-coverage is prescribed), and glc, wav and esp are stub components.
 
-Let's say we want to run two instances of CAM in this experiment. 
-We will also have to run two instances of CLM, CICE and RTM. 
-However, we can run either one or two instances of DOCN, and we can ignore glc and wav since they do not do anything in this compset as stub components.
- 
-To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following commands in your **$CASEROOT** directory:
+Let's say we want to run two instances of CAM in this experiment.
+We will also have to run two instances of CLM, CICE and RTM.
+However, we can run either one or two instances of DOCN, and we can ignore the stub components since they do not do anything in this compset.
+
+To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following :ref: `xmlchange<modifying-an-xml-file>` commands in your **$CASEROOT** directory:
 ::
 
    > ./xmlchange NINST_ATM=2
@@ -47,16 +45,22 @@ To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following comma
    > ./xmlchange NINST_ROF=2
    > ./xmlchange NINST_OCN=2
 
-As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, and DOCN, each running concurrently on 64 MPI tasks.
+As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, and DOCN, each running concurrently on 72 MPI tasks and all using the same coupler component.   In this single coupler mode the number of tasks for each component instance is NTASKS_COMPONENT/NINST_COMPONENT and the total number of tasks is the same as for the single instance case.
 
-**TODO: put in reference to xmlchange".**
+Now consider the multi coupler model.
+To use this mode change the NINST values for the individual components back to 1 and the NINST_CPL to 2.
+::
+   > ./xmlchange NINST=1
+   > ./xmlchange NINST_CPL=2
+
+This configuration will run each component instance on the original 144 tasks but will generate two copies of the model (in the same executable) for a total of 288 tasks.
 
 3. Set up the case
 ::
 
    > ./case.setup
 
-A new **user_nl_xxx_NNNN** file (where NNNN is the number of the component instances) is generated when **case.setup** is called. 
+A new **user_nl_xxx_NNNN** file (where NNNN is the number of the component instances) is generated when **case.setup** is called.
 When calling **case.setup** with the **env_mach_pes.xml** file specifically, these files are created in **$CASEROOT**:
 ::
 
@@ -79,17 +83,15 @@ Also, **case.setup** creates the following ``*_in_*`` files and ``*txt*`` files 
    lnd_in_0001, lnd_in_0002
    rof_in_0001, rof_in_0002
 
-The namelist for each component instance can be modified by changing the corresponding **user_nl_xxx_NNNN** file. 
-Modifying **user_nl_cam_0002** will result in your namelist changes being active ONLY for the second instance of CAM. 
+The namelist for each component instance can be modified by changing the corresponding **user_nl_xxx_NNNN** file.
+Modifying **user_nl_cam_0002** will result in your namelist changes being active ONLY for the second instance of CAM.
 To change the DOCN stream txt file instance 0002, copy **docn.streams.txt.prescribed_0002** to your **$CASEROOT** directory with the name **user_docn.streams.txt.prescribed_0002** and modify it accordlingly.
 
 Also keep these important points in mind:
 
 #. **Multiple component instances can differ ONLY in namelist settings; they ALL use the same model executable.**
 
-#. Multiple-instance implementation supports only one coupler component.
-
 #. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** files created by **case.setup**.
 
-#. Multiple instances generally should un concurrently, which is the default setting in **env_mach_pes.xml**. 
-   The serial setting is only for EXPERT USERS in upcoming development code implementations.
+#. A special variable NINST_LAYOUT is provided for some experimental compsets, its value should be
+   'concurrent' for all but a few special cases.

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -89,14 +89,13 @@ To change the DOCN stream txt file instance 0002, copy **docn.streams.txt.prescr
 
 Also keep these important points in mind:
 
-#. Note that these changes can be made at create_newcase time with option --ninst #, use the additional option --ninst-couplers to invoke the multi-coupler mode.
+#. Note that these changes can be made at create_newcase time with option --ninst # where # is a positive integer, use the additional logical option --ninst-couplers to invoke the multi-coupler mode.
 
 #. **Multiple component instances can differ ONLY in namelist settings; they ALL use the same model executable.**
 
-#. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** files created by **case.setup**.
+#. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** (where xxx is the component name) files created by **case.setup**.
 
 #. A special variable NINST_LAYOUT is provided for some experimental compsets, its value should be
    'concurrent' for all but a few special cases.
 
-#. In create test these options can be invoked with testname modifiers _N# for the single coupler mode and
-   _C# for the multi-coupler mode.
+#. In **create_test** these options can be invoked with testname modifiers _N# for the single coupler mode and _C# for the multi-coupler mode.  These are mutually exclusive options, they cannot be combined.

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -48,10 +48,9 @@ To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following :ref:
 As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, and DOCN, each running concurrently on 72 MPI tasks and all using the same coupler component.   In this single coupler mode the number of tasks for each component instance is NTASKS_COMPONENT/NINST_COMPONENT and the total number of tasks is the same as for the single instance case.
 
 Now consider the multi coupler model.
-To use this mode change the NINST values for the individual components back to 1 and the NINST_CPL to 2.
+To use this mode change
 ::
-   > ./xmlchange NINST=1
-   > ./xmlchange NINST_CPL=2
+   > ./xmlchange MULTI_COUPLER=TRUE
 
 This configuration will run each component instance on the original 144 tasks but will generate two copies of the model (in the same executable) for a total of 288 tasks.
 
@@ -96,6 +95,8 @@ Also keep these important points in mind:
 #. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** (where xxx is the component name) files created by **case.setup**.
 
 #. A special variable NINST_LAYOUT is provided for some experimental compsets, its value should be
-   'concurrent' for all but a few special cases.
+   'concurrent' for all but a few special cases and it cannot be used if MULTI_COUPLER=TRUE.
 
 #. In **create_test** these options can be invoked with testname modifiers _N# for the single coupler mode and _C# for the multi-coupler mode.  These are mutually exclusive options, they cannot be combined.
+
+#. In create_newcase you may use --ninst # to set the number of instances and --multi-coupler for multi-coupler mode.

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -89,9 +89,14 @@ To change the DOCN stream txt file instance 0002, copy **docn.streams.txt.prescr
 
 Also keep these important points in mind:
 
+#. Note that these changes can be made at create_newcase time with option --ninst #, use the additional option --ninst-couplers to invoke the multi-coupler mode.
+
 #. **Multiple component instances can differ ONLY in namelist settings; they ALL use the same model executable.**
 
 #. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** files created by **case.setup**.
 
 #. A special variable NINST_LAYOUT is provided for some experimental compsets, its value should be
    'concurrent' for all but a few special cases.
+
+#. In create test these options can be invoked with testname modifiers _N# for the single coupler mode and
+   _C# for the multi-coupler mode.

--- a/scripts/Tools/check_case
+++ b/scripts/Tools/check_case
@@ -50,9 +50,8 @@ def _main_func(description):
 
     parse_command_line(sys.argv, description)
 
-    check_lockedfiles()
-
     with Case(read_only=False) as case:
+        check_lockedfiles(case)
         create_namelists(case)
         build_complete = case.get_value("BUILD_COMPLETE")
 

--- a/scripts/Tools/check_lockedfiles
+++ b/scripts/Tools/check_lockedfiles
@@ -41,7 +41,7 @@ def _main_func(description):
 
     caseroot = parse_command_line(sys.argv, description)
 
-    with Case(read_only=True) as case:
+    with Case(case_root=caseroot, read_only=True) as case:
         check_lockedfiles(case)
 
 if __name__ == "__main__":

--- a/scripts/Tools/check_lockedfiles
+++ b/scripts/Tools/check_lockedfiles
@@ -5,6 +5,7 @@ This script compares xml files
 
 from standard_script_setup import *
 from CIME.check_lockedfiles import check_lockedfiles
+from CIME.case import Case
 
 def parse_command_line(args, description):
     parser = argparse.ArgumentParser(
@@ -40,7 +41,8 @@ def _main_func(description):
 
     caseroot = parse_command_line(sys.argv, description)
 
-    check_lockedfiles(caseroot)
+    with Case(read_only=True) as case:
+        check_lockedfiles(case)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -46,6 +46,10 @@ OR
                         help="Specify a compiler. "
                         "To see list of supported compilers for each machine, use the utility query_config in this directory")
 
+    parser.add_argument("--ncouplers",default=1,
+                        help="Specify number of coupler instances. "
+                        "Set the number of coupler instances in the case.")
+
     parser.add_argument("--ninst",default=1,
                         help="Specify number of component instances"
                         "Set the number of component instances in the case.")
@@ -142,6 +146,9 @@ OR
         expect(args.gridfile is not None,
                "User grid specification file must be set if the user grid is requested")
 
+    expect(not (int(args.ncouplers) > 1 and int(args.ninst) > 1),
+           "Only one component instance per coupler is allowed when using multiple couplers")
+
     run_unsupported = False
     if model == "cesm":
         run_unsupported = args.run_unsupported
@@ -155,7 +162,8 @@ OR
     return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.pesfile, \
-        args.user_grid, args.gridfile, args.srcroot, args.test, args.ninst, \
+        args.user_grid, args.gridfile, args.srcroot, args.test, args.ncouplers, \
+        args.ninst, \
         args.walltime, args.queue, args.output_root, args.script_root, \
         run_unsupported, args.answer, args.input_dir
 
@@ -167,7 +175,7 @@ def _main_func(description):
     casename, compset, grid, machine, compiler, \
         mpilib, project, pecount,  \
         user_mods_dir, pesfile, \
-        user_grid, gridfile, srcroot, test, ninst, walltime, queue, \
+        user_grid, gridfile, srcroot, test, ncouplers, ninst, walltime, queue, \
         output_root, script_root, run_unsupported, \
         answer, input_dir = parse_command_line(sys.argv, cimeroot, description)
 
@@ -187,9 +195,11 @@ def _main_func(description):
 
     with Case(caseroot, read_only=False) as case:
         # Configure the Case
-        case.create(casename, srcroot, compset, grid, user_mods_dir=user_mods_dir, machine_name=machine, project=project,
+        case.create(casename, srcroot, compset, grid, user_mods_dir=user_mods_dir,
+                    machine_name=machine, project=project,
                     pecount=pecount, compiler=compiler, mpilib=mpilib,
-                    pesfile=pesfile,user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
+                    pesfile=pesfile,user_grid=user_grid, gridfile=gridfile,
+                    ncouplers=ncouplers, ninst=ninst, test=test,
                     walltime=walltime, queue=queue, output_root=output_root,
                     run_unsupported=run_unsupported, answer=answer,
                     input_dir=input_dir)

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -46,13 +46,13 @@ OR
                         help="Specify a compiler. "
                         "To see list of supported compilers for each machine, use the utility query_config in this directory")
 
-    parser.add_argument("--ninst-couplers",action="store_true",
+    parser.add_argument("--multi-coupler",action="store_true",
                         help="Specify that ninst should modify number of coupler instances "
                         "default is to have one coupler supporting multiple component instances.")
 
     parser.add_argument("--ninst",default=1,
                         help="Specify number of model ensemble instances. "
-                        "Default is multiple components and one coupler.  Use --ninst-couplers to "
+                        "Default is multiple components and one coupler.  Use --multi-coupler to "
                         "run multiple couplers in the ensemble.")
 
     parser.add_argument("--mpilib", "-mpilib",
@@ -157,7 +157,7 @@ OR
     if args.input_dir is not None:
         args.input_dir = os.path.abspath(args.input_dir)
 
-    if args.ninst_couplers:
+    if args.multi_coupler:
         ncouplers = args.ninst
         ninst = 1
     else:

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -48,11 +48,13 @@ OR
 
     parser.add_argument("--ncouplers",default=1,
                         help="Specify number of coupler instances. "
-                        "Set the number of coupler instances in the case.")
+                        "Set the number of coupler instances in the case. "
+                        "If ncouplers is > 1 then ninst should = 1.")
 
     parser.add_argument("--ninst",default=1,
-                        help="Specify number of component instances"
-                        "Set the number of component instances in the case.")
+                        help="Specify number of component instances. "
+                        "Set the number of component instances in the case. "
+                        "If ninst > 1 then ncouplers should = 1")
 
     parser.add_argument("--mpilib", "-mpilib",
                         help="Specify the mpilib. "

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -157,19 +157,11 @@ OR
     if args.input_dir is not None:
         args.input_dir = os.path.abspath(args.input_dir)
 
-    if args.multi_coupler:
-        ncouplers = args.ninst
-        ninst = 1
-    else:
-        ncouplers = 1
-        ninst = args.ninst
-
-
     return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.pesfile, \
-        args.user_grid, args.gridfile, args.srcroot, args.test, ncouplers, \
-        ninst, args.walltime, args.queue, args.output_root, args.script_root, \
+        args.user_grid, args.gridfile, args.srcroot, args.test, args.multi_coupler, \
+        args.ninst, args.walltime, args.queue, args.output_root, args.script_root, \
         run_unsupported, args.answer, args.input_dir
 
 ###############################################################################
@@ -180,8 +172,8 @@ def _main_func(description):
     casename, compset, grid, machine, compiler, \
         mpilib, project, pecount,  \
         user_mods_dir, pesfile, \
-        user_grid, gridfile, srcroot, test, ncouplers, ninst, walltime, queue, \
-        output_root, script_root, run_unsupported, \
+        user_grid, gridfile, srcroot, test, multi_coupler, ninst, walltime, \
+        queue, output_root, script_root, run_unsupported, \
         answer, input_dir = parse_command_line(sys.argv, cimeroot, description)
 
     if script_root is None:
@@ -204,7 +196,7 @@ def _main_func(description):
                     machine_name=machine, project=project,
                     pecount=pecount, compiler=compiler, mpilib=mpilib,
                     pesfile=pesfile,user_grid=user_grid, gridfile=gridfile,
-                    ncouplers=ncouplers, ninst=ninst, test=test,
+                    multi_coupler=multi_coupler, ninst=ninst, test=test,
                     walltime=walltime, queue=queue, output_root=output_root,
                     run_unsupported=run_unsupported, answer=answer,
                     input_dir=input_dir)

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -46,15 +46,14 @@ OR
                         help="Specify a compiler. "
                         "To see list of supported compilers for each machine, use the utility query_config in this directory")
 
-    parser.add_argument("--ncouplers",default=1,
-                        help="Specify number of coupler instances. "
-                        "Set the number of coupler instances in the case. "
-                        "If ncouplers is > 1 then ninst should = 1.")
+    parser.add_argument("--ninst-couplers",action="store_true",
+                        help="Specify that ninst should modify number of coupler instances "
+                        "default is to have one coupler supporting multiple component instances.")
 
     parser.add_argument("--ninst",default=1,
-                        help="Specify number of component instances. "
-                        "Set the number of component instances in the case. "
-                        "If ninst > 1 then ncouplers should = 1")
+                        help="Specify number of model ensemble instances. "
+                        "Default is multiple components and one coupler.  Use --ninst-couplers to "
+                        "run multiple couplers in the ensemble.")
 
     parser.add_argument("--mpilib", "-mpilib",
                         help="Specify the mpilib. "
@@ -148,9 +147,6 @@ OR
         expect(args.gridfile is not None,
                "User grid specification file must be set if the user grid is requested")
 
-    expect(not (int(args.ncouplers) > 1 and int(args.ninst) > 1),
-           "Only one component instance per coupler is allowed when using multiple couplers")
-
     run_unsupported = False
     if model == "cesm":
         run_unsupported = args.run_unsupported
@@ -161,12 +157,19 @@ OR
     if args.input_dir is not None:
         args.input_dir = os.path.abspath(args.input_dir)
 
+    if args.ninst_couplers:
+        ncouplers = args.ninst
+        ninst = 1
+    else:
+        ncouplers = 1
+        ninst = args.ninst
+
+
     return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.pesfile, \
-        args.user_grid, args.gridfile, args.srcroot, args.test, args.ncouplers, \
-        args.ninst, \
-        args.walltime, args.queue, args.output_root, args.script_root, \
+        args.user_grid, args.gridfile, args.srcroot, args.test, ncouplers, \
+        ninst, args.walltime, args.queue, args.output_root, args.script_root, \
         run_unsupported, args.answer, args.input_dir
 
 ###############################################################################

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -26,9 +26,9 @@ class MCC(SystemTestsCompareTwo):
     def _case_one_setup(self):
         # The multicoupler case will increase the number of tasks by the
         # number of requested couplers.
-        self._case.set_value("NINST_CPL", self._test_instances)
+        self._case.set_value("COUPLER_COUNT", self._test_instances)
         case_setup(self._case, test_mode=False, reset=True)
 
     def _case_two_setup(self):
-        self._case.set_value("NINST_CPL", 1)
+        self._case.set_value("COUPLER_COUNT", 1)
         case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -26,9 +26,10 @@ class MCC(SystemTestsCompareTwo):
         # The multicoupler case will increase the number of tasks by the
         # number of requested couplers.
         self._case.set_value("MULTI_COUPLER",True)
-        self._case.set_value("NINST_CPL", self._test_instances)
+        self._case.set_value("NINST", self._test_instances)
+        self._case.set_value("NINST_ESP", 1)
         case_setup(self._case, test_mode=False, reset=True)
 
     def _case_two_setup(self):
-        self._case.set_value("NINST_CPL", 1)
+        self._case.set_value("NINST", 1)
         case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -2,8 +2,7 @@
 Implemetation of CIME MCC test: Compares ensemble methods
 
 This does two runs: In the first we run a three member ensemble using the
-original multi component single coupler method and in the second we use
-the new multi coupler method.  We then compare results with the expectation that they are bfb
+ MULTI_COUPLER capability, then we run a second single instance case and compare
 """
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
@@ -19,13 +18,14 @@ class MCC(SystemTestsCompareTwo):
         self._test_instances = 3
         SystemTestsCompareTwo.__init__(self, case,
                                        separate_builds = False,
-                                       run_two_suffix = 'multicoupler',
-                                       run_one_description = 'single instance',
-                                       run_two_description = 'multi coupler')
+                                       run_two_suffix = 'single_instance',
+                                       run_two_description = 'single instance',
+                                       run_one_description = 'multi coupler')
 
     def _case_one_setup(self):
         # The multicoupler case will increase the number of tasks by the
         # number of requested couplers.
+        self._case.set_value("MULTI_COUPLER",True)
         self._case.set_value("NINST_CPL", self._test_instances)
         case_setup(self._case, test_mode=False, reset=True)
 

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -26,9 +26,9 @@ class MCC(SystemTestsCompareTwo):
     def _case_one_setup(self):
         # The multicoupler case will increase the number of tasks by the
         # number of requested couplers.
-        self._case.set_value("COUPLER_COUNT", self._test_instances)
+        self._case.set_value("NINST_CPL", self._test_instances)
         case_setup(self._case, test_mode=False, reset=True)
 
     def _case_two_setup(self):
-        self._case.set_value("COUPLER_COUNT", 1)
+        self._case.set_value("NINST_CPL", 1)
         case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -1,0 +1,34 @@
+"""
+Implemetation of CIME MCC test: Compares ensemble methods
+
+This does two runs: In the first we run a three member ensemble using the
+original multi component single coupler method and in the second we use
+the new multi coupler method.  We then compare results with the expectation that they are bfb
+"""
+from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
+from CIME.case_setup import case_setup
+
+logger = logging.getLogger(__name__)
+
+
+class MCC(SystemTestsCompareTwo):
+
+    def __init__(self, case):
+        self._comp_classes = []
+        self._test_instances = 3
+        SystemTestsCompareTwo.__init__(self, case,
+                                       separate_builds = False,
+                                       run_two_suffix = 'multicoupler',
+                                       run_one_description = 'single instance',
+                                       run_two_description = 'multi coupler')
+
+    def _case_one_setup(self):
+        # The multicoupler case will increase the number of tasks by the
+        # number of requested couplers.
+        self._case.set_value("NINST_CPL", self._test_instances)
+        case_setup(self._case, test_mode=False, reset=True)
+
+    def _case_two_setup(self):
+        self._case.set_value("NINST_CPL", 1)
+        case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -17,7 +17,7 @@ class MCC(SystemTestsCompareTwo):
         self._comp_classes = []
         self._test_instances = 3
         SystemTestsCompareTwo.__init__(self, case,
-                                       separate_builds = False,
+                                       separate_builds = True,
                                        run_two_suffix = 'single_instance',
                                        run_two_description = 'single instance',
                                        run_one_description = 'multi coupler')

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -234,15 +234,18 @@ class SystemTestsCommon(object):
             case_st_archive(self._case)
 
     def _coupler_log_indicates_run_complete(self):
-        newestcpllogfile = self._case.get_latest_cpl_log()
-        logger.debug("Latest Coupler log file is {}".format(newestcpllogfile))
+        newestcpllogfiles = self._get_latest_cpl_logs()
+        logger.debug("Latest Coupler log file(s) {}" .format(newestcpllogfiles))
         # Exception is raised if the file is not compressed
-        try:
-            if "SUCCESSFUL TERMINATION" in gzip.open(newestcpllogfile, 'rb').read():
-                return True
-        except:
-            logger.info("{} is not compressed, assuming run failed".format(newestcpllogfile))
-        return False
+        allgood = len(newestcpllogfiles)
+        for cpllog in newestcpllogfiles:
+            try:
+                if "SUCCESSFUL TERMINATION" in gzip.open(cpllog, 'rb').read():
+                    allgood = allgood - 1
+            except:
+                logger.info("{} is not compressed, assuming run failed".format(cpllog))
+
+        return allgood==0
 
     def _component_compare_copy(self, suffix):
         comments = copy(self._case, suffix)
@@ -304,33 +307,33 @@ class SystemTestsCommon(object):
         Examine memory usage as recorded in the cpl log file and look for unexpected
         increases.
         """
-        cpllog = self._case.get_latest_cpl_log()
+        latestcpllogs = self._get_latest_cpl_logs()
+        for cpllog in latestcpllogs:
+            memlist = self._get_mem_usage(cpllog)
 
-        memlist = self._get_mem_usage(cpllog)
-
-        with self._test_status:
-            if len(memlist)<3:
-                self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS, comments="insuffiencient data for memleak test")
-            else:
-                finaldate = int(memlist[-1][0])
-                originaldate = int(memlist[0][0])
-                finalmem = float(memlist[-1][1])
-                originalmem = float(memlist[0][1])
-                memdiff = -1
-                if originalmem > 0:
-                    memdiff = (finalmem - originalmem)/originalmem
-                tolerance = self._case.get_value("TEST_MEMLEAK_TOLERANCE")
-                if tolerance is None:
-                    tolerance = 0.1
-                expect(tolerance > 0.0, "Bad value for memleak tolerance in test")
-                if memdiff < 0:
+            with self._test_status:
+                if len(memlist)<3:
                     self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS, comments="insuffiencient data for memleak test")
-                elif memdiff < tolerance:
-                    self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS)
                 else:
-                    comment = "memleak detected, memory went from {:f} to {:f} in {:d} days".format(originalmem, finalmem, finaldate-originaldate)
-                    append_testlog(comment)
-                    self._test_status.set_status(MEMLEAK_PHASE, TEST_FAIL_STATUS, comments=comment)
+                    finaldate = int(memlist[-1][0])
+                    originaldate = int(memlist[0][0])
+                    finalmem = float(memlist[-1][1])
+                    originalmem = float(memlist[0][1])
+                    memdiff = -1
+                    if originalmem > 0:
+                        memdiff = (finalmem - originalmem)/originalmem
+                    tolerance = self._case.get_value("TEST_MEMLEAK_TOLERANCE")
+                    if tolerance is None:
+                        tolerance = 0.1
+                    expect(tolerance > 0.0, "Bad value for memleak tolerance in test")
+                    if memdiff < 0:
+                        self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS, comments="insuffiencient data for memleak test")
+                    elif memdiff < tolerance:
+                        self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS)
+                    else:
+                        comment = "memleak detected, memory went from {:f} to {:f} in {:d} days".format(originalmem, finalmem, finaldate-originaldate)
+                        append_testlog(comment)
+                        self._test_status.set_status(MEMLEAK_PHASE, TEST_FAIL_STATUS, comments=comment)
 
     def compare_env_run(self, expected=None):
         """
@@ -349,6 +352,25 @@ class SystemTestsCommon(object):
                 return False
         return True
 
+    def _get_latest_cpl_logs(self):
+        """
+        find and return the latest cpl log file in the run directory
+        """
+        coupler_log_path = self._case.get_value("RUNDIR")
+        cpllogs = glob.glob(os.path.join(coupler_log_path, 'cpl*.log.*'))
+        lastcpllogs = []
+        if cpllogs:
+            lastcpllogs.append(max(cpllogs, key=os.path.getctime))
+            basename = os.path.basename(lastcpllogs[0])
+            suffix = basename.split('.',1)[1]
+            for log in cpllogs:
+                if log in lastcpllogs:
+                    continue
+                if log.endswith(suffix):
+                    lastcpllogs.append(log)
+
+        return lastcpllogs
+
     def _compare_baseline(self):
         """
         compare the current test output to a baseline result
@@ -364,42 +386,37 @@ class SystemTestsCommon(object):
             basecmp_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), baseline_name)
 
             # compare memory usage to baseline
-            newestcpllogfile = self._case.get_latest_cpl_log()
-            memlist = self._get_mem_usage(newestcpllogfile)
-            baselog = os.path.join(basecmp_dir, "cpl.log.gz")
-            if not os.path.isfile(baselog):
-                # for backward compatibility
-                baselog = os.path.join(basecmp_dir, "cpl.log")
-
-            if os.path.isfile(baselog) and len(memlist) > 3:
-                blmem = self._get_mem_usage(baselog)
-                blmem = 0 if blmem == [] else blmem[-1][1]
-                curmem = memlist[-1][1]
-                if blmem != 0:
-                    diff = (curmem - blmem) / blmem
-                    if diff < 0.1:
+            newestcpllogfiles = self._get_latest_cpl_logs()
+            memlist = self._get_mem_usage(newestcpllogfiles[0])
+            for cpllog in newestcpllogfiles:
+                m = re.search(r"(cpl.*.log).*.gz",cpllog)
+                if m is not None:
+                    baselog = os.path.join(basecmp_dir, m.group(1))+".gz"
+                if baselog is None or not os.path.isfile(baselog):
+                    # for backward compatibility
+                    baselog = os.path.join(basecmp_dir, "cpl.log")
+                if os.path.isfile(baselog) and len(memlist) > 3:
+                    blmem = self._get_mem_usage(baselog)[-1][1]
+                    curmem = memlist[-1][1]
+                    diff = (curmem-blmem)/blmem
+                    if(diff < 0.1):
                         self._test_status.set_status(MEMCOMP_PHASE, TEST_PASS_STATUS)
                     else:
                         comment = "Error: Memory usage increase > 10% from baseline"
                         self._test_status.set_status(MEMCOMP_PHASE, TEST_FAIL_STATUS, comments=comment)
                         append_testlog(comment)
-                else:
-                    comment = "Error: Could not determine baseline memory usage"
-                    self._test_status.set_status(MEMCOMP_PHASE, TEST_FAIL_STATUS, comments=comment)
-                    append_testlog(comment)
-
-            # compare throughput to baseline
-            current = self._get_throughput(newestcpllogfile)
-            baseline = self._get_throughput(baselog)
-            #comparing ypd so bigger is better
-            if baseline is not None and current is not None:
-                diff = (baseline - current)/baseline
-                if(diff < 0.25):
-                    self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)
-                else:
-                    comment = "Error: Computation time increase > 25% from baseline"
-                    self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
-                    append_testlog(comment)
+                    # compare throughput to baseline
+                    current = self._get_throughput(cpllog)
+                    baseline = self._get_throughput(baselog)
+                    #comparing ypd so bigger is better
+                    if baseline is not None and current is not None:
+                        diff = (baseline - current)/baseline
+                        if(diff < 0.25):
+                            self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)
+                        else:
+                            comment = "Error: Computation time increase > 25% from baseline"
+                            self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
+                            append_testlog(comment)
 
     def _generate_baseline(self):
         """
@@ -412,6 +429,16 @@ class SystemTestsCommon(object):
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             baseline_name = self._case.get_value("BASEGEN_CASE")
             self._test_status.set_status("{}".format(GENERATE_PHASE), status, comments=os.path.dirname(baseline_name))
+            basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))
+            # copy latest cpl log to baseline
+            # drop the date so that the name is generic
+            newestcpllogfiles = self._get_latest_cpl_logs()
+            for cpllog in newestcpllogfiles:
+                m = re.search(r"(cpl.*.log).*.gz",cpllog)
+                if m is not None:
+                    baselog = os.path.join(basegen_dir, m.group(1))+".gz"
+                    shutil.copyfile(cpllog,
+                                    os.path.join(basegen_dir,baselog))
 
 class FakeTest(SystemTestsCommon):
     """

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -368,7 +368,6 @@ class SystemTestsCommon(object):
                     continue
                 if log.endswith(suffix):
                     lastcpllogs.append(log)
-
         return lastcpllogs
 
     def _compare_baseline(self):
@@ -389,7 +388,7 @@ class SystemTestsCommon(object):
             newestcpllogfiles = self._get_latest_cpl_logs()
             memlist = self._get_mem_usage(newestcpllogfiles[0])
             for cpllog in newestcpllogfiles:
-                m = re.search(r"(cpl.*.log).*.gz",cpllog)
+                m = re.search(r"/(cpl.*.log).*.gz",cpllog)
                 if m is not None:
                     baselog = os.path.join(basecmp_dir, m.group(1))+".gz"
                 if baselog is None or not os.path.isfile(baselog):
@@ -434,7 +433,7 @@ class SystemTestsCommon(object):
             # drop the date so that the name is generic
             newestcpllogfiles = self._get_latest_cpl_logs()
             for cpllog in newestcpllogfiles:
-                m = re.search(r"(cpl.*.log).*.gz",cpllog)
+                m = re.search(r"/(cpl.*.log).*.gz",cpllog)
                 if m is not None:
                     baselog = os.path.join(basegen_dir, m.group(1))+".gz"
                     shutil.copyfile(cpllog,

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -173,7 +173,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._activate_case2()
         # we need to make sure run2 is properly staged.
         if run_type != "startup":
-            check_case(self._case2, self._caseroot2)
+            check_case(self._case2)
         self._force_case2_settings()
         self.run_indv(suffix = self._run_two_suffix)
 

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -121,7 +121,7 @@ class EntryID(GenericXML):
                     max_score = score
                     mnode = node
             else:
-                expect(False, 
+                expect(False,
                        "match attribute can only have a value of 'last' or 'first', value is %s" %match_type)
 
         return mnode.text
@@ -400,20 +400,27 @@ class EntryID(GenericXML):
                 if f1val is not None:
                     f2val = other.get_value(vid, resolved=False)
                     if f1val != f2val:
+                        logger.info("HERE %s %s "%(f1val, f2val))
                         xmldiffs[vid] = [f1val, f2val]
                 else:
-                    f1val = ET.tostring(node, method="text")
-                    f2val = ET.tostring(f2match, method="text")
-                    if f2val != f1val:
-                        f1value_nodes = self.get_nodes("value", root=node)
-                        for valnode in f1value_nodes:
-                            f2valnodes = other.get_nodes("value", root=f2match, attributes=valnode.attrib)
-                            for f2valnode in f2valnodes:
-                                if valnode.attrib is None and f2valnode.attrib is None or \
-                                   f2valnode.attrib == valnode.attrib:
-                                    if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
-                                        xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
-
+                    for comp in self.get_values("COMP_CLASSES"):
+                        f1val = self.get_value("{}_{}".format(vid,comp), resolved=False)
+                        if f1val is not None:
+                            f2val = other.get_value("{}_{}".format(vid,comp), resolved=False)
+                            if f1val != f2val:
+                                xmldiffs[vid] = [f1val, f2val]
+                        else:
+                            f1val = ET.tostring(node, method="text")
+                            f2val = ET.tostring(f2match, method="text")
+                            if f2val != f1val:
+                                f1value_nodes = self.get_nodes("value", root=node)
+                                for valnode in f1value_nodes:
+                                    f2valnodes = other.get_nodes("value", root=f2match, attributes=valnode.attrib)
+                                for f2valnode in f2valnodes:
+                                    if valnode.attrib is None and f2valnode.attrib is None or \
+                                       f2valnode.attrib == valnode.attrib:
+                                        if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
+                                            xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
         return xmldiffs
 
     def __iter__(self):

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -400,7 +400,6 @@ class EntryID(GenericXML):
                 if f1val is not None:
                     f2val = other.get_value(vid, resolved=False)
                     if f1val != f2val:
-                        logger.info("HERE %s %s "%(f1val, f2val))
                         xmldiffs[vid] = [f1val, f2val]
                 else:
                     for comp in self.get_values("COMP_CLASSES"):

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -416,11 +416,11 @@ class EntryID(GenericXML):
                                 f1value_nodes = self.get_nodes("value", root=node)
                                 for valnode in f1value_nodes:
                                     f2valnodes = other.get_nodes("value", root=f2match, attributes=valnode.attrib)
-                                for f2valnode in f2valnodes:
-                                    if valnode.attrib is None and f2valnode.attrib is None or \
-                                       f2valnode.attrib == valnode.attrib:
-                                        if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
-                                            xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
+                                    for f2valnode in f2valnodes:
+                                        if valnode.attrib is None and f2valnode.attrib is None or \
+                                           f2valnode.attrib == valnode.attrib:
+                                            if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
+                                                xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
         return xmldiffs
 
     def __iter__(self):

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -19,62 +19,69 @@ class EnvMachPes(EnvBase):
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_pes.xsd")
         EnvBase.__init__(self, case_root, infile, schema=schema)
 
-    def set_value(self, vid, value, subgroup=None, ignore_type=False):
-        """
-        Set the value of an entry-id field to value
-        Returns the value or None if not found
-        subgroup is ignored in the general routine and applied in specific methods
-        """
-        oldcomps = self._components[:]
-        nvid, comp, _ = self.check_if_comp_var(vid, None)
-        if nvid == "NINST":
-            if self.get_value("MULTI_COUPLER"):
-                self._components = ["CPL"]
-                if comp is None:
-                    comp = "CPL"
-                expect(comp == "CPL" or value == 1,"Cannot change {} when MULTI_COUPLER flag is TRUE".format(vid))
-            elif value != 1:
-                if 'CPL' in self._components:
-                    self._components.remove('CPL')
-                if 'ESP' in self._components and value != 1:
-                    self._components.remove('ESP')
-                expect(comp is None or comp != "CPL","Cannot change NINST_CPL if MULTI_COUPLER flag is FALSE")
-        # Toggling the
-        if vid == "MULTI_COUPLER":
-            newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-            if value:
-                maxinst = 1
-                for tcomp in self._components:
-                    if tcomp in ["CPL"]:
-                        continue
-                    tcomp_inst = "NINST_{}".format(tcomp)
-                    maxinst = max(maxinst, self.get_value(tcomp_inst))
-                    EnvBase.set_value(self,tcomp_inst, 1)
-                    self.set_value("NINST_CPL", maxinst)
-            else:
-                ninst = self.get_value("NINST_CPL")
-                newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-                cpl_index = None
-                esp_index = None
-                if 'CPL' in self._components:
-                    cpl_index = self._components.index('CPL')
-                    del self._components[cpl_index]
-                if 'ESP' in self._components:
-                    esp_index = self._components.index('ESP')
-                    del self._components[esp_index]
+    # def set_value(self, vid, value, subgroup=None, ignore_type=False):
+    #     """
+    #     Set the value of an entry-id field to value
+    #     Returns the value or None if not found
+    #     subgroup is ignored in the general routine and applied in specific methods
+    #     """
+    #     oldcomps = self._components[:]
+    #     nvid, comp, _ = self.check_if_comp_var(vid, None)
+    #     if nvid == "NINST":
+    #         if self.get_value("MULTI_COUPLER"):
+    #             self._components = ["CPL"]
+    #             if comp is None:
+    #                 comp = "CPL"
+    #             expect(comp == "CPL" or value == 1,"Cannot change {} when MULTI_COUPLER flag is TRUE".format(vid))
+    #         elif value != 1:
+    #             if 'CPL' in self._components:
+    #                 self._components.remove('CPL')
+    #             if 'ESP' in self._components and value != 1:
+    #                 self._components.remove('ESP')
+    #             expect(comp is None or comp != "CPL","Cannot change NINST_CPL if MULTI_COUPLER flag is FALSE")
+    #     # Toggling the
+    #     if vid == "MULTI_COUPLER":
+    #         newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
+    #         if value:
+    #             maxinst = 1
+    #             for tcomp in self._components:
+    #                 if tcomp in ["CPL"]:
+    #                     continue
+    #                 tcomp_inst = "NINST_{}".format(tcomp)
+    #                 maxinst = max(maxinst, self.get_value(tcomp_inst))
+    #                 EnvBase.set_value(self,tcomp_inst, 1)
+    #                 self.set_value("NINST_CPL", maxinst)
+    #         else:
+    #             ninst = self.get_value("NINST_CPL")
+    #             newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
+    #             cpl_index = None
+    #             esp_index = None
+    #             if 'CPL' in self._components:
+    #                 cpl_index = self._components.index('CPL')
+    #                 del self._components[cpl_index]
+    #             if 'ESP' in self._components:
+    #                 esp_index = self._components.index('ESP')
+    #                 del self._components[esp_index]
 
-                EnvBase.set_value(self, "NINST", ninst)
-                if cpl_index is not None:
-                    self._components.insert(cpl_index,'CPL')
-                if esp_index is not None:
-                    self._components.insert(esp_index,'ESP')
-                EnvBase.set_value(self, "NINST_CPL", 1)
-        else:
-            newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-        self._components = oldcomps
-        return newval
+    #             EnvBase.set_value(self, "NINST", ninst)
+    #             if cpl_index is not None:
+    #                 self._components.insert(cpl_index,'CPL')
+    #             if esp_index is not None:
+    #                 self._components.insert(esp_index,'ESP')
+    #             EnvBase.set_value(self, "NINST_CPL", 1)
+    #     else:
+    #         newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
+    #     self._components = oldcomps
+    #     return newval
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
+
+        if vid == "NINST_MAX":
+            value = 1
+            for comp in self._components:
+                value = max(value, self.get_value("NINST_{}".format(comp)))
+            return value
+
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
 
         if "NTASKS" in vid or "ROOTPE" in vid:
@@ -112,14 +119,16 @@ class EnvMachPes(EnvBase):
 
     def get_total_tasks(self, comp_classes):
         total_tasks = 0
+        maxinst = 1
         for comp in comp_classes:
             ntasks = self.get_value("NTASKS", attribute={"component":comp})
             rootpe = self.get_value("ROOTPE", attribute={"component":comp})
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
+            maxinst = max(maxinst, self.get_value("NINST", attribute={"component":comp}))
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
         if self.get_value("MULTI_COUPLER"):
-            total_tasks *= self.get_value("NINST_CPL")
+            total_tasks *= maxinst
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -19,6 +19,32 @@ class EnvMachPes(EnvBase):
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_pes.xsd")
         EnvBase.__init__(self, case_root, infile, schema=schema)
 
+    def set_value(self, vid, value, subgroup=None, ignore_type=False):
+        """
+        Set the value of an entry-id field to value
+        Returns the value or None if not found
+        subgroup is ignored in the general routine and applied in specific methods
+        """
+        vid, comp, iscompvar = self.check_if_comp_var(vid, None)
+        if vid == "COUPLER_COUNT":
+            if value > 1:
+                for othercomp in self._components:
+                    if othercomp != "CPL":
+                        ninst_string = "NINST_{}".format(othercomp)
+                        expect(self.get_value(ninst_string)==1,
+                               "Cannot change COUPLER_COUNT value if {} > 1".format(ninst_string))
+            elif value < 0:
+                # negative value effectively overrides safety check
+                value = -value
+        elif vid == "NINST":
+            if value > 1:
+                coupler_count = self.get_value("COUPLER_COUNT")
+                expect(coupler_count == 1,"Cannot change NINST value if COUPLER_COUNT > 1")
+            elif value < 0:
+                # negative value effectively overrides safety check
+                value = -value
+        return EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
+
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
 
@@ -63,7 +89,7 @@ class EnvMachPes(EnvBase):
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
-        total_tasks *= self.get_value("NINST_CPL")
+        total_tasks *= self.get_value("COUPLER_COUNT")
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -25,7 +25,7 @@ class EnvMachPes(EnvBase):
         Returns the value or None if not found
         subgroup is ignored in the general routine and applied in specific methods
         """
-        vid, comp, iscompvar = self.check_if_comp_var(vid, None)
+        nvid, comp, iscompvar = self.check_if_comp_var(vid, None)
         if vid == "COUPLER_COUNT":
             if value > 1:
                 for othercomp in self._components:
@@ -36,7 +36,7 @@ class EnvMachPes(EnvBase):
             elif value < 0:
                 # negative value effectively overrides safety check
                 value = -value
-        elif vid == "NINST":
+        elif nvid == "NINST":
             if value > 1:
                 coupler_count = self.get_value("COUPLER_COUNT")
                 expect(coupler_count == 1,"Cannot change NINST value if COUPLER_COUNT > 1")

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -63,8 +63,6 @@ class EnvMachPes(EnvBase):
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
-        import pdb
-        pdb.set_trace()
         total_tasks *= self.get_value("NINST_CPL")
         return total_tasks
 

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -63,6 +63,8 @@ class EnvMachPes(EnvBase):
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
+        import pdb
+        pdb.set_trace()
         total_tasks *= self.get_value("NINST_CPL")
         return total_tasks
 

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -26,7 +26,7 @@ class EnvMachPes(EnvBase):
         subgroup is ignored in the general routine and applied in specific methods
         """
         oldcomps = self._components[:]
-        nvid, comp, iscompvar = self.check_if_comp_var(vid, None)
+        nvid, comp, _ = self.check_if_comp_var(vid, None)
         if nvid == "NINST":
             if self.get_value("MULTI_COUPLER"):
                 self._components = ["CPL"]
@@ -41,7 +41,6 @@ class EnvMachPes(EnvBase):
                 expect(comp is None or comp != "CPL","Cannot change NINST_CPL if MULTI_COUPLER flag is FALSE")
         # Toggling the
         if vid == "MULTI_COUPLER":
-            oldval = self.get_value("MULTI_COUPLER")
             newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
             if value:
                 maxinst = 1

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -63,6 +63,7 @@ class EnvMachPes(EnvBase):
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
+        total_tasks *= self.get_value("NINST_CPL")
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -19,61 +19,6 @@ class EnvMachPes(EnvBase):
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_pes.xsd")
         EnvBase.__init__(self, case_root, infile, schema=schema)
 
-    # def set_value(self, vid, value, subgroup=None, ignore_type=False):
-    #     """
-    #     Set the value of an entry-id field to value
-    #     Returns the value or None if not found
-    #     subgroup is ignored in the general routine and applied in specific methods
-    #     """
-    #     oldcomps = self._components[:]
-    #     nvid, comp, _ = self.check_if_comp_var(vid, None)
-    #     if nvid == "NINST":
-    #         if self.get_value("MULTI_COUPLER"):
-    #             self._components = ["CPL"]
-    #             if comp is None:
-    #                 comp = "CPL"
-    #             expect(comp == "CPL" or value == 1,"Cannot change {} when MULTI_COUPLER flag is TRUE".format(vid))
-    #         elif value != 1:
-    #             if 'CPL' in self._components:
-    #                 self._components.remove('CPL')
-    #             if 'ESP' in self._components and value != 1:
-    #                 self._components.remove('ESP')
-    #             expect(comp is None or comp != "CPL","Cannot change NINST_CPL if MULTI_COUPLER flag is FALSE")
-    #     # Toggling the
-    #     if vid == "MULTI_COUPLER":
-    #         newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-    #         if value:
-    #             maxinst = 1
-    #             for tcomp in self._components:
-    #                 if tcomp in ["CPL"]:
-    #                     continue
-    #                 tcomp_inst = "NINST_{}".format(tcomp)
-    #                 maxinst = max(maxinst, self.get_value(tcomp_inst))
-    #                 EnvBase.set_value(self,tcomp_inst, 1)
-    #                 self.set_value("NINST_CPL", maxinst)
-    #         else:
-    #             ninst = self.get_value("NINST_CPL")
-    #             newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-    #             cpl_index = None
-    #             esp_index = None
-    #             if 'CPL' in self._components:
-    #                 cpl_index = self._components.index('CPL')
-    #                 del self._components[cpl_index]
-    #             if 'ESP' in self._components:
-    #                 esp_index = self._components.index('ESP')
-    #                 del self._components[esp_index]
-
-    #             EnvBase.set_value(self, "NINST", ninst)
-    #             if cpl_index is not None:
-    #                 self._components.insert(cpl_index,'CPL')
-    #             if esp_index is not None:
-    #                 self._components.insert(esp_index,'ESP')
-    #             EnvBase.set_value(self, "NINST_CPL", 1)
-    #     else:
-    #         newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-    #     self._components = oldcomps
-    #     return newval
-
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
 
         if vid == "NINST_MAX":

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -283,7 +283,7 @@ class GenericXML(object):
         return None
 
     def get_raw_record(self, root=None):
-        logger.info("writing file {}".format(self.filename))
+        logger.debug("writing file {}".format(self.filename))
         if root is None:
             root = self.root
         try:

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -82,8 +82,6 @@ class GenericXML(object):
             doc = minidom.parseString(xmlstr)
             with open(outfile,'w') as xmlout:
                 doc.writexml(xmlout,addindent='  ')
-        append_status("Flush completed at {}".format(get_timestamp()), CaseStatus)
-
 
     def get_node(self, nodename, attributes=None, root=None, xpath=None):
         """
@@ -286,6 +284,7 @@ class GenericXML(object):
         return None
 
     def get_raw_record(self, root=None):
+        logger.info("writing file {}".format(self.filename))
         if root is None:
             root = self.root
         try:

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -5,7 +5,6 @@ be used by other XML interface modules and not directly.
 from CIME.XML.standard_module_setup import *
 from distutils.spawn import find_executable
 from xml.dom import minidom
-from CIME.utils import append_status
 import getpass
 
 logger = logging.getLogger(__name__)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -5,7 +5,7 @@ be used by other XML interface modules and not directly.
 from CIME.XML.standard_module_setup import *
 from distutils.spawn import find_executable
 from xml.dom import minidom
-
+from CIME.utils import append_status
 import getpass
 
 logger = logging.getLogger(__name__)
@@ -82,6 +82,8 @@ class GenericXML(object):
             doc = minidom.parseString(xmlstr)
             with open(outfile,'w') as xmlout:
                 doc.writexml(xmlout,addindent='  ')
+        append_status("Flush completed at {}".format(get_timestamp()), CaseStatus)
+
 
     def get_node(self, nodename, attributes=None, root=None, xpath=None):
         """

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -377,7 +377,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only):
 
     comp_classes = case.get_values("COMP_CLASSES")
 
-    check_lockedfiles(caseroot)
+    check_lockedfiles(case)
 
     # Retrieve relevant case data
     # This environment variable gets set for cesm Make and

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -393,11 +393,10 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only):
 
     complist = []
     for comp_class in comp_classes:
+        ninst = case.get_value("NINST_{}".format(comp_class))
         if comp_class == "CPL":
-            ninst = 1
             config_dir = None
         else:
-            ninst = case.get_value("NINST_{}".format(comp_class))
             config_dir = os.path.dirname(case.get_value("CONFIG_{}_FILE".format(comp_class)))
         comp = case.get_value("COMP_{}".format(comp_class))
         thrds =  case.get_value("NTHRDS_{}".format(comp_class))

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -393,16 +393,14 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only):
 
     complist = []
     for comp_class in comp_classes:
+        ninst = case.get_value("NINST_{}".format(comp_class))
         if comp_class == "CPL":
-            ninst = case.get_value("COUPLER_COUNT")
             config_dir = None
-            expect(ninst is not None,"Failed to get COUPLER_COUNT value")
         else:
-            ninst = case.get_value("NINST_{}".format(comp_class))
             config_dir = os.path.dirname(case.get_value("CONFIG_{}_FILE".format(comp_class)))
-            expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))
         comp = case.get_value("COMP_{}".format(comp_class))
         thrds =  case.get_value("NTHRDS_{}".format(comp_class))
+        expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))
         complist.append((comp_class.lower(), comp, thrds, ninst, config_dir ))
         os.environ["COMP_{}".format(comp_class)] = comp
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -393,14 +393,16 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only):
 
     complist = []
     for comp_class in comp_classes:
-        ninst = case.get_value("NINST_{}".format(comp_class))
         if comp_class == "CPL":
+            ninst = case.get_value("COUPLER_COUNT")
             config_dir = None
+            expect(ninst is not None,"Failed to get COUPLER_COUNT value")
         else:
+            ninst = case.get_value("NINST_{}".format(comp_class))
             config_dir = os.path.dirname(case.get_value("CONFIG_{}_FILE".format(comp_class)))
+            expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))
         comp = case.get_value("COMP_{}".format(comp_class))
         thrds =  case.get_value("NTHRDS_{}".format(comp_class))
-        expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))
         complist.append((comp_class.lower(), comp, thrds, ninst, config_dir ))
         os.environ["COMP_{}".format(comp_class)] = comp
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -390,14 +390,21 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only):
     incroot             = os.path.abspath(case.get_value("INCROOT"))
     libroot             = os.path.abspath(case.get_value("LIBROOT"))
     sharedlibroot       = os.path.abspath(case.get_value("SHAREDLIBROOT"))
-
+    multi_coupler = case.get_value("MULTI_COUPLER")
     complist = []
+    ninst = 1
     for comp_class in comp_classes:
-        ninst = case.get_value("NINST_{}".format(comp_class))
         if comp_class == "CPL":
             config_dir = None
+            if multi_coupler:
+                ninst = case.get_value("NINST_MAX")
         else:
             config_dir = os.path.dirname(case.get_value("CONFIG_{}_FILE".format(comp_class)))
+            if multi_coupler:
+                ninst = 1
+            else:
+                ninst = case.get_value("NINST_{}".format(comp_class))
+
         comp = case.get_value("COMP_{}".format(comp_class))
         thrds =  case.get_value("NTHRDS_{}".format(comp_class))
         expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))

--- a/scripts/lib/CIME/buildnml.py
+++ b/scripts/lib/CIME/buildnml.py
@@ -78,7 +78,7 @@ def build_xcpl_nml(case, caseroot, compname):
         if ninst == 1:
             filename = os.path.join(rundir, "{}_in".format(compname))
         else:
-            filename = os.path.join(rundir, "{}_in_{:4.4d}".format(compname, i))
+            filename = os.path.join(rundir, "{}_in_{:04d}".format(compname, i))
 
         with open(filename, 'w') as infile:
             infile.write("{:<20d} ! i-direction global dimension\n".format(nx))

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -635,6 +635,7 @@ class Case(object):
 
         self.clean_up_lookups()
 
+
     def _setup_mach_pes(self, pecount, ncouplers, ninst, machine_name, mpilib):
         #--------------------------------------------
         # pe layout

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -727,12 +727,14 @@ class Case(object):
         for compclass in self._component_classes:
             key = "NINST_{}".format(compclass)
             if compclass == "CPL":
-                mach_pes_obj.set_value(key, ncouplers)
+                if ncouplers > 1:
+                    mach_pes_obj.set_value("MULTI_COUPLER", True)
+                    mach_pes_obj.set_value(key, ncouplers)
                 continue
             # ESP models are currently limited to 1 instance
             if compclass == "ESP":
                 mach_pes_obj.set_value(key, 1)
-            else:
+            elif ncouplers == 1:
                 mach_pes_obj.set_value(key, ninst)
 
             key = "NTASKS_{}".format(compclass)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -727,7 +727,7 @@ class Case(object):
         for compclass in self._component_classes:
             key = "NINST_{}".format(compclass)
             if compclass == "CPL":
-                mach_pes_obj.set_value("COUPLER_COUNT", ncouplers)
+                mach_pes_obj.set_value(key, ncouplers)
                 continue
             # ESP models are currently limited to 1 instance
             if compclass == "ESP":
@@ -1086,7 +1086,7 @@ class Case(object):
                 append_status("Component {} is {}".format(component_class, self._component_description[component_class]),"README.case", caseroot=self._caseroot)
             if component_class == "CPL":
                 append_status("Using %s coupler instances" %
-                              (self.get_value("COUPLER_COUNT")),
+                              (self.get_value("NINST_CPL")),
                               "README.case", caseroot=self._caseroot)
                 continue
             comp_grid = "{}_GRID".format(component_class)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -635,7 +635,6 @@ class Case(object):
 
         self.clean_up_lookups()
 
-
     def _setup_mach_pes(self, pecount, ncouplers, ninst, machine_name, mpilib):
         #--------------------------------------------
         # pe layout

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -727,7 +727,7 @@ class Case(object):
         for compclass in self._component_classes:
             key = "NINST_{}".format(compclass)
             if compclass == "CPL":
-                mach_pes_obj.set_value(key, ncouplers)
+                mach_pes_obj.set_value("COUPLER_COUNT", ncouplers)
                 continue
             # ESP models are currently limited to 1 instance
             if compclass == "ESP":
@@ -1086,7 +1086,7 @@ class Case(object):
                 append_status("Component {} is {}".format(component_class, self._component_description[component_class]),"README.case", caseroot=self._caseroot)
             if component_class == "CPL":
                 append_status("Using %s coupler instances" %
-                              (self.get_value("NINST_CPL")),
+                              (self.get_value("COUPLER_COUNT")),
                               "README.case", caseroot=self._caseroot)
                 continue
             comp_grid = "{}_GRID".format(component_class)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -635,7 +635,8 @@ class Case(object):
 
         self.clean_up_lookups()
 
-    def _setup_mach_pes(self, pecount, ninst, machine_name, mpilib):
+
+    def _setup_mach_pes(self, pecount, ncouplers, ninst, machine_name, mpilib):
         #--------------------------------------------
         # pe layout
         #--------------------------------------------
@@ -719,13 +720,15 @@ class Case(object):
                 val = -1*val*pes_per_node
             if val > pesize:
                 pesize = val
+        pesize *= int(ncouplers)
 
         # Make sure that every component has been accounted for
         # set, nthrds and ntasks to 1 otherwise. Also set the ninst values here.
         for compclass in self._component_classes:
-            if compclass == "CPL":
-                continue
             key = "NINST_{}".format(compclass)
+            if compclass == "CPL":
+                mach_pes_obj.set_value(key, ncouplers)
+                continue
             # ESP models are currently limited to 1 instance
             if compclass == "ESP":
                 mach_pes_obj.set_value(key, 1)
@@ -744,8 +747,10 @@ class Case(object):
 
     def configure(self, compset_name, grid_name, machine_name=None,
                   project=None, pecount=None, compiler=None, mpilib=None,
-                  pesfile=None,user_grid=False, gridfile=None, ninst=1, test=False,
-                  walltime=None, queue=None, output_root=None, run_unsupported=False, answer=None,
+                  pesfile=None,user_grid=False, gridfile=None,
+                  ncouplers=1, ninst=1, test=False,
+                  walltime=None, queue=None, output_root=None,
+                  run_unsupported=False, answer=None,
                   input_dir=None):
 
         expect(check_name(compset_name, additional_chars='.'), "Invalid compset name {}".format(compset_name))
@@ -834,7 +839,10 @@ class Case(object):
         env_mach_specific_obj.populate(machobj)
         self.schedule_rewrite(env_mach_specific_obj)
 
-        pesize = self._setup_mach_pes(pecount, ninst, machine_name, mpilib)
+        pesize = self._setup_mach_pes(pecount, ncouplers, ninst, machine_name, mpilib)
+
+        if ncouplers > 1:
+            logger.info(" Coupler has %s instances" % ncouplers)
 
         #--------------------------------------------
         # batch system
@@ -1077,6 +1085,9 @@ class Case(object):
                len(self._component_description[component_class])>0:
                 append_status("Component {} is {}".format(component_class, self._component_description[component_class]),"README.case", caseroot=self._caseroot)
             if component_class == "CPL":
+                append_status("Using %s coupler instances" %
+                              (self.get_value("NINST_CPL")),
+                              "README.case", caseroot=self._caseroot)
                 continue
             comp_grid = "{}_GRID".format(component_class)
 
@@ -1441,10 +1452,13 @@ class Case(object):
         else:
             return None
 
-    def create(self, casename, srcroot, compset_name, grid_name, user_mods_dir=None, machine_name=None,
+    def create(self, casename, srcroot, compset_name, grid_name,
+               user_mods_dir=None, machine_name=None,
                project=None, pecount=None, compiler=None, mpilib=None,
-               pesfile=None,user_grid=False, gridfile=None, ninst=1, test=False,
-               walltime=None, queue=None, output_root=None, run_unsupported=False, answer=None,
+               pesfile=None,user_grid=False, gridfile=None,
+               ncouplers=1, ninst=1, test=False,
+               walltime=None, queue=None, output_root=None,
+               run_unsupported=False, answer=None,
                input_dir=None):
         try:
             # Set values for env_case.xml
@@ -1453,10 +1467,13 @@ class Case(object):
             self.set_lookup_value("SRCROOT", srcroot)
 
             # Configure the Case
-            self.configure(compset_name, grid_name, machine_name=machine_name, project=project,
+            self.configure(compset_name, grid_name, machine_name=machine_name,
+                           project=project,
                            pecount=pecount, compiler=compiler, mpilib=mpilib,
-                           pesfile=pesfile,user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
-                           walltime=walltime, queue=queue, output_root=output_root,
+                           pesfile=pesfile,user_grid=user_grid, gridfile=gridfile,
+                           ncouplers=ncouplers, ninst=ninst, test=test,
+                           walltime=walltime, queue=queue,
+                           output_root=output_root,
                            run_unsupported=run_unsupported, answer=answer,
                            input_dir=input_dir)
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -636,7 +636,7 @@ class Case(object):
         self.clean_up_lookups()
 
 
-    def _setup_mach_pes(self, pecount, ncouplers, ninst, machine_name, mpilib):
+    def _setup_mach_pes(self, pecount, multi_coupler, ninst, machine_name, mpilib):
         #--------------------------------------------
         # pe layout
         #--------------------------------------------
@@ -720,21 +720,20 @@ class Case(object):
                 val = -1*val*pes_per_node
             if val > pesize:
                 pesize = val
-        pesize *= int(ncouplers)
+        if multi_coupler:
+            pesize *= int(ninst)
+            mach_pes_obj.set_value("MULTI_COUPLER", True)
 
         # Make sure that every component has been accounted for
         # set, nthrds and ntasks to 1 otherwise. Also set the ninst values here.
         for compclass in self._component_classes:
             key = "NINST_{}".format(compclass)
             if compclass == "CPL":
-                if ncouplers > 1:
-                    mach_pes_obj.set_value("MULTI_COUPLER", True)
-                    mach_pes_obj.set_value(key, ncouplers)
                 continue
             # ESP models are currently limited to 1 instance
             if compclass == "ESP":
                 mach_pes_obj.set_value(key, 1)
-            elif ncouplers == 1:
+            else:
                 mach_pes_obj.set_value(key, ninst)
 
             key = "NTASKS_{}".format(compclass)
@@ -750,7 +749,7 @@ class Case(object):
     def configure(self, compset_name, grid_name, machine_name=None,
                   project=None, pecount=None, compiler=None, mpilib=None,
                   pesfile=None,user_grid=False, gridfile=None,
-                  ncouplers=1, ninst=1, test=False,
+                  multi_coupler=False, ninst=1, test=False,
                   walltime=None, queue=None, output_root=None,
                   run_unsupported=False, answer=None,
                   input_dir=None):
@@ -841,10 +840,10 @@ class Case(object):
         env_mach_specific_obj.populate(machobj)
         self.schedule_rewrite(env_mach_specific_obj)
 
-        pesize = self._setup_mach_pes(pecount, ncouplers, ninst, machine_name, mpilib)
+        pesize = self._setup_mach_pes(pecount, multi_coupler, ninst, machine_name, mpilib)
 
-        if ncouplers > 1:
-            logger.info(" Coupler has %s instances" % ncouplers)
+        if multi_coupler and ninst>1:
+            logger.info(" Coupler has %s instances" % ninst)
 
         #--------------------------------------------
         # batch system
@@ -1458,7 +1457,7 @@ class Case(object):
                user_mods_dir=None, machine_name=None,
                project=None, pecount=None, compiler=None, mpilib=None,
                pesfile=None,user_grid=False, gridfile=None,
-               ncouplers=1, ninst=1, test=False,
+               multi_coupler=False, ninst=1, test=False,
                walltime=None, queue=None, output_root=None,
                run_unsupported=False, answer=None,
                input_dir=None):
@@ -1473,7 +1472,7 @@ class Case(object):
                            project=project,
                            pecount=pecount, compiler=compiler, mpilib=mpilib,
                            pesfile=pesfile,user_grid=user_grid, gridfile=gridfile,
-                           ncouplers=ncouplers, ninst=ninst, test=test,
+                           multi_coupler=multi_coupler, ninst=ninst, test=test,
                            walltime=walltime, queue=queue,
                            output_root=output_root,
                            run_unsupported=run_unsupported, answer=answer,

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -255,7 +255,7 @@ def case_run(case, skip_pnl=False):
            "You are not calling the run script via the submit script. "
            "As a result, short-term archiving will not be called automatically."
            "Please submit your run using the submit script like so:"
-           " ./case.submit Time: {}".format(get_timestamp())
+           " ./case.submit Time: {}".format(get_timestamp()))
 
     # Forces user to use case.submit if they re-submit
     if case.get_value("TESTCASE") is None:

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,6 +1,6 @@
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, append_status
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,6 +1,6 @@
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, get_timestamp
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance
@@ -255,7 +255,7 @@ def case_run(case, skip_pnl=False):
            "You are not calling the run script via the submit script. "
            "As a result, short-term archiving will not be called automatically."
            "Please submit your run using the submit script like so:"
-           " ./case.submit")
+           " ./case.submit Time: {}".format(get_timestamp())
 
     # Forces user to use case.submit if they re-submit
     if case.get_value("TESTCASE") is None:

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -152,7 +152,9 @@ def post_run_check(case, lid):
 
     rundir = case.get_value("RUNDIR")
     model = case.get_value("MODEL")
-    cpl_ninst = case.get_value("NINST_CPL")
+    cpl_ninst = 1
+    if case.get_value("MULTI_COUPLER"):
+        cpl_ninst = case.get_value("NINST_MAX")
     cpl_logs = []
     if cpl_ninst > 1:
         for inst in range(cpl_ninst):

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,6 +1,6 @@
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, append_status
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance
@@ -153,14 +153,14 @@ def post_run_check(case, lid):
     rundir = case.get_value("RUNDIR")
     model = case.get_value("MODEL")
     cpl_ninst = case.get_value("NINST_CPL")
-
     cpl_logs = []
     if cpl_ninst > 1:
         for inst in range(cpl_ninst):
             cpl_logs.append(os.path.join(rundir, "cpl_%04d.log." % (inst+1) + lid))
     else:
         cpl_logs = [os.path.join(rundir, "cpl" + ".log." + lid)]
-    
+    cpl_logfile = cpl_logs[0]
+
     # find the last model.log and cpl.log
     model_logfile = os.path.join(rundir, model + ".log." + lid)
 
@@ -176,7 +176,7 @@ def post_run_check(case, lid):
             with open(cpl_logfile, 'r') as fd:
                 if 'SUCCESSFUL TERMINATION' in fd.read():
                     count_ok += 1
-        if count_ok != cpl_ninst: 
+        if count_ok != cpl_ninst:
             expect(False, "Model did not complete - see {} \n " .format(cpl_logfile))
 
 ###############################################################################

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -152,10 +152,10 @@ def post_run_check(case, lid):
 
     rundir = case.get_value("RUNDIR")
     model = case.get_value("MODEL")
-    coupler_count = case.get_value("COUPLER_COUNT")
+    cpl_ninst = case.get_value("NINST_CPL")
     cpl_logs = []
-    if coupler_count > 1:
-        for inst in range(coupler_count):
+    if cpl_ninst > 1:
+        for inst in range(cpl_ninst):
             cpl_logs.append(os.path.join(rundir, "cpl_%04d.log." % (inst+1) + lid))
     else:
         cpl_logs = [os.path.join(rundir, "cpl" + ".log." + lid)]
@@ -176,7 +176,7 @@ def post_run_check(case, lid):
             with open(cpl_logfile, 'r') as fd:
                 if 'SUCCESSFUL TERMINATION' in fd.read():
                     count_ok += 1
-        if count_ok != coupler_count:
+        if count_ok != cpl_ninst:
             expect(False, "Model did not complete - see {} \n " .format(cpl_logfile))
 
 ###############################################################################

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -152,10 +152,10 @@ def post_run_check(case, lid):
 
     rundir = case.get_value("RUNDIR")
     model = case.get_value("MODEL")
-    cpl_ninst = case.get_value("NINST_CPL")
+    coupler_count = case.get_value("COUPLER_COUNT")
     cpl_logs = []
-    if cpl_ninst > 1:
-        for inst in range(cpl_ninst):
+    if coupler_count > 1:
+        for inst in range(coupler_count):
             cpl_logs.append(os.path.join(rundir, "cpl_%04d.log." % (inst+1) + lid))
     else:
         cpl_logs = [os.path.join(rundir, "cpl" + ".log." + lid)]
@@ -176,7 +176,7 @@ def post_run_check(case, lid):
             with open(cpl_logfile, 'r') as fd:
                 if 'SUCCESSFUL TERMINATION' in fd.read():
                     count_ok += 1
-        if count_ok != cpl_ninst:
+        if count_ok != coupler_count:
             expect(False, "Model did not complete - see {} \n " .format(cpl_logfile))
 
 ###############################################################################

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,6 +1,6 @@
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, append_status
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -28,7 +28,7 @@ def pre_run_check(case, lid, skip_pnl=False):
         shutil.copy(env_mach_pes,"{}.{}".format(env_mach_pes, lid))
 
     # check for locked files.
-    check_lockedfiles(case.get_value("CASEROOT"))
+    check_lockedfiles(case)
     logger.debug("check_lockedfiles OK")
 
     # check that build is done

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -34,11 +34,13 @@ def _build_usernl_files(case, model, comp):
     expect(os.path.isdir(model_dir),
            "cannot find cime_config directory {} for component {}".format(model_dir, comp))
 
+    ninst = case.get_value("NINST_CPL")
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
             shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")
     else:
-        ninst = case.get_value("NINST_{}".format(model))
+        if ninst == 1:
+            ninst = case.get_value("NINST_{}".format(model))
         nlfile = "user_nl_{}".format(comp)
         model_nl = os.path.join(model_dir, nlfile)
         if ninst > 1:

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -45,7 +45,7 @@ def _build_usernl_files(case, model, comp):
             ninst = case.get_value("NINST_{}".format(model))
         nlfile = "user_nl_{}".format(comp)
         model_nl = os.path.join(model_dir, nlfile)
-        if ninst > 1:
+        if ninst > 1 and not comp.endswith("esp"):
             for inst_counter in xrange(1, ninst+1):
                 inst_nlfile = "{}_{:04d}".format(nlfile, inst_counter)
                 if not os.path.exists(inst_nlfile):

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -33,8 +33,10 @@ def _build_usernl_files(case, model, comp):
 
     expect(os.path.isdir(model_dir),
            "cannot find cime_config directory {} for component {}".format(model_dir, comp))
-
-    ninst = case.get_value("NINST_CPL")
+    ninst = 1
+    multi_coupler = case.get_value("MULTI_COUPLER")
+    if multi_coupler:
+        ninst = case.get_value("NINST_MAX")
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
             shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")
@@ -124,6 +126,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 
         # Check ninst.
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.
+        multi_coupler = case.get_value("MULTI_COUPLER")
         for comp in models:
             if comp == "CPL":
                 continue
@@ -137,6 +140,10 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                     case.set_value("NTASKS_{}".format(comp), ninst)
                 else:
                     expect(False, "NINST_{} value {:d} greater than NTASKS_{} {:d}".format(comp, ninst, comp, ntasks))
+            # But the NINST_LAYOUT may only be concurrent in multi_coupler mode
+            if multi_coupler:
+                expect(case.get_value("NINST_LAYOUT_{}".format(comp)) == "concurrent",
+                       "If multi_coupler is TRUE, NINST_LAYOUT_{} must be concurrent".format(comp))
 
         if os.path.exists("case.run"):
             logger.info("Machine/Decomp/Pes configuration has already been done ...skipping")

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -148,7 +148,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             unlock_file("env_build.xml")
 
             case.flush()
-            check_lockedfiles()
+            check_lockedfiles(case)
             env_mach_pes = case.get_env("mach_pes")
             pestot = env_mach_pes.get_total_tasks(models)
             logger.debug("at update TOTALPES = {}".format(pestot))

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -34,7 +34,7 @@ def _build_usernl_files(case, model, comp):
     expect(os.path.isdir(model_dir),
            "cannot find cime_config directory {} for component {}".format(model_dir, comp))
 
-    ninst = case.get_value("COUPLER_COUNT")
+    ninst = case.get_value("NINST_CPL")
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
             shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")
@@ -126,14 +126,13 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.
         for comp in models:
             if comp == "CPL":
-                ninst = case.get_value("COUPLER_COUNT")
-            else:
-                ninst  = case.get_value("NINST_{}".format(comp))
+                continue
+            ninst  = case.get_value("NINST_{}".format(comp))
             ntasks = case.get_value("NTASKS_{}".format(comp))
             # ESP models are currently limited to 1 instance
             expect((comp != "ESP") or (ninst == 1),
                    "ESP components may only have one instance")
-            if ninst > ntasks and comp != "CPL":
+            if ninst > ntasks:
                 if ntasks == 1:
                     case.set_value("NTASKS_{}".format(comp), ninst)
                 else:

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -34,7 +34,7 @@ def _build_usernl_files(case, model, comp):
     expect(os.path.isdir(model_dir),
            "cannot find cime_config directory {} for component {}".format(model_dir, comp))
 
-    ninst = case.get_value("NINST_CPL")
+    ninst = case.get_value("COUPLER_COUNT")
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
             shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")
@@ -126,13 +126,14 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.
         for comp in models:
             if comp == "CPL":
-                continue
-            ninst  = case.get_value("NINST_{}".format(comp))
+                ninst = case.get_value("COUPLER_COUNT")
+            else:
+                ninst  = case.get_value("NINST_{}".format(comp))
             ntasks = case.get_value("NTASKS_{}".format(comp))
             # ESP models are currently limited to 1 instance
             expect((comp != "ESP") or (ninst == 1),
                    "ESP components may only have one instance")
-            if ninst > ntasks:
+            if ninst > ntasks and comp != "CPL":
                 if ntasks == 1:
                     case.set_value("NTASKS_{}".format(comp), ninst)
                 else:

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -45,8 +45,11 @@ def _get_datenames(case, last_date=None):
 ###############################################################################
 def _get_ninst_info(case, compclass):
 ###############################################################################
-
-    ninst = case.get_value('NINST_' + compclass.upper())
+    comp = compclass.upper()
+    if comp == "CPL":
+        ninst = case.get_value("COUPLER_COUNT")
+    else:
+        ninst = case.get_value('NINST_' + compclass.upper())
     ninst_strings = []
     if ninst is None:
         ninst = 1

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -25,9 +25,9 @@ def _get_datenames(case, last_date=None):
     rundir = case.get_value('RUNDIR')
     expect(isdir(rundir), 'Cannot open directory {} '.format(rundir))
     casename = case.get_value("CASE")
-    files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl.r*.nc')))
+    files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl*.r*.nc')))
     if not files:
-        expect(False, 'Cannot find a {}.cpl.r.*.nc file in directory {} '.format(casename, rundir))
+        expect(False, 'Cannot find a {}.cpl*.r.*.nc file in directory {} '.format(casename, rundir))
     datenames = []
     for filename in files:
         names = filename.split('.')
@@ -46,10 +46,7 @@ def _get_datenames(case, last_date=None):
 def _get_ninst_info(case, compclass):
 ###############################################################################
 
-    if compclass != 'cpl':
-        ninst = case.get_value('NINST_' + compclass.upper())
-    else:
-        ninst = 1
+    ninst = case.get_value('NINST_' + compclass.upper())
     ninst_strings = []
     if ninst is None:
         ninst = 1

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -45,11 +45,8 @@ def _get_datenames(case, last_date=None):
 ###############################################################################
 def _get_ninst_info(case, compclass):
 ###############################################################################
-    comp = compclass.upper()
-    if comp == "CPL":
-        ninst = case.get_value("COUPLER_COUNT")
-    else:
-        ninst = case.get_value('NINST_' + compclass.upper())
+
+    ninst = case.get_value('NINST_' + compclass.upper())
     ninst_strings = []
     if ninst is None:
         ninst = 1

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 def _submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
             mail_user=None, mail_type='never', batch_args=None):
-    caseroot = case.get_value("CASEROOT")
     if job is None:
         if case.get_value("TEST"):
             job = "case.test"

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -108,7 +108,7 @@ def submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
         raise
 
 def check_case(case, caseroot):
-    check_lockedfiles(caseroot)
+    check_lockedfiles(case)
     create_namelists(case) # Must be called before check_all_input_data
     logger.info("Checking that inputdata is available as part of case submission")
     check_all_input_data(case)

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 def _submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
             mail_user=None, mail_type='never', batch_args=None):
     caseroot = case.get_value("CASEROOT")
-
     if job is None:
         if case.get_value("TEST"):
             job = "case.test"
@@ -33,7 +32,7 @@ def _submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
             case.set_value("CONTINUE_RUN", True)
     else:
         if job in ("case.test","case.run"):
-            check_case(case, caseroot)
+            check_case(case)
             check_DA_settings(case)
             if case.get_value("MACH") == "mira":
                 with open(".original_host", "w") as fd:
@@ -107,7 +106,7 @@ def submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
 
         raise
 
-def check_case(case, caseroot):
+def check_case(case):
     check_lockedfiles(case)
     create_namelists(case) # Must be called before check_all_input_data
     logger.info("Checking that inputdata is available as part of case submission")

--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -77,13 +77,13 @@ def check_pelayouts_require_rebuild(case, models):
 
         unlock_file("env_mach_pes.xml", case.get_value("CASEROOT"))
 
-def check_lockedfiles(caseroot=None):
+def check_lockedfiles(case):
     """
     Check that all lockedfiles match what's in case
 
     If caseroot is not specified, it is set to the current working directory
     """
-    caseroot = os.getcwd() if caseroot is None else caseroot
+    caseroot = case.get_value("CASEROOT")
     lockedfiles = glob.glob(os.path.join(caseroot, "LockedFiles", "*.xml"))
     for lfile in lockedfiles:
         fpart = os.path.basename(lfile)
@@ -91,19 +91,20 @@ def check_lockedfiles(caseroot=None):
         if fpart.count('.') > 1:
             continue
         cfile = os.path.join(caseroot, fpart)
+        components = case.get_values("COMP_CLASSES")
         if os.path.isfile(cfile):
             objname = fpart.split('.')[0]
             if objname == "env_build":
-                f1obj = EnvBuild(caseroot, cfile)
+                f1obj = case.get_env('build')
                 f2obj = EnvBuild(caseroot, lfile)
             elif objname == "env_mach_pes":
-                f1obj = EnvMachPes(caseroot, cfile)
-                f2obj = EnvMachPes(caseroot, lfile)
+                f1obj = case.get_env('mach_pes')
+                f2obj = EnvMachPes(caseroot, lfile, components=components)
             elif objname == "env_case":
-                f1obj = EnvCase(caseroot, cfile)
+                f1obj = case.get_env('case')
                 f2obj = EnvCase(caseroot, lfile)
             elif objname == "env_batch":
-                f1obj = EnvBatch(caseroot, cfile)
+                f1obj = case.get_env('batch')
                 f2obj = EnvBatch(caseroot, lfile)
             else:
                 logging.warn("Locked XML file '{}' is not current being handled".format(fpart))
@@ -122,15 +123,13 @@ def check_lockedfiles(caseroot=None):
                            " recover the original copy from LockedFiles")
                 elif objname == "env_build":
                     logging.warn("Setting build complete to False")
-                    f1obj.set_value("BUILD_COMPLETE", False)
+                    case.set_value("BUILD_COMPLETE", False)
                     if "PIO_VERSION" in diffs.keys():
-                        f1obj.set_value("BUILD_STATUS", 2)
-                        f1obj.write()
+                        case.set_value("BUILD_STATUS", 2)
                         logging.critical("Changing PIO_VERSION requires running "
                                          "case.build --clean-all and rebuilding")
                     else:
-                        f1obj.set_value("BUILD_STATUS", 1)
-                        f1obj.write()
+                        case.set_value("BUILD_STATUS", 1)
                 elif objname == "env_batch":
                     expect(False, "Batch configuration has changed, please run case.setup --reset")
                 else:

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -93,7 +93,7 @@ class _TimingParser:
         return (0, 0, False)
 
     def getTiming(self):
-        ninst = self.case.get_value("COUPLER_COUNT")
+        ninst = self.case.get_value("NINST_CPL")
         if ninst > 1:
             for inst in range(ninst):
                 self._getTiming(inst+1)

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -93,7 +93,7 @@ class _TimingParser:
         return (0, 0, False)
 
     def getTiming(self):
-        ninst = self.case.get_value("NINST_CPL")
+        ninst = self.case.get_value("COUPLER_COUNT")
         if ninst > 1:
             for inst in range(ninst):
                 self._getTiming(inst+1)

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -93,7 +93,11 @@ class _TimingParser:
         return (0, 0, False)
 
     def getTiming(self):
-        ninst = self.case.get_value("NINST_CPL")
+        ninst = 1
+        multi_coupler = self.case.get_value("MULTI_COUPLER")
+        if multi_coupler:
+            ninst = self.case.get_value("NINST_MAX")
+
         if ninst > 1:
             for inst in range(ninst):
                 self._getTiming(inst+1)

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -72,7 +72,6 @@ def create_namelists(case, component=None):
         model_str = model.lower()
         config_file = case.get_value("CONFIG_{}_FILE".format(model_str.upper()))
         config_dir = os.path.dirname(config_file)
-        multicoupler = case.get_value("MULTI_COUPLER")
         if model_str == "cpl":
             compname = "drv"
         else:

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -83,6 +83,7 @@ def create_namelists(case, component=None):
         # are restored.
         if multicoupler and model_str != "cpl":
             case.set_value("MULTI_COUPLER",False)
+            print "HERE NINST_{} = {}".format(model_str.upper(), case.get_value("NINST_{}".format(model_str.upper())))
         if component is None or component == model_str:
             # first look in the case SourceMods directory
             cmd = os.path.join(caseroot, "SourceMods", "src."+compname, "buildnml")

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -66,8 +66,6 @@ def create_namelists(case, component=None):
     # Create namelists - must have cpl last in the list below
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
-    xmlfac = {}
-    cpl_ninst = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
     models += [models.pop(0)]
     for model in models:

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -77,12 +77,6 @@ def create_namelists(case, component=None):
             compname = "drv"
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
-        # We must temporarily toggle out of Multicoupler mode (MULTI_COUPLER )
-        # so that the component build namelists use the correct number of instances
-        # we can get rid of this hack when all of the components understand MULTI_COUPLER
-        # mode
-        if multicoupler and model_str != "cpl":
-            case.set_value("MULTI_COUPLER",False)
         if component is None or component == model_str:
             # first look in the case SourceMods directory
             cmd = os.path.join(caseroot, "SourceMods", "src."+compname, "buildnml")
@@ -94,8 +88,6 @@ def create_namelists(case, component=None):
             expect(os.path.isfile(cmd), "Could not find buildnml file for component {}".format(compname))
             run_sub_or_cmd(cmd, (caseroot), "buildnml", (case, caseroot, compname), case=case)
 
-        if multicoupler and model_str != "cpl":
-            case.set_value("MULTI_COUPLER",True)
     logger.info("Finished creating component namelists")
 
     # Save namelists to docdir

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -67,7 +67,7 @@ def create_namelists(case, component=None):
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
     xmlfac = {}
-    coupler_count = case.get_value("COUPLER_COUNT")
+    cpl_ninst = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
     models += [models.pop(0)]
     for model in models:
@@ -83,21 +83,20 @@ def create_namelists(case, component=None):
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
 
-        if coupler_count > 1:
-            if model_str == "cpl":
-                complist = [m for m in models if m.upper() != "CPL"]
-                if coupler_count > 1:
-                    xmlfac = {"NINST" : -(coupler_count), "NTASKS" : 1}
-            else:
-                complist = [model_str.upper()]
-                if coupler_count > 1:
-                    xmlfac = {"NINST" : -(coupler_count), "NTASKS" : coupler_count}
+            complist = [m for m in models if m.upper() != "CPL"]
+            if cpl_ninst > 1:
+                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : 1}
+        else:
+            compname = case.get_value("COMP_{}".format(model_str.upper()))
+            complist = [model_str.upper()]
+            if cpl_ninst > 1:
+                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : cpl_ninst}
 
-            xmlsave = {}
-            for k in xmlfac.keys():
-                for m in complist:
-                    key = "{}_{}" .format(k, m.upper())
-                    xmlsave[key] = case.get_value(key)
+        xmlsave = {}
+        for k in xmlfac.keys():
+            for m in complist:
+                key = "{}_{}" .format(k, m.upper())
+                xmlsave[key] = case.get_value(key)
 
         if component is None or component == model_str:
             # first look in the case SourceMods directory

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -74,22 +74,30 @@ def create_namelists(case, component=None):
         model_str = model.lower()
         config_file = case.get_value("CONFIG_{}_FILE".format(model_str.upper()))
         config_dir = os.path.dirname(config_file)
+        # Multicoupler mode (coupler_count > 1) must temporarily change
+        # NINST and NTASKS settings so that the component buildnml scripts
+        # will work correctly.  After the call to buildnml the original values
+        # are restored.
         if model_str == "cpl":
             compname = "drv"
-            complist = [m for m in models if m.upper() != "CPL"]
-            if coupler_count > 1:
-                xmlfac = {"NINST" : -(coupler_count), "NTASKS" : 1}
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
-            complist = [model_str.upper()]
-            if coupler_count > 1:
-                xmlfac = {"NINST" : -(coupler_count), "NTASKS" : coupler_count}
 
-        xmlsave = {}
-        for k in xmlfac.keys():
-            for m in complist:
-                key = "{}_{}" .format(k, m.upper())
-                xmlsave[key] = case.get_value(key)
+        if coupler_count > 1:
+            if model_str == "cpl":
+                complist = [m for m in models if m.upper() != "CPL"]
+                if coupler_count > 1:
+                    xmlfac = {"NINST" : -(coupler_count), "NTASKS" : 1}
+            else:
+                complist = [model_str.upper()]
+                if coupler_count > 1:
+                    xmlfac = {"NINST" : -(coupler_count), "NTASKS" : coupler_count}
+
+            xmlsave = {}
+            for k in xmlfac.keys():
+                for m in complist:
+                    key = "{}_{}" .format(k, m.upper())
+                    xmlsave[key] = case.get_value(key)
 
         if component is None or component == model_str:
             # first look in the case SourceMods directory

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -77,10 +77,10 @@ def create_namelists(case, component=None):
             compname = "drv"
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
-        # Multicoupler mode (MULTI_COUPLER ) must temporarily change
-        # NINST and NTASKS settings so that the component buildnml scripts
-        # will work correctly.  After the call to buildnml the original values
-        # are restored.
+        # We must temporarily toggle out of Multicoupler mode (MULTI_COUPLER )
+        # so that the component build namelists use the correct number of instances
+        # we can get rid of this hack when all of the components understand MULTI_COUPLER
+        # mode
         if multicoupler and model_str != "cpl":
             case.set_value("MULTI_COUPLER",False)
         if component is None or component == model_str:

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -83,7 +83,6 @@ def create_namelists(case, component=None):
         # are restored.
         if multicoupler and model_str != "cpl":
             case.set_value("MULTI_COUPLER",False)
-            print "HERE NINST_{} = {}".format(model_str.upper(), case.get_value("NINST_{}".format(model_str.upper())))
         if component is None or component == model_str:
             # first look in the case SourceMods directory
             cmd = os.path.join(caseroot, "SourceMods", "src."+compname, "buildnml")

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -67,7 +67,7 @@ def create_namelists(case, component=None):
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
     xmlfac = {}
-    cpl_ninst = case.get_value("NINST_CPL")
+    coupler_count = case.get_value("COUPLER_COUNT")
     models = case.get_values("COMP_CLASSES")
     models += [models.pop(0)]
     for model in models:
@@ -77,13 +77,13 @@ def create_namelists(case, component=None):
         if model_str == "cpl":
             compname = "drv"
             complist = [m for m in models if m.upper() != "CPL"]
-            if cpl_ninst > 1:
-                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : 1}
+            if coupler_count > 1:
+                xmlfac = {"NINST" : -(coupler_count), "NTASKS" : 1}
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
             complist = [model_str.upper()]
-            if cpl_ninst > 1:
-                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : cpl_ninst}
+            if coupler_count > 1:
+                xmlfac = {"NINST" : -(coupler_count), "NTASKS" : coupler_count}
 
         xmlsave = {}
         for k in xmlfac.keys():

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -66,6 +66,8 @@ def create_namelists(case, component=None):
     # Create namelists - must have cpl last in the list below
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
+    xmlfac = {}
+    cpl_ninst = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
     models += [models.pop(0)]
     for model in models:
@@ -74,8 +76,20 @@ def create_namelists(case, component=None):
         config_dir = os.path.dirname(config_file)
         if model_str == "cpl":
             compname = "drv"
+            complist = [m for m in models if m.upper() != "CPL"]
+            if cpl_ninst > 1:
+                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : 1}
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
+            complist = [model_str.upper()]
+            if cpl_ninst > 1:
+                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : cpl_ninst}
+
+        xmlsave = {}
+        for k in xmlfac.keys():
+            for m in complist:
+                key = "{}_{}" .format(k, m.upper())
+                xmlsave[key] = case.get_value(key)
 
         if component is None or component == model_str:
             # first look in the case SourceMods directory

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -399,7 +399,7 @@ class TestScheduler(object):
                     logger.debug (" NINST set to {}".format(ninst))
                 if case_opt.startswith('C'):
                     ncpl = case_opt[1:]
-                    create_newcase_cmd += " --ninst {} --ninst-coupler" .format(ncpl)
+                    create_newcase_cmd += " --ninst {} --ninst-couplers" .format(ncpl)
                     logger.debug (" NCPL set to {}" .format(ncpl))
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -397,6 +397,10 @@ class TestScheduler(object):
                     ninst = case_opt[1:]
                     create_newcase_cmd += " --ninst {}".format(ninst)
                     logger.debug (" NINST set to {}".format(ninst))
+                if case_opt.startswith('C'):
+                    ncpl = case_opt[1:]
+                    create_newcase_cmd += " --ncouplers {}" .format(ncpl)
+                    logger.debug (" NCPL set to {}" .format(ncpl))
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]
                     create_newcase_cmd += " --pecount {}".format(pesize)
@@ -514,6 +518,9 @@ class TestScheduler(object):
                     continue
 
                 elif opt.startswith('N'):
+                    # handled in create_newcase
+                    continue
+                elif opt.startswith('C'):
                     # handled in create_newcase
                     continue
                 elif opt.startswith('IOP'):

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -399,7 +399,7 @@ class TestScheduler(object):
                     logger.debug (" NINST set to {}".format(ninst))
                 if case_opt.startswith('C'):
                     ncpl = case_opt[1:]
-                    create_newcase_cmd += " --ncouplers {}" .format(ncpl)
+                    create_newcase_cmd += " --ninst {} --ninst-coupler" .format(ncpl)
                     logger.debug (" NCPL set to {}" .format(ncpl))
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -403,7 +403,7 @@ class TestScheduler(object):
                 if case_opt.startswith('C'):
                     expect(ninst == 1,"Cannot combine _C and _N options")
                     ncpl = case_opt[1:]
-                    create_newcase_cmd += " --ninst {} --ninst-couplers" .format(ncpl)
+                    create_newcase_cmd += " --ninst {} --multi-coupler" .format(ncpl)
                     logger.debug (" NCPL set to {}" .format(ncpl))
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -387,6 +387,8 @@ class TestScheduler(object):
             create_newcase_cmd += " --user-mods-dir {}".format(test_mod_file)
 
         mpilib = None
+        ninst = 1
+        ncpl = 1
         if case_opts is not None:
             for case_opt in case_opts: # pylint: disable=not-an-iterable
                 if case_opt.startswith('M'):
@@ -394,10 +396,12 @@ class TestScheduler(object):
                     create_newcase_cmd += " --mpilib {}".format(mpilib)
                     logger.debug (" MPILIB set to {}".format(mpilib))
                 if case_opt.startswith('N'):
+                    expect(ncpl == 1,"Cannot combine _C and _N options")
                     ninst = case_opt[1:]
                     create_newcase_cmd += " --ninst {}".format(ninst)
                     logger.debug (" NINST set to {}".format(ninst))
                 if case_opt.startswith('C'):
+                    expect(ninst == 1,"Cannot combine _C and _N options")
                     ncpl = case_opt[1:]
                     create_newcase_cmd += " --ninst {} --ninst-couplers" .format(ncpl)
                     logger.debug (" NCPL set to {}" .format(ncpl))

--- a/scripts/lib/update_acme_tests.py
+++ b/scripts/lib/update_acme_tests.py
@@ -51,7 +51,8 @@ _TEST_SUITES = {
                              "PET_P32.f19_f19.A",
                              "SMS.T42_T42.S",
                              "PRE.f19_f19.ADESP",
-                             "PRE.f19_f19.ADESP_TEST")
+                             "PRE.f19_f19.ADESP_TEST",
+                             "MCC_P12.f19_g16_rx1.A")
                             ),
 
     #

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -19,14 +19,27 @@ my $USE_ESMF_LIB	= `./xmlquery USE_ESMF_LIB	--value`;
 my $GMAKE_J		= `./xmlquery GMAKE_J		--value`;
 my $GMAKE		= `./xmlquery GMAKE		--value`;
 my $CASETOOLS		= `./xmlquery CASETOOLS		--value`;
-my $NINST_ATM		= `./xmlquery NINST_ATM		--value`;
-my $NINST_ICE		= `./xmlquery NINST_ICE		--value`;
-my $NINST_GLC		= `./xmlquery NINST_GLC		--value`;
-my $NINST_LND		= `./xmlquery NINST_LND		--value`;
-my $NINST_OCN		= `./xmlquery NINST_OCN		--value`;
-my $NINST_ROF		= `./xmlquery NINST_ROF		--value`;
-my $NINST_WAV		= `./xmlquery NINST_WAV		--value`;
-my $NINST_ESP		= `./xmlquery NINST_ESP		--value`;
+my $multi_coupler  	= `./xmlquery MULTI_COUPLER       --value`;
+
+my $NINST_ATM		= 1;
+my $NINST_ICE		= 1;
+my $NINST_GLC		= 1;
+my $NINST_LND		= 1;
+my $NINST_OCN		= 1;
+my $NINST_ROF		= 1;
+my $NINST_WAV		= 1;
+my $NINST_ESP		= 1;
+
+if ($multi_coupler == "FALSE") {
+    my $NINST_ATM		= `./xmlquery NINST_ATM		--value`;
+    my $NINST_ICE		= `./xmlquery NINST_ICE		--value`;
+    my $NINST_GLC		= `./xmlquery NINST_GLC		--value`;
+    my $NINST_LND		= `./xmlquery NINST_LND		--value`;
+    my $NINST_OCN		= `./xmlquery NINST_OCN		--value`;
+    my $NINST_ROF		= `./xmlquery NINST_ROF		--value`;
+    my $NINST_WAV		= `./xmlquery NINST_WAV		--value`;
+    my $NINST_ESP		= `./xmlquery NINST_ESP		--value`;
+}
 my $NINST_VALUE		= `./xmlquery NINST_VALUE	--value`;
 $ENV{PIO_VERSION}  	= `./xmlquery PIO_VERSION	--value`;
 #--------------------------------------------------------------------
@@ -73,6 +86,7 @@ if($#fp != $#filepath){
     close(F);
 }
 my $multiinst_cppdefs = "";
+
 $multiinst_cppdefs = "$multiinst_cppdefs -DNUM_COMP_INST_ATM=$NINST_ATM";
 $multiinst_cppdefs = "$multiinst_cppdefs -DNUM_COMP_INST_LND=$NINST_LND";
 $multiinst_cppdefs = "$multiinst_cppdefs -DNUM_COMP_INST_OCN=$NINST_OCN";

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -247,18 +247,23 @@ def _create_component_modelio_namelists(case, files):
 
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")
-    inst_cpl = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
+    #if we are in multi-coupler mode the number of instances of cpl will be the max
+    # of any NINST_* value
+    maxinst = 1
+    if case.get_value("MULTI_COUPLER"):
+        maxinst = case.get_value("NINST_MAX")
+
     for model in models:
         model = model.lower()
         with NamelistGenerator(case, definition_file) as nmlgen:
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-            if inst_cpl == 1:
+            if maxinst == 1:
                 inst_count = case.get_value("NINST_" + model.upper())
             elif model != 'ESP':
-                inst_count = inst_cpl
+                inst_count = maxinst
             else:
                 inst_count = 1
 

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -255,20 +255,14 @@ def _create_component_modelio_namelists(case, files):
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
 
-            if model == 'cpl':
-                inst_count = 1
-            else:
-                inst_count = case.get_value("NINST_" + model.upper())
+            inst_count = case.get_value("NINST_" + model.upper())
 
+            inst_string = ""
             inst_index = 1
             while inst_index <= inst_count:
-                inst_string = inst_index
-                if inst_index <= 999:
-                    inst_string = "0" + str(inst_string)
-                if inst_index <=  99:
-                    inst_string = "0" + str(inst_string)
-                if inst_index <=  9:
-                    inst_string = "0" + str(inst_string)
+                # determine instance string
+                if inst_count > 1:
+                    inst_string = '_%04d' % inst_index
 
                 # set default values
                 for entry in entries:
@@ -281,17 +275,11 @@ def _create_component_modelio_namelists(case, files):
                 moddiro = case.get_value('RUNDIR')
                 nmlgen.set_value('diro', moddiro)
 
-                if inst_count > 1:
-                    logfile = model + "_" + inst_string + ".log." + str(lid)
-                else:
-                    logfile = model + ".log." + str(lid)
+                logfile = model + inst_string + ".log." + str(lid)
                 nmlgen.set_value('logfile', logfile)
 
                 # Write output file
-                if inst_count > 1:
-                    modelio_file = model + "_modelio.nml_" + str(inst_string)
-                else:
-                    modelio_file = model + "_modelio.nml"
+                modelio_file = model + "_modelio.nml" + inst_string
                 nmlgen.write_modelio_file(os.path.join(confdir, modelio_file))
 
                 inst_index = inst_index + 1

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -272,7 +272,7 @@ def _create_component_modelio_namelists(case, files):
             while inst_index <= inst_count:
                 # determine instance string
                 if inst_count > 1:
-                    inst_string = '_{04d}'.format(inst_index)
+                    inst_string = '_{:04d}'.format(inst_index)
 
                 # set default values
                 for entry in entries:

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -247,7 +247,7 @@ def _create_component_modelio_namelists(case, files):
 
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")
-
+    inst_cpl = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
     for model in models:
         model = model.lower()
@@ -255,8 +255,12 @@ def _create_component_modelio_namelists(case, files):
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-
-            inst_count = case.get_value("NINST_" + model.upper())
+            if inst_cpl == 1:
+                inst_count = case.get_value("NINST_" + model.upper())
+            elif model != 'ESP':
+                inst_count = inst_cpl
+            else:
+                inst_count = 1
 
             inst_string = ""
             inst_index = 1

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -254,10 +254,8 @@ def _create_component_modelio_namelists(case, files):
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-            if model == "cpl":
-                inst_count = case.get_value("COUPLER_COUNT")
-            else:
-                inst_count = case.get_value("NINST_" + model.upper())
+
+            inst_count = case.get_value("NINST_" + model.upper())
 
             inst_string = ""
             inst_index = 1

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -260,9 +260,9 @@ def _create_component_modelio_namelists(case, files):
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-            if maxinst == 1:
+            if maxinst == 1 and model != 'cpl':
                 inst_count = case.get_value("NINST_" + model.upper())
-            elif model != 'ESP':
+            elif model != 'esp':
                 inst_count = maxinst
             else:
                 inst_count = 1
@@ -272,7 +272,7 @@ def _create_component_modelio_namelists(case, files):
             while inst_index <= inst_count:
                 # determine instance string
                 if inst_count > 1:
-                    inst_string = '_%04d' % inst_index
+                    inst_string = '_{04d}'.format(inst_index)
 
                 # set default values
                 for entry in entries:

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -248,8 +248,9 @@ def _create_component_modelio_namelists(case, files):
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")
 
-    models = ["cpl", "atm", "lnd", "ice", "ocn", "glc", "rof", "wav", "esp"]
+    models = case.get_values("COMP_CLASSES")
     for model in models:
+        model = model.lower()
         with NamelistGenerator(case, definition_file) as nmlgen:
             config = {}
             config['component'] = model

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -254,8 +254,10 @@ def _create_component_modelio_namelists(case, files):
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-
-            inst_count = case.get_value("NINST_" + model.upper())
+            if model == "cpl":
+                inst_count = case.get_value("COUPLER_COUNT")
+            else:
+                inst_count = case.get_value("NINST_" + model.upper())
 
             inst_string = ""
             inst_index = 1

--- a/src/drivers/mct/cime_config/config_archive.xml
+++ b/src/drivers/mct/cime_config/config_archive.xml
@@ -4,8 +4,8 @@
     <hist_file_extension>\.h.*.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.cpl</rpointer_file>
-      <rpointer_content >$CASE.cpl.r.$DATENAME.nc</rpointer_content>
+      <rpointer_file>rpointer$NINST_STRING.cpl</rpointer_file>
+      <rpointer_content >$CASE.cpl$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1945,7 +1945,7 @@
     <default_value>1</default_value>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.  Each coupler instance is an instance of the entier model.</desc>
+    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.  Each coupler instance is an instance of the entire model.</desc>
   </entry>
 
   <entry id="NINST">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1945,7 +1945,7 @@
     <default_value>1</default_value>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.</desc>
+    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.  Each coupler instance is an instance of the entier model.</desc>
   </entry>
 
   <entry id="NINST">
@@ -1962,7 +1962,9 @@
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of instances for each component in single coupler mode</desc>
+    <desc>Number of instances for each component in single coupler mode.
+          In multiple coupler mode (COUPLER_COUNT > 1) this must be 1 and
+          there are COUPLER_COUNT instances of the entire model.</desc>
   </entry>
 
   <entry id="NINST_LAYOUT">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1943,6 +1943,7 @@
   <entry id="NINST">
     <type>integer</type>
     <values>
+      <value component="CPL">1</value>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1942,7 +1942,8 @@
 
   <entry id="MULTI_COUPLER">
     <type>logical</type>
-    <default_value>False</default_value>
+    <default_value>FALSE</default_value>
+    <valid_values>TRUE,FALSE</valid_values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
     <desc>MULTI_COUPLER mode provides a separate coupler component for each

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1940,17 +1940,21 @@
     <desc>ROOTPE (mpi task in MPI_COMM_WORLD) for each component</desc>
   </entry>
 
-  <entry id="COUPLER_COUNT">
-    <type>integer</type>
-    <default_value>1</default_value>
+  <entry id="MULTI_COUPLER">
+    <type>logical</type>
+    <default_value>False</default_value>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.  Each coupler instance is an instance of the entire model.</desc>
+    <desc>MULTI_COUPLER mode provides a separate coupler component for each
+    ensemble member all components must have an equal number of members.  If
+    MULTI_COUPLER mode is False prognostic components must have the same number
+    of members but data or stub components may also have 1 member. </desc>
   </entry>
 
   <entry id="NINST">
     <type>integer</type>
     <values>
+      <value component="CPL">1</value>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>
@@ -1962,9 +1966,8 @@
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of instances for each component in single coupler mode.
-          In multiple coupler mode (COUPLER_COUNT > 1) this must be 1 and
-          there are COUPLER_COUNT instances of the entire model.</desc>
+    <desc>Number of instances for each component.  If MULTI_COUPLER is True
+    only NINST_CPL is used, if MULTI_COUPLER is False NINST_CPL is 1.</desc>
   </entry>
 
   <entry id="NINST_LAYOUT">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1940,10 +1940,17 @@
     <desc>ROOTPE (mpi task in MPI_COMM_WORLD) for each component</desc>
   </entry>
 
+  <entry id="COUPLER_COUNT">
+    <type>integer</type>
+    <default_value>1</default_value>
+    <group>mach_pes</group>
+    <file>env_mach_pes.xml</file>
+    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.</desc>
+  </entry>
+
   <entry id="NINST">
     <type>integer</type>
     <values>
-      <value component="CPL">1</value>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>
@@ -1955,7 +1962,7 @@
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of instances for each component</desc>
+    <desc>Number of instances for each component in single coupler mode</desc>
   </entry>
 
   <entry id="NINST_LAYOUT">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1968,7 +1968,8 @@
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
     <desc>Number of instances for each component.  If MULTI_COUPLER is True
-    only NINST_CPL is used, if MULTI_COUPLER is False NINST_CPL is 1.</desc>
+    only NINST_CPL is used and all components have NINST_CPL instances;
+    if MULTI_COUPLER is False NINST_CPL is 1.</desc>
   </entry>
 
   <entry id="NINST_LAYOUT">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1955,7 +1955,6 @@
   <entry id="NINST">
     <type>integer</type>
     <values>
-      <value component="CPL">1</value>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -44,15 +44,15 @@
   <!-- group cime_cpl_inst              -->
   <!-- =========================== -->
 
-  <entry id="ninst_cpl" modify_via_xml="COUPLER_COUNT">
+  <entry id="ninst_cpl" modify_via_xml="NINST_CPL">
     <type>integer</type>
     <category>cime_cpl_inst</category>
     <group>cime_cpl_inst</group>
     <desc>
-      Number of CESM coupler instances. If > 1 then all component instances must equal 1.
+      Number of CESM coupler instances.
     </desc>
     <values>
-      <value>$COUPLER_COUNT</value>
+      <value>$NINST_CPL</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -44,7 +44,7 @@
   <!-- group cime_cpl_inst              -->
   <!-- =========================== -->
 
-  <entry id="ninst_cpl" modify_via_xml="NINST_CPL">
+  <entry id="ninst_cpl" modify_via_xml="NINST_MAX">
     <type>integer</type>
     <category>cime_cpl_inst</category>
     <group>cime_cpl_inst</group>
@@ -52,7 +52,7 @@
       Number of CESM coupler instances.
     </desc>
     <values>
-      <value>$NINST_CPL</value>
+      <value>$NINST_MAX</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -41,13 +41,13 @@
   -->
 
   <!-- =========================== -->
-  <!-- group cesm_cpl              -->
+  <!-- group cime_cpl_inst              -->
   <!-- =========================== -->
 
-  <entry id="cpl_ninst" modify_via_xml="NINST_CPL">
+  <entry id="ninst_cpl" modify_via_xml="NINST_CPL">
     <type>integer</type>
-    <category>cesm_cpl</category>
-    <group>cesm_cpl</group>
+    <category>cime_cpl_inst</category>
+    <group>cime_cpl_inst</group>
     <desc>
       Number of CESM coupler instances.
     </desc>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -44,15 +44,15 @@
   <!-- group cime_cpl_inst              -->
   <!-- =========================== -->
 
-  <entry id="ninst_cpl" modify_via_xml="NINST_CPL">
+  <entry id="ninst_cpl" modify_via_xml="COUPLER_COUNT">
     <type>integer</type>
     <category>cime_cpl_inst</category>
     <group>cime_cpl_inst</group>
     <desc>
-      Number of CESM coupler instances.
+      Number of CESM coupler instances. If > 1 then all component instances must equal 1.
     </desc>
     <values>
-      <value>$NINST_CPL</value>
+      <value>$COUPLER_COUNT</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -41,6 +41,22 @@
   -->
 
   <!-- =========================== -->
+  <!-- group cesm_cpl              -->
+  <!-- =========================== -->
+
+  <entry id="cpl_ninst" modify_via_xml="NINST_CPL">
+    <type>integer</type>
+    <category>cesm_cpl</category>
+    <group>cesm_cpl</group>
+    <desc>
+      Number of CESM coupler instances.
+    </desc>
+    <values>
+      <value>$NINST_CPL</value>
+    </values>
+  </entry>
+
+  <!-- =========================== -->
   <!-- group seq_cplflds_inparm    -->
   <!-- =========================== -->
 

--- a/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -23,6 +23,15 @@
       </machine>
     </machines>
   </test>
+  <test name="ERS_C3" grid="f19_g17_rx1" compset="A">
+    <machines>
+      <machine name="cheyenne" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">00:30:00</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
   <test name="ERI_D" grid="T31_g37_rx1" compset="A">
     <machines>
       <machine name="hobart" compiler="intel" category="prebeta">

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -72,7 +72,7 @@ module cime_comp_mod
     use seq_comm_mct, only: seq_comm_iamin, seq_comm_name, seq_comm_namelen
     use seq_comm_mct, only: seq_comm_init, seq_comm_setnthreads, seq_comm_getnthreads
     use seq_comm_mct, only: seq_comm_getinfo => seq_comm_setptrs
-    use seq_comm_mct, only: seq_comm_petlist
+    use seq_comm_mct, only: seq_comm_petlist, cpl_inst_tag
 
    ! clock & alarm routines and variables
    use seq_timemgr_mod, only: seq_timemgr_type
@@ -534,8 +534,6 @@ module cime_comp_mod
    logical  :: iamin_CPLALLROFID     ! pe associated with CPLALLROFID
    logical  :: iamin_CPLALLWAVID     ! pe associated with CPLALLWAVID
 
-   ! suffix for log and timing files if multi coupler driver
-   character(len=seq_comm_namelen) :: cpl_inst_tag
 
    !----------------------------------------------------------------------------
    ! complist: list of comps on this pe
@@ -589,7 +587,7 @@ contains
 
 subroutine cime_pre_init1()
    use shr_pio_mod, only : shr_pio_init1, shr_pio_init2
-
+   use seq_comm_mct, only: num_inst_cpl
    !----------------------------------------------------------
    !| Initialize MCT and MPI communicators and IO
    !----------------------------------------------------------
@@ -598,7 +596,7 @@ subroutine cime_pre_init1()
    logical :: comp_iamin(num_inst_total)
    character(len=seq_comm_namelen) :: comp_name(num_inst_total)
    integer :: i, it
-   integer :: num_inst_cpl, cpl_id
+   integer :: cpl_id
    integer :: cpl_comm
 
    call mpi_init(ierr)
@@ -4068,7 +4066,7 @@ subroutine cime_comp_barriers(mpicom, timer)
 end subroutine cime_comp_barriers
 
 subroutine cime_cpl_init(comm_in, comm_out, num_inst_cpl, id)
-
+  use seq_comm_mct, only : cpl_inst_iamin
   !-----------------------------------------------------------------------
   !
   ! Initialize multiple coupler instances, if requested

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -26,10 +26,11 @@ module cime_comp_mod
    use shr_sys_mod,       only: shr_sys_abort, shr_sys_flush
    use shr_const_mod,     only: shr_const_cday
    use shr_file_mod,      only: shr_file_setLogLevel, shr_file_setLogUnit
-   use shr_file_mod,      only: shr_file_setIO, shr_file_getUnit
+   use shr_file_mod,      only: shr_file_setIO, shr_file_getUnit, shr_file_freeUnit
    use shr_scam_mod,      only: shr_scam_checkSurface
    use shr_map_mod,       only: shr_map_setDopole
    use shr_mpi_mod,       only: shr_mpi_min, shr_mpi_max
+   use shr_mpi_mod,       only: shr_mpi_bcast, shr_mpi_commrank, shr_mpi_commsize
    use shr_mem_mod,       only: shr_mem_init, shr_mem_getusage
    use shr_cal_mod,       only: shr_cal_date2ymd, shr_cal_ymd2date, shr_cal_advdateInt
    use shr_orb_mod,       only: shr_orb_params
@@ -534,6 +535,9 @@ module cime_comp_mod
    logical  :: iamin_CPLALLROFID     ! pe associated with CPLALLROFID
    logical  :: iamin_CPLALLWAVID     ! pe associated with CPLALLWAVID
 
+   ! suffix for log and timing files if multi coupler driver
+   character(len=seq_comm_namelen) :: cpl_inst_tag
+
    !----------------------------------------------------------------------------
    ! complist: list of comps on this pe
    !----------------------------------------------------------------------------
@@ -595,6 +599,7 @@ subroutine cime_pre_init1()
    logical :: comp_iamin(num_inst_total)
    character(len=seq_comm_namelen) :: comp_name(num_inst_total)
    integer :: i, it
+   integer :: num_inst_cpl, cpl_id
 
    call mpi_init(ierr)
    call shr_mpi_chkerr(ierr,subname//' mpi_init')
@@ -603,6 +608,9 @@ subroutine cime_pre_init1()
    comp_comm = MPI_COMM_NULL
    time_brun = mpi_wtime()
 
+   !--- Initialize multiple coupler instances, if requested ---
+   call cesm_cpl_init(Global_Comm, num_inst_cpl, cpl_id)
+
    call shr_pio_init1(num_inst_total,NLFileName, Global_Comm)
    !
    ! If pio_async_interface is true Global_Comm is MPI_COMM_NULL on the servernodes
@@ -610,7 +618,13 @@ subroutine cime_pre_init1()
    !
    !   if (Global_Comm /= MPI_COMM_NULL) then
 
-   call seq_comm_init(Global_Comm, NLFileName)
+   if (num_inst_cpl > 1) then
+      call seq_comm_init(Global_Comm, NLFileName, Comm_ID=cpl_id)
+      write(cpl_inst_tag,'("_",i4.4)') cpl_id
+   else
+      call seq_comm_init(Global_Comm, NLFileName)
+      cpl_inst_tag = ''
+   end if
 
    !--- set task based threading counts ---
    call seq_comm_getinfo(GLOID,pethreads=pethreads_GLOID,iam=iam_GLOID)
@@ -757,10 +771,10 @@ subroutine cime_pre_init1()
    !----------------------------------------------------------
 
    if (iamroot_CPLID) then
-      inquire(file='cpl_modelio.nml',exist=exists)
+      inquire(file='cpl_modelio.nml'//trim(cpl_inst_tag),exist=exists)
       if (exists) then
          logunit = shr_file_getUnit()
-         call shr_file_setIO('cpl_modelio.nml',logunit)
+         call shr_file_setIO('cpl_modelio.nml'//trim(cpl_inst_tag),logunit)
          call shr_file_setLogUnit(logunit)
          loglevel = 1
          call shr_file_setLogLevel(loglevel)
@@ -781,6 +795,8 @@ subroutine cime_pre_init1()
       write(logunit,'(2A)') subname,' USE_ESMF_LIB is NOT set, using esmf_wrf_timemgr'
 #endif
       write(logunit,'(2A)') subname,' MCT_INTERFACE is set'
+      if (num_inst_cpl > 1) &
+         write(logunit,'(2A,I0,A)') subname,' Driver is running with',num_inst_cpl,'instances'
    endif
 
    !
@@ -844,7 +860,12 @@ subroutine cime_pre_init2()
    !| Initialize infodata
    !----------------------------------------------------------
 
-   call seq_infodata_init(infodata,nlfilename, GLOID, pioid)
+   if (len(cpl_inst_tag) > 0) then
+      call seq_infodata_init(infodata,nlfilename, GLOID, pioid, &
+                             cpl_tag=cpl_inst_tag)
+   else
+      call seq_infodata_init(infodata,nlfilename, GLOID, pioid)
+   end if
 
    !----------------------------------------------------------
    ! Print Model heading and copyright message
@@ -3574,7 +3595,7 @@ end subroutine cime_init
          call seq_rest_write(EClock_d, seq_SyncClock, infodata,       &
               atm, lnd, ice, ocn, rof, glc, wav, esp,                 &
               fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-              fractions_rx, fractions_gx, fractions_wx)
+              fractions_rx, fractions_gx, fractions_wx, tag=trim(cpl_inst_tag))
 
          if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
          call t_drvstopf  ('CPL:RESTART',cplrun=.true.)
@@ -3853,7 +3874,8 @@ end subroutine cime_init
          call mpi_barrier(mpicom_GLOID,ierr)
          call t_stopf("sync1_tprof")
 
-         write(timing_file,'(a,i8.8,a1,i5.5)') trim(tchkpt_dir)//"/model_timing_",ymd,"_",tod
+         write(timing_file,'(a,i8.8,a1,i5.5)') &
+           trim(tchkpt_dir)//"/cesm_timing"//trim(cpl_inst_tag)//"_",ymd,"_",tod
          if (output_perf) then
             call t_prf(filename=trim(timing_file), mpicom=mpicom_GLOID, &
                        num_outpe=0, output_thispe=output_perf)
@@ -3966,10 +3988,11 @@ end subroutine cime_init
 
    call t_set_prefixf("final:")
    if (output_perf) then
-      call t_prf(trim(timing_dir)//'/model_timing', mpicom=mpicom_GLOID, &
-                 output_thispe=output_perf)
+      call t_prf(trim(timing_dir)//'/model_timing'//trim(cpl_inst_tag), &
+                 mpicom=mpicom_GLOID, output_thispe=output_perf)
    else
-      call t_prf(trim(timing_dir)//'/model_timing', mpicom=mpicom_GLOID)
+      call t_prf(trim(timing_dir)//'/model_timing'//trim(cpl_inst_tag), &
+                 mpicom=mpicom_GLOID)
    endif
    call t_unset_prefixf()
 
@@ -4042,5 +4065,61 @@ subroutine cime_comp_barriers(mpicom, timer)
      call t_drvstopf (trim(timer))
   endif
 end subroutine cime_comp_barriers
+
+subroutine cime_cpl_init(comm, ninst, id)
+
+  !-----------------------------------------------------------------------
+  !
+  ! Initialize multiple coupler instances, if requested
+  !
+  !-----------------------------------------------------------------------
+
+  implicit none
+
+  integer , intent(inout) :: comm
+  integer , intent(out)   :: ninst
+  integer , intent(out)   :: id      ! instance ID, starts from 1
+  !
+  ! Local variables
+  !
+  integer :: ierr, inst_comm, mype, nu, numpes !, pes
+  integer :: cpl_ninst
+
+  namelist /cime_cpl/ cpl_ninst
+
+  call shr_mpi_commrank(comm, mype  , ' cime_cpl_init')
+  call shr_mpi_commsize(comm, numpes, ' cime_cpl_init')
+
+  ninst = 1
+  id    = 0
+
+  if (mype == 0) then
+    ! Read coupler namelist if it exists
+    cpl_ninst = 1
+    nu = shr_file_getUnit()
+    open(unit = nu, file = NLFileName, status = 'old', iostat = ierr)
+    rewind(unit = nu)
+    read(unit = nu, nml = cime_cpl, iostat = ierr)
+    close(unit = nu)
+    call shr_file_freeUnit(nu)
+    ninst = max(cpl_ninst, 1)
+  end if
+
+  call shr_mpi_bcast(ninst, comm, 'cpl_ninst')
+
+  if (mod(numpes, ninst) /= 0) then
+    call shr_sys_abort(subname // &
+      ' : Total PE number must be a multiple of coupler instance number')
+  end if
+
+  if (ninst > 1) then
+    id = mype * ninst / numpes + 1
+    call mpi_comm_split(comm, id, 0, inst_comm, ierr)
+    if (ierr /= 0) &
+      call shr_sys_abort(subname // ' : Error in generating coupler instances')
+    comm = inst_comm
+  end if
+
+end subroutine cime_cpl_init
 
 end module cime_comp_mod

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -508,8 +508,7 @@ module cime_comp_mod
    !----------------------------------------------------------------------------
    ! communicator groups and related
    !----------------------------------------------------------------------------
-   integer  :: Global_Comm
-
+   integer :: driver_comm
    integer  :: mpicom_GLOID          ! MPI global communicator
    integer  :: mpicom_CPLID          ! MPI cpl communicator
    integer  :: mpicom_OCNID          ! MPI ocn communicator for ensemble member 1
@@ -600,29 +599,31 @@ subroutine cime_pre_init1()
    character(len=seq_comm_namelen) :: comp_name(num_inst_total)
    integer :: i, it
    integer :: num_inst_cpl, cpl_id
+   integer :: cpl_comm
 
    call mpi_init(ierr)
    call shr_mpi_chkerr(ierr,subname//' mpi_init')
+   call mpi_comm_dup(MPI_COMM_WORLD, driver_comm, ierr)
+   call shr_mpi_chkerr(ierr,subname//' mpi_comm_dup')
 
-   Global_Comm=MPI_COMM_WORLD
    comp_comm = MPI_COMM_NULL
    time_brun = mpi_wtime()
 
    !--- Initialize multiple coupler instances, if requested ---
-   call cime_cpl_init(Global_Comm, num_inst_cpl, cpl_id)
+   call cime_cpl_init(driver_comm, cpl_comm, num_inst_cpl, cpl_id)
 
-   call shr_pio_init1(num_inst_total,NLFileName, Global_Comm)
+   call shr_pio_init1(num_inst_total,NLFileName, cpl_comm)
    !
-   ! If pio_async_interface is true Global_Comm is MPI_COMM_NULL on the servernodes
+   ! If pio_async_interface is true Driver_comm is MPI_COMM_NULL on the servernodes
    ! and server nodes do not return from shr_pio_init2
    !
-   !   if (Global_Comm /= MPI_COMM_NULL) then
+   !   if (Driver_comm /= MPI_COMM_NULL) then
 
    if (num_inst_cpl > 1) then
-      call seq_comm_init(Global_Comm, NLFileName, cpl_comm_ID=cpl_id)
+      call seq_comm_init(cpl_comm, NLFileName, cpl_comm_ID=cpl_id)
       write(cpl_inst_tag,'("_",i4.4)') cpl_id
    else
-      call seq_comm_init(Global_Comm, NLFileName)
+      call seq_comm_init(cpl_comm, NLFileName)
       cpl_inst_tag = ''
    end if
 
@@ -2543,7 +2544,6 @@ end subroutine cime_init
       !----------------------------------------------------------
       !| WAV SETUP-SEND
       !----------------------------------------------------------
-
       if (wav_present .and. wavrun_alarm) then
 
          !----------------------------------------------------------
@@ -2744,7 +2744,6 @@ end subroutine cime_init
       !----------------------------------------------------------
       !| ATM/OCN SETUP (cesm1_orig, cesm1_orig_tight, cesm1_mod or cesm1_mod_tight)
       !----------------------------------------------------------
-
       if ((trim(cpl_seq_option) == 'CESM1_ORIG'       .or. &
            trim(cpl_seq_option) == 'CESM1_ORIG_TIGHT' .or. &
            trim(cpl_seq_option) == 'CESM1_MOD'        .or. &
@@ -3582,7 +3581,6 @@ end subroutine cime_init
       !----------------------------------------------------------
       !| Write driver restart file
       !----------------------------------------------------------
-
       if ( (restart_alarm .or. drv_pause) .and. iamin_CPLID) then
          call cime_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:RESTART_BARRIER')
          call t_drvstartf ('CPL:RESTART',cplrun=.true.,barrier=mpicom_CPLID)
@@ -3742,11 +3740,13 @@ end subroutine cime_init
          call t_drvstopf  ('CPL:HISTORY',cplrun=.true.)
 
       endif
-
       !----------------------------------------------------------
       !| RUN ESP MODEL
       !----------------------------------------------------------
       if (esp_present .and. esprun_alarm) then
+         ! Make sure that all couplers are here in multicoupler mode before running ESP component
+         call mpi_barrier(driver_comm, ierr)
+
          call component_run(Eclock_e, esp, esp_run, infodata, &
               comp_prognostic=esp_prognostic, comp_num=comp_num_esp, &
               timer_barrier= 'CPL:ESP_RUN_BARRIER', timer_comp_run='CPL:ESP_RUN', &
@@ -4067,7 +4067,7 @@ subroutine cime_comp_barriers(mpicom, timer)
   endif
 end subroutine cime_comp_barriers
 
-subroutine cime_cpl_init(comm, num_inst_cpl, id)
+subroutine cime_cpl_init(comm_in, comm_out, num_inst_cpl, id)
 
   !-----------------------------------------------------------------------
   !
@@ -4077,7 +4077,8 @@ subroutine cime_cpl_init(comm, num_inst_cpl, id)
 
   implicit none
 
-  integer , intent(inout) :: comm
+  integer , intent(in) :: comm_in
+  integer , intent(in) :: comm_out
   integer , intent(out)   :: num_inst_cpl
   integer , intent(out)   :: id      ! instance ID, starts from 1
   !
@@ -4088,8 +4089,8 @@ subroutine cime_cpl_init(comm, num_inst_cpl, id)
 
   namelist /cime_cpl_inst/ ninst_cpl
 
-  call shr_mpi_commrank(comm, mype  , ' cime_cpl_init')
-  call shr_mpi_commsize(comm, numpes, ' cime_cpl_init')
+  call shr_mpi_commrank(comm_in, mype  , ' cime_cpl_init')
+  call shr_mpi_commsize(comm_in, numpes, ' cime_cpl_init')
 
   num_inst_cpl = 1
   id    = 0
@@ -4106,19 +4107,20 @@ subroutine cime_cpl_init(comm, num_inst_cpl, id)
     num_inst_cpl = max(ninst_cpl, 1)
   end if
 
-  call shr_mpi_bcast(num_inst_cpl, comm, 'ninst_cpl')
+  call shr_mpi_bcast(num_inst_cpl, comm_in, 'ninst_cpl')
 
   if (mod(numpes, num_inst_cpl) /= 0) then
     call shr_sys_abort(subname // &
       ' : Total PE number must be a multiple of coupler instance number')
   end if
 
-  if (num_inst_cpl > 1) then
+  if (num_inst_cpl == 1) then
+     call mpi_comm_dup(comm_in, comm_out, ierr)
+     call shr_mpi_chkerr(ierr,subname//' mpi_comm_dup')
+  else
     id = mype * num_inst_cpl / numpes + 1
-    call mpi_comm_split(comm, id, 0, inst_comm, ierr)
-    if (ierr /= 0) &
-      call shr_sys_abort(subname // ' : Error in generating coupler instances')
-    comm = inst_comm
+    call mpi_comm_split(comm_in, id, 0, comm_out, ierr)
+    call shr_mpi_chkerr(ierr,subname//' mpi_comm_split')
   end if
 
 end subroutine cime_cpl_init

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -609,7 +609,7 @@ subroutine cime_pre_init1()
    time_brun = mpi_wtime()
 
    !--- Initialize multiple coupler instances, if requested ---
-   call cesm_cpl_init(Global_Comm, num_inst_cpl, cpl_id)
+   call cime_cpl_init(Global_Comm, num_inst_cpl, cpl_id)
 
    call shr_pio_init1(num_inst_total,NLFileName, Global_Comm)
    !
@@ -619,7 +619,7 @@ subroutine cime_pre_init1()
    !   if (Global_Comm /= MPI_COMM_NULL) then
 
    if (num_inst_cpl > 1) then
-      call seq_comm_init(Global_Comm, NLFileName, Comm_ID=cpl_id)
+      call seq_comm_init(Global_Comm, NLFileName, cpl_comm_ID=cpl_id)
       write(cpl_inst_tag,'("_",i4.4)') cpl_id
    else
       call seq_comm_init(Global_Comm, NLFileName)
@@ -4067,7 +4067,7 @@ subroutine cime_comp_barriers(mpicom, timer)
   endif
 end subroutine cime_comp_barriers
 
-subroutine cime_cpl_init(comm, ninst, id)
+subroutine cime_cpl_init(comm, num_inst_cpl, id)
 
   !-----------------------------------------------------------------------
   !
@@ -4078,43 +4078,43 @@ subroutine cime_cpl_init(comm, ninst, id)
   implicit none
 
   integer , intent(inout) :: comm
-  integer , intent(out)   :: ninst
+  integer , intent(out)   :: num_inst_cpl
   integer , intent(out)   :: id      ! instance ID, starts from 1
   !
   ! Local variables
   !
   integer :: ierr, inst_comm, mype, nu, numpes !, pes
-  integer :: cpl_ninst
+  integer :: ninst_cpl
 
-  namelist /cime_cpl/ cpl_ninst
+  namelist /cime_cpl_inst/ ninst_cpl
 
   call shr_mpi_commrank(comm, mype  , ' cime_cpl_init')
   call shr_mpi_commsize(comm, numpes, ' cime_cpl_init')
 
-  ninst = 1
+  num_inst_cpl = 1
   id    = 0
 
   if (mype == 0) then
     ! Read coupler namelist if it exists
-    cpl_ninst = 1
+    ninst_cpl = 1
     nu = shr_file_getUnit()
     open(unit = nu, file = NLFileName, status = 'old', iostat = ierr)
     rewind(unit = nu)
-    read(unit = nu, nml = cime_cpl, iostat = ierr)
+    read(unit = nu, nml = cime_cpl_inst, iostat = ierr)
     close(unit = nu)
     call shr_file_freeUnit(nu)
-    ninst = max(cpl_ninst, 1)
+    num_inst_cpl = max(ninst_cpl, 1)
   end if
 
-  call shr_mpi_bcast(ninst, comm, 'cpl_ninst')
+  call shr_mpi_bcast(num_inst_cpl, comm, 'ninst_cpl')
 
-  if (mod(numpes, ninst) /= 0) then
+  if (mod(numpes, num_inst_cpl) /= 0) then
     call shr_sys_abort(subname // &
       ' : Total PE number must be a multiple of coupler instance number')
   end if
 
-  if (ninst > 1) then
-    id = mype * ninst / numpes + 1
+  if (num_inst_cpl > 1) then
+    id = mype * num_inst_cpl / numpes + 1
     call mpi_comm_split(comm, id, 0, inst_comm, ierr)
     if (ierr /= 0) &
       call shr_sys_abort(subname // ' : Error in generating coupler instances')

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2060,7 +2060,7 @@ subroutine cime_init()
          call seq_hist_write(infodata, EClock_d, &
               atm, lnd, ice, ocn, rof, glc, wav, &
               fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-              fractions_rx, fractions_gx, fractions_wx)
+              fractions_rx, fractions_gx, fractions_wx, trim(cpl_inst_tag))
          if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
 
          call t_adj_detailf(-2)
@@ -3619,14 +3619,15 @@ end subroutine cime_init
             call seq_hist_write(infodata, EClock_d, &
                  atm, lnd, ice, ocn, rof, glc, wav, &
                  fractions_ax, fractions_lx, fractions_ix, fractions_ox,     &
-                 fractions_rx, fractions_gx, fractions_wx)
+                 fractions_rx, fractions_gx, fractions_wx, trim(cpl_inst_tag))
 
             if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
          endif
 
          if (do_histavg) then
             call seq_hist_writeavg(infodata, EClock_d, &
-                 atm, lnd, ice, ocn, rof, glc, wav, histavg_alarm)
+                 atm, lnd, ice, ocn, rof, glc, wav, histavg_alarm, &
+                 trim(cpl_inst_tag))
          endif
 
          if (do_hist_a2x) then

--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -130,7 +130,7 @@ contains
 subroutine seq_hist_write(infodata, EClock_d, &
      atm, lnd, ice, ocn, rof, glc, wav, &
      fractions_ax, fractions_lx, fractions_ix, fractions_ox, fractions_rx,  &
-     fractions_gx, fractions_wx)
+     fractions_gx, fractions_wx, tag)
 
    implicit none
    !
@@ -151,6 +151,7 @@ subroutine seq_hist_write(infodata, EClock_d, &
    type(mct_aVect)         , intent(inout) :: fractions_rx(:) ! Fractions on rof grid/decomp
    type(mct_aVect)         , intent(inout) :: fractions_gx(:) ! Fractions on glc grid/decomp
    type(mct_aVect)         , intent(inout) :: fractions_wx(:) ! Fractions on wav grid/decomp
+   character(len=*)        ,  intent(in) :: tag
    !
    ! Local Variables
    integer(IN)   :: curr_ymd     ! Current date YYYYMMDD
@@ -215,7 +216,7 @@ subroutine seq_hist_write(infodata, EClock_d, &
         calendar=calendar)
    call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
    write(hist_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-      trim(case_name), '.cpl.hi.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+      trim(case_name), '.cpl'//tag//'.hi.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
 
    time_units = 'days since ' &
         // seq_io_date2yyyymmdd(start_ymd) // ' ' // seq_io_sec2hms(start_tod)
@@ -389,7 +390,7 @@ end subroutine seq_hist_write
 !===============================================================================
 
 subroutine seq_hist_writeavg(infodata, EClock_d, &
-     atm, lnd, ice, ocn, rof, glc, wav, write_now)
+     atm, lnd, ice, ocn, rof, glc, wav, write_now, tag)
 
    implicit none
 
@@ -403,6 +404,7 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
    type (component_type)   ,  intent(in) :: glc(:)
    type (component_type)   ,  intent(in) :: wav(:)
    logical                 ,  intent(in) :: write_now  ! write or accumulate
+   character(len=*)        ,  intent(in) :: tag
 
    integer(IN)           :: curr_ymd     ! Current date YYYYMMDD
    integer(IN)           :: curr_tod     ! Current time-of-day (s)
@@ -764,19 +766,19 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
       if (seq_timemgr_histavg_type == seq_timemgr_type_nyear) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a)") &
-            trim(case_name),  '.cpl.ha.',  yy, '.nc'
+            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '.nc'
       elseif (seq_timemgr_histavg_type == seq_timemgr_type_nmonth) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a)") &
-            trim(case_name),  '.cpl.ha.',  yy, '-', mm, '.nc'
+            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '.nc'
       elseif (seq_timemgr_histavg_type == seq_timemgr_type_nday) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a, i2.2, a)") &
-            trim(case_name),  '.cpl.ha.',  yy, '-', mm, '-', dd, '.nc'
+            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '-', dd, '.nc'
       else
          call shr_cal_date2ymd(curr_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a, i2.2, a, i5.5, a)") &
-            trim(case_name),  '.cpl.ha.',  yy, '-', mm, '-', dd, '-', curr_tod, '.nc'
+            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '-', dd, '-', curr_tod, '.nc'
       endif
 
       time_units = 'days since ' &

--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -130,7 +130,7 @@ contains
 subroutine seq_hist_write(infodata, EClock_d, &
      atm, lnd, ice, ocn, rof, glc, wav, &
      fractions_ax, fractions_lx, fractions_ix, fractions_ox, fractions_rx,  &
-     fractions_gx, fractions_wx, tag)
+     fractions_gx, fractions_wx, cpl_inst_tag)
 
    implicit none
    !
@@ -151,7 +151,7 @@ subroutine seq_hist_write(infodata, EClock_d, &
    type(mct_aVect)         , intent(inout) :: fractions_rx(:) ! Fractions on rof grid/decomp
    type(mct_aVect)         , intent(inout) :: fractions_gx(:) ! Fractions on glc grid/decomp
    type(mct_aVect)         , intent(inout) :: fractions_wx(:) ! Fractions on wav grid/decomp
-   character(len=*)        ,  intent(in) :: tag
+   character(len=*)        ,  intent(in) :: cpl_inst_tag
    !
    ! Local Variables
    integer(IN)   :: curr_ymd     ! Current date YYYYMMDD
@@ -216,7 +216,7 @@ subroutine seq_hist_write(infodata, EClock_d, &
         calendar=calendar)
    call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
    write(hist_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-      trim(case_name), '.cpl'//tag//'.hi.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+      trim(case_name), '.cpl'//cpl_inst_tag//'.hi.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
 
    time_units = 'days since ' &
         // seq_io_date2yyyymmdd(start_ymd) // ' ' // seq_io_sec2hms(start_tod)
@@ -390,7 +390,7 @@ end subroutine seq_hist_write
 !===============================================================================
 
 subroutine seq_hist_writeavg(infodata, EClock_d, &
-     atm, lnd, ice, ocn, rof, glc, wav, write_now, tag)
+     atm, lnd, ice, ocn, rof, glc, wav, write_now, cpl_inst_tag)
 
    implicit none
 
@@ -404,7 +404,7 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
    type (component_type)   ,  intent(in) :: glc(:)
    type (component_type)   ,  intent(in) :: wav(:)
    logical                 ,  intent(in) :: write_now  ! write or accumulate
-   character(len=*)        ,  intent(in) :: tag
+   character(len=*)        ,  intent(in) :: cpl_inst_tag
 
    integer(IN)           :: curr_ymd     ! Current date YYYYMMDD
    integer(IN)           :: curr_tod     ! Current time-of-day (s)
@@ -766,19 +766,19 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
       if (seq_timemgr_histavg_type == seq_timemgr_type_nyear) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a)") &
-            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '.nc'
+            trim(case_name),  '.cpl'//cpl_inst_tag//'.ha.',  yy, '.nc'
       elseif (seq_timemgr_histavg_type == seq_timemgr_type_nmonth) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a)") &
-            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '.nc'
+            trim(case_name),  '.cpl'//cpl_inst_tag//'.ha.',  yy, '-', mm, '.nc'
       elseif (seq_timemgr_histavg_type == seq_timemgr_type_nday) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a, i2.2, a)") &
-            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '-', dd, '.nc'
+            trim(case_name),  '.cpl'//cpl_inst_tag//'.ha.',  yy, '-', mm, '-', dd, '.nc'
       else
          call shr_cal_date2ymd(curr_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a, i2.2, a, i5.5, a)") &
-            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '-', dd, '-', curr_tod, '.nc'
+            trim(case_name),  '.cpl'//cpl_inst_tag//'.ha.',  yy, '-', mm, '-', dd, '-', curr_tod, '.nc'
       endif
 
       time_units = 'days since ' &

--- a/src/drivers/mct/main/seq_rest_mod.F90
+++ b/src/drivers/mct/main/seq_rest_mod.F90
@@ -285,7 +285,7 @@ end subroutine seq_rest_read
 subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
      atm, lnd, ice, ocn, rof, glc, wav, esp,                 &
      fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-     fractions_rx, fractions_gx, fractions_wx)
+     fractions_rx, fractions_gx, fractions_wx, tag)
 
    implicit none
 
@@ -307,6 +307,7 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
    type(mct_aVect)        , intent(inout) :: fractions_rx(:)   ! Fractions on rof grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_gx(:)   ! Fractions on glc grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_wx(:)   ! Fractions on wav grid/decomp
+   character(len=*), optional, intent(in) :: tag
 
    integer(IN)   :: n,n1,n2,n3,fk
    integer(IN)   :: curr_ymd         ! Current date YYYYMMDD
@@ -367,8 +368,13 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
 
    call seq_timemgr_EClockGetData( EClock_d, curr_ymd=curr_ymd, curr_tod=curr_tod)
    call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
-   write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-      trim(case_name), '.cpl.r.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+   if (present(tag)) then   
+      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
+         trim(case_name), '.cpl'//trim(tag)//'.r.',yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+   else
+      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
+         trim(case_name), '.cpl.r.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+   end if
 
    ! Write driver data to restart file
 

--- a/src/drivers/mct/main/seq_rest_mod.F90
+++ b/src/drivers/mct/main/seq_rest_mod.F90
@@ -307,7 +307,7 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
    type(mct_aVect)        , intent(inout) :: fractions_rx(:)   ! Fractions on rof grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_gx(:)   ! Fractions on glc grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_wx(:)   ! Fractions on wav grid/decomp
-   character(len=*), optional, intent(in) :: tag
+   character(len=*)       , intent(in) :: tag
 
    integer(IN)   :: n,n1,n2,n3,fk
    integer(IN)   :: curr_ymd         ! Current date YYYYMMDD
@@ -368,13 +368,8 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
 
    call seq_timemgr_EClockGetData( EClock_d, curr_ymd=curr_ymd, curr_tod=curr_tod)
    call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
-   if (present(tag)) then   
-      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-         trim(case_name), '.cpl'//trim(tag)//'.r.',yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
-   else
-      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-         trim(case_name), '.cpl.r.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
-   end if
+   write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
+        trim(case_name), '.cpl'//trim(tag)//'.r.',yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
 
    ! Write driver data to restart file
 

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -199,7 +199,7 @@ contains
   end function seq_comm_get_ncomps
 
 
-  subroutine seq_comm_init(Comm_in, nmlfile)
+  subroutine seq_comm_init(Comm_in, nmlfile, Comm_ID)
 
     !----------------------------------------------------------
     !
@@ -207,6 +207,7 @@ contains
     implicit none
     integer, intent(in) :: Comm_in
     character(len=*), intent(IN) :: nmlfile
+    integer, optional, intent(in) :: Comm_ID
     !
     ! Local variables
     !
@@ -764,8 +765,13 @@ contains
           pelist(3,1) = astr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', n, num_inst_atm)
-       call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', n, num_inst_atm)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', n, num_inst_atm)
+          call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', n, num_inst_atm)
+       end if
     end do
     call seq_comm_jcommarr(ATMID,ALLATMID,'ALLATMID',1,1)
     call seq_comm_joincomm(CPLID,ALLATMID,CPLALLATMID,'CPLALLATMID',1,1)
@@ -777,8 +783,13 @@ contains
           pelist(3,1) = lstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', n, num_inst_lnd)
-       call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', n, num_inst_lnd)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', n, num_inst_lnd)
+          call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', n, num_inst_lnd)
+       end if
     end do
     call seq_comm_jcommarr(LNDID,ALLLNDID,'ALLLNDID',1,1)
     call seq_comm_joincomm(CPLID,ALLLNDID,CPLALLLNDID,'CPLALLLNDID',1,1)
@@ -790,8 +801,13 @@ contains
           pelist(3,1) = ostr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', n, num_inst_ocn)
-       call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', n, num_inst_ocn)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', n, num_inst_ocn)
+          call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', n, num_inst_ocn)
+       end if
     end do
     call seq_comm_jcommarr(OCNID,ALLOCNID,'ALLOCNID',1,1)
     call seq_comm_joincomm(CPLID,ALLOCNID,CPLALLOCNID,'CPLALLOCNID',1,1)
@@ -803,8 +819,13 @@ contains
           pelist(3,1) = istr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', n, num_inst_ice)
-       call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', n, num_inst_ice)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', n, num_inst_ice)
+          call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', n, num_inst_ice)
+       end if
     end do
     call seq_comm_jcommarr(ICEID,ALLICEID,'ALLICEID',1,1)
     call seq_comm_joincomm(CPLID,ALLICEID,CPLALLICEID,'CPLALLICEID',1,1)
@@ -816,8 +837,13 @@ contains
           pelist(3,1) = gstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', n, num_inst_glc)
-       call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', n, num_inst_glc)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', n, num_inst_glc)
+          call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', n, num_inst_glc)
+       end if
     end do
     call seq_comm_jcommarr(GLCID,ALLGLCID,'ALLGLCID',1,1)
     call seq_comm_joincomm(CPLID,ALLGLCID,CPLALLGLCID,'CPLALLGLCID',1,1)
@@ -829,8 +855,13 @@ contains
           pelist(3,1) = rstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', n, num_inst_rof)
-       call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', n, num_inst_rof)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', n, num_inst_rof)
+          call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', n, num_inst_rof)
+       end if
     end do
     call seq_comm_jcommarr(ROFID,ALLROFID,'ALLROFID',1,1)
     call seq_comm_joincomm(CPLID,ALLROFID,CPLALLROFID,'CPLALLROFID',1,1)
@@ -842,8 +873,13 @@ contains
           pelist(3,1) = wstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', n, num_inst_wav)
-       call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', n, num_inst_wav)
+       if (present(Comm_ID)) then
+          call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', inst=Comm_ID)
+          call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', inst=Comm_ID)
+       else
+          call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', n, num_inst_wav)
+          call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', n, num_inst_wav)
+       end if
     end do
     call seq_comm_jcommarr(WAVID,ALLWAVID,'ALLWAVID',1,1)
     call seq_comm_joincomm(CPLID,ALLWAVID,CPLALLWAVID,'CPLALLWAVID',1,1)

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -85,7 +85,8 @@ module seq_comm_mct
                                                 num_inst_wav + &
                                                 num_inst_rof + &
                                                 num_inst_esp + 1
-
+  integer, public :: num_inst_cpl = 1
+  integer, public :: cpl_inst_iamin = 1
   integer, public :: num_inst_min, num_inst_max
   integer, public :: num_inst_xao    ! for xao flux
   integer, public :: num_inst_frc    ! for fractions
@@ -150,6 +151,10 @@ module seq_comm_mct
 
   integer, parameter, public :: seq_comm_namelen=16
 
+  ! suffix for log and timing files if multi coupler driver
+  character(len=seq_comm_namelen), public  :: cpl_inst_tag
+
+
   type seq_comm_type
     character(len=seq_comm_namelen) :: name     ! my name
     character(len=seq_comm_namelen) :: suffix   ! recommended suffix
@@ -182,7 +187,7 @@ module seq_comm_mct
   character(*), parameter :: F12 = "(a,a,'(',i3,' ',a,')',a,2i6,6x,' (',a,i6,')',' (',a,i3,')','(',a,2i6,')')"
   character(*), parameter :: F13 = "(a,a,'(',i3,' ',a,')',a,2i6,6x,' (',a,i6,')',' (',a,i3,')')"
   character(*), parameter :: F14 = "(a,a,'(',i3,' ',a,')',a,    6x,' (',a,i6,')',' (',a,i3,')')"
-  integer :: Global_Comm
+  integer :: Coupler_Comm
 
 
   character(len=32), public :: &
@@ -263,7 +268,9 @@ contains
        call shr_sys_abort()
     endif
     seq_comm_mct_initialized = .true.
-    Global_Comm = Comm_in
+
+    call mpi_comm_dup(Comm_in, Coupler_Comm, ierr)
+    call shr_mpi_chkerr(ierr,subname//' mpi_comm_dup')
 
     !! Initialize seq_comms elements
 
@@ -289,9 +296,9 @@ contains
     ! Initialize MPI
     ! Note that if no MPI, will call MCTs fake version
 
-    call mpi_comm_rank(GLOBAL_COMM, mype  , ierr)
+    call mpi_comm_rank(Coupler_Comm, mype  , ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_rank comm_world')
-    call mpi_comm_size(GLOBAL_COMM, numpes, ierr)
+    call mpi_comm_size(Coupler_Comm, numpes, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_size comm_world')
 
     ! Initialize gloiam on all IDs
@@ -719,15 +726,15 @@ contains
        cstr = cpl_pestride
     end if
 
-    call shr_mpi_bcast(atm_nthreads,GLOBAL_COMM,'atm_nthreads')
-    call shr_mpi_bcast(lnd_nthreads,GLOBAL_COMM,'lnd_nthreads')
-    call shr_mpi_bcast(ocn_nthreads,GLOBAL_COMM,'ocn_nthreads')
-    call shr_mpi_bcast(ice_nthreads,GLOBAL_COMM,'ice_nthreads')
-    call shr_mpi_bcast(glc_nthreads,GLOBAL_COMM,'glc_nthreads')
-    call shr_mpi_bcast(wav_nthreads,GLOBAL_COMM,'wav_nthreads')
-    call shr_mpi_bcast(rof_nthreads,GLOBAL_COMM,'rof_nthreads')
-    call shr_mpi_bcast(esp_nthreads,GLOBAL_COMM,'esp_nthreads')
-    call shr_mpi_bcast(cpl_nthreads,GLOBAL_COMM,'cpl_nthreads')
+    call shr_mpi_bcast(atm_nthreads,Coupler_Comm,'atm_nthreads')
+    call shr_mpi_bcast(lnd_nthreads,Coupler_Comm,'lnd_nthreads')
+    call shr_mpi_bcast(ocn_nthreads,Coupler_Comm,'ocn_nthreads')
+    call shr_mpi_bcast(ice_nthreads,Coupler_Comm,'ice_nthreads')
+    call shr_mpi_bcast(glc_nthreads,Coupler_Comm,'glc_nthreads')
+    call shr_mpi_bcast(wav_nthreads,Coupler_Comm,'wav_nthreads')
+    call shr_mpi_bcast(rof_nthreads,Coupler_Comm,'rof_nthreads')
+    call shr_mpi_bcast(esp_nthreads,Coupler_Comm,'esp_nthreads')
+    call shr_mpi_bcast(cpl_nthreads,Coupler_Comm,'cpl_nthreads')
 
     call shr_mpi_bcast(atm_layout,GLOBAL_COMM,'atm_layout')
     call shr_mpi_bcast(lnd_layout,GLOBAL_COMM,'lnd_layout')
@@ -746,7 +753,7 @@ contains
        pelist(2,1) = numpes-1
        pelist(3,1) = 1
     end if
-    call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+    call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
     call seq_comm_setcomm(GLOID, pelist,iname='GLOBAL')
 
     if (mype == 0) then
@@ -754,7 +761,7 @@ contains
        pelist(2,1) = cmax
        pelist(3,1) = cstr
     end if
-    call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+    call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
     call seq_comm_setcomm(CPLID,pelist,cpl_nthreads,'CPL')
 
     do n = 1, num_inst_atm
@@ -763,7 +770,7 @@ contains
           pelist(2,1) = amax(n)
           pelist(3,1) = astr(n)
        end if
-       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
        if (present(Cpl_comm_id)) then
           call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', inst=Cpl_comm_id)
           call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', inst=Cpl_comm_id)
@@ -781,7 +788,7 @@ contains
           pelist(2,1) = lmax(n)
           pelist(3,1) = lstr(n)
        end if
-       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
        if (present(Cpl_comm_id)) then
           call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', inst=Cpl_comm_id)
           call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', inst=Cpl_comm_id)
@@ -799,7 +806,7 @@ contains
           pelist(2,1) = omax(n)
           pelist(3,1) = ostr(n)
        end if
-       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
        if (present(Cpl_comm_id)) then
           call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', inst=Cpl_comm_id)
           call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', inst=Cpl_comm_id)
@@ -817,7 +824,7 @@ contains
           pelist(2,1) = imax(n)
           pelist(3,1) = istr(n)
        end if
-       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
        if (present(Cpl_comm_id)) then
           call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', inst=Cpl_comm_id)
           call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', inst=Cpl_comm_id)
@@ -835,7 +842,7 @@ contains
           pelist(2,1) = gmax(n)
           pelist(3,1) = gstr(n)
        end if
-       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
        if (present(Cpl_comm_id)) then
           call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', inst=Cpl_comm_id)
           call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', inst=Cpl_comm_id)
@@ -853,7 +860,7 @@ contains
           pelist(2,1) = rmax(n)
           pelist(3,1) = rstr(n)
        end if
-       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
        if (present(Cpl_comm_id)) then
           call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', inst=Cpl_comm_id)
           call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', inst=Cpl_comm_id)
@@ -871,7 +878,7 @@ contains
           pelist(2,1) = wmax(n)
           pelist(3,1) = wstr(n)
        end if
-       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
        if (present(Cpl_comm_id)) then
           call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', inst=Cpl_comm_id)
           call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', inst=Cpl_comm_id)
@@ -889,7 +896,7 @@ contains
           pelist(2,1) = emax(n)
           pelist(3,1) = estr(n)
        end if
-       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, Coupler_Comm, ierr)
        call seq_comm_setcomm(ESPID(n), pelist, esp_nthreads, 'ESP', n, num_inst_esp)
     end do
     call seq_comm_jcommarr(ESPID,ALLESPID,'ALLESPID',1,1)
@@ -910,7 +917,7 @@ contains
     do n = 1,ncomps
        gloroot = -999
        if (seq_comms(n)%iamroot) gloroot = seq_comms(n)%gloiam
-       call shr_mpi_max(gloroot,seq_comms(n)%gloroot,GLOBAL_COMM, &
+       call shr_mpi_max(gloroot,seq_comms(n)%gloroot,Coupler_Comm, &
                         trim(subname)//' gloroot',all=.true.)
     enddo
 
@@ -948,12 +955,12 @@ contains
        call shr_sys_abort()
     endif
 
-    call mct_world_init(ncomps, GLOBAL_COMM, comms, comps)
+    call mct_world_init(ncomps, Coupler_Comm, comms, comps)
 
     deallocate(comps,comms)
 
     ! ESMF logging (only has effect if ESMF libraries are used)
-    call mpi_bcast(esmf_logging, len(esmf_logging), MPI_CHARACTER, 0, GLOBAL_COMM, ierr)
+    call mpi_bcast(esmf_logging, len(esmf_logging), MPI_CHARACTER, 0, Coupler_Comm, ierr)
 
     select case(esmf_logging)
     case ("ESMF_LOGKIND_SINGLE")
@@ -1028,11 +1035,11 @@ contains
        call shr_sys_abort()
     endif
 
-    call mpi_comm_group(GLOBAL_COMM, mpigrp_world, ierr)
+    call mpi_comm_group(Coupler_Comm, mpigrp_world, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_group mpigrp_world')
     call mpi_group_range_incl(mpigrp_world, 1, pelist, mpigrp,ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_group_range_incl mpigrp')
-    call mpi_comm_create(GLOBAL_COMM, mpigrp, mpicom, ierr)
+    call mpi_comm_create(Coupler_Comm, mpigrp, mpicom, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_create mpigrp')
 
     ntasks = ((pelist(2,1) - pelist(1,1)) / pelist(3,1)) + 1
@@ -1156,7 +1163,7 @@ contains
 
     call mpi_group_union(seq_comms(ID1)%mpigrp,seq_comms(ID2)%mpigrp,mpigrp,ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_union mpigrp')
-    call mpi_comm_create(GLOBAL_COMM, mpigrp, mpicom, ierr)
+    call mpi_comm_create(Coupler_Comm, mpigrp, mpicom, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_create mpigrp')
 
     seq_comms(ID)%set = .true.
@@ -1282,7 +1289,7 @@ contains
        call mpi_group_union(mpigrpp,seq_comms(IDs(n))%mpigrp,mpigrp,ierr)
        call shr_mpi_chkerr(ierr,subname//' mpi_comm_union mpigrp')
     enddo
-    call mpi_comm_create(GLOBAL_COMM, mpigrp, mpicom, ierr)
+    call mpi_comm_create(Coupler_Comm, mpigrp, mpicom, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_create mpigrp')
 
     seq_comms(ID)%set = .true.
@@ -1362,13 +1369,13 @@ contains
     character(*),parameter :: subName =   '(seq_comm_printcomms) '
     integer :: n,mype,npes,ierr
 
-    call mpi_comm_size(GLOBAL_COMM, npes  , ierr)
+    call mpi_comm_size(Coupler_Comm, npes  , ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_size comm_world')
-    call mpi_comm_rank(GLOBAL_COMM, mype  , ierr)
+    call mpi_comm_rank(Coupler_Comm, mype  , ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_rank comm_world')
 
     call shr_sys_flush(logunit)
-    call mpi_barrier(GLOBAL_COMM,ierr)
+    call mpi_barrier(Coupler_Comm,ierr)
     if (mype == 0) then
        do n = 1,ncomps
           write(logunit,'(a,4i6,2x,3a)') trim(subName),n, &

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -199,15 +199,16 @@ contains
   end function seq_comm_get_ncomps
 
 
-  subroutine seq_comm_init(Comm_in, nmlfile, Comm_ID)
-
+  subroutine seq_comm_init(Comm_in, nmlfile, Cpl_comm_id)
     !----------------------------------------------------------
     !
     ! Arguments
     implicit none
     integer, intent(in) :: Comm_in
     character(len=*), intent(IN) :: nmlfile
-    integer, optional, intent(in) :: Comm_ID
+    ! Optional argument cpl_comm_id is used to identify the particular
+    ! coupler instance used by each component instance in a multi-coupler case.
+    integer, optional, intent(in) :: Cpl_comm_id
     !
     ! Local variables
     !
@@ -765,9 +766,9 @@ contains
           pelist(3,1) = astr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       if (present(Comm_ID)) then
-          call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', inst=Comm_ID)
-          call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', inst=Comm_ID)
+       if (present(Cpl_comm_id)) then
+          call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', inst=Cpl_comm_id)
+          call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', inst=Cpl_comm_id)
        else
           call seq_comm_setcomm(ATMID(n), pelist, atm_nthreads, 'ATM', n, num_inst_atm)
           call seq_comm_joincomm(CPLID, ATMID(n), CPLATMID(n), 'CPLATM', n, num_inst_atm)
@@ -783,9 +784,9 @@ contains
           pelist(3,1) = lstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       if (present(Comm_ID)) then
-          call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', inst=Comm_ID)
-          call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', inst=Comm_ID)
+       if (present(Cpl_comm_id)) then
+          call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', inst=Cpl_comm_id)
+          call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', inst=Cpl_comm_id)
        else
           call seq_comm_setcomm(LNDID(n), pelist, lnd_nthreads, 'LND', n, num_inst_lnd)
           call seq_comm_joincomm(CPLID, LNDID(n), CPLLNDID(n), 'CPLLND', n, num_inst_lnd)
@@ -801,9 +802,9 @@ contains
           pelist(3,1) = ostr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       if (present(Comm_ID)) then
-          call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', inst=Comm_ID)
-          call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', inst=Comm_ID)
+       if (present(Cpl_comm_id)) then
+          call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', inst=Cpl_comm_id)
+          call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', inst=Cpl_comm_id)
        else
           call seq_comm_setcomm(OCNID(n), pelist, ocn_nthreads, 'OCN', n, num_inst_ocn)
           call seq_comm_joincomm(CPLID, OCNID(n), CPLOCNID(n), 'CPLOCN', n, num_inst_ocn)
@@ -819,9 +820,9 @@ contains
           pelist(3,1) = istr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       if (present(Comm_ID)) then
-          call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', inst=Comm_ID)
-          call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', inst=Comm_ID)
+       if (present(Cpl_comm_id)) then
+          call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', inst=Cpl_comm_id)
+          call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', inst=Cpl_comm_id)
        else
           call seq_comm_setcomm(ICEID(n), pelist, ice_nthreads, 'ICE', n, num_inst_ice)
           call seq_comm_joincomm(CPLID, ICEID(n), CPLICEID(n), 'CPLICE', n, num_inst_ice)
@@ -837,9 +838,9 @@ contains
           pelist(3,1) = gstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       if (present(Comm_ID)) then
-          call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', inst=Comm_ID)
-          call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', inst=Comm_ID)
+       if (present(Cpl_comm_id)) then
+          call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', inst=Cpl_comm_id)
+          call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', inst=Cpl_comm_id)
        else
           call seq_comm_setcomm(GLCID(n), pelist, glc_nthreads, 'GLC', n, num_inst_glc)
           call seq_comm_joincomm(CPLID, GLCID(n), CPLGLCID(n), 'CPLGLC', n, num_inst_glc)
@@ -855,9 +856,9 @@ contains
           pelist(3,1) = rstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       if (present(Comm_ID)) then
-          call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', inst=Comm_ID)
-          call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', inst=Comm_ID)
+       if (present(Cpl_comm_id)) then
+          call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', inst=Cpl_comm_id)
+          call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', inst=Cpl_comm_id)
        else
           call seq_comm_setcomm(ROFID(n), pelist, rof_nthreads, 'ROF', n, num_inst_rof)
           call seq_comm_joincomm(CPLID, ROFID(n), CPLROFID(n), 'CPLROF', n, num_inst_rof)
@@ -873,9 +874,9 @@ contains
           pelist(3,1) = wstr(n)
        end if
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
-       if (present(Comm_ID)) then
-          call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', inst=Comm_ID)
-          call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', inst=Comm_ID)
+       if (present(Cpl_comm_id)) then
+          call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', inst=Cpl_comm_id)
+          call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', inst=Cpl_comm_id)
        else
           call seq_comm_setcomm(WAVID(n), pelist, wav_nthreads, 'WAV', n, num_inst_wav)
           call seq_comm_joincomm(CPLID, WAVID(n), CPLWAVID(n), 'CPLWAV', n, num_inst_wav)

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -257,7 +257,6 @@ contains
          esp_ntasks, esp_rootpe, esp_pestride, esp_nthreads, esp_layout, &
          cpl_ntasks, cpl_rootpe, cpl_pestride, cpl_nthreads, esmf_logging
     !----------------------------------------------------------
-
     ! make sure this is first pass and set comms unset
     if (seq_comm_mct_initialized) then
        write(logunit,*) trim(subname),' ERROR seq_comm_init already called '
@@ -381,7 +380,6 @@ contains
     end if
 
     !--- compute some other num_inst values
-
     num_inst_xao = max(num_inst_atm,num_inst_ocn)
     num_inst_frc = num_inst_ice
 

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -18,6 +18,7 @@
 ! !REVISION HISTORY:
 !     2005-Nov-11 - E. Kluzek - creation of shr_inputinfo_mod
 !     2007-Nov-15 - T. Craig - refactor for ccsm4 system and move to seq_infodata_mod
+!     2016-Dec-08 - R. Montuoro - updated for multiple coupler instances
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
@@ -285,7 +286,7 @@ CONTAINS
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
+SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid, cpl_tag)
 
 ! !USES:
 
@@ -302,6 +303,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
    character(len=*),        intent(IN)    :: nmlfile   ! Name-list filename
    integer(SHR_KIND_IN),    intent(IN)    :: ID        ! seq_comm ID
    type(file_desc_T) :: pioid
+   character(len=*), optional, intent(IN) :: cpl_tag   ! cpl instance suffix
 !EOP
 
     !----- local -----
@@ -588,6 +590,20 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        infodata%brnch_retain_casename = brnch_retain_casename
        infodata%restart_pfile         = restart_pfile
        infodata%restart_file          = restart_file
+       if (present(cpl_tag)) then
+          if (len(cpl_tag) > 0) then
+             if (trim(restart_file) /= trim(sp_str)) then
+                write(logunit,*) trim(subname),' ERROR: restart_file can '//&
+                'only be read from restart pointer files when using multiple couplers '
+                call shr_sys_abort(subname//' ERROR: invalid settings for restart_file ')
+             end if
+          end if
+          infodata%restart_file       = restart_file
+          infodata%restart_pfile      = trim(restart_pfile) // trim(cpl_tag)
+       else
+          infodata%restart_pfile      = restart_pfile
+          infodata%restart_file       = restart_file
+       end if
        infodata%single_column         = single_column
        infodata%scmlat                = scmlat
        infodata%scmlon                = scmlon


### PR DESCRIPTION
This adds support for mutiple couplers in multiinstance cases and improves performance of the multiinstance capability.   It adds a new system test MCC to compare multicoupler to single instance runs and adds a new test modifier _C# where # is the number of coupler instances.  

Test suite:  scripts_regression_tests.py ERS_C3.f19_g16_rx1.A.cheyenne_intel, MCC.f19_g16_rx1.A.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes ESMCI/cime #1704 

Updated user doc to reflect this change.

User interface changes?:  Adds _C# modifier to test names for create_test adds --ncouplers option to create_newcase 
Code review: 
