### PR TITLE
DATM S1850 mode to CPLHIST

### DIFF
--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -30,7 +30,7 @@
       <value compset="%CRU">CLMCRUNCEP</value>
       <value compset="%GSW">CLMGSWP3</value>
       <value compset="%1PT">CLM1PT</value>
-      <value compset="%S1850">CPLHISTForcing</value>
+      <value compset="%CPLHIST">CPLHISTForcing</value>
     </values>
   </entry>
 
@@ -53,7 +53,7 @@
       <value compset="_DICE.*_POP2">none</value>
       <value compset="_DLND.*_DICE.*_DOCN">none</value>
       <value compset="_SLND.*_DICE.*_DOCN">none</value>
-      <value compset="_DATM%S185">cplhist</value>
+      <value compset="_DATM%CPLHIST">cplhist</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -105,7 +105,7 @@
     <valid_values></valid_values>
     <default_value>UNSET</default_value>
     <values>
-      <value compset="1850_DATM%S1850">b40.1850.track1.1deg.006a</value>
+      <value compset="1850_DATM%CPLHIST">b40.1850.track1.1deg.006a</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -117,7 +117,7 @@
     <valid_values></valid_values>
     <default_value>1</default_value>
     <values>
-      <value compset="1850_DATM%S1850">1</value>
+      <value compset="1850_DATM%PCLHIST">1</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -129,7 +129,7 @@
     <valid_values></valid_values>
     <default_value>-999</default_value>
     <values>
-      <value compset="1850_DATM%S1850">960</value>
+      <value compset="1850_DATM%PCLHIST">960</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -141,7 +141,7 @@
     <valid_values></valid_values>
     <default_value>-999</default_value>
     <values>
-      <value compset="1850_DATM%S1850">1030</value>
+      <value compset="1850_DATM%PCLHIST">1030</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -270,7 +270,7 @@
     <desc compset="^HIST_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
     <desc compset="^20TR_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
     <desc compset="^RCP[2468]_DATM%GSW"	>GSWP3 atm input data for 1991-2010:</desc>
-    <desc compset="^1850_DATM%S1850"	>CPL history input data:</desc>
+    <desc compset="^1850_DATM%PCLHIST"	>CPL history input data:</desc>
     <desc compset="^2000_DATM%1PT"	>single point tower site atm input data:</desc>
     <desc compset="_DATM%NYF"		>COREv2 datm normal year forcing: (requires additional user-supplied data)</desc>
     <desc compset="_DATM%IAF"		>COREv2 datm interannual year forcing: (requires additional user-supplied data)</desc>

--- a/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -184,7 +184,7 @@
       <value>null</value>
       <value stream="CLM1PT.1x1">$DIN_LOC_ROOT/atm/datm7/domain.clm</value>
       <value stream="CLM1PT.CLM_USRDAT">$ATM_DOMAIN_PATH</value>
-      <value stream="CPLHISTForcing">$DATM_CPLHIST_DIR</value>
+      <value stream="CPLHISTForcing">null</value>
       <value stream="CLM_QIAN">$DIN_LOC_ROOT/atm/datm7</value>
       <value stream="CLMCRUNCEP\.">$DIN_LOC_ROOT/share/domains/domain.clm</value>
       <value stream="CLMCRUNCEP_V5">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.V5.c140715</value>
@@ -216,7 +216,7 @@
       <value stream="BC.CRUNCEP.GPCP.Precip">$DIN_LOC_ROOT/atm/datm7/clm_output/cruncep_precip_1deg/gpcp_1deg_bias_correction</value>
       <value stream="BC.CRUNCEP.CMAP.Precip">$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/cmap/cruncep</value>
       <value stream="Anomaly">$DIN_LOC_ROOT/atm/datm7/anomaly_forcing</value>
-      <value stream="presaero.cplhist">$DATM_CPLHIST_DIR</value>
+      <value stream="presaero.cplhist">null</value>
       <value stream="presaero.clim_1850">$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/aero </value>
       <value stream="presaero.clim_2000">$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/aero </value>
       <value stream="presaero.trans_1850-2000">$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/aero</value>
@@ -1890,11 +1890,11 @@
     <values>
       <value>1.5</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1.e30</value>
-      <value stream="CPLHISTForcing.Solar">2.0</value>
-      <value stream="CPLHISTForcing.nonSolarFlux">2.0</value>
-      <value stream="CPLHISTForcing.State3hr">2.0</value>
-      <value stream="CPLHISTForcing.State1hr">2.0</value>
-      <value stream="presaero.cplhist">2.0</value>
+      <value stream="CPLHISTForcing.Solar">3.0</value>
+      <value stream="CPLHISTForcing.nonSolarFlux">3.0</value>
+      <value stream="CPLHISTForcing.State3hr">3.0</value>
+      <value stream="CPLHISTForcing.State1hr">3.0</value>
+      <value stream="presaero.cplhist">3.0</value>
     </values>
   </entry>
 

--- a/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -310,7 +310,7 @@
     <type>char(30)</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>"nomask,srcmask,dstmask,bothmask"</valid_values>
+    <valid_values>nomask,srcmask,dstmask,bothmask</valid_values>
     <desc>
       array (up to 30 elements) of masking algorithms for mapping input data
       associated with the array of streams.  valid options are map only from
@@ -327,7 +327,7 @@
     <type>char(30)</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>"copy,bilinear,nn,nnoni,nnonj,spval"</valid_values>
+    <valid_values>copy,bilinear,nn,nnoni,nnonj,spval</valid_values>
     <desc>
       array (up to 30 elements) of fill algorithms associated with the array
       of streams.  valid options are copy by index, set to special value,
@@ -397,7 +397,7 @@
     <type>char(30)</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>"extend,cycle,limit"</valid_values>
+    <valid_values>extend,cycle,limit</valid_values>
     <desc>
       array of time axis modes associated with the array of streams for
       handling data outside the specified stream time axis.
@@ -434,7 +434,7 @@
       to turn off trapping, set the value to 1.0e30 or something similar.
     </desc>
     <values>
-      <value>1.5e0</value>
+      <value>3.0</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -71,7 +71,7 @@
     <values>
       <value compset="_CAM"  >CO2A</value>
       <value compset="_DATM"    >none</value>
-      <value compset="_DATM%S1850.+POP\d">CO2A</value>
+      <value compset="_DATM%CPLHIST.+POP\d">CO2A</value>
       <value compset="_BGC%BPRP">CO2C</value>
       <value compset="_BGC%BDRD">CO2C</value>
       <value compset="HIST.*_DATM%(QIA|CRU)">CO2A</value>
@@ -116,7 +116,7 @@
       <value compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
       <value compset="_DATM.*_CICE.*_DOCN">24</value>
       <value compset="_DATM.*_DOCN%US20">24</value>
-      <value compset="_DATM%S1850.+POP\d">48</value>
+      <value compset="_DATM%CPLHIST.+POP\d">48</value>
       <value compset="_MPAS">1</value>
       <value compset=".+" grid="a%0.23x0.31">96</value>
       <value compset=".+" grid="a%ne60np4">96</value>
@@ -228,7 +228,7 @@
       <value compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
       <value compset="_DATM.*_SLND.*_DICE.*_DOCN">$ATM_NCPL</value>
-      <value compset="_DATM%S1850.+POP\d">8</value>
+      <value compset="_DATM%CPLHIST.+POP\d">8</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>
       <value compset="_DLND.*_CISM\d">1</value>
     </values>
@@ -259,7 +259,7 @@
     <values>
       <value compset="DATM.+POP\d">TRUE</value>
       <value compset="DATM.+DOCN%IAF">TRUE</value>
-      <value compset="DATM%S1850.+POP\d">FALSE</value>
+      <value compset="DATM%CPLHIST.+POP\d">FALSE</value>
     </values>
     <group>run_component_cpl</group>
     <file>env_run.xml</file>
@@ -285,7 +285,7 @@
     <default_value>off</default_value>
     <values>
       <value compset="DATM.+POP\d">ocn</value>
-      <value compset="DATM%S1850.+POP\d">off</value>
+      <value compset="DATM%CPLHIST.+POP\d">off</value>
     </values>
     <group>run_component_cpl</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Use %CPLHIST for DATM coupler hist forcing

Coupler history forcing should have a %CPLHIST mode for any data component
that uses it. This change makes DATM conform to this convention.

It also fixes the invalid quotes in DROF valid values in #1577

Test suite: scripts_regression_tests 
    also verified that the following CESM spinup compset
    `1850_DATM%CPLHIST_SLND_CICE_POP2%ECO_DROF%CPLHIST_SGLC_WW3`
     gave the correct values
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1577 #1576 
User interface changes?: None
Code review: 
