### PR TITLE
Remove grid attribute from compset elements

### DIFF
--- a/src/drivers/mct/cime_config/config_compsets.xml
+++ b/src/drivers/mct/cime_config/config_compsets.xml
@@ -50,7 +50,7 @@
     <lname>2000_DATM%NYF_SLND_DICE%SSMI_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST</lname>
   </compset>
 
-  <compset grid="a%1.9x2.5|a%0.9x1.25">
+  <compset>
     <alias>ADSOMAQP</alias>
     <lname>2000_DATM%NYF_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV</lname>
   </compset>
@@ -85,7 +85,7 @@
     <lname>2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_DESP%TEST</lname>
   </compset>
 
-  <compset grid="r%rx1">
+  <compset>
     <alias>AIAF</alias>
     <lname>2000_DATM%IAF_SLND_DICE%IAF_DOCN%IAF_DROF%IAF_SGLC_SWAV</lname>
   </compset>


### PR DESCRIPTION
This wasn't being checked, so wasn't serving any purpose

Test suite: none (the relevant compsets aren't covered by scripts_regression_tests anyway)
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #1583 

User interface changes?: none

Code review: 
