### PR TITLE
Xmlquery and config compset

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -216,7 +216,7 @@
 	<arg name="anum_tasks"> -np $TOTALPES</arg>
 	<arg name="labelstdout">-p "%g:"</arg>
 	<!-- the omplace argument needs to be last -->
-	<arg name="zthreadplacement"> omplace </arg>
+	<arg name="zthreadplacement"> omplace -tm open64 </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="default" unit_testing="true">
@@ -259,7 +259,7 @@
 	<command name="load">gnu/6.3.0</command>
       </modules>
       <modules>
-	<command name="load">mpt/2.15</command>
+	<command name="load">mpt/2.15f</command>
 	<command name="load">ncarcompilers/0.3.5</command>
       </modules>
       <modules mpilib="mpi-serial">

--- a/config/xml_schemas/config_compsets.xsd
+++ b/config/xml_schemas/config_compsets.xsd
@@ -33,7 +33,6 @@
         <xs:element ref="lname"/>
 	<xs:element ref="science_support" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
-      <xs:attribute ref="grid"/>
     </xs:complexType>
   </xs:element>
 
@@ -66,8 +65,8 @@
   <xs:element name="value">
     <xs:complexType>
       <xs:simpleContent>
-        <xs:extension base="xs:NMTOKEN">
-          <xs:attribute ref="compset" use="required"/>
+        <xs:extension base="xs:string">
+          <xs:attribute ref="compset"/>
           <xs:attribute ref="grid"/>
         </xs:extension>
       </xs:simpleContent>

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -147,10 +147,11 @@ def xmlquery(case, variables, subgroup=None, fileonly=False,
                 groups = ['none']
 
         if xmlfile:
-            value =  case.get_value(var, resolved=resolved)
-            results['none'] = {}
-            results['none'][var] = {}
-            results['none'][var]['value']  = value
+            if not groups:
+                value =  case.get_value(var, resolved=resolved)
+                results['none'] = {}
+                results['none'][var] = {}
+                results['none'][var]['value']  = value
         else:
             expect(groups, " No results found for variable %s"%var)
         for group in groups:


### PR DESCRIPTION
FIx an issue with xmlquery when the --file and --listall flags are used together, Update config_compsets.xml to remove grid attribute which isn't used.  Some minor updates for
cheyenne modules and omplace syntax.

Test suite: scripts_regression_tests.py, hand tests of xmlquery 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #946 

User interface changes?: 

Code review: 
