### PR TITLE
Update PGI compiler to 17.04 on hobart

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -878,7 +878,7 @@
 	<command name="load">  tool/parallel-netcdf/1.7.0/intel/mvapich2  </command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">compiler/pgi/15.1</command>
+	<command name="load">compiler/pgi/17.04</command>
       </modules>
       <modules  compiler="pgi" mpilib="mvapich2">
 	  <command name="load">  tool/parallel-netcdf/1.6.1/pgi/mvapich2  </command>


### PR DESCRIPTION
Update version of PGI compiler used on hobart

Test suite: verified CECO.hobart_pgi would not build with current master, but does build and run with this branch
Test baseline: N/A
Test namelist changes: N/A 
Test status: I don't know if there are any compsets on hobart that build / run with pgi on master, but if so they probably won't have the same answers now

Fixes #1599

User interface changes?: N/A

Code review: one line changes are fun to review
