### PR TITLE
Refcase fix

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -755,6 +755,8 @@ class Case(object):
 
         self.get_compset_var_settings()
 
+        self.clean_up_lookups()
+
         #--------------------------------------------
         # machine
         #--------------------------------------------
@@ -876,6 +878,8 @@ class Case(object):
                     expect(response.startswith("u"), "Aborting by user request")
 
         # miscellaneous settings
+        import pdb
+        pdb.set_trace()
         if self.get_value("RUN_TYPE") == 'hybrid':
             self.set_value("GET_REFCASE", True)
 
@@ -889,7 +893,6 @@ class Case(object):
         if test:
             self.set_value("TEST",True)
 
-        self.clean_up_lookups()
         self.initialize_derived_attributes()
 
         # Make sure that parallel IO is not specified if total_tasks==1

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -878,8 +878,6 @@ class Case(object):
                     expect(response.startswith("u"), "Aborting by user request")
 
         # miscellaneous settings
-        import pdb
-        pdb.set_trace()
         if self.get_value("RUN_TYPE") == 'hybrid':
             self.set_value("GET_REFCASE", True)
 

--- a/scripts/lib/update_acme_tests.py
+++ b/scripts/lib/update_acme_tests.py
@@ -39,8 +39,8 @@ _TEST_SUITES = {
 
     "cime_developer" : (None, "0:10:00",
                             ("NCK_Ld3.f45_g37_rx1.A",
-                             "ERI.f45_g37.X",
-                             "ERIO.f45_g37.X",
+                             "ERI.f09_g16.X",
+                             "ERIO.f09_g16.X",
                              "SEQ_Ln9.f19_g16_rx1.A",
                              "ERS.ne30_g16_rx1.A",
                              "ERS_N2.f19_g16_rx1.A",

--- a/scripts/lib/update_acme_tests.py
+++ b/scripts/lib/update_acme_tests.py
@@ -33,8 +33,8 @@ _TEST_SUITES = {
                     "TESTRUNFAILEXC_P1.f19_g16_rx1.A",
                     "TESTRUNPASS_P1.f19_g16_rx1.A",
                     "TESTTESTDIFF_P1.f19_g16_rx1.A",
-                    "TESTMEMLEAKFAIL_P1.f19_g16.X",
-                    "TESTMEMLEAKPASS_P1.f19_g16.X")
+                    "TESTMEMLEAKFAIL_P1.f09_g16.X",
+                    "TESTMEMLEAKPASS_P1.f09_g16.X")
                    ),
 
     "cime_developer" : (None, "0:10:00",

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -738,8 +738,8 @@ class O_TestTestScheduler(TestCreateTestCommon):
     ###########################################################################
         # exclude the MEMLEAK tests here.
         tests = update_acme_tests.get_full_test_names(["cime_test_only",
-                                                       "^TESTMEMLEAKFAIL_P1.f19_g16.X",
-                                                       "^TESTMEMLEAKPASS_P1.f19_g16.X",
+                                                       "^TESTMEMLEAKFAIL_P1.f09_g16.X",
+                                                       "^TESTMEMLEAKPASS_P1.f09_g16.X",
                                                        "^TESTTESTDIFF_P1.f19_g16_rx1.A",
                                                        "^TESTBUILDFAILEXC_P1.f19_g16_rx1.A",
                                                        "^TESTRUNFAILEXC_P1.f19_g16_rx1.A"],
@@ -1027,14 +1027,14 @@ class T_TestRunRestart(TestCreateTestCommon):
     ###########################################################################
     def test_run_restart(self):
     ###########################################################################
-        run_cmd_assert_result(self, "%s/create_test --test-root %s --output-root %s -t %s NODEFAIL_P1.f45_g37.X"
+        run_cmd_assert_result(self, "%s/create_test --test-root %s --output-root %s -t %s NODEFAIL_P1.f09_g16.X"
                               % (SCRIPT_DIR, TEST_ROOT, TEST_ROOT, self._baseline_name))
         if self._hasbatch:
             run_cmd_assert_result(self, "%s/wait_for_tests *%s/TestStatus" % (TOOLS_DIR, self._baseline_name),
                                   from_dir=self._testroot)
 
         casedir = os.path.join(self._testroot,
-                               "%s.%s" % (CIME.utils.get_full_test_name("NODEFAIL_P1.f45_g37.X", machine=self._machine, compiler=self._compiler), self._baseline_name))
+                               "%s.%s" % (CIME.utils.get_full_test_name("NODEFAIL_P1.f09_g16.X", machine=self._machine, compiler=self._compiler), self._baseline_name))
 
         fail_sentinel = os.path.join(casedir, "run", "FAIL_SENTINEL")
         self.assertTrue(os.path.exists(fail_sentinel), msg="Missing %s" % fail_sentinel)
@@ -1045,7 +1045,7 @@ class T_TestRunRestart(TestCreateTestCommon):
     def test_run_restart_too_many_fails(self):
     ###########################################################################
         os.environ["NODEFAIL_NUM_FAILS"] = "5"
-        run_cmd_assert_result(self, "%s/create_test --test-root %s --output-root %s -t %s NODEFAIL_P1.f45_g37.X"
+        run_cmd_assert_result(self, "%s/create_test --test-root %s --output-root %s -t %s NODEFAIL_P1.f09_g16.X"
                               % (SCRIPT_DIR, TEST_ROOT, TEST_ROOT, self._baseline_name),
                               expected_stat=(0 if self._hasbatch else CIME.utils.TESTS_FAILED_ERR_CODE))
         if self._hasbatch:
@@ -1053,7 +1053,7 @@ class T_TestRunRestart(TestCreateTestCommon):
                                   from_dir=self._testroot, expected_stat=CIME.utils.TESTS_FAILED_ERR_CODE)
 
         casedir = os.path.join(self._testroot,
-                               "%s.%s" % (CIME.utils.get_full_test_name("NODEFAIL_P1.f45_g37.X", machine=self._machine, compiler=self._compiler), self._baseline_name))
+                               "%s.%s" % (CIME.utils.get_full_test_name("NODEFAIL_P1.f09_g16.X", machine=self._machine, compiler=self._compiler), self._baseline_name))
 
         fail_sentinel = os.path.join(casedir, "run", "FAIL_SENTINEL")
         self.assertTrue(os.path.exists(fail_sentinel), msg="Missing %s" % fail_sentinel)


### PR DESCRIPTION
Fixed issue with GET_REFCASE not being set correctly that was introduced with PR#1561 and 
an issue with X compset mapping files that was introduced in #1586

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
