### PR TITLE
do not eval words - only strings with whitespace

### DIFF
--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -287,10 +287,13 @@ class EnvBatch(EnvBase):
                     val = case.get_resolved_value(name)
 
                 if val is not None and len(str(val)) > 0 and val != "None":
-                    # Try to evaluate val
-                    try:
-                        rval = eval(val)
-                    except:
+                    # Try to evaluate val if it contains any whitespace
+                    if " " in val:
+                        try:
+                            rval = eval(val)
+                        except:
+                            rval = val
+                    else:
                         rval = val
                     # need a correction for tasks per node
                     if flag == "-n" and rval<= 0:


### PR DESCRIPTION
eval on a word sometimes gives unexpected results, for example eval('long') results in
```<type 'long'>``` avoid this by only using eval if the string contains whitespace. 

Test suite: on hobart: create_test cime_developer --queue long, scripts_regression_tests.py --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1613 

User interface changes?: 

Code review: 
