### PR TITLE
Add more error-checking with gnu in debug mode

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -128,7 +128,12 @@ using a fortran linker.
        so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
     <base> -mcmodel=medium -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </base>
     <append compile_threaded="true"> -fopenmp </append>
-    <append DEBUG="TRUE"> -g -Wall </append>
+    <!-- Ideally, we would also have 'invalid' in the ffpe-trap list. But at
+         least with some versions of gfortran (confirmed with 5.3.0), gfortran's
+         isnan (which is called in cime via the CPRGNU-specific
+         shr_infnan_isnan) causes a floating point exception when called on a
+         signaling NaN. -->
+    <append DEBUG="TRUE"> -g -Wall -ffpe-trap=zero,overflow -fcheck=bounds </append>
     <append DEBUG="FALSE"> -O </append>
   </FFLAGS>
   <FFLAGS_NOOPT>


### PR DESCRIPTION
This adds more debug checks with gnu.

I thought this was done in #1339 (which claimed to fix #857), but I
realized that that only added flags for the C compiler, not the Fortran
compiler. This PR adds debug flags for the Fortran compiler, too.

Ideally, we would also have 'invalid' in the ffpe-trap list. But at
least with some versions of gfortran (confirmed with 5.3.0), gfortran's
isnan (which is called in cime via the CPRGNU-specific shr_infnan_isnan)
causes a floating point exception when called on a signaling NaN. (This
problem showed up in the unit tests on my Mac: Adding 'invalid' caused
the shr_strconvert unit tests to fail (specifically, the tests
toString_prints_snan_r4 and toString_prints_snan_r8).)

Test suite: Ran nearly all gnu debug tests that I could find in all CESM
test suites. This included:
- aux_clm45 yellowstone-gnu: all pass and are bit-for-bit
- The following yellowstone tests:

  ERS_D_Ly3.f09_g16_gl5.TG1.yellowstone_gnu.cism-noevolve
  SMS_D.T31_g37_gl20.IGCLM45.yellowstone_gnu.cism-test_coupling
  SMS_D.f09_g16_gl20.TG1.yellowstone_gnu
  SMS_D_Ly1.f09_g16_gl20.THISTG.yellowstone_gnu
  SMS_D_Ld5.f10_f10.IMCRUCLM50BGC.yellowstone_gnu.mosart-default
  SMS_D_Ld5.f10_f10.ICRUCLM50BGC.yellowstone_gnu.rtm-default
  SMS_D.f09_g16_gl20.TG1.yellowstone_gnu
  ERI_D.T31_g37_rx1.A.yellowstone_gnu
  SMS_D_Ld1.5x5_amazon.ITEST.yellowstone_gnu.clm-40default

  All pass except a build failure for
  SMS_D_Ld1.5x5_amazon.ITEST.yellowstone_gnu.clm-40default which doesn't
  look related to these new debug flags. This is a CLM40 test that isn't
  important.

- The following cheyenne tests:

  SMS_D.f09_g16_gl20.TG1.cheyenne_gnu
  ERI_D.T31_g37_rx1.A.cheyenne_gnu
  SMS_D_Ld1.5x5_amazon.ITEST.cheyenne_gnu.clm-40default

  The A test passed. The ITEST failed as for yellowstone. The TG1 test
  failed, unable to link some lapack routines (seems unrelated to the
  new build flags).

I ran these tests from
https://svn-ccsm-models.cgd.ucar.edu/clm2/branches/externals_update_cesm2_0_alpha06k
at r85267, with cime changes rebased onto cime5.3.0-alpha.13

Test baseline: For aux_clm45 tests, I compared against the above version
   of CLM unmodified. For other tests, I didn't do baseline comparisons
Test namelist changes: none
Test status: bit for bit

Fixes #1615

User interface changes?: none

Code review: 
