### PR TITLE
new match attribute in <values> node

### DIFF
--- a/config/xml_schemas/config_compsets.xsd
+++ b/config/xml_schemas/config_compsets.xsd
@@ -5,6 +5,7 @@
   <xs:attribute name="id" type="xs:NCName"/>
   <xs:attribute name="compset" type="xs:string"/>
   <xs:attribute name="grid" type="xs:string"/>
+  <xs:attribute name="match" type="xs:string"/>
 
   <!-- simple elements -->
   <xs:element name="help" type="xs:string"/>
@@ -59,6 +60,7 @@
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="value"/>
       </xs:sequence>
+      <xs:attribute ref="match"/>
     </xs:complexType>
   </xs:element>
 

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -41,6 +41,12 @@ class Component(EntryID):
         return components
 
     def _get_value_match(self, node, attributes=None, exact_match=False):
+        """
+        return the best match for the node <values> entries
+        Note that a component object uses a different matching algorithm than an entryid object
+        For a component object the _get_value_match used is below  and is not the one in entry_id.py
+        """
+
         match_value = None
         match_max = 0
         match_count = 0
@@ -50,6 +56,11 @@ class Component(EntryID):
         values = self.get_optional_node("values", root=node)
         if values is None:
             return
+
+        # determine match_type if there is a tie 
+        # ASSUME a default of "last" if "match" attribute is not there
+        match_type = values.get("match", default="last")
+
         # use the default_value if present
         val_node = self.get_optional_node("default_value", root=node)
         if val_node is None:
@@ -58,6 +69,7 @@ class Component(EntryID):
         value = val_node.text
         if value is not None and len(value) > 0 and value != "UNSET":
             match_values.append(value)
+
         for valnode in self.get_nodes("value", root=node):
             # loop through all the keys in valnode (value nodes) attributes
             for key,value in valnode.attrib.iteritems():
@@ -70,6 +82,8 @@ class Component(EntryID):
                     else:
                         match_count = 0
                         break
+
+            # a match is found
             if match_count > 0:
                 # append the current result
                 if values.get("modifier") == "additive":
@@ -82,11 +96,21 @@ class Component(EntryID):
                         del match_values[:]
                     match_values.append(valnode.text)
 
-                # take the *last* best match
-                elif match_count >= match_max:
-                    del match_values[:]
-                    match_max = match_count
-                    match_value = valnode.text
+                else: 
+                    if match_type == "last":
+                        # take the *last* best match
+                        if match_count >= match_max:
+                            del match_values[:]
+                            match_max = match_count
+                            match_value = valnode.text
+                    elif match_type == "first":
+                        # take the *first* best match
+                        if match_count > match_max:
+                            del match_values[:]
+                            match_max = match_count
+                            match_value = valnode.text
+                    else:
+                        expect(False, "match attribute can only have a value of 'last' or 'first'")
 
         if len(match_values) > 0:
             match_value = " ".join(match_values)

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -39,7 +39,7 @@ class Component(EntryID):
         components = comps.split(',')
         return components
 
-    def _get_value_match(self, node, attributes=None, exact_match=False, match_type=None):
+    def _get_value_match(self, node, attributes=None, exact_match=False):
         """
         return the best match for the node <values> entries
         Note that a component object uses a different matching algorithm than an entryid object
@@ -57,12 +57,6 @@ class Component(EntryID):
 
         # determine match_type if there is a tie 
         # ASSUME a default of "last" if "match" attribute is not there
-        # ***NOTE:*** regardless of the value of the input argument match_type - it is OVERWRITTEN here
-        # with the match attribute from the <values> element if it is present - and by default
-        # it is "last" if the match attribute is not present
-        # The argument match_type is ignored since this is an overloaded method that can be called for
-        # by the entry_id object when the object is a Component - and this needs to be cleaned up in a unified way
-
         match_type = values.get("match", default="last")
 
         # use the default_value if present

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -21,7 +21,6 @@ class Component(EntryID):
         cimeroot = get_cime_root()
         if  cimeroot in os.path.abspath(infile):
             schema = files.get_schema("CONFIG_CPL_FILE")
-
         EntryID.__init__(self, infile, schema=schema)
 
     #pylint: disable=arguments-differ
@@ -40,13 +39,12 @@ class Component(EntryID):
         components = comps.split(',')
         return components
 
-    def _get_value_match(self, node, attributes=None, exact_match=False):
+    def _get_value_match(self, node, attributes=None, exact_match=False, match_type=None):
         """
         return the best match for the node <values> entries
         Note that a component object uses a different matching algorithm than an entryid object
         For a component object the _get_value_match used is below  and is not the one in entry_id.py
         """
-
         match_value = None
         match_max = 0
         match_count = 0
@@ -59,6 +57,12 @@ class Component(EntryID):
 
         # determine match_type if there is a tie 
         # ASSUME a default of "last" if "match" attribute is not there
+        # ***NOTE:*** regardless of the value of the input argument match_type - it is OVERWRITTEN here
+        # with the match attribute from the <values> element if it is present - and by default
+        # it is "last" if the match attribute is not present
+        # The argument match_type is ignored since this is an overloaded method that can be called for
+        # by the entry_id object when the object is a Component - and this needs to be cleaned up in a unified way
+
         match_type = values.get("match", default="last")
 
         # use the default_value if present

--- a/scripts/lib/CIME/XML/compsets.py
+++ b/scripts/lib/CIME/XML/compsets.py
@@ -5,7 +5,6 @@ Common interface to XML files which follow the compsets format,
 from CIME.XML.standard_module_setup import *
 from CIME.XML.generic_xml import GenericXML
 from CIME.XML.entry_id import EntryID
-from CIME.XML.component import Component
 from CIME.XML.files import Files
 
 
@@ -19,7 +18,6 @@ class Compsets(GenericXML):
         schema = files.get_schema("COMPSETS_SPEC_FILE")
         GenericXML.__init__(self, infile, schema=schema)
         self.groups={}
-        self.infile=infile
 
     def get_compset_match(self, name):
         """
@@ -44,22 +42,18 @@ class Compsets(GenericXML):
         return (None, None, [False])
 
     def get_compset_var_settings(self, compset, grid):
-        '''Variables can be set in config_compsets.xml in entry id settings
-        with compset and grid attributes find and return id value pairs here.
-        For now, need to instantiate a component object since matches can be done via 'first' and 'last' 
-        match attributes and for backwards compatibility it is always last. 
-        An entryID object has a matching algorithm where the first match is always picked in if more than
-        one match is found - and until this is generalized a component object must be instantiated here.
         '''
-        result = []
+        Variables can be set in config_compsets.xml in entry id settings with compset and grid attributes
+        find and return id value pairs here
+        '''
         nodes = self.get_nodes("entry")
-        if nodes:
-            logger.info("Parsing entry nodes in compset definition file")
-            componentobj = Component(self.infile)
-            for node in nodes:
-                value = componentobj.get_default_value(node, {"grid":grid, "compset":compset})
-                if value is not None:
-                    result.append((node.get("id"), value))
+        # Get an empty entryid obj to use
+        entryidobj = EntryID()
+        result = []
+        for node in nodes:
+            value = entryidobj.get_default_value(node, {"grid":grid, "compset":compset})
+            if value is not None:
+                result.append((node.get("id"), value))
         return result
 
     #pylint: disable=arguments-differ

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -21,17 +21,7 @@ class EntryID(GenericXML):
         """
         Set the value of an entry to the default value for that entry
         """
-        # If there is a <values> node with a match attribute - then set the
-        # match_type to that attribute - otherwise set the default value of match_type
-        # to "first" for backwards compatibility
-
-        values_node = self.get_optional_node("values", root=node)
-        if values_node is not None:
-            match_type = values_node.get("match", default="first")
-        else:
-            match_type = "first"
-
-        value = self._get_value_match(node, attributes, match_type=match_type)
+        value = self._get_value_match(node, attributes)
         if value is None:
             # Fall back to default value
             value = self.get_element_text("default_value", root=node)
@@ -63,36 +53,27 @@ class EntryID(GenericXML):
         #  </values>
         # </entry>
 
-        # Note that here the default value of match_type is "first"
-        # Note that in components.py the default value of match_type is "last"
         if entry_node is not None:
-            values_node = self.get_optional_node("values", root=entry_node)
-            # if there is not a <values> child node for the <entry> node, then set the match attribute to "first"
-            if values_node is not None:
-                match_type = values_node.get("match", default="first")
-            else:
-                match_type = "first"
-            value = self._get_value_match(entry_node, attributes=attributes, exact_match=exact_match, match_type=match_type)
+            value = self._get_value_match(entry_node, attributes, exact_match)
         else:
             node = self.get_optional_node("entry", {"id":vid})
-            # if there is not a <values> child node for the <entry> node , then set the match attribute to "first"
-            values_node = self.get_optional_node("values", root=node)
-            if values_node is not None:
-                match_type = values_node.get("match", default="first")
-            else:
-                match_type = "first"
             value = None
             if node is not None:
-                value = self._get_value_match(node, attributes=attributes, exact_match=exact_match, match_type=match_type)
+                value = self._get_value_match(node, attributes, exact_match)
         logger.debug("(get_value_match) vid {} value {}".format(vid, value))
         return value
 
-    def _get_value_match(self, node, attributes=None, exact_match=False, match_type=None):
+    def _get_value_match(self, node, attributes=None, exact_match=False):
         '''
         Note that the component class has a specific version of this function
         '''
-        # By default the match_type is "first:
-        if match_type is None:
+        # if there is a <values> element - check to see if there is a match attribute
+        # if there is NOT a match attribute, then set the default to "first"
+        # this is different than the component class _get_value_match where the default is "last"
+        values_node = self.get_optional_node("values", root=node)
+        if values_node is not None:
+            match_type = values_node.get("match", default="first")
+        else:
             match_type = "first"
 
         # Store nodes that match the attributes and their scores.

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -4,6 +4,35 @@
 
 <entry_id>
 
+  <!-- NOTE that the description block determines what DATM% values can appear in the compset name 
+       For DATM this is determined by the DATM_MODE values in combination with the TIME prefix -->
+  <description>
+    <desc compset="^1850_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
+    <desc compset="^2000_DATM%WISOQIA"	>QIAN atm input data with water isotopes for 2000-2004:</desc>
+    <desc compset="^2000_DATM%QIA"	>QIAN atm input data for 1972-2004:</desc>
+    <desc compset="^2003_DATM%QIA"	>QIAN atm input data for 2002-2003:</desc>
+    <desc compset="^HIST_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
+    <desc compset="^20TR_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
+    <desc compset="^4804_DATM%QIA"	>QIAN atm input data for 1948-2004:</desc>
+    <desc compset="^RCP[2468]_DATM%QIA"	>QIAN atm input data for 1972-2004:</desc>
+    <desc compset="^1850_DATM%CRU"	>CRUNCEP atm input data for 1901-1920:</desc>
+    <desc compset="^2000_DATM%CRU"	>CRUNCEP atm input data for 1991-2010:</desc>
+    <desc compset="^2003_DATM%CRU"	>CRUNCEP atm input data for 2002-2003:</desc>
+    <desc compset="^HIST_DATM%CRU"	>CRUNCEP atm input data for 1901-1920:</desc>
+    <desc compset="^20TR_DATM%CRU"	>CRUNCEP atm input data for 1901-1920:</desc>
+    <desc compset="^RCP[2468]_DATM%CRU"	>CRUNCEP atm input data for 1991-2010:</desc>
+    <desc compset="^1850_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
+    <desc compset="^2000_DATM%GSW"	>GSWP3 atm input data for 1991-2010:</desc>
+    <desc compset="^2003_DATM%GSW"	>GSWP3 atm input data for 2002-2003:</desc>
+    <desc compset="^HIST_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
+    <desc compset="^20TR_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
+    <desc compset="^RCP[2468]_DATM%GSW"	>GSWP3 atm input data for 1991-2010:</desc>
+    <desc compset="^1850_DATM%PCLHIST"	>CPL history input data:</desc>
+    <desc compset="^2000_DATM%1PT"	>single point tower site atm input data:</desc>
+    <desc compset="_DATM%NYF"		>COREv2 datm normal year forcing: (requires additional user-supplied data)</desc>
+    <desc compset="_DATM%IAF"		>COREv2 datm interannual year forcing: (requires additional user-supplied data)</desc>
+  </description>
+
   <entry id="COMP_ATM">
     <type>char</type>
     <valid_values>datm</valid_values>
@@ -22,7 +51,7 @@
     <desc>Mode for data atmosphere component.
       CORE2_NYF (CORE2 normal year forcing) is the DATM mode used in C and G compsets. 
       CLM_QIAN, CLMCRUNCEP, CLMGSWP3 and CLM1PT are modes using observational data for I compsets.</desc>
-    <values>
+    <values match="last">
       <value compset="%NYF">CORE2_NYF</value>
       <value compset="%IAF">CORE2_IAF</value>
       <value compset="%WISOQIA">CLM_QIAN_WISO</value>
@@ -38,7 +67,7 @@
     <type>char</type>
     <valid_values>none,clim_1850,clim_2000,trans_1850-2000,rcp2.6,rcp4.5,rcp6.0,rcp8.5,cplhist</valid_values>
     <default_value>none</default_value>
-    <values>
+    <values match="last">
       <value compset="^1850_">clim_1850</value>
       <value compset="^2000_">clim_2000</value>
       <value compset="^2003_">clim_2000</value>
@@ -61,14 +90,14 @@
   </entry>
 
   <entry id="DATM_TOPO">
-     <type>char</type>
-     <valid_values>none,observed</valid_values>
-     <default_value>observed</default_value>
-     <values>
-        <!-- Only needed for compsets with active land; for other compsets, turn it off -->
-        <value compset="_SLND">none</value>
-        <value compset="_DLND">none</value>
-     </values>
+    <type>char</type>
+    <valid_values>none,observed</valid_values>
+    <default_value>observed</default_value>
+    <values match="last">
+      <!-- Only needed for compsets with active land; for other compsets, turn it off -->
+      <value compset="_SLND">none</value>
+      <value compset="_DLND">none</value>
+    </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
     <desc>DATM surface topography forcing</desc>
@@ -78,7 +107,7 @@
     <type>char</type>
     <valid_values>none,20tr,rcp2.6,rcp4.5,rcp6.0,rcp8.5</valid_values>
     <default_value>none</default_value>
-    <values>
+    <values match="last">
       <value compset="^RCP8">rcp8.5</value>
       <value compset="^RCP6">rcp6.0</value>
       <value compset="^RCP4">rcp4.5</value>
@@ -104,7 +133,7 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>UNSET</default_value>
-    <values>
+    <values match="last">
       <value compset="1850_DATM%CPLHIST">b40.1850.track1.1deg.006a</value>
     </values>
     <group>run_component_datm</group>
@@ -116,7 +145,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>1</default_value>
-    <values>
+    <values match="last">
       <value compset="1850_DATM%PCLHIST">1</value>
     </values>
     <group>run_component_datm</group>
@@ -128,7 +157,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>-999</default_value>
-    <values>
+    <values match="last">
       <value compset="1850_DATM%PCLHIST">960</value>
     </values>
     <group>run_component_datm</group>
@@ -140,7 +169,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>-999</default_value>
-    <values>
+    <values match="last">
       <value compset="1850_DATM%PCLHIST">1030</value>
     </values>
     <group>run_component_datm</group>
@@ -152,7 +181,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>1</default_value>
-    <values>
+    <values match="last">
       <value compset="2000.*_DATM%1PT">1</value>
       <value compset="1850.*_DATM%QIA">1</value>
       <value compset="1850.*_DATM%CRU">1</value>
@@ -185,7 +214,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>2004</default_value>
-    <values>
+    <values match="last">
       <value compset="2000.*_DATM%1PT">1972</value>
       <value compset="1850.*_DATM%QIA">1948</value>
       <value compset="1850.*_DATM%CRU">1901</value>
@@ -219,7 +248,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>2004</default_value>
-    <values>
+    <values match="last">
       <value   compset="2000.*_DATM%1PT">2004</value> 
       <value   compset="1850.*_DATM%QIA">1972</value> 
       <value   compset="1850.*_DATM%CRU">1920</value> 
@@ -248,33 +277,6 @@
     <file>env_run.xml</file>
     <desc>ending year to loop data over</desc>
   </entry>
-
-  <description>
-    <desc compset="^1850_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
-    <desc compset="^2000_DATM%WISOQIA"	>QIAN atm input data with water isotopes for 2000-2004:</desc>
-    <desc compset="^2000_DATM%QIA"	>QIAN atm input data for 1972-2004:</desc>
-    <desc compset="^2003_DATM%QIA"	>QIAN atm input data for 2002-2003:</desc>
-    <desc compset="^HIST_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
-    <desc compset="^20TR_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
-    <desc compset="^4804_DATM%QIA"	>QIAN atm input data for 1948-2004:</desc>
-    <desc compset="^RCP[2468]_DATM%QIA"	>QIAN atm input data for 1972-2004:</desc>
-    <desc compset="^1850_DATM%CRU"	>CRUNCEP atm input data for 1901-1920:</desc>
-    <desc compset="^2000_DATM%CRU"	>CRUNCEP atm input data for 1991-2010:</desc>
-    <desc compset="^2003_DATM%CRU"	>CRUNCEP atm input data for 2002-2003:</desc>
-    <desc compset="^HIST_DATM%CRU"	>CRUNCEP atm input data for 1901-1920:</desc>
-    <desc compset="^20TR_DATM%CRU"	>CRUNCEP atm input data for 1901-1920:</desc>
-    <desc compset="^RCP[2468]_DATM%CRU"	>CRUNCEP atm input data for 1991-2010:</desc>
-    <desc compset="^1850_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
-    <desc compset="^2000_DATM%GSW"	>GSWP3 atm input data for 1991-2010:</desc>
-    <desc compset="^2003_DATM%GSW"	>GSWP3 atm input data for 2002-2003:</desc>
-    <desc compset="^HIST_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
-    <desc compset="^20TR_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
-    <desc compset="^RCP[2468]_DATM%GSW"	>GSWP3 atm input data for 1991-2010:</desc>
-    <desc compset="^1850_DATM%PCLHIST"	>CPL history input data:</desc>
-    <desc compset="^2000_DATM%1PT"	>single point tower site atm input data:</desc>
-    <desc compset="_DATM%NYF"		>COREv2 datm normal year forcing: (requires additional user-supplied data)</desc>
-    <desc compset="_DATM%IAF"		>COREv2 datm interannual year forcing: (requires additional user-supplied data)</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -7,30 +7,30 @@
   <!-- NOTE that the description block determines what DATM% values can appear in the compset name 
        For DATM this is determined by the DATM_MODE values in combination with the TIME prefix -->
   <description>
-    <desc compset="^1850_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
-    <desc compset="^2000_DATM%WISOQIA"	>QIAN atm input data with water isotopes for 2000-2004:</desc>
-    <desc compset="^2000_DATM%QIA"	>QIAN atm input data for 1972-2004:</desc>
-    <desc compset="^2003_DATM%QIA"	>QIAN atm input data for 2002-2003:</desc>
-    <desc compset="^HIST_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
-    <desc compset="^20TR_DATM%QIA"	>QIAN atm input data for 1948-1972:</desc>
-    <desc compset="^4804_DATM%QIA"	>QIAN atm input data for 1948-2004:</desc>
-    <desc compset="^RCP[2468]_DATM%QIA"	>QIAN atm input data for 1972-2004:</desc>
-    <desc compset="^1850_DATM%CRU"	>CRUNCEP atm input data for 1901-1920:</desc>
-    <desc compset="^2000_DATM%CRU"	>CRUNCEP atm input data for 1991-2010:</desc>
-    <desc compset="^2003_DATM%CRU"	>CRUNCEP atm input data for 2002-2003:</desc>
-    <desc compset="^HIST_DATM%CRU"	>CRUNCEP atm input data for 1901-1920:</desc>
-    <desc compset="^20TR_DATM%CRU"	>CRUNCEP atm input data for 1901-1920:</desc>
-    <desc compset="^RCP[2468]_DATM%CRU"	>CRUNCEP atm input data for 1991-2010:</desc>
-    <desc compset="^1850_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
-    <desc compset="^2000_DATM%GSW"	>GSWP3 atm input data for 1991-2010:</desc>
-    <desc compset="^2003_DATM%GSW"	>GSWP3 atm input data for 2002-2003:</desc>
-    <desc compset="^HIST_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
-    <desc compset="^20TR_DATM%GSW"	>GSWP3 atm input data for 1901-1920:</desc>
-    <desc compset="^RCP[2468]_DATM%GSW"	>GSWP3 atm input data for 1991-2010:</desc>
-    <desc compset="^1850_DATM%PCLHIST"	>CPL history input data:</desc>
-    <desc compset="^2000_DATM%1PT"	>single point tower site atm input data:</desc>
-    <desc compset="_DATM%NYF"		>COREv2 datm normal year forcing: (requires additional user-supplied data)</desc>
-    <desc compset="_DATM%IAF"		>COREv2 datm interannual year forcing: (requires additional user-supplied data)</desc>
+    <desc compset="^1850_DATM%QIA">QIAN atm input data for 1948-1972:</desc>
+    <desc compset="^2000_DATM%WISOQIA">QIAN atm input data with water isotopes for 2000-2004:</desc>
+    <desc compset="^2000_DATM%QIA">QIAN atm input data for 1972-2004:</desc>
+    <desc compset="^2003_DATM%QIA">QIAN atm input data for 2002-2003:</desc>
+    <desc compset="^HIST_DATM%QIA">QIAN atm input data for 1948-1972:</desc>
+    <desc compset="^20TR_DATM%QIA">QIAN atm input data for 1948-1972:</desc>
+    <desc compset="^4804_DATM%QIA">QIAN atm input data for 1948-2004:</desc>
+    <desc compset="^RCP[2468]_DATM%QIA">QIAN atm input data for 1972-2004:</desc>
+    <desc compset="^1850_DATM%CRU">CRUNCEP atm input data for 1901-1920:</desc>
+    <desc compset="^2000_DATM%CRU">CRUNCEP atm input data for 1991-2010:</desc>
+    <desc compset="^2003_DATM%CRU">CRUNCEP atm input data for 2002-2003:</desc>
+    <desc compset="^HIST_DATM%CRU">CRUNCEP atm input data for 1901-1920:</desc>
+    <desc compset="^20TR_DATM%CRU">CRUNCEP atm input data for 1901-1920:</desc>
+    <desc compset="^RCP[2468]_DATM%CRU">CRUNCEP atm input data for 1991-2010:</desc>
+    <desc compset="^1850_DATM%GSW">GSWP3 atm input data for 1901-1920:</desc>
+    <desc compset="^2000_DATM%GSW">GSWP3 atm input data for 1991-2010:</desc>
+    <desc compset="^2003_DATM%GSW">GSWP3 atm input data for 2002-2003:</desc>
+    <desc compset="^HIST_DATM%GSW">GSWP3 atm input data for 1901-1920:</desc>
+    <desc compset="^20TR_DATM%GSW">GSWP3 atm input data for 1901-1920:</desc>
+    <desc compset="^RCP[2468]_DATM%GSW">GSWP3 atm input data for 1991-2010:</desc>
+    <desc compset="^1850_DATM%PCLHIST">CPL history input data:</desc>
+    <desc compset="^2000_DATM%1PT">single point tower site atm input data:</desc>
+    <desc compset="_DATM%NYF">COREv2 datm normal year forcing: (requires additional user-supplied data)</desc>
+    <desc compset="_DATM%IAF">COREv2 datm interannual year forcing: (requires additional user-supplied data)</desc>
   </description>
 
   <entry id="COMP_ATM">

--- a/src/components/data_comps/desp/cime_config/config_component.xml
+++ b/src/components/data_comps/desp/cime_config/config_component.xml
@@ -4,6 +4,13 @@
 
 <entry_id>
 
+  <!-- NOTE that the description block determines what DESP% values can appear in the compset name 
+       For DESP this is determined by the DESP_MODE values -->
+  <description>
+    <desc compset="_DESP%NOOP">no modification of any model data</desc>
+    <desc compset="_DESP%TEST">test modification of any model data</desc>
+  </description>
+
   <entry id="COMP_ESP">
     <type>char</type>
     <valid_values>desp</valid_values>
@@ -21,14 +28,11 @@
     <file>env_run.xml</file>
     <desc>Mode for external system processing component.
       The default is NOOP, do not modify any model data.</desc>
-    <values>
+    <values match="last">
       <value compset="%NOOP"  >NOCHANGE</value>
       <value compset="%TEST"  >DATATEST</value>
     </values>
   </entry>
-
-  <description>
-  </description>
 
   <help>
     =========================================

--- a/src/components/data_comps/dice/cime_config/config_component.xml
+++ b/src/components/data_comps/dice/cime_config/config_component.xml
@@ -4,6 +4,15 @@
 
 <entry_id>
 
+  <!-- NOTE that the description block determines what DICE% values can appear in the compset name 
+       For DICE this is determined by the DICE_MODE values -->
+  <description>
+    <desc compset="DICE%SSMI">dice mode is ssmi:</desc>
+    <desc compset="DICE%SIAF">dice mode is ssmi_iaf:</desc>
+    <desc compset="DICE%PRES">dice mode is prescribed:</desc>
+    <desc compset="DICE%NULL">dice mode is null:</desc>
+  </description>
+
   <entry id="COMP_ICE">
     <type>char</type>
     <valid_values>dice</valid_values>
@@ -17,7 +26,7 @@
     <type>char</type>
     <valid_values>prescribed,ssmi,ssmi_iaf,copyall,null</valid_values>
     <default_value>ssmi</default_value>
-    <values>
+    <values match="last">
       <value compset="DICE%SSMI">ssmi</value>
       <value compset="DICE%SIAF">ssmi_iaf</value>
       <value compset="DICE%PRES">prescribed</value>
@@ -42,13 +51,6 @@
       in the same file because the SST and ice fraction data are derived from the
       same observational data sets and are consistent with each other.</desc>
   </entry>
-
-  <description>
-    <desc compset="DICE%SSMI">dice mode is ssmi:</desc>
-    <desc compset="DICE%SIAF">dice mode is ssmi_iaf:</desc>
-    <desc compset="DICE%PRES">dice mode is prescribed:</desc>
-    <desc compset="DICE%NULL">dice mode is null:</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/data_comps/dlnd/cime_config/config_component.xml
+++ b/src/components/data_comps/dlnd/cime_config/config_component.xml
@@ -4,6 +4,14 @@
 
 <entry_id>
 
+  <!-- NOTE that the description block determines what DLND% values can appear in the compset name 
+       For DLND this is determined by the DLND_MODE values -->
+  <description>
+    <desc compset="_DLND%NULL">dlnd modes are DLND_MODE=NULL:</desc>
+    <desc compset="_DLND%SCPL">dlnd modes for coupler-hist snow coupling are DLND_MODE=GLC_CPLHIST:</desc>
+    <desc compset="_DLND%LCPL">dlnd modes for coupler-hist non-snow coupling are DLND_MODE=CPLHIST:</desc>
+  </description>
+
   <entry id="COMP_LND">
     <type>char</type>
     <valid_values>dlnd</valid_values>
@@ -17,7 +25,7 @@
     <type>char</type>
     <valid_values>CPLHIST,GLC_CPLHIST,NULL</valid_values>
     <default_value>NULL</default_value>
-    <values>
+    <values match="last">
       <value compset="DLND%NULL">NULL</value>
       <value compset="DLND%LCPL">CPLHIST</value>
       <value compset="DLND%SCPL">GLC_CPLHIST</value>
@@ -33,7 +41,7 @@
   <entry id="DLND_CPLHIST_DIR">
     <type>char</type>
     <default_value>UNSET</default_value>
-    <values>
+    <values match="last">
       <value compset="2000.*_DLND%SCPL" grid="l%0.9x1.25">$DIN_LOC_ROOT/lnd/dlnd7/CPLHIST_SNO/b.e10.BG20TRCN.f09_g16.002_c121001</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">$DIN_LOC_ROOT/lnd/dlnd7/CPLHIST_SNO/b.e10.BG1850CN.f09_g16.002_c121001</value>
       <value compset="HIST.*_DLND%SCPL" grid="l%0.9x1.25">$DIN_LOC_ROOT/lnd/dlnd7/CPLHIST_SNO/b.e10.BG20TRCN.f09_g16.002_c121001</value>
@@ -48,7 +56,7 @@
   <entry id="DLND_CPLHIST_CASE">
     <type>char</type>
     <default_value>UNSET</default_value>
-    <values>
+    <values match="last">
       <value compset="2000.*_DLND%SCPL" grid="l%0.9x1.25">b.e10.BG20TRCN.f09_g16.002</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">b.e10.BG1850CN.f09_g16.002</value>
       <value compset="HIST.*_DLND%SCPL" grid="l%0.9x1.25">b.e10.BG20TRCN.f09_g16.002</value>
@@ -63,7 +71,7 @@
   <entry id="DLND_CPLHIST_YR_ALIGN">
     <type>integer</type>
     <default_value>1</default_value>
-    <values>
+    <values match="last">
       <value compset="2000.*_DLND%SCPL" grid="l%0.9x1.25">1</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">1</value>
       <value compset="HIST.*_DLND%SCPL" grid="l%0.9x1.25">1850</value>
@@ -78,7 +86,7 @@
   <entry id="DLND_CPLHIST_YR_START">
     <type>integer</type>
     <default_value>1</default_value>
-    <values>
+    <values match="last">
       <value compset="2000.*_DLND%SCPL" grid="l%0.9x1.25">1976</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">26</value>
       <value compset="HIST.*_DLND%SCPL" grid="l%0.9x1.25">1850</value>
@@ -93,7 +101,7 @@
   <entry id="DLND_CPLHIST_YR_END">
     <type>integer</type>
     <default_value>1</default_value>
-    <values>
+    <values match="last">
       <value compset="2000.*_DLND%SCPL" grid="l%0.9x1.25">2005</value>
       <value compset="1850.*_DLND%SCPL" grid="l%0.9x1.25">100</value>
       <value compset="HIST.*_DLND%SCPL" grid="l%0.9x1.25">2005</value>
@@ -104,12 +112,6 @@
     <file>env_run.xml</file>
     <desc>ending year to loop data over (only used for CPLHIST mode)</desc>
   </entry>
-
-  <description>
-    <desc compset="_DLND%NULL">dlnd modes are DLND_MODE=NULL:</desc>
-    <desc compset="_DLND%SCPL">dlnd modes are DLND_MODE=GLC_CPLHIST:</desc>
-    <desc compset="_DLND%LCPL">dlnd modes are DLND_MODE=CPLHIST:</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/src/components/data_comps/docn/cime_config/config_component.xml
@@ -4,6 +4,28 @@
 
 <entry_id>
 
+  <!-- NOTE that the description block determines what DOCN% values can appear in the compset name 
+       For DOCN this is determined by the DOCN_MODE values -->
+  <description>
+    <desc compset="_DOCN%NULL">docn null mode</desc>
+    <desc compset="_DOCN%DOM">docn prescribed ocean mode</desc>
+    <desc compset="_DOCN%SOM">docn slab ocean mode</desc>
+    <desc compset="_DOCN%SOMAQP">docn aquaplanet slab ocean mode</desc>
+    <desc compset="_DOCN%IAF">docn interannual mode</desc>
+    <desc compset="_DOCN%SST_AQUAP">docn aquaplanet mode:</desc>
+    <desc compset="_DOCN%AQP1">docn analytic aquaplanet sst - option 1</desc>
+    <desc compset="_DOCN%AQP2">docn analytic aquaplanet sst - option 2</desc>
+    <desc compset="_DOCN%AQP3">docn analytic aquaplanet sst - option 3</desc>
+    <desc compset="_DOCN%AQP4">docn analytic aquaplanet sst - option 4</desc>
+    <desc compset="_DOCN%AQP5">docn analytic aquaplanet sst - option 5</desc>
+    <desc compset="_DOCN%AQP6">docn analytic aquaplanet sst - option 6</desc>
+    <desc compset="_DOCN%AQP7">docn analytic aquaplanet sst - option 7</desc>
+    <desc compset="_DOCN%AQP8">docn analytic aquaplanet sst - option 8</desc>
+    <desc compset="_DOCN%AQP9">docn analytic aquaplanet sst - option 9</desc>
+    <desc compset="_DOCN%AQP10">docn analytic aquaplanet sst - option 10</desc>
+    <desc compset="_DOCN%AQPFILE">docn file input aquaplanet sst </desc>
+  </description>
+
   <entry id="COMP_OCN">
     <type>char</type>
     <valid_values>docn</valid_values>
@@ -17,7 +39,7 @@
     <type>char</type>
     <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,sst_aquapfile,som,som_aquap,interannual,null</valid_values>
     <default_value>prescribed</default_value>
-    <values>
+    <values match="last">
       <value compset="_DOCN%NULL_">null</value>
       <value compset="_DOCN%DOM_" >prescribed</value>
       <value compset="_DOCN%SOM_" >som</value>
@@ -81,7 +103,7 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>UNSET</default_value>
-    <values>
+    <values match="last">
       <value compset="_DOCN%SOM.*_TEST">pop_frc.1x1d.090130.nc</value>
       <value compset="_DOCN%SOMAQP" grid="oi%1.9x2.5">default.som.forcing.aquaplanet.Qflux0_h30_sstQOBS.2degFV_c20170421.nc</value>
       <value compset="_DOCN%SOMAQP" grid="oi%0.9x1.25">default.som.forcing.aquaplanet.Qflux0_h30_sstQOBS.1degFV_c20170421.nc</value>
@@ -96,7 +118,7 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>UNSET</default_value>
-    <values>
+    <values match="last">
       <value compset="_DOCN%AQPFILE">sst_c4aquasom_0.9x1.25_clim.c170512.nc</value>
     </values>
     <group>run_component_docn</group>
@@ -120,7 +142,7 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_c101029.nc</default_value>
-    <values>
+    <values match="last">
       <value compset="DOCN%DOM" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_c050526.nc</value>
       <value compset="DOCN%DOM" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_c061031.nc</value>
       <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
@@ -154,7 +176,7 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.1x1.111007.nc</default_value>
-    <values>
+    <values match="last">
       <value compset="DOCN%DOM" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
       <value compset="DOCN%DOM" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc </value>
       <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v6"			>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
@@ -191,7 +213,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>1</default_value>
-    <values>
+    <values match="last">
       <value compset="(AMIP_|20TR_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
     </values>
     <group>run_component_cam_sstice</group>
@@ -213,7 +235,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>0</default_value>
-    <values>
+    <values match="last">
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)">1850</value>
     </values>
     <group>run_component_cam_sstice</group>
@@ -229,7 +251,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>0</default_value>
-    <values>
+    <values match="last">
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)">2012</value>
     </values>
     <group>run_component_cam_sstice</group>
@@ -240,26 +262,6 @@
     years 50-99 in the file will not be used.
     This is only used when DOCN_MODE=prescribed.</desc>
   </entry>
-
-  <description>
-    <desc compset="_DOCN%NULL">docn null mode</desc>
-    <desc compset="_DOCN%DOM" >docn prescribed ocean mode</desc>
-    <desc compset="_DOCN%SOM" >docn slab ocean mode</desc>
-    <desc compset="_DOCN%SOMAQP">docn aquaplanet slab ocean mode</desc>
-    <desc compset="_DOCN%IAF" >docn interannual mode</desc>
-    <desc compset="_DOCN%SST_AQUAP">docn aquaplanet mode:</desc>
-    <desc compset="_DOCN%AQP1">docn analytic aquaplanet sst - option 1</desc>
-    <desc compset="_DOCN%AQP2">docn analytic aquaplanet sst - option 2</desc>
-    <desc compset="_DOCN%AQP3">docn analytic aquaplanet sst - option 3</desc>
-    <desc compset="_DOCN%AQP4">docn analytic aquaplanet sst - option 4</desc>
-    <desc compset="_DOCN%AQP5">docn analytic aquaplanet sst - option 5</desc>
-    <desc compset="_DOCN%AQP6">docn analytic aquaplanet sst - option 6</desc>
-    <desc compset="_DOCN%AQP7">docn analytic aquaplanet sst - option 7</desc>
-    <desc compset="_DOCN%AQP8">docn analytic aquaplanet sst - option 8</desc>
-    <desc compset="_DOCN%AQP9">docn analytic aquaplanet sst - option 9</desc>
-    <desc compset="_DOCN%AQP10">docn analytic aquaplanet sst - option 10</desc>
-    <desc compset="_DOCN%AQPFILE">docn file input aquaplanet sst </desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/data_comps/drof/cime_config/config_component.xml
+++ b/src/components/data_comps/drof/cime_config/config_component.xml
@@ -4,6 +4,15 @@
 
 <entry_id>
 
+  <!-- NOTE that the description block determines what DROF% values can appear in the compset name 
+       For DROF this is determined by the DROF_MODE values -->
+  <description>
+    <desc compset="_DROF%NULL">NULL drof mode:</desc>
+    <desc compset="_DROF%NYF" >COREv2 drof normal year forcing:</desc>
+    <desc compset="_DROF%IAF" >COREv2 drof interannual year forcing:</desc>
+    <desc compset="_DROF%CPLHIST">CPLHIST mode:</desc>
+  </description>
+
   <entry id="COMP_ROF">
     <type>char</type>
     <valid_values>drof</valid_values>
@@ -17,7 +26,7 @@
     <type>char</type>
     <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
-    <values>
+    <values match="last"> 
       <value compset="_DROF%NULL">NULL</value>
       <value compset="_DROF%NYF" >DIATREN_ANN_RX1</value>
       <value compset="_DROF%IAF" >DIATREN_IAF_RX1</value>
@@ -80,13 +89,6 @@
     <file>env_run.xml</file>
     <desc>ending year to loop data over (only used for CPLHIST mode)</desc>
   </entry>
-
-  <description>
-    <desc compset="_DROF%NULL">NULL drof mode:</desc>
-    <desc compset="_DROF%NYF" >COREv2 drof normal year forcing:</desc>
-    <desc compset="_DROF%IAF" >COREv2 drof interannual year forcing:</desc>
-    <desc compset="_DROF%CPLHIST">CPLHIST mode:</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/data_comps/dwav/cime_config/config_component.xml
+++ b/src/components/data_comps/dwav/cime_config/config_component.xml
@@ -2,6 +2,13 @@
 
 <entry_id>
 
+  <!-- NOTE that the description block determines what DWAV% values can appear in the compset name 
+       For DWAV this is determined by the DWAV_MODE values -->
+  <description>
+    <desc compset="_DWAV%NULL">dwav null mode:</desc>
+    <desc compset="_DWAV%CLIMO">dwav climatological mode:</desc>
+  </description>
+
   <entry id="COMP_WAV">
     <type>char</type>
     <valid_values>dwav</valid_values>
@@ -15,7 +22,7 @@
     <type>char</type>
     <valid_values>NULL,CLIMO</valid_values>
     <default_value>NULL</default_value>
-    <values>
+    <values match="last">
       <value compset="_DWAV%NULL">NULL</value>
       <value compset="_DWAV%CLIMO">CLIMO</value>
     </values>
@@ -25,11 +32,6 @@
       In null mode, land forcing is set to zero and not used.
       default is copyall</desc>
   </entry>
-
-  <description>
-    <desc compset="_DWAV%NULL">dwav null mode:</desc>
-    <desc compset="_DWAV%CLIMO">dwav climatological mode:</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -384,7 +384,7 @@
   <entry id="PAUSE_COMPONENT_LIST">
     <type>char</type>
     <default_value>none</default_value>
-    <values>
+    <values match="last">
       <value compset="_DESP">cpl</value>
     </values>
     <group>run_begin_stop_restart</group>
@@ -1906,7 +1906,7 @@
 
   <entry id="NTASKS">
     <type>integer</type>
-    <values>
+    <values match="last">
       <value component="ATM"> 0</value>
       <value component="CPL"> 0</value>
       <value component="OCN"> 0</value>
@@ -1924,7 +1924,7 @@
 
   <entry id="NTHRDS">
     <type>integer</type>
-    <values>
+    <values match="last">
       <value component="ATM">1</value>
       <value component="CPL">1</value>
       <value component="OCN">1</value>
@@ -1942,7 +1942,7 @@
 
   <entry id="ROOTPE">
     <type>integer</type>
-    <values>
+    <values match="last">
       <value component="ATM">0</value>
       <value component="CPL">0</value>
       <value component="OCN">0</value>
@@ -1960,7 +1960,7 @@
 
   <entry id="NINST">
     <type>integer</type>
-    <values>
+    <values match="last">
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>
@@ -1978,7 +1978,7 @@
   <entry id="NINST_LAYOUT">
     <type>char</type>
     <valid_values>sequential,concurrent</valid_values>
-    <values>
+    <values match="last">
       <value component="ATM">concurrent</value>
       <value component="OCN">concurrent</value>
       <value component="WAV">concurrent</value>
@@ -1995,7 +1995,7 @@
 
   <entry id="PSTRID">
     <type>integer</type>
-    <values>
+    <values match="last">
       <value component="ATM">1</value>
       <value component="CPL">1</value>
       <value component="OCN">1</value>
@@ -2170,7 +2170,7 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio io type</desc>
-    <values>
+    <values match="last">
       <value component="ATM">default</value>
       <value component="CPL">default</value>
       <value component="OCN">default</value>
@@ -2191,7 +2191,7 @@
      stride in compute comm of io tasks for each component, if this value is -99 it will
      be computed based on PIO_NUMTASKS and number of compute tasks
     </desc>
-    <values>
+    <values match="last">
       <value component="ATM"></value>
       <value component="CPL"></value>
       <value component="OCN"></value>
@@ -2210,7 +2210,7 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio rearranger choice box=1, subset=2 </desc>
-    <values>
+    <values match="last">
       <value>$PIO_VERSION</value>
       <value component="ATM"></value>
       <value component="CPL"></value>
@@ -2229,7 +2229,7 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio root processor relative to component root</desc>
-    <values>
+    <values match="last">
       <value component="ATM">1</value>
       <value component="CPL">1</value>
       <value component="OCN">1</value>
@@ -2250,7 +2250,7 @@
       pio number of io tasks, if this value is -99 it will be computed based on PIO_STRIDE and
       number of tasks
     </desc>
-    <values>
+    <values match="last">
       <value component="ATM">-99</value>
       <value component="CPL">-99</value>
       <value component="OCN">-99</value>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1906,7 +1906,7 @@
 
   <entry id="NTASKS">
     <type>integer</type>
-    <values match="last">
+    <values>
       <value component="ATM"> 0</value>
       <value component="CPL"> 0</value>
       <value component="OCN"> 0</value>
@@ -1924,7 +1924,7 @@
 
   <entry id="NTHRDS">
     <type>integer</type>
-    <values match="last">
+    <values>
       <value component="ATM">1</value>
       <value component="CPL">1</value>
       <value component="OCN">1</value>
@@ -1942,7 +1942,7 @@
 
   <entry id="ROOTPE">
     <type>integer</type>
-    <values match="last">
+    <values>
       <value component="ATM">0</value>
       <value component="CPL">0</value>
       <value component="OCN">0</value>
@@ -1960,7 +1960,7 @@
 
   <entry id="NINST">
     <type>integer</type>
-    <values match="last">
+    <values>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>
@@ -1978,7 +1978,7 @@
   <entry id="NINST_LAYOUT">
     <type>char</type>
     <valid_values>sequential,concurrent</valid_values>
-    <values match="last">
+    <values>
       <value component="ATM">concurrent</value>
       <value component="OCN">concurrent</value>
       <value component="WAV">concurrent</value>
@@ -1995,7 +1995,7 @@
 
   <entry id="PSTRID">
     <type>integer</type>
-    <values match="last">
+    <values>
       <value component="ATM">1</value>
       <value component="CPL">1</value>
       <value component="OCN">1</value>
@@ -2170,7 +2170,7 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio io type</desc>
-    <values match="last">
+    <values>
       <value component="ATM">default</value>
       <value component="CPL">default</value>
       <value component="OCN">default</value>
@@ -2191,7 +2191,7 @@
      stride in compute comm of io tasks for each component, if this value is -99 it will
      be computed based on PIO_NUMTASKS and number of compute tasks
     </desc>
-    <values match="last">
+    <values>
       <value component="ATM"></value>
       <value component="CPL"></value>
       <value component="OCN"></value>
@@ -2210,7 +2210,7 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio rearranger choice box=1, subset=2 </desc>
-    <values match="last">
+    <values>
       <value>$PIO_VERSION</value>
       <value component="ATM"></value>
       <value component="CPL"></value>
@@ -2229,7 +2229,7 @@
     <group>run_pio</group>
     <file>env_run.xml</file>
     <desc>pio root processor relative to component root</desc>
-    <values match="last">
+    <values>
       <value component="ATM">1</value>
       <value component="CPL">1</value>
       <value component="OCN">1</value>
@@ -2250,7 +2250,7 @@
       pio number of io tasks, if this value is -99 it will be computed based on PIO_STRIDE and
       number of tasks
     </desc>
-    <values match="last">
+    <values>
       <value component="ATM">-99</value>
       <value component="CPL">-99</value>
       <value component="OCN">-99</value>

--- a/src/drivers/mct/cime_config/config_component_acme.xml
+++ b/src/drivers/mct/cime_config/config_component_acme.xml
@@ -52,7 +52,7 @@
     <type>char</type>
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
     <default_value>never</default_value>
-    <values>
+    <values match="last">
       <value compset="_DATM.+_CLM">ndays</value>
     </values>
     <group>run_begin_stop_restart</group>
@@ -66,7 +66,7 @@
     <type>real</type>
     <valid_values></valid_values>
     <default_value>284.7</default_value>
-    <values>
+    <values match="last">
       <value compset="^2000">367.0</value>
       <value compset="^4804">367.0</value>
     </values>
@@ -82,7 +82,7 @@
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
-    <values>
+    <values match="last">
       <value compset="%WISO">TRUE</value>
       <value compset="%ISO">TRUE</value>
     </values>
@@ -152,7 +152,7 @@
     <type>char</type>
     <valid_values>CESM1_ORIG,CESM1_ORIG_TIGHT,CESM1_MOD,CESM1_MOD_TIGHT,RASM_OPTION1,RASM_OPTION2</valid_values>
     <default_value>CESM1_MOD_TIGHT</default_value>
-    <values>
+    <values match="last">
       <value compset="_DATM.*_DOCN%SOM"          >CESM1_MOD</value>
       <value compset="_POP2"                     >CESM1_MOD</value>
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN">CESM1_MOD</value>
@@ -186,7 +186,7 @@
     <type>char</type>
     <valid_values>none,CO2A,CO2B,CO2C,CO2_DMSA</valid_values>
     <default_value>none</default_value>
-    <values>
+    <values match="last">
       <value compset="_CAM\d+"     >CO2A</value>
       <value compset="_DATM"    >none</value>
       <value compset="_BGC%BPRP">CO2C</value>
@@ -209,7 +209,7 @@
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <default_value>day</default_value>
-    <values>
+    <values match="last">
       <value compset="_DLND.*_CISM\d">year</value>
       <value compset="_DLND.*_MPASLI">year</value>
       <value compset="_SLND.*SOCN.*_MPASLI">day</value>
@@ -227,7 +227,7 @@
   <entry id="ATM_NCPL">
     <type>integer</type>
     <default_value>48</default_value>
-    <values>
+    <values match="last">
       <value compset="_SATM">48</value>
       <value compset="_XATM">48</value>
       <value compset="_CAM.*">48</value>
@@ -281,7 +281,7 @@
   <entry id="LND_NCPL">
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
-    <values>
+    <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DLND.*_MPASLI">1</value>
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
@@ -301,7 +301,7 @@
   <entry id="ICE_NCPL">
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
-    <values>
+    <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DLND.*_MPASLI">1</value>
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
@@ -321,7 +321,7 @@
   <entry id="OCN_NCPL">
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
-    <values>
+    <values match="last">
       <value compset="_POP2">1</value>
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
       <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
@@ -351,7 +351,7 @@
   <entry id="GLC_NCPL">
     <type>integer</type>
     <default_value>1</default_value>
-    <values>
+    <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DLND.*_MPASLI">1</value>
       <value compset="_SLND.*SOCN.*_MPASLI">1</value>
@@ -386,7 +386,7 @@
   <entry id="ROF_NCPL">
     <type>integer</type>
     <default_value>8</default_value>
-    <values>
+    <values match="last">
       <value compset=".+" grid="a%ne4np4">6</value>
       <value compset=".+" grid="a%ne11np4">6</value>
       <value compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
@@ -428,7 +428,7 @@
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
-    <values>
+    <values match="last">
       <value compset="DATM.+POP\d">TRUE</value>
       <value compset="DATM.*_MPASO">TRUE</value>
       <value compset="DATM.+DOCN%IAF">TRUE</value>
@@ -455,7 +455,7 @@
     <type>char</type>
     <valid_values>off,ocn</valid_values>
     <default_value>off</default_value>
-    <values>
+    <values match="last">
       <value compset="DATM.+POP\d">ocn</value>
     </values>
     <group>run_component_cpl</group>
@@ -475,7 +475,7 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>never</default_value>
-    <values>
+    <values match="last">
       <value compset="_DOCN%IAF">nmonths</value>
     </values>
     <group>run_drv_history</group>
@@ -487,7 +487,7 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>-999</default_value>
-    <values>
+    <values match="last">
       <value compset="_DOCN%IAF">1</value>
     </values>
     <group>run_drv_history</group>
@@ -508,7 +508,7 @@
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
-    <values>
+    <values match="last">
       <value compset="DATM.*_POP\d"    >TRUE</value>
       <value compset="CAM.*_POP\d"     >TRUE</value>
       <value compset="CAM.*_DOCN%SOM">TRUE</value>
@@ -522,7 +522,7 @@
     <type>real</type>
     <valid_values></valid_values>
     <default_value>379.000</default_value>
-    <values>
+    <values match="last">
       <value compset="^1850"					>284.7</value>
       <value compset="^HIST.+BGC%BPRP"				>284.7</value>
       <value compset="^20TR.+BGC%BPRP"				>284.7</value>
@@ -596,7 +596,7 @@
     <type>integer</type>
     <valid_values></valid_values>
     <default_value>0</default_value>
-    <values>
+    <values match="last">
       <!-- estimated cost (used only for development purposes) -->
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN.*_DROF.*_SGLC_SWAV"		>-3</value> <!-- A -->
       <value compset="_DATM.*_DICE.*_DOCN.*_WW3"				>-3</value> <!-- A_WAV -->
@@ -639,7 +639,7 @@
     <type>integer</type>
     <valid_values>0,1,3,5,10,36</valid_values>
     <default_value>10</default_value>
-    <values>
+    <values match="last">
       <value compset="_SGLC">0</value>
     </values>
     <group>run_glc</group>
@@ -652,7 +652,7 @@
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
-    <values>
+    <values match="last">
       <value compset="_CLM45.+CISM\d">TRUE</value>
       <value compset="_CLM45.*_MPASLI">TRUE</value>
       <value compset="_CLM50.+CISM\d">TRUE</value>

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -54,7 +54,7 @@
     <type>char</type>
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
     <default_value>never</default_value>
-    <values>
+    <values match="last">
       <value compset="_DATM.+_CLM">ndays</value>
     </values>
     <group>run_begin_stop_restart</group>
@@ -68,9 +68,9 @@
     <type>char</type>
     <valid_values>none,CO2A,CO2B,CO2C,CO2_DMSA</valid_values>
     <default_value>none</default_value>
-    <values>
-      <value compset="_CAM"  >CO2A</value>
-      <value compset="_DATM"    >none</value>
+    <values match="last">
+      <value compset="_CAM">CO2A</value>
+      <value compset="_DATM">none</value>
       <value compset="_DATM%CPLHIST.+POP\d">CO2A</value>
       <value compset="_BGC%BPRP">CO2C</value>
       <value compset="_BGC%BDRD">CO2C</value>
@@ -91,7 +91,7 @@
     <group>run_coupling</group>
     <file>env_run.xml</file>
     <default_value>day</default_value>
-    <values>
+    <values match="last">
       <value compset="_DLND.*_CISM\d">year</value>
       <value compset="_MPAS"       >hour</value>
     </values>
@@ -103,13 +103,10 @@
   <entry id="ATM_NCPL">
     <type>integer</type>
     <default_value>48</default_value>
-    <values>
-      <value compset="_CAM.*">48</value>
+    <values match="last">
       <value compset="_CAM\d+%WCBC">144</value>
       <value compset="_CAM\d+%WCMX">288</value>
       <value compset="_CAM\d+%WCXI">288</value>
-      <value compset="_CAM%ADIAB">48</value>
-      <value compset="_CAM%IDEAL">48</value>
       <value compset="_DATM%COPYALL_NPS">72</value>
       <value compset="_DATM.*_CLM">48</value>
       <value compset="_DATM.*_DICE.*_POP2">4</value>
@@ -143,7 +140,7 @@
   <entry id="LND_NCPL">
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
-    <values>
+    <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
     </values>
     <group>run_coupling</group>
@@ -156,7 +153,7 @@
   <entry id="ICE_NCPL">
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
-    <values>
+    <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
     </values>
     <group>run_coupling</group>
@@ -169,7 +166,7 @@
   <entry id="OCN_NCPL">
     <type>integer</type>
     <default_value>$ATM_NCPL</default_value>
-    <values>
+    <values match="last">
       <value compset="_POP2">1</value>
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
       <value compset="_POP2" grid="oi%gx1v6">24</value>
@@ -192,7 +189,7 @@
   <entry id="GLC_NCPL">
     <type>integer</type>
     <default_value>1</default_value>
-    <values>
+    <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
     </values>
     <group>run_coupling</group>
@@ -224,7 +221,7 @@
   <entry id="ROF_NCPL">
     <type>integer</type>
     <default_value>8</default_value>
-    <values>
+    <values match="last">
       <value compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
       <value compset="_DATM.*_SLND.*_DICE.*_DOCN">$ATM_NCPL</value>
@@ -256,7 +253,7 @@
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
-    <values>
+    <values match="last">
       <value compset="DATM.+POP\d">TRUE</value>
       <value compset="DATM.+DOCN%IAF">TRUE</value>
       <value compset="DATM%CPLHIST.+POP\d">FALSE</value>
@@ -283,7 +280,7 @@
     <type>char</type>
     <valid_values>off,ocn</valid_values>
     <default_value>off</default_value>
-    <values>
+    <values match="last">
       <value compset="DATM.+POP\d">ocn</value>
       <value compset="DATM%CPLHIST.+POP\d">off</value>
     </values>
@@ -304,7 +301,7 @@
     <type>char</type>
     <valid_values>CESM1_ORIG,CESM1_ORIG_TIGHT,CESM1_MOD,CESM1_MOD_TIGHT,RASM_OPTION1,RASM_OPTION2</valid_values>
     <default_value>CESM1_MOD_TIGHT</default_value>
-    <values>
+    <values match="last">
       <value compset="_DATM.*_DOCN%SOM"          >CESM1_MOD</value>
       <value compset="_POP2"                     >CESM1_MOD</value>
       <value compset="_POP2" grid="oi%gx1v6"     >RASM_OPTION1</value>
@@ -338,7 +335,7 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>never</default_value>
-    <values>
+    <values match="last">
       <value compset="_DOCN%IAF">nmonths</value>
     </values>
     <group>run_drv_history</group>
@@ -350,7 +347,7 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>-999</default_value>
-    <values>
+    <values match="last">
       <value compset="_DOCN%IAF">1</value>
     </values>
     <group>run_drv_history</group>
@@ -371,7 +368,7 @@
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
-    <values>
+    <values match="last">
       <value compset="DATM.*_POP\d">TRUE</value>
       <value compset="CAM.*_POP\d">TRUE</value>
       <value compset="CAM.*_DOCN%SOM">TRUE</value>
@@ -385,7 +382,7 @@
     <type>real</type>
     <valid_values></valid_values>
     <default_value>284.7</default_value>
-    <values>
+    <values match="last">
       <value compset="^2000">367.0</value>
       <value compset="DATM.*POP2%ECO">284.7</value>
     </values>
@@ -402,7 +399,7 @@
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
-    <values>
+    <values match="last">
       <value compset="%WISO">TRUE</value>
       <value compset="%ISO">TRUE</value>
     </values>
@@ -415,7 +412,7 @@
     <type>integer</type>
     <valid_values>0,1,3,5,10,36</valid_values>
     <default_value>10</default_value>
-    <values>
+    <values match="last">
       <value compset="_SGLC">0</value>
     </values>
     <group>run_glc</group>
@@ -428,7 +425,7 @@
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
-    <values>
+    <values match="last">
       <value compset="_CLM45.+CISM\d">TRUE</value>
       <value compset="_CLM50.+CISM\d">TRUE</value>
       <!-- Turn on two-way coupling for TG compsets - even though there are no


### PR DESCRIPTION
New match attribute that can be 'last' or 'first' for values match in component.py

Currently there is confusion as to how matches are found for multiple
`<value>` elements in a `<values>` node.

- `component.py ` is currently using a matching algorithm that picks the
  **last** match in case of multiple matches that are found. This
  matching algorithm is used anytime a Component object is
  instantiated (currently occurs in config_component.xml). By default
  if the match attribute DOES NOT appear, then the **last** match will
  be used, to make things backwards compatible.

- `namelist_definition_<component>.xml` uses the `entry_id.py`
  matching algorithm which picks the **first** match in case of
  multiple matches being found. So for setting namelists the first
  match is picked.

This PR adds a new, optional, attribute to the `<entry>` element in
EITHER a `config_component.xml`, `config_compset.xml` or `namelist_definition_<component>.xml` file.

```
<entry id="<name>">
   <values match="last"> will pick the last best match
   <values match="first"> will pick the first best match
      <value>...</value>
      <value>...</value>
   <values>
<entry_id>
```

As a result, there is new flexibility and transparency in how matches
are determined in component.py by adding a `match` attribute that can
be 'first' or 'last'. Having this be explicit will enable developers
to not trip up on assuming 'first' or 'last' match and be wrong. 
This capability has been added to the _get_value_match routine in BOTH 
entry_id.py AND component.py. However, the default values differ:
   - the default "match" value entry_id.py is "first"
   - the default "match" value in component.py is "last"
Having these default values differ preserves backwards compatibility when the 
"match" attribute is not there. Moving forwards, it would be good to always
have a "match" attribute.

The new `match = "last" `attribute has been added to all of the data
components component_component.xml and the config_component_cesm.xml
and config_component_acme.xml.

Test suite: scripts_regressions_tests and
   also verified that running the prealpha and prebeta tests on
   cheyenne, with just namelist comparisons, resulted in identical
   namelists when compared to cesm2_0_alpha06m
Test baseline: cesm2_0_alpha06m for cesm
Test namelist changes: None
Test status: bit for bit

Fixes #1617 

User interface changes?: New match attribute <values> elements that are children of `<entry>` nodes.

Code review: gold2718
