### PR TITLE
Macport issues

### DIFF
--- a/config/acme/machines/Makefile
+++ b/config/acme/machines/Makefile
@@ -90,12 +90,7 @@ ifeq ($(USE_ESMF_LIB), TRUE)
    CPPDEFS += -DUSE_ESMF_LIB
 endif
 
-# ESMF_INTERFACE is currently only defined in env_build.xml
-ifeq ($(COMP_INTERFACE), ESMF)
-   CPPDEFS += -DESMF_INTERFACE
-else
-   CPPDEFS += -DMCT_INTERFACE
-endif
+CPPDEFS += -DMCT_INTERFACE
 
 ifeq ($(strip $(MPILIB)),mpi-serial)
   CPPDEFS += -DNO_MPI2
@@ -351,6 +346,7 @@ else
   endif
 endif
 
+COMP_INTERFACE := $(shell echo $(COMP_INTERFACE) | tr A-Z a-z)
 #===============================================================================
 # Set include paths (needed after override for any model specific builds below)
 #===============================================================================

--- a/config/cesm/machines/Makefile
+++ b/config/cesm/machines/Makefile
@@ -88,12 +88,7 @@ ifeq ($(USE_ESMF_LIB), TRUE)
    CPPDEFS += -DUSE_ESMF_LIB
 endif
 
-# ESMF_INTERFACE is currently only defined in env_build.xml
-ifeq ($(COMP_INTERFACE), ESMF)
-   CPPDEFS += -DESMF_INTERFACE
-else
-   CPPDEFS += -DMCT_INTERFACE
-endif
+COMP_INTERFACE := $(shell echo $(COMP_INTERFACE) | tr A-Z a-z)
 
 ifeq ($(strip $(MPILIB)),mpi-serial)
   CPPDEFS += -DNO_MPI2

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -487,9 +487,6 @@ cp {}/scripts/tests/cpl.hi2.nc.test {}/{}.cpl.hi.0.nc.rest
         super(TESTTESTDIFF, self).build_phase(sharedlib_only=sharedlib_only,
                                               model_only=model_only)
 
-    def run_indv(self, suffix=None, st_archive=False ):
-        super(TESTTESTDIFF,self).run_indv(suffix, st_archive)
-
     def run_phase(self):
         super(TESTTESTDIFF, self).run_phase()
         self._component_compare_test("base", "rest")

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -480,7 +480,7 @@ class TESTTESTDIFF(FakeTest):
 """
 echo Insta pass
 echo SUCCESSFUL TERMINATION > {}/cpl.log.$LID
-cp {}/scripts/tests/cpl.hi1.nc.test {}/{}.cpl.hi.0.nc.base
+cp {}/scripts/tests/cpl.hi1.nc.test {}/{}.cpl.hi.0.nc
 cp {}/scripts/tests/cpl.hi2.nc.test {}/{}.cpl.hi.0.nc.rest
 """.format(rundir, cimeroot, rundir, case, cimeroot, rundir, case)
         self._set_script(script)

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -163,7 +163,7 @@ class Machines(GenericXML):
             self.machine = machine
 
         return machine
-
+    #pylint: disable=arguments-differ
     def get_value(self, name, attributes=None, resolved=True, subgroup=None):
         """
         Get Value of fields in the config_machines.xml file


### PR DESCRIPTION
Further cleanup and fixes addressing running scripts_regression_tests.py on a mac.
Issue #1644 is an outstanding problem with this port.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
