### PR TITLE
Fix relative path for --user-mods-dir

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -65,7 +65,13 @@ OR
 
     parser.add_argument("--user-mods-dir", "-user_mods_dir",
                         help="Path to directory with user_nl_* files and xmlchange "
-                        "commands to utilize. This can also include SourceMods")
+                        "commands to utilize. This can also include SourceMods. "
+                        "This can be an absolute path, a path relative to the "
+                        "current directory, or a path relative to "
+                        "cime_config/usermods_dirs/ under the primary component "
+                        "for the given compset (for example, in an F compset "
+                        "whose primary component is cam, '--user-mods-dir foo' "
+                        "could be found in components/cam/cime_config/usermods_dirs/foo).")
 
     parser.add_argument("--user-compset", action="store_true",
                         help="If set, then the --compset argument is treated as a user specified compset."

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -178,6 +178,10 @@ def _main_func(description):
     else:
         caseroot = os.path.abspath(script_root)
 
+    if user_mods_dir is not None:
+        if os.path.isdir(user_mods_dir):
+            user_mods_dir = os.path.abspath(user_mods_dir)
+
     # create_test creates the caseroot before calling create_newcase
     # otherwise throw an error if this directory exists
     expect(not (os.path.exists(caseroot) and not test),
@@ -202,9 +206,6 @@ def _main_func(description):
 
         # Write out the case files
         case.flush(flushall=True)
-        if user_mods_dir is not None:
-            if os.path.isdir(user_mods_dir):
-                user_mods_dir = os.path.abspath(user_mods_dir)
         case.apply_user_mods(user_mods_dir)
 
     # Lock env_case.xml


### PR DESCRIPTION
Converts user_mods_dir to abspath earlier

This is needed for relative paths to be handled correctly. The problem
with the former placement was that the working directory had been
changed to be inside the new case directory at that point, which made
os.path.isdir(user_mods_dir) False because it was interpreted as being
relative to the wrong starting point.

Test suite: scripts_regression_tests on yellowstone: all passed except
ERP.f45_g37_rx1.A.yellowstone_intel, which failed initially due to what looked
like a system problem; it passed upon rerunning it
(Ran testing on branch rebased onto 8517405)

Also did some manual testing of various forms of --user-mods-dir:
- Relative path:
  ./create_newcase --case test_usermods_0607f --compset A --res f45_g37_rx1 --user-mods-dir ../src/drivers/mct/cime_config/testdefs/testmods_dirs/drv/default
- Absolute path:
  ./create_newcase --case test_usermods_0607g --compset A --res f45_g37_rx1 --user-mods-dir /Users/sacks/cime/src/drivers/mct/cime_config/testdefs/testmods_dirs/drv/default
- Testmods:
  ./create_test --test-root . SMS.f45_g37_rx1.A.roo2_gnu.drv-default
- Path relative to the primary component's cime_config/usermods_dirs:
  ./create_newcase --case test_usermods_0607h --compset A --res f45_g37_rx1 --user-mods-dir wjs_test

  where I had created a user_mods dir:

  src/drivers/mct/cime_config/usermods_dirs/wjs_test

Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #1642

User interface changes?: none

Code review: 
