### PR TITLE
Update gnu modules on cheyenne to use openmpi

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -196,7 +196,7 @@
     <NODENAME_REGEX>.*.cheyenne.ucar.edu</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>mpt</MPILIBS>
+    <MPILIBS>mpt,openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/glade/scratch/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>$ENV{CESMDATAROOT}/lmwg</DIN_LOC_ROOT_CLMFORC>
@@ -217,6 +217,12 @@
 	<arg name="labelstdout">-p "%g:"</arg>
 	<!-- the omplace argument needs to be last -->
 	<arg name="zthreadplacement"> omplace -tm open64 </arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="openmpi">
+      <executable>mpirun</executable>
+      <arguments>
+	<arg name="anum_tasks"> -np $TOTALPES</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="default" unit_testing="true">
@@ -257,17 +263,22 @@
       </modules>
       <modules compiler="gnu">
 	<command name="load">gnu/6.3.0</command>
+	<command name="load">openblas/0.2.14</command>
+      </modules>
+      <modules mpilib="mpt">
+	<command name="load">mpt/2.15f</command>
+	<command name="load">netcdf-mpi/4.4.1.1</command>
+	<command name="load">pnetcdf/1.8.0</command>
+      </modules>
+      <modules mpilib="openmpi">
+	<command name="load">openmpi/2.1.0</command>
+	<command name="load">netcdf/4.4.1.1</command>
       </modules>
       <modules>
-	<command name="load">mpt/2.15f</command>
 	<command name="load">ncarcompilers/0.3.5</command>
       </modules>
       <modules mpilib="mpi-serial">
 	<command name="load">netcdf/4.4.1.1</command>
-      </modules>
-      <modules mpilib="mpt">
-	<command name="load">netcdf-mpi/4.4.1.1</command>
-	<command name="load">pnetcdf/1.8.0</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
On cheyenne, gnu and mpt tests were failing to build.  Switching to openmpi
allows the tests to passing.  There is a remaining issue that there is not pnetcdf
or netcdf-mpi library available to openmpi at this time.

Test suite: scripts_regression_test.py
Test baseline:
Test namelist changes:
Test status:

Fixes [CIME Github issue #]

User interface changes?:

Code review:


