### PR TITLE
fix issue with case of comp_interface field

### DIFF
--- a/config/acme/machines/Makefile
+++ b/config/acme/machines/Makefile
@@ -346,7 +346,6 @@ else
   endif
 endif
 
-COMP_INTERFACE := $(shell echo $(COMP_INTERFACE) | tr A-Z a-z)
 #===============================================================================
 # Set include paths (needed after override for any model specific builds below)
 #===============================================================================

--- a/config/cesm/machines/Makefile
+++ b/config/cesm/machines/Makefile
@@ -88,8 +88,6 @@ ifeq ($(USE_ESMF_LIB), TRUE)
    CPPDEFS += -DUSE_ESMF_LIB
 endif
 
-COMP_INTERFACE := $(shell echo $(COMP_INTERFACE) | tr A-Z a-z)
-
 ifeq ($(strip $(MPILIB)),mpi-serial)
   CPPDEFS += -DNO_MPI2
 else

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -121,6 +121,7 @@ def _build_checks(case, build_threaded, comp_interface, use_esmf_lib,
     ninst_value  = case.get_value("NINST_VALUE")
     smp_build    = case.get_value("SMP_BUILD")
     build_status = case.get_value("BUILD_STATUS")
+    expect(comp_interface == "mct", "Only supporting mct comp_interface at this time")
 
     smpstr = ""
     inststr = ""

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -189,12 +189,6 @@ ERROR env_build HAS CHANGED
     ./case.build --clean-all
 """)
 
-    expect(comp_interface != "ESMF" or use_esmf_lib,
-           """
-ERROR COMP_INTERFACE IS ESMF BUT USE_ESMF_LIB IS NOT TRUE
-  SET USE_ESMF_LIB to TRUE with:
-    ./xmlchange -file env_build.xml -id USE_ESMF_LIB -value TRUE
-""")
 
     expect(mpilib != "mpi-serial" or not use_esmf_lib,
            """

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -484,9 +484,7 @@ class TestScheduler(object):
 
                 elif opt == 'E':
                     envtest.set_test_parameter("USE_ESMF_LIB", "TRUE")
-                    envtest.set_test_parameter("COMP_INTERFACE", "ESMF")
                     logger.debug (" USE_ESMF_LIB set to TRUE")
-                    logger.debug (" COMP_INTERFACE set to ESMF")
 
                 elif opt == 'CG':
                     envtest.set_test_parameter("CALENDAR", "GREGORIAN")

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -701,8 +701,8 @@
 
   <entry id="COMP_INTERFACE">
     <type>char</type>
-    <valid_values>MCT</valid_values>
-    <default_value>MCT</default_value>
+    <valid_values>mct</valid_values>
+    <default_value>mct</default_value>
     <group>build_def</group>
     <file>env_build.xml</file>
     <desc>use MCT component interface</desc>


### PR DESCRIPTION
Remove COMP_INTERFACE references to esmf and downcase the value.

Test suite: scripts_regression_tests.py, SMS_D.f19_f19.F1850.cori-knl_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
