### PR TITLE
add a test to assure flush is not triggered by instantiation of case

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -262,6 +262,15 @@ class J_TestCreateNewcase(unittest.TestCase):
 
         cls._do_teardown.append(testdir)
 
+    def test_aa_no_flush_on_instantiate(self):
+        testdir = os.path.join(self.__class__._testroot, 'testcreatenewcase')
+        with Case(testdir, read_only=False) as case:
+            self.assertFalse(case._env_files_that_need_rewrite, msg="Instantiating a case should not trigger a flush call")
+        with Case(testdir, read_only=False) as case:
+            case.set_value("HIST_OPTION","nsteps")
+            self.assertTrue(case._env_files_that_need_rewrite, msg="Expected flush call not triggered")
+
+
     def test_b_user_mods(self):
         cls = self.__class__
 


### PR DESCRIPTION
Add a test to scripts_regression_tests.py to assure that instantiating a case does 
not invoke a flush command.   

Test suite: scripts_regression_tests.py J_TestCreateNewcase 
(I also ran a case with a modified case.py in which I added a
case.set_value call to initilize_derived_attributes to make sure the test failed as expected.  it did. )


Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1628

User interface changes?: 

Code review: 
