### PR TITLE
User compset fixes

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -74,10 +74,9 @@ OR
                         "If the compset name is found as a supported compset, then it will be treated as such.")
 
     parser.add_argument("--pesfile",
-                        help="Only used and required for --user-compset argument."
-                        "Full pathname of the pes specification file"
-                        "This argument is required if --user-compset is True"
-                        "The file can follow either the config_pes.xml or the env_mach_pes.xml format")
+                        help="Full pathname of an optional pes specification "
+                        "file. The file can follow either the config_pes.xml or "
+                        "the env_mach_pes.xml format.")
 
     parser.add_argument("--user-grid", action="store_true",
                         help="If set, then the -grid argument is treated as a user specified grid."

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1288,18 +1288,25 @@ class Case(object):
     def _check_testlists(self, compset_alias, grid_name, files):
         """
         CESM only: check the testlist file for tests of this compset grid combination
+
+        compset_alias should be None for a user-defined compset (i.e., a compset
+        without an alias)
         """
         if "TESTS_SPEC_FILE" in self.lookups:
             tests_spec_file = self.get_resolved_value(self.lookups["TESTS_SPEC_FILE"])
         else:
             tests_spec_file = self.get_value("TESTS_SPEC_FILE")
 
-        tests = Testlist(tests_spec_file, files)
-        testlist = tests.get_tests(compset=compset_alias, grid=grid_name)
         testcnt = 0
-        for test in testlist:
-            if test["category"] == "prealpha" or test["category"] == "prebeta" or "aux_" in test["category"]:
-                testcnt += 1
+        if compset_alias is not None:
+            # It's important that we not try to find matching tests if
+            # compset_alias is None, since compset=None tells get_tests to find
+            # tests of all compsets!
+            tests = Testlist(tests_spec_file, files)
+            testlist = tests.get_tests(compset=compset_alias, grid=grid_name)
+            for test in testlist:
+                if test["category"] == "prealpha" or test["category"] == "prebeta" or "aux_" in test["category"]:
+                    testcnt += 1
         if testcnt > 0:
             logger.info("\nThis compset and grid combination is not scientifically supported, however it is used in {:d} tests.\n".format(testcnt))
         else:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -410,7 +410,7 @@ class Case(object):
             if result is not None:
                 del self.lookups[key]
 
-    def _set_compset_and_primary_component(self, compset_name, files, user_compset=False):
+    def _set_compset(self, compset_name, files, user_compset=False):
         """
         Loop through all the compset files and find the compset
         specifation file that matches either the input 'compset_name'.
@@ -743,7 +743,7 @@ class Case(object):
         # compset, pesfile, and compset components
         #--------------------------------------------
         files = Files()
-        compset_alias, science_support, component_defining_compset = self._set_compset_and_primary_component(
+        compset_alias, science_support, component_defining_compset = self._set_compset(
             compset_name, files, user_compset=user_compset)
 
         self._components = self.get_compset_components()


### PR DESCRIPTION
Main change is to have user-defined compsets still pick up a usermods
directory under [primary_component]/cime_config/usermods_dirs/. Along
with this, I have refactored where some other things are set that depend
on primary component. A key aim here was to have various things set in
the same place regardless of whether we're using a compset with or
without an alias. I find this makes it easier to understand the code,
and less likely to introduce discrepancies between user-defined and
alias-defined compsets in the future.

Test suite: scripts_regression_tests on yellowstone
Also, manual testing:
- Compset with an alias: picks up PE settings and a usermods directory
- User compset picks up PE settings
- User compset picks up usermods directory, as in:
  ./create_newcase --case no_alias_0608d --compset 1850_DATM%GSWP3v1_CLM50%BGC-CROP_SICE_SOCN_RTM_CISM2%NOEVOLVE_SWAV --res f09_g16 --user-compset --user-mods-dir clm/clm5_OutputCrop
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#1658
Fixes ESMCI/cime#1664
Fixes ESMCI/cime#1665

User interface changes?: none

Code review: 
