### PR TITLE
fixed description for CCSM_BGC

### DIFF
--- a/src/drivers/mct/cime_config/config_component_acme.xml
+++ b/src/drivers/mct/cime_config/config_component_acme.xml
@@ -197,9 +197,21 @@
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
-    <desc>Flag to turn on new fields in coupling.
-    If the value is not none, the coupler is compiled so that optional
-    BGC related fields are exchanged between component models.
+    <desc>Activates additional CO2 related fields to be exchanged between components.
+       A value of CO2A sets the driver namelist variable flds_co2a = .true., this
+          adds prognostic CO2 and diagnostic CO2 at the lowest model level
+          to be sent from the atmosphere to be sent to the land and ocean.
+       A value of CO2B sets the driver namelist variable flds_co2b = .true., this
+          adds prognostic CO2 and diagnostic CO2 at the lowest model level to be
+          sent just to the land and the surface upward flux of CO2 to be sent from the land back
+          to the atmosphere
+       A value of CO2C sets the driver namelist variable flds_co2c = .true., this
+          adds prognostic CO2 and diagnostic CO2 at the lowest model level
+          to be sent from the atmosphere to be sent to the land and ocean and
+	  the surface upward flux of carbon dioxide from the land and the open ocean to be sent 
+          back to the atmosphere.
+      The namelist variables flds_co2a, flds_co2b and flds_co2c are in the namelist group
+      cpl_flds_inparm.
     </desc>
   </entry>
 

--- a/src/drivers/mct/cime_config/config_component_acme.xml
+++ b/src/drivers/mct/cime_config/config_component_acme.xml
@@ -197,21 +197,26 @@
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
-    <desc>Activates additional CO2 related fields to be exchanged between components.
-       A value of CO2A sets the driver namelist variable flds_co2a = .true., this
-          adds prognostic CO2 and diagnostic CO2 at the lowest model level
-          to be sent from the atmosphere to be sent to the land and ocean.
-       A value of CO2B sets the driver namelist variable flds_co2b = .true., this
-          adds prognostic CO2 and diagnostic CO2 at the lowest model level to be
-          sent just to the land and the surface upward flux of CO2 to be sent from the land back
-          to the atmosphere
-       A value of CO2C sets the driver namelist variable flds_co2c = .true., this
-          adds prognostic CO2 and diagnostic CO2 at the lowest model level
-          to be sent from the atmosphere to be sent to the land and ocean and
-	  the surface upward flux of carbon dioxide from the land and the open ocean to be sent 
-          back to the atmosphere.
-      The namelist variables flds_co2a, flds_co2b and flds_co2c are in the namelist group
-      cpl_flds_inparm.
+    <desc>Activates additional CO2-related fields to be exchanged between components. Possible values are:
+
+    CO2A: sets the driver namelist variable flds_co2a = .true.; this adds
+    prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
+    the atmosphere to the land and ocean.
+
+    CO2B: sets the driver namelist variable flds_co2b = .true.; this adds
+    prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
+    the atmosphere just to the land, and the surface upward flux of CO2 to be
+    sent from the land back to the atmosphere
+
+    CO2C: sets the driver namelist variable flds_co2c = .true.; this adds
+    prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
+    the atmosphere to the land and ocean, and the surface upward flux of CO2
+    to be sent from the land and the open ocean back to the atmosphere.
+
+    CO2_DMSA: sets the driver namelist variable flds_co2_dmsa = .true.
+
+    The namelist variables flds_co2a, flds_co2b, flds_co2c and flds_co2_dmsa are
+    in the namelist group cpl_flds_inparm.
     </desc>
   </entry>
 

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -66,7 +66,7 @@
 
   <entry id="CCSM_BGC">
     <type>char</type>
-    <valid_values>none,CO2A,CO2B,CO2C,CO2_DMSA</valid_values>
+    <valid_values>none,CO2A,CO2B,CO2C</valid_values>
     <default_value>none</default_value>
     <values match="last">
       <value compset="_CAM">CO2A</value>
@@ -79,9 +79,21 @@
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
-    <desc>Flag to turn on new fields in coupling.
-    If the value is not none, the coupler is compiled so that optional
-    BGC related fields are exchanged between component models.
+    <desc>Activates additional CO2 related fields to be exchanged between components.
+       A value of CO2A sets the driver namelist variable flds_co2a = .true., this
+          adds prognostic CO2 and diagnostic CO2 at the lowest model level
+          to be sent from the atmosphere to be sent to the land and ocean.
+       A value of CO2B sets the driver namelist variable flds_co2b = .true., this
+          adds prognostic CO2 and diagnostic CO2 at the lowest model level to be
+          sent just to the land and the surface upward flux of CO2 to be sent from the land back
+          to the atmosphere
+       A value of CO2C sets the driver namelist variable flds_co2c = .true., this
+          adds prognostic CO2 and diagnostic CO2 at the lowest model level
+          to be sent from the atmosphere to be sent to the land and ocean and
+	  the surface upward flux of carbon dioxide from the land and the open ocean to be sent 
+          back to the atmosphere.
+      The namelist variables flds_co2a, flds_co2b and flds_co2c are in the namelist group
+      cpl_flds_inparm.
     </desc>
   </entry>
 

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -79,21 +79,24 @@
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
-    <desc>Activates additional CO2 related fields to be exchanged between components.
-       A value of CO2A sets the driver namelist variable flds_co2a = .true., this
-          adds prognostic CO2 and diagnostic CO2 at the lowest model level
-          to be sent from the atmosphere to be sent to the land and ocean.
-       A value of CO2B sets the driver namelist variable flds_co2b = .true., this
-          adds prognostic CO2 and diagnostic CO2 at the lowest model level to be
-          sent just to the land and the surface upward flux of CO2 to be sent from the land back
-          to the atmosphere
-       A value of CO2C sets the driver namelist variable flds_co2c = .true., this
-          adds prognostic CO2 and diagnostic CO2 at the lowest model level
-          to be sent from the atmosphere to be sent to the land and ocean and
-	  the surface upward flux of carbon dioxide from the land and the open ocean to be sent 
-          back to the atmosphere.
-      The namelist variables flds_co2a, flds_co2b and flds_co2c are in the namelist group
-      cpl_flds_inparm.
+    <desc>Activates additional CO2-related fields to be exchanged between components. Possible values are:
+
+    CO2A: sets the driver namelist variable flds_co2a = .true.; this adds
+    prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
+    the atmosphere to the land and ocean.
+
+    CO2B: sets the driver namelist variable flds_co2b = .true.; this adds
+    prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
+    the atmosphere just to the land, and the surface upward flux of CO2 to be
+    sent from the land back to the atmosphere
+
+    CO2C: sets the driver namelist variable flds_co2c = .true.; this adds
+    prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
+    the atmosphere to the land and ocean, and the surface upward flux of CO2
+    to be sent from the land and the open ocean back to the atmosphere.
+
+    The namelist variables flds_co2a, flds_co2b and flds_co2c are in the
+    namelist group cpl_flds_inparm.
     </desc>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -49,11 +49,9 @@
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>
     <desc>
-      Previously, new fields that were needed to be passed between components
-      for certain compsets were specified by cpp-variables. This has been
-      modified to now be use cases. This use cases are specified in the
-      namelist cpl_flds_inparm and are currently triggered by the xml variable CCSM_BGC.
-      If CCSM_BGC is set to 'CO2A', then flds_co2a will be set to .true.
+      If set to .true., adds prognostic CO2 and diagnostic CO2 at the lowest
+      model level to be sent from the atmosphere to the land and ocean.
+      If CCSM_BGC is set to 'CO2A', then flds_co2a will be set to .true. by default
     </desc>
     <values>
       <value>.false.</value>
@@ -66,11 +64,11 @@
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>
     <desc>
-      Previously, new fields that were needed to be passed between components
-      for certain compsets were specified by cpp-variables. This has been
-      modified to now be use cases. This use cases are specified in the
-      namelist cpl_flds_inparm and are currently triggered by the xml variable CCSM_BGC.
-      If CCSM_BGC is set to 'CO2B', then flds_co2b will be set to .true.
+      If set to .true., adds prognostic CO2 and diagnostic CO2 at the lowest
+      model level to be sent from the atmosphere just to the land, and the
+      surface upward flux of CO2 to be sent from the land back to the
+      atmosphere.
+      If CCSM_BGC is set to 'CO2B', then flds_co2b will be set to .true. by default.
     </desc>
     <values>
       <value>.false.</value>
@@ -83,11 +81,11 @@
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>
     <desc>
-      Previously, new fields that were needed to be passed between components
-      for certain compsets were specified by cpp-variables. This has been
-      modified to now be use cases. This use cases are specified in the
-      namelist cpl_flds_inparm and are currently triggered by the xml variable CCSM_BGC.
-      If CCSM_BGC is set to 'CO2C', then flds_co2c will be set to .true.
+      If set to .true., adds prognostic CO2 and diagnostic CO2 at the lowest
+      model level to be sent from the atmosphere to the land and ocean, and the
+      surface upward flux of CO2 to be sent from the land and the open ocean
+      back to the atmosphere.
+      If CCSM_BGC is set to 'CO2C', then flds_co2c will be set to .true. by default.
     </desc>
     <values>
       <value>.false.</value>
@@ -100,11 +98,7 @@
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>
     <desc>
-      Previously, new fields that were needed to be passed between components
-      for certain compsets were specified by cpp-variables. This has been
-      modified to now be use cases. This use cases are specified in the
-      namelist cpl_flds_inparm and are currently triggered by the xml variable CCSM_BGC.
-      If CCSM_BGC is set to 'CO2_DMSA', then flds_co2_dmsa will be set to .true.
+      If CCSM_BGC is set to 'CO2_DMSA', then flds_co2_dmsa will be set to .true. by default.
     </desc>
     <values>
       <value>.false.</value>
@@ -117,12 +111,7 @@
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>
     <desc>
-      Previously, new fields that were needed to be passed between components
-      for certain compsets were specified by cpp-variables. This has been
-      modified to now be use cases. This use cases are specified in the
-      namelist cpl_flds_inparm and are currently triggered by the xml variable ACME_BGC.
-      This is a new master switch for turning ACME BGC off and on, just for testing.
-      If ACME_BGC is set to 'TRUE', then flds_bgc will be set to .true.
+      This is a master switch for turning ACME BGC off and on, just for testing.
     </desc>
     <values>
       <value>.false.</value>


### PR DESCRIPTION
Provides better description of CCSM_BGC xml variable for both ACME and CESM

Also removed the CO2_DMSA valid value for CESM since this is not supported by CESM.

Test suite: NA
Test baseline: NA 
Test namelist changes: NA
Test status: NA
Fixes #1650 
User interface changes?: NA
Code review: none
