### PR TITLE
Do not add empty user mods

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1115,10 +1115,11 @@ class Case(object):
         Returns None if no value was found, or if the value is an empty string.
         """
         comp_user_mods = self.get_value("{}_USER_MODS".format(component.upper()))
-        if comp_user_mods and not comp_user_mods.isspace():
-            return comp_user_mods
-        else:
+        if (comp_user_mods is None or comp_user_mods == "" or
+            (isinstance(comp_user_mods, basestring) and comp_user_mods.isspace())):
             return None
+        else:
+            return comp_user_mods
 
     def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
         if cime_output_root is None:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1115,11 +1115,17 @@ class Case(object):
         Returns None if no value was found, or if the value is an empty string.
         """
         comp_user_mods = self.get_value("{}_USER_MODS".format(component.upper()))
-        if (comp_user_mods is None or comp_user_mods == "" or
-            (isinstance(comp_user_mods, basestring) and comp_user_mods.isspace())):
+        if comp_user_mods is None or comp_user_mods == "":
             return None
         else:
-            return comp_user_mods
+            try:
+                is_space = comp_user_mods.isspace()
+            except AttributeError:
+                is_space = False
+            if is_space:
+                return None
+            else:
+                return comp_user_mods
 
     def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
         if cime_output_root is None:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1069,7 +1069,7 @@ class Case(object):
             append_status("{} is {}".format(comp_grid,self.get_value(comp_grid)),
                           "README.case", caseroot=self._caseroot)
             comp = str(self.get_value("COMP_{}".format(component_class)))
-            user_mods = self.get_value("{}_USER_MODS".format(comp.upper()))
+            user_mods = self._get_comp_user_mods(comp)
             if user_mods is not None:
                 note = "This component includes user_mods {}".format(user_mods)
                 append_status(note, "README.case", caseroot=self._caseroot)
@@ -1088,11 +1088,11 @@ class Case(object):
             component = str(self.get_value("COMP_{}".format(comp)))
             if component == self._primary_component:
                 continue
-            comp_user_mods = self.get_value("{}_USER_MODS".format(component.upper()))
+            comp_user_mods = self._get_comp_user_mods(component)
             if comp_user_mods is not None:
                 all_user_mods.append(comp_user_mods)
         # get the primary last so that it takes precidence over other components
-        comp_user_mods = self.get_value("{}_USER_MODS".format(self._primary_component.upper()))
+        comp_user_mods = self._get_comp_user_mods(self._primary_component)
         if comp_user_mods is not None:
             all_user_mods.append(comp_user_mods)
         if user_mods_dir is not None:
@@ -1107,6 +1107,18 @@ class Case(object):
                 user_mods_path = self.get_value('USER_MODS_DIR')
                 user_mods_path = os.path.join(user_mods_path, user_mods)
             apply_user_mods(self._caseroot, user_mods_path)
+
+    def _get_comp_user_mods(self, component):
+        """
+        For a component 'foo', gets the value of FOO_USER_MODS.
+
+        Returns None if no value was found, or if the value is an empty string.
+        """
+        comp_user_mods = self.get_value("{}_USER_MODS".format(component.upper()))
+        if comp_user_mods and not comp_user_mods.isspace():
+            return comp_user_mods
+        else:
+            return None
 
     def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
         if cime_output_root is None:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1115,17 +1115,11 @@ class Case(object):
         Returns None if no value was found, or if the value is an empty string.
         """
         comp_user_mods = self.get_value("{}_USER_MODS".format(component.upper()))
-        if comp_user_mods is None or comp_user_mods == "":
+        #pylint: disable=no-member
+        if comp_user_mods is None or comp_user_mods == "" or comp_user_mods.isspace():
             return None
         else:
-            try:
-                is_space = comp_user_mods.isspace()
-            except AttributeError:
-                is_space = False
-            if is_space:
-                return None
-            else:
-                return comp_user_mods
+            return comp_user_mods
 
     def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
         if cime_output_root is None:


### PR DESCRIPTION
Ignore empty COMP_USER_MODS values

If a component defined a COMPNAME_USER_MODS (e.g., CAM_USER_MODS) entry
in config_component.xml, but the value for the current case ends up
being blank, we were getting incorrect behavior: The expected behavior
is that no user mods directory would be included; the actual behavior
was that it tries to pull in user mods from
PRIMARY_COMPONENT/cime_config/usermods_dirs . This often will be
harmless, because that directory won't contain any user_nl files or
others (it typically just contains some subdirectories with the actual
user mods). But it's confusing, and it could give wrong behavior if that
directory happened to include any files that matched names that are
expected in a user_mods directory (e.g., user_nl files).

This PR fixes this behavior, so that if COMPNAME_USER_MODS evaluates to
an empty string, then we don't try to include it.

Test suite: scripts_regression_tests on yellowstone
Also, manual tests of create_newcase:
- B1850 (no user_mods)
- BHIST (picks up user_mods from CAM)
- FHIST_DEV (picks up user_mods from CAM, the primary_component)

Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#1673 

User interface changes?: none

Code review: 
