### PR TITLE
Add LVIRTUALGLC system test type

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -173,7 +173,7 @@ PRE    pause-resume test: by default a BFB test of pause-resume cycling
 
 LII    CLM initial condition interpolation test
 
-LVIRTUALGLC   CLM test: Ensure that adding virtual glacier columns doesn't change answers
+LVIRTUALGLC   CLM test: Verify that adding virtual glacier columns doesn't change answers
 
 ======================================================================
     Infrastructural tests for CIME. These are used by scripts_regression_tests.
@@ -462,7 +462,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
   </test>
 
   <test NAME="LVIRTUALGLC">
-    <DESC>CLM test: Ensure that adding virtual glacier columns doesn't change answers</DESC>
+    <DESC>CLM test: Verify that adding virtual glacier columns doesn't change answers</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -471,9 +471,11 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
          in the l2x fields that are separated by elevation class. So for this
          test, we just ensure that there are no answer changes in
          gridcell-average CLM fields, via comparison of the CLM history
-         files. (If we had a way to exclude individual fields from the list of
-         compared fields, then we could compare cpl hist files, excluding
-         certain l2x fields.) -->
+         files. This means that, for this test to be effective, it needs to be
+         done with a testmod that produces at least one CLM history file, which
+         should only contain gridcell-average fields. (If we had a way to
+         exclude individual fields from the list of compared fields, then we
+         could compare cpl hist files, excluding certain l2x fields.) -->
     <HIST_OPTION>never</HIST_OPTION>
   </test>
 

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -173,6 +173,8 @@ PRE    pause-resume test: by default a BFB test of pause-resume cycling
 
 LII    CLM initial condition interpolation test
 
+LVIRTUALGLC   CLM test: Ensure that adding virtual glacier columns doesn't change answers
+
 ======================================================================
     Infrastructural tests for CIME. These are used by scripts_regression_tests.
     Users won't generally run these.
@@ -451,6 +453,16 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
 
   <test NAME="LII">
     <DESC>CLM initial condition interpolation test (requires configuration with non-blank finidat)</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>never</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+  </test>
+
+  <test NAME="LVIRTUALGLC">
+    <DESC>CLM test: Ensure that adding virtual glacier columns doesn't change answers</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -467,8 +467,14 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <REST_OPTION>never</REST_OPTION>
-    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
-    <HIST_N>$STOP_N</HIST_N>
+    <!-- Need HIST_OPTION=never for this test because we expect answer changes
+         in the l2x fields that are separated by elevation class. So for this
+         test, we just ensure that there are no answer changes in
+         gridcell-average CLM fields, via comparison of the CLM history
+         files. (If we had a way to exclude individual fields from the list of
+         compared fields, then we could compare cpl hist files, excluding
+         certain l2x fields.) -->
+    <HIST_OPTION>never</HIST_OPTION>
   </test>
 
   <test NAME="PEA">

--- a/scripts/lib/CIME/SystemTests/lvirtualglc.py
+++ b/scripts/lib/CIME/SystemTests/lvirtualglc.py
@@ -1,0 +1,37 @@
+"""
+Implementation of the CIME LVIRTUALGLC test.
+
+This is a CLM specific test:
+Verifies that adding virtual glacier columns doesn't change answers
+(1) do a run with the standard set of virtual columns (suffix base)
+(2) add virtual columns over Antarctica (suffix more_virtual)
+
+This will only pass if there are no column or patch-level outputs in CLM's
+history files.
+"""
+
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
+from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.test_utils.user_nl_utils import append_to_user_nl_files
+
+logger = logging.getLogger(__name__)
+
+class LVIRTUALGLC(SystemTestsCompareTwo):
+
+    def __init__(self, case):
+        SystemTestsCompareTwo.__init__(self, case,
+                                       separate_builds = False,
+                                       run_two_suffix = 'more_virtual',
+                                       run_one_description = 'standard set of virtual columns',
+                                       run_two_description = 'add virtual columns over Antarctica')
+
+    def _case_one_setup(self):
+        append_to_user_nl_files(caseroot = self._get_caseroot(),
+                                component = "clm",
+                                contents = "glacier_region_behavior = 'single_at_atm_topo', 'virtual', 'multiple'")
+
+    def _case_two_setup(self):
+        append_to_user_nl_files(caseroot = self._get_caseroot(),
+                                component = "clm",
+                                contents = "glacier_region_behavior = 'single_at_atm_topo', 'virtual', 'virtual'")
+


### PR DESCRIPTION
Adds a test type that tests a specific aspect of CLM: this verifies that
adding virtual glacier columns doesn't change answers for
gridcell-average fields.

Eventually we should move this test into CLM, but we're waiting to do so
until we resolve some issues raised in the discussion in
ESMCI/cime#651 .

Test suite: In the context of
https://svn-ccsm-models.cgd.ucar.edu/clm2/branches/cmip6_glc, ran
LVIRTUALGLC_Ld5_D.f10_f10.IG1850CRUCLM50BGCCROP.cheyenne_intel.clm-no_vector_output
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#1676

User interface changes?: none

Code review: 
