### PR TITLE
Fix XML schemas error for ALCF's Mira/Cetus

### DIFF
--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -1057,8 +1057,8 @@
          </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
-      <cmd_path lang="csh">soft</cmd_path>
       <init_path lang="sh">/etc/profile.d/00softenv.sh</init_path>
+      <cmd_path lang="csh">soft</cmd_path>
       <cmd_path lang="sh">soft</cmd_path>
       <modules>
         <command name="add">+mpiwrapper-xl</command>
@@ -1150,8 +1150,8 @@
          </mpirun>
     <module_system type="soft">
       <init_path lang="csh">/etc/profile.d/00softenv.csh</init_path>
-      <cmd_path lang="csh">soft</cmd_path>
       <init_path lang="sh">/etc/profile.d/00softenv.sh</init_path>
+      <cmd_path lang="csh">soft</cmd_path>
       <cmd_path lang="sh">soft</cmd_path>
       <modules>
         <command name="add">+mpiwrapper-xl</command>


### PR DESCRIPTION
Reorder the sequences of init_path and cmd_path for Mira/Cetus
in config_machines.xml. All of the init_path statements should
precede the cmd_path statements, otherwise there is an error on
schemas validity in phase 'XML'.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: 

Fixes #1659

User interface changes?: 

Code review: 
