### PR TITLE
backward compatible change to allow more than one mach for each  grid

### DIFF
--- a/config/xml_schemas/config_pes.xsd
+++ b/config/xml_schemas/config_pes.xsd
@@ -58,7 +58,7 @@
   <xs:element name="grid">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="mach"/>
+        <xs:element maxOccurs="unbounded" ref="mach"/>
       </xs:sequence>
       <xs:attribute ref="name" use="required"/>
     </xs:complexType>


### PR DESCRIPTION
Minor change in schema definition to allow for multiple mach tags per grid tag

Test suite: by hand / cesm components/cam/cime_config/config_pes.xml 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Code review: 
