### PR TITLE
Apply OCN_NCPL setting to any version of CLM

### DIFF
--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -211,11 +211,10 @@
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
       <value compset="_POP2" grid="oi%gx1v6">24</value>
       <value compset="_POP2" grid="oi%gx1v7">24</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
       <value compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">1</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
+      <value compset="_DATM.*_CLM.*_SICE.*_SOCN">1</value>
       <value compset="_SATM.*_SLND.*_SICE.*_SOCN">1</value>
       <value compset="_DLND.*_CISM\d">1</value>
     </values>


### PR DESCRIPTION
Apply OCN_NCPL setting to any version of CLM

Also remove a duplicate line

Test suite: Ran a few tests in a CLM sandbox: I compsets with clm45 and clm50
before and after this change. Verified that, with this change,
OCN_NCPL is 1 as desired for both clm45 and clm50.
Test baseline: N/A
Test namelist changes: Changes ocn_cpl_dt in drv_in for I compsets with clm50 
Test status: bit for bit
I haven't tested for bit-for-bit, but this should be bit-for-bit, right?
i.e., answers shouldn't change based on the coupling frequency of a stub model, right?

Fixes ESMCI/cime#1687 

User interface changes?: none

Code review: 
