### PR TITLE
Remove empty proxy tag from anlworkstation

### DIFF
--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -646,7 +646,6 @@
 <machine MACH="anlworkstation">
     <DESC>Linux workstation for ANL</DESC>
     <NODENAME_REGEX>compute.*mcs.anl.gov</NODENAME_REGEX>
-    <PROXY></PROXY>
     <TESTS>acme_developer</TESTS>
     <OS>LINUX</OS>
     <COMPILERS>gnu</COMPILERS>


### PR DESCRIPTION
This is a regression: the empty proxy tag was removed by PR #1590, but
it was added back by PR #1634 during the merge.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: 

Fixes #1534

User interface changes?: 

Code review: 
