### PR TITLE
Add a warning about use of component_defining_compset

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -746,6 +746,10 @@ class Case(object):
         files = Files()
         compset_alias, science_support, component_defining_compset = self._set_compset(
             compset_name, files, user_compset=user_compset)
+        # WARNING: component_defining_compset will be None for a user-defined
+        # compset. If you use this variable, behavior of user-defined compsets
+        # will differ from behavior of compsets with aliases, which is typically
+        # undesirable. Instead, use self._primary_component, which is set below.
 
         self._components = self.get_compset_components()
         #--------------------------------------------


### PR DESCRIPTION
In my ideal world, we wouldn't have this component_defining_compset variable at
all, and so wouldn't need this warning. Instead, _set_compset would set
self._primary_component directly for both user-defined compsets and compsets
with aliases (it could then be renamed to
_set_compset_and_primary_component). However, for this to work, we'd need to
call self.set_comp_classes before self._set_compset. I haven't tracked the
dependencies of self.set_comp_classes to see if this would be possible.

Test suite: scripts_regression_tests B_CheckCode
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes none

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
