### PR TITLE
Description field error check of user compsets.

### DIFF
--- a/config/acme/config_files.xml
+++ b/config/acme/config_files.xml
@@ -257,6 +257,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing all non-component specific case configuration variables (for documentation only - DO NOT EDIT)</desc>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_CPL_FILE_MODEL_SPECIFIC">
@@ -265,7 +267,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing all component specific driver configuration variables (for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ATM_FILE">
@@ -280,6 +283,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_LND_FILE">
@@ -295,6 +300,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ROF_FILE">
@@ -310,6 +317,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ICE_FILE">
@@ -325,6 +334,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_OCN_FILE">
@@ -341,6 +352,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_GLC_FILE">
@@ -358,6 +371,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_WAV_FILE">
@@ -372,6 +387,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ESP_FILE">
@@ -384,6 +401,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
 </entry_id>

--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -2236,6 +2236,7 @@
   <MAX_TASKS_PER_NODE>30</MAX_TASKS_PER_NODE>
   <PES_PER_NODE>15</PES_PER_NODE>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+  <SAVE_TIMING_DIR>/glade/scratch/$USER/acme/timing/performance_archive</SAVE_TIMING_DIR>
   <mpirun >
     <executable>mpirun.lsf</executable>
   </mpirun>

--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -265,7 +265,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing all non-component specific case configuration variables (for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_CPL_FILE_MODEL_SPECIFIC">
@@ -274,7 +275,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing all component specific driver configuration variables (for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ATM_FILE">
@@ -289,7 +291,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_LND_FILE">
@@ -305,7 +308,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ROF_FILE">
@@ -321,7 +325,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ICE_FILE">
@@ -336,7 +341,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_OCN_FILE">
@@ -353,7 +359,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_GLC_FILE">
@@ -368,7 +375,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_WAV_FILE">
@@ -383,7 +391,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ESP_FILE">
@@ -396,7 +405,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
+    <schema version="2.0">$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema version="3.0">$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
 </entry_id>

--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -265,7 +265,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing all non-component specific case configuration variables (for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_CPL_FILE_MODEL_SPECIFIC">
@@ -274,7 +274,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing all component specific driver configuration variables (for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ATM_FILE">
@@ -289,7 +289,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_LND_FILE">
@@ -305,7 +305,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ROF_FILE">
@@ -321,7 +321,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ICE_FILE">
@@ -336,7 +336,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_OCN_FILE">
@@ -353,7 +353,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_GLC_FILE">
@@ -368,7 +368,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_WAV_FILE">
@@ -383,7 +383,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
   <entry id="CONFIG_ESP_FILE">
@@ -396,7 +396,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of component specific definitions and values(for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/entry_id.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/entry_id_version3.xsd</schema>
   </entry>
 
 </entry_id>

--- a/config/xml_schemas/entry_id_base.xsd
+++ b/config/xml_schemas/entry_id_base.xsd
@@ -14,7 +14,6 @@
   <xs:element name="help" type="xs:string"/>
   <xs:element name="default_value" type="xs:string"/>
   <xs:element name="valid_values" type="xs:string"/>
-  <xs:element name="schema" type="xs:string"/>
   <xs:element name="category" type="xs:string"/>
   <xs:element name="header" type="xs:string"/>
 
@@ -32,6 +31,12 @@
   <xs:element name="desc">
     <xs:complexType mixed="true">
       <xs:attribute ref="compset"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="schema">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="version"/>
     </xs:complexType>
   </xs:element>
 

--- a/config/xml_schemas/entry_id_base.xsd
+++ b/config/xml_schemas/entry_id_base.xsd
@@ -7,6 +7,7 @@
   <xs:attribute name="component" type="xs:string"/>
   <xs:attribute name="grid"  type="xs:string"/>
   <xs:attribute name="modifier" type="xs:NCName"/>
+  <xs:attribute name="match" type="xs:NCName"/>
   <xs:attribute name="version" type="xs:decimal"/>
 
   <!-- simple elements -->
@@ -48,6 +49,7 @@
         <xs:element ref="value" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute ref="modifier"/>
+      <xs:attribute ref="match"/>
     </xs:complexType>
   </xs:element>
 

--- a/config/xml_schemas/entry_id_base_version3.xsd
+++ b/config/xml_schemas/entry_id_base_version3.xsd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+
+  <!-- attributes -->
+  <xs:attribute name="id" type="xs:string"/>
+  <xs:attribute name="compset" type="xs:string"/>
+  <xs:attribute name="component" type="xs:string"/>
+  <xs:attribute name="grid"  type="xs:string"/>
+  <xs:attribute name="modifier" type="xs:NCName"/>
+  <xs:attribute name="match" type="xs:NCName"/>
+  <xs:attribute name="version" type="xs:decimal"/>
+
+
+  <!-- simple elements -->
+  <xs:element name="help" type="xs:string"/>
+  <xs:element name="default_value" type="xs:string"/>
+  <xs:element name="valid_values" type="xs:string"/>
+  <xs:element name="schema" type="xs:string"/>
+  <xs:element name="category" type="xs:string"/>
+  <xs:element name="header" type="xs:string"/>
+
+  <!-- complex elements -->
+  <xs:element name="value">
+    <xs:complexType>
+      <xs:simpleContent>
+	<xs:extension base="xs:string">
+	  <xs:anyAttribute processContents="lax"/>
+	</xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="desc">
+    <xs:complexType mixed="true">
+      <xs:attribute name="atm" type="xs:string"/>
+      <xs:attribute name="cpl" type="xs:string"/>
+      <xs:attribute name="ocn" type="xs:string"/>
+      <xs:attribute name="wav" type="xs:string"/>
+      <xs:attribute name="glc" type="xs:string"/>
+      <xs:attribute name="ice" type="xs:string"/>
+      <xs:attribute name="rof" type="xs:string"/>
+      <xs:attribute name="lnd" type="xs:string"/>
+
+      <xs:attribute name="esp" type="xs:string"/>
+      <xs:attribute name="forcing" type="xs:string"/>
+      <xs:attribute name="option" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="description">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="desc" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="modifier_mode" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="values">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="value" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute ref="modifier"/>
+      <xs:attribute ref="match"/>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="entry_id">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="description" />
+	<xs:element ref="entry" maxOccurs="unbounded" />
+	<xs:element ref="help" minOccurs="0"/>
+      </xs:sequence>
+      <xs:attribute ref="version"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/config/xml_schemas/entry_id_version3.xsd
+++ b/config/xml_schemas/entry_id_version3.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:include schemaLocation="entry_id_base_version3.xsd"/>
+  <xs:element name="type" type="xs:NCName"/>
+  <xs:element name="group" type="xs:NCName"/>
+  <xs:element name="file" type="xs:NCName"/>
+
+<!-- complex elements -->
+  <xs:element name="entry">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+	<xs:element ref="type"/>
+	<xs:element ref="valid_values"/>
+	<xs:element ref="default_value"/>
+	<xs:element ref="file"/>
+	<xs:element ref="group"/>
+	<xs:element ref="values"/>
+	<xs:element ref="desc"/>
+	<xs:element ref="schema" minOccurs="0"/>
+      </xs:choice>
+      <xs:attribute ref="id" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+</xs:schema>

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -44,7 +44,7 @@ OR
 
     files = Files()
     config_file = files.get_value("CONFIG_CPL_FILE")
-    component = Component(config_file)
+    component = Component(config_file, "CPL")
     comps = [x.lower() for x in component.get_valid_model_components()]
     libs  = ["csmshare", "mct", "pio", "gptl"]
     allobjs = comps + libs

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -226,6 +226,10 @@ class Component(EntryID):
         # The following is not allowed because the required WCCM field is missing
         >>> obj._get_description_match("1850_CAM50%RCO2_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]),{"RCO2":"CRU"}, "*")
         False
+        >>> obj._get_description_match("1850_CAM50_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]),{"RCO2":"CRU"}, "+")
+        False
+        >>> obj._get_description_match("1850_CAM50%WCCM_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]),{"RCO2":"CRU"}, "+")
+        True
         """
         match = False
         comparts = compsetname.split('_')

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -155,7 +155,8 @@ class Component(EntryID):
                     expect(len(desc)==0,
                            "Too many matches on forcing field {} in file {}".\
                                format(forcing, self.filename))
-                desc = node.text
+                    desc = node.text
+
             expect(len(desc) > 0,"No match found for forcing field {} in file {}".\
                        format(forcing, self.filename))
             return desc

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -195,8 +195,8 @@ class Component(EntryID):
             fullset = set(parts+opt_parts)
             if self._get_description_match(compsetname, reqset, fullset, modifier_mode):
                 desc = node.text
-        # cpl component may not have a description, all others must
-        if comp_class != 'cpl':
+        # cpl and esp components may not have a description
+        if comp_class not in ['cpl','esp']:
             expect(len(desc) > 0,
                    "No description found for comp_class {} matching compsetname {} in file {}"\
                        .format(comp_class,compsetname, self.filename))

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -21,8 +21,9 @@ class Component(EntryID):
         if comp_class is None:
             schema = files.get_schema("CONFIG_CPL_FILE", attributes={"version":"{}".format(self.get_version())})
         else:
-            schema = files.get_schema("CONFIG_{}_FILE".format(comp_class), attributes={"version":self.get_version()})
-        self.validate_xml_file(infile, schema)
+            schema = files.get_schema("CONFIG_{}_FILE".format(comp_class), attributes={"version":"{}".format(self.get_version())})
+        if schema is not None:
+            self.validate_xml_file(infile, schema)
 
     #pylint: disable=arguments-differ
     def get_value(self, name, attribute=None, resolved=False, subgroup=None):

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -123,18 +123,18 @@ class Component(EntryID):
     #pylint: disable=arguments-differ
     def get_description(self, compsetname):
         if self.get_version() == 3.0:
-            return self._get_description_v3(compsetname, comp_class=self._comp_class)
+            return self._get_description_v3(compsetname, self._comp_class)
         else:
             return self._get_description_v2(compsetname)
 
     def get_forcing_description(self, compsetname):
         if self.get_version() == 3.0:
-            return self._get_description_v3(compsetname, comp_class='forcing')
+            return self._get_description_v3(compsetname, 'forcing')
         else:
             return ""
 
 
-    def _get_description_v3(self, compsetname, comp_class=None):
+    def _get_description_v3(self, compsetname, comp_class):
         """
         version 3 of the config_component.xml file has the description section at the top of the file
         the description field has one attribute 'modifier_mode' which has allowed values
@@ -151,12 +151,12 @@ class Component(EntryID):
 
         component descriptions are matched to the compsetname using a set method
         """
+        expect(comp_class is not None,"comp_class argument required for version3 files")
         comp_class = comp_class.lower()
         rootnode = self.get_node("description")
         desc = ""
         desc_nodes = self.get_nodes("desc", root=rootnode)
 
-        expect(comp_class is not None,"comp_class argument required for version3 files")
         modifier_mode = rootnode.get('modifier_mode')
         if modifier_mode is None:
             modifier_mode = '*'
@@ -195,6 +195,7 @@ class Component(EntryID):
             fullset = set(parts+opt_parts)
             if self._get_description_match(compsetname, reqset, fullset, modifier_mode):
                 desc = node.text
+                break
         # cpl and esp components may not have a description
         if comp_class not in ['cpl','esp']:
             expect(len(desc) > 0,

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -193,7 +193,7 @@ class Component(EntryID):
 
             reqset = set(parts)
             fullset = set(parts+opt_parts)
-            if self._get_description_match(compsetname, reqset, fullset, optiondesc, modifier_mode):
+            if self._get_description_match(compsetname, reqset, fullset, modifier_mode):
                 desc = node.text
         # cpl component may not have a description, all others must
         if comp_class != 'cpl':
@@ -202,33 +202,33 @@ class Component(EntryID):
                        .format(comp_class,compsetname, self.filename))
         return desc
 
-    def _get_description_match(self, compsetname, reqset, fullset, optiondesc, modifier_mode):
+    def _get_description_match(self, compsetname, reqset, fullset, modifier_mode):
         """
 
         >>> obj = Component('testingonly', 'ATM')
-        >>> obj._get_description_match("1850_DATM%CRU_FRED",set(["DATM"]), set(["DATM","CRU","HSI"]),{"CRU":"CRU"}, "*")
+        >>> obj._get_description_match("1850_DATM%CRU_FRED",set(["DATM"]), set(["DATM","CRU","HSI"]), "*")
         True
-        >>> obj._get_description_match("1850_DATM%FRED_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]),{"CRU":"CRU"}, "*")
+        >>> obj._get_description_match("1850_DATM%FRED_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "*")
         False
-        >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]),{"CRU":"CRU"}, "?")
+        >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "?")
         True
-        >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]),{"CRU":"CRU"}, "1")
+        >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1")
         Traceback (most recent call last):
         ...
         SystemExit: ERROR: Expected exactly one modifer found 0
-        >>> obj._get_description_match("1850_DATM%CRU%HSI_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]),{"CRU":"CRU","HSI":"HSI"}, "1")
+        >>> obj._get_description_match("1850_DATM%CRU%HSI_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1")
         Traceback (most recent call last):
         ...
         SystemExit: ERROR: Expected exactly one modifer found 2
-        >>> obj._get_description_match("1850_CAM50%WCCM%RCO2_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]),{"RCO2":"CRU"}, "*")
+        >>> obj._get_description_match("1850_CAM50%WCCM%RCO2_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "*")
         True
 
         # The following is not allowed because the required WCCM field is missing
-        >>> obj._get_description_match("1850_CAM50%RCO2_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]),{"RCO2":"CRU"}, "*")
+        >>> obj._get_description_match("1850_CAM50%RCO2_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "*")
         False
-        >>> obj._get_description_match("1850_CAM50_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]),{"RCO2":"CRU"}, "+")
+        >>> obj._get_description_match("1850_CAM50_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "+")
         False
-        >>> obj._get_description_match("1850_CAM50%WCCM_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]),{"RCO2":"CRU"}, "+")
+        >>> obj._get_description_match("1850_CAM50%WCCM_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "+")
         True
         """
         match = False

--- a/scripts/lib/CIME/XML/files.py
+++ b/scripts/lib/CIME/XML/files.py
@@ -24,9 +24,9 @@ class Files(EntryID):
         schema = os.path.join(cimeroot, "config", "xml_schemas", "entry_id.xsd")
         EntryID.__init__(self, infile, schema=schema)
 
-    def get_schema(self, nodename):
+    def get_schema(self, nodename, attributes=None):
         node = self.get_optional_node("entry", {"id":nodename})
-        schemanode = self.get_optional_node("schema", root=node)
+        schemanode = self.get_optional_node("schema", root=node, attributes=attributes)
         if schemanode is not None:
             logger.debug("Found schema for {}".format(nodename))
             return self.get_resolved_value(schemanode.text)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -587,12 +587,12 @@ class Case(object):
             env_file.add_elements_by_group(files, attlist)
 
         drv_config_file = files.get_value("CONFIG_CPL_FILE")
-        drv_comp = Component(drv_config_file)
+        drv_comp = Component(drv_config_file, "CPL")
         for env_file in self._env_entryid_files:
             env_file.add_elements_by_group(drv_comp, attributes=attlist)
 
         drv_config_file_model_specific = files.get_value("CONFIG_CPL_FILE_MODEL_SPECIFIC")
-        drv_comp_model_specific = Component(drv_config_file_model_specific, comp_class='CPL')
+        drv_comp_model_specific = Component(drv_config_file_model_specific, 'CPL')
 
         self._component_description["forcing"] = drv_comp_model_specific.get_forcing_description(self._compsetname)
         logger.info("Compset forcing is {}".format(self._component_description["forcing"]))
@@ -620,9 +620,9 @@ class Case(object):
             comp_config_file = self.get_resolved_value(comp_config_file)
             expect(comp_config_file is not None and os.path.isfile(comp_config_file),
                    "Config file {} for component {} not found.".format(comp_config_file, comp_name))
-            compobj = Component(comp_config_file, comp_class=comp_class)
+            compobj = Component(comp_config_file, comp_class)
             compsetname = self._compsetname
-            if 'ESP_' not in compsetname:
+            if not compsetname.endswith('ESP'):
                 compsetname += '_SESP'
             # For files following version 3 schema this also checks the compsetname validity
             self._component_description[comp_class] = compobj.get_description(compsetname)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -595,6 +595,12 @@ class Case(object):
 
         drv_config_file_model_specific = files.get_value("CONFIG_CPL_FILE_MODEL_SPECIFIC")
         drv_comp_model_specific = Component(drv_config_file_model_specific)
+
+        self._component_description["forcing"] = drv_comp_model_specific.get_description(self._compsetname, 'forcing')
+        logger.info("Compset forcing is {}".format(self._component_description["forcing"]))
+        self._component_description["CPL"] = drv_comp_model_specific.get_description(self._compsetname, 'cpl')
+        if len(self._component_description["CPL"]) > 0:
+            logger.info("Com forcing is {}".format(self._component_description["CPL"]))
         for env_file in self._env_entryid_files:
             env_file.add_elements_by_group(drv_comp_model_specific, attributes=attlist)
 
@@ -611,6 +617,7 @@ class Case(object):
             comp_name  = self._components[i-1]
             node_name = 'CONFIG_' + comp_class + '_FILE'
             # Add the group and elements for the config_files.xml
+
             comp_config_file = files.get_value(node_name, {"component":comp_name}, resolved=False)
             self.set_value(node_name, comp_config_file)
             comp_config_file = self.get_resolved_value(comp_config_file)
@@ -625,6 +632,8 @@ class Case(object):
             logger.info("{} component is {}".format(comp_class, self._component_description[comp_class]))
             for env_file in self._env_entryid_files:
                 env_file.add_elements_by_group(compobj, attributes=attlist)
+
+
 
         self.clean_up_lookups()
 
@@ -1063,12 +1072,15 @@ class Case(object):
                       "README.case", caseroot=self._caseroot)
         append_status("Pes     specification file is {}".format(self.get_value("PES_SPEC_FILE")),
                       "README.case", caseroot=self._caseroot)
+        append_status("Forcing is {}".format(self._component_description["forcing"])
+                      ,"README.case", caseroot=self._caseroot)
         for component_class in self._component_classes:
+            if component_class in self._component_description:
+                append_status("Component {} is {}".format(component_class, self._component_description[component_class]),"README.case", caseroot=self._caseroot)
             if component_class == "CPL":
                 continue
             comp_grid = "{}_GRID".format(component_class)
-            append_status("Component {} is {}".format(component_class, self._component_description[component_class]),
-                          "README.case", caseroot=self._caseroot)
+
             append_status("{} is {}".format(comp_grid,self.get_value(comp_grid)),
                           "README.case", caseroot=self._caseroot)
             comp = str(self.get_value("COMP_{}".format(component_class)))

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -592,11 +592,11 @@ class Case(object):
             env_file.add_elements_by_group(drv_comp, attributes=attlist)
 
         drv_config_file_model_specific = files.get_value("CONFIG_CPL_FILE_MODEL_SPECIFIC")
-        drv_comp_model_specific = Component(drv_config_file_model_specific)
+        drv_comp_model_specific = Component(drv_config_file_model_specific, comp_class='CPL')
 
-        self._component_description["forcing"] = drv_comp_model_specific.get_description(self._compsetname, 'forcing')
+        self._component_description["forcing"] = drv_comp_model_specific.get_forcing_description(self._compsetname)
         logger.info("Compset forcing is {}".format(self._component_description["forcing"]))
-        self._component_description["CPL"] = drv_comp_model_specific.get_description(self._compsetname, 'cpl')
+        self._component_description["CPL"] = drv_comp_model_specific.get_description(self._compsetname)
         if len(self._component_description["CPL"]) > 0:
             logger.info("Com forcing is {}".format(self._component_description["CPL"]))
         for env_file in self._env_entryid_files:
@@ -624,7 +624,8 @@ class Case(object):
             compsetname = self._compsetname
             if 'ESP_' not in compsetname:
                 compsetname += '_SESP'
-            self._component_description[comp_class] = compobj.get_description(compsetname, comp_class)
+            # For files following version 3 schema this also checks the compsetname validity
+            self._component_description[comp_class] = compobj.get_description(compsetname)
             expect(self._component_description[comp_class] is not None,"No description found in file {} for component {} in comp_class {}".format(comp_config_file, comp_name, comp_class))
             logger.info("{} component is {}".format(comp_class, self._component_description[comp_class]))
             for env_file in self._env_entryid_files:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -606,7 +606,6 @@ class Case(object):
         if len(self._component_classes) > len(self._components):
             self._components.append('sesp')
 
-
         for i in xrange(1,len(self._component_classes)):
             comp_class = self._component_classes[i]
             comp_name  = self._components[i-1]
@@ -618,8 +617,11 @@ class Case(object):
             expect(comp_config_file is not None and os.path.isfile(comp_config_file),
                    "Config file {} for component {} not found.".format(comp_config_file, comp_name))
             compobj = Component(comp_config_file)
-            self._component_description[comp_class] = compobj.get_description(self._compsetname)
-            expect(self._component_description[comp_class] is not None,"No description found in file {} for component {}".format(comp_config_file, comp_name))
+            compsetname = self._compsetname
+            if 'ESP_' not in compsetname:
+                compsetname += '_SESP'
+            self._component_description[comp_class] = compobj.get_description(compsetname, comp_class)
+            expect(self._component_description[comp_class] is not None,"No description found in file {} for component {} in comp_class {}".format(comp_config_file, comp_name, comp_class))
             logger.info("{} component is {}".format(comp_class, self._component_description[comp_class]))
             for env_file in self._env_entryid_files:
                 env_file.add_elements_by_group(compobj, attributes=attlist)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -623,7 +623,7 @@ class Case(object):
             comp_config_file = self.get_resolved_value(comp_config_file)
             expect(comp_config_file is not None and os.path.isfile(comp_config_file),
                    "Config file {} for component {} not found.".format(comp_config_file, comp_name))
-            compobj = Component(comp_config_file)
+            compobj = Component(comp_config_file, comp_class=comp_class)
             compsetname = self._compsetname
             if 'ESP_' not in compsetname:
                 compsetname += '_SESP'
@@ -1072,10 +1072,12 @@ class Case(object):
                       "README.case", caseroot=self._caseroot)
         append_status("Pes     specification file is {}".format(self.get_value("PES_SPEC_FILE")),
                       "README.case", caseroot=self._caseroot)
-        append_status("Forcing is {}".format(self._component_description["forcing"])
+        if "forcing" in self._component_description:
+            append_status("Forcing is {}".format(self._component_description["forcing"])
                       ,"README.case", caseroot=self._caseroot)
         for component_class in self._component_classes:
-            if component_class in self._component_description:
+            if component_class in self._component_description and \
+               len(self._component_description[component_class])>0:
                 append_status("Component {} is {}".format(component_class, self._component_description[component_class]),"README.case", caseroot=self._caseroot)
             if component_class == "CPL":
                 continue

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -617,7 +617,6 @@ class Case(object):
             comp_name  = self._components[i-1]
             node_name = 'CONFIG_' + comp_class + '_FILE'
             # Add the group and elements for the config_files.xml
-
             comp_config_file = files.get_value(node_name, {"component":comp_name}, resolved=False)
             self.set_value(node_name, comp_config_file)
             comp_config_file = self.get_resolved_value(comp_config_file)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -621,11 +621,8 @@ class Case(object):
             expect(comp_config_file is not None and os.path.isfile(comp_config_file),
                    "Config file {} for component {} not found.".format(comp_config_file, comp_name))
             compobj = Component(comp_config_file, comp_class)
-            compsetname = self._compsetname
-            if not compsetname.endswith('ESP'):
-                compsetname += '_SESP'
             # For files following version 3 schema this also checks the compsetname validity
-            self._component_description[comp_class] = compobj.get_description(compsetname)
+            self._component_description[comp_class] = compobj.get_description(self._compsetname)
             expect(self._component_description[comp_class] is not None,"No description found in file {} for component {} in comp_class {}".format(comp_config_file, comp_name, comp_class))
             logger.info("{} component is {}".format(comp_class, self._component_description[comp_class]))
             for env_file in self._env_entryid_files:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -425,7 +425,6 @@ class Case(object):
         """
         science_support = []
         compset_alias = None
-        component_defining_compset = None
         components = files.get_components("COMPSETS_SPEC_FILE")
         logger.debug(" Possible components for COMPSETS_SPEC_FILE are {}".format(components))
 
@@ -445,13 +444,12 @@ class Case(object):
                     self._compsetname = match
                     self.set_lookup_value("COMPSETS_SPEC_FILE" ,
                                    files.get_value("COMPSETS_SPEC_FILE", {"component":component}, resolved=False))
-                    component_defining_compset = component
                     logger.info("Compset longname is {}".format(match))
                     logger.info("Compset specification file is {}".format(compsets_filename))
                     if user_compset is True:
                         logger.info("Found a compset match for longname {} in alias {}".format(compset_name, compset_alias))
 
-                    return compset_alias, science_support, component_defining_compset
+                    return compset_alias, science_support
 
         if user_compset is True:
             self._compsetname = compset_name
@@ -460,7 +458,7 @@ class Case(object):
                    "Could not find a compset match for either alias or longname in {}\n".format(compset_name)
                    + "You may need the --user-compset argument.")
 
-        return None, science_support, None
+        return None, science_support
 
     def _find_primary_component(self):
         """
@@ -754,7 +752,7 @@ class Case(object):
         # compset, pesfile, and compset components
         #--------------------------------------------
         files = Files()
-        compset_alias, science_support, component_defining_compset = self._set_compset(
+        compset_alias, science_support = self._set_compset(
             compset_name, files, user_compset=user_compset)
 
         self._components = self.get_compset_components()
@@ -777,12 +775,10 @@ class Case(object):
         #--------------------------------------------
         self._get_component_config_data(files)
 
-        if component_defining_compset is None:
-            # This needs to be called after self.set_comp_classes, which is called
-            # from self._get_component_config_data
-            self._primary_component = self._find_primary_component()
-        else:
-            self._primary_component = component_defining_compset
+        # This needs to be called after self.set_comp_classes, which is called
+        # from self._get_component_config_data
+        self._primary_component = self._find_primary_component()
+
         self._set_info_from_primary_component(files, pesfile=pesfile)
 
         self.get_compset_var_settings()

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -434,7 +434,7 @@ class TestScheduler(object):
         # to deal with. This list follows the same order as compset longnames follow.
         files = Files()
         drv_config_file = files.get_value("CONFIG_CPL_FILE")
-        drv_comp = Component(drv_config_file)
+        drv_comp = Component(drv_config_file, "CPL")
         envtest.add_elements_by_group(files, {}, "env_test.xml")
         envtest.add_elements_by_group(drv_comp, {}, "env_test.xml")
         envtest.set_value("TESTCASE", test_case)

--- a/scripts/manage_pes
+++ b/scripts/manage_pes
@@ -337,7 +337,7 @@ class ManagePes(object):
                         gridname, machname, compsetname, pesizename)
             drv_config_file = Files().get_value("CONFIG_CPL_FILE")
             drv_comps = [x.lower() for x in
-                        Component(drv_config_file).get_valid_model_components()]
+                        Component(drv_config_file, "CPL").get_valid_model_components()]
 
             logger.info("                   " +
                         (len(drv_comps)*' {:10}').format(*drv_comps))

--- a/scripts/query_config
+++ b/scripts/query_config
@@ -233,7 +233,7 @@ def get_components():
     '''
     files = Files()
     infile = files.get_value("CONFIG_CPL_FILE")
-    config_drv = Component(infile)
+    config_drv = Component(infile, "CPL")
     return files, config_drv.get_valid_model_components()
 
 # we override the error message from ArgumentParser to have a more helpful

--- a/scripts/query_config
+++ b/scripts/query_config
@@ -152,7 +152,7 @@ def query_component(name, all_components=False):
            "Cannot find any config_component.xml file for {}".format(name))
 
     # determine component xml content
-    component = Component(config_file)
+    component = Component(config_file, "CPL")
     component.print_values()
 
 ###############################################################################

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -33,14 +33,11 @@ $ENV{PIO_VERSION}  	= `./xmlquery PIO_VERSION	-value`;
 # Filepath: list of source code directories (in order of importance).
 #--------------------------------------------------------------------
 
-my $comp="mct";
-$comp = "esmf" if ($COMP_INTERFACE eq "ESMF");
-
 my $useesmf = "noesmf";
 $useesmf = "esmf" if ($USE_ESMF_LIB eq "TRUE");
 
-my $libdir = "$sharedlibroot/$comp/$useesmf/${NINST_VALUE}/csm_share";
-my $installdir = "$installroot/$comp/$useesmf/${NINST_VALUE}";
+my $libdir = "$sharedlibroot/$COMP_INTERFACE/$useesmf/${NINST_VALUE}/csm_share";
+my $installdir = "$installroot/$COMP_INTERFACE/$useesmf/${NINST_VALUE}";
 mkpath($libdir) unless -d $libdir;
 chdir($libdir) or die "Could not cd to $libdir: $!\n";
 

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0"?>
 
 <entry_id version="3.0">
-  <!-- NOTE that the description block determines what DATM% values can appear in the compset name
-       For DATM this is determined by the DATM_MODE values in combination with the FORCING prefix -->
+  <!-- modifier_mode allowed values are
+       '*' 0 or more modifiers (default)
+       '1' exactly 1 modifier
+       '?' 0 or 1 modifiers
+       '+' 1 or more modifiers
+
+       This file may have atm desc entries.
+  -->
   <description modifier_mode="1">
     <desc atm="DATM[%QIA][%WISOQIA][%CRU][%GSW][%CPLHIST][%1PT][%NYF][%IAF]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -1,36 +1,18 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="definitions_components.xsl" ?>
-
-<entry_id>
-
-  <!-- NOTE that the description block determines what DATM% values can appear in the compset name 
-       For DATM this is determined by the DATM_MODE values in combination with the TIME prefix -->
-  <description>
-    <desc compset="^1850_DATM%QIA">QIAN atm input data for 1948-1972:</desc>
-    <desc compset="^2000_DATM%WISOQIA">QIAN atm input data with water isotopes for 2000-2004:</desc>
-    <desc compset="^2000_DATM%QIA">QIAN atm input data for 1972-2004:</desc>
-    <desc compset="^2003_DATM%QIA">QIAN atm input data for 2002-2003:</desc>
-    <desc compset="^HIST_DATM%QIA">QIAN atm input data for 1948-1972:</desc>
-    <desc compset="^20TR_DATM%QIA">QIAN atm input data for 1948-1972:</desc>
-    <desc compset="^4804_DATM%QIA">QIAN atm input data for 1948-2004:</desc>
-    <desc compset="^RCP[2468]_DATM%QIA">QIAN atm input data for 1972-2004:</desc>
-    <desc compset="^1850_DATM%CRU">CRUNCEP atm input data for 1901-1920:</desc>
-    <desc compset="^2000_DATM%CRU">CRUNCEP atm input data for 1991-2010:</desc>
-    <desc compset="^2003_DATM%CRU">CRUNCEP atm input data for 2002-2003:</desc>
-    <desc compset="^HIST_DATM%CRU">CRUNCEP atm input data for 1901-1920:</desc>
-    <desc compset="^20TR_DATM%CRU">CRUNCEP atm input data for 1901-1920:</desc>
-    <desc compset="^RCP[2468]_DATM%CRU">CRUNCEP atm input data for 1991-2010:</desc>
-    <desc compset="^1850_DATM%GSW">GSWP3 atm input data for 1901-1920:</desc>
-    <desc compset="^2000_DATM%GSW">GSWP3 atm input data for 1991-2010:</desc>
-    <desc compset="^2003_DATM%GSW">GSWP3 atm input data for 2002-2003:</desc>
-    <desc compset="^HIST_DATM%GSW">GSWP3 atm input data for 1901-1920:</desc>
-    <desc compset="^20TR_DATM%GSW">GSWP3 atm input data for 1901-1920:</desc>
-    <desc compset="^RCP[2468]_DATM%GSW">GSWP3 atm input data for 1991-2010:</desc>
-    <desc compset="^1850_DATM%CPLHIST">CPL history input data:</desc>
-    <desc compset="^2000_DATM%1PT">single point tower site atm input data:</desc>
-    <desc compset="_DATM%NYF">COREv2 datm normal year forcing: (requires additional user-supplied data)</desc>
-    <desc compset="_DATM%IAF">COREv2 datm interannual year forcing: (requires additional user-supplied data)</desc>
+<entry_id version="3.0">
+  <!-- NOTE that the description block determines what DATM% values can appear in the compset name
+       For DATM this is determined by the DATM_MODE values in combination with the FORCING prefix -->
+  <description modifier_mode="1">
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%GSW][%CPLHIST][%1PT][%NYF][%IAF]"> Data driven ATM </desc>
+    <desc option="QIA"> QIAN data set </desc>
+    <desc option="WISOQIA">QIAN with water isotopes</desc>
+    <desc option="CRU"> CRUNCEP data set </desc>
+    <desc option="GSW"> GSWP3 data set </desc>
+    <desc option="CPLHIST"> Coupler hist data set </desc>
+    <desc option="1PT">single point tower site data set </desc>
+    <desc option="NYF">COREv2 normal year forcing</desc>
+    <desc option="IAF">COREv2 interannual forcing</desc>
   </description>
 
   <entry id="COMP_ATM">
@@ -49,7 +31,7 @@
     <group>run_component_datm</group>
     <file>env_run.xml</file>
     <desc>Mode for data atmosphere component.
-      CORE2_NYF (CORE2 normal year forcing) is the DATM mode used in C and G compsets. 
+      CORE2_NYF (CORE2 normal year forcing) is the DATM mode used in C and G compsets.
       CLM_QIAN, CLMCRUNCEP, CLMGSWP3 and CLM1PT are modes using observational data for I compsets.</desc>
     <values match="last">
       <value compset="%NYF">CORE2_NYF</value>
@@ -120,14 +102,14 @@
     <desc>DATM CO2 time series</desc>
   </entry>
 
-  <entry id="DATM_CPLHIST_DIR"> 
+  <entry id="DATM_CPLHIST_DIR">
     <type>char</type>
     <valid_values></valid_values>
     <default_value>UNSET</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
     <desc>directory for coupler history data mode (only used for CPLHIST3HrWx mode)</desc>
-  </entry> 
+  </entry>
 
   <entry id="DATM_CPLHIST_CASE">
     <type>char</type>
@@ -194,10 +176,10 @@
       <value compset="20TR.*_DATM%CRU">1901</value>
       <value compset="20TR.*_DATM%GSW">1901</value>
       <value compset="4804.*_DATM%QIA">1</value>
-      <value compset="RCP.*_DATM%QIA">2004</value> 
-      <value compset="RCP.*_DATM%CRU">2005</value> 
-      <value compset="RCP.*_DATM%GSW">2005</value> 
-      <value compset="2003.*_DATM%QIA.*_TEST">1</value> 
+      <value compset="RCP.*_DATM%QIA">2004</value>
+      <value compset="RCP.*_DATM%CRU">2005</value>
+      <value compset="RCP.*_DATM%GSW">2005</value>
+      <value compset="2003.*_DATM%QIA.*_TEST">1</value>
       <value compset="1850.*_DATM%CRU">1</value>
       <value compset="2000.*_DATM%CRU">1</value>
       <value compset="2003.*_DATM%CRU">1</value>
@@ -228,10 +210,10 @@
       <value compset="20TR.*_DATM%CRU">1901</value>
       <value compset="20TR.*_DATM%GSW">1901</value>
       <value compset="4804.*_DATM%QIA">1948</value>
-      <value compset="RCP.*_DATM%QIA" >1972</value> 
-      <value compset="RCP.*_DATM%CRU" >1991</value> 
-      <value compset="RCP.*_DATM%GSW" >1991</value> 
-      <value compset="2003.*_DATM%QIA.*_TEST">2002</value> 
+      <value compset="RCP.*_DATM%QIA" >1972</value>
+      <value compset="RCP.*_DATM%CRU" >1991</value>
+      <value compset="RCP.*_DATM%GSW" >1991</value>
+      <value compset="2003.*_DATM%QIA.*_TEST">2002</value>
       <value compset="1850.*_DATM%CRU">1901</value>
       <value compset="2000.*_DATM%CRU">1991</value>
       <value compset="2003.*_DATM%CRU">2002</value>
@@ -249,12 +231,12 @@
     <valid_values></valid_values>
     <default_value>2004</default_value>
     <values match="last">
-      <value   compset="2000.*_DATM%1PT">2004</value> 
-      <value   compset="1850.*_DATM%QIA">1972</value> 
-      <value   compset="1850.*_DATM%CRU">1920</value> 
-      <value   compset="1850.*_DATM%GSW">1920</value> 
-      <value   compset="2000.*_DATM%WISOQIA">2004</value> 
-      <value   compset="2000.*_DATM%QIA">2004</value> 
+      <value   compset="2000.*_DATM%1PT">2004</value>
+      <value   compset="1850.*_DATM%QIA">1972</value>
+      <value   compset="1850.*_DATM%CRU">1920</value>
+      <value   compset="1850.*_DATM%GSW">1920</value>
+      <value   compset="2000.*_DATM%WISOQIA">2004</value>
+      <value   compset="2000.*_DATM%QIA">2004</value>
       <value   compset="HIST.*_DATM%QIA">1972</value>
       <value   compset="HIST.*_DATM%CRU">1920</value>
       <value   compset="HIST.*_DATM%GSW">1920</value>
@@ -262,14 +244,14 @@
       <value   compset="20TR.*_DATM%CRU">1920</value>
       <value   compset="20TR.*_DATM%GSW">1920</value>
       <value   compset="4804.*_DATM%QIA">2004</value>
-      <value   compset="RCP.*_DATM%QIA">2004</value> 
-      <value   compset="RCP.*_DATM%CRU">2010</value> 
-      <value   compset="RCP.*_DATM%GSW">2010</value> 
-      <value   compset="2003.*_DATM%QIA.*_TEST">2003</value> 
-      <value   compset="1850.*_DATM%CRU">1920</value> 
+      <value   compset="RCP.*_DATM%QIA">2004</value>
+      <value   compset="RCP.*_DATM%CRU">2010</value>
+      <value   compset="RCP.*_DATM%GSW">2010</value>
+      <value   compset="2003.*_DATM%QIA.*_TEST">2003</value>
+      <value   compset="1850.*_DATM%CRU">1920</value>
       <value   compset="2000.*_DATM%CRU">2010</value>
       <value   compset="2003.*_DATM%CRU">2003</value>
-      <value   compset="1850.*_DATM%GSW">1920</value> 
+      <value   compset="1850.*_DATM%GSW">1920</value>
       <value   compset="2000.*_DATM%GSW">2010</value>
       <value   compset="2003.*_DATM%GSW">2003</value>
     </values>
@@ -285,4 +267,3 @@
   </help>
 
 </entry_id>
-

--- a/src/components/data_comps/desp/cime_config/config_component.xml
+++ b/src/components/data_comps/desp/cime_config/config_component.xml
@@ -2,13 +2,21 @@
 
 <?xml-stylesheet type="text/xsl" href="definitions_components.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
 
-  <!-- NOTE that the description block determines what DESP% values can appear in the compset name 
-       For DESP this is determined by the DESP_MODE values -->
+  <!-- modifier_mode allowed values are
+       '*' 0 or more modifiers (default)
+       '1' exactly 1 modifier
+       '?' 0 or 1 modifiers
+       '+' 1 or more modifiers
+
+       This file may have esp desc entries.
+  -->
+
   <description>
-    <desc compset="_DESP%NOOP">no modification of any model data</desc>
-    <desc compset="_DESP%TEST">test modification of any model data</desc>
+    <desc esp="DESP[%NOOP][%TEST]">Data External System Processor (DESP)</desc>
+    <desc option="NOOP">no modification of any model data</desc>
+    <desc option="TEST">test modification of any model data</desc>
   </description>
 
   <entry id="COMP_ESP">
@@ -41,4 +49,3 @@
   </help>
 
 </entry_id>
-

--- a/src/components/data_comps/desp/cime_config/config_component.xml
+++ b/src/components/data_comps/desp/cime_config/config_component.xml
@@ -13,7 +13,7 @@
        This file may have esp desc entries.
   -->
 
-  <description>
+  <description modifier_mode="1">
     <desc esp="DESP[%NOOP][%TEST]">Data External System Processor (DESP)</desc>
     <desc option="NOOP">no modification of any model data</desc>
     <desc option="TEST">test modification of any model data</desc>

--- a/src/components/data_comps/dice/cime_config/config_component.xml
+++ b/src/components/data_comps/dice/cime_config/config_component.xml
@@ -2,15 +2,16 @@
 
 <?xml-stylesheet type="text/xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
 
-  <!-- NOTE that the description block determines what DICE% values can appear in the compset name 
+  <!-- NOTE that the description block determines what DICE% values can appear in the compset name
        For DICE this is determined by the DICE_MODE values -->
-  <description>
-    <desc compset="DICE%SSMI">dice mode is ssmi:</desc>
-    <desc compset="DICE%SIAF">dice mode is ssmi_iaf:</desc>
-    <desc compset="DICE%PRES">dice mode is prescribed:</desc>
-    <desc compset="DICE%NULL">dice mode is null:</desc>
+  <description modifier_mode='1'>
+    <desc ice="DICE[%SSMI][%SIAF][%PRES][%NULL]">dice mode </desc>
+    <desc option="SSMI">is ssmi</desc>
+    <desc option="SIAF"> is siaf</desc>
+    <desc option="PRES"> is prescribed:</desc>
+    <desc option="NULL"> is null</desc>
   </description>
 
   <entry id="COMP_ICE">

--- a/src/components/data_comps/dice/cime_config/config_component.xml
+++ b/src/components/data_comps/dice/cime_config/config_component.xml
@@ -4,13 +4,19 @@
 
 <entry_id version="3.0">
 
-  <!-- NOTE that the description block determines what DICE% values can appear in the compset name
-       For DICE this is determined by the DICE_MODE values -->
+  <!-- modifier_mode allowed values are
+       '*' 0 or more modifiers (default)
+       '1' exactly 1 modifier
+       '?' 0 or 1 modifiers
+       '+' 1 or more modifiers
+
+       This file may have ice desc entries.
+  -->
   <description modifier_mode='1'>
     <desc ice="DICE[%SSMI][%SIAF][%PRES][%NULL]">dice mode </desc>
     <desc option="SSMI">is ssmi</desc>
     <desc option="SIAF"> is siaf</desc>
-    <desc option="PRES"> is prescribed:</desc>
+    <desc option="PRES"> is prescribed</desc>
     <desc option="NULL"> is null</desc>
   </description>
 

--- a/src/components/data_comps/dlnd/cime_config/config_component.xml
+++ b/src/components/data_comps/dlnd/cime_config/config_component.xml
@@ -2,14 +2,20 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <!-- modifier_mode allowed values are
+       '*' 0 or more modifiers (default)
+       '1' exactly 1 modifier
+       '?' 0 or 1 modifiers
+       '+' 1 or more modifiers
 
-  <!-- NOTE that the description block determines what DLND% values can appear in the compset name 
-       For DLND this is determined by the DLND_MODE values -->
-  <description>
-    <desc compset="_DLND%NULL">dlnd modes are DLND_MODE=NULL:</desc>
-    <desc compset="_DLND%SCPL">dlnd modes for coupler-hist snow coupling are DLND_MODE=GLC_CPLHIST:</desc>
-    <desc compset="_DLND%LCPL">dlnd modes for coupler-hist non-snow coupling are DLND_MODE=CPLHIST:</desc>
+       This file may have lnd desc entries.
+  -->
+  <description modifier_mode="1">
+    <desc lnd="DLND[%NULL][%SCPL][%LCPL]">Data land model (DLND) </desc>
+    <desc option="NULL">Null mode </desc>
+    <desc option="SCPL">snow coupling mode </desc>
+    <desc option="LCPL">non-snow coupling </desc>
   </description>
 
   <entry id="COMP_LND">
@@ -120,4 +126,3 @@
   </help>
 
 </entry_id>
-

--- a/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/src/components/data_comps/docn/cime_config/config_component.xml
@@ -2,28 +2,29 @@
 
 <?xml-stylesheet type="text/xsl" href="setup_comp.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
 
-  <!-- NOTE that the description block determines what DOCN% values can appear in the compset name 
+  <!-- NOTE that the description block determines what DOCN% values can appear in the compset name
        For DOCN this is determined by the DOCN_MODE values -->
-  <description>
-    <desc compset="_DOCN%NULL">docn null mode</desc>
-    <desc compset="_DOCN%DOM">docn prescribed ocean mode</desc>
-    <desc compset="_DOCN%SOM">docn slab ocean mode</desc>
-    <desc compset="_DOCN%SOMAQP">docn aquaplanet slab ocean mode</desc>
-    <desc compset="_DOCN%IAF">docn interannual mode</desc>
-    <desc compset="_DOCN%SST_AQUAP">docn aquaplanet mode:</desc>
-    <desc compset="_DOCN%AQP1">docn analytic aquaplanet sst - option 1</desc>
-    <desc compset="_DOCN%AQP2">docn analytic aquaplanet sst - option 2</desc>
-    <desc compset="_DOCN%AQP3">docn analytic aquaplanet sst - option 3</desc>
-    <desc compset="_DOCN%AQP4">docn analytic aquaplanet sst - option 4</desc>
-    <desc compset="_DOCN%AQP5">docn analytic aquaplanet sst - option 5</desc>
-    <desc compset="_DOCN%AQP6">docn analytic aquaplanet sst - option 6</desc>
-    <desc compset="_DOCN%AQP7">docn analytic aquaplanet sst - option 7</desc>
-    <desc compset="_DOCN%AQP8">docn analytic aquaplanet sst - option 8</desc>
-    <desc compset="_DOCN%AQP9">docn analytic aquaplanet sst - option 9</desc>
-    <desc compset="_DOCN%AQP10">docn analytic aquaplanet sst - option 10</desc>
-    <desc compset="_DOCN%AQPFILE">docn file input aquaplanet sst </desc>
+  <description modifier_mode="1">
+    <desc ocn="DOCN[%NULL][%DOM][%SOM][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQPFILE]">DOCN </desc>
+    <desc option="NULL">  null mode</desc>
+    <desc option="DOM">  prescribed ocean mode</desc>
+    <desc option="SOM">  slab ocean mode</desc>
+    <desc option="SOMAQP">  aquaplanet slab ocean mode</desc>
+    <desc option="IAF">  interannual mode</desc>
+    <desc option="SST_AQUAP">  aquaplanet mode:</desc>
+    <desc option="AQP1">  analytic aquaplanet sst - option 1</desc>
+    <desc option="AQP2">  analytic aquaplanet sst - option 2</desc>
+    <desc option="AQP3">  analytic aquaplanet sst - option 3</desc>
+    <desc option="AQP4">  analytic aquaplanet sst - option 4</desc>
+    <desc option="AQP5">  analytic aquaplanet sst - option 5</desc>
+    <desc option="AQP6">  analytic aquaplanet sst - option 6</desc>
+    <desc option="AQP7">  analytic aquaplanet sst - option 7</desc>
+    <desc option="AQP8">  analytic aquaplanet sst - option 8</desc>
+    <desc option="AQP9">  analytic aquaplanet sst - option 9</desc>
+    <desc option="AQP10">  analytic aquaplanet sst - option 10</desc>
+    <desc option="AQPFILE">  file input aquaplanet sst </desc>
   </description>
 
   <entry id="COMP_OCN">

--- a/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/src/components/data_comps/docn/cime_config/config_component.xml
@@ -4,8 +4,14 @@
 
 <entry_id version="3.0">
 
-  <!-- NOTE that the description block determines what DOCN% values can appear in the compset name
-       For DOCN this is determined by the DOCN_MODE values -->
+  <!-- modifier_mode allowed values are
+       '*' 0 or more modifiers (default)
+       '1' exactly 1 modifier
+       '?' 0 or 1 modifiers
+       '+' 1 or more modifiers
+
+       This file may have ocn desc entries.
+  -->
   <description modifier_mode="1">
     <desc ocn="DOCN[%NULL][%DOM][%SOM][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQPFILE]">DOCN </desc>
     <desc option="NULL">  null mode</desc>

--- a/src/components/data_comps/drof/cime_config/config_component.xml
+++ b/src/components/data_comps/drof/cime_config/config_component.xml
@@ -3,10 +3,16 @@
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
 <entry_id version="3.0">
+  <!-- modifier_mode allowed values are
+       '*' 0 or more modifiers (default)
+       '1' exactly 1 modifier
+       '?' 0 or 1 modifiers
+       '+' 1 or more modifiers
 
-  <!-- NOTE that the description block determines what DROF% values can appear in the compset name
-       For DROF this is determined by the DROF_MODE values -->
-  <description>
+       This file may have rof desc entries.
+  -->
+
+  <description modifier_mode="1">
     <desc rof="DROF[%NULL][%NYF][%IAF][%CPLHIST]">Data runoff model</desc>
     <desc option="NULL">NULL mode</desc>
     <desc option="NYF" >COREv2 normal year forcing:</desc>

--- a/src/components/data_comps/drof/cime_config/config_component.xml
+++ b/src/components/data_comps/drof/cime_config/config_component.xml
@@ -2,15 +2,16 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
 
-  <!-- NOTE that the description block determines what DROF% values can appear in the compset name 
+  <!-- NOTE that the description block determines what DROF% values can appear in the compset name
        For DROF this is determined by the DROF_MODE values -->
   <description>
-    <desc compset="_DROF%NULL">NULL drof mode:</desc>
-    <desc compset="_DROF%NYF" >COREv2 drof normal year forcing:</desc>
-    <desc compset="_DROF%IAF" >COREv2 drof interannual year forcing:</desc>
-    <desc compset="_DROF%CPLHIST">CPLHIST mode:</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%CPLHIST]">Data runoff model</desc>
+    <desc option="NULL">NULL mode</desc>
+    <desc option="NYF" >COREv2 normal year forcing:</desc>
+    <desc option="IAF" >COREv2 interannual year forcing:</desc>
+    <desc option="CPLHIST">CPLHIST mode:</desc>
   </description>
 
   <entry id="COMP_ROF">
@@ -26,7 +27,7 @@
     <type>char</type>
     <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
-    <values match="last"> 
+    <values match="last">
       <value compset="_DROF%NULL">NULL</value>
       <value compset="_DROF%NYF" >DIATREN_ANN_RX1</value>
       <value compset="_DROF%IAF" >DIATREN_IAF_RX1</value>

--- a/src/components/data_comps/dwav/cime_config/config_component.xml
+++ b/src/components/data_comps/dwav/cime_config/config_component.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0"?>
 
-<entry_id>
+<entry_id version="3.0">
 
-  <!-- NOTE that the description block determines what DWAV% values can appear in the compset name 
-       For DWAV this is determined by the DWAV_MODE values -->
+  <!-- modifier_mode allowed values are
+       '*' 0 or more modifiers (default)
+       '1' exactly 1 modifier
+       '?' 0 or 1 modifiers
+       '+' 1 or more modifiers
+
+       This file may have wav desc entries.
+  -->
   <description>
-    <desc compset="_DWAV%NULL">dwav null mode:</desc>
-    <desc compset="_DWAV%CLIMO">dwav climatological mode:</desc>
+    <desc wav="DWAV[%NULL][%CLIMO]">Data wave model (DWAV)</desc>
+    <desc option="NULL">null mode</desc>
+    <desc option="CLIMO">climatological mode</desc>
   </description>
 
   <entry id="COMP_WAV">

--- a/src/components/data_comps/dwav/cime_config/config_component.xml
+++ b/src/components/data_comps/dwav/cime_config/config_component.xml
@@ -10,7 +10,7 @@
 
        This file may have wav desc entries.
   -->
-  <description>
+  <description modifier_mode="1">
     <desc wav="DWAV[%NULL][%CLIMO]">Data wave model (DWAV)</desc>
     <desc option="NULL">null mode</desc>
     <desc option="CLIMO">climatological mode</desc>

--- a/src/components/stub_comps/satm/cime_config/config_component.xml
+++ b/src/components/stub_comps/satm/cime_config/config_component.xml
@@ -2,7 +2,10 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc atm="SATM">Stub atm component</desc>
+  </description>
 
   <entry id="COMP_ATM">
     <type>char</type>
@@ -13,9 +16,6 @@
     <desc>Name of atmosphere component</desc>
   </entry>
 
-  <description>
-    <desc compset="_SATM">Stub atm component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/stub_comps/sesp/cime_config/config_component.xml
+++ b/src/components/stub_comps/sesp/cime_config/config_component.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-
-<?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
-
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc esp="SESP">Stub external system processing (ESP) component</desc>
+  </description>
 
   <entry id="COMP_ESP">
     <type>char</type>
@@ -13,10 +13,6 @@
     <desc>Name of ESP component</desc>
   </entry>
 
-  <description>
-    <desc compset="_"> No ESP component  </desc>
-    <desc compset="_SESP">Stub esp component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/stub_comps/sglc/cime_config/config_component.xml
+++ b/src/components/stub_comps/sglc/cime_config/config_component.xml
@@ -2,7 +2,11 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc glc="SGLC">Stub glacier (land ice) component</desc>
+  </description>
+
 
   <entry id="COMP_GLC">
     <type>char</type>
@@ -12,10 +16,6 @@
     <file>env_case.xml</file>
     <desc>Name of land-ice component</desc>
   </entry>
-
-  <description>
-    <desc compset="_SGLC">Stub glc component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/stub_comps/sice/cime_config/config_component.xml
+++ b/src/components/stub_comps/sice/cime_config/config_component.xml
@@ -2,7 +2,11 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc ice="SICE">Stub ice component</desc>
+  </description>
+
 
   <entry id="COMP_ICE">
     <type>char</type>
@@ -12,10 +16,6 @@
     <file>env_case.xml</file>
     <desc>Name of sea-ice component</desc>
   </entry>
-
-  <description>
-    <desc compset="_SICE">Stub ice component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/stub_comps/slnd/cime_config/config_component.xml
+++ b/src/components/stub_comps/slnd/cime_config/config_component.xml
@@ -2,7 +2,11 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+
+  <description>
+    <desc lnd="SLND">Stub land component</desc>
+  </description>
 
   <entry id="COMP_LND">
     <type>char</type>
@@ -12,10 +16,6 @@
     <file>env_case.xml</file>
     <desc>Name of land component</desc>
   </entry>
-
-  <description>
-    <desc compset="_SLND">Stub lnd component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/stub_comps/swav/cime_config/config_component.xml
+++ b/src/components/stub_comps/swav/cime_config/config_component.xml
@@ -2,7 +2,12 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+
+
+  <description>
+    <desc wav="SWAV">Stub wave component</desc>
+  </description>
 
   <entry id="COMP_WAV">
     <type>char</type>
@@ -12,10 +17,6 @@
     <file>env_case.xml</file>
     <desc>Name of wave component</desc>
   </entry>
-
-  <description>
-    <desc compset="_SWAV">Stub wave component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/xcpl_comps/xatm/cime_config/config_component.xml
+++ b/src/components/xcpl_comps/xatm/cime_config/config_component.xml
@@ -2,7 +2,10 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc atm="XATM">Dead atm component</desc>
+  </description>
 
   <entry id="COMP_ATM">
     <type>char</type>
@@ -13,10 +16,6 @@
     <desc>Name of atmosphere component</desc>
   </entry>
 
-  <description>
-    <desc compset="_XATM">Dead atm component</desc>
-  </description>
-
   <help>
     =========================================
     XATM naming conventions in compset name
@@ -24,4 +23,3 @@
   </help>
 
 </entry_id>
-

--- a/src/components/xcpl_comps/xglc/cime_config/config_component.xml
+++ b/src/components/xcpl_comps/xglc/cime_config/config_component.xml
@@ -2,7 +2,10 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc glc="XGLC">Dead land-ice component</desc>
+  </description>
 
   <entry id="COMP_GLC">
     <type>char</type>
@@ -13,9 +16,6 @@
     <desc>Name of land-ice component</desc>
   </entry>
 
-  <description>
-    <desc compset="_XGLC">Dead land-ice component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/xcpl_comps/xice/cime_config/config_component.xml
+++ b/src/components/xcpl_comps/xice/cime_config/config_component.xml
@@ -2,7 +2,10 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc ice="XICE">Dead ice component</desc>
+  </description>
 
   <entry id="COMP_ICE">
     <type>char</type>
@@ -13,9 +16,6 @@
     <desc>Name of sea-ice component</desc>
   </entry>
 
-  <description>
-    <desc compset="_XICE">Dead ice component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/xcpl_comps/xlnd/cime_config/config_component.xml
+++ b/src/components/xcpl_comps/xlnd/cime_config/config_component.xml
@@ -2,7 +2,11 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc lnd="XLND">Dead land component</desc>
+  </description>
+
 
   <entry id="COMP_LND">
     <type>char</type>
@@ -12,10 +16,6 @@
     <file>env_case.xml</file>
     <desc>Name of land component</desc>
   </entry>
-
-  <description>
-    <desc compset="_XLND">Dead land component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/xcpl_comps/xocn/cime_config/config_component.xml
+++ b/src/components/xcpl_comps/xocn/cime_config/config_component.xml
@@ -2,7 +2,10 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc ocn="XOCN">Dead ocean component</desc>
+  </description>
 
   <entry id="COMP_OCN">
     <type>char</type>
@@ -13,9 +16,7 @@
     <desc>Name of ocean component</desc>
   </entry>
 
-  <description>
-    <desc compset="_XOCN">Dead ocean component</desc>
-  </description>
+
 
   <help>
     =========================================

--- a/src/components/xcpl_comps/xrof/cime_config/config_component.xml
+++ b/src/components/xcpl_comps/xrof/cime_config/config_component.xml
@@ -2,7 +2,10 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc rof="XROF">Dead river component</desc>
+  </description>
 
   <entry id="COMP_ROF">
     <type>char</type>
@@ -26,9 +29,6 @@
     <desc>mode for xrof flood feature, NULL means xrof flood is turned off</desc>
   </entry>
 
-  <description>
-    <desc compset="_XROF">Dead river component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/components/xcpl_comps/xwav/cime_config/config_component.xml
+++ b/src/components/xcpl_comps/xwav/cime_config/config_component.xml
@@ -2,7 +2,11 @@
 
 <?xml-stylesheet type="text/xsl" href="entry_id.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+  <description>
+    <desc wav="XWAV">Dead wave component</desc>
+  </description>
+
 
   <entry id="COMP_WAV">
     <type>char</type>
@@ -12,10 +16,6 @@
     <file>env_case.xml</file>
     <desc>Name of wave component</desc>
   </entry>
-
-  <description>
-    <desc compset="_XWAV">Dead wave component</desc>
-  </description>
 
   <help>
     =========================================

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2,7 +2,7 @@
 
 <?xml-stylesheet type="text/xsl" href="config_compsets.xsl" ?>
 
-<entry_id>
+<entry_id version="2.0">
 
 <!-- The list of component classes that this coupler/driver knows how
      to deal with.  Stub and data models for each component class
@@ -2566,7 +2566,7 @@
    <desc>whether the PROJECT value is required on this machine</desc>
  </entry>
 
-  <help>
+ <help>
     =========================================
     Notes:
     (1) Time period is first four characters of

--- a/src/drivers/mct/cime_config/config_component_acme.xml
+++ b/src/drivers/mct/cime_config/config_component_acme.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 
-<?xml-stylesheet type="text/xsl" href="config_compsets.xsl" ?>
-
-<entry_id>
+<entry_id version="2.0">
 
   <entry id="DRV_THREADING">
     <type>logical</type>
@@ -124,50 +122,6 @@
     <file>env_run.xml</file>
     <desc>Freezing point calculation for salt water.</desc>
   </entry>
-
-  <description>
-    <desc compset="BGC%BPRP">BGC CO2=prog, rad CO2=prog:</desc>
-    <desc compset="BGC%BDRD">BGC CO2=diag, rad CO2=diag:</desc>
-    <desc compset="POP2%ECO">ECO in POP:</desc>
-    <desc compset="_TEST" >--DO NOT USE FOR LONG SIMULATIONS:</desc>
-    <desc compset="1850_">pre-industrial:</desc>
-    <desc compset="2000_">present day:</desc>
-    <desc compset="HIST_">Historical 1850 to 2000 transient:</desc>
-    <desc compset="AMIP_">AMIP for stand-alone cam:</desc>
-    <desc compset="C2R[68]_">CCMI REFC2 1950 to 2100 transient:</desc>
-    <desc compset="C2R4_">CCMI REFC2 2004 to 2100 transient:</desc>
-    <desc compset="4804_">1948 to 2004 transient:</desc>
-    <desc compset="FRC1_">CCMI REFC1 Free running, 1950 to 2010 transient:</desc>
-    <desc compset="SDC1_">CCMI REFC1 Specified dynamics, 1975 to 2010 transient:</desc>
-    <desc compset="C2R8_">RCP8.5 future scenario:</desc>
-    <desc compset="C2R6_">RCP6.0 future scenario:</desc>
-    <desc compset="C2R4_">RCP4.5 future scenario:</desc>
-    <desc compset="5505_">1955 to 2005 transient:</desc>
-    <desc compset="RCP8_">RCP8.5 future scenario:</desc>
-    <desc compset="RCP6_">RCP6.0 future scenario:</desc>
-    <desc compset="RCP4_">RCP4.5 future scenario:</desc>
-    <desc compset="RCP2_">RCP2.6 future scenario:</desc>
-    <desc compset="2013_">RCP4.5 based scenario from 2013 (control for WACCM/CARMA nuclear winter study):</desc>
-    <desc compset="9205_CAM">1992 to 2005 transient:</desc>
-    <desc compset="SDYN_CAM">prescribed meteorology: for stand-alone cam</desc>
-    <desc compset="AR95_CAM">ARM95 IOP: for stand-alone cam</desc>
-    <desc compset="AR97_CAM">ARM97 IOP: for stand-alone cam</desc>
-    <desc compset="HIST_CLM4[05]%CN">CLM transient land use:</desc>
-    <desc compset="PIPD">
-      pre-industrial (1850) to present day:
-      -----------------------------WARNING ------------------------------------------------
-      "PIPD" compsets use complete forcing data from observed sources
-      up to the year 2005. Following this period they are a combination of observed sources
-      (land-use, SST, sea ice, CO2, CH4, N2O) to present day and IPCC RCP4.5 scenario data.
-      -------------------------------------------------------------------------------------
-    </desc>
-    <desc compset="CAM4.*_BGC%B">
-      -----------------------------WARNING ------------------------------------------------
-      This compset is not spun-up! In later versions of the model, spun-up initial
-      conditions will be provided and this warning will be removed.
-      -------------------------------------------------------------------------------------
-    </desc>
-  </description>
 
   <!-- ===================================================================== -->
   <!-- component coupling options and frequencies -->
@@ -752,7 +706,6 @@
     <desc compset="1850_">pre-industrial:</desc>
     <desc compset="2000_">present day:</desc>
     <desc compset="HIST_">Historical 1850 to 2000 transient:</desc>
-    <desc compset="20TR_">Historical 1850 to 2000 transient:</desc>
     <desc compset="AMIP_">AMIP for stand-alone cam:</desc>
     <desc compset="C2R[68]_">CCMI REFC2 1950 to 2100 transient:</desc>
     <desc compset="C2R4_">CCMI REFC2 2004 to 2100 transient:</desc>
@@ -769,11 +722,10 @@
     <desc compset="RCP2_">RCP2.6 future scenario:</desc>
     <desc compset="2013_">RCP4.5 based scenario from 2013 (control for WACCM/CARMA nuclear winter study):</desc>
     <desc compset="9205_CAM">1992 to 2005 transient:</desc>
-    <desc compset="GEOS_CAM">GEOS5 meteorology: for stand-alone cam</desc>
+    <desc compset="SDYN_CAM">prescribed meteorology: for stand-alone cam</desc>
     <desc compset="AR95_CAM">ARM95 IOP: for stand-alone cam</desc>
     <desc compset="AR97_CAM">ARM97 IOP: for stand-alone cam</desc>
     <desc compset="HIST_CLM4[05]%CN">CLM transient land use:</desc>
-    <desc compset="20TR_CLM4[05]%CN">CLM transient land use:</desc>
     <desc compset="PIPD">
       pre-industrial (1850) to present day:
       -----------------------------WARNING ------------------------------------------------
@@ -789,5 +741,4 @@
       -------------------------------------------------------------------------------------
     </desc>
   </description>
-
 </entry_id>

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -23,8 +23,8 @@
     <desc forcing="RCP6">CMIP5 rcp 6.0 forcing</desc>
     <desc forcing="RCP8">CMIP5 rcp 8.5 forcing</desc>
     <desc cpl="BGC[%BDRD][%BPRP]">Biogeochemistry intercomponent </desc>
-    <desc option="BDRD"> does something</desc>
-    <desc option="BPRP"> does another thing</desc>
+    <desc option="BDRD"> with diagnostic CO2</desc>
+    <desc option="BPRP"> with prognostic CO2 </desc>
 
   </description>
 

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -3,19 +3,30 @@
 <?xml-stylesheet type="text/xsl" href="config_compsets.xsl" ?>
 
 <entry_id version="3.0">
- <description>
-   <desc forcing="1850"></desc>
-   <desc forcing="2000">1972-2004</desc>
-   <desc forcing="2003">2002-2003</desc>
-   <desc forcing="HIST">Historic transient </desc>
-   <desc forcing="20TR">Twentieth century transient</desc>
-   <desc forcing="4804"></desc>
-   <desc forcing="RCP2">CMIP5 rcp 2.6 forcing</desc>
-   <desc forcing="RCP4">CMIP5 rcp 4.5 forcing</desc>
-   <desc forcing="RCP6">CMIP5 rcp 6.0 forcing</desc>
-   <desc forcing="RCP8">CMIP5 rcp 8.5 forcing</desc>
+  <!-- modifier_mode allowed values are
+       '*' 0 or more modifiers (default)
+       '1' exactly 1 modifier
+       '?' 0 or 1 modifiers
+       '+' 1 or more modifiers
 
-</description>
+       This file may have forcing and cpl desc entries.
+  -->
+  <description modifier_mode="1">
+    <desc forcing="1850"></desc>
+    <desc forcing="2000">1972-2004</desc>
+    <desc forcing="2003">2002-2003</desc>
+    <desc forcing="HIST">Historic transient </desc>
+    <desc forcing="20TR">Twentieth century transient</desc>
+    <desc forcing="4804"></desc>
+    <desc forcing="RCP2">CMIP5 rcp 2.6 forcing</desc>
+    <desc forcing="RCP4">CMIP5 rcp 4.5 forcing</desc>
+    <desc forcing="RCP6">CMIP5 rcp 6.0 forcing</desc>
+    <desc forcing="RCP8">CMIP5 rcp 8.5 forcing</desc>
+    <desc cpl="BGC[%BDRD][%BPRP]">Biogeochemistry intercomponent </desc>
+    <desc option="BDRD"> does something</desc>
+    <desc option="BPRP"> does another thing</desc>
+
+  </description>
 
   <entry id="DRV_THREADING">
     <type>logical</type>
@@ -505,48 +516,5 @@
     <desc>Freezing point calculation for salt water.</desc>
   </entry>
 
-  <description>
-    <desc compset="BGC%BPRP">BGC CO2=prog, rad CO2=prog:</desc>
-    <desc compset="BGC%BDRD">BGC CO2=diag, rad CO2=diag:</desc>
-    <desc compset="POP2%ECO">ECO in POP:</desc>
-    <desc compset="_TEST" >--DO NOT USE FOR LONG SIMULATIONS:</desc>
-    <desc compset="1850_">pre-industrial:</desc>
-    <desc compset="2000_">present day:</desc>
-    <desc compset="HIST_">Historical 1850 to 2000 transient:</desc>
-    <desc compset="AMIP_">AMIP for stand-alone cam:</desc>
-    <desc compset="C2R[68]_">CCMI REFC2 1950 to 2100 transient:</desc>
-    <desc compset="C2R4_">CCMI REFC2 2004 to 2100 transient:</desc>
-    <desc compset="4804_">1948 to 2004 transient:</desc>
-    <desc compset="FRC1_">CCMI REFC1 Free running, 1950 to 2010 transient:</desc>
-    <desc compset="SDC1_">CCMI REFC1 Specified dynamics, 1975 to 2010 transient:</desc>
-    <desc compset="C2R8_">RCP8.5 future scenario:</desc>
-    <desc compset="C2R6_">RCP6.0 future scenario:</desc>
-    <desc compset="C2R4_">RCP4.5 future scenario:</desc>
-    <desc compset="5505_">1955 to 2005 transient:</desc>
-    <desc compset="RCP8_">RCP8.5 future scenario:</desc>
-    <desc compset="RCP6_">RCP6.0 future scenario:</desc>
-    <desc compset="RCP4_">RCP4.5 future scenario:</desc>
-    <desc compset="RCP2_">RCP2.6 future scenario:</desc>
-    <desc compset="2013_">RCP4.5 based scenario from 2013 (control for WACCM/CARMA nuclear winter study):</desc>
-    <desc compset="9205_CAM">1992 to 2005 transient:</desc>
-    <desc compset="SDYN_CAM">prescribed meteorology: for stand-alone cam</desc>
-    <desc compset="AR95_CAM">ARM95 IOP: for stand-alone cam</desc>
-    <desc compset="AR97_CAM">ARM97 IOP: for stand-alone cam</desc>
-    <desc compset="HIST_CLM4[05]%CN">CLM transient land use:</desc>
-    <desc compset="PIPD">
-      pre-industrial (1850) to present day:
-      -----------------------------WARNING ------------------------------------------------
-      "PIPD" compsets use complete forcing data from observed sources
-      up to the year 2005. Following this period they are a combination of observed sources
-      (land-use, SST, sea ice, CO2, CH4, N2O) to present day and IPCC RCP4.5 scenario data.
-      -------------------------------------------------------------------------------------
-    </desc>
-    <desc compset="CAM4.*_BGC%B">
-      -----------------------------WARNING ------------------------------------------------
-      This compset is not spun-up! In later versions of the model, spun-up initial
-      conditions will be provided and this warning will be removed.
-      -------------------------------------------------------------------------------------
-    </desc>
-  </description>
 
 </entry_id>

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -2,7 +2,20 @@
 
 <?xml-stylesheet type="text/xsl" href="config_compsets.xsl" ?>
 
-<entry_id>
+<entry_id version="3.0">
+ <description>
+   <desc forcing="1850"></desc>
+   <desc forcing="2000">1972-2004</desc>
+   <desc forcing="2003">2002-2003</desc>
+   <desc forcing="HIST">Historic transient </desc>
+   <desc forcing="20TR">Twentieth century transient</desc>
+   <desc forcing="4804"></desc>
+   <desc forcing="RCP2">CMIP5 rcp 2.6 forcing</desc>
+   <desc forcing="RCP4">CMIP5 rcp 4.5 forcing</desc>
+   <desc forcing="RCP6">CMIP5 rcp 6.0 forcing</desc>
+   <desc forcing="RCP8">CMIP5 rcp 8.5 forcing</desc>
+
+</description>
 
   <entry id="DRV_THREADING">
     <type>logical</type>
@@ -429,8 +442,8 @@
     <group>run_co2</group>
     <file>env_run.xml</file>
     <desc>
-      Mechanism for setting the CO2 value in ppmv for 
-      CLM if CLM_CO2_TYPE is constant or for 
+      Mechanism for setting the CO2 value in ppmv for
+      CLM if CLM_CO2_TYPE is constant or for
       POP if OCN_CO2_TYPE is constant.
     </desc>
   </entry>


### PR DESCRIPTION
This PR introduces version 3.0 schema for entry_id files bringing the description field to the top of the file and refining it to better define valid compsetname values.   Change definition of primary component as suggested in PR 1692.

Test suite: scripts_regression_tests.py, several F case user compsets with modified cam config_component.xml
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes ESMCI/cime#1522  
Fixes ESMCI/cime#1683 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
