### PR TITLE
backed up datm tintalgo for AIAF to cesm default for just cesm

### DIFF
--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -17,7 +17,7 @@ sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect
+from CIME.utils import expect, get_model
 from CIME.buildnml import create_namelist_infile, parse_input
 from CIME.XML.files import Files
 
@@ -84,6 +84,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     config['datm_mode'] = datm_mode
     config['datm_co2_tseries'] = datm_co2_tseries
     config['datm_presaero'] = datm_presaero
+    config['cime_model'] = get_model()
 
     #----------------------------------------------------
     # Initialize namelist defaults

--- a/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -1843,7 +1843,7 @@
            steps, which is undesirable unless we truly want linear interpolation
            between multiple input values -->
       <value stream="topo.observed">lower</value>
-      <value stream="CORE2_IAF.GISS.SWDN">coszen</value>
+      <value stream="CORE2_IAF.GISS.SWDN" cime_model="acme">coszen</value>
     </values>
   </entry>
 


### PR DESCRIPTION
The recent acme merge brought in a change of setting in the tintalgo namelist variable that we do not want in cesm.   This backs out the change for cesm only. 

Test suite:  Hand tested AIAF creation for acme and cesm models and confirmed expected results
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:N

Code review: mvertens
