### PR TITLE
Fix bug in case.run where arg skip-preview-namelist is out of sequence

### DIFF
--- a/config/acme/machines/template.case.run
+++ b/config/acme/machines/template.case.run
@@ -51,10 +51,11 @@ OR
     parser.add_argument("--caseroot",
                         help="Case directory to build")
 
-    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     parser.add_argument("--skip-preview-namelist", action="store_true",
                         help="Skip calling preview-namelist during case.run")
+
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)


### PR DESCRIPTION
arg parsing needs to be done after adding arguments
master is broken on acme mira/cetus and blues/anvil without this fix

Test suite: acme_developer on anvil
Test baseline: 
Test namelist changes: 
Test status: 

Fixes #1690 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
