### PR TITLE
this change avoids an error if the forcing description is missing fro…

### DIFF
--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -172,9 +172,8 @@ class Component(EntryID):
                            "Too many matches on forcing field {} in file {}".\
                                format(forcing, self.filename))
                     desc = node.text
-
-            expect(len(desc) > 0,"No match found for forcing field {} in file {}".\
-                       format(forcing, self.filename))
+            if desc is None:
+                desc = compsetname.split('_')[0]
             return desc
 
         # first pass just make a hash of the option descriptions


### PR DESCRIPTION
this change avoids an error if the forcing description is missing from config_compsets_cesm.xml
Needed for interfacing old config_component.xml files with the new ones introduced in PR #1697 

Test suite: Hand test of ERS.f09_g17.B1850Ws.cheyenne_intel.allactive-defaultio
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes

User interface changes?: 

Update gh-pages html (Y/N)?: N

Code review: 
