### PR TITLE
eleminate --user-compset, allow longname in tests

### DIFF
--- a/config/acme/machines/Makefile
+++ b/config/acme/machines/Makefile
@@ -27,8 +27,8 @@ VPATH := $(subst $(space),:,$(VPATH))
 RM    := rm
 CP    := cp
 
-exec_se: $(EXEC_SE)  $(CURDIR)/Depends
-complib: $(COMPLIB)  $(CURDIR)/Depends
+exec_se: $(EXEC_SE)  Depends
+complib: $(COMPLIB)  Depends
 
 # Determine whether to compile threaded or not
 # Set the THREADDIR for the shared build
@@ -674,7 +674,7 @@ $(PIO_LIBDIR)/Makefile:
 #-------------------------------------------------------------------------------
 
 touch_filepath:
-	touch $(CURDIR)/Filepath
+	touch Filepath
 
 # Get list of files and build dependency file for all .o files
 #   using perl scripts mkSrcfiles and mkDepends
@@ -686,17 +686,17 @@ INCS    := $(foreach dir,$(cpp_dirs),-I$(dir))
 
 CURDIR := $(shell pwd)
 
-$(CURDIR)/Depends: $(CURDIR)/Srcfiles $(CURDIR)/Deppath
+Depends: Srcfiles Deppath
 	$(CASETOOLS)/mkDepends $(USER_MKDEPENDS_OPTS) Deppath Srcfiles > $@
 
-$(CURDIR)/Deppath: $(CURDIR)/Filepath
-	$(CP) -f $(CURDIR)/Filepath $@
+Deppath: Filepath
+	$(CP) -f Filepath $@
 	@echo "$(MINCROOT)" >> $@
 
-$(CURDIR)/Srcfiles: $(CURDIR)/Filepath
+Srcfiles: Filepath
 	$(CASETOOLS)/mkSrcfiles
 
-$(CURDIR)/Filepath:
+Filepath:
 	@echo "$(VPATH)" > $@
 
 
@@ -899,7 +899,7 @@ realclean: clean cleancsmshare cleanpio cleanmct cleangptl
 ifneq ($(MAKECMDGOALS), db_files)
 ifneq ($(MAKECMDGOALS), db_flags)
 ifeq (,$(findstring clean,$(MAKECMDGOALS)))
-    -include $(CURDIR)/Depends $(CASEROOT)/Depends.$(COMPILER) $(CASEROOT)/Depends.$(MACH) $(CASEROOT)/Depends.$(MACH).$(COMPILER)
+    -include Depends $(CASEROOT)/Depends.$(COMPILER) $(CASEROOT)/Depends.$(MACH) $(CASEROOT)/Depends.$(MACH).$(COMPILER)
 endif
 endif
 endif

--- a/config/cesm/machines/Makefile
+++ b/config/cesm/machines/Makefile
@@ -27,8 +27,8 @@ VPATH := $(subst $(space),:,$(VPATH))
 RM    := rm
 CP    := cp
 
-exec_se: $(EXEC_SE)  $(CURDIR)/Depends
-complib: $(COMPLIB)  $(CURDIR)/Depends
+exec_se: $(EXEC_SE)  Depends
+complib: $(COMPLIB)  Depends
 
 # Determine whether to compile threaded or not
 # Set the THREADDIR for the shared build
@@ -98,26 +98,26 @@ ifeq ($(compile_threaded), true)
 endif
 
 ifeq (,$(EXEROOT))
-  EXEROOT = $(shell ./xmlquery EXEROOT -value)
+  EXEROOT = $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) EXEROOT --value)
 endif
 ifeq (,$(BUILD_THREADED))
-  BUILD_THREADED = $(shell ./xmlquery BUILD_THREADED -value)
+  BUILD_THREADED = $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) BUILD_THREADED --value)
 endif
 
 ifeq (,$(LIBROOT))
-  LIBROOT = $(shell ./xmlquery LIBROOT -value)
+  LIBROOT = $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) LIBROOT --value)
 endif
 ifeq (,$(SHAREDLIBROOT))
-  SHAREDLIBROOT = $(shell ./xmlquery SHAREDLIBROOT -value)
+  SHAREDLIBROOT = $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) SHAREDLIBROOT --value)
 endif
 ifeq (,$(COMPILER))
-  COMPILER = $(shell ./xmlquery COMPILER -value)
+  COMPILER = $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) COMPILER --value)
 endif
 ifeq (,$(NINST_VALUE))
-  NINST_VALUE = $(shell ./xmlquery NINST_VALUE -value)
+  NINST_VALUE = $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) NINST_VALUE --value)
 endif
 ifeq (,$(MPILIB))
-  MPILIB = $(shell ./xmlquery MPILIB -value)
+  MPILIB = $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) MPILIB --value)
 endif
 ifeq ($(strip $(PIO_VERSION)),1)
   CPPDEFS += -DPIO1
@@ -616,7 +616,7 @@ $(PIO_LIBDIR)/Makefile:
 #-------------------------------------------------------------------------------
 
 touch_filepath:
-	touch $(CURDIR)/Filepath
+	touch Filepath
 
 # Get list of files and build dependency file for all .o files
 #   using perl scripts mkSrcfiles and mkDepends
@@ -626,19 +626,19 @@ BASENAMES := $(basename $(basename $(SOURCES)))
 OBJS    := $(addsuffix .o, $(BASENAMES))
 INCS    := $(foreach dir,$(cpp_dirs),-I$(dir))
 
-CURDIR := $(shell pwd)
+CASETOOLS := $(CASEROOT)/Tools
 
-$(CURDIR)/Depends: $(CURDIR)/Srcfiles $(CURDIR)/Deppath
+Depends: Srcfiles Deppath
 	$(CASETOOLS)/mkDepends $(USER_MKDEPENDS_OPTS) Deppath Srcfiles > $@
 
-$(CURDIR)/Deppath: $(CURDIR)/Filepath
-	$(CP) -f $(CURDIR)/Filepath $@
+Deppath: Filepath
+	$(CP) -f Filepath $@
 	@echo "$(MINCROOT)" >> $@
 
-$(CURDIR)/Srcfiles: $(CURDIR)/Filepath
+Srcfiles: Filepath
 	$(CASETOOLS)/mkSrcfiles
 
-$(CURDIR)/Filepath:
+Filepath:
 	@echo "$(VPATH)" > $@
 
 
@@ -852,7 +852,7 @@ realclean: clean cleancsmshare cleanpio cleanmct cleangptl
 ifneq ($(MAKECMDGOALS), db_files)
 ifneq ($(MAKECMDGOALS), db_flags)
 ifeq (,$(findstring clean,$(MAKECMDGOALS)))
-    -include $(CURDIR)/Depends $(CASEROOT)/Depends.$(COMPILER) $(CASEROOT)/Depends.$(MACH)
+    -include Depends $(CASEROOT)/Depends.$(COMPILER) $(CASEROOT)/Depends.$(MACH)
 endif
 endif
 endif

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -73,12 +73,6 @@ OR
                         "whose primary component is cam, '--user-mods-dir foo' "
                         "could be found in components/cam/cime_config/usermods_dirs/foo).")
 
-    parser.add_argument("--user-compset", action="store_true",
-                        help="If set, then the --compset argument is treated as a user specified compset."
-                        "This assumes that all of the compset settings in the"
-                        "compset along name have been defined for all of its components"
-                        "If the compset name is found as a supported compset, then it will be treated as such.")
-
     parser.add_argument("--pesfile",
                         help="Full pathname of an optional pes specification "
                         "file. The file can follow either the config_pes.xml or "
@@ -161,7 +155,7 @@ OR
 
     return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
-        args.user_mods_dir, args.user_compset, args.pesfile, \
+        args.user_mods_dir, args.pesfile, \
         args.user_grid, args.gridfile, args.srcroot, args.test, args.ninst, \
         args.walltime, args.queue, args.output_root, args.script_root, \
         run_unsupported, args.answer, args.input_dir
@@ -173,7 +167,7 @@ def _main_func(description):
 
     casename, compset, grid, machine, compiler, \
         mpilib, project, pecount,  \
-        user_mods_dir, user_compset, pesfile, \
+        user_mods_dir, pesfile, \
         user_grid, gridfile, srcroot, test, ninst, walltime, queue, \
         output_root, script_root, run_unsupported, \
         answer, input_dir = parse_command_line(sys.argv, cimeroot, description)
@@ -201,8 +195,7 @@ def _main_func(description):
         # Configure the Case
         case.configure(compset, grid, machine_name=machine, project=project,
                        pecount=pecount, compiler=compiler, mpilib=mpilib,
-                       user_compset=user_compset, pesfile=pesfile,
-                       user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
+                       pesfile=pesfile,user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
                        walltime=walltime, queue=queue, output_root=output_root,
                        run_unsupported=run_unsupported, answer=answer,
                        input_dir=input_dir)

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -353,6 +353,11 @@ OR
     if args.input_dir is not None:
         args.input_dir = os.path.abspath(args.input_dir)
 
+    # sanity check
+    for name in test_names:
+        dot_count = name.count('.')
+        expect(dot_count > 1 and dot_count <= 4, "Invalid test Name, '{}'".format(name))
+
     return test_names, test_extra_data, args.compiler, mach_obj.get_machine_name(), args.no_run, args.no_build, args.no_setup, args.no_batch,\
         args.test_root, args.baseline_root, args.clean, baseline_cmp_name, baseline_gen_name, \
         args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.walltime, \

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -411,7 +411,7 @@ class Case(object):
             if result is not None:
                 del self.lookups[key]
 
-    def _set_compset(self, compset_name, files, user_compset=False):
+    def _set_compset(self, compset_name, files):
         """
         Loop through all the compset files and find the compset
         specifation file that matches either the input 'compset_name'.
@@ -446,17 +446,11 @@ class Case(object):
                                    files.get_value("COMPSETS_SPEC_FILE", {"component":component}, resolved=False))
                     logger.info("Compset longname is {}".format(match))
                     logger.info("Compset specification file is {}".format(compsets_filename))
-                    if user_compset is True:
-                        logger.info("Found a compset match for longname {} in alias {}".format(compset_name, compset_alias))
-
                     return compset_alias, science_support
 
-        if user_compset is True:
+        if compset_alias is None:
+            logger.info("Did not find a compset match for longname {} ".format(compset_name))
             self._compsetname = compset_name
-        else:
-            expect(False,
-                   "Could not find a compset match for either alias or longname in {}\n".format(compset_name)
-                   + "You may need the --user-compset argument.")
 
         return None, science_support
 
@@ -529,6 +523,8 @@ class Case(object):
         else:
             self._pesfile = pesfile
             pesfile_unresolved = pesfile
+        expect(self._pesfile is not None,"No pesfile found for component {}".format(component))
+
         self.set_lookup_value("PES_SPEC_FILE", pesfile_unresolved)
 
         tests_filename = files.get_value("TESTS_SPEC_FILE", {"component":component}, resolved=False)
@@ -741,8 +737,7 @@ class Case(object):
 
     def configure(self, compset_name, grid_name, machine_name=None,
                   project=None, pecount=None, compiler=None, mpilib=None,
-                  user_compset=False, pesfile=None,
-                  user_grid=False, gridfile=None, ninst=1, test=False,
+                  pesfile=None,user_grid=False, gridfile=None, ninst=1, test=False,
                   walltime=None, queue=None, output_root=None, run_unsupported=False, answer=None,
                   input_dir=None):
 
@@ -751,7 +746,7 @@ class Case(object):
         #--------------------------------------------
         files = Files()
         compset_alias, science_support = self._set_compset(
-            compset_name, files, user_compset=user_compset)
+            compset_name, files)
 
         self._components = self.get_compset_components()
         #--------------------------------------------

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -10,7 +10,7 @@ from CIME.XML.standard_module_setup import *
 
 from CIME.utils                     import expect, get_cime_root, append_status
 from CIME.utils                     import convert_to_type, get_model, get_project
-from CIME.utils                     import get_current_commit
+from CIME.utils                     import get_current_commit, check_name
 from CIME.check_lockedfiles         import LOCKED_DIR, lock_file
 from CIME.XML.machines              import Machines
 from CIME.XML.pes                   import Pes
@@ -741,6 +741,7 @@ class Case(object):
                   walltime=None, queue=None, output_root=None, run_unsupported=False, answer=None,
                   input_dir=None):
 
+        expect(check_name(compset_name, additional_chars='.'), "Invalid compset name {}".format(compset_name))
         #--------------------------------------------
         # compset, pesfile, and compset components
         #--------------------------------------------

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -298,7 +298,9 @@ def normalize_case_id(case_id):
 def parse_test_name(test_name):
     """
     Given a CIME test name TESTCASE[_CASEOPTS].GRID.COMPSET[.MACHINE_COMPILER[.TESTMODS]],
-    return each component of the testname with machine and compiler split
+    return each component of the testname with machine and compiler split.
+    Do not error if a partial testname is provided (TESTCASE or TESTCASE.GRID) instead
+    parse and return the partial results.
 
     >>> parse_test_name('ERS')
     ['ERS', None, None, None, None, None, None]

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -316,11 +316,17 @@ def parse_test_name(test_name):
     ['ERS', None, 'fe12_123', 'JGF', 'machine', 'compiler', None]
     >>> parse_test_name('ERS.fe12_123.JGF.machine_compiler.test-mods')
     ['ERS', None, 'fe12_123', 'JGF', 'machine', 'compiler', 'test/mods']
+    >>> parse_test_name('SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods')
+    Traceback (most recent call last):
+        ...
+    SystemExit: ERROR: Expected 4th item of 'SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods' ('A_XLND_SICE_SOCN_XROF_XGLC_SWAV') to be in form machine_compiler
+    >>> parse_test_name('SMS.f19_g16.2000_DATM%QI/A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods')
+    Traceback (most recent call last):
+        ...
+    SystemExit: ERROR: Invalid compset name 2000_DATM%QI/A_XLND_SICE_SOCN_XROF_XGLC_SWAV
     """
     rv = [None] * 7
     num_dots = test_name.count(".")
-    expect(num_dots <= 4,
-           "'{}' does not look like a CIME test name, expect TESTCASE.GRID.COMPSET[.MACHINE_COMPILER[.TESTMODS]]".format(test_name))
 
     rv[0:num_dots+1] = test_name.split(".")
     testcase_field_underscores = rv[0].count("_")
@@ -332,6 +338,8 @@ def parse_test_name(test_name):
         rv[1]    = full_str.split("_")[1:]
 
     if (num_dots >= 3):
+        expect(check_name( rv[3] ), "Invalid compset name {}".format(rv[3]))
+
         expect(rv[4].count("_") == 1,
                "Expected 4th item of '{}' ('{}') to be in form machine_compiler".format(test_name, rv[4]))
         rv[4:5] = rv[4].split("_")
@@ -339,6 +347,9 @@ def parse_test_name(test_name):
 
     if (rv[-1] is not None):
         rv[-1] = rv[-1].replace("-", "/")
+
+    expect(num_dots <= 4,
+           "'{}' does not look like a CIME test name, expect TESTCASE.GRID.COMPSET[.MACHINE_COMPILER[.TESTMODS]]".format(test_name))
 
     return rv
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1298,13 +1298,6 @@ class R_TestUpdateACMETests(unittest.TestCase):
         # self.assertEqual(stat, 0,
         #                  msg="COMMAND SHOULD HAVE WORKED\ncs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
-###############################################################################
-class W_TestCreateTest(TestCreateTestCommon):
-###############################################################################
-    def test_create_test_longname(self):
-        create_test_cmd =  "%s/create_test SMS.f19_g16.2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --no-build --output-root %s" % (SCRIPT_DIR, TEST_ROOT)
-        run_cmd_assert_result(self, create_test_cmd)
-
 class Z_FullSystemTest(TestCreateTestCommon):
 ###############################################################################
 
@@ -1599,6 +1592,10 @@ class K_TestCimeCase(TestCreateTestCommon):
 
         result = run_cmd_assert_result(self, "./xmlquery JOB_QUEUE --subgroup=case.test --value", from_dir=casedir)
         self.assertEqual(result, "slartibartfast")
+
+    def test_create_test_longname(self):
+        create_test_cmd =  "%s/create_test SMS.f19_g16.2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --no-build --output-root %s" % (SCRIPT_DIR, TEST_ROOT)
+        run_cmd_assert_result(self, create_test_cmd)
 
 ###############################################################################
 class X_TestSingleSubmit(TestCreateTestCommon):

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -380,7 +380,7 @@ class J_TestCreateNewcase(unittest.TestCase):
         cls._testdirs.append(testdir)
 
         pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
-        args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --user-compset --pesfile %s --res f19_g16 --output-root %s" % (testdir, pesfile, cls._testroot)
+        args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV  --pesfile %s --res f19_g16 --output-root %s" % (testdir, pesfile, cls._testroot)
         if CIME.utils.get_model() == "cesm":
             args += " --run-unsupported"
 
@@ -400,7 +400,7 @@ class J_TestCreateNewcase(unittest.TestCase):
         cls._testdirs.append(testdir)
 
         pesfile = os.path.join(previous_testdir,"env_mach_pes.xml")
-        args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --user-compset --pesfile %s --res f19_g16 --output-root %s" % (testdir, pesfile, cls._testroot)
+        args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --pesfile %s --res f19_g16 --output-root %s" % (testdir, pesfile, cls._testroot)
         if CIME.utils.get_model() == "cesm":
             args += " --run-unsupported"
 
@@ -1299,6 +1299,12 @@ class R_TestUpdateACMETests(unittest.TestCase):
         #                  msg="COMMAND SHOULD HAVE WORKED\ncs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
 ###############################################################################
+class S_TestCreateTest(TestCreateTestCommon):
+###############################################################################
+    def test_create_test_longname(self):
+        create_test_cmd =  "%s/create_test SMS.f19_g16.2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --no-build --output-root %s" % (SCRIPT_DIR, TEST_ROOT)
+        run_cmd_assert_result(self, create_test_cmd)
+
 class Z_FullSystemTest(TestCreateTestCommon):
 ###############################################################################
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1299,7 +1299,7 @@ class R_TestUpdateACMETests(unittest.TestCase):
         #                  msg="COMMAND SHOULD HAVE WORKED\ncs.status output:\n%s\n\nerrput:\n%s\n\ncode: %d" % (output, errput, stat))
 
 ###############################################################################
-class S_TestCreateTest(TestCreateTestCommon):
+class W_TestCreateTest(TestCreateTestCommon):
 ###############################################################################
     def test_create_test_longname(self):
         create_test_cmd =  "%s/create_test SMS.f19_g16.2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --no-build --output-root %s" % (SCRIPT_DIR, TEST_ROOT)

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -13,22 +13,22 @@ my ($sharedlibroot, $installroot, $CASEROOT) = @ARGV;
 
 chdir "${CASEROOT}" or die "Could not cd to \"$CASEROOT\"";
 
-my $CIMEROOT		= `./xmlquery CIMEROOT		-value`;
-my $COMP_INTERFACE	= `./xmlquery COMP_INTERFACE	-value`;
-my $USE_ESMF_LIB	= `./xmlquery USE_ESMF_LIB	-value`;
-my $GMAKE_J		= `./xmlquery GMAKE_J		-value`;
-my $GMAKE		= `./xmlquery GMAKE		-value`;
-my $CASETOOLS		= `./xmlquery CASETOOLS		-value`;
-my $NINST_ATM		= `./xmlquery NINST_ATM		-value`;
-my $NINST_ICE		= `./xmlquery NINST_ICE		-value`;
-my $NINST_GLC		= `./xmlquery NINST_GLC		-value`;
-my $NINST_LND		= `./xmlquery NINST_LND		-value`;
-my $NINST_OCN		= `./xmlquery NINST_OCN		-value`;
-my $NINST_ROF		= `./xmlquery NINST_ROF		-value`;
-my $NINST_WAV		= `./xmlquery NINST_WAV		-value`;
-my $NINST_ESP		= `./xmlquery NINST_ESP		-value`;
-my $NINST_VALUE		= `./xmlquery NINST_VALUE	-value`;
-$ENV{PIO_VERSION}  	= `./xmlquery PIO_VERSION	-value`;
+my $CIMEROOT		= `./xmlquery CIMEROOT		--value`;
+my $COMP_INTERFACE	= `./xmlquery COMP_INTERFACE	--value`;
+my $USE_ESMF_LIB	= `./xmlquery USE_ESMF_LIB	--value`;
+my $GMAKE_J		= `./xmlquery GMAKE_J		--value`;
+my $GMAKE		= `./xmlquery GMAKE		--value`;
+my $CASETOOLS		= `./xmlquery CASETOOLS		--value`;
+my $NINST_ATM		= `./xmlquery NINST_ATM		--value`;
+my $NINST_ICE		= `./xmlquery NINST_ICE		--value`;
+my $NINST_GLC		= `./xmlquery NINST_GLC		--value`;
+my $NINST_LND		= `./xmlquery NINST_LND		--value`;
+my $NINST_OCN		= `./xmlquery NINST_OCN		--value`;
+my $NINST_ROF		= `./xmlquery NINST_ROF		--value`;
+my $NINST_WAV		= `./xmlquery NINST_WAV		--value`;
+my $NINST_ESP		= `./xmlquery NINST_ESP		--value`;
+my $NINST_VALUE		= `./xmlquery NINST_VALUE	--value`;
+$ENV{PIO_VERSION}  	= `./xmlquery PIO_VERSION	--value`;
 #--------------------------------------------------------------------
 # Filepath: list of source code directories (in order of importance).
 #--------------------------------------------------------------------


### PR DESCRIPTION
Remove the --user-compset arg, it's no longer needed.   Allow create_test to accept compset longname as part of the testname, add test to scripts_regression_tests.py of these features.
I also change some more internal cime calls to xmlquery to use --value instead of -value.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes ESMCI/cime#1718 
Fixes ESMCI/cime#1706 

User interface changes?: Remove --user-compset from create_newcase, allow compset longname in testname argument to create_test 

Update gh-pages html (Y/N)?: N

Code review: 
