### PR TITLE
update for hobart out-of-the-box support

### DIFF
--- a/config/cesm/machines/Depends.goldbach
+++ b/config/cesm/machines/Depends.goldbach
@@ -1,4 +1,0 @@
-ifeq  ($(strip $(COMPILER)),intel)
-cube_mod.o: cube_mod.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O0 $<
-endif

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -235,6 +235,8 @@
       <queue walltimemax="02:00:00" jobmin="1" jobmax="192" >short</queue>
       <queue walltimemax="06:00:00" jobmin="1" jobmax="192" default="true">medium</queue>
       <queue walltimemax="40:00:00" jobmin="1" jobmax="144" >long</queue>
+      <queue jobmax="768" jobmin="1" walltimemax="12:00:00">overnight</queue>
+      <queue jobmax="1536" jobmin="1" walltimemax="3000:00:">monster</queue>
     </queues>
   </batch_system>
 

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -715,6 +715,14 @@ using a fortran linker.
   </LDFLAGS>
 </compiler>
 
+<compiler MACH="hobart" COMPILER="gnu">
+  <MPI_LIB_NAME MPILIB="openmpi"> openmpi</MPI_LIB_NAME>
+  <LDFLAGS>
+    <append> -lm </append>
+    <append> -ldl </append>
+  </LDFLAGS>
+</compiler>
+
 <compiler MACH="juqueen" COMPILER="ibm">
   <MPICC> mpixlc_r </MPICC>
   <MPIFC> mpixlf2003_r </MPIFC>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -716,12 +716,10 @@ using a fortran linker.
 </compiler>
 
 <compiler MACH="hobart" COMPILER="gnu">
-  <MPI_LIB_NAME MPILIB="openmpi"> openmpi</MPI_LIB_NAME>
-  <LDFLAGS>
+  <SLIBS>
     <append> -lm </append>
     <append> -ldl </append>
-    <append> -lopenmpi </append>
-  </LDFLAGS>
+  </SLIBS>
 </compiler>
 
 <compiler MACH="juqueen" COMPILER="ibm">

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -720,6 +720,7 @@ using a fortran linker.
   <LDFLAGS>
     <append> -lm </append>
     <append> -ldl </append>
+    <append> -lopenmpi </append>
   </LDFLAGS>
 </compiler>
 

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -898,10 +898,6 @@
       <modules compiler="gnu">
 	<command name="load">compiler/gnu/5.4.0</command>
       </modules>
-      <modules compiler="gnu" mpilib="openmpi">
-	<command name="load">  mpi/gcc/openmpi-2.0.2-static  </command>
-	<command name="load">  tool/parallel-netcdf/1.8.1/gnu-5.4.0/openmpi  </command>
-      </modules>
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -861,10 +861,16 @@
     <SUPPORTED_BY> cseg </SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
     <PES_PER_NODE>48</PES_PER_NODE>
-    <mpirun mpilib="default">
+    <mpirun mpilib="mvapich2">
       <executable>mpiexec</executable>
       <arguments>
 	<arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
+	<arg name="num_tasks"> -n $TOTALPES </arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="openmpi">
+      <executable>mpiexec</executable>
+      <arguments>
 	<arg name="num_tasks"> -n $TOTALPES </arg>
       </arguments>
     </mpirun>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -848,7 +848,7 @@
     <NODENAME_REGEX>^hob.*</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,pgi,nag,gnu</COMPILERS>
-    <MPILIBS>mvapich2</MPILIBS>
+    <MPILIBS>mvapich2,openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/scratch/cluster/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/fs/cgd/csm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/project/tss</DIN_LOC_ROOT_CLMFORC>
@@ -896,7 +896,11 @@
 	<command name="load">compiler/nag/6.1</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">compiler/gnu/4.8.5</command>
+	<command name="load">compiler/gnu/5.4.0</command>
+      </modules>
+      <modules compiler="gnu" mpilib="openmpi">
+	<command name="load">  mpi/gcc/openmpi-2.0.2-static  </command>
+	<command name="load">  tool/parallel-netcdf/1.8.1/gnu-5.4.0/openmpi  </command>
       </modules>
     </module_system>
     <environment_variables>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -860,7 +860,7 @@
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
     <SUPPORTED_BY> cseg </SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>24</PES_PER_NODE>
+    <PES_PER_NODE>48</PES_PER_NODE>
     <mpirun mpilib="default">
       <executable>mpiexec</executable>
       <arguments>
@@ -895,8 +895,9 @@
       <modules compiler="nag">
 	<command name="load">compiler/nag/6.1</command>
       </modules>
-      <modules compiler="gnu">
+      <modules compiler="gnu" mpilib="openmpi">
 	<command name="load">compiler/gnu/5.4.0</command>
+	<command name="load">  tool/parallel-netcdf/1.8.1/gnu-5.4.0/openmpi  </command>
       </modules>
     </module_system>
     <environment_variables>

--- a/scripts/Tools/normalize_cases
+++ b/scripts/Tools/normalize_cases
@@ -53,8 +53,8 @@ def normalize_cases(case1, case2):
                 run_cmd_no_fail("gunzip -f {}".format(" ".join(gzips)))
 
     # Change case1 to be as if it had same test-id as case2
-    test_id1 = run_cmd_no_fail("./xmlquery -value TEST_TESTID", from_dir=case1)
-    test_id2 = run_cmd_no_fail("./xmlquery -value TEST_TESTID", from_dir=case2)
+    test_id1 = run_cmd_no_fail("./xmlquery --value TEST_TESTID", from_dir=case1)
+    test_id2 = run_cmd_no_fail("./xmlquery --value TEST_TESTID", from_dir=case2)
     run_cmd_no_fail("for item in $(find -type f); do  sed -i 's/{}/{}/g' $item; done".format(test_id1, test_id2),
             from_dir=case1)
 
@@ -83,8 +83,8 @@ def normalize_cases(case1, case2):
                 os.rename(os.path.join(case1, file_needing_rename), os.path.join(case1, new_name))
 
     # Normalize CIMEROOT
-    case1_root = run_cmd_no_fail("./xmlquery -value CIMEROOT", from_dir=case1)
-    case2_root = run_cmd_no_fail("./xmlquery -value CIMEROOT", from_dir=case2)
+    case1_root = run_cmd_no_fail("./xmlquery --value CIMEROOT", from_dir=case1)
+    case2_root = run_cmd_no_fail("./xmlquery --value CIMEROOT", from_dir=case2)
     if (case1_root != case2_root):
         run_cmd_no_fail("for item in $(find -type f); do  sed -i 's:{}:{}:g' $item; done".format(case1_root, case2_root),
                 from_dir=case1)

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -13,22 +13,22 @@ my ($sharedlibroot, $installroot, $CASEROOT) = @ARGV;
 
 chdir "${CASEROOT}" or die "Could not cd to \"$CASEROOT\"";
 
-my $CIMEROOT		= `./xmlquery CIMEROOT		-value`;
-my $COMP_INTERFACE	= `./xmlquery COMP_INTERFACE	-value`;
-my $USE_ESMF_LIB	= `./xmlquery USE_ESMF_LIB	-value`;
-my $GMAKE_J		= `./xmlquery GMAKE_J		-value`;
-my $GMAKE		= `./xmlquery GMAKE		-value`;
-my $CASETOOLS		= `./xmlquery CASETOOLS		-value`;
-my $NINST_ATM		= `./xmlquery NINST_ATM		-value`;
-my $NINST_ICE		= `./xmlquery NINST_ICE		-value`;
-my $NINST_GLC		= `./xmlquery NINST_GLC		-value`;
-my $NINST_LND		= `./xmlquery NINST_LND		-value`;
-my $NINST_OCN		= `./xmlquery NINST_OCN		-value`;
-my $NINST_ROF		= `./xmlquery NINST_ROF		-value`;
-my $NINST_WAV		= `./xmlquery NINST_WAV		-value`;
-my $NINST_ESP		= `./xmlquery NINST_ESP		-value`;
-my $NINST_VALUE		= `./xmlquery NINST_VALUE	-value`;
-$ENV{PIO_VERSION}  	= `./xmlquery PIO_VERSION	-value`;
+my $CIMEROOT		= `./xmlquery CIMEROOT		--value`;
+my $COMP_INTERFACE	= `./xmlquery COMP_INTERFACE	--value`;
+my $USE_ESMF_LIB	= `./xmlquery USE_ESMF_LIB	--value`;
+my $GMAKE_J		= `./xmlquery GMAKE_J		--value`;
+my $GMAKE		= `./xmlquery GMAKE		--value`;
+my $CASETOOLS		= `./xmlquery CASETOOLS		--value`;
+my $NINST_ATM		= `./xmlquery NINST_ATM		--value`;
+my $NINST_ICE		= `./xmlquery NINST_ICE		--value`;
+my $NINST_GLC		= `./xmlquery NINST_GLC		--value`;
+my $NINST_LND		= `./xmlquery NINST_LND		--value`;
+my $NINST_OCN		= `./xmlquery NINST_OCN		--value`;
+my $NINST_ROF		= `./xmlquery NINST_ROF		--value`;
+my $NINST_WAV		= `./xmlquery NINST_WAV		--value`;
+my $NINST_ESP		= `./xmlquery NINST_ESP		--value`;
+my $NINST_VALUE		= `./xmlquery NINST_VALUE	--value`;
+$ENV{PIO_VERSION}  	= `./xmlquery PIO_VERSION	--value`;
 #--------------------------------------------------------------------
 # Filepath: list of source code directories (in order of importance).
 #--------------------------------------------------------------------

--- a/src/build_scripts/buildlib.mct
+++ b/src/build_scripts/buildlib.mct
@@ -6,13 +6,13 @@
 
 cd $CASEROOT
 
-set CIMEROOT	= `./xmlquery  CIMEROOT	 -value `
-set CASETOOLS	= `./xmlquery  CASETOOLS -value `
-set GMAKE	= `./xmlquery  GMAKE	 -value `
-set GMAKE_J	= `./xmlquery  GMAKE_J	 -value `
-set MACH	= `./xmlquery  MACH	 -value `
-set MPILIB	= `./xmlquery  MPILIB	 -value `
-set OS		= `./xmlquery  OS	 -value `
+set CIMEROOT	= `./xmlquery  CIMEROOT	 --value `
+set CASETOOLS	= `./xmlquery  CASETOOLS --value `
+set GMAKE	= `./xmlquery  GMAKE	 --value `
+set GMAKE_J	= `./xmlquery  GMAKE_J	 --value `
+set MACH	= `./xmlquery  MACH	 --value `
+set MPILIB	= `./xmlquery  MPILIB	 --value `
+set OS		= `./xmlquery  OS	 --value `
 
 setenv MCT_DIR    $CIMEROOT/src/externals/mct   # mct directory
 setenv MCT_LIBDIR $1

--- a/src/build_scripts/buildlib.mpi-serial
+++ b/src/build_scripts/buildlib.mpi-serial
@@ -6,12 +6,12 @@
 
 cd $CASEROOT
 
-set CIMEROOT	= `./xmlquery  CIMEROOT	 -value `
-set CASETOOLS	= `./xmlquery  CASETOOLS -value `
-set GMAKE	= `./xmlquery  GMAKE	 -value `
-set GMAKE_J	= `./xmlquery  GMAKE_J	 -value `
-set MACH	= `./xmlquery  MACH	 -value `
-set OS		= `./xmlquery  OS	 -value `
+set CIMEROOT	= `./xmlquery  CIMEROOT	 --value `
+set CASETOOLS	= `./xmlquery  CASETOOLS --value `
+set GMAKE	= `./xmlquery  GMAKE	 --value `
+set GMAKE_J	= `./xmlquery  GMAKE_J	 --value `
+set MACH	= `./xmlquery  MACH	 --value `
+set OS		= `./xmlquery  OS	 --value `
 
 setenv MCT_DIR    $CIMEROOT/src/externals/mct   # mct directory
 setenv MCT_LIBDIR $1


### PR DESCRIPTION
NCAR-CGD medium size linux cluster, hobart, now supports fully coupled B1850, 1 degree
model runs out-of-the-box for both Intel / mvapich and Gnu / openmpi. 

Test suites: 
ERS_Pm.f09_g17.B1850.hobart_intel.allactive-defaultio
PFS.f09_g17.B1850.hobart_gnu.allactive-default
PFS.f09_g17.B1850.hobart_intel.allactive-default
9 month test run of fully-coupled configuration. 
Note: the ERS_Pm.f09_g17.B1850.hobart_gnu.allactive-defaultio had a runtime failure
in CLM. See bugzilla http://bugz.cgd.ucar.edu/show_bug.cgi?id=2490.
Also had to set all NTHRDS to 1 for all components in env_mach_pes.xml for all cases and tests.

Test baseline: None available
Test namelist changes:  none
Test status: bit-for-bit

Fixes [CIME Github issue #] #1601 

User interface changes?:  None

Update gh-pages html (Y/N)?: N

Code review: 
