### PR TITLE
Build scripts in source mods

### DIFF
--- a/doc/source/users_guide/create-a-case.rst
+++ b/doc/source/users_guide/create-a-case.rst
@@ -94,7 +94,8 @@ Running **create_newcase** creates various scripts, files and directories ``$CAS
 
    =====================  ===============================================================================================================================
    SourceMods             Top-level directory containing subdirectories for each compset component where
-                          you can place modified source code for that component.
+                          you can place modified source code for that component.  You may also place modified
+			  buildnml and buildlib scripts here.
    =====================  ===============================================================================================================================
 
 - ``Provenance``
@@ -137,5 +138,3 @@ These other files can be "unlocked" as follows:
 - To unlock **env_mach_pes.xml**, run ``case.setup --clean``.
 
 - To unlock **env_build.xml**, run ``case.build --clean``.
-
-

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -15,7 +15,7 @@ def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
                  lid, caseroot, cimeroot, compiler):
 ###############################################################################
     logs = []
-
+    sys.path.append(os.path.join(cimeroot,"scripts","Tools"))
     thread_bad_results = []
     for model, comp, nthrds, _, config_dir in complist:
 
@@ -57,7 +57,7 @@ def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
         # thread_bad_results captures error output from thread (expected to be empty)
         # logs is a list of log files to be compressed and added to the case logs/bld directory
         t = threading.Thread(target=_build_model_thread,
-            args=(config_dir, model, caseroot, libroot, bldroot, incroot, file_build,
+            args=(config_dir, model, comp, caseroot, libroot, bldroot, incroot, file_build,
                   thread_bad_results, smp, compiler))
         t.start()
 
@@ -66,18 +66,6 @@ def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
     # Wait for threads to finish
     while(threading.active_count() > 1):
         time.sleep(1)
-
-    # aquap has a dependency on atm so we build it after the threaded loop
-
-    for model, comp, nthrds, _, config_dir in complist:
-        smp = nthrds > 1 or build_threaded
-        if comp == "aquap":
-            logger.debug("Now build aquap ocn component")
-            # thread_bad_results captures error output from thread (expected to be empty)
-            # logs is a list of log files to be compressed and added to the case logs/bld directory
-            _build_model_thread(config_dir, comp, caseroot, libroot, bldroot, incroot, file_build,
-                                thread_bad_results, smp, compiler)
-            logs.append(file_build)
 
     expect(not thread_bad_results, "\n".join(thread_bad_results))
 
@@ -282,7 +270,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
             # thread_bad_results captures error output from thread (expected to be empty)
             # logs is a list of log files to be compressed and added to the case logs/bld directory
             thread_bad_results = []
-            _build_model_thread(config_lnd_dir, "lnd", caseroot, libroot, bldroot, incroot,
+            _build_model_thread(config_lnd_dir, "lnd", comp_lnd, caseroot, libroot, bldroot, incroot,
                                 file_build, thread_bad_results, smp, compiler)
             logs.append(file_build)
             expect(not thread_bad_results, "\n".join(thread_bad_results))
@@ -290,25 +278,32 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
     return logs
 
 ###############################################################################
-def _build_model_thread(config_dir, compclass, caseroot, libroot, bldroot, incroot, file_build,
+def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldroot, incroot, file_build,
                         thread_bad_results, smp, compiler):
 ###############################################################################
     logger.info("Building {} with output to {}".format(compclass, file_build))
     t1 = time.time()
+    cmd = os.path.join(caseroot, "SourceMods", "src." + compname, "buildlib")
+    if os.path.isfile(cmd):
+        logger.warn("WARNING: using local buildlib script for {}".format(compname))
+    else:
+        cmd = os.path.join(config_dir, "buildlib")
+        expect(os.path.isfile(cmd), "Could not find buildlib for {}".format(compname))
+
     with open(file_build, "w") as fd:
-        stat = run_cmd("MODEL={} SMP={} {}/buildlib {} {} {} "
-                       .format(compclass, stringify_bool(smp), config_dir, caseroot, libroot, bldroot),
+        stat = run_cmd("MODEL={} SMP={} {} {} {} {} "
+                       .format(compclass, stringify_bool(smp), cmd, caseroot, libroot, bldroot),
                        from_dir=bldroot,  arg_stdout=fd,
                        arg_stderr=subprocess.STDOUT)[0]
     analyze_build_log(compclass, file_build, compiler)
     if (stat != 0):
-        thread_bad_results.append("BUILD FAIL: {}.buildlib failed, cat {}".format(compclass, file_build))
+        thread_bad_results.append("BUILD FAIL: {}.buildlib failed, cat {}".format(compname, file_build))
 
     for mod_file in glob.glob(os.path.join(bldroot, "*_[Cc][Oo][Mm][Pp]_*.mod")):
         shutil.copy(mod_file, incroot)
 
     t2 = time.time()
-    logger.info("{} built in {:f} seconds".format(compclass, (t2 - t1)))
+    logger.info("{} built in {:f} seconds".format(compname, (t2 - t1)))
 
 ###############################################################################
 def _clean_impl(case, cleanlist, clean_all):

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -15,7 +15,7 @@ def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
                  lid, caseroot, cimeroot, compiler):
 ###############################################################################
     logs = []
-    sys.path.append(os.path.join(cimeroot,"scripts","Tools"))
+
     thread_bad_results = []
     for model, comp, nthrds, _, config_dir in complist:
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -297,7 +297,7 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
 #                       .format(compclass, stringify_bool(smp), config_dir, caseroot, libroot, bldroot),
 #                       from_dir=bldroot,  arg_stdout=fd,
 #                       arg_stderr=subprocess.STDOUT)[0]
-    analyze_build_log(compclass, file_build, compiler)
+#    analyze_build_log(compclass, file_build, compiler)
     if (stat != 0):
         thread_bad_results.append("BUILD FAIL: {}.buildlib failed, cat {}".format(compname, file_build))
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -2,7 +2,7 @@
 functions for building CIME models
 """
 from CIME.XML.standard_module_setup  import *
-from CIME.utils                 import get_model, analyze_build_log, stringify_bool, run_and_log_case_status, get_timestamp
+from CIME.utils                 import get_model, analyze_build_log, stringify_bool, run_and_log_case_status, get_timestamp, run_sub_or_cmd
 from CIME.provenance            import save_build_provenance
 from CIME.preview_namelists     import create_namelists, create_dirs
 from CIME.check_lockedfiles     import check_lockedfiles, lock_file, unlock_file
@@ -57,7 +57,7 @@ def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
         # thread_bad_results captures error output from thread (expected to be empty)
         # logs is a list of log files to be compressed and added to the case logs/bld directory
         t = threading.Thread(target=_build_model_thread,
-            args=(config_dir, model, caseroot, libroot, bldroot, incroot, file_build,
+            args=(config_dir, model, comp, caseroot, libroot, bldroot, incroot, file_build,
                   thread_bad_results, smp, compiler))
         t.start()
 
@@ -66,18 +66,6 @@ def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
     # Wait for threads to finish
     while(threading.active_count() > 1):
         time.sleep(1)
-
-    # aquap has a dependency on atm so we build it after the threaded loop
-
-    for model, comp, nthrds, _, config_dir in complist:
-        smp = nthrds > 1 or build_threaded
-        if comp == "aquap":
-            logger.debug("Now build aquap ocn component")
-            # thread_bad_results captures error output from thread (expected to be empty)
-            # logs is a list of log files to be compressed and added to the case logs/bld directory
-            _build_model_thread(config_dir, comp, caseroot, libroot, bldroot, incroot, file_build,
-                                thread_bad_results, smp, compiler)
-            logs.append(file_build)
 
     expect(not thread_bad_results, "\n".join(thread_bad_results))
 
@@ -282,7 +270,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
             # thread_bad_results captures error output from thread (expected to be empty)
             # logs is a list of log files to be compressed and added to the case logs/bld directory
             thread_bad_results = []
-            _build_model_thread(config_lnd_dir, "lnd", caseroot, libroot, bldroot, incroot,
+            _build_model_thread(config_lnd_dir, "lnd", comp_lnd, caseroot, libroot, bldroot, incroot,
                                 file_build, thread_bad_results, smp, compiler)
             logs.append(file_build)
             expect(not thread_bad_results, "\n".join(thread_bad_results))
@@ -290,25 +278,34 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
     return logs
 
 ###############################################################################
-def _build_model_thread(config_dir, compclass, caseroot, libroot, bldroot, incroot, file_build,
+def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldroot, incroot, file_build,
                         thread_bad_results, smp, compiler):
 ###############################################################################
-    logger.info("Building {} with output to {}".format(compclass, file_build))
+    logger.info("Building {} with output to {}".format(compname, file_build))
     t1 = time.time()
-    with open(file_build, "w") as fd:
-        stat = run_cmd("MODEL={} SMP={} {}/buildlib {} {} {} "
-                       .format(compclass, stringify_bool(smp), config_dir, caseroot, libroot, bldroot),
-                       from_dir=bldroot,  arg_stdout=fd,
-                       arg_stderr=subprocess.STDOUT)[0]
+    cmd = os.path.join(caseroot, "SourceMods", "src."+compname,"buildlib")
+    if os.path.isfile(cmd):
+        logger.warn("WARNING: Using local buildlib script for {}".format(compname))
+    else:
+        cmd = os.path.join(config_dir, "buildlib")
+    expect(os.path.isfile(cmd), "Could not find buildlib script for {}".format(compname))
+    stat, _, _ = run_sub_or_cmd(cmd, (caseroot, libroot, bldroot),
+                                "buildlib", (caseroot, libroot, bldroot, compname),
+                                from_dir=bldroot)
+
+#        stat = run_cmd("MODEL={} SMP={} {}/buildlib {} {} {} "
+#                       .format(compclass, stringify_bool(smp), config_dir, caseroot, libroot, bldroot),
+#                       from_dir=bldroot,  arg_stdout=fd,
+#                       arg_stderr=subprocess.STDOUT)[0]
     analyze_build_log(compclass, file_build, compiler)
     if (stat != 0):
-        thread_bad_results.append("BUILD FAIL: {}.buildlib failed, cat {}".format(compclass, file_build))
+        thread_bad_results.append("BUILD FAIL: {}.buildlib failed, cat {}".format(compname, file_build))
 
     for mod_file in glob.glob(os.path.join(bldroot, "*_[Cc][Oo][Mm][Pp]_*.mod")):
         shutil.copy(mod_file, incroot)
 
     t2 = time.time()
-    logger.info("{} built in {:f} seconds".format(compclass, (t2 - t1)))
+    logger.info("{} built in {:f} seconds".format(compname, (t2 - t1)))
 
 ###############################################################################
 def _clean_impl(case, cleanlist, clean_all):

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -34,64 +34,24 @@ def parse_input(argv):
 
     return args.caseroot, args.libroot, args.bldroot
 
-###############################################################################
-def build_data_lib(argv, compclass):
-###############################################################################
+def build_cime_component_lib(case, compname, libroot):
+    cimeroot  = case.get_value("CIMEROOT")
+    compclass = compname[1:]
 
-    caseroot, libroot, _ = parse_input(argv)
-
-    with Case(caseroot) as case:
-
-        cimeroot  = case.get_value("CIMEROOT")
-
-        # Write directory list (Filepath)
-        compname = "d" + compclass
-        with open('Filepath', 'w') as out:
-            out.write(os.path.join(caseroot, "SourceMods", "src.{}\n".format(compname)) + "\n")
+    with open('Filepath', 'w') as out:
+        out.write(os.path.join(case.get_value('CASEROOT'), "SourceMods",
+                               "src.{}\n".format(compname)) + "\n")
+        if compname.startswith('d'):
             out.write(os.path.join(cimeroot, "src", "components", "data_comps", compname) + "\n")
-
-        # Build the component
-        run_gmake(case, compclass, libroot)
-
-###############################################################################
-def build_xcpl_lib(argv, compclass):
-###############################################################################
-
-    caseroot, libroot, _ = parse_input(argv)
-
-    with Case(caseroot) as case:
-
-        cimeroot  = case.get_value("CIMEROOT")
-
-        # Write directory list
-        compname = "x" + compclass
-        with open('Filepath', 'w') as out:
-            out.write(os.path.join(caseroot, "SourceMods", "src.{}", compname) + "\n")
+        elif compname.startswith('x'):
             out.write(os.path.join(cimeroot, "src", "components", "xcpl_comps", "xshare") + "\n")
             out.write(os.path.join(cimeroot, "src", "components", "xcpl_comps",compname, "cpl") + "\n")
-
-        # Build the component
-        run_gmake(case, compclass, libroot)
-
-###############################################################################
-def build_stub_lib(argv, compclass):
-###############################################################################
-
-    caseroot, libroot, _ = parse_input(argv)
-
-    with Case(caseroot) as case:
-
-        cimeroot = case.get_value("CIMEROOT")
-
-        # Write directory list
-        compname = "s" + compclass
-        with open('Filepath', 'w') as out:
-            out.write(os.path.join(caseroot, "SourceMods", "src.{}", compname) + "\n")
+        elif compname.startswith('s'):
             out.write(os.path.join(cimeroot, "src", "components", "stub_comps", "xshare") + "\n")
             out.write(os.path.join(cimeroot, "src", "components", "stub_comps",compname, "cpl") + "\n")
 
-        # Build the component
-        run_gmake(case, compclass, libroot)
+    # Build the component
+    run_gmake(case, compclass, libroot)
 
 ###############################################################################
 def run_gmake(case, compclass, libroot, libname="", user_cppdefs=""):

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -80,4 +80,4 @@ def run_gmake(case, compclass, libroot, bldroot, libname="", user_cppdefs=""):
     rc, out, err = run_cmd(cmd)
     expect(rc == 0, "Command {} failed rc={:d}\nout={}\nerr={}".format(cmd, rc, out, err))
 
-    logger.info("Command {} completed with output {}\nerr {}".format(cmd, out, err))
+    print "Command {} completed with output {}\nerr {}".format(cmd, out, err)

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -4,7 +4,6 @@ common utilities for buildlib
 
 from CIME.XML.standard_module_setup import *
 from CIME.utils import parse_args_and_handle_standard_logging_options, setup_standard_logging_options
-from CIME.case  import Case
 import sys, os, argparse, doctest
 
 logger = logging.getLogger(__name__)

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -74,7 +74,14 @@ def create_namelists(case, component=None):
             compname = case.get_value("COMP_{}".format(model_str.upper()))
 
         if component is None or component == model_str:
-            cmd = os.path.join(config_dir, "buildnml")
+            # first look in the case SourceMods directory
+            cmd = os.path.join(caseroot, "SourceMods", "src."+compname, "buildnml")
+            if os.path.isfile(cmd):
+                logger.warn("\nWARNING: Using local buildnml file {}\n".format(cmd))
+            else:
+                # otherwise look in the component config_dir
+                cmd = os.path.join(config_dir, "buildnml")
+            expect(os.path.isfile(cmd), "Could not find buildnml file for component {}".format(compname))
             do_run_cmd = False
             # This code will try to import and run each buildnml as a subroutine
             # if that fails it will run it as a program in a seperate shell

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -3,8 +3,8 @@ API for preview namelist
 """
 
 from CIME.XML.standard_module_setup import *
-
-import glob, shutil, imp
+from CIME.utils import run_sub_or_cmd
+import glob, shutil
 logger = logging.getLogger(__name__)
 
 def create_dirs(case):
@@ -82,35 +82,36 @@ def create_namelists(case, component=None):
                 # otherwise look in the component config_dir
                 cmd = os.path.join(config_dir, "buildnml")
             expect(os.path.isfile(cmd), "Could not find buildnml file for component {}".format(compname))
-            do_run_cmd = False
-            # This code will try to import and run each buildnml as a subroutine
-            # if that fails it will run it as a program in a seperate shell
-            try:
-                with open(cmd, 'r') as f:
-                    first_line = f.readline()
-                if "python" in first_line:
-                    mod = imp.load_source("buildnml", cmd)
-                    logger.info("   Calling {} buildnml".format(compname))
-                    mod.buildnml(case, caseroot, compname)
-                else:
-                    raise SyntaxError
-            except SyntaxError as detail:
-                if 'python' in first_line:
-                    expect(False, detail)
-                else:
-                    do_run_cmd = True
-            except AttributeError:
-                do_run_cmd = True
-            except:
-                raise
+            run_sub_or_cmd(cmd, "buildnml", (case, caseroot, compname), case=case)
+            # do_run_cmd = False
+            # # This code will try to import and run each buildnml as a subroutine
+            # # if that fails it will run it as a program in a seperate shell
+            # try:
+            #     with open(cmd, 'r') as f:
+            #         first_line = f.readline()
+            #     if "python" in first_line:
+            #         mod = imp.load_source("buildnml", cmd)
+            #         logger.info("   Calling {} buildnml".format(compname))
+            #         mod.buildnml(case, caseroot, compname)
+            #     else:
+            #         raise SyntaxError
+            # except SyntaxError as detail:
+            #     if 'python' in first_line:
+            #         expect(False, detail)
+            #     else:
+            #         do_run_cmd = True
+            # except AttributeError:
+            #     do_run_cmd = True
+            # except:
+            #     raise
 
-            if do_run_cmd:
-                logger.info("   Running {} buildnml".format(compname))
-                case.flush()
-                output = run_cmd_no_fail("{} {}".format(cmd, caseroot), verbose=False)
-                logger.info(output)
-                # refresh case xml object from file
-                case.read_xml()
+            # if do_run_cmd:
+            #     logger.info("   Running {} buildnml".format(compname))
+            #     case.flush()
+            #     output = run_cmd_no_fail("{} {}".format(cmd, caseroot), verbose=False)
+            #     logger.info(output)
+            #     # refresh case xml object from file
+            #     case.read_xml()
 
     logger.info("Finished creating component namelists")
 

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -82,36 +82,7 @@ def create_namelists(case, component=None):
                 # otherwise look in the component config_dir
                 cmd = os.path.join(config_dir, "buildnml")
             expect(os.path.isfile(cmd), "Could not find buildnml file for component {}".format(compname))
-            run_sub_or_cmd(cmd, "buildnml", (case, caseroot, compname), case=case)
-            # do_run_cmd = False
-            # # This code will try to import and run each buildnml as a subroutine
-            # # if that fails it will run it as a program in a seperate shell
-            # try:
-            #     with open(cmd, 'r') as f:
-            #         first_line = f.readline()
-            #     if "python" in first_line:
-            #         mod = imp.load_source("buildnml", cmd)
-            #         logger.info("   Calling {} buildnml".format(compname))
-            #         mod.buildnml(case, caseroot, compname)
-            #     else:
-            #         raise SyntaxError
-            # except SyntaxError as detail:
-            #     if 'python' in first_line:
-            #         expect(False, detail)
-            #     else:
-            #         do_run_cmd = True
-            # except AttributeError:
-            #     do_run_cmd = True
-            # except:
-            #     raise
-
-            # if do_run_cmd:
-            #     logger.info("   Running {} buildnml".format(compname))
-            #     case.flush()
-            #     output = run_cmd_no_fail("{} {}".format(cmd, caseroot), verbose=False)
-            #     logger.info(output)
-            #     # refresh case xml object from file
-            #     case.read_xml()
+            run_sub_or_cmd(cmd, (caseroot), "buildnml", (case, caseroot, compname), case=case)
 
     logger.info("Finished creating component namelists")
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -5,6 +5,7 @@ Warning: you cannot use CIME Classes in this module as it causes circular depend
 import logging, gzip, sys, os, time, re, shutil, glob, string, random, imp
 import stat as statlib
 import warnings
+
 # Return this error code if the scripts worked but tests failed
 TESTS_FAILED_ERR_CODE = 100
 logger = logging.getLogger(__name__)

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -216,7 +216,7 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
                 getattr(mod, subname)(*subargs)
         else:
             getattr(mod, subname)(*subargs)
-    except SyntaxError as detail:
+    except SyntaxError:
         do_run_cmd = True
     except AttributeError:
         do_run_cmd = True

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -178,17 +178,20 @@ def _convert_to_fd(filearg, from_dir):
 
 _hack=object()
 
-def run_sub_or_cmd(cmd, subname, args, case=None,
+def run_sub_or_cmd(cmd, cmdargs, subname, subargs, case=None,
                    input_str=None, from_dir=None, verbose=None,
                    arg_stdout=_hack, arg_stderr=_hack, env=None, combine_output=False):
 
     # This code will try to import and run each buildnml as a subroutine
     # if that fails it will run it as a program in a seperate shell
     do_run_cmd = False
+    stat = 0
+    output = ""
+    errput = ""
     try:
         mod = imp.load_source(subname, cmd)
         logger.info("   Calling {}".format(cmd))
-        getattr(mod, subname)(*args)
+        getattr(mod, subname)(*subargs)
     except SyntaxError as detail:
         do_run_cmd = True
     except AttributeError:
@@ -200,7 +203,7 @@ def run_sub_or_cmd(cmd, subname, args, case=None,
         logger.info("   Running {} ".format(cmd))
         if case is not None:
             case.flush()
-        output = run_cmd_no_fail("{} {}".format(cmd, *args), input_str=input_str, from_dir=from_dir,
+        stat, output, errput = run_cmd("{} {}".format(cmd, cmdargs), input_str=input_str, from_dir=from_dir,
                                  verbose=verbose, arg_stdout=arg_stdout, arg_stderr=arg_stderr, env=env,
                                  combine_output=combine_output)
 
@@ -208,6 +211,7 @@ def run_sub_or_cmd(cmd, subname, args, case=None,
         # refresh case xml object from file
         if case is not None:
             case.read_xml()
+    return stat, output, errput
 
 def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
             arg_stdout=_hack, arg_stderr=_hack, env=None, combine_output=False):

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -7,19 +7,12 @@ components.
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *
 from CIME.buildlib import build_cime_component_lib, parse_input
 from CIME.case import Case
-import contextlib
-
-@contextlib.contextmanager
-def remember_cwd():
-    curdir= os.getcwd()
-    try: yield
-    finally: os.chdir(curdir)
 
 def buildlib(caseroot, libroot, bldroot, compname=None):
     with Case(caseroot) as case:
@@ -30,7 +23,8 @@ def buildlib(caseroot, libroot, bldroot, compname=None):
             if dir1 == "cime_config":
                 compname = dir2
             else:
-                compname = split(dir2, '.')(1)
+                print "HERE %s"%dir1
+                compname = dir1.split('.')[1]
         build_cime_component_lib(case, compname, libroot, bldroot)
 
 def _main_func(args):

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -13,6 +13,13 @@ sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 from standard_script_setup import *
 from CIME.buildlib import build_cime_component_lib, parse_input
 from CIME.case import Case
+import contextlib
+
+@contextlib.contextmanager
+def remember_cwd():
+    curdir= os.getcwd()
+    try: yield
+    finally: os.chdir(curdir)
 
 def buildlib(caseroot, libroot, bldroot, compname=None):
     with Case(caseroot) as case:
@@ -24,7 +31,7 @@ def buildlib(caseroot, libroot, bldroot, compname=None):
                 compname = dir2
             else:
                 compname = split(dir2, '.')(1)
-        build_cime_component_lib(case, compname, libroot)
+        build_cime_component_lib(case, compname, libroot, bldroot)
 
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -14,13 +14,21 @@ from standard_script_setup import *
 from CIME.buildlib import build_cime_component_lib, parse_input
 from CIME.case import Case
 
-def buildlib(case, libroot, bldroot, compname):
-    build_cime_component_lib(case, compname, libroot)
+def buildlib(caseroot, libroot, bldroot, compname=None):
+    with Case(caseroot) as case:
+        if compname is None:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            path, dir1 = os.path.split(thisdir)
+            _, dir2 = os.path.split(path)
+            if dir1 == "cime_config":
+                compname = dir2
+            else:
+                compname = split(dir2, '.')(1)
+        build_cime_component_lib(case, compname, libroot)
 
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)
-    with Case(caseroot) as case:
-        buildlib(case, libroot, bldroot)
+    buildlib(caseroot, libroot, bldroot)
 
 
 if __name__ == "__main__":

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+"""
+build cime component model library.   This buildlib script is used by all cime internal
+components.
+"""
+
+import sys, os
+
+_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
+sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
+
+from standard_script_setup import *
+from CIME.buildlib import build_cime_component_lib, parse_input
+from CIME.case import Case
+
+def buildlib(case, libroot, bldroot, compname):
+    build_cime_component_lib(case, compname, libroot)
+
+def _main_func(args):
+    caseroot, libroot, bldroot = parse_input(args)
+    with Case(caseroot) as case:
+        buildlib(case, libroot, bldroot)
+
+
+if __name__ == "__main__":
+    _main_func(sys.argv)

--- a/src/components/data_comps/datm/cime_config/buildlib
+++ b/src/components/data_comps/datm/cime_config/buildlib
@@ -1,18 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_data_lib
-
-build_data_lib(sys.argv, 'atm')
-
-
-
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/data_comps/desp/cime_config/buildlib
+++ b/src/components/data_comps/desp/cime_config/buildlib
@@ -1,18 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_data_lib
-
-build_data_lib(sys.argv, 'esp')
-
-
-
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/data_comps/dice/cime_config/buildlib
+++ b/src/components/data_comps/dice/cime_config/buildlib
@@ -1,18 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_data_lib
-
-build_data_lib(sys.argv, 'ice')
-
-
-
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/data_comps/dlnd/cime_config/buildlib
+++ b/src/components/data_comps/dlnd/cime_config/buildlib
@@ -1,18 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_data_lib
-
-build_data_lib(sys.argv, 'lnd')
-
-
-
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/data_comps/docn/cime_config/buildlib
+++ b/src/components/data_comps/docn/cime_config/buildlib
@@ -1,18 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_data_lib
-
-build_data_lib(sys.argv, 'ocn')
-
-
-
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/data_comps/drof/cime_config/buildlib
+++ b/src/components/data_comps/drof/cime_config/buildlib
@@ -1,18 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_data_lib
-
-build_data_lib(sys.argv, 'rof')
-
-
-
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/data_comps/dwav/cime_config/buildlib
+++ b/src/components/data_comps/dwav/cime_config/buildlib
@@ -1,18 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_data_lib
-
-build_data_lib(sys.argv, 'wav')
-
-
-
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/stub_comps/satm/cime_config/buildlib
+++ b/src/components/stub_comps/satm/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build stub model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_stub_lib
-
-build_stub_lib(sys.argv, 'atm')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/stub_comps/satm/cime_config/buildnml
+++ b/src/components/stub_comps/satm/cime_config/buildnml
@@ -4,5 +4,6 @@
 build stub model namelist
 """
 # DO NOTHING
+#pylint: disable=unused-argument
 def buildnml(case, caseroot, compname):
     pass

--- a/src/components/stub_comps/satm/cime_config/buildnml
+++ b/src/components/stub_comps/satm/cime_config/buildnml
@@ -3,5 +3,6 @@
 """
 build stub model namelist
 """
-
 # DO NOTHING
+def buildnml(case, caseroot, compname):
+    pass

--- a/src/components/stub_comps/sesp/cime_config/buildlib
+++ b/src/components/stub_comps/sesp/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build stub model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_stub_lib
-
-build_stub_lib(sys.argv, 'esp')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/stub_comps/sesp/cime_config/buildnml
+++ b/src/components/stub_comps/sesp/cime_config/buildnml
@@ -4,5 +4,6 @@
 build stub model namelist
 """
 # DO NOTHING
+#pylint: disable=unused-argument
 def buildnml(case, caseroot, compname):
     pass

--- a/src/components/stub_comps/sesp/cime_config/buildnml
+++ b/src/components/stub_comps/sesp/cime_config/buildnml
@@ -3,5 +3,6 @@
 """
 build stub model namelist
 """
-
 # DO NOTHING
+def buildnml(case, caseroot, compname):
+    pass

--- a/src/components/stub_comps/sglc/cime_config/buildlib
+++ b/src/components/stub_comps/sglc/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build stub model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_stub_lib
-
-build_stub_lib(sys.argv, 'glc')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/stub_comps/sglc/cime_config/buildnml
+++ b/src/components/stub_comps/sglc/cime_config/buildnml
@@ -4,5 +4,6 @@
 build stub model namelist
 """
 # DO NOTHING
+#pylint: disable=unused-argument
 def buildnml(case, caseroot, compname):
     pass

--- a/src/components/stub_comps/sglc/cime_config/buildnml
+++ b/src/components/stub_comps/sglc/cime_config/buildnml
@@ -3,5 +3,6 @@
 """
 build stub model namelist
 """
-
 # DO NOTHING
+def buildnml(case, caseroot, compname):
+    pass

--- a/src/components/stub_comps/sice/cime_config/buildlib
+++ b/src/components/stub_comps/sice/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build stub model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_stub_lib
-
-build_stub_lib(sys.argv, 'ice')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/stub_comps/sice/cime_config/buildnml
+++ b/src/components/stub_comps/sice/cime_config/buildnml
@@ -4,5 +4,6 @@
 build stub model namelist
 """
 # DO NOTHING
+#pylint: disable=unused-argument
 def buildnml(case, caseroot, compname):
     pass

--- a/src/components/stub_comps/sice/cime_config/buildnml
+++ b/src/components/stub_comps/sice/cime_config/buildnml
@@ -3,5 +3,6 @@
 """
 build stub model namelist
 """
-
 # DO NOTHING
+def buildnml(case, caseroot, compname):
+    pass

--- a/src/components/stub_comps/slnd/cime_config/buildlib
+++ b/src/components/stub_comps/slnd/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build stub model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_stub_lib
-
-build_stub_lib(sys.argv, 'lnd')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/stub_comps/slnd/cime_config/buildnml
+++ b/src/components/stub_comps/slnd/cime_config/buildnml
@@ -4,5 +4,6 @@
 build stub model namelist
 """
 # DO NOTHING
+#pylint: disable=unused-argument
 def buildnml(case, caseroot, compname):
     pass

--- a/src/components/stub_comps/slnd/cime_config/buildnml
+++ b/src/components/stub_comps/slnd/cime_config/buildnml
@@ -3,5 +3,6 @@
 """
 build stub model namelist
 """
-
 # DO NOTHING
+def buildnml(case, caseroot, compname):
+    pass

--- a/src/components/stub_comps/socn/cime_config/buildlib
+++ b/src/components/stub_comps/socn/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build stub model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_stub_lib
-
-build_stub_lib(sys.argv, 'ocn')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/stub_comps/socn/cime_config/buildnml
+++ b/src/components/stub_comps/socn/cime_config/buildnml
@@ -4,5 +4,6 @@
 build stub model namelist
 """
 # DO NOTHING
+#pylint: disable=unused-argument
 def buildnml(case, caseroot, compname):
     pass

--- a/src/components/stub_comps/socn/cime_config/buildnml
+++ b/src/components/stub_comps/socn/cime_config/buildnml
@@ -3,5 +3,6 @@
 """
 build stub model namelist
 """
-
 # DO NOTHING
+def buildnml(case, caseroot, compname):
+    pass

--- a/src/components/stub_comps/srof/cime_config/buildlib
+++ b/src/components/stub_comps/srof/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build stub model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_stub_lib
-
-build_stub_lib(sys.argv, 'rof')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/stub_comps/srof/cime_config/buildnml
+++ b/src/components/stub_comps/srof/cime_config/buildnml
@@ -4,5 +4,6 @@
 build stub model namelist
 """
 # DO NOTHING
+#pylint: disable=unused-argument
 def buildnml(case, caseroot, compname):
     pass

--- a/src/components/stub_comps/srof/cime_config/buildnml
+++ b/src/components/stub_comps/srof/cime_config/buildnml
@@ -3,5 +3,6 @@
 """
 build stub model namelist
 """
-
 # DO NOTHING
+def buildnml(case, caseroot, compname):
+    pass

--- a/src/components/stub_comps/swav/cime_config/buildlib
+++ b/src/components/stub_comps/swav/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build stub model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_stub_lib
-
-build_stub_lib(sys.argv, 'wav')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/stub_comps/swav/cime_config/buildnml
+++ b/src/components/stub_comps/swav/cime_config/buildnml
@@ -4,5 +4,6 @@
 build stub model namelist
 """
 # DO NOTHING
+#pylint: disable=unused-argument
 def buildnml(case, caseroot, compname):
     pass

--- a/src/components/stub_comps/swav/cime_config/buildnml
+++ b/src/components/stub_comps/swav/cime_config/buildnml
@@ -3,5 +3,6 @@
 """
 build stub model namelist
 """
-
 # DO NOTHING
+def buildnml(case, caseroot, compname):
+    pass

--- a/src/components/xcpl_comps/xatm/cime_config/buildlib
+++ b/src/components/xcpl_comps/xatm/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_xcpl_lib
-
-build_xcpl_lib(sys.argv, 'atm')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/xcpl_comps/xglc/cime_config/buildlib
+++ b/src/components/xcpl_comps/xglc/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_xcpl_lib
-
-build_xcpl_lib(sys.argv, 'glc')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/xcpl_comps/xice/cime_config/buildlib
+++ b/src/components/xcpl_comps/xice/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_xcpl_lib
-
-build_xcpl_lib(sys.argv, 'ice')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/xcpl_comps/xlnd/cime_config/buildlib
+++ b/src/components/xcpl_comps/xlnd/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_xcpl_lib
-
-build_xcpl_lib(sys.argv, 'lnd')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/xcpl_comps/xocn/cime_config/buildlib
+++ b/src/components/xcpl_comps/xocn/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_xcpl_lib
-
-build_xcpl_lib(sys.argv, 'ocn')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/xcpl_comps/xrof/cime_config/buildlib
+++ b/src/components/xcpl_comps/xrof/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_xcpl_lib
-
-build_xcpl_lib(sys.argv, 'rof')
+../../../../build_scripts/buildlib.internal_components

--- a/src/components/xcpl_comps/xwav/cime_config/buildlib
+++ b/src/components/xcpl_comps/xwav/cime_config/buildlib
@@ -1,15 +1,1 @@
-#!/usr/bin/env python
-
-"""
-build data model library
-"""
-
-import sys, os
-
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
-sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
-
-from standard_script_setup import *
-from CIME.buildlib import build_xcpl_lib
-
-build_xcpl_lib(sys.argv, 'wav')
+../../../../build_scripts/buildlib.internal_components


### PR DESCRIPTION
Allow the buildnml and buildlib scripts for each component to be located in the SourceMods subdirectories of the case.   Clean up some of the buildlib structure.

Test suite: scripts_regression_tests.py, hand tests with files in SourceMods.
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes ESMCI/cime#1727

User interface changes?: 

Update gh-pages html (Y/N)?:Y a minor change was made

Code review: 
