### PR TITLE
Fix PRE test with the ADESP and ADESP_TEST compsets

### DIFF
--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -60,7 +60,7 @@ class DAE(SystemTestsCompareTwo):
         self._case.flush()
 
     ###########################################################################
-    def run_phase(self):
+    def run_phase(self): # pylint: disable=arguments-differ
     ###########################################################################
         # Clean up any da.log files in case this is a re-run.
         self._activate_case2()

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -68,14 +68,15 @@ class PRE(SystemTestsCompareTwo):
     ###########################################################################
     def run_phase(self):
     ###########################################################################
-        SystemTestsCompareTwo.run_phase(self)
+        self._activate_case2()
+        should_match = (self._case.get_value("DESP_MODE") == "NOCHANGE")
+        SystemTestsCompareTwo.run_phase(self, success_change=not should_match)
         # Look for expected coupler restart files
         logger = logging.getLogger(__name__)
         self._activate_case1()
         rundir1 = self._case.get_value("RUNDIR")
         self._activate_case2()
         rundir2 = self._case.get_value("RUNDIR")
-        should_match = (self._case.get_value("DESP_MODE") == "NOCHANGE")
         compare_ok = True
         pause_comps = self._case.get_value("PAUSE_COMPONENT_LIST")
         expect((pause_comps != 'none'), "Pause/Resume (PRE) test has no pause components")

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -66,7 +66,7 @@ class PRE(SystemTestsCompareTwo):
         self._case.flush()
 
     ###########################################################################
-    def run_phase(self):
+    def run_phase(self): # pylint: disable=arguments-differ
     ###########################################################################
         self._activate_case2()
         should_match = (self._case.get_value("DESP_MODE") == "NOCHANGE")

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -256,7 +256,7 @@ class SystemTestsCommon(object):
         """
         success, comments = compare_test(self._case, suffix1, suffix2)
         if success_change:
-          success = not success
+            success = not success
 
         append_testlog(comments)
         status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -248,12 +248,16 @@ class SystemTestsCommon(object):
         comments = copy(self._case, suffix)
         append_testlog(comments)
 
-    def _component_compare_test(self, suffix1, suffix2):
+    def _component_compare_test(self, suffix1, suffix2, success_change=False):
         """
         Return value is not generally checked, but is provided in case a custom
         run case needs indirection based on success.
+        If success_change is True, success requires some files to be different
         """
         success, comments = compare_test(self._case, suffix1, suffix2)
+        if success_change:
+          success = not success
+
         append_testlog(comments)
         status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
         with self._test_status:

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -155,9 +155,10 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             self._case2.set_value("BUILD_COMPLETE",True)
             self._case2.flush()
 
-    def run_phase(self):
+    def run_phase(self, success_change=False):
         """
         Runs both phases of the two-phase test and compares their results
+        If success_change is True, success requires some files to be different
         """
 
         # First run
@@ -176,7 +177,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._activate_case1()
         self._link_to_case2_output()
 
-        self._component_compare_test(self._run_one_suffix, self._run_two_suffix)
+        self._component_compare_test(self._run_one_suffix, self._run_two_suffix, success_change)
 
     # ========================================================================
     # Private methods

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -155,7 +155,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             self._case2.set_value("BUILD_COMPLETE",True)
             self._case2.flush()
 
-    def run_phase(self, success_change=False):
+    def run_phase(self, success_change=False):  # pylint: disable=arguments-differ
         """
         Runs both phases of the two-phase test and compares their results
         If success_change is True, success requires some files to be different
@@ -177,7 +177,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._activate_case1()
         self._link_to_case2_output()
 
-        self._component_compare_test(self._run_one_suffix, self._run_two_suffix, success_change)
+        self._component_compare_test(self._run_one_suffix, self._run_two_suffix, success_change=success_change)
 
     # ========================================================================
     # Private methods

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -166,7 +166,8 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
         if casename not in self.run_pass_casenames:
             raise RuntimeError('casename not in run_pass_casenames')
 
-    def _component_compare_test(self, suffix1, suffix2, success_change=False):
+    #pylint: disable=arguments-differ
+    def _component_compare_test(self, suffix1, suffix2):
         # Trying to use the real version of _component_compare_test would pull
         # too much baggage into these tests. Since the return value from this
         # method isn't important, it's sufficient for the tests of this class to
@@ -186,9 +187,6 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
 
         self.log.append(Call(METHOD_component_compare_test,
                              {'suffix1': suffix1, 'suffix2': suffix2}))
-        if success_change:
-            return False
-        return True
 
     def _check_for_memleak(self):
         pass

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -166,7 +166,7 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
         if casename not in self.run_pass_casenames:
             raise RuntimeError('casename not in run_pass_casenames')
 
-    def _component_compare_test(self, suffix1, suffix2):
+    def _component_compare_test(self, suffix1, suffix2, success_change=False):
         # Trying to use the real version of _component_compare_test would pull
         # too much baggage into these tests. Since the return value from this
         # method isn't important, it's sufficient for the tests of this class to
@@ -186,6 +186,9 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
 
         self.log.append(Call(METHOD_component_compare_test,
                              {'suffix1': suffix1, 'suffix2': suffix2}))
+        if success_change:
+            return False
+        return True
 
     def _check_for_memleak(self):
         pass
@@ -395,4 +398,3 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
         # Verify
         self.assertEqual(test_status.TEST_FAIL_STATUS,
                          mytest._test_status.get_status(test_status.RUN_PHASE))
-

--- a/scripts/lib/update_acme_tests.py
+++ b/scripts/lib/update_acme_tests.py
@@ -50,7 +50,7 @@ _TEST_SUITES = {
                              "DAE.f19_f19.A",
                              "PET_P32.f19_f19.A",
                              "SMS.T42_T42.S",
-                             "PRE.f45_g37_rx1.ADESP")
+                             "PRE.f19_f19.ADESP")
                             ),
 
     #

--- a/src/components/data_comps/desp/cime_config/buildnml
+++ b/src/components/data_comps/desp/cime_config/buildnml
@@ -54,7 +54,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     # Clear out old data.
     #----------------------------------------------------
     data_list_path = os.path.join(case.get_case_root(), "Buildconf",
-                                  "datm.input_data_list")
+                                  "desp.input_data_list")
     if os.path.exists(data_list_path):
         os.remove(data_list_path)
 

--- a/src/components/data_comps/desp/desp_comp_mod.F90
+++ b/src/components/data_comps/desp/desp_comp_mod.F90
@@ -472,7 +472,7 @@ CONTAINS
           call get_restart_filenames(ind, cpl_resume, errcode)
           allocate(rfilenames(1))
           rfilenames(1) = cpl_resume
-          varname = 'a2x_ax_Sa_tbot'
+          varname = 'x2oacc_ox_Sa_pslv'
         case default
           call shr_sys_abort(subname//'Unrecognized ind')
         end select

--- a/src/drivers/mct/cime_config/config_compsets.xml
+++ b/src/drivers/mct/cime_config/config_compsets.xml
@@ -77,12 +77,12 @@
 
   <compset>
     <alias>ADESP</alias>
-    <lname>2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_DESP%NOOP</lname>
+    <lname>2000_DATM%NYF_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV_DESP%NOOP</lname>
   </compset>
 
   <compset>
     <alias>ADESP_TEST</alias>
-    <lname>2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_DESP%TEST</lname>
+    <lname>2000_DATM%NYF_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV_DESP%TEST</lname>
   </compset>
 
   <compset>

--- a/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -614,4 +614,22 @@
       </machine>
     </machines>
   </test>
+  <test name="PRE" grid="f09_g17" compset="ADESP" testmods="drv/som">
+    <machines>
+      <machine name="hobart" compiler="nag" category="pauseresume"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20 </option>
+    </options>
+  </test>
+  <test name="PRE" grid="f09_g17" compset="ADESP_TEST" testmods="drv/som">
+    <machines>
+      <machine name="hobart" compiler="gnu" category="prealpha"/>
+      <machine name="hobart" compiler="nag" category="prealpha"/>
+      <machine name="hobart" compiler="nag" category="pauseresume"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20 </option>
+    </options>
+  </test>
 </testlist>

--- a/src/drivers/mct/cime_config/testdefs/testmods_dirs/drv/som/shell_commands
+++ b/src/drivers/mct/cime_config/testdefs/testmods_dirs/drv/som/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange DOCN_SOM_FILENAME="pop_frc.1x1d.090130.nc"
+

--- a/src/drivers/mct/main/seq_io_mod.F90
+++ b/src/drivers/mct/main/seq_io_mod.F90
@@ -36,7 +36,7 @@ module seq_io_mod
 
   use shr_kind_mod, only: r4 => shr_kind_r4, r8 => shr_kind_r8, in => shr_kind_in
   use shr_kind_mod, only: cl => shr_kind_cl, cs => shr_kind_cs
-  use shr_sys_mod       ! system calls
+  use shr_sys_mod,  only: shr_sys_abort
   use seq_comm_mct, only: logunit, CPLID, seq_comm_setptrs
   use seq_comm_mct, only: seq_comm_namelen, seq_comm_name
   use seq_flds_mod, only : seq_flds_lookup

--- a/src/drivers/mct/shr/seq_timemgr_mod.F90
+++ b/src/drivers/mct/shr/seq_timemgr_mod.F90
@@ -744,7 +744,7 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
          (trim(pause_option) /= seq_timemgr_optNONE)  .and.                   &
          (trim(pause_option) /= seq_timemgr_optNever)) then
        do n = 1, max_clocks
-          if (pause_active(n)) then
+          if (pause_active(n) .and. (iam == 0)) then
              write(logunit, '(4a)') subname, ': Pause active for ',           &
                   trim(seq_timemgr_clocks(n)),' component'
           end if


### PR DESCRIPTION
Fix typo: datm.input_data_list -> desp.input_data_list in desp buildnml.
Moved PRE tests to driver testlist and added SOM testmods.
Add optional argument to SystemTestsCommon.component_compare_test to
   test for changed files.
Update PRE test to use new feature.
Only print pause active from one PE.
Change ADESP* compsets to use DOCN%AQPSOM and change PRE test field to match.

Test suite:  scripts_regression_tests.py on Cheyenne
PRE.f19_f19.ADESP and PRE.f19_f19.ADESP_TEST on Hobart
`./scripts_regression_tests.py B_CheckCode` on Yellowstone

Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes ESMCI/CIME/#1622

User interface changes?: NA

Update gh-pages html (Y/N)?: N

Code review: 
