### PR TITLE
add --pesfile option to create_test

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -225,6 +225,11 @@ OR
     parser.add_argument("-i", "--input-dir",
                         help="Use a non-default location for input files")
 
+    parser.add_argument("--pesfile",
+                        help="Full pathname of an optional pes specification "
+                        "file. The file can follow either the config_pes.xml or "
+                        "the env_mach_pes.xml format.")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     # generate and compare flags may not point to the same directory
@@ -362,7 +367,7 @@ OR
         args.test_root, args.baseline_root, args.clean, baseline_cmp_name, baseline_gen_name, \
         args.namelists_only, args.project, args.test_id, args.parallel_jobs, args.walltime, \
         args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue, \
-        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib, args.input_dir
+        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib, args.input_dir, args.pesfile
 
 ###############################################################################
 def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost_map, wall_time, test_root):
@@ -468,7 +473,7 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
 def create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                 baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, project, test_id, parallel_jobs,
                 walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite, output_root, wait,
-                force_procs, force_threads, mpilib, input_dir):
+                force_procs, force_threads, mpilib, input_dir, pesfile):
 ###############################################################################
     impl = TestScheduler(test_names, test_data=test_data,
                          no_run=no_run, no_build=no_build, no_setup=no_setup, no_batch=no_batch,
@@ -481,7 +486,7 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
                          proc_pool=proc_pool, use_existing=use_existing, save_timing=save_timing,
                          queue=queue, allow_baseline_overwrite=allow_baseline_overwrite,
                          output_root=output_root, force_procs=force_procs, force_threads=force_threads,
-                         mpilib=mpilib, input_dir=input_dir)
+                         mpilib=mpilib, input_dir=input_dir, pesfile=pesfile)
 
     success = impl.run_tests(wait=wait)
 
@@ -522,13 +527,13 @@ def _main_func(description):
     test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, \
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \
-    save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir \
+    save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile \
         = parse_command_line(sys.argv, description)
 
     sys.exit(create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                          baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only,
                          project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, save_timing,
-                         queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir))
+                         queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile))
 
 ###############################################################################
 

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -86,7 +86,8 @@ class TestScheduler(object):
                  walltime=None, proc_pool=None,
                  use_existing=False, save_timing=False, queue=None,
                  allow_baseline_overwrite=False, output_root=None,
-                 force_procs=None, force_threads=None, mpilib=None, input_dir=None):
+                 force_procs=None, force_threads=None, mpilib=None,
+                 input_dir=None, pesfile=None):
     ###########################################################################
         self._cime_root       = CIME.utils.get_cime_root()
         self._cime_model      = get_model()
@@ -96,7 +97,7 @@ class TestScheduler(object):
         self._mpilib          = mpilib  # allow override of default mpilib
         self._completed_tests = 0
         self._input_dir       = input_dir
-
+        self._pesfile         = pesfile
         self._allow_baseline_overwrite = allow_baseline_overwrite
 
         self._machobj = Machines(machine=machine_name)
@@ -364,6 +365,9 @@ class TestScheduler(object):
             create_newcase_cmd += " --output-root {} ".format(self._output_root)
         if self._input_dir is not None:
             create_newcase_cmd += " --input-dir {} ".format(self._input_dir)
+
+        if self._pesfile is not None:
+            create_newcase_cmd += " --pesfile {} ".format(self._pesfile)
 
         if test_mods is not None:
             files = Files()


### PR DESCRIPTION
Allows a user to run tests with non-default pe layout

Test suite: Hand tested with ERP_Ln9.f09_f09_mg17.F2000_DEV.cheyenne_intel.cam-outfrq9s and 
ERS_Ln9.f09_f09_mg17.F2000_DEV.cheyenne_intel.cam-outfrq9s
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: Adds --pesfile option to create_test

Update gh-pages html (Y/N)?: N

Code review: 
