### PR TITLE
update name to match other components

### DIFF
--- a/src/components/data_comps/dice/cime_config/config_component.xml
+++ b/src/components/data_comps/dice/cime_config/config_component.xml
@@ -13,9 +13,9 @@
        This file may have ice desc entries.
   -->
   <description modifier_mode='1'>
-    <desc ice="DICE[%SSMI][%SIAF][%PRES][%NULL]">dice mode </desc>
+    <desc ice="DICE[%SSMI][%IAF][%PRES][%NULL]">dice mode </desc>
     <desc option="SSMI">is ssmi</desc>
-    <desc option="SIAF"> is siaf</desc>
+    <desc option="IAF"> is siaf</desc>
     <desc option="PRES"> is prescribed</desc>
     <desc option="NULL"> is null</desc>
   </description>
@@ -35,7 +35,7 @@
     <default_value>ssmi</default_value>
     <values match="last">
       <value compset="DICE%SSMI">ssmi</value>
-      <value compset="DICE%SIAF">ssmi_iaf</value>
+      <value compset="DICE%IAF">ssmi_iaf</value>
       <value compset="DICE%PRES">prescribed</value>
       <value compset="DICE%NULL">null</value>
     </values>


### PR DESCRIPTION
Change SIAF compset name in dice to IAF to be consistent with other components. 

Test suite: ERS.f09_g17.AIAF.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
