### PR TITLE
System tests compare two stage two

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -26,6 +26,8 @@ In addition, they MAY require the following method:
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case import Case
+from CIME.check_input_data import check_all_input_data
+from CIME.preview_namelists import create_namelists
 
 import shutil, os, glob
 
@@ -164,11 +166,16 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # First run
         logger.info('Doing first run: ' + self._run_one_description)
         self._activate_case1()
+        run_type = self._case1.get_value("RUN_TYPE")
         self.run_indv(suffix = self._run_one_suffix)
 
         # Second run
         logger.info('Doing second run: ' + self._run_two_description)
         self._activate_case2()
+        # we need to make sure run2 is properly staged.
+        if run_type != "startup":
+            create_namelists(self._case2)
+            check_all_input_data(self._case2)
         self._force_case2_settings()
         self.run_indv(suffix = self._run_two_suffix)
 

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -26,8 +26,7 @@ In addition, they MAY require the following method:
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case import Case
-from CIME.check_input_data import check_all_input_data
-from CIME.preview_namelists import create_namelists
+from CIME.case_submit import check_case
 
 import shutil, os, glob
 
@@ -174,8 +173,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._activate_case2()
         # we need to make sure run2 is properly staged.
         if run_type != "startup":
-            create_namelists(self._case2)
-            check_all_input_data(self._case2)
+            check_case(self._case2, self._caseroot2)
         self._force_case2_settings()
         self.run_indv(suffix = self._run_two_suffix)
 

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -362,7 +362,6 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
             Call(METHOD_component_compare_test,
                 {'suffix1': run_one_suffix, 'suffix2': run_two_suffix})
         ]
-        print "HJERE %s"%mytest.log
         self.assertEqual(expected_calls, mytest.log)
 
     def test_run1_fails(self):

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -362,6 +362,7 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
             Call(METHOD_component_compare_test,
                 {'suffix1': run_one_suffix, 'suffix2': run_two_suffix})
         ]
+        print "HJERE %s"%mytest.log
         self.assertEqual(expected_calls, mytest.log)
 
     def test_run1_fails(self):

--- a/scripts/lib/CIME/tests/case_fake.py
+++ b/scripts/lib/CIME/tests/case_fake.py
@@ -22,6 +22,7 @@ class CaseFake(object):
         casename = os.path.basename(case_root)
         self.set_value('CASE', casename)
         self.set_value('CASEBASEID', casename)
+        self.set_value('RUN_TYPE', 'startup')
         self.set_rundir()
 
     def get_value(self, item):
@@ -100,4 +101,3 @@ class CaseFake(object):
         inside CASEROOT)
         """
         self.set_value('RUNDIR', os.path.join(self.get_value('CASEROOT'), 'run'))
-


### PR DESCRIPTION
The second test in a system_tests_compare_two type test was not getting its initial data in a RUN_TYPE='hybrid' case. 

Test suite: scripts_regression_tests.py & PET_Ln9.f09_f09_mg17.F2000_DEV.cheyenne_intel.cam-outfrq9s 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes ESMCI/cime#1737

User interface changes?: No

Update gh-pages html (Y/N)?: N

Code review: 
