### PR TITLE
Update netcdf version for ACME

### DIFF
--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -722,7 +722,7 @@
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>               <!-- complete path to a short term archiving directory -->
   <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>           <!-- complete path to a long term archiving directory -->
   <BASELINE_ROOT>/projects/ccsm/ccsm_baselines</BASELINE_ROOT>
-  <CCSM_CPRNC>/projects/ccsm/cprnc/build/cprnc_wrap</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
+  <CCSM_CPRNC>/projects/ccsm/cprnc/build.new/cprnc_wrap</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
   <SAVE_TIMING_DIR>/projects/ccsm/timings</SAVE_TIMING_DIR>
   <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
   <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
@@ -765,12 +765,12 @@
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="load">openmpi-intel/1.6</command>
-      <command name="load">sems-hdf5/1.8.12/base</command>
-      <command name="load">sems-netcdf/4.4.1/exo</command>
-    </modules>
-    <modules mpilib="mpi-serial">
       <command name="load">sems-hdf5/1.8.12/parallel</command>
       <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
+    </modules>
+    <modules mpilib="mpi-serial">
+      <command name="load">sems-hdf5/1.8.12/base</command>
+      <command name="load">sems-netcdf/4.4.1/exo</command>
     </modules>
   </module_system>
   <environment_variables>
@@ -782,10 +782,12 @@
     <!-- <env name="NETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env> -->
     <!-- <env name="PNETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env> -->
     <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
-    <env name="PNETCDFROOT" mpilib="!mpi-serial">$ENV{SEMS_NETCDF_ROOT}</env>
     <env name="NETCDF_INCLUDES">$ENV{SEMS_NETCDF_ROOT}/include</env>
     <env name="NETCDF_LIBS">$ENV{SEMS_NETCDF_ROOT}/lib</env>
     <env name="OMP_STACKSIZE">64M</env>
+  </environment_variables>
+  <environment_variables mpilib="!mpi-serial">
+    <env name="PNETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
   </environment_variables>
 </machine>
 
@@ -805,7 +807,7 @@
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>               <!-- complete path to a short term archiving directory -->
   <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>           <!-- complete path to a long term archiving directory -->
   <BASELINE_ROOT>/projects/ccsm/ccsm_baselines</BASELINE_ROOT>
-  <CCSM_CPRNC>/projects/ccsm/cprnc/build/cprnc_wrap</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
+  <CCSM_CPRNC>/projects/ccsm/cprnc/build.new/cprnc_wrap</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
   <SAVE_TIMING_DIR>/projects/ccsm/timings</SAVE_TIMING_DIR>
   <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
   <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
@@ -848,12 +850,12 @@
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="load">openmpi-intel/1.6</command>
-      <command name="load">sems-hdf5/1.8.12/base</command>
-      <command name="load">sems-netcdf/4.4.1/exo</command>
-    </modules>
-    <modules mpilib="mpi-serial">
       <command name="load">sems-hdf5/1.8.12/parallel</command>
       <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
+    </modules>
+    <modules mpilib="mpi-serial">
+      <command name="load">sems-hdf5/1.8.12/base</command>
+      <command name="load">sems-netcdf/4.4.1/exo</command>
     </modules>
   </module_system>
   <environment_variables>
@@ -865,10 +867,12 @@
     <!-- <env name="NETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env> -->
     <!-- <env name="PNETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env> -->
     <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
-    <env name="PNETCDFROOT" mpilib="!mpi-serial">$ENV{SEMS_NETCDF_ROOT}</env>
     <env name="NETCDF_INCLUDES">$ENV{SEMS_NETCDF_ROOT}/include</env>
     <env name="NETCDF_LIBS">$ENV{SEMS_NETCDF_ROOT}/lib</env>
     <env name="OMP_STACKSIZE">64M</env>
+  </environment_variables>
+  <environment_variables mpilib="!mpi-serial">
+    <env name="PNETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
   </environment_variables>
 </machine>
 

--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -567,7 +567,7 @@
       <modules>
         <command name="load">sems-openmpi/1.8.7</command>
         <command name="load">sems-cmake/2.8.12</command>
-        <command name="load">sems-netcdf/4.3.2/parallel</command>
+        <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -632,7 +632,7 @@
       <modules>
         <command name="load">sems-openmpi/1.8.7</command>
         <command name="load">sems-cmake/2.8.12</command>
-        <command name="load">sems-netcdf/4.3.2/parallel</command>
+        <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -761,31 +761,30 @@
       <command name="load">sems-cmake</command>
       <command name="load">gnu/4.9.2</command>
       <command name="load">intel/intel-15.0.3.187</command>
+      <command name="load">libraries/intel-mkl-15.0.2.164</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="load">openmpi-intel/1.6</command>
+      <command name="load">sems-hdf5/1.8.12/base</command>
+      <command name="load">sems-netcdf/4.4.1/exo</command>
     </modules>
-    <modules>
-      <command name="load">libraries/intel-mkl-15.0.2.164</command>
-      <!-- We want to use these modules but the segfault comes back if we do, maybe wait for new PIO? -->
-      <!-- <command name="load" mpilib="!mpi-serial">sems-hdf5/1.8.12/parallel</command> -->
-      <!-- <command name="load" mpilib="!mpi-serial">sems-netcdf/4.3.2/parallel</command> -->
-      <!-- <command name="load" mpilib="mpi-serial">sems-hdf5/1.8.11/base</command> -->
-      <!-- <command name="load" mpilib="mpi-serial">sems-netcdf/4.3.2/base</command> -->
+    <modules mpilib="mpi-serial">
+      <command name="load">sems-hdf5/1.8.12/parallel</command>
+      <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
     </modules>
   </module_system>
   <environment_variables>
     <!-- <env name="PATH">/projects/ccsm/cmake-2.8.10.2-Linux-i386/bin:$PATH</env> -->
-    <env name="PATH">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/bin:$ENV{PATH}</env>
-    <env name="LD_LIBRARY_PATH">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/lib:$ENV{LD_LIBRARY_PATH}</env>
-    <env name="NETCDF_INCLUDES">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/include</env>
-    <env name="NETCDF_LIBS">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/lib</env>
-    <env name="NETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env>
-    <env name="PNETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env>
-    <!-- <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env> -->
-    <!-- <env name="PNETCDFROOT" mpilib="!mpi-serial">$ENV{SEMS_NETCDF_ROOT}</env> -->
-    <!-- <env name="NETCDF_INCLUDES">$ENV{SEMS_NETCDF_ROOT}/include</env> -->
-    <!-- <env name="NETCDF_LIBS">$ENV{SEMS_NETCDF_ROOT}/lib</env> -->
+    <!-- <env name="PATH">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/bin:$ENV{PATH}</env> -->
+    <!-- <env name="LD_LIBRARY_PATH">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/lib:$ENV{LD_LIBRARY_PATH}</env> -->
+    <!-- <env name="NETCDF_INCLUDES">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/include</env> -->
+    <!-- <env name="NETCDF_LIBS">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/lib</env> -->
+    <!-- <env name="NETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env> -->
+    <!-- <env name="PNETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env> -->
+    <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
+    <env name="PNETCDFROOT" mpilib="!mpi-serial">$ENV{SEMS_NETCDF_ROOT}</env>
+    <env name="NETCDF_INCLUDES">$ENV{SEMS_NETCDF_ROOT}/include</env>
+    <env name="NETCDF_LIBS">$ENV{SEMS_NETCDF_ROOT}/lib</env>
     <env name="OMP_STACKSIZE">64M</env>
   </environment_variables>
 </machine>
@@ -845,31 +844,30 @@
       <command name="load">sems-cmake</command>
       <command name="load">gnu/4.9.2</command>
       <command name="load">intel/intel-15.0.3.187</command>
+      <command name="load">libraries/intel-mkl-15.0.2.164</command>
     </modules>
     <modules mpilib="!mpi-serial">
       <command name="load">openmpi-intel/1.6</command>
+      <command name="load">sems-hdf5/1.8.12/base</command>
+      <command name="load">sems-netcdf/4.4.1/exo</command>
     </modules>
-    <modules>
-      <command name="load">libraries/intel-mkl-15.0.2.164</command>
-      <!-- We want to use these modules but the segfault comes back if we do, maybe wait for new PIO? -->
-      <!-- <command name="load" mpilib="!mpi-serial">sems-hdf5/1.8.12/parallel</command> -->
-      <!-- <command name="load" mpilib="!mpi-serial">sems-netcdf/4.3.2/parallel</command> -->
-      <!-- <command name="load" mpilib="mpi-serial">sems-hdf5/1.8.11/base</command> -->
-      <!-- <command name="load" mpilib="mpi-serial">sems-netcdf/4.3.2/base</command> -->
+    <modules mpilib="mpi-serial">
+      <command name="load">sems-hdf5/1.8.12/parallel</command>
+      <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
     </modules>
   </module_system>
   <environment_variables>
     <!-- <env name="PATH">/projects/ccsm/cmake-2.8.10.2-Linux-i386/bin:$PATH</env> -->
-    <env name="PATH">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/bin:$ENV{PATH}</env>
-    <env name="LD_LIBRARY_PATH">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/lib:$ENV{LD_LIBRARY_PATH}</env>
-    <env name="NETCDF_INCLUDES">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/include</env>
-    <env name="NETCDF_LIBS">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/lib</env>
-    <env name="NETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env>
-    <env name="PNETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env>
-    <!-- <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env> -->
-    <!-- <env name="PNETCDFROOT" mpilib="!mpi-serial">$ENV{SEMS_NETCDF_ROOT}</env> -->
-    <!-- <env name="NETCDF_INCLUDES">$ENV{SEMS_NETCDF_ROOT}/include</env> -->
-    <!-- <env name="NETCDF_LIBS">$ENV{SEMS_NETCDF_ROOT}/lib</env> -->
+    <!-- <env name="PATH">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/bin:$ENV{PATH}</env> -->
+    <!-- <env name="LD_LIBRARY_PATH">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/lib:$ENV{LD_LIBRARY_PATH}</env> -->
+    <!-- <env name="NETCDF_INCLUDES">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/include</env> -->
+    <!-- <env name="NETCDF_LIBS">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5/lib</env> -->
+    <!-- <env name="NETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env> -->
+    <!-- <env name="PNETCDFROOT">/projects/ccsm/tpl/netcdf/4.3.2/intel/13.0.1/openmpi/1.6.5</env> -->
+    <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
+    <env name="PNETCDFROOT" mpilib="!mpi-serial">$ENV{SEMS_NETCDF_ROOT}</env>
+    <env name="NETCDF_INCLUDES">$ENV{SEMS_NETCDF_ROOT}/include</env>
+    <env name="NETCDF_LIBS">$ENV{SEMS_NETCDF_ROOT}/lib</env>
     <env name="OMP_STACKSIZE">64M</env>
   </environment_variables>
 </machine>

--- a/scripts/lib/update_acme_tests.py
+++ b/scripts/lib/update_acme_tests.py
@@ -37,7 +37,7 @@ _TEST_SUITES = {
                     "TESTMEMLEAKPASS_P1.f09_g16.X")
                    ),
 
-    "cime_developer" : (None, "0:10:00",
+    "cime_developer" : (None, "0:15:00",
                             ("NCK_Ld3.f45_g37_rx1.A",
                              "ERI.f09_g16.X",
                              "ERIO.f09_g16.X",


### PR DESCRIPTION
For Sandia machines. Necessary for ERIO test to work.

Test suite: scripts_regression_test Z_FullSystemTest
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?:N

Code review: None
