### PR TITLE
Fixed print statement in find_circular_dependecy.py

### DIFF
--- a/tools/utils/find_circular_dependency.py
+++ b/tools/utils/find_circular_dependency.py
@@ -11,12 +11,12 @@ modfile = re.compile(r"^([A-Za-z0-9_-]+)[.]mod$")
 
 def Usage ():
   thisFile = os.path.realpath(inspect.getfile(inspect.currentframe()))
-  print(""")
+  print("""
 Usage: {} <Depends file>
 
   Looks for circular dependencies in CESM Depends file
 
-  """.format(os.path.basename(thisFile))
+  """.format(os.path.basename(thisFile)))
 # End Usage
 
 def keylen(key):
@@ -76,7 +76,7 @@ def findCircularDep(filename):
 def main(filename):
   DepFile = os.path.abspath(filename)
   if (not os.path.exists(DepFile)):
-    print("ERROR: File '{}', does not exist".format(filename))
+    print("ERROR: File '{0}', does not exist".format(filename))
     return 1
   # End if
   cleanTree = findCircularDep(DepFile)


### PR DESCRIPTION
tools/utils/find_circular_dependency.py had a misplaced closing
parenthesis in a print statement. Additionally, there was an issue where
instead of using '{}' in a format an index had to be supplied '{0}'. Without this index the following error was thrown:
`ValueError: zero length field name in format`

Test suite: <cime_root>/tools/utils/find_circular_dependency.py <build_root>/bld/atm/obj/Depends
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1701 

User interface changes?: 

Update gh-pages html (Y/N)?: N

Code review: @gold2718 
