### PR TITLE
requested mods to ensemble.sh 

### DIFF
--- a/tools/statistical_ensemble_test/ensemble.sh
+++ b/tools/statistical_ensemble_test/ensemble.sh
@@ -241,7 +241,8 @@ while [ $i -le ${#Args[@]} ]; do
     --ensemble )
       i=$((i+1))
       # Set CLONECOUNT and runtype
-      CLONECOUNT=${Args[$i]}-1
+      #CLONECOUNT=${Args[$i]}-1
+      CLONECOUNT=$((${Args[$i]}-1))
       if [ $CLONECOUNT -gt 999 ]; then
         echo "ERROR: the number of ensemble member cannot be set to more than 999!"
         exit 2

--- a/tools/statistical_ensemble_test/single_run.sh
+++ b/tools/statistical_ensemble_test/single_run.sh
@@ -36,7 +36,7 @@ usage() {
   echo '  --walltime    Amount of walltime requested (default = 4:30)'
   echo '  --account     Account number to use in job scripts (default = machine default)'
   echo '  --compiler    Compiler to use '
-  echo '  --compset     Compset to use (default = FC5)'
+  echo '  --compset     Compset to use (default = F2000_DEV)'
   echo '  --res         Resolution to run (default = ne30_ne30'
   echo '  --uf          Enable ninth time step runs (ultra-fast mode)'
   if [ $ThisScript = "ensemble.sh" ]; then
@@ -110,7 +110,7 @@ ThisDir=$(cd `dirname $0`; pwd -P )
 
 # Default Values
 RES="ne30_ne30"
-COMPSET="FC5"
+COMPSET="F2000_DEV"
 CHANGE_NP=0
 CHANGE_NPICE=0
 CHANGE_NPOCN=0
@@ -302,7 +302,13 @@ case $MACH in
   ;;
 esac
 
-NewCaseFlags="$NewCaseFlags --res $RES --compset $COMPSET --run-unsupported --project $ACCOUNT"
+
+if [ ! -z $ACCOUNT ]; then
+    NewCaseFlags="$NewCaseFlags --res $RES --compset $COMPSET --run-unsupported --project $ACCOUNT"
+else
+    NewCaseFlags="$NewCaseFlags --res $RES --compset $COMPSET --run-unsupported"
+fi
+
 cd $SCRIPTS_ROOT
 echo "Currently in $SCRIPTS_ROOT"
 echo "Flags for create_newcase are $NewCaseFlags"


### PR DESCRIPTION
Fixed these two issues (from Chris F.):
1.  There is a known issue that needs to be fixed in ensemble.sh.
         Line 244 in ensemble.sh needs to be changed to.
         CLONECOUNT=$((${Args[$i]}-1))
2.  The next issue is single_run.sh requires a project/account.  This is causing problems
      on systems that don't require a project/account.  It should be simple enough to not append
      --project $ACCOUNT to the NewCaseFlags string at line 312, when $ACCOUNT isn't being set.

Also changed default case from FC5 to F2000_DEV (since FC5 not an option anymore)


Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
