### PR TITLE
Remove misleading text from the dependency string in config_batch.xml

### DIFF
--- a/config/acme/machines/config_batch.xml
+++ b/config/acme/machines/config_batch.xml
@@ -455,7 +455,7 @@
       <template>template.st_archive</template>
       <task_count>1</task_count>
       <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
-      <dependency>case.run or case.test</dependency>
+      <dependency>case.run case.test</dependency>
       <prereq>$DOUT_S</prereq>
     </job>
   </batch_jobs>


### PR DESCRIPTION
Removes misleading text from the dependency string in config_batch.xml, as cime does not implement logical dependencies between jobs

Test suite: scripts_regression_tests (pending, but run with this change in another branch)
Test status: ok

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
