### PR TITLE
Facilitate expected error unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ endif()
 # by different tests?)
 set(SHARE_ROOT "${CIME_ROOT}/src/share")
 add_subdirectory(${SHARE_ROOT}/util csm_share)
+add_subdirectory(${SHARE_ROOT}/unit_test_stubs/util csm_share_stubs)
 include_directories(${SHARE_ROOT}/include)
 
 # esmf_wrf_timemgr not built here because it depends on csm_share.

--- a/src/externals/CMake/CIME_utils.cmake
+++ b/src/externals/CMake/CIME_utils.cmake
@@ -72,6 +72,10 @@ find_package(pFUnit)
 # Preprocessor and driver handling.
 include(pFUnit_utils)
 
+# Need to add PFUNIT_INCLUDE_DIRS to the general list of include_directories
+# because we use pfunit's 'throw'.
+include_directories("${PFUNIT_INCLUDE_DIRS}")
+
 #=================================================
 # Source list and path utilities.
 #=================================================

--- a/src/share/test/unit/CMakeLists.txt
+++ b/src/share/test/unit/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(mock)
 
+add_subdirectory(shr_abort_test)
+
 add_subdirectory(shr_assert_test)
 
 add_subdirectory(shr_spfn_test)

--- a/src/share/test/unit/mock/README
+++ b/src/share/test/unit/mock/README
@@ -1,0 +1,4 @@
+This directory contains mock/stub modules that are just built as part of select
+unit tests of the share code. This directory should *NOT* generally be added by
+unit tests of other components.
+

--- a/src/share/test/unit/mock/shr_sys_mod.nompi_abortthrows.F90
+++ b/src/share/test/unit/mock/shr_sys_mod.nompi_abortthrows.F90
@@ -7,7 +7,6 @@ module shr_sys_mod
 use shr_kind_mod, only: &
      shr_kind_in, shr_kind_r8
 
-! This used to be in shr_sys_mod; we provide this rename for backwards compatibility
 use shr_abort_mod, only : shr_sys_abort => shr_abort_abort
 
 implicit none
@@ -15,7 +14,10 @@ private
 save
 
 ! Fake abort
-! Imported from shr_abort_mod and republished with renames for backwards compatibility
+! Imported from shr_abort_mod and republished with renames. Other code that wishes to use
+! these routines should use these shr_sys names rather than directly using the routines
+! from shr_abort_abort. (This is for consistency with older code, from when these routines
+! were defined in shr_sys_mod.)
 public :: shr_sys_abort
 
 ! Fake sleep

--- a/src/share/test/unit/mock/shr_sys_mod.nompi_abortthrows.F90
+++ b/src/share/test/unit/mock/shr_sys_mod.nompi_abortthrows.F90
@@ -4,6 +4,10 @@ module shr_sys_mod
 ! It contains only a few routines that are needed, and an abort method that throws a pFUnit
 ! exception instead of actually aborting.
 
+  ! TODO(wjs, 2017-07-27) I have now separated shr_sys_abort into its own module:
+  ! shr_abort_mod:shr_abort_abort. This mock should be revised or removed in light of
+  ! that.
+
 use shr_kind_mod, only: &
      shr_kind_in, shr_kind_r8
 

--- a/src/share/test/unit/mock/shr_sys_mod.nompi_abortthrows.F90
+++ b/src/share/test/unit/mock/shr_sys_mod.nompi_abortthrows.F90
@@ -4,18 +4,18 @@ module shr_sys_mod
 ! It contains only a few routines that are needed, and an abort method that throws a pFUnit
 ! exception instead of actually aborting.
 
-  ! TODO(wjs, 2017-07-27) I have now separated shr_sys_abort into its own module:
-  ! shr_abort_mod:shr_abort_abort. This mock should be revised or removed in light of
-  ! that.
-
 use shr_kind_mod, only: &
      shr_kind_in, shr_kind_r8
+
+! This used to be in shr_sys_mod; we provide this rename for backwards compatibility
+use shr_abort_mod, only : shr_sys_abort => shr_abort_abort
 
 implicit none
 private
 save
 
 ! Fake abort
+! Imported from shr_abort_mod and republished with renames for backwards compatibility
 public :: shr_sys_abort
 
 ! Fake sleep
@@ -25,19 +25,6 @@ public :: shr_sys_sleep
 public :: shr_sys_flush
 
 contains
-
-subroutine shr_sys_abort(string, rc)
-  use pfunit_mod, only: throw
-
-  character(*), optional :: string
-  integer(shr_kind_in), optional :: rc
-
-  ! Prevent compiler spam about unused variables.
-  if (.false.) rc = rc
-
-  call throw("ABORTED: "//trim(string))
-
-end subroutine shr_sys_abort
 
 subroutine shr_sys_sleep(sec)
   real(shr_kind_r8), intent(in) :: sec

--- a/src/share/test/unit/shr_abort_test/CMakeLists.txt
+++ b/src/share/test/unit/shr_abort_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Local pFUnit files.
+set(pf_sources
+  test_shr_abort.pf)
+
+# Sources to test.
+set(sources_needed
+  shr_kind_mod.F90
+  shr_abort_mod.abortthrows.F90)
+extract_sources("${sources_needed}" "${share_sources}" test_sources)
+
+# Do source preprocessing and add the executable.
+create_pFUnit_test(shr_abort_mod shr_abort_mod_exe "${pf_sources}"
+  "${test_sources}")

--- a/src/share/test/unit/shr_abort_test/README
+++ b/src/share/test/unit/shr_abort_test/README
@@ -1,0 +1,2 @@
+This directory tests the version of shr_abort_mod that is used in unit tests. It
+does NOT test the production version of shr_abort_mod.

--- a/src/share/test/unit/shr_abort_test/test_shr_abort.pf
+++ b/src/share/test/unit/shr_abort_test/test_shr_abort.pf
@@ -1,0 +1,39 @@
+module test_shr_abort
+
+  ! Tests of shr_abort_mod: version used in unit tests that throws a pfunit exception
+  ! rather than aborting
+
+  use pfunit_mod
+  use shr_abort_mod
+  use shr_kind_mod , only : r8 => shr_kind_r8
+
+  implicit none
+
+  @TestCase
+  type, extends(TestCase) :: TestShrAbort
+   contains
+     procedure :: setUp
+     procedure :: tearDown
+  end type TestShrAbort
+
+  real(r8), parameter :: tol = 1.e-13_r8
+
+contains
+
+  subroutine setUp(this)
+    class(TestShrAbort), intent(inout) :: this
+  end subroutine setUp
+
+  subroutine tearDown(this)
+    class(TestShrAbort), intent(inout) :: this
+  end subroutine tearDown
+
+  @Test
+  subroutine test_abort(this)
+    class(TestShrAbort), intent(inout) :: this
+
+    call shr_abort_abort('Test message')
+    @assertExceptionRaised('ABORTED: Test message')
+  end subroutine test_abort
+
+end module test_shr_abort

--- a/src/share/test/unit/shr_assert_test/CMakeLists.txt
+++ b/src/share/test/unit/shr_assert_test/CMakeLists.txt
@@ -3,7 +3,8 @@ set(pf_sources test_assert.pf test_assert_array.pf test_macro.pf
 
 set(sources_needed shr_kind_mod.F90 shr_infnan_mod.F90
   shr_strconvert_mod.F90 shr_log_mod.F90
-  shr_sys_mod.nompi_abortthrows.F90 shr_assert_mod.F90)
+  shr_sys_mod.nompi_abortthrows.F90 shr_abort_mod.abortthrows.F90
+  shr_assert_mod.F90)
 
 extract_sources("${sources_needed}" "${share_sources}" test_sources)
 

--- a/src/share/test/unit/shr_spfn_test/CMakeLists.txt
+++ b/src/share/test/unit/shr_spfn_test/CMakeLists.txt
@@ -3,7 +3,8 @@ set(pf_sources test_erf_r4.pf test_erf_r8.pf test_gamma_factorial.pf
 
 set(sources_needed shr_kind_mod.F90 shr_const_mod.F90 shr_infnan_mod.F90
   shr_strconvert_mod.F90 shr_log_mod.F90
-  shr_sys_mod.nompi_abortthrows.F90 shr_spfn_mod.F90)
+  shr_sys_mod.nompi_abortthrows.F90 shr_abort_mod.abortthrows.F90
+  shr_spfn_mod.F90)
 
 extract_sources("${sources_needed}" "${share_sources}" test_sources)
 

--- a/src/share/test/unit/shr_string_test/CMakeLists.txt
+++ b/src/share/test/unit/shr_string_test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(sources_needed
   shr_log_mod.F90
   shr_strconvert_mod.F90
   shr_sys_mod.nompi_abortthrows.F90
+  shr_abort_mod.abortthrows.F90
   shr_timer_mod.F90)
 
 extract_sources("${sources_needed}" "${share_sources}" test_sources)

--- a/src/share/unit_test_stubs/README
+++ b/src/share/unit_test_stubs/README
@@ -1,2 +1,2 @@
-This directory contains stubs that may be useful for the unit test builds for a
-number of components.
+This directory contains stubs and other unit test-specific implementations that
+may be useful for the unit test builds for a number of components.

--- a/src/share/unit_test_stubs/util/CMakeLists.txt
+++ b/src/share/unit_test_stubs/util/CMakeLists.txt
@@ -1,0 +1,4 @@
+list(APPEND share_sources
+  shr_abort_mod.abortthrows.F90)
+
+sourcelist_to_parent(share_sources)

--- a/src/share/unit_test_stubs/util/README
+++ b/src/share/unit_test_stubs/util/README
@@ -1,0 +1,3 @@
+This directory contains some fake modules that should generally be used in place
+of their real counterparts by ALL unit tests. So this directory generally should
+be added by unit tests of other components.

--- a/src/share/unit_test_stubs/util/shr_abort_mod.abortthrows.F90
+++ b/src/share/unit_test_stubs/util/shr_abort_mod.abortthrows.F90
@@ -1,0 +1,41 @@
+module shr_abort_mod
+
+  ! This is a replacement for shr_abort_mod that throws a pfunit exception rather than
+  ! aborting
+
+  use shr_kind_mod, only : shr_kind_in
+  use pfunit_mod, only : throw
+
+  implicit none
+  private
+
+  public :: shr_abort_abort ! Replacement for shr_abort_abort that throws a pfunit exception rather than aborting
+
+  public :: shr_abort_backtrace ! Just to satisfy the public interface of shr_abort_abort
+
+contains
+
+  subroutine shr_abort_abort(string,rc)
+    ! Replacement for shr_abort_abort that throws a pfunit exception rather than aborting
+
+    !----- arguments -----
+    character(len=*)    , intent(in), optional :: string  ! error message string
+    integer(shr_kind_in), intent(in), optional :: rc      ! error code
+
+    !----- locals -----
+    integer(shr_kind_in) :: my_rc
+
+    ! Prevent compiler spam about unused variables.
+    if (.false.) my_rc = rc
+
+    call throw("ABORTED: "//trim(string))
+  end subroutine shr_abort_abort
+
+  subroutine shr_abort_backtrace()
+    ! Just to satisfy the public interface of shr_abort_abort
+    !
+    ! Does nothing
+
+  end subroutine shr_abort_backtrace
+
+end module shr_abort_mod

--- a/src/share/unit_test_stubs/util/shr_abort_mod.abortthrows.F90
+++ b/src/share/unit_test_stubs/util/shr_abort_mod.abortthrows.F90
@@ -17,6 +17,28 @@ contains
 
   subroutine shr_abort_abort(string,rc)
     ! Replacement for shr_abort_abort that throws a pfunit exception rather than aborting
+    !
+    ! This can be used to test expected errors (i.e., failure testing).
+    !
+    ! If this occurs within a pFUnit-based test:
+    !
+    ! - If you have code like:
+    !
+    !   @assertExceptionRaised(expected_message)
+    !
+    !   then your test will pass if the actual message in the 'throw' call (including the
+    !   'ABORTED: ' prefix) matches expected_message; it will fail if the actual message
+    !   doesn't match the expected message
+    !
+    ! - If you don't have
+    !
+    !   @assertExceptionRaised
+    !
+    !   or
+    !
+    !   call assertExceptionRaised
+    !
+    !   then this will result in the given pFUnit test failing.
 
     !----- arguments -----
     character(len=*)    , intent(in), optional :: string  ! error message string

--- a/src/share/util/CMakeLists.txt
+++ b/src/share/util/CMakeLists.txt
@@ -7,20 +7,37 @@ sourcelist_to_parent(share_genf90_sources)
 
 list(APPEND share_sources "${share_genf90_sources}")
 
-list(APPEND share_sources shr_file_mod.F90 shr_kind_mod.F90 shr_const_mod.F90
-  shr_sys_mod.F90 shr_log_mod.F90 shr_orb_mod.F90 shr_spfn_mod.F90 shr_strconvert_mod.F90
-  shr_nl_mod.F90 shr_precip_mod.F90 shr_string_mod.F90 shr_timer_mod.F90 shr_vmath_mod.F90
+list(APPEND share_sources
+  shr_file_mod.F90
+  shr_kind_mod.F90
+  shr_const_mod.F90
+  shr_abort_mod.F90
+  shr_sys_mod.F90
+  shr_log_mod.F90
+  shr_orb_mod.F90
+  shr_spfn_mod.F90
+  shr_strconvert_mod.F90
+  shr_nl_mod.F90
+  shr_precip_mod.F90
+  shr_string_mod.F90
+  shr_timer_mod.F90
+  shr_vmath_mod.F90
   shr_wv_sat_mod.F90)
 
 # Build a separate list containing the mct wrapper and its dependencies. That
 # way, this list can be easily included in unit test builds that link to mct,
 # but excluded from builds that do not include mct.
-list(APPEND share_mct_sources mct_mod.F90 shr_mct_mod.F90 shr_mpi_mod.F90 shr_pcdf_mod.F90)
+list(APPEND share_mct_sources
+  mct_mod.F90
+  shr_mct_mod.F90
+  shr_mpi_mod.F90
+  shr_pcdf_mod.F90)
 
 # Build a separate list containing the pio wrapper and its dependencies. That
 # way, this list can be easily included in unit test builds that include PIO or
 # a stub of PIO, but excluded from builds that do not include PIO.
-list(APPEND share_pio_sources shr_pio_mod.F90)
+list(APPEND share_pio_sources
+  shr_pio_mod.F90)
 
 sourcelist_to_parent(share_sources)
 sourcelist_to_parent(share_mct_sources)

--- a/src/share/util/CMakeLists.txt
+++ b/src/share/util/CMakeLists.txt
@@ -11,7 +11,6 @@ list(APPEND share_sources
   shr_file_mod.F90
   shr_kind_mod.F90
   shr_const_mod.F90
-  shr_abort_mod.F90
   shr_sys_mod.F90
   shr_log_mod.F90
   shr_orb_mod.F90

--- a/src/share/util/shr_abort_mod.F90
+++ b/src/share/util/shr_abort_mod.F90
@@ -1,6 +1,11 @@
 module shr_abort_mod
   ! This module defines procedures that can be used to abort the model cleanly in a
   ! system-specific manner
+  !
+  ! The public routines here are only meant to be used directly by shr_sys_mod. Other code
+  ! that wishes to use these routines should use the republished names from shr_sys_mod
+  ! (shr_sys_abort, shr_sys_backtrace). (This is for consistency with older code, from
+  ! when these routines were defined in shr_sys_mod.)
 
   use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
 
@@ -20,6 +25,10 @@ module shr_abort_mod
 
   private
 
+  ! The public routines here are only meant to be used directly by shr_sys_mod. Other code
+  ! that wishes to use these routines should use the republished names from shr_sys_mod
+  ! (shr_sys_abort, shr_sys_backtrace). (This is for consistency with older code, from
+  ! when these routines were defined in shr_sys_mod.)
   public :: shr_abort_abort     ! abort a program
   public :: shr_abort_backtrace ! print a backtrace, if possible
 

--- a/src/share/util/shr_abort_mod.F90
+++ b/src/share/util/shr_abort_mod.F90
@@ -1,0 +1,155 @@
+module shr_abort_mod
+  ! This module defines procedures that can be used to abort the model cleanly in a
+  ! system-specific manner
+
+  use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
+
+  use shr_kind_mod, only : shr_kind_in, shr_kind_cx
+  use shr_mpi_mod , only : shr_mpi_initialized, shr_mpi_abort
+  use shr_log_mod , only : s_logunit => shr_log_Unit
+
+#ifdef CPRNAG
+   ! NAG does not provide this as an intrinsic, but it does provide modules
+   ! that implement commonly used POSIX routines.
+   use f90_unix_proc, only: abort
+#endif  
+
+  implicit none
+
+  ! PUBLIC: Public interfaces
+
+  private
+
+  public :: shr_abort_abort     ! abort a program
+  public :: shr_abort_backtrace ! print a backtrace, if possible
+
+contains
+
+  !===============================================================================
+  subroutine shr_abort_abort(string,rc)
+    ! Consistent stopping mechanism
+
+    !----- arguments -----
+    character(len=*)    , intent(in), optional :: string  ! error message string
+    integer(shr_kind_in), intent(in), optional :: rc      ! error code
+
+    !----- local -----
+    logical :: flag
+
+    ! Local version of the string.
+    ! (Gets a default value if string is not present.)
+    character(len=shr_kind_cx) :: local_string
+    !-------------------------------------------------------------------------------
+
+    if (present(string)) then
+       local_string = trim(string)
+    else
+       local_string = "Unknown error submitted to shr_abort_abort."
+    end if
+
+    call print_error_to_logs("ERROR", local_string)
+
+    call shr_abort_backtrace()
+
+    call shr_mpi_initialized(flag)
+
+    if (flag) then
+       if (present(rc)) then
+          call shr_mpi_abort(trim(local_string),rc)
+       else
+          call shr_mpi_abort(trim(local_string))
+       endif
+    endif
+
+    ! A compiler's abort method may print a backtrace or do other nice
+    ! things, but in fact we can rarely leverage this, because MPI_Abort
+    ! usually sends SIGTERM to the process, and we don't catch that signal.
+    call abort()
+
+  end subroutine shr_abort_abort
+  !===============================================================================
+
+  !===============================================================================
+  subroutine shr_abort_backtrace()
+    ! This routine uses compiler-specific facilities to print a backtrace to
+    ! error_unit (standard error, usually unit 0).
+
+#if defined(CPRIBM)
+
+    ! This theoretically should be in xlfutility, but using it from that
+    ! module doesn't seem to always work.
+    interface
+       subroutine xl_trbk()
+       end subroutine xl_trbk
+    end interface
+
+    call xl__trbk()
+
+#elif defined(CPRGNU) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8 ))
+
+    ! gfortran 4.8 and later implement this intrinsic. We explicitly call it
+    ! out as such to make sure that it really is available, just in case the
+    ! CPP logic above screws up.
+    intrinsic :: backtrace
+
+    call backtrace()
+
+#elif defined(CPRINTEL)
+
+    ! tracebackqq uses optional arguments, so *must* have an explicit
+    ! interface.
+    use ifcore, only: tracebackqq
+
+    ! An exit code of -1 is a special value that prevents this subroutine
+    ! from aborting the run.
+    call tracebackqq(user_exit_code=-1)
+
+#else
+
+    ! Currently we have no means to request a backtrace from the NAG runtime,
+    ! even though it is capable of emitting backtraces itself, if you use the
+    ! "-gline" option.
+
+    ! Similarly, PGI has a -traceback option, but no user interface for
+    ! requesting a backtrace to be printed.
+
+#endif
+
+    flush(error_unit)
+
+  end subroutine shr_abort_backtrace
+  !===============================================================================
+
+  !===============================================================================
+  subroutine print_error_to_logs(error_type, message)
+    ! This routine prints error messages to s_logunit (which is standard output
+    ! for most tasks in CESM) and also to standard error if s_logunit is a
+    ! file.
+    !
+    ! It also flushes these output units.
+
+    character(len=*), intent(in) :: error_type, message
+
+    integer, allocatable :: log_units(:)
+
+    integer :: i
+
+    if (s_logunit == output_unit .or. s_logunit == error_unit) then
+       ! If the log unit number is standard output or standard error, just
+       ! print to that.
+       allocate(log_units(1), source=[s_logunit])
+    else
+       ! Otherwise print the same message to both the log unit and standard
+       ! error.
+       allocate(log_units(2), source=[error_unit, s_logunit])
+    end if
+
+    do i = 1, size(log_units)
+       write(log_units(i),*) trim(error_type), ": ", trim(message)
+       flush(log_units(i))
+    end do
+
+  end subroutine print_error_to_logs
+  !===============================================================================
+
+end module shr_abort_mod

--- a/src/share/util/shr_sys_mod.F90
+++ b/src/share/util/shr_sys_mod.F90
@@ -21,8 +21,6 @@ MODULE shr_sys_mod
    use shr_kind_mod  ! defines real & integer kinds
    use shr_log_mod, only: s_loglev  => shr_log_Level
    use shr_log_mod, only: s_logunit => shr_log_Unit
-
-   ! These used to be in shr_sys_mod; we provide these renames for backwards compatibility
    use shr_abort_mod, only: shr_sys_abort => shr_abort_abort
    use shr_abort_mod, only: shr_sys_backtrace => shr_abort_backtrace
 
@@ -46,7 +44,10 @@ MODULE shr_sys_mod
    public :: shr_sys_sleep   ! have program sleep for a while
    public :: shr_sys_flush   ! flush an i/o buffer
 
-   ! Imported from shr_abort_mod and republished with renames for backwards compatibility
+   ! Imported from shr_abort_mod and republished with renames. Other code that wishes to
+   ! use these routines should use these shr_sys names rather than directly using the
+   ! routines from shr_abort_abort. (This is for consistency with older code, from when
+   ! these routines were defined in shr_sys_mod.)
    public :: shr_sys_abort     ! abort a program
    public :: shr_sys_backtrace ! print a backtrace, if possible
 


### PR DESCRIPTION
Pull shr_sys_abort into its own module - now call shr_abort_abort in
shr_abort_mod. (The routine name, while redundant, follows the share
code convention of MODULENAME_VERB.) Other code can still use this via
shr_sys_mod: shr_sys_abort, via a rename done in that module. Two other
routines from shr_sys_abort that are used by shr_abort_abort are also
moved into shr_abort_abort to avoid circular dependencies.

There are no substantive changes in shr_abort_mod relative to the code
that used to be in shr_sys_abort: I have just moved code into this new
module and done some reformatting.

The purpose of this separation was to facilitate using a replacement
abort routine in pFUnit-based unit tests. This PR also adds a module
thath provides that replacement, which throws a pFUnit exception rather
than actually aborting. This also changes the cime unit test build so
that this new pFUnit-based abort routine is included in all drv unit
tests.

This also adds a simple unit test of the pFUnit-based abort
routine. This demonstrates how you can use this to write your own
"expected failure" unit tests:

```Fortran
  @Test
  subroutine test_abort(this)
    class(TestShrAbort), intent(inout) :: this

    call shr_abort_abort('Test message')
    @assertExceptionRaised('ABORTED: Test message')
  end subroutine test_abort
```

Test suite:
- scripts_regression_tests on yellowstone and cheyenne
- cime fortran unit tests with gnu on my Mac
- SMS.f09_g16.X and SMS_D.f09_g16.X with:
  - hobart_nag
  - hobart_pgi
  - yellowstone_intel
  - cheyenne_gnu
- SMS.f09_g16.X and SMS_D.f09_g16.X with cheyenne_intel, with a
  shr_sys_abort call inserted: made sure runs still die properly when
  they call shr_sys_abort
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#140

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 

@ekluzek @bandre-ucar - this could be useful for adding expected error
unit tests in CLM
