### PR TITLE
backout change for gnu and pgi on yellowstone

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1677,10 +1677,24 @@
       <modules compiler="gnu">
 	<command name="load">gnu/5.2.0</command>
       </modules>
-      <modules mpilib="mpi-serial">
+      <modules mpilib="mpi-serial" compiler="gnu">
+	<command name="load">netcdf/4.3.3.1</command>
+      </modules>
+      <modules mpilib="!mpi-serial" compiler="gnu">
+	<command name="load">netcdf-mpi/4.3.3.1</command>
+	<command name="load">pnetcdf/1.6.1</command>
+      </modules>
+      <modules mpilib="mpi-serial" compiler="pgi">
+	<command name="load">netcdf/4.3.3.1</command>
+      </modules>
+      <modules mpilib="!mpi-serial" compiler="pgi">
+	<command name="load">netcdf-mpi/4.3.3.1</command>
+	<command name="load">pnetcdf/1.6.1</command>
+      </modules>
+      <modules mpilib="mpi-serial" compiler="intel">
 	<command name="load">netcdf/4.4.1</command>
       </modules>
-      <modules mpilib="!mpi-serial">
+      <modules mpilib="!mpi-serial" compiler="intel">
 	<command name="load">netcdf-mpi/4.4.1</command>
 	<command name="load">pnetcdf/1.6.1</command>
       </modules>


### PR DESCRIPTION
Revert the netcdf update on yellowstone for gnu and pgi compilers. 
Test suite: cime_developer with pgi and gnu on yellowstone
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1769 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
