### PR TITLE
dont use Machines object to get DIN_LOC_ROOT

### DIFF
--- a/scripts/Tools/case.qstatus
+++ b/scripts/Tools/case.qstatus
@@ -7,9 +7,6 @@ Show the batch status of all jobs associated with this case.
 from standard_script_setup import *
 
 from CIME.case            import Case
-from CIME.utils           import find_system_test
-from CIME.XML.files       import Files
-from CIME.XML.component   import Component
 from CIME.test_status     import *
 
 ###############################################################################

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -7,7 +7,7 @@ Should be run from case.
 """
 from standard_script_setup import *
 
-from CIME.utils import get_model, run_cmd_no_fail
+from CIME.utils import get_model
 from CIME.check_input_data import check_input_data, SVN_LOCS
 from CIME.case import Case
 
@@ -38,10 +38,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--svn-loc", default=SVN_LOCS[get_model()],
                         help="The input data repository from which to download data.")
 
-    din_loc_root = run_cmd_no_fail("./xmlquery --value DIN_LOC_ROOT")
 
-    parser.add_argument("-i", "--input-data-root", default=din_loc_root,
-                        help="The root directory where input data goes. ")
+    parser.add_argument("-i", "--input-data-root",default="xmlquery DIN_LOC_ROOT",
+                        help="The root directory where input data goes.")
 
 
     parser.add_argument("--data-list-dir", default="Buildconf",

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -7,14 +7,11 @@ Should be run from case.
 """
 from standard_script_setup import *
 
-from CIME.utils import get_model
-from CIME.XML.machines import Machines
+from CIME.utils import get_model, run_cmd_no_fail
 from CIME.check_input_data import check_input_data, SVN_LOCS
 from CIME.case import Case
 
 import argparse, doctest
-
-MACHINE = Machines()
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -41,10 +38,11 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--svn-loc", default=SVN_LOCS[get_model()],
                         help="The input data repository from which to download data.")
 
-    parser.add_argument("-i", "--input-data-root", default=None,
-                        help="The root directory where input data goes. "
-                        "Default value will come from DIN_LOC_ROOT from case which itself "
-                        "defaults to '{}'".format(MACHINE.get_value("DIN_LOC_ROOT")))
+    din_loc_root = run_cmd_no_fail("./xmlquery --value DIN_LOC_ROOT")
+
+    parser.add_argument("-i", "--input-data-root", default=din_loc_root,
+                        help="The root directory where input data goes. ")
+
 
     parser.add_argument("--data-list-dir", default="Buildconf",
                         help="Where to find list of input files")

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -39,8 +39,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="The input data repository from which to download data.")
 
 
-    parser.add_argument("-i", "--input-data-root",default="xmlquery DIN_LOC_ROOT",
-                        help="The root directory where input data goes.")
+    parser.add_argument("-i", "--input-data-root",default=None,
+                        help="The root directory where input data goes, "
+                        "use xmlquery DIN_LOC_ROOT to see default value.")
 
 
     parser.add_argument("--data-list-dir", default="Buildconf",

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -572,8 +572,8 @@ class EnvBatch(EnvBase):
 
             cmd += jobid
 
-            stat, out, err = run_cmd(cmd)
-            if stat != 0:
+            status, out, err = run_cmd(cmd)
+            if status != 0:
                 logger.warning("Batch query command '{}' failed with error '{}'".format(cmd, err))
             else:
                 return out.strip()

--- a/src/drivers/mct/main/component_type_mod.F90
+++ b/src/drivers/mct/main/component_type_mod.F90
@@ -252,7 +252,7 @@ contains
                 if(shr_infnan_isnan(comp%c2x_cc%rattr(fld,n))) then
                    call mpi_comm_rank(comp%mpicom_compid, rank, ierr)
                    call mct_gsMap_orderedPoints(comp%gsmap_cc, rank, gpts)
-                   write(msg,*)'component_mod:check_fields NaN found in ',trim(comp%name),' instance: ',&
+                   write(msg,'(a,a,a,i4,a,a,a,i8)')'component_mod:check_fields NaN found in ',trim(comp%name),' instance: ',&
                         comp_index,' field ',trim(mct_avect_getRList2c(fld, comp%c2x_cc)), ' 1d global index: ',gpts(n)
                    call shr_sys_abort(msg)
                 endif

--- a/src/drivers/mct/unit_test/check_fields_test/test_check_fields.pf
+++ b/src/drivers/mct/unit_test/check_fields_test/test_check_fields.pf
@@ -59,7 +59,7 @@ contains
     call create_gsmap(this%comp%gsmap_cc, lsize)
 
     call check_fields(this%comp, 1)
-    @assertExceptionRaised('ABORTED:  component_mod:check_fields NaN found in pfunittest instance:            1  field foo 1d global index:            3')
+    @assertExceptionRaised('ABORTED: component_mod:check_fields NaN found in pfunittest instance:    1 field foo 1d global index:        3')
 
   end subroutine createAVectWithoutData_1Field_checkField
 
@@ -93,7 +93,7 @@ contains
 
     call check_fields(this%comp, 1)
 
-    @assertExceptionRaised('ABORTED:  component_mod:check_fields NaN found in pfunittest instance:            1  field foo2 1d global index:            3')
+    @assertExceptionRaised('ABORTED: component_mod:check_fields NaN found in pfunittest instance:    1 field foo2 1d global index:        3')
   end subroutine createAVectWithoutData_3Field_checkFields
 
 end module test_check_fields

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -610,8 +610,10 @@ contains
        pio_netcdf_ioformat = 0
     elseif ( pio_netcdf_format .eq. '64BIT_OFFSET' ) then
        pio_netcdf_ioformat = PIO_64BIT_OFFSET
+#ifdef _PNETCDF
     elseif ( pio_netcdf_format .eq. '64BIT_DATA' ) then
        pio_netcdf_ioformat = PIO_64BIT_DATA
+#endif
     else
        pio_netcdf_ioformat = pio_default_netcdf_ioformat
     endif


### PR DESCRIPTION
Using the Machines object in check_input_data meant that either we needed to add --machine as a command line argument or we needed the optional NODENAME_REGEX defined for every machine.  Looking at the code I realized that there was no real requirement to have a Machines object and so I removed it and replaced with a call to xmlquery.  Also added a fix for a pylint error in case.qstatus and a unit test problem in check_fields.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1773 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
