### PR TITLE
Pio netcdf format

### DIFF
--- a/scripts/lib/CIME/XML/env_run.py
+++ b/scripts/lib/CIME/XML/env_run.py
@@ -15,10 +15,7 @@ class EnvRun(EnvBase):
         """
         self._components = components
         self._component_value_list = ["PIO_TYPENAME", "PIO_STRIDE", "PIO_REARRANGER",
-                                      "PIO_NUMTASKS", "PIO_ROOT"]
+                                      "PIO_NUMTASKS", "PIO_ROOT", "PIO_NETCDF_FORMAT"]
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_entry_id.xsd")
 
         EnvBase.__init__(self, case_root, infile, schema=schema)
-
-
-

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2165,6 +2165,27 @@
     </values>
   </entry>
 
+  <entry id="PIO_NETCDF_FORMAT">
+    <type>char</type>
+    <valid_values>classic,64bit_offset,64bit_data</valid_values>
+    <group>run_pio</group>
+    <file>env_run.xml</file>
+    <desc>pio netcdf format (ignored for netcdf4p and netcdf4c)
+    https://www.unidata.ucar.edu/software/netcdf/docs/data_type.html
+    </desc>
+    <values>
+      <value component="ATM">64bit_offset</value>
+      <value component="CPL">64bit_offset</value>
+      <value component="OCN">64bit_offset</value>
+      <value component="WAV">64bit_offset</value>
+      <value component="GLC">64bit_offset</value>
+      <value component="ICE">64bit_offset</value>
+      <value component="ROF">64bit_offset</value>
+      <value component="LND">64bit_offset</value>
+      <value component="ESP">64bit_offset</value>
+    </values>
+  </entry>
+
   <entry id="PIO_STRIDE">
     <type>integer</type>
     <group>run_pio</group>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -849,18 +849,6 @@
     </values>
   </entry>
 
-  <entry id="cpl_cdf64">
-    <type>logical</type>
-    <category>expdef</category>
-    <group>seq_infodata_inparm</group>
-    <desc>
-      default: true
-    </desc>
-    <values>
-      <value>.true.</value>
-    </values>
-  </entry>
-
   <entry id="do_budgets" modify_via_xml="BUDGETS">
     <type>logical</type>
     <category>budget</category>
@@ -3948,4 +3936,3 @@
   </entry>
 
 </entry_id>
-

--- a/src/drivers/mct/cime_config/namelist_definition_modelio.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_modelio.xml
@@ -147,6 +147,28 @@
     </values>
   </entry>
 
+  <entry id="pio_netcdf_format" modify_via_xml="PIO_NETCDF_FORMAT">
+    <type>char*64</type>
+    <category>pio</category>
+    <group>pio_inparm</group>
+    <valid_values>classic,64bit_offset,64bit_data</valid_values>
+    <desc>
+      format of netcdf files created by pio, ignored if
+      PIO_TYPENAME is netcdf4p or netcdf4c.  64bit_data only
+      supported in netcdf 4.4.0 or newer
+    </desc>
+    <values>
+    <value component="cpl">$CPL_PIO_NETCDF_FORMAT</value>
+    <value component="atm">$ATM_PIO_NETCDF_FORMAT</value>
+    <value component="lnd">$LND_PIO_NETCDF_FORMAT</value>
+    <value component="ocn">$OCN_PIO_NETCDF_FORMAT</value>
+    <value component="ice">$ICE_PIO_NETCDF_FORMAT</value>
+    <value component="rof">$ROF_PIO_NETCDF_FORMAT</value>
+    <value component="glc">$GLC_PIO_NETCDF_FORMAT</value>
+    <value component="wav">$WAV_PIO_NETCDF_FORMAT</value>
+    </values>
+  </entry>
+
   <!-- =========================== -->
   <!-- group modelio               -->
   <!-- =========================== -->

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -475,7 +475,6 @@ module cime_comp_mod
    logical  :: exists                 ! true if file exists
    integer  :: ierr                   ! MPI error return
    integer  :: rc                     ! return code
-   logical  :: cdf64                  ! true => use 64 bit addressing in netCDF files
 
    character(*), parameter :: NLFileName = "drv_in"  ! input namelist filename
 
@@ -1340,7 +1339,6 @@ subroutine cime_init()
         glc_nx=glc_nx, glc_ny=glc_ny,          &
         ocn_nx=ocn_nx, ocn_ny=ocn_ny,          &
         wav_nx=wav_nx, wav_ny=wav_ny,          &
-        cpl_cdf64=cdf64,                       &
         atm_aero=atm_aero )
 
    ! derive samegrid flags
@@ -1522,7 +1520,6 @@ subroutine cime_init()
       write(logunit,F0L)'samegrid_ow           = ',samegrid_ow
       write(logunit,F0L)'skip init ocean run   = ',skip_ocean_run
       write(logunit,F00)'cpl sequence option   = ',trim(cpl_seq_option)
-      write(logunit,F0L)'cpl_cdf64             = ',cdf64
       write(logunit,F0L)'do_histavg            = ',do_histavg
       write(logunit,F0L)'atm_aero              = ',atm_aero
       write(logunit,*  )' '

--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -103,7 +103,6 @@ module seq_hist_mod
    logical     :: histavg_wav            ! .true.  => write wav fields to average history file
    logical     :: histavg_xao            ! .true.  => write flux xao fields to average history file
 
-   logical     :: cdf64                  ! true => use 64 bit addressing in netCDF files
 
    !--- domain equivalent 2d grid size ---
    integer(IN) :: atm_nx, atm_ny         ! nx,ny of 2d grid, if known
@@ -207,7 +206,6 @@ subroutine seq_hist_write(infodata, EClock_d, &
         glc_nx=glc_nx, glc_ny=glc_ny,        &
         wav_nx=wav_nx, wav_ny=wav_ny,        &
         ocn_nx=ocn_nx, ocn_ny=ocn_ny,        &
-        cpl_cdf64=cdf64,                     &
         case_name=case_name)
 
    !--- Get current date from clock needed to label the history pointer file ---
@@ -225,7 +223,7 @@ subroutine seq_hist_write(infodata, EClock_d, &
    if (iamin_CPLID) then
 
       if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
-      call seq_io_wopen(hist_file,clobber=.true.,cdf64=cdf64)
+      call seq_io_wopen(hist_file,clobber=.true.)
 
       ! loop twice, first time write header, second time write data for perf
 
@@ -494,8 +492,7 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
         histavg_rof=histavg_rof,             &
         histavg_glc=histavg_glc,             &
         histavg_wav=histavg_wav,             &
-        histavg_xao=histavg_xao,             &
-        cpl_cdf64=cdf64 )
+        histavg_xao=histavg_xao)
 
    ! Get current date from clock needed to label the histavg pointer file
 
@@ -788,7 +785,7 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
       if (iamin_CPLID) then
 
          if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
-         call seq_io_wopen(hist_file, clobber=.true., cdf64=cdf64)
+         call seq_io_wopen(hist_file, clobber=.true.)
 
          ! loop twice,  first time write header,  second time write data for perf
 
@@ -1061,8 +1058,7 @@ subroutine seq_hist_writeaux(infodata, EClock_d, comp, flow, aname, dname, &
         ice_present=ice_present,       &
         ocn_present=ocn_present,       &
         glc_present=glc_present,       &
-        wav_present=wav_present,       &
-        cpl_cdf64=cdf64 )
+        wav_present=wav_present)
 
    lwrite_now = .true.
    useavg = .false.
@@ -1160,7 +1156,7 @@ subroutine seq_hist_writeaux(infodata, EClock_d, comp, flow, aname, dname, &
 
          if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
          if (fk1 == 1) then
-            call seq_io_wopen(hist_file(found), clobber=.true., cdf64=cdf64, file_ind=found)
+            call seq_io_wopen(hist_file(found), clobber=.true., file_ind=found)
          endif
 
          ! loop twice,  first time write header,  second time write data for perf
@@ -1320,8 +1316,7 @@ subroutine seq_hist_spewav(infodata, aname, gsmap, av, nx, ny, nt, write_now, fl
         ice_present=ice_present,       &
         ocn_present=ocn_present,       &
         glc_present=glc_present,       &
-        wav_present=wav_present,       &
-        cpl_cdf64=cdf64 )
+        wav_present=wav_present)
 
    lwrite_now = .true.
    useavg = .false.
@@ -1390,9 +1385,9 @@ subroutine seq_hist_spewav(infodata, aname, gsmap, av, nx, ny, nt, write_now, fl
 
       if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
       if (fk1 == 1) then
-         call seq_io_wopen(hist_file(found), clobber=.true., cdf64=cdf64)
+         call seq_io_wopen(hist_file(found), clobber=.true.)
       else
-         call seq_io_wopen(hist_file(found), clobber=.false., cdf64=cdf64)
+         call seq_io_wopen(hist_file(found), clobber=.false.)
       endif
 
       ! loop twice,  first time write header,  second time write data for perf

--- a/src/drivers/mct/main/seq_io_mod.F90
+++ b/src/drivers/mct/main/seq_io_mod.F90
@@ -106,6 +106,7 @@ module seq_io_mod
    character(CL)                  :: wfilename = ''
    type(file_desc_t), save        :: cpl_io_file(0:file_desc_t_cnt)
    integer(IN)                    :: cpl_pio_iotype
+   integer(IN)                    :: cpl_pio_ioformat
    type(iosystem_desc_t), pointer :: cpl_io_subsystem
 
    character(CL) :: charvar   ! buffer for string read/write
@@ -116,14 +117,11 @@ contains
 !=================================================================================
 
   subroutine seq_io_cpl_init()
-    use shr_pio_mod, only: shr_pio_getiosys, shr_pio_getiotype
+    use shr_pio_mod, only: shr_pio_getiosys, shr_pio_getiotype, shr_pio_getioformat
 
-    character(len=seq_comm_namelen) :: cpl_name
-
-    ! For consistency with how io_compname is set, we get the coupler name here
-    cpl_name = seq_comm_name(CPLID)
-    cpl_io_subsystem=>shr_pio_getiosys(cpl_name)
-    cpl_pio_iotype = shr_pio_getiotype(cpl_name)
+    cpl_io_subsystem=>shr_pio_getiosys(CPLID)
+    cpl_pio_iotype = shr_pio_getiotype(CPLID)
+    cpl_pio_ioformat = shr_pio_getioformat(CPLID)
 
   end subroutine seq_io_cpl_init
 
@@ -140,20 +138,18 @@ contains
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine seq_io_wopen(filename,clobber,cdf64,file_ind)
+subroutine seq_io_wopen(filename,clobber,file_ind)
 
     ! !INPUT/OUTPUT PARAMETERS:
     implicit none
     character(*),intent(in) :: filename
     logical,optional,intent(in):: clobber
-    logical,optional,intent(in):: cdf64
     integer,optional,intent(in):: file_ind
 
     !EOP
 
     logical :: exists
     logical :: lclobber
-    logical :: lcdf64
     integer :: iam,mpicom
     integer :: rcode
     integer :: nmode
@@ -170,9 +166,6 @@ subroutine seq_io_wopen(filename,clobber,cdf64,file_ind)
     lclobber = .false.
     if (present(clobber)) lclobber=clobber
 
-    lcdf64 = .false.
-    if (present(cdf64)) lcdf64=cdf64
-
     lfile_ind = 0
     if (present(file_ind)) lfile_ind=file_ind
 
@@ -185,14 +178,13 @@ subroutine seq_io_wopen(filename,clobber,cdf64,file_ind)
        if (exists) then
           if (lclobber) then
              nmode = pio_clobber
-             !lcdf64 only applies to classic NETCDF files.
-             if (lcdf64) then
-                if(cpl_pio_iotype == PIO_IOTYPE_NETCDF) then
-                   nmode = ior(nmode,PIO_64BIT_OFFSET)
-                elseif(cpl_pio_iotype == PIO_IOTYPE_PNETCDF) then
-                   nmode = ior(nmode,PIO_64BIT_DATA)
-                endif
+
+             ! only applies to classic NETCDF files.
+             if(cpl_pio_iotype == PIO_IOTYPE_NETCDF .or. &
+                  cpl_pio_iotype == PIO_IOTYPE_PNETCDF) then
+                   nmode = ior(nmode,cpl_pio_ioformat)
              endif
+
              rcode = pio_createfile(cpl_io_subsystem, cpl_io_file(lfile_ind), cpl_pio_iotype, trim(filename), nmode)
              if(iam==0) write(logunit,*) subname,' create file ',trim(filename)
              rcode = pio_put_att(cpl_io_file(lfile_ind),pio_global,"file_version",version)
@@ -211,13 +203,10 @@ subroutine seq_io_wopen(filename,clobber,cdf64,file_ind)
           endif
        else
           nmode = pio_noclobber
-          !lcdf64 only applies to classic NETCDF files.
-          if (lcdf64) then
-             if(cpl_pio_iotype == PIO_IOTYPE_NETCDF) then
-                nmode = ior(nmode,PIO_64BIT_OFFSET)
-             elseif(cpl_pio_iotype == PIO_IOTYPE_PNETCDF) then
-                nmode = ior(nmode,PIO_64BIT_DATA)
-             endif
+          ! only applies to classic NETCDF files.
+          if(cpl_pio_iotype == PIO_IOTYPE_NETCDF .or. &
+               cpl_pio_iotype == PIO_IOTYPE_PNETCDF) then
+             nmode = ior(nmode,cpl_pio_ioformat)
           endif
           rcode = pio_createfile(cpl_io_subsystem, cpl_io_file(lfile_ind), cpl_pio_iotype, trim(filename), nmode)
           if(iam==0) write(logunit,*) subname,' create file ',trim(filename)

--- a/src/drivers/mct/main/seq_rest_mod.F90
+++ b/src/drivers/mct/main/seq_rest_mod.F90
@@ -362,7 +362,6 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
         glc_prognostic=glc_prognostic,      &
         wav_prognostic=wav_prognostic,      &
         esp_prognostic=esp_prognostic,      &
-        cpl_cdf64=cdf64,            &
         case_name=case_name)
 
    ! Write out infodata and time manager data to restart file
@@ -406,7 +405,7 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
       endif
 
       call shr_mpi_bcast(rest_file,mpicom_CPLID)
-      call seq_io_wopen(rest_file,clobber=.true.,cdf64=cdf64)
+      call seq_io_wopen(rest_file,clobber=.true.)
 
       ! loop twice (for perf), first time write header, second time write data
       do fk = 1,2

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -139,7 +139,7 @@ MODULE seq_infodata_mod
       character(SHR_KIND_CS)  :: aoflux_grid     ! grid for atm ocn flux calc
       integer                 :: cpl_decomp      ! coupler decomp
       character(SHR_KIND_CL)  :: cpl_seq_option  ! coupler sequencing option
-      logical                 :: cpl_cdf64       ! use netcdf 64 bit offset, large file support
+
       logical                 :: do_budgets      ! do heat/water budgets diagnostics
       logical                 :: do_histinit     ! write out initial history file
       integer                 :: budget_inst     ! instantaneous budget level
@@ -372,7 +372,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
     character(SHR_KIND_CS) :: aoflux_grid        ! grid for atm ocn flux calc
     integer                :: cpl_decomp         ! coupler decomp
     character(SHR_KIND_CL) :: cpl_seq_option     ! coupler sequencing option
-    logical                :: cpl_cdf64          ! use netcdf 64 bit offset, large file support
+
     logical                :: do_budgets         ! do heat/water budgets diagnostics
     logical                :: do_histinit        ! write out initial history file
     integer                :: budget_inst        ! instantaneous budget level
@@ -440,7 +440,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
          histavg_atm, histavg_lnd, histavg_ocn, histavg_ice, &
          histavg_rof, histavg_glc, histavg_wav, histavg_xao, &
          histaux_l2x1yr, cpl_seq_option,                   &
-         cpl_cdf64, eps_frac, eps_amask,                   &
+         eps_frac, eps_amask,                   &
          eps_agrid, eps_aarea, eps_omask, eps_ogrid,       &
          eps_oarea, esmf_map_flag,                         &
          reprosum_use_ddpdd, reprosum_diffmax, reprosum_recompute, &
@@ -513,7 +513,6 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        aoflux_grid           = 'ocn'
        cpl_decomp            = 0
        cpl_seq_option        = 'CESM1_MOD'
-       cpl_cdf64             = .true.
        do_budgets            = .false.
        do_histinit           = .false.
        budget_inst           = 0
@@ -620,7 +619,6 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        infodata%aoflux_grid           = aoflux_grid
        infodata%cpl_decomp            = cpl_decomp
        infodata%cpl_seq_option        = cpl_seq_option
-       infodata%cpl_cdf64             = cpl_cdf64
        infodata%do_budgets            = do_budgets
        infodata%do_histinit           = do_histinit
        infodata%budget_inst           = budget_inst
@@ -935,7 +933,7 @@ SUBROUTINE seq_infodata_GetData_explicit( infodata, cime_model, case_name, case_
            histaux_a2x24hr, histaux_l2x   , histaux_r2x     , orb_obliq,      &
            histavg_atm, histavg_lnd, histavg_ocn, histavg_ice,                &
            histavg_rof, histavg_glc, histavg_wav, histavg_xao,                &
-           cpl_cdf64, orb_iyear, orb_iyear_align, orb_mode, orb_mvelp,        &
+           orb_iyear, orb_iyear_align, orb_mode, orb_mvelp,        &
            orb_eccen, orb_obliqr, orb_lambm0, orb_mvelpp, wv_sat_scheme,      &
            wv_sat_transition_start, wv_sat_use_tables, wv_sat_table_spacing,  &
            tfreeze_option, glc_renormalize_smb,                               &
@@ -1012,7 +1010,6 @@ SUBROUTINE seq_infodata_GetData_explicit( infodata, cime_model, case_name, case_
    character(len=*),       optional, intent(OUT) :: aoflux_grid             ! grid for atm ocn flux calc
    integer,                optional, intent(OUT) :: cpl_decomp              ! coupler decomp
    character(len=*),       optional, intent(OUT) :: cpl_seq_option          ! coupler sequencing option
-   logical,                optional, intent(OUT) :: cpl_cdf64               ! netcdf large file setting
    logical,                optional, intent(OUT) :: do_budgets              ! heat/water budgets
    logical,                optional, intent(OUT) :: do_histinit             ! initial history file
    integer,                optional, intent(OUT) :: budget_inst             ! inst budget
@@ -1184,7 +1181,6 @@ SUBROUTINE seq_infodata_GetData_explicit( infodata, cime_model, case_name, case_
     if ( present(aoflux_grid)    ) aoflux_grid    = infodata%aoflux_grid
     if ( present(cpl_decomp)     ) cpl_decomp     = infodata%cpl_decomp
     if ( present(cpl_seq_option) ) cpl_seq_option = infodata%cpl_seq_option
-    if ( present(cpl_cdf64)      ) cpl_cdf64      = infodata%cpl_cdf64
     if ( present(do_budgets)     ) do_budgets     = infodata%do_budgets
     if ( present(do_histinit)    ) do_histinit    = infodata%do_histinit
     if ( present(budget_inst)    ) budget_inst    = infodata%budget_inst
@@ -1500,7 +1496,7 @@ SUBROUTINE seq_infodata_PutData_explicit( infodata, cime_model, case_name, case_
            histaux_a2x24hr, histaux_l2x   , histaux_r2x     , orb_obliq,      &
            histavg_atm, histavg_lnd, histavg_ocn, histavg_ice,                &
            histavg_rof, histavg_glc, histavg_wav, histavg_xao,                &
-           cpl_cdf64, orb_iyear, orb_iyear_align, orb_mode, orb_mvelp,        &
+           orb_iyear, orb_iyear_align, orb_mode, orb_mvelp,        &
            orb_eccen, orb_obliqr, orb_lambm0, orb_mvelpp, wv_sat_scheme,      &
            wv_sat_transition_start, wv_sat_use_tables, wv_sat_table_spacing,  &
            tfreeze_option, glc_renormalize_smb, &
@@ -1577,7 +1573,6 @@ SUBROUTINE seq_infodata_PutData_explicit( infodata, cime_model, case_name, case_
    character(len=*),       optional, intent(IN)    :: aoflux_grid             ! grid for atm ocn flux calc
    integer,                optional, intent(IN)    :: cpl_decomp              ! coupler decomp
    character(len=*),       optional, intent(IN)    :: cpl_seq_option          ! coupler sequencing option
-   logical,                optional, intent(IN)    :: cpl_cdf64               ! netcdf large file setting
    logical,                optional, intent(IN)    :: do_budgets              ! heat/water budgets
    logical,                optional, intent(IN)    :: do_histinit             ! initial history file
    integer,                optional, intent(IN)    :: budget_inst             ! inst budget
@@ -1748,7 +1743,6 @@ SUBROUTINE seq_infodata_PutData_explicit( infodata, cime_model, case_name, case_
     if ( present(aoflux_grid)    ) infodata%aoflux_grid    = aoflux_grid
     if ( present(cpl_decomp)     ) infodata%cpl_decomp     = cpl_decomp
     if ( present(cpl_seq_option) ) infodata%cpl_seq_option = cpl_seq_option
-    if ( present(cpl_cdf64)      ) infodata%cpl_cdf64      = cpl_cdf64
     if ( present(do_budgets)     ) infodata%do_budgets     = do_budgets
     if ( present(do_histinit)    ) infodata%do_histinit    = do_histinit
     if ( present(budget_inst)    ) infodata%budget_inst    = budget_inst
@@ -2168,7 +2162,6 @@ subroutine seq_infodata_bcast(infodata,mpicom)
     call shr_mpi_bcast(infodata%aoflux_grid,             mpicom)
     call shr_mpi_bcast(infodata%cpl_decomp,              mpicom)
     call shr_mpi_bcast(infodata%cpl_seq_option,          mpicom)
-    call shr_mpi_bcast(infodata%cpl_cdf64,               mpicom)
     call shr_mpi_bcast(infodata%do_budgets,              mpicom)
     call shr_mpi_bcast(infodata%do_histinit,             mpicom)
     call shr_mpi_bcast(infodata%budget_inst,             mpicom)
@@ -2836,7 +2829,6 @@ SUBROUTINE seq_infodata_print( infodata )
        write(logunit,F0A) subname,'aoflux_grid              = ', trim(infodata%aoflux_grid)
        write(logunit,F0A) subname,'cpl_seq_option           = ', trim(infodata%cpl_seq_option)
        write(logunit,F0S) subname,'cpl_decomp               = ', infodata%cpl_decomp
-       write(logunit,F0L) subname,'cpl_cdf64                = ', infodata%cpl_cdf64
        write(logunit,F0L) subname,'do_budgets               = ', infodata%do_budgets
        write(logunit,F0L) subname,'do_histinit              = ', infodata%do_histinit
        write(logunit,F0S) subname,'budget_inst              = ', infodata%budget_inst

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -19,9 +19,13 @@ module shr_pio_mod
   public :: shr_pio_getiotype
   public :: shr_pio_getioroot
   public :: shr_pio_finalize
+  public :: shr_pio_getioformat
 
   interface shr_pio_getiotype
      module procedure shr_pio_getiotype_fromid, shr_pio_getiotype_fromname
+  end interface
+  interface shr_pio_getioformat
+     module procedure shr_pio_getioformat_fromid, shr_pio_getioformat_fromname
   end interface
   interface shr_pio_getiosys
      module procedure shr_pio_getiosys_fromid, shr_pio_getiosys_fromname
@@ -278,6 +282,25 @@ contains
     io_type = pio_comp_settings(shr_pio_getindex(component))%pio_iotype
 
   end function shr_pio_getiotype_fromname
+
+  function shr_pio_getioformat_fromid(compid) result(io_format)
+    integer, intent(in) :: compid
+    integer :: io_format
+
+    io_format = pio_comp_settings(shr_pio_getindex(compid))%pio_netcdf_ioformat
+
+  end function shr_pio_getioformat_fromid
+
+
+  function shr_pio_getioformat_fromname(component) result(io_format)
+    ! 'component' must be equal to some element of io_compname(:)
+    ! (but it is case-insensitive)
+    character(len=*), intent(in) :: component
+    integer :: io_format
+
+    io_format = pio_comp_settings(shr_pio_getindex(component))%pio_netcdf_ioformat
+
+  end function shr_pio_getioformat_fromname
 
 !===============================================================================
   function shr_pio_getioroot_fromid(compid) result(io_root)

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -42,6 +42,7 @@ module shr_pio_mod
      integer :: pio_numiotasks
      integer :: pio_iotype
      integer :: pio_rearranger
+     integer :: pio_netcdf_ioformat
   end type pio_comp_t
 
   character(len=16), allocatable :: io_compname(:)
@@ -82,7 +83,7 @@ contains
     integer, intent(inout) :: Global_Comm
 
 
-    integer :: i, pio_root, pio_stride, pio_numiotasks, pio_iotype, pio_rearranger
+    integer :: i, pio_root, pio_stride, pio_numiotasks, pio_iotype, pio_rearranger, pio_netcdf_ioformat
     integer :: mpigrp_world, mpigrp, ierr, mpicom
     character(*),parameter :: subName =   '(shr_pio_init1) '
     integer :: pelist(3,1)
@@ -101,6 +102,7 @@ contains
        pio_comp_settings(i)%pio_numiotasks = pio_numiotasks
        pio_comp_settings(i)%pio_iotype = pio_iotype
        pio_comp_settings(i)%pio_rearranger = pio_rearranger
+       pio_comp_settings(i)%pio_netcdf_ioformat = pio_netcdf_ioformat
     end do
     if(pio_async_interface) then
 #ifdef NO_MPI2
@@ -206,7 +208,8 @@ contains
 
              call shr_pio_read_component_namelist(nlfilename , comp_comm(i), pio_comp_settings(i)%pio_stride, &
                   pio_comp_settings(i)%pio_root, pio_comp_settings(i)%pio_numiotasks, &
-                  pio_comp_settings(i)%pio_iotype, pio_comp_settings(i)%pio_rearranger)
+                  pio_comp_settings(i)%pio_iotype, pio_comp_settings(i)%pio_rearranger, &
+                  pio_comp_settings(i)%pio_netcdf_ioformat)
              call pio_init(comp_comm_iam(i), comp_comm(i), pio_comp_settings(i)%pio_numiotasks, 0, &
                   pio_comp_settings(i)%pio_stride, &
                   pio_comp_settings(i)%pio_rearranger, iosystems(i), &
@@ -386,6 +389,7 @@ contains
 
     character(len=shr_kind_cs) :: pio_typename
     character(len=shr_kind_cs) :: pio_rearr_comm_type, pio_rearr_comm_fcd
+    integer :: pio_netcdf_ioformat
     integer :: pio_rearr_comm_max_pend_req_comp2io
     logical :: pio_rearr_comm_enable_hs_comp2io, pio_rearr_comm_enable_isend_comp2io
     integer :: pio_rearr_comm_max_pend_req_io2comp
@@ -427,7 +431,7 @@ contains
     pio_debug_level = 0 ! no debug info by default
     pio_async_interface = .false.   ! pio tasks are a subset of component tasks
     pio_rearranger = PIO_REARR_SUBSET
-
+    pio_netcdf_ioformat = PIO_64BIT_OFFSET
     pio_rearr_comm_type = 'p2p'
     pio_rearr_comm_fcd = '2denable'
     pio_rearr_comm_max_pend_req_comp2io = 0
@@ -459,7 +463,7 @@ contains
     end if
 
      call shr_pio_namelist_set(npes, Comm, pio_stride, pio_root, pio_numiotasks, pio_iotype, &
-          iamroot, pio_rearranger)
+          iamroot, pio_rearranger, pio_netcdf_ioformat)
 
     call shr_mpi_bcast(pio_debug_level, Comm)
     call shr_mpi_bcast(pio_blocksize, Comm)
@@ -475,22 +479,24 @@ contains
 
   end subroutine shr_pio_read_default_namelist
 
-  subroutine shr_pio_read_component_namelist(nlfilename, Comm, pio_stride, pio_root, pio_numiotasks, pio_iotype, pio_rearranger)
+  subroutine shr_pio_read_component_namelist(nlfilename, Comm, pio_stride, pio_root, pio_numiotasks, pio_iotype, pio_rearranger, pio_netcdf_ioformat)
     character(len=*), intent(in) :: nlfilename
     integer, intent(in) :: Comm
 
-    integer, intent(inout) :: pio_stride, pio_root, pio_numiotasks, pio_iotype, pio_rearranger
+    integer, intent(inout) :: pio_stride, pio_root, pio_numiotasks
+    integer, intent(inout) :: pio_iotype, pio_rearranger, pio_netcdf_ioformat
     character(len=SHR_KIND_CS) ::  pio_typename
+    character(len=SHR_KIND_CS) ::  pio_netcdf_format
     integer :: unitn
 
     integer :: iam, ierr, npes
     logical :: iamroot
     character(*),parameter :: subName =   '(shr_pio_read_component_namelist) '
     integer :: pio_default_stride, pio_default_root, pio_default_numiotasks, pio_default_iotype
-    integer :: pio_default_rearranger
+    integer :: pio_default_rearranger, pio_default_netcdf_ioformat
 
     namelist /pio_inparm/ pio_stride, pio_root, pio_numiotasks, &
-         pio_typename, pio_rearranger
+         pio_typename, pio_rearranger, pio_netcdf_format
 
 
 
@@ -510,7 +516,7 @@ contains
     pio_default_numiotasks = pio_numiotasks
     pio_default_iotype = pio_iotype
     pio_default_rearranger = pio_rearranger
-
+    pio_default_netcdf_ioformat = PIO_64BIT_OFFSET
 
     !--------------------------------------------------------------------------
     ! read io nml parameters
@@ -520,6 +526,7 @@ contains
     pio_root     = -99
     pio_typename = 'nothing'
     pio_rearranger = -99
+    pio_netcdf_format = '64bit_offset'
 
     if(iamroot) then
        unitn=shr_file_getunit()
@@ -531,6 +538,7 @@ contains
            pio_numiotasks = pio_default_numiotasks
            pio_iotype     = pio_default_iotype
            pio_rearranger = pio_default_rearranger
+           pio_netcdf_ioformat = pio_default_netcdf_ioformat
        else
           ierr = 1
           do while( ierr /= 0 )
@@ -544,6 +552,7 @@ contains
           call shr_file_freeUnit( unitn )
 
           call shr_pio_getiotypefromname(pio_typename, pio_iotype, pio_default_iotype)
+          call shr_pio_getioformatfromname(pio_netcdf_format, pio_netcdf_ioformat, pio_default_netcdf_ioformat)
        end if
        if(pio_stride== -99) then
           if (pio_numiotasks > 0) then
@@ -562,10 +571,30 @@ contains
 
 
     call shr_pio_namelist_set(npes, Comm, pio_stride, pio_root, pio_numiotasks, pio_iotype, &
-         iamroot, pio_rearranger)
+         iamroot, pio_rearranger, pio_netcdf_ioformat)
 
 
   end subroutine shr_pio_read_component_namelist
+
+  subroutine shr_pio_getioformatfromname(pio_netcdf_format, pio_netcdf_ioformat, pio_default_netcdf_ioformat)
+    use shr_string_mod, only : shr_string_toupper
+    character(len=*), intent(inout) :: pio_netcdf_format
+    integer, intent(out) :: pio_netcdf_ioformat
+    integer, intent(in) :: pio_default_netcdf_ioformat
+
+    pio_netcdf_format = shr_string_toupper(pio_netcdf_format)
+    if ( pio_netcdf_format .eq. 'CLASSIC' ) then
+       pio_netcdf_ioformat = 0
+    elseif ( pio_netcdf_format .eq. '64BIT_OFFSET' ) then
+       pio_netcdf_ioformat = PIO_64BIT_OFFSET
+    elseif ( pio_netcdf_format .eq. '64BIT_DATA' ) then
+       pio_netcdf_ioformat = PIO_64BIT_DATA
+    else
+       pio_netcdf_ioformat = pio_default_netcdf_ioformat
+    endif
+
+  end subroutine shr_pio_getioformatfromname
+
 
   subroutine shr_pio_getiotypefromname(typename, iotype, defaulttype)
     use shr_string_mod, only : shr_string_toupper
@@ -582,9 +611,6 @@ contains
        iotype = pio_iotype_netcdf4p
     else if ( typename .eq. 'NETCDF4C') then
        iotype = pio_iotype_netcdf4c
-!  Not yet supported
-!    else if ( typename .eq. 'VDC') then
-!       iotype = pio_iotype_vdc
     else if ( typename .eq. 'NOTHING') then
        iotype = defaulttype
     else if ( typename .eq. 'DEFAULT') then
@@ -598,10 +624,10 @@ contains
 
 !===============================================================================
   subroutine shr_pio_namelist_set(npes,mycomm, pio_stride, pio_root, pio_numiotasks, &
-       pio_iotype, iamroot, pio_rearranger)
+       pio_iotype, iamroot, pio_rearranger, pio_netcdf_ioformat)
     integer, intent(in) :: npes, mycomm
     integer, intent(inout) :: pio_stride, pio_root, pio_numiotasks
-    integer, intent(inout) :: pio_iotype, pio_rearranger
+    integer, intent(inout) :: pio_iotype, pio_rearranger, pio_netcdf_ioformat
     logical, intent(in) :: iamroot
     character(*),parameter :: subName =   '(shr_pio_namelist_set) '
 
@@ -610,6 +636,7 @@ contains
     call shr_mpi_bcast(pio_root    , mycomm)
     call shr_mpi_bcast(pio_numiotasks, mycomm)
     call shr_mpi_bcast(pio_rearranger, mycomm)
+    call shr_mpi_bcast(pio_netcdf_ioformat, mycomm)
 
     if (pio_root<0) then
        pio_root = 1


### PR DESCRIPTION
Replace cdf64 logical with PIO_NETCDF_FORMAT character variable, this variable can have values
'classic', '64bit_offset', '64bit_data' and is ignored in netcdf4p and netcdf4c iotype modes.

Test suite: scripts_regression_tests.py and hand testing with all formats 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1760 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
