### PR TITLE
update cori-knl batch and fix xsd error

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -397,6 +397,7 @@
     <batch_submit>sbatch</batch_submit>
     <directives>
       <directive>-C knl,quad,cache </directive>
+      <directive>-S 2 </directive>
     </directives>
     <queues>
       <queue walltimemax="02:00:00" jobmin="1" jobmax="45440">regular</queue>

--- a/config/xml_schemas/env_mach_specific.xsd
+++ b/config/xml_schemas/env_mach_specific.xsd
@@ -4,7 +4,7 @@
 <xs:attribute name="id" type="xs:NCName"/>
 <xs:attribute name="version" type="xs:decimal"/>
 <xs:attribute name="lang" type="xs:NCName"/>
-<xs:attribute name="compiler" type="xs:NCName"/>
+<xs:attribute name="compiler" type="xs:string"/>
 <xs:attribute name="debug" type="xs:boolean"/>
 <xs:attribute name="mpilib" type="xs:string"/>
 <xs:attribute name="value" type="xs:string"/>


### PR DESCRIPTION
Fix for compiler attribute in env_mach_specific.xsd and an additional batch flag for cori-knl

Test suite:  scripts_regression_tests.py on cori-knl
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
