### PR TITLE
Fix to get PRE test working on ADESP_TEST on Cheyenne

### DIFF
--- a/scripts/lib/update_acme_tests.py
+++ b/scripts/lib/update_acme_tests.py
@@ -50,7 +50,8 @@ _TEST_SUITES = {
                              "DAE.f19_f19.A",
                              "PET_P32.f19_f19.A",
                              "SMS.T42_T42.S",
-                             "PRE.f19_f19.ADESP")
+                             "PRE.f19_f19.ADESP",
+                             "PRE.f19_f19.ADESP_TEST")
                             ),
 
     #

--- a/src/components/data_comps/desp/desp_comp_mod.F90
+++ b/src/components/data_comps/desp/desp_comp_mod.F90
@@ -427,6 +427,13 @@ CONTAINS
 
     call t_startf('desp_mode')
 
+    if (.not. ANY(pause_sig)) then
+      if ((my_task == master_task) .and. (loglevel > 0)) then
+        write(logunit, '(2a,i4.4,"-",i2.2,"-",i2.2,"-",i5.5)') subname,       &
+             'WARNING: No pause signals found at',yy,mm,dd,CurrentTOD
+      end if
+    end if
+
     ! Find the active components and their restart files
     ! Note hard-coded variable names are just for testing. This could be
     !   changed if this feature comes to regular use
@@ -472,7 +479,7 @@ CONTAINS
           call get_restart_filenames(ind, cpl_resume, errcode)
           allocate(rfilenames(1))
           rfilenames(1) = cpl_resume
-          varname = 'x2oacc_ox_Sa_pslv'
+          varname = 'x2oacc_ox_Foxx_swnet'
         case default
           call shr_sys_abort(subname//'Unrecognized ind')
         end select


### PR DESCRIPTION
Modified PRE test to look for no pause signal situation.
Modified ADESP_TEST variable change to get output change with new docn aquaplanet.
Added ADESP_TEST to cime_developer suite.

Test suite: scripts_regression_tests.py on Yellowstone, Cheyenne, and Hobart
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes #1622

User interface changes?: No

Update gh-pages html (Y/N)?: N

Code review: 
