### PR TITLE
revert to netcdf 4.3.3.1 on yellowstone

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1705,10 +1705,10 @@
 	<command name="load">pnetcdf/1.6.1</command>
       </modules>
       <modules mpilib="mpi-serial" compiler="intel">
-	<command name="load">netcdf/4.4.1</command>
+	<command name="load">netcdf/4.3.3.1</command>
       </modules>
       <modules mpilib="!mpi-serial" compiler="intel">
-	<command name="load">netcdf-mpi/4.4.1</command>
+	<command name="load">netcdf-mpi/4.3.3.1</command>
 	<command name="load">pnetcdf/1.6.1</command>
       </modules>
       <modules>


### PR DESCRIPTION
netcdf4.4.1.1 was causing a core dump on job launch, revert to 4.3.3.1 while the cause is being investigated.

Test suite: PFS.f09_g17.B1850.yellowstone_intel 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
