### PR TITLE
allow --compiler and --mpilib

### DIFF
--- a/scripts/tests/CMakeLists.txt
+++ b/scripts/tests/CMakeLists.txt
@@ -1,3 +1,8 @@
+#
+# Environment variables CIME_COMPILER and CIME_MPILIB
+# can be used to send --compiler and --mpilib settings to scripts_regression_tests.py
+#
+
 cmake_minimum_required(VERSION 2.8)
 
 include(CTest)

--- a/scripts/tests/CMakeLists.txt
+++ b/scripts/tests/CMakeLists.txt
@@ -13,7 +13,7 @@ if (DEFINED ENV{CIME_COMPILER})
   set(args "--compiler $ENV{CIME_COMPILER}")
 endif()
 if (DEFINED ENV{CIME_MPILIB})
-  set(args "${args} --compiler $ENV{CIME_MPILIB}")
+  set(args "${args} --mpilib $ENV{CIME_MPILIB}")
 endif()
 separate_arguments(ARG_LIST UNIX_COMMAND ${args})
 

--- a/scripts/tests/CMakeLists.txt
+++ b/scripts/tests/CMakeLists.txt
@@ -8,9 +8,18 @@ execute_process(COMMAND "python" "list_tests" OUTPUT_VARIABLE STR_TESTS
                 ERROR_STRIP_TRAILING_WHITESPACE)
 separate_arguments(TEST_LIST UNIX_COMMAND ${STR_TESTS})
 
+set(args "")
+if (DEFINED ENV{CIME_COMPILER})
+  set(args "--compiler $ENV{CIME_COMPILER}")
+endif()
+if (DEFINED ENV{CIME_MPILIB})
+  set(args "${args} --compiler $ENV{CIME_MPILIB}")
+endif()
+separate_arguments(ARG_LIST UNIX_COMMAND ${args})
+
 foreach(ATEST ${TEST_LIST})
     # this assignment prevents quotes being added to testname in add_test
     set(fulltest "${ATEST}")
-    add_test(NAME ${ATEST} COMMAND ./scripts_regression_tests.py -v ${fulltest}
+    add_test(NAME ${ATEST} COMMAND ./scripts_regression_tests.py -v ${fulltest} ${ARG_LIST}
              WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach(ATEST)

--- a/scripts/tests/CTestConfig.cmake
+++ b/scripts/tests/CTestConfig.cmake
@@ -1,3 +1,8 @@
+#
+# Environment variables CIME_COMPILER and CIME_MPILIB
+# can be used to send --compiler and --mpilib settings to scripts_regression_tests.py
+#
+
 set(CTEST_PROJECT_NAME "CIME")
 string(TIMESTAMP CURRTIME "%H:%M:%S" UTC)
 set(CTEST_NIGHTLY_START_TIME "${CURRTIME} UTC")

--- a/scripts/tests/CTestConfig.cmake
+++ b/scripts/tests/CTestConfig.cmake
@@ -10,4 +10,17 @@ set(CTEST_DROP_SITE_CDASH TRUE)
 set(CTEST_TEST_TIMEOUT 82800 CACHE STRING "")
 set(DART_TESTING_TIMEOUT 82800 CACHE STRING "")
 
-set(BUILDNAME "cime_regression_$ENV{SHELL}")
+set(shell $ENV{SHELL})
+
+if (DEFINED ENV{CIME_COMPILER})
+   set(compiler $ENV{CIME_COMPILER})
+else()
+   set(compiler "default")
+endif()
+if (DEFINED ENV{CIME_MPILIB})
+   set(mpilib $ENV{CIME_MPILIB})
+else()
+   set(mpilib "default")
+endif()
+
+set(BUILDNAME "scripts_regression_${shell}_${compiler}_${mpilib}")


### PR DESCRIPTION
This PR allows ctest to use the new --compiler and --mpilib options in scripts_regression_tests.py
by using env variables CIME_COMPILER and CIME_MPILIB

Test suite: CIME_COMPILER=nag ./cime.ctest.hobart
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1770 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
