### PR TITLE
Add -Og -fbacktrace to gnu debug flags

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -109,7 +109,7 @@ using a fortran linker.
   <CFLAGS>
     <base> -mcmodel=medium -std=gnu99 </base>
     <append compile_threaded="true"> -fopenmp </append>
-    <append DEBUG="TRUE"> -g -Wall -ffpe-trap=invalid,zero,overflow -fcheck=bounds </append>
+    <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=bounds </append>
     <append DEBUG="FALSE"> -O </append>
   </CFLAGS>
   <CPPDEFS>
@@ -126,11 +126,11 @@ using a fortran linker.
     <base> -mcmodel=medium -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </base>
     <append compile_threaded="true"> -fopenmp </append>
     <!-- Ideally, we would also have 'invalid' in the ffpe-trap list. But at
-         least with some versions of gfortran (confirmed with 5.3.0), gfortran's
-         isnan (which is called in cime via the CPRGNU-specific
-         shr_infnan_isnan) causes a floating point exception when called on a
-         signaling NaN. -->
-    <append DEBUG="TRUE"> -g -Wall -ffpe-trap=zero,overflow -fcheck=bounds </append>
+         least with some versions of gfortran (confirmed with 5.4.0, 6.3.0 and
+         7.1.0), gfortran's isnan (which is called in cime via the
+         CPRGNU-specific shr_infnan_isnan) causes a floating point exception
+         when called on a signaling NaN. -->
+    <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=zero,overflow -fcheck=bounds </append>
     <append DEBUG="FALSE"> -O </append>
   </FFLAGS>
   <FFLAGS_NOOPT>


### PR DESCRIPTION
Inspired by ACME's gnu debug flags

Test suite: SMS_D.f09_g16.X.cheyenne_gnu
   Also ran all of CESM's gnu tests on an earlier version of this,
   which had some other changes folded in (which I haven't kept)
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#1621

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
