### PR TITLE
Allow running infnan unit tests even in DEBUG mode

### DIFF
--- a/src/share/test/unit/shr_infnan_test/CMakeLists.txt
+++ b/src/share/test/unit/shr_infnan_test/CMakeLists.txt
@@ -8,24 +8,7 @@ add_executable(infnan_test_exe ${test_sources})
 
 declare_generated_dependencies(infnan_test_exe "${share_genf90_sources}")
 
-if("${CMAKE_BUILD_TYPE}" MATCHES CESM_DEBUG)
-  set(FPES_ARE_TRAPPED TRUE)
-endif()
+# Add the actual test.
+add_test(infnan infnan_test_exe)
 
-if(NOT FPES_ARE_TRAPPED)
-
-  # Add the actual test.
-  add_test(infnan infnan_test_exe)
-
-  define_Fortran_stop_failure(infnan)
-
-else()
-
-  # CESM_DEBUG turns on floating point trapping, causing checks in this
-  # test to fail. We'd like the users to be able to see that the test
-  # was skipped but didn't fail, but CTest has no mechanism for this.
-  # Instead, hack around it by adding a test that will always pass but
-  # is likely to stand out as a skipped test.
-  add_test(SKIPPED_infnan true)
-
-endif()
+define_Fortran_stop_failure(infnan)


### PR DESCRIPTION
Up until now, we have been skipping the shr_infnan unit tests when
building in DEBUG mode. Since we pretty much always build the unit tests
in DEBUG mode, that means that we're pretty much never running the
shr_infnan unit tests.

In trying (and failing) to solve #1763, I came up with a way to get the
shr_infnan unit tests to run and pass even when building in debug
mode. That is implemented here.

Test suite: ./scripts_regression_tests.py N_TestUnitTest on cheyenne
   Also, cime fortran unit tests on my mac (with gnu)
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#1809

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: 
