### PR TITLE
Fix SEQ test on skybridge.

### DIFF
--- a/scripts/lib/CIME/SystemTests/seq.py
+++ b/scripts/lib/CIME/SystemTests/seq.py
@@ -58,6 +58,7 @@ class SEQ(SystemTestsCommon):
                     self._case.set_value("NTASKS_{}".format(comp), newntasks)
                     self._case.set_value("ROOTPE_{}".format(comp), rootpe)
                     rootpe += newntasks
+
         self._case.flush()
         case_setup(self._case, test_mode=True, reset=True)
         self.clean_build()
@@ -91,6 +92,9 @@ class SEQ(SystemTestsCommon):
         # update the pelayout settings for this run
         self._case.read_xml()
 
+        case_setup(self._case, test_mode=True, reset=True)
+        self._case.set_value("BUILD_COMPLETE", True) # rootpe changes should not require a rebuild
+
         self.run_indv()
 
         restore("env_mach_pes.SEQ2.xml", newname="env_mach_pes.xml")
@@ -102,6 +106,9 @@ class SEQ(SystemTestsCommon):
         logger.info("doing a second {:d} {} test with rootpes set to zero".format(stop_n, stop_option))
         # update the pelayout settings for this run
         self._case.read_xml()
+
+        case_setup(self._case, test_mode=True, reset=True)
+        self._case.set_value("BUILD_COMPLETE", True) # rootpe changes should not require a rebuild
 
         self.run_indv(suffix="seq")
         self._component_compare_test("base", "seq")

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -76,13 +76,11 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         expect(not (type(value) is str and "USERDEFINED_required_build" in value),
                "Parameter '{}' must be defined".format(vid))
 
-    # Create batch script
+    # Remove batch scripts
     if reset or clean:
-        # back up relevant files
         if os.path.exists("case.run"):
             os.remove("case.run")
 
-        # only do the following if are NOT in testmode
         if not test_mode:
             # rebuild the models (even on restart)
             case.set_value("BUILD_COMPLETE", False)


### PR DESCRIPTION
Without this change, skybridge was trying to run this on a single node:
mpiexec --np 16 ppr=5 ...

With the PPR lowered to 5 due to the ROOTPE changes, but the --np not adjusted, the node could not accomodate this request.

After this change, it runs:
mpiexec --np 9 ppr=5 ...

Test suite: ./create_test SEQ_Ln9.f19_g16_rx1.A 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?:

Code review: @jedwards4b 
