### PR TITLE
Remove mask specification for test using DOCN%SOMAQP.

### DIFF
--- a/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -507,7 +507,7 @@
       </machine>
     </machines>
   </test>
-  <test name="PRE" grid="f19_f19_mg17" compset="ADESP_TEST">
+  <test name="PRE" grid="f19_f19" compset="ADESP_TEST">
     <machines>
       <machine name="hobart" compiler="nag" category="prealpha"/>
     </machines>
@@ -614,7 +614,7 @@
       </machine>
     </machines>
   </test>
-  <test name="PRE" grid="f09_g17" compset="ADESP" testmods="drv/som">
+  <test name="PRE" grid="f09_f09" compset="ADESP">
     <machines>
       <machine name="hobart" compiler="nag" category="pauseresume"/>
     </machines>
@@ -622,7 +622,7 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="PRE" grid="f09_g17" compset="ADESP_TEST" testmods="drv/som">
+  <test name="PRE" grid="f09_f09" compset="ADESP_TEST">
     <machines>
       <machine name="hobart" compiler="gnu" category="prealpha"/>
       <machine name="hobart" compiler="nag" category="prealpha"/>


### PR DESCRIPTION
The mg16 and mg17 grid has a hole over Greenland.  This was causing Nans when
running SOM aquaplanet at f09_f09_mg17.  The fix is not to specify a mask when using
DOCN%SOMAQP.

Test suite: scripts_regression_tests.py, PRE.f09_f09_ADESP_TEST.hobart_nag,
                   PRE.f19_f19.ADESP_TEST.hobart_nag
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #1801

User interface changes?:

Update gh-pages html (Y/N)?:

Code review:

