### PR TITLE
Multiple drivers

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -517,6 +517,24 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
   </test>
 
+  <test NAME="MCC">
+    <DESC>multi-instance validation vs multi-coupler (default length)</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>none</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+    <NINST_CPL>1</NINST_CPL>
+    <NINST_ATM>1</NINST_ATM>
+    <NINST_OCN>1</NINST_OCN>
+    <NINST_WAV>1</NINST_WAV>
+    <NINST_GLC>1</NINST_GLC>
+    <NINST_ICE>1</NINST_ICE>
+    <NINST_ROF>1</NINST_ROF>
+    <NINST_LND>1</NINST_LND>
+  </test>
+
   <test NAME="NCK">
     <DESC>multi-instance validation vs single instance (default length)</DESC>
     <INFO_DBUG>1</INFO_DBUG>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -525,7 +525,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <COUPLER_COUNT>1</COUPLER_COUNT>
+    <NINST_CPL>1</NINST_CPL>
     <NINST_ATM>1</NINST_ATM>
     <NINST_OCN>1</NINST_OCN>
     <NINST_WAV>1</NINST_WAV>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -518,14 +518,14 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
   </test>
 
   <test NAME="MCC">
-    <DESC>multi-coupler validation vs single-instance (default length)</DESC>
+    <DESC>multi-driver validation vs single-instance (default length)</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <MULTI_COUPLER>TRUE</MULTI_COUPLER>
+    <MULTI_DRIVER>TRUE</MULTI_DRIVER>
   </test>
 
   <test NAME="NCK">

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -125,7 +125,6 @@ NCR    multi-instance validation vs single instance - concurrent PE for instance
        do an initial run test with NINST 1 (suffix: base)
        do an initial run test with NINST 2 (suffix: multiinst for both _0001 and _0002)
         compare base and _0001 and _0002
-       (***note that NCR_script and NCK_script are the same - but NCR_build.csh and NCK_build.csh are different***)
 
 NOC    multi-instance validation for single instance ocean (default length)
        do an initial run test with NINST 2 (other than ocn), with mod to instance 1 (suffix: inst1_base, inst2_mod)

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -525,7 +525,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <NINST_CPL>1</NINST_CPL>
+    <COUPLER_COUNT>1</COUPLER_COUNT>
     <NINST_ATM>1</NINST_ATM>
     <NINST_OCN>1</NINST_OCN>
     <NINST_WAV>1</NINST_WAV>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -518,7 +518,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
   </test>
 
   <test NAME="MCC">
-    <DESC>multi-instance validation vs multi-coupler (default length)</DESC>
+    <DESC>multi-coupler validation vs single-instance (default length)</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -525,14 +525,8 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <NINST_CPL>1</NINST_CPL>
-    <NINST_ATM>1</NINST_ATM>
-    <NINST_OCN>1</NINST_OCN>
-    <NINST_WAV>1</NINST_WAV>
-    <NINST_GLC>1</NINST_GLC>
-    <NINST_ICE>1</NINST_ICE>
-    <NINST_ROF>1</NINST_ROF>
-    <NINST_LND>1</NINST_LND>
+    <MULTI_COUPLER>TRUE</MULTI_COUPLER>
+    <NINST_CPL>3</NINST_CPL>
   </test>
 
   <test NAME="NCK">

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -526,7 +526,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
     <MULTI_COUPLER>TRUE</MULTI_COUPLER>
-    <NINST_CPL>3</NINST_CPL>
   </test>
 
   <test NAME="NCK">

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -105,3 +105,5 @@ Also keep these important points in mind:
 #. In **create_test** these options can be invoked with testname modifiers _N# for the single driver mode and _C# for the multi-driver mode.  These are mutually exclusive options, they cannot be combined.
 
 #. In create_newcase you may use --ninst # to set the number of instances and --multi-driver for multi-driver mode.
+
+#. In multi-driver mode you will always get 1 instance of each component for each driver/coupler, if you change a case using xmlchange MULTI_COUPLER=TRUE you will get a number of driver/couplers equal to the maximum NINST value over all components.

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -1,44 +1,42 @@
 .. _multi-instance:
 
-**TODO: Need to update PE elements and explain + and - values**
-
-
 Multi-instance component functionality
 ======================================
 
-The CIME coupling infrastructure is capable of running multiple component instances under one model executable. 
-One caveat: If N multiple instances of any one active component are used, the same number of multiple instances of ALL active components are required. 
-More details are discussed below.
+The CIME coupling infrastructure is capable of running multiple component instances (ensembles) under one model executable.  There are two modes of ensemble capability, single coupler in which all component instances are handled by a single coupler component or multi-coupler in which each instance includes a separate coupler component.  In the multi-coupler mode the entire model is duplicated for each instance while in the single coupler mode only active components need be duplicated.   In most cases the multi-coupler mode will give better performance and should be used.
 
-The primary motivation for this development was to be able to run an ensemble Kalman-Filter for data assimilation and parameter estimation (UQ, for example). 
-However, it also provides the ability to run a set of experiments within a single model executable where each instance can have a different namelist, and to have all the output go to one directory. 
+The primary motivation for this development was to be able to run an ensemble Kalman-Filter for data assimilation and parameter estimation (UQ, for example).
+However, it also provides the ability to run a set of experiments within a single model executable where each instance can have a different namelist, and to have all the output go to one directory.
 
 An F compset is used in the following example. Using the multiple-instance code involves the following steps:
 
 1. Create the case.
 ::
 
-   > create_newcase --case Fmulti --compset F --res ne30_g16 
+   > create_newcase --case Fmulti --compset F --res ne30_ne30_mg17
    > cd Fmulti
 
-2. Assume this is the out-of-the-box pe-layout: 
+2. Assume this is the out-of-the-box pe-layout:
 ::
 
-   NTASKS(ATM)=128, NTHRDS(ATM)=1, ROOTPE(ATM)=0, NINST(ATM)=1
-   NTASKS(LND)=128, NTHRDS(LND)=1, ROOTPE(LND)=0, NINST(LND)=1
-   NTASKS(ICE)=128, NTHRDS(ICE)=1, ROOTPE(ICE)=0, NINST(ICE)=1
-   NTASKS(OCN)=128, NTHRDS(OCN)=1, ROOTPE(OCN)=0, NINST(OCN)=1
-   NTASKS(GLC)=128, NTHRDS(GLC)=1, ROOTPE(GLC)=0, NINST(GLC)=1
-   NTASKS(WAV)=128, NTHRDS(WAV)=1, ROOTPE(WAV)=0, NINST(WAV)=1
-   NTASKS(CPL)=128, NTHRDS(CPL)=1, ROOTPE(CPL)=0
+   Comp  NTASKS  NTHRDS  ROOTPE
+   CPL :    144/     1;      0
+   ATM :    144/     1;      0
+   LND :    144/     1;      0
+   ICE :    144/     1;      0
+   OCN :    144/     1;      0
+   ROF :    144/     1;      0
+   GLC :    144/     1;      0
+   WAV :    144/     1;      0
+   ESP :      1/     1;      0
 
-The atm, lnd and rof are active components in this compset. The ocn is a prescribed data component, cice is a mixed prescribed/active component (ice-coverage is prescribed), and glc and wav are stub components.
+The atm, lnd and rof are active components in this compset. The ocn is a prescribed data component, cice is a mixed prescribed/active component (ice-coverage is prescribed), and glc, wav and esp are stub components.
 
-Let's say we want to run two instances of CAM in this experiment. 
-We will also have to run two instances of CLM, CICE and RTM. 
-However, we can run either one or two instances of DOCN, and we can ignore glc and wav since they do not do anything in this compset as stub components.
- 
-To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following commands in your **$CASEROOT** directory:
+Let's say we want to run two instances of CAM in this experiment.
+We will also have to run two instances of CLM, CICE and RTM.
+However, we can run either one or two instances of DOCN, and we can ignore the stub components since they do not do anything in this compset.
+
+To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following :ref: `xmlchange<modifying-an-xml-file>` commands in your **$CASEROOT** directory:
 ::
 
    > ./xmlchange NINST_ATM=2
@@ -47,16 +45,22 @@ To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following comma
    > ./xmlchange NINST_ROF=2
    > ./xmlchange NINST_OCN=2
 
-As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, and DOCN, each running concurrently on 64 MPI tasks.
+As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, and DOCN, each running concurrently on 72 MPI tasks and all using the same coupler component.   In this single coupler mode the number of tasks for each component instance is NTASKS_COMPONENT/NINST_COMPONENT and the total number of tasks is the same as for the single instance case.
 
-**TODO: put in reference to xmlchange".**
+Now consider the multi coupler model.
+To use this mode change the NINST values for the individual components back to 1 and the NINST_CPL to 2.
+::
+   > ./xmlchange NINST=1
+   > ./xmlchange NINST_CPL=2
+
+This configuration will run each component instance on the original 144 tasks but will generate two copies of the model (in the same executable) for a total of 288 tasks.
 
 3. Set up the case
 ::
 
    > ./case.setup
 
-A new **user_nl_xxx_NNNN** file (where NNNN is the number of the component instances) is generated when **case.setup** is called. 
+A new **user_nl_xxx_NNNN** file (where NNNN is the number of the component instances) is generated when **case.setup** is called.
 When calling **case.setup** with the **env_mach_pes.xml** file specifically, these files are created in **$CASEROOT**:
 ::
 
@@ -79,17 +83,15 @@ Also, **case.setup** creates the following ``*_in_*`` files and ``*txt*`` files 
    lnd_in_0001, lnd_in_0002
    rof_in_0001, rof_in_0002
 
-The namelist for each component instance can be modified by changing the corresponding **user_nl_xxx_NNNN** file. 
-Modifying **user_nl_cam_0002** will result in your namelist changes being active ONLY for the second instance of CAM. 
+The namelist for each component instance can be modified by changing the corresponding **user_nl_xxx_NNNN** file.
+Modifying **user_nl_cam_0002** will result in your namelist changes being active ONLY for the second instance of CAM.
 To change the DOCN stream txt file instance 0002, copy **docn.streams.txt.prescribed_0002** to your **$CASEROOT** directory with the name **user_docn.streams.txt.prescribed_0002** and modify it accordlingly.
 
 Also keep these important points in mind:
 
 #. **Multiple component instances can differ ONLY in namelist settings; they ALL use the same model executable.**
 
-#. Multiple-instance implementation supports only one coupler component.
-
 #. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** files created by **case.setup**.
 
-#. Multiple instances generally should un concurrently, which is the default setting in **env_mach_pes.xml**. 
-   The serial setting is only for EXPERT USERS in upcoming development code implementations.
+#. A special variable NINST_LAYOUT is provided for some experimental compsets, its value should be
+   'concurrent' for all but a few special cases.

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -89,14 +89,13 @@ To change the DOCN stream txt file instance 0002, copy **docn.streams.txt.prescr
 
 Also keep these important points in mind:
 
-#. Note that these changes can be made at create_newcase time with option --ninst #, use the additional option --ninst-couplers to invoke the multi-coupler mode.
+#. Note that these changes can be made at create_newcase time with option --ninst # where # is a positive integer, use the additional logical option --ninst-couplers to invoke the multi-coupler mode.
 
 #. **Multiple component instances can differ ONLY in namelist settings; they ALL use the same model executable.**
 
-#. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** files created by **case.setup**.
+#. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** (where xxx is the component name) files created by **case.setup**.
 
 #. A special variable NINST_LAYOUT is provided for some experimental compsets, its value should be
    'concurrent' for all but a few special cases.
 
-#. In create test these options can be invoked with testname modifiers _N# for the single coupler mode and
-   _C# for the multi-coupler mode.
+#. In **create_test** these options can be invoked with testname modifiers _N# for the single coupler mode and _C# for the multi-coupler mode.  These are mutually exclusive options, they cannot be combined.

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -48,10 +48,9 @@ To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following :ref:
 As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, and DOCN, each running concurrently on 72 MPI tasks and all using the same coupler component.   In this single coupler mode the number of tasks for each component instance is NTASKS_COMPONENT/NINST_COMPONENT and the total number of tasks is the same as for the single instance case.
 
 Now consider the multi coupler model.
-To use this mode change the NINST values for the individual components back to 1 and the NINST_CPL to 2.
+To use this mode change
 ::
-   > ./xmlchange NINST=1
-   > ./xmlchange NINST_CPL=2
+   > ./xmlchange MULTI_COUPLER=TRUE
 
 This configuration will run each component instance on the original 144 tasks but will generate two copies of the model (in the same executable) for a total of 288 tasks.
 
@@ -96,6 +95,8 @@ Also keep these important points in mind:
 #. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** (where xxx is the component name) files created by **case.setup**.
 
 #. A special variable NINST_LAYOUT is provided for some experimental compsets, its value should be
-   'concurrent' for all but a few special cases.
+   'concurrent' for all but a few special cases and it cannot be used if MULTI_COUPLER=TRUE.
 
 #. In **create_test** these options can be invoked with testname modifiers _N# for the single coupler mode and _C# for the multi-coupler mode.  These are mutually exclusive options, they cannot be combined.
+
+#. In create_newcase you may use --ninst # to set the number of instances and --multi-coupler for multi-coupler mode.

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -3,7 +3,7 @@
 Multi-instance component functionality
 ======================================
 
-The CIME coupling infrastructure is capable of running multiple component instances (ensembles) under one model executable.  There are two modes of ensemble capability, single coupler in which all component instances are handled by a single coupler component or multi-coupler in which each instance includes a separate coupler component.  In the multi-coupler mode the entire model is duplicated for each instance while in the single coupler mode only active components need be duplicated.   In most cases the multi-coupler mode will give better performance and should be used.
+The CIME coupling infrastructure is capable of running multiple component instances (ensembles) under one model executable.  There are two modes of ensemble capability, single driver in which all component instances are handled by a single driver/coupler component or multi-driver in which each instance includes a separate driver/coupler component.  In the multi-driver mode the entire model is duplicated for each instance while in the single driver mode only active components need be duplicated.   In most cases the multi-driver mode will give better performance and should be used.
 
 The primary motivation for this development was to be able to run an ensemble Kalman-Filter for data assimilation and parameter estimation (UQ, for example).
 However, it also provides the ability to run a set of experiments within a single model executable where each instance can have a different namelist, and to have all the output go to one directory.
@@ -45,12 +45,12 @@ To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following :ref:
    > ./xmlchange NINST_ROF=2
    > ./xmlchange NINST_OCN=2
 
-As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, and DOCN, each running concurrently on 72 MPI tasks and all using the same coupler component.   In this single coupler mode the number of tasks for each component instance is NTASKS_COMPONENT/NINST_COMPONENT and the total number of tasks is the same as for the single instance case.
+As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, and DOCN, each running concurrently on 72 MPI tasks and all using the same driver/coupler component.   In this single driver/coupler mode the number of tasks for each component instance is NTASKS_COMPONENT/NINST_COMPONENT and the total number of tasks is the same as for the single instance case.
 
-Now consider the multi coupler model.
+Now consider the multi driver model.
 To use this mode change
 ::
-   > ./xmlchange MULTI_COUPLER=TRUE
+   > ./xmlchange MULTI_DRIVER=TRUE
 
 This configuration will run each component instance on the original 144 tasks but will generate two copies of the model (in the same executable) for a total of 288 tasks.
 
@@ -88,15 +88,15 @@ To change the DOCN stream txt file instance 0002, copy **docn.streams.txt.prescr
 
 Also keep these important points in mind:
 
-#. Note that these changes can be made at create_newcase time with option --ninst # where # is a positive integer, use the additional logical option --ninst-couplers to invoke the multi-coupler mode.
+#. Note that these changes can be made at create_newcase time with option --ninst # where # is a positive integer, use the additional logical option --multi-driver to invoke the multi-driver mode.
 
 #. **Multiple component instances can differ ONLY in namelist settings; they ALL use the same model executable.**
 
 #. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** (where xxx is the component name) files created by **case.setup**.
 
 #. A special variable NINST_LAYOUT is provided for some experimental compsets, its value should be
-   'concurrent' for all but a few special cases and it cannot be used if MULTI_COUPLER=TRUE.
+   'concurrent' for all but a few special cases and it cannot be used if MULTI_DRIVER=TRUE.
 
-#. In **create_test** these options can be invoked with testname modifiers _N# for the single coupler mode and _C# for the multi-coupler mode.  These are mutually exclusive options, they cannot be combined.
+#. In **create_test** these options can be invoked with testname modifiers _N# for the single driver mode and _C# for the multi-driver mode.  These are mutually exclusive options, they cannot be combined.
 
-#. In create_newcase you may use --ninst # to set the number of instances and --multi-coupler for multi-coupler mode.
+#. In create_newcase you may use --ninst # to set the number of instances and --multi-driver for multi-driver mode.

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -3,17 +3,30 @@
 Multi-instance component functionality
 ======================================
 
-The CIME coupling infrastructure is capable of running multiple component instances (ensembles) under one model executable.  There are two modes of ensemble capability, single driver in which all component instances are handled by a single driver/coupler component or multi-driver in which each instance includes a separate driver/coupler component.  In the multi-driver mode the entire model is duplicated for each instance while in the single driver mode only active components need be duplicated.   In most cases the multi-driver mode will give better performance and should be used.
+The CIME coupling infrastructure is capable of running multiple
+component instances (ensembles) under one model executable.  There are
+two modes of ensemble capability, single driver in which all component
+instances are handled by a single driver/coupler component or
+multi-driver in which each instance includes a separate driver/coupler
+component.  In the multi-driver mode the entire model is duplicated
+for each instance while in the single driver mode only active
+components need be duplicated.  In most cases the multi-driver mode
+will give better performance and should be used.
 
-The primary motivation for this development was to be able to run an ensemble Kalman-Filter for data assimilation and parameter estimation (UQ, for example).
-However, it also provides the ability to run a set of experiments within a single model executable where each instance can have a different namelist, and to have all the output go to one directory.
+The primary motivation for this development was to be able to run an
+ensemble Kalman-Filter for data assimilation and parameter estimation
+(UQ, for example).  However, it also provides the ability to run a set
+of experiments within a single model executable where each instance
+can have a different namelist, and to have all the output go to one
+directory.
 
-An F compset is used in the following example. Using the multiple-instance code involves the following steps:
+An F compset is used in the following example. Using the
+multiple-instance code involves the following steps:
 
 1. Create the case.
 ::
 
-   > create_newcase --case Fmulti --compset F --res ne30_ne30_mg17
+   > create_newcase --case Fmulti --compset F2000_DEV --res f19_f19_mg17
    > cd Fmulti
 
 2. Assume this is the out-of-the-box pe-layout:
@@ -30,22 +43,27 @@ An F compset is used in the following example. Using the multiple-instance code 
    WAV :    144/     1;      0
    ESP :      1/     1;      0
 
-The atm, lnd and rof are active components in this compset. The ocn is a prescribed data component, cice is a mixed prescribed/active component (ice-coverage is prescribed), and glc, wav and esp are stub components.
+The atm, lnd, rof and glc are active components in this compset. The ocn is
+a prescribed data component, cice is a mixed prescribed/active
+component (ice-coverage is prescribed), and wav and esp are stub
+components.
 
-Let's say we want to run two instances of CAM in this experiment.
-We will also have to run two instances of CLM, CICE and RTM.
-However, we can run either one or two instances of DOCN, and we can ignore the stub components since they do not do anything in this compset.
+Let's say we want to run two instances of CAM in this experiment.  We
+will also have to run two instances of CLM, CICE, RTM and GLC.  However, we
+can run either one or two instances of DOCN, and we can ignore the
+stub components since they do not do anything in this compset.
 
-To run two instances of CAM, CLM, CICE, RTM and DOCN, invoke the following :ref: `xmlchange<modifying-an-xml-file>` commands in your **$CASEROOT** directory:
+To run two instances of CAM, CLM, CICE, RTM, GLC and DOCN, invoke the following :ref: `xmlchange<modifying-an-xml-file>` commands in your **$CASEROOT** directory:
 ::
 
    > ./xmlchange NINST_ATM=2
    > ./xmlchange NINST_LND=2
    > ./xmlchange NINST_ICE=2
    > ./xmlchange NINST_ROF=2
+   > ./xmlchange NINST_GLC=2
    > ./xmlchange NINST_OCN=2
 
-As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, and DOCN, each running concurrently on 72 MPI tasks and all using the same driver/coupler component.   In this single driver/coupler mode the number of tasks for each component instance is NTASKS_COMPONENT/NINST_COMPONENT and the total number of tasks is the same as for the single instance case.
+As a result, you will have two instances of CAM, CLM and CICE (prescribed), RTM, GLC, and DOCN, each running concurrently on 72 MPI tasks and all using the same driver/coupler component.   In this single driver/coupler mode the number of tasks for each component instance is NTASKS_COMPONENT/NINST_COMPONENT and the total number of tasks is the same as for the single instance case.
 
 Now consider the multi driver model.
 To use this mode change
@@ -63,24 +81,11 @@ A new **user_nl_xxx_NNNN** file (where NNNN is the number of the component insta
 When calling **case.setup** with the **env_mach_pes.xml** file specifically, these files are created in **$CASEROOT**:
 ::
 
-   user_nl_cam_0001,  user_nl_cam_0002
-   user_nl_cice_0001, user_nl_cice_0002
-   user_nl_clm_0001,  user_nl_clm_0002
-   user_nl_rtm_0001,  user_nl_rtm_0002
-   user_nl_docn_0001, user_nl_docn_0002
+   user_nl_cam_0001 user_nl_clm_0001 user_nl_docn_0001 user_nl_cice_0001
+   user_nl_cism_0001 user_nl_mosart_0001
+   user_nl_cam_0002 user_nl_clm_0002 user_nl_docn_0002 user_nl_cice_0002
+   user_nl_cism_0002 user_nl_mosart_0002
    user_nl_cpl
-
-Also, **case.setup** creates the following ``*_in_*`` files and ``*txt*`` files in **$CASEROOT/CaseDocs**:
-::
-
-   atm_in_0001, atm_in_0002
-   docn.streams.txt.prescribed_0001, docn.streams.txt.prescribed_0002
-   docn_in_0001, docn_in_0002
-   docn_ocn_in_0001, docn_ocn_in_0002
-   drv_flds_in, drv_in
-   ice_in_0001, ice_in_0002
-   lnd_in_0001, lnd_in_0002
-   rof_in_0001, rof_in_0002
 
 The namelist for each component instance can be modified by changing the corresponding **user_nl_xxx_NNNN** file.
 Modifying **user_nl_cam_0002** will result in your namelist changes being active ONLY for the second instance of CAM.

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -77,7 +77,7 @@ This configuration will run each component instance on the original 144 tasks bu
 
    > ./case.setup
 
-A new **user_nl_xxx_NNNN** file (where NNNN is the number of the component instances) is generated when **case.setup** is called.
+A new **user_nl_xxx_NNNN** file is generated for each component instance when case.setup is called (where xxx is the component type and NNNN is the number of the component instance).
 When calling **case.setup** with the **env_mach_pes.xml** file specifically, these files are created in **$CASEROOT**:
 ::
 

--- a/doc/source/users_guide/multi-instance.rst
+++ b/doc/source/users_guide/multi-instance.rst
@@ -89,9 +89,14 @@ To change the DOCN stream txt file instance 0002, copy **docn.streams.txt.prescr
 
 Also keep these important points in mind:
 
+#. Note that these changes can be made at create_newcase time with option --ninst #, use the additional option --ninst-couplers to invoke the multi-coupler mode.
+
 #. **Multiple component instances can differ ONLY in namelist settings; they ALL use the same model executable.**
 
 #. Calling **case.setup** with ``--clean`` *DOES NOT* remove the **user_nl_xxx_NN** files created by **case.setup**.
 
 #. A special variable NINST_LAYOUT is provided for some experimental compsets, its value should be
    'concurrent' for all but a few special cases.
+
+#. In create test these options can be invoked with testname modifiers _N# for the single coupler mode and
+   _C# for the multi-coupler mode.

--- a/scripts/Tools/check_case
+++ b/scripts/Tools/check_case
@@ -50,9 +50,8 @@ def _main_func(description):
 
     parse_command_line(sys.argv, description)
 
-    check_lockedfiles()
-
     with Case(read_only=False) as case:
+        check_lockedfiles(case)
         create_namelists(case)
         build_complete = case.get_value("BUILD_COMPLETE")
 

--- a/scripts/Tools/check_lockedfiles
+++ b/scripts/Tools/check_lockedfiles
@@ -41,7 +41,7 @@ def _main_func(description):
 
     caseroot = parse_command_line(sys.argv, description)
 
-    with Case(read_only=True) as case:
+    with Case(case_root=caseroot, read_only=True) as case:
         check_lockedfiles(case)
 
 if __name__ == "__main__":

--- a/scripts/Tools/check_lockedfiles
+++ b/scripts/Tools/check_lockedfiles
@@ -5,6 +5,7 @@ This script compares xml files
 
 from standard_script_setup import *
 from CIME.check_lockedfiles import check_lockedfiles
+from CIME.case import Case
 
 def parse_command_line(args, description):
     parser = argparse.ArgumentParser(
@@ -40,7 +41,8 @@ def _main_func(description):
 
     caseroot = parse_command_line(sys.argv, description)
 
-    check_lockedfiles(caseroot)
+    with Case(read_only=True) as case:
+        check_lockedfiles(case)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -46,13 +46,13 @@ OR
                         help="Specify a compiler. "
                         "To see list of supported compilers for each machine, use the utility query_config in this directory")
 
-    parser.add_argument("--multi-coupler",action="store_true",
-                        help="Specify that ninst should modify number of coupler instances "
-                        "default is to have one coupler supporting multiple component instances.")
+    parser.add_argument("--multi-driver",action="store_true",
+                        help="Specify that ninst should modify number of driver/coupler instances "
+                        "default is to have one driver/coupler supporting multiple component instances.")
 
     parser.add_argument("--ninst",default=1,
                         help="Specify number of model ensemble instances. "
-                        "Default is multiple components and one coupler.  Use --multi-coupler to "
+                        "Default is multiple components and one coupler.  Use --multi-driver to "
                         "run multiple couplers in the ensemble.")
 
     parser.add_argument("--mpilib", "-mpilib",
@@ -160,7 +160,7 @@ OR
     return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.pesfile, \
-        args.user_grid, args.gridfile, args.srcroot, args.test, args.multi_coupler, \
+        args.user_grid, args.gridfile, args.srcroot, args.test, args.multi_driver, \
         args.ninst, args.walltime, args.queue, args.output_root, args.script_root, \
         run_unsupported, args.answer, args.input_dir
 
@@ -172,7 +172,7 @@ def _main_func(description):
     casename, compset, grid, machine, compiler, \
         mpilib, project, pecount,  \
         user_mods_dir, pesfile, \
-        user_grid, gridfile, srcroot, test, multi_coupler, ninst, walltime, \
+        user_grid, gridfile, srcroot, test, multi_driver, ninst, walltime, \
         queue, output_root, script_root, run_unsupported, \
         answer, input_dir = parse_command_line(sys.argv, cimeroot, description)
 
@@ -196,7 +196,7 @@ def _main_func(description):
                     machine_name=machine, project=project,
                     pecount=pecount, compiler=compiler, mpilib=mpilib,
                     pesfile=pesfile,user_grid=user_grid, gridfile=gridfile,
-                    multi_coupler=multi_coupler, ninst=ninst, test=test,
+                    multi_driver=multi_driver, ninst=ninst, test=test,
                     walltime=walltime, queue=queue, output_root=output_root,
                     run_unsupported=run_unsupported, answer=answer,
                     input_dir=input_dir)

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -46,6 +46,10 @@ OR
                         help="Specify a compiler. "
                         "To see list of supported compilers for each machine, use the utility query_config in this directory")
 
+    parser.add_argument("--ncouplers",default=1,
+                        help="Specify number of coupler instances. "
+                        "Set the number of coupler instances in the case.")
+
     parser.add_argument("--ninst",default=1,
                         help="Specify number of component instances"
                         "Set the number of component instances in the case.")
@@ -142,6 +146,9 @@ OR
         expect(args.gridfile is not None,
                "User grid specification file must be set if the user grid is requested")
 
+    expect(not (int(args.ncouplers) > 1 and int(args.ninst) > 1),
+           "Only one component instance per coupler is allowed when using multiple couplers")
+
     run_unsupported = False
     if model == "cesm":
         run_unsupported = args.run_unsupported
@@ -155,7 +162,8 @@ OR
     return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.pesfile, \
-        args.user_grid, args.gridfile, args.srcroot, args.test, args.ninst, \
+        args.user_grid, args.gridfile, args.srcroot, args.test, args.ncouplers, \
+        args.ninst, \
         args.walltime, args.queue, args.output_root, args.script_root, \
         run_unsupported, args.answer, args.input_dir
 
@@ -167,7 +175,7 @@ def _main_func(description):
     casename, compset, grid, machine, compiler, \
         mpilib, project, pecount,  \
         user_mods_dir, pesfile, \
-        user_grid, gridfile, srcroot, test, ninst, walltime, queue, \
+        user_grid, gridfile, srcroot, test, ncouplers, ninst, walltime, queue, \
         output_root, script_root, run_unsupported, \
         answer, input_dir = parse_command_line(sys.argv, cimeroot, description)
 
@@ -187,9 +195,11 @@ def _main_func(description):
 
     with Case(caseroot, read_only=False) as case:
         # Configure the Case
-        case.create(casename, srcroot, compset, grid, user_mods_dir=user_mods_dir, machine_name=machine, project=project,
+        case.create(casename, srcroot, compset, grid, user_mods_dir=user_mods_dir,
+                    machine_name=machine, project=project,
                     pecount=pecount, compiler=compiler, mpilib=mpilib,
-                    pesfile=pesfile,user_grid=user_grid, gridfile=gridfile, ninst=ninst, test=test,
+                    pesfile=pesfile,user_grid=user_grid, gridfile=gridfile,
+                    ncouplers=ncouplers, ninst=ninst, test=test,
                     walltime=walltime, queue=queue, output_root=output_root,
                     run_unsupported=run_unsupported, answer=answer,
                     input_dir=input_dir)

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -46,13 +46,13 @@ OR
                         help="Specify a compiler. "
                         "To see list of supported compilers for each machine, use the utility query_config in this directory")
 
-    parser.add_argument("--ninst-couplers",action="store_true",
+    parser.add_argument("--multi-coupler",action="store_true",
                         help="Specify that ninst should modify number of coupler instances "
                         "default is to have one coupler supporting multiple component instances.")
 
     parser.add_argument("--ninst",default=1,
                         help="Specify number of model ensemble instances. "
-                        "Default is multiple components and one coupler.  Use --ninst-couplers to "
+                        "Default is multiple components and one coupler.  Use --multi-coupler to "
                         "run multiple couplers in the ensemble.")
 
     parser.add_argument("--mpilib", "-mpilib",
@@ -157,7 +157,7 @@ OR
     if args.input_dir is not None:
         args.input_dir = os.path.abspath(args.input_dir)
 
-    if args.ninst_couplers:
+    if args.multi_coupler:
         ncouplers = args.ninst
         ninst = 1
     else:

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -48,11 +48,13 @@ OR
 
     parser.add_argument("--ncouplers",default=1,
                         help="Specify number of coupler instances. "
-                        "Set the number of coupler instances in the case.")
+                        "Set the number of coupler instances in the case. "
+                        "If ncouplers is > 1 then ninst should = 1.")
 
     parser.add_argument("--ninst",default=1,
-                        help="Specify number of component instances"
-                        "Set the number of component instances in the case.")
+                        help="Specify number of component instances. "
+                        "Set the number of component instances in the case. "
+                        "If ninst > 1 then ncouplers should = 1")
 
     parser.add_argument("--mpilib", "-mpilib",
                         help="Specify the mpilib. "

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -157,19 +157,11 @@ OR
     if args.input_dir is not None:
         args.input_dir = os.path.abspath(args.input_dir)
 
-    if args.multi_coupler:
-        ncouplers = args.ninst
-        ninst = 1
-    else:
-        ncouplers = 1
-        ninst = args.ninst
-
-
     return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.pesfile, \
-        args.user_grid, args.gridfile, args.srcroot, args.test, ncouplers, \
-        ninst, args.walltime, args.queue, args.output_root, args.script_root, \
+        args.user_grid, args.gridfile, args.srcroot, args.test, args.multi_coupler, \
+        args.ninst, args.walltime, args.queue, args.output_root, args.script_root, \
         run_unsupported, args.answer, args.input_dir
 
 ###############################################################################
@@ -180,8 +172,8 @@ def _main_func(description):
     casename, compset, grid, machine, compiler, \
         mpilib, project, pecount,  \
         user_mods_dir, pesfile, \
-        user_grid, gridfile, srcroot, test, ncouplers, ninst, walltime, queue, \
-        output_root, script_root, run_unsupported, \
+        user_grid, gridfile, srcroot, test, multi_coupler, ninst, walltime, \
+        queue, output_root, script_root, run_unsupported, \
         answer, input_dir = parse_command_line(sys.argv, cimeroot, description)
 
     if script_root is None:
@@ -204,7 +196,7 @@ def _main_func(description):
                     machine_name=machine, project=project,
                     pecount=pecount, compiler=compiler, mpilib=mpilib,
                     pesfile=pesfile,user_grid=user_grid, gridfile=gridfile,
-                    ncouplers=ncouplers, ninst=ninst, test=test,
+                    multi_coupler=multi_coupler, ninst=ninst, test=test,
                     walltime=walltime, queue=queue, output_root=output_root,
                     run_unsupported=run_unsupported, answer=answer,
                     input_dir=input_dir)

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -46,15 +46,14 @@ OR
                         help="Specify a compiler. "
                         "To see list of supported compilers for each machine, use the utility query_config in this directory")
 
-    parser.add_argument("--ncouplers",default=1,
-                        help="Specify number of coupler instances. "
-                        "Set the number of coupler instances in the case. "
-                        "If ncouplers is > 1 then ninst should = 1.")
+    parser.add_argument("--ninst-couplers",action="store_true",
+                        help="Specify that ninst should modify number of coupler instances "
+                        "default is to have one coupler supporting multiple component instances.")
 
     parser.add_argument("--ninst",default=1,
-                        help="Specify number of component instances. "
-                        "Set the number of component instances in the case. "
-                        "If ninst > 1 then ncouplers should = 1")
+                        help="Specify number of model ensemble instances. "
+                        "Default is multiple components and one coupler.  Use --ninst-couplers to "
+                        "run multiple couplers in the ensemble.")
 
     parser.add_argument("--mpilib", "-mpilib",
                         help="Specify the mpilib. "
@@ -148,9 +147,6 @@ OR
         expect(args.gridfile is not None,
                "User grid specification file must be set if the user grid is requested")
 
-    expect(not (int(args.ncouplers) > 1 and int(args.ninst) > 1),
-           "Only one component instance per coupler is allowed when using multiple couplers")
-
     run_unsupported = False
     if model == "cesm":
         run_unsupported = args.run_unsupported
@@ -161,12 +157,19 @@ OR
     if args.input_dir is not None:
         args.input_dir = os.path.abspath(args.input_dir)
 
+    if args.ninst_couplers:
+        ncouplers = args.ninst
+        ninst = 1
+    else:
+        ncouplers = 1
+        ninst = args.ninst
+
+
     return args.case, args.compset, args.res, args.machine, args.compiler,\
         args.mpilib, args.project, args.pecount, \
         args.user_mods_dir, args.pesfile, \
-        args.user_grid, args.gridfile, args.srcroot, args.test, args.ncouplers, \
-        args.ninst, \
-        args.walltime, args.queue, args.output_root, args.script_root, \
+        args.user_grid, args.gridfile, args.srcroot, args.test, ncouplers, \
+        ninst, args.walltime, args.queue, args.output_root, args.script_root, \
         run_unsupported, args.answer, args.input_dir
 
 ###############################################################################

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -52,8 +52,8 @@ OR
 
     parser.add_argument("--ninst",default=1,
                         help="Specify number of model ensemble instances. "
-                        "Default is multiple components and one coupler.  Use --multi-driver to "
-                        "run multiple couplers in the ensemble.")
+                        "Default is multiple components and one driver/coupler.  Use --multi-driver to "
+                        "run multiple driver/couplers in the ensemble.")
 
     parser.add_argument("--mpilib", "-mpilib",
                         help="Specify the mpilib. "

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -26,9 +26,9 @@ class MCC(SystemTestsCompareTwo):
     def _case_one_setup(self):
         # The multicoupler case will increase the number of tasks by the
         # number of requested couplers.
-        self._case.set_value("NINST_CPL", self._test_instances)
+        self._case.set_value("COUPLER_COUNT", self._test_instances)
         case_setup(self._case, test_mode=False, reset=True)
 
     def _case_two_setup(self):
-        self._case.set_value("NINST_CPL", 1)
+        self._case.set_value("COUPLER_COUNT", 1)
         case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -2,7 +2,7 @@
 Implemetation of CIME MCC test: Compares ensemble methods
 
 This does two runs: In the first we run a three member ensemble using the
- MULTI_COUPLER capability, then we run a second single instance case and compare
+ MULTI_DRIVER capability, then we run a second single instance case and compare
 """
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
@@ -20,14 +20,13 @@ class MCC(SystemTestsCompareTwo):
                                        separate_builds = True,
                                        run_two_suffix = 'single_instance',
                                        run_two_description = 'single instance',
-                                       run_one_description = 'multi coupler')
+                                       run_one_description = 'multi driver')
 
     def _case_one_setup(self):
         # The multicoupler case will increase the number of tasks by the
         # number of requested couplers.
-        self._case.set_value("MULTI_COUPLER",True)
+        self._case.set_value("MULTI_DRIVER",True)
         self._case.set_value("NINST", self._test_instances)
-        self._case.set_value("NINST_ESP", 1)
         case_setup(self._case, test_mode=False, reset=True)
 
     def _case_two_setup(self):

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -26,9 +26,10 @@ class MCC(SystemTestsCompareTwo):
         # The multicoupler case will increase the number of tasks by the
         # number of requested couplers.
         self._case.set_value("MULTI_COUPLER",True)
-        self._case.set_value("NINST_CPL", self._test_instances)
+        self._case.set_value("NINST", self._test_instances)
+        self._case.set_value("NINST_ESP", 1)
         case_setup(self._case, test_mode=False, reset=True)
 
     def _case_two_setup(self):
-        self._case.set_value("NINST_CPL", 1)
+        self._case.set_value("NINST", 1)
         case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -2,8 +2,7 @@
 Implemetation of CIME MCC test: Compares ensemble methods
 
 This does two runs: In the first we run a three member ensemble using the
-original multi component single coupler method and in the second we use
-the new multi coupler method.  We then compare results with the expectation that they are bfb
+ MULTI_COUPLER capability, then we run a second single instance case and compare
 """
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
@@ -19,13 +18,14 @@ class MCC(SystemTestsCompareTwo):
         self._test_instances = 3
         SystemTestsCompareTwo.__init__(self, case,
                                        separate_builds = False,
-                                       run_two_suffix = 'multicoupler',
-                                       run_one_description = 'single instance',
-                                       run_two_description = 'multi coupler')
+                                       run_two_suffix = 'single_instance',
+                                       run_two_description = 'single instance',
+                                       run_one_description = 'multi coupler')
 
     def _case_one_setup(self):
         # The multicoupler case will increase the number of tasks by the
         # number of requested couplers.
+        self._case.set_value("MULTI_COUPLER",True)
         self._case.set_value("NINST_CPL", self._test_instances)
         case_setup(self._case, test_mode=False, reset=True)
 

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -26,9 +26,9 @@ class MCC(SystemTestsCompareTwo):
     def _case_one_setup(self):
         # The multicoupler case will increase the number of tasks by the
         # number of requested couplers.
-        self._case.set_value("COUPLER_COUNT", self._test_instances)
+        self._case.set_value("NINST_CPL", self._test_instances)
         case_setup(self._case, test_mode=False, reset=True)
 
     def _case_two_setup(self):
-        self._case.set_value("COUPLER_COUNT", 1)
+        self._case.set_value("NINST_CPL", 1)
         case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -1,0 +1,34 @@
+"""
+Implemetation of CIME MCC test: Compares ensemble methods
+
+This does two runs: In the first we run a three member ensemble using the
+original multi component single coupler method and in the second we use
+the new multi coupler method.  We then compare results with the expectation that they are bfb
+"""
+from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
+from CIME.case_setup import case_setup
+
+logger = logging.getLogger(__name__)
+
+
+class MCC(SystemTestsCompareTwo):
+
+    def __init__(self, case):
+        self._comp_classes = []
+        self._test_instances = 3
+        SystemTestsCompareTwo.__init__(self, case,
+                                       separate_builds = False,
+                                       run_two_suffix = 'multicoupler',
+                                       run_one_description = 'single instance',
+                                       run_two_description = 'multi coupler')
+
+    def _case_one_setup(self):
+        # The multicoupler case will increase the number of tasks by the
+        # number of requested couplers.
+        self._case.set_value("NINST_CPL", self._test_instances)
+        case_setup(self._case, test_mode=False, reset=True)
+
+    def _case_two_setup(self):
+        self._case.set_value("NINST_CPL", 1)
+        case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -17,7 +17,7 @@ class MCC(SystemTestsCompareTwo):
         self._comp_classes = []
         self._test_instances = 3
         SystemTestsCompareTwo.__init__(self, case,
-                                       separate_builds = False,
+                                       separate_builds = True,
                                        run_two_suffix = 'single_instance',
                                        run_two_description = 'single instance',
                                        run_one_description = 'multi coupler')

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -85,11 +85,11 @@ class PRE(SystemTestsCompareTwo):
         else:
             pause_comps = pause_comps.split(':')
 
-        multi_coupler = self._case.get_value("MULTI_COUPLER")
+        multi_driver = self._case.get_value("MULTI_DRIVER")
 
         for comp in pause_comps:
             if comp == "cpl":
-                if multi_coupler:
+                if multi_driver:
                     ninst = self._case.get_value("NINST_MAX")
                 else:
                     ninst = 1

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -95,6 +95,7 @@ class PRE(SystemTestsCompareTwo):
                     ninst = 1
             else:
                 ninst = self._case.get_value("NINST_{}".format(comp.upper()))
+
             comp_name = self._case.get_value('COMP_{}'.format(comp.upper()))
             for index in range(1,ninst+1):
                 if ninst == 1:

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -234,15 +234,18 @@ class SystemTestsCommon(object):
             case_st_archive(self._case)
 
     def _coupler_log_indicates_run_complete(self):
-        newestcpllogfile = self._case.get_latest_cpl_log()
-        logger.debug("Latest Coupler log file is {}".format(newestcpllogfile))
+        newestcpllogfiles = self._get_latest_cpl_logs()
+        logger.debug("Latest Coupler log file(s) {}" .format(newestcpllogfiles))
         # Exception is raised if the file is not compressed
-        try:
-            if "SUCCESSFUL TERMINATION" in gzip.open(newestcpllogfile, 'rb').read():
-                return True
-        except:
-            logger.info("{} is not compressed, assuming run failed".format(newestcpllogfile))
-        return False
+        allgood = len(newestcpllogfiles)
+        for cpllog in newestcpllogfiles:
+            try:
+                if "SUCCESSFUL TERMINATION" in gzip.open(cpllog, 'rb').read():
+                    allgood = allgood - 1
+            except:
+                logger.info("{} is not compressed, assuming run failed".format(cpllog))
+
+        return allgood==0
 
     def _component_compare_copy(self, suffix):
         comments = copy(self._case, suffix)
@@ -304,33 +307,33 @@ class SystemTestsCommon(object):
         Examine memory usage as recorded in the cpl log file and look for unexpected
         increases.
         """
-        cpllog = self._case.get_latest_cpl_log()
+        latestcpllogs = self._get_latest_cpl_logs()
+        for cpllog in latestcpllogs:
+            memlist = self._get_mem_usage(cpllog)
 
-        memlist = self._get_mem_usage(cpllog)
-
-        with self._test_status:
-            if len(memlist)<3:
-                self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS, comments="insuffiencient data for memleak test")
-            else:
-                finaldate = int(memlist[-1][0])
-                originaldate = int(memlist[0][0])
-                finalmem = float(memlist[-1][1])
-                originalmem = float(memlist[0][1])
-                memdiff = -1
-                if originalmem > 0:
-                    memdiff = (finalmem - originalmem)/originalmem
-                tolerance = self._case.get_value("TEST_MEMLEAK_TOLERANCE")
-                if tolerance is None:
-                    tolerance = 0.1
-                expect(tolerance > 0.0, "Bad value for memleak tolerance in test")
-                if memdiff < 0:
+            with self._test_status:
+                if len(memlist)<3:
                     self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS, comments="insuffiencient data for memleak test")
-                elif memdiff < tolerance:
-                    self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS)
                 else:
-                    comment = "memleak detected, memory went from {:f} to {:f} in {:d} days".format(originalmem, finalmem, finaldate-originaldate)
-                    append_testlog(comment)
-                    self._test_status.set_status(MEMLEAK_PHASE, TEST_FAIL_STATUS, comments=comment)
+                    finaldate = int(memlist[-1][0])
+                    originaldate = int(memlist[0][0])
+                    finalmem = float(memlist[-1][1])
+                    originalmem = float(memlist[0][1])
+                    memdiff = -1
+                    if originalmem > 0:
+                        memdiff = (finalmem - originalmem)/originalmem
+                    tolerance = self._case.get_value("TEST_MEMLEAK_TOLERANCE")
+                    if tolerance is None:
+                        tolerance = 0.1
+                    expect(tolerance > 0.0, "Bad value for memleak tolerance in test")
+                    if memdiff < 0:
+                        self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS, comments="insuffiencient data for memleak test")
+                    elif memdiff < tolerance:
+                        self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS)
+                    else:
+                        comment = "memleak detected, memory went from {:f} to {:f} in {:d} days".format(originalmem, finalmem, finaldate-originaldate)
+                        append_testlog(comment)
+                        self._test_status.set_status(MEMLEAK_PHASE, TEST_FAIL_STATUS, comments=comment)
 
     def compare_env_run(self, expected=None):
         """
@@ -349,6 +352,25 @@ class SystemTestsCommon(object):
                 return False
         return True
 
+    def _get_latest_cpl_logs(self):
+        """
+        find and return the latest cpl log file in the run directory
+        """
+        coupler_log_path = self._case.get_value("RUNDIR")
+        cpllogs = glob.glob(os.path.join(coupler_log_path, 'cpl*.log.*'))
+        lastcpllogs = []
+        if cpllogs:
+            lastcpllogs.append(max(cpllogs, key=os.path.getctime))
+            basename = os.path.basename(lastcpllogs[0])
+            suffix = basename.split('.',1)[1]
+            for log in cpllogs:
+                if log in lastcpllogs:
+                    continue
+                if log.endswith(suffix):
+                    lastcpllogs.append(log)
+
+        return lastcpllogs
+
     def _compare_baseline(self):
         """
         compare the current test output to a baseline result
@@ -364,42 +386,37 @@ class SystemTestsCommon(object):
             basecmp_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), baseline_name)
 
             # compare memory usage to baseline
-            newestcpllogfile = self._case.get_latest_cpl_log()
-            memlist = self._get_mem_usage(newestcpllogfile)
-            baselog = os.path.join(basecmp_dir, "cpl.log.gz")
-            if not os.path.isfile(baselog):
-                # for backward compatibility
-                baselog = os.path.join(basecmp_dir, "cpl.log")
-
-            if os.path.isfile(baselog) and len(memlist) > 3:
-                blmem = self._get_mem_usage(baselog)
-                blmem = 0 if blmem == [] else blmem[-1][1]
-                curmem = memlist[-1][1]
-                if blmem != 0:
-                    diff = (curmem - blmem) / blmem
-                    if diff < 0.1:
+            newestcpllogfiles = self._get_latest_cpl_logs()
+            memlist = self._get_mem_usage(newestcpllogfiles[0])
+            for cpllog in newestcpllogfiles:
+                m = re.search(r"(cpl.*.log).*.gz",cpllog)
+                if m is not None:
+                    baselog = os.path.join(basecmp_dir, m.group(1))+".gz"
+                if baselog is None or not os.path.isfile(baselog):
+                    # for backward compatibility
+                    baselog = os.path.join(basecmp_dir, "cpl.log")
+                if os.path.isfile(baselog) and len(memlist) > 3:
+                    blmem = self._get_mem_usage(baselog)[-1][1]
+                    curmem = memlist[-1][1]
+                    diff = (curmem-blmem)/blmem
+                    if(diff < 0.1):
                         self._test_status.set_status(MEMCOMP_PHASE, TEST_PASS_STATUS)
                     else:
                         comment = "Error: Memory usage increase > 10% from baseline"
                         self._test_status.set_status(MEMCOMP_PHASE, TEST_FAIL_STATUS, comments=comment)
                         append_testlog(comment)
-                else:
-                    comment = "Error: Could not determine baseline memory usage"
-                    self._test_status.set_status(MEMCOMP_PHASE, TEST_FAIL_STATUS, comments=comment)
-                    append_testlog(comment)
-
-            # compare throughput to baseline
-            current = self._get_throughput(newestcpllogfile)
-            baseline = self._get_throughput(baselog)
-            #comparing ypd so bigger is better
-            if baseline is not None and current is not None:
-                diff = (baseline - current)/baseline
-                if(diff < 0.25):
-                    self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)
-                else:
-                    comment = "Error: Computation time increase > 25% from baseline"
-                    self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
-                    append_testlog(comment)
+                    # compare throughput to baseline
+                    current = self._get_throughput(cpllog)
+                    baseline = self._get_throughput(baselog)
+                    #comparing ypd so bigger is better
+                    if baseline is not None and current is not None:
+                        diff = (baseline - current)/baseline
+                        if(diff < 0.25):
+                            self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)
+                        else:
+                            comment = "Error: Computation time increase > 25% from baseline"
+                            self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
+                            append_testlog(comment)
 
     def _generate_baseline(self):
         """
@@ -412,6 +429,16 @@ class SystemTestsCommon(object):
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             baseline_name = self._case.get_value("BASEGEN_CASE")
             self._test_status.set_status("{}".format(GENERATE_PHASE), status, comments=os.path.dirname(baseline_name))
+            basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))
+            # copy latest cpl log to baseline
+            # drop the date so that the name is generic
+            newestcpllogfiles = self._get_latest_cpl_logs()
+            for cpllog in newestcpllogfiles:
+                m = re.search(r"(cpl.*.log).*.gz",cpllog)
+                if m is not None:
+                    baselog = os.path.join(basegen_dir, m.group(1))+".gz"
+                    shutil.copyfile(cpllog,
+                                    os.path.join(basegen_dir,baselog))
 
 class FakeTest(SystemTestsCommon):
     """

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -368,7 +368,6 @@ class SystemTestsCommon(object):
                     continue
                 if log.endswith(suffix):
                     lastcpllogs.append(log)
-
         return lastcpllogs
 
     def _compare_baseline(self):
@@ -389,7 +388,7 @@ class SystemTestsCommon(object):
             newestcpllogfiles = self._get_latest_cpl_logs()
             memlist = self._get_mem_usage(newestcpllogfiles[0])
             for cpllog in newestcpllogfiles:
-                m = re.search(r"(cpl.*.log).*.gz",cpllog)
+                m = re.search(r"/(cpl.*.log).*.gz",cpllog)
                 if m is not None:
                     baselog = os.path.join(basecmp_dir, m.group(1))+".gz"
                 if baselog is None or not os.path.isfile(baselog):
@@ -434,7 +433,7 @@ class SystemTestsCommon(object):
             # drop the date so that the name is generic
             newestcpllogfiles = self._get_latest_cpl_logs()
             for cpllog in newestcpllogfiles:
-                m = re.search(r"(cpl.*.log).*.gz",cpllog)
+                m = re.search(r"/(cpl.*.log).*.gz",cpllog)
                 if m is not None:
                     baselog = os.path.join(basegen_dir, m.group(1))+".gz"
                     shutil.copyfile(cpllog,

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -366,8 +366,10 @@ class SystemTestsCommon(object):
             for log in cpllogs:
                 if log in lastcpllogs:
                     continue
+
                 if log.endswith(suffix):
                     lastcpllogs.append(log)
+
         return lastcpllogs
 
     def _compare_baseline(self):

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -222,7 +222,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 self._activate_case2()
                 # we need to make sure run2 is properly staged.
                 if run_type != "startup":
-                    check_case(self._case2, self._caseroot2)
+                    check_case(self._case2)
                 self._force_case2_settings()
 
                 self._case_two_custom_prerun_action()

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -228,7 +228,6 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 self._case_two_custom_prerun_action()
                 self.run_indv(suffix = self._run_two_suffix)
                 self._case_two_custom_postrun_action()
-
             # Compare results
             # Case1 is the "main" case, and we need to do the comparisons from there
             self._activate_case1()

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -121,7 +121,7 @@ class EntryID(GenericXML):
                     max_score = score
                     mnode = node
             else:
-                expect(False, 
+                expect(False,
                        "match attribute can only have a value of 'last' or 'first', value is %s" %match_type)
 
         return mnode.text
@@ -400,20 +400,27 @@ class EntryID(GenericXML):
                 if f1val is not None:
                     f2val = other.get_value(vid, resolved=False)
                     if f1val != f2val:
+                        logger.info("HERE %s %s "%(f1val, f2val))
                         xmldiffs[vid] = [f1val, f2val]
                 else:
-                    f1val = ET.tostring(node, method="text")
-                    f2val = ET.tostring(f2match, method="text")
-                    if f2val != f1val:
-                        f1value_nodes = self.get_nodes("value", root=node)
-                        for valnode in f1value_nodes:
-                            f2valnodes = other.get_nodes("value", root=f2match, attributes=valnode.attrib)
-                            for f2valnode in f2valnodes:
-                                if valnode.attrib is None and f2valnode.attrib is None or \
-                                   f2valnode.attrib == valnode.attrib:
-                                    if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
-                                        xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
-
+                    for comp in self.get_values("COMP_CLASSES"):
+                        f1val = self.get_value("{}_{}".format(vid,comp), resolved=False)
+                        if f1val is not None:
+                            f2val = other.get_value("{}_{}".format(vid,comp), resolved=False)
+                            if f1val != f2val:
+                                xmldiffs[vid] = [f1val, f2val]
+                        else:
+                            f1val = ET.tostring(node, method="text")
+                            f2val = ET.tostring(f2match, method="text")
+                            if f2val != f1val:
+                                f1value_nodes = self.get_nodes("value", root=node)
+                                for valnode in f1value_nodes:
+                                    f2valnodes = other.get_nodes("value", root=f2match, attributes=valnode.attrib)
+                                for f2valnode in f2valnodes:
+                                    if valnode.attrib is None and f2valnode.attrib is None or \
+                                       f2valnode.attrib == valnode.attrib:
+                                        if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
+                                            xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
         return xmldiffs
 
     def __iter__(self):

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -400,7 +400,6 @@ class EntryID(GenericXML):
                 if f1val is not None:
                     f2val = other.get_value(vid, resolved=False)
                     if f1val != f2val:
-                        logger.info("HERE %s %s "%(f1val, f2val))
                         xmldiffs[vid] = [f1val, f2val]
                 else:
                     for comp in self.get_values("COMP_CLASSES"):

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -416,11 +416,11 @@ class EntryID(GenericXML):
                                 f1value_nodes = self.get_nodes("value", root=node)
                                 for valnode in f1value_nodes:
                                     f2valnodes = other.get_nodes("value", root=f2match, attributes=valnode.attrib)
-                                for f2valnode in f2valnodes:
-                                    if valnode.attrib is None and f2valnode.attrib is None or \
-                                       f2valnode.attrib == valnode.attrib:
-                                        if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
-                                            xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
+                                    for f2valnode in f2valnodes:
+                                        if valnode.attrib is None and f2valnode.attrib is None or \
+                                           f2valnode.attrib == valnode.attrib:
+                                            if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
+                                                xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
         return xmldiffs
 
     def __iter__(self):

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -19,62 +19,69 @@ class EnvMachPes(EnvBase):
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_pes.xsd")
         EnvBase.__init__(self, case_root, infile, schema=schema)
 
-    def set_value(self, vid, value, subgroup=None, ignore_type=False):
-        """
-        Set the value of an entry-id field to value
-        Returns the value or None if not found
-        subgroup is ignored in the general routine and applied in specific methods
-        """
-        oldcomps = self._components[:]
-        nvid, comp, _ = self.check_if_comp_var(vid, None)
-        if nvid == "NINST":
-            if self.get_value("MULTI_COUPLER"):
-                self._components = ["CPL"]
-                if comp is None:
-                    comp = "CPL"
-                expect(comp == "CPL" or value == 1,"Cannot change {} when MULTI_COUPLER flag is TRUE".format(vid))
-            elif value != 1:
-                if 'CPL' in self._components:
-                    self._components.remove('CPL')
-                if 'ESP' in self._components and value != 1:
-                    self._components.remove('ESP')
-                expect(comp is None or comp != "CPL","Cannot change NINST_CPL if MULTI_COUPLER flag is FALSE")
-        # Toggling the
-        if vid == "MULTI_COUPLER":
-            newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-            if value:
-                maxinst = 1
-                for tcomp in self._components:
-                    if tcomp in ["CPL"]:
-                        continue
-                    tcomp_inst = "NINST_{}".format(tcomp)
-                    maxinst = max(maxinst, self.get_value(tcomp_inst))
-                    EnvBase.set_value(self,tcomp_inst, 1)
-                    self.set_value("NINST_CPL", maxinst)
-            else:
-                ninst = self.get_value("NINST_CPL")
-                newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-                cpl_index = None
-                esp_index = None
-                if 'CPL' in self._components:
-                    cpl_index = self._components.index('CPL')
-                    del self._components[cpl_index]
-                if 'ESP' in self._components:
-                    esp_index = self._components.index('ESP')
-                    del self._components[esp_index]
+    # def set_value(self, vid, value, subgroup=None, ignore_type=False):
+    #     """
+    #     Set the value of an entry-id field to value
+    #     Returns the value or None if not found
+    #     subgroup is ignored in the general routine and applied in specific methods
+    #     """
+    #     oldcomps = self._components[:]
+    #     nvid, comp, _ = self.check_if_comp_var(vid, None)
+    #     if nvid == "NINST":
+    #         if self.get_value("MULTI_COUPLER"):
+    #             self._components = ["CPL"]
+    #             if comp is None:
+    #                 comp = "CPL"
+    #             expect(comp == "CPL" or value == 1,"Cannot change {} when MULTI_COUPLER flag is TRUE".format(vid))
+    #         elif value != 1:
+    #             if 'CPL' in self._components:
+    #                 self._components.remove('CPL')
+    #             if 'ESP' in self._components and value != 1:
+    #                 self._components.remove('ESP')
+    #             expect(comp is None or comp != "CPL","Cannot change NINST_CPL if MULTI_COUPLER flag is FALSE")
+    #     # Toggling the
+    #     if vid == "MULTI_COUPLER":
+    #         newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
+    #         if value:
+    #             maxinst = 1
+    #             for tcomp in self._components:
+    #                 if tcomp in ["CPL"]:
+    #                     continue
+    #                 tcomp_inst = "NINST_{}".format(tcomp)
+    #                 maxinst = max(maxinst, self.get_value(tcomp_inst))
+    #                 EnvBase.set_value(self,tcomp_inst, 1)
+    #                 self.set_value("NINST_CPL", maxinst)
+    #         else:
+    #             ninst = self.get_value("NINST_CPL")
+    #             newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
+    #             cpl_index = None
+    #             esp_index = None
+    #             if 'CPL' in self._components:
+    #                 cpl_index = self._components.index('CPL')
+    #                 del self._components[cpl_index]
+    #             if 'ESP' in self._components:
+    #                 esp_index = self._components.index('ESP')
+    #                 del self._components[esp_index]
 
-                EnvBase.set_value(self, "NINST", ninst)
-                if cpl_index is not None:
-                    self._components.insert(cpl_index,'CPL')
-                if esp_index is not None:
-                    self._components.insert(esp_index,'ESP')
-                EnvBase.set_value(self, "NINST_CPL", 1)
-        else:
-            newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-        self._components = oldcomps
-        return newval
+    #             EnvBase.set_value(self, "NINST", ninst)
+    #             if cpl_index is not None:
+    #                 self._components.insert(cpl_index,'CPL')
+    #             if esp_index is not None:
+    #                 self._components.insert(esp_index,'ESP')
+    #             EnvBase.set_value(self, "NINST_CPL", 1)
+    #     else:
+    #         newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
+    #     self._components = oldcomps
+    #     return newval
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
+
+        if vid == "NINST_MAX":
+            value = 1
+            for comp in self._components:
+                value = max(value, self.get_value("NINST_{}".format(comp)))
+            return value
+
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
 
         if "NTASKS" in vid or "ROOTPE" in vid:
@@ -112,14 +119,16 @@ class EnvMachPes(EnvBase):
 
     def get_total_tasks(self, comp_classes):
         total_tasks = 0
+        maxinst = 1
         for comp in comp_classes:
             ntasks = self.get_value("NTASKS", attribute={"component":comp})
             rootpe = self.get_value("ROOTPE", attribute={"component":comp})
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
+            maxinst = max(maxinst, self.get_value("NINST", attribute={"component":comp}))
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
         if self.get_value("MULTI_COUPLER"):
-            total_tasks *= self.get_value("NINST_CPL")
+            total_tasks *= maxinst
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -19,6 +19,32 @@ class EnvMachPes(EnvBase):
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_pes.xsd")
         EnvBase.__init__(self, case_root, infile, schema=schema)
 
+    def set_value(self, vid, value, subgroup=None, ignore_type=False):
+        """
+        Set the value of an entry-id field to value
+        Returns the value or None if not found
+        subgroup is ignored in the general routine and applied in specific methods
+        """
+        vid, comp, iscompvar = self.check_if_comp_var(vid, None)
+        if vid == "COUPLER_COUNT":
+            if value > 1:
+                for othercomp in self._components:
+                    if othercomp != "CPL":
+                        ninst_string = "NINST_{}".format(othercomp)
+                        expect(self.get_value(ninst_string)==1,
+                               "Cannot change COUPLER_COUNT value if {} > 1".format(ninst_string))
+            elif value < 0:
+                # negative value effectively overrides safety check
+                value = -value
+        elif vid == "NINST":
+            if value > 1:
+                coupler_count = self.get_value("COUPLER_COUNT")
+                expect(coupler_count == 1,"Cannot change NINST value if COUPLER_COUNT > 1")
+            elif value < 0:
+                # negative value effectively overrides safety check
+                value = -value
+        return EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
+
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
 
@@ -63,7 +89,7 @@ class EnvMachPes(EnvBase):
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
-        total_tasks *= self.get_value("NINST_CPL")
+        total_tasks *= self.get_value("COUPLER_COUNT")
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -25,7 +25,7 @@ class EnvMachPes(EnvBase):
         Returns the value or None if not found
         subgroup is ignored in the general routine and applied in specific methods
         """
-        vid, comp, iscompvar = self.check_if_comp_var(vid, None)
+        nvid, comp, iscompvar = self.check_if_comp_var(vid, None)
         if vid == "COUPLER_COUNT":
             if value > 1:
                 for othercomp in self._components:
@@ -36,7 +36,7 @@ class EnvMachPes(EnvBase):
             elif value < 0:
                 # negative value effectively overrides safety check
                 value = -value
-        elif vid == "NINST":
+        elif nvid == "NINST":
             if value > 1:
                 coupler_count = self.get_value("COUPLER_COUNT")
                 expect(coupler_count == 1,"Cannot change NINST value if COUPLER_COUNT > 1")

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -72,7 +72,7 @@ class EnvMachPes(EnvBase):
             maxinst = max(maxinst, self.get_value("NINST", attribute={"component":comp}))
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
-        if self.get_value("MULTI_COUPLER"):
+        if self.get_value("MULTI_DRIVER"):
             total_tasks *= maxinst
         return total_tasks
 

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -63,8 +63,6 @@ class EnvMachPes(EnvBase):
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
-        import pdb
-        pdb.set_trace()
         total_tasks *= self.get_value("NINST_CPL")
         return total_tasks
 

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -38,6 +38,24 @@ class EnvMachPes(EnvBase):
 
         return value
 
+    def set_value(self, vid, value, subgroup=None, ignore_type=False):
+        """
+        Set the value of an entry-id field to value
+        Returns the value or None if not found
+        subgroup is ignored in the general routine and applied in specific methods
+        """
+        if vid == "MULTI_DRIVER" and value:
+            ninst_max = self.get_value("NINST_MAX")
+            for comp in self._components:
+                if comp == "CPL":
+                    continue
+                ninst = self.get_value("NINST_{}".format(comp))
+                expect(ninst == ninst_max,
+                       "All components must have the same NINST value in multi_driver mode.  NINST_{}={} shoud be {}".format(comp,ninst,ninst_max))
+
+        return EnvBase.set_value(self, vid, value, subgroup=subgroup, ignore_type=ignore_type)
+
+
     def get_max_thread_count(self, comp_classes):
         ''' Find the maximum number of openmp threads for any component in the case '''
         max_threads = 1

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -63,6 +63,8 @@ class EnvMachPes(EnvBase):
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
+        import pdb
+        pdb.set_trace()
         total_tasks *= self.get_value("NINST_CPL")
         return total_tasks
 

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -20,7 +20,8 @@ class EnvMachPes(EnvBase):
         EnvBase.__init__(self, case_root, infile, schema=schema)
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
-
+        # Special variable NINST_MAX is used to determine the number of
+        # drivers in multi-driver mode.
         if vid == "NINST_MAX":
             value = 1
             for comp in self._components:

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -26,7 +26,7 @@ class EnvMachPes(EnvBase):
         subgroup is ignored in the general routine and applied in specific methods
         """
         oldcomps = self._components[:]
-        nvid, comp, iscompvar = self.check_if_comp_var(vid, None)
+        nvid, comp, _ = self.check_if_comp_var(vid, None)
         if nvid == "NINST":
             if self.get_value("MULTI_COUPLER"):
                 self._components = ["CPL"]
@@ -41,7 +41,6 @@ class EnvMachPes(EnvBase):
                 expect(comp is None or comp != "CPL","Cannot change NINST_CPL if MULTI_COUPLER flag is FALSE")
         # Toggling the
         if vid == "MULTI_COUPLER":
-            oldval = self.get_value("MULTI_COUPLER")
             newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
             if value:
                 maxinst = 1

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -63,6 +63,7 @@ class EnvMachPes(EnvBase):
             pstrid = self.get_value("PSTRID", attribute={"component":comp})
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
+        total_tasks *= self.get_value("NINST_CPL")
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -19,61 +19,6 @@ class EnvMachPes(EnvBase):
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_pes.xsd")
         EnvBase.__init__(self, case_root, infile, schema=schema)
 
-    # def set_value(self, vid, value, subgroup=None, ignore_type=False):
-    #     """
-    #     Set the value of an entry-id field to value
-    #     Returns the value or None if not found
-    #     subgroup is ignored in the general routine and applied in specific methods
-    #     """
-    #     oldcomps = self._components[:]
-    #     nvid, comp, _ = self.check_if_comp_var(vid, None)
-    #     if nvid == "NINST":
-    #         if self.get_value("MULTI_COUPLER"):
-    #             self._components = ["CPL"]
-    #             if comp is None:
-    #                 comp = "CPL"
-    #             expect(comp == "CPL" or value == 1,"Cannot change {} when MULTI_COUPLER flag is TRUE".format(vid))
-    #         elif value != 1:
-    #             if 'CPL' in self._components:
-    #                 self._components.remove('CPL')
-    #             if 'ESP' in self._components and value != 1:
-    #                 self._components.remove('ESP')
-    #             expect(comp is None or comp != "CPL","Cannot change NINST_CPL if MULTI_COUPLER flag is FALSE")
-    #     # Toggling the
-    #     if vid == "MULTI_COUPLER":
-    #         newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-    #         if value:
-    #             maxinst = 1
-    #             for tcomp in self._components:
-    #                 if tcomp in ["CPL"]:
-    #                     continue
-    #                 tcomp_inst = "NINST_{}".format(tcomp)
-    #                 maxinst = max(maxinst, self.get_value(tcomp_inst))
-    #                 EnvBase.set_value(self,tcomp_inst, 1)
-    #                 self.set_value("NINST_CPL", maxinst)
-    #         else:
-    #             ninst = self.get_value("NINST_CPL")
-    #             newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-    #             cpl_index = None
-    #             esp_index = None
-    #             if 'CPL' in self._components:
-    #                 cpl_index = self._components.index('CPL')
-    #                 del self._components[cpl_index]
-    #             if 'ESP' in self._components:
-    #                 esp_index = self._components.index('ESP')
-    #                 del self._components[esp_index]
-
-    #             EnvBase.set_value(self, "NINST", ninst)
-    #             if cpl_index is not None:
-    #                 self._components.insert(cpl_index,'CPL')
-    #             if esp_index is not None:
-    #                 self._components.insert(esp_index,'ESP')
-    #             EnvBase.set_value(self, "NINST_CPL", 1)
-    #     else:
-    #         newval = EnvBase.set_value(self, vid, value,subgroup=subgroup, ignore_type=ignore_type)
-    #     self._components = oldcomps
-    #     return newval
-
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, pes_per_node=None): # pylint: disable=arguments-differ
 
         if vid == "NINST_MAX":

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -283,7 +283,7 @@ class GenericXML(object):
         return None
 
     def get_raw_record(self, root=None):
-        logger.info("writing file {}".format(self.filename))
+        logger.debug("writing file {}".format(self.filename))
         if root is None:
             root = self.root
         try:

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -82,8 +82,6 @@ class GenericXML(object):
             doc = minidom.parseString(xmlstr)
             with open(outfile,'w') as xmlout:
                 doc.writexml(xmlout,addindent='  ')
-        append_status("Flush completed at {}".format(get_timestamp()), CaseStatus)
-
 
     def get_node(self, nodename, attributes=None, root=None, xpath=None):
         """
@@ -286,6 +284,7 @@ class GenericXML(object):
         return None
 
     def get_raw_record(self, root=None):
+        logger.info("writing file {}".format(self.filename))
         if root is None:
             root = self.root
         try:

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -5,7 +5,6 @@ be used by other XML interface modules and not directly.
 from CIME.XML.standard_module_setup import *
 from distutils.spawn import find_executable
 from xml.dom import minidom
-from CIME.utils import append_status
 import getpass
 
 logger = logging.getLogger(__name__)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -5,7 +5,7 @@ be used by other XML interface modules and not directly.
 from CIME.XML.standard_module_setup import *
 from distutils.spawn import find_executable
 from xml.dom import minidom
-
+from CIME.utils import append_status
 import getpass
 
 logger = logging.getLogger(__name__)
@@ -82,6 +82,8 @@ class GenericXML(object):
             doc = minidom.parseString(xmlstr)
             with open(outfile,'w') as xmlout:
                 doc.writexml(xmlout,addindent='  ')
+        append_status("Flush completed at {}".format(get_timestamp()), CaseStatus)
+
 
     def get_node(self, nodename, attributes=None, root=None, xpath=None):
         """

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -398,14 +398,16 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
 
     complist = []
     for comp_class in comp_classes:
-        ninst = case.get_value("NINST_{}".format(comp_class))
         if comp_class == "CPL":
+            ninst = case.get_value("COUPLER_COUNT")
             config_dir = None
+            expect(ninst is not None,"Failed to get COUPLER_COUNT value")
         else:
+            ninst = case.get_value("NINST_{}".format(comp_class))
             config_dir = os.path.dirname(case.get_value("CONFIG_{}_FILE".format(comp_class)))
+            expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))
         comp = case.get_value("COMP_{}".format(comp_class))
         thrds =  case.get_value("NTHRDS_{}".format(comp_class))
-        expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))
         complist.append((comp_class.lower(), comp, thrds, ninst, config_dir ))
         os.environ["COMP_{}".format(comp_class)] = comp
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -398,16 +398,14 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
 
     complist = []
     for comp_class in comp_classes:
+        ninst = case.get_value("NINST_{}".format(comp_class))
         if comp_class == "CPL":
-            ninst = case.get_value("COUPLER_COUNT")
             config_dir = None
-            expect(ninst is not None,"Failed to get COUPLER_COUNT value")
         else:
-            ninst = case.get_value("NINST_{}".format(comp_class))
             config_dir = os.path.dirname(case.get_value("CONFIG_{}_FILE".format(comp_class)))
-            expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))
         comp = case.get_value("COMP_{}".format(comp_class))
         thrds =  case.get_value("NTHRDS_{}".format(comp_class))
+        expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))
         complist.append((comp_class.lower(), comp, thrds, ninst, config_dir ))
         os.environ["COMP_{}".format(comp_class)] = comp
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -382,7 +382,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
 
     comp_classes = case.get_values("COMP_CLASSES")
 
-    check_lockedfiles(caseroot)
+    check_lockedfiles(case)
 
     # Retrieve relevant case data
     # This environment variable gets set for cesm Make and

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -395,14 +395,21 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
     incroot             = os.path.abspath(case.get_value("INCROOT"))
     libroot             = os.path.abspath(case.get_value("LIBROOT"))
     sharedlibroot       = os.path.abspath(case.get_value("SHAREDLIBROOT"))
-
+    multi_coupler = case.get_value("MULTI_COUPLER")
     complist = []
+    ninst = 1
     for comp_class in comp_classes:
-        ninst = case.get_value("NINST_{}".format(comp_class))
         if comp_class == "CPL":
             config_dir = None
+            if multi_coupler:
+                ninst = case.get_value("NINST_MAX")
         else:
             config_dir = os.path.dirname(case.get_value("CONFIG_{}_FILE".format(comp_class)))
+            if multi_coupler:
+                ninst = 1
+            else:
+                ninst = case.get_value("NINST_{}".format(comp_class))
+
         comp = case.get_value("COMP_{}".format(comp_class))
         thrds =  case.get_value("NTHRDS_{}".format(comp_class))
         expect(ninst is not None,"Failed to get ninst for comp_class {}".format(comp_class))

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -398,11 +398,10 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
 
     complist = []
     for comp_class in comp_classes:
+        ninst = case.get_value("NINST_{}".format(comp_class))
         if comp_class == "CPL":
-            ninst = 1
             config_dir = None
         else:
-            ninst = case.get_value("NINST_{}".format(comp_class))
             config_dir = os.path.dirname(case.get_value("CONFIG_{}_FILE".format(comp_class)))
         comp = case.get_value("COMP_{}".format(comp_class))
         thrds =  case.get_value("NTHRDS_{}".format(comp_class))

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -395,17 +395,17 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
     incroot             = os.path.abspath(case.get_value("INCROOT"))
     libroot             = os.path.abspath(case.get_value("LIBROOT"))
     sharedlibroot       = os.path.abspath(case.get_value("SHAREDLIBROOT"))
-    multi_coupler = case.get_value("MULTI_COUPLER")
+    multi_driver = case.get_value("MULTI_DRIVER")
     complist = []
     ninst = 1
     for comp_class in comp_classes:
         if comp_class == "CPL":
             config_dir = None
-            if multi_coupler:
+            if multi_driver:
                 ninst = case.get_value("NINST_MAX")
         else:
             config_dir = os.path.dirname(case.get_value("CONFIG_{}_FILE".format(comp_class)))
-            if multi_coupler:
+            if multi_driver:
                 ninst = 1
             else:
                 ninst = case.get_value("NINST_{}".format(comp_class))

--- a/scripts/lib/CIME/buildnml.py
+++ b/scripts/lib/CIME/buildnml.py
@@ -78,7 +78,7 @@ def build_xcpl_nml(case, caseroot, compname):
         if ninst == 1:
             filename = os.path.join(rundir, "{}_in".format(compname))
         else:
-            filename = os.path.join(rundir, "{}_in_{:4.4d}".format(compname, i))
+            filename = os.path.join(rundir, "{}_in_{:04d}".format(compname, i))
 
         with open(filename, 'w') as infile:
             infile.write("{:<20d} ! i-direction global dimension\n".format(nx))

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -635,6 +635,7 @@ class Case(object):
 
         self.clean_up_lookups()
 
+
     def _setup_mach_pes(self, pecount, ncouplers, ninst, machine_name, mpilib):
         #--------------------------------------------
         # pe layout

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -727,12 +727,14 @@ class Case(object):
         for compclass in self._component_classes:
             key = "NINST_{}".format(compclass)
             if compclass == "CPL":
-                mach_pes_obj.set_value(key, ncouplers)
+                if ncouplers > 1:
+                    mach_pes_obj.set_value("MULTI_COUPLER", True)
+                    mach_pes_obj.set_value(key, ncouplers)
                 continue
             # ESP models are currently limited to 1 instance
             if compclass == "ESP":
                 mach_pes_obj.set_value(key, 1)
-            else:
+            elif ncouplers == 1:
                 mach_pes_obj.set_value(key, ninst)
 
             key = "NTASKS_{}".format(compclass)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -727,7 +727,7 @@ class Case(object):
         for compclass in self._component_classes:
             key = "NINST_{}".format(compclass)
             if compclass == "CPL":
-                mach_pes_obj.set_value("COUPLER_COUNT", ncouplers)
+                mach_pes_obj.set_value(key, ncouplers)
                 continue
             # ESP models are currently limited to 1 instance
             if compclass == "ESP":
@@ -1086,7 +1086,7 @@ class Case(object):
                 append_status("Component {} is {}".format(component_class, self._component_description[component_class]),"README.case", caseroot=self._caseroot)
             if component_class == "CPL":
                 append_status("Using %s coupler instances" %
-                              (self.get_value("COUPLER_COUNT")),
+                              (self.get_value("NINST_CPL")),
                               "README.case", caseroot=self._caseroot)
                 continue
             comp_grid = "{}_GRID".format(component_class)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -635,7 +635,6 @@ class Case(object):
 
         self.clean_up_lookups()
 
-
     def _setup_mach_pes(self, pecount, ncouplers, ninst, machine_name, mpilib):
         #--------------------------------------------
         # pe layout

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -730,11 +730,7 @@ class Case(object):
             key = "NINST_{}".format(compclass)
             if compclass == "CPL":
                 continue
-            # ESP models are currently limited to 1 instance
-            if compclass == "ESP":
-                mach_pes_obj.set_value(key, 1)
-            else:
-                mach_pes_obj.set_value(key, ninst)
+            mach_pes_obj.set_value(key, ninst)
 
             key = "NTASKS_{}".format(compclass)
             if key not in pes_ntasks.keys():

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -727,7 +727,7 @@ class Case(object):
         for compclass in self._component_classes:
             key = "NINST_{}".format(compclass)
             if compclass == "CPL":
-                mach_pes_obj.set_value(key, ncouplers)
+                mach_pes_obj.set_value("COUPLER_COUNT", ncouplers)
                 continue
             # ESP models are currently limited to 1 instance
             if compclass == "ESP":
@@ -1086,7 +1086,7 @@ class Case(object):
                 append_status("Component {} is {}".format(component_class, self._component_description[component_class]),"README.case", caseroot=self._caseroot)
             if component_class == "CPL":
                 append_status("Using %s coupler instances" %
-                              (self.get_value("NINST_CPL")),
+                              (self.get_value("COUPLER_COUNT")),
                               "README.case", caseroot=self._caseroot)
                 continue
             comp_grid = "{}_GRID".format(component_class)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -636,7 +636,7 @@ class Case(object):
         self.clean_up_lookups()
 
 
-    def _setup_mach_pes(self, pecount, multi_coupler, ninst, machine_name, mpilib):
+    def _setup_mach_pes(self, pecount, multi_driver, ninst, machine_name, mpilib):
         #--------------------------------------------
         # pe layout
         #--------------------------------------------
@@ -720,9 +720,9 @@ class Case(object):
                 val = -1*val*pes_per_node
             if val > pesize:
                 pesize = val
-        if multi_coupler:
+        if multi_driver:
             pesize *= int(ninst)
-            mach_pes_obj.set_value("MULTI_COUPLER", True)
+            mach_pes_obj.set_value("MULTI_DRIVER", True)
 
         # Make sure that every component has been accounted for
         # set, nthrds and ntasks to 1 otherwise. Also set the ninst values here.
@@ -745,7 +745,7 @@ class Case(object):
     def configure(self, compset_name, grid_name, machine_name=None,
                   project=None, pecount=None, compiler=None, mpilib=None,
                   pesfile=None,user_grid=False, gridfile=None,
-                  multi_coupler=False, ninst=1, test=False,
+                  multi_driver=False, ninst=1, test=False,
                   walltime=None, queue=None, output_root=None,
                   run_unsupported=False, answer=None,
                   input_dir=None):
@@ -836,10 +836,10 @@ class Case(object):
         env_mach_specific_obj.populate(machobj)
         self.schedule_rewrite(env_mach_specific_obj)
 
-        pesize = self._setup_mach_pes(pecount, multi_coupler, ninst, machine_name, mpilib)
+        pesize = self._setup_mach_pes(pecount, multi_driver, ninst, machine_name, mpilib)
 
-        if multi_coupler and ninst>1:
-            logger.info(" Coupler has %s instances" % ninst)
+        if multi_driver and ninst>1:
+            logger.info(" Driver/Coupler has %s instances" % ninst)
 
         #--------------------------------------------
         # batch system
@@ -1458,7 +1458,7 @@ class Case(object):
                user_mods_dir=None, machine_name=None,
                project=None, pecount=None, compiler=None, mpilib=None,
                pesfile=None,user_grid=False, gridfile=None,
-               multi_coupler=False, ninst=1, test=False,
+               multi_driver=False, ninst=1, test=False,
                walltime=None, queue=None, output_root=None,
                run_unsupported=False, answer=None,
                input_dir=None):
@@ -1473,7 +1473,7 @@ class Case(object):
                            project=project,
                            pecount=pecount, compiler=compiler, mpilib=mpilib,
                            pesfile=pesfile,user_grid=user_grid, gridfile=gridfile,
-                           multi_coupler=multi_coupler, ninst=ninst, test=test,
+                           multi_driver=multi_driver, ninst=ninst, test=test,
                            walltime=walltime, queue=queue,
                            output_root=output_root,
                            run_unsupported=run_unsupported, answer=answer,

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -255,7 +255,7 @@ def case_run(case, skip_pnl=False):
            "You are not calling the run script via the submit script. "
            "As a result, short-term archiving will not be called automatically."
            "Please submit your run using the submit script like so:"
-           " ./case.submit Time: {}".format(get_timestamp())
+           " ./case.submit Time: {}".format(get_timestamp()))
 
     # Forces user to use case.submit if they re-submit
     if case.get_value("TESTCASE") is None:

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,6 +1,6 @@
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, append_status
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,6 +1,6 @@
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, get_timestamp
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance
@@ -255,7 +255,7 @@ def case_run(case, skip_pnl=False):
            "You are not calling the run script via the submit script. "
            "As a result, short-term archiving will not be called automatically."
            "Please submit your run using the submit script like so:"
-           " ./case.submit")
+           " ./case.submit Time: {}".format(get_timestamp())
 
     # Forces user to use case.submit if they re-submit
     if case.get_value("TESTCASE") is None:

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -152,7 +152,9 @@ def post_run_check(case, lid):
 
     rundir = case.get_value("RUNDIR")
     model = case.get_value("MODEL")
-    cpl_ninst = case.get_value("NINST_CPL")
+    cpl_ninst = 1
+    if case.get_value("MULTI_COUPLER"):
+        cpl_ninst = case.get_value("NINST_MAX")
     cpl_logs = []
     if cpl_ninst > 1:
         for inst in range(cpl_ninst):

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,6 +1,6 @@
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, append_status
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance
@@ -153,14 +153,14 @@ def post_run_check(case, lid):
     rundir = case.get_value("RUNDIR")
     model = case.get_value("MODEL")
     cpl_ninst = case.get_value("NINST_CPL")
-
     cpl_logs = []
     if cpl_ninst > 1:
         for inst in range(cpl_ninst):
             cpl_logs.append(os.path.join(rundir, "cpl_%04d.log." % (inst+1) + lid))
     else:
         cpl_logs = [os.path.join(rundir, "cpl" + ".log." + lid)]
-    
+    cpl_logfile = cpl_logs[0]
+
     # find the last model.log and cpl.log
     model_logfile = os.path.join(rundir, model + ".log." + lid)
 
@@ -176,7 +176,7 @@ def post_run_check(case, lid):
             with open(cpl_logfile, 'r') as fd:
                 if 'SUCCESSFUL TERMINATION' in fd.read():
                     count_ok += 1
-        if count_ok != cpl_ninst: 
+        if count_ok != cpl_ninst:
             expect(False, "Model did not complete - see {} \n " .format(cpl_logfile))
 
 ###############################################################################

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -152,10 +152,10 @@ def post_run_check(case, lid):
 
     rundir = case.get_value("RUNDIR")
     model = case.get_value("MODEL")
-    coupler_count = case.get_value("COUPLER_COUNT")
+    cpl_ninst = case.get_value("NINST_CPL")
     cpl_logs = []
-    if coupler_count > 1:
-        for inst in range(coupler_count):
+    if cpl_ninst > 1:
+        for inst in range(cpl_ninst):
             cpl_logs.append(os.path.join(rundir, "cpl_%04d.log." % (inst+1) + lid))
     else:
         cpl_logs = [os.path.join(rundir, "cpl" + ".log." + lid)]
@@ -176,7 +176,7 @@ def post_run_check(case, lid):
             with open(cpl_logfile, 'r') as fd:
                 if 'SUCCESSFUL TERMINATION' in fd.read():
                     count_ok += 1
-        if count_ok != coupler_count:
+        if count_ok != cpl_ninst:
             expect(False, "Model did not complete - see {} \n " .format(cpl_logfile))
 
 ###############################################################################

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -152,10 +152,10 @@ def post_run_check(case, lid):
 
     rundir = case.get_value("RUNDIR")
     model = case.get_value("MODEL")
-    cpl_ninst = case.get_value("NINST_CPL")
+    coupler_count = case.get_value("COUPLER_COUNT")
     cpl_logs = []
-    if cpl_ninst > 1:
-        for inst in range(cpl_ninst):
+    if coupler_count > 1:
+        for inst in range(coupler_count):
             cpl_logs.append(os.path.join(rundir, "cpl_%04d.log." % (inst+1) + lid))
     else:
         cpl_logs = [os.path.join(rundir, "cpl" + ".log." + lid)]
@@ -176,7 +176,7 @@ def post_run_check(case, lid):
             with open(cpl_logfile, 'r') as fd:
                 if 'SUCCESSFUL TERMINATION' in fd.read():
                     count_ok += 1
-        if count_ok != cpl_ninst:
+        if count_ok != coupler_count:
             expect(False, "Model did not complete - see {} \n " .format(cpl_logfile))
 
 ###############################################################################

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,6 +1,6 @@
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, append_status
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -153,7 +153,7 @@ def post_run_check(case, lid):
     rundir = case.get_value("RUNDIR")
     model = case.get_value("MODEL")
     cpl_ninst = 1
-    if case.get_value("MULTI_COUPLER"):
+    if case.get_value("MULTI_DRIVER"):
         cpl_ninst = case.get_value("NINST_MAX")
     cpl_logs = []
     if cpl_ninst > 1:

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -28,7 +28,7 @@ def pre_run_check(case, lid, skip_pnl=False):
         shutil.copy(env_mach_pes,"{}.{}".format(env_mach_pes, lid))
 
     # check for locked files.
-    check_lockedfiles(case.get_value("CASEROOT"))
+    check_lockedfiles(case)
     logger.debug("check_lockedfiles OK")
 
     # check that build is done

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -146,7 +146,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             unlock_file("env_build.xml")
 
             case.flush()
-            check_lockedfiles()
+            check_lockedfiles(case)
             env_mach_pes = case.get_env("mach_pes")
             pestot = env_mach_pes.get_total_tasks(models)
             logger.debug("at update TOTALPES = {}".format(pestot))

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -34,11 +34,13 @@ def _build_usernl_files(case, model, comp):
     expect(os.path.isdir(model_dir),
            "cannot find cime_config directory {} for component {}".format(model_dir, comp))
 
+    ninst = case.get_value("NINST_CPL")
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
             shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")
     else:
-        ninst = case.get_value("NINST_{}".format(model))
+        if ninst == 1:
+            ninst = case.get_value("NINST_{}".format(model))
         nlfile = "user_nl_{}".format(comp)
         model_nl = os.path.join(model_dir, nlfile)
         if ninst > 1:

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -130,9 +130,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 continue
             ninst  = case.get_value("NINST_{}".format(comp))
             ntasks = case.get_value("NTASKS_{}".format(comp))
-            # ESP models are currently limited to 1 instance
-            expect((comp != "ESP") or (ninst == 1),
-                   "ESP components may only have one instance")
             if ninst > ntasks:
                 if ntasks == 1:
                     case.set_value("NTASKS_{}".format(comp), ninst)

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -45,7 +45,7 @@ def _build_usernl_files(case, model, comp):
             ninst = case.get_value("NINST_{}".format(model))
         nlfile = "user_nl_{}".format(comp)
         model_nl = os.path.join(model_dir, nlfile)
-        if ninst > 1:
+        if ninst > 1 and not comp.endswith("esp"):
             for inst_counter in xrange(1, ninst+1):
                 inst_nlfile = "{}_{:04d}".format(nlfile, inst_counter)
                 if not os.path.exists(inst_nlfile):

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -34,7 +34,7 @@ def _build_usernl_files(case, model, comp):
     expect(os.path.isdir(model_dir),
            "cannot find cime_config directory {} for component {}".format(model_dir, comp))
 
-    ninst = case.get_value("COUPLER_COUNT")
+    ninst = case.get_value("NINST_CPL")
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
             shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")
@@ -124,14 +124,13 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.
         for comp in models:
             if comp == "CPL":
-                ninst = case.get_value("COUPLER_COUNT")
-            else:
-                ninst  = case.get_value("NINST_{}".format(comp))
+                continue
+            ninst  = case.get_value("NINST_{}".format(comp))
             ntasks = case.get_value("NTASKS_{}".format(comp))
             # ESP models are currently limited to 1 instance
             expect((comp != "ESP") or (ninst == 1),
                    "ESP components may only have one instance")
-            if ninst > ntasks and comp != "CPL":
+            if ninst > ntasks:
                 if ntasks == 1:
                     case.set_value("NTASKS_{}".format(comp), ninst)
                 else:

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -34,7 +34,7 @@ def _build_usernl_files(case, model, comp):
     expect(os.path.isdir(model_dir),
            "cannot find cime_config directory {} for component {}".format(model_dir, comp))
 
-    ninst = case.get_value("NINST_CPL")
+    ninst = case.get_value("COUPLER_COUNT")
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
             shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")
@@ -124,13 +124,14 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.
         for comp in models:
             if comp == "CPL":
-                continue
-            ninst  = case.get_value("NINST_{}".format(comp))
+                ninst = case.get_value("COUPLER_COUNT")
+            else:
+                ninst  = case.get_value("NINST_{}".format(comp))
             ntasks = case.get_value("NTASKS_{}".format(comp))
             # ESP models are currently limited to 1 instance
             expect((comp != "ESP") or (ninst == 1),
                    "ESP components may only have one instance")
-            if ninst > ntasks:
+            if ninst > ntasks and comp != "CPL":
                 if ntasks == 1:
                     case.set_value("NTASKS_{}".format(comp), ninst)
                 else:

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -36,7 +36,10 @@ def _build_usernl_files(case, model, comp):
     ninst = 1
     multi_driver = case.get_value("MULTI_DRIVER")
     if multi_driver:
-        ninst = case.get_value("NINST_MAX")
+        ninst_max = case.get_value("NINST_MAX")
+        if model not in ("DRV","CPL"):
+            ninst_model = case.get_value("NINST_{}".format(model))
+            expect(ninst_model==ninst_max,"MULTI_DRIVER mode, all components must have same NINST value.  NINST_{} != {}".format(model,ninst_max))
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
             shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -34,8 +34,8 @@ def _build_usernl_files(case, model, comp):
     expect(os.path.isdir(model_dir),
            "cannot find cime_config directory {} for component {}".format(model_dir, comp))
     ninst = 1
-    multi_coupler = case.get_value("MULTI_COUPLER")
-    if multi_coupler:
+    multi_driver = case.get_value("MULTI_DRIVER")
+    if multi_driver:
         ninst = case.get_value("NINST_MAX")
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
@@ -45,7 +45,7 @@ def _build_usernl_files(case, model, comp):
             ninst = case.get_value("NINST_{}".format(model))
         nlfile = "user_nl_{}".format(comp)
         model_nl = os.path.join(model_dir, nlfile)
-        if ninst > 1 and not comp.endswith("esp"):
+        if ninst > 1:
             for inst_counter in xrange(1, ninst+1):
                 inst_nlfile = "{}_{:04d}".format(nlfile, inst_counter)
                 if not os.path.exists(inst_nlfile):
@@ -124,7 +124,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 
         # Check ninst.
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.
-        multi_coupler = case.get_value("MULTI_COUPLER")
+        multi_driver = case.get_value("MULTI_DRIVER")
         for comp in models:
             if comp == "CPL":
                 continue
@@ -135,10 +135,10 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                     case.set_value("NTASKS_{}".format(comp), ninst)
                 else:
                     expect(False, "NINST_{} value {:d} greater than NTASKS_{} {:d}".format(comp, ninst, comp, ntasks))
-            # But the NINST_LAYOUT may only be concurrent in multi_coupler mode
-            if multi_coupler:
+            # But the NINST_LAYOUT may only be concurrent in multi_driver mode
+            if multi_driver:
                 expect(case.get_value("NINST_LAYOUT_{}".format(comp)) == "concurrent",
-                       "If multi_coupler is TRUE, NINST_LAYOUT_{} must be concurrent".format(comp))
+                       "If multi_driver is TRUE, NINST_LAYOUT_{} must be concurrent".format(comp))
 
         if os.path.exists("case.run"):
             logger.info("Machine/Decomp/Pes configuration has already been done ...skipping")

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -39,8 +39,9 @@ def _get_datenames(case, last_date=None):
     rundir = case.get_value('RUNDIR')
     expect(isdir(rundir), 'Cannot open directory {} '.format(rundir))
     casename = case.get_value("CASE")
-    files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl.r*.nc')))
-
+    files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl*.r*.nc')))
+    if not files:
+        expect(False, 'Cannot find a {}.cpl*.r.*.nc file in directory {} '.format(casename, rundir))
     datenames = []
     for filename in files:
         names = filename.split('.')
@@ -59,10 +60,7 @@ def _get_datenames(case, last_date=None):
 def _get_ninst_info(case, compclass):
 ###############################################################################
 
-    if compclass != 'cpl':
-        ninst = case.get_value('NINST_' + compclass.upper())
-    else:
-        ninst = 1
+    ninst = case.get_value('NINST_' + compclass.upper())
     ninst_strings = []
     if ninst is None:
         ninst = 1

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -59,8 +59,11 @@ def _get_datenames(case, last_date=None):
 ###############################################################################
 def _get_ninst_info(case, compclass):
 ###############################################################################
-
-    ninst = case.get_value('NINST_' + compclass.upper())
+    comp = compclass.upper()
+    if comp == "CPL":
+        ninst = case.get_value("COUPLER_COUNT")
+    else:
+        ninst = case.get_value('NINST_' + compclass.upper())
     ninst_strings = []
     if ninst is None:
         ninst = 1

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -59,11 +59,8 @@ def _get_datenames(case, last_date=None):
 ###############################################################################
 def _get_ninst_info(case, compclass):
 ###############################################################################
-    comp = compclass.upper()
-    if comp == "CPL":
-        ninst = case.get_value("COUPLER_COUNT")
-    else:
-        ninst = case.get_value('NINST_' + compclass.upper())
+
+    ninst = case.get_value('NINST_' + compclass.upper())
     ninst_strings = []
     if ninst is None:
         ninst = 1

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 def _submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
             mail_user=None, mail_type='never', batch_args=None):
-    caseroot = case.get_value("CASEROOT")
     if job is None:
         if case.get_value("TEST"):
             job = "case.test"

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -108,7 +108,7 @@ def submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
         raise
 
 def check_case(case, caseroot):
-    check_lockedfiles(caseroot)
+    check_lockedfiles(case)
     create_namelists(case) # Must be called before check_all_input_data
     logger.info("Checking that inputdata is available as part of case submission")
     check_all_input_data(case)

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 def _submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
             mail_user=None, mail_type='never', batch_args=None):
     caseroot = case.get_value("CASEROOT")
-
     if job is None:
         if case.get_value("TEST"):
             job = "case.test"
@@ -33,7 +32,7 @@ def _submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
             case.set_value("CONTINUE_RUN", True)
     else:
         if job in ("case.test","case.run"):
-            check_case(case, caseroot)
+            check_case(case)
             check_DA_settings(case)
             if case.get_value("MACH") == "mira":
                 with open(".original_host", "w") as fd:
@@ -107,7 +106,7 @@ def submit(case, job=None, resubmit=False, no_batch=False, skip_pnl=False,
 
         raise
 
-def check_case(case, caseroot):
+def check_case(case):
     check_lockedfiles(case)
     create_namelists(case) # Must be called before check_all_input_data
     logger.info("Checking that inputdata is available as part of case submission")

--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -77,13 +77,13 @@ def check_pelayouts_require_rebuild(case, models):
 
         unlock_file("env_mach_pes.xml", case.get_value("CASEROOT"))
 
-def check_lockedfiles(caseroot=None):
+def check_lockedfiles(case):
     """
     Check that all lockedfiles match what's in case
 
     If caseroot is not specified, it is set to the current working directory
     """
-    caseroot = os.getcwd() if caseroot is None else caseroot
+    caseroot = case.get_value("CASEROOT")
     lockedfiles = glob.glob(os.path.join(caseroot, "LockedFiles", "*.xml"))
     for lfile in lockedfiles:
         fpart = os.path.basename(lfile)
@@ -91,19 +91,20 @@ def check_lockedfiles(caseroot=None):
         if fpart.count('.') > 1:
             continue
         cfile = os.path.join(caseroot, fpart)
+        components = case.get_values("COMP_CLASSES")
         if os.path.isfile(cfile):
             objname = fpart.split('.')[0]
             if objname == "env_build":
-                f1obj = EnvBuild(caseroot, cfile)
+                f1obj = case.get_env('build')
                 f2obj = EnvBuild(caseroot, lfile)
             elif objname == "env_mach_pes":
-                f1obj = EnvMachPes(caseroot, cfile)
-                f2obj = EnvMachPes(caseroot, lfile)
+                f1obj = case.get_env('mach_pes')
+                f2obj = EnvMachPes(caseroot, lfile, components=components)
             elif objname == "env_case":
-                f1obj = EnvCase(caseroot, cfile)
+                f1obj = case.get_env('case')
                 f2obj = EnvCase(caseroot, lfile)
             elif objname == "env_batch":
-                f1obj = EnvBatch(caseroot, cfile)
+                f1obj = case.get_env('batch')
                 f2obj = EnvBatch(caseroot, lfile)
             else:
                 logging.warn("Locked XML file '{}' is not current being handled".format(fpart))
@@ -122,15 +123,13 @@ def check_lockedfiles(caseroot=None):
                            " recover the original copy from LockedFiles")
                 elif objname == "env_build":
                     logging.warn("Setting build complete to False")
-                    f1obj.set_value("BUILD_COMPLETE", False)
+                    case.set_value("BUILD_COMPLETE", False)
                     if "PIO_VERSION" in diffs.keys():
-                        f1obj.set_value("BUILD_STATUS", 2)
-                        f1obj.write()
+                        case.set_value("BUILD_STATUS", 2)
                         logging.critical("Changing PIO_VERSION requires running "
                                          "case.build --clean-all and rebuilding")
                     else:
-                        f1obj.set_value("BUILD_STATUS", 1)
-                        f1obj.write()
+                        case.set_value("BUILD_STATUS", 1)
                 elif objname == "env_batch":
                     expect(False, "Batch configuration has changed, please run case.setup --reset")
                 else:

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -163,7 +163,7 @@ class _TimingParser:
             inittype = "TRUE"
 
         if inst > 0:
-            inst_label = '_{04d}'.format(inst)
+            inst_label = '_{:04d}'.format(inst)
         else:
             inst_label = ''
 

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -93,7 +93,7 @@ class _TimingParser:
         return (0, 0, False)
 
     def getTiming(self):
-        ninst = self.case.get_value("COUPLER_COUNT")
+        ninst = self.case.get_value("NINST_CPL")
         if ninst > 1:
             for inst in range(ninst):
                 self._getTiming(inst+1)

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -125,7 +125,7 @@ class _TimingParser:
         ncpl_base_period = self.case.get_value("NCPL_BASE_PERIOD")
         ncpl = 0
         for compclass in self.case.get_values("COMP_CLASSES"):
-            ncpl = max(ncpl, self.case.get_value("%s_NCPL"%compclass))
+            ncpl = max(ncpl, self.case.get_value("{}_NCPL".format(compclass)))
         ocn_ncpl = self.case.get_value("OCN_NCPL")
 
         compset = self.case.get_value("COMPSET")
@@ -163,11 +163,11 @@ class _TimingParser:
             inittype = "TRUE"
 
         if inst > 0:
-            inst_label = '_%04d' % inst
+            inst_label = '_{04d}'.format(inst)
         else:
             inst_label = ''
 
-        binfilename = os.path.join(rundir, "timing", "model_timing%s_stats" % inst_label)
+        binfilename = os.path.join(rundir, "timing", "model_timing{}_stats" . format(inst_label))
         finfilename = os.path.join(self.caseroot, "timing",
                                    "{}_timing{}_stats.{}".format(cime_model, inst_label, self.lid))
         foutfilename = os.path.join(self.caseroot, "timing",

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -93,7 +93,7 @@ class _TimingParser:
         return (0, 0, False)
 
     def getTiming(self):
-        ninst = self.case.get_value("NINST_CPL")
+        ninst = self.case.get_value("COUPLER_COUNT")
         if ninst > 1:
             for inst in range(ninst):
                 self._getTiming(inst+1)

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -94,8 +94,8 @@ class _TimingParser:
 
     def getTiming(self):
         ninst = 1
-        multi_coupler = self.case.get_value("MULTI_COUPLER")
-        if multi_coupler:
+        multi_driver = self.case.get_value("MULTI_DRIVER")
+        if multi_driver:
             ninst = self.case.get_value("NINST_MAX")
 
         if ninst > 1:

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -93,7 +93,11 @@ class _TimingParser:
         return (0, 0, False)
 
     def getTiming(self):
-        ninst = self.case.get_value("NINST_CPL")
+        ninst = 1
+        multi_coupler = self.case.get_value("MULTI_COUPLER")
+        if multi_coupler:
+            ninst = self.case.get_value("NINST_MAX")
+
         if ninst > 1:
             for inst in range(ninst):
                 self._getTiming(inst+1)

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -182,10 +182,10 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
     all_success = True
     num_compared = 0
     comments = "Comparing hists for case '{}' dir1='{}', suffix1='{}',  dir2='{}' suffix2='{}'\n".format(testcase, from_dir1, suffix1, from_dir2, suffix2)
-    multiinst_cpl_compare = False
+    multiinst_driver_compare = False
     for model in _iter_model_file_substrs(case):
         if model == 'cpl' and suffix2 == 'multiinst':
-            multiinst_cpl_compare = True
+            multiinst_driver_compare = True
         comments += "  comparing model '{}'\n".format(model)
         hists1 = _get_latest_hist_files(testcase, model, from_dir1, suffix1)
         hists2 = _get_latest_hist_files(testcase, model, from_dir2, suffix2)
@@ -205,7 +205,7 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
 
         for hist1, hist2 in match_ups:
             success, cprnc_log_file = cprnc(model, hist1, hist2, case, from_dir1,
-                                            multiinst_cpl_compare=multiinst_cpl_compare,
+                                            multiinst_driver_compare=multiinst_driver_compare,
                                             outfile_suffix=outfile_suffix)
             if success:
                 comments += "    {} matched {}\n".format(hist1, hist2)
@@ -237,7 +237,7 @@ def compare_test(case, suffix1, suffix2):
 
     return _compare_hists(case, rundir, rundir, suffix1, suffix2)
 
-def cprnc(model, file1, file2, case, rundir, multiinst_cpl_compare=False, outfile_suffix=""):
+def cprnc(model, file1, file2, case, rundir, multiinst_driver_compare=False, outfile_suffix=""):
     """
     Run cprnc to compare two individual nc files
 
@@ -277,7 +277,7 @@ def cprnc(model, file1, file2, case, rundir, multiinst_cpl_compare=False, outfil
         with open(output_filename, "r") as fd:
             out = fd.read()
 
-    if multiinst_cpl_compare:
+    if multiinst_driver_compare:
         #  In a multiinstance test the cpl hist file will have a different number of
         # dimensions and so cprnc will indicate that the files seem to be DIFFERENT
         # in this case we only want to check that the fields we are able to compare

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -72,7 +72,6 @@ def create_namelists(case, component=None):
         model_str = model.lower()
         config_file = case.get_value("CONFIG_{}_FILE".format(model_str.upper()))
         config_dir = os.path.dirname(config_file)
-        multicoupler = case.get_value("MULTI_COUPLER")
         if model_str == "cpl":
             compname = "drv"
         else:

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -83,6 +83,7 @@ def create_namelists(case, component=None):
         # are restored.
         if multicoupler and model_str != "cpl":
             case.set_value("MULTI_COUPLER",False)
+            print "HERE NINST_{} = {}".format(model_str.upper(), case.get_value("NINST_{}".format(model_str.upper())))
         if component is None or component == model_str:
             # first look in the case SourceMods directory
             cmd = os.path.join(caseroot, "SourceMods", "src."+compname, "buildnml")

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -66,8 +66,6 @@ def create_namelists(case, component=None):
     # Create namelists - must have cpl last in the list below
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
-    xmlfac = {}
-    cpl_ninst = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
     models += [models.pop(0)]
     for model in models:

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -77,12 +77,6 @@ def create_namelists(case, component=None):
             compname = "drv"
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
-        # We must temporarily toggle out of Multicoupler mode (MULTI_COUPLER )
-        # so that the component build namelists use the correct number of instances
-        # we can get rid of this hack when all of the components understand MULTI_COUPLER
-        # mode
-        if multicoupler and model_str != "cpl":
-            case.set_value("MULTI_COUPLER",False)
         if component is None or component == model_str:
             # first look in the case SourceMods directory
             cmd = os.path.join(caseroot, "SourceMods", "src."+compname, "buildnml")
@@ -94,8 +88,6 @@ def create_namelists(case, component=None):
             expect(os.path.isfile(cmd), "Could not find buildnml file for component {}".format(compname))
             run_sub_or_cmd(cmd, (caseroot), "buildnml", (case, caseroot, compname), case=case)
 
-        if multicoupler and model_str != "cpl":
-            case.set_value("MULTI_COUPLER",True)
     logger.info("Finished creating component namelists")
 
     # Save namelists to docdir

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -67,7 +67,7 @@ def create_namelists(case, component=None):
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
     xmlfac = {}
-    coupler_count = case.get_value("COUPLER_COUNT")
+    cpl_ninst = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
     models += [models.pop(0)]
     for model in models:
@@ -83,21 +83,20 @@ def create_namelists(case, component=None):
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
 
-        if coupler_count > 1:
-            if model_str == "cpl":
-                complist = [m for m in models if m.upper() != "CPL"]
-                if coupler_count > 1:
-                    xmlfac = {"NINST" : -(coupler_count), "NTASKS" : 1}
-            else:
-                complist = [model_str.upper()]
-                if coupler_count > 1:
-                    xmlfac = {"NINST" : -(coupler_count), "NTASKS" : coupler_count}
+            complist = [m for m in models if m.upper() != "CPL"]
+            if cpl_ninst > 1:
+                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : 1}
+        else:
+            compname = case.get_value("COMP_{}".format(model_str.upper()))
+            complist = [model_str.upper()]
+            if cpl_ninst > 1:
+                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : cpl_ninst}
 
-            xmlsave = {}
-            for k in xmlfac.keys():
-                for m in complist:
-                    key = "{}_{}" .format(k, m.upper())
-                    xmlsave[key] = case.get_value(key)
+        xmlsave = {}
+        for k in xmlfac.keys():
+            for m in complist:
+                key = "{}_{}" .format(k, m.upper())
+                xmlsave[key] = case.get_value(key)
 
         if component is None or component == model_str:
             # first look in the case SourceMods directory

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -74,22 +74,30 @@ def create_namelists(case, component=None):
         model_str = model.lower()
         config_file = case.get_value("CONFIG_{}_FILE".format(model_str.upper()))
         config_dir = os.path.dirname(config_file)
+        # Multicoupler mode (coupler_count > 1) must temporarily change
+        # NINST and NTASKS settings so that the component buildnml scripts
+        # will work correctly.  After the call to buildnml the original values
+        # are restored.
         if model_str == "cpl":
             compname = "drv"
-            complist = [m for m in models if m.upper() != "CPL"]
-            if coupler_count > 1:
-                xmlfac = {"NINST" : -(coupler_count), "NTASKS" : 1}
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
-            complist = [model_str.upper()]
-            if coupler_count > 1:
-                xmlfac = {"NINST" : -(coupler_count), "NTASKS" : coupler_count}
 
-        xmlsave = {}
-        for k in xmlfac.keys():
-            for m in complist:
-                key = "{}_{}" .format(k, m.upper())
-                xmlsave[key] = case.get_value(key)
+        if coupler_count > 1:
+            if model_str == "cpl":
+                complist = [m for m in models if m.upper() != "CPL"]
+                if coupler_count > 1:
+                    xmlfac = {"NINST" : -(coupler_count), "NTASKS" : 1}
+            else:
+                complist = [model_str.upper()]
+                if coupler_count > 1:
+                    xmlfac = {"NINST" : -(coupler_count), "NTASKS" : coupler_count}
+
+            xmlsave = {}
+            for k in xmlfac.keys():
+                for m in complist:
+                    key = "{}_{}" .format(k, m.upper())
+                    xmlsave[key] = case.get_value(key)
 
         if component is None or component == model_str:
             # first look in the case SourceMods directory

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -77,10 +77,10 @@ def create_namelists(case, component=None):
             compname = "drv"
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
-        # Multicoupler mode (MULTI_COUPLER ) must temporarily change
-        # NINST and NTASKS settings so that the component buildnml scripts
-        # will work correctly.  After the call to buildnml the original values
-        # are restored.
+        # We must temporarily toggle out of Multicoupler mode (MULTI_COUPLER )
+        # so that the component build namelists use the correct number of instances
+        # we can get rid of this hack when all of the components understand MULTI_COUPLER
+        # mode
         if multicoupler and model_str != "cpl":
             case.set_value("MULTI_COUPLER",False)
         if component is None or component == model_str:

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -83,7 +83,6 @@ def create_namelists(case, component=None):
         # are restored.
         if multicoupler and model_str != "cpl":
             case.set_value("MULTI_COUPLER",False)
-            print "HERE NINST_{} = {}".format(model_str.upper(), case.get_value("NINST_{}".format(model_str.upper())))
         if component is None or component == model_str:
             # first look in the case SourceMods directory
             cmd = os.path.join(caseroot, "SourceMods", "src."+compname, "buildnml")

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -67,7 +67,7 @@ def create_namelists(case, component=None):
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
     xmlfac = {}
-    cpl_ninst = case.get_value("NINST_CPL")
+    coupler_count = case.get_value("COUPLER_COUNT")
     models = case.get_values("COMP_CLASSES")
     models += [models.pop(0)]
     for model in models:
@@ -77,13 +77,13 @@ def create_namelists(case, component=None):
         if model_str == "cpl":
             compname = "drv"
             complist = [m for m in models if m.upper() != "CPL"]
-            if cpl_ninst > 1:
-                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : 1}
+            if coupler_count > 1:
+                xmlfac = {"NINST" : -(coupler_count), "NTASKS" : 1}
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
             complist = [model_str.upper()]
-            if cpl_ninst > 1:
-                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : cpl_ninst}
+            if coupler_count > 1:
+                xmlfac = {"NINST" : -(coupler_count), "NTASKS" : coupler_count}
 
         xmlsave = {}
         for k in xmlfac.keys():

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -66,6 +66,8 @@ def create_namelists(case, component=None):
     # Create namelists - must have cpl last in the list below
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
+    xmlfac = {}
+    cpl_ninst = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
     models += [models.pop(0)]
     for model in models:
@@ -74,8 +76,20 @@ def create_namelists(case, component=None):
         config_dir = os.path.dirname(config_file)
         if model_str == "cpl":
             compname = "drv"
+            complist = [m for m in models if m.upper() != "CPL"]
+            if cpl_ninst > 1:
+                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : 1}
         else:
             compname = case.get_value("COMP_{}".format(model_str.upper()))
+            complist = [model_str.upper()]
+            if cpl_ninst > 1:
+                xmlfac = {"NINST" : cpl_ninst, "NTASKS" : cpl_ninst}
+
+        xmlsave = {}
+        for k in xmlfac.keys():
+            for m in complist:
+                key = "{}_{}" .format(k, m.upper())
+                xmlsave[key] = case.get_value(key)
 
         if component is None or component == model_str:
             # first look in the case SourceMods directory

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -411,7 +411,7 @@ class TestScheduler(object):
                 if case_opt.startswith('C'):
                     expect(ninst == 1,"Cannot combine _C and _N options")
                     ncpl = case_opt[1:]
-                    create_newcase_cmd += " --ninst {} --ninst-couplers" .format(ncpl)
+                    create_newcase_cmd += " --ninst {} --multi-coupler" .format(ncpl)
                     logger.debug (" NCPL set to {}" .format(ncpl))
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -405,6 +405,10 @@ class TestScheduler(object):
                     ninst = case_opt[1:]
                     create_newcase_cmd += " --ninst {}".format(ninst)
                     logger.debug (" NINST set to {}".format(ninst))
+                if case_opt.startswith('C'):
+                    ncpl = case_opt[1:]
+                    create_newcase_cmd += " --ncouplers {}" .format(ncpl)
+                    logger.debug (" NCPL set to {}" .format(ncpl))
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]
                     create_newcase_cmd += " --pecount {}".format(pesize)
@@ -522,6 +526,9 @@ class TestScheduler(object):
                     continue
 
                 elif opt.startswith('N'):
+                    # handled in create_newcase
+                    continue
+                elif opt.startswith('C'):
                     # handled in create_newcase
                     continue
                 elif opt.startswith('IOP'):

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -407,7 +407,7 @@ class TestScheduler(object):
                     logger.debug (" NINST set to {}".format(ninst))
                 if case_opt.startswith('C'):
                     ncpl = case_opt[1:]
-                    create_newcase_cmd += " --ninst {} --ninst-coupler" .format(ncpl)
+                    create_newcase_cmd += " --ninst {} --ninst-couplers" .format(ncpl)
                     logger.debug (" NCPL set to {}" .format(ncpl))
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -411,7 +411,7 @@ class TestScheduler(object):
                 if case_opt.startswith('C'):
                     expect(ninst == 1,"Cannot combine _C and _N options")
                     ncpl = case_opt[1:]
-                    create_newcase_cmd += " --ninst {} --multi-coupler" .format(ncpl)
+                    create_newcase_cmd += " --ninst {} --multi-driver" .format(ncpl)
                     logger.debug (" NCPL set to {}" .format(ncpl))
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -395,6 +395,8 @@ class TestScheduler(object):
             create_newcase_cmd += " --user-mods-dir {}".format(test_mod_file)
 
         mpilib = None
+        ninst = 1
+        ncpl = 1
         if case_opts is not None:
             for case_opt in case_opts: # pylint: disable=not-an-iterable
                 if case_opt.startswith('M'):
@@ -402,10 +404,12 @@ class TestScheduler(object):
                     create_newcase_cmd += " --mpilib {}".format(mpilib)
                     logger.debug (" MPILIB set to {}".format(mpilib))
                 if case_opt.startswith('N'):
+                    expect(ncpl == 1,"Cannot combine _C and _N options")
                     ninst = case_opt[1:]
                     create_newcase_cmd += " --ninst {}".format(ninst)
                     logger.debug (" NINST set to {}".format(ninst))
                 if case_opt.startswith('C'):
+                    expect(ninst == 1,"Cannot combine _C and _N options")
                     ncpl = case_opt[1:]
                     create_newcase_cmd += " --ninst {} --ninst-couplers" .format(ncpl)
                     logger.debug (" NCPL set to {}" .format(ncpl))

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -407,7 +407,7 @@ class TestScheduler(object):
                     logger.debug (" NINST set to {}".format(ninst))
                 if case_opt.startswith('C'):
                     ncpl = case_opt[1:]
-                    create_newcase_cmd += " --ncouplers {}" .format(ncpl)
+                    create_newcase_cmd += " --ninst {} --ninst-coupler" .format(ncpl)
                     logger.debug (" NCPL set to {}" .format(ncpl))
                 if case_opt.startswith('P'):
                     pesize = case_opt[1:]

--- a/scripts/lib/update_acme_tests.py
+++ b/scripts/lib/update_acme_tests.py
@@ -51,7 +51,8 @@ _TEST_SUITES = {
                              "PET_P32.f19_f19.A",
                              "SMS.T42_T42.S",
                              "PRE.f19_f19.ADESP",
-                             "PRE.f19_f19.ADESP_TEST")
+                             "PRE.f19_f19.ADESP_TEST",
+                             "MCC_P12.f19_g16_rx1.A")
                             ),
 
     #

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -19,7 +19,7 @@ my $USE_ESMF_LIB	= `./xmlquery USE_ESMF_LIB	--value`;
 my $GMAKE_J		= `./xmlquery GMAKE_J		--value`;
 my $GMAKE		= `./xmlquery GMAKE		--value`;
 my $CASETOOLS		= `./xmlquery CASETOOLS		--value`;
-my $multi_coupler  	= `./xmlquery MULTI_COUPLER       --value`;
+my $multi_driver  	= `./xmlquery MULTI_DRIVER       --value`;
 
 my $NINST_ATM		= 1;
 my $NINST_ICE		= 1;
@@ -30,15 +30,15 @@ my $NINST_ROF		= 1;
 my $NINST_WAV		= 1;
 my $NINST_ESP		= 1;
 
-if ($multi_coupler == "FALSE") {
-    my $NINST_ATM		= `./xmlquery NINST_ATM		--value`;
-    my $NINST_ICE		= `./xmlquery NINST_ICE		--value`;
-    my $NINST_GLC		= `./xmlquery NINST_GLC		--value`;
-    my $NINST_LND		= `./xmlquery NINST_LND		--value`;
-    my $NINST_OCN		= `./xmlquery NINST_OCN		--value`;
-    my $NINST_ROF		= `./xmlquery NINST_ROF		--value`;
-    my $NINST_WAV		= `./xmlquery NINST_WAV		--value`;
-    my $NINST_ESP		= `./xmlquery NINST_ESP		--value`;
+if ($multi_driver eq "FALSE") {
+    $NINST_ATM		= `./xmlquery NINST_ATM		--value`;
+    $NINST_ICE		        = `./xmlquery NINST_ICE		--value`;
+    $NINST_GLC		= `./xmlquery NINST_GLC		--value`;
+    $NINST_LND		= `./xmlquery NINST_LND		--value`;
+    $NINST_OCN		= `./xmlquery NINST_OCN		--value`;
+    $NINST_ROF		= `./xmlquery NINST_ROF		--value`;
+    $NINST_WAV		= `./xmlquery NINST_WAV		--value`;
+    $NINST_ESP		= `./xmlquery NINST_ESP		--value`;
 }
 my $NINST_VALUE		= `./xmlquery NINST_VALUE	--value`;
 $ENV{PIO_VERSION}  	= `./xmlquery PIO_VERSION	--value`;

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -19,14 +19,27 @@ my $USE_ESMF_LIB	= `./xmlquery USE_ESMF_LIB	--value`;
 my $GMAKE_J		= `./xmlquery GMAKE_J		--value`;
 my $GMAKE		= `./xmlquery GMAKE		--value`;
 my $CASETOOLS		= `./xmlquery CASETOOLS		--value`;
-my $NINST_ATM		= `./xmlquery NINST_ATM		--value`;
-my $NINST_ICE		= `./xmlquery NINST_ICE		--value`;
-my $NINST_GLC		= `./xmlquery NINST_GLC		--value`;
-my $NINST_LND		= `./xmlquery NINST_LND		--value`;
-my $NINST_OCN		= `./xmlquery NINST_OCN		--value`;
-my $NINST_ROF		= `./xmlquery NINST_ROF		--value`;
-my $NINST_WAV		= `./xmlquery NINST_WAV		--value`;
-my $NINST_ESP		= `./xmlquery NINST_ESP		--value`;
+my $multi_coupler  	= `./xmlquery MULTI_COUPLER       --value`;
+
+my $NINST_ATM		= 1;
+my $NINST_ICE		= 1;
+my $NINST_GLC		= 1;
+my $NINST_LND		= 1;
+my $NINST_OCN		= 1;
+my $NINST_ROF		= 1;
+my $NINST_WAV		= 1;
+my $NINST_ESP		= 1;
+
+if ($multi_coupler == "FALSE") {
+    my $NINST_ATM		= `./xmlquery NINST_ATM		--value`;
+    my $NINST_ICE		= `./xmlquery NINST_ICE		--value`;
+    my $NINST_GLC		= `./xmlquery NINST_GLC		--value`;
+    my $NINST_LND		= `./xmlquery NINST_LND		--value`;
+    my $NINST_OCN		= `./xmlquery NINST_OCN		--value`;
+    my $NINST_ROF		= `./xmlquery NINST_ROF		--value`;
+    my $NINST_WAV		= `./xmlquery NINST_WAV		--value`;
+    my $NINST_ESP		= `./xmlquery NINST_ESP		--value`;
+}
 my $NINST_VALUE		= `./xmlquery NINST_VALUE	--value`;
 $ENV{PIO_VERSION}  	= `./xmlquery PIO_VERSION	--value`;
 #--------------------------------------------------------------------
@@ -73,6 +86,7 @@ if($#fp != $#filepath){
     close(F);
 }
 my $multiinst_cppdefs = "";
+
 $multiinst_cppdefs = "$multiinst_cppdefs -DNUM_COMP_INST_ATM=$NINST_ATM";
 $multiinst_cppdefs = "$multiinst_cppdefs -DNUM_COMP_INST_LND=$NINST_LND";
 $multiinst_cppdefs = "$multiinst_cppdefs -DNUM_COMP_INST_OCN=$NINST_OCN";

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -32,7 +32,7 @@ my $NINST_ESP		= 1;
 
 if ($multi_driver eq "FALSE") {
     $NINST_ATM		= `./xmlquery NINST_ATM		--value`;
-    $NINST_ICE		        = `./xmlquery NINST_ICE		--value`;
+    $NINST_ICE	        = `./xmlquery NINST_ICE		--value`;
     $NINST_GLC		= `./xmlquery NINST_GLC		--value`;
     $NINST_LND		= `./xmlquery NINST_LND		--value`;
     $NINST_OCN		= `./xmlquery NINST_OCN		--value`;

--- a/src/components/data_comps/desp/cime_config/buildnml
+++ b/src/components/data_comps/desp/cime_config/buildnml
@@ -42,8 +42,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
     #----------------------------------------------------
     # Check for incompatible options.
     #----------------------------------------------------
-    # At this point, we don't know what multiple instances of ESP means
-    expect(len(inst_string) == 0, "Multiple ESP instances not supported")
 
     #----------------------------------------------------
     # Log some settings.

--- a/src/components/data_comps/desp/cime_config/buildnml
+++ b/src/components/data_comps/desp/cime_config/buildnml
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
-def _create_namelists(case, confdir, inst_string, infile, nmlgen):
+def _create_namelists(case, confdir, infile, nmlgen):
 ####################################################################################
     """Write out the namelist for this component.
 
@@ -146,7 +146,7 @@ def buildnml(case, caseroot, compname):
         namelist_infile = [infile]
 
         # create namelist and stream file(s) data component
-        _create_namelists(case, confdir, inst_string, namelist_infile, nmlgen)
+        _create_namelists(case, confdir, namelist_infile, nmlgen)
 
         # copy namelist files and stream text files, to rundir
         if os.path.isdir(rundir):

--- a/src/components/data_comps/desp/desp_comp_mod.F90
+++ b/src/components/data_comps/desp/desp_comp_mod.F90
@@ -18,7 +18,7 @@ module desp_comp_mod
   use seq_timemgr_mod, only: seq_timemgr_EClockGetData
   use seq_timemgr_mod, only: seq_timemgr_RestartAlarmIsOn
   use seq_comm_mct,    only: seq_comm_inst, seq_comm_name, seq_comm_suffix
-  use seq_comm_mct,    only: num_inst_cpl
+  use seq_comm_mct,    only: num_inst_cpl => num_inst_driver
 
 
   implicit none
@@ -607,7 +607,7 @@ CONTAINS
 
   subroutine get_restart_filenames_a(comp_ind, filenames, retcode)
     use seq_comm_mct, only: ATMID, LNDID, OCNID, ICEID, GLCID, ROFID
-    use seq_comm_mct, only: WAVID, CPLID, seq_comm_suffix, cpl_inst_tag, num_inst_cpl
+    use seq_comm_mct, only: WAVID, CPLID, seq_comm_suffix, cpl_inst_tag
     use shr_file_mod, only: shr_file_getUnit, shr_file_freeUnit
 
     ! Dummy arguments

--- a/src/components/data_comps/desp/desp_comp_mod.F90
+++ b/src/components/data_comps/desp/desp_comp_mod.F90
@@ -19,7 +19,8 @@ module desp_comp_mod
   use seq_timemgr_mod, only: seq_timemgr_RestartAlarmIsOn
   use seq_comm_mct,    only: seq_comm_inst, seq_comm_name, seq_comm_suffix
   use seq_comm_mct,    only: num_inst_cpl => num_inst_driver
-
+  ! Used to link esp components across multiple drivers
+  use seq_comm_mct,    only: global_comm
 
   implicit none
   private
@@ -130,6 +131,7 @@ CONTAINS
     integer(IN)                    :: CurrentTOD ! model sec into model date
     integer(IN)                    :: stepno     ! step number
     character(len=CL)              :: calendar   ! calendar type
+    integer :: global_mype, global_numpes
 
     !----- define namelist -----
     namelist / desp_nml /                                                     &
@@ -218,6 +220,12 @@ CONTAINS
       !------------------------------------------------------------------------
 
       call shr_strdata_pioinit(SDESP, COMPID)
+
+      call mpi_comm_rank(global_comm, global_mype, ierr)
+      call mpi_comm_size(global_comm, global_numpes, ierr)
+
+      write(logunit,*)'DESP: I am global rank ',global_mype,' of ',global_numpes
+
 
       !------------------------------------------------------------------------
       ! Validate mode

--- a/src/components/xcpl_comps/xshare/dead_mod.F90
+++ b/src/components/xcpl_comps/xshare/dead_mod.F90
@@ -216,8 +216,6 @@ subroutine dead_setNewGrid(decomp_type,nxg,nyg,totpe,mype,lsize,gbuf,seg_len,npr
          i = i + 1
       enddo
 
-!      write(logunit,*) 'dead_setNewGrid decomp seg ',mype,lsize,nx
-
       found = .true.
 
    endif

--- a/src/components/xcpl_comps/xshare/dead_mod.F90
+++ b/src/components/xcpl_comps/xshare/dead_mod.F90
@@ -216,7 +216,7 @@ subroutine dead_setNewGrid(decomp_type,nxg,nyg,totpe,mype,lsize,gbuf,seg_len,npr
          i = i + 1
       enddo
 
-      write(logunit,*) 'dead_setNewGrid decomp seg ',mype,lsize,nx
+!      write(logunit,*) 'dead_setNewGrid decomp seg ',mype,lsize,nx
 
       found = .true.
 

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -247,18 +247,23 @@ def _create_component_modelio_namelists(case, files):
 
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")
-    inst_cpl = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
+    #if we are in multi-coupler mode the number of instances of cpl will be the max
+    # of any NINST_* value
+    maxinst = 1
+    if case.get_value("MULTI_COUPLER"):
+        maxinst = case.get_value("NINST_MAX")
+
     for model in models:
         model = model.lower()
         with NamelistGenerator(case, definition_file) as nmlgen:
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-            if inst_cpl == 1:
+            if maxinst == 1:
                 inst_count = case.get_value("NINST_" + model.upper())
             elif model != 'ESP':
-                inst_count = inst_cpl
+                inst_count = maxinst
             else:
                 inst_count = 1
 

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -255,20 +255,14 @@ def _create_component_modelio_namelists(case, files):
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
 
-            if model == 'cpl':
-                inst_count = 1
-            else:
-                inst_count = case.get_value("NINST_" + model.upper())
+            inst_count = case.get_value("NINST_" + model.upper())
 
+            inst_string = ""
             inst_index = 1
             while inst_index <= inst_count:
-                inst_string = inst_index
-                if inst_index <= 999:
-                    inst_string = "0" + str(inst_string)
-                if inst_index <=  99:
-                    inst_string = "0" + str(inst_string)
-                if inst_index <=  9:
-                    inst_string = "0" + str(inst_string)
+                # determine instance string
+                if inst_count > 1:
+                    inst_string = '_%04d' % inst_index
 
                 # set default values
                 for entry in entries:
@@ -281,17 +275,11 @@ def _create_component_modelio_namelists(case, files):
                 moddiro = case.get_value('RUNDIR')
                 nmlgen.set_value('diro', moddiro)
 
-                if inst_count > 1:
-                    logfile = model + "_" + inst_string + ".log." + str(lid)
-                else:
-                    logfile = model + ".log." + str(lid)
+                logfile = model + inst_string + ".log." + str(lid)
                 nmlgen.set_value('logfile', logfile)
 
                 # Write output file
-                if inst_count > 1:
-                    modelio_file = model + "_modelio.nml_" + str(inst_string)
-                else:
-                    modelio_file = model + "_modelio.nml"
+                modelio_file = model + "_modelio.nml" + inst_string
                 nmlgen.write_modelio_file(os.path.join(confdir, modelio_file))
 
                 inst_index = inst_index + 1

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -272,7 +272,7 @@ def _create_component_modelio_namelists(case, files):
             while inst_index <= inst_count:
                 # determine instance string
                 if inst_count > 1:
-                    inst_string = '_{04d}'.format(inst_index)
+                    inst_string = '_{:04d}'.format(inst_index)
 
                 # set default values
                 for entry in entries:

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -263,10 +263,8 @@ def _create_component_modelio_namelists(case, files):
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
             if maxinst == 1 and model != 'cpl':
                 inst_count = case.get_value("NINST_" + model.upper())
-            elif model != 'esp':
-                inst_count = maxinst
             else:
-                inst_count = 1
+                inst_count = maxinst
 
             inst_string = ""
             inst_index = 1

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -247,7 +247,7 @@ def _create_component_modelio_namelists(case, files):
 
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")
-
+    inst_cpl = case.get_value("NINST_CPL")
     models = case.get_values("COMP_CLASSES")
     for model in models:
         model = model.lower()
@@ -255,8 +255,12 @@ def _create_component_modelio_namelists(case, files):
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-
-            inst_count = case.get_value("NINST_" + model.upper())
+            if inst_cpl == 1:
+                inst_count = case.get_value("NINST_" + model.upper())
+            elif model != 'ESP':
+                inst_count = inst_cpl
+            else:
+                inst_count = 1
 
             inst_string = ""
             inst_index = 1

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -41,6 +41,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['BUDGETS'] = case.get_value('BUDGETS')
     config['MACH'] = case.get_value('MACH')
     config['MPILIB'] = case.get_value('MPILIB')
+    config['MULTI_DRIVER'] = '.true.' if case.get_value('MULTI_DRIVER') else '.false.'
     config['OS'] = case.get_value('OS')
     config['glc_nec'] = 0 if case.get_value('GLC_NEC') == 0 else case.get_value('GLC_NEC')
     config['single_column'] = 'true' if case.get_value('PTS_MODE') else 'false'
@@ -251,7 +252,7 @@ def _create_component_modelio_namelists(case, files):
     #if we are in multi-coupler mode the number of instances of cpl will be the max
     # of any NINST_* value
     maxinst = 1
-    if case.get_value("MULTI_COUPLER"):
+    if case.get_value("MULTI_DRIVER"):
         maxinst = case.get_value("NINST_MAX")
 
     for model in models:

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -254,10 +254,8 @@ def _create_component_modelio_namelists(case, files):
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-            if model == "cpl":
-                inst_count = case.get_value("COUPLER_COUNT")
-            else:
-                inst_count = case.get_value("NINST_" + model.upper())
+
+            inst_count = case.get_value("NINST_" + model.upper())
 
             inst_string = ""
             inst_index = 1

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -260,9 +260,9 @@ def _create_component_modelio_namelists(case, files):
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-            if maxinst == 1:
+            if maxinst == 1 and model != 'cpl':
                 inst_count = case.get_value("NINST_" + model.upper())
-            elif model != 'ESP':
+            elif model != 'esp':
                 inst_count = maxinst
             else:
                 inst_count = 1
@@ -272,7 +272,7 @@ def _create_component_modelio_namelists(case, files):
             while inst_index <= inst_count:
                 # determine instance string
                 if inst_count > 1:
-                    inst_string = '_%04d' % inst_index
+                    inst_string = '_{04d}'.format(inst_index)
 
                 # set default values
                 for entry in entries:

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -248,8 +248,9 @@ def _create_component_modelio_namelists(case, files):
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")
 
-    models = ["cpl", "atm", "lnd", "ice", "ocn", "glc", "rof", "wav", "esp"]
+    models = case.get_values("COMP_CLASSES")
     for model in models:
+        model = model.lower()
         with NamelistGenerator(case, definition_file) as nmlgen:
             config = {}
             config['component'] = model

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -254,8 +254,10 @@ def _create_component_modelio_namelists(case, files):
             config = {}
             config['component'] = model
             entries = nmlgen.init_defaults(infiles, config, skip_entry_loop=True)
-
-            inst_count = case.get_value("NINST_" + model.upper())
+            if model == "cpl":
+                inst_count = case.get_value("COUPLER_COUNT")
+            else:
+                inst_count = case.get_value("NINST_" + model.upper())
 
             inst_string = ""
             inst_index = 1

--- a/src/drivers/mct/cime_config/config_archive.xml
+++ b/src/drivers/mct/cime_config/config_archive.xml
@@ -4,8 +4,8 @@
     <hist_file_extension>\.h.*.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.drv</rpointer_file>
-      <rpointer_content >$CASE.cpl.r.$DATENAME.nc</rpointer_content>
+      <rpointer_file>rpointer$NINST_STRING.drv</rpointer_file>
+      <rpointer_content >$CASE.cpl$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
   </comp_archive_spec>
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1951,7 +1951,8 @@
 
   <entry id="MULTI_COUPLER">
     <type>logical</type>
-    <default_value>False</default_value>
+    <default_value>FALSE</default_value>
+    <valid_values>TRUE,FALSE</valid_values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
     <desc>MULTI_COUPLER mode provides a separate coupler component for each

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1955,7 +1955,7 @@
     <valid_values>TRUE,FALSE</valid_values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>MULTI_DRIVER mode provides a separate driver (and coupler) component for each
+    <desc>MULTI_DRIVER mode provides a separate driver/coupler component for each
     ensemble member.  All components must have an equal number of members.  If
     MULTI_DRIVER mode is False prognostic components must have the same number
     of members but data or stub components may also have 1 member. </desc>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1952,6 +1952,7 @@
   <entry id="NINST">
     <type>integer</type>
     <values>
+      <value component="CPL">1</value>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1975,9 +1975,9 @@
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of instances for each component.  If MULTI_COUPLER is True
-    only NINST_CPL is used and all components have NINST_CPL instances;
-    if MULTI_COUPLER is False NINST_CPL is 1.</desc>
+    <desc>Number of instances for each component.  If MULTI_DRIVER is True
+    the NINST_MAX value will be used.
+    </desc>
   </entry>
 
   <entry id="NINST_LAYOUT">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1949,10 +1949,17 @@
     <desc>ROOTPE (mpi task in MPI_COMM_WORLD) for each component</desc>
   </entry>
 
+  <entry id="COUPLER_COUNT">
+    <type>integer</type>
+    <default_value>1</default_value>
+    <group>mach_pes</group>
+    <file>env_mach_pes.xml</file>
+    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.</desc>
+  </entry>
+
   <entry id="NINST">
     <type>integer</type>
     <values>
-      <value component="CPL">1</value>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>
@@ -1964,7 +1971,7 @@
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of instances for each component</desc>
+    <desc>Number of instances for each component in single coupler mode</desc>
   </entry>
 
   <entry id="NINST_LAYOUT">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1954,7 +1954,7 @@
     <default_value>1</default_value>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.</desc>
+    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.  Each coupler instance is an instance of the entier model.</desc>
   </entry>
 
   <entry id="NINST">
@@ -1971,7 +1971,9 @@
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of instances for each component in single coupler mode</desc>
+    <desc>Number of instances for each component in single coupler mode.
+          In multiple coupler mode (COUPLER_COUNT > 1) this must be 1 and
+          there are COUPLER_COUNT instances of the entire model.</desc>
   </entry>
 
   <entry id="NINST_LAYOUT">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1977,7 +1977,8 @@
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
     <desc>Number of instances for each component.  If MULTI_COUPLER is True
-    only NINST_CPL is used, if MULTI_COUPLER is False NINST_CPL is 1.</desc>
+    only NINST_CPL is used and all components have NINST_CPL instances;
+    if MULTI_COUPLER is False NINST_CPL is 1.</desc>
   </entry>
 
   <entry id="NINST_LAYOUT">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1954,7 +1954,7 @@
     <default_value>1</default_value>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.  Each coupler instance is an instance of the entier model.</desc>
+    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.  Each coupler instance is an instance of the entire model.</desc>
   </entry>
 
   <entry id="NINST">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1949,15 +1949,15 @@
     <desc>ROOTPE (mpi task in MPI_COMM_WORLD) for each component</desc>
   </entry>
 
-  <entry id="MULTI_COUPLER">
+  <entry id="MULTI_DRIVER">
     <type>logical</type>
     <default_value>FALSE</default_value>
     <valid_values>TRUE,FALSE</valid_values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>MULTI_COUPLER mode provides a separate coupler component for each
-    ensemble member all components must have an equal number of members.  If
-    MULTI_COUPLER mode is False prognostic components must have the same number
+    <desc>MULTI_DRIVER mode provides a separate driver (and coupler) component for each
+    ensemble member.  All components must have an equal number of members.  If
+    MULTI_DRIVER mode is False prognostic components must have the same number
     of members but data or stub components may also have 1 member. </desc>
   </entry>
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1964,7 +1964,6 @@
   <entry id="NINST">
     <type>integer</type>
     <values>
-      <value component="CPL">1</value>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1949,17 +1949,21 @@
     <desc>ROOTPE (mpi task in MPI_COMM_WORLD) for each component</desc>
   </entry>
 
-  <entry id="COUPLER_COUNT">
-    <type>integer</type>
-    <default_value>1</default_value>
+  <entry id="MULTI_COUPLER">
+    <type>logical</type>
+    <default_value>False</default_value>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of couplers in ensemble: if COUPLER_COUNT > 1 then NINST must be 1 for all components.  Each coupler instance is an instance of the entire model.</desc>
+    <desc>MULTI_COUPLER mode provides a separate coupler component for each
+    ensemble member all components must have an equal number of members.  If
+    MULTI_COUPLER mode is False prognostic components must have the same number
+    of members but data or stub components may also have 1 member. </desc>
   </entry>
 
   <entry id="NINST">
     <type>integer</type>
     <values>
+      <value component="CPL">1</value>
       <value component="ATM">1</value>
       <value component="OCN">1</value>
       <value component="WAV">1</value>
@@ -1971,9 +1975,8 @@
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
-    <desc>Number of instances for each component in single coupler mode.
-          In multiple coupler mode (COUPLER_COUNT > 1) this must be 1 and
-          there are COUPLER_COUNT instances of the entire model.</desc>
+    <desc>Number of instances for each component.  If MULTI_COUPLER is True
+    only NINST_CPL is used, if MULTI_COUPLER is False NINST_CPL is 1.</desc>
   </entry>
 
   <entry id="NINST_LAYOUT">

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -44,15 +44,15 @@
   <!-- group cime_cpl_inst              -->
   <!-- =========================== -->
 
-  <entry id="ninst_cpl" modify_via_xml="COUPLER_COUNT">
+  <entry id="ninst_cpl" modify_via_xml="NINST_CPL">
     <type>integer</type>
     <category>cime_cpl_inst</category>
     <group>cime_cpl_inst</group>
     <desc>
-      Number of CESM coupler instances. If > 1 then all component instances must equal 1.
+      Number of CESM coupler instances.
     </desc>
     <values>
-      <value>$COUPLER_COUNT</value>
+      <value>$NINST_CPL</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -41,18 +41,19 @@
   -->
 
   <!-- =========================== -->
-  <!-- group cime_cpl_inst              -->
+  <!-- group cime_driver_inst              -->
   <!-- =========================== -->
 
-  <entry id="ninst_cpl" modify_via_xml="NINST_MAX">
+  <entry id="ninst_driver" modify_via_xml="NINST_MAX">
     <type>integer</type>
-    <category>cime_cpl_inst</category>
-    <group>cime_cpl_inst</group>
+    <category>cime_driver_inst</category>
+    <group>cime_driver_inst</group>
     <desc>
-      Number of CESM coupler instances.
+      Number of CESM driver instances.  Only used if MULTI_DRIVER is TRUE.
     </desc>
     <values>
-      <value>$NINST_MAX</value>
+      <value>1</value>
+      <value MULTI_DRIVER="TRUE">$NINST_MAX</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -44,7 +44,7 @@
   <!-- group cime_cpl_inst              -->
   <!-- =========================== -->
 
-  <entry id="ninst_cpl" modify_via_xml="NINST_CPL">
+  <entry id="ninst_cpl" modify_via_xml="NINST_MAX">
     <type>integer</type>
     <category>cime_cpl_inst</category>
     <group>cime_cpl_inst</group>
@@ -52,7 +52,7 @@
       Number of CESM coupler instances.
     </desc>
     <values>
-      <value>$NINST_CPL</value>
+      <value>$NINST_MAX</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -41,13 +41,13 @@
   -->
 
   <!-- =========================== -->
-  <!-- group cesm_cpl              -->
+  <!-- group cime_cpl_inst              -->
   <!-- =========================== -->
 
-  <entry id="cpl_ninst" modify_via_xml="NINST_CPL">
+  <entry id="ninst_cpl" modify_via_xml="NINST_CPL">
     <type>integer</type>
-    <category>cesm_cpl</category>
-    <group>cesm_cpl</group>
+    <category>cime_cpl_inst</category>
+    <group>cime_cpl_inst</group>
     <desc>
       Number of CESM coupler instances.
     </desc>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -44,15 +44,15 @@
   <!-- group cime_cpl_inst              -->
   <!-- =========================== -->
 
-  <entry id="ninst_cpl" modify_via_xml="NINST_CPL">
+  <entry id="ninst_cpl" modify_via_xml="COUPLER_COUNT">
     <type>integer</type>
     <category>cime_cpl_inst</category>
     <group>cime_cpl_inst</group>
     <desc>
-      Number of CESM coupler instances.
+      Number of CESM coupler instances. If > 1 then all component instances must equal 1.
     </desc>
     <values>
-      <value>$NINST_CPL</value>
+      <value>$COUPLER_COUNT</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -41,6 +41,22 @@
   -->
 
   <!-- =========================== -->
+  <!-- group cesm_cpl              -->
+  <!-- =========================== -->
+
+  <entry id="cpl_ninst" modify_via_xml="NINST_CPL">
+    <type>integer</type>
+    <category>cesm_cpl</category>
+    <group>cesm_cpl</group>
+    <desc>
+      Number of CESM coupler instances.
+    </desc>
+    <values>
+      <value>$NINST_CPL</value>
+    </values>
+  </entry>
+
+  <!-- =========================== -->
   <!-- group seq_cplflds_inparm    -->
   <!-- =========================== -->
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -53,7 +53,7 @@
     </desc>
     <values>
       <value>1</value>
-      <value MULTI_DRIVER="TRUE">$NINST_MAX</value>
+      <value MULTI_DRIVER=".true.">$NINST_MAX</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -23,6 +23,15 @@
       </machine>
     </machines>
   </test>
+  <test name="ERS_C3" grid="f19_g17_rx1" compset="A">
+    <machines>
+      <machine name="cheyenne" compiler="pgi" category="prealpha">
+        <options>
+          <option name="wallclock">00:30:00</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
   <test name="ERI_D" grid="T31_g37_rx1" compset="A">
     <machines>
       <machine name="hobart" compiler="intel" category="prebeta">

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -72,6 +72,7 @@ module cime_comp_mod
     use seq_comm_mct, only: seq_comm_iamin, seq_comm_name, seq_comm_namelen
     use seq_comm_mct, only: seq_comm_init, seq_comm_setnthreads, seq_comm_getnthreads
     use seq_comm_mct, only: seq_comm_getinfo => seq_comm_setptrs
+    use seq_comm_mct, only: cpl_inst_tag
 
    ! clock & alarm routines and variables
    use seq_timemgr_mod, only: seq_timemgr_type
@@ -533,8 +534,6 @@ module cime_comp_mod
    logical  :: iamin_CPLALLROFID     ! pe associated with CPLALLROFID
    logical  :: iamin_CPLALLWAVID     ! pe associated with CPLALLWAVID
 
-   ! suffix for log and timing files if multi coupler driver
-   character(len=seq_comm_namelen) :: cpl_inst_tag
 
    !----------------------------------------------------------------------------
    ! complist: list of comps on this pe
@@ -588,7 +587,7 @@ contains
 
 subroutine cime_pre_init1()
    use shr_pio_mod, only : shr_pio_init1, shr_pio_init2
-
+   use seq_comm_mct, only: num_inst_cpl
    !----------------------------------------------------------
    !| Initialize MCT and MPI communicators and IO
    !----------------------------------------------------------
@@ -597,7 +596,7 @@ subroutine cime_pre_init1()
    logical :: comp_iamin(num_inst_total)
    character(len=seq_comm_namelen) :: comp_name(num_inst_total)
    integer :: i, it
-   integer :: num_inst_cpl, cpl_id
+   integer :: cpl_id
    integer :: cpl_comm
 
    call mpi_init(ierr)
@@ -4067,7 +4066,7 @@ subroutine cime_comp_barriers(mpicom, timer)
 end subroutine cime_comp_barriers
 
 subroutine cime_cpl_init(comm_in, comm_out, num_inst_cpl, id)
-
+  use seq_comm_mct, only : cpl_inst_iamin
   !-----------------------------------------------------------------------
   !
   ! Initialize multiple coupler instances, if requested

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -4116,7 +4116,6 @@ subroutine cime_cpl_init(comm_in, comm_out, num_inst_driver, id)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_split')
   end if
   call shr_mpi_commsize(comm_out, drvpes, ' cime_cpl_init')
-  print *,__FILE__,__LINE__,numpes,drvpes
 end subroutine cime_cpl_init
 
 end module cime_comp_mod

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -4071,7 +4071,7 @@ subroutine cime_cpl_init(comm_in, comm_out, num_inst_driver, id)
   implicit none
 
   integer , intent(in) :: comm_in
-  integer , intent(in) :: comm_out
+  integer , intent(out) :: comm_out
   integer , intent(out)   :: num_inst_driver
   integer , intent(out)   :: id      ! instance ID, starts from 1
   !
@@ -4079,6 +4079,7 @@ subroutine cime_cpl_init(comm_in, comm_out, num_inst_driver, id)
   !
   integer :: ierr, inst_comm, mype, nu, numpes !, pes
   integer :: ninst_driver, drvpes
+  character(len=*),    parameter :: subname = '(cime_cpl_init) '
 
   namelist /cime_driver_inst/ ninst_driver
 
@@ -4094,7 +4095,14 @@ subroutine cime_cpl_init(comm_in, comm_out, num_inst_driver, id)
     nu = shr_file_getUnit()
     open(unit = nu, file = NLFileName, status = 'old', iostat = ierr)
     rewind(unit = nu)
-    read(unit = nu, nml = cime_driver_inst, iostat = ierr)
+    ierr = 1
+    do while ( ierr /= 0 ) 
+       read(unit = nu, nml = cime_driver_inst, iostat = ierr)
+       if (ierr < 0) then
+          call shr_sys_abort( subname//':: namelist read returns an'// &
+               ' end of file or end of record condition' )
+       endif
+    enddo
     close(unit = nu)
     call shr_file_freeUnit(nu)
     num_inst_driver = max(ninst_driver, 1)

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -855,7 +855,7 @@ subroutine cime_pre_init2()
    !| Initialize infodata
    !----------------------------------------------------------
 
-   if (len(cpl_inst_tag) > 0) then
+   if (len_trim(cpl_inst_tag) > 0) then
       call seq_infodata_init(infodata,nlfilename, GLOID, pioid, &
                              cpl_tag=cpl_inst_tag)
    else
@@ -3587,7 +3587,7 @@ end subroutine cime_init
          call seq_rest_write(EClock_d, seq_SyncClock, infodata,       &
               atm, lnd, ice, ocn, rof, glc, wav, esp,                 &
               fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-              fractions_rx, fractions_gx, fractions_wx, tag=trim(cpl_inst_tag))
+              fractions_rx, fractions_gx, fractions_wx, trim(cpl_inst_tag))
 
          if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
          call t_drvstopf  ('CPL:RESTART',cplrun=.true.)
@@ -4096,7 +4096,7 @@ subroutine cime_cpl_init(comm_in, comm_out, num_inst_driver, id)
     open(unit = nu, file = NLFileName, status = 'old', iostat = ierr)
     rewind(unit = nu)
     ierr = 1
-    do while ( ierr /= 0 ) 
+    do while ( ierr /= 0 )
        read(unit = nu, nml = cime_driver_inst, iostat = ierr)
        if (ierr < 0) then
           call shr_sys_abort( subname//':: namelist read returns an'// &

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2059,7 +2059,7 @@ subroutine cime_init()
          call seq_hist_write(infodata, EClock_d, &
               atm, lnd, ice, ocn, rof, glc, wav, &
               fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-              fractions_rx, fractions_gx, fractions_wx)
+              fractions_rx, fractions_gx, fractions_wx, trim(cpl_inst_tag))
          if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
 
          call t_adj_detailf(-2)
@@ -3618,14 +3618,15 @@ end subroutine cime_init
             call seq_hist_write(infodata, EClock_d, &
                  atm, lnd, ice, ocn, rof, glc, wav, &
                  fractions_ax, fractions_lx, fractions_ix, fractions_ox,     &
-                 fractions_rx, fractions_gx, fractions_wx)
+                 fractions_rx, fractions_gx, fractions_wx, trim(cpl_inst_tag))
 
             if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
          endif
 
          if (do_histavg) then
             call seq_hist_writeavg(infodata, EClock_d, &
-                 atm, lnd, ice, ocn, rof, glc, wav, histavg_alarm)
+                 atm, lnd, ice, ocn, rof, glc, wav, histavg_alarm, &
+                 trim(cpl_inst_tag))
          endif
 
          if (do_hist_a2x) then

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -614,7 +614,7 @@ subroutine cime_pre_init1()
    !   if (Global_comm /= MPI_COMM_NULL) then
 
    if (num_inst_driver > 1) then
-      call seq_comm_init(global_comm, driver_comm, NLFileName, driver_comm_ID=driver_id)
+      call seq_comm_init(global_comm, driver_comm, NLFileName, drv_comm_ID=driver_id)
       write(cpl_inst_tag,'("_",i4.4)') driver_id
    else
       call seq_comm_init(global_comm, driver_comm, NLFileName)

--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -130,7 +130,7 @@ contains
 subroutine seq_hist_write(infodata, EClock_d, &
      atm, lnd, ice, ocn, rof, glc, wav, &
      fractions_ax, fractions_lx, fractions_ix, fractions_ox, fractions_rx,  &
-     fractions_gx, fractions_wx)
+     fractions_gx, fractions_wx, tag)
 
    implicit none
    !
@@ -151,6 +151,7 @@ subroutine seq_hist_write(infodata, EClock_d, &
    type(mct_aVect)         , intent(inout) :: fractions_rx(:) ! Fractions on rof grid/decomp
    type(mct_aVect)         , intent(inout) :: fractions_gx(:) ! Fractions on glc grid/decomp
    type(mct_aVect)         , intent(inout) :: fractions_wx(:) ! Fractions on wav grid/decomp
+   character(len=*)        ,  intent(in) :: tag
    !
    ! Local Variables
    integer(IN)   :: curr_ymd     ! Current date YYYYMMDD
@@ -215,7 +216,7 @@ subroutine seq_hist_write(infodata, EClock_d, &
         calendar=calendar)
    call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
    write(hist_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-      trim(case_name), '.cpl.hi.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+      trim(case_name), '.cpl'//tag//'.hi.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
 
    time_units = 'days since ' &
         // seq_io_date2yyyymmdd(start_ymd) // ' ' // seq_io_sec2hms(start_tod)
@@ -389,7 +390,7 @@ end subroutine seq_hist_write
 !===============================================================================
 
 subroutine seq_hist_writeavg(infodata, EClock_d, &
-     atm, lnd, ice, ocn, rof, glc, wav, write_now)
+     atm, lnd, ice, ocn, rof, glc, wav, write_now, tag)
 
    implicit none
 
@@ -403,6 +404,7 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
    type (component_type)   ,  intent(in) :: glc(:)
    type (component_type)   ,  intent(in) :: wav(:)
    logical                 ,  intent(in) :: write_now  ! write or accumulate
+   character(len=*)        ,  intent(in) :: tag
 
    integer(IN)           :: curr_ymd     ! Current date YYYYMMDD
    integer(IN)           :: curr_tod     ! Current time-of-day (s)
@@ -764,19 +766,19 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
       if (seq_timemgr_histavg_type == seq_timemgr_type_nyear) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a)") &
-            trim(case_name),  '.cpl.ha.',  yy, '.nc'
+            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '.nc'
       elseif (seq_timemgr_histavg_type == seq_timemgr_type_nmonth) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a)") &
-            trim(case_name),  '.cpl.ha.',  yy, '-', mm, '.nc'
+            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '.nc'
       elseif (seq_timemgr_histavg_type == seq_timemgr_type_nday) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a, i2.2, a)") &
-            trim(case_name),  '.cpl.ha.',  yy, '-', mm, '-', dd, '.nc'
+            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '-', dd, '.nc'
       else
          call shr_cal_date2ymd(curr_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a, i2.2, a, i5.5, a)") &
-            trim(case_name),  '.cpl.ha.',  yy, '-', mm, '-', dd, '-', curr_tod, '.nc'
+            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '-', dd, '-', curr_tod, '.nc'
       endif
 
       time_units = 'days since ' &

--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -130,7 +130,7 @@ contains
 subroutine seq_hist_write(infodata, EClock_d, &
      atm, lnd, ice, ocn, rof, glc, wav, &
      fractions_ax, fractions_lx, fractions_ix, fractions_ox, fractions_rx,  &
-     fractions_gx, fractions_wx, tag)
+     fractions_gx, fractions_wx, cpl_inst_tag)
 
    implicit none
    !
@@ -151,7 +151,7 @@ subroutine seq_hist_write(infodata, EClock_d, &
    type(mct_aVect)         , intent(inout) :: fractions_rx(:) ! Fractions on rof grid/decomp
    type(mct_aVect)         , intent(inout) :: fractions_gx(:) ! Fractions on glc grid/decomp
    type(mct_aVect)         , intent(inout) :: fractions_wx(:) ! Fractions on wav grid/decomp
-   character(len=*)        ,  intent(in) :: tag
+   character(len=*)        ,  intent(in) :: cpl_inst_tag
    !
    ! Local Variables
    integer(IN)   :: curr_ymd     ! Current date YYYYMMDD
@@ -216,7 +216,7 @@ subroutine seq_hist_write(infodata, EClock_d, &
         calendar=calendar)
    call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
    write(hist_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-      trim(case_name), '.cpl'//tag//'.hi.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+      trim(case_name), '.cpl'//cpl_inst_tag//'.hi.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
 
    time_units = 'days since ' &
         // seq_io_date2yyyymmdd(start_ymd) // ' ' // seq_io_sec2hms(start_tod)
@@ -390,7 +390,7 @@ end subroutine seq_hist_write
 !===============================================================================
 
 subroutine seq_hist_writeavg(infodata, EClock_d, &
-     atm, lnd, ice, ocn, rof, glc, wav, write_now, tag)
+     atm, lnd, ice, ocn, rof, glc, wav, write_now, cpl_inst_tag)
 
    implicit none
 
@@ -404,7 +404,7 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
    type (component_type)   ,  intent(in) :: glc(:)
    type (component_type)   ,  intent(in) :: wav(:)
    logical                 ,  intent(in) :: write_now  ! write or accumulate
-   character(len=*)        ,  intent(in) :: tag
+   character(len=*)        ,  intent(in) :: cpl_inst_tag
 
    integer(IN)           :: curr_ymd     ! Current date YYYYMMDD
    integer(IN)           :: curr_tod     ! Current time-of-day (s)
@@ -766,19 +766,19 @@ subroutine seq_hist_writeavg(infodata, EClock_d, &
       if (seq_timemgr_histavg_type == seq_timemgr_type_nyear) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a)") &
-            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '.nc'
+            trim(case_name),  '.cpl'//cpl_inst_tag//'.ha.',  yy, '.nc'
       elseif (seq_timemgr_histavg_type == seq_timemgr_type_nmonth) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a)") &
-            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '.nc'
+            trim(case_name),  '.cpl'//cpl_inst_tag//'.ha.',  yy, '-', mm, '.nc'
       elseif (seq_timemgr_histavg_type == seq_timemgr_type_nday) then
          call shr_cal_date2ymd(prev_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a, i2.2, a)") &
-            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '-', dd, '.nc'
+            trim(case_name),  '.cpl'//cpl_inst_tag//'.ha.',  yy, '-', mm, '-', dd, '.nc'
       else
          call shr_cal_date2ymd(curr_ymd, yy, mm, dd)
          write(hist_file, "(2a, i4.4, a, i2.2, a, i2.2, a, i5.5, a)") &
-            trim(case_name),  '.cpl'//tag//'.ha.',  yy, '-', mm, '-', dd, '-', curr_tod, '.nc'
+            trim(case_name),  '.cpl'//cpl_inst_tag//'.ha.',  yy, '-', mm, '-', dd, '-', curr_tod, '.nc'
       endif
 
       time_units = 'days since ' &

--- a/src/drivers/mct/main/seq_rest_mod.F90
+++ b/src/drivers/mct/main/seq_rest_mod.F90
@@ -285,7 +285,7 @@ end subroutine seq_rest_read
 subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
      atm, lnd, ice, ocn, rof, glc, wav, esp,                 &
      fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-     fractions_rx, fractions_gx, fractions_wx)
+     fractions_rx, fractions_gx, fractions_wx, tag)
 
    implicit none
 
@@ -307,6 +307,7 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
    type(mct_aVect)        , intent(inout) :: fractions_rx(:)   ! Fractions on rof grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_gx(:)   ! Fractions on glc grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_wx(:)   ! Fractions on wav grid/decomp
+   character(len=*), optional, intent(in) :: tag
 
    integer(IN)   :: n,n1,n2,n3,fk
    integer(IN)   :: curr_ymd         ! Current date YYYYMMDD
@@ -367,8 +368,13 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
 
    call seq_timemgr_EClockGetData( EClock_d, curr_ymd=curr_ymd, curr_tod=curr_tod)
    call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
-   write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-      trim(case_name), '.cpl.r.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+   if (present(tag)) then   
+      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
+         trim(case_name), '.cpl'//trim(tag)//'.r.',yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+   else
+      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
+         trim(case_name), '.cpl.r.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
+   end if
 
    ! Write driver data to restart file
 

--- a/src/drivers/mct/main/seq_rest_mod.F90
+++ b/src/drivers/mct/main/seq_rest_mod.F90
@@ -307,7 +307,7 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
    type(mct_aVect)        , intent(inout) :: fractions_rx(:)   ! Fractions on rof grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_gx(:)   ! Fractions on glc grid/decomp
    type(mct_aVect)        , intent(inout) :: fractions_wx(:)   ! Fractions on wav grid/decomp
-   character(len=*), optional, intent(in) :: tag
+   character(len=*)       , intent(in) :: tag
 
    integer(IN)   :: n,n1,n2,n3,fk
    integer(IN)   :: curr_ymd         ! Current date YYYYMMDD
@@ -368,13 +368,8 @@ subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
 
    call seq_timemgr_EClockGetData( EClock_d, curr_ymd=curr_ymd, curr_tod=curr_tod)
    call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
-   if (present(tag)) then   
-      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-         trim(case_name), '.cpl'//trim(tag)//'.r.',yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
-   else
-      write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
-         trim(case_name), '.cpl.r.', yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
-   end if
+   write(rest_file,"(2a,i4.4,a,i2.2,a,i2.2,a,i5.5,a)") &
+        trim(case_name), '.cpl'//trim(tag)//'.r.',yy,'-',mm,'-',dd,'-',curr_tod,'.nc'
 
    ! Write driver data to restart file
 

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -215,7 +215,7 @@ contains
     logical :: error_state
     integer :: ierr, n, count
     character(*), parameter :: subName =   '(seq_comm_init) '
-    integer :: mype,numpes,myncomps,max_threads,gloroot
+    integer :: mype,numpes,myncomps,max_threads,gloroot, global_numpes
     integer :: pelist(3,1)       ! start, stop, stride for group
     integer, pointer :: comps(:) ! array with component ids
     integer, pointer :: comms(:) ! array with mpicoms
@@ -252,9 +252,6 @@ contains
     seq_comm_mct_initialized = .true.
     global_comm = global_comm_in
     driver_comm = driver_comm_in
-
-    call mpi_comm_dup(Comm_in, Coupler_Comm, ierr)
-    call shr_mpi_chkerr(ierr,subname//' mpi_comm_dup')
 
     !! Initialize seq_comms elements
 

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -184,7 +184,9 @@ module seq_comm_mct
   character(*), parameter :: F12 = "(a,a,'(',i3,' ',a,')',a,2i6,6x,' (',a,i6,')',' (',a,i3,')','(',a,2i6,')')"
   character(*), parameter :: F13 = "(a,a,'(',i3,' ',a,')',a,2i6,6x,' (',a,i6,')',' (',a,i3,')')"
   character(*), parameter :: F14 = "(a,a,'(',i3,' ',a,')',a,    6x,' (',a,i6,')',' (',a,i3,')')"
-  integer :: Global_Comm
+
+  ! Exposed for use in the esp component, please don't use this elsewhere
+  integer, public :: Global_Comm
   integer :: driver_comm
 
   character(len=32), public :: &

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -185,7 +185,7 @@ module seq_comm_mct
   character(*), parameter :: F13 = "(a,a,'(',i3,' ',a,')',a,2i6,6x,' (',a,i6,')',' (',a,i3,')')"
   character(*), parameter :: F14 = "(a,a,'(',i3,' ',a,')',a,    6x,' (',a,i6,')',' (',a,i3,')')"
   integer :: Global_Comm
-
+  integer :: driver_comm
 
   character(len=32), public :: &
        atm_layout, lnd_layout, ice_layout, glc_layout, rof_layout, &
@@ -250,7 +250,8 @@ contains
        call shr_sys_abort()
     endif
     seq_comm_mct_initialized = .true.
-    Global_Comm = driver_comm_in
+    global_comm = global_comm_in
+    driver_comm = driver_comm_in
 
     call mpi_comm_dup(Comm_in, Coupler_Comm, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_dup')
@@ -280,9 +281,9 @@ contains
 
     call mpi_comm_size(GLOBAL_COMM_IN, global_numpes , ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_size comm_world')
-    call mpi_comm_rank(GLOBAL_COMM, mype  , ierr)
+    call mpi_comm_rank(DRIVER_COMM, mype  , ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_rank driver')
-    call mpi_comm_size(GLOBAL_COMM, numpes, ierr)
+    call mpi_comm_size(DRIVER_COMM, numpes, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_size driver')
 
     if (mod(global_numpes, numpes) .ne. 0) then
@@ -327,24 +328,24 @@ contains
        call shr_file_freeUnit(nu)
     end if
 
-    call shr_mpi_bcast(atm_nthreads,GLOBAL_COMM,'atm_nthreads')
-    call shr_mpi_bcast(lnd_nthreads,GLOBAL_COMM,'lnd_nthreads')
-    call shr_mpi_bcast(ocn_nthreads,GLOBAL_COMM,'ocn_nthreads')
-    call shr_mpi_bcast(ice_nthreads,GLOBAL_COMM,'ice_nthreads')
-    call shr_mpi_bcast(glc_nthreads,GLOBAL_COMM,'glc_nthreads')
-    call shr_mpi_bcast(wav_nthreads,GLOBAL_COMM,'wav_nthreads')
-    call shr_mpi_bcast(rof_nthreads,GLOBAL_COMM,'rof_nthreads')
-    call shr_mpi_bcast(esp_nthreads,GLOBAL_COMM,'esp_nthreads')
-    call shr_mpi_bcast(cpl_nthreads,GLOBAL_COMM,'cpl_nthreads')
+    call shr_mpi_bcast(atm_nthreads,DRIVER_COMM,'atm_nthreads')
+    call shr_mpi_bcast(lnd_nthreads,DRIVER_COMM,'lnd_nthreads')
+    call shr_mpi_bcast(ocn_nthreads,DRIVER_COMM,'ocn_nthreads')
+    call shr_mpi_bcast(ice_nthreads,DRIVER_COMM,'ice_nthreads')
+    call shr_mpi_bcast(glc_nthreads,DRIVER_COMM,'glc_nthreads')
+    call shr_mpi_bcast(wav_nthreads,DRIVER_COMM,'wav_nthreads')
+    call shr_mpi_bcast(rof_nthreads,DRIVER_COMM,'rof_nthreads')
+    call shr_mpi_bcast(esp_nthreads,DRIVER_COMM,'esp_nthreads')
+    call shr_mpi_bcast(cpl_nthreads,DRIVER_COMM,'cpl_nthreads')
 
-    call shr_mpi_bcast(atm_layout,GLOBAL_COMM,'atm_layout')
-    call shr_mpi_bcast(lnd_layout,GLOBAL_COMM,'lnd_layout')
-    call shr_mpi_bcast(ocn_layout,GLOBAL_COMM,'ocn_layout')
-    call shr_mpi_bcast(ice_layout,GLOBAL_COMM,'ice_layout')
-    call shr_mpi_bcast(glc_layout,GLOBAL_COMM,'glc_layout')
-    call shr_mpi_bcast(wav_layout,GLOBAL_COMM,'wav_layout')
-    call shr_mpi_bcast(rof_layout,GLOBAL_COMM,'rof_layout')
-    call shr_mpi_bcast(esp_layout,GLOBAL_COMM,'esp_layout')
+    call shr_mpi_bcast(atm_layout,DRIVER_COMM,'atm_layout')
+    call shr_mpi_bcast(lnd_layout,DRIVER_COMM,'lnd_layout')
+    call shr_mpi_bcast(ocn_layout,DRIVER_COMM,'ocn_layout')
+    call shr_mpi_bcast(ice_layout,DRIVER_COMM,'ice_layout')
+    call shr_mpi_bcast(glc_layout,DRIVER_COMM,'glc_layout')
+    call shr_mpi_bcast(wav_layout,DRIVER_COMM,'wav_layout')
+    call shr_mpi_bcast(rof_layout,DRIVER_COMM,'rof_layout')
+    call shr_mpi_bcast(esp_layout,DRIVER_COMM,'esp_layout')
 
 
     !--- compute some other num_inst values
@@ -396,7 +397,7 @@ contains
        pelist(2,1) = numpes-1
        pelist(3,1) = 1
     end if
-    call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+    call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, DRIVER_COMM, ierr)
     call seq_comm_setcomm(GLOID, pelist,iname='GLOBAL')
 
     if (mype == 0) then
@@ -404,24 +405,24 @@ contains
        pelist(2,1) = cpl_rootpe + (cpl_ntasks -1) * cpl_pestride
        pelist(3,1) = cpl_pestride
     end if
-    call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+    call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, DRIVER_COMM, ierr)
     call seq_comm_setcomm(CPLID,pelist,cpl_nthreads,'CPL')
 
-    call comp_comm_init(global_comm, atm_rootpe, atm_nthreads, atm_layout, atm_ntasks, atm_pestride, num_inst_atm, &
+    call comp_comm_init(driver_comm, atm_rootpe, atm_nthreads, atm_layout, atm_ntasks, atm_pestride, num_inst_atm, &
          CPLID, ATMID, CPLATMID, ALLATMID, CPLALLATMID, 'ATM', count, drv_comm_id)
-    call comp_comm_init(global_comm, lnd_rootpe, lnd_nthreads, lnd_layout, lnd_ntasks, lnd_pestride, num_inst_lnd, &
+    call comp_comm_init(driver_comm, lnd_rootpe, lnd_nthreads, lnd_layout, lnd_ntasks, lnd_pestride, num_inst_lnd, &
          CPLID, LNDID, CPLLNDID, ALLLNDID, CPLALLLNDID, 'LND', count, drv_comm_id)
-    call comp_comm_init(global_comm, ice_rootpe, ice_nthreads, ice_layout, ice_ntasks, ice_pestride, num_inst_ice, &
+    call comp_comm_init(driver_comm, ice_rootpe, ice_nthreads, ice_layout, ice_ntasks, ice_pestride, num_inst_ice, &
          CPLID, ICEID, CPLICEID, ALLICEID, CPLALLICEID, 'ICE', count, drv_comm_id)
-    call comp_comm_init(global_comm, ocn_rootpe, ocn_nthreads, ocn_layout, ocn_ntasks, ocn_pestride, num_inst_ocn, &
+    call comp_comm_init(driver_comm, ocn_rootpe, ocn_nthreads, ocn_layout, ocn_ntasks, ocn_pestride, num_inst_ocn, &
          CPLID, OCNID, CPLOCNID, ALLOCNID, CPLALLOCNID, 'OCN', count, drv_comm_id)
-    call comp_comm_init(global_comm, rof_rootpe, rof_nthreads, rof_layout, rof_ntasks, rof_pestride, num_inst_rof, &
+    call comp_comm_init(driver_comm, rof_rootpe, rof_nthreads, rof_layout, rof_ntasks, rof_pestride, num_inst_rof, &
          CPLID, ROFID, CPLROFID, ALLROFID, CPLALLROFID, 'ROF', count, drv_comm_id)
-    call comp_comm_init(global_comm, glc_rootpe, glc_nthreads, glc_layout, glc_ntasks, glc_pestride, num_inst_glc, &
+    call comp_comm_init(driver_comm, glc_rootpe, glc_nthreads, glc_layout, glc_ntasks, glc_pestride, num_inst_glc, &
          CPLID, GLCID, CPLGLCID, ALLGLCID, CPLALLGLCID, 'GLC', count, drv_comm_id)
-    call comp_comm_init(global_comm, wav_rootpe, wav_nthreads, wav_layout, wav_ntasks, wav_pestride, num_inst_wav, &
+    call comp_comm_init(driver_comm, wav_rootpe, wav_nthreads, wav_layout, wav_ntasks, wav_pestride, num_inst_wav, &
          CPLID, WAVID, CPLWAVID, ALLWAVID, CPLALLWAVID, 'WAV', count, drv_comm_id)
-    call comp_comm_init(global_comm, esp_rootpe, esp_nthreads, esp_layout, esp_ntasks, esp_pestride, num_inst_esp, &
+    call comp_comm_init(driver_comm, esp_rootpe, esp_nthreads, esp_layout, esp_ntasks, esp_pestride, num_inst_esp, &
          CPLID, ESPID, CPLESPID, ALLESPID, CPLALLESPID, 'ESP', count, drv_comm_id)
 
     if (count /= ncomps) then
@@ -443,7 +444,7 @@ contains
     do n = 1,ncomps
        gloroot = -999
        if (seq_comms(n)%iamroot) gloroot = seq_comms(n)%gloiam
-       call shr_mpi_max(gloroot,seq_comms(n)%gloroot,GLOBAL_COMM, &
+       call shr_mpi_max(gloroot,seq_comms(n)%gloroot,DRIVER_COMM, &
                         trim(subname)//' gloroot',all=.true.)
     enddo
 
@@ -481,7 +482,7 @@ contains
        call shr_sys_abort()
     endif
 
-    call mct_world_init(ncomps, GLOBAL_COMM, comms, comps)
+    call mct_world_init(ncomps, DRIVER_COMM, comms, comps)
 
     deallocate(comps,comms)
 
@@ -490,10 +491,10 @@ contains
 
   end subroutine seq_comm_init
 
-  subroutine comp_comm_init(global_comm, comp_rootpe, comp_nthreads, comp_layout, &
+  subroutine comp_comm_init(driver_comm, comp_rootpe, comp_nthreads, comp_layout, &
        comp_ntasks, comp_pestride, num_inst_comp, &
        CPLID, COMPID, CPLCOMPID, ALLCOMPID, CPLALLCOMPID, name, count, drv_comm_id)
-    integer, intent(in) :: global_comm
+    integer, intent(in) :: driver_comm
     integer, intent(in) :: comp_rootpe
     integer, intent(in) :: comp_nthreads
     character(len=*), intent(in) :: comp_layout
@@ -519,7 +520,7 @@ contains
     integer :: ierr
     integer :: mype
 
-    call mpi_comm_rank(global_comm, mype, ierr)
+    call mpi_comm_rank(driver_comm, mype, ierr)
 
     count = count + 1
     ALLCOMPID = count
@@ -569,7 +570,7 @@ contains
           pelist(2,1) = cmax(n)
           pelist(3,1) = cstr(n)
        endif
-       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, GLOBAL_COMM, ierr)
+       call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, DRIVER_COMM, ierr)
        if (present(drv_comm_id)) then
           call seq_comm_setcomm(COMPID(n), pelist, comp_nthreads,name, drv_comm_id)
        else
@@ -645,11 +646,11 @@ contains
        call shr_sys_abort()
     endif
 
-    call mpi_comm_group(GLOBAL_COMM, mpigrp_world, ierr)
+    call mpi_comm_group(DRIVER_COMM, mpigrp_world, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_group mpigrp_world')
     call mpi_group_range_incl(mpigrp_world, 1, pelist, mpigrp,ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_group_range_incl mpigrp')
-    call mpi_comm_create(GLOBAL_COMM, mpigrp, mpicom, ierr)
+    call mpi_comm_create(DRIVER_COMM, mpigrp, mpicom, ierr)
 
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_create mpigrp')
 
@@ -762,7 +763,7 @@ contains
 
     call mpi_group_union(seq_comms(ID1)%mpigrp,seq_comms(ID2)%mpigrp,mpigrp,ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_union mpigrp')
-    call mpi_comm_create(GLOBAL_COMM, mpigrp, mpicom, ierr)
+    call mpi_comm_create(DRIVER_COMM, mpigrp, mpicom, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_create mpigrp')
 
     seq_comms(ID)%set = .true.
@@ -887,6 +888,7 @@ contains
        call mpi_group_union(mpigrpp,seq_comms(IDs(n))%mpigrp,mpigrp,ierr)
        call shr_mpi_chkerr(ierr,subname//' mpi_comm_union mpigrp')
     enddo
+    ! The allcompid is created across multiple drivers.
     call mpi_comm_create(GLOBAL_COMM, mpigrp, mpicom, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_create mpigrp')
 
@@ -967,13 +969,13 @@ contains
     character(*),parameter :: subName =   '(seq_comm_printcomms) '
     integer :: n,mype,npes,ierr
 
-    call mpi_comm_size(GLOBAL_COMM, npes  , ierr)
+    call mpi_comm_size(DRIVER_COMM, npes  , ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_size comm_world')
-    call mpi_comm_rank(GLOBAL_COMM, mype  , ierr)
+    call mpi_comm_rank(DRIVER_COMM, mype  , ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_rank comm_world')
 
     call shr_sys_flush(logunit)
-    call mpi_barrier(GLOBAL_COMM,ierr)
+    call mpi_barrier(DRIVER_COMM,ierr)
     if (mype == 0) then
        do n = 1,ncomps
           write(logunit,'(a,4i6,2x,3a)') trim(subName),n, &

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -242,7 +242,6 @@ contains
          esp_ntasks, esp_rootpe, esp_pestride, esp_nthreads, esp_layout, &
          cpl_ntasks, cpl_rootpe, cpl_pestride, cpl_nthreads
     !----------------------------------------------------------
-
     ! make sure this is first pass and set comms unset
     if (seq_comm_mct_initialized) then
        write(logunit,*) trim(subname),' ERROR seq_comm_init already called '
@@ -337,7 +336,6 @@ contains
 
 
     !--- compute some other num_inst values
-
     num_inst_xao = max(num_inst_atm,num_inst_ocn)
     num_inst_frc = num_inst_ice
 

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -180,7 +180,7 @@ module seq_comm_mct
   character(*), parameter :: layout_concurrent = 'concurrent'
   character(*), parameter :: layout_sequential = 'sequential'
 
-  character(*), parameter :: F11 = "(a,a,'(',i3,' ',a,')',a,   3i6,' (',a,i6,')',' (',a,i3,')')"
+  character(*), parameter :: F11 = "(a,a,'(',i3,' ',a,')',a,   3i6,' (',a,i6,')',' (',a,i3,')','(',a,a,')')"
   character(*), parameter :: F12 = "(a,a,'(',i3,' ',a,')',a,2i6,6x,' (',a,i6,')',' (',a,i3,')','(',a,2i6,')')"
   character(*), parameter :: F13 = "(a,a,'(',i3,' ',a,')',a,2i6,6x,' (',a,i6,')',' (',a,i3,')')"
   character(*), parameter :: F14 = "(a,a,'(',i3,' ',a,')',a,    6x,' (',a,i6,')',' (',a,i3,')')"
@@ -571,6 +571,7 @@ contains
        endif
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, DRIVER_COMM, ierr)
        if (present(drv_comm_id)) then
+          print *,__FILE__,__LINE__,drv_comm_id
           call seq_comm_setcomm(COMPID(n), pelist, comp_nthreads,name, drv_comm_id)
        else
           call seq_comm_setcomm(COMPID(n), pelist, comp_nthreads,name, n, num_inst_comp)
@@ -712,7 +713,8 @@ contains
 
     if (seq_comms(ID)%iamroot) then
        write(logunit,F11) trim(subname),'  initialize ID ',ID,seq_comms(ID)%name, &
-         ' pelist   =',pelist,' npes =',seq_comms(ID)%npes,' nthreads =',seq_comms(ID)%nthreads
+         ' pelist   =',pelist,' npes =',seq_comms(ID)%npes,' nthreads =',seq_comms(ID)%nthreads,&
+         ' suffix =',trim(seq_comms(ID)%suffix)
     endif
 
   end subroutine seq_comm_setcomm

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -198,15 +198,16 @@ contains
   end function seq_comm_get_ncomps
 
 
-  subroutine seq_comm_init(Comm_in, nmlfile, Comm_ID)
-
+  subroutine seq_comm_init(Comm_in, nmlfile, Cpl_comm_id)
     !----------------------------------------------------------
     !
     ! Arguments
     implicit none
     integer, intent(in) :: Comm_in
     character(len=*), intent(IN) :: nmlfile
-    integer, optional, intent(in) :: Comm_ID
+    ! Optional argument cpl_comm_id is used to identify the particular
+    ! coupler instance used by each component instance in a multi-coupler case.
+    integer, optional, intent(in) :: Cpl_comm_id
     !
     ! Local variables
     !

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -198,7 +198,7 @@ contains
   end function seq_comm_get_ncomps
 
 
-  subroutine seq_comm_init(Comm_in, nmlfile)
+  subroutine seq_comm_init(Comm_in, nmlfile, Comm_ID)
 
     !----------------------------------------------------------
     !
@@ -206,6 +206,7 @@ contains
     implicit none
     integer, intent(in) :: Comm_in
     character(len=*), intent(IN) :: nmlfile
+    integer, optional, intent(in) :: Comm_ID
     !
     ! Local variables
     !

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -18,6 +18,7 @@
 ! !REVISION HISTORY:
 !     2005-Nov-11 - E. Kluzek - creation of shr_inputinfo_mod
 !     2007-Nov-15 - T. Craig - refactor for ccsm4 system and move to seq_infodata_mod
+!     2016-Dec-08 - R. Montuoro - updated for multiple coupler instances
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
@@ -285,7 +286,7 @@ CONTAINS
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
+SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid, cpl_tag)
 
 ! !USES:
 
@@ -302,6 +303,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
    character(len=*),        intent(IN)    :: nmlfile   ! Name-list filename
    integer(SHR_KIND_IN),    intent(IN)    :: ID        ! seq_comm ID
    type(file_desc_T) :: pioid
+   character(len=*), optional, intent(IN) :: cpl_tag   ! cpl instance suffix
 !EOP
 
     !----- local -----
@@ -588,6 +590,20 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid)
        infodata%brnch_retain_casename = brnch_retain_casename
        infodata%restart_pfile         = restart_pfile
        infodata%restart_file          = restart_file
+       if (present(cpl_tag)) then
+          if (len(cpl_tag) > 0) then
+             if (trim(restart_file) /= trim(sp_str)) then
+                write(logunit,*) trim(subname),' ERROR: restart_file can '//&
+                'only be read from restart pointer files when using multiple couplers '
+                call shr_sys_abort(subname//' ERROR: invalid settings for restart_file ')
+             end if
+          end if
+          infodata%restart_file       = restart_file
+          infodata%restart_pfile      = trim(restart_pfile) // trim(cpl_tag)
+       else
+          infodata%restart_pfile      = restart_pfile
+          infodata%restart_file       = restart_file
+       end if
        infodata%single_column         = single_column
        infodata%scmlat                = scmlat
        infodata%scmlon                = scmlon

--- a/src/drivers/mct/unit_test/utils/mct_wrapper_mod.F90
+++ b/src/drivers/mct/unit_test/utils/mct_wrapper_mod.F90
@@ -39,7 +39,7 @@ contains
     character(len=*), parameter :: subname = 'mct_init'
     !-----------------------------------------------------------------------
 
-    call seq_comm_init(Comm_in = mct_communicator, nmlfile = ' ')
+    call seq_comm_init(mct_communicator, mct_communicator, nmlfile = ' ')
   end subroutine mct_init
 
   !-----------------------------------------------------------------------

--- a/src/externals/mct/mct/m_MCTWorld.F90
+++ b/src/externals/mct/mct/m_MCTWorld.F90
@@ -282,7 +282,6 @@
 
 ! allocate a tmp array for the receive on root.
   if(myGid == 0) then
-     print *,__FILE__,__LINE__,Gsize, ncomps
     allocate(tmparray(0:Gsize-1,ncomps),stat=ier)
     if(ier/=0) call die(myname_,'allocate(tmparray)',ier)
 

--- a/src/externals/mct/mct/m_MCTWorld.F90
+++ b/src/externals/mct/mct/m_MCTWorld.F90
@@ -282,6 +282,7 @@
 
 ! allocate a tmp array for the receive on root.
   if(myGid == 0) then
+     print *,__FILE__,__LINE__,Gsize, ncomps
     allocate(tmparray(0:Gsize-1,ncomps),stat=ier)
     if(ier/=0) call die(myname_,'allocate(tmparray)',ier)
 
@@ -880,4 +881,3 @@
 
 
  end module m_MCTWorld
-


### PR DESCRIPTION
Implementation of multiple MCT drivers as an option for multi-instance simulations. If multi-instance is enabled, N drivers are run, each with one instance.

Also (changes not directly related to multi-driver):

- Changed interface of `check_lockedfiles` (check_lockedfiles.py) to take a case instead of a caseroot.
- Use `case.get_env` instead of `EnvBuild` in check_lockedfiles.py
- Changed `check_case` (case_submit.py) to not take a caseroot input.
- Cleaned up memleak testing in `_check_for_memleak` (system_tests_common.py)
- Fixed bad format in `build_xcpl_nml` (buildnml.py)

Test suite: scripts_regression_tests.py
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit
Fixes: #1704 
Fixes: #1714 

User interface changes?: new --multi-driver option to create_newcase and _C# modifier to tests

Update gh-pages html (Y/N)?: Y

Code review: @gold2718