### PR TITLE
Fix use-existing feature for create_test

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -512,12 +512,20 @@ class TESTRUNFAIL(FakeTest):
 
     def build_phase(self, sharedlib_only=False, model_only=False):
         rundir = self._case.get_value("RUNDIR")
+        cimeroot = self._case.get_value("CIMEROOT")
+        case = self._case.get_value("CASE")
         script = \
 """
-echo Insta fail
-echo model failed > {}/cpl.log.$LID
-exit -1
-""".format(rundir)
+if [ -z "$TESTRUNFAIL_PASS" ]; then
+  echo Insta fail
+  echo model failed > {}/cpl.log.$LID
+  exit -1
+else
+  echo Insta pass
+  echo SUCCESSFUL TERMINATION > {}/cpl.log.$LID
+  cp {}/scripts/tests/cpl.hi1.nc.test {}/{}.cpl.hi.0.nc
+fi
+""".format(rundir, rundir, cimeroot, rundir, case)
         self._set_script(script)
         FakeTest.build_phase(self,
                              sharedlib_only=sharedlib_only, model_only=model_only)

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -224,8 +224,15 @@ class TestScheduler(object):
                             # We need to pick up here
                             break
                         else:
-                            self._update_test_status(test, phase, TEST_PEND_STATUS)
-                            self._update_test_status(test, phase, status)
+                            if phase != SUBMIT_PHASE:
+                                # Somewhat subtle. Create_test considers submit/run to be the run phase,
+                                # so don't try to update test status for a passed submit phase
+                                self._update_test_status(test, phase, TEST_PEND_STATUS)
+                                self._update_test_status(test, phase, status)
+
+                                if phase == RUN_PHASE:
+                                    logger.info("Test {} passed and will not be re-run".format(test))
+
                 logger.info("Using existing test directory {}".format(self._get_test_dir(test)))
         else:
             # None of the test directories should already exist.

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -927,13 +927,14 @@ class O_TestTestScheduler(TestCreateTestCommon):
     ###########################################################################
     def test_c_use_existing(self):
     ###########################################################################
-        tests = update_acme_tests.get_full_test_names(["TESTBUILDFAIL_P1.f19_g16_rx1.A", "TESTRUNPASS_P1.f19_g16_rx1.A"],
+        tests = update_acme_tests.get_full_test_names(["TESTBUILDFAIL_P1.f19_g16_rx1.A", "TESTRUNFAIL_P1.f19_g16_rx1.A", "TESTRUNPASS_P1.f19_g16_rx1.A"],
                                                       self._machine, self._compiler)
         test_id="%s-%s" % (self._baseline_name, CIME.utils.get_timestamp())
-        ct = TestScheduler(tests, test_id=test_id, no_batch=NO_BATCH, no_run=True,test_root=TEST_ROOT,
+        ct = TestScheduler(tests, test_id=test_id, no_batch=NO_BATCH, test_root=TEST_ROOT,
                            output_root=TEST_ROOT,compiler=self._compiler, mpilib=self._mpilib)
 
         build_fail_test     = [item for item in tests if "TESTBUILDFAIL" in item][0]
+        run_fail_test       = [item for item in tests if "TESTRUNFAIL" in item][0]
         pass_test           = [item for item in tests if "TESTRUNPASS" in item][0]
 
         log_lvl = logging.getLogger().getEffectiveLevel()
@@ -946,17 +947,24 @@ class O_TestTestScheduler(TestCreateTestCommon):
         test_statuses = glob.glob("%s/*%s/TestStatus" % (self._testroot, test_id))
         self.assertEqual(len(tests), len(test_statuses))
 
+        if (self._hasbatch):
+            run_cmd_assert_result(self, "%s/wait_for_tests *%s/TestStatus" % (TOOLS_DIR, test_id), from_dir=self._testroot)
+
         for test_status in test_statuses:
             ts = TestStatus(test_dir=os.path.dirname(test_status))
             test_name = ts.get_name()
             if test_name == build_fail_test:
                 self.assertEqual(ts.get_status(CIME.test_scheduler.MODEL_BUILD_PHASE), TEST_FAIL_STATUS)
+            elif test_name == run_fail_test:
+                self.assertEqual(ts.get_status(CIME.test_scheduler.RUN_PHASE), TEST_FAIL_STATUS)
             else:
                 self.assertTrue(test_name == pass_test)
                 self.assertEqual(ts.get_status(CIME.test_scheduler.MODEL_BUILD_PHASE), TEST_PASS_STATUS)
-                self.assertEqual(ts.get_status(CIME.test_scheduler.SUBMIT_PHASE), TEST_PEND_STATUS)
+                self.assertEqual(ts.get_status(CIME.test_scheduler.SUBMIT_PHASE), TEST_PASS_STATUS)
+                self.assertEqual(ts.get_status(CIME.test_scheduler.RUN_PHASE), TEST_PASS_STATUS)
 
         os.environ["TESTBUILDFAIL_PASS"] = "True"
+        os.environ["TESTRUNFAIL_PASS"] = "True"
         ct2 = TestScheduler(tests, test_id=test_id, no_batch=NO_BATCH, use_existing=True,
                             test_root=TEST_ROOT,output_root=TEST_ROOT,compiler=self._compiler,
                             mpilib=self._mpilib)


### PR DESCRIPTION
There was a bug when trying to use-existing on a case that previously
had a fail in the RUN phase.

This PR also adds a test for this in the test for use-existing.

Test suite: code_checker, scripts_regression_tests O_TestTestScheduler
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1803 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: jedwards
