### PR TITLE
Add message at end of successful build

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -516,6 +516,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only):
 
     logger.info("Time spent not building: {:f} sec".format(t2 - t1))
     logger.info("Time spent building: {:f} sec".format(t3 - t2))
+    logger.info("MODEL BUILD HAS FINISHED SUCCESSFULLY")
 
     return True
 


### PR DESCRIPTION
Old versions of CESM scripts had a message like this at the end of a
successful build:

``` CCSM BUILDEXE SCRIPT HAS FINISHED SUCCESSFULLY ```

This was helpful to determine at a glance if the build had completed
successfully. It would be even more helpful now, since the build prints
even more information than it used to.

Test suite: manual tests of failed and successful builds
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#1825

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: 
