### PR TITLE
new capability to apply user mods in a case - needed for SCAM workflow

### DIFF
--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -7,7 +7,11 @@ case.setup - create the $caseroot/case.run script and user_nl_xxx component name
 from standard_script_setup import *
 
 from CIME.case_setup import case_setup
-from CIME.case       import Case
+from CIME.case import Case
+from CIME.user_mod_support import apply_user_mods
+from CIME.utils import expect
+
+logger = logging.getLogger(__name__)
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -45,9 +49,16 @@ OR
     parser.add_argument("-r", "--reset", action="store_true",
                         help="Does a clean followed by setup")
 
+    parser.add_argument("-a", "--apply-usermods",
+                        help="Specify a directory to apply user mods")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.caseroot, args.clean, args.test_mode, args.reset
+    if args.apply_usermods is not None:
+        expect(not args.reset and not args.clean,
+               "Error: cannot set --reset or --clean if are using --apply-usermods")
+
+    return args.caseroot, args.clean, args.test_mode, args.reset, args.apply_usermods
 
 ###############################################################################
 def _main_func(description):
@@ -56,9 +67,14 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, clean, test_mode, reset = parse_command_line(sys.argv, description)
-    with Case(caseroot, read_only=False) as case:
-        case_setup(case, clean=clean, test_mode=test_mode, reset=reset)
+    caseroot, clean, test_mode, reset, usermods_dir = parse_command_line(sys.argv, description)
+
+    if usermods_dir is not None:
+        logger.warn("WARNING: REMOVING all user_nl_xxx files as part of ./case_setup --apply-usermods")
+        apply_user_mods(caseroot, usermods_dir, cleanfirst=True)
+    else:
+        with Case(caseroot, read_only=False) as case:
+            case_setup(case, clean=clean, test_mode=test_mode, reset=reset)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/lib/CIME/user_mod_support.py
+++ b/scripts/lib/CIME/user_mod_support.py
@@ -8,7 +8,7 @@ import shutil, glob
 
 logger = logging.getLogger(__name__)
 
-def apply_user_mods(caseroot, user_mods_path):
+def apply_user_mods(caseroot, user_mods_path, cleanfirst=None):
     '''
     Recursivlely apply user_mods to caseroot - this includes updating user_nl_xxx,
     updating SourceMods and creating case shell_commands and xmlchange_cmds files
@@ -25,6 +25,15 @@ def apply_user_mods(caseroot, user_mods_path):
             os.remove(shell_command_file)
 
     include_dirs = build_include_dirs_list(user_mods_path)
+
+    # Clean all user_nl_xxx files
+    if cleanfirst is not None:
+        for filename in glob.iglob(os.path.join(caseroot,"user_nl_*")):
+            if os.path.exists(filename):
+                os.remove(os.path.join(caseroot, filename))
+                # Opening a blank user_nl file
+                open(filename, 'w').close()
+
     # If a user_mods dir 'foo' includes 'bar', the include_dirs list returned
     # from build_include_dirs has 'foo' before 'bar'. But with the below code,
     # directories that occur later in the list take precedence over the earlier


### PR DESCRIPTION
New case.setup to apply usermods after case creation.

This PR adds a new argument to case.setup that permits usermods to be applied after case creation. The caveat is that when these usermods are applied - all user_nl_xxx files are first scrubbed and empty ones are created. 

SCAM would like the capability to have one executable but easily change the IOP forcing data that is needed. Currently, they have a compset for each new IOP dataset. This is very cumbersome and is a step backwards from their previous workflow. With this change - a single SCAM compset can be user - with a time prefix SCAM. The a combination of 
./case.setup --apply-usermods and create_clone --keepexe can be used to satisfy the requirements of a SCAM workflow that would be suitable for scientific experimentation.

Test suite: None - hand tested the capability
Test baseline: None
Test namelist changes: None
Test status: bit for bit, roundoff

Fixes: None 
User interface changes?: None
Update gh-pages html (Y/N)?: N
Code review: jedwards
