### PR TITLE
Rewrite ERP and ERS to use SystemTestsCompareTwo

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -244,7 +244,12 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <BFBFLAG>TRUE</BFBFLAG>
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>11</STOP_N>
+    <REST_N>$STOP_N / 2 + 1</REST_N>
+    <REST_OPTION>$STOP_OPTION</REST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
   </test>
 
   <test NAME="ERS">

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -40,6 +40,9 @@ def parse_command_line(args):
                         help="Specify the root output directory"
 			"default: setting in case, create_clone will fail if this directory is not writable")
 
+    parser.add_argument("--share-rundir", action="store_true",
+                        help="Sets RUNDIR to point to original run")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.case is None:
@@ -51,20 +54,20 @@ def parse_command_line(args):
                "Must specify -clone as an input argument")
 
     return args.case, args.clone, args.keepexe, args.mach_dir, args.project, \
-        args.cime_output_root
+        args.cime_output_root, args.share_rundir
 
 ##############################################################################
 def _main_func():
 ###############################################################################
 
-    case, clone, keepexe, mach_dir, project, cime_output_root = parse_command_line(sys.argv)
+    case, clone, keepexe, mach_dir, project, cime_output_root, share_rundir = parse_command_line(sys.argv)
 
     cloneroot = os.path.abspath(clone)
     expect(os.path.isdir(cloneroot),
            "Missing cloneroot directory %s " % cloneroot)
 
     with Case(cloneroot, read_only=False) as clone:
-        clone.create_clone(case, keepexe, mach_dir, project, cime_output_root)
+        clone.create_clone(case, keepexe, mach_dir, project, cime_output_root, share_rundir)
 
 ###############################################################################
 

--- a/scripts/lib/CIME/SystemTests/erp.py
+++ b/scripts/lib/CIME/SystemTests/erp.py
@@ -23,7 +23,7 @@ class ERP(SystemTestsCompareTwo):
         """
         SystemTestsCompareTwo.__init__(self, case,
                                        separate_builds = True,
-                                       separate_runs = False,
+                                       separate_rundirs = False,
                                        run_two_suffix = 'rest',
                                        run_one_description = 'initial',
                                        run_two_description = 'restart')

--- a/scripts/lib/CIME/SystemTests/erp.py
+++ b/scripts/lib/CIME/SystemTests/erp.py
@@ -1,5 +1,5 @@
 """
-CIME ERP test.  This class inherits from SystemTestsCommon
+CIME ERP test.  This class inherits from SystemTestsCompareTwo
 
 This is a pes counts hybrid (open-MP/MPI) restart bfb test from
 startup.  This is just like an ERS test but the pe-counts/threading
@@ -8,132 +8,57 @@ count are modified on retart.
 (2) Do a restart test with half the number of tasks and threads (suffix rest)
 """
 
-import shutil
 from CIME.XML.standard_module_setup import *
 from CIME.case_setup import case_setup
-import CIME.utils
-from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.check_lockedfiles import *
 
 logger = logging.getLogger(__name__)
 
-class ERP(SystemTestsCommon):
+class ERP(SystemTestsCompareTwo):
 
     def __init__(self, case):
         """
         initialize a test object
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCompareTwo.__init__(self, case,
+                                       separate_builds = True,
+                                       separate_runs = False,
+                                       run_two_suffix = 'rest',
+                                       run_one_description = 'initial',
+                                       run_two_description = 'restart')
 
-    def build_phase(self, sharedlib_only=False, model_only=False):
-        """
-        Build two cases.  Case one uses defaults, case2 uses half the number of threads
-        and tasks. This test will fail for components (e.g. pop) that do not reproduce exactly
-        with different numbers of mpi tasks.
-        """
+    def _common_setup(self):
         self._case.set_value("BUILD_THREADED",True)
-        if sharedlib_only:
-            return self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
-        exeroot = self._case.get_value("EXEROOT")
-        cime_model = CIME.utils.get_model()
+    def _case_one_setup(self):
+        stop_n      = self._case.get_value("STOP_N")
 
-        # Make backup copies of the ORIGINAL env_mach_pes.xml and
-        # env_build.xml in LockedFiles if they are not there. If there
-        # are already copies there then simply copy them back to
-        # have the starting env_mach_pes.xml and env_build.xml
-        machpes1 = "env_mach_pes.ERP1.xml"
-        envbuild1 = "env_build.ERP1.xml"
-        if is_locked(machpes1):
-            restore(machpes1, newname="env_mach_pes.xml")
-        else:
-            lock_file("env_mach_pes.xml", newname=machpes1)
+        expect(stop_n > 2, "ERROR: stop_n value {:d} too short".format(stop_n))
 
-        if is_locked(envbuild1):
-            restore(envbuild1, newname="env_build.xml")
+    def _case_two_setup(self):
+        # halve the number of tasks and threads
+        for comp in self._case.get_values("COMP_CLASSES"):
+            ntasks    = self._case1.get_value("NTASKS_{}".format(comp))
+            nthreads  = self._case1.get_value("NTHRDS_{}".format(comp))
+            rootpe    = self._case1.get_value("ROOTPE_{}".format(comp))
+            if ( nthreads > 1 ):
+                self._case.set_value("NTHRDS_{}".format(comp), nthreads/2)
+            if ( ntasks > 1 ):
+                self._case.set_value("NTASKS_{}".format(comp), ntasks/2)
+                self._case.set_value("ROOTPE_{}".format(comp), rootpe/2)
 
-        # Build two executables, one using the original tasks and threads (ERP1) and
-        # one using the modified tasks and threads (ERP2)
-        # The reason we currently need two executables that CESM-CICE has a compile time decomposition
-        # For cases where ERP works, changing this decomposition will not affect answers, but it will
-        # affect the executable that is used
-        for bld in range(1,3):
-            logging.warn("Starting bld {}".format(bld))
+        stop_n = self._case.get_value("STOP_N")
 
-            if (bld == 2):
-                # halve the number of tasks and threads
-                for comp in self._case.get_values("COMP_CLASSES"):
-                    ntasks    = self._case.get_value("NTASKS_{}".format(comp))
-                    nthreads  = self._case.get_value("NTHRDS_{}".format(comp))
-                    rootpe    = self._case.get_value("ROOTPE_{}".format(comp))
-                    if ( nthreads > 1 ):
-                        self._case.set_value("NTHRDS_{}".format(comp), nthreads/2)
-                    if ( ntasks > 1 ):
-                        self._case.set_value("NTASKS_{}".format(comp), ntasks/2)
-                        self._case.set_value("ROOTPE_{}".format(comp), rootpe/2)
+        rest_n = stop_n/2 + 1
+        stop_new = stop_n - rest_n
+        expect(stop_new > 0, "ERROR: stop_n value {:d} too short {:d} {:d}".format(stop_new,stop_n,rest_n))
+        self._case.set_value("STOP_N", stop_new)
+        self._case.set_value("CONTINUE_RUN", True)
+        self._case.set_value("REST_OPTION","never")
 
-                # Note, some components, like CESM-CICE, have
-                # decomposition information in env_build.xml
-                # case_setup(self._case, test_mode=True, reset=True)that
-                # needs to be regenerated for the above new tasks and thread counts
-                case_setup(self._case, test_mode=True, reset=True)
-
-            # Now rebuild the system, given updated information in env_build.xml
-            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-            shutil.move("{}/{}.exe".format(exeroot,cime_model),
-                        "{}/{}.ERP{}.exe".format(exeroot,cime_model,bld))
-
-            # Make copies of the new env_mach_pes.xml and the new
-            # env_build.xml to be used in the run phase
-            lock_file("env_mach_pes.xml", newname="env_mach_pes.ERP{}.xml".format(bld))
-            lock_file("env_build.xml", newname="env_build.ERP{}.xml".format(bld))
-
-    def run_phase(self):
-        # run will have values 1,2
-        for run in range(1,3):
-
-            expect(is_locked("env_mach_pes.ERP{:d}.xml".format(run)),
-                   "ERROR: LockedFiles/env_mach_pes.ERP{:d}.xml does not exist, run case.build".format(run ))
-
-            # Use the second env_mach_pes.xml and env_build.xml files
-            restore("env_mach_pes.ERP{:d}.xml".format(run), newname="env_mach_pes.xml")
-            restore("env_build.ERP{:d}.xml".format(run), newname="env_build.xml")
-
-            # update the case to use the new values
-            self._case.read_xml()
-
-            # Use the second executable that was created
-            exeroot = self._case.get_value("EXEROOT")
-            cime_model = CIME.utils.get_model()
-            exefile  = os.path.join(exeroot,"{}.exe".format(cime_model))
-            exefile2 = os.path.join(exeroot,"{}.ERP{:d}.exe".format(cime_model,run))
-            if (os.path.isfile(exefile)):
-                os.remove(exefile)
-            shutil.copy(exefile2, exefile)
-
-            stop_n      = self._case.get_value("STOP_N")
-            stop_option = self._case.get_value("STOP_OPTION")
-
-            if run == 1:
-                expect(stop_n > 2, "ERROR: stop_n value {:d} too short".format(stop_n))
-                rest_n = stop_n/2 + 1
-                self._case.set_value("REST_N", rest_n)
-                self._case.set_value("REST_OPTION", stop_option)
-                self._case.set_value("HIST_N", stop_n)
-                self._case.set_value("HIST_OPTION", stop_option)
-                self._case.set_value("CONTINUE_RUN", False)
-                suffix = "base"
-            else:
-                rest_n = stop_n/2 + 1
-                stop_new = stop_n - rest_n
-                expect(stop_new > 0, "ERROR: stop_n value {:d} too short {:d} {:d}".format(stop_new,stop_n,rest_n))
-                self._case.set_value("STOP_N", stop_new)
-                self._case.set_value("CONTINUE_RUN", True)
-                self._case.set_value("REST_OPTION","never")
-                suffix = "rest"
-
-            case_setup(self._case, test_mode=True, reset=True)
-
-            self.run_indv(suffix=suffix)
-
-        self._component_compare_test("base", "rest")
+        # Note, some components, like CESM-CICE, have
+        # decomposition information in env_build.xml
+        # case_setup(self._case, test_mode=True, reset=True)that
+        # needs to be regenerated for the above new tasks and thread counts
+        case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/erp.py
+++ b/scripts/lib/CIME/SystemTests/erp.py
@@ -57,6 +57,10 @@ class ERP(SystemTestsCompareTwo):
         self._case.set_value("CONTINUE_RUN", True)
         self._case.set_value("REST_OPTION","never")
 
+        # May need to change EXEROOT since separate_rundirs is False and separate_builds is True
+        if self._case1.get_value("EXEROOT") == self._case2.get_value("EXEROOT"):
+            self._case.set_value("EXEROOT", self._case.get_value("EXEROOT") + "_" + self._run_two_description)
+
         # Note, some components, like CESM-CICE, have
         # decomposition information in env_build.xml
         # case_setup(self._case, test_mode=True, reset=True)that

--- a/scripts/lib/CIME/SystemTests/err.py
+++ b/scripts/lib/CIME/SystemTests/err.py
@@ -3,6 +3,7 @@ CIME ERR test  This class inherits from ERS
 ERR tests short term archiving and restart capabilities
 """
 from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.SystemTests.ers import ERS
 
 import shutil, glob
@@ -11,31 +12,30 @@ logger = logging.getLogger(__name__)
 
 class ERR(ERS):
 
-    def __init__(self, case):
+    def __init__(self, case): # pylint: disable=super-init-not-called
         """
         initialize an object interface to the ERR system test
         """
-        ERS.__init__(self, case)
+        SystemTestsCompareTwo.__init__(self, case, # pylint: disable=non-parent-init-called
+                                       separate_builds = False,
+                                       separate_runs = False,
+                                       run_two_suffix = 'rest',
+                                       run_one_description = 'initial',
+                                       run_two_description = 'restart',
+                                       multisubmit = True)
 
-    def run_phase(self):
-        first_phase = self._case.get_value("RESUBMIT") == 1
-
-        if first_phase:
-            self._case.set_value("DOUT_S", True)
-            self._case.flush()
-            self._ers_first_phase()
-        else:
-            dout_s_root = self._case.get_value("DOUT_S_ROOT")
-            rundir = self._case.get_value("RUNDIR")
-            case = self._case.get_value("CASE")
-            # First remove restart, history and rpointer files from the run directory
-            for item in glob.iglob(os.path.join(rundir, "{}.*".format(case))):
-                if not item.endswith("base"):
-                    os.remove(item)
-            for item in glob.iglob(os.path.join(rundir, "rpointer.*")):
+    def _case_two_custom_prerun_action(self):
+        dout_s_root = self._case.get_value("DOUT_S_ROOT")
+        rundir = self._case.get_value("RUNDIR")
+        case = self._case.get_value("CASE")
+        # First remove restart, history and rpointer files from the run directory
+        for item in glob.iglob(os.path.join(rundir, "{}.*".format(case))):
+            if not item.endswith("base"):
                 os.remove(item)
-            # Then replace them from the restart directory
-            for item in glob.iglob(os.path.join(dout_s_root,"rest","*","*")):
-                shutil.copy(item, rundir)
 
-            self._ers_second_phase()
+        for item in glob.iglob(os.path.join(rundir, "rpointer.*")):
+            os.remove(item)
+
+        # Then replace them from the restart directory
+        for item in glob.iglob(os.path.join(dout_s_root,"rest","*","*")):
+            shutil.copy(item, rundir)

--- a/scripts/lib/CIME/SystemTests/err.py
+++ b/scripts/lib/CIME/SystemTests/err.py
@@ -18,7 +18,7 @@ class ERR(ERS):
         """
         SystemTestsCompareTwo.__init__(self, case, # pylint: disable=non-parent-init-called
                                        separate_builds = False,
-                                       separate_runs = False,
+                                       separate_rundirs = False,
                                        run_two_suffix = 'rest',
                                        run_one_description = 'initial',
                                        run_two_description = 'restart',

--- a/scripts/lib/CIME/SystemTests/erri.py
+++ b/scripts/lib/CIME/SystemTests/erri.py
@@ -18,17 +18,12 @@ class ERRI(ERR):
         """
         ERR.__init__(self, case)
 
-    def run_phase(self):
-        first_phase = self._case.get_value("RESUBMIT") == 1
-
-        ERR.run_phase(self)
-
-        if not first_phase:
-            rundir = self._case.get_value("RUNDIR")
-            for logname_gz in glob.glob(os.path.join(rundir, '*.log*.gz')):
-                # gzipped logfile names are of the form $LOGNAME.gz
-                # Removing the last three characters restores the original name
-                logname = logname_gz[:-3]
-                with gzip.open(logname_gz, 'rb') as f_in, open(logname, 'w') as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-                os.remove(logname_gz)
+    def _case_two_custom_postrun_action(self):
+        rundir = self._case.get_value("RUNDIR")
+        for logname_gz in glob.glob(os.path.join(rundir, '*.log*.gz')):
+            # gzipped logfile names are of the form $LOGNAME.gz
+            # Removing the last three characters restores the original name
+            logname = logname_gz[:-3]
+            with gzip.open(logname_gz, 'rb') as f_in, open(logname, 'w') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+            os.remove(logname_gz)

--- a/scripts/lib/CIME/SystemTests/ers.py
+++ b/scripts/lib/CIME/SystemTests/ers.py
@@ -1,32 +1,32 @@
 """
-CIME restart test  This class inherits from SystemTestsCommon
+CIME restart test  This class inherits from SystemTestsCompareTwo
 """
 from CIME.XML.standard_module_setup import *
-from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 
 logger = logging.getLogger(__name__)
 
-class ERS(SystemTestsCommon):
+class ERS(SystemTestsCompareTwo):
 
     def __init__(self, case):
         """
         initialize an object interface to the ERS system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCompareTwo.__init__(self, case,
+                                       separate_builds = False,
+                                       separate_runs = False,
+                                       run_two_suffix = 'rest',
+                                       run_one_description = 'initial',
+                                       run_two_description = 'restart')
 
-    def _ers_first_phase(self):
+    def _case_one_setup(self):
         stop_n      = self._case.get_value("STOP_N")
-        stop_option = self._case.get_value("STOP_OPTION")
-        rest_n      = self._case.get_value("REST_N")
+
         expect(stop_n > 0, "Bad STOP_N: {:d}".format(stop_n))
-
         expect(stop_n > 2, "ERROR: stop_n value {:d} too short".format(stop_n))
-        logger.info("doing an {} {} initial test with restart file at {} {}".format(str(stop_n), stop_option, str(rest_n), stop_option))
-        self.run_indv()
 
-    def _ers_second_phase(self):
+    def _case_two_setup(self):
         stop_n      = self._case.get_value("STOP_N")
-        stop_option = self._case.get_value("STOP_OPTION")
 
         rest_n = stop_n/2 + 1
         stop_new = stop_n - rest_n
@@ -37,12 +37,3 @@ class ERS(SystemTestsCommon):
         self._case.set_value("CONTINUE_RUN", True)
         self._case.set_value("REST_OPTION","never")
         self._case.flush()
-        logger.info("doing an {} {} restart test".format(str(stop_new), stop_option))
-        self.run_indv(suffix="rest")
-
-        # Compare restart file
-        self._component_compare_test("base", "rest")
-
-    def run_phase(self):
-        self._ers_first_phase()
-        self._ers_second_phase()

--- a/scripts/lib/CIME/SystemTests/ers.py
+++ b/scripts/lib/CIME/SystemTests/ers.py
@@ -14,7 +14,7 @@ class ERS(SystemTestsCompareTwo):
         """
         SystemTestsCompareTwo.__init__(self, case,
                                        separate_builds = False,
-                                       separate_runs = False,
+                                       separate_rundirs = False,
                                        run_two_suffix = 'rest',
                                        run_one_description = 'initial',
                                        run_two_description = 'restart')

--- a/scripts/lib/CIME/SystemTests/nodefail.py
+++ b/scripts/lib/CIME/SystemTests/nodefail.py
@@ -18,7 +18,8 @@ class NODEFAIL(ERS):
         self._fail_sentinel = os.path.join(case.get_value("RUNDIR"), "FAIL_SENTINEL")
         self._fail_str      = case.get_value("NODE_FAIL_REGEX")
 
-    def _restart_fake_phase(self):
+
+    def _case_two_custom_prerun_action(self):
         # Swap out model.exe for one that emits node failures
         rundir = self._case.get_value("RUNDIR")
         exeroot = self._case.get_value("EXEROOT")
@@ -69,8 +70,3 @@ fi
         env_mach_specific = self._case.get_env("mach_specific")
         env_mach_specific.set_value("run_exe", prev_run_exe)
         self._case.flush(flushall=True)
-
-    def run_phase(self):
-        self._ers_first_phase()
-        self._restart_fake_phase()
-        self._ers_second_phase()

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -14,13 +14,24 @@ Classes that inherit from this are REQUIRED to implement the following methods:
 (2) _case_two_setup
     This method will be called to set up case 2, the "test" case
 
-In addition, they MAY require the following method:
+In addition, they MAY require the following methods:
 
 (1) _common_setup
     This method will be called to set up both cases. It should contain any setup
     that's needed in both cases. This is called before _case_one_setup or
     _case_two_setup.
 
+(2) _case_one_custom_prerun_action(self):
+    Use this to do arbitrary actions immediately before running case one
+
+(3) _case_two_custom_prerun_action(self):
+    Use this to do arbitrary actions immediately before running case two
+
+(4) _case_one_custom_postrun_action(self):
+    Use this to do arbitrary actions immediately after running case one
+
+(5) _case_two_custom_postrun_action(self):
+    Use this to do arbitrary actions immediately after running case two
 """
 
 from CIME.XML.standard_module_setup import *
@@ -37,7 +48,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
     def __init__(self,
                  case,
                  separate_builds=True,
-                 separate_runs=True,
+                 separate_rundirs=True,
                  run_two_suffix = 'test',
                  run_one_description = '',
                  run_two_description = '',
@@ -51,7 +62,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 test. This is the main case associated with the test.
             separate_builds (bool): Whether separate builds are needed for the
                 two cases. If False, case2 uses the case1 executable.
-            separate_builds (bool): Whether separate runs are needed for the
+            separate_rundirs (bool): Whether separate run directories are needed for the
                 two cases. If False, case2 uses the case1 run area. Can be useful for restart tests
             run_two_suffix (str, optional): Suffix appended to the case name for
                 the second run. Defaults to 'test'. This can be anything other
@@ -60,12 +71,13 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 when starting the first run. Defaults to ''.
             run_two_description (str, optional): Description printed to log file
                 when starting the second run. Defaults to ''.
-            multisubmit (bool): Do first and second runs as different submissions
+            multisubmit (bool): Do first and second runs as different submissions.
+                Designed for tests with RESUBMIT=1
         """
         SystemTestsCommon.__init__(self, case)
 
-        self._separate_builds = separate_builds
-        self._separate_runs   = separate_runs
+        self._separate_builds  = separate_builds
+        self._separate_rundirs = separate_rundirs
 
         # run_one_suffix is just used as the suffix for the netcdf files
         # produced by the first case; we may eventually remove this, but for now
@@ -193,7 +205,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         Runs both phases of the two-phase test and compares their results
         If success_change is True, success requires some files to be different
         """
-        first_phase = self._case1.get_value("RESUBMIT") == 1
+        first_phase = self._case1.get_value("RESUBMIT") == 1 # Only relevant for multi-submit tests
         run_type = self._case1.get_value("RUN_TYPE")
 
         # First run
@@ -221,7 +233,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             # Compare results
             # Case1 is the "main" case, and we need to do the comparisons from there
             self._activate_case1()
-            if self._separate_runs:
+            if self._separate_rundirs:
                 self._link_to_case2_output()
 
             self._component_compare_test(self._run_one_suffix, self._run_two_suffix, success_change=success_change)
@@ -240,7 +252,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         casename1 = self._case1.get_value("CASE")
         caseroot1 = self._case1.get_value("CASEROOT")
 
-        casename2 = "{}.{}".format(casename1, self._run_two_suffix) if self._separate_runs else casename1
+        casename2 = "{}.{}".format(casename1, self._run_two_suffix) if self._separate_rundirs else casename1
 
         # Nest the case directory for case2 inside the case directory for case1
         caseroot2 = os.path.join(caseroot1, casename2)
@@ -280,7 +292,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 self._case2 = self._case1.create_clone(
                     self._caseroot2,
                     keepexe=not self._separate_builds,
-                    share_rundir=not self._separate_runs)
+                    share_rundir=not self._separate_rundirs)
                 self._setup_cases()
             except:
                 # If a problem occurred in setting up the test cases, it's

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -182,6 +182,9 @@ class SystemTestsCompareTwo(SystemTestsCommon):
 
     def build_phase(self, sharedlib_only=False, model_only=False):
         if self._separate_builds:
+            expect(self._case1.get_value("EXEROOT") != self._case2.get_value("EXEROOT"),
+                   "Separate builds cannot live in same EXEROOT")
+
             self._activate_case1()
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
             self._activate_case2()
@@ -256,7 +259,13 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         casename1 = self._case1.get_value("CASE")
         caseroot1 = self._case1.get_value("CASEROOT")
 
-        casename2 = "{}.{}".format(casename1, self._run_two_suffix) if self._separate_rundirs else casename1
+        if self._separate_rundirs:
+            casename2 = "{}.{}".format(casename1, self._run_two_suffix)
+        else:
+            # Cases need the exact same name for restart tests which is a common usage
+            # of shared rundirs. We insert an intermediary directory to help clarify things.
+            intermediary = self._run_two_description.replace(" ", "_") if self._run_two_description else self._run_two_suffix
+            casename2 = os.path.join(intermediary, casename1)
 
         # Nest the case directory for case2 inside the case directory for case1
         caseroot2 = os.path.join(caseroot1, casename2)

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -218,6 +218,10 @@ class SystemTestsCompareTwo(SystemTestsCommon):
 
         # Second run
         if not self._multisubmit or not first_phase:
+            # Subtle issue: case1 is already in a writeable state since it tends to be opened
+            # with a with statement in all the API entrances in CIME. case2 was created via clone,
+            # not a with statement, so it's not in a writeable state, so we need to use a with
+            # statement here to put it in a writeable state.
             with self._case2:
                 logger.info('Doing second run: ' + self._run_two_description)
                 self._activate_case2()

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1135,7 +1135,7 @@ class Case(object):
         else:
             return comp_user_mods
 
-    def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
+    def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None, share_rundir=False):
         if cime_output_root is None:
             cime_output_root = self.get_value("CIME_OUTPUT_ROOT")
         expect(os.access(cime_output_root, os.W_OK), "Directory {} is not writable"
@@ -1177,6 +1177,7 @@ class Case(object):
                     raise
             newcase.set_value("CIME_OUTPUT_ROOT", outputroot)
             newcase.set_value("USER", newuser)
+
         # determine if will use clone executable or not
         if keepexe:
             orig_exeroot = self.get_value("EXEROOT")
@@ -1188,6 +1189,10 @@ class Case(object):
                 logger.warn("Avoid this message by building case one before you clone.\n")
         else:
             newcase.set_value("BUILD_COMPLETE","FALSE")
+
+        if share_rundir:
+            orig_rundir = self.get_value("RUNDIR")
+            newcase.set_value("RUNDIR", orig_rundir)
 
         # set machdir
         if mach_dir is not None:

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -345,6 +345,7 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
         casename = 'mytest'
         case1root = os.path.join(self.tempdir, casename)
         case1 = CaseFake(case1root)
+
         mytest = SystemTestsCompareTwoFake(case1,
             run_one_suffix = run_one_suffix,
             run_two_suffix = run_two_suffix)
@@ -362,6 +363,7 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
             Call(METHOD_component_compare_test,
                 {'suffix1': run_one_suffix, 'suffix2': run_two_suffix})
         ]
+
         self.assertEqual(expected_calls, mytest.log)
 
     def test_run1_fails(self):
@@ -395,3 +397,6 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
         # Verify
         self.assertEqual(test_status.TEST_FAIL_STATUS,
                          mytest._test_status.get_status(test_status.RUN_PHASE))
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2, catchbreak=True)

--- a/scripts/lib/CIME/tests/case_fake.py
+++ b/scripts/lib/CIME/tests/case_fake.py
@@ -63,7 +63,7 @@ class CaseFake(object):
 
         return newcase
 
-    def create_clone(self, newcase, keepexe=False):
+    def create_clone(self, newcase, keepexe=False, share_rundir=False):
         # Need to disable unused-argument checking: keepexe is needed to match
         # the interface of Case, but is not used in this fake implementation
         #
@@ -101,3 +101,9 @@ class CaseFake(object):
         inside CASEROOT)
         """
         self.set_value('RUNDIR', os.path.join(self.get_value('CASEROOT'), 'run'))
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *_):
+        pass


### PR DESCRIPTION
This required some significant changes, foremost it introduces
the concept of a cloned case to re-use the exact same RUNDIR as
its parent.

The other big change was adding the concept of disabling separate_runs
much like the preexisting option to disable separate_builds, in
SystemTestsCompareTwo.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1647 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @billsacks 
