### PR TITLE
compare two test case names match

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -92,7 +92,10 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._case2 = None
 
         self._setup_cases_if_not_yet_done()
-
+        # Since case 2 has the same name as case1 it's CIME_OUTPUT_ROOT must also be different
+        self._case2.set_value("CIME_OUTPUT_ROOT",
+                              os.path.join(self._case1.get_value("CIME_OUTPUT_ROOT"),
+                                           self._case1.get_value("CASE")))
     # ========================================================================
     # Methods that MUST be implemented by specific tests that inherit from this
     # base class
@@ -195,10 +198,8 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         Assumes that self._case1 is already set to point to the case1 object,
         and that self._run_two_suffix is already set.
         """
-        casename1 = self._case1.get_value("CASE")
+        casename2 = self._case1.get_value("CASE")
         caseroot1 = self._case1.get_value("CASEROOT")
-
-        casename2 = "{}.{}".format(casename1, self._run_two_suffix)
 
         # Nest the case directory for case2 inside the case directory for case1
         caseroot2 = os.path.join(caseroot1, casename2)

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -92,10 +92,6 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._case2 = None
 
         self._setup_cases_if_not_yet_done()
-        # Since case 2 has the same name as case1 it's CIME_OUTPUT_ROOT must also be different
-        self._case2.set_value("CIME_OUTPUT_ROOT",
-                              os.path.join(self._case1.get_value("CIME_OUTPUT_ROOT"),
-                                           self._case1.get_value("CASE")))
     # ========================================================================
     # Methods that MUST be implemented by specific tests that inherit from this
     # base class
@@ -236,9 +232,13 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             self._case2 = self._case_from_existing_caseroot(self._caseroot2)
         else:
             try:
+                # Since case 2 has the same name as case1 it's CIME_OUTPUT_ROOT must also be different
                 self._case2 = self._case1.create_clone(
                     newcase = self._caseroot2,
-                    keepexe = self._separate_builds==False)
+                    keepexe = self._separate_builds==False,
+                    cime_output_root=os.path.join(self._case1.get_value("CIME_OUTPUT_ROOT"),
+                                                  self._case1.get_value("CASE")))
+
                 self._setup_cases()
             except:
                 # If a problem occurred in setting up the test cases, it's

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -198,7 +198,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         caseroot1 = self._case1.get_value("CASEROOT")
 
         # Nest the case directory for case2 inside the case directory for case1
-        caseroot2 = os.path.join(caseroot1, casename2)
+        caseroot2 = os.path.join(caseroot1, "case2", casename2)
 
         return caseroot2
 
@@ -227,18 +227,17 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # test setup when it's not needed - e.g., by appending things to user_nl
         # files multiple times. This is why we want to make sure to just do the
         # test setup once.)
-
         if os.path.exists(self._caseroot2):
             self._case2 = self._case_from_existing_caseroot(self._caseroot2)
         else:
             try:
                 # Since case 2 has the same name as case1 its CIME_OUTPUT_ROOT must also be different
+                case2_output_root = os.path.join(self._case1.get_value("CIME_OUTPUT_ROOT"),
+                                                  "case2",self._case1.get_value("CASE"))
                 self._case2 = self._case1.create_clone(
                     newcase = self._caseroot2,
                     keepexe = self._separate_builds==False,
-                    cime_output_root=os.path.join(self._case1.get_value("CIME_OUTPUT_ROOT"),
-                                                  self._case1.get_value("CASE")))
-
+                    cime_output_root = case2_output_root)
                 self._setup_cases()
             except:
                 # If a problem occurred in setting up the test cases, it's
@@ -249,7 +248,8 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 # case, but if we didn't remove the case2 directory, the next
                 # re-build of the test would think, "okay, setup is done, I can
                 # move on to the build", which would be wrong.
-                shutil.rmtree(self._caseroot2)
+                if os.path.isdir(self._caseroot2):
+                    shutil.rmtree(self._caseroot2)
                 self._activate_case1()
                 logger.warning("WARNING: Test case setup failed. Case2 has been removed, "
                                "but the main case may be in an inconsistent state. "

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -116,11 +116,11 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
                     break
                 self._test_status.set_status(phase, test_status.TEST_PASS_STATUS)
 
-        self.run_pass_casenames = []
+        self.run_pass_caseroot = []
         if run_one_should_pass:
-            self.run_pass_casenames.append(self._case1.get_value('CASE'))
+            self.run_pass_caseroot.append(self._case1.get_value('CASEROOT'))
         if run_two_should_pass:
-            self.run_pass_casenames.append(self._case2.get_value('CASE'))
+            self.run_pass_caseroot.append(self._case2.get_value('CASEROOT'))
 
         self.log = []
 
@@ -153,9 +153,9 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
         proper suffix is used for the proper case, but this extra check can be
         removed if it's a maintenance problem.)
         """
-        casename = self._case.get_value('CASE')
+        caseroot = self._case.get_value('CASEROOT')
         self.log.append(Call(METHOD_run_indv,
-                             {'suffix': suffix, 'CASE': casename}))
+                             {'suffix': suffix, 'CASEROOT': caseroot}))
 
         # Determine whether we should raise an exception
         #
@@ -163,8 +163,8 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
         # self._case object, to ensure that the right case has been activated
         # for this call to run_indv (e.g., to catch if we forgot to activate
         # case2 before the second call to run_indv).
-        if casename not in self.run_pass_casenames:
-            raise RuntimeError('casename not in run_pass_casenames')
+        if caseroot not in self.run_pass_caseroot:
+            raise RuntimeError('caseroot not in run_pass_caseroot')
 
     def _component_compare_test(self, suffix1, suffix2, success_change=False):
         # Trying to use the real version of _component_compare_test would pull
@@ -279,7 +279,7 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
         # Setup
         case1root = os.path.join(self.tempdir, 'case1')
         case1 = CaseFake(case1root)
-        os.makedirs(os.path.join(case1root, 'case1.test'))
+        os.makedirs(os.path.join(case1root, 'case2','case1'))
 
         # Exercise
         mytest = SystemTestsCompareTwoFake(case1,
@@ -288,7 +288,7 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
         # Verify:
 
         # Make sure that case2 object is set (i.e., that it doesn't remain None)
-        self.assertEqual('case1.test', mytest._case2.get_value('CASE'))
+        self.assertEqual('case1', mytest._case2.get_value('CASE'))
 
         # Variables set in various setup methods should not be set
         # (In the real world - i.e., outside of this unit testing fakery - these
@@ -344,6 +344,7 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
         run_two_suffix = 'run2'
         casename = 'mytest'
         case1root = os.path.join(self.tempdir, casename)
+        case2root = os.path.join(case1root, 'case2', casename)
         case1 = CaseFake(case1root)
         mytest = SystemTestsCompareTwoFake(case1,
             run_one_suffix = run_one_suffix,
@@ -355,9 +356,9 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
         # Verify
         expected_calls = [
             Call(METHOD_run_indv,
-                {'suffix': run_one_suffix, 'CASE': casename}),
+                 {'suffix': run_one_suffix, 'CASEROOT': case1root}),
             Call(METHOD_run_indv,
-                {'suffix': run_two_suffix, 'CASE': '{}.{}'.format(casename, run_two_suffix)}),
+                 {'suffix': run_two_suffix, 'CASEROOT': case2root}),
             Call(METHOD_link_to_case2_output, {}),
             Call(METHOD_component_compare_test,
                 {'suffix1': run_one_suffix, 'suffix2': run_two_suffix})

--- a/scripts/lib/CIME/tests/case_fake.py
+++ b/scripts/lib/CIME/tests/case_fake.py
@@ -20,6 +20,7 @@ class CaseFake(object):
             os.makedirs(case_root)
         self.set_value('CASEROOT', case_root)
         casename = os.path.basename(case_root)
+        self.set_value('CIME_OUTPUT_ROOT','/tmp')
         self.set_value('CASE', casename)
         self.set_value('CASEBASEID', casename)
         self.set_value('RUN_TYPE', 'startup')
@@ -63,7 +64,7 @@ class CaseFake(object):
 
         return newcase
 
-    def create_clone(self, newcase, keepexe=False):
+    def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
         # Need to disable unused-argument checking: keepexe is needed to match
         # the interface of Case, but is not used in this fake implementation
         #


### PR DESCRIPTION
This PR makes the case2 casename in system_tests_compare_two match the case one casename and nests both the case directory and the output directories inside that of case1.   This is a precursor for a PR to address issue #1640  

Addresses #1640

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?: N

Code review: