### PR TITLE
fix issue with clone to new user

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1138,12 +1138,6 @@ class Case(object):
     def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None, cime_output_root=None):
         if cime_output_root is None:
             cime_output_root = self.get_value("CIME_OUTPUT_ROOT")
-        if os.path.isdir(cime_output_root):
-            expect(os.access(cime_output_root, os.W_OK), "Directory {} is not writable"
-                   "by this user.  Use the --cime-output-root flag to provide a writable "
-                   "scratch directory".format(cime_output_root))
-        else:
-            os.makedirs(cime_output_root)
 
         newcaseroot = os.path.abspath(newcase)
         expect(not os.path.isdir(newcaseroot),
@@ -1158,28 +1152,32 @@ class Case(object):
             logger.warning(" clone CIMEROOT is {} ".format(clone_cimeroot))
             logger.warning(" It is NOT recommended to clone cases from different versions of CIME.")
 
-
         # *** create case object as deepcopy of clone object ***
         srcroot = os.path.join(newcase_cimeroot,"..")
         newcase = self.copy(newcasename, newcaseroot, newsrcroot=srcroot)
         newcase.set_value("CIMEROOT", newcase_cimeroot)
-        newcase.set_value("CIME_OUTPUT_ROOT", cime_output_root)
 
         # if we are cloning to a different user modify the output directory
         olduser = self.get_value("USER")
         newuser = os.environ.get("USER")
         if olduser != newuser:
-            outputroot = self.get_value("CIME_OUTPUT_ROOT")
-            outputroot = string.replace(outputroot, olduser, newuser)
-            # try to make the new output directory and raise an exception
-            # on any error other than directory already exists.
-            try:
-                os.makedirs(outputroot)
-            except OSError:
-                if not os.path.isdir(outputroot):
-                    raise
-            newcase.set_value("CIME_OUTPUT_ROOT", outputroot)
+            cime_output_root = string.replace(cime_output_root, olduser, newuser)
             newcase.set_value("USER", newuser)
+        newcase.set_value("CIME_OUTPUT_ROOT", cime_output_root)
+
+        # try to make the new output directory and raise an exception
+        # on any error other than directory already exists.
+        if os.path.isdir(cime_output_root):
+            expect(os.access(cime_output_root, os.W_OK), "Directory {} is not writable"
+                   "by this user.  Use the --cime-output-root flag to provide a writable "
+                   "scratch directory".format(cime_output_root))
+        else:
+            try:
+                os.makedirs(cime_output_root)
+            except:
+                if not os.path.isdir(cime_output_root):
+                    raise
+
         # determine if will use clone executable or not
         if keepexe:
             orig_exeroot = self.get_value("EXEROOT")

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -333,13 +333,17 @@ class J_TestCreateNewcase(unittest.TestCase):
         # this is intended as a test of whether create_clone is independent of user
         run_cmd_assert_result(self, "./xmlchange USER=this_is_not_a_user",
                               from_dir=prevtestdir)
+
         fakeoutputroot = string.replace(cls._testroot, os.environ.get("USER"), "this_is_not_a_user")
         run_cmd_assert_result(self, "./xmlchange CIME_OUTPUT_ROOT=%s"%fakeoutputroot,
                               from_dir=prevtestdir)
-        # this test should fail
+
+        # this test should pass (user name is replaced)
         run_cmd_assert_result(self, "%s/create_clone --clone %s --case %s " %
-                              (SCRIPT_DIR, prevtestdir, testdir),from_dir=SCRIPT_DIR, expected_stat=1)
-        #this test should pass
+                              (SCRIPT_DIR, prevtestdir, testdir),from_dir=SCRIPT_DIR)
+
+        shutil.rmtree(testdir)
+        # this test should pass
         run_cmd_assert_result(self, "%s/create_clone --clone %s --case %s --cime-output-root %s" %
                               (SCRIPT_DIR, prevtestdir, testdir, cls._testroot),from_dir=SCRIPT_DIR)
 


### PR DESCRIPTION
The create_clone new user test was failing.   I took this opportunity to rearrange the code a little so that the --cime-output-root is not necessarily required which meant I had to modify the test as well.

Test suite: scripts_regression_tests.py on hobart 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1834 

User interface changes?: 

Update gh-pages html (Y/N)?: N

Code review: 
