### PR TITLE
make warning prominent

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1355,7 +1355,9 @@ class Case(object):
                 if test["category"] == "prealpha" or test["category"] == "prebeta" or "aux_" in test["category"]:
                     testcnt += 1
         if testcnt > 0:
-            logger.info("\nThis compset and grid combination is not scientifically supported, however it is used in {:d} tests.\n".format(testcnt))
+            logger.warn("\n*********************************************************************************************************************************")
+            logger.warn("This compset and grid combination is not scientifically supported, however it is used in {:d} tests.".format(testcnt))
+            logger.warn("*********************************************************************************************************************************\n")
         else:
             expect(False, "\nThis compset and grid combination is untested in CESM.  "
                    "Override this warning with the --run-unsupported option to create_newcase.",


### PR DESCRIPTION
Make the unsupported warning from create_newcase more prominent in the output.
Test suite: hand tests of create_newcase 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1839 

User interface changes?: 

Update gh-pages html (Y/N)?: N

Code review: 
