### PR TITLE
Get PFUnit working on melvin.

### DIFF
--- a/config/acme/machines/config_compilers.xml
+++ b/config/acme/machines/config_compilers.xml
@@ -673,6 +673,7 @@ for mct, etc.
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
   <NETCDF_PATH>$(NETCDFROOT)</NETCDF_PATH>
   <PNETCDF_PATH>$(PNETCDFROOT)</PNETCDF_PATH>
+  <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="false">/sems-data-store/ACME/pfunit/pfunit-3.2.8</PFUNIT_PATH>
   <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -lblas -llapack</ADD_SLIBS>
   <CXX_LIBS>-lstdc++ -lmpi_cxx</CXX_LIBS>
   <ALBANY_PATH>/projects/install/rhel6-x86_64/ACME/AlbanyTrilinos/Albany/build/install</ALBANY_PATH>

--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -546,6 +546,7 @@
         <command name="load">sems-env</command>
         <command name="load">sems-git</command>
         <command name="load">sems-python/2.7.9</command>
+        <command name="load">sems-cmake/2.8.12</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">sems-gcc/5.3.0</command>
@@ -553,9 +554,11 @@
       <modules compiler="intel">
         <command name="load">sems-intel/16.0.3</command>
       </modules>
-      <modules>
+      <modules mpilib="mpi-serial">
+        <command name="load">sems-netcdf/4.4.1/exo</command>
+      </modules>
+      <modules mpilib="!mpi-serial">
         <command name="load">sems-openmpi/1.8.7</command>
-        <command name="load">sems-cmake/2.8.12</command>
         <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
       </modules>
     </module_system>

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -178,6 +178,7 @@ def cmake_stage(name, test_spec_dir, build_optimized, use_mpiserial, mpirun_comm
 
         cmake_command = [
             "cmake",
+            "-C Macros.cmake",
             test_spec_dir,
             "-DCIME_CMAKE_MODULE_DIRECTORY="+os.path.abspath(os.path.join(_CIMEROOT,"src","CMake")),
             "-DCMAKE_BUILD_TYPE="+build_type,

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -146,7 +146,7 @@ override the command provided by Machines."""
         args.use_openmp, args.xml_test_list, args.verbose
 
 
-def cmake_stage(name, test_spec_dir, build_optimized, use_mpiserial, mpirun_command, output,
+def cmake_stage(name, test_spec_dir, build_optimized, use_mpiserial, mpirun_command, output, pfunit_path,
                 cmake_args=None, clean=False, verbose=False, enable_genf90=True, color=True):
     """Run cmake in the current working directory.
 
@@ -182,6 +182,7 @@ def cmake_stage(name, test_spec_dir, build_optimized, use_mpiserial, mpirun_comm
             "-DCIME_CMAKE_MODULE_DIRECTORY="+os.path.abspath(os.path.join(_CIMEROOT,"src","CMake")),
             "-DCMAKE_BUILD_TYPE="+build_type,
             "-DPFUNIT_MPIRUN='"+mpirun_command+"'",
+            "-DPFUNIT_PATH="+pfunit_path
             ]
         if use_mpiserial:
             cmake_command.append("-DUSE_MPI_SERIAL=ON")
@@ -241,6 +242,7 @@ def find_pfunit(compilerobj, mpilib, use_openmp):
            """PFUNIT_PATH not found for this machine and compiler, with MPILIB={} and compile_threaded={}.
 You must specify PFUNIT_PATH in config_compilers.xml, with attributes MPILIB and compile_threaded.""".format(mpilib, attrs['compile_threaded']))
     logger.info("Using PFUNIT_PATH: {}".format(pfunit_path.text))
+    return pfunit_path.text
 
 #=================================================
 # Iterate over input suite specs, building the tests.
@@ -306,7 +308,7 @@ def _main():
 
     compilerobj = Compilers(machobj, compiler=compiler, mpilib=mpilib)
 
-    find_pfunit(compilerobj, mpilib=mpilib, use_openmp=use_openmp)
+    pfunit_path = find_pfunit(compilerobj, mpilib=mpilib, use_openmp=use_openmp)
 
     debug = not build_optimized
     os_ = machobj.get_value("OS")
@@ -375,7 +377,7 @@ def _main():
             if not os.path.islink("Macros.cmake"):
                 os.symlink(os.path.join(build_dir,"Macros.cmake"), "Macros.cmake")
             use_mpiserial = not use_mpi
-            cmake_stage(name, directory, build_optimized, use_mpiserial, mpirun_command, output, verbose=verbose,
+            cmake_stage(name, directory, build_optimized, use_mpiserial, mpirun_command, output, pfunit_path, verbose=verbose,
                         enable_genf90=enable_genf90, cmake_args=cmake_args)
             make_stage(name, output, make_j, clean=clean, verbose=verbose)
 
@@ -397,9 +399,6 @@ def _main():
                 ctest_command.extend(ctest_args.split(" "))
 
             run_cmd_no_fail(" ".join(ctest_command), from_dir=label, arg_stdout=None, arg_stderr=subprocess.STDOUT)
-
-
-
 
 
 if __name__ == "__main__":

--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -66,7 +66,6 @@ def _copy_depends_files(machine_name, machines_dir, output_dir, compiler):
             if os.path.isfile(dfile) and not os.path.isfile(outputdfile):
                 shutil.copyfile(dfile, outputdfile)
 
-
 def _generate_env_mach_specific(output_dir, machobj, compiler, mpilib, debug,
                                 sysos, unit_testing):
     """
@@ -79,6 +78,7 @@ def _generate_env_mach_specific(output_dir, machobj, compiler, mpilib, debug,
     ems_file = EnvMachSpecific(output_dir, unit_testing=unit_testing)
     ems_file.populate(machobj)
     ems_file.write()
+    ems_file.load_env(compiler, debug, mpilib)
     for shell in ('sh', 'csh'):
         ems_file.make_env_mach_specific_file(compiler, debug, mpilib, shell)
         shell_path = os.path.join(output_dir, ".env_mach_specific." + shell)

--- a/src/CMake/Compilers.cmake
+++ b/src/CMake/Compilers.cmake
@@ -57,7 +57,7 @@ endfunction()
 #=================================================
 
 # Detect "STOP" for CTest.
-if(${CMAKE_Fortran_COMPILER_ID} STREQUAL NAG)
+if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL NAG)
   # NAG prints the stop code instead of yielding a non-zero return, so we
   # have to use a regex to catch that.
   function(define_Fortran_stop_failure test_name)


### PR DESCRIPTION
1) Fix up serial settings in melvin.
2) Need to explicitly declare PFUNIT_PATH in cmake calls in run_tests.py
3) Need to load env before making env XML files, some compiler vars pull from environment
4) Need to not crash when CMAKE_Fortran_COMPILER_ID is empty

Test suite: scripts_regression_tests.py N_TestUnitTest
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1297 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @billsacks @jedwards4b 
