### PR TITLE
mv erp test to compare two

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -78,11 +78,11 @@
     <hist_file_extension>\.h.*.nc$|\.d[dovt]\.</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.ocn.restart$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.ocn$NINST_STRING.restart</rpointer_file>
       <rpointer_content>./$CASE.pop$NINST_STRING.r.$DATENAME.nc,RESTART_FMT=nc</rpointer_content>
     </rpointer>
     <rpointer>
-      <rpointer_file>rpointer.ocn.ovf$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.ocn$NINST_STRING.ovf</rpointer_file>
       <rpointer_content>./$CASE.pop$NINST_STRING.ro.$DATENAME</rpointer_content>
     </rpointer>
   </comp_archive_spec>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -245,6 +245,10 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>11</STOP_N>
     <DOUT_S>FALSE</DOUT_S>
+    <REST_N>$STOP_N / 2 + 1 </REST_N>
+    <REST_OPTION>$STOP_OPTION</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
   </test>
 
   <test NAME="ERS">

--- a/scripts/lib/CIME/SystemTests/erp.py
+++ b/scripts/lib/CIME/SystemTests/erp.py
@@ -12,7 +12,6 @@ from CIME.XML.standard_module_setup import *
 from CIME.case_setup import case_setup
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.check_lockedfiles import *
-from CIME.case_st_archive import _get_datenames
 
 logger = logging.getLogger(__name__)
 
@@ -63,17 +62,4 @@ class ERP(SystemTestsCompareTwo):
         case_setup(self._case, test_mode=True, reset=True)
 
     def _case_one_custom_postrun_action(self):
-        rundir1 = self._case1.get_value("RUNDIR")
-        rundir2 = self._case2.get_value("RUNDIR")
-        case = self._case1.get_value("CASE")
-        datenames = _get_datenames(self._case1)
-        for file_ in glob.iglob(os.path.join(rundir1,"*")):
-            logger.info("File is {}".format(file_))
-            if os.path.basename(file_).startswith("rpointer"):
-                logger.info("Copy {} to {}".format(file_, rundir2))
-                shutil.copy(file_, rundir2)
-            elif os.path.basename(file_).startswith(case) and datenames[0] in file_:
-                file_case2 = os.path.join(rundir2, os.path.basename(file_))
-                if not os.path.isfile(file_case2):
-                    logger.info("Link {} to {}".format(file_, rundir2))
-                    os.symlink(file_, file_case2)
+        self.setup_restart()

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -254,16 +254,19 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 shutil.copy(file_, rundir2)
             elif os.path.basename(file_).startswith(case) and datenames[0] in file_:
                 file_case2 = os.path.join(rundir2, os.path.basename(file_))
-                if not os.path.isfile(file_case2):
+                hfile_found = False
+                for arch_entry in arch_entries:
+                    histfiles = get_histfiles_for_restarts(self._case1, arch, arch_entry, file_)
+                    for histfile in histfiles:
+                        logger.info("Copying histfile {}".format(histfile))
+                        shutil.copy(os.path.join(rundir1,histfile), rundir2)
+                    for suffix in arch.get_hist_file_extensions(arch_entry):
+                        hfile = re.compile(suffix)
+                        if hfile.search(file_):
+                            hfile_found = True
+                if not os.path.isfile(file_case2) and not hfile_found:
                     logger.info("Link {} to {}".format(file_, rundir2))
                     os.symlink(file_, file_case2)
-                    for arch_entry in arch_entries:
-                        histfiles = get_histfiles_for_restarts(self._case1, arch, arch_entry, file_)
-                        for histfile in histfiles:
-                            logger.info("Copying histfile {}".format(histfile))
-                            shutil.copy(os.path.join(rundir1,histfile), rundir2)
-
-
 
     # ========================================================================
     # Private methods

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -14,7 +14,7 @@ import datetime
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def _get_datenames(case, last_date=None):
+def get_datenames(case, last_date=None):
 ###############################################################################
     if last_date is not None:
         try:
@@ -365,7 +365,7 @@ def _archive_process(case, archive, last_date, archive_incomplete_logs, copy_onl
         logger.info('-------------------------------------------')
         logger.info('doing short term archiving for {} ({})'.format(compname, compclass))
         logger.info('-------------------------------------------')
-        datenames = _get_datenames(case, last_date)
+        datenames = get_datenames(case, last_date)
         for datename in datenames:
             logger.info('Archiving for date %s' % datename)
             datename_is_last = False


### PR DESCRIPTION
Rewrite erp test using the compare two paradigm

Test suite: scripts_regression_tests.py, ERP_Ln9.f09_f09_mg17.F2000_DEV.cheyenne_intel.cam-outfrq9s
Test baseline: cesm2_0_alpha07d
Test namelist changes: 
Test status: bit for bit

Addresses #1647 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
