### PR TITLE
allow user to adjust ulimits

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -292,6 +292,9 @@
       -->
       <env name="MPI_USE_ARRAY">false</env>
     </environment_variables>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
   </machine>
 
   <machine MACH="constance">

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -116,6 +116,7 @@
 	<!-- environment_variables: environment_variables to set on this system,
 	  see detail below-->
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
       </xs:sequence>
       <xs:attribute ref="MACH" use="required"/>
     </xs:complexType>
@@ -187,7 +188,24 @@
       <xs:attribute ref="unit_testing"/>
     </xs:complexType>
   </xs:element>
+  <xs:element name="resource_limits">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="resource"/>
+      </xs:sequence>
+      <xs:attribute ref="debug"/>
+      <xs:attribute ref="mpilib"/>
+      <xs:attribute ref="compiler"/>
+      <xs:attribute ref="unit_testing"/>
+    </xs:complexType>
+  </xs:element>
+
   <xs:element name="env">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="name" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="resource">
     <xs:complexType mixed="true">
       <xs:attribute ref="name" use="required"/>
     </xs:complexType>

--- a/config/xml_schemas/config_machines_template.xml
+++ b/config/xml_schemas/config_machines_template.xml
@@ -143,5 +143,9 @@
       <env name="OMP_STACKSIZE">256M</env>
       <env name="MPI_TYPE_DEPTH">16</env>
     </environment_variables>
+    <!-- resource settings as defined in https://docs.python.org/2/library/resource.html -->
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
   </machine>
 </config_machines>

--- a/config/xml_schemas/env_mach_specific.xsd
+++ b/config/xml_schemas/env_mach_specific.xsd
@@ -25,6 +25,7 @@
         <xs:element ref="header"/>
         <xs:element ref="module_system"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="mpirun"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="entry"/>
       </xs:sequence>
@@ -85,6 +86,24 @@
     </xs:complexType>
   </xs:element>
   <xs:element name="env">
+    <xs:complexType mixed="true">
+      <xs:attribute name="name" use="required" type="xs:NCName"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="resource_limits">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="resource"/>
+      </xs:sequence>
+      <xs:attribute ref="debug"/>
+      <xs:attribute ref="mpilib"/>
+      <xs:attribute ref="compiler"/>
+      <xs:attribute ref="unit_testing"/>
+      <xs:attribute ref="SMP_PRESENT"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="resource">
     <xs:complexType mixed="true">
       <xs:attribute name="name" use="required" type="xs:NCName"/>
     </xs:complexType>

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -5,7 +5,7 @@ from CIME.XML.standard_module_setup import *
 
 from CIME.XML.env_base import EnvBase
 from CIME.utils import transform_vars, get_cime_root
-import string
+import string, resource
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class EnvMachSpecific(EnvBase):
 
     def populate(self, machobj):
         """Add entries to the file using information from a Machines object."""
-        items = ("module_system", "environment_variables", "mpirun", "run_exe","run_misc_suffix")
+        items = ("module_system", "environment_variables", "resource_limits", "mpirun", "run_exe","run_misc_suffix")
         default_run_exe_node = machobj.get_node("default_run_exe")
         default_run_misc_suffix_node = machobj.get_node("default_run_misc_suffix")
 
@@ -84,6 +84,24 @@ class EnvMachSpecific(EnvBase):
         envs_to_set = self._get_envs_for_case(compiler, debug, mpilib)
         if (envs_to_set is not None):
             self.load_envs(envs_to_set)
+
+
+        self._get_resources_for_case(compiler, debug, mpilib)
+
+    def _get_resources_for_case(self, compiler, debug, mpilib):
+        resource_nodes = self.get_nodes("resource_limits")
+        if resource_nodes is not None:
+            nodes = self._compute_resource_actions(resource_nodes, compiler, debug, mpilib)
+            for name, val in nodes:
+                try:
+                    attr = getattr(resource, name)
+                    limits = resource.getrlimit(attr)
+                    logger.info("Setting resource.{} to {} from {}".format(name, val, limits))
+                    limits = (int(val), limits[1])
+                    resource.setrlimit(attr, limits)
+                except:
+                    raise
+
 
     def load_modules(self, modules_to_load):
         module_system = self.get_module_system_type()
@@ -162,6 +180,11 @@ class EnvMachSpecific(EnvBase):
 
     def _compute_env_actions(self, env_nodes, compiler, debug, mpilib):
         return self._compute_actions(env_nodes, "env", compiler, debug, mpilib)
+
+    def _compute_resource_actions(self, resource_nodes, compiler, debug, mpilib):
+        return self._compute_actions(resource_nodes, "resource", compiler, debug, mpilib)
+
+
 
     def _compute_actions(self, nodes, child_tag, compiler, debug, mpilib):
         result = [] # list of tuples ("name", "argument")

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -93,15 +93,11 @@ class EnvMachSpecific(EnvBase):
         if resource_nodes is not None:
             nodes = self._compute_resource_actions(resource_nodes, compiler, debug, mpilib)
             for name, val in nodes:
-                try:
-                    attr = getattr(resource, name)
-                    limits = resource.getrlimit(attr)
-                    logger.info("Setting resource.{} to {} from {}".format(name, val, limits))
-                    limits = (int(val), limits[1])
-                    resource.setrlimit(attr, limits)
-                except:
-                    raise
-
+                attr = getattr(resource, name)
+                limits = resource.getrlimit(attr)
+                logger.info("Setting resource.{} to {} from {}".format(name, val, limits))
+                limits = (int(val), limits[1])
+                resource.setrlimit(attr, limits)
 
     def load_modules(self, modules_to_load):
         module_system = self.get_module_system_type()


### PR DESCRIPTION
Adds a resource limits section to config_machines.xml allowing the user to adjust environment ulimits

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Addresses #771 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
