### PR TITLE
Rewrite ERP with SystemTestsCompareTwo

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -78,11 +78,11 @@
     <hist_file_extension>\.h.*.nc$|\.d[dovt]\.</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.ocn.restart$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.ocn$NINST_STRING.restart</rpointer_file>
       <rpointer_content>./$CASE.pop$NINST_STRING.r.$DATENAME.nc,RESTART_FMT=nc</rpointer_content>
     </rpointer>
     <rpointer>
-      <rpointer_file>rpointer.ocn.ovf$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.ocn$NINST_STRING.ovf</rpointer_file>
       <rpointer_content>./$CASE.pop$NINST_STRING.ro.$DATENAME</rpointer_content>
     </rpointer>
   </comp_archive_spec>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -245,6 +245,10 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>11</STOP_N>
     <DOUT_S>FALSE</DOUT_S>
+    <REST_N>$STOP_N / 2 + 1 </REST_N>
+    <REST_OPTION>$STOP_OPTION</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
   </test>
 
   <test NAME="ERS">

--- a/scripts/lib/CIME/SystemTests/erp.py
+++ b/scripts/lib/CIME/SystemTests/erp.py
@@ -12,7 +12,6 @@ from CIME.XML.standard_module_setup import *
 from CIME.case_setup import case_setup
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.check_lockedfiles import *
-from CIME.case_st_archive import _get_datenames
 
 logger = logging.getLogger(__name__)
 
@@ -63,17 +62,4 @@ class ERP(SystemTestsCompareTwo):
         case_setup(self._case, test_mode=True, reset=True)
 
     def _case_one_custom_postrun_action(self):
-        rundir1 = self._case1.get_value("RUNDIR")
-        rundir2 = self._case2.get_value("RUNDIR")
-        case = self._case1.get_value("CASE")
-        datenames = _get_datenames(self._case1)
-        for file_ in glob.iglob(os.path.join(rundir1,"*")):
-            logger.info("File is {}".format(file_))
-            if os.path.basename(file_).startswith("rpointer"):
-                logger.info("Copy {} to {}".format(file_, rundir2))
-                shutil.copy(file_, rundir2)
-            elif os.path.basename(file_).startswith(case) and datenames[0] in file_:
-                file_case2 = os.path.join(rundir2, os.path.basename(file_))
-                if not os.path.isfile(file_case2):
-                    logger.info("Link {} to {}".format(file_, rundir2))
-                    os.symlink(file_, file_case2)
+        self.copy_case1_restarts_to_case2()

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -38,6 +38,7 @@ from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case import Case
 from CIME.case_submit import check_case
+from CIME.case_st_archive import archive_last_restarts
 
 import shutil, os, glob
 
@@ -234,6 +235,20 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._link_to_case2_output()
 
         self._component_compare_test(self._run_one_suffix, self._run_two_suffix, success_change=success_change)
+
+    def copy_case1_restarts_to_case2(self):
+        """
+        Makes a copy (or symlink) of restart files and related files
+        (necessary history files, rpointer files) from case1 to case2.
+
+        This is not done automatically, but can be called by individual
+        tests where case2 does a continue_run using case1's restart
+        files.
+        """
+        rundir2 = self._case2.get_value("RUNDIR")
+        archive_last_restarts(case = self._case1,
+                              archive_restdir = rundir2,
+                              link_to_restart_files = True)
 
     # ========================================================================
     # Private methods

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -245,7 +245,7 @@ def get_histfiles_for_restarts(case, archive, archive_entry, restfile):
 ###############################################################################
 def _archive_restarts_date(case, archive,
                            datename, datename_is_last,
-                           archive_file_fn):
+                           archive_restdir, archive_file_fn):
 ###############################################################################
     """
     Archive restart files for a single date
@@ -266,7 +266,7 @@ def _archive_restarts_date(case, archive,
         histfiles_savein_rundir = _archive_restarts_comp_date(case, archive, archive_entry,
                                                               compclass, compname,
                                                               datename, datename_is_last,
-                                                              archive_file_fn)
+                                                              archive_restdir, archive_file_fn)
         histfiles_savein_rundir_by_compname[compname] = histfiles_savein_rundir
 
     return histfiles_savein_rundir_by_compname
@@ -274,17 +274,15 @@ def _archive_restarts_date(case, archive,
 ###############################################################################
 def _archive_restarts_comp_date(case, archive, archive_entry,
                                 compclass, compname, datename, datename_is_last,
-                                archive_file_fn):
+                                archive_restdir, archive_file_fn):
 ###############################################################################
     """
     Archive restart files for a single component and single date
     """
 
     # determine directory for archiving restarts based on datename
-    dout_s_root = case.get_value("DOUT_S_ROOT")
     rundir = case.get_value("RUNDIR")
     casename = case.get_value("CASE")
-    archive_restdir = join(dout_s_root, 'rest', datename)
     if datename_is_last or case.get_value('DOUT_S_SAVE_INTERIM_RESTART_FILES'):
         if not os.path.exists(archive_restdir):
             os.makedirs(archive_restdir)
@@ -405,14 +403,16 @@ def _archive_process(case, archive, last_date, archive_incomplete_logs, copy_onl
 
     # archive restarts and all necessary associated files (e.g. rpointer files)
     histfiles_savein_rundir_by_compname = {}
+    dout_s_root = case.get_value("DOUT_S_ROOT")
     datenames = _get_datenames(case, last_date)
     for datename in datenames:
         datename_is_last = False
         if datename == datenames[-1]:
             datename_is_last = True
 
+        archive_restdir = join(dout_s_root, 'rest', datename)
         histfiles_savein_rundir_by_compname_this_date = _archive_restarts_date(
-            case, archive, datename, datename_is_last, archive_file_fn)
+            case, archive, datename, datename_is_last, archive_restdir, archive_file_fn)
         if datename_is_last:
             histfiles_savein_rundir_by_compname = histfiles_savein_rundir_by_compname_this_date
 

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -267,7 +267,8 @@ def get_histfiles_for_restarts(case, archive, archive_entry, restfile):
 ###############################################################################
 def _archive_restarts_date(case, archive,
                            datename, datename_is_last,
-                           archive_restdir, archive_file_fn):
+                           archive_restdir, archive_file_fn,
+                           link_to_last_restart_files=False):
 ###############################################################################
     """
     Archive restart files for a single date
@@ -288,7 +289,8 @@ def _archive_restarts_date(case, archive,
         histfiles_savein_rundir = _archive_restarts_date_comp(case, archive, archive_entry,
                                                               compclass, compname,
                                                               datename, datename_is_last,
-                                                              archive_restdir, archive_file_fn)
+                                                              archive_restdir, archive_file_fn,
+                                                              link_to_last_restart_files)
         histfiles_savein_rundir_by_compname[compname] = histfiles_savein_rundir
 
     return histfiles_savein_rundir_by_compname

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -243,10 +243,13 @@ def get_histfiles_for_restarts(case, archive, archive_entry, restfile):
     return histfiles
 
 ###############################################################################
-def _archive_restarts(case, archive, archive_entry,
-                      compclass, compname, datename, datename_is_last,
-                      archive_file_fn):
+def _archive_restarts_comp_date(case, archive, archive_entry,
+                                compclass, compname, datename, datename_is_last,
+                                archive_file_fn):
 ###############################################################################
+    """
+    Archive restart files for a single component and single date
+    """
 
     # determine directory for archiving restarts based on datename
     dout_s_root = case.get_value("DOUT_S_ROOT")
@@ -371,29 +374,31 @@ def _archive_process(case, archive, last_date, archive_incomplete_logs, copy_onl
     # archive log files
     _archive_log_files(case, archive_incomplete_logs, archive_file_fn)
 
+    # archive restarts and all necessary associated fields (e.g. rpointer files)
     histfiles_savein_rundir_by_compname = {}
-    for (archive_entry, compname, compclass) in _get_component_archive_entries(case, archive):
+    datenames = _get_datenames(case, last_date)
+    for datename in datenames:
+        logger.info('-------------------------------------------')
+        logger.info('Archiving restarts for date {}'.format(datename))
+        logger.info('-------------------------------------------')
 
-        # archive restarts and all necessary associated fields (e.g. rpointer files)
-        logger.info('-------------------------------------------')
-        logger.info('doing short term archiving for {} ({})'.format(compname, compclass))
-        logger.info('-------------------------------------------')
-        datenames = _get_datenames(case, last_date)
-        for datename in datenames:
-            logger.info('Archiving for date %s' % datename)
-            datename_is_last = False
-            if datename == datenames[-1]:
-                datename_is_last = True
+        datename_is_last = False
+        if datename == datenames[-1]:
+            datename_is_last = True
+
+        for (archive_entry, compname, compclass) in _get_component_archive_entries(case, archive):
+            logger.info('Archiving restarts for {} ({})'.format(compname, compclass))
 
             # archive restarts
-            histfiles_savein_rundir = _archive_restarts(case, archive, archive_entry,
-                                                        compclass, compname,
-                                                        datename, datename_is_last,
-                                                        archive_file_fn)
+            histfiles_savein_rundir = _archive_restarts_comp_date(case, archive, archive_entry,
+                                                                  compclass, compname,
+                                                                  datename, datename_is_last,
+                                                                  archive_file_fn)
             if datename_is_last:
                 histfiles_savein_rundir_by_compname[compname] = histfiles_savein_rundir
 
     for (archive_entry, compname, compclass) in _get_component_archive_entries(case, archive):
+        logger.info('Archiving history files for {} ({})'.format(compname, compclass))
         histfiles_savein_rundir = histfiles_savein_rundir_by_compname.get(compname, [])
         logger.info("histfiles_savein_rundir {} ".format(histfiles_savein_rundir))
         _archive_history_files(case, archive, archive_entry,

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -2,7 +2,7 @@
 Common functions used by cime python scripts
 Warning: you cannot use CIME Classes in this module as it causes circular dependencies
 """
-import logging, gzip, sys, os, time, re, shutil, glob, string, random, imp
+import logging, gzip, sys, os, time, re, shutil, glob, string, random, imp, errno
 import stat as statlib
 import warnings
 from contextlib import contextmanager
@@ -601,6 +601,21 @@ def safe_copy(src_dir, tgt_dir, file_map):
         if (os.path.isfile(full_tgt)):
             os.remove(full_tgt)
         shutil.copy2(full_src, full_tgt)
+
+def symlink_force(target, link_name):
+    """
+    Makes a symlink from link_name to target. Unlike the standard
+    os.symlink, this will work even if link_name already exists (in
+    which case link_name will be overwritten).
+    """
+    try:
+        os.symlink(target, link_name)
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            os.remove(link_name)
+            os.symlink(target, link_name)
+        else:
+            raise e
 
 def find_proc_id(proc_name=None,
                  children_only=False,


### PR DESCRIPTION
Yet another attempt to rewrite the ERP test using the
SystemTestsCompareTwo infrastructure. If approved, this will supersede
#1830 and #1845.

This version is similar to the version of @jedwards4b in #1845. However,
rather than building our own mini-archiving functionality into
SystemTestsCompareTwo, I have refactored case_st_archive to extract a
function that can be called from SystemTestsCompareTwo. In this way,
there is very little test-specific code: we pretty much can just reuse
the existing logic for archiving restart files. This should reduce the
chance for errors and the maintenance cost compared with #1845.

In doing the refactoring for this, I stumbled upon and fixed two issues
with the short-term archiver: #1851 and #1853. Fixing #1853 uncovered
#1854, which is not fixed here.

Testing done: In addition to the standard scripts_regression_tests, I
have done the following testing, using
https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_16_r253:

1. ERP_P24x2_Ld5.f10_f10.I1850Clm50Bgc.cheyenne_intel.clm-default
  - made sure it passes
  - made sure the two cases use the correct ntasks and nthreads
  - made sure it still passes if I rerun it

2. ERP_P24x2_Ln240.f10_f10.I1850Clm50Bgc.cheyenne_intel.clm-default
  - needs ./xmlchange GLC_NCPL=48,OCN_NCPL=48,ROF_NCPL=48

3. ERP_P24x2_Ld5.f10_f10.I1850Clm50Bgc.cheyenne_intel.clm-default with
  SourceMods to make the restart fail; confirmed it really does fail:

```diff
--- ../../../components/clm/src/biogeophys/WaterStateType.F902017-08-31 08:01:21.094907095 -0600
+++ SourceMods/src.clm/WaterStateType.F902017-08-31 08:54:32.910961000 -0600
@@ -862,7 +862,7 @@
     use clm_varcon       , only : denice, denh2o, pondmx, watmin, spval, nameg
     use landunit_varcon  , only : istcrop, istdlak, istsoil
     use column_varcon    , only : icol_roof, icol_sunwall, icol_shadewall
-    use clm_time_manager , only : is_first_step
+    use clm_time_manager , only : is_first_step, is_restart
     use clm_varctl       , only : bound_h2osoi
     use ncdio_pio        , only : file_desc_t, ncd_io, ncd_double
     use restUtilMod
@@ -875,7 +875,7 @@
     real(r8)         , intent(in)    :: watsat_col (bounds%begc:, 1:)  ! volumetric soil water at saturation (porosity)
     !
     ! !LOCAL VARIABLES:
-    integer  :: c,l,j,nlevs
+    integer  :: p,c,l,j,nlevs
     logical  :: readvar
     real(r8) :: maxwatsat    ! maximum porosity
     real(r8) :: excess       ! excess volumetric soil water
@@ -920,6 +920,14 @@
          long_name='canopy water', units='kg/m2', &
          interpinic_flag='interp', readvar=readvar, data=this%h2ocan_patch)

+    if (flag == 'read' .and. is_restart()) then
+       do p = bounds%begp, bounds%endp
+          if (this%h2ocan_patch(p) < 1._r8) then
+             this%h2ocan_patch(p) = this%h2ocan_patch(p) * (1._r8 + 1.e-14_r8)
+          end if
+       end do
+    end if
+
     call restartvar(ncid=ncid, flag=flag, varname='SNOCAN', xtype=ncd_double,  &
          dim1name='pft', &
          long_name='canopy snow water', units='kg/m2', &

--- ../../../components/clm/src/biogeophys/BalanceCheckMod.F902017-08-31 08:01:21.149685054 -0600
+++ SourceMods/src.clm/BalanceCheckMod.F902017-08-31 08:55:49.498168158 -0600
@@ -333,7 +333,6 @@
                   qflx_surf(indexc)+qflx_h2osfc_surf(indexc)+qflx_drain(indexc))

              write(iulog,*)'clm model is stopping'
-             call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))

           else if (abs(errh2o(indexc)) > 1.e-5_r8 .and. (nstep > 2) ) then

@@ -361,7 +360,6 @@
              write(iulog,*)'qflx_snwcp_discarded_liq = ',qflx_snwcp_discarded_liq(indexc)*dtime
              write(iulog,*)'qflx_rootsoi_col(1:nlevsoil)  = ',qflx_rootsoi_col(indexc,:)*dtime
              write(iulog,*)'clm model is stopping'
-             call endrun(decomp_index=indexc, clmlevel=namec, msg=errmsg(sourcefile, __LINE__))
           end if
        end if
```

4. In this case, confirmed that the directory listings of both the
archive directory and the run directory (post-archiving) match master:

```
./create_newcase --case check_clm_archiving_0830a --compset I1850Clm45Bgc --res f10_f10_musgs --user-mods-dir /glade/scratch/sacks/cesm_code/clm4_5_16_r253_newCime2/components/clm/cime_config/testdefs/testmods_dirs/clm/default

./xmlchange HIST_OPTION=ndays,HIST_N=1,REST_OPTION=ndays,REST_N=1
```

5. Same as (4) but with:

```
./xmlchange DOUT_S_SAVE_INTERIM_RESTART_FILES=TRUE
```

In (5), differences from master are the presence of rpointer.unset files
in the interim restart directories. This is due to the pre-existing
issue #1854 (which was masked in master due to #1853)


Test suite: scripts_regression_tests.py on cheyenne
  Also tests listed above
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#1851
Fixes ESMCI/cime#1853
Addresses ESMCI/cime#1647 (rewrites ERP, not ERS)

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
