### PR TITLE
get log file from logdir instead of rundir

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1431,11 +1431,13 @@ class Case(object):
         self._files.append(new_object)
         self.schedule_rewrite(new_object)
 
-    def get_latest_cpl_log(self):
+    def get_latest_cpl_log(self, coupler_log_path=None):
         """
-        find and return the latest cpl log file in the run directory
+        find and return the latest cpl log file in the
+        coupler_log_path directory
         """
-        coupler_log_path = self.get_value("RUNDIR")
+        if coupler_log_path is None:
+            coupler_log_path = self.get_value("RUNDIR")
         cpllog = None
         cpllogs = glob.glob(os.path.join(coupler_log_path, 'cpl.log.*'))
         if cpllogs:

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -401,10 +401,12 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
 
     # copy latest cpl log to baseline
     # drop the date so that the name is generic
-    newestcpllogfile = case.get_latest_cpl_log()
-    if newestcpllogfile:
+    newestcpllogfile = case.get_latest_cpl_log(coupler_log_path=case.get_value("LOGDIR"))
+    if newestcpllogfile is None:
+        logger.warn("No cpl.log file found in log directory {}".format(case.get_value("LOGDIR")))
+    else:
         shutil.copyfile(newestcpllogfile,
-                        os.path.join(basegen_dir, "cpl.log.gz"))
+                    os.path.join(basegen_dir, "cpl.log.gz"))
 
     expect(num_gen > 0, "Could not generate any hist files for case '{}', something is seriously wrong".format(testcase))
     #make sure permissions are open in baseline directory


### PR DESCRIPTION
Some tests move the cpl.log from the run directory before the generate function is run, so 
cpl.log file should come from LOGDIR instead 

Test suite: scripts_regression_tests.py, hand test with --generate
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
