### PR TITLE
add new user-mods option to create_clone 

### DIFF
--- a/doc/source/users_guide/cloning-a-case.rst
+++ b/doc/source/users_guide/cloning-a-case.rst
@@ -28,14 +28,16 @@ See the **help** text for more usage information.
 
 If the ``--keepexe`` optional argument is used, then no SourceMods will be permitted in the cloned directory.
 A link will be made when the cloned case is created pointing the cloned SourceMods/ directory to the original case SourceMods directory.
-In addition, no changes should be made to ``env_build.xml`` or ``env_mach_pes.xml`` in the cloned directory.
+
+.. warning:: No changes should be made to ``env_build.xml`` or ``env_mach_pes.xml`` in the cloned directory.
 
 **create_clone** also permits you to invoked the ``shell_commands`` and ``user_nl_xxx`` files in a user_mods directory by calling:
 ::
 
    > create_clone --case $CASEROOT --clone $CLONEROOT --user-mods-dir USER_MODS_DIR [--keepexe]
 
-Note that an optional ``--keepexe`` flag can also be used in this case. If there is a ``shell_commands`` file, it should not have any changes to xml variables in either
-``env_build.xml`` or ``env_mach_pes.xml``.
+Note that an optional ``--keepexe`` flag can also be used in this case.
+
+.. warning:: If there is a ``shell_commands`` file, it should not have any changes to xml variables in either ``env_build.xml`` or ``env_mach_pes.xml``.
 
 Another approach to duplicating a case is to use the information in the case's **README.case** and **CaseStatus** files to create a new case and duplicate the relevant **xlmchange** commands that were issued in the original case. This alternative will *not* preserve any local modifications that were made to the original case, such as source-code or build-script revisions; you will need to import those changes manually.

--- a/doc/source/users_guide/cloning-a-case.rst
+++ b/doc/source/users_guide/cloning-a-case.rst
@@ -21,4 +21,21 @@ See the **help** text for more usage information.
 
    > create_clone --help
 
+**create_clone** has several useful optional arguments. To point to the executable of the original case you are cloning from.
+::
+
+   > create_clone --case $CASEROOT --clone $CLONEROOT --keepexe
+
+If the ``--keepexe`` optional argument is used, then no SourceMods will be permitted in the cloned directory.
+A link will be made when the cloned case is created pointing the cloned SourceMods/ directory to the original case SourceMods directory.
+In addition, no changes should be made to ``env_build.xml`` or ``env_mach_pes.xml`` in the cloned directory.
+
+**create_clone** also permits you to invoked the ``shell_commands`` and ``user_nl_xxx`` files in a user_mods directory by calling:
+::
+
+   > create_clone --case $CASEROOT --clone $CLONEROOT --user-mods-dir USER_MODS_DIR [--keepexe]
+
+Note that an optional ``--keepexe`` flag can also be used in this case. If there is a ``shell_commands`` file, it should not have any changes to xml variables in either
+``env_build.xml`` or ``env_mach_pes.xml``.
+
 Another approach to duplicating a case is to use the information in the case's **README.case** and **CaseStatus** files to create a new case and duplicate the relevant **xlmchange** commands that were issued in the original case. This alternative will *not* preserve any local modifications that were made to the original case, such as source-code or build-script revisions; you will need to import those changes manually.

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -24,7 +24,7 @@ def parse_command_line(args):
                         "If not a full pathname, then the case to be cloned"
                         "is assumed to be under then current working directory ")
 
-    parser.add_argument("--user-mods-dir", "-user_mods_dir",
+    parser.add_argument("--user-mods-dir",
                         help="Path to directory with user_nl_* files and xmlchange "
                         "commands to utilize. This can also include SourceMods. "
                         "This can be an absolute path, a path relative to the "
@@ -32,11 +32,15 @@ def parse_command_line(args):
                         "cime_config/usermods_dirs/ under the primary component "
                         "for the given compset (for example, in an F compset "
                         "whose primary component is cam, '--user-mods-dir foo' "
-                        "could be found in components/cam/cime_config/usermods_dirs/foo).")
+                        "could be found in $SRCROOT/components/cam/cime_config/usermods_dirs/foo). "
+                        "If this argument is used in conjunction with the --keepexe flag, then "
+                        "no changes will be permitted to the env_build.xml in the --case entry directory. ")
 
     parser.add_argument("--keepexe", "-keepexe", action="store_true",
                         help="Sets EXEROOT to point to original build, it is highly recommended"
-                        "that the original case be built before cloning if using the --keepexe flag")
+                        "that the original case be built before cloning if using the --keepexe flag "
+                        "This flag will make SourceMods in the --case entry directory a symbolic link "
+                        " to the SourceMods in the --clone entry directory ")
 
     parser.add_argument("--mach-dir", "-mach_dir",
                         help="Specify the locations of the Machines directory, other than the default"
@@ -79,11 +83,7 @@ def _main_func():
             user_mods_dir = os.path.abspath(user_mods_dir)
 
     with Case(cloneroot, read_only=False) as clone:
-        if user_mods_dir is not None:
-            clone.create_clone(case, keepexe, mach_dir, project, cime_output_root, user_mods_dir)
-        else:
-            clone.create_clone(case, keepexe, mach_dir, project, cime_output_root)
-
+        clone.create_clone(case, keepexe, mach_dir, project, cime_output_root, user_mods_dir)
 
 ###############################################################################
 

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -24,8 +24,19 @@ def parse_command_line(args):
                         "If not a full pathname, then the case to be cloned"
                         "is assumed to be under then current working directory ")
 
+    parser.add_argument("--user-mods-dir", "-user_mods_dir",
+                        help="Path to directory with user_nl_* files and xmlchange "
+                        "commands to utilize. This can also include SourceMods. "
+                        "This can be an absolute path, a path relative to the "
+                        "current directory, or a path relative to "
+                        "cime_config/usermods_dirs/ under the primary component "
+                        "for the given compset (for example, in an F compset "
+                        "whose primary component is cam, '--user-mods-dir foo' "
+                        "could be found in components/cam/cime_config/usermods_dirs/foo).")
+
     parser.add_argument("--keepexe", "-keepexe", action="store_true",
-                        help="Sets EXEROOT to point to original build, it is highly recommended that the original case be built before cloning if using the --keepexe flag")
+                        help="Sets EXEROOT to point to original build, it is highly recommended"
+                        "that the original case be built before cloning if using the --keepexe flag")
 
     parser.add_argument("--mach-dir", "-mach_dir",
                         help="Specify the locations of the Machines directory, other than the default"
@@ -51,20 +62,28 @@ def parse_command_line(args):
                "Must specify -clone as an input argument")
 
     return args.case, args.clone, args.keepexe, args.mach_dir, args.project, \
-        args.cime_output_root
+        args.cime_output_root, args.user_mods_dir
 
 ##############################################################################
 def _main_func():
 ###############################################################################
 
-    case, clone, keepexe, mach_dir, project, cime_output_root = parse_command_line(sys.argv)
+    case, clone, keepexe, mach_dir, project, cime_output_root, user_mods_dir = parse_command_line(sys.argv)
 
     cloneroot = os.path.abspath(clone)
     expect(os.path.isdir(cloneroot),
            "Missing cloneroot directory %s " % cloneroot)
 
+    if user_mods_dir is not None:
+        if os.path.isdir(user_mods_dir):
+            user_mods_dir = os.path.abspath(user_mods_dir)
+
     with Case(cloneroot, read_only=False) as clone:
-        clone.create_clone(case, keepexe, mach_dir, project, cime_output_root)
+        if user_mods_dir is not None:
+            clone.create_clone(case, keepexe, mach_dir, project, cime_output_root, user_mods_dir)
+        else:
+            clone.create_clone(case, keepexe, mach_dir, project, cime_output_root)
+
 
 ###############################################################################
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1247,8 +1247,10 @@ class Case(object):
                 success, comment = compare_files(os.path.join(newcaseroot, "env_build.xml"),
                                                  os.path.join(newcaseroot, "LockedFiles", "env_build.xml"))
                 if not success:
-                    logger.info(comment)
-                    expect(False, "env_build.xml cannot be changed via usermods if keepexe is an option")
+                    logger.warn(comment)
+                    shutil.rmtree(newcase_root)
+                    expect(False, "env_build.xml cannot be changed via usermods if keepexe is an option: \n "
+                           "Failed to clone case, removed {}\n".format(newcase_root))
 
         # if keep executable, then remove the new case SourceMods directory and link SourceMods to
         # the clone directory

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1250,10 +1250,12 @@ class Case(object):
                     logger.info(comment)
                     expect(False, "env_build.xml cannot be changed in usermods if keepexe is an option")
 
-                # Remove the new case SourceMods directory and link SourceMods to the clone directory
-                shutil.rmtree(os.path.join(newcase_root, "SourceMods"))
-                os.symlink(os.path.join(cloneroot, "SourceMods"),
-                           os.path.join(newcase_root, "SourceMods"))
+        # If keep executable, then remove the new case SourceMods directory and link SourceMods to
+        # the clone directory
+        if keepexe:
+            shutil.rmtree(os.path.join(newcase_root, "SourceMods"))
+            os.symlink(os.path.join(cloneroot, "SourceMods"),
+                       os.path.join(newcase_root, "SourceMods"))
 
         # Update README.case
         fclone   = open(cloneroot + "/README.case", "r")

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1242,13 +1242,13 @@ class Case(object):
             # Now apply contents of user_mods directory
             apply_user_mods(newcase_root, user_mods_dir, keepexe=keepexe)
 
-            # Determine if env_build.xml has changed and if there are any sourcemods in u
+            # Determine if env_build.xml has changed
             if keepexe:
                 success, comment = compare_files(os.path.join(newcaseroot, "env_build.xml"),
                                                  os.path.join(newcaseroot, "LockedFiles", "env_build.xml"))
                 if not success:
                     logger.info(comment)
-                    expect(False, "env_build.xml cannot be changed in usermods if keepexe is an option")
+                    expect(False, "env_build.xml cannot be changed via usermods if keepexe is an option")
 
         # If keep executable, then remove the new case SourceMods directory and link SourceMods to
         # the clone directory

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1231,8 +1231,8 @@ class Case(object):
         lock_file("env_case.xml", newcaseroot)
 
         # apply user_mods if appropriate
+        newcase_root = newcase.get_value("CASEROOT")
         if user_mods_dir is not None:
-            newcase_root = newcase.get_value("CASEROOT")
             if keepexe:
                 # If keepexe CANNOT change any env_build.xml variables - so make a temporary copy of
                 # env_build.xml and verify that it has not been modified
@@ -1250,7 +1250,7 @@ class Case(object):
                     logger.info(comment)
                     expect(False, "env_build.xml cannot be changed via usermods if keepexe is an option")
 
-        # If keep executable, then remove the new case SourceMods directory and link SourceMods to
+        # if keep executable, then remove the new case SourceMods directory and link SourceMods to
         # the clone directory
         if keepexe:
             shutil.rmtree(os.path.join(newcase_root, "SourceMods"))

--- a/scripts/lib/CIME/tests/test_user_mod_support.py
+++ b/scripts/lib/CIME/tests/test_user_mod_support.py
@@ -112,6 +112,13 @@ class TestUserModSupport(unittest.TestCase):
                            expected_sourcemod = "foo\n",
                            msg = "test_basic")
 
+    def test_keepexe(self):
+        self.createUserMod("foo")
+        with self.assertRaisesRegexp(SystemExit,
+                                     "cannot have any source mods"):
+            apply_user_mods(self._caseroot,
+                            os.path.join(self._user_mods_parent_dir, "foo"), keepexe=True)
+
     def test_two_applications(self):
         """If apply_user_mods is called twice, the second should appear after the first so that it takes precedence."""
 

--- a/scripts/lib/CIME/tests/test_user_mod_support.py
+++ b/scripts/lib/CIME/tests/test_user_mod_support.py
@@ -114,8 +114,7 @@ class TestUserModSupport(unittest.TestCase):
 
     def test_keepexe(self):
         self.createUserMod("foo")
-        with self.assertRaisesRegexp(SystemExit,
-                                     "cannot have any source mods"):
+        with self.assertRaises(SystemExit):
             apply_user_mods(self._caseroot,
                             os.path.join(self._user_mods_parent_dir, "foo"), keepexe=True)
 

--- a/scripts/lib/CIME/tests/test_user_mod_support.py
+++ b/scripts/lib/CIME/tests/test_user_mod_support.py
@@ -114,7 +114,7 @@ class TestUserModSupport(unittest.TestCase):
 
     def test_keepexe(self):
         self.createUserMod("foo")
-        with self.assertRaises(SystemExit):
+        with self.assertRaisesRegexp(SystemExit, "cannot have any source mods"):
             apply_user_mods(self._caseroot,
                             os.path.join(self._user_mods_parent_dir, "foo"), keepexe=True)
 

--- a/scripts/lib/CIME/user_mod_support.py
+++ b/scripts/lib/CIME/user_mod_support.py
@@ -8,7 +8,7 @@ import shutil, glob
 
 logger = logging.getLogger(__name__)
 
-def apply_user_mods(caseroot, user_mods_path):
+def apply_user_mods(caseroot, user_mods_path, keepexe=None):
     '''
     Recursivlely apply user_mods to caseroot - this includes updating user_nl_xxx,
     updating SourceMods and creating case shell_commands and xmlchange_cmds files
@@ -17,6 +17,9 @@ def apply_user_mods(caseroot, user_mods_path):
 
     If this function is called multiple times, settings from later calls will
     take precedence over earlier calls, if there are conflicts.
+
+    keepexe is an optional argument that is needed for cases where apply_user_mods is
+    called from create_clone
     '''
     case_shell_command_files = [os.path.join(caseroot,"shell_commands"),
                            os.path.join(caseroot,"xmlchange_cmnds")]
@@ -50,6 +53,9 @@ def apply_user_mods(caseroot, user_mods_path):
         # update SourceMods in caseroot
         for root, _, files in os.walk(include_dir,followlinks=True,topdown=False):
             if "src" in os.path.basename(root):
+                if keepexe is not None:
+                    expect(False,
+                           "cannot have any source mods in {} if keepexe is an option".format(user_mods_path))
                 for sfile in files:
                     source_mods = os.path.join(root,sfile)
                     case_source_mods = source_mods.replace(include_dir, caseroot)

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -321,8 +321,6 @@ class J_TestCreateNewcase(unittest.TestCase):
               % (SCRIPT_DIR, prevtestdir, testdir, user_mods_dir)
         run_cmd_assert_result(self, cmd, from_dir=SCRIPT_DIR, expected_stat=1)
 
-        cls._do_teardown.append(testdir)
-
     def test_d_create_clone_new_user(self):
         cls = self.__class__
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -315,15 +315,13 @@ class J_TestCreateNewcase(unittest.TestCase):
             shutil.rmtree(testdir)
         prevtestdir = cls._testdirs[0]
         cls._testdirs.append(testdir)
-
         user_mods_dir = os.path.join(CIME.utils.get_python_libs_root(), "..", "tests", "user_mods_test3")
-        with self.assertRaisesRegexp(SystemExit,
-                                     "cannot change env_build.xml if keepexe"):
-            cmd = "%s/create_clone --clone %s --case %s --keepexe --user-mods-dir %s" % (SCRIPT_DIR, prevtestdir, testdir, user_mods_dir)
-            stat, output, errput = run_cmd(cmd, from_dir=SCRIPT_DIR, verbose=True)
+
+        cmd = "%s/create_clone --clone %s --case %s --keepexe --user-mods-dir %s" \
+              % (SCRIPT_DIR, prevtestdir, testdir, user_mods_dir)
+        run_cmd_assert_result(self, cmd, from_dir=SCRIPT_DIR, expected_stat=1)
 
         cls._do_teardown.append(testdir)
-
 
     def test_d_create_clone_new_user(self):
         cls = self.__class__

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -316,10 +316,14 @@ class J_TestCreateNewcase(unittest.TestCase):
         prevtestdir = cls._testdirs[0]
         cls._testdirs.append(testdir)
 
-        run_cmd_assert_result(self, "%s/create_clone --clone %s --case %s --keepexe" %
-                              (SCRIPT_DIR, prevtestdir, testdir),from_dir=SCRIPT_DIR)
+        user_mods_dir = os.path.join(CIME.utils.get_python_libs_root(), "..", "tests", "user_mods_test3")
+        with self.assertRaisesRegexp(SystemExit,
+                                     "cannot change env_build.xml if keepexe"):
+            cmd = "%s/create_clone --clone %s --case %s --keepexe --user-mods-dir %s" % (SCRIPT_DIR, prevtestdir, testdir, user_mods_dir)
+            stat, output, errput = run_cmd(cmd, from_dir=SCRIPT_DIR, verbose=True)
 
         cls._do_teardown.append(testdir)
+
 
     def test_d_create_clone_new_user(self):
         cls = self.__class__

--- a/scripts/tests/user_mods_test3/shell_commands
+++ b/scripts/tests/user_mods_test3/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange GMAKE_J=0


### PR DESCRIPTION
New user-mods option to `create_clone`

This PR adds the capability to  clone a directory multiple times with different user_mods - but with the executable created in the original create_newcase directory. A new `user_mods` argument has been added to `create_clone`. If  `--keepexe `is an argument along with `--user_mods`  then
- any SourceMods in the original clone will  point to the original template SourceMods.
- the usermods directory CANNOT have any SourceMods (and an error us thrown if that is the case)
- env_build.xml  modifications CANNOT be in the usermods shell_commands file in usermods

In addition, this PR adds new functionality to scripts_regressions_tests and test_user_mod_support.py to test these new features.

Test suite: scripts_regression_tests (cheyenne)
Test baseline: No
Test namelist changes: None
Test status: bit for bit

Fixes: #1846 
User interface changes?: Yes - new argument to create_clone
Update gh-pages html (Y/N)?: Y
Code review: @billsacks, @jedwards4b
