### PR TITLE
make sure file exists

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1285,10 +1285,12 @@ def analyze_build_log(comp, log, compiler):
         logger.info("Component {} build complete with {} warnings".format(comp, warncnt))
 
 def is_python_executable(filepath):
-    with open(filepath, "r") as f:
-        first_line = f.readline()
+    if os.path.isfile(filepath):
+        with open(filepath, "r") as f:
+            first_line = f.readline()
 
-    return first_line.startswith("#!") and "python" in first_line
+        return first_line.startswith("#!") and "python" in first_line
+    return False
 
 def get_umask():
     current_umask = os.umask(0)


### PR DESCRIPTION
When testing branches or sandboxes that do not have files currently on master the 
is_python_executable subroutine may be called with filepaths that do not exist.   Instead of failing just return False so that testing may continue

Test suite: hand tested, scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
