### PR TITLE
improve error check for non-python sub processes

### DIFF
--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -85,7 +85,8 @@ def create_namelists(case, component=None):
                 # otherwise look in the component config_dir
                 cmd = os.path.join(config_dir, "buildnml")
             expect(os.path.isfile(cmd), "Could not find buildnml file for component {}".format(compname))
-            run_sub_or_cmd(cmd, (caseroot), "buildnml", (case, caseroot, compname), case=case)
+            run_sub_or_cmd(cmd, (caseroot), "buildnml", (case, caseroot, compname), case=case,
+                           combine_output=True)
 
     logger.info("Finished creating component namelists")
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -199,8 +199,7 @@ def _convert_to_fd(filearg, from_dir):
 _hack=object()
 
 def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
-                   input_str=None, from_dir=None, verbose=None,
-                   arg_stdout=_hack, arg_stderr=_hack, env=None, combine_output=False):
+                   from_dir=None, combine_output=False):
 
     # This code will try to import and run each buildnml as a subroutine
     # if that fails it will run it as a program in a seperate shell
@@ -227,7 +226,8 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
         logger.info("   Running {} ".format(cmd))
         if case is not None:
             case.flush()
-        output = run_cmd_no_fail("{} {}".format(cmd, cmdargs), combine_output=True)
+        output = run_cmd_no_fail("{} {}".format(cmd, cmdargs), combine_output=combine_output,
+                                 from_dir=from_dir)
         logger.info(output)
         # refresh case xml object from file
         if case is not None:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -227,11 +227,7 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
         logger.info("   Running {} ".format(cmd))
         if case is not None:
             case.flush()
-        stat, output, errput = run_cmd("{} {}".format(cmd, cmdargs), input_str=input_str, from_dir=from_dir,
-                                 verbose=verbose, arg_stdout=arg_stdout, arg_stderr=arg_stderr, env=env,
-                                 combine_output=combine_output)
-        expect(stat==0, errput)
-
+        output = run_cmd_no_fail("{} {}".format(cmd, cmdargs), combine_output=True)
         logger.info(output)
         # refresh case xml object from file
         if case is not None:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -230,6 +230,7 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
         stat, output, errput = run_cmd("{} {}".format(cmd, cmdargs), input_str=input_str, from_dir=from_dir,
                                  verbose=verbose, arg_stdout=arg_stdout, arg_stderr=arg_stderr, env=env,
                                  combine_output=combine_output)
+        expect(stat==0, errput)
 
         logger.info(output)
         # refresh case xml object from file


### PR DESCRIPTION
Subprocesses which are not python are not causing failures when they exit abnormally.
This fixes that problem for build-namelist.

Test suite: hand testing, scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1874 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
