### PR TITLE
Allow queue selection by node count instead of task count

### DIFF
--- a/config/acme/machines/config_batch.xml
+++ b/config/acme/machines/config_batch.xml
@@ -445,17 +445,15 @@
     <!-- order matters, with no-batch jobs will be run in the order listed here -->
     <job name="case.run">
       <template>template.case.run</template>
-      <node_count>default</node_count>
       <prereq>$BUILD_COMPLETE and not $TEST</prereq>
     </job>
     <job name="case.test">
       <template>template.case.test</template>
-      <node_count>default</node_count>
       <prereq>$BUILD_COMPLETE and $TEST</prereq>
     </job>
     <job name="case.st_archive">
       <template>template.st_archive</template>
-      <node_count>1</node_count>
+      <task_count>1</task_count>
       <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
       <dependency>case.run case.test</dependency>
       <prereq>$DOUT_S</prereq>

--- a/config/acme/machines/config_batch.xml
+++ b/config/acme/machines/config_batch.xml
@@ -312,7 +312,8 @@
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue jobmin="1" jobmax="1024" walltimemax="06:00:00" default="true">ec</queue>
+      <queue nodemin="1" nodemax="12" walltimemax="04:00:00" default="true">short</queue>
+      <queue nodemin="1" nodemax="64" walltimemax="24:00:00">batch</queue>
     </queues>
   </batch_system>
 
@@ -321,7 +322,8 @@
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue jobmin="1" jobmax="1024" walltimemax="06:00:00" default="true">ec</queue>
+      <queue nodemin="1" nodemax="12" walltimemax="04:00:00" default="true">short</queue>
+      <queue nodemin="1" nodemax="64" walltimemax="24:00:00">batch</queue>
     </queues>
   </batch_system>
 
@@ -423,7 +425,7 @@
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
      </directives>
     <queues>
-      <queue walltimemin="0" walltimemax="01:00:00" jobmin="0" jobmax="64" default="true">lr3</queue>
+      <queue walltimemax="01:00:00" jobmin="0" jobmax="64" default="true">lr3</queue>
     </queues>
   </batch_system>
 
@@ -435,7 +437,7 @@
       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue walltimemin="0" walltimemax="01:00:00" jobmin="0" jobmax="64" default="true">lr3</queue>
+      <queue walltimemax="01:00:00" jobmin="0" jobmax="64" default="true">lr3</queue>
     </queues>
   </batch_system>
 
@@ -443,17 +445,17 @@
     <!-- order matters, with no-batch jobs will be run in the order listed here -->
     <job name="case.run">
       <template>template.case.run</template>
-      <task_count>default</task_count>
+      <node_count>default</node_count>
       <prereq>$BUILD_COMPLETE and not $TEST</prereq>
     </job>
     <job name="case.test">
       <template>template.case.test</template>
-      <task_count>default</task_count>
+      <node_count>default</node_count>
       <prereq>$BUILD_COMPLETE and $TEST</prereq>
     </job>
     <job name="case.st_archive">
       <template>template.st_archive</template>
-      <task_count>1</task_count>
+      <node_count>1</node_count>
       <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
       <dependency>case.run case.test</dependency>
       <prereq>$DOUT_S</prereq>

--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -809,12 +809,12 @@
     <executable></executable>
   </mpirun>
   <module_system type="module">
-    <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
-    <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
-    <init_path lang="sh">/usr/share/Modules/init/sh</init_path>
-    <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
-    <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
-    <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+    <init_path lang="python">/usr/share/lmod/lmod/init/python.py</init_path>
+    <init_path lang="perl">/usr/share/lmod/lmod/init/perl.pm</init_path>
+    <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
+    <init_path lang="csh">/usr/share/lmod/lmod/init/csh</init_path>
+    <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+    <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
     <cmd_path lang="csh">module</cmd_path>
     <cmd_path lang="sh">module</cmd_path>
     <modules>
@@ -824,16 +824,14 @@
       <command name="load">sems-python/2.7.9</command>
       <command name="load">sems-cmake</command>
       <command name="load">gnu/4.9.2</command>
-      <command name="load">intel/intel-15.0.3.187</command>
-      <command name="load">libraries/intel-mkl-15.0.2.164</command>
+      <command name="load">sems-intel/16.0.2</command>
+      <command name="load">mkl/16.0</command>
     </modules>
     <modules mpilib="!mpi-serial">
-      <command name="load">openmpi-intel/1.6</command>
-      <command name="load">sems-hdf5/1.8.12/parallel</command>
+      <command name="load">sems-openmpi/1.10.5</command>
       <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
     </modules>
     <modules mpilib="mpi-serial">
-      <command name="load">sems-hdf5/1.8.12/base</command>
       <command name="load">sems-netcdf/4.4.1/exo</command>
     </modules>
   </module_system>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -448,17 +448,17 @@
     <!-- order matters, with no-batch jobs will be run in the order listed here -->
     <job name="case.run">
       <template>template.case.run</template>
-      <task_count>default</task_count>
+      <node_count>default</node_count>
       <prereq>$BUILD_COMPLETE and not $TEST</prereq>
     </job>
     <job name="case.test">
       <template>template.case.test</template>
-      <task_count>default</task_count>
+      <node_count>default</node_count>
       <prereq>$BUILD_COMPLETE and $TEST</prereq>
     </job>
     <job name="case.st_archive">
       <template>template.st_archive</template>
-      <task_count>1</task_count>
+      <node_count>1</node_count>
       <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
       <dependency>case.run or case.test</dependency>
       <prereq>$DOUT_S</prereq>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -25,8 +25,10 @@
  be used.  The following variables can be used to choose a queue :
  walltimemin: Giving the minimum amount of walltime for the queue.
  walltimemax: The maximum amount of walltime for a queue.
- jobmin:      The minimum node count required to use this queue.
- jobmax:      The maximum node count required to use this queue.
+ jobmin:      The minimum task count required to use this queue.
+ jobmax:      The maximum task count required to use this queue.
+ nodemin:      The minimum node count required to use this queue.
+ nodemax:      The maximum node count required to use this queue.
     -->
   <batch_system type="template" >
     <batch_query args=""></batch_query>
@@ -448,17 +450,15 @@
     <!-- order matters, with no-batch jobs will be run in the order listed here -->
     <job name="case.run">
       <template>template.case.run</template>
-      <node_count>default</node_count>
       <prereq>$BUILD_COMPLETE and not $TEST</prereq>
     </job>
     <job name="case.test">
       <template>template.case.test</template>
-      <node_count>default</node_count>
       <prereq>$BUILD_COMPLETE and $TEST</prereq>
     </job>
     <job name="case.st_archive">
       <template>template.st_archive</template>
-      <node_count>1</node_count>
+      <task_count>1</task_count>
       <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
       <dependency>case.run or case.test</dependency>
       <prereq>$DOUT_S</prereq>

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -19,7 +19,7 @@
   <xs:element name="batch_mail_type_flag" type="xs:string"/>
   <xs:element name="batch_mail_type" type="xs:string"/>
   <xs:element name="template" type="xs:NCName"/>
-  <xs:element name="node_count" type="xs:NMTOKEN"/>
+  <xs:element name="task_count" type="xs:integer"/>
   <xs:element name="dependency" type="xs:string"/>
   <xs:element name="prereq" type="xs:string"/>
 
@@ -166,7 +166,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="template"/>
-        <xs:element ref="node_count"/>
+        <xs:element minOccurs="0" ref="task_count"/>
         <xs:element minOccurs="0" ref="dependency"/>
         <xs:element ref="prereq"/>
       </xs:sequence>

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -19,7 +19,7 @@
   <xs:element name="batch_mail_type_flag" type="xs:string"/>
   <xs:element name="batch_mail_type" type="xs:string"/>
   <xs:element name="template" type="xs:NCName"/>
-  <xs:element name="task_count" type="xs:NMTOKEN"/>
+  <xs:element name="node_count" type="xs:NMTOKEN"/>
   <xs:element name="dependency" type="xs:string"/>
   <xs:element name="prereq" type="xs:string"/>
 
@@ -144,6 +144,8 @@
           <xs:attribute name="strict" type="xs:boolean"/>
           <xs:attribute name="jobmax" type="xs:integer"/>
           <xs:attribute name="jobmin" type="xs:integer"/>
+          <xs:attribute name="nodemax" type="xs:integer"/>
+          <xs:attribute name="nodemin" type="xs:integer"/>
           <xs:attribute name="jobname" type="xs:NCName"/>
           <xs:attribute name="walltimemax"/>
           <xs:attribute name="walltimemin"/>
@@ -164,7 +166,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="template"/>
-        <xs:element ref="task_count"/>
+        <xs:element ref="node_count"/>
         <xs:element minOccurs="0" ref="dependency"/>
         <xs:element ref="prereq"/>
       </xs:sequence>

--- a/config/xml_schemas/env_batch.xsd
+++ b/config/xml_schemas/env_batch.xsd
@@ -8,6 +8,8 @@
   <xs:attribute name="default" type="xs:NCName"/>
   <xs:attribute name="jobmax" type="xs:integer"/>
   <xs:attribute name="jobmin"  type="xs:integer"/>
+  <xs:attribute name="nodemax" type="xs:integer"/>
+  <xs:attribute name="nodemin"  type="xs:integer"/>
   <xs:attribute name="jobname" type="xs:NCName"/>
   <xs:attribute name="walltimemax" type="xs:NMTOKEN"/>
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -930,7 +930,7 @@ class Case(object):
 
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
         env_batch.create_job_groups(bjobs)
-        env_batch.set_job_defaults(bjobs, pesize=pesize, num_nodes=self.num_nodes, walltime=walltime, force_queue=queue, allow_walltime_override=test)
+        env_batch.set_job_defaults(bjobs, pesize=pesize, num_nodes=self.num_nodes, tasks_per_node=self.tasks_per_node, walltime=walltime, force_queue=queue, allow_walltime_override=test)
         self.schedule_rewrite(env_batch)
 
         # Make sure that parallel IO is not specified if total_tasks==1


### PR DESCRIPTION
All the HPCs care about is how many nodes you request, so it makes
more sense to do selection by nodes instead of tasks. Also, the
mapping of tasks to nodes depends on the number of threads, so
task count alone is not a detemistic way of know how many nodes
you'll need.

1) Chama and skybridge to select queue based on node count
2) Change job-based task_count override to a node_count override
3) XSD changes to support these changes
4) Batch system setup must happen after initialize_derived_attributes (computes num_nodes)
5) Lots of changes to env_batch to support nodemin, nodemax

Test suite: scripts_regression_tests (TBD)
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #1861 

User interface changes?: Yes, new ways to select queue in config_batch.xml

Update gh-pages html (Y/N)?:N

Code review: @jedwards4b 
