### PR TITLE
Add a timeout option to wait_for_tests

### DIFF
--- a/scripts/Tools/wait_for_tests
+++ b/scripts/Tools/wait_for_tests
@@ -66,9 +66,12 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-g", "--cdash-build-group", default=CIME.wait_for_tests.CDASH_DEFAULT_BUILD_GROUP,
                         help="The build group to be used to display results on the CDash dashboard.")
 
+    parser.add_argument("--timeout", type=int,
+                        help="Timeout wait in seconds.")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.paths, args.no_wait, args.check_throughput, args.check_memory, args.ignore_namelist_diffs, args.ignore_memleak, args.cdash_build_name, args.cdash_project, args.cdash_build_group
+    return args.paths, args.no_wait, args.check_throughput, args.check_memory, args.ignore_namelist_diffs, args.ignore_memleak, args.cdash_build_name, args.cdash_project, args.cdash_build_group, args.timeout
 
 ###############################################################################
 def _main_func(description):
@@ -77,18 +80,19 @@ def _main_func(description):
         CIME.utils.run_cmd_no_fail("python -m doctest %s/wait_for_tests.py -v" % CIME.utils.get_python_libs_root(), arg_stdout=None, arg_stderr=None)
         return
 
-    test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, ignore_memleak, cdash_build_name, cdash_project, cdash_build_group = \
+    test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, ignore_memleak, cdash_build_name, cdash_project, cdash_build_group, timeout = \
         parse_command_line(sys.argv, description)
 
     sys.exit(0 if CIME.wait_for_tests.wait_for_tests(test_paths,
-                                                no_wait=no_wait,
-                                                check_throughput=check_throughput,
-                                                check_memory=check_memory,
-                                                ignore_namelists=ignore_namelist_diffs,
-                                                ignore_memleak=ignore_memleak,
-                                                cdash_build_name=cdash_build_name,
-                                                cdash_project=cdash_project,
-                                                cdash_build_group=cdash_build_group)
+                                                     no_wait=no_wait,
+                                                     check_throughput=check_throughput,
+                                                     check_memory=check_memory,
+                                                     ignore_namelists=ignore_namelist_diffs,
+                                                     ignore_memleak=ignore_memleak,
+                                                     cdash_build_name=cdash_build_name,
+                                                     cdash_project=cdash_project,
+                                                     cdash_build_group=cdash_build_group,
+                                                     timeout=timeout)
              else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -3,7 +3,7 @@ import logging
 import xml.etree.ElementTree as xmlet
 
 import CIME.utils
-from CIME.utils import expect
+from CIME.utils import expect, Timeout
 from CIME.XML.machines import Machines
 from CIME.test_status import *
 
@@ -337,13 +337,15 @@ def wait_for_tests(test_paths,
                    ignore_memleak=False,
                    cdash_build_name=None,
                    cdash_project=ACME_MAIN_CDASH,
-                   cdash_build_group=CDASH_DEFAULT_BUILD_GROUP):
+                   cdash_build_group=CDASH_DEFAULT_BUILD_GROUP,
+                   timeout=None):
 ###############################################################################
     # Set up signal handling, we want to print results before the program
     # is terminated
     set_up_signal_handlers()
 
-    test_results = wait_for_tests_impl(test_paths, no_wait, check_throughput, check_memory, ignore_namelists, ignore_memleak)
+    with Timeout(timeout, action=signal_handler):
+        test_results = wait_for_tests_impl(test_paths, no_wait, check_throughput, check_memory, ignore_namelists, ignore_memleak)
 
     all_pass = True
     for test_name, test_data in sorted(test_results.iteritems()):

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1307,7 +1307,7 @@ class Z_FullSystemTest(TestCreateTestCommon):
         if (FAST_ONLY):
             self.skipTest("Skipping slow test")
 
-        self._create_test(["--walltime=0:15:00"], test_id=self._baseline_name)
+        self._create_test(["--walltime=0:15:00", "cime_developer"], test_id=self._baseline_name)
 
         run_cmd_assert_result(self, "%s/cs.status.%s" % (self._testroot, self._baseline_name),
                               from_dir=self._testroot)

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -610,6 +610,12 @@ class M_TestWaitForTests(unittest.TestCase):
         self.simple_test(self._testdir_unfinished, expected_results, "-n")
 
     ###########################################################################
+    def test_wait_for_test_timeout(self):
+    ###########################################################################
+        expected_results = ["PEND" if item == 5 else "PASS" for item in range(10)]
+        self.simple_test(self._testdir_unfinished, expected_results, "--timeout=3")
+
+    ###########################################################################
     def test_wait_for_test_wait_for_pend(self):
     ###########################################################################
         run_thread = threading.Thread(target=self.threaded_test, args=(self._testdir_unfinished, ["PASS"] * 10))

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -926,7 +926,7 @@ class O_TestTestScheduler(TestCreateTestCommon):
         finally:
             logging.getLogger().setLevel(log_lvl)
 
-        self._wait_for_tests(test_id, CIME.utils.TESTS_FAILED_ERR_CODE)
+        self._wait_for_tests(test_id, expect_works=False)
 
         test_statuses = glob.glob("%s/*%s/TestStatus" % (self._testroot, test_id))
         self.assertEqual(len(tests), len(test_statuses))
@@ -991,7 +991,7 @@ class O_TestTestScheduler(TestCreateTestCommon):
         test_statuses = glob.glob("%s/*%s/TestStatus" % (self._testroot, test_id))
         self.assertEqual(len(tests), len(test_statuses))
 
-        self._wait_for_tests(test_id, CIME.utils.TESTS_FAILED_ERR_CODE)
+        self._wait_for_tests(test_id, expect_works=False)
 
         for test_status in test_statuses:
             casedir = os.path.dirname(test_status)


### PR DESCRIPTION
Our current timeout system is dependent on Jenkins hitting processes
with signals. This option will allow for a timeout mechanism independent
of Jenkins.

Also add a regression test for this feature.

Test suite: scripts_regression_tests M_TestWaitForTests, code_checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1867 

User interface changes?: Yes, new --timeout flag for wait_for_tests

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
