### PR TITLE
Fix T31_g37 grid match in config_grids for cesm

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1510,7 +1510,7 @@
       <map name="ICE2WAV_SMAPNAME">cpl/gridmaps/tx1v1/map_tx1v1_TO_ww3a_blin.170523.nc</map>
     </gridmap>
 
-    <gridmap atm_grid="48x96" wav_grid="ww3a">
+    <gridmap atm_grid="T31" wav_grid="ww3a">
       <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/T31/map_T31_TO_ww3a_bilin_131104.nc</map>
     </gridmap>
 


### PR DESCRIPTION
Change atm_grid match from "48x96" to T31 to match the atm grid name
that is actually being used.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?: N

Code review:
