### PR TITLE
rename PES_PER_NODE to MAX_MPITASKS_PER_NODE

### DIFF
--- a/config/acme/allactive/config_pesall.xml
+++ b/config/acme/allactive/config_pesall.xml
@@ -4181,7 +4181,7 @@
     <mach name="anvil">
       <pes compset="any" pesize="S">
         <comment>ne30_ne30 grid on 45 nodes 32 ppn pure-MPI</comment>
-        <PES_PER_NODE>32</PES_PER_NODE>
+        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
         <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>1350</ntasks_atm>
@@ -6317,7 +6317,7 @@
     <mach name="anvil">
       <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="S">
         <comment> -compset A_WCYCL* -res ne30_oEC* on 32 nodes pure-MPI </comment>
-        <PES_PER_NODE>32</PES_PER_NODE>
+        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
         <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>675</ntasks_atm>
@@ -6352,7 +6352,7 @@
       </pes>
       <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="any">
         <comment> -compset A_WCYCL* -res ne30_oEC* on 59 nodes pure-MPI </comment>
-        <PES_PER_NODE>32</PES_PER_NODE>
+        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
         <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>1350</ntasks_atm>
@@ -6387,7 +6387,7 @@
       </pes>
       <pes compset=".*CAM5.+CLM45.+MPASCICE.+MPASO.+MOSART.+SGLC.+SWAV" pesize="L">
         <comment> -compset A_WCYCL* -res ne30_oEC* on 115 nodes pure-MPI </comment>
-        <PES_PER_NODE>32</PES_PER_NODE>
+        <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
         <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
         <ntasks>
           <ntasks_atm>2700</ntasks_atm>

--- a/config/acme/machines/config_batch.xml
+++ b/config/acme/machines/config_batch.xml
@@ -47,7 +47,7 @@
       <arg flag="--cwd" name="CASEROOT"/>
       <arg flag="-A" name="PROJECT"/>
       <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
-      <arg flag="-n" name=" $TOTALPES/$PES_PER_NODE"/>
+      <arg flag="-n" name=" $TOTALPES/$MAX_MPITASKS_PER_NODE"/>
       <arg flag="-q" name="JOB_QUEUE"/>
       <arg flag="--mode script"/>
     </submit_args>
@@ -65,7 +65,7 @@
     <submit_args>
       <arg flag="-A" name="PROJECT"/>
       <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
-      <arg flag="-n" name=" $TOTALPES/$PES_PER_NODE"/>
+      <arg flag="-n" name=" $TOTALPES/$MAX_MPITASKS_PER_NODE"/>
       <arg flag="-q" name="JOB_QUEUE"/>
       <arg flag="--mode script"/>
     </submit_args>

--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -72,7 +72,7 @@
   <SUPPORTED_BY>acme</SUPPORTED_BY>
   <GMAKE_J>8</GMAKE_J>
   <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
-  <PES_PER_NODE>24</PES_PER_NODE>
+  <MAX_MPITASKS_PER_NODE>24</MAX_MPITASKS_PER_NODE>
   <PROJECT>acme</PROJECT>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
@@ -196,7 +196,7 @@
     <SUPPORTED_BY>acme</SUPPORTED_BY>
     <GMAKE_J>8</GMAKE_J>
     <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>32</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
     <PROJECT>acme</PROJECT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
@@ -333,7 +333,7 @@
     <SUPPORTED_BY>acme</SUPPORTED_BY>
     <GMAKE_J>8</GMAKE_J>
     <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <PROJECT>acme</PROJECT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
@@ -469,7 +469,7 @@
 <!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
     <GMAKE_J>4</GMAKE_J>
     <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>2</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>2</MAX_MPITASKS_PER_NODE>
 </machine>
 
 <machine MACH="linux-generic">
@@ -493,7 +493,7 @@
 <!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
     <GMAKE_J>4</GMAKE_J>
     <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>2</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>2</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
@@ -524,7 +524,7 @@
 <!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
     <GMAKE_J>32</GMAKE_J>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
@@ -591,7 +591,7 @@
 <!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
     <GMAKE_J>32</GMAKE_J>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
@@ -657,7 +657,7 @@
     <GMAKE>make</GMAKE>
     <GMAKE_J>32</GMAKE_J>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
@@ -719,7 +719,7 @@
   <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
   <GMAKE_J>8</GMAKE_J>
   <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-  <PES_PER_NODE>16</PES_PER_NODE>
+  <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
   <PIO_BUFFER_SIZE_LIMIT>1</PIO_BUFFER_SIZE_LIMIT>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <PROJECT>fy150001</PROJECT>
@@ -794,7 +794,7 @@
   <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
   <GMAKE_J>8</GMAKE_J>
   <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-  <PES_PER_NODE>16</PES_PER_NODE>
+  <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
   <PIO_BUFFER_SIZE_LIMIT>1</PIO_BUFFER_SIZE_LIMIT>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <PROJECT>fy150001</PROJECT>
@@ -869,7 +869,7 @@
   <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
   <GMAKE_J>8</GMAKE_J>
   <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
-  <PES_PER_NODE>36</PES_PER_NODE>
+  <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
   <PIO_BUFFER_SIZE_LIMIT>1</PIO_BUFFER_SIZE_LIMIT>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <PROJECT>fy150001</PROJECT>
@@ -935,7 +935,7 @@
          <SUPPORTED_BY>acme</SUPPORTED_BY>
          <GMAKE_J>4</GMAKE_J>
          <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-	 <PES_PER_NODE>16</PES_PER_NODE>
+	 <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
          <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	 <PROJECT>ACME</PROJECT>
          <mpirun mpilib="mvapich">
@@ -1047,7 +1047,7 @@
          <SUPPORTED_BY>acme</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
          <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
-	 <PES_PER_NODE>36</PES_PER_NODE>
+	 <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
          <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
 	 <PROJECT>ACME</PROJECT>
          <mpirun mpilib="openmpi">
@@ -1153,7 +1153,7 @@
     <SUPPORTED_BY>acme</SUPPORTED_BY>
     <GMAKE_J>8</GMAKE_J>
     <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>36</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT>acme</PROJECT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
@@ -1226,7 +1226,7 @@
          <BATCH_SYSTEM>cobalt</BATCH_SYSTEM>
          <SUPPORTED_BY>   jayesh -at- mcs.anl.gov</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
-         <PES_PER_NODE>4</PES_PER_NODE>
+         <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
          <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
          <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
          <PROJECT>ClimateEnergy_2</PROJECT>
@@ -1235,7 +1235,7 @@
            <executable>/usr/bin/runjob</executable>
              <arguments>
                <arg name="label">--label short</arg>
-               <arg name="tasks_per_node">--ranks-per-node $PES_PER_NODE</arg>
+               <arg name="tasks_per_node">--ranks-per-node $MAX_MPITASKS_PER_NODE</arg>
                <arg name="num_tasks">--np $TOTALPES</arg>
                <arg name="locargs">--block $COBALT_PARTNAME $LOCARGS</arg>
                <arg name="bgq_smp_vars">$ENV{BGQ_SMP_VARS}</arg>
@@ -1280,7 +1280,7 @@
          <SUPPORTED_BY>bogenschutz1 -at- llnl.gov</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
          <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-	 <PES_PER_NODE>16</PES_PER_NODE>
+	 <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
 	 <BATCH_SYSTEM>lc_slurm</BATCH_SYSTEM>
 	 <mpirun mpilib="mpi-serial">
 	   <executable></executable>
@@ -1336,7 +1336,7 @@
          <SUPPORTED_BY>bogenschutz1 -at- llnl.gov</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
          <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-	 <PES_PER_NODE>16</PES_PER_NODE>
+	 <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
 	 <BATCH_SYSTEM>lc_slurm</BATCH_SYSTEM>
 	 <mpirun mpilib="mpi-serial">
 	   <executable></executable>
@@ -1397,7 +1397,7 @@
          <SUPPORTED_BY>donahue5 -at- llnl.gov</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
          <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
-	 <PES_PER_NODE>36</PES_PER_NODE>
+	 <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
 	 <BATCH_SYSTEM>lc_slurm</BATCH_SYSTEM>
 	 <mpirun mpilib="mpi-serial">
 	   <executable></executable>
@@ -1451,7 +1451,7 @@
 	 <BATCH_SYSTEM>cobalt</BATCH_SYSTEM>
          <SUPPORTED_BY>   mickelso -at- mcs.anl.gov</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
-         <PES_PER_NODE>4</PES_PER_NODE>
+         <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
          <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
          <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
          <PROJECT>ClimateEnergy_2</PROJECT>
@@ -1460,7 +1460,7 @@
            <executable>/usr/bin/runjob</executable>
              <arguments>
                <arg name="label">--label short</arg>
-               <arg name="tasks_per_node">--ranks-per-node $PES_PER_NODE</arg>
+               <arg name="tasks_per_node">--ranks-per-node $MAX_MPITASKS_PER_NODE</arg>
                <arg name="num_tasks">--np $TOTALPES</arg>
                <arg name="locargs">--block $COBALT_PARTNAME $LOCARGS</arg>
                <arg name="bgq_smp_vars">$ENV{BGQ_SMP_VARS}</arg>
@@ -1505,7 +1505,7 @@
     <SUPPORTED_BY>acme</SUPPORTED_BY>
     <GMAKE_J>8</GMAKE_J>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <PROJECT>OceanClimate</PROJECT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
@@ -1513,7 +1513,7 @@
       <executable>aprun</executable>
       <arguments>
         <arg name="num_tasks" >-n $TOTALPES</arg>
-        <arg name="tasks_per_node" >-N $PES_PER_NODE</arg>
+        <arg name="tasks_per_node" >-N $MAX_MPITASKS_PER_NODE</arg>
         <arg name="thread_count">--cc depth -d $OMP_NUM_THREADS</arg>
         <arg name="env_omp_stacksize">-e OMP_STACKSIZE=128M</arg>
         <arg name="env_thread_count">-e OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
@@ -1601,7 +1601,7 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>balwinder.singh -at- pnnl.gov</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>8</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>8</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>8</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="mpi-serial">
       <executable/>
@@ -1674,7 +1674,7 @@
     <SUPPORTED_BY>balwinder.singh -at- pnnl.gov</SUPPORTED_BY>
     <GMAKE_J>8</GMAKE_J>
     <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>16</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="mpi-serial">
       <executable></executable>
@@ -1741,7 +1741,7 @@
          <SUPPORTED_BY>balwinder.singh -at- pnnl.gov</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
 	 <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
-	 <PES_PER_NODE>24</PES_PER_NODE>
+	 <MAX_MPITASKS_PER_NODE>24</MAX_MPITASKS_PER_NODE>
 	 <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
 	 <mpirun mpilib="mpi-serial">
 	   <executable></executable>
@@ -1840,7 +1840,7 @@
 	 <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
          <SUPPORTED_BY>dmricciuto</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
-	 <PES_PER_NODE>8</PES_PER_NODE>
+	 <MAX_MPITASKS_PER_NODE>8</MAX_MPITASKS_PER_NODE>
          <MAX_TASKS_PER_NODE>8</MAX_TASKS_PER_NODE>
          <mpirun mpilib="mpich">
               <executable args="default">/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpirun </executable>
@@ -1888,7 +1888,7 @@
 	 <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
          <SUPPORTED_BY>dmricciuto</SUPPORTED_BY>
          <GMAKE_J>32</GMAKE_J>
-	 <PES_PER_NODE>32</PES_PER_NODE>
+	 <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
          <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
          <mpirun mpilib="mpich">
               <executable args="default">/projects/cesm/devtools/mpich-3.0.4-gcc4.8.1/bin/mpirun </executable>
@@ -1924,7 +1924,7 @@
       <SUPPORTED_BY>yinj -at- ornl.gov</SUPPORTED_BY>
       <GMAKE_J>4</GMAKE_J>
       <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-      <PES_PER_NODE>16</PES_PER_NODE>
+      <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
       <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
       <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
       <mpirun mpilib="openmpi" compiler="gnu">
@@ -1982,7 +1982,7 @@
     <SAVE_TIMING_DIR>$ENV{PROJWORK}/$PROJECT</SAVE_TIMING_DIR>
     <OS>CNL</OS>
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
-    <PES_PER_NODE>16</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
     <!-- difference to MAX_TASKS_PER_NODE-->
     <SUPPORTED_BY>acme</SUPPORTED_BY>
     <GMAKE_J>8</GMAKE_J>
@@ -1997,7 +1997,7 @@
 	<!-- <arg name="hyperthreading" default="2"> -j {{ hyperthreading }}</arg>
         <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
         <arg name="num_tasks" > -n $TOTALPES</arg>
-        <arg name="tasks_per_node" > -N $PES_PER_NODE</arg>
+        <arg name="tasks_per_node" > -N $MAX_MPITASKS_PER_NODE</arg>
         <arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
         <arg name="numa_node" > -cc numa_node </arg>
 	-->
@@ -2170,7 +2170,7 @@
          <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
          <SUPPORTED_BY>acme</SUPPORTED_BY>
          <GMAKE_J>8</GMAKE_J>
-         <PES_PER_NODE>16</PES_PER_NODE>
+         <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
          <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
          <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
          <PIO_CONFIG_OPTS> -D PIO_BUILD_TIMING:BOOL=ON </PIO_CONFIG_OPTS>
@@ -2180,7 +2180,7 @@
              <arg name="hyperthreading" default="2"> -j {{ hyperthreading }}</arg>
              <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
              <arg name="num_tasks" > -n $TOTALPES</arg>
-             <arg name="tasks_per_node" > -N $PES_PER_NODE</arg>
+             <arg name="tasks_per_node" > -N $MAX_MPITASKS_PER_NODE</arg>
              <arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
              <arg name="numa_node" > -cc numa_node</arg>
            </arguments>
@@ -2320,7 +2320,7 @@
 	</mpirun>
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
-	<PES_PER_NODE>32</PES_PER_NODE>
+	<MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
 	<PROJECT>climateacme</PROJECT>
     	<PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     	<SUPPORTED_BY>luke.vanroekel @ gmail.com</SUPPORTED_BY>
@@ -2342,7 +2342,7 @@
 	<SUPPORTED_BY>jonbob -at- lanl.gov</SUPPORTED_BY>
 	<GMAKE_J>4</GMAKE_J>
 	<MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-	<PES_PER_NODE>16</PES_PER_NODE>
+	<MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
 	<PROJECT>climateacme</PROJECT>
 	<PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	<DIN_LOC_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data</DIN_LOC_ROOT>
@@ -2430,7 +2430,7 @@
   <SUPPORTED_BY>jedwards@ucar.edu</SUPPORTED_BY>
   <GMAKE_J>8</GMAKE_J>
   <MAX_TASKS_PER_NODE>30</MAX_TASKS_PER_NODE>
-  <PES_PER_NODE>15</PES_PER_NODE>
+  <MAX_MPITASKS_PER_NODE>15</MAX_MPITASKS_PER_NODE>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <SAVE_TIMING_DIR>/glade/scratch/$USER/acme/timing/performance_archive</SAVE_TIMING_DIR>
   <mpirun >
@@ -2542,7 +2542,7 @@
              <arguments>
                 <arg name="num_tasks"> -n $TOTALPES</arg>
                 <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg>
-                <arg name="tasks_per_node"> -N $PES_PER_NODE</arg>
+                <arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
                 <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
              </arguments>
          </mpirun>
@@ -2581,7 +2581,7 @@
              <arguments>
                 <arg name="num_tasks"> -n $TOTALPES</arg>
                 <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg>
-                <arg name="tasks_per_node"> -N $PES_PER_NODE</arg>
+                <arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
                 <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
              </arguments>
          </mpirun>
@@ -2606,20 +2606,20 @@
   <SUPPORTED_BY>gbisht at lbl dot gov </SUPPORTED_BY>
   <GMAKE_J>4</GMAKE_J>
   <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-  <PES_PER_NODE>16</PES_PER_NODE>
+  <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <mpirun mpilib="mpi-serial">
     <executable>mpirun</executable>
     <arguments>
       <arg name="num_tasks">-np $TOTALPES</arg>
-      <arg name="tasks_per_node"> -npernode $PES_PER_NODE</arg>
+      <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
     </arguments>
   </mpirun>
   <mpirun mpilib="default">
     <executable>mpirun</executable>
     <arguments>
       <arg name="num_tasks">-np $TOTALPES</arg>
-      <arg name="tasks_per_node"> -npernode $PES_PER_NODE</arg>
+      <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
     </arguments>
   </mpirun>
   <module_system type="module">
@@ -2669,20 +2669,20 @@
   <SUPPORTED_BY>gbisht at lbl dot gov</SUPPORTED_BY>
   <GMAKE_J>4</GMAKE_J>
   <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
-  <PES_PER_NODE>12</PES_PER_NODE>
+  <MAX_MPITASKS_PER_NODE>12</MAX_MPITASKS_PER_NODE>
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <mpirun mpilib="mpi-serial">
     <executable>mpirun</executable>
     <arguments>
       <arg name="num_tasks">-np $TOTALPES</arg>
-      <arg name="tasks_per_node"> -npernode $PES_PER_NODE</arg>
+      <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
     </arguments>
   </mpirun>
   <mpirun mpilib="default">
     <executable>mpirun</executable>
     <arguments>
       <arg name="num_tasks">-np $TOTALPES</arg>
-      <arg name="tasks_per_node"> -npernode $PES_PER_NODE</arg>
+      <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
     </arguments>
   </mpirun>
   <module_system type="module">
@@ -2730,7 +2730,7 @@
   <BATCH_SYSTEM>none</BATCH_SYSTEM>
   <SUPPORTED_BY>rgknox at lbl gov</SUPPORTED_BY>
   <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
-  <PES_PER_NODE>4</PES_PER_NODE>
+  <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
   <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
   <mpirun mpilib="mpi-serial">
     <executable></executable>
@@ -2739,7 +2739,7 @@
     <executable>mpirun</executable>
     <arguments>
       <arg name="num_tasks">-np $TOTALPES</arg>
-      <arg name="tasks_per_node"> -npernode $PES_PER_NODE</arg>
+      <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
     </arguments>
   </mpirun>
   <module_system type="none"/>
@@ -2766,7 +2766,7 @@
 	 <BATCH_SYSTEM>lsf</BATCH_SYSTEM>
 	 <SUPPORTED_BY>acme</SUPPORTED_BY>
 	 <GMAKE_J>32</GMAKE_J>
-	 <PES_PER_NODE>20</PES_PER_NODE>
+	 <MAX_MPITASKS_PER_NODE>20</MAX_MPITASKS_PER_NODE>
 	 <MAX_TASKS_PER_NODE>160</MAX_TASKS_PER_NODE>
 	 <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	 <PROJECT>csc249</PROJECT>
@@ -2781,7 +2781,7 @@
 		 <arg name="show-binding"> --report-bindings </arg>
 		 <arg name="show-processmap"> --display-map </arg>
 		 <!--
-		 <arg name="tasks_per_node"> map-by ppr:$PES_PER_NODE:node</arg>
+		 <arg name="tasks_per_node"> map-by ppr:$MAX_MPITASKS_PER_NODE:node</arg>
 		 -->
 	 </arguments>  
 	 </mpirun>

--- a/config/acme/machines/config_pio.xml
+++ b/config/acme/machines/config_pio.xml
@@ -20,7 +20,7 @@
 
   <entry id="PIO_STRIDE">
     <values>
-      <value>$PES_PER_NODE</value>
+      <value>$MAX_MPITASKS_PER_NODE</value>
       <value mach="yellowstone" grid="a%ne120.+oi%gx1">60</value>
       <value mach="mira|cetus">128</value>
       <value mach="cori-knl">64</value>

--- a/config/acme/machines/userdefined_laptop_template/config_machines.xml
+++ b/config/acme/machines/userdefined_laptop_template/config_machines.xml
@@ -19,7 +19,7 @@
       <SUPPORTED_BY>__YOUR_NAME_HERE__</SUPPORTED_BY>
       <GMAKE_J>4</GMAKE_J>
       <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
-      <PES_PER_NODE>2</PES_PER_NODE>
+      <MAX_MPITASKS_PER_NODE>2</MAX_MPITASKS_PER_NODE>
       <module_system type="none"/>
    </machine>
 

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -65,7 +65,7 @@
       <arg flag="-A" name="PROJECT"/>
       <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
       <!-- space required at beginning of name -->
-      <arg flag="-n" name=" $TOTALPES / $PES_PER_NODE"/>
+      <arg flag="-n" name=" $TOTALPES / $MAX_MPITASKS_PER_NODE"/>
       <arg flag="-q" name="JOB_QUEUE"/>
       <arg flag="--mode script"/>
     </submit_args>
@@ -83,7 +83,7 @@
     <submit_args>
       <arg flag="-A" name="PROJECT"/>
       <arg flag="-t" name="JOB_WALLCLOCK_TIME"/>
-      <arg flag="-n" name=" $TOTALPES/$PES_PER_NODE"/>
+      <arg flag="-n" name=" $TOTALPES/$MAX_MPITASKS_PER_NODE"/>
       <arg flag="-q" name="JOB_QUEUE"/>
       <arg flag="--mode script"/>
     </submit_args>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -66,14 +66,14 @@
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>16</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
 	<arg name="num_tasks"> -n $TOTALPES</arg>
 	<!-- <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg> -->
-	<arg name="tasks_per_node"> -N $PES_PER_NODE</arg>
+	<arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
 	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
@@ -145,12 +145,12 @@
     <BATCH_SYSTEM>lsf</BATCH_SYSTEM>
     <SUPPORTED_BY>tcraig -at- ucar.edu</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>16</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="mpich">
       <executable>mpirun</executable>
       <arguments>
 	<arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
-	<arg name="tasks_per_node"> -ppn $PES_PER_NODE</arg>
+	<arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
 	<arg name="num_tasks"> -n $TOTALPES</arg>
       </arguments>
     </mpirun>
@@ -208,7 +208,7 @@
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <!-- have not seen any performance benefit in smt -->
     <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>36</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
@@ -312,7 +312,7 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>tcraig -at- ucar.edu</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>24</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>24</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
@@ -409,7 +409,7 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>32</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
@@ -512,7 +512,7 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
@@ -612,7 +612,7 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>tcraig -at- ucar.edu</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>12</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>12</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>12</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="mvapich">
       <executable>srun</executable>
       <arguments>
@@ -669,7 +669,7 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>24</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>24</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
@@ -768,14 +768,14 @@
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
     <SUPPORTED_BY>julio -at- ucar.edu</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>24</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>24</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
 	<arg name="hyperthreading" default="2"> -j {{ hyperthreading }}</arg>
 	<arg name="num_tasks" > -n $TOTALPES</arg>
 	<arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
-	<arg name="tasks_per_node" > -N $PES_PER_NODE</arg>
+	<arg name="tasks_per_node" > -N $MAX_MPITASKS_PER_NODE</arg>
 	<arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
@@ -834,7 +834,7 @@
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
     <SUPPORTED_BY> cseg </SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>48</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>48</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>48</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="mvapich2">
       <executable>mpiexec</executable>
       <arguments>
@@ -889,7 +889,7 @@
     <DESC>
 
      Customize these fields as appropriate for your system,
-     particularly changing MAX_TASKS_PER_NODE and PES_PER_NODE to the
+     particularly changing MAX_TASKS_PER_NODE and MAX_MPITASKS_PER_NODE to the
      number of cores on your machine.  You may also want to change
      instances of '$ENV{HOME}/projects' to your desired directory
      organization.  You can use this in either of two ways: (1)
@@ -918,7 +918,7 @@
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <SUPPORTED_BY>__YOUR_NAME_HERE__</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>4</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
@@ -950,7 +950,7 @@
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <!-- have not seen any performance benefit in smt -->
     <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>36</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
@@ -1017,7 +1017,7 @@
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
@@ -1069,14 +1069,14 @@
     <BATCH_SYSTEM>cobalt</BATCH_SYSTEM>
     <SUPPORTED_BY> cseg </SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>8</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>8</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
        <executable>/usr/bin/runjob</executable>
       <arguments>
 	<arg name="label"> --label short</arg>
 	<!-- Ranks per node!! -->
-	<arg name="tasks_per_node"> --ranks-per-node $PES_PER_NODE</arg>
+	<arg name="tasks_per_node"> --ranks-per-node $MAX_MPITASKS_PER_NODE</arg>
 	<!-- Total MPI Tasks -->
 	<arg name="num_tasks"> --np $TOTALPES</arg>
 	<arg name="locargs">--block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
@@ -1120,7 +1120,7 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>tcraig -at- ucar.edu</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>32</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
@@ -1165,7 +1165,7 @@
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
     <SUPPORTED_BY>fvitt -at- ucar.edu</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>28</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>28</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>28</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
@@ -1219,7 +1219,7 @@
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
     <SUPPORTED_BY>fvitt -at- ucar.edu</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>24</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>24</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>24</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
@@ -1273,7 +1273,7 @@
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
     <SUPPORTED_BY>fvitt -at- ucar.edu</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>16</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
@@ -1327,7 +1327,7 @@
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
     <SUPPORTED_BY>fvitt -at- ucar.edu</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>20</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>20</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>20</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
@@ -1381,12 +1381,12 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>edouard.davin -at- env.ethz.ch</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>32</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
 	<arg name="num_tasks"> -n $TOTALPES</arg>
-	<arg name="tasks_per_node"> -N $PES_PER_NODE</arg>
+	<arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
 	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
@@ -1417,7 +1417,7 @@
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
@@ -1469,14 +1469,14 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>16</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
 	<arg name="num_tasks"> -np $TOTALPES</arg>
-	<arg name="tasks_per_node"> -npernode $PES_PER_NODE</arg>
+	<arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1531,7 +1531,7 @@
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>16</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>16</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>16</MAX_MPITASKS_PER_NODE>
 
     <mpirun mpilib="impi">
       <executable>ibrun</executable>
@@ -1594,13 +1594,13 @@
     <BATCH_SYSTEM>cobalt_theta</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>64</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
 	<arg name="num_tasks" >-n $TOTALPES</arg>
-	<arg name="tasks_per_node" >-N $PES_PER_NODE</arg>
+	<arg name="tasks_per_node" >-N $MAX_MPITASKS_PER_NODE</arg>
 	<arg name="thread_count">--cc depth -d $OMP_NUM_THREADS</arg>
 	<arg name="env_omp_stacksize">-e OMP_STACKSIZE=64M</arg>
 	<arg name="env_thread_count">-e OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
@@ -1682,7 +1682,7 @@
     <BATCH_SYSTEM>lsf</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>30</MAX_TASKS_PER_NODE>
-    <PES_PER_NODE>15</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>15</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default" unit_testing="true">
       <!-- For unit testing, avoid all of the extra stuff that we use before and

--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -20,7 +20,7 @@
 
   <entry id="PIO_STRIDE">
     <values>
-      <value>$PES_PER_NODE</value>
+      <value>$MAX_MPITASKS_PER_NODE</value>
       <value mach="yellowstone" grid="a%ne120.+oi%gx1">60</value>
     </values>
   </entry>

--- a/config/cesm/machines/userdefined_laptop_template/config_machines.xml
+++ b/config/cesm/machines/userdefined_laptop_template/config_machines.xml
@@ -19,7 +19,7 @@
       <BATCH_SYSTEM>none</BATCH_SYSTEM>
       <SUPPORTED_BY>__YOUR_NAME_HERE__</SUPPORTED_BY>
       <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
-      <PES_PER_NODE>4</PES_PER_NODE>
+      <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
       <mpirun mpilib="default">
 	<executable>mpiexec_mpt</executable>
 	<arguments>

--- a/config/config_headers.xml
+++ b/config/config_headers.xml
@@ -67,7 +67,7 @@
     to determine how those mpi tasks should be placed across the machine.
 
     The following values should not be set by the user since they'll be
-    overwritten by scripts: TOTALPES, MAX_TASKS_PER_NODE, PES_PER_NODE
+    overwritten by scripts: TOTALPES, MAX_TASKS_PER_NODE, MAX_MPITASKS_PER_NODE
     </header>
   </file>
 

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -32,7 +32,7 @@
   <xs:element name="SUPPORTED_BY" type="xs:string"/>
   <xs:element name="GMAKE_J" type="xs:integer"/>
   <xs:element name="MAX_TASKS_PER_NODE" type="xs:integer"/>
-  <xs:element name="PES_PER_NODE" type="xs:integer"/>
+  <xs:element name="MAX_MPITASKS_PER_NODE" type="xs:integer"/>
   <xs:element name="PROJECT_REQUIRED" type="xs:NCName"/>
   <xs:element name="GMAKE" type="xs:string"/>
   <xs:element name="TESTS" type="xs:string"/>
@@ -101,9 +101,9 @@
 	<!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
 	     shared memory node on this machine-->
         <xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="1"/>
-	<!-- PES_PER_NODE: number of physical PES per shared node on
+	<!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
 	     this machine, in practice the MPI tasks per node will not exceed this value -->
-        <xs:element ref="PES_PER_NODE" minOccurs="1" maxOccurs="1"/>
+        <xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="1"/>
 	<!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
 	     the batch system?  See PROJECT above -->
         <xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>

--- a/config/xml_schemas/config_machines_template.xml
+++ b/config/xml_schemas/config_machines_template.xml
@@ -75,12 +75,12 @@
 
     <!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
 	 shared memory node on this machine,
-	 should always be >= PES_PER_NODE -->
+	 should always be >= MAX_MPITASKS_PER_NODE -->
     <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
 
-    <!-- PES_PER_NODE: number of physical PES per shared node on
+    <!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
 	 this machine, in practice the MPI tasks per node will not exceed this value -->
-    <PES_PER_NODE>36</PES_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
 
     <!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
 	 the batch system?  See PROJECT above -->

--- a/config/xml_schemas/config_pes.xsd
+++ b/config/xml_schemas/config_pes.xsd
@@ -8,7 +8,7 @@
 
 <!-- simple elements -->
 <xs:element name="comment" type="xs:string"/>
-<xs:element name="PES_PER_NODE" type="xs:integer"/>
+<xs:element name="MAX_MPITASKS_PER_NODE" type="xs:integer"/>
 <xs:element name="MAX_TASKS_PER_NODE" type="xs:integer"/>
 <xs:element name="ntasks_atm" type="xs:integer"/>
 <xs:element name="ntasks_lnd" type="xs:integer"/>
@@ -76,7 +76,7 @@
   <xs:element name="pes">
     <xs:complexType>
       <xs:choice maxOccurs="unbounded">
-        <xs:element minOccurs="0" ref="PES_PER_NODE"/>
+        <xs:element minOccurs="0" ref="MAX_MPITASKS_PER_NODE"/>
         <xs:element minOccurs="0" ref="MAX_TASKS_PER_NODE"/>
         <xs:element minOccurs="0" ref="comment"/>
         <xs:element minOccurs="0" ref="ntasks"/>

--- a/doc/source/users_guide/customizing-a-case.rst
+++ b/doc/source/users_guide/customizing-a-case.rst
@@ -67,12 +67,12 @@ The entries in **env_mach_pes.xml** have the following meanings:
    MAX_TASKS_PER_MODE The total number of (MPI tasks) * (OpenMP threads) allowed on a node.
                          This is defined in **config_machines.xml** and therefore given a default setting, but
                          can be user modified.
-   PES_PER_NODE       The maximum number of MPI tasks per node.
+   MAX_MPITASKS_PER_NODE       The maximum number of MPI tasks per node.
                          This is defined in **config_machines.xml** and therefore given a default setting, but
                          can be user modified.
    NTASKS             Total number of MPI tasks.
                           A negative value indicates nodes rather than tasks, where
-                          PES_PER_NODE * -NTASKS equals the number of MPI tasks.
+                          MAX_MPITASKS_PER_NODE * -NTASKS equals the number of MPI tasks.
    NTHRDS             Number of OpenMP threads per MPI task.
    ROOTPE             The global MPI task of the component root task; if negative, indicates nodes rather than tasks.
    PSTRID             The stride of MPI tasks across the global set of pes (for now set to 1).
@@ -117,9 +117,9 @@ If you had set ``ROOTPE_OCN`` to 64 in this example, a total of 176 processors w
 **Example 2**
 ----------------
 
-If a component has **NTASKS=-2**, **NTHRDS=4** and **ROOTPE=0**, **PES_PER_NODE=4**, **MAX_TASKS_PER_NODE=4**, it will run on (8 MPI tasks * 4 threads) = 32 hardware processors on 8 nodes.
+If a component has **NTASKS=-2**, **NTHRDS=4** and **ROOTPE=0**, **MAX_MPITASKS_PER_NODE=4**, **MAX_TASKS_PER_NODE=4**, it will run on (8 MPI tasks * 4 threads) = 32 hardware processors on 8 nodes.
 
-If you intended 2 nodes INSTEAD of 8 nodes, then you would change **PES_PER_NODE=1** (using **xmlchange**).
+If you intended 2 nodes INSTEAD of 8 nodes, then you would change **MAX_MPITASKS_PER_NODE=1** (using **xmlchange**).
 
 
 **Note**: **env_mach_pes.xml** *cannot* be modified after **case.setup** has been invoked without first running the following:

--- a/doc/source/users_guide/porting-cime.rst
+++ b/doc/source/users_guide/porting-cime.rst
@@ -117,7 +117,7 @@ Each ``<machine>`` tag requires the following input:
 - ``BATCH_SYSTEM``: batch system used on this machine (none is okay)
 - ``SUPPORTED_BY``: contact information for support for this system
 - ``MAX_TASKS_PER_NODE``: maximum number of threads/tasks per shared memory node on the machine
-- ``PES_PER_NODE``: number of physical PES per shared node on the machine. In practice the MPI tasks per node will not exceed this value.
+- ``MAX_MPITASKS_PER_NODE``: number of physical PES per shared node on the machine. In practice the MPI tasks per node will not exceed this value.
 - ``PROJECT_REQUIRED``: Does this machine require a project to be specified to the batch system?
 - ``mpirun``: The mpi exec to start a job on this machine.
   This is itself an element that has sub-elements that must be filled:

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -195,7 +195,7 @@ OR
 
     parser.add_argument("--proc-pool", type=int, default=None,
                         help="The size of the processor pool that create_test can use. Default "
-                        "is PES_PER_NODE + 25 percent.")
+                        "is MAX_MPITASKS_PER_NODE + 25 percent.")
 
     parser.add_argument("--walltime", default=os.getenv("CIME_GLOBAL_WALLTIME"),
                         help="Set the wallclock limit for all tests in the suite. "
@@ -429,7 +429,7 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
         submit_cmd  = env_batch.get_value("batch_submit", subgroup=None)
         submit_args = env_batch.get_submit_args(case, "case.run")
 
-    tasks_per_node = mach.get_value("PES_PER_NODE")
+    tasks_per_node = mach.get_value("MAX_MPITASKS_PER_NODE")
     num_nodes = int(math.ceil(float(proc_pool) / tasks_per_node))
     if wall_time is None:
         wall_time = compute_total_time(job_cost_map, proc_pool)

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -298,13 +298,13 @@ class Machines(GenericXML):
             os_  = machine.find("OS")
             compilers = machine.find("COMPILERS")
             max_tasks_per_node = machine.find("MAX_TASKS_PER_NODE")
-            pes_per_node = machine.find("PES_PER_NODE")
+            MAX_MPITASKS_PER_NODE = machine.find("MAX_MPITASKS_PER_NODE")
 
             print( "  {} : {} ".format(name , desc.text))
             print( "      os             ", os_.text)
             print( "      compilers      ",compilers.text)
-            if pes_per_node is not None:
-                print( "      pes/node       ",pes_per_node.text)
+            if MAX_MPITASKS_PER_NODE is not None:
+                print( "      pes/node       ",MAX_MPITASKS_PER_NODE.text)
             if max_tasks_per_node is not None:
                 print( "      max_tasks/node ",max_tasks_per_node.text)
 
@@ -318,10 +318,10 @@ class Machines(GenericXML):
             os_  = machine.find("OS")
             compilers = machine.find("COMPILERS")
             max_tasks_per_node = machine.find("MAX_TASKS_PER_NODE")
-            pes_per_node = machine.find("PES_PER_NODE")
+            MAX_MPITASKS_PER_NODE = machine.find("MAX_MPITASKS_PER_NODE")
             ppn = ''
-            if pes_per_node is not None:
-                ppn = pes_per_node.text
+            if MAX_MPITASKS_PER_NODE is not None:
+                ppn = MAX_MPITASKS_PER_NODE.text
 
             max_tasks_pn = ''
             if max_tasks_per_node is not None:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -129,7 +129,7 @@ class Case(object):
         env_mach_pes  = self.get_env("mach_pes")
         env_mach_spec = self.get_env('mach_specific')
         comp_classes  = self.get_values("COMP_CLASSES")
-        pes_per_node  = self.get_value("PES_PER_NODE")
+        MAX_MPITASKS_PER_NODE  = self.get_value("MAX_MPITASKS_PER_NODE")
 
         self.total_tasks = env_mach_pes.get_total_tasks(comp_classes)
         self.thread_count = env_mach_pes.get_max_thread_count(comp_classes)
@@ -137,10 +137,10 @@ class Case(object):
         logger.debug("total_tasks {} thread_count {}".format(self.total_tasks, self.thread_count))
 
         self.tasks_per_numa = int(math.ceil(self.tasks_per_node / 2.0))
-        smt_factor = max(1,int(self.get_value("MAX_TASKS_PER_NODE") / pes_per_node))
+        smt_factor = max(1,int(self.get_value("MAX_TASKS_PER_NODE") / MAX_MPITASKS_PER_NODE))
 
         threads_per_node = self.tasks_per_node * self.thread_count
-        threads_per_core = 1 if (threads_per_node <= pes_per_node) else smt_factor
+        threads_per_core = 1 if (threads_per_node <= MAX_MPITASKS_PER_NODE) else smt_factor
         self.cores_per_task = self.thread_count / threads_per_core
 
         mpi_attribs = {
@@ -719,10 +719,10 @@ class Case(object):
             mach_pes_obj.set_value(rootpe_str, rootpe)
 
         pesize = 1
-        pes_per_node = self.get_value("PES_PER_NODE")
+        MAX_MPITASKS_PER_NODE = self.get_value("MAX_MPITASKS_PER_NODE")
         for val in totaltasks:
             if val < 0:
-                val = -1*val*pes_per_node
+                val = -1*val*MAX_MPITASKS_PER_NODE
             if val > pesize:
                 pesize = val
         if multi_driver:

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -137,8 +137,8 @@ class _TimingParser:
         stop_n = self.case.get_value("STOP_N")
         cost_pes = self.case.get_value("COST_PES")
         totalpes = self.case.get_value("TOTALPES")
-        pes_per_node = self.case.get_value("PES_PER_NODE")
-        smt_factor = max(1,int(self.case.get_value("MAX_TASKS_PER_NODE") / pes_per_node))
+        MAX_MPITASKS_PER_NODE = self.case.get_value("MAX_MPITASKS_PER_NODE")
+        smt_factor = max(1,int(self.case.get_value("MAX_TASKS_PER_NODE") / MAX_MPITASKS_PER_NODE))
 
         if cost_pes > 0:
             pecost = cost_pes
@@ -306,7 +306,7 @@ class _TimingParser:
 
         self.write("\n")
         self.write("  total pes active           : {} \n".format(totalpes*maxthrds*smt_factor ))
-        self.write("  pes per node               : {} \n".format(pes_per_node))
+        self.write("  pes per node               : {} \n".format(MAX_MPITASKS_PER_NODE))
         self.write("  pe count for cost estimate : {} \n".format(pecost))
         self.write("\n")
 

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -199,7 +199,7 @@ class TestScheduler(object):
 
         # Oversubscribe by 1/4
         if proc_pool is None:
-            pes = int(self._machobj.get_value("PES_PER_NODE"))
+            pes = int(self._machobj.get_value("MAX_MPITASKS_PER_NODE"))
             self._proc_pool = int(pes * 1.25)
         else:
             self._proc_pool = int(proc_pool)

--- a/scripts/query_config
+++ b/scripts/query_config
@@ -295,7 +295,7 @@ class Machines(CIME.XML.machines.Machines):
                 os_  = machine.find("OS")
                 compilers = machine.find("COMPILERS")
                 max_tasks_per_node = machine.find("MAX_TASKS_PER_NODE")
-                pes_per_node = machine.find("PES_PER_NODE")
+                MAX_MPITASKS_PER_NODE = machine.find("MAX_MPITASKS_PER_NODE")
 
                 current_machine = self.probe_machine_name(warn=False)
                 if not single_machine:
@@ -303,16 +303,16 @@ class Machines(CIME.XML.machines.Machines):
                     print  "  {} : {} ".format(name, desc.text)
                     print  "      os             ", os_.text
                     print  "      compilers      ",compilers.text
-                    if pes_per_node is not None:
-                        print  "      pes/node       ",pes_per_node.text
+                    if MAX_MPITASKS_PER_NODE is not None:
+                        print  "      pes/node       ",MAX_MPITASKS_PER_NODE.text
                     if max_tasks_per_node is not None:
                         print  "      max_tasks/node ",max_tasks_per_node.text
                 elif single_machine and machine_name in name:
                     print  "  {} : {} ".format(name, desc.text)
                     print  "      os             ", os_.text
                     print  "      compilers      ",compilers.text
-                    if pes_per_node is not None:
-                        print  "      pes/node       ",pes_per_node.text
+                    if MAX_MPITASKS_PER_NODE is not None:
+                        print  "      pes/node       ",MAX_MPITASKS_PER_NODE.text
                     if max_tasks_per_node is not None:
                         print  "      max_tasks/node ",max_tasks_per_node.text
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -949,7 +949,7 @@
     <default_value>0</default_value>
     <group>mach_pes_last</group>
     <file>env_mach_pes.xml</file>
-    <desc>pes or cores used relative to PES_PER_NODE for accounting (0 means TOTALPES is valid)</desc>
+    <desc>pes or cores used relative to MAX_MPITASKS_PER_NODE for accounting (0 means TOTALPES is valid)</desc>
   </entry>
 
   <!-- ===================================================================== -->
@@ -2032,7 +2032,7 @@
     <desc>maximum number of tasks/ threads allowed per node </desc>
   </entry>
 
-  <entry id="PES_PER_NODE">
+  <entry id="MAX_MPITASKS_PER_NODE">
     <type>integer</type>
     <default_value>0</default_value>
     <group>mach_pes_last</group>


### PR DESCRIPTION
Some people found the name PES_PER_NODE less than fully descriptive
Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1885 

User interface changes?: 

Update gh-pages html (Y/N)?: Y

Code review: 
