### PR TITLE
new error trap if invalid "idmap" file is present in seq_maps.rc

### DIFF
--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -175,6 +175,14 @@ class NamelistGenerator(object):
                 value[i] = self.quote_string(scalar)
         return compress_literal_list(value)
 
+    def get_group_variables(self, group_name):
+        group_variables = {}
+        group = self._namelist._groups[group_name]
+        for name in sorted(group.keys()):
+            value = group[name][0]
+            group_variables[name] = value
+        return group_variables
+
     def get_value(self, name):
         """Get the current value of a given namelist variable.
 

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -198,27 +198,30 @@ def write_seq_maps_file(case, nmlgen, confdir):
     gridvalue = {}
     ignore_component = {}
     exclude_list = ["CPL","ESP"]
-    for item in case.get_values("COMP_CLASSES"):
-        if item not in exclude_list:
-            gridvalue[item.lower()] = case.get_value(item + "_GRID" )
-            component = case.get_value("COMP_" + item)
-            if case.get_value(item + "_GRID" ) == 'null':
-                ignore_component[item.lower()] = True
+    for comp_class in case.get_values("COMP_CLASSES"):
+        if comp_class not in exclude_list:
+            gridvalue[comp_class.lower()] = case.get_value(comp_class + "_GRID" )
+            component = case.get_value("COMP_" + comp_class)
+            if case.get_value(comp_class + "_GRID" ) == 'null':
+                ignore_component[comp_class.lower()] = True
             else:
-                ignore_component[item.lower()] = False
+                ignore_component[comp_class.lower()] = False
+
+    # Currently, hard-wire values of mapping file names to ignore
+    # TODO: for rof2ocn_fmapname -needs to be resolved since this is currently
+    # used in prep_ocn_mod.F90 if flood_present is True - this is in issue #1908.
+    ignore_idmaps = ["rof2ocn_fmapname", "glc2ice_rmapname"]
 
     group_variables = nmlgen.get_group_variables("seq_maps")
     for name in group_variables:
         value = group_variables[name]
-        if "type" not in name:
+        if "mapname" in name:
             value = re.sub('\"', '', value)
             if 'idmap' == value:
                 component1 = name[0:3]
                 component2 = name[4:7]
                 if not ignore_component[component1]  and not ignore_component[component2]:
-                    if name == "rof2ocn_fmapname" or name == "glc2ice_rmapname":
-                        # TODO: for rof2ocn_fmapname -needs to be resolved since this is
-                        # currently used in prep_ocn_mod.F90 if flood_present is True
+                    if name in ignore_idmaps:
                         logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
                     else:
                         if "rof2ocn_" in name:
@@ -296,7 +299,7 @@ def _create_component_modelio_namelists(case, files):
 
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")
-    models = case.get_values("COMP_CLASSES")
+
     #if we are in multi-coupler mode the number of instances of cpl will be the max
     # of any NINST_* value
     maxinst = 1

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -182,8 +182,14 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     # first determine if there are invalid idmap settings
     # if source and destination grid are different, mapping file must not be "idmap"
     gridvalue = {}
-    for item in ["ATM", "LND", "OCN", "ICE", "ROF", "MASK", "GLC", "WAV"]:
+    ignore_component = {}
+    for item in ["ATM", "LND", "OCN", "ICE", "ROF", "GLC", "WAV"]:
         gridvalue[item.lower()] = case.get_value(item + "_GRID" )
+        component = case.get_value("COMP_" + item)
+        if case.get_value(item + "_GRID" ) == 'null':
+            ignore_component[item.lower()] = True
+        else:
+            ignore_component[item.lower()] = False
 
     group_variables = nmlgen.get_group_variables("seq_maps")
     for name in group_variables:
@@ -191,11 +197,21 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         if "type" not in name:
             value = re.sub('\"', '', value)
             if 'idmap' == value:
-                grid1 = name[0:3]
-                grid2 = name[4:7]
-                expect(gridvalue[grid1] == gridvalue[grid2],
-                       "invalid idmap value for grids that are not the same \n %s=%s and  %s=%s" \
-                       %(grid1, gridvalue[grid1], grid2, gridvalue[grid2]))
+                component1 = name[0:3]
+                component2 = name[4:7]
+                if not ignore_component[component1]  and not ignore_component[component2]:
+                    if name == "rof2ocn_fmapname" or name == "glc2ice_rmapname":
+                        # TODO: for rof2ocn_fmapname -needs to be resolved since this is
+                        # currently used in prep_ocn_mod.F90 if flood_present is True
+                        logger.warning("NOTE: ignoring setting of %s to idmap in seq_maps.rc" %(name))
+                    else:
+                        if "rof2ocn_" in name:
+                            if case.get_value("COMP_OCN") == 'docn':
+                                logger.warning("NOTE: ignoring setting of %s to idmap in seq_maps.rc" %(name))
+                        else:
+                            expect(gridvalue[component1] == gridvalue[component2],
+                                   "invalid idmap value for non-stub grids that are not the same \n %s=%s and  %s=%s" \
+                                   %(component1, gridvalue[component1], component2, gridvalue[component2]))
 
     # now write out the file
     seq_maps_file = os.path.join(confdir, "seq_maps.rc")

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -7,7 +7,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob, itertools
+import os, shutil, sys, glob, itertools, re
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -179,6 +179,25 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     #--------------------------------
     # (2) Write out seq_map.rc file
     #--------------------------------
+    # first determine if there are invalid idmap settings
+    # if source and destination grid are different, mapping file must not be "idmap"
+    gridvalue = {}
+    for item in ["ATM", "LND", "OCN", "ICE", "ROF", "MASK", "GLC", "WAV"]:
+        gridvalue[item.lower()] = case.get_value(item + "_GRID" )
+
+    group_variables = nmlgen.get_group_variables("seq_maps")
+    for name in group_variables:
+        value = group_variables[name]
+        if "type" not in name:
+            value = re.sub('\"', '', value)
+            if 'idmap' == value:
+                grid1 = name[0:3]
+                grid2 = name[4:7]
+                expect(gridvalue[grid1] == gridvalue[grid2],
+                       "invalid idmap value for grids that are not the same \n %s=%s and  %s=%s" \
+                       %(grid1, gridvalue[grid1], grid2, gridvalue[grid2]))
+
+    # now write out the file
     seq_maps_file = os.path.join(confdir, "seq_maps.rc")
     nmlgen.write_seq_maps(seq_maps_file)
 

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -81,17 +81,17 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         if case.get_value('CALENDAR') == 'NO_LEAP':
             basedt = 3600 * 24 * 365
         else:
-            expect(False, "Invalid CALENDAR for NCPL_BASE_PERIOD %s " %ncpl_base_period)
+            expect(False, "Invalid CALENDAR for NCPL_BASE_PERIOD {} ".format(ncpl_base_period))
     elif ncpl_base_period == 'decade':
         if case.get_value('CALENDAR') == 'NO_LEAP':
             basedt = 3600 * 24 * 365 * 10
         else:
-            expect(False, "invalid NCPL_BASE_PERIOD NCPL_BASE_PERIOD %s " %ncpl_base_period)
+            expect(False, "invalid NCPL_BASE_PERIOD NCPL_BASE_PERIOD {} ".format(ncpl_base_period))
     else:
-        expect(False, "invalid NCPL_BASE_PERIOD NCPL_BASE_PERIOD %s " %ncpl_base_period)
+        expect(False, "invalid NCPL_BASE_PERIOD NCPL_BASE_PERIOD {} ".format(ncpl_base_period))
 
     if basedt < 0:
-        expect(False, "basedt invalid overflow for NCPL_BASE_PERIOD %s " %ncpl_base_period)
+        expect(False, "basedt invalid overflow for NCPL_BASE_PERIOD {} ".format(ncpl_base_period))
 
     comps = case.get_values("COMP_CLASSES")
     mindt = basedt
@@ -101,10 +101,9 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             cpl_dt = basedt / int(ncpl)
             totaldt = cpl_dt * int(ncpl)
             if totaldt != basedt:
-                expect(False, " %s ncpl doesn't divide base dt evenly" %comp)
+                expect(False, " {} ncpl doesn't divide base dt evenly".format(comp))
             nmlgen.add_default(comp.lower() + '_cpl_dt', value=cpl_dt)
             mindt = min(mindt, cpl_dt)
-#        elif comp.lower() is not 'cpl':
 
     #--------------------------------
     # Overwrite: set start_ymd
@@ -155,7 +154,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             comp_classes = case.get_values("COMP_CLASSES")
             for comp in pause_comps:
                 expect(comp == 'drv' or comp.upper() in comp_classes,
-                       "Invalid PAUSE_COMPONENT_LIST, %s is not a valid component type"%comp)
+                       "Invalid PAUSE_COMPONENT_LIST, {} is not a valid component type".format(comp))
             # End for
         # End if
         # Set esp interval
@@ -170,26 +169,43 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     #--------------------------------
     # (1) Write output namelist file drv_in and  input dataset list.
     #--------------------------------
+    write_drv_in_file(case, nmlgen, confdir)
+
+    #--------------------------------
+    # (2) Write out seq_map.rc file
+    #--------------------------------
+    write_seq_maps_file(case, nmlgen, confdir)
+
+    #--------------------------------
+    # (3) Construct and write out drv_flds_in
+    #--------------------------------
+    write_drv_flds_in_file(case, nmlgen, confdir, files)
+
+###############################################################################
+def write_drv_in_file(case, nmlgen, confdir):
+###############################################################################
     data_list_path = os.path.join(case.get_case_root(), "Buildconf", "cpl.input_data_list")
     if os.path.exists(data_list_path):
         os.remove(data_list_path)
     namelist_file = os.path.join(confdir, "drv_in")
     nmlgen.write_output_file(namelist_file, data_list_path )
 
-    #--------------------------------
-    # (2) Write out seq_map.rc file
-    #--------------------------------
+###############################################################################
+def write_seq_maps_file(case, nmlgen, confdir):
+###############################################################################
     # first determine if there are invalid idmap settings
     # if source and destination grid are different, mapping file must not be "idmap"
     gridvalue = {}
     ignore_component = {}
-    for item in ["ATM", "LND", "OCN", "ICE", "ROF", "GLC", "WAV"]:
-        gridvalue[item.lower()] = case.get_value(item + "_GRID" )
-        component = case.get_value("COMP_" + item)
-        if case.get_value(item + "_GRID" ) == 'null':
-            ignore_component[item.lower()] = True
-        else:
-            ignore_component[item.lower()] = False
+    exclude_list = ["CPL","ESP"]
+    for item in case.get_values("COMP_CLASSES"):
+        if item not in exclude_list:
+            gridvalue[item.lower()] = case.get_value(item + "_GRID" )
+            component = case.get_value("COMP_" + item)
+            if case.get_value(item + "_GRID" ) == 'null':
+                ignore_component[item.lower()] = True
+            else:
+                ignore_component[item.lower()] = False
 
     group_variables = nmlgen.get_group_variables("seq_maps")
     for name in group_variables:
@@ -203,23 +219,22 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
                     if name == "rof2ocn_fmapname" or name == "glc2ice_rmapname":
                         # TODO: for rof2ocn_fmapname -needs to be resolved since this is
                         # currently used in prep_ocn_mod.F90 if flood_present is True
-                        logger.warning("NOTE: ignoring setting of %s to idmap in seq_maps.rc" %(name))
+                        logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
                     else:
                         if "rof2ocn_" in name:
                             if case.get_value("COMP_OCN") == 'docn':
-                                logger.warning("NOTE: ignoring setting of %s to idmap in seq_maps.rc" %(name))
+                                logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
                         else:
                             expect(gridvalue[component1] == gridvalue[component2],
-                                   "invalid idmap value for non-stub grids that are not the same \n %s=%s and  %s=%s" \
-                                   %(component1, gridvalue[component1], component2, gridvalue[component2]))
+                                   "Need to provide valid mapping file between {} and {} in xml variable {} ".format(component1, component2, name))
 
     # now write out the file
     seq_maps_file = os.path.join(confdir, "seq_maps.rc")
     nmlgen.write_seq_maps(seq_maps_file)
 
-    #--------------------------------
-    # (3) Construct and write out drv_flds_in
-    #--------------------------------
+###############################################################################
+def write_drv_flds_in_file(case, nmlgen, confdir, files):
+###############################################################################
     # In thte following, all values come simply from the infiles - no default values need to be added
     # FIXME - do want to add the possibility that will use a user definition file for drv_flds_in
 
@@ -236,7 +251,6 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             infiles.append(infile)
 
     if len(infiles) != 0:
-
         # First read the drv_flds_in files and make sure that
         # for any key there are not two conflicting values
         dicts = {}
@@ -270,8 +284,7 @@ def compare_drv_flds_in(first, second, infile1, infile2):
     for key in sharedKeys:
         if first[key] != second[key]:
             print('Key: {}, \n Value 1: {}, \n Value 2: {}'.format(key, first[key], second[key]))
-            expect(False, "incompatible settings in drv_flds_in from \n %s \n and \n %s"
-                   % (infile1, infile2))
+            expect(False, "incompatible settings in drv_flds_in from \n {} \n and \n {}".format(infile1, infile2))
 
 ###############################################################################
 def _create_component_modelio_namelists(case, files):
@@ -290,7 +303,7 @@ def _create_component_modelio_namelists(case, files):
     if case.get_value("MULTI_DRIVER"):
         maxinst = case.get_value("NINST_MAX")
 
-    for model in models:
+    for model in case.get_values("COMP_CLASSES"):
         model = model.lower()
         with NamelistGenerator(case, definition_file) as nmlgen:
             config = {}
@@ -343,7 +356,7 @@ def buildnml(case, caseroot, component):
     user_xml_dir = os.path.join(caseroot, "SourceMods", "src.drv")
 
     expect (os.path.isdir(user_xml_dir),
-            "user_xml_dir %s does not exist " %user_xml_dir)
+            "user_xml_dir {} does not exist ".format(user_xml_dir))
 
     files = Files()
     definition_file = [files.get_value("NAMELIST_DEFINITION_FILE", {"component": "drv"})]


### PR DESCRIPTION
New error trap if invalid "idmap" file is present in the driver input file seq_maps.rc

This PR will result in an error if a mapping file that should exist is instead set to "idmap".
The driver buildnml has been modularized to add this new check more clearly.
There are two hard-wired assumptions that need to be raised as issues.
- This check is not done for the fields` rof2ocn_fmapname` or `glc2ice_rmapname`. (The `rof2ocn_fmapname `is used if the run time namelist variable flood_present is set to `True`).
- This check is not done for `rof2ocn_*` if the ocn component is data ocean. (In this case, this would be triggered by a flood_present flag that should never be on for a data_ocean and is a run time namelist setting).

Test suite: scripts_regression_tests
    also ran the prealpha tests on cheyenne with only the namelist compare and verified that
    the changes did not change the namelists
Test baseline: cesm2_0_alpha07c
Test namelist changes: Yes
Test status: bit for bit, roundoff

Fixes #962 
Fixes #1158 
Fixes #1603 
User interface changes?: None
Update gh-pages html (Y/N)?: N
Code review: jedwards4b