### PR TITLE
Test fixes

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1693,7 +1693,7 @@
       <executable>TARGET_PROCESSOR_LIST=AUTO_SELECT $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
       <arguments>
 	<arg name="anum_tasks"> -n $TOTALPES</arg>
-        <arg name="tasks_per_node"> -tpn $PES_PER_NODE </arg>
+        <arg name="tasks_per_node"> -tpn $MAX_MPITASKS_PER_NODE </arg>
 	<arg name="bindtool">$ENV{CESMDATAROOT}/tools/bin/launch </arg>
       </arguments>
     </mpirun>
@@ -1701,7 +1701,7 @@
       <executable>unset MP_PE_AFFINITY; unset MP_TASK_AFFINITY; unset MP_CPU_BIND_LIST; $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
       <arguments>
 	<arg name="anum_tasks"> -n $TOTALPES</arg>
-        <arg name="tasks_per_node"> -tpn $PES_PER_NODE </arg>
+        <arg name="tasks_per_node"> -tpn $MAX_MPITASKS_PER_NODE </arg>
 	<arg name="bindtool">$ENV{CESMDATAROOT}/tools/bin/hybrid_launch </arg>
       </arguments>
     </mpirun>
@@ -1709,7 +1709,7 @@
       <executable> $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
       <arguments>
 	<arg name="anum_tasks"> -n $TOTALPES</arg>
-        <arg name="tasks_per_node"> -tpn $PES_PER_NODE </arg>
+        <arg name="tasks_per_node"> -tpn $MAX_MPITASKS_PER_NODE </arg>
       </arguments>
     </mpirun>
     <module_system type="module">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1690,13 +1690,24 @@
       <executable>mpirun.lsf </executable>
     </mpirun>
     <mpirun mpilib="default" threaded="false">
-      <executable>TARGET_PROCESSOR_LIST=AUTO_SELECT mpirun.lsf $ENV{CESMDATAROOT}/tools/bin/launch </executable>
+      <executable>TARGET_PROCESSOR_LIST=AUTO_SELECT $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
+      <arguments>
+	<arg name="anum_tasks"> -n $TOTALPES</arg>
+	<arg name="bindtool">$ENV{CESMDATAROOT}/tools/bin/launch </arg>
+      </arguments>
     </mpirun>
     <mpirun mpilib="default" threaded="true">
-      <executable>unset MP_PE_AFFINITY; unset MP_TASK_AFFINITY; unset MP_CPU_BIND_LIST; mpirun.lsf $ENV{CESMDATAROOT}/tools/bin/hybrid_launch </executable>
+      <executable>unset MP_PE_AFFINITY; unset MP_TASK_AFFINITY; unset MP_CPU_BIND_LIST; $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
+      <arguments>
+	<arg name="anum_tasks"> -n $TOTALPES</arg>
+	<arg name="bindtool">$ENV{CESMDATAROOT}/tools/bin/hybrid_launch </arg>
+      </arguments>
     </mpirun>
     <mpirun compiler="gnu">
-      <executable>mpirun.lsf </executable>
+      <executable> $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
+      <arguments>
+	<arg name="anum_tasks"> -n $TOTALPES</arg>
+      </arguments>
     </mpirun>
     <module_system type="module">
       <init_path lang="perl">/glade/apps/opt/lmod/lmod/init/perl</init_path>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1693,6 +1693,7 @@
       <executable>TARGET_PROCESSOR_LIST=AUTO_SELECT $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
       <arguments>
 	<arg name="anum_tasks"> -n $TOTALPES</arg>
+        <arg name="tasks_per_node"> -tpn $PES_PER_NODE </arg>
 	<arg name="bindtool">$ENV{CESMDATAROOT}/tools/bin/launch </arg>
       </arguments>
     </mpirun>
@@ -1700,6 +1701,7 @@
       <executable>unset MP_PE_AFFINITY; unset MP_TASK_AFFINITY; unset MP_CPU_BIND_LIST; $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
       <arguments>
 	<arg name="anum_tasks"> -n $TOTALPES</arg>
+        <arg name="tasks_per_node"> -tpn $PES_PER_NODE </arg>
 	<arg name="bindtool">$ENV{CESMDATAROOT}/tools/bin/hybrid_launch </arg>
       </arguments>
     </mpirun>
@@ -1707,6 +1709,7 @@
       <executable> $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
       <arguments>
 	<arg name="anum_tasks"> -n $TOTALPES</arg>
+        <arg name="tasks_per_node"> -tpn $PES_PER_NODE </arg>
       </arguments>
     </mpirun>
     <module_system type="module">

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -491,7 +491,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <REST_OPTION>none</REST_OPTION>
   </test>
 
   <test NAME="PET">

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -388,7 +388,8 @@ class SystemTestsCommon(object):
 
             # compare memory usage to baseline
             newestcpllogfiles = self._get_latest_cpl_logs()
-            memlist = self._get_mem_usage(newestcpllogfiles[0])
+            if len(newestcpllogfiles) > 0:
+                memlist = self._get_mem_usage(newestcpllogfiles[0])
             for cpllog in newestcpllogfiles:
                 m = re.search(r"/(cpl.*.log).*.gz",cpllog)
                 if m is not None:

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -133,15 +133,15 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 continue
             ninst  = case.get_value("NINST_{}".format(comp))
             ntasks = case.get_value("NTASKS_{}".format(comp))
-            if ninst > ntasks:
-                if ntasks == 1:
-                    case.set_value("NTASKS_{}".format(comp), ninst)
-                else:
-                    expect(False, "NINST_{} value {:d} greater than NTASKS_{} {:d}".format(comp, ninst, comp, ntasks))
             # But the NINST_LAYOUT may only be concurrent in multi_driver mode
             if multi_driver:
                 expect(case.get_value("NINST_LAYOUT_{}".format(comp)) == "concurrent",
                        "If multi_driver is TRUE, NINST_LAYOUT_{} must be concurrent".format(comp))
+            elif ninst > ntasks:
+                if ntasks == 1:
+                    case.set_value("NTASKS_{}".format(comp), ninst)
+                else:
+                    expect(False, "NINST_{} value {:d} greater than NTASKS_{} {:d}".format(comp, ninst, comp, ntasks))
 
         if os.path.exists("case.run"):
             logger.info("Machine/Decomp/Pes configuration has already been done ...skipping")

--- a/src/components/data_comps/docn/docn_shr_mod.F90
+++ b/src/components/data_comps/docn/docn_shr_mod.F90
@@ -178,9 +178,6 @@ CONTAINS
     if (trim(ocn_mode) == 'SOM' .or. trim(ocn_mode) == 'SOM_AQUAP') then
        ocn_prognostic = .true.
     endif
-    write(6,*)'DEBUG: ocn_present is ',ocn_present
-    write(6,*)'DEBUG: ocn_prognostic is ',ocn_prognostic
-
 
   end subroutine docn_shr_read_namelists
 

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2083,6 +2083,7 @@ end subroutine cime_init
    use seq_comm_mct,   only: atm_layout, lnd_layout, ice_layout, glc_layout,  &
         rof_layout, ocn_layout, wav_layout, esp_layout
    use shr_string_mod, only: shr_string_listGetIndexF
+   use seq_comm_mct, only: num_inst_driver
 
    ! gptl timer lookup variables
    integer, parameter :: hashcnt=7
@@ -3739,8 +3740,9 @@ end subroutine cime_init
       !----------------------------------------------------------
       if (esp_present .and. esprun_alarm) then
          ! Make sure that all couplers are here in multicoupler mode before running ESP component
-         call mpi_barrier(global_comm, ierr)
-
+         if (num_inst_driver > 1) then
+            call mpi_barrier(global_comm, ierr)
+         endif
          call component_run(Eclock_e, esp, esp_run, infodata, &
               comp_prognostic=esp_prognostic, comp_num=comp_num_esp, &
               timer_barrier= 'CPL:ESP_RUN_BARRIER', timer_comp_run='CPL:ESP_RUN', &


### PR DESCRIPTION
On yellowstone if the model run expected less that the allocated tasks for a job, it would use all the tasks anyway and extra tasks would just fall through to finalize.  This broke with the multi-driver PR.
The fix is to specify the number of tasks used on the mpirun command line - we already do this on 
all other machines so only yellowstone was affected.  There are also a couple of miscellaneous fixes
for multi driver and removing some debug print statements 

Test suite: scripts_regression_tests.py on yellowstone PEM_Ln9.f19_g16_rx1.A.yellowstone_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1892 
Fixes #1890 
Fixes #1894

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
