### PR TITLE
Added new CAM-SE FVM grids and removed incorrect aliases

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -613,10 +613,24 @@
 
     <!--  spectral element grids -->
 
+    <model_grid alias="ne5_ne5_mg37" not_compset="_POP">
+      <grid name="atm">ne5np4</grid>
+      <grid name="lnd">ne5np4</grid>
+      <grid name="ocnice">ne5np4</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+
     <model_grid alias="ne16_g37">
       <grid name="atm">ne16np4</grid>
       <grid name="lnd">ne16np4</grid>
       <grid name="ocnice">gx3v7</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne16_ne16_mg37" not_compset="_POP">
+      <grid name="atm">ne16np4</grid>
+      <grid name="lnd">ne16np4</grid>
+      <grid name="ocnice">ne16np4</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
@@ -666,6 +680,20 @@
       <mask>gx1v7</mask>
     </model_grid>
 
+    <model_grid alias="ne30_ne30_mg16" not_compset="_POP">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">ne30np4</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+
+    <model_grid alias="ne30_ne30_mg17" not_compset="_POP">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">ne30np4</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
     <model_grid alias="ne60_g16">
       <grid name="atm">ne60np4</grid>
       <grid name="lnd">ne60np4</grid>
@@ -677,6 +705,20 @@
       <grid name="atm">ne60np4</grid>
       <grid name="lnd">ne60np4</grid>
       <grid name="ocnice">gx1v7</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne60_ne60_mg16" not_compset="_POP">
+      <grid name="atm">ne60np4</grid>
+      <grid name="lnd">ne60np4</grid>
+      <grid name="ocnice">ne60np4</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+
+    <model_grid alias="ne60_ne60_mg17" not_compset="_POP">
+      <grid name="atm">ne60np4</grid>
+      <grid name="lnd">ne60np4</grid>
+      <grid name="ocnice">ne60np4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
@@ -699,6 +741,20 @@
       <grid name="lnd">ne120np4</grid>
       <grid name="ocnice">tx0.1v2</grid>
       <mask>tx0.1v2</mask>
+    </model_grid>
+
+    <model_grid alias="ne120_ne120_mg16" not_compset="_POP">
+      <grid name="atm">ne120np4</grid>
+      <grid name="lnd">ne120np4</grid>
+      <grid name="ocnice">ne120np4</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+
+    <model_grid alias="ne120_ne120_mg17" not_compset="_POP">
+      <grid name="atm">ne120np4</grid>
+      <grid name="lnd">ne120np4</grid>
+      <grid name="ocnice">ne120np4</grid>
+      <mask>gx1v7</mask>
     </model_grid>
 
     <model_grid alias="ne240_f02_g16">
@@ -724,90 +780,6 @@
       <mask>tx0.1v2</mask>
     </model_grid>
 
-    <model_grid alias="ne16_ne16" not_compset="_POP">
-      <grid name="atm">ne16np4</grid>
-      <grid name="lnd">ne16np4</grid>
-      <grid name="ocnice">ne16np4</grid>
-      <mask>gx3v7</mask>
-    </model_grid>
-
-    <model_grid alias="ne16_ne16_mg37" not_compset="_POP">
-      <grid name="atm">ne16np4</grid>
-      <grid name="lnd">ne16np4</grid>
-      <grid name="ocnice">ne16np4</grid>
-      <mask>gx3v7</mask>
-    </model_grid>
-
-    <model_grid alias="ne30_ne30" not_compset="_POP">
-      <grid name="atm">ne30np4</grid>
-      <grid name="lnd">ne30np4</grid>
-      <grid name="ocnice">ne30np4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="ne30_ne30_mg16" not_compset="_POP">
-      <grid name="atm">ne30np4</grid>
-      <grid name="lnd">ne30np4</grid>
-      <grid name="ocnice">ne30np4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="ne30_ne30_mg17" not_compset="_POP">
-      <grid name="atm">ne30np4</grid>
-      <grid name="lnd">ne30np4</grid>
-      <grid name="ocnice">ne30np4</grid>
-      <mask>gx1v7</mask>
-    </model_grid>
-
-    <model_grid alias="ne60_ne60" not_compset="_POP">
-      <grid name="atm">ne60np4</grid>
-      <grid name="lnd">ne60np4</grid>
-      <grid name="ocnice">ne60np4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="ne60_ne60_mg16" not_compset="_POP">
-      <grid name="atm">ne60np4</grid>
-      <grid name="lnd">ne60np4</grid>
-      <grid name="ocnice">ne60np4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="ne60_ne60_mg17" not_compset="_POP">
-      <grid name="atm">ne60np4</grid>
-      <grid name="lnd">ne60np4</grid>
-      <grid name="ocnice">ne60np4</grid>
-      <mask>gx1v7</mask>
-    </model_grid>
-
-    <model_grid alias="ne120_ne120" not_compset="_POP">
-      <grid name="atm">ne120np4</grid>
-      <grid name="lnd">ne120np4</grid>
-      <grid name="ocnice">ne120np4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="ne120_ne120_mg16" not_compset="_POP">
-      <grid name="atm">ne120np4</grid>
-      <grid name="lnd">ne120np4</grid>
-      <grid name="ocnice">ne120np4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="ne120_ne120_mg17" not_compset="_POP">
-      <grid name="atm">ne120np4</grid>
-      <grid name="lnd">ne120np4</grid>
-      <grid name="ocnice">ne120np4</grid>
-      <mask>gx1v7</mask>
-    </model_grid>
-
-    <model_grid alias="ne240_ne240" not_compset="_POP">
-      <grid name="atm">ne240np4</grid>
-      <grid name="lnd">ne240np4</grid>
-      <grid name="ocnice">ne240np4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
     <model_grid alias="ne240_ne240_mg16" not_compset="_POP">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">ne240np4</grid>
@@ -820,6 +792,112 @@
       <grid name="lnd">ne240np4</grid>
       <grid name="ocnice">ne240np4</grid>
       <mask>gx1v7</mask>
+    </model_grid>
+
+    <!--  spectral element grids with 2x2 FVM physics grid -->
+
+    <model_grid alias="ne30pg2_ne30pg2_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne30np4.pg2</grid>
+      <grid name="lnd">ne30np4.pg2</grid>
+      <grid name="ocnice">ne30np4.pg2</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne60pg2_ne60pg2_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne60np4.pg2</grid>
+      <grid name="lnd">ne60np4.pg2</grid>
+      <grid name="ocnice">ne60np4.pg2</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne120pg2_ne120pg2_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne120np4.pg2</grid>
+      <grid name="lnd">ne120np4.pg2</grid>
+      <grid name="ocnice">ne120np4.pg2</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne240pg2_ne240pg2_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne240np4.pg2</grid>
+      <grid name="lnd">ne240np4.pg2</grid>
+      <grid name="ocnice">ne240np4.pg2</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <!--  spectral element grids with 3x3 FVM physics grid -->
+
+    <model_grid alias="ne5pg3_ne5pg3_mg37" not_compset="_POP">
+      <grid name="atm">ne5np4.pg3</grid>
+      <grid name="lnd">ne5np4.pg3</grid>
+      <grid name="ocnice">ne5np4.pg3</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne16pg3_ne16pg3_mg37" not_compset="_POP|_CLM">
+      <grid name="atm">ne16np4.pg3</grid>
+      <grid name="lnd">ne16np4.pg3</grid>
+      <grid name="ocnice">ne16np4.pg3</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne30pg3_ne30pg3_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne30np4.pg3</grid>
+      <grid name="lnd">ne30np4.pg3</grid>
+      <grid name="ocnice">ne30np4.pg3</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne60pg3_ne60pg3_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne60np4.pg3</grid>
+      <grid name="lnd">ne60np4.pg3</grid>
+      <grid name="ocnice">ne60np4.pg3</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne120pg3_ne120pg3_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne120np4.pg3</grid>
+      <grid name="lnd">ne120np4.pg3</grid>
+      <grid name="ocnice">ne120np4.pg3</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne240pg3_ne240pg3_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne240np4.pg3</grid>
+      <grid name="lnd">ne240np4.pg3</grid>
+      <grid name="ocnice">ne240np4.pg3</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <!--  spectral element grids with 4x4 FVM physics grid -->
+
+    <model_grid alias="ne30pg4_ne30pg4_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne30np4.pg4</grid>
+      <grid name="lnd">ne30np4.pg4</grid>
+      <grid name="ocnice">ne30np4.pg4</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne60pg4_ne60pg4_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne60np4.pg4</grid>
+      <grid name="lnd">ne60np4.pg4</grid>
+      <grid name="ocnice">ne60np4.pg4</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="ne120pg4_ne120pg4_mg17" not_compset="_POP|_CLM">
+      <grid name="atm">ne120np4.pg4</grid>
+      <grid name="lnd">ne120np4.pg4</grid>
+      <grid name="ocnice">ne120np4.pg4</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+   <!-- VR-CESM grids with CAM-SE -->
+
+    <model_grid alias="ne0CONUSne30x8_ne0CONUSne30x8_mg17" not_compset="_POP">
+      <grid name="atm">ne0np4CONUS.ne30x8</grid>
+      <grid name="lnd">ne0np4CONUS.ne30x8</grid>
+      <grid name="ocnice">ne0np4CONUS.ne30x8</grid>
+      <mask>tx0.1v2</mask>
     </model_grid>
 
     <!-- new runoff grids for data runoff model DROF -->
@@ -1064,12 +1142,35 @@
       <desc>T42 is Gaussian grid:</desc>
     </domain>
 
+    <domain name="ne5np4">
+      <nx>1352</nx> <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.lnd.ne5np4_gx3v7.140810.nc</file>
+      <file grid="ocnice">$DIN_LOC_ROOT/share/domains/domain.ocn.ne5np4_gx3v7.140810.nc</file>
+      <desc>ne5np4 is Spectral Elem 6-deg grid:</desc>
+      <support>For ultra-low resolution spectral element grid testing</support>
+    </domain>
+
+    <domain name="ne5np4.pg3">
+      <nx>1350</nx> <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.lnd.ne5np4.pg3_gx3v7.170605.nc</file>
+      <file grid="ocnice">$DIN_LOC_ROOT/share/domains/domain.ocn.ne5np4.pg3_gx3v7.170605.nc</file>
+      <desc>ne5np4 is Spectral Elem 6-deg grid with a 3x3 FVM physics grid:</desc>
+      <support>For ultra-low resolution spectral element grid testing</support>
+    </domain>
+
     <domain name="ne16np4">
       <nx>13826</nx> <ny>1</ny>
       <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.lnd.ne16np4_gx3v7.120406.nc</file>
       <file grid="ocnice">$DIN_LOC_ROOT/share/domains/domain.ocn.ne16np4_gx3v7.121113.nc</file>
       <desc>ne16np4 is Spectral Elem 2-deg grid:</desc>
       <support>For low resolution spectral element grid testing</support>
+    </domain>
+
+    <domain name="ne16np4.pg3">
+      <nx>13824</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne16np4.pg3_gx1v7.170607.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne16np4.pg3_gx1v7_170607.nc</file>
+      <desc>ne16np4.pg3 is a Spectral Elem 2-deg grid with a 3x3 FVM physics grid:</desc>
     </domain>
 
     <domain name="ne30np4">
@@ -1079,11 +1180,53 @@
       <desc>ne30np4 is Spectral Elem 1-deg grid:</desc>
     </domain>
 
+    <domain name="ne30np4.pg2">
+      <nx>21600</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4.pg2_gx1v7.170628.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4.pg2_gx1v7.170628.nc</file>
+      <desc>ne30np4.pg2 is a Spectral Elem 1-deg grid with a 2x2 FVM physics grid:</desc>
+    </domain>
+
+    <domain name="ne30np4.pg3">
+      <nx>48600</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4.pg3_gx1v7.170605.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4.pg3_gx1v7_170605.nc</file>
+      <desc>ne30np4.pg3 is a Spectral Elem 1-deg grid with a 3x3 FVM physics grid:</desc>
+    </domain>
+
+    <domain name="ne30np4.pg4">
+      <nx>86400</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4.pg4_gx1v7.170628.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4.pg4_gx1v7.170628.nc</file>
+      <desc>ne30np4.pg4 is a Spectral Elem 1-deg grid with a 4x4 FVM physics grid:</desc>
+    </domain>
+
     <domain name="ne60np4">
       <nx>194402</nx> <ny>1</ny>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne60np4_gx1v6.120406.nc</file>
       <file grid="ocnice"  mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne60np4_gx1v6.121113.nc</file>
       <desc>ne60np4 is Spectral Elem 1/2-deg grid:</desc>
+    </domain>
+
+    <domain name="ne60np4.pg2">
+      <nx>86400</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne60np4.pg2_gx1v7.170628.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne60np4.pg2_gx1v7.170628.nc</file>
+      <desc>ne60np4.pg2 is a Spectral Elem 0.5-deg grid with a 2x2 FVM physics grid:</desc>
+    </domain>
+
+    <domain name="ne60np4.pg3">
+      <nx>194400</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne60np4.pg3_gx1v7.170628.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne60np4.pg3_gx1v7.170628.nc</file>
+      <desc>ne60np4.pg3 is a Spectral Elem 0.5-deg grid with a 3x3 FVM physics grid:</desc>
+    </domain>
+
+    <domain name="ne60np4.pg4">
+      <nx>345600</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne60np4.pg4_gx1v7.170628.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne60np4.pg4_gx1v7.170628.nc</file>
+      <desc>ne60np4.pg4 is a Spectral Elem 0.5-deg grid with a 4x4 FVM physics grid:</desc>
     </domain>
 
     <domain name="ne120np4">
@@ -1093,12 +1236,47 @@
       <desc>ne120np4 is Spectral Elem 1/4-deg grid:</desc>
     </domain>
 
+    <domain name="ne120np4.pg2">
+      <nx>345600</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg2_gx1v7.170629.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg2_gx1v7.170629.nc</file>
+      <desc>ne120np4.pg2 is a Spectral Elem 0.25-deg grid with a 2x2 FVM physics grid:</desc>
+    </domain>
+
+    <domain name="ne120np4.pg3">
+      <nx>777600</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg3_gx1v7.170629.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg3_gx1v7.170629.nc</file>
+      <desc>ne120np4.pg3 is a Spectral Elem 0.25-deg grid with a 3x3 FVM physics grid:</desc>
+    </domain>
+
+    <domain name="ne120np4.pg4">
+      <nx>1382400</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg4_gx1v7.170629.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg4_gx1v7.170629.nc</file>
+      <desc>ne120np4.pg4 is a Spectral Elem 0.25-deg grid with a 4x4 FVM physics grid:</desc>
+    </domain>
+
     <domain name="ne240np4">
       <nx>3110402</nx> <ny>1</ny>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne240np4_gx1v6.111226.nc</file>
       <file grid="ocnice"  mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne240np4_gx1v6.111226.nc</file>
       <desc>ne240np4 is Spectral Elem 1/8-deg grid:</desc>
       <support>Experimental for very high resolution experiments</support>
+    </domain>
+
+    <domain name="ne240np4.pg2">
+      <nx>1382400</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne240np4.pg2_gx1v7.170629.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne240np4.pg2_gx1v7.170629.nc</file>
+      <desc>ne240np4.pg2 is a Spectral Elem 0.125-deg grid with a 2x2 FVM physics grid:</desc>
+    </domain>
+
+    <domain name="ne240np4.pg3">
+      <nx>3110400</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne240np4.pg3_gx1v7.170629.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne240np4.pg3_gx1v7.170629.nc</file>
+      <desc>ne240np4.pg3 is a Spectral Elem 0.125-deg grid with a 3x3 FVM physics grid:</desc>
     </domain>
 
     <domain name="gx1v6">


### PR DESCRIPTION
Cleaned up CAM-SE grid aliases in preparation for new CAM-SE dycore.
Added new grid aliases and domain files for new FVM physics grids using CAM-SE.

Test suite:

- scripts_regression_test.py on Cheyenne.
- Create setup a case for each CAM-SE grid alias (on Hobart)
- prealpha test suite on Hobart
- aquaplanet test case on Cheyenne
- 

Test baseline: NA
Test namelist changes: 
Test status: bit for bit

Fixes #1550

User interface changes?: All CAM-SE grid aliases for data ocean models require a mask.

Update gh-pages html (Y/N)?: N

Code review: 
