### PR TITLE
We don't want check_if_comp_var to return a new vid if it's not a comp var

### DIFF
--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -42,17 +42,22 @@ class EnvBase(EntryID):
             if attribute is not None:
                 if "component" in attribute:
                     comp = attribute["component"]
+
             return vid, comp, True
 
+        new_vid = None
         for comp in self._components:
             if "_"+comp in vid:
-                vid = string.replace(vid, '_'+comp, '', 1)
-                break
+                new_vid = string.replace(vid, '_'+comp, '', 1)
             elif comp+"_" in vid:
-                vid = string.replace(vid, comp+'_', '', 1)
+                new_vid = string.replace(vid, comp+'_', '', 1)
+
+            if new_vid is not None:
                 break
-        if vid in self._component_value_list:
-            return vid, comp, True
+
+        if new_vid is not None and new_vid in self._component_value_list:
+            return new_vid, comp, True
+
         return vid, None, False
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None):

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -112,14 +112,12 @@ class Case(object):
             self.initialize_derived_attributes()
 
     def check_if_comp_var(self, vid):
-        vid = vid
-        comp = None
-        iscompvar = False
         for env_file in self._env_entryid_files:
             new_vid, new_comp, iscompvar = env_file.check_if_comp_var(vid)
             if iscompvar:
                 return new_vid, new_comp, iscompvar
-        return vid, comp, iscompvar
+
+        return vid, None, False
 
     def initialize_derived_attributes(self):
         """

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -116,9 +116,9 @@ class Case(object):
         comp = None
         iscompvar = False
         for env_file in self._env_entryid_files:
-            vid, comp, iscompvar = env_file.check_if_comp_var(vid)
+            new_vid, new_comp, iscompvar = env_file.check_if_comp_var(vid)
             if iscompvar:
-                return vid, comp, iscompvar
+                return new_vid, new_comp, iscompvar
         return vid, comp, iscompvar
 
     def initialize_derived_attributes(self):


### PR DESCRIPTION
This was causing very confusing messages from xmlquery.

Test suite: scripts_regression_tests J_TestCreateNewcase, code-checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit 

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
