### PR TITLE
Fix gen and comp

### DIFF
--- a/scripts/lib/CIME/SystemTests/restart_tests.py
+++ b/scripts/lib/CIME/SystemTests/restart_tests.py
@@ -38,9 +38,3 @@ class RestartTest(SystemTestsCompareTwo):
         self._case.set_value("STOP_N", stop_new)
         self._case.set_value("CONTINUE_RUN",True)
         self._case.set_value("REST_OPTION", "never")
-
-    def _case_one_custom_prerun_action(self):
-        # only case 2 should generate and compare baselines
-        self._case.set_value("GENERATE_BASELINE", False)
-        self._case.set_value("COMPARE_BASELINE", False)
-

--- a/scripts/lib/CIME/SystemTests/restart_tests.py
+++ b/scripts/lib/CIME/SystemTests/restart_tests.py
@@ -38,3 +38,9 @@ class RestartTest(SystemTestsCompareTwo):
         self._case.set_value("STOP_N", stop_new)
         self._case.set_value("CONTINUE_RUN",True)
         self._case.set_value("REST_OPTION", "never")
+
+    def _case_one_custom_prerun_action(self):
+        # only case 2 should generate and compare baselines
+        self._case.set_value("GENERATE_BASELINE", False)
+        self._case.set_value("COMPARE_BASELINE", False)
+

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -179,8 +179,10 @@ class SystemTestsCompareTwo(SystemTestsCommon):
     def build_phase(self, sharedlib_only=False, model_only=False):
         if self._separate_builds:
             self._activate_case1()
+            sharedlibroot = self._case1.get_value("SHAREDLIBROOT")
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
             self._activate_case2()
+            self._case.set_value("SHAREDLIBROOT", sharedlibroot)
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
         else:
             self._activate_case1()

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -234,8 +234,9 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             # Case1 is the "main" case, and we need to do the comparisons from there
             self._activate_case1()
             self._link_to_case2_output()
-
             self._component_compare_test(self._run_one_suffix, self._run_two_suffix, success_change=success_change)
+            # Go to case2 for the generate and compare baselines
+            self._activate_case2()
 
     def copy_case1_restarts_to_case2(self):
         """

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -3,6 +3,7 @@ common utilities for buildlib
 """
 
 from CIME.XML.standard_module_setup import *
+from CIME.case import Case
 from CIME.utils import parse_args_and_handle_standard_logging_options, setup_standard_logging_options
 import sys, os, argparse, doctest
 
@@ -30,6 +31,14 @@ def parse_input(argv):
                         help="root for building library")
 
     args = parse_args_and_handle_standard_logging_options(argv, parser)
+
+    # Some compilers have trouble with long include paths, setting
+    # EXEROOT to the relative path from bldroot solves the problem
+    # doing it in the environment means we don't need to change all of
+    # the component buildlib scripts
+    with Case(args.caseroot) as case:
+        os.environ["EXEROOT"] = os.path.relpath(case.get_value("EXEROOT"), args.bldroot)
+
 
     return args.caseroot, args.libroot, args.bldroot
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -986,7 +986,6 @@ class Case(object):
                     os.path.join(toolsdir, "preview_run"),
                     os.path.join(toolsdir, "check_input_data"),
                     os.path.join(toolsdir, "check_case"),
-                    os.path.join(toolsdir, "archive_metadata.sh"),
                     os.path.join(toolsdir, "xmlchange"),
                     os.path.join(toolsdir, "xmlquery"),
                     os.path.join(toolsdir, "pelayout"))

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -11,6 +11,8 @@ if ($#ARGV < 2) {
 }
 my ($sharedlibroot, $installroot, $CASEROOT) = @ARGV;
 
+print "$sharedlibroot <> $installroot <> $CASEROOT\n";
+
 chdir "${CASEROOT}" or die "Could not cd to \"$CASEROOT\"";
 
 my $CIMEROOT		= `./xmlquery CIMEROOT		--value`;
@@ -51,6 +53,7 @@ $useesmf = "esmf" if ($USE_ESMF_LIB eq "TRUE");
 
 my $libdir = "$sharedlibroot/$COMP_INTERFACE/$useesmf/${NINST_VALUE}/csm_share";
 my $installdir = "$installroot/$COMP_INTERFACE/$useesmf/${NINST_VALUE}";
+print "installdir is $installdir\nlibdir is $libdir\n";
 mkpath($libdir) unless -d $libdir;
 chdir($libdir) or die "Could not cd to $libdir: $!\n";
 
@@ -96,7 +99,7 @@ $multiinst_cppdefs = "$multiinst_cppdefs -DNUM_COMP_INST_WAV=$NINST_WAV";
 $multiinst_cppdefs = "$multiinst_cppdefs -DNUM_COMP_INST_ROF=$NINST_ROF";
 $multiinst_cppdefs = "$multiinst_cppdefs -DNUM_COMP_INST_ESP=$NINST_ESP";
 
-my $bld = "$GMAKE  complib -j $GMAKE_J MODEL=csm_share COMPLIB=libcsm_share.a USER_CPPDEFS=\" $multiinst_cppdefs\" -f $CASETOOLS/Makefile ";
+my $bld = "$GMAKE complib -j $GMAKE_J MODEL=csm_share COMPLIB=libcsm_share.a USER_CPPDEFS=\" $multiinst_cppdefs\" -f $CASETOOLS/Makefile ";
 
 my $rc = system($bld);
 if ($rc==0xff00){
@@ -113,8 +116,11 @@ if ($rc==0xff00){
     die "signal $rc\n";
 }
 if ( ! -d "$installdir/lib"){
+    print "Creating installdir in $installdir\n";
     mkpath("$installdir/lib");
     mkpath("$installdir/include");
 }
+print "Copying libcsm_share.a to $installdir/lib\n";
 system("cp -p -f libcsm_share.a $installdir/lib/");
+print "Copying modules to $installdir/include\n";
 system("cp -p -f *.mod $installdir/include/");


### PR DESCRIPTION
Fix some issues with tests - ERR was trying to use the first case for generate and compare baseline functions.   ERP test exposed a problem in the PGI compiler - it's not able to handle long include paths, this fixes it by setting EXEROOT to the relative path from the current build directory. 
(Note that the ERP test reveled problems in CISM that I've reported to @billsacks 

Test suite: scripts_regression_tests.py ERP.f10_f10_musgs.I1850Clm45BgcCru.yellowstone_pgi
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
