### PR TITLE
Add '-framework Accelerate' to LDFLAGS on a mac

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -722,6 +722,14 @@ using a fortran linker.
   </SLIBS>
 </compiler>
 
+<compiler MACH="homebrew" COMPILER="gnu">
+  <LDFLAGS>
+    <!-- These LDFLAGS provide lapack and blas support on a Mac. This
+         may require installation of the Apple Developer Tools. -->
+    <append> -framework Accelerate </append>
+  </LDFLAGS>
+</compiler>
+
 <compiler MACH="juqueen" COMPILER="ibm">
   <MPICC> mpixlc_r </MPICC>
   <MPIFC> mpixlf2003_r </MPIFC>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -898,9 +898,12 @@
      config_machines.xml file in your personal .cime directory and
      then changing the machine name (MACH="homebrew") to
      your machine name and the NODENAME_REGEX to something matching
-     your machine's hostname.  In this case, you should not need the
+     your machine's hostname.  With (2), you should not need the
      `--machine` argument, because the machine should be determined
-     automatically.
+     automatically.  However, with (2), you will also need to copy the
+     homebrew-specific settings in config_compilers.xml into a
+     config_compilers.xml file in your personal .cime directory, again
+     changing the machine name (MACH="homebrew") to your machine name.
 
     </DESC>
     <NODENAME_REGEX> something.matching.your.machine.hostname </NODENAME_REGEX>


### PR DESCRIPTION
This is needed for code that uses lapack and/or blas routines, such as
CLM

Test suite: ./create_test --no-run SMS_D.f10_f10.I2000Clm50SpGs.homebrew_gnu
(from a CLM sandbox)
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes #1905

User interface changes?: no

Update gh-pages html (Y/N)?:

Code review: 
