### PR TITLE
Yellowstone tpn correction

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1693,7 +1693,7 @@
       <executable>TARGET_PROCESSOR_LIST=AUTO_SELECT $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
       <arguments>
 	<arg name="anum_tasks"> -n $TOTALPES</arg>
-        <arg name="tasks_per_node"> -tpn $MAX_MPITASKS_PER_NODE </arg>
+        <arg name="tasks_per_node"> -tpn {{ tasks_per_node }} </arg>
 	<arg name="bindtool">$ENV{CESMDATAROOT}/tools/bin/launch </arg>
       </arguments>
     </mpirun>
@@ -1701,7 +1701,7 @@
       <executable>unset MP_PE_AFFINITY; unset MP_TASK_AFFINITY; unset MP_CPU_BIND_LIST; $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
       <arguments>
 	<arg name="anum_tasks"> -n $TOTALPES</arg>
-        <arg name="tasks_per_node"> -tpn $MAX_MPITASKS_PER_NODE </arg>
+        <arg name="tasks_per_node"> -tpn {{ tasks_per_node }} </arg>
 	<arg name="bindtool">$ENV{CESMDATAROOT}/tools/bin/hybrid_launch </arg>
       </arguments>
     </mpirun>
@@ -1709,7 +1709,7 @@
       <executable> $ENV{CESMDATAROOT}/tools/bin/mpirun </executable>
       <arguments>
 	<arg name="anum_tasks"> -n $TOTALPES</arg>
-        <arg name="tasks_per_node"> -tpn $MAX_MPITASKS_PER_NODE </arg>
+        <arg name="tasks_per_node"> -tpn {{ tasks_per_node }} </arg>
       </arguments>
     </mpirun>
     <module_system type="module">

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -131,7 +131,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         for comp in models:
             ntasks = case.get_value("NTASKS_{}".format(comp))
             if comp == "CPL":
-                case.set_value("NTASKS_PER_INST_{}".format(comp), ntasks )
                 continue
             ninst  = case.get_value("NINST_{}".format(comp))
             # But the NINST_LAYOUT may only be concurrent in multi_driver mode

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1917,7 +1917,6 @@
     <type>integer</type>
     <values>
       <value component="ATM"> 0</value>
-      <value component="CPL"> 0</value>
       <value component="OCN"> 0</value>
       <value component="WAV"> 0</value>
       <value component="GLC"> 0</value>


### PR DESCRIPTION
Fixes an issue with computing tasks per node on yellowstone, also clean up the NTASKS_PER_INST variable by removing CPL from the list. 

Test suite: scripts_regression_tests.py PFS_PX2.f09_g17.B1850.yellowstone_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit,
Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
