### PR TITLE
Err test rework

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -307,7 +307,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>$STOP_OPTION</REST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
-    <DOUT_S>TRUE</DOUT_S>
     <RESUBMIT>1</RESUBMIT>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
   </test>

--- a/scripts/lib/CIME/SystemTests/err.py
+++ b/scripts/lib/CIME/SystemTests/err.py
@@ -2,6 +2,7 @@
 CIME ERR test  This class inherits from ERS
 ERR tests short term archiving and restart capabilities
 """
+import glob, os
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.restart_tests import RestartTest
 from CIME.case_st_archive import restore_from_archive
@@ -31,4 +32,10 @@ class ERR(RestartTest):
             os.path.join(rest_root, restart_list[0]))
 
     def _case_two_custom_postrun_action(self):
-        restore_from_archive(self._case1)
+        # Link back to original case1 name
+        for case_file in glob.iglob(os.path.join(self._case1.get_value("RUNDIR"),
+                                                 "*.nc.{}".format(self._run_one_suffix))):
+            orig_file = case_file[:-(1+len(self._run_one_suffix))]
+            if not os.path.isfile(orig_file):
+                os.symlink(case_file, orig_file)
+

--- a/scripts/lib/CIME/SystemTests/err.py
+++ b/scripts/lib/CIME/SystemTests/err.py
@@ -2,7 +2,7 @@
 CIME ERR test  This class inherits from ERS
 ERR tests short term archiving and restart capabilities
 """
-import glob, os
+import glob, os, shutil
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.restart_tests import RestartTest
 from CIME.case_st_archive import restore_from_archive
@@ -11,17 +11,25 @@ from CIME.utils import ls_sorted_by_mtime
 logger = logging.getLogger(__name__)
 
 class ERR(RestartTest):
-
     def __init__(self, case): # pylint: disable=super-init-not-called
         """
         initialize an object interface to the ERR system test
         """
-        RestartTest.__init__(self, case, # pylint: disable=non-parent-init-called
+        super(ERR, self).__init__(case,
                              separate_builds = False,
                              run_two_suffix = 'rest',
                              run_one_description = 'initial',
                              run_two_description = 'restart',
                              multisubmit = True)
+
+    def _case_one_setup(self):
+        super(ERR, self)._case_one_setup()
+        self._case.set_value("DOUT_S", True)
+
+    def _case_two_setup(self):
+        super(ERR, self)._case_two_setup()
+        self._case.set_value("DOUT_S", False)
+
 
     def _case_two_custom_prerun_action(self):
         dout_s_root = self._case1.get_value("DOUT_S_ROOT")
@@ -33,9 +41,12 @@ class ERR(RestartTest):
 
     def _case_two_custom_postrun_action(self):
         # Link back to original case1 name
+        # This is needed so that the necessary files are present for
+        # baseline comparison and generation,
+        # since some of them may have been moved to the archive directory
         for case_file in glob.iglob(os.path.join(self._case1.get_value("RUNDIR"),
                                                  "*.nc.{}".format(self._run_one_suffix))):
             orig_file = case_file[:-(1+len(self._run_one_suffix))]
             if not os.path.isfile(orig_file):
-                os.symlink(case_file, orig_file)
+                shutil.copyfile(case_file, orig_file)
 

--- a/scripts/lib/CIME/SystemTests/err.py
+++ b/scripts/lib/CIME/SystemTests/err.py
@@ -29,3 +29,6 @@ class ERR(RestartTest):
         expect(len(restart_list) >= 1, "No restart files found in {}".format(rest_root))
         restore_from_archive(self._case, rest_dir=
             os.path.join(rest_root, restart_list[0]))
+
+    def _case_two_custom_postrun_action(self):
+        restore_from_archive(self._case1)

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -235,8 +235,6 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             self._activate_case1()
             self._link_to_case2_output()
             self._component_compare_test(self._run_one_suffix, self._run_two_suffix, success_change=success_change)
-            # Go to case2 for the generate and compare baselines
-            self._activate_case2()
 
     def copy_case1_restarts_to_case2(self):
         """


### PR DESCRIPTION
Addresses the problem in ERR test baseline generation and compare by linking the 
.base files created in the case1 run directory back to the original history file names. 

Test suite:  scripts_regression_tests.py ERR.f19_g16_rx1.A with generate and compare options.
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1909 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
