### PR TITLE
Big refactor to queue selection.

### DIFF
--- a/config/acme/machines/config_batch.xml
+++ b/config/acme/machines/config_batch.xml
@@ -92,8 +92,8 @@
       <directive                       > -R "span[ptile={{ tasks_per_node }}]"</directive>
       <directive                       > -N  </directive>
       <directive default="poe"         > -a {{ poe }} </directive>
-      <directive default="acme.stdout" > -o {{ output_error_path }}.%J  </directive>
-      <directive default="acme.stderr" > -e {{ output_error_path }}.%J  </directive>
+      <directive default="acme.stdout" > -o {{ job_id }}.%J  </directive>
+      <directive default="acme.stderr" > -e {{ job_id }}.%J  </directive>
       <directive                       > -J {{ job_id }} </directive>
     </directives>
   </batch_system>
@@ -116,7 +116,7 @@
     <directives>
       <directive> -N {{ job_id }}</directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
-      <!-- <directive> -j oe {{ output_error_path }} </directive> -->
+      <!-- <directive> -j oe {{ job_id }} </directive> -->
       <directive> -j oe </directive>
       <directive> -V </directive>
     </directives>
@@ -157,13 +157,13 @@
        <directive>-N {{ job_id }}</directive>
        <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
        <directive>-l walltime={{ job_wallclock_time }}</directive>
-       <directive>-o {{ output_error_path }}.out</directive>
-       <directive>-e {{ output_error_path }}.err</directive>
+       <directive>-o {{ job_id }}.out</directive>
+       <directive>-e {{ job_id }}.err</directive>
        <directive>-m be</directive>
       <directive> -A {{ project }} </directive>
      </directives>
      <queues>
-        <queue walltimemax="01:00:00" jobmin="1" jobmax="4320" default="true">pbatch</queue>
+        <queue walltimemax="01:00:00" nodemin="1" nodemax="270" default="true">pbatch</queue>
      </queues>
    </batch_system>
 
@@ -187,7 +187,7 @@
     <directives>
       <directive> --job-name={{ job_id }}</directive>
       <directive> --nodes={{ num_nodes }}</directive>
-      <directive> --output={{ output_error_path }}.%j </directive>
+      <directive> --output={{ job_id }}.%j </directive>
       <directive> --exclusive                        </directive>
     </directives>
   </batch_system>
@@ -199,8 +199,8 @@
       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue walltimemax="01:00:00" jobmin="1" jobmax="64" strict="true">shared</queue>
-      <queue walltimemax="03:00:00" jobmin="1" jobmax="4096" default="true">batch</queue>
+      <queue walltimemax="01:00:00" nodemin="1" nodemax="4" strict="true">shared</queue>
+      <queue walltimemax="03:00:00" nodemin="1" nodemax="256" default="true">batch</queue>
     </queues>
   </batch_system>
 
@@ -211,15 +211,15 @@
       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue walltimemax="01:00:00" jobmin="1" jobmax="4320" default="true">acme</queue>
+      <queue walltimemax="01:00:00" nodemin="1" nodemax="120" default="true">acme</queue>
     </queues>
   </batch_system>
 
   <!-- edison is SLURM as of Jan-4-2016 -->
   <batch_system MACH="edison" type="slurm" >
     <queues>
-      <queue walltimemax="00:30:00" jobmin="1" jobmax="12288" strict="true">debug</queue>
-      <queue walltimemax="01:30:00" jobmin="1" jobmax="150000" default="true">regular</queue>
+      <queue walltimemax="00:30:00" nodemin="1" nodemax="512" strict="true">debug</queue>
+      <queue walltimemax="01:30:00" nodemin="1" nodemax="6250" default="true">regular</queue>
     </queues>
   </batch_system>
 
@@ -230,7 +230,7 @@
       <directive>-l  nodes={{ num_nodes }}</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:30:00" jobmin="1" jobmax="9999" default="true">batch</queue>
+      <queue walltimemax="00:30:00" nodemin="1" nodemax="312" default="true">batch</queue>
     </queues>
   </batch_system>
 
@@ -239,8 +239,8 @@
         <directive> --constraint=haswell</directive>
       </directives>
       <queues>
-	<queue walltimemax="00:30:00" jobmin="1" jobmax="4096" strict="true">debug</queue>
-        <queue walltimemax="01:00:00" jobmin="1" jobmax="10000" default="true">regular</queue>
+	<queue walltimemax="00:30:00" nodemin="1" nodemax="128" strict="true">debug</queue>
+        <queue walltimemax="01:00:00" nodemin="1" nodemax="312" default="true">regular</queue>
       </queues>
     </batch_system>
 
@@ -249,26 +249,26 @@
         <directive> --constraint=knl,quad,cache</directive>
       </directives>
       <queues>
-	<queue walltimemax="00:30:00" jobmin="1" jobmax="100000" strict="true">debug</queue>
-        <queue walltimemax="01:00:00" jobmin="1" jobmax="3000000" default="true">regular</queue>
+	<queue walltimemax="00:30:00" nodemin="1" nodemax="390" strict="true">debug</queue>
+        <queue walltimemax="01:00:00" nodemin="1" nodemax="11718" default="true">regular</queue>
       </queues>
     </batch_system>
 
     <batch_system MACH="mira" type="cobalt">
       <queues>
-        <queue walltimemax="03:00:00" jobmin="1" jobmax="786432" default="true">default</queue>
+        <queue walltimemax="03:00:00" nodemin="1" nodemax="12288" default="true">default</queue>
       </queues>
     </batch_system>
 
     <batch_system MACH="cetus" type="cobalt">
       <queues>
-        <queue walltimemax="01:00:00" jobmin="1" jobmax="65536" default="true">default</queue>
+        <queue walltimemax="01:00:00" nodemin="1" nodemax="1024" default="true">default</queue>
       </queues>
     </batch_system>
 
     <batch_system MACH="theta" type="cobalt_theta">
       <queues>
-        <queue walltimemax="00:60:00" jobmin="1" jobmax="3200" default="true">default</queue>
+        <queue walltimemax="00:60:00" nodemin="1" nodemax="50" default="true">default</queue>
       </queues>
     </batch_system>
 
@@ -278,7 +278,7 @@
         <directive>--mail-user=email@pnnl.gov</directive>
       </directives>
       <queues>
-        <queue walltimemax="00:30:00" jobmin="1" jobmax="9999" default="true">small</queue>
+        <queue walltimemax="00:30:00" nodemin="1" nodemax="624" default="true">small</queue>
       </queues>
     </batch_system>
 
@@ -290,7 +290,7 @@
        <directive>--error=slurm.err</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:59:00" jobmin="1" jobmax="9999" default="true">slurm</queue>
+      <queue walltimemax="00:59:00" nodemin="1" nodemax="416" default="true">slurm</queue>
     </queues>
    </batch_system>
 
@@ -303,7 +303,7 @@
        <directive>--error=slurm.err</directive>
      </directives>
      <queues>
-       <queue walltimemax="00:59:00" jobmin="1" jobmax="9999" default="true">slurm</queue>
+       <queue walltimemax="00:59:00" nodemin="1" nodemax="1249" default="true">slurm</queue>
      </queues>
    </batch_system>
 
@@ -324,15 +324,6 @@
     <queues>
       <queue nodemin="1" nodemax="12" walltimemax="04:00:00" default="true">short</queue>
       <queue nodemin="1" nodemax="64" walltimemax="24:00:00">batch</queue>
-    </queues>
-  </batch_system>
-
-  <batch_system MACH="redsky" type="slurm" >
-    <directives>
-       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
-    </directives>
-    <queues>
-      <queue jobmin="1" jobmax="1024" walltimemax="06:00:00" default="true">ec</queue>
     </queues>
   </batch_system>
 
@@ -413,7 +404,7 @@
      </directives>
      <queues>
        <queue walltimemax="02:00:00" default="true">batch</queue>
-       <queue walltimemax="01:00:00" jobmin="0" jobmax="64" strict="true">debug</queue>
+       <queue walltimemax="01:00:00" nodemin="0" nodemax="4" strict="true">debug</queue>
      </queues>
    </batch_system>
 
@@ -425,7 +416,7 @@
        <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
      </directives>
     <queues>
-      <queue walltimemax="01:00:00" jobmin="0" jobmax="64" default="true">lr3</queue>
+      <queue walltimemax="01:00:00" nodemin="0" nodemax="6" default="true">lr3</queue>
     </queues>
   </batch_system>
 
@@ -437,7 +428,7 @@
       <directive>--ntasks-per-node={{ tasks_per_node }}</directive>
     </directives>
     <queues>
-      <queue walltimemax="01:00:00" jobmin="0" jobmax="64" default="true">lr3</queue>
+      <queue walltimemax="01:00:00" nodemin="0" nodemax="4" default="true">lr3</queue>
     </queues>
   </batch_system>
 

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -25,8 +25,6 @@
  be used.  The following variables can be used to choose a queue :
  walltimemin: Giving the minimum amount of walltime for the queue.
  walltimemax: The maximum amount of walltime for a queue.
- jobmin:      The minimum task count required to use this queue.
- jobmax:      The maximum task count required to use this queue.
  nodemin:      The minimum node count required to use this queue.
  nodemax:      The maximum node count required to use this queue.
     -->
@@ -110,8 +108,8 @@
       <directive                       > -R "span[ptile={{ tasks_per_node }}]"</directive>
       <directive                       > -N  </directive>
       <directive default="poe"         > -a {{ poe }} </directive>
-      <directive default="cesm.stdout" > -o {{ output_error_path }}.%J  </directive>
-      <directive default="cesm.stderr" > -e {{ output_error_path }}.%J  </directive>
+      <directive default="cesm.stdout" > -o {{ job_id }}.%J  </directive>
+      <directive default="cesm.stderr" > -e {{ job_id }}.%J  </directive>
       <directive                       > -J {{ job_id }} </directive>
     </directives>
   </batch_system>
@@ -134,7 +132,7 @@
     <directives>
       <directive> -N {{ job_id }}</directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
-      <!-- <directive> -j oe {{ output_error_path }} </directive> -->
+      <!-- <directive> -j oe {{ job_id }} </directive> -->
       <directive> -j oe </directive>
       <directive> -V </directive>
     </directives>
@@ -158,7 +156,7 @@
       <directive> --job-name={{ job_id }}</directive>
       <directive> --nodes={{ num_nodes }}</directive>
       <directive> --ntasks-per-node={{ tasks_per_node }}</directive>
-      <directive> --output={{ output_error_path }}   </directive>
+      <directive> --output={{ job_id }}   </directive>
       <directive> --exclusive                        </directive>
     </directives>
   </batch_system>
@@ -183,7 +181,7 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemax="00:59:00" jobmin="1" jobmax="9999" default="true">batch</queue>
+      <queue walltimemax="00:59:00" nodemin="1" nodemax="624" default="true">batch</queue>
     </queues>
   </batch_system>
 
@@ -195,7 +193,7 @@
     </directives>
     <queues>
       <queue walltimemax="24:00:00" default="true">regular</queue>
-      <queue walltimemax="00:30:00" jobmin="1" jobmax="512">debug</queue>
+      <queue walltimemax="00:30:00" nodemin="1" nodemax="16">debug</queue>
     </queues>
   </batch_system>
 
@@ -236,8 +234,8 @@
       <directive>-S /bin/bash  </directive>
     </directives>
     <queues>
-      <queue walltimemax="01:00:00" jobmin="1" jobmax="860">debug</queue>
-      <queue walltimemax="24:00:00" jobmin="861" jobmax="99999" default="true">batch</queue>
+      <queue walltimemax="01:00:00" nodemin="1" nodemax="35">debug</queue>
+      <queue walltimemax="24:00:00" nodemin="861" nodemax="4166" default="true">batch</queue>
     </queues>
   </batch_system>
 
@@ -248,11 +246,11 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemax="02:00:00" jobmin="1" jobmax="192" >short</queue>
-      <queue walltimemax="06:00:00" jobmin="1" jobmax="192" default="true">medium</queue>
-      <queue walltimemax="40:00:00" jobmin="1" jobmax="144" >long</queue>
-      <queue jobmax="768" jobmin="1" walltimemax="12:00:00">overnight</queue>
-      <queue jobmax="1536" jobmin="1" walltimemax="3000:00:">monster</queue>
+      <queue walltimemax="02:00:00" nodemin="1" nodemax="4" >short</queue>
+      <queue walltimemax="06:00:00" nodemin="1" nodemax="4" default="true">medium</queue>
+      <queue walltimemax="40:00:00" nodemin="1" nodemax="3" >long</queue>
+      <queue nodemax="16" nodemin="1" walltimemax="12:00:00">overnight</queue>
+      <queue nodemax="32" nodemin="1" walltimemax="3000:00:">monster</queue>
     </queues>
   </batch_system>
 
@@ -272,7 +270,7 @@
       <directive> -l select={{ num_nodes }}:ncpus={{ max_tasks_per_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}</directive>
     </directives>
     <queues>
-      <queue default="true" walltimemax="12:00" jobmin="1" jobmax="2592">regular</queue>
+      <queue default="true" walltimemax="12:00" nodemin="1" nodemax="72">regular</queue>
     </queues>
   </batch_system>
 
@@ -282,26 +280,26 @@
       <directive> -l select={{ num_nodes }}:ncpus={{ max_tasks_per_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}</directive>
     </directives>
     <queues>
-      <queue default="true" walltimemax="12:00" jobmin="1" jobmax="2592">regular</queue>
+      <queue default="true" walltimemax="12:00" nodemin="1" nodemax="72">regular</queue>
     </queues>
   </batch_system>
 
   <batch_system MACH="mira" type="cobalt">
     <queues>
-      <queue walltimemax="06:00:00" jobmin="1" jobmax="786432" default="true">default</queue>
+      <queue walltimemax="06:00:00" nodemin="1" nodemax="12288" default="true">default</queue>
     </queues>
   </batch_system>
 
   <batch_system MACH="theta" type="cobalt_theta">
     <queues>
-      <queue walltimemax="00:60:00" jobmin="1" jobmax="3200" default="true">default</queue>
+      <queue walltimemax="00:60:00" nodemin="1" nodemax="50" default="true">default</queue>
     </queues>
   </batch_system>
 
   <batch_system MACH="olympus" type="slurm">
     <batch_submit>sbatch</batch_submit>
     <queues>
-      <queue walltimemin="0" walltimemax="00:59:00" jobmin="0" jobmax="9999" default="true">queue</queue>
+      <queue walltimemin="0" walltimemax="00:59:00" nodemin="0" nodemax="312" default="true">queue</queue>
     </queues>
   </batch_system>
 
@@ -314,7 +312,7 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemin="" walltimemax="08:00:00" jobmin="0" jobmax="9999" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="08:00:00" nodemin="0" nodemax="357" default="true">normal</queue>
     </queues>
   </batch_system>
 
@@ -326,7 +324,7 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemin="" walltimemax="08:00:00" jobmin="0" jobmax="9999" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="08:00:00" nodemin="0" nodemax="357" default="true">normal</queue>
     </queues>
   </batch_system>
 
@@ -338,7 +336,7 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemin="" walltimemax="08:00:00" jobmin="0" jobmax="9999" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="08:00:00" nodemin="0" nodemax="500" default="true">normal</queue>
     </queues>
   </batch_system>
 
@@ -350,14 +348,7 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemin="" walltimemax="08:00:00" jobmin="0" jobmax="9999" default="true">normal</queue>
-    </queues>
-  </batch_system>
-
-  <batch_system MACH="skybridge" type="slurm" >
-    <batch_submit>sbatch</batch_submit>
-    <queues>
-      <queue jobmin="1" jobmax="480" default="true">ec</queue>
+      <queue walltimemin="" walltimemax="08:00:00" nodemin="0" nodemax="624" default="true">normal</queue>
     </queues>
   </batch_system>
 
@@ -376,7 +367,7 @@
   <batch_system MACH="eastwind" type="slurm" >
     <batch_submit>sbatch</batch_submit>
     <queues>
-      <queue jobmin="1" jobmax="9999" default="true">batch</queue>
+      <queue nodemin="1" nodemax="833" default="true">batch</queue>
     </queues>
   </batch_system>
 
@@ -386,8 +377,8 @@
       <directive>-C haswell </directive>
     </directives>
     <queues>
-      <queue walltimemax="06:00:00" jobmin="1" jobmax="45440">regular</queue>
-    <!--  <queue walltimemax="00:30:00" jobmin="1" jobmax="3072" default="true">debug</queue> -->
+      <queue walltimemax="06:00:00" nodemin="1" nodemax="710">regular</queue>
+    <!--  <queue walltimemax="00:30:00" nodemin="1" nodemax="3072" default="true">debug</queue> -->
     </queues>
   </batch_system>
 
@@ -398,24 +389,24 @@
       <directive>-S 2 </directive>
     </directives>
     <queues>
-      <queue walltimemax="02:00:00" jobmin="1" jobmax="45440">regular</queue>
-    <!--  <queue walltimemax="00:30:00" jobmin="1" jobmax="3072" default="true">debug</queue> -->
+      <queue walltimemax="02:00:00" nodemin="1" nodemax="177">regular</queue>
+    <!--  <queue walltimemax="00:30:00" nodemin="1" nodemax="3072" default="true">debug</queue> -->
     </queues>
   </batch_system>
 
   <batch_system MACH="edison" type="slurm" >
     <batch_submit>sbatch</batch_submit>
     <queues>
-      <queue walltimemax="36:00:00" jobmin="1" jobmax="130181" >regular</queue>
-      <queue walltimemax="00:30:00" jobmin="1" jobmax="12288" default="true">debug</queue>
+      <queue walltimemax="36:00:00" nodemin="1" nodemax="2712" >regular</queue>
+      <queue walltimemax="00:30:00" nodemin="1" nodemax="256" default="true">debug</queue>
     </queues>
   </batch_system>
 
   <batch_system MACH="stampede" type="slurm" >
     <batch_submit>ssh stampede.tacc.utexas.edu cd $CASEROOT ; sbatch</batch_submit>
     <queues>
-      <queue walltimemax="48:00:00" jobmin="1" jobmax="4096" >normal</queue>
-      <queue walltimemax="02:00:00" jobmin="1" jobmax="256" default="true">development</queue>
+      <queue walltimemax="48:00:00" nodemin="1" nodemax="256" >normal</queue>
+      <queue walltimemax="02:00:00" nodemin="1" nodemax="16" default="true">development</queue>
     </queues>
   </batch_system>
 
@@ -439,10 +430,10 @@
 
   <batch_system MACH="yellowstone" type="lsf" version="9.1">
     <queues>
-      <queue walltimemax="24:00" jobmin="1" jobmax="8" >caldera</queue>
-      <queue walltimemax="12:00" jobmin="9" jobmax="16384" default="true">regular</queue>
-      <queue walltimemax="12:00" jobmin="16385" jobmax="65536">capability</queue>
-      <queue walltimemax="12:00" jobmin="1" jobmax="16384">premium</queue>
+      <queue walltimemax="24:00" nodemin="1" nodemax="1" >caldera</queue>
+      <queue walltimemax="12:00" nodemin="9" nodemax="546" default="true">regular</queue>
+      <queue walltimemax="12:00" nodemin="16385" nodemax="2184">capability</queue>
+      <queue walltimemax="12:00" nodemin="1" nodemax="546">premium</queue>
     </queues>
   </batch_system>
 

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -79,7 +79,7 @@
         <xs:element minOccurs="0" ref="directives"/>
 
   <!-- queues: The list of queue options for this machine, not all system queues need be listed
-       attributes of this field include walltimemin, walltimemax, jobmin and jobmax and strict
+       attributes of this field include walltimemin, walltimemax, nodemin and nodemax and strict
     default wallclock time for a job is the walltimemax in this field -->
         <xs:element minOccurs="0" ref="queues"/>
       </xs:sequence>
@@ -142,8 +142,6 @@
         <xs:extension base="xs:NCName">
           <xs:attribute name="default" type="xs:boolean"/>
           <xs:attribute name="strict" type="xs:boolean"/>
-          <xs:attribute name="jobmax" type="xs:integer"/>
-          <xs:attribute name="jobmin" type="xs:integer"/>
           <xs:attribute name="nodemax" type="xs:integer"/>
           <xs:attribute name="nodemin" type="xs:integer"/>
           <xs:attribute name="jobname" type="xs:NCName"/>

--- a/config/xml_schemas/env_batch.xsd
+++ b/config/xml_schemas/env_batch.xsd
@@ -6,8 +6,6 @@
   <!-- attributes -->
   <xs:attribute name="id" type="xs:NCName"/>
   <xs:attribute name="default" type="xs:NCName"/>
-  <xs:attribute name="jobmax" type="xs:integer"/>
-  <xs:attribute name="jobmin"  type="xs:integer"/>
   <xs:attribute name="nodemax" type="xs:integer"/>
   <xs:attribute name="nodemin"  type="xs:integer"/>
   <xs:attribute name="jobname" type="xs:NCName"/>

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -425,7 +425,6 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
     with Case(first_case, read_only=False) as case:
         env_batch = case.get_env("batch")
 
-        directives = env_batch.get_batch_directives(case, "case.run", raw=True)
         submit_cmd  = env_batch.get_value("batch_submit", subgroup=None)
         submit_args = env_batch.get_submit_args(case, "case.run")
 
@@ -438,27 +437,23 @@ def single_submit_impl(machine_name, test_id, proc_pool, project, args, job_cost
         wall_time_bab = wall_time
 
     queue = env_batch.select_best_queue(proc_pool, num_nodes, wall_time_bab)
-    wall_time_max_bab = env_batch.get_queue_specs(queue)[5]
+    wall_time_max_bab = env_batch.get_queue_specs(queue)[3]
     if wall_time_max_bab is not None:
         wall_time_max = convert_to_seconds(wall_time_max_bab)
         if wall_time_max < wall_time:
             wall_time = wall_time_max
             wall_time_bab = convert_to_babylonian_time(wall_time)
 
-    job_id = "create_test_single_submit_%s" % test_id
-    directives = directives.replace("{{ job_id }}", job_id)
-    directives = directives.replace("{{ num_nodes }}", str(num_nodes))
-    directives = directives.replace("{{ tasks_per_node }}", str(tasks_per_node))
-    directives = directives.replace("{{ ptile }}", str(tasks_per_node))
-    directives = directives.replace("{{ totaltasks }}", str(tasks_per_node * num_nodes))
+    overrides = {
+        "job_id" : "create_test_single_submit_%s" % test_id,
+        "num_nodes" : num_nodes,
+        "tasks_per_node": tasks_per_node,
+        "totaltasks" : tasks_per_node * num_nodes,
+        "job_wallclock_time": wall_time_bab,
+        "job_queue": queue
+        }
 
-    directives = directives.replace("{{ output_error_path }}", "create_test_single_submit_%s.err" % test_id)
-    directives = directives.replace("{{ job_wallclock_time }}", wall_time_bab)
-    directives = directives.replace("{{ job_queue }}", queue)
-    if project is not None:
-        directives = directives.replace("{{ project }}", project)
-
-    expect("{{" not in directives, "Could not resolve all items in directives:\n%s" % directives)
+    directives = env_batch.get_batch_directives(case, "case.run", overrides=overrides)
 
     #
     # Make simple submit script and submit

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -178,8 +178,8 @@ class EnvBatch(EnvBase):
         os.chmod(job, os.stat(job).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     def set_job_defaults(self, batch_jobs, case):
-        walltime    = case.get_value("USER_REQUESTED_WALLTIME")
-        force_queue = case.get_value("USER_REQUESTED_QUEUE")
+        walltime    = case.get_value("USER_REQUESTED_WALLTIME") if case.get_value("USER_REQUESTED_WALLTIME") else None
+        force_queue = case.get_value("USER_REQUESTED_QUEUE") if case.get_value("USER_REQUESTED_QUEUE") else None
 
         if self._batchtype is None:
             self._batchtype = self.get_batch_system_type()

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -21,8 +21,8 @@ class EnvBatch(EnvBase):
         """
         initialize an object interface to file env_batch.xml in the case directory
         """
-        self.prereq_jobid = None
-        self.batchtype = None
+        self._prereq_jobid = None
+        self._batchtype = None
         # This arbitrary setting should always be overwritten
         self._default_walltime = "00:20:00"
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_batch.xsd")
@@ -155,68 +155,60 @@ class EnvBatch(EnvBase):
         if batchobj.machine_node is not None:
             self.root.append(deepcopy(batchobj.machine_node))
 
-    def make_batch_script(self, input_template, job, case, total_tasks, tasks_per_node, num_nodes, thread_count):
+    def make_batch_script(self, input_template, job, case):
         expect(os.path.exists(input_template), "input file '{}' does not exist".format(input_template))
 
-        self.tasks_per_node = tasks_per_node
-        self.num_tasks = total_tasks
-        self.tasks_per_numa = tasks_per_node / 2
-        self.thread_count = thread_count
         task_count = self.get_value("task_count", subgroup=job)
+        overrides = {}
+        if task_count is not None:
+            overrides["total_tasks"] = int(task_count)
+            overrides["num_nodes"]   = int(math.ceil(float(task_count)/float(case.tasks_per_node)))
 
-        if task_count is None:
-            self.total_tasks = total_tasks
-            self.num_nodes = num_nodes
-        else:
-            self.total_tasks = int(task_count)
-            self.num_nodes = int(math.ceil(float(task_count)/float(tasks_per_node)))
-
-        self.pedocumentation = ""
-        self.job_id = case.get_value("CASE") + os.path.splitext(job)[1]
+        overrides["pedocumentation"] = "" # TODO?
+        overrides["job_id"] = case.get_value("CASE") + os.path.splitext(job)[1]
         if "pleiades" in case.get_value("MACH"):
             # pleiades jobname needs to be limited to 15 chars
-            self.job_id = self.job_id[:15]
-        self.output_error_path = self.job_id
+            overrides["job_id"] = overrides["job_id"][:15]
 
-        self.batchdirectives = self.get_batch_directives(case, job)
+        overrides["batchdirectives"] = self.get_batch_directives(case, job, overrides=overrides)
 
-        output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, check_members=self)
+        output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)
         with open(job, "w") as fd:
             fd.write(output_text)
         os.chmod(job, os.stat(job).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
-    def set_job_defaults(self, batch_jobs, pesize=None, num_nodes=None, tasks_per_node=None, walltime=None, force_queue=None, allow_walltime_override=False):
-        if self.batchtype is None:
-            self.batchtype = self.get_batch_system_type()
+    def set_job_defaults(self, batch_jobs, case):
+        walltime    = case.get_value("USER_REQUESTED_WALLTIME")
+        force_queue = case.get_value("USER_REQUESTED_QUEUE")
 
-        if self.batchtype == 'none':
+        if self._batchtype is None:
+            self._batchtype = self.get_batch_system_type()
+
+        if self._batchtype == 'none':
             return
 
         for job, jsect in batch_jobs:
             task_count = jsect["task_count"] if "task_count" in jsect else None
             if task_count is None:
-                task_count = pesize
-                node_count = num_nodes
+                node_count = case.num_nodes
             else:
-                expect(tasks_per_node is not None, "Must provide tasks_per_node for custom task_count job '{}'".format(job))
-                task_count = task_count
-                node_count = int(math.ceil(float(task_count)/float(tasks_per_node)))
+                node_count = int(math.ceil(float(task_count)/float(case.tasks_per_node)))
 
             if force_queue:
-                if not self.queue_meets_spec(force_queue, task_count, node_count, walltime=walltime, job=job):
+                if not self.queue_meets_spec(force_queue, node_count, walltime=walltime, job=job):
                     logger.warning("WARNING: User-requested queue '{}' does not meet requirements for job '{}'".format(force_queue, job))
                 queue = force_queue
             else:
-                queue = self.select_best_queue(task_count, node_count, walltime=walltime, job=job)
+                queue = self.select_best_queue(node_count, walltime=walltime, job=job)
                 if queue is None and walltime is not None:
                     # Try to see if walltime was the holdup
-                    queue = self.select_best_queue(task_count, node_count, walltime=None, job=job)
+                    queue = self.select_best_queue(node_count, walltime=None, job=job)
                     if queue is not None:
                         # It was, override the walltime if a test, otherwise just warn the user
-                        new_walltime = self.get_queue_specs(queue)[5]
+                        new_walltime = self.get_queue_specs(queue)[3]
                         expect(new_walltime is not None, "Should never make it here")
                         logger.warning("WARNING: Requested walltime '{}' could not be matched by any queue".format(walltime))
-                        if allow_walltime_override:
+                        if case.get_value("TEST"):
                             logger.warning("  Using walltime '{}' instead".format(new_walltime))
                             walltime = new_walltime
                         else:
@@ -226,7 +218,7 @@ class EnvBatch(EnvBase):
                     logger.warning("WARNING: No queue on this system met the requirements for this job. Falling back to defaults")
                     default_queue_node = self.get_default_queue()
                     queue = default_queue_node.text
-                    walltime = self.get_queue_specs(queue)[5]
+                    walltime = self.get_queue_specs(queue)[3]
 
             if walltime is None:
                 # Figure out walltime
@@ -235,7 +227,7 @@ class EnvBatch(EnvBase):
                     # Queue is unknown, use specs from default queue
                     walltime = self.get_default_queue().get("walltimemax")
                 else:
-                    walltime = specs[5]
+                    walltime = specs[3]
 
                 walltime = self._default_walltime if walltime is None else walltime # last-chance fallback
 
@@ -243,7 +235,7 @@ class EnvBatch(EnvBase):
             self.set_value("JOB_WALLCLOCK_TIME", walltime, subgroup=job)
             logger.debug("Job {} queue {} walltime {}".format(job, queue, walltime))
 
-    def get_batch_directives(self, case, job, raw=False):
+    def get_batch_directives(self, case, job, overrides=None):
         """
         """
         result = []
@@ -257,10 +249,11 @@ class EnvBatch(EnvBase):
                 for node in nodes:
                     directive = self.get_resolved_value("" if node.text is None else node.text)
                     default = node.get("default")
-                    if not raw:
-                        directive = transform_vars(directive, case=case, subgroup=job, default=default, check_members=self)
-                    elif default is not None:
+                    if default is None:
+                        directive = transform_vars(directive, case=case, subgroup=job, default=default, overrides=overrides)
+                    else:
                         directive = transform_vars(directive, default=default)
+
                     result.append("{} {}".format(directive_prefix, directive))
 
         return "\n".join(result)
@@ -279,7 +272,7 @@ class EnvBatch(EnvBase):
         for arg in submit_arg_nodes:
             flag = arg.get("flag")
             name = arg.get("name")
-            if self.batchtype == "cobalt" and job == "case.st_archive":
+            if self._batchtype == "cobalt" and job == "case.st_archive":
                 if flag == "-n":
                     name = 'task_count'
                 if flag == "--mode":
@@ -351,7 +344,7 @@ class EnvBatch(EnvBase):
             if prereq:
                 jobs.append((job, self.get_value('dependency', subgroup=job)))
 
-            if self.batchtype == "cobalt":
+            if self._batchtype == "cobalt":
                 break
 
         depid = OrderedDict()
@@ -363,8 +356,8 @@ class EnvBatch(EnvBase):
             else:
                 deps = []
             jobid = ""
-            if self.prereq_jobid is not None:
-                jobid = self.prereq_jobid
+            if self._prereq_jobid is not None:
+                jobid = self._prereq_jobid
             for dep in deps:
                 if dep in depid.keys() and depid[dep] is not None:
                     jobid += " " + str(depid[dep])
@@ -390,7 +383,7 @@ class EnvBatch(EnvBase):
             batch_job_id = str(alljobs.index(job)) if dry_run else result
             depid[job] = batch_job_id
             jobcmds.append( (job, result) )
-            if self.batchtype == "cobalt":
+            if self._batchtype == "cobalt":
                 break
 
         if dry_run:
@@ -473,11 +466,11 @@ class EnvBatch(EnvBase):
         for node in nodes:
             type_ = node.get("type")
             if type_ is not None:
-                self.batchtype = type_
-        return self.batchtype
+                self._batchtype = type_
+        return self._batchtype
 
     def set_batch_system_type(self, batchtype):
-        self.batchtype = batchtype
+        self._batchtype = batchtype
 
     def get_job_id(self, output):
         jobid_pattern = self.get_value("jobid_pattern", subgroup=None)
@@ -488,22 +481,21 @@ class EnvBatch(EnvBase):
         jobid = search_match.group(1)
         return jobid
 
-    def queue_meets_spec(self, queue, num_pes, num_nodes, walltime=None, job=None):
+    def queue_meets_spec(self, queue, num_nodes, walltime=None, job=None):
         specs = self.get_queue_specs(queue)
         if specs is None:
             logger.warning("WARNING: queue '{}' is unknown to this system".format(queue))
             return True
 
-        jobmin, jobmax, nodemin, nodemax, jobname, walltimemax, strict = specs
+        nodemin, nodemax, jobname, walltimemax, strict = specs
 
         # A job name match automatically meets spec
         if job is not None and jobname is not None:
             return jobname == job
 
-        for minval, maxval, val in [(jobmin, jobmax, num_pes), (nodemin, nodemax, num_nodes)]:
-            if (minval is not None and val < int(minval)) or \
-               (maxval is not None and val > int(maxval)):
-                return False
+        if nodemin is not None and num_nodes < int(nodemin) or \
+           nodemax is not None and num_nodes > int(nodemax):
+            return False
 
         if walltime is not None and walltimemax is not None and strict:
             walltime_s = convert_to_seconds(walltime)
@@ -513,7 +505,7 @@ class EnvBatch(EnvBase):
 
         return True
 
-    def select_best_queue(self, num_pes, num_nodes, walltime=None, job=None):
+    def select_best_queue(self, num_nodes, walltime=None, job=None):
         # Make sure to check default queue first.
         all_queues = []
         all_queues.append( self.get_default_queue())
@@ -521,7 +513,7 @@ class EnvBatch(EnvBase):
         for queue in all_queues:
             if queue is not None:
                 qname = queue.text
-                if self.queue_meets_spec(qname, num_pes, num_nodes, walltime=walltime, job=job):
+                if self.queue_meets_spec(qname, num_nodes, walltime=walltime, job=job):
                     return qname
 
         return None
@@ -530,19 +522,17 @@ class EnvBatch(EnvBase):
         """
         Get queue specifications by name.
 
-        Returns (jobmin, jobmax, jobname, walltimemax, is_strict)
+        Returns (nodemin, nodemax, jobname, walltimemax, is_strict)
         """
         for queue_node in self.get_all_queues():
             if queue_node.text == queue:
-                jobmin = queue_node.get("jobmin")
-                jobmax = queue_node.get("jobmax")
                 nodemin = queue_node.get("nodemin")
                 nodemax = queue_node.get("nodemax")
                 jobname = queue_node.get("jobname")
                 walltimemax = queue_node.get("walltimemax")
                 strict = queue_node.get("strict") == "true"
 
-                return jobmin, jobmax, nodemin, nodemax, jobname, walltimemax, strict
+                return nodemin, nodemax, jobname, walltimemax, strict
 
         return None
 

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -340,7 +340,7 @@ class EnvMachSpecific(EnvBase):
         cmd_nodes = self.get_optional_node("cmd_path", attributes={"lang":lang})
         return cmd_nodes.text if cmd_nodes is not None else None
 
-    def get_mpirun(self, case, attribs, check_members=None, job="case.run", exe_only=False):
+    def get_mpirun(self, case, attribs, job="case.run", exe_only=False):
         """
         Find best match, return (executable, {arg_name : text})
         """
@@ -402,7 +402,6 @@ class EnvMachSpecific(EnvBase):
                     arg_value = transform_vars(arg_node.text,
                                                case=case,
                                                subgroup=job,
-                                               check_members=check_members,
                                                default=arg_node.get("default"))
                     args.append(arg_value)
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -633,10 +633,7 @@ class Case(object):
             for env_file in self._env_entryid_files:
                 env_file.add_elements_by_group(compobj, attributes=attlist)
 
-
-
         self.clean_up_lookups()
-
 
     def _setup_mach_pes(self, pecount, multi_driver, ninst, machine_name, mpilib):
         #--------------------------------------------
@@ -744,7 +741,6 @@ class Case(object):
 
         return pesize
 
-
     def configure(self, compset_name, grid_name, machine_name=None,
                   project=None, pecount=None, compiler=None, mpilib=None,
                   pesfile=None,user_grid=False, gridfile=None,
@@ -839,7 +835,7 @@ class Case(object):
         env_mach_specific_obj.populate(machobj)
         self.schedule_rewrite(env_mach_specific_obj)
 
-        pesize = self._setup_mach_pes(pecount, multi_driver, ninst, machine_name, mpilib)
+        self._setup_mach_pes(pecount, multi_driver, ninst, machine_name, mpilib)
 
         if multi_driver and ninst>1:
             logger.info(" Driver/Coupler has %s instances" % ninst)
@@ -919,6 +915,11 @@ class Case(object):
         #--------------------------------------------
         # batch system (must come after initialize_derived_attributes)
         #--------------------------------------------
+        if walltime:
+            self.set_value("USER_REQUESTED_WALLTIME", walltime)
+        if queue:
+            self.set_value("USER_REQUESTED_QUEUE", queue)
+
         env_batch = self.get_env("batch")
 
         batch_system_type = machobj.get_value("BATCH_SYSTEM")
@@ -927,7 +928,7 @@ class Case(object):
 
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
         env_batch.create_job_groups(bjobs)
-        env_batch.set_job_defaults(bjobs, pesize=pesize, num_nodes=self.num_nodes, tasks_per_node=self.tasks_per_node, walltime=walltime, force_queue=queue, allow_walltime_override=test)
+        env_batch.set_job_defaults(bjobs, self)
         self.schedule_rewrite(env_batch)
 
         # Make sure that parallel IO is not specified if total_tasks==1

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -181,7 +181,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                     env_batch.make_batch_script(input_batch_script, job, case)
 
             # May need to select new batch settings if pelayout changed (e.g. problem is now too big for prev-selected queue)
-            env_batch.set_job_defaults([("case.test" if case.get_value("TEST") else "case.run"), {}], case)
+            env_batch.set_job_defaults([(("case.test" if case.get_value("TEST") else "case.run"), {})], case)
+            case.schedule_rewrite(env_batch)
 
             # Make a copy of env_mach_pes.xml in order to be able
             # to check that it does not change once case.setup is invoked

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -166,23 +166,22 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             cost_pes = env_mach_pes.get_cost_pes(pestot, thread_count, machine=case.get_value("MACH"))
             case.set_value("COST_PES", cost_pes)
 
-            # Make sure pio settings are consistent
-            tasks_per_node = env_mach_pes.get_tasks_per_node(pestot, thread_count)
-
             case.initialize_derived_attributes()
 
             # create batch files
             logger.info("Creating batch script case.run")
             env_batch = case.get_env("batch")
-            num_nodes = case.num_nodes
             for job in env_batch.get_jobs():
                 input_batch_script  = os.path.join(case.get_value("MACHDIR"), env_batch.get_value('template', subgroup=job))
                 if job == "case.test" and testcase is not None and not test_mode:
                     logger.info("Writing {} script".format(job))
-                    env_batch.make_batch_script(input_batch_script, job, case, pestot, tasks_per_node, num_nodes, thread_count)
+                    env_batch.make_batch_script(input_batch_script, job, case)
                 elif job != "case.test":
                     logger.info("Writing {} script from input template {}".format(job, input_batch_script))
-                    env_batch.make_batch_script(input_batch_script, job, case, pestot, tasks_per_node, num_nodes, thread_count)
+                    env_batch.make_batch_script(input_batch_script, job, case)
+
+            # May need to select new batch settings if pelayout changed (e.g. problem is now too big for prev-selected queue)
+            env_batch.set_job_defaults([("case.test" if case.get_value("TEST") else "case.run"), {}], case)
 
             # Make a copy of env_mach_pes.xml in order to be able
             # to check that it does not change once case.setup is invoked

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1093,13 +1093,21 @@ def transform_vars(text, case=None, subgroup=None, overrides=None, default=None)
             repl = overrides[variable.lower()]
             logger.debug("from overrides: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
             text = text.replace(whole_match, str(repl))
+
+        elif case is not None and hasattr(case, variable.lower()) and getattr(case, variable.lower()) is not None:
+            repl = getattr(case, variable.lower())
+            logger.debug("from case members: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
+            text = text.replace(whole_match, str(repl))
+
         elif case is not None and case.get_value(variable.upper(), subgroup=subgroup) is not None:
             repl = case.get_value(variable.upper(), subgroup=subgroup)
             logger.debug("from case: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
             text = text.replace(whole_match, str(repl))
+
         elif default is not None:
             logger.debug("from default: in {}, replacing {} with {}".format(text, whole_match, str(default)))
             text = text.replace(whole_match, default)
+
         else:
             # If no queue exists, then the directive '-q' by itself will cause an error
             if "-q {{ queue }}" in text:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1070,7 +1070,7 @@ def does_file_have_string(filepath, text):
     """
     return os.path.isfile(filepath) and text in open(filepath).read()
 
-def transform_vars(text, case=None, subgroup=None, check_members=None, default=None):
+def transform_vars(text, case=None, subgroup=None, overrides=None, default=None):
     """
     Do the variable substitution for any variables that need transforms
     recursively.
@@ -1079,21 +1079,19 @@ def transform_vars(text, case=None, subgroup=None, check_members=None, default=N
     'cesm.stdout'
     >>> member_store = lambda : None
     >>> member_store.foo = "hi"
-    >>> transform_vars("I say {{ foo }}", check_members=member_store)
+    >>> transform_vars("I say {{ foo }}", overrides={"foo":"hi"})
     'I say hi'
     """
     directive_re = re.compile(r"{{ (\w+) }}", flags=re.M)
     # loop through directive text, replacing each string enclosed with
     # template characters with the necessary values.
-    if check_members is None and case is not None:
-        check_members = case
     while directive_re.search(text):
         m = directive_re.search(text)
         variable = m.groups()[0]
         whole_match = m.group()
-        if check_members is not None and hasattr(check_members, variable.lower()) and getattr(check_members, variable.lower()) is not None:
-            repl = getattr(check_members, variable.lower())
-            logger.debug("from check_members: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
+        if overrides is not None and variable.lower() in overrides and overrides[variable.lower()] is not None:
+            repl = overrides[variable.lower()]
+            logger.debug("from overrides: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
             text = text.replace(whole_match, str(repl))
         elif case is not None and case.get_value(variable.upper(), subgroup=subgroup) is not None:
             repl = case.get_value(variable.upper(), subgroup=subgroup)

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2581,6 +2581,20 @@
   </entry>
 
  <!-- Job Submission stuff -->
+ <entry id="USER_REQUESTED_QUEUE">
+   <type>char</type>
+   <group>run_desc</group>
+   <file>env_run.xml</file>
+   <desc>Store user override for queue</desc>
+ </entry>
+
+ <entry id="USER_REQUESTED_WALLTIME">
+   <type>char</type>
+   <group>run_desc</group>
+   <file>env_run.xml</file>
+   <desc>Store user override for walltime</desc>
+ </entry>
+
  <entry id="JOB_QUEUE">
    <type>char</type>
    <valid_values></valid_values>


### PR DESCRIPTION
Main goal was to dynamically reselect queue during case.setup. This allows us to
reselect an appropriate queue when PE layout changes are made.
    
Change list:
1) Remove jobmin and jobmax entirely from the system, nodemin and nodemax should be used instead
2) Remove output_error_path, it just obfuscated that it's the same as job_id
3) Refactor transform_vars and its usage.
    Remove check_members: allows us to avoid setting otherwise pointless members on our objects
4) Re-select queue for primary job (case.run/case.test) during case setup
5) Need to store user-requested queue and walltime so it can be reused during case setup queue selection

Test suite: scripts_regression_tests, melvin and chama, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1913 

User interface changes?: Y, jobmin and jobmax gone from config_batch.xml

Update gh-pages html (Y/N)?:  N

Code review: @jedwards4b 
