### PR TITLE
Update atm coupling frequency for high-resolution grids

### DIFF
--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -180,8 +180,16 @@
       <value compset="_MPAS">1</value>
       <value compset=".+" grid="a%0.23x0.31">96</value>
       <value compset=".+" grid="a%ne60np4">96</value>
+      <value compset=".+" grid="a%ne60np4.pg3">96</value>
+      <value compset=".+" grid="a%ne60np4.pg4">96</value>
       <value compset=".+" grid="a%ne120np4">96</value>
-      <value compset=".+" grid="a%ne240np4">96</value>
+      <value compset=".+" grid="a%ne120np4.pg2">96</value>
+      <value compset=".+" grid="a%ne120np4.pg3">96</value>
+      <value compset=".+" grid="a%ne120np4.pg4">144</value>
+      <value compset=".+" grid="a%ne240np4">144</value>
+      <value compset=".+" grid="a%ne240np4.pg2">144</value>
+      <value compset=".+" grid="a%ne240np4.pg3">144</value>
+      <value compset=".+" grid="a%ne0np4CONUS.ne30x8">144</value>
       <value compset=".+" grid="a%T42">72</value>
       <value compset=".+" grid="a%T85">144</value>
       <value compset=".+" grid="a%T341">288</value>


### PR DESCRIPTION
Update default atm coupling frequencies for high-resolution CAM-SE grids.
Also added default atm coupling frequencies for new FVM physics grid CAM-SE runs.

Test suite: scripts_regression_tests.py on Hobart
xmllint on modified XML file
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #1920

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
