### PR TITLE
Document uniqueness requirement for test-id

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -191,7 +191,7 @@ OR
                         "If test-id is specified, it is the user's responsibility to ensure "
                         "that each run of create_test uses a unique test-id. "
                         "(All sorts of problems can occur if you use the same test-id twice "
-                        "on the same file system.)")
+                        "on the same file system, even if the test lists are completely different.)")
 
     parser.add_argument("-j", "--parallel-jobs", type=int, default=None,
                         help="Number of tasks create_test should perform simultaneously. Default "

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -184,10 +184,14 @@ OR
                         "The default is user-specified environment variable PROJECT")
 
     parser.add_argument("-t", "--test-id",
-                        help="Specify an 'id' for the test. This is simply a"
-                        "string that is appended to the end of a test name."
-                        "If no testid is specified, then a time stamp plus random number"
-                        "will be used.")
+                        help="Specify an 'id' for the test. This is simply a "
+                        "string that is appended to the end of a test name. "
+                        "If no test-id is specified, then a time stamp plus random "
+                        "string will be used (ensuring a high probability of uniqueness). "
+                        "If test-id is specified, it is the user's responsibility to ensure "
+                        "that each run of create_test uses a unique test-id. "
+                        "(All sorts of problems can occur if you use the same test-id twice "
+                        "on the same file system.)")
 
     parser.add_argument("-j", "--parallel-jobs", type=int, default=None,
                         help="Number of tasks create_test should perform simultaneously. Default "


### PR DESCRIPTION
Test suite: scripts_regression_tests - just A_RunUnitTests and B_CheckCode
Also, manual inspection of `create_test -h` output
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#1933

User interface changes?: none

Update gh-pages html (Y/N)?:

Code review: 
