### PR TITLE
use local baseline directory for testing

### DIFF
--- a/scripts/Tools/case.cmpgen_namelists
+++ b/scripts/Tools/case.cmpgen_namelists
@@ -49,9 +49,12 @@ OR
                         help="Force generation to use baselines with this name. "
                         "Default will be to follow the case specification")
 
+    parser.add_argument("--baseline-root",
+                        help="Root of baselines.")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.caseroot, args.compare, args.generate, args.compare_name, args.generate_name
+    return args.caseroot, args.compare, args.generate, args.compare_name, args.generate_name, args.baseline_root
 
 ###############################################################################
 def _main_func(description):
@@ -60,9 +63,10 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, compare, generate, compare_name, generate_name = parse_command_line(sys.argv, description)
+    caseroot, compare, generate, compare_name, generate_name, baseline_root \
+        = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=True) as case:
-        success = case_cmpgen_namelists(case, compare, generate, compare_name, generate_name)
+        success = case_cmpgen_namelists(case, compare, generate, compare_name, generate_name, baseline_root)
 
     sys.exit(0 if success else CIME.utils.TESTS_FAILED_ERR_CODE)
 

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -280,6 +280,7 @@ def case_run(case, skip_pnl=False):
         if cycle > 0:
             case.set_value("CONTINUE_RUN", "TRUE")
             lid = new_lid()
+            skip_pnl = True
 
         if prerun_script:
             case.flush()


### PR DESCRIPTION
Not all users of scripts_regression_tests.py have write permissions in the machines default
baseline area, it's also a good idea not to pollute this area with scripts_regression_tests.py output.
So scripts_regression_tests.py now sets its own baseline directory. 
Also a one line change in case_run.py to make sure that preview_namelists is only run on the first pass of data assimilation.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1928 

User interface changes?:  added --baseline-root argument to case.cmpgen_baselines

Update gh-pages html (Y/N)?:

Code review: 
