### PR TITLE
archive pop tavg rpointer file

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -85,6 +85,10 @@
       <rpointer_file>rpointer.ocn$NINST_STRING.ovf</rpointer_file>
       <rpointer_content>./$CASE.pop$NINST_STRING.ro.$DATENAME</rpointer_content>
     </rpointer>
+    <rpointer>
+      <rpointer_file>rpointer.ocn$NINST_STRING.tavg</rpointer_file>
+      <rpointer_content>./$CASE.pop$NINST_STRING.rh.$DATENAME.nc</rpointer_content>
+    </rpointer>
   </comp_archive_spec>
 
   <comp_archive_spec compname="cism" compclass="glc">


### PR DESCRIPTION
The pop tavg rpointer file was not being archived.  This error is masked by the allactive.defaultio testmod which sets tavg output to daily and so doesn't need an rpointer file. 

Test suite:  IRT_Ld7.T31_g37.B1850C5L45BGCR.cheyenne_intel.
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
