### PR TITLE
Refactor args to submit scripts

### DIFF
--- a/config/acme/machines/config_batch.xml
+++ b/config/acme/machines/config_batch.xml
@@ -39,6 +39,7 @@
     <batch_query>qstat</batch_query>
     <batch_submit>qsub</batch_submit>
     <batch_cancel>qdel</batch_cancel>
+    <batch_env>-v</batch_env>
     <batch_directive></batch_directive>
     <jobid_pattern>(\d+)</jobid_pattern>
     <depend_string> --dependencies</depend_string>
@@ -60,6 +61,7 @@
     <batch_query>qstat</batch_query>
     <batch_submit>qsub</batch_submit>
     <batch_cancel>qdel</batch_cancel>
+    <batch_env>-v</batch_env>
     <batch_directive>#COBALT</batch_directive>
     <jobid_pattern>(\d+)</jobid_pattern>
     <depend_string> --dependencies</depend_string>
@@ -107,6 +109,7 @@
     <batch_query args="-f" >qstat</batch_query>
     <batch_submit>qsub </batch_submit>
     <batch_cancel>qdel</batch_cancel>
+    <batch_env>-v</batch_env>
     <batch_directive>#PBS</batch_directive>
     <jobid_pattern>^(\S+)$</jobid_pattern>
     <depend_string> -W depend=afterok:jobid</depend_string>

--- a/config/acme/machines/template.case.run
+++ b/config/acme/machines/template.case.run
@@ -71,6 +71,8 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
+    sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
+
     caseroot, skip_pnl = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
         success = case_run(case, skip_pnl=skip_pnl)

--- a/config/acme/machines/template.case.test
+++ b/config/acme/machines/template.case.test
@@ -63,6 +63,8 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
+    sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
+
     caseroot, testname, reset = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
         success = case_test(case, testname, reset)

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -52,6 +52,7 @@
     <batch_query>qstat</batch_query>
     <batch_submit>qsub</batch_submit>
     <batch_cancel>qdel</batch_cancel>
+    <batch_env>-v</batch_env>
     <batch_directive></batch_directive>
     <jobid_pattern>(\d+)</jobid_pattern>
     <depend_string> --dependencies</depend_string>
@@ -74,6 +75,7 @@
     <batch_query>qstat</batch_query>
     <batch_submit>qsub</batch_submit>
     <batch_cancel>qdel</batch_cancel>
+    <batch_env>-v</batch_env>
     <batch_directive>#COBALT</batch_directive>
     <jobid_pattern>(\d+)</jobid_pattern>
     <depend_string> --dependencies</depend_string>
@@ -121,6 +123,7 @@
     <batch_query args="-f" >qstat</batch_query>
     <batch_submit>qsub </batch_submit>
     <batch_cancel>qdel</batch_cancel>
+    <batch_env>-v</batch_env>
     <batch_directive>#PBS</batch_directive>
     <jobid_pattern>^(\S+)$</jobid_pattern>
     <depend_string> -W depend=afterok:jobid</depend_string>

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -68,6 +68,8 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
+    sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
+
     caseroot, skip_pnl = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
         success = case_run(case, skip_pnl=skip_pnl)

--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -63,6 +63,8 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
+    sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
+
     caseroot, testname, reset = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
         success = case_test(case, testname, reset)

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -12,6 +12,7 @@
   <xs:element name="batch_submit" type="xs:string"/>
   <xs:element name="batch_cancel" type="xs:string"/>
   <xs:element name="batch_redirect" type="xs:string"/>
+  <xs:element name="batch_env" type="xs:string"/>
   <xs:element name="batch_directive" type="xs:string"/>
   <xs:element name="jobid_pattern" type="xs:string"/>
   <xs:element name="depend_string" type="xs:string"/>
@@ -52,6 +53,9 @@
   <!-- batch_redirect: some batch systems (lsf) require the script to be read from stdin,
        this is the shell redirect to handle that -->
         <xs:element minOccurs="0" ref="batch_redirect"/>
+
+  <!-- batch_env: The flag passed to submit command to set environment variable; only use if batch system doesn't support normal option passing -->
+        <xs:element minOccurs="0" ref="batch_env"/>
 
   <!-- batch_directive: The prefix used for batch directives in script comments -->
         <xs:element minOccurs="0" ref="batch_directive"/>

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -446,7 +446,7 @@ class EnvBatch(EnvBase):
             if not batch_env_flag:
                 submitcmd += " --skip-preview-namelist"
             else:
-                submitcmd += " {} ARGS_FOR_SCRIPT='--skip-preview-namelist'"
+                submitcmd += " {} ARGS_FOR_SCRIPT='--skip-preview-namelist'".format(batch_env_flag)
 
         if dry_run:
             return submitcmd

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -442,7 +442,11 @@ class EnvBatch(EnvBase):
                 submitcmd += string + " "
 
         if job == 'case.run' and skip_pnl:
-            submitcmd += " --skip-preview-namelist"
+            batch_env_flag = self.get_value("batch_env", subgroup=None)
+            if not batch_env_flag:
+                submitcmd += " --skip-preview-namelist"
+            else:
+                submitcmd += " {} ARGS_FOR_SCRIPT='--skip-preview-namelist'"
 
         if dry_run:
             return submitcmd


### PR DESCRIPTION
Allow certain batch systems to pass flags to case.run/case.test via environment var.

Some systems like PBS do not support normal arguments to submit scripts.

Test suite: scripts_regression_tests + by-hand on blues
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1935 

User interface changes?: Y, New batch_env optional entry in config_batch

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
