### PR TITLE
Use keyword-value pairs for create_clone call

### DIFF
--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -83,7 +83,10 @@ def _main_func():
             user_mods_dir = os.path.abspath(user_mods_dir)
 
     with Case(cloneroot, read_only=False) as clone:
-        clone.create_clone(case, keepexe, mach_dir, project, cime_output_root, user_mods_dir)
+        clone.create_clone(case, keepexe=keepexe, mach_dir=mach_dir,
+                           project=project,
+                           cime_output_root=cime_output_root,
+                           user_mods_dir=user_mods_dir)
 
 ###############################################################################
 


### PR DESCRIPTION
This fixes a problem with out-of-order arguments

Test suite: scripts_regression_tests on cheyenne
   Also, manual test of create_clone as:
   `./create_clone --clone $scratch/mycase_1009 --case $scratch/myclone_1009c --keepexe --user-mods-dir ~/temporary/my_user_mods/`
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#1954

User interface changes?: n

Update gh-pages html (Y/N)?: N

Code review: 
