### PR TITLE
Add auto-normalization to case_diff

### DIFF
--- a/scripts/Tools/case_diff
+++ b/scripts/Tools/case_diff
@@ -6,11 +6,9 @@ directory trees.
 """
 
 from standard_script_setup import *
-from CIME.utils import run_cmd
+from CIME.utils import run_cmd, run_cmd_no_fail
 
 import argparse, sys, os, doctest
-
-IGNORE = [".git", "bin", "bakefiles", "SNTools.project"]
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -35,7 +33,8 @@ OR
 
     parser.add_argument("case2", help="Second case.")
 
-    parser.add_argument("skip_list", nargs="*", help="skip these files")
+    parser.add_argument("skip_list", nargs="*",
+                        help="skip these files. You'll probably want to skip the bld directory if it's inside the case")
 
     parser.add_argument("-b", "--show-binary", action="store_true",
                         help="Show binary diffs")
@@ -45,7 +44,7 @@ OR
     return args.case1, args.case2, args.show_binary, args.skip_list
 
 ###############################################################################
-def recursive_diff(dir1, dir2, show_binary=False, skip_list=()):
+def recursive_diff(dir1, dir2, repls, show_binary=False, skip_list=()):
 ###############################################################################
     """
     Starting at dir1, dir2 respectively, compare their contents
@@ -68,14 +67,14 @@ def recursive_diff(dir1, dir2, show_binary=False, skip_list=()):
     # Print the unique items
     for dirname, set_obj in [(dir1, dir1_only), (dir2, dir2_only)]:
         for item in sorted(set_obj):
-            if (item not in IGNORE and item not in skip_list):
+            if (item not in skip_list):
                 print "==============================================================================="
                 print os.path.join(dirname, item), "is unique"
                 num_differing_files += 1
 
     # Handling of the common items is trickier
     for item in sorted(both):
-        if (item in IGNORE or item in skip_list):
+        if (item in skip_list):
             continue
         path1 = os.path.join(dir1, item)
         path2 = os.path.join(dir2, item)
@@ -92,7 +91,7 @@ def recursive_diff(dir1, dir2, show_binary=False, skip_list=()):
         # files are directories, recursively check them, otherwise check
         # that the file contents match
         if (path1isdir):
-            num_differing_files += recursive_diff(path1, path2, show_binary)
+            num_differing_files += recursive_diff(path1, path2, repls, show_binary, skip_list)
         else:
             # # As a (huge) performance enhancement, if the files have the same
             # # size, we assume the contents match
@@ -106,7 +105,11 @@ def recursive_diff(dir1, dir2, show_binary=False, skip_list=()):
 
             is_text_file = "text" in out
             if (not (not show_binary and not is_text_file)):
-                stat, out, _ = run_cmd("diff -w {} {}".format(path1, path2))
+                the_text = open(path2, "r").read()
+                for replace_item, replace_with in repls.iteritems():
+                    the_text = the_text.replace(replace_item, replace_with)
+
+                stat, out, _ = run_cmd("diff -w {} -".format(path1), input_str=the_text)
                 if (stat != 0):
                     print "==============================================================================="
                     print path1 + " DIFFERS (contents)"
@@ -124,7 +127,14 @@ def _main_func(description):
 
     case1, case2, show_binary, skip_list = parse_command_line(sys.argv, description)
 
-    num_differing_files = recursive_diff(case1, case2, show_binary, skip_list)
+    xml_normalize_fields = ["TEST_TESTID", "SRCROOT"]
+    repls = {}
+    for xml_normalize_field in xml_normalize_fields:
+        val1 = run_cmd_no_fail("./xmlquery --value {}".format(xml_normalize_field), from_dir=case1)
+        val2 = run_cmd_no_fail("./xmlquery --value {}".format(xml_normalize_field), from_dir=case2)
+        repls[val2] = val1
+
+    num_differing_files = recursive_diff(case1, case2, repls, show_binary, skip_list)
     print num_differing_files, "files are different"
     sys.exit(0 if num_differing_files == 0 else 1)
 


### PR DESCRIPTION
It will auto-normalize TESTID and SRCROOT.

Test suite: code_checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Yes, but this is not a core CIME tool

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
