### PR TITLE
Fix a slightly incorrect error message in summarize_cprnc_diffs

### DIFF
--- a/tools/cprnc/summarize_cprnc_diffs
+++ b/tools/cprnc/summarize_cprnc_diffs
@@ -175,7 +175,7 @@ sub process_cprnc_output {
    }  # foreach test_dir
 
    if ($num_files == 0) {
-      die "ERROR: no base.cprnc.out files found\n";
+      die "ERROR: no cprnc.out files found\n";
    }
 
    return \%diffs;


### PR DESCRIPTION
It used to be that we were looking for base.cprnc.out files, but that's
not true any more.

Test suite: none
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: n

Update gh-pages html (Y/N)?: N

Code review: 
