### PR TITLE
Iscompvar cleanup

### DIFF
--- a/config/xml_schemas/env_mach_pes.xsd
+++ b/config/xml_schemas/env_mach_pes.xsd
@@ -57,7 +57,7 @@
     <xs:complexType>
       <xs:simpleContent>
         <xs:extension base="xs:NMTOKEN">
-          <xs:attribute name="component" use="required" type="xs:NCName"/>
+          <xs:attribute name="compclass" use="required" type="xs:NCName"/>
         </xs:extension>
       </xs:simpleContent>
     </xs:complexType>

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -244,9 +244,9 @@ def xmlquery_sub(case, variables, subgroup=None, fileonly=False,
                     value = []
                     for comp in comp_classes:
                         try:
-                            nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=resolved, subgroup=group)
+                            nextval = get_value_as_string(case,var, attribute={"compclass" : comp}, resolved=resolved, subgroup=group)
                         except:
-                            nextval = get_value_as_string(case,var, attribute={"component" : comp}, resolved=False, subgroup=group)
+                            nextval = get_value_as_string(case,var, attribute={"compclass" : comp}, resolved=False, subgroup=group)
 
                         if nextval is not None:
                             value.append(comp + ":" + "%s"%nextval)

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -36,13 +36,13 @@ class EnvBase(EntryID):
         if len(nodes):
             node = nodes[0]
         if node:
-            valnodes = node.findall(".//value")
+            valnodes = node.findall(".//value[@compclass]")
             if len(valnodes) == 0:
                 logger.debug("vid {} is not a compvar".format(vid))
                 return vid, None, False
             else:
                 logger.debug("vid {} is a compvar".format(vid))
-                if attribute is not None and "compclass" in attribute:
+                if attribute is not None:
                     comp = attribute["compclass"]
                 return vid, comp, True
         else:

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -30,9 +30,9 @@ class EnvBase(EntryID):
             self._components = components
 
     def check_if_comp_var(self, vid, attribute=None):
-        # pylint: disable=no-member
         nodes = self.get_nodes("entry", {"id" : vid})
         node = None
+        comp = None
         if len(nodes):
             node = nodes[0]
         if node:
@@ -41,7 +41,6 @@ class EnvBase(EntryID):
                 logger.debug("vid {} is not a compvar".format(vid))
                 return vid, None, False
             else:
-                comp = None
                 logger.debug("vid {} is a compvar".format(vid))
                 if attribute is not None and "compclass" in attribute:
                     comp = attribute["compclass"]

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -14,8 +14,6 @@ class EnvMachPes(EnvBase):
         initialize an object interface to file env_mach_pes.xml in the case directory
         """
         self._components = components
-        self._component_value_list = ["NTASKS", "NTHRDS", "NINST",
-                                      "ROOTPE", "PSTRID", "NINST_LAYOUT", "NTASKS_PER_INST"]
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_pes.xsd")
         EnvBase.__init__(self, case_root, infile, schema=schema)
 
@@ -61,7 +59,7 @@ class EnvMachPes(EnvBase):
         ''' Find the maximum number of openmp threads for any component in the case '''
         max_threads = 1
         for comp in comp_classes:
-            threads = self.get_value("NTHRDS",attribute={"component":comp})
+            threads = self.get_value("NTHRDS",attribute={"compclass":comp})
             expect(threads is not None, "Error no thread count found for component class {}".format(comp))
             if threads > max_threads:
                 max_threads = threads
@@ -86,11 +84,11 @@ class EnvMachPes(EnvBase):
         total_tasks = 0
         maxinst = 1
         for comp in comp_classes:
-            ntasks = self.get_value("NTASKS", attribute={"component":comp})
-            rootpe = self.get_value("ROOTPE", attribute={"component":comp})
-            pstrid = self.get_value("PSTRID", attribute={"component":comp})
+            ntasks = self.get_value("NTASKS", attribute={"compclass":comp})
+            rootpe = self.get_value("ROOTPE", attribute={"compclass":comp})
+            pstrid = self.get_value("PSTRID", attribute={"compclass":comp})
             if comp != "CPL":
-                ninst = self.get_value("NINST", attribute={"component":comp})
+                ninst = self.get_value("NINST", attribute={"compclass":comp})
                 maxinst = max(maxinst, ninst)
             tt = rootpe + (ntasks - 1) * pstrid + 1
             total_tasks = max(tt, total_tasks)
@@ -99,7 +97,7 @@ class EnvMachPes(EnvBase):
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):
-        expect(total_tasks > 0,"totaltasks > 0 expected totaltasks = {}".format(total_tasks))
+        expect(total_tasks > 0,"totaltasks > 0 expected, totaltasks = {}".format(total_tasks))
         tasks_per_node = min(self.get_value("MAX_TASKS_PER_NODE")/ max_thread_count,
                              self.get_value("MAX_MPITASKS_PER_NODE"), total_tasks)
         return tasks_per_node if tasks_per_node > 0 else 1

--- a/scripts/lib/CIME/XML/env_run.py
+++ b/scripts/lib/CIME/XML/env_run.py
@@ -14,8 +14,6 @@ class EnvRun(EnvBase):
         initialize an object interface to file env_run.xml in the case directory
         """
         self._components = components
-        self._component_value_list = ["PIO_TYPENAME", "PIO_STRIDE", "PIO_REARRANGER",
-                                      "PIO_NUMTASKS", "PIO_ROOT", "PIO_NETCDF_FORMAT"]
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_entry_id.xsd")
 
         EnvBase.__init__(self, case_root, infile, schema=schema)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -129,7 +129,6 @@ class Case(object):
         env_mach_spec = self.get_env('mach_specific')
         comp_classes  = self.get_values("COMP_CLASSES")
         MAX_MPITASKS_PER_NODE  = self.get_value("MAX_MPITASKS_PER_NODE")
-
         self.total_tasks = env_mach_pes.get_total_tasks(comp_classes)
         self.thread_count = env_mach_pes.get_max_thread_count(comp_classes)
         self.tasks_per_node = env_mach_pes.get_tasks_per_node(self.total_tasks, self.thread_count)

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1222,7 +1222,6 @@ def find_system_test(testname, case):
 
             if tdir is not None:
                 tdir = os.path.abspath(tdir)
-                print (tdir)
                 system_test_file = os.path.join(tdir  ,"{}.py".format(testname.lower()))
                 if os.path.isfile(system_test_file):
                     fdir.append(tdir)

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1222,6 +1222,7 @@ def find_system_test(testname, case):
 
             if tdir is not None:
                 tdir = os.path.abspath(tdir)
+                print (tdir)
                 system_test_file = os.path.join(tdir  ,"{}.py".format(testname.lower()))
                 if os.path.isfile(system_test_file):
                     fdir.append(tdir)
@@ -1233,6 +1234,7 @@ def find_system_test(testname, case):
                         if system_test_dir not in sys.path:
                             sys.path.append(system_test_dir)
                         system_test_path = "{}.{}".format(testname.lower(), testname)
+        expect(len(fdir) > 0, "Test {} not found, aborting".format(testname))
         expect(len(fdir) == 1, "Test {} found in multiple locations {}, aborting".format(testname, fdir))
     expect(system_test_path is not None, "No test {} found".format(testname))
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1898,15 +1898,15 @@
   <entry id="NTASKS">
     <type>integer</type>
     <values>
-      <value component="ATM"> 0</value>
-      <value component="CPL"> 0</value>
-      <value component="OCN"> 0</value>
-      <value component="WAV"> 0</value>
-      <value component="GLC"> 0</value>
-      <value component="ICE"> 0</value>
-      <value component="ROF"> 0</value>
-      <value component="LND"> 0</value>
-      <value component="ESP"> 0</value>
+      <value compclass="ATM"> 0</value>
+      <value compclass="CPL"> 0</value>
+      <value compclass="OCN"> 0</value>
+      <value compclass="WAV"> 0</value>
+      <value compclass="GLC"> 0</value>
+      <value compclass="ICE"> 0</value>
+      <value compclass="ROF"> 0</value>
+      <value compclass="LND"> 0</value>
+      <value compclass="ESP"> 0</value>
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
@@ -1916,14 +1916,14 @@
   <entry id="NTASKS_PER_INST">
     <type>integer</type>
     <values>
-      <value component="ATM"> 0</value>
-      <value component="OCN"> 0</value>
-      <value component="WAV"> 0</value>
-      <value component="GLC"> 0</value>
-      <value component="ICE"> 0</value>
-      <value component="ROF"> 0</value>
-      <value component="LND"> 0</value>
-      <value component="ESP"> 0</value>
+      <value compclass="ATM"> 0</value>
+      <value compclass="OCN"> 0</value>
+      <value compclass="WAV"> 0</value>
+      <value compclass="GLC"> 0</value>
+      <value compclass="ICE"> 0</value>
+      <value compclass="ROF"> 0</value>
+      <value compclass="LND"> 0</value>
+      <value compclass="ESP"> 0</value>
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
@@ -1933,15 +1933,15 @@
   <entry id="NTHRDS">
     <type>integer</type>
     <values>
-      <value component="ATM">1</value>
-      <value component="CPL">1</value>
-      <value component="OCN">1</value>
-      <value component="WAV">1</value>
-      <value component="GLC">1</value>
-      <value component="ICE">1</value>
-      <value component="ROF">1</value>
-      <value component="LND">1</value>
-      <value component="ESP">1</value>
+      <value compclass="ATM">1</value>
+      <value compclass="CPL">1</value>
+      <value compclass="OCN">1</value>
+      <value compclass="WAV">1</value>
+      <value compclass="GLC">1</value>
+      <value compclass="ICE">1</value>
+      <value compclass="ROF">1</value>
+      <value compclass="LND">1</value>
+      <value compclass="ESP">1</value>
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
@@ -1951,15 +1951,15 @@
   <entry id="ROOTPE">
     <type>integer</type>
     <values>
-      <value component="ATM">0</value>
-      <value component="CPL">0</value>
-      <value component="OCN">0</value>
-      <value component="WAV">0</value>
-      <value component="GLC">0</value>
-      <value component="ICE">0</value>
-      <value component="ROF">0</value>
-      <value component="LND">0</value>
-      <value component="ESP">0</value>
+      <value compclass="ATM">0</value>
+      <value compclass="CPL">0</value>
+      <value compclass="OCN">0</value>
+      <value compclass="WAV">0</value>
+      <value compclass="GLC">0</value>
+      <value compclass="ICE">0</value>
+      <value compclass="ROF">0</value>
+      <value compclass="LND">0</value>
+      <value compclass="ESP">0</value>
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
@@ -1981,14 +1981,14 @@
   <entry id="NINST">
     <type>integer</type>
     <values>
-      <value component="ATM">1</value>
-      <value component="OCN">1</value>
-      <value component="WAV">1</value>
-      <value component="GLC">1</value>
-      <value component="ICE">1</value>
-      <value component="ROF">1</value>
-      <value component="LND">1</value>
-      <value component="ESP">1</value>
+      <value compclass="ATM">1</value>
+      <value compclass="OCN">1</value>
+      <value compclass="WAV">1</value>
+      <value compclass="GLC">1</value>
+      <value compclass="ICE">1</value>
+      <value compclass="ROF">1</value>
+      <value compclass="LND">1</value>
+      <value compclass="ESP">1</value>
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
@@ -2001,14 +2001,14 @@
     <type>char</type>
     <valid_values>sequential,concurrent</valid_values>
     <values>
-      <value component="ATM">concurrent</value>
-      <value component="OCN">concurrent</value>
-      <value component="WAV">concurrent</value>
-      <value component="GLC">concurrent</value>
-      <value component="ICE">concurrent</value>
-      <value component="ROF">concurrent</value>
-      <value component="LND">concurrent</value>
-      <value component="ESP">concurrent</value>
+      <value compclass="ATM">concurrent</value>
+      <value compclass="OCN">concurrent</value>
+      <value compclass="WAV">concurrent</value>
+      <value compclass="GLC">concurrent</value>
+      <value compclass="ICE">concurrent</value>
+      <value compclass="ROF">concurrent</value>
+      <value compclass="LND">concurrent</value>
+      <value compclass="ESP">concurrent</value>
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
@@ -2018,15 +2018,15 @@
   <entry id="PSTRID">
     <type>integer</type>
     <values>
-      <value component="ATM">1</value>
-      <value component="CPL">1</value>
-      <value component="OCN">1</value>
-      <value component="WAV">1</value>
-      <value component="GLC">1</value>
-      <value component="ICE">1</value>
-      <value component="ROF">1</value>
-      <value component="LND">1</value>
-      <value component="ESP">1</value>
+      <value compclass="ATM">1</value>
+      <value compclass="CPL">1</value>
+      <value compclass="OCN">1</value>
+      <value compclass="WAV">1</value>
+      <value compclass="GLC">1</value>
+      <value compclass="ICE">1</value>
+      <value compclass="ROF">1</value>
+      <value compclass="LND">1</value>
+      <value compclass="ESP">1</value>
     </values>
     <group>mach_pes</group>
     <file>env_mach_pes.xml</file>
@@ -2193,15 +2193,15 @@
     <file>env_run.xml</file>
     <desc>pio io type</desc>
     <values>
-      <value component="ATM">default</value>
-      <value component="CPL">default</value>
-      <value component="OCN">default</value>
-      <value component="WAV">default</value>
-      <value component="GLC">default</value>
-      <value component="ICE">default</value>
-      <value component="ROF">default</value>
-      <value component="LND">default</value>
-      <value component="ESP">default</value>
+      <value compclass="ATM">default</value>
+      <value compclass="CPL">default</value>
+      <value compclass="OCN">default</value>
+      <value compclass="WAV">default</value>
+      <value compclass="GLC">default</value>
+      <value compclass="ICE">default</value>
+      <value compclass="ROF">default</value>
+      <value compclass="LND">default</value>
+      <value compclass="ESP">default</value>
     </values>
   </entry>
 
@@ -2214,15 +2214,15 @@
     https://www.unidata.ucar.edu/software/netcdf/docs/data_type.html
     </desc>
     <values>
-      <value component="ATM">64bit_offset</value>
-      <value component="CPL">64bit_offset</value>
-      <value component="OCN">64bit_offset</value>
-      <value component="WAV">64bit_offset</value>
-      <value component="GLC">64bit_offset</value>
-      <value component="ICE">64bit_offset</value>
-      <value component="ROF">64bit_offset</value>
-      <value component="LND">64bit_offset</value>
-      <value component="ESP">64bit_offset</value>
+      <value compclass="ATM">64bit_offset</value>
+      <value compclass="CPL">64bit_offset</value>
+      <value compclass="OCN">64bit_offset</value>
+      <value compclass="WAV">64bit_offset</value>
+      <value compclass="GLC">64bit_offset</value>
+      <value compclass="ICE">64bit_offset</value>
+      <value compclass="ROF">64bit_offset</value>
+      <value compclass="LND">64bit_offset</value>
+      <value compclass="ESP">64bit_offset</value>
     </values>
   </entry>
 
@@ -2235,15 +2235,15 @@
      be computed based on PIO_NUMTASKS and number of compute tasks
     </desc>
     <values>
-      <value component="ATM"></value>
-      <value component="CPL"></value>
-      <value component="OCN"></value>
-      <value component="WAV"></value>
-      <value component="GLC"></value>
-      <value component="ICE"></value>
-      <value component="ROF"></value>
-      <value component="LND"></value>
-      <value component="ESP"></value>
+      <value compclass="ATM"></value>
+      <value compclass="CPL"></value>
+      <value compclass="OCN"></value>
+      <value compclass="WAV"></value>
+      <value compclass="GLC"></value>
+      <value compclass="ICE"></value>
+      <value compclass="ROF"></value>
+      <value compclass="LND"></value>
+      <value compclass="ESP"></value>
     </values>
   </entry>
 
@@ -2255,15 +2255,15 @@
     <desc>pio rearranger choice box=1, subset=2 </desc>
     <values>
       <value>$PIO_VERSION</value>
-      <value component="ATM"></value>
-      <value component="CPL"></value>
-      <value component="OCN"></value>
-      <value component="WAV"></value>
-      <value component="GLC"></value>
-      <value component="ICE"></value>
-      <value component="ROF"></value>
-      <value component="LND"></value>
-      <value component="ESP"></value>
+      <value compclass="ATM"></value>
+      <value compclass="CPL"></value>
+      <value compclass="OCN"></value>
+      <value compclass="WAV"></value>
+      <value compclass="GLC"></value>
+      <value compclass="ICE"></value>
+      <value compclass="ROF"></value>
+      <value compclass="LND"></value>
+      <value compclass="ESP"></value>
     </values>
   </entry>
 
@@ -2273,15 +2273,15 @@
     <file>env_run.xml</file>
     <desc>pio root processor relative to component root</desc>
     <values>
-      <value component="ATM">1</value>
-      <value component="CPL">1</value>
-      <value component="OCN">1</value>
-      <value component="WAV">1</value>
-      <value component="GLC">1</value>
-      <value component="ICE">1</value>
-      <value component="ROF">1</value>
-      <value component="LND">1</value>
-      <value component="ESP">1</value>
+      <value compclass="ATM">1</value>
+      <value compclass="CPL">1</value>
+      <value compclass="OCN">1</value>
+      <value compclass="WAV">1</value>
+      <value compclass="GLC">1</value>
+      <value compclass="ICE">1</value>
+      <value compclass="ROF">1</value>
+      <value compclass="LND">1</value>
+      <value compclass="ESP">1</value>
     </values>
   </entry>
 
@@ -2294,15 +2294,15 @@
       number of tasks
     </desc>
     <values>
-      <value component="ATM">-99</value>
-      <value component="CPL">-99</value>
-      <value component="OCN">-99</value>
-      <value component="WAV">-99</value>
-      <value component="GLC">-99</value>
-      <value component="ICE">-99</value>
-      <value component="ROF">-99</value>
-      <value component="LND">-99</value>
-      <value component="ESP">-99</value>
+      <value compclass="ATM">-99</value>
+      <value compclass="CPL">-99</value>
+      <value compclass="OCN">-99</value>
+      <value compclass="WAV">-99</value>
+      <value compclass="GLC">-99</value>
+      <value compclass="ICE">-99</value>
+      <value compclass="ROF">-99</value>
+      <value compclass="LND">-99</value>
+      <value compclass="ESP">-99</value>
     </values>
   </entry>
 

--- a/src/externals/pio2/src/clib/bget.c
+++ b/src/externals/pio2/src/clib/bget.c
@@ -1021,7 +1021,7 @@ void *buf;
         b->ql.blink->ql.flink = b->ql.flink;
         b->ql.flink->ql.blink = b->ql.blink;
         //      printf("%s %d calling direct release for %x\n",__FILE__,__LINE__,b);
-//        (*relfcn)(b);
+        (*relfcn)(b);
         //      printf("%s %d completed direct release \n",__FILE__,__LINE__);
 #ifdef BufStats
         numprel++;                    /* Nr of expansion block releases */

--- a/src/externals/pio2/src/clib/bget.c
+++ b/src/externals/pio2/src/clib/bget.c
@@ -1021,7 +1021,7 @@ void *buf;
         b->ql.blink->ql.flink = b->ql.flink;
         b->ql.flink->ql.blink = b->ql.blink;
         //      printf("%s %d calling direct release for %x\n",__FILE__,__LINE__,b);
-        (*relfcn)(b);
+//        (*relfcn)(b);
         //      printf("%s %d completed direct release \n",__FILE__,__LINE__);
 #ifdef BufStats
         numprel++;                    /* Nr of expansion block releases */


### PR DESCRIPTION
This is a cleanup of the compvar implementation.   There was a confusion between component attributes which represented components (cam, datm, etc) vs those which represented component classes (ATM, LND, etc).  I've renamed the attributes associated with component classes to be compclass instead of component.   This change also allowed me to get rid of the explicit list of compvars in env_mach_pes.py and env_run.py

Test suite:  scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes:

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
