### PR TITLE
Adjustments for new CAM-SE dycore

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -620,18 +620,18 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16_g37">
+    <model_grid alias="ne16_g17">
       <grid name="atm">ne16np4</grid>
       <grid name="lnd">ne16np4</grid>
-      <grid name="ocnice">gx3v7</grid>
-      <mask>gx3v7</mask>
+      <grid name="ocnice">gx1v7</grid>
+      <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16_ne16_mg37" not_compset="_POP">
+    <model_grid alias="ne16_ne16_mg17" not_compset="_POP">
       <grid name="atm">ne16np4</grid>
       <grid name="lnd">ne16np4</grid>
       <grid name="ocnice">ne16np4</grid>
-      <mask>gx3v7</mask>
+      <mask>gx1v7</mask>
     </model_grid>
 
     <model_grid alias="ne30_g16">
@@ -1139,8 +1139,8 @@
 
     <domain name="ne16np4">
       <nx>13826</nx> <ny>1</ny>
-      <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne16np4_gx3v7.120406.nc</file>
-      <file grid="ocnice" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne16np4_gx3v7.121113.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne16np4_gx1v7.171018.nc</file>
+      <file grid="ocnice" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne16np4_gx1v7.171018.nc</file>
       <desc>ne16np4 is Spectral Elem 2-deg grid:</desc>
       <support>For low resolution spectral element grid testing</support>
     </domain>
@@ -1479,12 +1479,12 @@
       <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_gx3v7_to_fv4x5_aave_da_091218.nc</map>
     </gridmap>
 
-    <gridmap atm_grid="ne16np4" ocn_grid="gx3v7">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gx3v7_aave.120406.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gx3v7_aave.120406.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gx3v7_aave.120406.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx3v7/map_gx3v7_TO_ne16np4_aave.120406.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx3v7/map_gx3v7_TO_ne16np4_aave.120406.nc</map>
+    <gridmap atm_grid="ne16np4" ocn_grid="gx1v7">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gx1v7_aave.171018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gx1v7_aave.171018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gx1v7_aave.171018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne16np4_aave.171018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne16np4_aave.171018.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="gx1v6">

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -182,13 +182,13 @@
       <value compset=".+" grid="a%ne60np4">96</value>
       <value compset=".+" grid="a%ne60np4.pg3">96</value>
       <value compset=".+" grid="a%ne60np4.pg4">96</value>
-      <value compset=".+" grid="a%ne120np4">96</value>
-      <value compset=".+" grid="a%ne120np4.pg2">96</value>
-      <value compset=".+" grid="a%ne120np4.pg3">96</value>
-      <value compset=".+" grid="a%ne120np4.pg4">96</value>
-      <value compset=".+" grid="a%ne240np4">144</value>
-      <value compset=".+" grid="a%ne240np4.pg2">144</value>
-      <value compset=".+" grid="a%ne240np4.pg3">144</value>
+      <value compset=".+" grid="a%ne120np4">192</value>
+      <value compset=".+" grid="a%ne120np4.pg2">192</value>
+      <value compset=".+" grid="a%ne120np4.pg3">192</value>
+      <value compset=".+" grid="a%ne120np4.pg4">192</value>
+      <value compset=".+" grid="a%ne240np4">384</value>
+      <value compset=".+" grid="a%ne240np4.pg2">384</value>
+      <value compset=".+" grid="a%ne240np4.pg3">384</value>
       <value compset=".+" grid="a%ne0np4CONUS.ne30x8">144</value>
       <value compset=".+" grid="a%T42">72</value>
       <value compset=".+" grid="a%T85">144</value>


### PR DESCRIPTION
Changed ne16np4 resolutions so that all now use mg17 mask for consistency.
Updated default coupling intervals for high-resolution CAM-SE simulations based on recent testing with new SE dycore.

Test suite: scripts_regression_tests.py on Cheyenne
     Test run with ne16_ne16_mg17 alias (compset QPC6).
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1977 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
