### PR TITLE
Resolve compset issue

### DIFF
--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -255,7 +255,7 @@
     <type>char</type>
     <values>
       <value>$CIMEROOT/config/cesm/config_archive.xml</value>
-      <value component="cpl"      >$COMP_ROOT_DIR_CPL/cime_config/config_archive.xml</value>
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_archive.xml</value>
       <!-- data model components -->
       <value component="drof">$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
       <value component="datm">$COMP_ROOT_DIR_ATM/cime_config/config_archive.xml</value>

--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -88,10 +88,10 @@
   <entry id="COMP_ROOT_DIR_ATM">
     <type>char</type>
     <values>
-      <value component="cam"      >$SRCROOT/components/cam/</value>
       <value component="datm"      >$CIMEROOT/src/components/data_comps/datm</value>
       <value component="satm"      >$CIMEROOT/src/components/stub_comps/satm</value>
       <value component="xatm"      >$CIMEROOT/src/components/xcpl_comps/xatm</value>
+      <value component="cam"      >$SRCROOT/components/cam/</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -103,7 +103,7 @@
     <type>char</type>
     <values>
       <value >$CIMEROOT/src/drivers/mct</value>
-      <value component="mct">$CIMEROOT/src/drivers/mct</value>
+      <value component="drv">$CIMEROOT/src/drivers/mct</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -356,8 +356,6 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="modelio" >$COMP_ROOT_DIR_CPL/cime_config/namelist_definition_modelio.xml</value>
-      <value component="drv_flds">$COMP_ROOT_DIR_CPL/cime_config/namelist_definition_drv_flds.xml</value>
       <value component="drv"     >$COMP_ROOT_DIR_CPL/cime_config/namelist_definition_drv.xml</value>
       <!-- data model components -->
       <value component="drof">$CIMEROOT/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml</value>

--- a/scripts/lib/CIME/XML/archive.py
+++ b/scripts/lib/CIME/XML/archive.py
@@ -31,8 +31,8 @@ class Archive(GenericXML):
 
 
         model = get_model()
-        if 'cpl' not in components:
-            components.append('cpl')
+        if 'drv' not in components:
+            components.append('drv')
         if 'dart' not in components and model == 'cesm':
             components.append('dart')
 
@@ -55,4 +55,3 @@ class Archive(GenericXML):
                 logger.debug("adding archive spec for {}".format(comp))
                 components_node.append(specs)
         env_archive.add_child(components_node)
-

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -422,6 +422,16 @@ class EntryID(GenericXML):
                                                 xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
         return xmldiffs
 
+    def overwrite_existing_entries(self):
+        # if there
+        for node in self.get_nodes("entry"):
+            vid = node.get("id")
+            samenodes = self.get_nodes_by_id(vid)
+            if len(samenodes) > 1:
+                expect(len(samenodes) == 2, "Too many matchs for id {} in file {}".format(vid, self.filename))
+                logger.debug("Overwriting node {}".format(vid))
+                self.root.remove(samenodes[0])
+
     def __iter__(self):
         for node in self.get_nodes("entry"):
             vid = node.get("id")

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -423,7 +423,7 @@ class EntryID(GenericXML):
         return xmldiffs
 
     def overwrite_existing_entries(self):
-        # if there
+        # if there exist two nodes with the same id delete the first one.
         for node in self.get_nodes("entry"):
             vid = node.get("id")
             samenodes = self.get_nodes_by_id(vid)

--- a/scripts/lib/CIME/XML/files.py
+++ b/scripts/lib/CIME/XML/files.py
@@ -28,13 +28,7 @@ class Files(EntryID):
         # .config_file.xml at the top level may overwrite COMP_ROOT_DIR_ nodes in config_files
         if os.path.isfile(config_files_override):
             self.read(config_files_override)
-            for vid in ("COMP_ROOT_DIR_LND", "COMP_ROOT_DIR_ATM", "COMP_ROOT_DIR_ICE",
-                        "COMP_ROOT_DIR_OCN", "COMP_ROOT_DIR_GLC", "COMP_ROOT_DIR_RTM"):
-                nodes = self.get_nodes_by_id(vid)
-                if len(nodes) > 1:
-                    self.root.remove(nodes[0])
-
-
+            self.overwrite_existing_entries()
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None):
         value = super(Files, self).get_value(vid, attribute=attribute, resolved=False, subgroup=subgroup)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -430,9 +430,6 @@ class Case(object):
         """
         science_support = []
         compset_alias = None
-
-
-
         components = files.get_components("COMPSETS_SPEC_FILE")
         logger.debug(" Possible components for COMPSETS_SPEC_FILE are {}".format(components))
 
@@ -632,7 +629,6 @@ class Case(object):
         self.clean_up_lookups(allow_undefined=True)
         # loop over all elements of both component_classes and components - and get config_component_file for
         # for each component
-        #        self.set_comp_classes(drv_comp.get_valid_model_components())
 
         if len(self._component_classes) > len(self._components):
             self._components.append('sesp')

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -433,40 +433,25 @@ class Case(object):
         components = files.get_components("COMPSETS_SPEC_FILE")
         logger.debug(" Possible components for COMPSETS_SPEC_FILE are {}".format(components))
 
-        cpl_root_dir = files.get_value("COMP_ROOT_DIR_CPL", {"component":"drv"},resolved=False)
-        if cpl_root_dir is not None:
-            files.set_value("COMP_ROOT_DIR_CPL", cpl_root_dir)
-        drv_config_file = files.get_value("CONFIG_CPL_FILE")
-        expect(os.path.isfile(drv_config_file), "Could not find CONFIG_CPL_FILE {}".format(drv_config_file))
-        drv_comp = Component(drv_config_file, "CPL")
-        self.set_comp_classes(drv_comp.get_valid_model_components())
-
         # Loop through all of the files listed in COMPSETS_SPEC_FILE and find the file
         # that has a match for either the alias or the longname in that order
-        for comp_class in self._component_classes:
-            if comp_class == "CPL":
-                continue
-            comp_root_dir_var  = "COMP_ROOT_DIR_{}".format(comp_class)
-            for component in components:
-                comp_root_dir = files.get_value(comp_root_dir_var,{"component":component},
-                                                resolved=False)
-                if comp_root_dir is not None:
-                    files.set_value(comp_root_dir_var, comp_root_dir)
+        for component in components:
 
-                # Determine the compsets file for this component
-                compsets_filename = files.get_value("COMPSETS_SPEC_FILE", {"component":component})
-                # If the file exists, read it and see if there is a match for the compset alias or longname
-                if (os.path.isfile(compsets_filename)):
-                    compsets = Compsets(compsets_filename)
-                    match, compset_alias, science_support = compsets.get_compset_match(name=compset_name)
-                    if match is not None:
-                        self._compsetsfile = compsets_filename
-                        self._compsetname = match
-                        self.set_lookup_value("COMPSETS_SPEC_FILE" ,
+            # Determine the compsets file for this component
+            compsets_filename = files.get_value("COMPSETS_SPEC_FILE", {"component":component})
+
+            # If the file exists, read it and see if there is a match for the compset alias or longname
+            if (os.path.isfile(compsets_filename)):
+                compsets = Compsets(compsets_filename)
+                match, compset_alias, science_support = compsets.get_compset_match(name=compset_name)
+                if match is not None:
+                    self._compsetsfile = compsets_filename
+                    self._compsetname = match
+                    self.set_lookup_value("COMPSETS_SPEC_FILE" ,
                                    files.get_value("COMPSETS_SPEC_FILE", {"component":component}, resolved=False))
-                        logger.info("Compset longname is {}".format(match))
-                        logger.info("Compset specification file is {}".format(compsets_filename))
-                        return compset_alias, science_support
+                    logger.info("Compset longname is {}".format(match))
+                    logger.info("Compset specification file is {}".format(compsets_filename))
+                    return compset_alias, science_support
 
         if compset_alias is None:
             logger.info("Did not find an alias or longname compset match for {} ".format(compset_name))
@@ -629,6 +614,7 @@ class Case(object):
         self.clean_up_lookups(allow_undefined=True)
         # loop over all elements of both component_classes and components - and get config_component_file for
         # for each component
+        self.set_comp_classes(drv_comp.get_valid_model_components())
 
         if len(self._component_classes) > len(self._components):
             self._components.append('sesp')
@@ -636,13 +622,13 @@ class Case(object):
         for i in range(1,len(self._component_classes)):
             comp_class = self._component_classes[i]
             comp_name  = self._components[i-1]
+            root_dir_node_name = 'COMP_ROOT_DIR_' + comp_class
             node_name = 'CONFIG_' + comp_class + '_FILE'
-            root_dir_var  = "COMP_ROOT_DIR_{}".format(comp_class)
-            comp_root_dir = files.get_value(root_dir_var, {"component":comp_name}, resolved=False)
+            comp_root_dir = files.get_value(root_dir_node_name, {"component":comp_name}, resolved=False)
             if comp_root_dir is not None:
                 # the set_value in files is needed for the archiver setup below
-                files.set_value(root_dir_var, comp_root_dir)
-                self.set_value(root_dir_var, comp_root_dir)
+                files.set_value(root_dir_node_name, comp_root_dir)
+                self.set_value(root_dir_node_name, comp_root_dir)
                 compatt = None
             else:
                 compatt = {"component":comp_name}

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -180,6 +180,7 @@ def _archive_history_files(case, archive, archive_entry,
     if not os.path.exists(archive_histdir):
         os.makedirs(archive_histdir)
         logger.debug("created directory {}".format(archive_histdir))
+    # the compname is drv but the files are named cpl
     if compname == 'drv':
         compname = 'cpl'
 
@@ -321,6 +322,7 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
         last_restart_file_fn = shutil.copy
         last_restart_file_fn_msg = "copying"
 
+    # the compname is drv but the files are named cpl
     if compname == 'drv':
         compname = 'cpl'
 

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -80,7 +80,7 @@ def _get_component_archive_entries(case, archive):
     case's compset components.
     """
     compset_comps = case.get_compset_components()
-    compset_comps.append('cpl')
+    compset_comps.append('drv')
     compset_comps.append('dart')
 
     for compname in compset_comps:
@@ -180,6 +180,8 @@ def _archive_history_files(case, archive, archive_entry,
     if not os.path.exists(archive_histdir):
         os.makedirs(archive_histdir)
         logger.debug("created directory {}".format(archive_histdir))
+    if compname == 'drv':
+        compname = 'cpl'
 
     # determine ninst and ninst_string
     ninst, ninst_string = _get_ninst_info(case, compclass)
@@ -319,6 +321,9 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
         last_restart_file_fn = shutil.copy
         last_restart_file_fn_msg = "copying"
 
+    if compname == 'drv':
+        compname = 'cpl'
+
     # get file_extension suffixes
     for suffix in archive.get_rest_file_extensions(archive_entry):
         for i in range(ninst):
@@ -337,7 +342,7 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
                     pattern = suffix + datename
                 pfile = re.compile(pattern)
                 restfiles = [f for f in files if pfile.search(f)]
-
+            logger.debug("Pattern is {} restfiles {}".format(pattern, restfiles))
             for restfile in restfiles:
                 restfile = os.path.basename(restfile)
 

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -274,7 +274,8 @@ def write_drv_flds_in_file(case, nmlgen, files):
 
         # Now create drv_flds_in
         config = {}
-        definition_file = [files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv_flds"})]
+        definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"}))
+        definition_file = [os.path.join(definition_dir, "namelist_definition_drv_flds.xml")]
         nmlgen = NamelistGenerator(case, definition_file, files=files)
         skip_entry_loop = True
         nmlgen.init_defaults(infiles, config, skip_entry_loop=skip_entry_loop)
@@ -296,7 +297,8 @@ def _create_component_modelio_namelists(case, files):
 
     # will need to create a new namelist generator
     infiles = []
-    definition_file = [files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"modelio"})]
+    definition_dir = os.path.dirname(files.get_value("NAMELIST_DEFINITION_FILE", attribute={"component":"drv"}))
+    definition_file = [os.path.join(definition_dir, "namelist_definition_modelio.xml")]
 
     confdir = os.path.join(case.get_value("CASEBUILD"), "cplconf")
     lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")

--- a/src/drivers/mct/cime_config/config_archive.xml
+++ b/src/drivers/mct/cime_config/config_archive.xml
@@ -1,5 +1,5 @@
 <components version="2.0">
-  <comp_archive_spec compname="cpl" compclass="cpl">
+  <comp_archive_spec compname="drv" compclass="cpl">
     <rest_file_extension>\.r\..*</rest_file_extension>
     <hist_file_extension>\.h.*.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>


### PR DESCRIPTION
A subtle bug fix - the discovery of compsets needs to have information about available components so that it can look in the correct cime_config directories for config_compsets.xml files. 

Test suite: scripts_regression_tests.py + cesm F cases
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
