### PR TITLE
Updates for testreporter and remove AWAV from testlist

### DIFF
--- a/scripts/Tools/testreporter.py
+++ b/scripts/Tools/testreporter.py
@@ -125,75 +125,77 @@ def get_testreporter_xml(testroot, testid, tagname, testtype):
                 test_status['BASELINE']=line[0:4]
             if "TPUTCOMP" in line:
                 test_status['TPUTCOMP']=line[0:4]
+                if "FAIL PFS" in line:
+                    test_status['STATUS']="FAIL"
             if "INIT" in line:
                 test_status['INIT']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['STATUS']="SFAIL"
                     test_status['COMMENT']+="INIT fail! "
                     break
             if "CREATE_NEWCASE" in line:
                 test_status['CREATE_NEWCASE']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['STATUS']="SFAIL"
                     test_status['COMMENT']+="CREATE_NEWCASE fail! "
                     break
             if "XML" in line:
                 test_status['XML']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['STATUS']="SFAIL"
                     test_status['COMMENT']+="XML fail! "
                     break
             if "SETUP" in line:
                 test_status['SETUP']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['STATUS']="SFAIL"
                     test_status['COMMENT']+="SETUP fail! "
                     break
             if "SHAREDLIB_BUILD" in line:
                 test_status['SHAREDLIB_BUILD']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['STATUS']="CFAIL"
                     test_status['COMMENT']+="SHAREDLIB_BUILD fail! "
                     break
             if "MODEL_BUILD" in line:
                 test_status['MODEL_BUILD']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['STATUS']="CFAIL"
                     test_status['COMMENT']+="MODEL_BUILD fail! "
                     break
             if "SUBMIT" in line:
                 test_status['STATUS']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['COMMENT']+="SUBMIT fail! "
                     break
             if "RUN" in line:
                 test_status['STATUS']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['COMMENT']+="RUN fail! "
                     break
             if "COMPARE_base_rest" in line:
                 test_status['STATUS']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['COMMENT']+="Restart fail! "
                     break
             if "COMPARE_base_hybrid" in line:
                 test_status['STATUS']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['COMMENT']+="Hybrid fail! "
                     break
             if "COMPARE_base_multiinst" in line:
                 test_status['STATUS']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['COMMENT']+="Multi instance fail! "
                     break
             if "COMPARE_base_test" in line:
                 test_status['STATUS']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['COMMENT']+="Base test fail! "
                     break
             if "COMPARE_base_single_thread" in line:
                 test_status['STATUS']=line[0:4]
-                if line[0:4] == "FAIL":
+                if line[0:4] in ("FAIL","PEND"):
                     test_status['COMMENT']+="Thread test fail! "
                     break
 

--- a/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -614,15 +614,6 @@
       </machine>
     </machines>
   </test>
-  <test name="SMS_Ld3" grid="ww3a_ww3a" compset="AWAV">
-    <machines>
-      <machine name="hobart" compiler="pgi" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-    </machines>
-  </test>
   <test name="PRE" grid="f09_f09" compset="ADESP">
     <machines>
       <machine name="hobart" compiler="nag" category="pauseresume"/>


### PR DESCRIPTION
Fix testreporter so it'll report a failed PFS tests to the database.
Testreporter also handles the PEND status from TestStatus correctly now, 
it was being skipping it before.
Removed AWAV from the testlist.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #1924

User interface changes?:

Update gh-pages html (Y/N)?:

Code review:

[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
