### PR TITLE
Update NCAR machines to use Intel version 17

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1062,6 +1062,7 @@ using a fortran linker.
     <append MPILIB="mpich2"> -Wl,-rpath ${PAPI_LIB} -L${PAPI_LIB} -lpapi</append>
   </SLIBS>
   <TRILINOS_PATH MPILIB="mpich2">$ENV{TRILINOS_PATH}</TRILINOS_PATH>
+  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
 </compiler>
 
 <compiler MACH="yellowstone" COMPILER="pgi">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1891,7 +1891,7 @@
 	<command name="load">git</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/15.0.3</command>
+	<command name="load">intel/17.0.1</command>
 	<command name="load">mkl/11.1.2</command>
 	<command name="load">trilinos/11.10.2</command>
 	<command name="load">esmf</command>


### PR DESCRIPTION
**NB: NOT READY TO MERGE, see comment in discussion**
Update Yellowstone and Hobart to use Intel 17.

Test suite:  scripts_regression_tests.py on Yellowstone
Test baseline: NA
Test namelist changes: NA
Test status: roundoff

Fixes #1982 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
