### PR TITLE
Fix COST_PES and TOTALPES for titan (aprun)

### DIFF
--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -17,7 +17,7 @@ class EnvMachPes(EnvBase):
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_pes.xsd")
         EnvBase.__init__(self, case_root, infile, schema=schema)
 
-    def get_value(self, vid, attribute=None, resolved=True, subgroup=None, MAX_MPITASKS_PER_NODE=None): # pylint: disable=arguments-differ
+    def get_value(self, vid, attribute=None, resolved=True, subgroup=None, max_mpitasks_per_node=None): # pylint: disable=arguments-differ
         # Special variable NINST_MAX is used to determine the number of
         # drivers in multi-driver mode.
         if vid == "NINST_MAX":
@@ -30,10 +30,10 @@ class EnvMachPes(EnvBase):
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
 
         if "NTASKS" in vid or "ROOTPE" in vid:
-            if MAX_MPITASKS_PER_NODE is None:
-                MAX_MPITASKS_PER_NODE = self.get_value("MAX_MPITASKS_PER_NODE")
+            if max_mpitasks_per_node is None:
+                max_mpitasks_per_node = self.get_value("MAX_MPITASKS_PER_NODE")
             if value is not None and value < 0:
-                value = -1*value*MAX_MPITASKS_PER_NODE
+                value = -1*value*max_mpitasks_per_node
 
         return value
 
@@ -64,21 +64,6 @@ class EnvMachPes(EnvBase):
             if threads > max_threads:
                 max_threads = threads
         return max_threads
-
-    def get_cost_pes(self, totaltasks, max_thread_count, machine=None):
-        """
-        figure out the value of COST_PES which is the pe value used to estimate model cost
-        """
-        expect(totaltasks > 0,"totaltasks > 0 expected totaltasks = {}".format(totaltasks))
-        pespn = self.get_value("MAX_MPITASKS_PER_NODE")
-        num_nodes, spare_nodes = self.get_total_nodes(totaltasks, max_thread_count)
-        num_nodes += spare_nodes
-        # This is hardcoded because on yellowstone by default we
-        # run with 15 pes per node
-        # but pay for 16 pes per node.  See github issue #518
-        if machine is not None and machine == "yellowstone":
-            pespn = 16
-        return num_nodes * pespn
 
     def get_total_tasks(self, comp_classes):
         total_tasks = 0

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -298,13 +298,13 @@ class Machines(GenericXML):
             os_  = machine.find("OS")
             compilers = machine.find("COMPILERS")
             max_tasks_per_node = machine.find("MAX_TASKS_PER_NODE")
-            MAX_MPITASKS_PER_NODE = machine.find("MAX_MPITASKS_PER_NODE")
+            max_mpitasks_per_node = machine.find("MAX_MPITASKS_PER_NODE")
 
             print( "  {} : {} ".format(name , desc.text))
             print( "      os             ", os_.text)
             print( "      compilers      ",compilers.text)
-            if MAX_MPITASKS_PER_NODE is not None:
-                print("      pes/node       ",MAX_MPITASKS_PER_NODE.text)
+            if max_mpitasks_per_node is not None:
+                print("      pes/node       ",max_mpitasks_per_node.text)
             if max_tasks_per_node is not None:
                 print("      max_tasks/node ",max_tasks_per_node.text)
 
@@ -318,10 +318,10 @@ class Machines(GenericXML):
             os_  = machine.find("OS")
             compilers = machine.find("COMPILERS")
             max_tasks_per_node = machine.find("MAX_TASKS_PER_NODE")
-            MAX_MPITASKS_PER_NODE = machine.find("MAX_MPITASKS_PER_NODE")
+            max_mpitasks_per_node = machine.find("MAX_MPITASKS_PER_NODE")
             ppn = ''
-            if MAX_MPITASKS_PER_NODE is not None:
-                ppn = MAX_MPITASKS_PER_NODE.text
+            if max_mpitasks_per_node is not None:
+                ppn = max_mpitasks_per_node.text
 
             max_tasks_pn = ''
             if max_tasks_per_node is not None:

--- a/scripts/lib/CIME/aprun.py
+++ b/scripts/lib/CIME/aprun.py
@@ -30,17 +30,17 @@ def _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids,
     >>> machine = "titan"
     >>> run_exe = "acme.exe"
     >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
-    (' -S 4 -n 680 -N 8 -d 2 acme.exe : -S 2 -n 128 -N 4 -d 4 acme.exe ', 117)
+    (' -S 4 -n 680 -N 8 -d 2 acme.exe : -S 2 -n 128 -N 4 -d 4 acme.exe ', 117, 128, 4, 4)
     >>> compiler = "intel"
     >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
-    (' -S 4 -cc numa_node -n 680 -N 8 -d 2 acme.exe : -S 2 -cc numa_node -n 128 -N 4 -d 4 acme.exe ', 117)
+    (' -S 4 -cc numa_node -n 680 -N 8 -d 2 acme.exe : -S 2 -cc numa_node -n 128 -N 4 -d 4 acme.exe ', 117, 128, 4, 4)
 
     >>> ntasks = [64, 64, 64, 64, 64, 64, 64, 64, 1]
     >>> nthreads = [1, 1, 1, 1, 1, 1, 1, 1, 1]
     >>> rootpes = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     >>> pstrids = [1, 1, 1, 1, 1, 1, 1, 1, 1]
     >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
-    (' -S 8 -cc numa_node -n 64 -N 16 -d 1 acme.exe ', 4)
+    (' -S 8 -cc numa_node -n 64 -N 16 -d 1 acme.exe ', 4, 64, 16, 1)
     """
     max_tasks_per_node = 1 if max_tasks_per_node < 1 else max_tasks_per_node
 

--- a/scripts/lib/CIME/aprun.py
+++ b/scripts/lib/CIME/aprun.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 ###############################################################################
 def _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids,
-                                 max_tasks_per_node, MAX_MPITASKS_PER_NODE,
+                                 max_tasks_per_node, max_mpitasks_per_node,
                                  pio_numtasks, pio_async_interface,
                                  compiler, machine, run_exe):
 ###############################################################################
@@ -23,23 +23,23 @@ def _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids,
     >>> rootpes = [0, 0, 512, 0, 680, 512, 512, 0, 0]
     >>> pstrids = [1, 1, 1, 1, 1, 1, 1, 1, 1]
     >>> max_tasks_per_node = 16
-    >>> MAX_MPITASKS_PER_NODE = 16
+    >>> max_mpitasks_per_node = 16
     >>> pio_numtasks = -1
     >>> pio_async_interface = False
     >>> compiler = "pgi"
     >>> machine = "titan"
     >>> run_exe = "acme.exe"
-    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, MAX_MPITASKS_PER_NODE, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
+    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
     (' -S 4 -n 680 -N 8 -d 2 acme.exe : -S 2 -n 128 -N 4 -d 4 acme.exe ', 117)
     >>> compiler = "intel"
-    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, MAX_MPITASKS_PER_NODE, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
+    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
     (' -S 4 -cc numa_node -n 680 -N 8 -d 2 acme.exe : -S 2 -cc numa_node -n 128 -N 4 -d 4 acme.exe ', 117)
 
     >>> ntasks = [64, 64, 64, 64, 64, 64, 64, 64, 1]
     >>> nthreads = [1, 1, 1, 1, 1, 1, 1, 1, 1]
     >>> rootpes = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     >>> pstrids = [1, 1, 1, 1, 1, 1, 1, 1, 1]
-    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, MAX_MPITASKS_PER_NODE, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
+    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
     (' -S 8 -cc numa_node -n 64 -N 16 -d 1 acme.exe ', 4)
     """
     max_tasks_per_node = 1 if max_tasks_per_node < 1 else max_tasks_per_node
@@ -51,7 +51,7 @@ def _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids,
 
     # Check if we need to add pio's tasks to the total task count
     if pio_async_interface:
-        total_tasks += pio_numtasks if pio_numtasks > 0 else MAX_MPITASKS_PER_NODE
+        total_tasks += pio_numtasks if pio_numtasks > 0 else max_mpitasks_per_node
 
     # Compute max threads for each mpi task
     maxt = [0] * total_tasks
@@ -74,7 +74,7 @@ def _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids,
         0, 1, maxt[0], maxt[0], 0, ""
     for c1 in range(1, total_tasks):
         if maxt[c1] != thread_count:
-            tasks_per_node = min(MAX_MPITASKS_PER_NODE, int(max_tasks_per_node / thread_count))
+            tasks_per_node = min(max_mpitasks_per_node, int(max_tasks_per_node / thread_count))
 
             tasks_per_node = min(task_count, tasks_per_node)
 
@@ -98,8 +98,8 @@ def _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids,
         else:
             task_count += 1
 
-    if MAX_MPITASKS_PER_NODE > 0:
-        tasks_per_node = min(MAX_MPITASKS_PER_NODE, int(max_tasks_per_node / thread_count))
+    if max_mpitasks_per_node > 0:
+        tasks_per_node = min(max_mpitasks_per_node, int(max_tasks_per_node / thread_count))
     else:
         tasks_per_node = max_tasks_per_node / thread_count
 
@@ -117,7 +117,7 @@ def _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids,
 
     aprun_args += " -n {:d} -N {:d} -d {:d} {} ".format(task_count, tasks_per_node, thread_count, run_exe)
 
-    return aprun_args, total_node_count
+    return aprun_args, total_node_count, task_count, tasks_per_node, thread_count
 
 ###############################################################################
 def get_aprun_cmd_for_case(case, run_exe):

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -160,16 +160,12 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 
             case.flush()
             check_lockedfiles(case)
-            env_mach_pes = case.get_env("mach_pes")
-            pestot = env_mach_pes.get_total_tasks(models)
-            logger.debug("at update TOTALPES = {}".format(pestot))
-            case.set_value("TOTALPES", pestot)
-            thread_count = env_mach_pes.get_max_thread_count(models)
-            cost_pes = env_mach_pes.get_cost_pes(pestot, thread_count, machine=case.get_value("MACH"))
-            case.set_value("COST_PES", cost_pes)
 
             case.initialize_derived_attributes()
 
+            cost_per_node = 16 if case.get_value("MACH") == "yellowstone" else case.get_value("MAX_MPITASKS_PER_NODE")
+            case.set_value("COST_PES", (case.num_nodes - case.spare_nodes) * cost_per_node)
+            case.set_value("TOTALPES", case.total_tasks)
             case.set_value("SMP_PRESENT", case.get_build_threaded())
 
             # create batch files

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -164,7 +164,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             case.initialize_derived_attributes()
 
             cost_per_node = 16 if case.get_value("MACH") == "yellowstone" else case.get_value("MAX_MPITASKS_PER_NODE")
-            case.set_value("COST_PES", (case.num_nodes - case.spare_nodes) * cost_per_node)
+            case.set_value("COST_PES", case.num_nodes * cost_per_node)
             case.set_value("TOTALPES", case.total_tasks)
             case.set_value("SMP_PRESENT", case.get_build_threaded())
 

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -140,8 +140,8 @@ class _TimingParser:
         stop_n = self.case.get_value("STOP_N")
         cost_pes = self.case.get_value("COST_PES")
         totalpes = self.case.get_value("TOTALPES")
-        MAX_MPITASKS_PER_NODE = self.case.get_value("MAX_MPITASKS_PER_NODE")
-        smt_factor = max(1,int(self.case.get_value("MAX_TASKS_PER_NODE") / MAX_MPITASKS_PER_NODE))
+        max_mpitasks_per_node = self.case.get_value("MAX_MPITASKS_PER_NODE")
+        smt_factor = max(1,int(self.case.get_value("MAX_TASKS_PER_NODE") / max_mpitasks_per_node))
 
         if cost_pes > 0:
             pecost = cost_pes
@@ -309,7 +309,7 @@ class _TimingParser:
 
         self.write("\n")
         self.write("  total pes active           : {} \n".format(totalpes*maxthrds*smt_factor ))
-        self.write("  pes per node               : {} \n".format(MAX_MPITASKS_PER_NODE))
+        self.write("  pes per node               : {} \n".format(max_mpitasks_per_node))
         self.write("  pe count for cost estimate : {} \n".format(pecost))
         self.write("\n")
 

--- a/scripts/query_config
+++ b/scripts/query_config
@@ -295,7 +295,7 @@ class Machines(CIME.XML.machines.Machines):
                 os_  = machine.find("OS")
                 compilers = machine.find("COMPILERS")
                 max_tasks_per_node = machine.find("MAX_TASKS_PER_NODE")
-                MAX_MPITASKS_PER_NODE = machine.find("MAX_MPITASKS_PER_NODE")
+                max_mpitasks_per_node = machine.find("MAX_MPITASKS_PER_NODE")
 
                 current_machine = self.probe_machine_name(warn=False)
                 if not single_machine:
@@ -303,16 +303,16 @@ class Machines(CIME.XML.machines.Machines):
                     print("  {} : {} ".format(name, desc.text))
                     print("      os             ", os_.text)
                     print("      compilers      ",compilers.text)
-                    if MAX_MPITASKS_PER_NODE is not None:
-                        print("      pes/node       ",MAX_MPITASKS_PER_NODE.text)
+                    if max_mpitasks_per_node is not None:
+                        print("      pes/node       ",max_mpitasks_per_node.text)
                     if max_tasks_per_node is not None:
                         print("      max_tasks/node ",max_tasks_per_node.text)
                 elif single_machine and machine_name in name:
                     print("  {} : {} ".format(name, desc.text))
                     print("      os             ", os_.text)
                     print("      compilers      ",compilers.text)
-                    if MAX_MPITASKS_PER_NODE is not None:
-                        print("      pes/node       ",MAX_MPITASKS_PER_NODE.text)
+                    if max_mpitasks_per_node is not None:
+                        print("      pes/node       ",max_mpitasks_per_node.text)
                     if max_tasks_per_node is not None:
                         print("      max_tasks/node ",max_tasks_per_node.text)
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2047,7 +2047,7 @@
     <default_value>0</default_value>
     <group>mach_pes_last</group>
     <file>env_mach_pes.xml</file>
-    <desc>total number of tasks and threads (setup automatically - DO NOT EDIT)</desc>
+    <desc>total number of MPI tasks (setup automatically - DO NOT EDIT)</desc>
   </entry>
 
   <entry id="MAX_TASKS_PER_NODE">


### PR DESCRIPTION
COST_PES should not take spare nodes into consideration.

Most fields that get set in case.initialize_derived_attributes are impacted
by aprun.

Fix string search/replace that capitalized regular stack variables by mistake.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @worleyph 
