### PR TITLE
Add check for a batch system when testing user prerequisites

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1399,6 +1399,8 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_prereq(self):
     ###########################################################################
+        if not MACHINE.has_batch_system() or NO_BATCH:
+            self.skipTest("Skipping testing user prerequisites without batch systems")
         testcase_name = 'prereq_test'
         testdir = os.path.join(TEST_ROOT, testcase_name)
         if os.path.exists(testdir):


### PR DESCRIPTION
Adds a check to verify there is a batch system when testing setting user prerequisites.

Test suite: scripts_regression_tests.py --no-batch K_TestCimeCase B_CheckCode

Fixes #1994

Code review:  @jedwards4b 
