### PR TITLE
Only report mem and tput errors once.

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -424,7 +424,7 @@ class SystemTestsCommon(object):
                         if diff < tolerance and self._test_status.get_status(THROUGHPUT_PHASE) is None:
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)
                         elif self._test_status.get_status(THROUGHPUT_PHASE) != TEST_FAIL_STATUS:
-                            comment = "Error: Computation time increase > %f pct from baseline" % tolerance*100
+                            comment = "Error: Computation time increase > {:d} pct from baseline".format(int(tolerance*100))
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
                             append_testlog(comment)
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -404,12 +404,13 @@ class SystemTestsCommon(object):
                     blmem = 0 if blmem == [] else blmem[-1][1]
                     curmem = memlist[-1][1]
                     diff = (curmem-blmem)/blmem
-                    if(diff < 0.1):
+                    if diff < 0.1 and self._test_status.get_status(MEMCOMP_PHASE) is None:
                         self._test_status.set_status(MEMCOMP_PHASE, TEST_PASS_STATUS)
-                    else:
+                    elif self._test_status.get_status(MEMCOMP_PHASE) != TEST_FAIL_STATUS:
                         comment = "Error: Memory usage increase > 10% from baseline"
                         self._test_status.set_status(MEMCOMP_PHASE, TEST_FAIL_STATUS, comments=comment)
                         append_testlog(comment)
+
                     # compare throughput to baseline
                     current = self._get_throughput(cpllog)
                     baseline = self._get_throughput(baselog)
@@ -420,9 +421,9 @@ class SystemTestsCommon(object):
                         if tolerance is None:
                             tolerance = 0.25
                         expect(tolerance > 0.0, "Bad value for throughput tolerance in test")
-                        if diff < tolerance:
+                        if diff < tolerance and self._test_status.get_status(THROUGHPUT_PHASE) is None:
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)
-                        else:
+                        elif self._test_status.get_status(THROUGHPUT_PHASE) != TEST_FAIL_STATUS:
                             comment = "Error: Computation time increase > %f pct from baseline" % tolerance*100
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
                             append_testlog(comment)


### PR DESCRIPTION
Also, a PASS should never override an earlier failure.

Test suite: code_checker
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #1995 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
