### PR TITLE
Fix critical problems found during ACME/ESMCI integration

### DIFF
--- a/config/acme/config_files.xml
+++ b/config/acme/config_files.xml
@@ -124,7 +124,7 @@
     <type>char</type>
     <values>
       <value>$CIMEROOT/config/acme/config_archive.xml</value>
-      <value component="cpl"      >$CIMEROOT/src/drivers/mct/cime_config/config_archive.xml</value>
+      <value component="drv"      >$CIMEROOT/src/drivers/mct/cime_config/config_archive.xml</value>
       <!-- data model components -->
       <value component="drof">$CIMEROOT/src/components/data_comps/drof/cime_config/config_archive.xml</value>
       <value component="datm">$CIMEROOT/src/components/data_comps/datm/cime_config/config_archive.xml</value>

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -122,7 +122,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         # Set tasks to 1 if mpi-serial library
         if mpilib == "mpi-serial":
             for vid, value in case:
-                if vid.startswith("NTASKS_") and value != 1:
+                if vid.startswith("NTASKS") and value != 1:
                     case.set_value(vid, 1)
 
         # Check ninst.

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1496,10 +1496,10 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_force_pecount(self):
     ###########################################################################
-        self._create_test(["--no-build", "--force-procs=16", "--force-threads=8", "TESTRUNPASS_Mmpi-serial.f19_g16_rx1.A"], test_id=self._baseline_name)
+        self._create_test(["--no-build", "--force-procs=16", "--force-threads=8", "TESTRUNPASS.f19_g16_rx1.A"], test_id=self._baseline_name)
 
         casedir = os.path.join(self._testroot,
-                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_Mmpi-serial_P16x8.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
+                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_P16x8.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
         self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
 
         with Case(casedir, read_only=True) as case:

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1479,10 +1479,10 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_mpi_serial(self):
     ###########################################################################
-        self._create_test(["--no-build", "TESTRUNPASS_Mmpi-serial.f19_g16_rx1.A"], test_id=self._baseline_name)
+        self._create_test(["--no-build", "TESTRUNPASS_Mmpi-serial_P10.f19_g16_rx1.A"], test_id=self._baseline_name)
 
         casedir = os.path.join(self._testroot,
-                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_Mmpi-serial.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
+                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS_Mmpi-serial_P10.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
         self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
 
         with Case(casedir, read_only=True) as case:
@@ -1492,6 +1492,8 @@ class K_TestCimeCase(TestCreateTestCommon):
 
             # Serial cases should be using 1 task
             self.assertEqual(case.get_value("TOTALPES"), 1)
+
+            self.assertEqual(case.get_value("NTASKS_CPL"), 1)
 
     ###########################################################################
     def test_cime_case_force_pecount(self):


### PR DESCRIPTION
1) Was trying to find config_archive for cpl instead of drv
2) mpi-serial was not forcing all NTASKS_$COMP to be 1

Add regression test to catch (2)

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
