### PR TITLE
Handle the case where no points are mapped to marginal seas

### DIFF
--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/ncl/merge_mapping_files.ncl
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/ncl/merge_mapping_files.ncl
@@ -146,12 +146,12 @@ begin
 
   print("determining map_ms vals where REGION_MASK<0")
   sign_REGION_MASK_ms = sign_matlab(REGION_MASK_1d(map_in_ms_row-1))
-  if (any(sign_REGION_MASK_ms .lt. 0)) then
-    ind_vals_ms = ind(sign_REGION_MASK_ms .lt. 0)
-    n_s_subset_ms = dimsizes(ind_vals_ms)
-  else
+  ind_vals_ms = ind(sign_REGION_MASK_ms .lt. 0)
+  if (all(ismissing(ind_vals_ms))) then
     print("No source points mapped to marginal seas: output will just contain points mapped to open ocean")
     n_s_subset_ms = 0
+  else
+    n_s_subset_ms = dimsizes(ind_vals_ms)
   end if
 
   n_s_out = n_s_subset_oo + n_s_subset_ms

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/ncl/merge_mapping_files.ncl
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/ncl/merge_mapping_files.ncl
@@ -146,8 +146,13 @@ begin
 
   print("determining map_ms vals where REGION_MASK<0")
   sign_REGION_MASK_ms = sign_matlab(REGION_MASK_1d(map_in_ms_row-1))
-  ind_vals_ms = ind(sign_REGION_MASK_ms .lt. 0)
-  n_s_subset_ms = dimsizes(ind_vals_ms)
+  if (any(sign_REGION_MASK_ms .lt. 0)) then
+    ind_vals_ms = ind(sign_REGION_MASK_ms .lt. 0)
+    n_s_subset_ms = dimsizes(ind_vals_ms)
+  else
+    print("No source points mapped to marginal seas: output will just contain points mapped to open ocean")
+    n_s_subset_ms = 0
+  end if
 
   n_s_out = n_s_subset_oo + n_s_subset_ms
 
@@ -174,9 +179,11 @@ begin
   map_out_col(0:n_s_subset_oo-1) = (/ map_in_oo_col(ind_vals_oo) /)
   map_out_row(0:n_s_subset_oo-1) = (/ map_in_oo_row(ind_vals_oo) /)
 
-  map_out_S(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1)   = (/ map_in_ms_S(ind_vals_ms) /)
-  map_out_col(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1) = (/ map_in_ms_col(ind_vals_ms) /)
-  map_out_row(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1) = (/ map_in_ms_row(ind_vals_ms) /)
+  if (n_s_subset_ms .gt. 0) then
+    map_out_S(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1)   = (/ map_in_ms_S(ind_vals_ms) /)
+    map_out_col(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1) = (/ map_in_ms_col(ind_vals_ms) /)
+    map_out_row(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1) = (/ map_in_ms_row(ind_vals_ms) /)
+  end if
 
   print("writing merged map, " + MAP_OUT_FNAME)
   system("rm -f " + MAP_OUT_FNAME)


### PR DESCRIPTION
This case came up in mapping the regional Greenland grid to an ocean
grid. Without this fix in place, we got the following error:

```
fatal:Subscript out of range, error in subscript #0
fatal:An error occurred reading map_in_ms_S
fatal:["Execute.c":8640]:Execute: Error occurred at or near line 177
in file ncl/merge_mapping_files.ncl
```

Mike Levy gets most of the credit for this fix.

Test suite: Just ran the run_merge_mapping_files.sh case that was giving problems
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes ESMCI/cime#2006

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: 
