### PR TITLE
Fixes for ACME MPAS builds

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -190,7 +190,8 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 # the MPAS build system
                 self._case2.set_value("SHAREDLIBROOT",
                                       self._case1.get_value("SHAREDLIBROOT"))
-                self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+
+            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
         else:
             self._activate_case1()
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -39,6 +39,7 @@ from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case import Case
 from CIME.case_submit import check_case
 from CIME.case_st_archive import archive_last_restarts
+from CIME.utils import get_model
 
 import shutil, os, glob
 
@@ -184,8 +185,9 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             # Although we're doing separate builds, it still makes sense
             # to share the sharedlibroot area with case1 so we can reuse
             # pieces of the build from there.
-            self._case2.set_value("SHAREDLIBROOT",
-                                  self._case1.get_value("SHAREDLIBROOT"))
+            if get_model() != "acme":
+                self._case2.set_value("SHAREDLIBROOT",
+                                      self._case1.get_value("SHAREDLIBROOT"))
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
         else:
             self._activate_case1()
@@ -299,7 +301,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             # to this case. (If case2's CIME_OUTPUT_ROOT were in some
             # more generic location, then this would result in its bld
             # directory being inadvertently shared with other tests.)
-            case2_exeroot = os.path.join(self._get_output_root2(), "bld")
+            case2_exeroot = os.path.join(self._get_output_root2(), self._case1.get_value("CASE"), "bld")
         else:
             # Use default exeroot
             case2_exeroot = None
@@ -311,7 +313,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         """
         # Put the case2 run directory alongside its bld directory for
         # consistency. (See notes about EXEROOT in _get_case2_exeroot.)
-        case2_rundir = os.path.join(self._get_output_root2(), "run")
+        case2_rundir = os.path.join(self._get_output_root2(), self._case1.get_value("CASE"), "run")
         return case2_rundir
 
     def _setup_cases_if_not_yet_done(self):

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -186,9 +186,11 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             # to share the sharedlibroot area with case1 so we can reuse
             # pieces of the build from there.
             if get_model() != "acme":
+                # We need to turn off this change for ACME because it breaks
+                # the MPAS build system
                 self._case2.set_value("SHAREDLIBROOT",
                                       self._case1.get_value("SHAREDLIBROOT"))
-            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+                self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
         else:
             self._activate_case1()
             self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
@@ -301,7 +303,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             # to this case. (If case2's CIME_OUTPUT_ROOT were in some
             # more generic location, then this would result in its bld
             # directory being inadvertently shared with other tests.)
-            case2_exeroot = os.path.join(self._get_output_root2(), self._case1.get_value("CASE"), "bld")
+            case2_exeroot = os.path.join(self._get_output_root2(), "bld")
         else:
             # Use default exeroot
             case2_exeroot = None
@@ -313,7 +315,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         """
         # Put the case2 run directory alongside its bld directory for
         # consistency. (See notes about EXEROOT in _get_case2_exeroot.)
-        case2_rundir = os.path.join(self._get_output_root2(), self._case1.get_value("CASE"), "run")
+        case2_rundir = os.path.join(self._get_output_root2(), "run")
         return case2_rundir
 
     def _setup_cases_if_not_yet_done(self):


### PR DESCRIPTION
It  makes it so acme does not try to reuse sharedlib for both cases.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @billsacks 
