### PR TITLE
For runoff map: fix mask_b and frac_b in nearest neighbor map

### DIFF
--- a/tools/mapping/check_maps/src/ESMF_RegridWeightGenCheck.F90
+++ b/tools/mapping/check_maps/src/ESMF_RegridWeightGenCheck.F90
@@ -57,7 +57,7 @@ program OfflineTester
 
       type(ESMF_VM) :: vm
 
-      character(ESMF_MAXSTR) :: wgtfile, title
+      character(ESMF_MAXSTR) :: wgtfile
 
       real(ESMF_KIND_R8), pointer :: factorList(:)
       integer, pointer            :: factorIndexList(:,:)
@@ -155,7 +155,7 @@ program OfflineTester
       totCnt = 0
 
       ! read in the grid dimensions
-      call NCFileInquire(wgtfile, title, src_dim, nxs, nys, &
+      call NCFileInquire(wgtfile, src_dim, nxs, nys, &
                                          dst_dim, nxd, nyd, localrc=status)
       if (ESMF_LogFoundError(rcToCheck=status, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__, file=__FILE__, rcToReturn=rc)) &
@@ -774,10 +774,9 @@ contains
 ! The weights file should have the source and destination grid information
 ! provided.
 !***********************************************************************************
-  subroutine NCFileInquire (wgtfile, title, src_dim, nxs, nys, dst_dim, nxd, nyd, localrc)
+  subroutine NCFileInquire (wgtfile, src_dim, nxs, nys, dst_dim, nxd, nyd, localrc)
 
     character(ESMF_MAXSTR), intent(in)  :: wgtfile
-    character(ESMF_MAXSTR), intent(out)  :: title
     integer, intent(out)                :: src_dim
     integer, intent(out)                :: nxs, nys
     integer, intent(out)                :: dst_dim
@@ -786,7 +785,6 @@ contains
 
     integer :: ncstat,  nc_file_id,  nc_srcdim_id, nc_dstdim_id, srcdim, dstdim
     integer :: gdims(2), dim_ids(1)
-    integer :: titleLen
 
     character(ESMF_MAXSTR) :: msg
 
@@ -799,29 +797,6 @@ contains
         write (msg, '(a,i4)') "- nf90_open error:", ncstat
         call ESMF_LogSetError(ESMF_RC_SYS, msg=msg, &
           line=__LINE__, file=__FILE__, rcToReturn=rc)
-        return
-      endif
-
-      !-----------------------------------------------------------------
-      ! source grid dimensions
-      !-----------------------------------------------------------------
-
-      ncstat = nf90_inquire_attribute(nc_file_id, nf90_global, 'title', len=titleLen)
-      if(ncstat /= 0) then
-        write (msg, '(a,i4)') "- nf90_inquire_attribute error:", ncstat
-        call ESMF_LogSetError(ESMF_RC_SYS, msg=msg, &
-          line=__LINE__, file=__FILE__ , rcToReturn=rc)
-        return
-      endif
-      if(len(title) < titleLen) then
-        print *, "Not enough space to put title."
-        return
-      end if
-      ncstat = nf90_get_att(nc_file_id, nf90_global, "title", title)
-      if(ncstat /= 0) then
-        write (msg, '(a,i4)') "- nf90_get_att error:", ncstat
-        call ESMF_LogSetError(ESMF_RC_SYS, msg=msg, &
-          line=__LINE__, file=__FILE__ , rcToReturn=rc)
         return
       endif
 

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/ncl/merge_mapping_files.ncl
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/ncl/merge_mapping_files.ncl
@@ -146,12 +146,12 @@ begin
 
   print("determining map_ms vals where REGION_MASK<0")
   sign_REGION_MASK_ms = sign_matlab(REGION_MASK_1d(map_in_ms_row-1))
-  if (any(sign_REGION_MASK_ms .lt. 0)) then
-    ind_vals_ms = ind(sign_REGION_MASK_ms .lt. 0)
-    n_s_subset_ms = dimsizes(ind_vals_ms)
-  else
+  ind_vals_ms = ind(sign_REGION_MASK_ms .lt. 0)
+  if (all(ismissing(ind_vals_ms))) then
     print("No source points mapped to marginal seas: output will just contain points mapped to open ocean")
     n_s_subset_ms = 0
+  else
+    n_s_subset_ms = dimsizes(ind_vals_ms)
   end if
 
   n_s_out = n_s_subset_oo + n_s_subset_ms

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/ncl/merge_mapping_files.ncl
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/ncl/merge_mapping_files.ncl
@@ -146,8 +146,13 @@ begin
 
   print("determining map_ms vals where REGION_MASK<0")
   sign_REGION_MASK_ms = sign_matlab(REGION_MASK_1d(map_in_ms_row-1))
-  ind_vals_ms = ind(sign_REGION_MASK_ms .lt. 0)
-  n_s_subset_ms = dimsizes(ind_vals_ms)
+  if (any(sign_REGION_MASK_ms .lt. 0)) then
+    ind_vals_ms = ind(sign_REGION_MASK_ms .lt. 0)
+    n_s_subset_ms = dimsizes(ind_vals_ms)
+  else
+    print("No source points mapped to marginal seas: output will just contain points mapped to open ocean")
+    n_s_subset_ms = 0
+  end if
 
   n_s_out = n_s_subset_oo + n_s_subset_ms
 
@@ -174,9 +179,11 @@ begin
   map_out_col(0:n_s_subset_oo-1) = (/ map_in_oo_col(ind_vals_oo) /)
   map_out_row(0:n_s_subset_oo-1) = (/ map_in_oo_row(ind_vals_oo) /)
 
-  map_out_S(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1)   = (/ map_in_ms_S(ind_vals_ms) /)
-  map_out_col(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1) = (/ map_in_ms_col(ind_vals_ms) /)
-  map_out_row(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1) = (/ map_in_ms_row(ind_vals_ms) /)
+  if (n_s_subset_ms .gt. 0) then
+    map_out_S(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1)   = (/ map_in_ms_S(ind_vals_ms) /)
+    map_out_col(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1) = (/ map_in_ms_col(ind_vals_ms) /)
+    map_out_row(n_s_subset_oo:n_s_subset_oo+n_s_subset_ms-1) = (/ map_in_ms_row(ind_vals_ms) /)
+  end if
 
   print("writing merged map, " + MAP_OUT_FNAME)
   system("rm -f " + MAP_OUT_FNAME)

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/src/main.F90
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/src/main.F90
@@ -214,10 +214,6 @@ if (step3) then
    ! map because, in the case where the nearest neighbor map uses a file_ocn_coastal_mask
    ! that is a subset of file_ocn, the nearest neighbor map has a too-limited mask_b and
    ! frac_b (containing only the coastal points).
-   !
-   ! It may be possible to simply use map_smooth in place of map_orig in the above
-   ! map_dup call (thus removing the need for these overrides), but that has not been
-   ! tested.
    map_new%mask_b = map_smooth%mask_b
    map_new%frac_b = map_smooth%frac_b
 

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/src/main.F90
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/src/main.F90
@@ -209,6 +209,18 @@ if (step3) then
    call map_dup(map_orig,map_new)
    map_new%title  = trim(title)
    map_new%domain_b = trim(map_smooth%domain_b)
+
+   ! Need to use mask_b and frac_b from the smooth map rather than the nearest neighbor
+   ! map because, in the case where the nearest neighbor map uses a file_ocn_coastal_mask
+   ! that is a subset of file_ocn, the nearest neighbor map has a too-limited mask_b and
+   ! frac_b (containing only the coastal points).
+   !
+   ! It may be possible to simply use map_smooth in place of map_orig in the above
+   ! map_dup call (thus removing the need for these overrides), but that has not been
+   ! tested.
+   map_new%mask_b = map_smooth%mask_b
+   map_new%frac_b = map_smooth%frac_b
+
    call map_matMatMult(map_orig,map_new,map_smooth) ! mult(A,B,S): B=S*A
    call mapsort_sort(map_new)
    call map_check(map_new)


### PR DESCRIPTION
Main change: For runoff map: fix mask_b and frac_b in nearest neighbor map.
Previously, mask_b and frac_b were taken from the nearest neighbor map
to the coastal ocean, which is a small subset of what this mask/frac
should be.

Also, in the check_map tool: Do not try to get title attribute.
This wasn't being used, and I was worried that it might cause a crash
when trying to run check_map on files created with
run_merge_mapping_files.sh (because no title attribute was present on
the resulting files).

Test suite: manual checks of mapping files generated with runoff_to_ocn tool
   and run of check_map.sh tool
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes ESMCI/cime#2009

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
