### PR TITLE
Add NLCOMP warning if comparison fails and RUN phase is complete.

### DIFF
--- a/scripts/lib/CIME/case_cmpgen_namelists.py
+++ b/scripts/lib/CIME/case_cmpgen_namelists.py
@@ -119,6 +119,13 @@ def case_cmpgen_namelists(case, compare=False, generate=False, compare_name=None
             output = ""
             if compare:
                 success, output = _do_full_nl_comp(case, test_name, compare_name, baseline_root)
+                if not success and ts.get_status(RUN_PHASE) is not None:
+                    run_warn = \
+"""NOTE: It is not necessarily safe to compare namelists after RUN
+phase has completed. Running a case can pollute namelists. The namelists
+kept in the baselines are pre-RUN namelists."""
+                    output += run_warn
+                    logging.info(run_warn)
             if generate:
                 _do_full_nl_gen(case, test_name, generate_name, baseline_root)
         except:


### PR DESCRIPTION
Run phase can pollute namelists.

Test suite: code-checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2002 

User interface changes?: Some additional output from nl comp code in some cases

Update gh-pages html (Y/N)?:N

Code review: @billsacks 
