### PR TITLE
Fix cprnc build on my mac

### DIFF
--- a/tools/cprnc/Makefile
+++ b/tools/cprnc/Makefile
@@ -45,7 +45,6 @@ GENF90 = ../../src/externals/genf90/genf90.pl
 
 FC := $(SFC)
 FFLAGS += -I$(INC_NETCDF) -I.
-LDFLAGS=$(SLIBS)
 #------------------------------------------------------------------------
 # Default rules and macros
 #------------------------------------------------------------------------
@@ -72,7 +71,7 @@ endif
 	$(FC) -c $(FFLAGS) $<
 
 $(EXEDIR)/$(EXENAME): $(OBJS)
-	$(FC) -o $@ $(OBJS) $(LDFLAGS)
+	$(FC) -o $@ $(OBJS) $(LDFLAGS) $(SLIBS)
 
 compare_vars_mod.F90 : compare_vars_mod.F90.in
 	perl $(GENF90) $< > $@


### PR DESCRIPTION
The original version was overwriting LDFLAGS with SLIBS, where the
latter was unset. The new version preserves both.

It's possible that the overwriting of LDFLAGS with SLIBS (from
e2323e10f1) was needed on some systems, but that seems like the wrong
thing to do in general.

Test suite: Just tested cprnc build on my Mac (with gnu), hobart (intel) and edison (intel)
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes #2020 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
