### PR TITLE
fix machines option to srt and unitialzed var

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -31,7 +31,7 @@ TOOLS_DIR   = os.path.join(SCRIPT_DIR,"Tools")
 TEST_COMPILER = None
 GLOBAL_TIMEOUT = None
 TEST_MPILIB = None
-MACHINE     = Machines()
+MACHINE     = None
 FAST_ONLY   = False
 NO_BATCH    = False
 NO_CMAKE    = False
@@ -2466,9 +2466,10 @@ def _main_func():
         midx = sys.argv.index("--machine")
         mach_name = sys.argv[midx + 1]
         MACHINE = Machines(machine=mach_name)
-        os.environ["CIME_MACHINE"] = mach_name
         del sys.argv[midx + 1]
         del sys.argv[midx]
+    else:
+        MACHINE = Machines()
 
     if "--compiler" in sys.argv:
         global TEST_COMPILER

--- a/src/drivers/mct/main/prep_ocn_mod.F90
+++ b/src/drivers/mct/main/prep_ocn_mod.F90
@@ -160,6 +160,7 @@ contains
          wav_gnam=wav_gnam             , &
          atm_nx=atm_nx                 , &
          atm_ny=atm_ny                 , &
+         glc_gnam=glc_gnam             , &
          esmf_map_flag=esmf_map_flag   )
 
     allocate(mapper_Sa2o)


### PR DESCRIPTION
Fix an unitialized variable in prep_ocn_mod.F90, fix the --machine option to scripts_regression_tests.py

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #1952 
Fixes #2019 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
