### PR TITLE
add function to rebuild dependencies

### DIFF
--- a/config/acme/machines/Makefile
+++ b/config/acme/machines/Makefile
@@ -868,6 +868,39 @@ $(COMPLIB): $(OBJS)
 %.F90: %.F90.in
 	$(CIMEROOT)/src/externals/genf90/genf90.pl $< > $@
 
+clean_dependsatm:
+	$(RM) -f $(EXEROOT)/atm/obj/Srcfiles
+
+clean_dependscpl:
+	$(RM) -f $(EXEROOT)/cpl/obj/Srcfiles
+
+clean_dependsocn:
+	$(RM) -f $(EXEROOT)/ocn/obj/Srcfiles
+
+clean_dependswav:
+	$(RM) -f $(EXEROOT)/wav/obj/Srcfiles
+
+clean_dependsglc:
+	$(RM) -f $(EXEROOT)/glc/obj/Srcfiles
+
+clean_dependsice:
+	$(RM) -f $(EXEROOT)/ice/obj/Srcfiles
+
+clean_dependsrof:
+	$(RM) -f $(EXEROOT)/rof/obj/Srcfiles
+
+clean_dependsesp:
+	$(RM) -f $(EXEROOT)/esp/obj/Srcfiles
+
+clean_dependslnd:
+	$(RM) -f $(LNDOBJDIR)/Srcfiles
+
+clean_dependscsmshare:
+	$(RM) -f $(SHAREDLIBROOT)/$(SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/csm_share/Srcfiles
+
+clean_depends: clean_dependsatm clean_dependscpl clean_dependswav clean_dependsglc clean_dependsice clean_dependsrof clean_dependslnd clean_dependscsmshare clean_dependsesp
+
+
 cleanatm:
 	$(RM) -f $(LIBROOT)/libatm.a
 	$(RM) -fr $(EXEROOT)/atm/obj

--- a/config/cesm/machines/Makefile
+++ b/config/cesm/machines/Makefile
@@ -793,6 +793,39 @@ endif
 %.F90: %.F90.in
 	$(CIMEROOT)/src/externals/genf90/genf90.pl $< > $@
 
+clean_dependsatm:
+	$(RM) -f $(EXEROOT)/atm/obj/Srcfiles
+
+clean_dependscpl:
+	$(RM) -f $(EXEROOT)/cpl/obj/Srcfiles
+
+clean_dependsocn:
+	$(RM) -f $(EXEROOT)/ocn/obj/Srcfiles
+
+clean_dependswav:
+	$(RM) -f $(EXEROOT)/wav/obj/Srcfiles
+
+clean_dependsglc:
+	$(RM) -f $(EXEROOT)/glc/obj/Srcfiles
+
+clean_dependsice:
+	$(RM) -f $(EXEROOT)/ice/obj/Srcfiles
+
+clean_dependsrof:
+	$(RM) -f $(EXEROOT)/rof/obj/Srcfiles
+
+clean_dependsesp:
+	$(RM) -f $(EXEROOT)/esp/obj/Srcfiles
+
+clean_dependslnd:
+	$(RM) -f $(LNDOBJDIR)/Srcfiles
+
+clean_dependscsmshare:
+	$(RM) -f $(SHAREDLIBROOT)/$(SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/$(NINST_VALUE)/csm_share/Srcfiles
+
+clean_depends: clean_dependsatm clean_dependscpl clean_dependswav clean_dependsglc clean_dependsice clean_dependsrof clean_dependslnd clean_dependscsmshare clean_dependsesp
+
+
 cleanatm:
 	$(RM) -f $(LIBROOT)/libatm.a
 	$(RM) -fr $(EXEROOT)/atm/obj

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -61,7 +61,7 @@ OR
     mutex_group.add_argument("--clean-all", action="store_true",
                              help="clean all objects including sharedlibobjects that may be used by other builds")
 
-    mutex_group.add_argument("--clean-depends", nargs="*", choices=allobjs,
+    mutex_group.add_argument("--clean-depends", nargs="*", choices=comps+["csmshare"],
                              help="clean Depends and Srcfiles only - "
                              "this allows you to rebuild after adding new "
                              "files in the source tree or in SourceMods")

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -61,12 +61,17 @@ OR
     mutex_group.add_argument("--clean-all", action="store_true",
                              help="clean all objects including sharedlibobjects that may be used by other builds")
 
+    mutex_group.add_argument("--clean-depends", nargs="*", choices=allobjs,
+                             help="clean Depends and Srcfiles only - this allows new files to be added in SourceMods")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    clean_depends = args.clean_depends if args.clean_depends is None or len(args.clean_depends) else comps
 
     cleanlist = args.clean if args.clean is None or len(args.clean) else comps
     buildlist = None if args.build is None or len(args.build) == 0 else args.build
 
-    return args.caseroot, args.sharedlib_only, args.model_only, cleanlist, args.clean_all, buildlist
+    return args.caseroot, args.sharedlib_only, args.model_only, cleanlist, args.clean_all, buildlist, clean_depends
 
 ###############################################################################
 def _main_func(description):
@@ -75,14 +80,14 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    caseroot, sharedlib_only, model_only, cleanlist, clean_all, buildlist = parse_command_line(sys.argv, description)
+    caseroot, sharedlib_only, model_only, cleanlist, clean_all, buildlist, clean_depends = parse_command_line(sys.argv, description)
 
     success = True
     with Case(caseroot, read_only=False) as case:
         testname = case.get_value('TESTCASE')
 
-        if cleanlist is not None or clean_all:
-            build.clean(case, cleanlist, clean_all)
+        if cleanlist is not None or clean_all or clean_depends is not None:
+            build.clean(case, cleanlist=cleanlist, clean_all=clean_all, clean_depends=clean_depends)
         elif(testname is not None):
             logging.warning("Building test for {} in directory {}".format(testname,
                                                                        caseroot))


### PR DESCRIPTION
Add an argument to case.build --clean-depends that will go through each of the component obj files and remove file Srcfiles which will cause this file and the Depends file to be recreated.   This allows a user to add files to SourceMods and rebuild without requiring a full clean build.

Test suite: scripts_regression_tests.py, hand tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1889 

User interface changes?: Yes add --clean-depends to case.build, this argument can take a component list and will clean all components if one is not provided

Update gh-pages html (Y/N)?:

Code review: 
