### PR TITLE
Better errormsg for compsets

### DIFF
--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -212,11 +212,11 @@ class Component(EntryID):
 
         >>> obj = Component('testingonly', 'ATM')
         >>> obj._get_description_match("1850_DATM%CRU_FRED",set(["DATM"]), set(["DATM","CRU","HSI"]), "*")
-        True
+        (True, ['DATM', 'CRU'])
         >>> obj._get_description_match("1850_DATM%FRED_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "*")
-        False
+        (False, None)
         >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "?")
-        True
+        (True, ['DATM'])
         >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1")
         Traceback (most recent call last):
         ...
@@ -226,15 +226,15 @@ class Component(EntryID):
         ...
         SystemExit: ERROR: Expected exactly one modifer found 2 in ['DATM', 'CRU', 'HSI']
         >>> obj._get_description_match("1850_CAM50%WCCM%RCO2_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "*")
-        True
+        (True, ['CAM50', 'WCCM', 'RCO2'])
 
         # The following is not allowed because the required WCCM field is missing
         >>> obj._get_description_match("1850_CAM50%RCO2_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "*")
-        False
+        (False, None)
         >>> obj._get_description_match("1850_CAM50_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "+")
-        False
+        (False, None)
         >>> obj._get_description_match("1850_CAM50%WCCM_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "+")
-        True
+        (True, ['CAM50', 'WCCM'])
         """
         match = False
         comparts = compsetname.split('_')

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -198,8 +198,8 @@ class Component(EntryID):
         # cpl and esp components may not have a description
         if comp_class not in ['cpl','esp']:
             expect(len(desc) > 0,
-                   "No description found for comp_class {} matching compsetname {} in file {}"\
-                       .format(comp_class,compsetname, self.filename))
+                   "No description found for comp_class {} matching compsetname {} in file {}, expected match in {} % {}"\
+                       .format(comp_class,compsetname, self.filename, list(reqset), list(opt_parts)))
         return desc
 
     def _get_description_match(self, compsetname, reqset, fullset, modifier_mode):
@@ -239,13 +239,13 @@ class Component(EntryID):
             if cset == reqset or (cset > reqset and cset <= fullset):
                 if modifier_mode == '1':
                     expect(len(complist) == 2,
-                           "Expected exactly one modifer found {}".format(len(complist)-1))
+                           "Expected exactly one modifer found {} in {}".format(len(complist)-1,complist))
                 elif modifier_mode == '+':
                     expect(len(complist) >= 2,
-                           "Expected one or more modifers found {}".format(len(complist)-1))
+                           "Expected one or more modifers found {} in {}".format(len(complist)-1, list(reqset)))
                 elif modifier_mode == '?':
                     expect(len(complist) <= 2,
-                           "Expected 0 or one modifers found {}".format(len(complist)-1))
+                           "Expected 0 or one modifers found {} in {}".format(len(complist)-1, complist))
                 expect(not match,"Found multiple matches in file {} for {}".format(self.filename,comp))
                 match = True
                 # found a match

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -215,11 +215,11 @@ class Component(EntryID):
         >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1")
         Traceback (most recent call last):
         ...
-        SystemExit: ERROR: Expected exactly one modifer found 0
+        SystemExit: ERROR: Expected exactly one modifer found 0 in ['DATM']
         >>> obj._get_description_match("1850_DATM%CRU%HSI_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1")
         Traceback (most recent call last):
         ...
-        SystemExit: ERROR: Expected exactly one modifer found 2
+        SystemExit: ERROR: Expected exactly one modifer found 2 in ['DATM', 'CRU', 'HSI']
         >>> obj._get_description_match("1850_CAM50%WCCM%RCO2_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "*")
         True
 


### PR DESCRIPTION
Improve error messages for compset match

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1860 
Fixes #1859 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
