### PR TITLE
handle case when cmdargs is not a list

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -229,8 +229,11 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
         if case is not None:
             case.flush()
         fullcmd = cmd
-        for arg in cmdargs:
-            fullcmd += " " + str(arg)
+        if isinstance(cmdargs, list):
+            for arg in cmdargs:
+                fullcmd += " " + str(arg)
+        else:
+            fullcmd += " " + cmdargs
         output = run_cmd_no_fail("{} 1> {} 2>&1".format(fullcmd, logfile),
                                  combine_output=combine_output,
                                  from_dir=from_dir)


### PR DESCRIPTION
cmdargs should be a list, but some component models are sending a single string.  This handles both.
Test suite:  hand tested B1850 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
