### PR TITLE
Improve email handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,27 @@
 ======================================================================
 
+Originator: Chris Fischer
+Date: 11-07-2017
+Tag: cime5.4.0-alpha.08
+Answer Changes: None
+Tests: Hand test B1850 
+Dependencies:
+
+Brief Summary:
+    - Handle case when cmdargs is not a list
+
+User interface changes: 
+
+PR summary: git log --oneline --first-parent [previous_tag]..master 
+fc72203 Merge pull request #2032 from jedwards4b/cmdargs_fix
+
+Modified files: git diff --name-status [previous_tag]
+M       scripts/lib/CIME/utils.py
+
+======================================================================
+
+======================================================================
+
 Originator: Chris Fischer 
 Date: 11-06-2017
 Tag: cime5.4.0-alpha.07

--- a/config/acme/machines/config_batch.xml
+++ b/config/acme/machines/config_batch.xml
@@ -133,7 +133,6 @@
       <directive default="n"> -r {{ rerunnable }} </directive>
       <!-- <directive> -j oe {{ job_id }} </directive> -->
       <directive> -j oe </directive>
-      <directive default="ae"  > -m {{ mail_options }} </directive>
       <directive> -V </directive>
     </directives>
   </batch_system>
@@ -158,39 +157,38 @@
       <directive> -N {{ job_id }}</directive>
       <directive> -j oe </directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
-      <directive default="ae"  > -m {{ mail_options }} </directive>
       <directive default="/bin/bash" > -S {{ shell }}</directive>
     </directives>
   </batch_system>
 
   <!-- for lawrence livermore computing -->
-   <batch_system type="lc_slurm">
-     <batch_submit>sbatch</batch_submit>
-     <batch_cancel>scancel</batch_cancel>
-     <batch_directive>#SBATCH</batch_directive>
-     <jobid_pattern>(\d+)$</jobid_pattern>
-     <depend_string> -l depend=jobid</depend_string>
-     <depend_separator>:</depend_separator>
-     <walltime_format>%H:%M:%S</walltime_format>
-     <batch_mail_flag>--mail-user</batch_mail_flag>
-     <batch_mail_type_flag>--mail-type</batch_mail_type_flag>
-     <batch_mail_type>none, all, begin, end, fail</batch_mail_type>
-     <directives>
-       <directive>--export=ALL</directive>
-       <directive>-p {{ job_queue }}</directive>
-       <directive>-J {{ job_id }}</directive>
-       <directive>-N {{ num_nodes }}</directive>
-       <directive>-n {{ total_tasks }}</directive>
-       <directive>-t {{ job_wallclock_time }}</directive>
-       <directive>-o {{ job_id }}.out</directive>
-       <directive>-e {{ job_id }}.err</directive>
-       <directive>--mail-type=all</directive>
+  <batch_system type="lc_slurm">
+    <batch_submit>sbatch</batch_submit>
+    <batch_cancel>scancel</batch_cancel>
+    <batch_directive>#SBATCH</batch_directive>
+    <jobid_pattern>(\d+)$</jobid_pattern>
+    <depend_string> -l depend=jobid</depend_string>
+    <depend_separator>:</depend_separator>
+    <walltime_format>%H:%M:%S</walltime_format>
+    <batch_mail_flag>--mail-user</batch_mail_flag>
+    <batch_mail_type_flag>--mail-type</batch_mail_type_flag>
+    <batch_mail_type>none, all, begin, end, fail</batch_mail_type>
+    <directives>
+      <directive>--export=ALL</directive>
+      <directive>-p {{ job_queue }}</directive>
+      <directive>-J {{ job_id }}</directive>
+      <directive>-N {{ num_nodes }}</directive>
+      <directive>-n {{ total_tasks }}</directive>
+      <directive>-t {{ job_wallclock_time }}</directive>
+      <directive>-o {{ job_id }}.out</directive>
+      <directive>-e {{ job_id }}.err</directive>
+      <directive>--mail-type=all</directive>
       <directive> -A {{ project }} </directive>
-     </directives>
-     <queues>
-        <queue walltimemax="01:00:00" nodemin="1" nodemax="270" default="true">pbatch</queue>
-     </queues>
-   </batch_system>
+    </directives>
+    <queues>
+      <queue walltimemax="01:00:00" nodemin="1" nodemax="270" default="true">pbatch</queue>
+    </queues>
+  </batch_system>
   <!-- for lawrence livermore computing -->
 
   <batch_system type="slurm" >

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -21,6 +21,7 @@
   <xs:element name="batch_mail_flag" type="xs:string"/>
   <xs:element name="batch_mail_type_flag" type="xs:string"/>
   <xs:element name="batch_mail_type" type="xs:string"/>
+  <xs:element name="batch_mail_default" type="xs:string"/>
   <xs:element name="template" type="xs:NCName"/>
   <xs:element name="task_count" type="xs:integer"/>
   <xs:element name="dependency" type="xs:string"/>
@@ -81,6 +82,8 @@
         <xs:element minOccurs="0" ref="batch_mail_type_flag"/>
   <!-- batch_mail_flag: user email type expected by batch system -->
         <xs:element minOccurs="0" ref="batch_mail_type"/>
+  <!-- batch_mail_flag: default user email type -->
+        <xs:element minOccurs="0" ref="batch_mail_default"/>
 
   <!-- submit_args: A list of arguments to pass when submitting a job, queue, wallclock time
        and project are typical sub fields -->

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -52,7 +52,7 @@ OR
 
     parser.add_argument("-M", "--mail-user", help="email to be used for batch notification.")
 
-    parser.add_argument("-m", "--mail-type", default="never",
+    parser.add_argument("-m", "--mail-type", action="append",
                         choices=("never", "all", "begin", "end", "fail"),
                         help="when to send user email.")
 

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -53,27 +53,14 @@ OR
     parser.add_argument("--skip-preview-namelist", action="store_true",
                         help="Skip calling preview-namelist during case.run")
 
-    parser.add_argument("-M", "--mail-user", help="email to be used for batch notification.")
-
-    parser.add_argument("-m", "--mail-type", action="append",
-                        help="when to send user email. Options are: never, all, begin, end, fail."
-                        "You can specify multiple types with either comma-separate args or multiple -m flags")
+    CIME.utils.add_mail_type_args(parser)
 
     parser.add_argument("-a", "--batch-args",
                         help="Used to pass additional arguments to batch system. ")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    if args.mail_type is not None:
-        resolved_mail_types = []
-        for mail_type in args.mail_type:
-            resolved_mail_types.extend(mail_type.split(","))
-
-        for mail_type in resolved_mail_types:
-            CIME.utils.expect(mail_type in ("never", "all", "begin", "end", "fail"),
-                              "Unsupported mail-type '{}'".format(mail_type))
-
-        args.mail_type = resolved_mail_types
+    CIME.utils.resolve_mail_type_args(args)
 
     return args.test, args.caseroot, args.job, args.no_batch, args.prereq, \
         args.resubmit, args.skip_preview_namelist, args.mail_user, args.mail_type, \

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -20,6 +20,9 @@ OR
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Setup case \033[0m
     > {0}
+
+    \033[1;32m# Setup case, request mail at job begin and job end \033[0m
+    > {0} -m begin,end
 """.format(os.path.basename(args[0])),
         description=description,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -53,13 +56,24 @@ OR
     parser.add_argument("-M", "--mail-user", help="email to be used for batch notification.")
 
     parser.add_argument("-m", "--mail-type", action="append",
-                        choices=("never", "all", "begin", "end", "fail"),
-                        help="when to send user email.")
+                        help="when to send user email. Options are: never, all, begin, end, fail."
+                        "You can specify multiple types with either comma-separate args or multiple -m flags")
 
     parser.add_argument("-a", "--batch-args",
                         help="Used to pass additional arguments to batch system. ")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    if args.mail_type is not None:
+        resolved_mail_types = []
+        for mail_type in args.mail_type:
+            resolved_mail_types.extend(mail_type.split(","))
+
+        for mail_type in resolved_mail_types:
+            CIME.utils.expect(mail_type in ("never", "all", "begin", "end", "fail"),
+                              "Unsupported mail-type '{}'".format(mail_type))
+
+        args.mail_type = resolved_mail_types
 
     return args.test, args.caseroot, args.job, args.no_batch, args.prereq, \
         args.resubmit, args.skip_preview_namelist, args.mail_user, args.mail_type, \

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -234,7 +234,11 @@ OR
                         "file. The file can follow either the config_pes.xml or "
                         "the env_mach_pes.xml format.")
 
+    CIME.utils.add_mail_type_args(parser)
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    CIME.utils.resolve_mail_type_args(args)
 
     # generate and compare flags may not point to the same directory
     if model == "cesm":
@@ -379,7 +383,7 @@ OR
         args.namelists_only, args.project, \
         args.test_id, args.parallel_jobs, args.walltime, \
         args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue, \
-        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib, args.input_dir, args.pesfile
+        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib, args.input_dir, args.pesfile, args.mail_user, args.mail_type
 
 ###############################################################################
 def single_submit_impl(machine_name, test_id, proc_pool, _, args, job_cost_map, wall_time, test_root):
@@ -475,7 +479,7 @@ def single_submit_impl(machine_name, test_id, proc_pool, _, args, job_cost_map, 
 def create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                 baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, project, test_id, parallel_jobs,
                 walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite, output_root, wait,
-                force_procs, force_threads, mpilib, input_dir, pesfile):
+                force_procs, force_threads, mpilib, input_dir, pesfile, mail_user, mail_type):
 ###############################################################################
     impl = TestScheduler(test_names, test_data=test_data,
                          no_run=no_run, no_build=no_build, no_setup=no_setup, no_batch=no_batch,
@@ -488,7 +492,7 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
                          proc_pool=proc_pool, use_existing=use_existing, save_timing=save_timing,
                          queue=queue, allow_baseline_overwrite=allow_baseline_overwrite,
                          output_root=output_root, force_procs=force_procs, force_threads=force_threads,
-                         mpilib=mpilib, input_dir=input_dir, pesfile=pesfile)
+                         mpilib=mpilib, input_dir=input_dir, pesfile=pesfile, mail_user=mail_user, mail_type=mail_type)
 
     success = impl.run_tests(wait=wait)
 
@@ -529,13 +533,15 @@ def _main_func(description):
     test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, \
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \
-    save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile \
-        = parse_command_line(sys.argv, description)
+    save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile, \
+    mail_user, mail_type = \
+        parse_command_line(sys.argv, description)
 
     sys.exit(create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
                          baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only,
                          project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, save_timing,
-                         queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile))
+                         queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile,
+                         mail_user, mail_type))
 
 ###############################################################################
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -456,7 +456,7 @@ class EnvBatch(EnvBase):
                     # hacky, PBS-type systems pass multiple mail-types differently
                     submitargs += " {} {}".format(mail_type_flag, "".join(mail_type_args))
                 else:
-                    submitargs += " {} {}".format(mail_type_flag, " {}".format(mail_type_flag).join(mail_type_args))
+                    submitargs += " {} {}".format(mail_type_flag, " {} ".format(mail_type_flag).join(mail_type_args))
 
         batchsubmit = self.get_value("batch_submit", subgroup=None)
         expect(batchsubmit is not None,

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -438,7 +438,7 @@ class EnvBatch(EnvBase):
         if mail_type is None:
             if job == "case.test" and cime_config.has_option("create_test", "MAILTYPE"):
                 mail_type = cime_config.get("create_test", "MAILTYPE")
-            else if cime_config.has_option("main", "MAILTYPE"):
+            elif cime_config.has_option("main", "MAILTYPE"):
                 mail_type = cime_config.get("main", "MAILTYPE")
             else:
                 mail_type = self.get_value("batch_mail_default")

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -436,10 +436,10 @@ class EnvBatch(EnvBase):
                 submitargs += " " + mail_user_flag + " " + mail_user
 
         if mail_type is None:
-            if job == "case.test" and cime_config.has_option("create_test", "MAILTYPE"):
-                mail_type = cime_config.get("create_test", "MAILTYPE")
-            elif cime_config.has_option("main", "MAILTYPE"):
-                mail_type = cime_config.get("main", "MAILTYPE")
+            if job == "case.test" and cime_config.has_option("create_test", "MAIL_TYPE"):
+                mail_type = cime_config.get("create_test", "MAIL_TYPE")
+            elif cime_config.has_option("main", "MAIL_TYPE"):
+                mail_type = cime_config.get("main", "MAIL_TYPE")
             else:
                 mail_type = self.get_value("batch_mail_default")
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -436,7 +436,9 @@ class EnvBatch(EnvBase):
                 submitargs += " " + mail_user_flag + " " + mail_user
 
         if mail_type is None:
-            if cime_config.has_option("main", "MAILTYPE"):
+            if job == "case.test" and cime_config.has_option("create_test", "MAILTYPE"):
+                mail_type = cime_config.get("create_test", "MAILTYPE")
+            else if cime_config.has_option("main", "MAILTYPE"):
                 mail_type = cime_config.get("main", "MAILTYPE")
             else:
                 mail_type = self.get_value("batch_mail_default")

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -427,8 +427,8 @@ class EnvBatch(EnvBase):
 
         cime_config = get_cime_config()
 
-        if mail_user is None and cime_config.has_option("main", "MAILUSER"):
-            mail_user = cime_config.get("main", "MAILUSER")
+        if mail_user is None and cime_config.has_option("main", "MAIL_USER"):
+            mail_user = cime_config.get("main", "MAIL_USER")
 
         if mail_user is not None:
             mail_user_flag = self.get_value('batch_mail_flag', subgroup=None)

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -3,9 +3,8 @@ Interface to the env_batch.xml file.  This class inherits from EnvBase
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import format_time
 from CIME.XML.env_base import EnvBase
-from CIME.utils import transform_vars, get_cime_root, convert_to_seconds
+from CIME.utils import transform_vars, get_cime_root, convert_to_seconds, format_time, get_cime_config
 
 from copy import deepcopy
 from collections import OrderedDict
@@ -426,13 +425,22 @@ class EnvBatch(EnvBase):
         if batch_args is not None:
             submitargs += " " + batch_args
 
+        cime_config = get_cime_config()
+
+        if mail_user is None and cime_config.has_option("main", "MAILUSER"):
+            mail_user = cime_config.get("main", "MAILUSER")
+
         if mail_user is not None:
             mail_user_flag = self.get_value('batch_mail_flag', subgroup=None)
             if mail_user_flag is not None:
                 submitargs += " " + mail_user_flag + " " + mail_user
 
         if mail_type is None:
-            mail_type = self.get_value("batch_mail_default")
+            if cime_config.has_option("main", "MAILTYPE"):
+                mail_type = cime_config.get("main", "MAILTYPE")
+            else:
+                mail_type = self.get_value("batch_mail_default")
+
             if mail_type:
                 mail_type = mail_type.split(",") # pylint: disable=no-member
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1173,7 +1173,7 @@ class Case(object):
             return comp_user_mods
 
     def submit_jobs(self, no_batch=False, job=None, prereq=None, skip_pnl=False,
-                    mail_user=None, mail_type='never', batch_args=None,
+                    mail_user=None, mail_type=None, batch_args=None,
                     dry_run=False):
         env_batch = self.get_env('batch')
         return env_batch.submit_jobs(self, no_batch=no_batch, job=job, user_prereq=prereq,

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -16,7 +16,7 @@ from CIME.test_status               import *
 logger = logging.getLogger(__name__)
 
 def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
-            skip_pnl=False, mail_user=None, mail_type='never', batch_args=None):
+            skip_pnl=False, mail_user=None, mail_type=None, batch_args=None):
     if job is None:
         if case.get_value("TEST"):
             job = "case.test"
@@ -83,7 +83,7 @@ def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
         case.set_value("JOB_IDS", xml_jobid_text)
 
 def submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
-           skip_pnl=False, mail_user=None, mail_type='never', batch_args=None):
+           skip_pnl=False, mail_user=None, mail_type=None, batch_args=None):
     if case.get_value("TEST"):
         caseroot = case.get_value("CASEROOT")
         casebaseid = case.get_value("CASEBASEID")

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -88,7 +88,7 @@ class TestScheduler(object):
                  use_existing=False, save_timing=False, queue=None,
                  allow_baseline_overwrite=False, output_root=None,
                  force_procs=None, force_threads=None, mpilib=None,
-                 input_dir=None, pesfile=None):
+                 input_dir=None, pesfile=None, mail_user=None, mail_type=None):
     ###########################################################################
         self._cime_root       = CIME.utils.get_cime_root()
         self._cime_model      = get_model()
@@ -100,6 +100,9 @@ class TestScheduler(object):
         self._input_dir       = input_dir
         self._pesfile         = pesfile
         self._allow_baseline_overwrite = allow_baseline_overwrite
+
+        self._mail_user = mail_user
+        self._mail_type = mail_type
 
         self._machobj = Machines(machine=machine_name)
 
@@ -613,10 +616,14 @@ class TestScheduler(object):
     def _run_phase(self, test):
     ###########################################################################
         test_dir = self._get_test_dir(test)
+
+        cmd = "./case.submit --skip-preview-namelist"
         if self._no_batch:
-            cmd = "./case.submit --no-batch --skip-preview-namelist"
-        else:
-            cmd = "./case.submit --skip-preview-namelist"
+            cmd += " --no-batch"
+        if self._mail_user:
+            cmd += " --mail-user={}".format(self._mail_user)
+        if self._mail_type:
+            cmd += " -M={}".format(",".join(self._mail_type))
 
         return self._shell_cmd_for_phase(test, cmd, RUN_PHASE, from_dir=test_dir)
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1408,6 +1408,25 @@ def _check_for_invalid_args(args):
             if arg.startswith("-") and len(arg) > 2:
                 sys.stderr.write( "WARNING: The {} argument is depricated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options\n".format(arg))
 
+def add_mail_type_args(parser):
+    parser.add_argument("--mail-user", help="email to be used for batch notification.")
+
+    parser.add_argument("-M", "--mail-type", action="append",
+                        help="when to send user email. Options are: never, all, begin, end, fail."
+                        "You can specify multiple types with either comma-separate args or multiple -M flags")
+
+def resolve_mail_type_args(args):
+    if args.mail_type is not None:
+        resolved_mail_types = []
+        for mail_type in args.mail_type:
+            resolved_mail_types.extend(mail_type.split(","))
+
+        for mail_type in resolved_mail_types:
+            expect(mail_type in ("never", "all", "begin", "end", "fail"),
+                   "Unsupported mail-type '{}'".format(mail_type))
+
+        args.mail_type = resolved_mail_types
+
 class SharedArea(object):
     """
     Enable 0002 umask within this manager


### PR DESCRIPTION
Improve email handling
    
1) Allow multiple event selections in case.submit
2) Remove hardcoded 'never' as mail_type
3) Allow batch systems to specify their own default
4) Allow mail settings to be configured by a users's cime_config

Test suite: by-hand on skybridge, code_checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2004 

User interface changes?: Yes. Allows multiple -m args to case.submit. Allows user to put email settings in .cime/config

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @billsacks 
