### PR TITLE
Change paths to case2 rundir and exeroot

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -282,9 +282,13 @@ class SystemTestsCompareTwo(SystemTestsCommon):
 
         Assumes that self._case1 is already set to point to the case1 object
         """
-        # Since case 2 has the same name as case1 its CIME_OUTPUT_ROOT must also be different
+        # Since case2 has the same name as case1, its CIME_OUTPUT_ROOT
+        # must also be different, so that anything put in
+        # $CIME_OUTPUT_ROOT/$CASE/ is not accidentally shared between
+        # case1 and case2. (Currently nothing is placed here, but this
+        # helps prevent future problems.)
         output_root2 = os.path.join(self._case1.get_value("CIME_OUTPUT_ROOT"),
-                                    self._case1.get_value("CASE"), "case2")
+                                    self._case1.get_value("CASE"), "case2_output_root")
         return output_root2
 
     def _get_case2_exeroot(self):
@@ -294,17 +298,13 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         Returns None if we should use the default value of exeroot.
         """
         if self._separate_builds:
-            # Put the case2 bld directory directly under the case2
-            # CIME_OUTPUT_ROOT, rather than following the typical
-            # practice of putting it under CIME_OUTPUT_ROOT/CASENAME,
-            # because the latter leads to too-long paths that make some
-            # compilers fail.
-            #
-            # This only works because case2's CIME_OUTPUT_ROOT is unique
-            # to this case. (If case2's CIME_OUTPUT_ROOT were in some
-            # more generic location, then this would result in its bld
-            # directory being inadvertently shared with other tests.)
-            case2_exeroot = os.path.join(self._get_output_root2(), "bld")
+            # case2's EXEROOT needs to be somewhere that (1) is unique
+            # to this case (considering that case1 and case2 have the
+            # same case name), and (2) does not have too long of a path
+            # name (because too-long paths can make some compilers
+            # fail).
+            case1_exeroot = self._case1.get_value("EXEROOT")
+            case2_exeroot = os.path.join(case1_exeroot, "case2bld")
         else:
             # Use default exeroot
             case2_exeroot = None
@@ -314,9 +314,12 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         """
         Gets rundir for case2.
         """
-        # Put the case2 run directory alongside its bld directory for
-        # consistency. (See notes about EXEROOT in _get_case2_exeroot.)
-        case2_rundir = os.path.join(self._get_output_root2(), "run")
+        # case2's RUNDIR needs to be somewhere that is unique to this
+        # case (considering that case1 and case2 have the same case
+        # name). Note that the location below is symmetrical to the
+        # location of case2's EXEROOT set in _get_case2_exeroot.
+        case1_rundir = self._case1.get_value("RUNDIR")
+        case2_rundir = os.path.join(case1_rundir, "case2run")
         return case2_rundir
 
     def _setup_cases_if_not_yet_done(self):
@@ -354,6 +357,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                     cime_output_root = self._get_output_root2(),
                     exeroot = self._get_case2_exeroot(),
                     rundir = self._get_case2_rundir())
+                self._write_info_to_case2_output_root()
                 self._setup_cases()
             except:
                 # If a problem occurred in setting up the test cases, it's
@@ -395,6 +399,38 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         """
         os.chdir(self._caseroot2)
         self._set_active_case(self._case2)
+
+    def _write_info_to_case2_output_root(self):
+        """
+        Writes a file with some helpful information to case2's
+        output_root.
+
+        The motivation here is two-fold:
+
+        (1) Currently, case2's output_root directory is empty. This
+            could be confusing.
+
+        (2) For users who don't know where to look, it could be hard to
+            find case2's bld and run directories. It is somewhat easier
+            to stumble upon case2's output_root, so we put a file there
+            pointing them to the right place.
+        """
+
+        readme_path = os.path.join(self._get_output_root2(), "README")
+        try:
+            with open(readme_path, "w") as fd:
+                fd.write("This directory is typically empty.\n\n")
+                fd.write("case2's run dir is here: {}\n\n".format(
+                    self._case2.get_value("RUNDIR")))
+                fd.write("case2's bld dir is here: {}\n".format(
+                    self._case2.get_value("EXEROOT")))
+        except IOError:
+            # It's not a big deal if we can't write the README file
+            # (e.g., because the directory doesn't exist or isn't
+            # writeable; note that the former may be the case in unit
+            # tests). So just continue merrily on our way if there was a
+            # problem.
+            pass
 
     def _setup_cases(self):
         """

--- a/scripts/lib/CIME/tests/case_fake.py
+++ b/scripts/lib/CIME/tests/case_fake.py
@@ -29,6 +29,7 @@ class CaseFake(object):
         self.set_value('CASE', casename)
         self.set_value('CASEBASEID', casename)
         self.set_value('RUN_TYPE', 'startup')
+        self.set_exeroot()
         self.set_rundir()
 
     def get_value(self, item):
@@ -65,6 +66,7 @@ class CaseFake(object):
         newcase.set_value('CASE', newcasename)
         newcase.set_value('CASEBASEID', newcasename)
         newcase.set_value('CASEROOT', newcaseroot)
+        newcase.set_exeroot()
         newcase.set_rundir()
 
         return newcase
@@ -86,8 +88,7 @@ class CaseFake(object):
             mach_dir (str, optional): Ignored
             project (str, optional): Ignored
             cime_output_root (str, optional): New CIME_OUTPUT_ROOT for the clone
-            exeroot (str, optional): Ignored (because exeroot isn't used
-                in this fake case implementation)
+            exeroot (str, optional): New EXEROOT for the clone
             rundir (str, optional): New RUNDIR for the clone
 
         Returns the clone case object
@@ -97,9 +98,11 @@ class CaseFake(object):
         os.makedirs(newcaseroot)
         clone = self.copy(newcasename = newcasename, newcaseroot = newcaseroot)
         if cime_output_root is not None:
-            self.set_value('CIME_OUTPUT_ROOT', cime_output_root)
+            clone.set_value('CIME_OUTPUT_ROOT', cime_output_root)
+        if exeroot is not None:
+            clone.set_value('EXEROOT', exeroot)
         if rundir is not None:
-            self.set_value('RUNDIR', rundir)
+            clone.set_value('RUNDIR', rundir)
 
         return clone
 
@@ -111,6 +114,13 @@ class CaseFake(object):
         Make directory given by RUNDIR
         """
         os.makedirs(self.get_value('RUNDIR'))
+
+    def set_exeroot(self):
+        """
+        Assumes CASEROOT is already set; sets an appropriate EXEROOT
+        (nested inside CASEROOT)
+        """
+        self.set_value('EXEROOT', os.path.join(self.get_value('CASEROOT'), 'bld'))
 
     def set_rundir(self):
         """


### PR DESCRIPTION
Previously, the code assumed that rundir and exeroot were subdirectories
of CIME_OUTPUT_ROOT. This is the case for CESM machines, but not for all
ACME machines. The new version doesn't make this assumption.

Test suite: scripts_regression_tests.py on hobart
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#2031

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
