### PR TITLE
convert line to utf-8

### DIFF
--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -95,11 +95,12 @@ class DAE(SystemTestsCompareTwo):
             found_caseroot = False
             found_cycle = False
             with gzip.open(fname, "r") as dfile:
-                for line in dfile:
-                    expect(line[0:5] != 'ERROR', "ERROR, error line found in {}".format(fname))
-                    if line[0:8] == 'caseroot':
+                for bline in dfile:
+                    line = bline.decode("utf-8")
+                    expect(not 'ERROR' in line, "ERROR, error line {} found in {}".format(line, fname))
+                    if 'caseroot' in line[0:8]:
                         found_caseroot = True
-                    elif line[0:5] == 'cycle':
+                    elif 'cycle' in line[0:5]:
                         found_cycle = True
                         expect(int(line[7:]) == cycle_num,
                                "ERROR: Wrong cycle ({:d}) found in {} (expected {:d})".format(int(line[7:]), fname, cycle_num))


### PR DESCRIPTION
Sometimes line is interpreted as binary, this makes sure its always a string and so can be compared.

Test suite:   DAE.f19_f19.A using python2.7 and python 3.6
Test baseline: 
Test namelist changes: 
Test status: bit for bit,

Fixes 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
