### PR TITLE
Data assimilation to fortran try1

### DIFF
--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -50,7 +50,7 @@ class DAE(SystemTestsCompareTwo):
         expect(os.path.isfile(da_file), "ERROR: da_file, '{}', does not exist".format(da_file))
 
         # Set up two data assimilation cycles each half of the full run
-        self._case.set_value("DATA_ASSIMILATION", "TRUE")
+        self._case.set_value("DATA_ASSIMILATION_ATM", "TRUE")
         self._case.set_value("DATA_ASSIMILATION_SCRIPT", da_file)
         self._case.set_value("DATA_ASSIMILATION_CYCLES", 2)
         stopn = self._case.get_value("STOP_N")

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -40,28 +40,32 @@ class PRE(SystemTestsCompareTwo):
     def _case_one_setup(self):
     ###########################################################################
         case_setup(self._case, test_mode=True, reset=True)
-        self._stopopt = self._case.get_value("STOP_OPTION")
-        self._stopn = self._case.get_value("STOP_N")
 
     ###########################################################################
     def _case_two_setup(self):
     ###########################################################################
         # Set up a pause/resume run
-        self._case.set_value("STOP_OPTION", self._stopopt)
-        self._case.set_value("STOP_N", self._stopn)
+        stopopt = self._case1.get_value("STOP_OPTION")
+        stopn = self._case1.get_value("STOP_N")
+        self._case.set_value("STOP_OPTION", stopopt)
+        self._case.set_value("STOP_N", stopn)
         self._case.set_value("ESP_RUN_ON_PAUSE", "TRUE")
-        if self._stopn > 3:
+        if stopn > 3:
             pausen = 2
         else:
             pausen = 1
         # End if
 
-        self._case.set_value("PAUSE_OPTION", self._stopopt)
-        self._case.set_value("PAUSE_N", pausen)
-        comps = [ x.lower() for x in self._case.get_values("COMP_CLASSES") ]
-        pcl = self._case.get_value("PAUSE_COMPONENT_LIST")
-        expect(pcl == "all" or set(pcl.split(':')).issubset(comps),
-               "PRE ERROR: Invalid PAUSE_COMPONENT_LIST, '{}'".format(pcl))
+        self._case.set_value("DATA_ASSIMILATION_PAUSE_OPTION", stopopt)
+        self._case.set_value("DATA_ASSIMILATION_PAUSE_N", pausen)
+        comps = self._case.get_values("COMP_CLASSES")
+        data_assimilation = []
+        for comp in comps:
+            data_assimilation.append(self._case.get_value("DATA_ASSIMILATION_{}".format(comp)))
+
+        print "HERE: {}".format(data_assimilation)
+
+        expect(any(data_assimilation), "No Data_Assimilation flag is set")
 
         self._case.flush()
 
@@ -78,25 +82,18 @@ class PRE(SystemTestsCompareTwo):
         self._activate_case2()
         rundir2 = self._case.get_value("RUNDIR")
         compare_ok = True
-        pause_comps = self._case.get_value("PAUSE_COMPONENT_LIST")
-        expect((pause_comps != 'none'), "Pause/Resume (PRE) test has no pause components")
-        if pause_comps == 'all':
-            pause_comps = self._case.get_values("COMP_CLASSES")
-        else:
-            pause_comps = pause_comps.split(':')
-
         multi_driver = self._case.get_value("MULTI_DRIVER")
-
-        for comp in pause_comps:
-            if comp == "cpl":
+        comps = self._case.get_values("COMP_CLASSES")
+        for comp in comps:
+            if comp == "CPL":
                 if multi_driver:
                     ninst = self._case.get_value("NINST_MAX")
                 else:
                     ninst = 1
             else:
-                ninst = self._case.get_value("NINST_{}".format(comp.upper()))
+                ninst = self._case.get_value("NINST_{}".format(comp))
 
-            comp_name = self._case.get_value('COMP_{}'.format(comp.upper()))
+            comp_name = self._case.get_value('COMP_{}'.format(comp))
             for index in range(1,ninst+1):
                 if ninst == 1:
                     rname = '*.{}.r.*'.format(comp_name)

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -56,8 +56,8 @@ class PRE(SystemTestsCompareTwo):
             pausen = 1
         # End if
 
-        self._case.set_value("DATA_ASSIMILATION_PAUSE_OPTION", stopopt)
-        self._case.set_value("DATA_ASSIMILATION_PAUSE_N", pausen)
+        self._case.set_value("PAUSE_OPTION", stopopt)
+        self._case.set_value("PAUSE_N", pausen)
         comps = self._case.get_values("COMP_CLASSES")
         data_assimilation = []
         for comp in comps:

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -85,6 +85,8 @@ class PRE(SystemTestsCompareTwo):
         multi_driver = self._case.get_value("MULTI_DRIVER")
         comps = self._case.get_values("COMP_CLASSES")
         for comp in comps:
+            if not self._case.get_value("DATA_ASSIMILATION_{}".format(comp)):
+                continue
             if comp == "CPL":
                 if multi_driver:
                     ninst = self._case.get_value("NINST_MAX")

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -63,8 +63,6 @@ class PRE(SystemTestsCompareTwo):
         for comp in comps:
             data_assimilation.append(self._case.get_value("DATA_ASSIMILATION_{}".format(comp)))
 
-        print "HERE: {}".format(data_assimilation)
-
         expect(any(data_assimilation), "No Data_Assimilation flag is set")
 
         self._case.flush()

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -268,7 +268,7 @@ def case_run(case, skip_pnl=False):
     prerun_script = case.get_value("PRERUN_SCRIPT")
     postrun_script = case.get_value("POSTRUN_SCRIPT")
 
-    data_assimilation = case.get_value("DATA_ASSIMILATION")
+    data_assimilation = any(case.get_values("DATA_ASSIMILATION"))
     data_assimilation_cycles = case.get_value("DATA_ASSIMILATION_CYCLES")
     data_assimilation_script = case.get_value("DATA_ASSIMILATION_SCRIPT")
 

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -268,10 +268,11 @@ def case_run(case, skip_pnl=False):
     prerun_script = case.get_value("PRERUN_SCRIPT")
     postrun_script = case.get_value("POSTRUN_SCRIPT")
 
-    data_assimilation = any(case.get_values("DATA_ASSIMILATION"))
     data_assimilation_cycles = case.get_value("DATA_ASSIMILATION_CYCLES")
     data_assimilation_script = case.get_value("DATA_ASSIMILATION_SCRIPT")
-
+    data_assimilation = (data_assimilation_cycles > 0 and
+                         len(data_assimilation_script) > 0 and
+                         os.path.isfile(data_assimilation_script))
     # set up the LID
     lid = new_lid()
 

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -123,7 +123,7 @@ def check_case(case):
     logger.info("Check case OK")
 
 def check_DA_settings(case):
-    if case.get_value("DATA_ASSIMILATION"):
+    if any(case.get_values("DATA_ASSIMILATION")):
         script = case.get_value("DATA_ASSIMILATION_SCRIPT")
         cycles = case.get_value("DATA_ASSIMILATION_CYCLES")
         logger.info("Data Assimilation enabled using script {} with {:d} cycles".format(script,cycles))

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -123,7 +123,7 @@ def check_case(case):
     logger.info("Check case OK")
 
 def check_DA_settings(case):
-    if any(case.get_values("DATA_ASSIMILATION")):
-        script = case.get_value("DATA_ASSIMILATION_SCRIPT")
-        cycles = case.get_value("DATA_ASSIMILATION_CYCLES")
+    script = case.get_value("DATA_ASSIMILATION_SCRIPT")
+    cycles = case.get_value("DATA_ASSIMILATION_CYCLES")
+    if len(script) > 0 and os.path.isfile(script) and cycles > 0:
         logger.info("Data Assimilation enabled using script {} with {:d} cycles".format(script,cycles))

--- a/src/components/data_comps/desp/cime_config/namelist_definition_desp.xml
+++ b/src/components/data_comps/desp/cime_config/namelist_definition_desp.xml
@@ -41,7 +41,7 @@
       The mode of operation for the DESP model.
       NOCHANGE: report  status of model 'pause' but make no changes
       DATATEST: make a roundoff change  to the restart files of the
-                components in the 'PAUSE_COMPONENT_LIST' XML variable.
+                components in the 'DATA_ASSIMILATION' XML variable.
       Default: NOCHANGE
     </desc>
     <values>

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -144,20 +144,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
 
     # Set up the pause_component_list if pause is active
     pauseo = case.get_value('PAUSE_OPTION')
-    if pauseo != 'never' and pauseo != 'none':
+    if pauseo is not None and pauseo != 'never' and pauseo != 'none':
         pausen = case.get_value('PAUSE_N')
-        pcl = nmlgen.get_default('pause_component_list')
-        nmlgen.add_default('pause_component_list', pcl)
-        # Check to make sure pause_component_list is valid
-        pcl = nmlgen.get_value('pause_component_list')
-        if pcl != 'none' and pcl != 'all':
-            pause_comps = pcl.split(':')
-            comp_classes = case.get_values("COMP_CLASSES")
-            for comp in pause_comps:
-                expect(comp == 'drv' or comp.upper() in comp_classes,
-                       "Invalid PAUSE_COMPONENT_LIST, {} is not a valid component type".format(comp))
-            # End for
-        # End if
         # Set esp interval
         if 'nstep' in pauseo:
             esp_time = mindt

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -360,24 +360,24 @@
     </desc>
   </entry>
 
-  <entry id="DATA_ASSIMILATION_PAUSE_OPTION">
+  <entry id="PAUSE_OPTION">
     <type>char</type>
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear</valid_values>
     <default_value>never</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
     <desc>
-      Sets the pause frequency along with DATA_ASSIMILATION_PAUSE_N
+      Sets the pause frequency along with PAUSE_N
     </desc>
   </entry>
 
-  <entry id="DATA_ASSIMILATION_PAUSE_N">
+  <entry id="PAUSE_N">
     <type>integer</type>
     <default_value>0</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
     <desc>
-      Provides a numerical count for $DATA_ASSIMILATION_PAUSE_OPTION.
+      Provides a numerical count for $PAUSE_OPTION.
     </desc>
   </entry>
 
@@ -410,8 +410,8 @@
     <file>env_run.xml</file>
     <desc>
       ESP component runs after driver 'pause cycle' If any component
-      'pauses' (see DATA_ASSIMILATION_PAUSE_OPTION,
-      DATA_ASSIMILATION_PAUSE_N and DATA_ASSIMILATION XML variables),
+      'pauses' (see PAUSE_OPTION,
+      PAUSE_N and DATA_ASSIMILATION XML variables),
       the ESP component (if present) will be run to process the
       component 'pause' (restart) files and set any required 'resume'
       signals.  If true, esp_cpl_dt and esp_cpl_offset settings are

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -360,39 +360,24 @@
     </desc>
   </entry>
 
-  <entry id="PAUSE_OPTION">
+  <entry id="DATA_ASSIMILATION_PAUSE_OPTION">
     <type>char</type>
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear</valid_values>
     <default_value>never</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
     <desc>
-      Sets the pause frequency along with PAUSE_N
+      Sets the pause frequency along with DATA_ASSIMILATION_PAUSE_N
     </desc>
   </entry>
 
-  <entry id="PAUSE_N">
+  <entry id="DATA_ASSIMILATION_PAUSE_N">
     <type>integer</type>
     <default_value>0</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
     <desc>
-      Provides a numerical count for $PAUSE_OPTION.
-    </desc>
-  </entry>
-
-  <entry id="PAUSE_COMPONENT_LIST">
-    <type>char</type>
-    <default_value>none</default_value>
-    <values match="last">
-      <value compset="_DESP">cpl</value>
-    </values>
-    <group>run_begin_stop_restart</group>
-    <file>env_run.xml</file>
-    <desc>
-      A colon-separated list of components to receive pause and resume signals
-      A value of 'all' means all components will pause and resume
-      A value of 'none' means that no components will pause or resume
+      Provides a numerical count for $DATA_ASSIMILATION_PAUSE_OPTION.
     </desc>
   </entry>
 
@@ -424,13 +409,13 @@
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
     <desc>
-      ESP component runs after driver 'pause cycle'
-      If any component 'pauses' (see PAUSE_OPTION, PAUSE_N and
-      PAUSE_COMPONENT_LIST XML variables), the ESP component (if
-      present) will be run to process the component 'pause' (restart)
-      files and set any required 'resume' signals.
-      If true, esp_cpl_dt and esp_cpl_offset settings are ignored.
-      default: false
+      ESP component runs after driver 'pause cycle' If any component
+      'pauses' (see DATA_ASSIMILATION_PAUSE_OPTION,
+      DATA_ASSIMILATION_PAUSE_N and DATA_ASSIMILATION XML variables),
+      the ESP component (if present) will be run to process the
+      component 'pause' (restart) files and set any required 'resume'
+      signals.  If true, esp_cpl_dt and esp_cpl_offset settings are
+      ignored.  default: false
     </desc>
   </entry>
 
@@ -2580,6 +2565,7 @@
     <desc> Run the external tool pointed to by DATA_ASSIMILATION_SCRIPT after the model run completes </desc>
     <values>
       <value compclass="ATM">FALSE</value>
+      <value compclass="CPL">FALSE</value>
       <value compclass="OCN">FALSE</value>
       <value compclass="WAV">FALSE</value>
       <value compclass="GLC">FALSE</value>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2575,11 +2575,20 @@
   <entry id="DATA_ASSIMILATION">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
-    <default_value>FALSE</default_value>
     <group>external_tools</group>
     <file>env_run.xml</file>
     <desc> Run the external tool pointed to by DATA_ASSIMILATION_SCRIPT after the model run completes </desc>
+    <values>
+      <value compclass="ATM">FALSE</value>
+      <value compclass="OCN">FALSE</value>
+      <value compclass="WAV">FALSE</value>
+      <value compclass="GLC">FALSE</value>
+      <value compclass="ICE">FALSE</value>
+      <value compclass="ROF">FALSE</value>
+      <value compclass="LND">FALSE</value>
+    </values>
   </entry>
+
   <entry id="DATA_ASSIMILATION_CYCLES">
     <type>integer</type>
     <valid_values></valid_values>

--- a/src/drivers/mct/cime_config/config_compsets.xml
+++ b/src/drivers/mct/cime_config/config_compsets.xml
@@ -100,4 +100,11 @@
     <lname>2000_XATM_XLND_XICE_XOCN_XROF_XGLC_XWAV</lname>
   </compset>
 
+  <entries>
+    <entry id="DATA_ASSIMILATION_CPL">
+      <values match="last">
+	<value compset="DESP">TRUE</value>
+      </values>
+    </entry>
+  </entries>
 </compsets>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1643,13 +1643,13 @@
     <category>time</category>
     <group>seq_timemgr_inparm</group>
     <desc>
-      true => ESP component runs after driver 'pause cycle'
-      If any component 'pauses' (see PAUSE_OPTION, PAUSE_N and
-      PAUSE_COMPONENT_LIST XML variables), the ESP component (if
-      present) will be run to process the component 'pause' (restart)
-      files and set any required 'resume' signals.
-      If true, esp_cpl_dt and esp_cpl_offset settings are ignored.
-      default: true
+      true => ESP component runs after driver 'pause cycle' If any
+      component 'pauses' (see DATA_ASSIMILATION_PAUSE_OPTION,
+      DATA_ASSIMILATION_PAUSE_N and DATA_ASSIMILATION_XXX XML
+      variables), the ESP component (if present) will be run to
+      process the component 'pause' (restart) files and set any
+      required 'resume' signals.  If true, esp_cpl_dt and
+      esp_cpl_offset settings are ignored.  default: true
     </desc>
     <values>
       <value>.true.</value>
@@ -2024,52 +2024,38 @@
     </values>
   </entry>
 
-  <entry id="pause_option" modify_via_xml="PAUSE_OPTION">
+  <entry id="data_assimilation_pause_option" modify_via_xml="DATA_ASSIMILATION_PAUSE_OPTION">
     <type>char</type>
-    <category>time</category>
+    <category>data_assimilation</category>
     <group>seq_timemgr_inparm</group>
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear</valid_values>
     <desc>
-      sets the pause frequency with pause_n
-      pause_option alarms are:
+      sets the pause frequency with data_assimilation_pause_n
+      data_assimilation_pause_option alarms are:
       [none/never], turns option off
-      [nstep/s]   , pauses every pause_n nsteps  , relative to start or last pause time
-      [nsecond/s] , pauses every pause_n nseconds, relative to start or last pause time
-      [nminute/s] , pauses every pause_n nminutes, relative to start or last pause time
-      [nhour/s]   , pauses every pause_n nhours  , relative to start or last pause time
-      [nday/s]    , pauses every pause_n ndays   , relative to start or last pause time
-      [nmonth/s]  , pauses every pause_n nmonths , relative to start or last pause time
+      [nstep/s]   , pauses every data_assimilation_pause_n nsteps  , relative to start or last pause time
+      [nsecond/s] , pauses every data_assimilation_pause_n nseconds, relative to start or last pause time
+      [nminute/s] , pauses every data_assimilation_pause_n nminutes, relative to start or last pause time
+      [nhour/s]   , pauses every data_assimilation_pause_n nhours  , relative to start or last pause time
+      [nday/s]    , pauses every data_assimilation_pause_n ndays   , relative to start or last pause time
+      [nmonth/s]  , pauses every data_assimilation_pause_n nmonths , relative to start or last pause time
       [monthly/s] , pauses every        month    , relative to start or last pause time
-      [nyear/s]   , pauses every pause_n nyears  , relative to start or last pause time
+      [nyear/s]   , pauses every data_assimilation_pause_n nyears  , relative to start or last pause time
     </desc>
     <values>
-      <value>$PAUSE_OPTION</value>
+      <value>$DATA_ASSIMILATION_PAUSE_OPTION</value>
     </values>
   </entry>
 
-  <entry id="pause_n" modify_via_xml="PAUSE_N">
+  <entry id="data_assimilation_pause_n" modify_via_xml="DATA_ASSIMILATION_PAUSE_N">
     <type>integer</type>
-    <category>time</category>
+    <category>data_assimilation</category>
     <group>seq_timemgr_inparm</group>
     <desc>
-      Sets the pause frequency with pause_option
+      Sets the pause frequency with data_assimilation_pause_option
     </desc>
     <values>
-      <value>$PAUSE_N</value>
-    </values>
-  </entry>
-
-  <entry id="pause_component_list" modify_via_xml="PAUSE_COMPONENT_LIST" skip_default_entry="true">
-    <type>char</type>
-    <category>time</category>
-    <group>seq_timemgr_inparm</group>
-    <desc>
-      A colon-separated list of component types (e.g., ocn,atm) to receive a
-      resume signal after a pause has happened. Special values "all" or "none"
-      may be used in place of a list
-    </desc>
-    <values>
-      <value>$PAUSE_COMPONENT_LIST</value>
+      <value>$DATA_ASSIMILATION_PAUSE_N</value>
     </values>
   </entry>
 
@@ -3937,7 +3923,7 @@
   <entry id="data_assimilation_atm" modify_via_xml="DATA_ASSIMILATION_ATM">
     <type>logical</type>
     <category>data_assimilation</category>
-    <group>seq_infodata_inparm</group>
+    <group>seq_timemgr_inparm</group>
     <desc>
       Whether Data Assimilation is on for component atm
     </desc>
@@ -3946,10 +3932,22 @@
     </values>
   </entry>
 
+  <entry id="data_assimilation_cpl" modify_via_xml="DATA_ASSIMILATION_CPL">
+    <type>logical</type>
+    <category>data_assimilation</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      Whether Data Assimilation is on for component CPL
+    </desc>
+    <values>
+      <value>$DATA_ASSIMILATION_CPL</value>
+    </values>
+  </entry>
+
   <entry id="data_assimilation_ocn" modify_via_xml="DATA_ASSIMILATION_OCN">
     <type>logical</type>
     <category>data_assimilation</category>
-    <group>seq_infodata_inparm</group>
+    <group>seq_timemgr_inparm</group>
     <desc>
       Whether Data Assimilation is on for component ocn
     </desc>
@@ -3961,7 +3959,7 @@
   <entry id="data_assimilation_wav" modify_via_xml="DATA_ASSIMILATION_WAV">
     <type>logical</type>
     <category>data_assimilation</category>
-    <group>seq_infodata_inparm</group>
+    <group>seq_timemgr_inparm</group>
     <desc>
       Whether Data Assimilation is on for component wav
     </desc>
@@ -3973,7 +3971,7 @@
   <entry id="data_assimilation_glc" modify_via_xml="DATA_ASSIMILATION_GLC">
     <type>logical</type>
     <category>data_assimilation</category>
-    <group>seq_infodata_inparm</group>
+    <group>seq_timemgr_inparm</group>
     <desc>
       Whether Data Assimilation is on for component glc
     </desc>
@@ -3985,7 +3983,7 @@
   <entry id="data_assimilation_rof" modify_via_xml="DATA_ASSIMILATION_ROF">
     <type>logical</type>
     <category>data_assimilation</category>
-    <group>seq_infodata_inparm</group>
+    <group>seq_timemgr_inparm</group>
     <desc>
       Whether Data Assimilation is on for component rof
     </desc>
@@ -3997,7 +3995,7 @@
   <entry id="data_assimilation_ice" modify_via_xml="DATA_ASSIMILATION_ICE">
     <type>logical</type>
     <category>data_assimilation</category>
-    <group>seq_infodata_inparm</group>
+    <group>seq_timemgr_inparm</group>
     <desc>
       Whether Data Assimilation is on for component ice
     </desc>
@@ -4009,7 +4007,7 @@
   <entry id="data_assimilation_lnd" modify_via_xml="DATA_ASSIMILATION_LND">
     <type>logical</type>
     <category>data_assimilation</category>
-    <group>seq_infodata_inparm</group>
+    <group>seq_timemgr_inparm</group>
     <desc>
       Whether Data Assimilation is on for component lnd
     </desc>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -3934,4 +3934,88 @@
     </values>
   </entry>
 
+  <entry id="data_assimilation_atm" modify_via_xml="DATA_ASSIMILATION_ATM">
+    <type>logical</type>
+    <category>data_assimilation</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Whether Data Assimilation is on for component atm
+    </desc>
+    <values>
+      <value>$DATA_ASSIMILATION_ATM</value>
+    </values>
+  </entry>
+
+  <entry id="data_assimilation_ocn" modify_via_xml="DATA_ASSIMILATION_OCN">
+    <type>logical</type>
+    <category>data_assimilation</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Whether Data Assimilation is on for component ocn
+    </desc>
+    <values>
+      <value>$DATA_ASSIMILATION_OCN</value>
+    </values>
+  </entry>
+
+  <entry id="data_assimilation_wav" modify_via_xml="DATA_ASSIMILATION_WAV">
+    <type>logical</type>
+    <category>data_assimilation</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Whether Data Assimilation is on for component wav
+    </desc>
+    <values>
+      <value>$DATA_ASSIMILATION_WAV</value>
+    </values>
+  </entry>
+
+  <entry id="data_assimilation_glc" modify_via_xml="DATA_ASSIMILATION_GLC">
+    <type>logical</type>
+    <category>data_assimilation</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Whether Data Assimilation is on for component glc
+    </desc>
+    <values>
+      <value>$DATA_ASSIMILATION_GLC</value>
+    </values>
+  </entry>
+
+  <entry id="data_assimilation_rof" modify_via_xml="DATA_ASSIMILATION_ROF">
+    <type>logical</type>
+    <category>data_assimilation</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Whether Data Assimilation is on for component rof
+    </desc>
+    <values>
+      <value>$DATA_ASSIMILATION_ROF</value>
+    </values>
+  </entry>
+
+  <entry id="data_assimilation_ice" modify_via_xml="DATA_ASSIMILATION_ICE">
+    <type>logical</type>
+    <category>data_assimilation</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Whether Data Assimilation is on for component ice
+    </desc>
+    <values>
+      <value>$DATA_ASSIMILATION_ICE</value>
+    </values>
+  </entry>
+
+  <entry id="data_assimilation_lnd" modify_via_xml="DATA_ASSIMILATION_LND">
+    <type>logical</type>
+    <category>data_assimilation</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Whether Data Assimilation is on for component lnd
+    </desc>
+    <values>
+      <value>$DATA_ASSIMILATION_LND</value>
+    </values>
+  </entry>
+
 </entry_id>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1644,8 +1644,8 @@
     <group>seq_timemgr_inparm</group>
     <desc>
       true => ESP component runs after driver 'pause cycle' If any
-      component 'pauses' (see DATA_ASSIMILATION_PAUSE_OPTION,
-      DATA_ASSIMILATION_PAUSE_N and DATA_ASSIMILATION_XXX XML
+      component 'pauses' (see PAUSE_OPTION,
+      PAUSE_N and DATA_ASSIMILATION_XXX XML
       variables), the ESP component (if present) will be run to
       process the component 'pause' (restart) files and set any
       required 'resume' signals.  If true, esp_cpl_dt and
@@ -2024,38 +2024,38 @@
     </values>
   </entry>
 
-  <entry id="data_assimilation_pause_option" modify_via_xml="DATA_ASSIMILATION_PAUSE_OPTION">
+  <entry id="pause_option" modify_via_xml="PAUSE_OPTION">
     <type>char</type>
     <category>data_assimilation</category>
     <group>seq_timemgr_inparm</group>
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear</valid_values>
     <desc>
-      sets the pause frequency with data_assimilation_pause_n
-      data_assimilation_pause_option alarms are:
+      sets the pause frequency with pause_n
+      pause_option alarms are:
       [none/never], turns option off
-      [nstep/s]   , pauses every data_assimilation_pause_n nsteps  , relative to start or last pause time
-      [nsecond/s] , pauses every data_assimilation_pause_n nseconds, relative to start or last pause time
-      [nminute/s] , pauses every data_assimilation_pause_n nminutes, relative to start or last pause time
-      [nhour/s]   , pauses every data_assimilation_pause_n nhours  , relative to start or last pause time
-      [nday/s]    , pauses every data_assimilation_pause_n ndays   , relative to start or last pause time
-      [nmonth/s]  , pauses every data_assimilation_pause_n nmonths , relative to start or last pause time
+      [nstep/s]   , pauses every pause_n nsteps  , relative to start or last pause time
+      [nsecond/s] , pauses every pause_n nseconds, relative to start or last pause time
+      [nminute/s] , pauses every pause_n nminutes, relative to start or last pause time
+      [nhour/s]   , pauses every pause_n nhours  , relative to start or last pause time
+      [nday/s]    , pauses every pause_n ndays   , relative to start or last pause time
+      [nmonth/s]  , pauses every pause_n nmonths , relative to start or last pause time
       [monthly/s] , pauses every        month    , relative to start or last pause time
-      [nyear/s]   , pauses every data_assimilation_pause_n nyears  , relative to start or last pause time
+      [nyear/s]   , pauses every pause_n nyears  , relative to start or last pause time
     </desc>
     <values>
-      <value>$DATA_ASSIMILATION_PAUSE_OPTION</value>
+      <value>$PAUSE_OPTION</value>
     </values>
   </entry>
 
-  <entry id="data_assimilation_pause_n" modify_via_xml="DATA_ASSIMILATION_PAUSE_N">
+  <entry id="pause_n" modify_via_xml="PAUSE_N">
     <type>integer</type>
     <category>data_assimilation</category>
     <group>seq_timemgr_inparm</group>
     <desc>
-      Sets the pause frequency with data_assimilation_pause_option
+      Sets the pause frequency with pause_option
     </desc>
     <values>
-      <value>$DATA_ASSIMILATION_PAUSE_N</value>
+      <value>$PAUSE_N</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -2026,7 +2026,7 @@
 
   <entry id="pause_option" modify_via_xml="PAUSE_OPTION">
     <type>char</type>
-    <category>data_assimilation</category>
+    <category>time</category>
     <group>seq_timemgr_inparm</group>
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,monthly,nmonths,nmonth,nyears,nyear</valid_values>
     <desc>
@@ -2049,7 +2049,7 @@
 
   <entry id="pause_n" modify_via_xml="PAUSE_N">
     <type>integer</type>
-    <category>data_assimilation</category>
+    <category>time</category>
     <group>seq_timemgr_inparm</group>
     <desc>
       Sets the pause frequency with pause_option

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2090,7 +2090,7 @@ end subroutine cime_init
    integer            :: hashint(hashcnt)
    ! Driver pause/resume
    logical            :: drv_pause  ! Driver writes pause restart file
-   logical            :: drv_resume ! Driver resets state from restart file
+   character(len=CL)  :: drv_resume ! Driver resets state from restart file
    integer            :: iamroot_ESPID
 
 101 format( A, 2i8, 12A, A, F8.2, A, F8.2 )

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2090,7 +2090,7 @@ end subroutine cime_init
    integer            :: hashint(hashcnt)
    ! Driver pause/resume
    logical            :: drv_pause  ! Driver writes pause restart file
-   character(len=CL)  :: drv_resume ! Driver resets state from restart file
+   logical            :: drv_resume ! Driver resets state from restart file
    integer            :: iamroot_ESPID
 
 101 format( A, 2i8, 12A, A, F8.2, A, F8.2 )

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -68,14 +68,14 @@ MODULE seq_infodata_mod
    ! Type to hold pause/resume signaling information
    type seq_pause_resume_type
       private
-      character(SHR_KIND_CL) :: atm_resume(num_inst_atm) = ' ' ! atm resume file
-      character(SHR_KIND_CL) :: lnd_resume(num_inst_lnd) = ' ' ! lnd resume file
-      character(SHR_KIND_CL) :: ice_resume(num_inst_ice) = ' ' ! ice resume file
-      character(SHR_KIND_CL) :: ocn_resume(num_inst_ocn) = ' ' ! ocn resume file
-      character(SHR_KIND_CL) :: glc_resume(num_inst_glc) = ' ' ! glc resume file
-      character(SHR_KIND_CL) :: rof_resume(num_inst_rof) = ' ' ! rof resume file
-      character(SHR_KIND_CL) :: wav_resume(num_inst_wav) = ' ' ! wav resume file
-      character(SHR_KIND_CL) :: cpl_resume = ' '               ! cpl resume file
+      logical :: data_assimilation_atm(num_inst_atm) = .false.
+      logical :: data_assimilation_cpl                           = .false.
+      logical :: data_assimilation_ocn(num_inst_ocn) = .false.
+      logical :: data_assimilation_wav(num_inst_wav) = .false.
+      logical :: data_assimilation_glc(num_inst_glc) = .false.
+      logical :: data_assimilation_ice(num_inst_ice) = .false.
+      logical :: data_assimilation_rof(num_inst_rof) = .false.
+      logical :: data_assimilation_lnd(num_inst_lnd) = .false.
    end type seq_pause_resume_type
 
    ! InputInfo derived type
@@ -181,15 +181,6 @@ MODULE seq_infodata_mod
       real(SHR_KIND_R8)       :: reprosum_diffmax    ! maximum difference tolerance
       logical                 :: reprosum_recompute  ! recompute reprosum with nonscalable algorithm
                                                      ! if reprosum_diffmax is exceeded
-
-      logical :: data_assimilation_atm
-      logical :: data_assimilation_ocn
-      logical :: data_assimilation_wav
-      logical :: data_assimilation_glc
-      logical :: data_assimilation_ice
-      logical :: data_assimilation_rof
-      logical :: data_assimilation_lnd
-
       !--- set via namelist and may be time varying ---
       integer(SHR_KIND_IN)    :: info_debug      ! debug level
       logical                 :: bfbflag         ! turn on bfb option
@@ -424,14 +415,6 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid, cpl_tag)
     logical                :: mct_usevector      ! flag for mct vector
     real(shr_kind_r8) :: max_cplstep_time  ! abort if cplstep time exceeds this value
 
-    logical :: data_assimilation_atm
-    logical :: data_assimilation_ocn
-    logical :: data_assimilation_wav
-    logical :: data_assimilation_glc
-    logical :: data_assimilation_ice
-    logical :: data_assimilation_rof
-    logical :: data_assimilation_lnd
-
     namelist /seq_infodata_inparm/  &
          cime_model, case_desc, case_name, start_type, tchkpt_dir,     &
          model_version, username, hostname, timing_dir,    &
@@ -462,11 +445,7 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid, cpl_tag)
          eps_agrid, eps_aarea, eps_omask, eps_ogrid,       &
          eps_oarea, esmf_map_flag,                         &
          reprosum_use_ddpdd, reprosum_diffmax, reprosum_recompute, &
-         mct_usealltoall, mct_usevector, max_cplstep_time, &
-         data_assimilation_atm, data_assimilation_ocn, &
-         data_assimilation_wav, data_assimilation_glc, &
-         data_assimilation_ice, data_assimilation_rof, &
-         data_assimilation_lnd
+         mct_usealltoall, mct_usevector, max_cplstep_time
 
 !-------------------------------------------------------------------------------
 
@@ -574,15 +553,6 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid, cpl_tag)
        mct_usealltoall       = .false.
        mct_usevector         = .false.
        max_cplstep_time      = 0.0
-
-       data_assimilation_atm = .false.
-       data_assimilation_ocn = .false.
-       data_assimilation_wav = .false.
-       data_assimilation_glc = .false.
-       data_assimilation_ice = .false.
-       data_assimilation_rof = .false.
-       data_assimilation_lnd = .false.
-
 
        !---------------------------------------------------------------------------
        ! Read in namelist
@@ -728,14 +698,6 @@ SUBROUTINE seq_infodata_Init( infodata, nmlfile, ID, pioid, cpl_tag)
        infodata%ocnrof_prognostic = .false.
        infodata%ice_prognostic = .false.
        infodata%glc_prognostic = .false.
-
-       infodata%data_assimilation_atm = data_assimilation_atm
-       infodata%data_assimilation_ocn = data_assimilation_ocn
-       infodata%data_assimilation_wav = data_assimilation_wav
-       infodata%data_assimilation_glc =  data_assimilation_glc
-       infodata%data_assimilation_ice =  data_assimilation_ice
-       infodata%data_assimilation_rof =  data_assimilation_rof
-       infodata%data_assimilation_lnd = data_assimilation_lnd
 
        ! It's safest to assume glc_coupled_fluxes = .true. if it's not set elsewhere,
        ! because this is needed for conservation in some cases. Note that it is ignored
@@ -999,12 +961,7 @@ SUBROUTINE seq_infodata_GetData_explicit( infodata, cime_model, case_name, case_
            reprosum_use_ddpdd, reprosum_diffmax, reprosum_recompute,          &
            atm_resume, lnd_resume, ocn_resume, ice_resume,                    &
            glc_resume, rof_resume, wav_resume, cpl_resume,                    &
-           mct_usealltoall, mct_usevector, max_cplstep_time, glc_valid_input, &
-           data_assimilation_atm, data_assimilation_ocn, &
-           data_assimilation_wav, data_assimilation_glc, &
-           data_assimilation_ice, data_assimilation_rof, &
-           data_assimilation_lnd)
-
+           mct_usealltoall, mct_usevector, max_cplstep_time, glc_valid_input)
 
    implicit none
 
@@ -1166,22 +1123,14 @@ SUBROUTINE seq_infodata_GetData_explicit( infodata, cime_model, case_name, case_
    logical,                optional, intent(OUT) :: glc_g2lupdate           ! update glc2lnd fields in lnd model
    real(shr_kind_r8),      optional, intent(out) :: max_cplstep_time
    logical,                optional, intent(OUT) :: glc_valid_input
-   character(SHR_KIND_CL), optional, intent(OUT) :: atm_resume(:) ! atm read resume state
-   character(SHR_KIND_CL), optional, intent(OUT) :: lnd_resume(:) ! lnd read resume state
-   character(SHR_KIND_CL), optional, intent(OUT) :: ice_resume(:) ! ice read resume state
-   character(SHR_KIND_CL), optional, intent(OUT) :: ocn_resume(:) ! ocn read resume state
-   character(SHR_KIND_CL), optional, intent(OUT) :: glc_resume(:) ! glc read resume state
-   character(SHR_KIND_CL), optional, intent(OUT) :: rof_resume(:) ! rof read resume state
-   character(SHR_KIND_CL), optional, intent(OUT) :: wav_resume(:) ! wav read resume state
-   character(SHR_KIND_CL), optional, intent(OUT) :: cpl_resume ! cpl read resume state
-
-   logical, optional, intent(OUT) :: data_assimilation_atm
-   logical, optional, intent(OUT) :: data_assimilation_ocn
-   logical, optional, intent(OUT) :: data_assimilation_wav
-   logical, optional, intent(OUT) :: data_assimilation_glc
-   logical, optional, intent(OUT) :: data_assimilation_ice
-   logical, optional, intent(OUT) :: data_assimilation_rof
-   logical, optional, intent(OUT) :: data_assimilation_lnd
+   logical, optional, intent(OUT) :: atm_resume(:) ! atm read resume state
+   logical, optional, intent(OUT) :: lnd_resume(:) ! lnd read resume state
+   logical, optional, intent(OUT) :: ice_resume(:) ! ice read resume state
+   logical, optional, intent(OUT) :: ocn_resume(:) ! ocn read resume state
+   logical, optional, intent(OUT) :: glc_resume(:) ! glc read resume state
+   logical, optional, intent(OUT) :: rof_resume(:) ! rof read resume state
+   logical, optional, intent(OUT) :: wav_resume(:) ! wav read resume state
+   logical, optional, intent(OUT) :: cpl_resume ! cpl read resume state
 
     !----- local -----
     character(len=*), parameter :: subname = '(seq_infodata_GetData_explicit) '
@@ -1357,70 +1306,62 @@ SUBROUTINE seq_infodata_GetData_explicit( infodata, cime_model, case_name, case_
     if ( present(glc_g2lupdate)  ) glc_g2lupdate  = infodata%glc_g2lupdate
     if ( present(atm_resume) ) then
       if (associated(infodata%pause_resume)) then
-        atm_resume(:)  = infodata%pause_resume%atm_resume(:)
+        atm_resume(:)  = infodata%pause_resume%data_assimilation_atm(:)
       else
         atm_resume(:) = ' '
       end if
     end if
     if ( present(lnd_resume) ) then
       if (associated(infodata%pause_resume)) then
-        lnd_resume(:)  = infodata%pause_resume%lnd_resume(:)
+        lnd_resume(:)  = infodata%pause_resume%data_assimilation_lnd(:)
       else
         lnd_resume(:) = ' '
       end if
     end if
     if ( present(ice_resume) ) then
       if (associated(infodata%pause_resume)) then
-        ice_resume(:)  = infodata%pause_resume%ice_resume(:)
+        ice_resume(:)  = infodata%pause_resume%data_assimilation_ice(:)
       else
         ice_resume(:) = ' '
       end if
     end if
     if ( present(ocn_resume) ) then
       if (associated(infodata%pause_resume)) then
-        ocn_resume(:)  = infodata%pause_resume%ocn_resume(:)
+        ocn_resume(:)  = infodata%pause_resume%data_assimilation_ocn(:)
       else
         ocn_resume(:) = ' '
       end if
     end if
     if ( present(glc_resume) ) then
       if (associated(infodata%pause_resume)) then
-        glc_resume(:)  = infodata%pause_resume%glc_resume(:)
+        glc_resume(:)  = infodata%pause_resume%data_assimilation_glc(:)
       else
         glc_resume(:) = ' '
       end if
     end if
     if ( present(rof_resume) ) then
       if (associated(infodata%pause_resume)) then
-        rof_resume(:)  = infodata%pause_resume%rof_resume(:)
+        rof_resume(:)  = infodata%pause_resume%data_assimilation_rof(:)
       else
         rof_resume(:) = ' '
       end if
     end if
     if ( present(wav_resume) ) then
       if (associated(infodata%pause_resume)) then
-        wav_resume(:)  = infodata%pause_resume%wav_resume(:)
+        wav_resume(:)  = infodata%pause_resume%data_assimilation_wav(:)
       else
         wav_resume(:) = ' '
       end if
     end if
     if ( present(cpl_resume) ) then
       if (associated(infodata%pause_resume)) then
-        cpl_resume     = infodata%pause_resume%cpl_resume
+        cpl_resume     = infodata%pause_resume%data_assimilation_cpl
       else
         cpl_resume = ' '
       end if
     end if
     if ( present(max_cplstep_time) ) max_cplstep_time = infodata%max_cplstep_time
     if ( present(glc_valid_input)) glc_valid_input = infodata%glc_valid_input
-
-    if ( present(data_assimilation_atm)) data_assimilation_atm = infodata%data_assimilation_atm
-    if ( present(data_assimilation_ocn)) data_assimilation_ocn = infodata%data_assimilation_ocn
-    if ( present(data_assimilation_wav)) data_assimilation_wav = infodata%data_assimilation_wav
-    if ( present(data_assimilation_glc)) data_assimilation_glc = infodata%data_assimilation_glc
-    if ( present(data_assimilation_ice)) data_assimilation_ice = infodata%data_assimilation_ice
-    if ( present(data_assimilation_rof)) data_assimilation_rof = infodata%data_assimilation_rof
-    if ( present(data_assimilation_lnd)) data_assimilation_lnd = infodata%data_assimilation_lnd
 
 END SUBROUTINE seq_infodata_GetData_explicit
 
@@ -1452,7 +1393,7 @@ SUBROUTINE seq_infodata_GetData_bytype( component_firstletter, infodata,      &
    integer(SHR_KIND_IN),   optional, intent(OUT) :: comp_ny         ! nx,ny 2d grid size global
    integer(SHR_KIND_IN),   optional, intent(OUT) :: comp_phase
    logical,                optional, intent(OUT) :: histavg_comp
-   character(SHR_KIND_CL), optional, intent(OUT) :: comp_resume(:)
+   logical, optional, intent(OUT) :: comp_resume(:)
 
     !----- local -----
     character(len=*), parameter :: subname = '(seq_infodata_GetData_bytype) '
@@ -1743,14 +1684,14 @@ SUBROUTINE seq_infodata_PutData_explicit( infodata, cime_model, case_name, case_
    logical,                optional, intent(IN) :: atm_aero              ! atm aerosols
    logical,                optional, intent(IN) :: glc_g2lupdate         ! update glc2lnd fields in lnd model
    logical,                optional, intent(IN) :: glc_valid_input
-   character(SHR_KIND_CL), optional, intent(IN) :: atm_resume(:)         ! atm resume
-   character(SHR_KIND_CL), optional, intent(IN) :: lnd_resume(:)         ! lnd resume
-   character(SHR_KIND_CL), optional, intent(IN) :: ice_resume(:)         ! ice resume
-   character(SHR_KIND_CL), optional, intent(IN) :: ocn_resume(:)         ! ocn resume
-   character(SHR_KIND_CL), optional, intent(IN) :: glc_resume(:)         ! glc resume
-   character(SHR_KIND_CL), optional, intent(IN) :: rof_resume(:)         ! rof resume
-   character(SHR_KIND_CL), optional, intent(IN) :: wav_resume(:)         ! wav resume
-   character(SHR_KIND_CL), optional, intent(IN) :: cpl_resume            ! cpl resume
+   logical, optional, intent(IN) :: atm_resume(:)         ! atm resume
+   logical, optional, intent(IN) :: lnd_resume(:)         ! lnd resume
+   logical, optional, intent(IN) :: ice_resume(:)         ! ice resume
+   logical, optional, intent(IN) :: ocn_resume(:)         ! ocn resume
+   logical, optional, intent(IN) :: glc_resume(:)         ! glc resume
+   logical, optional, intent(IN) :: rof_resume(:)         ! rof resume
+   logical, optional, intent(IN) :: wav_resume(:)         ! wav resume
+   logical, optional, intent(IN) :: cpl_resume            ! cpl resume
 
 !EOP
 
@@ -1915,66 +1856,66 @@ SUBROUTINE seq_infodata_PutData_explicit( infodata, cime_model, case_name, case_
     if ( present(glc_valid_input) ) infodata%glc_valid_input = glc_valid_input
     if ( present(atm_resume) ) then
       if (associated(infodata%pause_resume)) then
-        infodata%pause_resume%atm_resume(:) = atm_resume(:)
-      else if (ANY(len_trim(atm_resume(:)) > 0)) then
+        infodata%pause_resume%data_assimilation_atm(:) = atm_resume(:)
+      else if (ANY(atm_resume(:))) then
         allocate(infodata%pause_resume)
-        infodata%pause_resume%atm_resume(:) = atm_resume(:)
+        infodata%pause_resume%data_assimilation_atm(:) = atm_resume(:)
       end if
     end if
     if ( present(lnd_resume) ) then
       if (associated(infodata%pause_resume)) then
-        infodata%pause_resume%lnd_resume(:) = lnd_resume(:)
-      else if (ANY(len_trim(lnd_resume(:)) > 0)) then
+        infodata%pause_resume%data_assimilation_lnd(:) = lnd_resume(:)
+      else if (ANY(lnd_resume(:))) then
         allocate(infodata%pause_resume)
-        infodata%pause_resume%lnd_resume(:) = lnd_resume(:)
+        infodata%pause_resume%data_assimilation_lnd(:) = lnd_resume(:)
       end if
     end if
     if ( present(ice_resume) ) then
       if (associated(infodata%pause_resume)) then
-        infodata%pause_resume%ice_resume(:) = ice_resume(:)
-      else if (ANY(len_trim(ice_resume(:)) > 0)) then
+        infodata%pause_resume%data_assimilation_ice(:) = ice_resume(:)
+      else if (ANY(ice_resume(:))) then
         allocate(infodata%pause_resume)
-        infodata%pause_resume%ice_resume(:) = ice_resume(:)
+        infodata%pause_resume%data_assimilation_ice(:) = ice_resume(:)
       end if
     end if
     if ( present(ocn_resume) ) then
       if (associated(infodata%pause_resume)) then
-        infodata%pause_resume%ocn_resume(:) = ocn_resume(:)
-      else if (ANY(len_trim(ocn_resume(:)) > 0)) then
+        infodata%pause_resume%data_assimilation_ocn(:) = ocn_resume(:)
+      else if (ANY(ocn_resume(:))) then
         allocate(infodata%pause_resume)
-        infodata%pause_resume%ocn_resume(:) = ocn_resume(:)
+        infodata%pause_resume%data_assimilation_ocn(:) = ocn_resume(:)
       end if
     end if
     if ( present(glc_resume) ) then
       if (associated(infodata%pause_resume)) then
-        infodata%pause_resume%glc_resume(:) = glc_resume(:)
-      else if (ANY(len_trim(glc_resume(:)) > 0)) then
+        infodata%pause_resume%data_assimilation_glc(:) = glc_resume(:)
+      else if (ANY(glc_resume(:))) then
         allocate(infodata%pause_resume)
-        infodata%pause_resume%glc_resume(:) = glc_resume(:)
+        infodata%pause_resume%data_assimilation_glc(:) = glc_resume(:)
       end if
     end if
     if ( present(rof_resume) ) then
       if (associated(infodata%pause_resume)) then
-        infodata%pause_resume%rof_resume(:) = rof_resume(:)
-      else if (ANY(len_trim(rof_resume(:)) > 0)) then
+        infodata%pause_resume%data_assimilation_rof(:) = rof_resume(:)
+      else if (ANY(rof_resume(:))) then
         allocate(infodata%pause_resume)
-        infodata%pause_resume%rof_resume(:) = rof_resume(:)
+        infodata%pause_resume%data_assimilation_rof(:) = rof_resume(:)
       end if
     end if
     if ( present(wav_resume) ) then
       if (associated(infodata%pause_resume)) then
-        infodata%pause_resume%wav_resume(:) = wav_resume(:)
-      else if (ANY(len_trim(wav_resume(:)) > 0)) then
+        infodata%pause_resume%data_assimilation_wav(:) = wav_resume(:)
+      else if (ANY(wav_resume(:))) then
         allocate(infodata%pause_resume)
-        infodata%pause_resume%wav_resume(:) = wav_resume(:)
+        infodata%pause_resume%data_assimilation_wav(:) = wav_resume(:)
       end if
     end if
     if ( present(cpl_resume) ) then
       if (associated(infodata%pause_resume)) then
-        infodata%pause_resume%cpl_resume = cpl_resume
-      else if (len_trim(cpl_resume) > 0) then
+        infodata%pause_resume%data_assimilation_cpl = cpl_resume
+      else if (cpl_resume) then
         allocate(infodata%pause_resume)
-        infodata%pause_resume%cpl_resume = cpl_resume
+        infodata%pause_resume%data_assimilation_cpl = cpl_resume
       end if
     end if
 
@@ -2007,7 +1948,7 @@ SUBROUTINE seq_infodata_PutData_bytype( component_firstletter, infodata,      &
    integer(SHR_KIND_IN),   optional, intent(IN)    :: comp_ny         ! nx,ny 2d grid size global
    integer(SHR_KIND_IN),   optional, intent(IN)    :: comp_phase
    logical,                optional, intent(IN)    :: histavg_comp
-   character(SHR_KIND_CL), optional, intent(IN) :: comp_resume(:)
+   logical, optional, intent(IN) :: comp_resume(:)
 
 !EOP
 
@@ -2116,36 +2057,22 @@ subroutine seq_infodata_pauseresume_bcast(infodata, mpicom, pebcast)
   end if
 
   if (associated(infodata%pause_resume)) then
-    do ind = 1, num_inst_atm
-      call shr_mpi_bcast(infodata%pause_resume%atm_resume(ind), mpicom,       &
-           pebcast=pebcast_local)
-    end do
-    do ind = 1, num_inst_lnd
-      call shr_mpi_bcast(infodata%pause_resume%lnd_resume(ind), mpicom,       &
-           pebcast=pebcast_local)
-    end do
-    do ind = 1, num_inst_ice
-      call shr_mpi_bcast(infodata%pause_resume%ice_resume(ind), mpicom,       &
-           pebcast=pebcast_local)
-    end do
-    do ind = 1, num_inst_ocn
-      call shr_mpi_bcast(infodata%pause_resume%ocn_resume(ind), mpicom,       &
-           pebcast=pebcast_local)
-    end do
-    do ind = 1, num_inst_glc
-      call shr_mpi_bcast(infodata%pause_resume%glc_resume(ind), mpicom,       &
-           pebcast=pebcast_local)
-    end do
-    do ind = 1, num_inst_rof
-      call shr_mpi_bcast(infodata%pause_resume%rof_resume(ind), mpicom,       &
-           pebcast=pebcast_local)
-    end do
-    do ind = 1, num_inst_wav
-      call shr_mpi_bcast(infodata%pause_resume%wav_resume(ind), mpicom,       &
-           pebcast=pebcast_local)
-    end do
-    call shr_mpi_bcast(infodata%pause_resume%cpl_resume,        mpicom,       &
-         pebcast=pebcast_local)
+     call shr_mpi_bcast(infodata%pause_resume%data_assimilation_atm, mpicom,       &
+          pebcast=pebcast_local)
+     call shr_mpi_bcast(infodata%pause_resume%data_assimilation_lnd, mpicom,       &
+          pebcast=pebcast_local)
+     call shr_mpi_bcast(infodata%pause_resume%data_assimilation_ice, mpicom,       &
+          pebcast=pebcast_local)
+     call shr_mpi_bcast(infodata%pause_resume%data_assimilation_ocn, mpicom,       &
+          pebcast=pebcast_local)
+     call shr_mpi_bcast(infodata%pause_resume%data_assimilation_glc, mpicom,       &
+          pebcast=pebcast_local)
+     call shr_mpi_bcast(infodata%pause_resume%data_assimilation_rof, mpicom,       &
+          pebcast=pebcast_local)
+     call shr_mpi_bcast(infodata%pause_resume%data_assimilation_wav, mpicom,       &
+          pebcast=pebcast_local)
+     call shr_mpi_bcast(infodata%pause_resume%data_assimilation_cpl,        mpicom,       &
+          pebcast=pebcast_local)
   end if
 end subroutine seq_infodata_pauseresume_bcast
 
@@ -2332,14 +2259,6 @@ subroutine seq_infodata_bcast(infodata,mpicom)
     call shr_mpi_bcast(infodata%atm_aero,                mpicom)
     call shr_mpi_bcast(infodata%glc_g2lupdate,           mpicom)
     call shr_mpi_bcast(infodata%glc_valid_input,         mpicom)
-
-    call shr_mpi_bcast(infodata%data_assimilation_atm, mpicom)
-    call shr_mpi_bcast(infodata%data_assimilation_ocn, mpicom)
-    call shr_mpi_bcast(infodata%data_assimilation_wav, mpicom)
-    call shr_mpi_bcast(infodata%data_assimilation_glc, mpicom)
-    call shr_mpi_bcast(infodata%data_assimilation_ice, mpicom)
-    call shr_mpi_bcast(infodata%data_assimilation_rof, mpicom)
-    call shr_mpi_bcast(infodata%data_assimilation_lnd, mpicom)
 
     call seq_infodata_pauseresume_bcast(infodata,        mpicom)
 
@@ -3011,57 +2930,18 @@ SUBROUTINE seq_infodata_print( infodata )
        write(logunit,F0S) subname,'rof_phase                = ', infodata%rof_phase
        write(logunit,F0S) subname,'wav_phase                = ', infodata%wav_phase
 
-       write(logunit,F0L) subname,'data_assimilation_atm = ', infodata%data_assimilation_atm
-       write(logunit,F0L) subname,'data_assimilation_ocn = ', infodata%data_assimilation_ocn
-       write(logunit,F0L) subname,'data_assimilation_wav = ', infodata%data_assimilation_wav
-       write(logunit,F0L) subname,'data_assimilation_glc = ', infodata%data_assimilation_glc
-       write(logunit,F0L) subname,'data_assimilation_rof = ', infodata%data_assimilation_rof
-       write(logunit,F0L) subname,'data_assimilation_ice = ', infodata%data_assimilation_ice
-       write(logunit,F0L) subname,'data_assimilation_lnd = ', infodata%data_assimilation_lnd
-
        write(logunit,F0L) subname,'glc_g2lupdate            = ', infodata%glc_g2lupdate
        if (associated(infodata%pause_resume)) then
-         do ind = 1, num_inst_atm
-           if (len_trim(infodata%pause_resume%atm_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'atm_resume(',ind,')        = ', trim(infodata%pause_resume%atm_resume(ind))
-           end if
-         end do
-         do ind = 1, num_inst_lnd
-           if (len_trim(infodata%pause_resume%lnd_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'lnd_resume(',ind,')        = ', trim(infodata%pause_resume%lnd_resume(ind))
-           end if
-         end do
-         do ind = 1, num_inst_ocn
-           if (len_trim(infodata%pause_resume%ocn_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'ocn_resume(',ind,')        = ', trim(infodata%pause_resume%ocn_resume(ind))
-           end if
-         end do
-         do ind = 1, num_inst_ice
-           if (len_trim(infodata%pause_resume%ice_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'ice_resume(',ind,')        = ', trim(infodata%pause_resume%ice_resume(ind))
-           end if
-         end do
-         do ind = 1, num_inst_glc
-           if (len_trim(infodata%pause_resume%glc_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'glc_resume(',ind,')        = ', trim(infodata%pause_resume%glc_resume(ind))
-           end if
-         end do
-         do ind = 1, num_inst_rof
-           if (len_trim(infodata%pause_resume%rof_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'rof_resume(',ind,')        = ', trim(infodata%pause_resume%rof_resume(ind))
-           end if
-         end do
-         do ind = 1, num_inst_wav
-           if (len_trim(infodata%pause_resume%wav_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'wav_resume(',ind,')        = ', trim(infodata%pause_resume%wav_resume(ind))
-           end if
-         end do
-         if (len_trim(infodata%pause_resume%cpl_resume) > 0) then
-           write(logunit,F0A) subname,'cpl_resume               = ', trim(infodata%pause_resume%cpl_resume)
-         end if
-       end if
-!     endif
-
+          write(logunit,FIA) subname,'atm_resume = ', infodata%pause_resume%data_assimilation_atm
+          write(logunit,FIA) subname,'cpl_resume = ', infodata%pause_resume%data_assimilation_cpl
+          write(logunit,FIA) subname,'ocn_resume = ', infodata%pause_resume%data_assimilation_ocn
+          write(logunit,FIA) subname,'wav_resume = ', infodata%pause_resume%data_assimilation_wav
+          write(logunit,FIA) subname,'glc_resume = ', infodata%pause_resume%data_assimilation_glc
+          write(logunit,FIA) subname,'ice_resume = ', infodata%pause_resume%data_assimilation_ice
+          write(logunit,FIA) subname,'rof_resume = ', infodata%pause_resume%data_assimilation_rof
+          write(logunit,FIA) subname,'lnd_resume = ', infodata%pause_resume%data_assimilation_lnd
+       endif
+       ! endif
 END SUBROUTINE seq_infodata_print
 
 !===============================================================================

--- a/src/drivers/mct/shr/seq_timemgr_mod.F90
+++ b/src/drivers/mct/shr/seq_timemgr_mod.F90
@@ -304,8 +304,8 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
     character(SHR_KIND_CS)  :: restart_option        ! Restart option units
     integer(SHR_KIND_IN)    :: restart_n             ! Number until restart interval
     integer(SHR_KIND_IN)    :: restart_ymd           ! Restart date (YYYYMMDD)
-    character(SHR_KIND_CS)  :: data_assimilation_pause_option          ! Pause option units
-    integer(SHR_KIND_IN)    :: data_assimilation_pause_n               ! Number between pause intervals
+    character(SHR_KIND_CS)  :: pause_option          ! Pause option units
+    integer(SHR_KIND_IN)    :: pause_n               ! Number between pause intervals
 
     logical :: data_assimilation_atm
     logical :: data_assimilation_cpl
@@ -362,8 +362,8 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
     namelist /seq_timemgr_inparm/  calendar, curr_ymd, curr_tod,  &
          stop_option, stop_n, stop_ymd, stop_tod,                &
          restart_option, restart_n, restart_ymd,                 &
-         data_assimilation_pause_option,   &
-         data_assimilation_pause_n,           &
+         pause_option,   &
+         pause_n,           &
          data_assimilation_atm, &
          data_assimilation_cpl, &
          data_assimilation_ocn, &
@@ -415,8 +415,8 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
        restart_option   = seq_timemgr_optYearly
        restart_n        = -1
        restart_ymd      = -1
-       data_assimilation_pause_option     = seq_timemgr_optNever
-       data_assimilation_pause_n          = -1
+       pause_option     = seq_timemgr_optNever
+       pause_n          = -1
        data_assimilation_atm = .false.
        data_assimilation_cpl = .false.
        data_assimilation_ocn = .false.
@@ -567,10 +567,10 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
        write(logunit,F0I) trim(subname),' restart_n      = ',restart_n
        write(logunit,F0I) trim(subname),' restart_ymd    = ',restart_ymd
        write(logunit,F0L) trim(subname),' end_restart    = ',end_restart
-       write(logunit,F0A) trim(subname),' data_assimilation_pause_option   = ',&
-            trim(data_assimilation_pause_option)
-       write(logunit,F0I) trim(subname),' data_assimilation_pause_n        = ',&
-            data_assimilation_pause_n
+       write(logunit,F0A) trim(subname),' pause_option   = ',&
+            trim(pause_option)
+       write(logunit,F0I) trim(subname),' pause_n        = ',&
+            pause_n
        write(logunit,F0L) trim(subname),' esp_run_on_pause = ',esp_run_on_pause
        write(logunit,F0A) trim(subname),' history_option = ',trim(history_option)
        write(logunit,F0I) trim(subname),' history_n      = ',history_n
@@ -657,8 +657,8 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
     call shr_mpi_bcast( restart_n,            mpicom )
     call shr_mpi_bcast( restart_option,       mpicom )
     call shr_mpi_bcast( restart_ymd,          mpicom )
-    call shr_mpi_bcast( data_assimilation_pause_n,              mpicom )
-    call shr_mpi_bcast( data_assimilation_pause_option,         mpicom )
+    call shr_mpi_bcast( pause_n,              mpicom )
+    call shr_mpi_bcast( pause_option,         mpicom )
     call shr_mpi_bcast(data_assimilation_atm, mpicom)
     call shr_mpi_bcast(data_assimilation_cpl, mpicom)
     call shr_mpi_bcast(data_assimilation_ocn, mpicom)
@@ -762,8 +762,8 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
     endif
 
     if ( ANY(pause_active) .and.                                              &
-         (trim(data_assimilation_pause_option) /= seq_timemgr_optNONE)  .and.                   &
-         (trim(data_assimilation_pause_option) /= seq_timemgr_optNever)) then
+         (trim(pause_option) /= seq_timemgr_optNONE)  .and.                   &
+         (trim(pause_option) /= seq_timemgr_optNever)) then
        do n = 1, max_clocks
           if (pause_active(n) .and. (iam == 0)) then
              write(logunit, '(4a)') subname, ': Pause active for ',           &
@@ -917,8 +917,8 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
        if (pause_active(n)) then
          call seq_timemgr_alarmInit(SyncClock%ECP(n)%EClock,                  &
               EAlarm  = SyncClock%EAlarm(n,seq_timemgr_nalarm_pause),         &
-              option  = data_assimilation_pause_option,                                         &
-              opt_n   = data_assimilation_pause_n,                                              &
+              option  = pause_option,                                         &
+              opt_n   = pause_n,                                              &
               RefTime = CurrTime,                                             &
               alarmname = trim(seq_timemgr_alarm_pause))
        else

--- a/src/drivers/mct/shr/seq_timemgr_mod.F90
+++ b/src/drivers/mct/shr/seq_timemgr_mod.F90
@@ -304,9 +304,18 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
     character(SHR_KIND_CS)  :: restart_option        ! Restart option units
     integer(SHR_KIND_IN)    :: restart_n             ! Number until restart interval
     integer(SHR_KIND_IN)    :: restart_ymd           ! Restart date (YYYYMMDD)
-    character(SHR_KIND_CS)  :: pause_option          ! Pause option units
-    integer(SHR_KIND_IN)    :: pause_n               ! Number between pause intervals
-    character(SHR_KIND_CS)  :: pause_component_list  ! Pause - resume components
+    character(SHR_KIND_CS)  :: data_assimilation_pause_option          ! Pause option units
+    integer(SHR_KIND_IN)    :: data_assimilation_pause_n               ! Number between pause intervals
+
+    logical :: data_assimilation_atm
+    logical :: data_assimilation_cpl
+    logical :: data_assimilation_ocn
+    logical :: data_assimilation_wav
+    logical :: data_assimilation_glc
+    logical :: data_assimilation_ice
+    logical :: data_assimilation_rof
+    logical :: data_assimilation_lnd
+
     character(SHR_KIND_CS)  :: history_option        ! History option units
     integer(SHR_KIND_IN)    :: history_n             ! Number until history interval
     integer(SHR_KIND_IN)    :: history_ymd           ! History date (YYYYMMDD)
@@ -353,7 +362,16 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
     namelist /seq_timemgr_inparm/  calendar, curr_ymd, curr_tod,  &
          stop_option, stop_n, stop_ymd, stop_tod,                &
          restart_option, restart_n, restart_ymd,                 &
-         pause_option,   pause_n,   pause_component_list,        &
+         data_assimilation_pause_option,   &
+         data_assimilation_pause_n,           &
+         data_assimilation_atm, &
+         data_assimilation_cpl, &
+         data_assimilation_ocn, &
+         data_assimilation_wav, &
+         data_assimilation_glc, &
+         data_assimilation_ice, &
+         data_assimilation_rof, &
+         data_assimilation_lnd, &
          history_option, history_n, history_ymd,                 &
          histavg_option, histavg_n, histavg_ymd,                 &
          barrier_option, barrier_n, barrier_ymd,                 &
@@ -397,9 +415,17 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
        restart_option   = seq_timemgr_optYearly
        restart_n        = -1
        restart_ymd      = -1
-       pause_option     = seq_timemgr_optNever
-       pause_n          = -1
-       pause_component_list = ' '
+       data_assimilation_pause_option     = seq_timemgr_optNever
+       data_assimilation_pause_n          = -1
+       data_assimilation_atm = .false.
+       data_assimilation_cpl = .false.
+       data_assimilation_ocn = .false.
+       data_assimilation_wav = .false.
+       data_assimilation_glc = .false.
+       data_assimilation_ice = .false.
+       data_assimilation_rof = .false.
+       data_assimilation_lnd = .false.
+
        history_option   = seq_timemgr_optNever
        history_n        = -1
        history_ymd      = -1
@@ -541,9 +567,10 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
        write(logunit,F0I) trim(subname),' restart_n      = ',restart_n
        write(logunit,F0I) trim(subname),' restart_ymd    = ',restart_ymd
        write(logunit,F0L) trim(subname),' end_restart    = ',end_restart
-       write(logunit,F0A) trim(subname),' pause_option   = ',trim(pause_option)
-       write(logunit,F0I) trim(subname),' pause_n        = ',pause_n
-       write(logunit,F0A) trim(subname),' pause_component_list = ',trim(pause_component_list)
+       write(logunit,F0A) trim(subname),' data_assimilation_pause_option   = ',&
+            trim(data_assimilation_pause_option)
+       write(logunit,F0I) trim(subname),' data_assimilation_pause_n        = ',&
+            data_assimilation_pause_n
        write(logunit,F0L) trim(subname),' esp_run_on_pause = ',esp_run_on_pause
        write(logunit,F0A) trim(subname),' history_option = ',trim(history_option)
        write(logunit,F0I) trim(subname),' history_n      = ',history_n
@@ -630,9 +657,17 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
     call shr_mpi_bcast( restart_n,            mpicom )
     call shr_mpi_bcast( restart_option,       mpicom )
     call shr_mpi_bcast( restart_ymd,          mpicom )
-    call shr_mpi_bcast( pause_n,              mpicom )
-    call shr_mpi_bcast( pause_option,         mpicom )
-    call shr_mpi_bcast( pause_component_list, mpicom )
+    call shr_mpi_bcast( data_assimilation_pause_n,              mpicom )
+    call shr_mpi_bcast( data_assimilation_pause_option,         mpicom )
+    call shr_mpi_bcast(data_assimilation_atm, mpicom)
+    call shr_mpi_bcast(data_assimilation_cpl, mpicom)
+    call shr_mpi_bcast(data_assimilation_ocn, mpicom)
+    call shr_mpi_bcast(data_assimilation_wav, mpicom)
+    call shr_mpi_bcast(data_assimilation_glc, mpicom)
+    call shr_mpi_bcast(data_assimilation_ice, mpicom)
+    call shr_mpi_bcast(data_assimilation_rof, mpicom)
+    call shr_mpi_bcast(data_assimilation_lnd, mpicom)
+
     call shr_mpi_bcast( history_n,            mpicom )
     call shr_mpi_bcast( history_option,       mpicom )
     call shr_mpi_bcast( history_ymd,          mpicom )
@@ -701,48 +736,34 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
     ! --- Figure out which components (if any) are doing pause this run
     rc = 1
     i = 1
-    if (trim(pause_component_list) == 'all') then
-      pause_active = .true.
-    else if (trim(pause_component_list) == 'none') then
-      pause_active = .false.
-    else
-      do
-        i = scan(trim(pause_component_list(rc:)), ':') - 1
-        if ((i < 0) .and. (len_trim(pause_component_list) >= rc)) then
-          i = len_trim(pause_component_list(rc:))
-        end if
-        if (i > 0) then
-          found = .false.
-          do n = 1, max_clocks
-            if (pause_component_list(rc:rc+i-1) == trim(seq_timemgr_clocks(n))) then
-              pause_active(n) = .true.
-              found = .true.
-              exit
-            end if
-          end do
-          ! Special case for cpl -- synonym for drv
-          if ((.not. found) .and. (pause_component_list(rc:rc+i-1) == 'cpl')) then
-            pause_active(seq_timemgr_nclock_drv) = .true.
-            found = .true.
-          end if
-          if (.not. found) then
-            call shr_sys_abort(subname//': unknown pause component, '//pause_component_list(rc:rc+i-1))
-          end if
-          rc = rc + i
-          if (pause_component_list(rc:rc) == ':') then
-            rc = rc + 1
-          end if
-          if (rc >= len_trim(pause_component_list)) then
-            exit
-          end if
-        else
-          exit
-        end if
-      end do
-    end if
+    if (data_assimilation_atm) then
+       pause_active(seq_timemgr_nclock_atm) = .true.
+    endif
+    if (data_assimilation_cpl) then
+       pause_active(seq_timemgr_nclock_drv) = .true.
+    endif
+    if (data_assimilation_ocn) then
+       pause_active(seq_timemgr_nclock_ocn) = .true.
+    endif
+    if (data_assimilation_wav) then
+       pause_active(seq_timemgr_nclock_wav) = .true.
+    endif
+    if (data_assimilation_glc) then
+       pause_active(seq_timemgr_nclock_glc) = .true.
+    endif
+    if (data_assimilation_ice) then
+       pause_active(seq_timemgr_nclock_ice) = .true.
+    endif
+    if (data_assimilation_rof) then
+       pause_active(seq_timemgr_nclock_rof) = .true.
+    endif
+    if (data_assimilation_lnd) then
+       pause_active(seq_timemgr_nclock_lnd) = .true.
+    endif
+
     if ( ANY(pause_active) .and.                                              &
-         (trim(pause_option) /= seq_timemgr_optNONE)  .and.                   &
-         (trim(pause_option) /= seq_timemgr_optNever)) then
+         (trim(data_assimilation_pause_option) /= seq_timemgr_optNONE)  .and.                   &
+         (trim(data_assimilation_pause_option) /= seq_timemgr_optNever)) then
        do n = 1, max_clocks
           if (pause_active(n) .and. (iam == 0)) then
              write(logunit, '(4a)') subname, ': Pause active for ',           &
@@ -896,8 +917,8 @@ subroutine seq_timemgr_clockInit(SyncClock, nmlfile, restart, restart_file, pioi
        if (pause_active(n)) then
          call seq_timemgr_alarmInit(SyncClock%ECP(n)%EClock,                  &
               EAlarm  = SyncClock%EAlarm(n,seq_timemgr_nalarm_pause),         &
-              option  = pause_option,                                         &
-              opt_n   = pause_n,                                              &
+              option  = data_assimilation_pause_option,                                         &
+              opt_n   = data_assimilation_pause_n,                                              &
               RefTime = CurrTime,                                             &
               alarmname = trim(seq_timemgr_alarm_pause))
        else


### PR DESCRIPTION
Separate DATA_ASSIMILATION flag by component and add to Fortran infodata.
Components can now query infodata for the flag data_assimilation_xxx where xxx is one of
(cpl, atm, ocn, wav, glc, ice, rof, lnd)
Removes variable PAUSE_COMPONENT_LIST
Note that while this brings the appropriate signals into CIME, no components yet test for their presence at the appropriate times. These tests will be part of future PRs.

Supersedes #2028 
Test suite: scripts_regression_tests.py
Test baseline: NA
Test namelist changes: XML variable PAUSE_COMPONENT_LIST eliminated
        namelist variable pause_component_list eliminated
        XML variables DATA_ASSIMILATION_XXX added for XXX = [ CPL, ATM, OCN, WAV, GLC, ICE, ROF, LND ]
        namelist variables data_assimilation_xxx added for xxx = [ cpl, atm, ocn, wav, glc, ice, rof, lnd ]
Test status: bit for bit

Partially fixes #1980
This PR will close #1980 and new issues to address the remaining requests.

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @gold2718 

