### PR TITLE
USER_REQUESTED_ vars should go in env_batch

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -102,6 +102,7 @@
     <batch_directive>#BSUB</batch_directive>
     <jobid_pattern>&lt;(\d+)&gt;</jobid_pattern>
     <depend_string> -w 'done(jobid)'</depend_string>
+    <depend_separator>&amp;&amp;</depend_separator>
     <walltime_format>%H:%M</walltime_format>
     <batch_mail_flag>-u</batch_mail_flag>
     <batch_mail_type_flag></batch_mail_type_flag>

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -135,10 +135,10 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
         # store these choices in USER_REQUESTED_WALLTIME and/or USER_REQUESTED_QUEUE so they
         # are not lost if the user does a case.setup --reset.
         if xmlid == "JOB_WALLCLOCK_TIME":
-            case.set_value("USER_REQUESTED_WALLTIME", xmlval)
+            case.set_value("USER_REQUESTED_WALLTIME", xmlval, subgroup)
 
         if xmlid == "JOB_QUEUE":
-            case.set_value("USER_REQUESTED_QUEUE", xmlval)
+            case.set_value("USER_REQUESTED_QUEUE", xmlval, subgroup)
 
     if not noecho:
         argstr = ""

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -183,9 +183,6 @@ class EnvBatch(EnvBase):
         os.chmod(job, os.stat(job).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     def set_job_defaults(self, batch_jobs, case):
-        walltime    = case.get_value("USER_REQUESTED_WALLTIME") if case.get_value("USER_REQUESTED_WALLTIME") else None
-        force_queue = case.get_value("USER_REQUESTED_QUEUE") if case.get_value("USER_REQUESTED_QUEUE") else None
-
         if self._batchtype is None:
             self._batchtype = self.get_batch_system_type()
 
@@ -193,6 +190,9 @@ class EnvBatch(EnvBase):
             return
 
         for job, jsect in batch_jobs:
+            walltime    = case.get_value("USER_REQUESTED_WALLTIME", subgroup=job) if case.get_value("USER_REQUESTED_WALLTIME", subgroup=job) else None
+            force_queue = case.get_value("USER_REQUESTED_QUEUE", subgroup=job) if case.get_value("USER_REQUESTED_QUEUE", subgroup=job) else None
+            logger.info("job is {} USER_REQUESTED_WALLTIME {} USER_REQUESTED_QUEUE {}".format(job, walltime, force_queue))
             task_count = jsect["task_count"] if "task_count" in jsect else None
             if task_count is None:
                 node_count = case.num_nodes

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -415,6 +415,7 @@ class EnvBatch(EnvBase):
             logger.info("dependencies: {}".format(dep_jobs))
             dep_string = self.get_value("depend_string", subgroup=None)
             separator_string = self.get_value("depend_separator", subgroup=None)
+            expect(separator_string is not None,"depend_separator string not defined")
             expect("jobid" in dep_string, "depend_string is missing jobid for prerequisite jobs")
             dep_ids_str = str(dep_jobs[0])
             for dep_id in dep_jobs[1:]:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -391,8 +391,12 @@ class Case(object):
                 self._env_files_that_need_rewrite.add(env_file)
                 return result
 
-        expect(allow_undefined or result is not None,
-               "No variable {} found in case".format(item))
+        if len(self._files) == 1:
+            expect(allow_undefined or result is not None,
+                   "No variable {} found in file {}".format(item, self._files[0].filename))
+        else:
+            expect(allow_undefined or result is not None,
+                   "No variable {} found in case".format(item))
 
     def set_valid_values(self, item, valid_values):
         """

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2600,15 +2600,15 @@
  <!-- Job Submission stuff -->
  <entry id="USER_REQUESTED_QUEUE">
    <type>char</type>
-   <group>run_desc</group>
-   <file>env_run.xml</file>
+   <group>job_submission</group>
+   <file>env_batch.xml</file>
    <desc>Store user override for queue</desc>
  </entry>
 
  <entry id="USER_REQUESTED_WALLTIME">
    <type>char</type>
-   <group>run_desc</group>
-   <file>env_run.xml</file>
+   <group>job_submission</group>
+   <file>env_batch.xml</file>
    <desc>Store user override for walltime</desc>
  </entry>
 


### PR DESCRIPTION
The USER_REQUESTED_WALLTIME AND USER_REQUESTED_QUEUE flags need to be aware of the subgroup they are operating on.   

Test suite: scripts_regression_tests.py, hand testing of issue
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2046 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
