### PR TITLE
add optional COSTPES_PER_NODE

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -572,6 +572,7 @@
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <COST_PER_NODE>68</COST_PER_NODE>
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
@@ -1843,6 +1844,7 @@
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>30</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>15</MAX_MPITASKS_PER_NODE>
+    <COST_PER_NODE>16</COST_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default" unit_testing="true">
       <!-- For unit testing, avoid all of the extra stuff that we use before and

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -572,7 +572,7 @@
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>256</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
-    <COST_PER_NODE>68</COST_PER_NODE>
+    <COSTPES_PER_NODE>68</COSTPES_PER_NODE>
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
@@ -1844,7 +1844,7 @@
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>30</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>15</MAX_MPITASKS_PER_NODE>
-    <COST_PER_NODE>16</COST_PER_NODE>
+    <COSTPES_PER_NODE>16</COSTPES_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default" unit_testing="true">
       <!-- For unit testing, avoid all of the extra stuff that we use before and

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -40,7 +40,7 @@
   <xs:element name="GMAKE_J" type="xs:integer"/>
   <xs:element name="MAX_TASKS_PER_NODE" type="xs:integer"/>
   <xs:element name="MAX_MPITASKS_PER_NODE" type="xs:integer"/>
-  <xs:element name="COST_PER_NODE" type="xs:integer"/>
+  <xs:element name="COSTPES_PER_NODE" type="xs:integer"/>
   <xs:element name="PROJECT_REQUIRED" type="xs:NCName"/>
   <xs:element name="GMAKE" type="xs:string"/>
   <xs:element name="TESTS" type="xs:string"/>
@@ -116,7 +116,7 @@
 	     this machine, in practice the MPI tasks per node will not exceed this value -->
         <xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="1"/>
 	<!-- Optional cost factor per node unit -->
-        <xs:element ref="COST_PER_NODE" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
 	<!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
 	     the batch system?  See PROJECT above -->
         <xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -40,6 +40,7 @@
   <xs:element name="GMAKE_J" type="xs:integer"/>
   <xs:element name="MAX_TASKS_PER_NODE" type="xs:integer"/>
   <xs:element name="MAX_MPITASKS_PER_NODE" type="xs:integer"/>
+  <xs:element name="COST_PER_NODE" type="xs:integer"/>
   <xs:element name="PROJECT_REQUIRED" type="xs:NCName"/>
   <xs:element name="GMAKE" type="xs:string"/>
   <xs:element name="TESTS" type="xs:string"/>
@@ -114,6 +115,8 @@
 	<!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
 	     this machine, in practice the MPI tasks per node will not exceed this value -->
         <xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="1"/>
+	<!-- Optional cost factor per node unit -->
+        <xs:element ref="COST_PER_NODE" minOccurs="0" maxOccurs="1"/>
 	<!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
 	     the batch system?  See PROJECT above -->
         <xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -138,13 +138,18 @@ class _TimingParser:
         run_type = self.case.get_value("RUN_TYPE")
         stop_option = self.case.get_value("STOP_OPTION")
         stop_n = self.case.get_value("STOP_N")
+
         cost_pes = self.case.get_value("COST_PES")
+        cost_per_node = self.case.get_value("COST_PER_NODE")
+
         totalpes = self.case.get_value("TOTALPES")
         max_mpitasks_per_node = self.case.get_value("MAX_MPITASKS_PER_NODE")
         smt_factor = max(1,int(self.case.get_value("MAX_TASKS_PER_NODE") / max_mpitasks_per_node))
 
         if cost_pes > 0:
             pecost = cost_pes
+        elif cost_per_node:
+            pecost = self.case.num_nodes * cost_per_node
         else:
             pecost = totalpes
 
@@ -309,7 +314,7 @@ class _TimingParser:
 
         self.write("\n")
         self.write("  total pes active           : {} \n".format(totalpes*maxthrds*smt_factor ))
-        self.write("  pes per node               : {} \n".format(max_mpitasks_per_node))
+        self.write("  mpi tasks per node               : {} \n".format(max_mpitasks_per_node))
         self.write("  pe count for cost estimate : {} \n".format(pecost))
         self.write("\n")
 

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -140,7 +140,7 @@ class _TimingParser:
         stop_n = self.case.get_value("STOP_N")
 
         cost_pes = self.case.get_value("COST_PES")
-        cost_per_node = self.case.get_value("COST_PER_NODE")
+        costpes_per_node = self.case.get_value("COSTPES_PER_NODE")
 
         totalpes = self.case.get_value("TOTALPES")
         max_mpitasks_per_node = self.case.get_value("MAX_MPITASKS_PER_NODE")
@@ -148,8 +148,8 @@ class _TimingParser:
 
         if cost_pes > 0:
             pecost = cost_pes
-        elif cost_per_node:
-            pecost = self.case.num_nodes * cost_per_node
+        elif costpes_per_node:
+            pecost = self.case.num_nodes * costpes_per_node
         else:
             pecost = totalpes
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2063,6 +2063,14 @@
     <default_value>0</default_value>
     <group>mach_pes_last</group>
     <file>env_mach_pes.xml</file>
+    <desc>pes or cores per node for mpitasks </desc>
+  </entry>
+
+  <entry id="COST_PER_NODE">
+    <type>integer</type>
+    <default_value>$MAX_MPITASKS_PER_NODE</default_value>
+    <group>mach_pes_last</group>
+    <file>env_mach_pes.xml</file>
     <desc>pes or cores per node for accounting purposes </desc>
   </entry>
 

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2066,7 +2066,7 @@
     <desc>pes or cores per node for mpitasks </desc>
   </entry>
 
-  <entry id="COST_PER_NODE">
+  <entry id="COSTPES_PER_NODE">
     <type>integer</type>
     <default_value>$MAX_MPITASKS_PER_NODE</default_value>
     <group>mach_pes_last</group>


### PR DESCRIPTION
Add a variable for COST_PER_NODE this variable is optional and can be used for machines that make that value difficult to compute automatically

Test suite: scripts_regression_tests.py PFS.f09_g17.B1850.yellowstone_intel 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1993 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
