### PR TITLE
locked files needs to handle BUILD_COMPLETE better

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1330,8 +1330,6 @@ class Case(object):
         gfile = GenericXML(infile=xmlfile)
         ftype = gfile.get_id()
 
-        self.flush(flushall=True)
-
         logger.warning("setting case file to {}".format(xmlfile))
         components = self.get_value("COMP_CLASSES")
         new_env_file = None

--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -111,10 +111,12 @@ def check_lockedfiles(case):
                 continue
             diffs = f1obj.compare_xml(f2obj)
             if diffs:
+
                 logging.warning("File {} has been modified".format(lfile))
                 for key in diffs.keys():
-                    print("  found difference in {} : case {} locked {}"
-                          .format(key, repr(diffs[key][0]), repr(diffs[key][1])))
+                    if key != "BUILD_COMPLETE":
+                        print("  found difference in {} : case {} locked {}"
+                              .format(key, repr(diffs[key][0]), repr(diffs[key][1])))
 
                 if objname == "env_mach_pes":
                     expect(False, "Invoke case.setup --reset ")
@@ -128,8 +130,9 @@ def check_lockedfiles(case):
                         case.set_value("BUILD_STATUS", 2)
                         logging.critical("Changing PIO_VERSION requires running "
                                          "case.build --clean-all and rebuilding")
-                    else:
+                    elif key != "BUILD_COMPLETE":
                         case.set_value("BUILD_STATUS", 1)
+                    f2obj.set_value("BUILD_COMPLETE", False)
                 elif objname == "env_batch":
                     expect(False, "Batch configuration has changed, please run case.setup --reset")
                 else:


### PR DESCRIPTION
If BUILD_COMPLETE is the only variable changed in env_build.xml it should not flag in check_lockedfiles

Test suite: scripts_regression_tests.py, hand testing - see test in issue #1971
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #1971 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
