### PR TITLE
Add unit tests of compare_two's handling of pass/fail in comparison

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -259,7 +259,7 @@ class SystemTestsCommon(object):
         run case needs indirection based on success.
         If success_change is True, success requires some files to be different
         """
-        success, comments = compare_test(self._case, suffix1, suffix2)
+        success, comments = self._do_compare_test(suffix1, suffix2)
         if success_change:
             success = not success
 
@@ -268,6 +268,13 @@ class SystemTestsCommon(object):
         with self._test_status:
             self._test_status.set_status("{}_{}_{}".format(COMPARE_PHASE, suffix1, suffix2), status)
         return success
+
+    def _do_compare_test(self, suffix1, suffix2):
+        """
+        Wraps the call to compare_test to facilitate replacement in unit
+        tests
+        """
+        return compare_test(self._case, suffix1, suffix2)
 
     def _get_mem_usage(self, cpllog):
         """


### PR DESCRIPTION
Previously, I had figured that it was sufficient to ensure that
`_component_compare_test` was actually being called, figuring that the
tests of `_component_compare_test` belong elsewhere. But, since this is
such a critical aspect of the `system_test_compare_two` infrastructure,
I'm adding some tests covering `_component_compare_test` here.

These new tests cover the logic related to in-test comparisons in
`system_tests_compare_two` and `system_tests_common`. However, they will
NOT cover the logic in hist_utils: I'm stubbing out the actual call into
hist_utils, under the assumption that this is - or should be - covered
by other tests. But I'm not sure if hist_utils is actually covered
sufficiently by unit tests. If it isn't, it should be.

This also required some minor refactoring of system_tests_common in
order to allow stubbing out the call into hist_utils. (This refactoring
would not have been needed if we allowed use of the `mock` module: see
#2056.)

Test suite: scripts_regression_tests on yellowstone
   Passes other than the issues documented in #2057 and #2059

   Also ensured that comparison failures are still reported correctly by
   running a REP test that forces a comparison failure (due to missing
   cprnc).
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes: #1640

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 