### PR TITLE
Major refactor of baseline handling.

### DIFF
--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -76,7 +76,7 @@
   <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
   <DIN_LOC_ROOT>/project/projectdirs/acme/inputdata</DIN_LOC_ROOT>
   <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-  <BASELINE_ROOT>/project/projectdirs/acme/baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>/project/projectdirs/acme/baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.edison/cprnc</CCSM_CPRNC>
   <SAVE_TIMING_DIR>/project/projectdirs/acme</SAVE_TIMING_DIR>
   <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
@@ -201,7 +201,7 @@
   <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <BASELINE_ROOT>/project/projectdirs/acme/baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>/project/projectdirs/acme/baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.cori/cprnc</CCSM_CPRNC>
   <SAVE_TIMING_DIR>/project/projectdirs/acme</SAVE_TIMING_DIR>
   <OS>CNL</OS>
@@ -345,7 +345,7 @@
   <DIN_LOC_ROOT_CLMFORC>/project/projectdirs/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <BASELINE_ROOT>/project/projectdirs/acme/baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>/project/projectdirs/acme/baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>/project/projectdirs/acme/tools/cprnc.cori/cprnc</CCSM_CPRNC>
   <SAVE_TIMING_DIR>/project/projectdirs/acme</SAVE_TIMING_DIR>
   <OS>CNL</OS>
@@ -506,7 +506,7 @@
     <DOUT_S_ROOT>$ENV{HOME}/projects/acme/scratch/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/projects/acme/scratch</CIME_OUTPUT_ROOT>
-    <BASELINE_ROOT>$ENV{HOME}/projects/acme/baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>$ENV{HOME}/projects/acme/baselines/$COMPILER</BASELINE_ROOT>
     <!-- cmake -DCMAKE_Fortran_COMPILER=/opt/local/bin/mpif90-mpich-gcc48 -DHDF5_DIR=/opt/local -DNetcdf_INCLUDE_DIR=/opt/local/include .. -->
 >
     <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
@@ -531,7 +531,7 @@
     <DOUT_S_ROOT>$ENV{HOME}/projects/acme/scratch/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
     <CIME_OUTPUT_ROOT>$ENV{HOME}/projects/acme/scratch</CIME_OUTPUT_ROOT>
-    <BASELINE_ROOT>$ENV{HOME}/projects/acme/baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>$ENV{HOME}/projects/acme/baselines/$COMPILER</BASELINE_ROOT>
     <!-- cmake -DCMAKE_Fortran_COMPILER=/opt/local/bin/mpif90-mpich-gcc48 -DHDF5_DIR=/opt/local -DNetcdf_INCLUDE_DIR=/opt/local/include .. -->>
     <CCSM_CPRNC>$CCSMROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
     <SUPPORTED_BY>jayesh at mcs dot anl dot gov</SUPPORTED_BY>
@@ -562,7 +562,7 @@
     <DIN_LOC_ROOT_CLMFORC>/sems-data-store/ACME/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-    <BASELINE_ROOT>/sems-data-store/ACME/baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>/sems-data-store/ACME/baselines/$COMPILER</BASELINE_ROOT>
     <SAVE_TIMING_DIR>/sems-data-store/ACME/timings</SAVE_TIMING_DIR>
     <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build.new/cprnc</CCSM_CPRNC>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
@@ -634,7 +634,7 @@
     <DIN_LOC_ROOT_CLMFORC>/sems-data-store/ACME/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-    <BASELINE_ROOT>/sems-data-store/ACME/baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>/sems-data-store/ACME/baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build/cprnc</CCSM_CPRNC>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
 <!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
@@ -698,7 +698,7 @@
     <DIN_LOC_ROOT_CLMFORC>/home/climate1/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-    <BASELINE_ROOT>/home/climate1/acme/baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>/home/climate1/acme/baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/home/climate1/acme/cprnc/build/cprnc</CCSM_CPRNC>
     <BATCHQUERY></BATCHQUERY>
     <BATCHSUBMIT></BATCHSUBMIT>
@@ -761,7 +761,7 @@
   <DIN_LOC_ROOT_CLMFORC>/projects/ccsm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>               <!-- complete path to a short term archiving directory -->
   <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>           <!-- complete path to a long term archiving directory -->
-  <BASELINE_ROOT>/projects/ccsm/ccsm_baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>/projects/ccsm/ccsm_baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>/projects/ccsm/cprnc/build.toss3/cprnc_wrap</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
   <SAVE_TIMING_DIR>/projects/ccsm/timings</SAVE_TIMING_DIR>
   <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -837,7 +837,7 @@
   <DIN_LOC_ROOT_CLMFORC>/projects/ccsm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>               <!-- complete path to a short term archiving directory -->
   <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>           <!-- complete path to a long term archiving directory -->
-  <BASELINE_ROOT>/projects/ccsm/ccsm_baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>/projects/ccsm/ccsm_baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>/projects/ccsm/cprnc/build.toss3/cprnc_wrap</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
   <SAVE_TIMING_DIR>/projects/ccsm/timings</SAVE_TIMING_DIR>
   <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -913,7 +913,7 @@
   <DIN_LOC_ROOT_CLMFORC>/projects/ccsm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>               <!-- complete path to a short term archiving directory -->
   <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>           <!-- complete path to a long term archiving directory -->
-  <BASELINE_ROOT>/projects/ccsm/ccsm_baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>/projects/ccsm/ccsm_baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>/projects/ccsm/cprnc/build.toss3/cprnc_wrap</CCSM_CPRNC>                <!-- path to the cprnc tool used to compare netcdf history files in testing -->
   <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
   <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>
@@ -982,7 +982,7 @@
          <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/lcrc/project/ACME/$USER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>/lcrc/project/ACME/$USER/archive/$CASE</DOUT_L_MSROOT>
-         <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/blues</BASELINE_ROOT>
+         <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/blues/$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/home/ccsm-data/tools/cprnc</CCSM_CPRNC>
          <OS>LINUX</OS>
 	 <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
@@ -1085,7 +1085,7 @@
          <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/lcrc/group/acme/$USER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>/lcrc/project/ACME/$USER/archive/$CASE</DOUT_L_MSROOT>
-         <BASELINE_ROOT>/lcrc/group/acme/acme_baselines</BASELINE_ROOT>
+         <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/home/ccsm-data/tools/cprnc</CCSM_CPRNC>
          <OS>LINUX</OS>
 	 <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
@@ -1204,7 +1204,7 @@
     <DIN_LOC_ROOT_CLMFORC>/home/ccsm-data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-    <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/bebop</BASELINE_ROOT>
+    <BASELINE_ROOT>/lcrc/group/acme/acme_baselines/bebop/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/lcrc/group/acme/tools/cprnc/cprnc</CCSM_CPRNC>
     <OS>LINUX</OS>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -1287,7 +1287,7 @@
          <DIN_LOC_ROOT_CLMFORC>/projects/ccsm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/projects/$PROJECT/$USER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>/home/$USER/csm/$CASE/</DOUT_L_MSROOT>
-         <BASELINE_ROOT>/projects/ccsm/ccsm_baselines/</BASELINE_ROOT>
+         <BASELINE_ROOT>/projects/ccsm/ccsm_baselines//$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/projects/ccsm/tools/cprnc/cprnc</CCSM_CPRNC>
          <OS>BGQ</OS>
          <BATCH_SYSTEM>cobalt</BATCH_SYSTEM>
@@ -1350,7 +1350,7 @@
          <DOUT_S_ROOT>/p/lscratche/$CCSMUSER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_HTAR>FALSE</DOUT_L_HTAR>
          <DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
-         <BASELINE_ROOT>/p/lscratchd/$CCSMUSER/ccsm_baselines</BASELINE_ROOT>
+         <BASELINE_ROOT>/p/lscratchd/$CCSMUSER/ccsm_baselines/$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/p/lscratchd/ma21/ccsm3data/tools/cprnc/cprnc</CCSM_CPRNC>
          <OS>LINUX</OS>
          <SUPPORTED_BY>bogenschutz1 -at- llnl.gov</SUPPORTED_BY>
@@ -1406,7 +1406,7 @@
          <DOUT_S_ROOT>/p/lscratche/$CCSMUSER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_HTAR>FALSE</DOUT_L_HTAR>
          <DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
-         <BASELINE_ROOT>/p/lscratchd/$CCSMUSER/ccsm_baselines</BASELINE_ROOT>
+         <BASELINE_ROOT>/p/lscratchd/$CCSMUSER/ccsm_baselines/$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/p/lscratchd/ma21/ccsm3data/tools/cprnc/cprnc</CCSM_CPRNC>
          <OS>LINUX</OS>
          <SUPPORTED_BY>bogenschutz1 -at- llnl.gov</SUPPORTED_BY>
@@ -1467,7 +1467,7 @@
          <DOUT_S_ROOT>/p/lscratchh/$CCSMUSER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_HTAR>FALSE</DOUT_L_HTAR>
          <DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
-         <BASELINE_ROOT>/p/lscratchh/$CCSMUSER/ccsm_baselines</BASELINE_ROOT>
+         <BASELINE_ROOT>/p/lscratchh/$CCSMUSER/ccsm_baselines/$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/p/lscratchd/ma21/ccsm3data/tools/cprnc/cprnc</CCSM_CPRNC>
          <OS>LINUX</OS>
          <SUPPORTED_BY>donahue5 -at- llnl.gov</SUPPORTED_BY>
@@ -1522,7 +1522,7 @@
          <DIN_LOC_ROOT_CLMFORC>/projects/ccsm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/projects/$PROJECT/$USER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>/home/$USER/csm/$CASE/</DOUT_L_MSROOT>
-         <BASELINE_ROOT>/projects/ccsm/ccsm_baselines/</BASELINE_ROOT>
+         <BASELINE_ROOT>/projects/ccsm/ccsm_baselines//$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/projects/ccsm/tools/cprnc/cprnc</CCSM_CPRNC>
          <SAVE_TIMING_DIR>/projects/$PROJECT</SAVE_TIMING_DIR>
          <OS>BGQ</OS>
@@ -1585,7 +1585,7 @@
     <DIN_LOC_ROOT_CLMFORC>/projects/$PROJECT/acme/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>$CIME_OUTPUT_ROOT/csm/$CASE</DOUT_L_MSROOT>
-    <BASELINE_ROOT>/projects/$PROJECT/acme/baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>/projects/$PROJECT/acme/baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/projects/$PROJECT/acme/tools/cprnc/cprnc</CCSM_CPRNC>
     <OS>CNL</OS>
     <BATCH_SYSTEM>cobalt_theta</BATCH_SYSTEM>
@@ -1685,7 +1685,7 @@
     <DIN_LOC_ROOT_CLMFORC>/lustre/climate/csmdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/lustre/$USER/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
-    <BASELINE_ROOT>/lustre/climate/acme_baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>/lustre/climate/acme_baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/lustre/climate/acme_baselines/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
@@ -1825,7 +1825,7 @@
          <DIN_LOC_ROOT_CLMFORC>/pic/projects/climate/csmdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>/pic/scratch/$USER/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
-         <BASELINE_ROOT>/pic/projects/climate/acme_baselines</BASELINE_ROOT>
+         <BASELINE_ROOT>/pic/projects/climate/acme_baselines/$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/pic/projects/climate/acme_baselines/cprnc/cprnc</CCSM_CPRNC>
 	 <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
          <SUPPORTED_BY>balwinder.singh -at- pnnl.gov</SUPPORTED_BY>
@@ -2009,7 +2009,7 @@
       <DIN_LOC_ROOT_CLMFORC>/lustre/or-hydra/cades-ccsi/proj-shared/project_acme/ACME_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
       <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
       <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-      <BASELINE_ROOT>/lustre/or-hydra/cades-ccsi/proj-shared/project_acme/baselines</BASELINE_ROOT>
+      <BASELINE_ROOT>/lustre/or-hydra/cades-ccsi/proj-shared/project_acme/baselines/$COMPILER</BASELINE_ROOT>
       <CCSM_CPRNC>/lustre/or-hydra/cades-ccsi/proj-shared/tools/cprnc.orcondo</CCSM_CPRNC>
       <SUPPORTED_BY>yinj -at- ornl.gov</SUPPORTED_BY>
       <GMAKE_J>4</GMAKE_J>
@@ -2079,7 +2079,7 @@
     <DIN_LOC_ROOT_CLMFORC>/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$ENV{MEMBERWORK}/$PROJECT/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-    <BASELINE_ROOT>/lustre/atlas1/cli900/world-shared/cesm/baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>/lustre/atlas1/cli900/world-shared/cesm/baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/lustre/atlas1/cli900/world-shared/cesm/tools/cprnc/cprnc.titan</CCSM_CPRNC>
     <SAVE_TIMING_DIR>$ENV{PROJWORK}/$PROJECT</SAVE_TIMING_DIR>
     <OS>CNL</OS>
@@ -2260,7 +2260,7 @@
          <DIN_LOC_ROOT_CLMFORC>/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
          <DOUT_S_ROOT>$ENV{MEMBERWORK}/$PROJECT/archive/$CASE</DOUT_S_ROOT>
          <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-         <BASELINE_ROOT>/lustre/atlas1/cli900/world-shared/cesm/baselines</BASELINE_ROOT>
+         <BASELINE_ROOT>/lustre/atlas1/cli900/world-shared/cesm/baselines/$COMPILER</BASELINE_ROOT>
          <CCSM_CPRNC>/lustre/atlas1/cli900/world-shared/cesm/tools/cprnc/cprnc.eos</CCSM_CPRNC>
          <SAVE_TIMING_DIR>$ENV{PROJWORK}/$PROJECT</SAVE_TIMING_DIR>
          <OS>CNL</OS>
@@ -2352,7 +2352,7 @@
 	<DIN_LOC_ROOT_CLMFORC>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/atm/datm7</DIN_LOC_ROOT_CLMFORC>
 	<DOUT_S_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/archive/$CASE</DOUT_S_ROOT>
 	<DOUT_L_MSROOT>UNSET</DOUT_L_MSROOT>
-	<BASELINE_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/ccsm_baselines</BASELINE_ROOT>
+	<BASELINE_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/ccsm_baselines/$COMPILER</BASELINE_ROOT>
 	<CIME_OUTPUT_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/scratch</CIME_OUTPUT_ROOT>
 	<CCSM_CPRNC>/turquoise/usr/projects/climate/SHARED_CLIMATE/software/wolf/cprnc/v0.40/cprnc</CCSM_CPRNC>
 	<module_system type="module">
@@ -2444,7 +2444,7 @@
 	<PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
 	<DIN_LOC_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data</DIN_LOC_ROOT>
 	<DIN_LOC_ROOT_CLMFORC>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/atm/datm7</DIN_LOC_ROOT_CLMFORC>
-	<BASELINE_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/ccsm_baselines</BASELINE_ROOT>
+	<BASELINE_ROOT>/lustre/scratch3/turquoise/$ENV{USER}/ACME/input_data/ccsm_baselines/$COMPILER</BASELINE_ROOT>
 	<CCSM_CPRNC>/turquoise/usr/projects/climate/SHARED_CLIMATE/software/wolf/cprnc/v0.40/cprnc</CCSM_CPRNC>
 	<mpirun mpilib="default">
 		<executable>mpirun</executable>
@@ -2520,7 +2520,7 @@
   <DIN_LOC_ROOT_CLMFORC>$ENV{CESMROOT}/lmwg</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <BASELINE_ROOT>$ENV{CESMDATAROOT}/ccsm_baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>$ENV{CESMDATAROOT}/ccsm_baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>$ENV{CESMDATAROOT}/tools/cime/tools/cprnc/cprnc</CCSM_CPRNC>
   <PERL5LIB>/glade/apps/opt/perlmods/lib64/perl5:/glade/apps/opt/perlmods/share/perl5</PERL5LIB>
   <BATCH_SYSTEM>none</BATCH_SYSTEM>
@@ -2624,7 +2624,7 @@
 <!-- complete path to a short term archiving directory -->
         <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>
 <!-- complete path to a long term archiving directory -->
-        <BASELINE_ROOT>USERDEFINED_optional_run</BASELINE_ROOT>
+        <BASELINE_ROOT>USERDEFINED_optional_run/$COMPILER</BASELINE_ROOT>
 <!-- where the cesm testing scripts write and read baseline results -->
         <CCSM_CPRNC>USERDEFINED_optional_test</CCSM_CPRNC>
 <!-- path to the cprnc tool used to compare netcdf history files in testing -->
@@ -2664,7 +2664,7 @@
 <!-- complete path to a short term archiving directory -->
         <DOUT_L_MSROOT>USERDEFINED_optional_run</DOUT_L_MSROOT>
 <!-- complete path to a long term archiving directory -->
-        <BASELINE_ROOT>USERDEFINED_optional_run</BASELINE_ROOT>
+        <BASELINE_ROOT>USERDEFINED_optional_run/$COMPILER</BASELINE_ROOT>
 <!-- where the cesm testing scripts write and read baseline results -->
         <CCSM_CPRNC>USERDEFINED_optional_test</CCSM_CPRNC>
 <!-- path to the cprnc tool used to compare netcdf history files in testing -->
@@ -2696,7 +2696,7 @@
   <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>/$CIME_OUTPUT_ROOT/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
   <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
   <SUPPORTED_BY>gbisht at lbl dot gov </SUPPORTED_BY>
@@ -2759,7 +2759,7 @@
   <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>/$CIME_OUTPUT_ROOT/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
   <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
   <SUPPORTED_BY>gbisht at lbl dot gov</SUPPORTED_BY>
@@ -2820,7 +2820,7 @@
   <DIN_LOC_ROOT_CLMFORC>/home/lbleco/cesm/cesm_input_datasets/atm/datm7/</DIN_LOC_ROOT_CLMFORC>
   <DOUT_S_ROOT>/home/lbleco/acme/cesm_archive/$CASE</DOUT_S_ROOT>
   <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-  <BASELINE_ROOT>/home/lbleco/acme/cesm_baselines</BASELINE_ROOT>
+  <BASELINE_ROOT>/home/lbleco/acme/cesm_baselines/$COMPILER</BASELINE_ROOT>
   <CCSM_CPRNC>/home/lbleco/cesm/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
   <GMAKE_J>1</GMAKE_J>
   <BATCH_SYSTEM>none</BATCH_SYSTEM>
@@ -2855,7 +2855,7 @@
 	 <DIN_LOC_ROOT_CLMFORC>/lustre/atlas1/cli900/world-shared/cesm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
 	 <DOUT_S_ROOT>/lustre/atlas/scratch/$ENV{USER}/$PROJECT/archive/$CASE</DOUT_S_ROOT>
 	 <DOUT_L_MSROOT>csm/$CASE</DOUT_L_MSROOT>
-	 <BASELINE_ROOT>/lustre/atlas1/cli900/world-shared/cesm/baselines</BASELINE_ROOT>
+	 <BASELINE_ROOT>/lustre/atlas1/cli900/world-shared/cesm/baselines/$COMPILER</BASELINE_ROOT>
 	 <CCSM_CPRNC>/lustre/atlas1/cli900/world-shared/cesm/tools/cprnc/cprnc</CCSM_CPRNC>
 	 <SAVE_TIMING_DIR>/lustre/atlas/proj-shared/$PROJECT</SAVE_TIMING_DIR>
 	 <OS>LINUX</OS>

--- a/scripts/Tools/bless_test_results
+++ b/scripts/Tools/bless_test_results
@@ -45,8 +45,6 @@ OR
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    default_baseline_name = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
-    default_baseline_root = _MACHINE.get_value("BASELINE_ROOT")
     default_compiler      = _MACHINE.get_default_compiler()
     scratch_root          = _MACHINE.get_value("CIME_OUTPUT_ROOT")
     default_testroot      = os.path.join(scratch_root)
@@ -59,11 +57,11 @@ OR
     parser.add_argument("--hist-only", action="store_true",
                         help="Only analyze history files.")
 
-    parser.add_argument("-b", "--baseline-name", default=default_baseline_name,
-                        help="Name of baselines to use, corresponds to branch used.")
+    parser.add_argument("-b", "--baseline-name",
+                        help="Name of baselines to use. Default will use BASELINE_NAME_CMP first if possible, otherwise branch name.")
 
-    parser.add_argument("--baseline-root", default=default_baseline_root,
-                        help="Root of baselines.")
+    parser.add_argument("--baseline-root",
+                        help="Root of baselines. Default will use the BASELINE_ROOT from the case.")
 
     parser.add_argument("-c", "--compiler", default=default_compiler,
                         help="Compiler of run you want to bless")

--- a/scripts/Tools/case.cmpgen_namelists
+++ b/scripts/Tools/case.cmpgen_namelists
@@ -50,7 +50,7 @@ OR
                         "Default will be to follow the case specification")
 
     parser.add_argument("--baseline-root",
-                        help="Root of baselines.")
+                        help="Root of baselines. Default will be BASELINE_ROOT.")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 

--- a/scripts/Tools/compare_test_results
+++ b/scripts/Tools/compare_test_results
@@ -58,8 +58,6 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
-    default_baseline_name = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
-    default_baseline_root = _MACHINE.get_value("BASELINE_ROOT")
     default_compiler      = _MACHINE.get_default_compiler()
     scratch_root          = _MACHINE.get_value("CIME_OUTPUT_ROOT")
     default_testroot      = os.path.join(scratch_root)
@@ -72,11 +70,11 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--hist-only", action="store_true",
                         help="Only analyze history files.")
 
-    parser.add_argument("-b", "--baseline-name", default=default_baseline_name,
-                        help="Name of baselines to use, corresponds to branch used.")
+    parser.add_argument("-b", "--baseline-name",
+                        help="Name of baselines to use. Default will use BASELINE_NAME_CMP first if possible, otherwise branch name.")
 
-    parser.add_argument("--baseline-root", default=default_baseline_root,
-                        help="Root of baselines.")
+    parser.add_argument("--baseline-root",
+                        help="Root of baselines. Default will use BASELINE_ROOT from the case.")
 
     parser.add_argument("-c", "--compiler", default=default_compiler,
                         help="Compiler of run you want to compare")

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -419,7 +419,6 @@ OR
             baseline_name = args.baseline_name if args.baseline_name else CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
             expect(baseline_name is not None,
                    "Could not determine baseline name from branch, please use -b option")
-            baseline_name = os.path.join(args.compiler, baseline_name)
             if args.compare:
                 baseline_cmp_name = baseline_name
             elif args.generate:

--- a/scripts/lib/CIME/compare_test_results.py
+++ b/scripts/lib/CIME/compare_test_results.py
@@ -1,5 +1,5 @@
 import CIME.compare_namelists, CIME.simple_compare
-from CIME.utils import expect, get_model, append_status
+from CIME.utils import expect, append_status
 from CIME.test_status import *
 from CIME.hist_utils import compare_baseline
 from CIME.case_cmpgen_namelists import case_cmpgen_namelists
@@ -16,11 +16,8 @@ def append_status_cprnc_log(msg, logfile_name, test_dir):
         pass
 
 ###############################################################################
-def compare_namelists(case, baseline_name, baseline_root, logfile_name, compiler):
+def compare_namelists(case, baseline_name, baseline_root, logfile_name):
 ###############################################################################
-    if get_model() == "acme":
-        baseline_name = os.path.join(compiler, baseline_name)
-
     log_lvl = logging.getLogger().getEffectiveLevel()
     logging.disable(logging.CRITICAL)
     success = case_cmpgen_namelists(case, compare=True, compare_name=baseline_name, baseline_root=baseline_root, logfile_name=logfile_name)
@@ -28,12 +25,9 @@ def compare_namelists(case, baseline_name, baseline_root, logfile_name, compiler
     return success
 
 ###############################################################################
-def compare_history(case, baseline_name, baseline_root, log_id, compiler):
+def compare_history(case, baseline_name, baseline_root, log_id):
 ###############################################################################
-    if get_model() == "acme":
-        baseline_full_dir = os.path.join(baseline_root, compiler, baseline_name, case.get_value("CASEBASEID"))
-    else:
-        baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
+    baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
 
     outfile_suffix = "{}.{}".format(baseline_name, log_id)
     try:
@@ -47,7 +41,9 @@ def compare_history(case, baseline_name, baseline_root, log_id, compiler):
 
 ###############################################################################
 def compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, compare_tests=None, namelists_only=False, hist_only=False):
-    """Compares with baselines for all matching tests
+###############################################################################
+    """
+    Compares with baselines for all matching tests
 
     Outputs results for each test to stdout (one line per test); possible status
     codes are: PASS, FAIL, SKIP. (A SKIP denotes a test that did not make it to
@@ -60,17 +56,14 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
 
     Returns True if all tests generated either PASS or SKIP results, False if
     there was at least one FAIL result.
-
     """
-###############################################################################
-    test_id_glob = "*{}*{}*".format(compiler, baseline_name) if test_id is None else "*{}".format(test_id)
+    test_id_glob = "*{}*".format(compiler) if test_id is None else "*{}".format(test_id)
     test_status_files = glob.glob("{}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
     expect(test_status_files, "No matching test cases found in for {}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
 
     # ID to use in the log file names, to avoid file name collisions with
     # earlier files that may exist.
     log_id = CIME.utils.get_timestamp()
-    logfile_name = "compare.log.{}.{}".format(baseline_name.replace("/", "_"), log_id)
 
     all_pass_or_skip = True
 
@@ -79,11 +72,6 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
         ts = TestStatus(test_dir=test_dir)
         test_name = ts.get_name()
         if (compare_tests in [[], None] or CIME.utils.match_any(test_name, compare_tests)):
-            append_status_cprnc_log(
-                "Comparing against baseline with compare_test_results:\n"
-                "Baseline: {}\n In baseline_root: {}".format(baseline_name, baseline_root),
-                logfile_name,
-                test_dir)
 
             if (not hist_only):
                 nl_compare_result = None
@@ -118,8 +106,25 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
 
             if nl_do_compare or do_compare:
                 with Case(test_dir) as case:
+
+                    if baseline_name is None:
+                        baseline_name = case.get_value("BASELINE_NAME_CMP")
+                        if not baseline_name:
+                            baseline_name = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
+
+                    if baseline_root is None:
+                        baseline_root = case.get_value("BASELINE_ROOT")
+
+                    logfile_name = "compare.log.{}.{}".format(baseline_name.replace("/", "_"), log_id)
+
+                    append_status_cprnc_log(
+                        "Comparing against baseline with compare_test_results:\n"
+                        "Baseline: {}\n In baseline_root: {}".format(baseline_name, baseline_root),
+                        logfile_name,
+                        test_dir)
+
                     if nl_do_compare:
-                        nl_success = compare_namelists(case, baseline_name, baseline_root, logfile_name, compiler)
+                        nl_success = compare_namelists(case, baseline_name, baseline_root, logfile_name)
                         if nl_success:
                             nl_compare_result = TEST_PASS_STATUS
                             nl_compare_comment = ""
@@ -129,7 +134,7 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                             all_pass_or_skip = False
 
                     if do_compare:
-                        success, detailed_comments = compare_history(case, baseline_name, baseline_root, log_id, compiler)
+                        success, detailed_comments = compare_history(case, baseline_name, baseline_root, log_id)
                         if success:
                             compare_result = TEST_PASS_STATUS
                         else:


### PR DESCRIPTION
Major refactor of baseline handling.
    
1) Instead of hard-coding ACME's addition of compiler name to baseline area,
just use XML configuration to achieve this.
    
2) Improve default values for all baseline generation and comparison tools.
Priority will be given to the BASELINE_GEN|CMP_NAME as default baseline name.
BASELINE_ROOT for the case will be used as the default baseline_root.
    
3) Change scripts_regression_test to make much heavier use of default values
now that they are better

4) I should also note, if you have a set of cases with different baseline names and baseline roots, the system handles it much better now.

Test suite: scripts_regression_tests 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Yes, better defaults for bless_test_results and compare_test_results

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @billsacks 
