### PR TITLE
Fix run_sub_or_cmd in the case where a cmd is run and log is None

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -240,7 +240,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
         logger.info("Building {} with output to file {}".format(lib,file_build))
 
         stat,_,_ = run_sub_or_cmd(my_file, [full_lib_path, os.path.join(exeroot, sharedpath), caseroot], 'buildlib',
-                              [full_lib_path, os.path.join(exeroot, sharedpath), caseroot], logfile=file_build, combine_output=True)
+                                  [full_lib_path, os.path.join(exeroot, sharedpath), caseroot], logfile=file_build)
 
         analyze_build_log(lib, file_build, compiler)
         expect(stat == 0, "BUILD FAIL: buildlib.{} failed, cat {}".format(lib, file_build))

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -244,7 +244,7 @@ def do_external(script_name, caseroot, rundir, lid, prefix):
     expect(os.path.isfile(script_name), "External script {} not found".format(script_name))
     filename = "{}.external.log.{}".format(prefix, lid)
     outfile = os.path.join(rundir, filename)
-    run_sub_or_cmd(script_name, [caseroot], os.path.basename(script_name), [caseroot], logfile=outfile,combine_output=True)
+    run_sub_or_cmd(script_name, [caseroot], os.path.basename(script_name), [caseroot], logfile=outfile)
 
 ###############################################################################
 def do_data_assimilation(da_script, caseroot, cycle, lid, rundir):
@@ -252,7 +252,7 @@ def do_data_assimilation(da_script, caseroot, cycle, lid, rundir):
     expect(os.path.isfile(da_script), "Data Assimilation script {} not found".format(da_script))
     filename = "da.log.{}".format(lid)
     outfile = os.path.join(rundir, filename)
-    run_sub_or_cmd(da_script, [caseroot, cycle], os.path.basename(da_script), [caseroot, cycle], logfile=outfile,combine_output=True)
+    run_sub_or_cmd(da_script, [caseroot, cycle], os.path.basename(da_script), [caseroot, cycle], logfile=outfile)
 
 ###############################################################################
 def case_run(case, skip_pnl=False):

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -85,8 +85,7 @@ def create_namelists(case, component=None):
                 # otherwise look in the component config_dir
                 cmd = os.path.join(config_dir, "buildnml")
             expect(os.path.isfile(cmd), "Could not find buildnml file for component {}".format(compname))
-            run_sub_or_cmd(cmd, (caseroot), "buildnml", (case, caseroot, compname), case=case,
-                           combine_output=True)
+            run_sub_or_cmd(cmd, (caseroot), "buildnml", (case, caseroot, compname), case=case)
 
     logger.info("Finished creating component namelists")
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -225,8 +225,7 @@ def _convert_to_fd(filearg, from_dir):
 
 _hack=object()
 
-def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
-                   from_dir=None, combine_output=False):
+def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None, from_dir=None):
 
     # This code will try to import and run each buildnml as a subroutine
     # if that fails it will run it as a program in a seperate shell
@@ -253,14 +252,19 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
         logger.info("   Running {} ".format(cmd))
         if case is not None:
             case.flush()
+
         fullcmd = cmd
         if isinstance(cmdargs, list):
             for arg in cmdargs:
                 fullcmd += " " + str(arg)
         else:
             fullcmd += " " + cmdargs
-        output = run_cmd_no_fail("{} 1> {} 2>&1".format(fullcmd, logfile),
-                                 combine_output=combine_output,
+
+        if logfile:
+            fullcmd += " > {} ".format(logfile)
+
+        output = run_cmd_no_fail("{}".format(fullcmd),
+                                 combine_output=True,
                                  from_dir=from_dir)
         logger.info(output)
         # refresh case xml object from file


### PR DESCRIPTION
Also, refactor to remove combine_output arg. It was always True and
the implementation made it so False wouldn't de-combine output anyway.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2085 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
