### PR TITLE
Add mkl_rt library needed for Skybridge

### DIFF
--- a/config/acme/machines/config_compilers.xml
+++ b/config/acme/machines/config_compilers.xml
@@ -773,7 +773,7 @@ for mct, etc.
   <MPI_PATH MPILIB="openmpi">/opt/openmpi-1.8-intel</MPI_PATH>
   <ESMF_LIBDIR>/projects/ccsm/esmf-6.3.0rp1/lib/libO/Linux.intel.64.openmpi.default</ESMF_LIBDIR>
   <CONFIG_ARGS> --host=Linux </CONFIG_ARGS>
-  <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -L/projects/ccsm/BLAS-intel -lblas_LINUX</ADD_SLIBS>
+  <ADD_SLIBS> $(shell $(NETCDF_PATH)/bin/nf-config --flibs) -L/projects/ccsm/BLAS-intel -lblas_LINUX -L$ENV{MKL_LIBS} -lmkl_rt</ADD_SLIBS>
   <PIO_FILESYSTEM_HINTS>lustre </PIO_FILESYSTEM_HINTS>
   <ADD_SLIBS MPILIB="openmpi"> -mkl=cluster </ADD_SLIBS>
   <ADD_SLIBS MPILIB="mpi-serial"> -mkl </ADD_SLIBS>


### PR DESCRIPTION
This links the Intel Math Kernel Library with vector functions needed for the unit tests when compiling with the Intel compiler.

Test suite: scripts_regression_tests.py
Test status: so far all ok, in particular N_TestUnitTest with PFUNIT_PATH set and Z_FullSystemTest

Fixes ESMCI/cime#2080

Code review: @jgfouca 
