### PR TITLE
Check for unicode in expect()

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -74,7 +74,12 @@ def expect(condition, error_msg, exc_type=SystemExit, error_prefix="ERROR:"):
         if logger.isEnabledFor(logging.DEBUG):
             import pdb
             pdb.set_trace()
-        raise exc_type(error_prefix + " " + error_msg)
+        try:
+            msg = str(error_prefix + " " + error_msg)
+        except UnicodeEncodeError:
+            msg = (error_prefix + " " + error_msg).encode('utf-8')
+        raise exc_type(msg)
+
 
 def id_generator(size=6, chars=string.ascii_lowercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))


### PR DESCRIPTION
expect() can fail if it is given a unicode string without printing out the message. This checks for failure and provides a chance to encode the message.


The following simple test should recreate the error on master:

generate_unicode_error.py:
```
#!/usr/bin/env python
import CIME.utils
errmsg = u"\u2018var\u2019"
CIME.utils.expect(False,errmsg)
```

catch_unicode_error.py:
```
#!/usr/bin/env python
import CIME.utils
rc, out, err = CIME.utils.run_cmd('./generate_unicode_error.py')
CIME.utils.expect(rc==0,'rc=%d\nout=%s\nerr=%s\n' % (rc,out,err))
```

Before this patch, the underlying error is lost:

```
./generate_unicode_error.py:
ERROR: ‘var’
./catch_unicode_error.py:
ERROR: rc=1
out=
err=
```

After the fix, we know what happened:

```
./generate_unicode_error.py:
ERROR: ‘var’
./catch_unicode_error.py:
ERROR: rc=1
out=
err=ERROR: ‘var’
```




Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2093 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
