### PR TITLE
correct path for includes used in build

### DIFF
--- a/src/build_scripts/buildlib.mpi-serial
+++ b/src/build_scripts/buildlib.mpi-serial
@@ -49,7 +49,7 @@ def buildlib(bldroot, installpath, caseroot):
         cimeroot = case.get_value("CIMEROOT")
         mct_dir = os.path.join(cimeroot,"src","externals","mct")
         for _file in glob.iglob(os.path.join(mct_dir, "mpi-serial","*.h")):
-            copyifnewer(_file, os.path.join(my_installpath,os.path.basename(_file)))
+            copyifnewer(_file, os.path.join(bldroot,os.path.basename(_file)))
 
         gmake_opts = "-f {} ".format(os.path.join(caseroot,"Tools","Makefile"))
         gmake_opts += " -C {} ".format(bldroot)


### PR DESCRIPTION
Correct the build path for mpi-serial when the sharedlibroot option is used.

Test suite: scripts_regression_tests.py & ./create_test SMS_D_Ld1_Mmpi-serial.f45_f45_mg37.I2000Clm50SpGs.yellowstone_intel.clm-ptsRLA SMS_D_Mmpi-serial.f19_g16.X 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
