### PR TITLE
fix gptl threaded build, batch change for cheyenne

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -294,7 +294,8 @@
       <directive> -l select={{ num_nodes }}:ncpus={{ max_tasks_per_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}</directive>
     </directives>
     <queues>
-      <queue default="true" walltimemax="12:00" nodemin="1" nodemax="72">regular</queue>
+      <queue default="true" walltimemax="12:00" nodemin="1" nodemax="32">regular</queue>
+      <queue walltimemax="12:00" nodemin="1" nodemax="32">economy</queue>
     </queues>
   </batch_system>
 

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -44,13 +44,17 @@ PIO_VERSION ?= $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) PIO_VERSION -
 # Determine whether to compile threaded or not
 # Set the THREADDIR for the shared build
 # based on the threaded build status
+
 ifeq ($(strip $(SMP)),TRUE)
    THREADDIR = threads
+   compile_threaded = true
 else
    ifeq ($(strip $(BUILD_THREADED)),TRUE)
       THREADDIR = threads
+      compile_threaded = true
    else
       THREADDIR = nothreads
+      compile_threaded = false
    endif
 endif
 

--- a/src/build_scripts/buildlib.gptl
+++ b/src/build_scripts/buildlib.gptl
@@ -51,7 +51,7 @@ def buildlib(bldroot, installpath, caseroot):
                     gptl_dir, bldroot, installpath)
         build_threaded = case.get_value("SMP") or case.get_value("BUILD_THREADED")
         if build_threaded:
-            gmake_opts += " GPTL_CPPDEFS=-DTHREADED_OMP"
+            gmake_opts += " compile_threaded=true "
 
         gmake_cmd = case.get_value("GMAKE")
 

--- a/src/build_scripts/buildlib.mpi-serial
+++ b/src/build_scripts/buildlib.mpi-serial
@@ -44,7 +44,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
 def buildlib(bldroot, installpath, caseroot):
 ###############################################################################
-    my_installpath = os.path.join(installpath,"mct","mpi-serial")
     with Case(caseroot, read_only=False) as case:
         cimeroot = case.get_value("CIMEROOT")
         mct_dir = os.path.join(cimeroot,"src","externals","mct")


### PR DESCRIPTION
gptl uses the Macros.make file but not the default cime Makefile, so defaults defined in the cime Makefile are not available for gptl.   Thus recent changes in PR #2092 broke gptl threaded build.  
This restores that capability.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2098 

User interface changes?: 

Update gh-pages html (Y/N)?:N

Code review: 
