### PR TITLE
nthrds > 1 should set build_threaded flag

### DIFF
--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -128,8 +128,10 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         # Check ninst.
         # In CIME there can be multiple instances of each component model (an ensemble) NINST is the instance of that component.
         multi_driver = case.get_value("MULTI_DRIVER")
+        nthrds = 1
         for comp in models:
             ntasks = case.get_value("NTASKS_{}".format(comp))
+            nthrds = max(nthrds,case.get_value("NTHRDS_{}".format(comp)))
             if comp == "CPL":
                 continue
             ninst  = case.get_value("NINST_{}".format(comp))
@@ -145,6 +147,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                     else:
                         expect(False, "NINST_{} value {:d} greater than NTASKS_{} {:d}".format(comp, ninst, comp, ntasks))
                 case.set_value("NTASKS_PER_INST_{}".format(comp), int(ntasks / ninst))
+        if nthrds > 1:
+            case.set_value("BUILD_THREADED",True)
 
         if os.path.exists("case.run"):
             logger.info("Machine/Decomp/Pes configuration has already been done ...skipping")


### PR DESCRIPTION
BUILD_THREADED needs to be set if any nthrds > 1.

Test suite: scripts_regression_tests.py, SMS_P8x2.f19_g16.X.yellowstone_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
