### PR TITLE
Fixes a memory leak in gptl

### DIFF
--- a/src/share/timing/gptl.c
+++ b/src/share/timing/gptl.c
@@ -3389,6 +3389,7 @@ static int merge_thread_data()
     }
   }
 
+  free(newtimers);
   free(sort[0]);
   /* don't free timerlist[0], since needed for subsequent steps in gathering global statistics */
   for (t = 1; t < nthreads; t++) {


### PR DESCRIPTION
GPTL was leaking the newtimers array in the merge_thread_data function, this correctly frees it.
Note I decided not to correctly free all memory in the event of an error at this time due to the amount of effort required, but will do so at a later date.

Test suite: address sanitizer no longer complains when running, otherwise none
Test status: BFB

Fixes ESMCI/cime#2102

Code review: @jedwards4b @jgfouca @worleyph 
