### PR TITLE
Add ability to customize CaseStatus success message for a phase.

### DIFF
--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -7,7 +7,7 @@ jobs.
 """
 import socket
 from CIME.XML.standard_module_setup import *
-from CIME.utils                     import expect, run_and_log_case_status
+from CIME.utils                     import expect, run_and_log_case_status, verbatim_success_msg
 from CIME.preview_namelists         import create_namelists
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.check_input_data          import check_all_input_data
@@ -82,6 +82,8 @@ def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
     if xml_jobid_text:
         case.set_value("JOB_IDS", xml_jobid_text)
 
+    return xml_jobid_text
+
 def submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
            skip_pnl=False, mail_user=None, mail_type=None, batch_args=None):
     if case.get_value("TEST"):
@@ -102,7 +104,8 @@ def submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
                                   resubmit=resubmit, skip_pnl=skip_pnl,
                                   mail_user=mail_user, mail_type=mail_type,
                                   batch_args=batch_args)
-        run_and_log_case_status(functor, "case.submit", caseroot=case.get_value("CASEROOT"))
+        run_and_log_case_status(functor, "case.submit", caseroot=case.get_value("CASEROOT"),
+                                custom_success_msg_functor=verbatim_success_msg)
     except:
         # If something failed in the batch system, make sure to mark
         # the test as failed if we are running a test.

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1420,7 +1420,10 @@ def stringify_bool(val):
     expect(type(val) is bool, "Wrong type for val '{}'".format(repr(val)))
     return "TRUE" if val else "FALSE"
 
-def run_and_log_case_status(func, phase, caseroot='.'):
+def verbatim_success_msg(return_val):
+    return return_val
+
+def run_and_log_case_status(func, phase, caseroot='.', custom_success_msg_functor=None):
     append_case_status(phase, "starting", caseroot=caseroot)
     rv = None
     try:
@@ -1430,7 +1433,8 @@ def run_and_log_case_status(func, phase, caseroot='.'):
         append_case_status(phase, "error", msg=("\n{}".format(e)), caseroot=caseroot)
         raise
     else:
-        append_case_status(phase, "success", caseroot=caseroot)
+        custom_success_msg = custom_success_msg_functor(rv) if custom_success_msg_functor else None
+        append_case_status(phase, "success", msg=custom_success_msg, caseroot=caseroot)
 
     return rv
 


### PR DESCRIPTION
Add ability to customize CaseStatus success message for a phase.

Test suite: code_checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2108 

User interface changes?: jobid now added to CaseStatus case_submit entry

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
