### PR TITLE
Docn mode fix

### DIFF
--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -49,11 +49,12 @@ class EnvBase(EntryID):
             if hasattr(self, "_components"):
                 new_vid = None
                 for comp in self._components:
-                    if vid.endswith("_"+comp):
+                    if vid.endswith('_'+comp):
                         new_vid = vid.replace('_'+comp, '', 1)
-                    elif vid.startswith(comp+"_"):
+                    elif vid.startswith(comp+'_'):
                         new_vid = vid.replace(comp+'_', '', 1)
-
+                    elif '_' + comp + '_' in vid:
+                        new_vid = vid.replace(comp+'_','', 1)
                     if new_vid is not None:
                         break
                 if new_vid is not None:

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -49,9 +49,9 @@ class EnvBase(EntryID):
             if hasattr(self, "_components"):
                 new_vid = None
                 for comp in self._components:
-                    if "_"+comp in vid:
+                    if vid.endswith("_"+comp):
                         new_vid = vid.replace('_'+comp, '', 1)
-                    elif comp+"_" in vid:
+                    elif vid.startswith(comp+"_"):
                         new_vid = vid.replace(comp+'_', '', 1)
 
                     if new_vid is not None:

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1504,7 +1504,7 @@ class K_TestCimeCase(TestCreateTestCommon):
 
         with Case(casedir, read_only=False) as case:
             build_threaded = case.get_value("BUILD_THREADED")
-            self.assertFalse(build_threaded)
+            self.assertTrue(build_threaded)
 
             build_threaded = case.get_build_threaded()
             self.assertTrue(build_threaded)

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -381,6 +381,14 @@ class J_TestCreateNewcase(unittest.TestCase):
             cmd = xmlquery + " BUILD_COMPLETE --value"
             output = run_cmd_no_fail(cmd, from_dir=casedir)
             self.assertTrue(output == "TRUE", msg="%s != %s"%(output, BUILD_COMPLETE))
+            # we expect DOCN_MODE to be undefined in this X compset
+            # this test assures that we do not try to resolve this as a compvar
+            cmd = xmlquery + " DOCN_MODE --value"
+            _, output, error = run_cmd(cmd, from_dir=casedir)
+            self.assertTrue(error == "ERROR:  No results found for variable DOCN_MODE",
+                            msg="unexpected result for DOCN_MODE, output {}, error {}".
+                            format(output, error))
+
             for comp in COMP_CLASSES:
                 caseresult = case.get_value("NTASKS_%s"%comp)
                 cmd = xmlquery + " NTASKS_%s --value"%comp
@@ -2499,7 +2507,7 @@ def _main_func():
         MACHINE = Machines(machine=mach_name)
     else:
         MACHINE = Machines()
-        
+
 
     if "--compiler" in sys.argv:
         global TEST_COMPILER


### PR DESCRIPTION
variables with component names as subsets were incorrectly being interpreted as component valued variables.  Fix this and add a test.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?: N

Code review: 
