### PR TITLE
Miscellaneous tool improvement

### DIFF
--- a/scripts/Tools/list_acme_tests
+++ b/scripts/Tools/list_acme_tests
@@ -37,25 +37,25 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    parser.add_argument("thing_to_list", choices=("compsets", "grids", "testcases", "tests"),
-                        help="The thing you want to list")
+    parser.add_argument("suites", nargs="+",
+                        help="The tests suites to list. Test suites: {}".format(", ".join(update_acme_tests.get_test_suites())))
 
-    parser.add_argument("categories", nargs="*",
-                        help="The test categories to list. Default will list all. Test categories: {}".format(", ".join(update_acme_tests.get_test_suites())))
+    parser.add_argument("-t", "--thing-to-list", choices=("compsets", "grids", "testcases", "tests"), default="tests",
+                        help="The thing you want to list")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    if (not args.categories):
-        args.categories = update_acme_tests.get_test_suites()
+    if (not args.suites):
+        args.suites = update_acme_tests.get_test_suites()
 
-    return args.thing_to_list, args.categories
+    return args.thing_to_list, args.suites
 
 ###############################################################################
-def list_tests(thing_to_list, categories):
+def list_tests(thing_to_list, suites):
 ###############################################################################
     things = set()
-    for category in categories:
-        tests = update_acme_tests.get_test_suite(category)
+    for suite in suites:
+        tests = update_acme_tests.get_test_suite(suite)
         for test in tests:
             testcase, _, grid, compset = CIME.utils.parse_test_name(test)[:4]
             if (thing_to_list == "compsets"):
@@ -69,9 +69,9 @@ def list_tests(thing_to_list, categories):
             else:
                 expect(False, "Unrecognized thing to list '{}'".format(thing_to_list))
 
-    print("Tested {} for test categories: {}".format(thing_to_list, ", ".join(categories)))
+    print("Tested {} for test suites: {}".format(thing_to_list, ", ".join(suites)))
     for item in sorted(things):
-        print(" ", item)
+        print("  {}".format(item))
 
 ###############################################################################
 def _main_func(description):
@@ -80,9 +80,9 @@ def _main_func(description):
         test_results = doctest.testmod(verbose=True)
         sys.exit(1 if test_results.failed > 0 else 0)
 
-    thing_to_list, categories = parse_command_line(sys.argv, description)
+    thing_to_list, suites = parse_command_line(sys.argv, description)
 
-    list_tests(thing_to_list, categories)
+    list_tests(thing_to_list, suites)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/Tools/simple-py-prof
+++ b/scripts/Tools/simple-py-prof
@@ -2,7 +2,17 @@
 
 if [ "$#" -eq 0 ]; then
     echo "Usage: simple-py-prof <python exec and arguments>"
+    echo ""
+    echo "This will produce a file called 'profile'."
+    echo "To turn this data into a graph, use the following command:"
+    echo "  gprof2dot -f pstats profile -o profile.dot"
+    echo ""
+    echo "To make the graph more easily viewable, convert to PDF:"
+    echo "dot -Tpdf profile.dot -o profile.pdf"
     exit 0
 fi
 
-python -m cProfile -s time "$@"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export PYTHONPATH=$DIR:$DIR/../lib:$PYTHONPATH
+
+python -m cProfile -s time -o profile "$@"


### PR DESCRIPTION
simple-py-prof should auto-adjust PYTHONPATH for profiling scripts and scripts/Tools.

Also, add documention for converting python profiles into a viewable graph.

Also, minor fixes to list_acme_tests to make it more convenient to use.

Test suite: code-checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: simple-py-prof sets PYTHONPATH for you, list_acme_tests assumes you want to list tests

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
