### PR TITLE
move gmake and gmake_j to env_run

### DIFF
--- a/scripts/tests/user_mods_test3/shell_commands
+++ b/scripts/tests/user_mods_test3/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange GMAKE_J=0
+./xmlchange PIO_VERSION=2

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -782,7 +782,7 @@
     <valid_values></valid_values>
     <default_value>gmake</default_value>
     <group>build_def</group>
-    <file>env_build.xml</file>
+    <file>env_run.xml</file>
     <desc>GNU make command</desc>
   </entry>
 
@@ -791,7 +791,7 @@
     <valid_values></valid_values>
     <default_value>1</default_value>
     <group>build_def</group>
-    <file>env_build.xml</file>
+    <file>env_run.xml</file>
     <desc>Number of processors for gmake</desc>
   </entry>
 


### PR DESCRIPTION
Move GMAKE and GMAKE_J options to env_run so that changing them doesn't require a rebuild.

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2118 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
