### PR TITLE
Pio1 update

### DIFF
--- a/src/externals/pio1/pio/pio_types.F90
+++ b/src/externals/pio1/pio/pio_types.F90
@@ -373,7 +373,7 @@ module pio_types
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_NAME = nf_max_name
-   integer, public, parameter :: PIO_MAX_VAR_DIMS = nf_max_var_dims
+   integer, public, parameter :: PIO_MAX_VAR_DIMS = min(128,nf_max_var_dims)
    integer, public, parameter :: PIO_64BIT_OFFSET = nf_64bit_offset
    integer, public, parameter :: PIO_64BIT_DATA = nf_64bit_data
 


### PR DESCRIPTION
The upcoming pnetcdf 1.9.0 and netcdf 4.5.0 libraries no longer need or use NC_MAX_VAR_DIMS and set to MAX_INT.   This patch allows pio1 to work with this change

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jayeshkrishna
