### PR TITLE
Pio2 update

### DIFF
--- a/src/externals/pio2/configure.ac
+++ b/src/externals/pio2/configure.ac
@@ -26,8 +26,17 @@ AC_ARG_WITH([piobuffersize],
 AC_MSG_RESULT([$PIO_BUFFER_SIZE])
 AC_DEFINE_UNQUOTED([PIO_BUFFER_SIZE], [$PIO_BUFFER_SIZE], [buffer size for darray data.])
 
-# Need to allow user to set this.
-AC_DEFINE([PIO_ENABLE_LOGGING], [1], [log messages from library])
+# Does the user want to enable logging?
+AC_MSG_CHECKING([whether debug logging is enabled])
+AC_ARG_ENABLE([logging],
+              [AS_HELP_STRING([--enable-logging],
+                              [enable debug logging capability (will negatively impact performance). \
+			      This debugging feature is probably only of interest to PIO developers.])])
+test "x$enable_logging" = xyes || enable_logging=no
+AC_MSG_RESULT([$enable_logging])
+if test "x$enable_logging" = xyes; then
+   AC_DEFINE([PIO_ENABLE_LOGGING], 1, [If true, turn on logging.])
+fi
 
 # NetCDF (at least classic) is required for PIO to build.
 AC_DEFINE([_NETCDF], [1], [netCDF classic library available])

--- a/src/externals/pio2/ctest/runcdash-nwscla-intel.sh
+++ b/src/externals/pio2/ctest/runcdash-nwscla-intel.sh
@@ -14,14 +14,14 @@ module unload netcdf
 module swap intel intel/17.0.1
 module load cmake/3.7.2
 module load netcdf-mpi/4.4.1.1
-module load pnetcdf/1.8.0
-module switch mpt mpt/2.15
+module load pnetcdf/1.8.1
+module switch mpt mpt/2.16
 echo "MODULE LIST..."
 module list
 
 export CC=mpicc
 export FC=mpif90
-
+export MPI_TYPE_DEPTH=24
 export PIO_DASHBOARD_ROOT=/glade/scratch/jedwards/dashboard
 export PIO_COMPILER_ID=Intel-`$CC --version | head -n 1 | cut -d' ' -f3`
 

--- a/src/externals/pio2/doc/source/mach_walkthrough.txt
+++ b/src/externals/pio2/doc/source/mach_walkthrough.txt
@@ -454,10 +454,10 @@ which causes the build commands to be made visible.
 autoreconf -i && LD_LIBRARY_PATH=/usr/local/netcdf-4.4.1_mpich-3.2/lib CC=mpicc CFLAGS='-g' CPPFLAGS='-I/usr/local/netcdf-4.4.1_mpich-3.2/include/ -I/usr/local/pnetcdf-1.8.1_mpich-3.2/include' LDFLAGS='-L/usr/local/netcdf-4.4.1_mpich-3.2/lib -L/usr/local/pnetcdf-1.8.1_mpich-3.2/lib' ./configure && make check
 </pre>
 
-<p>To build with the address sanitizer for memory checking (debugging builds only!):
+<p>To build with debug logging and the address sanitizer for memory checking (debugging builds only!):
 
 <pre>
-autoreconf -i && LD_LIBRARY_PATH=/usr/local/netcdf-4.4.1_mpich-3.2/lib CC=mpicc CFLAGS='-g -fsanitize=address -fno-omit-frame-pointer' CPPFLAGS='-I/usr/local/netcdf-4.4.1_mpich-3.2/include/ -I/usr/local/pnetcdf-1.8.1_mpich-3.2/include' LDFLAGS='-L/usr/local/netcdf-4.4.1_mpich-3.2/lib -L/usr/local/pnetcdf-1.8.1_mpich-3.2/lib' ./configure && make check
+autoreconf -i && LD_LIBRARY_PATH=/usr/local/netcdf-4.4.1_mpich-3.2/lib CC=mpicc CFLAGS='-g -fsanitize=address -fno-omit-frame-pointer' CPPFLAGS='-I/usr/local/netcdf-4.4.1_mpich-3.2/include/ -I/usr/local/pnetcdf-1.8.1_mpich-3.2/include' LDFLAGS='-L/usr/local/netcdf-4.4.1_mpich-3.2/lib -L/usr/local/pnetcdf-1.8.1_mpich-3.2/lib' ./configure --enable-logging && make check
  </pre>
 
 <li>Building and Running Performance Tests

--- a/src/externals/pio2/src/clib/pio_darray.c
+++ b/src/externals/pio2/src/clib/pio_darray.c
@@ -485,6 +485,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 #endif
     int mpierr = MPI_SUCCESS;  /* Return code from MPI functions. */
     int ierr = PIO_NOERR;      /* Return code. */
+    size_t io_data_size;          /* potential size of data on io task */
 
     LOG((1, "PIOc_write_darray ncid = %d varid = %d ioid = %d arraylen = %d",
          ncid, varid, ioid, arraylen));
@@ -532,7 +533,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (fillvalue)
         if (memcmp(fillvalue, vdesc->fillvalue, vdesc->pio_type_size))
             return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
-    
+
     /* Move to end of list or the entry that matches this ioid. */
     for (wmb = &file->buffer; wmb->next; wmb = wmb->next)
         if (wmb->ioid == ioid && wmb->recordvar == vdesc->rec_var)
@@ -560,13 +561,12 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     }
     LOG((2, "wmb->num_arrays = %d arraylen = %d vdesc->mpi_type_size = %d\n",
          wmb->num_arrays, arraylen, vdesc->mpi_type_size));
-
 #if PIO_USE_MALLOC
     /* Try realloc first and call flush if realloc fails. */
     if (arraylen > 0)
     {
         size_t data_size = (1 + wmb->num_arrays) * arraylen * vdesc->mpi_type_size;
-        
+
         if ((realloc_data = realloc(wmb->data, data_size)))
         {
             needsflush = 0;
@@ -588,6 +588,12 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (needsflush == 0)
         needsflush = (maxfree <= 1.1 * (1 + wmb->num_arrays) * arraylen * vdesc->mpi_type_size);
 #endif
+    /* the limit of data_size < INT_MAX is due to a bug in ROMIO which limits
+       the size of contiguous data to INT_MAX, a fix has been proposed in
+       https://github.com/pmodels/mpich/pull/2888 */
+    io_data_size = (1 + wmb->num_arrays) * iodesc->maxiobuflen * vdesc->mpi_type_size;
+    if(io_data_size > INT_MAX)
+	needsflush = 2;
 
     /* Tell all tasks on the computation communicator whether we need
      * to flush data. */

--- a/src/externals/pio2/src/clib/pio_nc4.c
+++ b/src/externals/pio2/src/clib/pio_nc4.c
@@ -401,6 +401,8 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
             if (!mpierr)
                 mpierr = MPI_Bcast(&storage_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             if (!mpierr)
+                mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->compmaster, ios->intercomm);
+            if (!mpierr)
                 mpierr = MPI_Bcast(&chunksizes_present, 1, MPI_CHAR, ios->compmaster, ios->intercomm);
             LOG((2, "PIOc_inq_var_chunking ncid = %d varid = %d storage_present = %d chunksizes_present = %d",
                  ncid, varid, storage_present, chunksizes_present));

--- a/src/externals/pio2/src/clib/pioc_support.c
+++ b/src/externals/pio2/src/clib/pioc_support.c
@@ -1937,7 +1937,7 @@ int check_unlim_use(int ncid)
  * @author Ed Hartnett
  */
 int inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int **rec_var,
-                      int **pio_type, int **pio_type_size, int **mpi_type, int **mpi_type_size)
+                      int **pio_type, int **pio_type_size, MPI_Datatype **mpi_type, int **mpi_type_size)
 {
     int nunlimdims;        /* The number of unlimited dimensions. */
     int unlimdimid;
@@ -1966,7 +1966,7 @@ int inq_file_metadata(file_desc_t *file, int ncid, int iotype, int *nvars, int *
             return PIO_ENOMEM;
         if (!(*pio_type_size = malloc(*nvars * sizeof(int))))
             return PIO_ENOMEM;
-        if (!(*mpi_type = malloc(*nvars * sizeof(int))))
+        if (!(*mpi_type = malloc(*nvars * sizeof(MPI_Datatype))))
             return PIO_ENOMEM;
         if (!(*mpi_type_size = malloc(*nvars * sizeof(int))))
             return PIO_ENOMEM;
@@ -2145,7 +2145,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
     int *rec_var = NULL;
     int *pio_type = NULL;
     int *pio_type_size = NULL;
-    int *mpi_type = NULL;
+    MPI_Datatype *mpi_type = NULL;
     int *mpi_type_size = NULL;
     int mpierr = MPI_SUCCESS, mpierr2;  /** Return code from MPI function codes. */
     int ierr = PIO_NOERR;      /* Return code from function calls. */
@@ -2355,7 +2355,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
         if (!(pio_type_size = malloc(nvars * sizeof(int))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
-        if (!(mpi_type = malloc(nvars * sizeof(int))))
+        if (!(mpi_type = malloc(nvars * sizeof(MPI_Datatype))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
         if (!(mpi_type_size = malloc(nvars * sizeof(int))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);                    
@@ -2368,7 +2368,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
             return check_mpi(file, mpierr, __FILE__, __LINE__);
         if ((mpierr = MPI_Bcast(pio_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
             return check_mpi(file, mpierr, __FILE__, __LINE__);
-        if ((mpierr = MPI_Bcast(mpi_type, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
+        if ((mpierr = MPI_Bcast(mpi_type, nvars*(int)(sizeof(MPI_Datatype)/sizeof(int)), MPI_INT, ios->ioroot, ios->my_comm)))
             return check_mpi(file, mpierr, __FILE__, __LINE__);
         if ((mpierr = MPI_Bcast(mpi_type_size, nvars, MPI_INT, ios->ioroot, ios->my_comm)))
             return check_mpi(file, mpierr, __FILE__, __LINE__);

--- a/src/externals/pio2/src/flib/pio_types.F90
+++ b/src/externals/pio2/src/flib/pio_types.F90
@@ -186,7 +186,7 @@ module pio_types
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_NAME = nf_max_name
-   integer, public, parameter :: PIO_MAX_VAR_DIMS = nf_max_var_dims
+   integer, public, parameter :: PIO_MAX_VAR_DIMS = min(6,nf_max_var_dims)
    integer, public, parameter :: PIO_64BIT_OFFSET = nf_64bit_offset
    integer, public, parameter :: PIO_64BIT_DATA = nf_64bit_data
    integer, public, parameter :: PIO_FILL_INT = nf_fill_int;
@@ -209,7 +209,7 @@ module pio_types
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_NAME = nf_max_name
-   integer, public, parameter :: PIO_MAX_VAR_DIMS = nf_max_var_dims
+   integer, public, parameter :: PIO_MAX_VAR_DIMS = min(6,nf_max_var_dims)
    integer, public, parameter :: PIO_64BIT_OFFSET = nf_64bit_offset
    integer, public, parameter :: PIO_64BIT_DATA = 0
    integer, public, parameter :: PIO_FILL_INT = nf_fill_int;
@@ -239,7 +239,7 @@ module pio_types
 
 !>
 !! @defgroup PIO_rearr_comm_t PIO_rearr_comm_t
-!! @public 
+!! @public
 !! @brief The two choices for rearranger communication
 !! @details
 !!  - PIO_rearr_comm_p2p : Point to point
@@ -252,7 +252,7 @@ module pio_types
 
 !>
 !! @defgroup PIO_rearr_comm_dir PIO_rearr_comm_dir
-!! @public 
+!! @public
 !! @brief The four choices for rearranger communication direction
 !! @details
 !!  - PIO_rearr_comm_fc_2d_enable : COMM procs to IO procs and vice versa
@@ -271,7 +271,7 @@ module pio_types
 !! @defgroup PIO_rearr_comm_fc_options PIO_rearr_comm_fc_options
 !! @brief Type that defines the PIO rearranger options
 !! @details
-!!  - enable_hs : Enable handshake (true/false) 
+!!  - enable_hs : Enable handshake (true/false)
 !!  - enable_isend : Enable Isends (true/false)
 !!  - max_pend_req : Maximum pending requests (To indicated unlimited
 !!                    number of requests use PIO_REARR_COMM_UNLIMITED_PEND_REQ)


### PR DESCRIPTION
pnetcdf 1.9.0 and netcdf 4.5 will no longer use NC_MAX variables and set them to INT_MAX.  This can cause the compiler to generate medium memory model code.   

There are 4 major changes:

limit to 2GiB due to romio bug
dont use NC_MAX values
Fix for incorrect type of 'mpi_type' in pioc_support.c
added enable-logging option to autotools build

Test suite: external pio2 test suite using pnetcdf/1.9.0 candidate as well as pnetcdf/1.8.1 and netcdf 4.4.1.1
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
