### PR TITLE
Address slow CIME performance (do NOT merge)

### DIFF
--- a/scripts/lib/CIME/XML/archive.py
+++ b/scripts/lib/CIME/XML/archive.py
@@ -4,7 +4,7 @@ Interface to the archive.xml file.  This class inherits from GenericXML.py
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.XML.generic_xml import GenericXML
+from CIME.XML.generic_xml import GenericXML, ConstantElement
 from CIME.XML.files import Files
 from CIME.utils import expect, get_model
 
@@ -26,9 +26,8 @@ class Archive(GenericXML):
         if files is None:
             files = Files()
 
-        components_node = ET.Element("components")
+        components_node = ConstantElement(ET.Element("components"))
         components_node.set("version", "2.0")
-
 
         model = get_model()
         if 'drv' not in components:

--- a/scripts/lib/CIME/XML/batch.py
+++ b/scripts/lib/CIME/XML/batch.py
@@ -113,11 +113,11 @@ class Batch(GenericXML):
         jobs = []
         bnode = self.get_node("batch_jobs")
         for jnode in bnode:
-            if jnode.tag == "job":
+            if jnode.tag() == "job":
                 name = jnode.get("name")
                 jdict = {}
                 for child in jnode:
-                    jdict[child.tag] = child.text()
+                    jdict[child.tag()] = child.text()
 
             jobs.append((name, jdict))
 

--- a/scripts/lib/CIME/XML/batch.py
+++ b/scripts/lib/CIME/XML/batch.py
@@ -91,7 +91,7 @@ class Batch(GenericXML):
 
         node = self.get_optional_batch_node(name)
         if node is not None:
-            value = node.text
+            value = node.text()
 
         if value is None:
             # if all else fails
@@ -117,7 +117,7 @@ class Batch(GenericXML):
                 name = jnode.get("name")
                 jdict = {}
                 for child in jnode:
-                    jdict[child.tag] = child.text
+                    jdict[child.tag] = child.text()
 
             jobs.append((name, jdict))
 

--- a/scripts/lib/CIME/XML/compilerblock.py
+++ b/scripts/lib/CIME/XML/compilerblock.py
@@ -114,7 +114,7 @@ class CompilerBlock(object):
         modified and thus serve as additional outputs.
         """
         writer = self._writer
-        output = elem.text
+        output = elem.text()
         if output is None:
             output = ""
         logger.debug("Initial output={}".format(output))
@@ -159,7 +159,7 @@ class CompilerBlock(object):
         for child in elem:
             if child.tag == "env":
                 # <env> tags just need to be expanded by the writer.
-                output += writer.environment_variable_string(child.text)
+                output += writer.environment_variable_string(child.text())
             elif child.tag == "shell":
                 # <shell> tags can contain other tags, so handle those.
                 command = self._handle_references(child, set_up, tear_down,
@@ -175,7 +175,7 @@ class CompilerBlock(object):
             elif child.tag == "var":
                 # <var> commands also need expansion by the writer, and can
                 # add dependencies.
-                var_name = child.text
+                var_name = child.text()
                 output += writer.variable_string(var_name)
                 depends.add(var_name)
             else:

--- a/scripts/lib/CIME/XML/compilerblock.py
+++ b/scripts/lib/CIME/XML/compilerblock.py
@@ -157,10 +157,10 @@ class CompilerBlock(object):
         logger.debug("First pass output={}".format(output))
 
         for child in elem:
-            if child.tag == "env":
+            if child.tag() == "env":
                 # <env> tags just need to be expanded by the writer.
                 output += writer.environment_variable_string(child.text())
-            elif child.tag == "shell":
+            elif child.tag() == "shell":
                 # <shell> tags can contain other tags, so handle those.
                 command = self._handle_references(child, set_up, tear_down,
                                                   depends)
@@ -172,7 +172,7 @@ class CompilerBlock(object):
                 if new_tear_down is not None:
                     tear_down.append(new_tear_down)
                 logger.debug("set_up {} inline {} tear_down {}".format(new_set_up,inline,new_tear_down))
-            elif child.tag == "var":
+            elif child.tag() == "var":
                 # <var> commands also need expansion by the writer, and can
                 # add dependencies.
                 var_name = child.text()
@@ -180,7 +180,7 @@ class CompilerBlock(object):
                 depends.add(var_name)
             else:
                 expect(False,
-                       "Unexpected tag "+child.tag+" encountered in "
+                       "Unexpected tag "+child.tag()+" encountered in "
                        "config_build.xml. Check that the file is valid "
                        "according to the schema.")
             if child.tail is not None:
@@ -211,7 +211,7 @@ class CompilerBlock(object):
         value_text = self._handle_references(elem, set_up,
                                              tear_down, depends)
         # Create the setting object.
-        setting = ValueSetting(value_text, elem.tag == "append",
+        setting = ValueSetting(value_text, elem.tag() == "append",
                                conditions, set_up, tear_down)
         return (setting, depends)
 
@@ -246,11 +246,11 @@ class CompilerBlock(object):
         """
         for elem in self._compiler_elem:
             # Deal with "flag"-type variables.
-            if elem.tag in flag_vars:
+            if elem.tag() in flag_vars:
                 for child in elem:
-                    self._add_elem_to_lists(elem.tag, child, value_lists)
+                    self._add_elem_to_lists(elem.tag(), child, value_lists)
             else:
-                self._add_elem_to_lists(elem.tag, elem, value_lists)
+                self._add_elem_to_lists(elem.tag(), elem, value_lists)
 
     def matches_machine(self):
         """Check whether this block matches a machine/os.

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -126,7 +126,7 @@ class Compilers(GenericXML):
 
         node = self.get_optional_compiler_node(name, attributes=attribute)
         if node is not None:
-            value = node.text
+            value = node.text()
 
         if value is None:
             # if all else fails
@@ -239,7 +239,7 @@ def _add_to_macros(node, macros):
     for child in node:
         name = child.tag
         attrib = child.attrib()
-        value = child.text
+        value = child.text()
 
         if not attrib:
             if name.startswith("ADD_"):

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -83,7 +83,7 @@ class Compilers(GenericXML):
 
     def _is_compatible(self, compiler_node, compiler, machine, os_, mpilib):
         for xmlid, value in [ ("COMPILER", compiler), ("MACH", machine), ("OS", os_), ("MPILIB", mpilib) ]:
-            if value is not None and xmlid in compiler_node.attrib and value != compiler_node.get(xmlid):
+            if value is not None and compiler_node.has(xmlid) and value != compiler_node.get(xmlid):
                 return False
 
         return True
@@ -238,7 +238,7 @@ class Compilers(GenericXML):
 def _add_to_macros(node, macros):
     for child in node:
         name = child.tag
-        attrib = child.attrib
+        attrib = child.attrib()
         value = child.text
 
         if not attrib:
@@ -255,7 +255,7 @@ def _add_to_macros(node, macros):
 
         else:
             cond_macros = macros["_COND_"]
-            for key, value2 in attrib.items():
+            for key, value2 in attrib:
                 if key not in cond_macros:
                     cond_macros[key] = {}
                 if value2 not in cond_macros[key]:

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -237,7 +237,7 @@ class Compilers(GenericXML):
 
 def _add_to_macros(node, macros):
     for child in node:
-        name = child.tag
+        name = child.tag()
         attrib = child.attrib()
         value = child.text()
 

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -69,7 +69,7 @@ class Component(EntryID):
         if val_node is None:
             logger.debug("No default_value for {}".format(node.get("id")))
             return val_node
-        value = val_node.text
+        value = val_node.text()
         if value is not None and len(value) > 0 and value != "UNSET":
             match_values.append(value)
 
@@ -90,14 +90,14 @@ class Component(EntryID):
             if match_count > 0:
                 # append the current result
                 if values.get("modifier") == "additive":
-                    match_values.append(valnode.text)
+                    match_values.append(valnode.text())
 
                 # replace the current result if it already contains the new value
                 # otherwise append the current result
                 elif values.get("modifier") == "merge":
-                    if valnode.text in match_values:
+                    if valnode.text() in match_values:
                         del match_values[:]
-                    match_values.append(valnode.text)
+                    match_values.append(valnode.text())
 
                 else:
                     if match_type == "last":
@@ -105,13 +105,13 @@ class Component(EntryID):
                         if match_count >= match_max:
                             del match_values[:]
                             match_max = match_count
-                            match_value = valnode.text
+                            match_value = valnode.text()
                     elif match_type == "first":
                         # take the *first* best match
                         if match_count > match_max:
                             del match_values[:]
                             match_max = match_count
-                            match_value = valnode.text
+                            match_value = valnode.text()
                     else:
                         expect(False, "match attribute can only have a value of 'last' or 'first'")
 
@@ -170,7 +170,7 @@ class Component(EntryID):
                     expect(len(desc)==0,
                            "Too many matches on forcing field {} in file {}".\
                                format(forcing, self.filename))
-                    desc = node.text
+                    desc = node.text()
             if desc is None:
                 desc = compsetname.split('_')[0]
             return desc
@@ -180,7 +180,7 @@ class Component(EntryID):
         for node in desc_nodes:
             option = node.get('option')
             if option is not None:
-                optiondesc[option] = node.text
+                optiondesc[option] = node.text()
 
         #second pass find a comp_class match
         desc = ""
@@ -194,7 +194,7 @@ class Component(EntryID):
                 fullset = set(parts+opt_parts)
                 match, complist =  self._get_description_match(compsetname, reqset, fullset, modifier_mode)
                 if match:
-                    desc = node.text
+                    desc = node.text()
                     for opt in complist:
                         if opt in optiondesc:
                             desc += optiondesc[opt]
@@ -269,7 +269,7 @@ class Component(EntryID):
         for node in desc_nodes:
             compsetmatch = node.get("compset")
             if compsetmatch is not None and re.search(compsetmatch, compsetname):
-                desc += node.text
+                desc += node.text()
 
         return desc
 
@@ -278,14 +278,14 @@ class Component(EntryID):
         print values for help and description in target config_component.xml file
         """
         rootnode = self.get_node("help")
-        helptext = rootnode.text
+        helptext = rootnode.text()
 
         rootnode = self.get_node("description")
         compsets = {}
         descs = self.get_nodes("desc", root=rootnode)
         for desc in descs:
             attrib = desc.get("compset")
-            text = desc.text
+            text = desc.text()
             compsets[attrib] = text
 
         logger.info(" {}".format(helptext))

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -75,7 +75,7 @@ class Component(EntryID):
 
         for valnode in self.get_nodes("value", root=node):
             # loop through all the keys in valnode (value nodes) attributes
-            for key,value in valnode.attrib.items():
+            for key,value in valnode.attrib():
                 # determine if key is in attributes dictionary
                 match_count = 0
                 if attributes is not None and key in attributes:

--- a/scripts/lib/CIME/XML/compsets.py
+++ b/scripts/lib/CIME/XML/compsets.py
@@ -60,18 +60,18 @@ class Compsets(GenericXML):
         expect(subgroup is None, "This class does not support subgroups")
         if name == "help":
             rootnode = self.get_node("help")
-            helptext = rootnode.text
+            helptext = rootnode.text()
             return helptext
         else:
             compsets = {}
             nodes = self.get_nodes(nodename="compset")
             for node in nodes:
                 for child in node:
-                    logger.debug ("Here child is {} with value {}".format(child.tag,child.text))
+                    logger.debug ("Here child is {} with value {}".format(child.tag,child.text()))
                     if child.tag == "alias":
-                        alias = child.text
+                        alias = child.text()
                     if child.tag == "lname":
-                        lname = child.text
+                        lname = child.text()
                 compsets[alias] = lname
             return compsets
 

--- a/scripts/lib/CIME/XML/compsets.py
+++ b/scripts/lib/CIME/XML/compsets.py
@@ -67,10 +67,10 @@ class Compsets(GenericXML):
             nodes = self.get_nodes(nodename="compset")
             for node in nodes:
                 for child in node:
-                    logger.debug ("Here child is {} with value {}".format(child.tag,child.text()))
-                    if child.tag == "alias":
+                    logger.debug ("Here child is {} with value {}".format(child.tag(),child.text()))
+                    if child.tag() == "alias":
                         alias = child.text()
-                    if child.tag == "lname":
+                    if child.tag() == "lname":
                         lname = child.text()
                 compsets[alias] = lname
             return compsets

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -5,7 +5,7 @@ be used by other XML interface modules and not directly.
 """
 from CIME.XML.standard_module_setup import *
 from CIME.utils import expect, convert_to_string, convert_to_type
-from CIME.XML.generic_xml import GenericXML
+from CIME.XML.generic_xml import GenericXML, ConstantElement
 
 from copy import deepcopy
 import six
@@ -125,7 +125,7 @@ class EntryID(GenericXML):
                 expect(False,
                        "match attribute can only have a value of 'last' or 'first', value is %s" %match_type)
 
-        return mnode.text
+        return mnode.text()
 
     def get_node_element_info(self, vid, element_name):
         node = self.get_optional_node("entry", {"id":vid})
@@ -201,8 +201,8 @@ class EntryID(GenericXML):
     def _set_valid_values(self, node, new_valid_values):
         old_vv = self._get_valid_values(node)
         if old_vv is None:
-            vv_node = ET.Element("valid_values")
-            vv_node.text = new_valid_values
+            vv_node = ConstantElement(ET.Element("valid_values"))
+            vv_node.set_text(new_valid_values)
             self.add_child(vv_node)
             logger.debug("Adding valid_values {} for {}".format(new_valid_values, node.get("id")))
         else:
@@ -356,13 +356,13 @@ class EntryID(GenericXML):
         for src_node in nodelist:
             node  = deepcopy(src_node)
             gnode = src_node.find(".//group")
-            gname = gnode.text
+            gname = gnode.text()
             if gname is None:
                 gname = "group_not_set"
             # If group with id=$gname does not exist in self.groups
             # then create the group node and add it to infile file
             if gname not in self.groups.keys():
-                newgroup = ET.Element("group")
+                newgroup = ConstantElement(ET.Element("group"))
                 newgroup.set("id",gname)
                 # initialize an empty list
                 self.groups[gname] = newgroup
@@ -419,8 +419,8 @@ class EntryID(GenericXML):
                                     for f2valnode in f2valnodes:
                                         if valnode.attrib() is None and f2valnode.attrib() is None or \
                                            f2valnode.attrib() == valnode.attrib():
-                                            if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
-                                                xmldiffs["{}:{}".format(vid, valnode.attrib())] = [valnode.text, f2valnode.text]
+                                            if other.get_resolved_value(f2valnode.text()) != self.get_resolved_value(valnode.text()):
+                                                xmldiffs["{}:{}".format(vid, valnode.attrib())] = [valnode.text(), f2valnode.text()]
         return xmldiffs
 
     def overwrite_existing_entries(self):

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -306,7 +306,7 @@ class EntryID(GenericXML):
             logger.debug("No node")
             return val
 
-        logger.debug("Found node {} with attributes {}".format(node.tag , node.attrib))
+        logger.debug("Found node {} with attributes {}".format(node.tag , node.attrib()))
         if attribute:
             val = self.get_element_text("value", attributes=attribute, root=node)
         elif node.get("value") is not None:
@@ -415,12 +415,12 @@ class EntryID(GenericXML):
                             if f2val != f1val:
                                 f1value_nodes = self.get_nodes("value", root=node)
                                 for valnode in f1value_nodes:
-                                    f2valnodes = other.get_nodes("value", root=f2match, attributes=valnode.attrib)
+                                    f2valnodes = other.get_nodes("value", root=f2match, attributes=dict(valnode.attrib()))
                                     for f2valnode in f2valnodes:
-                                        if valnode.attrib is None and f2valnode.attrib is None or \
-                                           f2valnode.attrib == valnode.attrib:
+                                        if valnode.attrib() is None and f2valnode.attrib() is None or \
+                                           f2valnode.attrib() == valnode.attrib():
                                             if other.get_resolved_value(f2valnode.text) != self.get_resolved_value(valnode.text):
-                                                xmldiffs["{}:{}".format(vid, valnode.attrib)] = [valnode.text, f2valnode.text]
+                                                xmldiffs["{}:{}".format(vid, valnode.attrib())] = [valnode.text, f2valnode.text]
         return xmldiffs
 
     def overwrite_existing_entries(self):

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -306,7 +306,7 @@ class EntryID(GenericXML):
             logger.debug("No node")
             return val
 
-        logger.debug("Found node {} with attributes {}".format(node.tag , node.attrib()))
+        logger.debug("Found node {} with attributes {}".format(node.tag() , node.attrib()))
         if attribute:
             val = self.get_element_text("value", attributes=attribute, root=node)
         elif node.get("value") is not None:

--- a/scripts/lib/CIME/XML/env_archive.py
+++ b/scripts/lib/CIME/XML/env_archive.py
@@ -49,21 +49,21 @@ class EnvArchive(GenericXML):
     def get_entry_value(self, name, archive_entry):
         node = self.get_optional_node(name, root=archive_entry)
         if node is not None:
-            return node.text
+            return node.text()
         return None
 
     def get_rest_file_extensions(self, archive_entry):
         file_extensions = []
         nodes = self.get_nodes('rest_file_extension', root=archive_entry)
         for node in nodes:
-            file_extensions.append(node.text)
+            file_extensions.append(node.text())
         return file_extensions
 
     def get_hist_file_extensions(self, archive_entry):
         file_extensions = []
         nodes = self.get_nodes('hist_file_extension', root=archive_entry)
         for node in nodes:
-            file_extensions.append(node.text)
+            file_extensions.append(node.text())
         return file_extensions
 
     def get_rpointer_contents(self, archive_entry):
@@ -72,5 +72,5 @@ class EnvArchive(GenericXML):
         for rpointer_node in rpointer_nodes:
             file_node = self.get_node('rpointer_file', root=rpointer_node)
             content_node = self.get_node('rpointer_content', root=rpointer_node)
-            rpointer_items.append([file_node.text,content_node.text])
+            rpointer_items.append([file_node.text(),content_node.text()])
         return rpointer_items

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -136,26 +136,26 @@ class EnvBase(EntryID):
         """
         Remove the <group>, <file>, <values> and <value> childnodes from node
         """
-        fnode = node.find(".//file")
-        node.remove(fnode)
-        gnode = node.find(".//group")
-        node.remove(gnode)
-        dnode = node.find(".//default_value")
-        if dnode is not None:
-            node.remove(dnode)
-        vnode = node.find(".//values")
-        if vnode is not None:
-            componentatt = vnode.findall(".//value[@component=\"ATM\"]")
-            # backward compatibility (compclasses and component were mixed
-            # now we seperated into component and compclass)
-            if len(componentatt) > 0:
-                for ccnode in vnode.findall(".//value[@component]"):
-                    val = ccnode.attrib.get("component")
-                    ccnode.attrib.pop("component")
-                    ccnode.set("compclass",val)
-            compclassatt = vnode.findall(".//value[@compclass]")
+        for xpath in [".//file", ".//group", ".//default_value"]:
+            removes = node.findall(xpath)
+            if removes:
+                for remove in removes:
+                    node.remove(remove)
 
-            if len(compclassatt) == 0:
-                node.remove(vnode)
+        vnodes = node.findall(".//values")
+        if vnodes:
+            for vnode in vnodes:
+                componentatt = vnode.findall(".//value[@component=\"ATM\"]")
+                # backward compatibility (compclasses and component were mixed
+                # now we seperated into component and compclass)
+                if len(componentatt) > 0:
+                    for ccnode in vnode.findall(".//value[@component]"):
+                        val = ccnode.attrib.get("component")
+                        ccnode.pop("component")
+                        ccnode.set("compclass", val)
+                compclassatt = vnode.findall(".//value[@compclass]")
+
+                if len(compclassatt) == 0:
+                    node.remove(vnode)
 
         return node

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -150,7 +150,7 @@ class EnvBase(EntryID):
                 # now we seperated into component and compclass)
                 if len(componentatt) > 0:
                     for ccnode in vnode.findall(".//value[@component]"):
-                        val = ccnode.attrib.get("component")
+                        val = ccnode.get("component")
                         ccnode.pop("component")
                         ccnode.set("compclass", val)
                 compclassatt = vnode.findall(".//value[@compclass]")

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -151,9 +151,9 @@ class EnvBatch(EnvBase):
 
         if batchobj.batch_system_node is not None and batchobj.machine_node is not None:
             for node in batchobj.get_nodes('any', root=batchobj.machine_node, xpath='*'):
-                oldnode = batchobj.get_optional_node(node.tag, root=batchobj.batch_system_node)
-                if oldnode is not None and oldnode.tag != "directives":
-                    logger.debug( "Replacing {}".format(oldnode.tag))
+                oldnode = batchobj.get_optional_node(node.tag(), root=batchobj.batch_system_node)
+                if oldnode is not None and oldnode.tag() != "directives":
+                    logger.debug( "Replacing {}".format(oldnode.tag()))
                     batchobj.batch_system_node.remove(oldnode)
 
         if batchobj.batch_system_node is not None:

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -593,7 +593,7 @@ class EnvBatch(EnvBase):
             logger.warning("Batch queries not supported on this platform")
         else:
             cmd = batch_query.text + " "
-            if "per_job_arg" in batch_query.attrib:
+            if batch_query.has("per_job_arg"):
                 cmd += batch_query.get("per_job_arg") + " "
 
             cmd += jobid

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -111,8 +111,9 @@ class EnvBatch(EnvBase):
         orig_group = self.get_optional_node("group", {"id":"job_submission"})
         expect(orig_group, "Looks like job groups have already been created")
 
+        rev_child = [child for child in orig_group]
         childnodes = []
-        for child in reversed(orig_group):
+        for child in reversed(rev_child):
             childnodes.append(deepcopy(child))
             orig_group.remove(child)
 
@@ -123,8 +124,8 @@ class EnvBatch(EnvBase):
             new_job_group.set("id", name)
             for field in jdict.keys():
                 val = jdict[field]
-                node = ConstantElement(ET.SubElement(new_job_group, "entry", {"id":field,"value":val}))
-                tnode = ConstantElement(ET.SubElement(node, "type"))
+                node = ConstantElement(ET.SubElement(new_job_group._xml_element, "entry", {"id":field,"value":val}))
+                tnode = ConstantElement(ET.SubElement(node._xml_element, "type"))
                 tnode.set_text("char")
 
             for child in childnodes:

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -4,6 +4,7 @@ Interface to the env_mach_specific.xml file.  This class inherits from EnvBase
 from CIME.XML.standard_module_setup import *
 
 from CIME.XML.env_base import EnvBase
+from CIME.XML.generic_xml import ConstantElement
 from CIME.utils import transform_vars, get_cime_root
 import string, resource
 
@@ -32,16 +33,16 @@ class EnvMachSpecific(EnvBase):
         for item in items:
             nodes = machobj.get_first_child_nodes(item)
             if item == "run_exe" or item == "run_misc_suffix":
-                newnode = ET.Element(item)
+                newnode = ConstantElement(ET.Element(item))
                 newnode.tag = "entry"
                 newnode.set("id", item)
                 if len(nodes) == 0:
                     if item == "run_exe":
-                        value = default_run_exe_node.text
+                        value = default_run_exe_node.text()
                     else:
-                        value =  default_run_misc_suffix_node.text
+                        value =  default_run_misc_suffix_node.text()
                 else:
-                    value = nodes[0].text
+                    value = nodes[0].text()
                 newnode.set("value", value)
                 newnode = self.add_sub_node(newnode, "type", "char")
                 if item == "run_exe":
@@ -190,7 +191,7 @@ class EnvMachSpecific(EnvBase):
                 for child in node:
                     expect(child.tag == child_tag, "Expected {} element".format(child_tag))
                     if (self._match_attribs(child.attrib(), case)):
-                        val = child.text
+                        val = child.text()
                         if val is not None:
                             # We allow a couple special substitutions for these fields
                             for repl_this, repl_with in [("$COMPILER", compiler), ("$MPILIB", mpilib)]:
@@ -337,11 +338,11 @@ class EnvMachSpecific(EnvBase):
 
     def get_module_system_init_path(self, lang):
         init_nodes = self.get_optional_node("init_path", attributes={"lang":lang})
-        return init_nodes.text if init_nodes is not None else None
+        return init_nodes.text() if init_nodes is not None else None
 
     def get_module_system_cmd_path(self, lang):
         cmd_nodes = self.get_optional_node("cmd_path", attributes={"lang":lang})
-        return cmd_nodes.text if cmd_nodes is not None else None
+        return cmd_nodes.text() if cmd_nodes is not None else None
 
     def get_mpirun(self, case, attribs, job="case.run", exe_only=False):
         """
@@ -402,7 +403,7 @@ class EnvMachSpecific(EnvBase):
             if arg_node is not None:
                 arg_nodes = self.get_nodes("arg", root=arg_node)
                 for arg_node in arg_nodes:
-                    arg_value = transform_vars(arg_node.text,
+                    arg_value = transform_vars(arg_node.text(),
                                                case=case,
                                                subgroup=job,
                                                default=arg_node.get("default"))
@@ -410,6 +411,6 @@ class EnvMachSpecific(EnvBase):
 
         exec_node = self.get_node("executable", root=the_match)
         expect(exec_node is not None,"No executable found")
-        executable = exec_node.text
+        executable = exec_node.text()
 
         return executable, args

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -186,10 +186,10 @@ class EnvMachSpecific(EnvBase):
         compiler, mpilib = case.get_value("COMPILER"), case.get_value("MPILIB")
 
         for node in nodes:
-            if (self._match_attribs(node.attrib, case)):
+            if (self._match_attribs(node.attrib(), case)):
                 for child in node:
                     expect(child.tag == child_tag, "Expected {} element".format(child_tag))
-                    if (self._match_attribs(child.attrib, case)):
+                    if (self._match_attribs(child.attrib(), case)):
                         val = child.text
                         if val is not None:
                             # We allow a couple special substitutions for these fields
@@ -206,16 +206,16 @@ class EnvMachSpecific(EnvBase):
 
     def _match_attribs(self, attribs, case):
         # check for matches with case-vars
-        for attrib in attribs:
-            if attrib == "unit_testing": # special case
-                if not self._match(self._unit_testing, attribs["unit_testing"].upper()):
+        for key, value in attribs:
+            if key == "unit_testing": # special case
+                if not self._match(self._unit_testing, value.upper()):
                     return False
-            elif attrib == "name":
+            elif key == "name":
                 pass
             else:
-                val = case.get_value(attrib.upper())
-                expect(val is not None, "Cannot match attrib '%s', case has no value for it" % attrib.upper())
-                if not self._match(val, attribs[attrib]):
+                val = case.get_value(key)
+                expect(val is not None, "Cannot match attrib '%s', case has no value for it" % key.upper())
+                if not self._match(val, value):
                     return False
 
         return True
@@ -354,7 +354,7 @@ class EnvMachSpecific(EnvBase):
         best_num_matched_default = -1
         args = []
         for mpirun_node in mpirun_nodes:
-            xml_attribs = mpirun_node.attrib
+            xml_attribs = dict(mpirun_node.attrib())
             all_match = True
             matches = 0
             is_default = False

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -34,7 +34,7 @@ class EnvMachSpecific(EnvBase):
             nodes = machobj.get_first_child_nodes(item)
             if item == "run_exe" or item == "run_misc_suffix":
                 newnode = ConstantElement(ET.Element(item))
-                newnode.tag = "entry"
+                newnode.set_tag("entry")
                 newnode.set("id", item)
                 if len(nodes) == 0:
                     if item == "run_exe":
@@ -189,7 +189,7 @@ class EnvMachSpecific(EnvBase):
         for node in nodes:
             if (self._match_attribs(node.attrib(), case)):
                 for child in node:
-                    expect(child.tag == child_tag, "Expected {} element".format(child_tag))
+                    expect(child.tag() == child_tag, "Expected {} element".format(child_tag))
                     if (self._match_attribs(child.attrib(), case)):
                         val = child.text()
                         if val is not None:

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -214,7 +214,7 @@ class EnvMachSpecific(EnvBase):
             elif key == "name":
                 pass
             else:
-                val = case.get_value(key)
+                val = case.get_value(key.upper())
                 expect(val is not None, "Cannot match attrib '%s', case has no value for it" % key.upper())
                 if not self._match(val, value):
                     return False

--- a/scripts/lib/CIME/XML/env_test.py
+++ b/scripts/lib/CIME/XML/env_test.py
@@ -30,13 +30,13 @@ class EnvTest(EnvBase):
         tnode = self.get_node("test")
         for child in tnode:
             if child.text() is not None:
-                logger.debug("Setting {} to {} for test".format(child.tag, child.text()))
+                logger.debug("Setting {} to {} for test".format(child.tag(), child.text()))
                 if "$" in child.text():
-                    case.set_value(child.tag,child.text(),ignore_type=True)
+                    case.set_value(child.tag(),child.text(),ignore_type=True)
                 else:
-                    item_type = case.get_type_info(child.tag)
-                    value = convert_to_type(child.text(),item_type,child.tag)
-                    case.set_value(child.tag,value)
+                    item_type = case.get_type_info(child.tag())
+                    value = convert_to_type(child.text(),item_type,child.tag())
+                    case.set_value(child.tag(),value)
         case.flush()
         return
 
@@ -80,8 +80,8 @@ class EnvTest(EnvBase):
         settings = []
         if node is not None:
             for child in node:
-                logger.debug ("Here child is {} with value {}".format(child.tag, child.text()))
-                settings.append((child.tag, child.text()))
+                logger.debug ("Here child is {} with value {}".format(child.tag(), child.text()))
+                settings.append((child.tag(), child.text()))
 
         return settings
 

--- a/scripts/lib/CIME/XML/env_test.py
+++ b/scripts/lib/CIME/XML/env_test.py
@@ -72,7 +72,7 @@ class EnvTest(EnvBase):
         bldnodes = self.get_nodes(step)
         cnt = 0
         for node in bldnodes:
-            cnt = max(cnt, int(node.attrib["phase"]))
+            cnt = max(cnt, int(node.get("phase")))
         return cnt
 
     def get_settings_for_phase(self, name, cnt):
@@ -87,8 +87,8 @@ class EnvTest(EnvBase):
 
     def run_phase_get_clone_name(self, phase):
         node = self.get_node("RUN",attributes={"phase":str(phase)})
-        if "clone" in node.attrib:
-            return node.attrib["clone"]
+        if node.has("clone"):
+            return node.get("clone")
         return None
 
     def cleanupnode(self, node):

--- a/scripts/lib/CIME/XML/env_test.py
+++ b/scripts/lib/CIME/XML/env_test.py
@@ -29,13 +29,13 @@ class EnvTest(EnvBase):
         """
         tnode = self.get_node("test")
         for child in tnode:
-            if child.text is not None:
-                logger.debug("Setting {} to {} for test".format(child.tag, child.text))
-                if "$" in child.text:
-                    case.set_value(child.tag,child.text,ignore_type=True)
+            if child.text() is not None:
+                logger.debug("Setting {} to {} for test".format(child.tag, child.text()))
+                if "$" in child.text():
+                    case.set_value(child.tag,child.text(),ignore_type=True)
                 else:
                     item_type = case.get_type_info(child.tag)
-                    value = convert_to_type(child.text,item_type,child.tag)
+                    value = convert_to_type(child.text(),item_type,child.tag)
                     case.set_value(child.tag,value)
         case.flush()
         return
@@ -53,9 +53,9 @@ class EnvTest(EnvBase):
 
         if idnode is None:
             newnode = ET.SubElement(tnode, name)
-            newnode.text = value
+            newnode.set_text(value)
         else:
-            idnode.text = value
+            idnode.set_text(value)
 
     def get_test_parameter(self, name):
         case = self.get_value("TESTCASE")
@@ -65,7 +65,7 @@ class EnvTest(EnvBase):
         value = None
         idnode = self.get_optional_node(name, root=tnode, xpath=name)
         if idnode is not None:
-            value = idnode.text
+            value = idnode.text()
         return value
 
     def get_step_phase_cnt(self,step):
@@ -80,8 +80,8 @@ class EnvTest(EnvBase):
         settings = []
         if node is not None:
             for child in node:
-                logger.debug ("Here child is {} with value {}".format(child.tag, child.text))
-                settings.append((child.tag, child.text))
+                logger.debug ("Here child is {} with value {}".format(child.tag, child.text()))
+                settings.append((child.tag, child.text()))
 
         return settings
 

--- a/scripts/lib/CIME/XML/files.py
+++ b/scripts/lib/CIME/XML/files.py
@@ -47,7 +47,7 @@ class Files(EntryID):
         schemanode = self.get_optional_node("schema", root=node, attributes=attributes)
         if schemanode is not None:
             logger.debug("Found schema for {}".format(nodename))
-            return self.get_resolved_value(schemanode.text)
+            return self.get_resolved_value(schemanode.text())
         return None
 
     def get_components(self, nodename):

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -34,8 +34,12 @@ class ConstantElement(object):
     def tag(self):
         return self._xml_element.tag
 
+    def set_tag(self, value):
+        # Technically not constant, but it won't affect findall cache
+        self._xml_element.tag = value
+
     def set_text(self, text):
-        # Technically, not constant, but it won't affect findall cache
+        # Technically not constant, but it won't affect findall cache
         self._xml_element.text = text
 
     def text(self):
@@ -59,7 +63,9 @@ class ConstantElement(object):
         if xpath in self._cache_find:
             return self._cache_find[xpath]
         else:
-            return [ConstantElement(item) for item in self._xml_element.findall(xpath)]
+            result = [ConstantElement(item) for item in self._xml_element.findall(xpath)]
+            self._cache_find[xpath] = result
+            return result
 
     def find(self, xpath):
         all_matches = self.findall(xpath)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -19,11 +19,14 @@ class ConstantElement(object):
     # const methods
     #
 
-    def get(self, key):
-        return self._xml_element.get(key)
+    def get(self, key, default=None):
+        return self._xml_element.get(key, default=default)
 
     def has(self, key):
         return key in self._xml_element.attrib
+
+    def keys(self):
+        return self._xml_element.keys()
 
     def attrib(self):
         return None if self._xml_element.attrib is None else tuple(self._xml_element.attrib.iteritems())
@@ -35,7 +38,7 @@ class ConstantElement(object):
         # Technically, not constant, but it won't affect findall cache
         self._xml_element.text = text
 
-    def get_text(self):
+    def text(self):
         return self._xml_element.text
 
     def __eq__(self, rhs):
@@ -64,6 +67,10 @@ class ConstantElement(object):
             return all_matches[0]
         else:
             return None
+
+    def __iter__(self):
+        for child in self._xml_element:
+            yield(ConstantElement(child))
 
     #
     # non-const methods
@@ -356,13 +363,13 @@ class GenericXML(object):
     def get_element_text(self, element_name, attributes=None, root=None, xpath=None):
         element_node = self.get_optional_node(element_name, attributes, root, xpath)
         if element_node is not None:
-            return element_node.get_text()
+            return element_node.text()
         return None
 
     def set_element_text(self, element_name, new_text, attributes=None, root=None, xpath=None):
         element_node = self.get_optional_node(element_name, attributes, root, xpath)
         if element_node is not None:
-            element_node.text = new_text
+            element_node.set_text(new_text)
             return new_text
         return None
 
@@ -371,9 +378,9 @@ class GenericXML(object):
         if root is None:
             root = self.root
         try:
-            xmlstr = ET.tostring(root)
+            xmlstr = ET.tostring(root._xml_element) # pylint: disable=protected-access
         except ET.ParseError as e:
-            ET.dump(root)
+            ET.dump(root._xml_element) # pylint: disable=protected-access
             expect(False, "Could not write file {}, xml formatting error '{}'".format(self.filename, e))
         return xmlstr
 

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -187,7 +187,7 @@ class GenericXML(object):
 
         nodes = self.get_nodes(nodename, attributes=attributes, root=root, xpath=xpath)
 
-        expect(len(nodes) == 1, "Incorrect number of matches, {:d}, for nodename '{}' and attrs '{}' in file '{}'".format(len(nodes), nodename, attributes, self.filename))
+        #expect(len(nodes) == 1, "Incorrect number of matches, {:d}, for nodename '{}' and attrs '{}' in file '{}'".format(len(nodes), nodename, attributes, self.filename))
         return nodes[0]
 
     def get_optional_node(self, nodename, attributes=None, root=None, xpath=None):
@@ -198,20 +198,20 @@ class GenericXML(object):
         """
         nodes = self.get_nodes(nodename, attributes=attributes, root=root, xpath=xpath)
 
-        expect(len(nodes) <= 1, "Multiple matches for nodename '{}' and attrs '{}' in file '{}'".format(nodename, attributes, self.filename))
+        #expect(len(nodes) <= 1, "Multiple matches for nodename '{}' and attrs '{}' in file '{}'".format(nodename, attributes, self.filename))
         return nodes[0] if nodes else None
 
     def get_nodes(self, nodename, attributes=None, root=None, xpath=None):
-        expect(root is None or isinstance(root, ConstantElement), "Wrong type")
+        #expect(root is None or isinstance(root, ConstantElement), "Wrong type")
 
-        logger.debug("(get_nodes) Input values: {}, {}, {}, {}, {}".format(self.__class__.__name__, nodename, attributes, root, xpath))
+        #logger.debug("(get_nodes) Input values: {}, {}, {}, {}, {}".format(self.__class__.__name__, nodename, attributes, root, xpath))
 
         if root is None:
             root = self.root
         nodes = []
 
-        expect(attributes is None or xpath is None,
-               " Arguments attributes and xpath are exclusive")
+        #expect(attributes is None or xpath is None,
+        #       " Arguments attributes and xpath are exclusive")
         if xpath is None:
             xpath = ".//"+nodename
 
@@ -222,15 +222,15 @@ class GenericXML(object):
 
             for key, value in attributes.items():
                 if value is not None:
-                    expect(isinstance(value, six.string_types),
-                           " Bad value passed for key {}".format(key))
+                    #expect(isinstance(value, six.string_types),
+                    #       " Bad value passed for key {}".format(key))
                     xpath = ".//{}[@{}=\'{}\']".format(nodename, key, value)
-                    logger.debug("xpath is {}".format(xpath))
+                    #logger.debug("xpath is {}".format(xpath))
 
-                    try:
-                        newnodes = root.findall(xpath)
-                    except Exception as e:
-                        expect(False, "Bad xpath search term '{}', error: {}".format(xpath, e))
+                    #try:
+                    newnodes = root.findall(xpath)
+                    #except Exception as e:
+                    #    expect(False, "Bad xpath search term '{}', error: {}".format(xpath, e))
 
                     if not nodes:
                         nodes = newnodes
@@ -242,10 +242,10 @@ class GenericXML(object):
                         return []
 
         else:
-            logger.debug("xpath: {}".format(xpath))
+            #logger.debug("xpath: {}".format(xpath))
             nodes = root.findall(xpath)
 
-        logger.debug("Returning {} nodes ({})".format(len(nodes), nodes))
+        #logger.debug("Returning {} nodes ({})".format(len(nodes), nodes))
 
         return nodes
 

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -373,9 +373,9 @@ class Grids(GenericXML):
                 nodes = self.get_nodes(nodename="gridmap", attributes={grid[0]:grid[1], other_grid[0]:other_grid[1]})
                 for gridmap_node in nodes:
                     for child in gridmap_node:
-                        gridmap = (child.tag, child.text())
+                        gridmap = (child.tag(), child.text())
                         if gridmap is not None:
-                            gridmaps[child.tag] = child.text()
+                            gridmaps[child.tag()] = child.text()
                             logger.debug(" {}: {}".format(*gridmap))
 
         return gridmaps
@@ -548,7 +548,7 @@ class Grids(GenericXML):
                         logger.info("   domain is {}".format(domain))
                         domain_node = self.get_node(nodename="domain", attributes={"name":domain})
                         for child in domain_node:
-                            logger.info("        {}: {}".format(child.tag, child.text()))
+                            logger.info("        {}: {}".format(child.tag(), child.text()))
 
                 # write out mapping files
                 grids = [ ("atm_grid", component_grids[0]), ("lnd_grid", component_grids[1]), ("ocn_grid", component_grids[2]), \
@@ -559,7 +559,7 @@ class Grids(GenericXML):
                         nodes = self.get_nodes(nodename="gridmap", attributes={grid[0]:grid[1], other_grid[0]:other_grid[1]})
                         for gridmap_node in nodes:
                             for child in gridmap_node:
-                                logger.info("    mapping file {}: {}".format(child.tag, child.text()))
+                                logger.info("    mapping file {}: {}".format(child.tag(), child.text()))
 
                 logger.info("   ")
 
@@ -598,7 +598,7 @@ class Grids(GenericXML):
                     domain_list = list()
                     domain_node = self.get_node(nodename="domain", attributes={"name":domain})
                     for child in domain_node:
-                        domain_list.append({'domain':child.tag, 'text':child.text()})
+                        domain_list.append({'domain':child.tag(), 'text':child.text()})
 
             grid_info.update({'domains': domain_list})
 
@@ -612,7 +612,7 @@ class Grids(GenericXML):
                     nodes = self.get_nodes(nodename="gridmap", attributes={grid[0]:grid[1], other_grid[0]:other_grid[1]})
                     for gridmap_node in nodes:
                         for child in gridmap_node:
-                            map_list.append({'map':child.tag, 'file':child.text()})
+                            map_list.append({'map':child.tag(), 'file':child.text()})
 
             grid_info.update({'maps': map_list})
 

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -134,7 +134,7 @@ class Grids(GenericXML):
             compset_attrib = grid_node.get("compset")
             compset_match = re.search(compset_attrib, compset)
             if compset_match is not None:
-                model_grid[name_attrib] = grid_node.text
+                model_grid[name_attrib] = grid_node.text()
 
         # (2)loop over all of the "model grid" nodes and determine is there an alias match with the
         # input grid name -  if there is an alias match determine if the "compset" and "not_compset"
@@ -188,12 +188,12 @@ class Grids(GenericXML):
         grid_nodes = self.get_nodes("grid", root=model_gridnode)
         for grid_node in grid_nodes:
             name = grid_node.get("name")
-            value = grid_node.text
+            value = grid_node.text()
             if model_grid[name] != "null":
                 model_grid[name] = value
         mask_node = self.get_optional_node("mask",root=model_gridnode)
         if mask_node is not None:
-            model_grid["mask"] = mask_node.text
+            model_grid["mask"] = mask_node.text()
         else:
             model_grid["mask"] = model_grid["ocnice"]
 
@@ -268,15 +268,15 @@ class Grids(GenericXML):
                         if mask_name is not None:
                             mask_match = re.search(mask_name, mask_attrib)
                         if grid_match is not None and mask_match is not None:
-                            domain_name = file_node.text
+                            domain_name = file_node.text()
                     elif grid_attrib is not None:
                         grid_match = re.search(comp_name.lower(), grid_attrib)
                         if grid_match is not None:
-                            domain_name = file_node.text
+                            domain_name = file_node.text()
                     elif mask_attrib is not None:
                         mask_match = re.search(mask_name.lower(), mask_attrib)
                         if mask_match is not None:
-                            domain_name = file_node.text
+                            domain_name = file_node.text()
                     if domain_name:
                         domains[file_name] = os.path.basename(domain_name)
                         path = os.path.dirname(domain_name)
@@ -373,9 +373,9 @@ class Grids(GenericXML):
                 nodes = self.get_nodes(nodename="gridmap", attributes={grid[0]:grid[1], other_grid[0]:other_grid[1]})
                 for gridmap_node in nodes:
                     for child in gridmap_node:
-                        gridmap = (child.tag, child.text)
+                        gridmap = (child.tag, child.text())
                         if gridmap is not None:
-                            gridmaps[child.tag] = child.text
+                            gridmaps[child.tag] = child.text()
                             logger.debug(" {}: {}".format(*gridmap))
 
         return gridmaps
@@ -392,7 +392,7 @@ class Grids(GenericXML):
         required_gridmaps_node = self.get_node(nodename="required_gridmaps")
         required_gridmap_nodes = self.get_nodes(nodename="required_gridmap", root=required_gridmaps_node)
         for node in required_gridmap_nodes:
-            gridmaps[node.text] = "idmap"
+            gridmaps[node.text()] = "idmap"
 
         # (2) determine values gridmaps for target grid
         for idx, grid in enumerate(grids):
@@ -411,7 +411,7 @@ class Grids(GenericXML):
                     map_nodes = self.get_nodes(nodename="map",root=gridmap_node)
                     for map_node in map_nodes:
                         name = map_node.get("name")
-                        value = map_node.text
+                        value = map_node.text()
                         if name is not None and value is not None:
                             gridmaps[name] = value
                             logger.debug(" gridmap name,value are {}: {}"
@@ -428,12 +428,12 @@ class Grids(GenericXML):
             grid2_value = component_grids[prefix2]
             if grid1_value is not None and grid2_value is not None:
                 if grid1_value != grid2_value and grid1_value != 'null' and grid2_value != 'null':
-                    map_ = gridmaps[node.text]
+                    map_ = gridmaps[node.text()]
                     if map_ == 'idmap':
                         if grid1_name == "ocn_grid" and grid1_value == atm_gridvalue:
                             logger.debug('ocn_grid == atm_grid so this is not an idmap error')
                         else:
-                            logger.warning("Warning: missing non-idmap {} for {}, {} and {} {} ".format(node.text, grid1_name, grid1_value, grid2_name, grid2_value))
+                            logger.warning("Warning: missing non-idmap {} for {}, {} and {} {} ".format(node.text(), grid1_name, grid1_value, grid2_name, grid2_value))
 
         return gridmaps
 
@@ -459,7 +459,7 @@ class Grids(GenericXML):
             for grid_node in grid_nodes:
                 name = grid_node.get("name")
                 compset = grid_node.get("compset")
-                value = grid_node.text
+                value = grid_node.text()
                 logger.info("     {:6s}   {:15s}   {:10s}".format(name, compset, value))
         logger.info("{:5s}-------------------------------------------------------------".format(""))
 
@@ -470,12 +470,12 @@ class Grids(GenericXML):
                 name = domain_node.get("name")
                 if name == 'null':
                     continue
-                desc = self.get_node("desc", root=domain_node).text
-                #support = self.get_optional_node("support", root=domain_node).text
+                desc = self.get_node("desc", root=domain_node).text()
+                #support = self.get_optional_node("support", root=domain_node).text()
                 files = ""
                 file_nodes = self.get_nodes("file", root=domain_node)
                 for file_node in file_nodes:
-                    filename = file_node.text
+                    filename = file_node.text()
                     mask_attrib = file_node.get("mask")
                     grid_attrib = file_node.get("grid")
                     files += "\n       " + filename
@@ -507,12 +507,12 @@ class Grids(GenericXML):
             grids = ""
             gridnames = []
             for grid_node in grid_nodes:
-                gridnames.append(grid_node.text)
-                grids += grid_node.get("name") + ":" + grid_node.text + "  "
+                gridnames.append(grid_node.text())
+                grids += grid_node.get("name") + ":" + grid_node.text() + "  "
             logger.info("       non-default grids are: {}".format(grids))
             mask_nodes = self.get_nodes("mask", root=model_grid_node)
             for mask_node in mask_nodes:
-                logger.info("       mask is: {}".format(mask_node.text))
+                logger.info("       mask is: {}".format(mask_node.text()))
             if long_output is not None:
                 gridnames = set(gridnames)
                 for gridname in gridnames:
@@ -548,7 +548,7 @@ class Grids(GenericXML):
                         logger.info("   domain is {}".format(domain))
                         domain_node = self.get_node(nodename="domain", attributes={"name":domain})
                         for child in domain_node:
-                            logger.info("        {}: {}".format(child.tag, child.text))
+                            logger.info("        {}: {}".format(child.tag, child.text()))
 
                 # write out mapping files
                 grids = [ ("atm_grid", component_grids[0]), ("lnd_grid", component_grids[1]), ("ocn_grid", component_grids[2]), \
@@ -559,7 +559,7 @@ class Grids(GenericXML):
                         nodes = self.get_nodes(nodename="gridmap", attributes={grid[0]:grid[1], other_grid[0]:other_grid[1]})
                         for gridmap_node in nodes:
                             for child in gridmap_node:
-                                logger.info("    mapping file {}: {}".format(child.tag, child.text))
+                                logger.info("    mapping file {}: {}".format(child.tag, child.text()))
 
                 logger.info("   ")
 
@@ -598,7 +598,7 @@ class Grids(GenericXML):
                     domain_list = list()
                     domain_node = self.get_node(nodename="domain", attributes={"name":domain})
                     for child in domain_node:
-                        domain_list.append({'domain':child.tag, 'text':child.text})
+                        domain_list.append({'domain':child.tag, 'text':child.text()})
 
             grid_info.update({'domains': domain_list})
 
@@ -612,7 +612,7 @@ class Grids(GenericXML):
                     nodes = self.get_nodes(nodename="gridmap", attributes={grid[0]:grid[1], other_grid[0]:other_grid[1]})
                     for gridmap_node in nodes:
                         for child in gridmap_node:
-                            map_list.append({'map':child.tag, 'file':child.text})
+                            map_list.append({'map':child.tag, 'file':child.text()})
 
             grid_info.update({'maps': map_list})
 
@@ -631,7 +631,7 @@ class Grids(GenericXML):
             for grid_node in grid_nodes:
                 name = grid_node.get("name")
                 compset = grid_node.get("compset")
-                value = grid_node.text
+                value = grid_node.text()
                 default_comp_grids.append({'component':name,
                                            'compset':compset,
                                            'value':value,})
@@ -642,12 +642,12 @@ class Grids(GenericXML):
             name = domain_node.get("name")
             if name == 'null':
                 continue
-            desc = self.get_node("desc", root=domain_node).text
-            ##support = self.get_optional_node("support", root=domain_node).text
+            desc = self.get_node("desc", root=domain_node).text()
+            ##support = self.get_optional_node("support", root=domain_node).text()
             files = ""
             file_nodes = self.get_nodes("file", root=domain_node)
             for file_node in file_nodes:
-                filename = file_node.text
+                filename = file_node.text()
                 mask_attrib = file_node.get("mask")
                 grid_attrib = file_node.get("grid")
                 files += "\n       " + filename
@@ -681,14 +681,14 @@ class Grids(GenericXML):
             grids = ""
             gridnames = []
             for grid_node in grid_nodes:
-                gridnames.append(grid_node.text)
-                grids += grid_node.get("name") + ":" + grid_node.text + "  "
+                gridnames.append(grid_node.text())
+                grids += grid_node.get("name") + ":" + grid_node.text() + "  "
             grids = "       non-default grids are: %s" %grids
 
             mask = ""
             mask_nodes = self.get_nodes("mask", root=model_grid_node)
             for mask_node in mask_nodes:
-                mask += "\n       mask is: %s" %(mask_node.text)
+                mask += "\n       mask is: %s" %(mask_node.text())
 
             grids_dict[alias] = {'aliases':aliases,
                                  'grids':grids,

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -92,7 +92,7 @@ class Grids(GenericXML):
         nodes = self.get_nodes("grid")
         # first search for all grids that have a compset match - if one is found then return
         for node in nodes:
-            if "compset" in node.attrib:
+            if node.has("compset"):
                 attrib = node.get("compset")
                 compset_match = re.search(attrib,compset)
                 if compset_match is not None:
@@ -106,7 +106,7 @@ class Grids(GenericXML):
         # if no matches were found for a possible compset match, then search for just a grid match with no
         # compset attribute
         for node in nodes:
-            if "compset" not in node.attrib:
+            if not node.has("compset"):
                 sname = self.get_element_text("sname", root=node)
                 alias = self.get_element_text("alias", root=node)
                 lname = self.get_element_text("lname", root=node)
@@ -406,8 +406,8 @@ class Grids(GenericXML):
                 gridmap_nodes = self.get_nodes(nodename="gridmap",
                                                attributes={gridname:gridvalue, other_gridname:other_gridvalue})
                 for gridmap_node in gridmap_nodes:
-                    expect(len(gridmap_node.attrib) == 2,
-                           " Bad attribute count in gridmap node %s"%gridmap_node.attrib)
+                    expect(len(gridmap_node.attrib()) == 2,
+                           " Bad attribute count in gridmap node %s"%gridmap_node.attrib())
                     map_nodes = self.get_nodes(nodename="map",root=gridmap_node)
                     for map_node in map_nodes:
                         name = map_node.get("name")

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -131,7 +131,7 @@ class Machines(GenericXML):
             machtocheck = node.get("MACH")
             logger.debug("machine is " + machtocheck)
             regex_str_node = self.get_optional_node("NODENAME_REGEX", root=node)
-            regex_str = machtocheck if regex_str_node is None else regex_str_node.text
+            regex_str = machtocheck if regex_str_node is None else regex_str_node.text()
 
             if regex_str is not None:
                 logger.debug("machine regex string is " + regex_str)
@@ -181,7 +181,7 @@ class Machines(GenericXML):
         else:
             node = self.get_optional_node(name, root=self.machine_node, attributes=attributes)
             if node is not None:
-                value = node.text
+                value = node.text()
 
         if value is None:
             # if all else fails
@@ -275,7 +275,7 @@ class Machines(GenericXML):
         result = False
         batch_system = self.get_optional_node("BATCH_SYSTEM", root=self.machine_node)
         if batch_system is not None:
-            result = (batch_system.text is not None and batch_system.text != "none")
+            result = (batch_system.text() is not None and batch_system.text() != "none")
         logger.debug("Machine {} has batch: {}".format(self.machine, result))
         return result
 
@@ -284,7 +284,7 @@ class Machines(GenericXML):
         if node is not None:
             suffix_node = self.get_optional_node(suffix_type, root=node)
             if suffix_node is not None:
-                return suffix_node.text
+                return suffix_node.text()
 
         return None
 
@@ -300,13 +300,13 @@ class Machines(GenericXML):
             max_tasks_per_node = machine.find("MAX_TASKS_PER_NODE")
             max_mpitasks_per_node = machine.find("MAX_MPITASKS_PER_NODE")
 
-            print( "  {} : {} ".format(name , desc.text))
-            print( "      os             ", os_.text)
-            print( "      compilers      ",compilers.text)
+            print( "  {} : {} ".format(name , desc.text()))
+            print( "      os             ", os_.text())
+            print( "      compilers      ",compilers.text())
             if max_mpitasks_per_node is not None:
-                print("      pes/node       ",max_mpitasks_per_node.text)
+                print("      pes/node       ",max_mpitasks_per_node.text())
             if max_tasks_per_node is not None:
-                print("      max_tasks/node ",max_tasks_per_node.text)
+                print("      max_tasks/node ",max_tasks_per_node.text())
 
     def return_all_values(self):
         # return a dictionary of machines
@@ -321,15 +321,15 @@ class Machines(GenericXML):
             max_mpitasks_per_node = machine.find("MAX_MPITASKS_PER_NODE")
             ppn = ''
             if max_mpitasks_per_node is not None:
-                ppn = max_mpitasks_per_node.text
+                ppn = max_mpitasks_per_node.text()
 
             max_tasks_pn = ''
             if max_tasks_per_node is not None:
-                max_tasks_pn = max_tasks_per_node.text
+                max_tasks_pn = max_tasks_per_node.text()
 
-            mach_dict[name] = { 'description'    : desc.text,
-                                'os'             : os_.text,
-                                'compilers'      : compilers.text,
+            mach_dict[name] = { 'description'    : desc.text(),
+                                'os'             : os_.text(),
+                                'compilers'      : compilers.text(),
                                 'pes/node'       : ppn,
                                 'max_tasks/node' : max_tasks_pn }
 

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -70,7 +70,7 @@ class Machines(GenericXML):
         nodes = self.machine_node.findall("./")
         node_names = []
         for node in nodes:
-            node_names.append(node.tag)
+            node_names.append(node.tag())
         return node_names
 
     def get_first_child_nodes(self, nodename):

--- a/scripts/lib/CIME/XML/pes.py
+++ b/scripts/lib/CIME/XML/pes.py
@@ -94,16 +94,16 @@ class Pes(GenericXML):
                                         logger.info("vid is {}".format(vid))
                                         if "ntasks" in vid:
                                             for child in node:
-                                                pes_ntasks[child.tag.upper()] = int(child.text)
+                                                pes_ntasks[child.tag.upper()] = int(child.text())
                                         elif "nthrds" in vid:
                                             for child in node:
-                                                pes_nthrds[child.tag.upper()] = int(child.text)
+                                                pes_nthrds[child.tag.upper()] = int(child.text())
                                         elif "rootpe" in vid:
                                             for child in node:
-                                                pes_rootpe[child.tag.upper()] = int(child.text)
+                                                pes_rootpe[child.tag.upper()] = int(child.text())
                                     # if the value is already upper case its something else we are trying to set
                                         elif vid == node.tag:
-                                            other_settings[vid] = node.text
+                                            other_settings[vid] = node.text()
 
                                 else:
                                     if points > max_points:
@@ -126,16 +126,16 @@ class Pes(GenericXML):
                 logger.debug("vid is {}".format(vid))
                 if "ntasks" in vid:
                     for child in node:
-                        pes_ntasks[child.tag.upper()] = int(child.text)
+                        pes_ntasks[child.tag.upper()] = int(child.text())
                 elif "nthrds" in vid:
                     for child in node:
-                        pes_nthrds[child.tag.upper()] = int(child.text)
+                        pes_nthrds[child.tag.upper()] = int(child.text())
                 elif "rootpe" in vid:
                     for child in node:
-                        pes_rootpe[child.tag.upper()] = int(child.text)
+                        pes_rootpe[child.tag.upper()] = int(child.text())
             # if the value is already upper case its something else we are trying to set
                 elif vid == node.tag and vid != "comment":
-                    other_settings[vid] = node.text
+                    other_settings[vid] = node.text()
             if grid_choice != 'any' or logger.isEnabledFor(logging.DEBUG):
                 logger.info("Pes setting: grid match    is {} ".format(grid_choice ))
             if mach_choice != 'any' or logger.isEnabledFor(logging.DEBUG):

--- a/scripts/lib/CIME/XML/pes.py
+++ b/scripts/lib/CIME/XML/pes.py
@@ -90,19 +90,19 @@ class Pes(GenericXML):
                                     int(compset_match!="any")*2+int(pesize_match!="any")
                                 if override and points > 0:
                                     for node in pes_node:
-                                        vid = node.tag
+                                        vid = node.tag()
                                         logger.info("vid is {}".format(vid))
                                         if "ntasks" in vid:
                                             for child in node:
-                                                pes_ntasks[child.tag.upper()] = int(child.text())
+                                                pes_ntasks[child.tag().upper()] = int(child.text())
                                         elif "nthrds" in vid:
                                             for child in node:
-                                                pes_nthrds[child.tag.upper()] = int(child.text())
+                                                pes_nthrds[child.tag().upper()] = int(child.text())
                                         elif "rootpe" in vid:
                                             for child in node:
-                                                pes_rootpe[child.tag.upper()] = int(child.text())
+                                                pes_rootpe[child.tag().upper()] = int(child.text())
                                     # if the value is already upper case its something else we are trying to set
-                                        elif vid == node.tag:
+                                        elif vid == node.tag():
                                             other_settings[vid] = node.text()
 
                                 else:
@@ -122,19 +122,19 @@ class Pes(GenericXML):
                                         expect(False, "More than one PE layout matches given PE specs")
         if not override:
             for node in pe_select:
-                vid = node.tag
+                vid = node.tag()
                 logger.debug("vid is {}".format(vid))
                 if "ntasks" in vid:
                     for child in node:
-                        pes_ntasks[child.tag.upper()] = int(child.text())
+                        pes_ntasks[child.tag().upper()] = int(child.text())
                 elif "nthrds" in vid:
                     for child in node:
-                        pes_nthrds[child.tag.upper()] = int(child.text())
+                        pes_nthrds[child.tag().upper()] = int(child.text())
                 elif "rootpe" in vid:
                     for child in node:
-                        pes_rootpe[child.tag.upper()] = int(child.text())
+                        pes_rootpe[child.tag().upper()] = int(child.text())
             # if the value is already upper case its something else we are trying to set
-                elif vid == node.tag and vid != "comment":
+                elif vid == node.tag() and vid != "comment":
                     other_settings[vid] = node.text()
             if grid_choice != 'any' or logger.isEnabledFor(logging.DEBUG):
                 logger.info("Pes setting: grid match    is {} ".format(grid_choice ))

--- a/scripts/lib/CIME/XML/testlist.py
+++ b/scripts/lib/CIME/XML/testlist.py
@@ -76,10 +76,10 @@ class Testlist(GenericXML):
                     for mach in machnodes:
                         thistest = {}
                         save_this = True
-                        if machine is None or (machine is not None and mach.text == machine):
+                        if machine is None or (machine is not None and mach.text() == machine):
                             thistest["compiler"] = mach.get("compiler")
                             thistest["category"] = mach.get("testtype")
-                            thistest["machine"] = mach.text
+                            thistest["machine"] = mach.text()
                             thistest["testname"] = tnode.get("name")
                             thistest["grid"] = gnode.get("name")
                             thistest["compset"] = cnode.get("name")
@@ -137,12 +137,12 @@ class Testlist(GenericXML):
                     # machines block
                     optionnodes = self.get_nodes("option", root=tnode, xpath="options/option")
                     for onode in optionnodes:
-                        this_test['options'][onode.get('name')] = onode.text
+                        this_test['options'][onode.get('name')] = onode.text()
 
                     # Now get options specific to this machine/compiler
                     optionnodes = self.get_nodes("option", root=mach)
                     for onode in optionnodes:
-                        this_test['options'][onode.get('name')] = onode.text
+                        this_test['options'][onode.get('name')] = onode.text()
 
 
                     tests.append(this_test)

--- a/scripts/lib/CIME/XML/testlist.py
+++ b/scripts/lib/CIME/XML/testlist.py
@@ -83,7 +83,7 @@ class Testlist(GenericXML):
                             thistest["testname"] = tnode.get("name")
                             thistest["grid"] = gnode.get("name")
                             thistest["compset"] = cnode.get("name")
-                            if ("testmods" in mach.attrib):
+                            if (mach.has("testmods")):
                                 thistest["testmods"] = mach.get("testmods")
                             if compset is not None and compset != thistest["compset"]:
                                 save_this = False

--- a/scripts/lib/CIME/XML/tests.py
+++ b/scripts/lib/CIME/XML/tests.py
@@ -30,7 +30,7 @@ class Tests(GenericXML):
     def get_test_node(self, testname):
         logger.debug("Get settings for {}".format(testname))
         node = self.get_node("test",{"NAME":testname})
-        logger.debug("Found {}".format(node.text))
+        logger.debug("Found {}".format(node.text()))
         return node
 
     def print_values(self, skip_infrastructure_tests=True):
@@ -49,5 +49,5 @@ class Tests(GenericXML):
                     infrastructure_test.upper() == "TRUE"):
                     continue
             name = one_test.get("NAME")
-            desc = one_test.find("DESC").text
+            desc = one_test.find("DESC").text()
             print("{}: {}".format(name, desc))


### PR DESCRIPTION
Hi all,

I wanted to start a discussion about CIME's performance and it's use of XML as a database. I've been doing some unrelated work for ACME where I've been watching "top" while running create_test. Far too often, I see cases bottle-necked in python instead of building/running. Some recent testing on melvin (fast machine, local disk) consistently shows that it takes about 15 seconds for the first 3 phases (create, xml, setup) on the cime_tiny tests, with case_setup being the most expensive at about 10 seconds. Surely, we can do better than this?

I profiled case.setup and attached the profile to our slack. The thing that caught my eye is that we're spending 60% of our runtime in generic_xml.get_nodes, so this is obviously the area to focus  on. I do not have much experience with python XML libraries, but it seems like we're being very inefficient in the way we're doing queries.

In this PR, I did some prototyping. The goal was to fully encapsulate our use of XML (no direct calls to XML libs) and to try to use caching to speed things up. Our encapsulation was pretty good with most queries going through our classes, but direct access of XML elements was done in several places.

I had some modest success with this toy PR, reducing time spent in get_nodes by 50%, and reducing the cost of case.submit from 10 seconds down to 7 seconds on melvin. Logging showed about 10k cache "hits" and 5k "misses".

Anyway, I don't trust this PR and this was only intended as a discussion topic. Ideally, I'd like to see full encapsulation of our use of XML, and the addition of a high-performing internal representation as an in-memory intermediary between CIME and the XML file database.