### PR TITLE
allow python to be specified in environment

### DIFF
--- a/scripts/tests/CMakeLists.txt
+++ b/scripts/tests/CMakeLists.txt
@@ -6,8 +6,13 @@
 cmake_minimum_required(VERSION 2.8)
 
 include(CTest)
+if (DEFINED ENV{PYTHON})
+  set(PYTHON "ENV{PYTHON}")
+else()
+  set(PYTHON "python")
+endif()
 
-execute_process(COMMAND "python" "list_tests" OUTPUT_VARIABLE STR_TESTS
+execute_process(COMMAND ${PYTHON} "list_tests" OUTPUT_VARIABLE STR_TESTS
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 OUTPUT_STRIP_TRAILING_WHITESPACE
                 ERROR_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Allows the python used by cmake in cime/scripts/tests to be specified as an environment variable. 

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #2137 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
