### PR TITLE
Utf8 encoding

### DIFF
--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -46,20 +46,13 @@ class GenericXML(object):
         Read and parse an xml file into the object
         """
         logger.debug("read: " + infile)
-        if six.PY3:
-            with open(infile, mode='r', encoding='utf-8') as fd:
-                if self.tree:
-                    self.root.append(ET.parse(fd).getroot())
-                else:
-                    self.tree = ET.parse(fd)
-                    self.root = self.tree.getroot()
-        else:
-            with open(infile, mode='r') as fd:
-                if self.tree:
-                    self.root.append(ET.parse(fd).getroot())
-                else:
-                    self.tree = ET.parse(fd)
-                    self.root = self.tree.getroot()
+        file_open = (lambda x: open(x, 'r', encoding='utf-8')) if six.PY3 else (lambda x: open(x, 'r'))
+        with file_open(infile) as fd:
+            if self.tree:
+                self.root.append(ET.parse(fd).getroot())
+            else:
+                self.tree = ET.parse(fd)
+                self.root = self.tree.getroot()
 
         if schema is not None and self.get_version() > 1.0:
             self.validate_xml_file(infile, schema)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -46,12 +46,20 @@ class GenericXML(object):
         Read and parse an xml file into the object
         """
         logger.debug("read: " + infile)
-        with open(infile, mode='r', encoding='utf-8') as fd:
-            if self.tree:
-                self.root.append(ET.parse(fd).getroot())
-            else:
-                self.tree = ET.parse(fd)
-                self.root = self.tree.getroot()
+        if six.PY3:
+            with open(infile, mode='r', encoding='utf-8') as fd:
+                if self.tree:
+                    self.root.append(ET.parse(fd).getroot())
+                else:
+                    self.tree = ET.parse(fd)
+                    self.root = self.tree.getroot()
+        else:
+            with open(infile, mode='r') as fd:
+                if self.tree:
+                    self.root.append(ET.parse(fd).getroot())
+                else:
+                    self.tree = ET.parse(fd)
+                    self.root = self.tree.getroot()
 
         if schema is not None and self.get_version() > 1.0:
             self.validate_xml_file(infile, schema)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -46,7 +46,7 @@ class GenericXML(object):
         Read and parse an xml file into the object
         """
         logger.debug("read: " + infile)
-        with open(infile, 'r') as fd:
+        with open(infile, mode='r', encoding='utf-8') as fd:
             if self.tree:
                 self.root.append(ET.parse(fd).getroot())
             else:


### PR DESCRIPTION
Use the encoding flag to open in py3 to set utf-8 

Test suite: scripts_regression_tests.py py2 and py3
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes cdash testing with py3

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
