### PR TITLE
add the batch jobid to the lid

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1354,8 +1354,22 @@ def get_lids(case):
 
 def new_lid():
     lid = time.strftime("%y%m%d-%H%M%S")
+    jobid = batch_jobid()
+    if jobid is not None:
+        lid = jobid+'.'+lid
     os.environ["LID"] = lid
     return lid
+
+def batch_jobid():
+    jobid = os.environ.get("PBS_JOBID")
+    if jobid is None:
+        jobid = os.environ.get("SLURM_JOB_ID")
+    if jobid is None:
+        jobid = os.environ.get("LSB_JOBID")
+    if jobid is None:
+        jobid = os.environ.get("COBALT_JOBID")
+    return jobid
+
 
 def analyze_build_log(comp, log, compiler):
     """


### PR DESCRIPTION
Add jobid to log files, this has been a long standing request from user support at nersc and ncar.
I wanted to introduce a format for the log file string but just adding jobid to the lid turns out to be much easier.   

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2116 sorta

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
