### PR TITLE
Fix typo of xcpl_comps dir in buildlib.csm_share

### DIFF
--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -49,7 +49,7 @@ def buildlib(bldroot, installpath, caseroot):
         cimeroot = case.get_value("CIMEROOT")
         filepath = [os.path.join(caseroot,"SourceMods","src.share"),
                     os.path.join(cimeroot,"src","drivers","mct","shr"),
-                    os.path.join(cimeroot,"src","components","xcpl_models","xshare"),
+                    os.path.join(cimeroot,"src","components","xcpl_comps","xshare"),
                     os.path.join(cimeroot,"src","share","streams"),
                     os.path.join(cimeroot,"src","share","util"),
                     os.path.join(cimeroot,"src","share","RandNum","src"),


### PR DESCRIPTION
Code was including  src/components/xcpl_models instead of xcpl_comps

This is causing a few dozen warnings in bld/csm_shr.bldlog

Test suite: Just ran ERS.f19_g16_rx1.A and looked in csm_shr.bldlog
