### PR TITLE
Remove unused doctests

### DIFF
--- a/config/acme/machines/template.case.run
+++ b/config/acme/machines/template.case.run
@@ -22,7 +22,7 @@ from CIME.case import Case
 
 logger = logging.getLogger(__name__)
 
-import argparse, doctest
+import argparse
 
 
 # PE Layout Documentation:
@@ -35,8 +35,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# case.run SMS\033[0m
@@ -67,10 +65,6 @@ OR
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
     caseroot, skip_pnl = parse_command_line(sys.argv, description)

--- a/config/acme/machines/template.case.test
+++ b/config/acme/machines/template.case.test
@@ -22,14 +22,14 @@ import argparse
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n%s [<testname>] [--verbose]
+        usage="""\n{0} [<testname>] [--verbose]
 OR
-%s --help
+{0} --help
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# case.test SMS\033[0m
-    > %s
-""" % ((os.path.basename(args[0]), ) * 4),
+    > {0}
+""".format(os.path.basename(args[0])),
 
 description=description,
 

--- a/config/acme/machines/template.case.test
+++ b/config/acme/machines/template.case.test
@@ -16,7 +16,7 @@ from standard_script_setup import *
 from CIME.case_test import case_test
 from CIME.case import Case
 
-import argparse, doctest
+import argparse
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -25,8 +25,6 @@ def parse_command_line(args, description):
         usage="""\n%s [<testname>] [--verbose]
 OR
 %s --help
-OR
-%s --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# case.test SMS\033[0m
@@ -59,10 +57,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
     caseroot, testname, reset = parse_command_line(sys.argv, description)

--- a/config/acme/machines/template.st_archive
+++ b/config/acme/machines/template.st_archive
@@ -30,8 +30,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# case.run SMS\033[0m
@@ -80,10 +78,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     caseroot, last_date, no_incomplete_logs, copy_only = parse_command_line(sys.argv, description)
 
     if last_date is not None and copy_only is False:

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -23,7 +23,7 @@ from CIME.case import Case
 
 logger = logging.getLogger(__name__)
 
-import argparse, doctest
+import argparse
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -32,8 +32,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# case.run SMS\033[0m
@@ -64,10 +62,6 @@ OR
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
     caseroot, skip_pnl = parse_command_line(sys.argv, description)

--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -16,7 +16,7 @@ from standard_script_setup import *
 from CIME.case_test import case_test
 from CIME.case import Case
 
-import argparse, doctest
+import argparse
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -25,8 +25,6 @@ def parse_command_line(args, description):
         usage="""\n%s [<testname>] [--verbose]
 OR
 %s --help
-OR
-%s --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# case.test SMS\033[0m
@@ -59,10 +57,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
     caseroot, testname, reset = parse_command_line(sys.argv, description)

--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -22,14 +22,14 @@ import argparse
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n%s [<testname>] [--verbose]
+        usage="""\n{0} [<testname>] [--verbose]
 OR
-%s --help
+{0} --help
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# case.test SMS\033[0m
-    > %s
-""" % ((os.path.basename(args[0]), ) * 4),
+    > {0}
+"""format(os.path.basename(args[0])),
 
 description=description,
 

--- a/config/cesm/machines/template.st_archive
+++ b/config/cesm/machines/template.st_archive
@@ -29,8 +29,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# case.run SMS\033[0m
@@ -63,10 +61,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     caseroot, no_incomplete_logs, copy_only = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
         success = case_st_archive(case, archive_incomplete_logs=not no_incomplete_logs, copy_only=copy_only)

--- a/scripts/Tools/bless_test_results
+++ b/scripts/Tools/bless_test_results
@@ -15,7 +15,7 @@ from CIME.utils import expect
 from CIME.XML.machines import Machines
 from CIME.bless_test_results import bless_test_results
 
-import argparse, sys, os, doctest
+import argparse, sys, os
 
 _MACHINE = Machines()
 
@@ -26,8 +26,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [-n] [-r <TESTROOT>] [-b <BRANCH>] [-c <COMPILER>] [<TEST> <TEST> ...] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# From most recent run, bless any namelist changes \033[0m
@@ -97,10 +95,6 @@ OR
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     baseline_name, baseline_root, test_root, compiler, test_id, namelists_only, hist_only, report_only, force, bless_tests, no_skip_pass = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -20,8 +20,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--verbose] [--clean [atm lnd pio ...]] [--clean-all]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Build case \033[0m
@@ -78,10 +76,6 @@ OR
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if "--test" in sys.argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     caseroot, sharedlib_only, model_only, cleanlist, clean_all, buildlist, clean_depends = parse_command_line(sys.argv, description)
 
     success = True

--- a/scripts/Tools/case.cmpgen_namelists
+++ b/scripts/Tools/case.cmpgen_namelists
@@ -17,8 +17,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [<casedir>] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Setup case \033[0m
@@ -59,10 +57,6 @@ OR
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if "--test" in sys.argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     caseroot, compare, generate, compare_name, generate_name, baseline_root \
         = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=True) as case:

--- a/scripts/Tools/case.qstatus
+++ b/scripts/Tools/case.qstatus
@@ -16,8 +16,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Show case jobs status \033[0m
@@ -39,10 +37,6 @@ OR
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if "--test" in sys.argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     caseroot = parse_command_line(sys.argv, description)
 
     with Case(caseroot, read_only=False) as case:

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -16,8 +16,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [<casedir>] [--verbose] [--clean] [--reset]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Setup case \033[0m
@@ -52,10 +50,6 @@ OR
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if "--test" in sys.argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     caseroot, clean, test_mode, reset = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
         case_setup(case, clean=clean, test_mode=test_mode, reset=reset)

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -15,8 +15,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [<casedir>] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Setup case \033[0m
     > {0}
@@ -32,9 +30,6 @@ OR
 
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
                         help="Case directory to setup")
-
-    parser.add_argument("--test", action="store_true",
-                        help="Run case as a test.")
 
     parser.add_argument("--job", "-j",
                         help="Name of the job to be submitted, default is case.run"
@@ -62,18 +57,15 @@ OR
 
     CIME.utils.resolve_mail_type_args(args)
 
-    return args.test, args.caseroot, args.job, args.no_batch, args.prereq, \
+    return args.caseroot, args.job, args.no_batch, args.prereq, \
         args.resubmit, args.skip_preview_namelist, args.mail_user, args.mail_type, \
         args.batch_args
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    test, caseroot, job, no_batch, prereq, resubmit, skip_pnl, \
+    caseroot, job, no_batch, prereq, resubmit, skip_pnl, \
         mail_user, mail_type, batch_args = parse_command_line(sys.argv, description)
-    if test:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
 
     with Case(caseroot, read_only=False) as case:
         submit(case, job=job, no_batch=no_batch, prereq=prereq, resubmit=resubmit,

--- a/scripts/Tools/case_diff
+++ b/scripts/Tools/case_diff
@@ -8,7 +8,7 @@ directory trees.
 from standard_script_setup import *
 from CIME.utils import run_cmd, run_cmd_no_fail
 
-import argparse, sys, os, doctest
+import argparse, sys, os
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -17,8 +17,6 @@ def parse_command_line(args, description):
         usage="""\n{0} case1 case2 [skip-files]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     > {0} case1 case2
@@ -121,10 +119,6 @@ def recursive_diff(dir1, dir2, repls, show_binary=False, skip_list=()):
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     case1, case2, show_binary, skip_list = parse_command_line(sys.argv, description)
 
     xml_normalize_fields = ["TEST_TESTID", "SRCROOT"]

--- a/scripts/Tools/check_case
+++ b/scripts/Tools/check_case
@@ -11,7 +11,7 @@ from CIME.case  import Case
 from CIME.check_lockedfiles import check_lockedfiles
 from CIME.preview_namelists import create_namelists
 
-import argparse, doctest
+import argparse
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +23,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run \033[0m
@@ -43,11 +41,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     parse_command_line(sys.argv, description)
 
     with Case(read_only=False) as case:

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -11,7 +11,7 @@ from CIME.utils import get_model
 from CIME.check_input_data import check_input_data, SVN_LOCS
 from CIME.case import Case
 
-import argparse, doctest
+import argparse
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -20,8 +20,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--download] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Download input data \033[0m
@@ -57,10 +55,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     svn_loc, input_data_root, data_list_dir, download = parse_command_line(sys.argv, description)
 
     with Case() as case:

--- a/scripts/Tools/check_lockedfiles
+++ b/scripts/Tools/check_lockedfiles
@@ -12,8 +12,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# check_lockedfiles SMS\033[0m
@@ -35,10 +33,6 @@ OR
     return args.caseroot
 
 def _main_func(description):
-    if "--test" in sys.argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     caseroot = parse_command_line(sys.argv, description)
 
     with Case(case_root=caseroot, read_only=True) as case:

--- a/scripts/Tools/cime_bisect
+++ b/scripts/Tools/cime_bisect
@@ -9,7 +9,7 @@ from standard_script_setup import *
 from CIME.utils import expect, run_cmd_no_fail, run_cmd
 from CIME.XML.machines import Machines
 
-import argparse, sys, os, doctest, re
+import argparse, sys, os, re
 
 _MACHINE = Machines()
 
@@ -20,8 +20,6 @@ def parse_command_line(args, description):
         usage="""\n{0} <testargs> <last-known-good-commit> [<bad>] [--compare=<baseline-id>] [--no-batch]  [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Bisect ERS.f45_g37.B1850C5 which got broken in the last 4 commits \033[0m
@@ -174,10 +172,6 @@ def cime_bisect(testargs, good, bad, testroot, compiler, project, baseline_name,
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     testargs, good, bad, testroot, compiler, project, baseline_name, check_namelists, check_throughput, check_memory, check_memleak, all_commits = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/Tools/code_checker
+++ b/scripts/Tools/code_checker
@@ -9,7 +9,7 @@ from standard_script_setup import *
 
 from CIME.code_checker import check_code, expect
 
-import argparse, sys, os, doctest
+import argparse, sys, os
 from distutils.spawn import find_executable
 
 logger = logging.getLogger(__name__)
@@ -21,8 +21,6 @@ def parse_command_line(args, description):
 usage="""\n{0} [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Check code \033[0m
@@ -53,10 +51,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     pylint = find_executable("pylint")
     expect(pylint is not None, "pylint not found")
 

--- a/scripts/Tools/compare_namelists
+++ b/scripts/Tools/compare_namelists
@@ -18,8 +18,6 @@ def parse_command_line(args, description):
 usage="""\n{0} <Path to gold namelist file> <Path to new namelist file> [-c <CASEBASEID>] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Compare namelist files\033[0m
@@ -51,10 +49,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        CIME.utils.run_cmd_no_fail("python -m doctest {}/compare_namelists.py -v".format(CIME.utils.get_python_libs_root()), arg_stdout=None, arg_stderr=None)
-        return
-
     gold_file, compare_file, case = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/Tools/compare_test_results
+++ b/scripts/Tools/compare_test_results
@@ -26,7 +26,7 @@ from standard_script_setup import *
 from CIME.XML.machines import Machines
 from CIME.compare_test_results import compare_test_results
 
-import argparse, sys, os, doctest
+import argparse, sys, os
 
 _MACHINE = Machines()
 
@@ -37,8 +37,6 @@ def parse_command_line(args, description):
 usage="""\n{0} [-r <TESTROOT>] [-b <BRANCH> -c <COMPILER>] [-t <TESTID>] [<TEST> <TEST> ...] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# From most recent run, compare all changes \033[0m
@@ -95,10 +93,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     baseline_name, baseline_root, test_root, compiler, test_id, compare_tests, namelists_only, hist_only = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/Tools/component_compare_baseline
+++ b/scripts/Tools/component_compare_baseline
@@ -16,8 +16,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [<casedir>] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Compare baselines \033[0m

--- a/scripts/Tools/component_compare_copy
+++ b/scripts/Tools/component_compare_copy
@@ -17,8 +17,6 @@ def parse_command_line(args, description):
         usage="""\n{0} suffix [<casedir>] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Setup case \033[0m

--- a/scripts/Tools/component_compare_test
+++ b/scripts/Tools/component_compare_test
@@ -16,8 +16,6 @@ def parse_command_line(args, description):
         usage="""\n{0} suffix1 suffix2 [<casedir>] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Setup case \033[0m

--- a/scripts/Tools/component_generate_baseline
+++ b/scripts/Tools/component_generate_baseline
@@ -16,8 +16,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [<casedir>] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Generate baselines \033[0m

--- a/scripts/Tools/cs.status
+++ b/scripts/Tools/cs.status
@@ -15,8 +15,6 @@ def parse_command_line(args, description):
 usage="""\n{0} <Glob of TestStatus> [<Path/Glob to TestStatus> ...]  [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Wait for all tests in a test area\033[0m

--- a/scripts/Tools/jenkins_generic_job
+++ b/scripts/Tools/jenkins_generic_job
@@ -24,8 +24,6 @@ def parse_command_line(args, description):
 usage="""\n{0} [-g] [-d] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run the tests and compare baselines \033[0m
@@ -124,10 +122,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler, real_baseline_name = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/Tools/list_acme_tests
+++ b/scripts/Tools/list_acme_tests
@@ -9,7 +9,7 @@ from standard_script_setup import *
 from CIME.utils import expect
 import update_acme_tests
 
-import sys, argparse, os, doctest
+import sys, argparse, os
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -18,8 +18,6 @@ def parse_command_line(args, description):
 usage="""\n{0} <thing-to-list> [<test category> <test category> ...] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# List all tested compsets \033[0m
@@ -76,10 +74,6 @@ def list_tests(thing_to_list, suites):
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     thing_to_list, suites = parse_command_line(sys.argv, description)
 
     list_tests(thing_to_list, suites)

--- a/scripts/Tools/normalize_cases
+++ b/scripts/Tools/normalize_cases
@@ -11,7 +11,7 @@ when they want to run case_diff.
 from standard_script_setup import *
 from CIME.utils import expect, run_cmd_no_fail
 
-import argparse, sys, os, doctest, glob
+import argparse, sys, os, glob
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -20,8 +20,6 @@ def parse_command_line(args, description):
         usage="""\n{0} case1 case2
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     > {0} case1 case2
@@ -92,10 +90,6 @@ def normalize_cases(case1, case2):
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     case1, case2 = parse_command_line(sys.argv, description)
 
     normalize_cases(case1, case2)

--- a/scripts/Tools/pelayout
+++ b/scripts/Tools/pelayout
@@ -194,10 +194,6 @@ def modify_ntasks(case, new_tot_tasks):
 ###############################################################################
 def _main_func():
 ###############################################################################
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     # Initialize command line parser and get command line options
     arg_format, set_ntasks, set_nthrds, header, caseroot = parse_command_line(sys.argv)
 

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -12,7 +12,7 @@ from CIME.preview_namelists import create_namelists
 from CIME.case              import Case
 from CIME.utils             import expect
 
-import argparse, doctest
+import argparse
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -24,8 +24,6 @@ def parse_command_line(args, description):
                         help="Case directory to build")
     parser.add_argument('--component',
                         help="Specify component's namelist to build.")
-    parser.add_argument('--test', action='store_true',
-                        help="Run preview_namelist in test mode.")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
@@ -35,9 +33,6 @@ def parse_command_line(args, description):
 def _main_func(description):
 ###############################################################################
     args = parse_command_line(sys.argv, description)
-    if args.test:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
 
     expect(os.path.isfile(os.path.join(args.caseroot, "CaseStatus")),
            "case.setup must be run prior to running preview_namelists")

--- a/scripts/Tools/preview_run
+++ b/scripts/Tools/preview_run
@@ -27,8 +27,6 @@ def parse_command_line(args, description):
         usage="""\n{0} [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run the tool \033[0m
@@ -48,10 +46,6 @@ OR
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if "--test" in sys.argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     caseroot = parse_command_line(sys.argv, description)
 
     logging.disable(logging.CRITICAL)

--- a/scripts/Tools/save_provenance
+++ b/scripts/Tools/save_provenance
@@ -18,8 +18,6 @@ def parse_command_line(args, description):
         usage="""\n{0} <MODE> [<casedir>] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Save run (timing) provenance for current case \033[0m

--- a/scripts/Tools/simple_compare
+++ b/scripts/Tools/simple_compare
@@ -18,8 +18,6 @@ def parse_command_line(args, description):
 usage="""\n{0} <Path to gold namelist file> <Path to non-namelist file> [-c <CASEBASEID>] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Compare files\033[0m
@@ -51,10 +49,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        CIME.utils.run_cmd_no_fail("python -m doctest {}/simple_compare.py -v".format(CIME.utils.get_python_libs_root(), arg_stdout=None, arg_stderr=None))
-        return
-
     gold_file, compare_file, case = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/Tools/standard_script_setup.py
+++ b/scripts/Tools/standard_script_setup.py
@@ -16,4 +16,4 @@ os.environ["CIMEROOT"] = _CIMEROOT
 import CIME.utils
 CIME.utils.check_minimum_python_version(2, 7)
 CIME.utils.stop_buffering_output()
-import logging, doctest, argparse
+import logging, argparse

--- a/scripts/Tools/update_acme_tests
+++ b/scripts/Tools/update_acme_tests
@@ -21,8 +21,6 @@ def parse_command_line(args, description):
 usage="""\n{0} testlist.xml [<test category> <test category> ...] [--verbose]
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Update all acme test suites for all platforms \033[0m
@@ -64,10 +62,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        CIME.utils.run_cmd_no_fail("python -m doctest {}/update_acme_tests.py -v".format(CIME.utils.get_python_libs_root(), arg_stdout=None, arg_stderr=None))
-        return
-
     categories, test_list_path, platform = parse_command_line(sys.argv, description)
 
     update_acme_tests(test_list_path, categories, platform)

--- a/scripts/Tools/wait_for_tests
+++ b/scripts/Tools/wait_for_tests
@@ -18,18 +18,18 @@ import argparse, sys, os
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-usage="""\n%s [<Path to TestStatus> <Path to TestStatus> ...]  [--verbose]
+usage="""\n{0} [<Path to TestStatus> <Path to TestStatus> ...]  [--verbose]
 OR
-%s --help
+{0} --help
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Wait for test in current dir\033[0m
-    > %s
+    > {0}
     \033[1;32m# Wait for test in user specified tests\033[0m
-    > %s path/to/testdir
+    > {0} path/to/testdir
     \033[1;32m# Wait for all tests in a test area\033[0m
-    > %s path/to/testarea/*/TestStatus
-""" % ((os.path.basename(args[0]), ) * 6),
+    > {0} path/to/testarea/*/TestStatus
+""".format(os.path.basename(args[0])),
 
 description=description,
 

--- a/scripts/Tools/wait_for_tests
+++ b/scripts/Tools/wait_for_tests
@@ -21,8 +21,6 @@ def parse_command_line(args, description):
 usage="""\n%s [<Path to TestStatus> <Path to TestStatus> ...]  [--verbose]
 OR
 %s --help
-OR
-%s --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Wait for test in current dir\033[0m
@@ -76,10 +74,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if ("--test" in sys.argv):
-        CIME.utils.run_cmd_no_fail("python -m doctest %s/wait_for_tests.py -v" % CIME.utils.get_python_libs_root(), arg_stdout=None, arg_stderr=None)
-        return
-
     test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, ignore_memleak, cdash_build_name, cdash_project, cdash_build_group, timeout = \
         parse_command_line(sys.argv, description)
 

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -24,14 +24,14 @@ logger = logging.getLogger("xmlchange")
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n%s [<changeargs>] [--verbose][--file file][--id id][--val value][--noecho][--append][--force]
+        usage="""\n{0} [<changeargs>] [--verbose][--file file][--id id][--val value][--noecho][--append][--force]
 OR
-%s --help
+{0} --help
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# xmlchange REST_OPT=ndays,REST_N=4 \033[0m
-    > %s
-""" % ((os.path.basename(args[0]), ) * 4),
+    > {0}
+""".format(os.path.basename(args[0])),
 
 description=description,
 

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -27,8 +27,6 @@ def parse_command_line(args, description):
         usage="""\n%s [<changeargs>] [--verbose][--file file][--id id][--val value][--noecho][--append][--force]
 OR
 %s --help
-OR
-%s --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# xmlchange REST_OPT=ndays,REST_N=4 \033[0m
@@ -148,9 +146,6 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
         append_case_status("xmlchange", "success", msg=msg, caseroot=caseroot)
 
 def _main_func(description):
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
     # pylint: disable=unused-variable
     caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup, append, noecho, force , dry = parse_command_line(sys.argv, description)
 

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -275,10 +275,6 @@ def xmlquery_sub(case, variables, subgroup=None, fileonly=False,
     return results
 
 def _main_func():
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
-
     # Initialize command line parser and get command line options
     variables, subgroup, caseroot, listall,  fileonly, \
         value, no_resolve, raw, description, get_group, full, dtype, \

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -31,8 +31,6 @@ def parse_command_line(args, description):
 %s --xml-category [CATEGORY] [--xml-machine ...] [--xml-compiler ...] [ --xml-testlist ...]
 OR
 %s --help
-OR
-%s --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run all tests in the xml prealpha category and yellowstone machine \033[0m
@@ -45,8 +43,6 @@ OR
 %s <TEST|SUITE> [<TEST|SUITE> ...] [--verbose]
 OR
 %s --help
-OR
-%s --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run single test \033[0m
@@ -618,13 +614,6 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    if "--test" in sys.argv:
-        libroot = CIME.utils.get_python_libs_root()
-
-        CIME.utils.run_cmd_no_fail("PYTHONPATH=%s python -m doctest %s/CIME/test_scheduler.py -v" %
-                                   (libroot, libroot), arg_stdout=None, arg_stderr=None)
-        return
-
     test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, \
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -28,41 +28,41 @@ def parse_command_line(args, description):
     if model == "cesm":
         help_str = \
 """
-%s --xml-category [CATEGORY] [--xml-machine ...] [--xml-compiler ...] [ --xml-testlist ...]
+{0} --xml-category [CATEGORY] [--xml-machine ...] [--xml-compiler ...] [ --xml-testlist ...]
 OR
-%s --help
+{0} --help
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run all tests in the xml prealpha category and yellowstone machine \033[0m
-    > %s --xml-machine yellowstone --xml-category prealpha
-""" % ((os.path.basename(args[0]), ) * 4)
+    > {0} --xml-machine yellowstone --xml-category prealpha
+""".format(os.path.basename(args[0]))
 
     else:
         help_str = \
 """
-%s <TEST|SUITE> [<TEST|SUITE> ...] [--verbose]
+{0} <TEST|SUITE> [<TEST|SUITE> ...] [--verbose]
 OR
-%s --help
+{0} --help
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run single test \033[0m
-    > %s <TESTNAME>
+    > {0} <TESTNAME>
 
     \033[1;32m# Run test suite \033[0m
-    > %s <SUITE>
+    > {0} <SUITE>
 
     \033[1;32m# Run two tests \033[0m
-    > %s <TESTNAME1> <TESTNAME2>
+    > {0} <TESTNAME1> <TESTNAME2>
 
     \033[1;32m# Run two suites \033[0m
-    > %s <SUITE1> <SUITE2>
+    > {0} <SUITE1> <SUITE2>
 
     \033[1;32m# Run all tests in a suite except for one \033[0m
-    > %s <SUITE> ^<TESTNAME>
+    > {0} <SUITE> ^<TESTNAME>
 
     \033[1;32m# Run all tests in a suite except for tests that are in another suite \033[0m
-    > %s <SUITE1> ^<SUITE2>
-""" % ((os.path.basename(args[0]), ) * 9)
+    > {0} <SUITE1> ^<SUITE2>
+""".format(os.path.basename(args[0]))
 
     parser = argparse.ArgumentParser(usage=help_str,
                                      description=description,

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -5,16 +5,12 @@ common utilities for buildlib
 from CIME.XML.standard_module_setup import *
 from CIME.case import Case
 from CIME.utils import parse_args_and_handle_standard_logging_options, setup_standard_logging_options
-import sys, os, argparse, doctest
+import sys, os, argparse
 logger = logging.getLogger(__name__)
 
 ###############################################################################
 def parse_input(argv):
 ###############################################################################
-
-    if "--test" in argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
 
     parser = argparse.ArgumentParser()
 

--- a/scripts/lib/CIME/buildnml.py
+++ b/scripts/lib/CIME/buildnml.py
@@ -6,17 +6,13 @@ These are used by components/<model_type>/<component>/cime_config/buildnml
 
 from CIME.XML.standard_module_setup import *
 from CIME.utils import expect, parse_args_and_handle_standard_logging_options, setup_standard_logging_options
-import sys, os, argparse, doctest
+import sys, os, argparse
 
 logger = logging.getLogger(__name__)
 
 ###############################################################################
 def parse_input(argv):
 ###############################################################################
-
-    if "--test" in argv:
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
 
     parser = argparse.ArgumentParser()
 

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -968,7 +968,7 @@ class Namelist(object):
         This function is similar to `get_variable_value`, except that it does
         not require a `group_name`, and it requires that the `variable_name` be
         unique across all groups.
-        
+
         >>> parse(text='&foo bar=1 / &bazz bar=1 /').get_value('bar')  # doctest: +ELLIPSIS
         Traceback (most recent call last):
         ...
@@ -1332,7 +1332,7 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> x._advance(3)
         >>> (x._pos, x._line, x._col)
         (7, 3, 1)
-        >>> shouldRaise(_NamelistEOF, x._advance, 1) 
+        >>> shouldRaise(_NamelistEOF, x._advance, 1)
 
         >>> shouldRaise(_NamelistEOF, _NamelistParser('abc\n')._advance, 4)
 

--- a/scripts/manage_pes
+++ b/scripts/manage_pes
@@ -359,10 +359,6 @@ class ManagePes(object):
 ###############################################################################
 def __main_func(description):
 ###############################################################################
-    if "--test" in sys.argv:
-        testresults = doctest.testmod(verbose=True)
-        sys.exit(1 if testresults.failed > 0 else 0)
-
     filename, add, query, setby, grid, machine = parse_command_line(sys.argv,
                                                                     description)
     manager = ManagePes(filename, add, query, setby, grid, machine)

--- a/scripts/query_config
+++ b/scripts/query_config
@@ -16,7 +16,7 @@ from CIME.XML.grids     import Grids
 #from CIME.XML.machines  import Machines
 import CIME.XML.machines
 
-import re, argparse, doctest
+import re, argparse
 
 def query_grids(long_output):
     """

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -14,8 +14,6 @@ OR
 {0} --verbose
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run \033[0m
@@ -123,7 +121,4 @@ def _main(argv, documentation):
     buildlib(bldroot, installpath, caseroot)
 
 if (__name__ == "__main__"):
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
     _main(sys.argv, __doc__)

--- a/src/build_scripts/buildlib.gptl
+++ b/src/build_scripts/buildlib.gptl
@@ -13,8 +13,6 @@ OR
 {0} --verbose
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run \033[0m
@@ -65,7 +63,4 @@ def _main(argv, documentation):
     buildlib(bldroot, installpath, caseroot)
 
 if (__name__ == "__main__"):
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
     _main(sys.argv, __doc__)

--- a/src/build_scripts/buildlib.mct
+++ b/src/build_scripts/buildlib.mct
@@ -14,8 +14,6 @@ OR
 {0} --verbose
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run \033[0m
@@ -85,9 +83,5 @@ def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)
     buildlib(bldroot, installpath, caseroot)
 
-
 if (__name__ == "__main__"):
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
     _main(sys.argv, __doc__)

--- a/src/build_scripts/buildlib.mpi-serial
+++ b/src/build_scripts/buildlib.mpi-serial
@@ -14,8 +14,6 @@ OR
 {0} --verbose
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run \033[0m
@@ -80,7 +78,4 @@ def _main(argv, documentation):
     buildlib(bldroot, installpath, caseroot)
 
 if (__name__ == "__main__"):
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
     _main(sys.argv, __doc__)

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -15,8 +15,6 @@ OR
 {0} --verbose
 OR
 {0} --help
-OR
-{0} --test
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Run \033[0m
@@ -152,7 +150,4 @@ def _main(argv, documentation):
     buildlib(bldroot, installpath, caseroot)
 
 if (__name__ == "__main__"):
-    if ("--test" in sys.argv):
-        test_results = doctest.testmod(verbose=True)
-        sys.exit(1 if test_results.failed > 0 else 0)
     _main(sys.argv, __doc__)


### PR DESCRIPTION
While profiling, I inadvertently discovered that the import of doctest
is actually somewhat expensive computationally. We had copy/pasted a
pattern of supporting a --test option for all our exes but --test was
rarely doing anything. We currently have a good platform for running
doctests in scripts_regression_tests, so there's no need to try to
duplicate this in our exes.

Test suite: scripts_regression_tests --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Yes, remove dead --test options

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
