### PR TITLE
Always use GLC_NEC=10 for CLM45/CLM5; remove tropicAtl grid in CESM

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -108,12 +108,6 @@
       <grid name="rof">null</grid>
     </model_grid>
 
-    <model_grid alias="1x1_tropicAtl" compset="DATM.+CLM">
-      <grid name="atm">1x1_tropicAtl</grid>
-      <grid name="lnd">1x1_tropicAtl</grid>
-      <grid name="rof">null</grid>
-    </model_grid>
-
     <model_grid alias="1x1_urbanc_alpha" compset="DATM.+CLM">
       <grid name="atm">1x1_urbanc_alpha</grid>
       <grid name="lnd">1x1_urbanc_alpha</grid>
@@ -990,12 +984,6 @@
       <nx>1</nx> <ny>1</ny>
       <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>
       <desc>1x1 Vancouver Canada -- only valid for DATM/CLM compset</desc>
-    </domain>
-
-    <domain name="1x1_tropicAtl">
-      <nx>1</nx> <ny>1</ny>
-      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-tropicAtl_test.111004.nc</file>
-      <desc>1x1 Tropical Atlantic Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_urbanc_alpha">

--- a/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -61,7 +61,6 @@
 
     CLM1PT.1x1_brazil
     CLM1PT.1x1_camdenNJ
-    CLM1PT.1x1_tropicAtl
     CLM1PT.1x1_asphaltjungleNJ
     CLM1PT.1x1_mexicocityMEX
     CLM1PT.1x1_vancouverCAN
@@ -281,11 +280,6 @@
       <value stream="presaero.rcp4.5" atm_grid="CLM_USRDAT">aerosoldep_rcp4.5_monthly_1849-2104_${CLM_USRDAT_NAME}.nc</value>
       <value stream="presaero.rcp6.0" atm_grid="CLM_USRDAT">aerosoldep_rcp6_monthly_1849-2104_${CLM_USRDAT_NAME}.nc</value>
 
-      <!-- Need to resolve if want to use single point forcing or not
-      <value stream="presaero.clim_1850" atm_grid="1x1_tropicAtl">aerosoldep_monthly_1850_1x1_tropicAtl_c091026.nc</value>
-      <value stream="presaero.clim_2000" atm_grid="1x1_tropicAtl">aerosoldep_monthly_1849-2006_1x1_tropicAtl_c091026.nc</value>
-      <value stream="presaero.trans_1850-2000" atm_grid="1x1_tropicAtl">aerosoldep_monthly_1849-2006_1x1_tropicAtl_c091026.nc</value>
-      -->
       <value stream="presaero.clim_1850">aerosoldep_monthly_1850_mean_1.9x2.5_c090421.nc</value>
       <value stream="presaero.clim_2000">aerosoldep_monthly_2000_mean_1.9x2.5_c090421.nc</value>
       <value stream="presaero.trans_1850-2000">aerosoldep_monthly_1849-2006_1.9x2.5_c090803.nc</value>
@@ -1108,11 +1102,6 @@
       <value stream="Anomaly.Forcing.Shortwave">af.rsds.ccsm4.rcp45.2006-2300.nc</value>
       <value stream="Anomaly.Forcing.Longwave">af.rlds.ccsm4.rcp45.2006-2300.nc</value>
 
-      <!-- Need to resolve if want to use single point forcing or not
-      <value stream="presaero.clim_1850" atm_grid="1x1_tropicAtl">aerosoldep_monthly_1850_1x1_tropicAtl_c091026.nc</value>
-      <value stream="presaero.clim_2000" atm_grid="1x1_tropicAtl">aerosoldep_monthly_1849-2006_1x1_tropicAtl_c091026.nc</value>
-      <value stream="presaero.trans_1850-2000" atm_grid="1x1_tropicAtl">aerosoldep_monthly_1849-2006_1x1_tropicAtl_c091026.nc</value>
-      -->
       <value stream="presaero.clim_1850">aerosoldep_monthly_1850_mean_1.9x2.5_c090421.nc</value>
       <value stream="presaero.clim_2000">aerosoldep_monthly_2000_mean_1.9x2.5_c090421.nc</value>
       <value stream="presaero.trans_1850-2000">aerosoldep_monthly_1849-2006_1.9x2.5_c090803.nc</value>

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -483,12 +483,14 @@
     <valid_values>0,1,3,5,10,36</valid_values>
     <default_value>10</default_value>
     <values match="last">
-      <value compset="_SGLC">0</value>
+      <value compset="_CLM40.*_SGLC">0</value>
     </values>
     <group>run_glc</group>
     <file>env_run.xml</file>
-    <desc>Glacier model number of elevation classes, 0 implies no glacier land unit in clm
-    Used by both CLM and CISM (even if CISM is not running, and only SGLC is used).</desc>
+    <desc>Number of glacier elevation classes used in CLM.
+    0 implies no glacier_mec (glacier multiple elevation classes)
+    landunit in CLM. 0 is only valid for CLM40.
+    Used by both CLM and the coupler (even if CISM is not running, and only SGLC is used).</desc>
   </entry>
 
   <entry id="GLC_TWO_WAY_COUPLING">


### PR DESCRIPTION
Two changes that are mostly-unrelated, which I'm combining because they
are both attached to the same CLM branch:

1. Use GLC_NEC=10 for CLM45/CLM50, even when running with a stub glc
   model. CLM now always uses the multiple elevation class scheme.

2. Remove references to the no-longer-used tropicAtl grid in CESM.

This PR only affects CESM. The only non-CESM-specific changes here are
in comments.

@fischer-ncar @jedwards4b Note that these changes depend on a CLM trunk
tag that has not yet been made, but will be made in the next couple of
days. So we'll need to coordinate those changes. 

Test suite: scripts_regression_tests on cheyenne
   Also, aux_clm test suite
Test baseline: For aux_clm tests: clm4_5_18_r268
Test namelist changes: Changes glc_nec in drv_in for cases with SGLC
Test status: climate changing for cases with SGLC (together with the
   associated changes in CLM)

Fixes ESMCI/cime#2149

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
