### PR TITLE
several data model updates

### DIFF
--- a/doc/source/data_models/data-ocean.rst
+++ b/doc/source/data_models/data-ocean.rst
@@ -188,41 +188,21 @@ Field names
 -----------
 
 DOCN defines a set of pre-defined internal field names as well as mappings for how those field names map to the fields sent to the coupler.
-In general, the stream input file should translate the stream input variable names into the ``docn_fld`` names below for use within the data ocn model.
+
+.. note:: In general, the stream input file should translate the stream input variable names into the ``docn_fld`` names below for use within the data ocn model.
 
 .. csv-table:: "DOCN internal field names"
    :header: "docn_fld (avifld)", "driver_fld (avofld)"
    :widths: 30, 30
 
-   "ifrac", "Si_ifrac" 
-   "pslv", "Sa_pslv" 
-   "duu10n", "So_duu10n" 
-   "taux", "Foxx_taux" 
-   "tauy", "Foxx_tauy" 
-   "swnet", "Foxx_swnet" 
-   "lat", "Foxx_lat" 
-   "sen", "Foxx_sen" 
-   "lwup", "Foxx_lwup" 
-   "lwdn", "Faxa_lwdn" 
-   "melth", "Fioi_melth" 
-   "salt", "Fioi_salt" 
-   "prec", "Faxa_prec" 
-   "snow", "Faxa_snow" 
-   "rain", "Faxa_rain" 
-   "evap", "Foxx_evap" 
-   "meltw", "Fioi_meltw" 
-   "rofl", "Foxx_rofl" 
-   "rofi", "Foxx_rofi" 
    "t", "So_t" 
    "u", "So_u" 
    "v", "So_v" 
    "dhdx", "So_dhdx" 
    "dhdy", "So_dhdy" 
    "s", "So_s" 
-   "q", "Fioo_q" 
-   "h", "strm_h" 
-   "qbot", "strm_qbot" 
-   "fswpen", "So_fswpen" 
+   "h", "strm_h" (internal to docn_comp_mod only)
+   "qbot", "strm_qbot" (internal to docn_comp_mod only)
 
 .. _creating-sstdata-input-from-prognostic-run:
 

--- a/doc/source/data_models/data-seaice.rst
+++ b/doc/source/data_models/data-seaice.rst
@@ -127,54 +127,14 @@ Field names
 -----------
 
 DICE defines a set of pre-defined internal field names as well as mappings for how those field names map to the fields sent to the coupler.
-In general, the stream input file should translate the stream input variable names into the ``dice_fld`` names below for use within the data ice model.
+
+.. note:: In general, the stream input file should translate the stream input variable names into the ``docn_fld`` names below for use within the data ocn model.
 
 .. csv-table:: "DICE internal field names"
    :header: "dice_fld (avifld)", "driver_fld (avofld)"
    :widths: 30, 30
 
-   "to",    "So_t"	       
-   "s",	    "So_s"	       
-   "uo",    "So_u"	       
-   "vo",    "So_v"	       
-   "dhdx",  "So_dhdx"      
-   "dhdy",  "So_dhdy"      
-   "q",	    "Fioo_q"       
-   "z",	    "Sa_z"	       
-   "ua",    "Sa_u"	       
-   "va",    "Sa_v"	       
-   "ptem",  "Sa_ptem"      
-   "tbot",  "Sa_tbot"      
-   "shum",  "Sa_shum"      
-   "dens",  "Sa_dens"      
-   "swndr", "Faxa_swndr"   
-   "swvdr", "Faxa_swvdr"   
-   "swndf", "Faxa_swndf"   
-   "swvdf", "Faxa_swvdf"   
-   "lwdn",  "Faxa_lwdn"    
-   "rain",  "Faxa_rain"    
-   "snow",  "Faxa_snow"    
-   "t",	    "Si_t"	       
-   "tref",  "Si_tref"      
-   "qref",  "Si_qref"      
    "ifrac", "Si_ifrac"     
-   "avsdr", "Si_avsdr"     
-   "anidr", "Si_anidr"     
-   "avsdf", "Si_avsdf"     
-   "anidf", "Si_anidf"     
-   "tauxa", "Faii_taux"    
-   "tauya", "Faii_tauy"    
-   "lat",   "Faii_lat"     
-   "sen",   "Faii_sen"     
-   "lwup",  "Faii_lwup"    
-   "evap",  "Faii_evap"    
-   "swnet", "Faii_swnet"   
-   "swpen", "Fioi_swpen"   
-   "melth", "Fioi_melth"   
-   "meltw", "Fioi_meltw"   
-   "salt",  "Fioi_salt"    
-   "tauxo", "Fioi_taux"    
-   "tauyo", "Fioi_tauy"    
 
 
 

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -72,9 +72,6 @@
       <value compset="^RCP2_">rcp2.6</value>
       <value compset="^HIST_">trans_1850-2000</value>
       <value compset="^20TR_">trans_1850-2000</value>
-      <value compset="_DICE.*_POP2">none</value>
-      <value compset="_DLND.*_DICE.*_DOCN">none</value>
-      <value compset="_SLND.*_DICE.*_DOCN">none</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
     </values>
     <group>run_component_datm</group>

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -72,6 +72,8 @@
       <value compset="^RCP2_">rcp2.6</value>
       <value compset="^HIST_">trans_1850-2000</value>
       <value compset="^20TR_">trans_1850-2000</value>
+      <value compset="_DLND.*_DICE.*_DOCN">none</value>
+      <value compset="_SLND.*_DICE.*_DOCN">none</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
     </values>
     <group>run_component_datm</group>

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -59,12 +59,8 @@
   <entry id="DATM_PRESAERO">
     <type>char</type>
     <valid_values>none,clim_1850,clim_2000,trans_1850-2000,rcp2.6,rcp4.5,rcp6.0,rcp8.5,cplhist</valid_values>
-    <default_value>none</default_value>
+    <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850_">clim_1850</value>
-      <value compset="^2000_">clim_2000</value>
-      <value compset="^2003_">clim_2000</value>
-      <value compset="^4804_">clim_2000</value>
       <value compset="^1850_">clim_1850</value>
       <value compset="^RCP8_">rcp8.5</value>
       <value compset="^RCP6_">rcp6.0</value>
@@ -72,8 +68,6 @@
       <value compset="^RCP2_">rcp2.6</value>
       <value compset="^HIST_">trans_1850-2000</value>
       <value compset="^20TR_">trans_1850-2000</value>
-      <value compset="_DLND.*_DICE.*_DOCN">none</value>
-      <value compset="_SLND.*_DICE.*_DOCN">none</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
     </values>
     <group>run_component_datm</group>

--- a/src/components/data_comps/datm/datm_comp_mod.F90
+++ b/src/components/data_comps/datm/datm_comp_mod.F90
@@ -58,7 +58,6 @@ module datm_comp_mod
 
   character(len=*),parameter :: rpfile = 'rpointer.atm'
 
-  real(R8),parameter :: aerodep_spval = 1.e29_r8    ! special aerosol deposition
   real(R8),parameter :: tKFrz  = SHR_CONST_TKFRZ
   real(R8),parameter :: degtorad = SHR_CONST_PI/180.0_R8
   real(R8),parameter :: pstd   = SHR_CONST_PSTD     ! standard pressure ~ Pa
@@ -76,8 +75,7 @@ module datm_comp_mod
        -1.99_R8,-0.91_R8, 1.72_R8,   2.30_R8, 1.81_R8, 1.06_R8/
 
   integer(IN) :: kz,ktopo,ku,kv,ktbot,kptem,kshum,kdens,kpbot,kpslv,klwdn
-  integer(IN) :: krc,krl,ksc,ksl,kswndr,kswndf,kswvdr,kswvdf,kswnet,kco2p,kco2d
-  integer(IN) :: kbid,kbod,kbiw,koid,kood,koiw,kdw1,kdw2,kdw3,kdw4,kdd1,kdd2,kdd3,kdd4
+  integer(IN) :: krc,krl,ksc,ksl,kswndr,kswndf,kswvdr,kswvdf,kswnet
   integer(IN) :: kanidr,kanidf,kavsdr,kavsdf
   integer(IN) :: stbot,swind,sz,spbot,sshum,stdew,srh,slwdn,sswdn,sswdndf,sswdndr
   integer(IN) :: sprecc,sprecl,sprecn,sco2p,sco2d,sswup,sprec,starcf
@@ -387,8 +385,6 @@ CONTAINS
        kswvdr= mct_aVect_indexRA(a2x,'Faxa_swvdr')
        kswvdf= mct_aVect_indexRA(a2x,'Faxa_swvdf')
        kswnet= mct_aVect_indexRA(a2x,'Faxa_swnet')
-       kco2p = mct_aVect_indexRA(a2x,'Sa_co2prog',perrWith='quiet')
-       kco2d = mct_aVect_indexRA(a2x,'Sa_co2diag',perrWith='quiet')
 
        if (wiso_datm) then  ! water isotopic forcing
           kshum_16O = mct_aVect_indexRA(a2x,'Sa_shum_16O')
@@ -403,21 +399,6 @@ CONTAINS
           ksl_18O   = mct_aVect_indexRA(a2x,'Faxa_snowl_18O')
           ksl_HDO   = mct_aVect_indexRA(a2x,'Faxa_snowl_HDO')
        end if
-
-       kbid  = mct_aVect_indexRA(a2x,'Faxa_bcphidry')
-       kbod  = mct_aVect_indexRA(a2x,'Faxa_bcphodry')
-       kbiw  = mct_aVect_indexRA(a2x,'Faxa_bcphiwet')
-       koid  = mct_aVect_indexRA(a2x,'Faxa_ocphidry')
-       kood  = mct_aVect_indexRA(a2x,'Faxa_ocphodry')
-       koiw  = mct_aVect_indexRA(a2x,'Faxa_ocphiwet')
-       kdd1  = mct_aVect_indexRA(a2x,'Faxa_dstdry1')
-       kdd2  = mct_aVect_indexRA(a2x,'Faxa_dstdry2')
-       kdd3  = mct_aVect_indexRA(a2x,'Faxa_dstdry3')
-       kdd4  = mct_aVect_indexRA(a2x,'Faxa_dstdry4')
-       kdw1  = mct_aVect_indexRA(a2x,'Faxa_dstwet1')
-       kdw2  = mct_aVect_indexRA(a2x,'Faxa_dstwet2')
-       kdw3  = mct_aVect_indexRA(a2x,'Faxa_dstwet3')
-       kdw4  = mct_aVect_indexRA(a2x,'Faxa_dstwet4')
 
        call mct_aVect_init(x2a, rList=seq_flds_x2a_fields, lsize=lsize)
        call mct_aVect_zero(x2a)
@@ -670,25 +651,6 @@ CONTAINS
     call t_barrierf('datm_scatter_BARRIER',mpicom)
 
     call t_startf('datm_scatter')
-    if (trim(datamode) /= 'COPYALL') then
-       lsize = mct_avect_lsize(a2x)
-       do n = 1,lsize
-          a2x%rAttr(kbid,n) = aerodep_spval
-          a2x%rAttr(kbod,n) = aerodep_spval
-          a2x%rAttr(kbiw,n) = aerodep_spval
-          a2x%rAttr(koid,n) = aerodep_spval
-          a2x%rAttr(kood,n) = aerodep_spval
-          a2x%rAttr(koiw,n) = aerodep_spval
-          a2x%rAttr(kdd1,n) = aerodep_spval
-          a2x%rAttr(kdd2,n) = aerodep_spval
-          a2x%rAttr(kdd3,n) = aerodep_spval
-          a2x%rAttr(kdd4,n) = aerodep_spval
-          a2x%rAttr(kdw1,n) = aerodep_spval
-          a2x%rAttr(kdw2,n) = aerodep_spval
-          a2x%rAttr(kdw3,n) = aerodep_spval
-          a2x%rAttr(kdw4,n) = aerodep_spval
-       enddo
-    endif
     if (firstcall) then
        allocate(ilist_av(SDATM%nstreams))
        allocate(olist_av(SDATM%nstreams))

--- a/src/components/data_comps/desp/desp_comp_mod.F90
+++ b/src/components/data_comps/desp/desp_comp_mod.F90
@@ -11,14 +11,13 @@ module desp_comp_mod
   use shr_mpi_mod,     only: shr_mpi_bcast
   use esmf,            only: ESMF_Clock
   use perf_mod,        only: t_startf, t_stopf, t_barrierf
-
   use shr_strdata_mod, only: shr_strdata_type, shr_strdata_advance
   use shr_strdata_mod, only: shr_strdata_pioinit
-
   use seq_timemgr_mod, only: seq_timemgr_EClockGetData
   use seq_timemgr_mod, only: seq_timemgr_RestartAlarmIsOn
   use seq_comm_mct,    only: seq_comm_inst, seq_comm_name, seq_comm_suffix
   use seq_comm_mct,    only: num_inst_cpl => num_inst_driver
+
   ! Used to link esp components across multiple drivers
   use seq_comm_mct,    only: global_comm
 
@@ -51,11 +50,10 @@ module desp_comp_mod
   integer(IN)                 :: npes                   ! total number of tasks
   integer(IN),      parameter :: master_task=0          ! task number of master task
   integer(IN)                 :: logunit                ! logging unit number
-  integer(IN)                 :: loglevel
+  integer(IN)                 :: loglevel               ! logging level
   integer                     :: inst_index             ! number of current instance (ie. 1)
   character(len=16)           :: inst_name              ! fullname of current instance (ie. "lnd_0001")
-  character(len=16)           :: inst_suffix            ! char string associated with instance
-  ! (ie. "_0001" or "")
+  character(len=16)           :: inst_suffix            ! char string associated with instance (ie. "_0001" or "")
   character(len=CL)           :: desp_mode              ! mode of operation
   character(len=*), parameter :: rpprefix  = 'rpointer.'
   character(len=*), parameter :: rpfile    = rpprefix//'esp'
@@ -81,30 +79,18 @@ module desp_comp_mod
      module procedure get_restart_filenames_a
      module procedure get_restart_filenames_s
   end interface get_restart_filenames
-
-  SAVE
-
+  
   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CONTAINS
   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   !===============================================================================
-  !BOP ===========================================================================
-  !
-  ! !IROUTINE: desp_comp_init
-  !
-  ! !DESCRIPTION:
-  !     initialize data esp model
-  !
-  ! !REVISION HISTORY:
-  !
-  ! !INTERFACE: ------------------------------------------------------------------
-
   subroutine desp_comp_init(EClock, espid, mpicom_in, phase, read_restart,    &
        esp_present, esp_prognostic)
 
-    ! !INPUT/OUTPUT PARAMETERS:
+    ! !DESCRIPTION: initialize data esp model
 
+    ! !INPUT/OUTPUT PARAMETERS:
     type(ESMF_Clock), intent(in)  :: EClock
     integer,          intent(in)  :: espid
     integer,          intent(in)  :: mpicom_in
@@ -112,8 +98,6 @@ CONTAINS
     logical,          intent(in)  :: read_restart
     logical,          intent(out) :: esp_present    ! flag
     logical,          intent(out) :: esp_prognostic ! flag
-
-    !EOP
 
     !--- local variables ---
     integer(IN)                    :: ierr       ! error code
@@ -323,20 +307,12 @@ CONTAINS
   end subroutine desp_comp_init
 
   !=============================================================================
-  !BOP==========================================================================
-  !
-  ! !IROUTINE: desp_comp_run
-  !
-  ! !DESCRIPTION:
-  !     run method for data esp model
-  !
-  ! !REVISION HISTORY:
-  !
-  ! !INTERFACE: ---------------------------------------------------------------
-
   subroutine desp_comp_run(EClock, case_name, pause_sig, atm_resume,          &
        lnd_resume, rof_resume, ocn_resume, ice_resume, glc_resume,            &
        wav_resume, cpl_resume)
+
+    ! !DESCRIPTION: run method for data esp model
+
     use seq_comm_mct, only: num_inst_atm, num_inst_lnd, num_inst_rof
     use seq_comm_mct, only: num_inst_ocn, num_inst_ice, num_inst_glc
     use seq_comm_mct, only: num_inst_wav
@@ -577,28 +553,13 @@ CONTAINS
   end subroutine desp_comp_run
 
   !============================================================================
-  !BOP ========================================================================
-  !
-  ! !IROUTINE: desp_comp_final
-  !
-  ! !DESCRIPTION:
-  !     finalize method for data esp model
-  !
-  ! !REVISION HISTORY:
-  !
-  ! !INTERFACE: ---------------------------------------------------------------
-  !
   subroutine desp_comp_final()
 
-    !EOP
-
+    ! !DESCRIPTION: finalize method for data esp model
     !--- formats ---
     character(*), parameter :: F00   = "('(desp_comp_final) ',8a)"
     character(*), parameter :: F91   = "('(desp_comp_final) ',73('-'))"
     character(*), parameter :: subName = "(desp_comp_final) "
-
-    !--------------------------------------------------------------------------
-    !
     !--------------------------------------------------------------------------
 
     call t_startf('DESP_FINAL')
@@ -612,9 +573,8 @@ CONTAINS
     call t_stopf('DESP_FINAL')
 
   end subroutine desp_comp_final
-  !============================================================================
-  !============================================================================
 
+  !============================================================================
   subroutine get_restart_filenames_a(comp_ind, filenames, retcode)
     use seq_comm_mct, only: ATMID, LNDID, OCNID, ICEID, GLCID, ROFID
     use seq_comm_mct, only: WAVID, CPLID, seq_comm_suffix, cpl_inst_tag
@@ -714,6 +674,7 @@ CONTAINS
 
   end subroutine get_restart_filenames_a
 
+  !============================================================================
   subroutine get_restart_filenames_s(comp_ind, filename, retcode)
 
     ! Dummy arguments

--- a/src/components/data_comps/dice/dice_comp_mod.F90
+++ b/src/components/data_comps/dice/dice_comp_mod.F90
@@ -54,6 +54,7 @@ module dice_comp_mod
   logical       :: firstcall = .true.    ! first call logical
   character(len=*),parameter :: rpfile = 'rpointer.ice'
 
+  real(R8),parameter  :: aerodep_spval = shr_const_spval_aerodep ! special aerosol deposition
   real(R8),parameter  :: pi     = shr_const_pi      ! pi
   real(R8),parameter  :: spval  = shr_const_spval   ! flags invalid data
   real(R8),parameter  :: tFrz   = shr_const_tkfrz   ! temp of freezing
@@ -618,12 +619,21 @@ CONTAINS
 
        ! Compute outgoing aerosol fluxes
        do n = 1,lsize
-          i2x%rAttr(kbcpho ,n) = x2i%rAttr(kbcphodry,n)
-          i2x%rAttr(kbcphi ,n) = x2i%rAttr(kbcphidry,n) + x2i%rAttr(kbcphiwet,n)
-          i2x%rAttr(kflxdst,n) = x2i%rAttr(kdstdry1,n) + x2i%rAttr(kdstwet1,n) &
-                               + x2i%rAttr(kdstdry2,n) + x2i%rAttr(kdstwet2,n) &
-                               + x2i%rAttr(kdstdry3,n) + x2i%rAttr(kdstwet3,n) &
-                               + x2i%rAttr(kdstdry4,n) + x2i%rAttr(kdstwet4,n)
+          i2x%rAttr(kbcpho ,n) = 0.0_r8
+          i2x%rAttr(kbcphi ,n) = 0.0_r8
+          i2x%rAttr(kflxdst,n) = 0.0_r8
+          if (i2x%rAttr(kbcpho ,n) > 1.e26_r8) then
+             i2x%rAttr(kbcpho ,n) = x2i%rAttr(kbcphodry,n)
+          end if
+          if (i2x%rAttr(kbcphi ,n) > 1.e26_r8) then
+             i2x%rAttr(kbcphi ,n) = x2i%rAttr(kbcphidry,n) + x2i%rAttr(kbcphiwet,n)
+          end if
+          if (i2x%rAttr(kbcpho ,n) > 1.e26_r8) then
+             i2x%rAttr(kflxdst,n) = x2i%rAttr(kdstdry1,n) + x2i%rAttr(kdstwet1,n) &
+                                  + x2i%rAttr(kdstdry2,n) + x2i%rAttr(kdstwet2,n) &
+                                  + x2i%rAttr(kdstdry3,n) + x2i%rAttr(kdstwet3,n) &
+                                  + x2i%rAttr(kdstdry4,n) + x2i%rAttr(kdstwet4,n)
+          end if
        end do
 
     end select

--- a/src/components/data_comps/dice/dice_comp_mod.F90
+++ b/src/components/data_comps/dice/dice_comp_mod.F90
@@ -647,7 +647,6 @@ CONTAINS
 
     if (write_restart) then
        call t_startf('dice_restart')
-       ! Write rpointer file
        call shr_cal_ymdtod2string(date_str, yy, mm, dd, currentTOD)
        write(rest_file,"(6a)") &
             trim(case_name), '.dice',trim(inst_suffix),'.r.', &
@@ -663,7 +662,6 @@ CONTAINS
           close(nu)
           call shr_file_freeUnit(nu)
        endif
-       ! Write restart info
        if (my_task == master_task) write(logunit,F04) ' writing ',trim(rest_file),currentYMD,currentTOD
        call shr_pcdf_readwrite('write',SDICE%pio_subsystem, SDICE%io_type, &
             trim(rest_file),mpicom,gsmap,clobber=.true.,rf1=water,rf1n='water')

--- a/src/components/data_comps/dice/dice_comp_mod.F90
+++ b/src/components/data_comps/dice/dice_comp_mod.F90
@@ -80,6 +80,9 @@ module dice_comp_mod
   integer(IN) :: kiFrac,kt,kavsdr,kanidr,kavsdf,kanidf,kswnet,kmelth,kmeltw
   integer(IN) :: ksen,klat,klwup,kevap,ktauxa,ktauya,ktref,kqref,kswpen,ktauxo,ktauyo,ksalt
   integer(IN) :: ksalinity
+  integer(IN) :: kbcpho, kbcphi, kflxdst
+  integer(IN) :: kbcphidry, kbcphodry, kbcphiwet, kocphidry, kocphodry, kocphiwet
+  integer(IN) :: kdstdry1, kdstdry2, kdstdry3, kdstdry4, kdstwet1, kdstwet2, kdstwet3, kdstwet4
 
   ! optional per thickness category fields
   integer(IN) :: kiFrac_01,kswpen_iFrac_01
@@ -93,35 +96,9 @@ module dice_comp_mod
   !  real(R8)    , pointer :: ifrac0(:)
 
   !--------------------------------------------------------------------------
-  integer(IN),parameter :: ktrans = 42
-  character(16),parameter  :: avofld(1:ktrans) = &
-       (/"So_t            ","So_s            ","So_u            ","So_v            ", &
-       "So_dhdx         ","So_dhdy         ","Fioo_q          ","Sa_z            ", &
-       "Sa_u            ","Sa_v            ","Sa_ptem         ","Sa_tbot         ", &
-       "Sa_shum         ","Sa_dens         ","Faxa_swndr      ","Faxa_swvdr      ", &
-       "Faxa_swndf      ","Faxa_swvdf      ","Faxa_lwdn       ","Faxa_rain       ", &
-       "Faxa_snow       ","Si_t            ","Si_tref         ","Si_qref         ", &
-       "Si_ifrac        ","Si_avsdr        ","Si_anidr        ","Si_avsdf        ", &
-       "Si_anidf        ","Faii_taux       ","Faii_tauy       ","Faii_lat        ", &
-       "Faii_sen        ","Faii_lwup       ","Faii_evap       ","Faii_swnet      ", &
-       "Fioi_swpen      ","Fioi_melth      ","Fioi_meltw      ","Fioi_salt       ", &
-       "Fioi_taux       ","Fioi_tauy       " /)
-
-  character(16),parameter  :: avifld(1:ktrans) = &
-       (/"to              ","s               ","uo              ","vo              ", &
-       "dhdx            ","dhdy            ","q               ","z               ", &
-       "ua              ","va              ","ptem            ","tbot            ", &
-       "shum            ","dens            ","swndr           ","swvdr           ", &
-       "swndf           ","swvdf           ","lwdn            ","rain            ", &
-       "snow            ","t               ","tref            ","qref            ", &
-       "ifrac           ","avsdr           ","anidr           ","avsdf           ", &
-       "anidf           ","tauxa           ","tauya           ","lat             ", &
-       "sen             ","lwup            ","evap            ","swnet           ", &
-       "swpen           ","melth           ","meltw           ","salt            ", &
-       "tauxo           ","tauyo           " /)
-  !--------------------------------------------------------------------------
-
-  save
+  integer(IN),parameter :: ktrans = 1
+  character(16),parameter  :: avofld(1:ktrans) = (/"Si_ifrac        "/)
+  character(16),parameter  :: avifld(1:ktrans) = (/"ifrac           "/)
 
   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CONTAINS
@@ -276,9 +253,11 @@ CONTAINS
     ktauxo = mct_aVect_indexRA(i2x,'Fioi_taux')
     ktauyo = mct_aVect_indexRA(i2x,'Fioi_tauy')
     ksalt  = mct_aVect_indexRA(i2x,'Fioi_salt')
+    kbcpho = mct_aVect_indexRA(i2x,'Fioi_bcpho')
+    kbcphi = mct_aVect_indexRA(i2x,'Fioi_bcphi')
+    kflxdst= mct_aVect_indexRA(i2x,'Fioi_flxdst')
 
     ! optional per thickness category fields
-
     if (seq_flds_i2o_per_cat) then
        kiFrac_01       = mct_aVect_indexRA(i2x,'Si_ifrac_01')
        kswpen_iFrac_01 = mct_aVect_indexRA(i2x,'PFioi_swpen_ifrac_01')
@@ -287,19 +266,33 @@ CONTAINS
     call mct_aVect_init(x2i, rList=seq_flds_x2i_fields, lsize=lsize)
     call mct_aVect_zero(x2i)
 
-    kswvdr = mct_aVect_indexRA(x2i,'Faxa_swvdr')
-    kswndr = mct_aVect_indexRA(x2i,'Faxa_swndr')
-    kswvdf = mct_aVect_indexRA(x2i,'Faxa_swvdf')
-    kswndf = mct_aVect_indexRA(x2i,'Faxa_swndf')
-    kq     = mct_aVect_indexRA(x2i,'Fioo_q')
-    kz     = mct_aVect_indexRA(x2i,'Sa_z')
-    kua    = mct_aVect_indexRA(x2i,'Sa_u')
-    kva    = mct_aVect_indexRA(x2i,'Sa_v')
-    kptem  = mct_aVect_indexRA(x2i,'Sa_ptem')
-    kshum  = mct_aVect_indexRA(x2i,'Sa_shum')
-    kdens  = mct_aVect_indexRA(x2i,'Sa_dens')
-    ktbot  = mct_aVect_indexRA(x2i,'Sa_tbot')
+    kswvdr    = mct_aVect_indexRA(x2i,'Faxa_swvdr')
+    kswndr    = mct_aVect_indexRA(x2i,'Faxa_swndr')
+    kswvdf    = mct_aVect_indexRA(x2i,'Faxa_swvdf')
+    kswndf    = mct_aVect_indexRA(x2i,'Faxa_swndf')
+    kq        = mct_aVect_indexRA(x2i,'Fioo_q')
+    kz        = mct_aVect_indexRA(x2i,'Sa_z')
+    kua       = mct_aVect_indexRA(x2i,'Sa_u')
+    kva       = mct_aVect_indexRA(x2i,'Sa_v')
+    kptem     = mct_aVect_indexRA(x2i,'Sa_ptem')
+    kshum     = mct_aVect_indexRA(x2i,'Sa_shum')
+    kdens     = mct_aVect_indexRA(x2i,'Sa_dens')
+    ktbot     = mct_aVect_indexRA(x2i,'Sa_tbot')
     ksalinity = mct_aVect_indexRA(x2i,'So_s')
+    kbcphidry = mct_aVect_indexRA(x2i,'Faxa_bcphidry')
+    kbcphodry = mct_aVect_indexRA(x2i,'Faxa_bcphodry')
+    kbcphiwet = mct_aVect_indexRA(x2i,'Faxa_bcphiwet')
+    kocphidry = mct_aVect_indexRA(x2i,'Faxa_ocphidry')
+    kocphodry = mct_aVect_indexRA(x2i,'Faxa_ocphodry')
+    kocphiwet = mct_aVect_indexRA(x2i,'Faxa_ocphiwet')
+    kdstdry1  = mct_aVect_indexRA(x2i,'Faxa_dstdry1')
+    kdstdry2  = mct_aVect_indexRA(x2i,'Faxa_dstdry2')
+    kdstdry3  = mct_aVect_indexRA(x2i,'Faxa_dstdry3')
+    kdstdry4  = mct_aVect_indexRA(x2i,'Faxa_dstdry4')
+    kdstwet1  = mct_aVect_indexRA(x2i,'Faxa_dstwet1')
+    kdstwet2  = mct_aVect_indexRA(x2i,'Faxa_dstwet2')
+    kdstwet3  = mct_aVect_indexRA(x2i,'Faxa_dstwet3')
+    kdstwet4  = mct_aVect_indexRA(x2i,'Faxa_dstwet4')
 
     ! call mct_aVect_init(avstrm, rList=flds_strm, lsize=lsize)
     ! call mct_aVect_zero(avstrm)
@@ -524,9 +517,9 @@ CONTAINS
           !--- newly recv'd swdn goes with previously sent albedo ---
           !--- but albedos are (currently) time invariant         ---
           i2x%rAttr(kswnet,n) = (1.0_R8 - i2x%rAttr(kavsdr,n))*x2i%rAttr(kswvdr,n) &
-               &                   + (1.0_R8 - i2x%rAttr(kanidr,n))*x2i%rAttr(kswndr,n) &
-               &                   + (1.0_R8 - i2x%rAttr(kavsdf,n))*x2i%rAttr(kswvdf,n) &
-               &                   + (1.0_R8 - i2x%rAttr(kanidf,n))*x2i%rAttr(kswndf,n)
+                              + (1.0_R8 - i2x%rAttr(kanidr,n))*x2i%rAttr(kswndr,n) &
+                              + (1.0_R8 - i2x%rAttr(kavsdf,n))*x2i%rAttr(kswvdf,n) &
+                              + (1.0_R8 - i2x%rAttr(kanidf,n))*x2i%rAttr(kswndf,n)
 
           !--- compute melt/freeze water balance, adjust iFrac  -------------
           if ( .not. flux_Qacc ) then ! Q accumulation option is OFF
@@ -590,8 +583,9 @@ CONTAINS
        end do
 
        ! compute atm/ice surface fluxes
-       call shr_flux_atmIce(iMask  ,x2i%rAttr(kz,:)     ,x2i%rAttr(kua,:)    ,x2i%rAttr(kva,:), &
-            x2i%rAttr(kptem,:) ,x2i%rAttr(kshum,:)  ,x2i%rAttr(kdens,:)  ,x2i%rAttr(ktbot,:),  &
+       call shr_flux_atmIce(&
+            iMask              ,x2i%rAttr(kz,:)     ,x2i%rAttr(kua,:)    ,x2i%rAttr(kva,:)  , &
+            x2i%rAttr(kptem,:) ,x2i%rAttr(kshum,:)  ,x2i%rAttr(kdens,:)  ,x2i%rAttr(ktbot,:), &
             i2x%rAttr(kt,:)    ,i2x%rAttr(ksen,:)   ,i2x%rAttr(klat,:)   ,i2x%rAttr(klwup,:), &
             i2x%rAttr(kevap,:) ,i2x%rAttr(ktauxa,:) ,i2x%rAttr(ktauya,:) ,i2x%rAttr(ktref,:), &
             i2x%rAttr(kqref,:) )
@@ -620,6 +614,16 @@ CONTAINS
 
           !         !--- save ifrac for next timestep
           !         iFrac0(n) = i2x%rAttr(kiFrac,n)
+       end do
+
+       ! Compute outgoing aerosol fluxes
+       do n = 1,lsize
+          i2x%rAttr(kbcpho ,n) = x2i%rAttr(kbcphodry,n)
+          i2x%rAttr(kbcphi ,n) = x2i%rAttr(kbcphidry,n) + x2i%rAttr(kbcphiwet,n)
+          i2x%rAttr(kflxdst,n) = x2i%rAttr(kdstdry1,n) + x2i%rAttr(kdstwet1,n) &
+                               + x2i%rAttr(kdstdry2,n) + x2i%rAttr(kdstwet2,n) &
+                               + x2i%rAttr(kdstdry3,n) + x2i%rAttr(kdstwet3,n) &
+                               + x2i%rAttr(kdstdry4,n) + x2i%rAttr(kdstwet4,n)
        end do
 
     end select

--- a/src/components/data_comps/dice/dice_comp_mod.F90
+++ b/src/components/data_comps/dice/dice_comp_mod.F90
@@ -54,7 +54,6 @@ module dice_comp_mod
   logical       :: firstcall = .true.    ! first call logical
   character(len=*),parameter :: rpfile = 'rpointer.ice'
 
-  real(R8),parameter  :: aerodep_spval = shr_const_spval_aerodep ! special aerosol deposition
   real(R8),parameter  :: pi     = shr_const_pi      ! pi
   real(R8),parameter  :: spval  = shr_const_spval   ! flags invalid data
   real(R8),parameter  :: tFrz   = shr_const_tkfrz   ! temp of freezing
@@ -619,21 +618,12 @@ CONTAINS
 
        ! Compute outgoing aerosol fluxes
        do n = 1,lsize
-          i2x%rAttr(kbcpho ,n) = 0.0_r8
-          i2x%rAttr(kbcphi ,n) = 0.0_r8
-          i2x%rAttr(kflxdst,n) = 0.0_r8
-          if (i2x%rAttr(kbcpho ,n) > 1.e26_r8) then
-             i2x%rAttr(kbcpho ,n) = x2i%rAttr(kbcphodry,n)
-          end if
-          if (i2x%rAttr(kbcphi ,n) > 1.e26_r8) then
-             i2x%rAttr(kbcphi ,n) = x2i%rAttr(kbcphidry,n) + x2i%rAttr(kbcphiwet,n)
-          end if
-          if (i2x%rAttr(kbcpho ,n) > 1.e26_r8) then
-             i2x%rAttr(kflxdst,n) = x2i%rAttr(kdstdry1,n) + x2i%rAttr(kdstwet1,n) &
-                                  + x2i%rAttr(kdstdry2,n) + x2i%rAttr(kdstwet2,n) &
-                                  + x2i%rAttr(kdstdry3,n) + x2i%rAttr(kdstwet3,n) &
-                                  + x2i%rAttr(kdstdry4,n) + x2i%rAttr(kdstwet4,n)
-          end if
+          i2x%rAttr(kbcpho ,n) = x2i%rAttr(kbcphodry,n)
+          i2x%rAttr(kbcphi ,n) = x2i%rAttr(kbcphidry,n) + x2i%rAttr(kbcphiwet,n)
+          i2x%rAttr(kflxdst,n) = x2i%rAttr(kdstdry1,n) + x2i%rAttr(kdstwet1,n) &
+                               + x2i%rAttr(kdstdry2,n) + x2i%rAttr(kdstwet2,n) &
+                               + x2i%rAttr(kdstdry3,n) + x2i%rAttr(kdstwet3,n) &
+                               + x2i%rAttr(kdstdry4,n) + x2i%rAttr(kdstwet4,n)
        end do
 
     end select

--- a/src/components/data_comps/dice/mct/ice_comp_mct.F90
+++ b/src/components/data_comps/dice/mct/ice_comp_mct.F90
@@ -40,6 +40,7 @@ module ice_comp_mct
   character(len=16)      :: inst_suffix         ! char string associated with instance (ie. "_0001" or "")
   integer(IN)            :: logunit             ! logging unit number
   integer(IN)            :: compid              ! mct comp id
+  logical                :: read_restart        ! start from restart
 
   character(*), parameter :: F00   = "('(dice_comp_init) ',8a)"
   integer(IN) , parameter :: master_task=0 ! task number of master task
@@ -69,7 +70,6 @@ CONTAINS
     logical           :: ice_prognostic            ! flag
     integer(IN)       :: shrlogunit                ! original log unit
     integer(IN)       :: shrloglev                 ! original log level
-    logical           :: read_restart              ! start from restart
     integer(IN)       :: ierr                      ! error code
     logical           :: scmMode = .false.         ! single column mode
     real(R8)          :: scmLat  = shr_const_SPVAL ! single column lat
@@ -186,7 +186,6 @@ CONTAINS
     type(mct_gGrid)        , pointer :: ggrid
     integer(IN)                      :: shrlogunit   ! original log unit
     integer(IN)                      :: shrloglev    ! original log level
-    logical                          :: read_restart ! start from restart
     character(CL)                    :: case_name    ! case name
     character(*), parameter :: subName = "(ice_run_mct) "
     !-------------------------------------------------------------------------------

--- a/src/components/data_comps/dlnd/dlnd_comp_mod.F90
+++ b/src/components/data_comps/dlnd/dlnd_comp_mod.F90
@@ -18,6 +18,7 @@ module dlnd_comp_mod
   use shr_strdata_mod   , only: shr_strdata_advance, shr_strdata_restWrite
   use shr_dmodel_mod    , only: shr_dmodel_gsmapcreate, shr_dmodel_rearrGGrid
   use shr_dmodel_mod    , only: shr_dmodel_translate_list, shr_dmodel_translateAV_list, shr_dmodel_translateAV
+  use shr_cal_mod       , only: shr_cal_ymdtod2string
   use seq_timemgr_mod   , only: seq_timemgr_EClockGetData, seq_timemgr_RestartAlarmIsOn
   use glc_elevclass_mod , only: glc_get_num_elevation_classes, glc_elevclass_as_string
 
@@ -299,7 +300,7 @@ CONTAINS
     call t_adj_detailf(+2)
     call dlnd_comp_run(EClock, x2l, l2x, &
          SDLND, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-         inst_suffix, logunit, read_restart)
+         inst_suffix, logunit)
     call t_adj_detailf(-2)
 
     if (my_task == master_task) write(logunit,F00) 'dlnd_comp_init done'
@@ -312,8 +313,7 @@ CONTAINS
   !===============================================================================
   subroutine dlnd_comp_run(EClock, x2l, l2x, &
        SDLND, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-       inst_suffix, logunit, read_restart, case_name)
-    use shr_cal_mod, only: shr_cal_ymdtod2string
+       inst_suffix, logunit, case_name)
 
     ! !DESCRIPTION:  run method for dlnd model
     implicit none
@@ -331,7 +331,6 @@ CONTAINS
     integer(IN)            , intent(in)    :: master_task      ! task number of master task
     character(len=*)       , intent(in)    :: inst_suffix      ! char string associated with instance
     integer(IN)            , intent(in)    :: logunit          ! logging unit number
-    logical                , intent(in)    :: read_restart     ! start from restart
     character(CL)          , intent(in), optional :: case_name ! case name
 
     !--- local ---

--- a/src/components/data_comps/dlnd/mct/lnd_comp_mct.F90
+++ b/src/components/data_comps/dlnd/mct/lnd_comp_mct.F90
@@ -192,7 +192,6 @@ CONTAINS
     type(mct_gGrid)        , pointer :: ggrid
     integer(IN)                      :: shrlogunit   ! original log unit
     integer(IN)                      :: shrloglev    ! original log level
-    logical                          :: read_restart ! start from restart
     character(CL)                    :: case_name    ! case name
     character(*), parameter :: subName = "(lnd_run_mct) "
     !-------------------------------------------------------------------------------
@@ -211,7 +210,7 @@ CONTAINS
 
     call dlnd_comp_run(EClock, x2l, l2x, &
          SDLND, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-         inst_suffix, logunit, read_restart, case_name)
+         inst_suffix, logunit, case_name)
 
     call shr_file_setLogUnit (shrlogunit)
     call shr_file_setLogLevel(shrloglev)

--- a/src/components/data_comps/docn/docn_comp_mod.F90
+++ b/src/components/data_comps/docn/docn_comp_mod.F90
@@ -70,24 +70,14 @@ module docn_comp_mod
   real(R8), pointer      :: xc(:), yc(:) ! arryas of model latitudes and longitudes
 
   !--------------------------------------------------------------------------
-  character(len=*),parameter :: flds_strm = 'strm_h:strm_qbot'
-
-  integer(IN),parameter :: ktrans = 29
-  character(12),parameter  :: avifld(1:ktrans) = &
-       (/ "ifrac       ","pslv        ","duu10n      ","taux        ","tauy        ", &
-       "swnet       ","lat         ","sen         ","lwup        ","lwdn        ", &
-       "melth       ","salt        ","prec        ","snow        ","rain        ", &
-       "evap        ","meltw       ","rofl        ","rofi        ",                &
-       "t           ","u           ","v           ","dhdx        ","dhdy        ", &
-       "s           ","q           ","h           ","qbot        ","fswpen      "  /)
-
-  character(12),parameter  :: avofld(1:ktrans) = &
-       (/ "Si_ifrac    ","Sa_pslv     ","So_duu10n   ","Foxx_taux   ","Foxx_tauy   ", &
-       "Foxx_swnet  ","Foxx_lat    ","Foxx_sen    ","Foxx_lwup   ","Faxa_lwdn   ", &
-       "Fioi_melth  ","Fioi_salt   ","Faxa_prec   ","Faxa_snow   ","Faxa_rain   ", &
-       "Foxx_evap   ","Fioi_meltw  ","Foxx_rofl   ","Foxx_rofi   ",                &
-       "So_t        ","So_u        ","So_v        ","So_dhdx     ","So_dhdy     ", &
-       "So_s        ","Fioo_q      ","strm_h      ","strm_qbot   ","So_fswpen   "  /)
+  integer(IN)     , parameter :: ktrans = 8
+  character(12)   , parameter :: avifld(1:ktrans) = &
+       (/ "t           ","u           ","v           ","dhdx        ",&
+          "dhdy        ","s           ","h           ","qbot        "/)
+  character(12)   , parameter  :: avofld(1:ktrans) = &
+       (/ "So_t        ","So_u        ","So_v        ","So_dhdx     ",&
+          "So_dhdy     ","So_s        ","strm_h      ","strm_qbot   "/)
+  character(len=*), parameter :: flds_strm = 'strm_h:strm_qbot'
   !--------------------------------------------------------------------------
 
   save

--- a/src/components/data_comps/docn/mct/ocn_comp_mct.F90
+++ b/src/components/data_comps/docn/mct/ocn_comp_mct.F90
@@ -41,6 +41,7 @@ module ocn_comp_mct
   character(len=16)      :: inst_suffix         ! char string associated with instance (ie. "_0001" or "")
   integer(IN)            :: logunit             ! logging unit number
   integer(IN)            :: compid              ! mct comp id
+  logical                :: read_restart        ! start from restart
 
   character(*), parameter :: F00   = "('(docn_comp_init) ',8a)"
   integer(IN) , parameter :: master_task=0 ! task number of master task
@@ -72,7 +73,6 @@ CONTAINS
     logical           :: ocnrof_prognostic         ! flag
     integer(IN)       :: shrlogunit                ! original log unit
     integer(IN)       :: shrloglev                 ! original log level
-    logical           :: read_restart              ! start from restart
     integer(IN)       :: ierr                      ! error code
     logical           :: scmMode = .false.         ! single column mode
     real(R8)          :: scmLat  = shr_const_SPVAL ! single column lat
@@ -194,7 +194,6 @@ CONTAINS
     type(mct_gGrid)        , pointer :: ggrid
     integer(IN)                      :: shrlogunit   ! original log unit
     integer(IN)                      :: shrloglev    ! original log level
-    logical                          :: read_restart ! start from restart
     character(CL)                    :: case_name    ! case name
     character(*), parameter :: subName = "(ocn_run_mct) "
     !-------------------------------------------------------------------------------
@@ -211,6 +210,7 @@ CONTAINS
 
     call seq_infodata_GetData(infodata, case_name=case_name)
 
+    ! Note that docn_comp_run is already called 
     call docn_comp_run(EClock, x2o, o2x, &
          SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
          inst_suffix, logunit, read_restart, case_name)

--- a/src/components/data_comps/drof/drof_comp_mod.F90
+++ b/src/components/data_comps/drof/drof_comp_mod.F90
@@ -17,6 +17,7 @@ module drof_comp_mod
   use shr_strdata_mod , only: shr_strdata_advance, shr_strdata_restWrite
   use shr_dmodel_mod  , only: shr_dmodel_gsmapcreate, shr_dmodel_rearrGGrid
   use shr_dmodel_mod  , only: shr_dmodel_translate_list, shr_dmodel_translateAV_list, shr_dmodel_translateAV
+  use shr_cal_mod     , only: shr_cal_ymdtod2string
   use seq_timemgr_mod , only: seq_timemgr_EClockGetData, seq_timemgr_RestartAlarmIsOn
 
   use drof_shr_mod   , only: datamode       ! namelist input
@@ -242,7 +243,7 @@ CONTAINS
     call t_adj_detailf(+2)
     call drof_comp_run(EClock, x2r, r2x, &
          SDROF, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-         inst_suffix, logunit, read_restart)
+         inst_suffix, logunit)
     call t_adj_detailf(-2)
 
     if (my_task == master_task) write(logunit,F00) 'drof_comp_init done'
@@ -255,8 +256,8 @@ CONTAINS
   !===============================================================================
   subroutine drof_comp_run(EClock, x2r, r2x, &
        SDROF, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-       inst_suffix, logunit, read_restart, case_name)
-    use shr_cal_mod, only : shr_cal_ymdtod2string
+       inst_suffix, logunit, case_name)
+
     ! !DESCRIPTION:  run method for drof model
     implicit none
 
@@ -273,7 +274,6 @@ CONTAINS
     integer(IN)            , intent(in)    :: master_task      ! task number of master task
     character(len=*)       , intent(in)    :: inst_suffix      ! char string associated with instance
     integer(IN)            , intent(in)    :: logunit          ! logging unit number
-    logical                , intent(in)    :: read_restart     ! start from restart
     character(CL)          , intent(in), optional :: case_name ! case name
 
     !--- local ---

--- a/src/components/data_comps/drof/mct/rof_comp_mct.F90
+++ b/src/components/data_comps/drof/mct/rof_comp_mct.F90
@@ -185,7 +185,6 @@ CONTAINS
     type(mct_gGrid)        , pointer :: ggrid
     integer(IN)                      :: shrlogunit   ! original log unit
     integer(IN)                      :: shrloglev    ! original log level
-    logical                          :: read_restart ! start from restart
     character(CL)                    :: case_name    ! case name
     character(*), parameter :: subName = "(rof_run_mct) "
     !-------------------------------------------------------------------------------
@@ -204,7 +203,7 @@ CONTAINS
 
     call drof_comp_run(EClock, x2r, r2x, &
        SDROF, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-       inst_suffix, logunit, read_restart, case_name)
+       inst_suffix, logunit, case_name=case_name)
 
     call shr_file_setLogUnit (shrlogunit)
     call shr_file_setLogLevel(shrloglev)

--- a/src/components/data_comps/dwav/dwav_comp_mod.F90
+++ b/src/components/data_comps/dwav/dwav_comp_mod.F90
@@ -240,7 +240,7 @@ CONTAINS
     call t_adj_detailf(+2)
     call dwav_comp_run(EClock, x2w, w2x, &
          SDWAV, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-         inst_suffix, logunit, read_restart)
+         inst_suffix, logunit)
     call t_adj_detailf(-2)
 
     if (my_task == master_task) write(logunit, F00) 'dwav_comp_init done'
@@ -253,7 +253,7 @@ CONTAINS
   !===============================================================================
   subroutine dwav_comp_run(EClock, x2w, w2x, &
        SDWAV, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-       inst_suffix, logunit, read_restart, case_name)
+       inst_suffix, logunit, case_name)
 
     use shr_cal_mod, only : shr_cal_ymdtod2string
     ! !DESCRIPTION:  run method for dwav model
@@ -272,7 +272,6 @@ CONTAINS
     integer(IN)            , intent(in)    :: master_task      ! task number of master task
     character(len=*)       , intent(in)    :: inst_suffix      ! char string associated with instance
     integer(IN)            , intent(in)    :: logunit          ! logging unit number
-    logical                , intent(in)    :: read_restart     ! start from restart
     character(CL)          , intent(in), optional :: case_name ! case name
 
     !--- local ---

--- a/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/src/drivers/mct/shr/seq_flds_mod.F90
@@ -129,6 +129,7 @@ module seq_flds_mod
   use shr_fire_emis_mod , only : shr_fire_emis_readnl, shr_fire_emis_mechcomps_n, shr_fire_emis_ztop_token
   use shr_carma_mod     , only : shr_carma_readnl
   use shr_ndep_mod      , only : shr_ndep_readnl
+  use shr_flds_mod      , only : seq_flds_dom_coord, seq_flds_dom_other
 
   implicit none
   public
@@ -157,13 +158,6 @@ module seq_flds_mod
   integer         ,parameter :: nmax      = 1000        ! maximum number of entries in lookup_entry
   integer                    :: n_entries = 0           ! actual number of entries in lookup_entry
   character(len=CSS), dimension(nmax, 4) :: lookup_entry = undef
-
-  !----------------------------------------------------------------------------
-  ! for the domain
-  !----------------------------------------------------------------------------
-
-  character(CXX) :: seq_flds_dom_coord
-  character(CXX) :: seq_flds_dom_other
 
   !----------------------------------------------------------------------------
   ! state + flux fields

--- a/src/share/streams/shr_dmodel_mod.F90
+++ b/src/share/streams/shr_dmodel_mod.F90
@@ -202,8 +202,8 @@ CONTAINS
        decomp, lonname, latname, hgtname, maskname, areaname, fracname, readfrac, &
        scmmode, scmlon, scmlat)
 
-    use seq_flds_mod, only : seq_flds_dom_coord, seq_flds_dom_other
-    use shr_file_mod, only : shr_file_noprefix, shr_file_queryprefix, shr_file_get
+    use shr_flds_mod  , only : seq_flds_dom_coord, seq_flds_dom_other
+    use shr_file_mod  , only : shr_file_noprefix, shr_file_queryprefix, shr_file_get
     use shr_string_mod, only : shr_string_lastindex
     use shr_ncread_mod, only : shr_ncread_domain, shr_ncread_vardimsizes, &
          shr_ncread_varexists, shr_ncread_vardimnum, &

--- a/src/share/util/shr_const_mod.F90
+++ b/src/share/util/shr_const_mod.F90
@@ -57,10 +57,11 @@ MODULE shr_const_mod
    real(R8),parameter :: SHR_CONST_OCN_REF_SAL = 34.7_R8     ! ocn ref salinity (psu)
    real(R8),parameter :: SHR_CONST_ICE_REF_SAL =  4.0_R8     ! ice ref salinity (psu)
 
-   real(R8),parameter :: SHR_CONST_SPVAL      = 1.0e30_R8     ! special missing value
-   real(R8),parameter :: SHR_CONST_SPVAL_TOLMIN = 0.99_R8 * SHR_CONST_SPVAL  ! min spval tolerance
-   real(R8),parameter :: SHR_CONST_SPVAL_TOLMAX = 1.01_R8 * SHR_CONST_SPVAL  ! max spval tolerance
-
+   real(R8),parameter :: SHR_CONST_SPVAL        = 1.0e30_R8                 ! special missing value
+   real(R8),parameter :: SHR_CONST_SPVAL_TOLMIN = 0.99_R8 * SHR_CONST_SPVAL ! min spval tolerance
+   real(R8),parameter :: SHR_CONST_SPVAL_TOLMAX = 1.01_R8 * SHR_CONST_SPVAL ! max spval tolerance
+   real(R8),parameter :: SHR_CONST_SPVAL_AERODEP= 1.e29_r8                  ! special aerosol deposition
+   
    !Water Isotope Ratios in Vienna Standard Mean Ocean Water (VSMOW):
    real(R8),parameter :: SHR_CONST_VSMOW_18O   = 2005.2e-6_R8   ! 18O/16O in VMSOW
    real(R8),parameter :: SHR_CONST_VSMOW_17O   = 379.e-6_R8   ! 18O/16O in VMSOW

--- a/src/share/util/shr_flds_mod.F90
+++ b/src/share/util/shr_flds_mod.F90
@@ -1,0 +1,19 @@
+module shr_flds_mod
+
+   use shr_kind_mod      , only : CX => shr_kind_CX, CXX => shr_kind_CXX
+   use shr_sys_mod       , only : shr_sys_abort
+
+   implicit none
+   public
+   save
+
+   !----------------------------------------------------------------------------
+   ! for the domain
+   !----------------------------------------------------------------------------
+
+   ! These are set by the call to seq_flds_set in seq_flds_mod
+
+   character(CXX) :: seq_flds_dom_coord
+   character(CXX) :: seq_flds_dom_other
+
+end module shr_flds_mod


### PR DESCRIPTION
new routing of aerosols from dice to ocean

1) the main purpose of this PR is to be able to route aerosols that come from datm to dice back to the prognostic ocean. As a result the following fields will be changed for dice:
```
      i2x_Fioi_bcphi
      i2x_Fioi_bcpho
      i2x_Fioi_flxdst
```   
and the following fields will be changed for what the coupler sends the prognostic ocean
```
     x2oacc_Fioi_bcphi
     x2oacc_Fioi_bcpho
     x2oacc_Fioi_flxdst
```

2) datm no longer presets the following fields to aerodep_spval = 1.e29_r8. As a result the following fields are changed for datm:
```
     a2x_Faxa_bcphidry,a2x_Faxa_bcphodry,a2x_Faxa_bcphiwet,a2x_Faxa_ocphidry
     a2x_Faxa_ocphodry,a2x_Faxa_ocphiwet
     a2x_Faxa_dstwet1,a2x_Faxa_dstwet2,a2x_Faxa_dstwet3,a2x_Faxa_dstwet4
     a2x_Faxa_dstdry1,a2x_Faxa_dstdry2,a2x_Faxa_dstdry3,a2x_Faxa_dstdry4
```  
and the following fields will also be different for A and C compsets
```
     x2oacc_Faxa_bcphidry,x2oacc_Faxa_bcphodry,x2oacc_Faxa_bcphiwet,x2oacc_Faxa_ocphidry
     x2oacc_Faxa_ocphodry,x2oacc_Faxa_ocphiwet
     x2oacc_Faxa_dstwet1,x2oacc_Faxa_dstwet2,x2oacc_Faxa_dstwet3,x2oacc_Faxa_dstwet4
     x2oacc_Faxa_dstdry1,x2oacc_Faxa_dstdry2,x2oacc_Faxa_dstdry3,x2oacc_Faxa_dstdry4
     x2i_Faxa_bcphidry,x2i_Faxa_bcphodry,x2i_Faxa_bcphiwet,x2i_Faxa_ocphidry
     x2i_Faxa_ocphodry,x2i_Faxa_ocphiwet
     x2i_Faxa_dstwet1,x2i_Faxa_dstwet2,x2i_Faxa_dstwet3,x2i_Faxa_dstwet4
     x2i_Faxa_dstdry1,x2i_Faxa_dstdry2,x2i_Faxa_dstdry3,x2i_Faxa_dstdry4
```
3) simplified contents of avifld/avofld for DOCN and DICE
  Data models define a set of pre-defined internal field names as well
  as mappings for how those field names map to the fields sent to the
  coupler.  These are contained in avifld and avofld. DOCN and DICE
  had a lot of extraneous fields that were not needed and caused
  confusion. These have been removed.  The only fields needed for DOCN are:
```
    "t", "So_t"
    "u", "So_u"
    "v", "So_v"
    "dhdx", "So_dhdx"
    "dhdy", "So_dhdy"
    "s", "So_s"
    "h", "strm_h" (internal to docn_comp_mod only)
    "qbot", "strm_qbot" (internal to docn_comp_mod only)
``` 
The only fields needed for DICE are now: ` "ifrac","Si_ifrac"`

4) Made read_restart a module variable in the mct caps rather than a local variable. This was done incorrectly when the refactorization of the data models was done to permit new coupling infrastructures to use the data models. However, this does not change answers.

5) Removed dependence on seq_flds_mod in shr_dmodel_mod by add a new file, shr_flds_mod in share/utils that contains the variables needed by shr_dmodel_mod  (seq_flds_dom_coord and seq_flds_dom_other) The routine seq_flds_set (in seq_flds_mod) now sets these variables on initialization and shr_dmodel_mod  can then use them.

6)  Previously, the default value for DATM_PRESAERO was was also explicitly set to none for   stub compsets and compsets with DICE/POP. Now the default balue DATM_PRESAERO is clim_2000 and there are no explicit compsets where this value is none.

Test suite: scripts_regression_tests
- To verify that this functionality worked the CESM. prealpha tests were run in an 
       cesm2_0_alpha08d configuration - where cime was this branch (rebased to master 39d7442)
- NOTE: all A compsets and C will no longer be bfb due to (1) and (2) 
      To clarify: In CESM C compsets, POP does not respond to changes in the aerosols - so it is 
       still  BFB - but dice and datm will not be bfb due to the fact that aerosols are now added

Test baseline: yes - everything is bfb where expected
Test namelist changes: no
Test status: bit for bit for preapha tests - 

Fixes: None
User interface changes?: 
Update gh-pages html (Y/N)?:Y
Code review: 

  