### PR TITLE
Allowmultiplempilibs

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1090,7 +1090,7 @@ using a fortran linker.
   </FFLAGS>
   <CFLAGS>
     <append DEBUG="TRUE"> -ftrapuv </append>
-  </CFLAGS> 
+  </CFLAGS>
   <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
 </compiler>
 
@@ -1106,7 +1106,7 @@ using a fortran linker.
   </FFLAGS>
   <CFLAGS>
     <append DEBUG="TRUE"> -ftrapuv </append>
-  </CFLAGS> 
+  </CFLAGS>
   <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
 </compiler>
 

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -255,7 +255,8 @@
     <NODENAME_REGEX>.*.cheyenne.ucar.edu</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>mpt,openmpi</MPILIBS>
+    <MPILIBS compiler="intel" >mpt,openmpi</MPILIBS>
+    <MPILIBS compiler="gnu" >openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/glade/scratch/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>$ENV{CESMDATAROOT}/lmwg</DIN_LOC_ROOT_CLMFORC>
@@ -321,16 +322,17 @@
 	<command name="load">esmf-7.0.0-ncdfio-uni-O</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">gnu/6.3.0</command>
-	<command name="load">openblas/0.2.14</command>
+	<command name="load">gnu/7.1.0</command>
       </modules>
       <modules mpilib="mpt">
 	<command name="load">mpt/2.16</command>
 	<command name="load">netcdf-mpi/4.4.1.1</command>
+      </modules>
+      <modules mpilib="mpt" compiler="intel">
 	<command name="load">pnetcdf/1.8.1</command>
       </modules>
       <modules mpilib="openmpi">
-	<command name="load">openmpi/2.1.0</command>
+	<command name="load">openmpi/3.0.0</command>
 	<command name="load">netcdf/4.4.1.1</command>
       </modules>
       <modules>

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -28,7 +28,7 @@
   <xs:element name="PROJECT" type="xs:NCName" />
   <xs:element name="CHARGE_ACCOUNT" type="xs:NCName" />
   <xs:element name="COMPILERS" type="xs:string"/>
-  <xs:element name="MPILIBS" type="xs:string"/>
+  <xs:element name="MPILIBS" type="AttrElement"/>
   <xs:element name="CIME_OUTPUT_ROOT" type="xs:string"/>
   <xs:element name="DIN_LOC_ROOT" type="xs:string"/>
   <xs:element name="DIN_LOC_ROOT_CLMFORC" type="xs:string"/>
@@ -50,6 +50,16 @@
   <xs:element name="default_run_misc_suffix" type="xs:string"/>
 
   <!-- complex elements -->
+
+  <xs:complexType name="AttrElement">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="compiler">
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
 
   <xs:element name="config_machines">
     <xs:complexType>
@@ -76,7 +86,7 @@
 	<!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
         <xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
 	<!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
-        <xs:element ref="MPILIBS" minOccurs="1" maxOccurs="1"/>
+        <xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
 	<!-- PROJECT: A project or account number used for batch jobs
 	  can be overridden in environment or $HOME/.cime/config -->
 	<xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>

--- a/scripts/lib/CIME/XML/compilerblock.py
+++ b/scripts/lib/CIME/XML/compilerblock.py
@@ -224,10 +224,6 @@ class CompilerBlock(object):
         value_lists - A dictionary of PossibleValues, containing the lists
                       of all settings for each variable.
         """
-        # Skip this if the element's MPILIB is not valid.
-        if "MPILIB" in elem.keys() and \
-           not self._machobj.is_valid_MPIlib(elem.get("MPILIB")):
-            return
         setting, depends = self._elem_to_setting(elem)
         if name not in value_lists:
             value_lists[name] = PossibleValues(name, setting,

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -42,7 +42,10 @@ class Compilers(GenericXML):
         self.compiler       = compiler
 
         if mpilib is None:
-            mpilib = machobj.get_default_MPIlib(attributes={'compiler':compiler})
+            if compiler is None:
+                mpilib = machobj.get_default_MPIlib()
+            else:
+                mpilib = machobj.get_default_MPIlib(attributes={'compiler':compiler})
         self.mpilib = mpilib
 
         self.compiler_nodes = None # Listed from last to first

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -37,12 +37,13 @@ class Compilers(GenericXML):
 
         self.machine  = machobj.get_machine_name()
         self.os = machobj.get_value("OS")
-        if mpilib is None:
-            mpilib = machobj.get_default_MPIlib()
-        self.mpilib = mpilib
         if compiler is None:
             compiler = machobj.get_default_compiler()
         self.compiler       = compiler
+
+        if mpilib is None:
+            mpilib = machobj.get_default_MPIlib(attributes={'compiler':compiler})
+        self.mpilib = mpilib
 
         self.compiler_nodes = None # Listed from last to first
         #Append the contents of $HOME/.cime/config_compilers.xml if it exists

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1912,7 +1912,7 @@ query:
             query_result = output.read().strip()
 
         # Clean up the Makefiles.
-#        shutil.rmtree(temp_dir)
+        shutil.rmtree(temp_dir)
 
         return query_result
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1797,7 +1797,7 @@ class MockMachines(object):
         """Assume all MPILIB settings are valid."""
         return True
 
-    def get_default_MPIlib(self):
+    def get_default_MPIlib(self, attributes=None):
         return "mpich2"
 
     def get_default_compiler(self):
@@ -1912,7 +1912,7 @@ query:
             query_result = output.read().strip()
 
         # Clean up the Makefiles.
-        shutil.rmtree(temp_dir)
+#        shutil.rmtree(temp_dir)
 
         return query_result
 
@@ -2192,8 +2192,8 @@ class H_TestMakeMacros(unittest.TestCase):
         xml1 = """<compiler><SUPPORTS_CXX>FALSE</SUPPORTS_CXX></compiler>"""
         xml2 = """<compiler COMPILER="gnu"><SUPPORTS_CXX>TRUE</SUPPORTS_CXX></compiler>"""
         tester = self.xml_to_tester(xml1+xml2)
-        tester.assert_variable_equals("SUPPORTS_CXX", "FALSE")
         tester.assert_variable_equals("SUPPORTS_CXX", "TRUE", env={"COMPILER": "gnu"})
+        tester.assert_variable_equals("SUPPORTS_CXX", "FALSE")
 
     def test_base_flags(self):
         """Test that we get "base" compiler flags."""

--- a/tools/configure
+++ b/tools/configure
@@ -114,7 +114,7 @@ def parse_command_line(args):
     elif "MPILIB" in os.environ:
         mpilib = os.environ["MPILIB"]
     else:
-        mpilib = machobj.get_default_MPIlib()
+        mpilib = machobj.get_default_MPIlib(attributes={"compiler":compiler})
         os.environ["MPILIB"] = mpilib
 
     expect(opts['machobj'].is_valid_MPIlib(mpilib),

--- a/tools/load_balancing_tool/load_balancing_submit.py
+++ b/tools/load_balancing_tool/load_balancing_submit.py
@@ -238,7 +238,7 @@ def load_balancing_submit(compset, res, pesfile, mpilib, compiler, project, mach
         compiler = machobj.get_default_compiler()
         print "compiler is {}".format(compiler)
     if mpilib is None:
-        mpilib = machobj.get_default_MPIlib()
+        mpilib = machobj.get_default_MPIlib({"compiler":compiler})
 
 
 


### PR DESCRIPTION
Allows available and default MPILIBS to be specified per compiler.

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2128 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
