### PR TITLE
Revert to previous cheyenne gnu environment

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -322,7 +322,8 @@
 	<command name="load">esmf-7.0.0-ncdfio-uni-O</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">gnu/7.1.0</command>
+        <command name="load">gnu/6.3.0</command>
+        <command name="load">openblas/0.2.14</command>
       </modules>
       <modules mpilib="mpt">
 	<command name="load">mpt/2.16</command>
@@ -332,7 +333,7 @@
 	<command name="load">pnetcdf/1.8.1</command>
       </modules>
       <modules mpilib="openmpi">
-	<command name="load">openmpi/3.0.0</command>
+	<command name="load">openmpi/2.1.0</command>
 	<command name="load">netcdf/4.4.1.1</command>
       </modules>
       <modules>


### PR DESCRIPTION
Back out changes to cheyenne gnu environment that were made in d7d96b5a9

However, leave in place the central change of that commit: using openmpi
rather than mpt

Test suite: `./create_test --no-run SMS_D.f09_g16.T1850G.cheyenne_gnu`
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#2165

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: 
