### PR TITLE
Generalize some paths to support a standalone CISM checkout

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -442,6 +442,10 @@ endif
 ifndef CISM_LIBDIR
   CISM_LIBDIR=$(GLC_DIR)/lib
 endif
+ifndef GLCROOT
+  # Backwards compatibility
+  GLCROOT=$(CIMEROOT)/../components/cism
+endif
 
 INCLDIR +=	-I$(INSTALL_SHAREDPATH)/include
 
@@ -678,7 +682,7 @@ CMAKE_ENV_VARS += CC=$(CC) \
 .PHONY: $(GLC_DIR)/Makefile
 $(GLC_DIR)/Makefile:
 	cd $(GLC_DIR); \
-	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(CIMEROOT)/../components/cism/glimmer-cism
+	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(GLCROOT)/glimmer-cism
 
 $(PIO_LIBDIR)/Makefile:
 	cd $(PIO_LIBDIR); \

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -205,7 +205,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             logger.debug("Building {} usernl files".format(model))
             _build_usernl_files(case, model, comp)
             if comp == "cism":
-                run_cmd_no_fail("{}/../components/cism/cime_config/cism.template {}".format(cimeroot, caseroot))
+                glcroot = case.get_value("COMP_ROOT_DIR_GLC")
+                run_cmd_no_fail("{}/cime_config/cism.template {}".format(glcroot, caseroot))
 
         _build_usernl_files(case, "drv", "cpl")
 


### PR DESCRIPTION
This allows having CISM checked out in $SRCROOT rather than
$SRCROOT/components/cism

Test suite: `./create_test --no-run SMS_D.f09_g16.T1850G.cheyenne_intel`
from a CESM sandbox, and similar from a standalone CISM sandbox
with CISM stuff at $SRCROOT
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#2166

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: 
