### PR TITLE
Pass CIMEROOT to CMake unit test builds

### DIFF
--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -180,6 +180,7 @@ def cmake_stage(name, test_spec_dir, build_optimized, use_mpiserial, mpirun_comm
             "cmake",
             "-C Macros.cmake",
             test_spec_dir,
+            "-DCIMEROOT="+_CIMEROOT,
             "-DCIME_CMAKE_MODULE_DIRECTORY="+os.path.abspath(os.path.join(_CIMEROOT,"src","CMake")),
             "-DCMAKE_BUILD_TYPE="+build_type,
             "-DPFUNIT_MPIRUN='"+mpirun_command+"'",


### PR DESCRIPTION
This is needed to support flexible directory structures

Test suite: scripts_regression_tests on hobart
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#2175

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
