### PR TITLE
Fix shr_cal_advDate with non-zero secIN

### DIFF
--- a/src/share/test/unit/shr_cal_test/test_shr_cal.pf
+++ b/src/share/test/unit/shr_cal_test/test_shr_cal.pf
@@ -122,9 +122,7 @@ contains
   ! Tests of shr_cal_advDate
   ! ------------------------------------------------------------------------
 
-  ! BUG(wjs, 2017-12-22, https://github.com/ESMCI/cime/issues/2164) Skipping this test
-  ! until shr_cal_advDate is fixed
-  ! @Test
+  @Test
   subroutine advDate_int_1dayPlus1sec(this)
     class(TestShrCal), intent(inout) :: this
     integer(i4) :: date_in, date_out
@@ -141,9 +139,7 @@ contains
     @assertEqual(101._r8, sec_out, tolerance=tol)
   end subroutine advDate_int_1dayPlus1sec
 
-  ! BUG(wjs, 2017-12-22, https://github.com/ESMCI/cime/issues/2164) Skipping this test
-  ! until shr_cal_advDate is fixed
-  ! @Test
+  @Test
   subroutine advDate_int_minus1dayMinus1sec(this)
     class(TestShrCal), intent(inout) :: this
     integer(i4) :: date_in, date_out
@@ -180,9 +176,7 @@ contains
     @assertEqual(1._r8, sec_out, tolerance=tol)
   end subroutine advDate_int_1dayPlus1sec_secIn0
 
-  ! BUG(wjs, 2017-12-22, https://github.com/ESMCI/cime/issues/2164) Skipping this test
-  ! until shr_cal_advDate is fixed
-  ! @Test
+  @Test
   subroutine advDate_long_1dayPlus1sec(this)
     class(TestShrCal), intent(inout) :: this
     integer(i8) :: date_in, date_out
@@ -199,9 +193,7 @@ contains
     @assertEqual(101._r8, sec_out, tolerance=tol)
   end subroutine advDate_long_1dayPlus1sec
 
-  ! BUG(wjs, 2017-12-22, https://github.com/ESMCI/cime/issues/2164) Skipping this test
-  ! until shr_cal_advDate is fixed
-  ! @Test
+  @Test
   subroutine advDate_long_minus1dayMinus1sec(this)
     class(TestShrCal), intent(inout) :: this
     integer(i8) :: date_in, date_out

--- a/src/share/test/unit/shr_cal_test/test_shr_cal.pf
+++ b/src/share/test/unit/shr_cal_test/test_shr_cal.pf
@@ -157,26 +157,6 @@ contains
   end subroutine advDate_int_minus1dayMinus1sec
 
   @Test
-  subroutine advDate_int_1dayPlus1sec_secIn0(this)
-    ! This is like advDate_int_1dayPlus1sec, but with secIN = 0. This test serves a
-    ! purpose while advDate_int_1dayPlus1sec is failing; once that one is passing, this
-    ! one can be removed.
-    class(TestShrCal), intent(inout) :: this
-    integer(i4) :: date_in, date_out
-    real(r8) :: sec_in, sec_out
-
-    date_in = 98760317
-    sec_in = 0._r8
-    call shr_cal_advDate(delta = 86401._r8, units = 'seconds', &
-         dateIN = date_in, secIN = sec_in, &
-         dateOUT = date_out, secOUT = sec_out, &
-         calendar = 'noleap')
-
-    @assertEqual(98760318, date_out)
-    @assertEqual(1._r8, sec_out, tolerance=tol)
-  end subroutine advDate_int_1dayPlus1sec_secIn0
-
-  @Test
   subroutine advDate_long_1dayPlus1sec(this)
     class(TestShrCal), intent(inout) :: this
     integer(i8) :: date_in, date_out
@@ -209,26 +189,6 @@ contains
     @assertEqual(9876540316_i8, date_out)
     @assertEqual(99._r8, sec_out, tolerance=tol)
   end subroutine advDate_long_minus1dayMinus1sec
-
-  @Test
-  subroutine advDate_long_1dayPlus1sec_secIn0(this)
-    ! This is like advDate_long_1dayPlus1sec, but with secIN = 0. This test serves a
-    ! purpose while advDate_long_1dayPlus1sec is failing; once that one is passing, this
-    ! one can be removed.
-    class(TestShrCal), intent(inout) :: this
-    integer(i8) :: date_in, date_out
-    real(r8) :: sec_in, sec_out
-
-    date_in = 9876540317_i8
-    sec_in = 0._r8
-    call shr_cal_advDate(delta = 86401._r8, units = 'seconds', &
-         dateIN = date_in, secIN = sec_in, &
-         dateOUT = date_out, secOUT = sec_out, &
-         calendar = 'noleap')
-
-    @assertEqual(9876540318_i8, date_out)
-    @assertEqual(1._r8, sec_out, tolerance=tol)
-  end subroutine advDate_long_1dayPlus1sec_secIn0
 
   ! ------------------------------------------------------------------------
   ! Tests of shr_cal_advDateInt

--- a/src/share/util/shr_cal_mod.F90
+++ b/src/share/util/shr_cal_mod.F90
@@ -783,7 +783,7 @@ contains
     endif
 
     ! take secIn into account here since it's real
-    dSec = dSec - secIn
+    dSec = dSec + secIn
 
     ! i8 math, convert reals to nearest second
     i8dSec = nint(dSec,SHR_KIND_I8)
@@ -870,7 +870,7 @@ contains
     endif
 
     ! take secIn into account here since it's real
-    dSec = dSec - secIn
+    dSec = dSec + secIn
 
     ! i8 math, convert reals to nearest second
     i8dSec = nint(dSec,SHR_KIND_I8)


### PR DESCRIPTION
The sign on the adjustment of secIN was wrong

Test suite: scripts_regression_tests on hobart
Test baseline: N/A
Test namelist changes: none
Test status: expected to be bit for bit, but I'm not positive

Fixes ESMCI/cime#2164
Fixes ESMCI/cime#858

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
