### PR TITLE
add flux convergence criteria

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -666,6 +666,32 @@
     </values>
   </entry>
 
+  <entry id="flux_convergence">
+    <type>real</type>
+    <category>control</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Iterate atmocn flux calculation to this % difference
+    </desc>
+    <values>
+      <value cime_model='cesm'>0.01</value>
+      <value cime_model='acme'>0.0</value>
+    </values>
+  </entry>
+
+  <entry id="flux_max_iteration">
+    <type>integer</type>
+    <category>control</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      Iterate atmocn flux calculation a max of this value
+    </desc>
+    <values>
+      <value cime_model='cesm'>5</value>
+      <value cime_model='acme'>2</value>
+    </values>
+  </entry>
+
   <entry id="gust_fac">
     <type>real</type>
     <category>control</category>

--- a/src/drivers/mct/main/seq_flux_mct.F90
+++ b/src/drivers/mct/main/seq_flux_mct.F90
@@ -2,7 +2,7 @@ module seq_flux_mct
 
   use shr_kind_mod,      only: r8 => shr_kind_r8, in=>shr_kind_in
   use shr_sys_mod,       only: shr_sys_abort
-  use shr_flux_mod,      only: shr_flux_atmocn, shr_flux_atmocn_diurnal
+  use shr_flux_mod,      only: shr_flux_atmocn, shr_flux_atmocn_diurnal, shr_flux_adjust_constants
   use shr_orb_mod,       only: shr_orb_params, shr_orb_cosz, shr_orb_decl
   use shr_mct_mod,       only: shr_mct_queryConfigFile, shr_mct_sMatReaddnc
 
@@ -1216,10 +1216,12 @@ contains
     real(r8),parameter :: albdif = 0.06_r8 ! 60 deg reference albedo, diffuse
     real(r8),parameter :: albdir = 0.07_r8 ! 60 deg reference albedo, direct
     character(*),parameter :: subName =   '(seq_flux_atmocn_mct) '
+    character(len=shr_kind_cs) :: cime_model
     !
     !-----------------------------------------------------------------------
 
     call seq_infodata_getData(infodata , &
+         cime_model = cime_model, &
          read_restart=read_restart, &
          flux_albav=flux_albav, &
          dead_comps=dead_comps, &
@@ -1294,6 +1296,10 @@ contains
        index_o2x_So_roce_16O = mct_aVect_indexRA(o2x,'So_roce_16O', perrWith='quiet')
        index_o2x_So_roce_HDO = mct_aVect_indexRA(o2x,'So_roce_HDO', perrWith='quiet')
        index_o2x_So_roce_18O = mct_aVect_indexRA(o2x,'So_roce_18O', perrWith='quiet')
+       if (trim(cime_model) .eq. 'cesm') then
+          call shr_flux_adjust_constants(flux_convergence_tolerance=0.01_R8, &
+               flux_convergence_max_iteration=5)
+       endif
        first_call = .false.
     end if
 

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -9,7 +9,7 @@
 ! !DESCRIPTION:
 !
 !     CCSM shared flux calculations.
-!     
+!
 ! !REVISION HISTORY:
 !     2006-Nov-07 - B. Kauffman - first version, code taken/migrated from cpl6
 !
@@ -59,7 +59,7 @@ module shr_flux_mod
 ! The follow variables are not declared as parameters so that they can be
 ! adjusted to support aquaplanet and potentially other simple model modes.
 ! The shr_flux_adjust_constants subroutine is called to set the desired
-! values.  The default values are from shr_const_mod.  Currently they are 
+! values.  The default values are from shr_const_mod.  Currently they are
 ! only used by the shr_flux_atmocn and shr_flux_atmice routines.
    real(R8) :: loc_zvir   = shr_const_zvir
    real(R8) :: loc_cpdair = shr_const_cpdair
@@ -116,7 +116,7 @@ end subroutine shr_flux_adjust_constants
 ! !DESCRIPTION:
 !
 !     Internal atm/ocn flux calculation
-!     
+!
 ! !REVISION HISTORY:
 !     2002-Jun-10 - B. Kauffman - code migrated from cpl5 to cpl6
 !     2003-Apr-02 - B. Kauffman - taux & tauy now utilize ocn velocity
@@ -128,7 +128,7 @@ end subroutine shr_flux_adjust_constants
 ! !INTERFACE: ------------------------------------------------------------------
 
 SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_fac, &
-           &               qbot  ,s16O  ,sHDO  ,s18O  ,rbot  ,   & 
+           &               qbot  ,s16O  ,sHDO  ,s18O  ,rbot  ,   &
            &               tbot  ,us    ,vs    ,   &
            &               ts    ,mask  ,sen   ,lat   ,lwup  ,   &
            &               r16O, rhdo, r18O, &
@@ -156,11 +156,11 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    real(R8)   ,intent(in) :: s16O (nMax) ! atm H216O tracer conc. (kg/kg)
    real(R8)   ,intent(in) :: sHDO (nMax) ! atm HDO tracer conc.  (kg/kg)
    real(R8)   ,intent(in) :: s18O (nMax) ! atm H218O tracer conc. (kg/kg)
-   real(R8)   ,intent(in) :: r16O (nMax) ! ocn H216O tracer ratio/Rstd  
-   real(R8)   ,intent(in) :: rHDO (nMax) ! ocn HDO tracer ratio/Rstd   
-   real(R8)   ,intent(in) :: r18O (nMax) ! ocn H218O tracer ratio/Rstd   
+   real(R8)   ,intent(in) :: r16O (nMax) ! ocn H216O tracer ratio/Rstd
+   real(R8)   ,intent(in) :: rHDO (nMax) ! ocn HDO tracer ratio/Rstd
+   real(R8)   ,intent(in) :: r18O (nMax) ! ocn H218O tracer ratio/Rstd
    real(R8)   ,intent(in) :: rbot (nMax) ! atm air density       (kg/m^3)
-   real(R8)   ,intent(in) :: tbot (nMax) ! atm T                 (K) 
+   real(R8)   ,intent(in) :: tbot (nMax) ! atm T                 (K)
    real(R8)   ,intent(in) :: us   (nMax) ! ocn u-velocity        (m/s)
    real(R8)   ,intent(in) :: vs   (nMax) ! ocn v-velocity        (m/s)
    real(R8)   ,intent(in) :: ts   (nMax) ! ocn temperature       (K)
@@ -184,7 +184,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    real(R8),intent(out),optional :: ustar_sv(nMax) ! diag: ustar
    real(R8),intent(out),optional :: re_sv   (nMax) ! diag: sqrt of exchange coefficient (water)
    real(R8),intent(out),optional :: ssq_sv  (nMax) ! diag: sea surface humidity  (kg/kg)
- 
+
    real(R8),intent(in) ,optional :: missval        ! masked value
 
 ! !EOP
@@ -203,16 +203,16 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    real(R8)    :: delt   ! potential T difference   (K)
    real(R8)    :: delq   ! humidity difference      (kg/kg)
    real(R8)    :: stable ! stability factor
-   real(R8)    :: rdn    ! sqrt of neutral exchange coeff (momentum) 
-   real(R8)    :: rhn    ! sqrt of neutral exchange coeff (heat)     
-   real(R8)    :: ren    ! sqrt of neutral exchange coeff (water)    
-   real(R8)    :: rd     ! sqrt of exchange coefficient (momentum)         
-   real(R8)    :: rh     ! sqrt of exchange coefficient (heat)             
-   real(R8)    :: re     ! sqrt of exchange coefficient (water)            
-   real(R8)    :: ustar  ! ustar             
+   real(R8)    :: rdn    ! sqrt of neutral exchange coeff (momentum)
+   real(R8)    :: rhn    ! sqrt of neutral exchange coeff (heat)
+   real(R8)    :: ren    ! sqrt of neutral exchange coeff (water)
+   real(R8)    :: rd     ! sqrt of exchange coefficient (momentum)
+   real(R8)    :: rh     ! sqrt of exchange coefficient (heat)
+   real(R8)    :: re     ! sqrt of exchange coefficient (water)
+   real(R8)    :: ustar  ! ustar
    real(r8)     :: ustar_prev
-   real(R8)    :: qstar  ! qstar             
-   real(R8)    :: tstar  ! tstar             
+   real(R8)    :: qstar  ! qstar
+   real(R8)    :: tstar  ! tstar
    real(R8)    :: hol    ! H (at zbot) over L
    real(R8)    :: xsq    ! ?
    real(R8)    :: xqq    ! ?
@@ -221,7 +221,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    real(R8)    :: psix2  ! stability function at ztref reference height
    real(R8)    :: alz    ! ln(zbot/zref)
    real(R8)    :: al2    ! ln(zref/ztref)
-   real(R8)    :: u10n   ! 10m neutral wind 
+   real(R8)    :: u10n   ! 10m neutral wind
    real(R8)    :: tau    ! stress at zbot
    real(R8)    :: cp     ! specific heat of moist air
    real(R8)    :: fac    ! vertical interpolation factor
@@ -237,7 +237,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    real(R8)    :: Tk     ! dummy arg ~ temperature (K)
    real(R8)    :: xd     ! dummy arg ~ ?
    real(R8)    :: gprec  ! dummy arg ~ ?
- 
+
    qsat(Tk)   = 640380.0_R8 / exp(5107.4_R8/Tk)
    cdn(Umps)  =   0.0027_R8 / Umps + 0.000142_R8 + 0.0000764_R8 * Umps
    psimhu(xd) = log((1.0_R8+xd*(2.0_R8+xd))*(1.0_R8+xd*xd)/8.0_R8) - 2.0_R8*atan(xd) + 1.571_R8
@@ -248,7 +248,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    ! Ug = log(1.0+6.69R-0.476R^2)
    ! Coefficients X by 8640 for mm/s (from cam) -> cm/day (for above forumla)
    ugust(gprec) = gust_fac*log(1._R8+57801.6_R8*gprec-3.55332096e7_R8*(gprec**2.0_R8))
- 
+
    !--- formats ----------------------------------------
    character(*),parameter :: subName = '(shr_flux_atmOcn) '
    character(*),parameter ::   F00 = "('(shr_flux_atmOcn) ',4a)"
@@ -257,12 +257,12 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
 ! PURPOSE:
 !   computes atm/ocn surface fluxes
 !
-! NOTES: 
+! NOTES:
 !   o all fluxes are positive downward
 !   o net heat flux = net sw + lw up + lw down + sen + lat
 !   o here, tstar = <WT>/U*, and qstar = <WQ>/U*.
 !   o wind speeds should all be above a minimum speed (eg. 1.0 m/s)
-! 
+!
 ! ASSUMPTIONS:
 !   o Neutral 10m drag coeff: cdn = .0027/U10 + .000142 + .0000764 U10
 !   o Neutral 10m stanton number: ctn = .0327 sqrt(cdn), unstable
@@ -278,21 +278,21 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    else
       spval = shr_const_spval
    endif
- 
+
    al2 = log(zref/ztref)
 
    DO n=1,nMax
      if (mask(n) /= 0) then
-    
+
         !--- compute some needed quantities ---
 
         ! old version
         !vmag   = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
 
         !--- vmag+ugust (convective gustiness) Limit to a max precip 6 cm/day = 0.00069444 m/s.
-        !--- reverts to original formula if gust_fac=0 
+        !--- reverts to original formula if gust_fac=0
 
-        !PMA saves vmag_old for taux tauy computation 
+        !PMA saves vmag_old for taux tauy computation
 
         vmag_old    = max(umin, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
 
@@ -305,23 +305,23 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
         ssq    = 0.98_R8 * qsat(ts(n)) / rbot(n)   ! sea surf hum (kg/kg)
         delt   = thbot(n) - ts(n)                  ! pot temp diff (K)
         delq   = qbot(n) - ssq                     ! spec hum dif (kg/kg)
-        alz    = log(zbot(n)/zref) 
-        cp     = loc_cpdair*(1.0_R8 + loc_cpvir*ssq) 
-   
+        alz    = log(zbot(n)/zref)
+        cp     = loc_cpdair*(1.0_R8 + loc_cpvir*ssq)
+
         !------------------------------------------------------------
         ! first estimate of Z/L and ustar, tstar and qstar
         !------------------------------------------------------------
         !--- neutral coefficients, z/L = 0.0 ---
         stable = 0.5_R8 + sign(0.5_R8 , delt)
         rdn    = sqrt(cdn(vmag))
-        rhn    = (1.0_R8-stable) * 0.0327_R8 + stable * 0.018_R8 
-        ren    = 0.0346_R8 
-        
+        rhn    = (1.0_R8-stable) * 0.0327_R8 + stable * 0.018_R8
+        ren    = 0.0346_R8
+
         !--- ustar, tstar, qstar ---
         ustar = rdn * vmag
-        tstar = rhn * delt  
-        qstar = ren * delq  
-        ustar_prev = ustar - ustar * flux_con_tol * 2.0_R8
+        tstar = rhn * delt
+        qstar = ren * delq
+        ustar_prev = ustar * 2.0_R8
         iter = 0
         do while( abs((ustar - ustar_prev)/ustar) > flux_con_tol .and. iter < flux_con_max_iter)
            iter = iter + 1
@@ -335,45 +335,45 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
            xqq    = sqrt(xsq)
            psimh  = -5.0_R8*hol*stable + (1.0_R8-stable)*psimhu(xqq)
            psixh  = -5.0_R8*hol*stable + (1.0_R8-stable)*psixhu(xqq)
-   
+
            !--- shift wind speed using old coefficient ---
            rd   = rdn / (1.0_R8 + rdn/loc_karman*(alz-psimh))
-           u10n = vmag * rd / rdn 
-   
+           u10n = vmag * rd / rdn
+
            !--- update transfer coeffs at 10m and neutral stability ---
            rdn = sqrt(cdn(u10n))
            ren = 0.0346_R8
-           rhn = (1.0_R8-stable)*0.0327_R8 + stable * 0.018_R8 
-    
+           rhn = (1.0_R8-stable)*0.0327_R8 + stable * 0.018_R8
+
            !--- shift all coeffs to measurement height and stability ---
-           rd = rdn / (1.0_R8 + rdn/loc_karman*(alz-psimh)) 
-           rh = rhn / (1.0_R8 + rhn/loc_karman*(alz-psixh)) 
-           re = ren / (1.0_R8 + ren/loc_karman*(alz-psixh)) 
-   
+           rd = rdn / (1.0_R8 + rdn/loc_karman*(alz-psimh))
+           rh = rhn / (1.0_R8 + rhn/loc_karman*(alz-psixh))
+           re = ren / (1.0_R8 + ren/loc_karman*(alz-psixh))
+
            !--- update ustar, tstar, qstar using updated, shifted coeffs --
-           ustar = rd * vmag 
-           tstar = rh * delt 
-           qstar = re * delq 
+           ustar = rd * vmag
+           tstar = rh * delt
+           qstar = re * delq
         enddo
-    
+
         !------------------------------------------------------------
         ! compute the fluxes
         !------------------------------------------------------------
-    
-        tau = rbot(n) * ustar * ustar 
-       
+
+        tau = rbot(n) * ustar * ustar
+
         !--- momentum flux ---
-        taux(n) = tau * (ubot(n)-us(n)) / vmag_old !PMA uses vmag_old for taux 
+        taux(n) = tau * (ubot(n)-us(n)) / vmag_old !PMA uses vmag_old for taux
         tauy(n) = tau * (vbot(n)-vs(n)) / vmag_old !    tauy c20170620
-        
+
         !--- heat flux ---
-        sen (n) =          cp * tau * tstar / ustar 
+        sen (n) =          cp * tau * tstar / ustar
         lat (n) =  loc_latvap * tau * qstar / ustar
-        lwup(n) = -loc_stebol * ts(n)**4 
-      
+        lwup(n) = -loc_stebol * ts(n)**4
+
         !--- water flux ---
-        evap(n) = lat(n)/loc_latvap 
-    
+        evap(n) = lat(n)/loc_latvap
+
         !---water isotope flux ---
 
         call wiso_flxoce(2,rbot(n),zbot(n),s16O(n),ts(n),r16O(n),ustar,re,ssq,evap_16O(n), &
@@ -391,11 +391,11 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
         xqq = sqrt(xsq)
         psix2   = -5.0_R8*hol*stable + (1.0_R8-stable)*psixhu(xqq)
         fac     = (rh/loc_karman) * (alz + al2 - psixh + psix2 )
-        tref(n) = thbot(n) - delt*fac 
+        tref(n) = thbot(n) - delt*fac
         tref(n) = tref(n) - 0.01_R8*ztref   ! pot temp to temp correction
         fac     = (re/loc_karman) * (alz + al2 - psixh + psix2 )
         qref(n) =  qbot(n) - delq*fac
-    
+
         duu10n(n) = u10n*u10n ! 10m wind speed squared
 
         !------------------------------------------------------------
@@ -413,7 +413,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
         lat   (n) = spval  ! latent           heat flux  (W/m^2)
         lwup  (n) = spval  ! long-wave upward heat flux  (W/m^2)
         evap  (n) = spval  ! evaporative water flux ((kg/s)/m^2)
-        evap_16O (n) = spval !water tracer flux (kg/s)/m^2) 
+        evap_16O (n) = spval !water tracer flux (kg/s)/m^2)
         evap_HDO (n) = spval !HDO tracer flux  (kg/s)/m^2)
         evap_18O (n) = spval !H218O tracer flux (kg/s)/m^2)
         taux  (n) = spval  ! x surface stress (N)
@@ -426,7 +426,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
         if (present(re_sv   )) re_sv   (n) = spval
         if (present(ssq_sv  )) ssq_sv  (n) = spval
      endif
-   ENDDO 
+   ENDDO
 
 END subroutine shr_flux_atmOcn
 
@@ -438,7 +438,7 @@ END subroutine shr_flux_atmOcn
 ! !DESCRIPTION:
 !
 !     Internal atm/ocn flux calculation
-!     
+!
 ! !REVISION HISTORY:
 !     2002-Jun-10 - B. Kauffman - code migrated from cpl5 to cpl6
 !     2003-Apr-02 - B. Kauffman - taux & tauy now utilize ocn velocity
@@ -448,7 +448,7 @@ END subroutine shr_flux_atmOcn
 ! !INTERFACE: ------------------------------------------------------------------
 
 SUBROUTINE shr_flux_atmOcn_diurnal &
-                          (nMax  ,zbot  ,ubot  ,vbot  ,thbot ,             & 
+                          (nMax  ,zbot  ,ubot  ,vbot  ,thbot ,             &
                            qbot  ,s16O  ,sHDO  ,s18O  ,rbot  ,             &
                            tbot  ,us    ,vs    ,                           &
                            ts    ,mask  ,sen   ,lat   ,lwup  ,             &
@@ -487,7 +487,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8)   ,intent(in) :: rHDO (nMax) ! ocn HDO tracer ratio/Rstd
    real(R8)   ,intent(in) :: r18O (nMax) ! ocn H218O tracer ratio/Rstd
    real(R8)   ,intent(in) :: rbot (nMax) ! atm air density       (kg/m^3)
-   real(R8)   ,intent(in) :: tbot (nMax) ! atm T                 (K) 
+   real(R8)   ,intent(in) :: tbot (nMax) ! atm T                 (K)
    real(R8)   ,intent(in) :: us   (nMax) ! ocn u-velocity        (m/s)
    real(R8)   ,intent(in) :: vs   (nMax) ! ocn v-velocity        (m/s)
    real(R8)   ,intent(in) :: ts   (nMax) ! ocn temperature       (K)
@@ -548,7 +548,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8),intent(out),optional :: ustar_sv(nMax) ! diag: ustar
    real(R8),intent(out),optional :: re_sv   (nMax) ! diag: sqrt of exchange coefficient (water)
    real(R8),intent(out),optional :: ssq_sv  (nMax) ! diag: sea surface humidity  (kg/kg)
- 
+
 ! !EOP
 
 
@@ -560,7 +560,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
 
    real(R8),parameter :: lambdaC  = 6.0_R8
    real(R8),parameter :: lambdaL  = 0.0_R8
-   real(R8),parameter :: doLMax   = 1.0_R8 
+   real(R8),parameter :: doLMax   = 1.0_R8
    real(R8),parameter :: pwr      = 0.2_R8
    real(R8),parameter :: Rizero   = 1.0_R8
    real(R8),parameter :: NUzero   = 40.0e-4_R8
@@ -575,7 +575,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8),parameter :: tiny     = 1.0e-12_R8
    real(R8),parameter :: tiny2    = 1.0e-6_R8
    real(R8),parameter :: pi       = SHR_CONST_PI
-  
+
 
    !--- local variables --------------------------------
    integer(IN) :: n       ! vector loop index
@@ -588,16 +588,16 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8)    :: delt    ! potential T difference   (K)
    real(R8)    :: delq    ! humidity difference      (kg/kg)
    real(R8)    :: stable  ! stability factor
-   real(R8)    :: rdn     ! sqrt of neutral exchange coeff (momentum) 
-   real(R8)    :: rhn     ! sqrt of neutral exchange coeff (heat)     
-   real(R8)    :: ren     ! sqrt of neutral exchange coeff (water)    
-   real(R8)    :: rd      ! sqrt of exchange coefficient (momentum)         
-   real(R8)    :: rh      ! sqrt of exchange coefficient (heat)             
-   real(R8)    :: re      ! sqrt of exchange coefficient (water)            
-   real(R8)    :: ustar   ! ustar             
-   real(R8)    :: ustar_prev   ! ustar             
-   real(R8)    :: qstar   ! qstar             
-   real(R8)    :: tstar   ! tstar             
+   real(R8)    :: rdn     ! sqrt of neutral exchange coeff (momentum)
+   real(R8)    :: rhn     ! sqrt of neutral exchange coeff (heat)
+   real(R8)    :: ren     ! sqrt of neutral exchange coeff (water)
+   real(R8)    :: rd      ! sqrt of exchange coefficient (momentum)
+   real(R8)    :: rh      ! sqrt of exchange coefficient (heat)
+   real(R8)    :: re      ! sqrt of exchange coefficient (water)
+   real(R8)    :: ustar   ! ustar
+   real(R8)    :: ustar_prev   ! ustar
+   real(R8)    :: qstar   ! qstar
+   real(R8)    :: tstar   ! tstar
    real(R8)    :: hol     ! H (at zbot) over L
    real(R8)    :: xsq     ! ?
    real(R8)    :: xqq     ! ?
@@ -606,41 +606,41 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8)    :: psix2   ! stability function at ztref reference height
    real(R8)    :: alz     ! ln(zbot/zref)
    real(R8)    :: al2     ! ln(zref/ztref)
-   real(R8)    :: u10n    ! 10m neutral wind 
+   real(R8)    :: u10n    ! 10m neutral wind
    real(R8)    :: tau     ! stress at zbot
    real(R8)    :: cp      ! specific heat of moist air
    real(R8)    :: fac     ! vertical interpolation factor
-   real(R8)    :: DTiter  !              
-   real(R8)    :: DSiter  !              
-   real(R8)    :: DViter  !              
+   real(R8)    :: DTiter  !
+   real(R8)    :: DSiter  !
+   real(R8)    :: DViter  !
 
-   real(R8)    :: Dcool   !              
+   real(R8)    :: Dcool   !
    real(R8)    :: Qdel    ! net cool skin heating
-   real(R8)    :: Hd      ! net heating above -z=d             
-   real(R8)    :: Hb      ! net kinematic heating above -z = delta              
-   real(R8)    :: lambdaV !              
+   real(R8)    :: Hd      ! net heating above -z=d
+   real(R8)    :: Hb      ! net kinematic heating above -z = delta
+   real(R8)    :: lambdaV !
    real(R8)    :: Fd      ! net fresh water forcing above -z=d
    real(R8)    :: ustarw  ! surface wind forcing of layer above -z=d
 
-   real(R8)    :: Qsol   ! solar heat flux (W/m2)             
-   real(R8)    :: Qnsol  ! non-solar heat flux (W/m2) 
+   real(R8)    :: Qsol   ! solar heat flux (W/m2)
+   real(R8)    :: Qnsol  ! non-solar heat flux (W/m2)
 
-   real(R8)    :: SSS  ! sea surface salinity              
-   real(R8)    :: alphaT  !              
-   real(R8)    :: betaS  !              
+   real(R8)    :: SSS  ! sea surface salinity
+   real(R8)    :: alphaT  !
+   real(R8)    :: betaS  !
 
-   real(R8)    :: doL     ! ocean forcing stablity parameter             
-   real(R8)    :: Rid     ! Richardson number at depth d              
+   real(R8)    :: doL     ! ocean forcing stablity parameter
+   real(R8)    :: Rid     ! Richardson number at depth d
    real(R8)    :: Ribulk  ! Bulk  Richardson number at depth d
    real(R8)    :: FofRi   ! Richardon number dependent diffusivity
-   real(R8)    :: Smult   ! multiplicative term based on regime              
-   real(R8)    :: Sfact   ! multiplicative term based on regime              
-   real(R8)    :: Kdiff   ! diffusive term based on regime              
+   real(R8)    :: Smult   ! multiplicative term based on regime
+   real(R8)    :: Sfact   ! multiplicative term based on regime
+   real(R8)    :: Kdiff   ! diffusive term based on regime
    real(R8)    :: Kvisc   ! viscosity term based on regime
-   real(R8)    :: rhocn   !              
-   real(R8)    :: rcpocn  !              
-   real(R8)    :: Nreset  ! value for multiplicative reset factor             
-   real(R8)    :: resec   ! reset offset value in seconds              
+   real(R8)    :: rhocn   !
+   real(R8)    :: rcpocn  !
+   real(R8)    :: Nreset  ! value for multiplicative reset factor
+   real(R8)    :: resec   ! reset offset value in seconds
    logical     :: lmidnight
    logical     :: ltwopm
    logical     :: ltwoam
@@ -648,8 +648,8 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    integer     :: nsum
    real(R8)    :: pexp   ! eqn 19
    real(R8)    :: AMP    ! eqn 18
-   real(R8)    :: dif3   
-   real(R8)    :: phid   
+   real(R8)    :: dif3
+   real(R8)    :: phid
    real(R8)    :: spval
 
    !--- local functions --------------------------------
@@ -661,7 +661,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8)    :: Tk     ! dummy arg ~ temperature (K)
    real(R8)    :: xd     ! dummy arg ~ ?
    real(R8)    :: molvisc ! molecular viscosity
-   real(R8)    :: molPr   ! molecular Prandtl number 
+   real(R8)    :: molPr   ! molecular Prandtl number
 
 
    qsat(Tk)   = 640380.0_R8 / exp(5107.4_R8/Tk)
@@ -679,12 +679,12 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
 ! PURPOSE:
 !   computes atm/ocn surface fluxes
 !
-! NOTES: 
+! NOTES:
 !   o all fluxes are positive downward
 !   o net heat flux = net sw + lw up + lw down + sen + lat
 !   o here, tstar = <WT>/U*, and qstar = <WQ>/U*.
 !   o wind speeds should all be above a minimum speed (eg. 1.0 m/s)
-! 
+!
 ! ASSUMPTIONS:
 !   o Neutral 10m drag coeff: cdn = .0027/U10 + .000142 + .0000764 U10
 !   o Neutral 10m stanton number: ctn = .0327 sqrt(cdn), unstable
@@ -700,7 +700,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
       write(s_logunit,F00) "ERROR: flux_diurnal must be true"
       call shr_sys_abort(subName//"flux diurnal must be true")
    endif
- 
+
    spval = shr_const_spval
 
    al2 = log(zref/ztref)
@@ -717,7 +717,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    else
       ! use swpen and ocnsal from input argument
    endif
- 
+
    if (cold_start) then
       !         if (s_loglev > 0) then
       write(s_logunit,F00) "Initialize diurnal cycle fields"
@@ -729,7 +729,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
       qSolAvg    (:) = 0.0_R8
       windAvg    (:) = 0.0_R8
       warmMax    (:) = 0.0_R8
-      windMax    (:) = 0.0_R8 
+      windMax    (:) = 0.0_R8
       warmMaxInc (:) = 0.0_R8
       windMaxInc (:) = 0.0_R8
       qSolInc    (:) = 0.0_R8
@@ -756,7 +756,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
          tBulk(n) = ts(n)+warm(n)    ! first guess for tBulk from read in ts,warm
          tSkin(n) = tBulk(n)
          Qsol     = swdn(n) + swup(n)
-         SSS      = 1000.0_R8*ocnsal(n)+salt(n) 
+         SSS      = 1000.0_R8*ocnsal(n)+salt(n)
          lambdaV = lambdaC
 
          alphaT   = 0.000297_R8*(1.0_R8+0.0256_R8*(ts(n)-298.15_R8)+0.003_R8*(SSS - 35.0_R8))
@@ -785,35 +785,35 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
          nsum = nint(nInc(n))
 
          if ( lmidnight ) then
-            Regime(n)  = 1.0_R8               !  RESET DIURNAL 
+            Regime(n)  = 1.0_R8               !  RESET DIURNAL
             warm(n)    = 0.0_R8
             salt(n)    = 0.0_R8
             speed(n)   = 0.0_R8
          endif
-        
+
          ssq    = 0.98_R8 * qsat(tBulk(n)) / rbot(n)   ! sea surf hum (kg/kg)
          delt   = thbot(n) - tBulk(n)                  ! pot temp diff (K)
          delq   = qbot(n) - ssq                     ! spec hum dif (kg/kg)
-         cp     = shr_const_cpdair*(1.0_R8 + shr_const_cpvir*ssq) 
+         cp     = shr_const_cpdair*(1.0_R8 + shr_const_cpvir*ssq)
          stable = 0.5_R8 + sign(0.5_R8 , delt)
-   
+
 
          !--- shift wind speed using old coefficient  and stability function
 
          rd   = rdn / (1.0_R8 + rdn/shr_const_karman*(alz-psimh))
          u10n = vmag * rd / rdn
 
-         !--- initial neutral  transfer coeffs at 10m 
+         !--- initial neutral  transfer coeffs at 10m
          rdn    = sqrt(cdn(u10n))
-         rhn    = (1.0_R8-stable) * 0.0327_R8 + stable * 0.018_R8 
-         ren    = 0.0346_R8 
-   
+         rhn    = (1.0_R8-stable) * 0.0327_R8 + stable * 0.018_R8
+         ren    = 0.0346_R8
+
          !--- initial ustar, tstar, qstar ---
          ustar = rdn * vmag
-         tstar = rhn * delt  
-         qstar = ren * delq  
+         tstar = rhn * delt
+         qstar = ren * delq
 
-        ustar_prev = ustar * (1_R8 - flux_con_tol * 2.0_R8)
+        ustar_prev = ustar * 2.0_R8
         iter = 0
          ! --- iterate ---
 
@@ -824,7 +824,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             ! iterate to converge on FLUXES  Z/L, ustar, tstar and qstar
             ! and on Rid  in the DIURNAL CYCLE
             !------------------------------------------------------------
-            Smult = 0.0_R8 
+            Smult = 0.0_R8
             Sfact = 0.0_R8
             Kdiff = 0.0_R8
             Kvisc = 0.0_R8
@@ -844,11 +844,11 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             Hb = min(Hb , 0.0_R8)
             lambdaV = lambdaC*(1.0_R8 + ( (0.0_R8-Hb)*16.0_R8*molvisc(tBulk(n))* &
                  shr_const_g*alphaT*molPr(tBulk(n))**2/ustarw**4)**0.75)**(-1/3)
-            cSkin(n) =  MIN(0.0_R8, lambdaV * molPr(tBulk(n)) * Qdel / ustarw / rcpocn )   
+            cSkin(n) =  MIN(0.0_R8, lambdaV * molPr(tBulk(n)) * Qdel / ustarw / rcpocn )
 
             !--- REGIME ---
             doL = shr_const_zsrflyr*shr_const_karman*shr_const_g* &
-                 (alphaT*Hd + betaS*Fd ) / ustarw**3 
+                 (alphaT*Hd + betaS*Fd ) / ustarw**3
             Rid = MAX(0.0_R8,Rid)
             Smult = dt * (pwr+1.0_R8) / (shr_const_zsrflyr*pwr)
             Sfact = dt * (pwr+1.0_R8) / (shr_const_zsrflyr)**2
@@ -880,7 +880,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                      Kvisc = Prandtl* kappa0 + NUzero * FofRi
                   else
                      regime(n) = 4.0_R8
-                     Kdiff = shr_const_karman*ustarw*shr_const_zsrflyr *(1.0_R8-7.0_R8*doL)**(1/3) 
+                     Kdiff = shr_const_karman*ustarw*shr_const_zsrflyr *(1.0_R8-7.0_R8*doL)**(1/3)
                      Kvisc = Kdiff
                   endif
                endif
@@ -889,25 +889,25 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
 
             !--- IMPLICIT INTEGRATION ---
 
-            DTiter = (warm(n)  +(Smult*Hd))               /(1.+ Sfact*Kdiff) 
+            DTiter = (warm(n)  +(Smult*Hd))               /(1.+ Sfact*Kdiff)
             DSiter = (salt(n)  -(Smult*Fd))               /(1.+ Sfact*Kdiff)
             DViter = (speed(n) +(Smult*ustarw*ustarw))    /(1.+ Sfact*Kvisc)
             DTiter = MAX( 0.0_R8, DTiter)
-            DViter = MAX( 0.0_R8, DViter)  
+            DViter = MAX( 0.0_R8, DViter)
 
             Rid =(shr_const_g*(alphaT*DTiter-betaS*DSiter)*pwr*shr_const_zsrflyr)  / &
                  (pwr*MAX(tiny,DViter))**2
             Ribulk = Rid * pwr
             Ribulk = 0.0_R8
             tBulk(n) = ts(n) + DTiter
-            tSkin(n) = tBulk(n) + cskin(n)    
+            tSkin(n) = tBulk(n) + cskin(n)
 
             !--need to update ssq,delt,delq as function of tBulk ----
 
             ssq    = 0.98_R8 * qsat(tBulk(n)) / rbot(n)   ! sea surf hum (kg/kg)
             delt   = thbot(n) - tBulk(n)                  ! pot temp diff (K)
             delq   = qbot(n) - ssq                        ! spec hum dif (kg/kg)
- 
+
             !--- UPDATE FLUX ITERATION ---
 
             !--- compute stability & evaluate all stability functions ---
@@ -924,22 +924,22 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             rd   = rdn / (1.0_R8 + rdn/shr_const_karman*(alz-psimh))
             u10n = vmag * rd / rdn
 
-            !--- update neutral  transfer coeffs at 10m 
+            !--- update neutral  transfer coeffs at 10m
             rdn    = sqrt(cdn(u10n))
-            rhn    = (1.0_R8-stable) * 0.0327_R8 + stable * 0.018_R8 
-            ren    = 0.0346_R8 
-   
+            rhn    = (1.0_R8-stable) * 0.0327_R8 + stable * 0.018_R8
+            ren    = 0.0346_R8
+
             !--- shift all coeffs to measurement height and stability ---
             rd = rdn / (1.0_R8 + rdn/shr_const_karman*(alz-psimh))
             rh = rhn / (1.0_R8 + rhn/shr_const_karman*(alz-psixh))
             re = ren / (1.0_R8 + ren/shr_const_karman*(alz-psixh))
 
             ustar = rd * vmag
-            tstar = rh * delt  
-            qstar = re * delq  
+            tstar = rh * delt
+            qstar = re * delq
 
          ENDDO   ! end iteration loop
-          
+
          !--- COMPUTE FLUXES TO ATMOSPHERE AND OCEAN ---
          tau = rbot(n) * ustar * ustar
 
@@ -963,7 +963,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                           qbot(n),evap(n))
          call wiso_flxoce(4,rbot(n),zbot(n),s18O(n),ts(n),r18O(n),ustar,re,ssq, evap_18O(n),&
                           qbot(n),evap(n))
- 
+
          !------------------------------------------------------------
          ! compute diagnostics: 2m ref T & Q, 10m wind speed squared
          !------------------------------------------------------------
@@ -980,7 +980,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
 
          duu10n(n) = u10n*u10n ! 10m wind speed squared
 
-         if (flux_diurnal) then 
+         if (flux_diurnal) then
 
             !------------------------------------------------------------
             ! update new prognostic variables
@@ -1000,7 +1000,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                cSkin_night(n) = cSkin(n)
             endif
 
-            if ((lmidnight).and.(lfullday)) then        
+            if ((lmidnight).and.(lfullday)) then
                qSolAvg(n) = qSolInc(n)/real(nsum+1,R8)
                windAvg(n) = windInc(n)/real(nsum+1,R8)
                ! warmMax(n) = max(DTiter,warmMaxInc(n))
@@ -1017,7 +1017,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
 !               tSkin_night(n) = tSkin(n)
 !               cSkin_night(n) = cSkin(n)
 
-            else          
+            else
 
                if ((lmidnight).and.(.not.(lfullday))) then
 
@@ -1129,7 +1129,7 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
    real(R8)   ,intent(in)  :: thbot(:)    ! atm potential T   (K)
    real(R8)   ,intent(in)  :: qbot (:)    ! atm specific humidity (kg/kg)
    real(R8)   ,intent(in)  :: rbot (:)    ! atm air density   (kg/m^3)
-   real(R8)   ,intent(in)  :: tbot (:)    ! atm T       (K) 
+   real(R8)   ,intent(in)  :: tbot (:)    ! atm T       (K)
    real(R8)   ,intent(in)  :: ts   (:)    ! surface temperature
 
    !--- output arguments -------------------------------
@@ -1141,7 +1141,7 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
    real(R8)   ,intent(out) :: tauy (:)    ! y surface stress (N)
    real(R8)   ,intent(out) :: tref (:)    ! 2m reference height temperature
    real(R8)   ,intent(out) :: qref (:)    ! 2m reference height humidity
- 
+
 !EOP
 
    !--- local constants --------------------------------
@@ -1165,7 +1165,7 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
    real(R8)    :: ren    ! sqrt of neutral exchange coefficient (water)
    real(R8)    :: rd     ! sqrt of exchange coefficient (momentum)
    real(R8)    :: rh     ! sqrt of exchange coefficient (heat)
-   real(R8)    :: re     ! sqrt of exchange coefficient (water)      
+   real(R8)    :: re     ! sqrt of exchange coefficient (water)
    real(R8)    :: ustar  ! ustar
    real(R8)    :: qstar  ! qstar
    real(R8)    :: tstar  ! tstar
@@ -1189,7 +1189,7 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
    real(R8)   :: Tk      ! temperature (K)
    real(R8)   :: qsat    ! the saturation humidity of air (kg/m^3)
    real(R8)   :: dqsatdt ! derivative of qsat wrt surface temperature
-   real(R8)   :: xd      ! dummy argument  
+   real(R8)   :: xd      ! dummy argument
    real(R8)   :: psimhu  ! unstable part of psimh
    real(R8)   :: psixhu  ! unstable part of psimx
 
@@ -1203,15 +1203,15 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
 
 !-------------------------------------------------------------------------------
 ! PURPOSE:
-!   using atm & ice state variables, compute atm/ice fluxes 
+!   using atm & ice state variables, compute atm/ice fluxes
 !   and diagnostic 10m air temperature and humidity
 !
-! NOTE: 
+! NOTE:
 !   o all fluxes are positive downward
 !   o net heat flux = net sw + lw up + lw down + sen + lat
 !   o here, tstar = <WT>/U*, and qstar = <WQ>/U*.
 !   o wind speeds should all be above a minimum speed (eg. 1.0 m/s)
-! 
+!
 ! ASSUME:
 !   o The saturation humidity of air at T(K): qsat(T)  (kg/m^3)
 !-------------------------------------------------------------------------------
@@ -1236,8 +1236,8 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
          ssq   =  qsat  (ts(n)) / rbot(n)           ! sea surf hum (kg/kg)
         delt   = thbot(n) - ts(n)                   ! pot temp diff (K)
         delq   = qbot(n) - ssq                        ! spec hum dif (kg/kg)
-        alz    = log(zbot(n)/zref) 
-        cp     = loc_cpdair*(1.0_R8 + loc_cpvir*ssq) 
+        alz    = log(zbot(n)/zref)
+        cp     = loc_cpdair*(1.0_R8 + loc_cpvir*ssq)
         ltheat = loc_latvap + loc_latice
 
         !----------------------------------------------------------
@@ -1251,8 +1251,8 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
 
         !--- ustar,tstar,qstar ----
         ustar = rdn * vmag
-        tstar = rhn * delt  
-        qstar = ren * delq  
+        tstar = rhn * delt
+        qstar = ren * delq
 
         !--- compute stability & evaluate all stability functions ---
         hol    = loc_karman * loc_g * zbot(n) &
@@ -1270,9 +1270,9 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
         re = ren / (1.0_R8+ren/loc_karman*(alz-psixh))
 
         !--- update ustar, tstar, qstar w/ updated, shifted coeffs --
-        ustar = rd * vmag 
-        tstar = rh * delt 
-        qstar = re * delq 
+        ustar = rd * vmag
+        tstar = rh * delt
+        qstar = re * delq
 
         !----------------------------------------------------------
         ! iterate to converge on Z/L, ustar, tstar and qstar
@@ -1289,40 +1289,40 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
         psixh  = -5.0_R8*hol*stable + (1.0_R8-stable)*psixhu(xqq)
 
         !--- shift all coeffs to measurement height and stability ---
-        rd = rdn / (1.0_R8+rdn/loc_karman*(alz-psimh)) 
-        rh = rhn / (1.0_R8+rhn/loc_karman*(alz-psixh)) 
-        re = ren / (1.0_R8+ren/loc_karman*(alz-psixh)) 
+        rd = rdn / (1.0_R8+rdn/loc_karman*(alz-psimh))
+        rh = rhn / (1.0_R8+rhn/loc_karman*(alz-psixh))
+        re = ren / (1.0_R8+ren/loc_karman*(alz-psixh))
 
         !--- update ustar, tstar, qstar w/ updated, shifted coeffs --
-        ustar = rd * vmag 
-        tstar = rh * delt 
-        qstar = re * delq 
+        ustar = rd * vmag
+        tstar = rh * delt
+        qstar = re * delq
 
         !----------------------------------------------------------
         ! compute the fluxes
         !----------------------------------------------------------
 
-        tau = rbot(n) * ustar * ustar 
-    
+        tau = rbot(n) * ustar * ustar
+
         !--- momentum flux ---
-        taux(n) = tau * ubot(n) / vmag 
-        tauy(n) = tau * vbot(n) / vmag 
-     
+        taux(n) = tau * ubot(n) / vmag
+        tauy(n) = tau * vbot(n) / vmag
+
         !--- heat flux ---
-        sen (n) =   cp * tau * tstar / ustar 
+        sen (n) =   cp * tau * tstar / ustar
         lat (n) =  ltheat * tau * qstar / ustar
-        lwup(n) = -loc_stebol * ts(n)**4 
-     
+        lwup(n) = -loc_stebol * ts(n)**4
+
         !--- water flux ---
-        evap(n) = lat(n)/ltheat 
+        evap(n) = lat(n)/ltheat
 
         !----------------------------------------------------------
         ! compute diagnostic: 2m reference height temperature
         !----------------------------------------------------------
 
-        !--- Compute function of exchange coefficients. Assume that 
-        !--- cn = rdn*rdn, cm=rd*rd and ch=rh*rd, and therefore 
-        !--- 1/sqrt(cn(n))=1/rdn and sqrt(cm(n))/ch(n)=1/rh 
+        !--- Compute function of exchange coefficients. Assume that
+        !--- cn = rdn*rdn, cm=rd*rd and ch=rh*rd, and therefore
+        !--- 1/sqrt(cn(n))=1/rdn and sqrt(cm(n))/ch(n)=1/rh
         bn = loc_karman/rdn
         bh = loc_karman/rh
 
@@ -1338,10 +1338,10 @@ subroutine shr_flux_atmIce(mask  ,zbot  ,ubot  ,vbot  ,thbot  &
         qref(n) = qbot(n) - delq*fac
 
      endif
-   enddo 
+   enddo
 
 end subroutine shr_flux_atmIce
- 
+
 !===============================================================================
 ! !BOP =========================================================================
 !
@@ -1352,7 +1352,7 @@ end subroutine shr_flux_atmIce
 !    Monin-Obukhov boundary layer stability functions, two options:
 !    turbulent velocity scales or gradient and integral functions
 !    via option = shr_flux_MOwScales or shr_flux_MOfunctions
-!     
+!
 ! !REVISION HISTORY:
 !    2007-Sep-19 - B. Kauffman, Bill Large - first version
 !
@@ -1366,13 +1366,13 @@ subroutine shr_flux_MOstability(option,arg1,arg2,arg3,arg4,arg5)
 
 ! !INPUT/OUTPUT PARAMETERS:
 
-   integer(IN),intent(in)           :: option ! shr_flux_MOwScales or MOfunctions 
+   integer(IN),intent(in)           :: option ! shr_flux_MOwScales or MOfunctions
    real(R8)   ,intent(in)           :: arg1   ! scales: uStar (in)  funct: zeta (in)
    real(R8)   ,intent(inout)        :: arg2   ! scales: zkB   (in)  funct: phim (out)
    real(R8)   ,intent(out)          :: arg3   ! scales: phim  (out) funct: phis (out)
    real(R8)   ,intent(out)          :: arg4   ! scales: phis  (out) funct: psim (out)
    real(R8)   ,intent(out),optional :: arg5   ! scales:    (unused) funct: psis (out)
- 
+
 ! !EOP
 
    !----- local variables -----
@@ -1393,7 +1393,7 @@ subroutine shr_flux_MOstability(option,arg1,arg2,arg3,arg4,arg5)
    real(R8),parameter :: d = 0.350_R8  ! constant from Holtslag & de Bruin, equation 12
 
    !----- local variables, unstable case -----
-   real(R8),parameter :: a2 = 3.0_R8   ! constant from Wilson, equation 10 
+   real(R8),parameter :: a2 = 3.0_R8   ! constant from Wilson, equation 10
 
    !----- formats -----
    character(*),parameter :: subName = '(shr_flux_MOstability) '
@@ -1408,8 +1408,8 @@ subroutine shr_flux_MOstability(option,arg1,arg2,arg3,arg4,arg5)
 !     "Applied Modeling of the Nighttime Surface Energy Balance over Land",
 !     Journal of Applied Meteorology, Vol. 27, No. 6, June 1988, 659-704
 !   o the unstable calculation is taken from...
-!     D. Keith Wilson, 2001: "An Alternative Function for the Wind and 
-!     Temperature Gradients in Unstable Surface Layers", 
+!     D. Keith Wilson, 2001: "An Alternative Function for the Wind and
+!     Temperature Gradients in Unstable Surface Layers",
 !     Boundary-Layer Meteorology, 99 (2001), 151-158
 !-------------------------------------------------------------------------------
 
@@ -1422,7 +1422,7 @@ subroutine shr_flux_MOstability(option,arg1,arg2,arg3,arg4,arg5)
       else if ( option == shr_flux_MOfunctions .and. .not. present(arg5) ) then
          write(s_logunit,F01) "ERROR: option2 must have five arguments"
          call shr_sys_abort(subName//"option inconsistant with arguments")
-      else 
+      else
          write(s_logunit,F01) "invalid option = ",option
          call shr_sys_abort(subName//"invalid option")
       end if
@@ -1462,7 +1462,7 @@ subroutine shr_flux_MOstability(option,arg1,arg2,arg3,arg4,arg5)
          phim =        1.0_R8 + zeta*(a + b*(1.0_R8 + c - d*zeta)*temp)
          phis = phim
          psim = -a*zeta - b*(zeta - c/d)*temp - b*c/d
-         psis = psim 
+         psis = psim
       else                    ! ----- unstable ----
          temp = (zeta*zeta)**(1.0_R8/a2)   ! note: zeta < 0, zeta*zeta > 0
          phim = 1.0_R8/sqrt(1.0_R8 + shr_flux_MOgammaM*temp)
@@ -1477,7 +1477,7 @@ subroutine shr_flux_MOstability(option,arg1,arg2,arg3,arg4,arg5)
       arg4 = psim
       arg5 = psis
    !----------------------------------------------------------------------------
-   else 
+   else
       write(s_logunit,F01) "invalid option = ",option
       call shr_sys_abort(subName//"invalid option")
    endif

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -321,7 +321,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
         ustar = rdn * vmag
         tstar = rhn * delt
         qstar = ren * delq
-        ustar_prev = ustar * 2.0_R8
+        ustar_prev = ustar*2.0_R8
         iter = 0
         do while( abs((ustar - ustar_prev)/ustar) > flux_con_tol .and. iter < flux_con_max_iter)
            iter = iter + 1
@@ -355,7 +355,6 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
            tstar = rh * delt
            qstar = re * delq
         enddo
-
         !------------------------------------------------------------
         ! compute the fluxes
         !------------------------------------------------------------
@@ -556,7 +555,6 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8),parameter :: umin  =  0.5_R8 ! minimum wind speed       (m/s)
    real(R8),parameter :: zref  = 10.0_R8 ! reference height           (m)
    real(R8),parameter :: ztref =  2.0_R8 ! reference height for air T (m)
-   integer(IN),parameter  :: iMax = 3
 
    real(R8),parameter :: lambdaC  = 6.0_R8
    real(R8),parameter :: lambdaL  = 0.0_R8
@@ -815,9 +813,11 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
 
         ustar_prev = ustar * 2.0_R8
         iter = 0
-         ! --- iterate ---
-
-         do while( abs((ustar - ustar_prev)/ustar) > flux_con_tol .and. iter < flux_con_max_iter)
+        ! --- iterate ---
+        ! Originally this code did three iterations while the non-diurnal version did two
+        ! So in the new loop this is <= flux_con_max_iter instead of < so that the same defaults
+        ! will give the same answers in both cases.
+        do while( abs((ustar - ustar_prev)/ustar) > flux_con_tol .and. iter <= flux_con_max_iter)
             iter = iter + 1
             ustar_prev = ustar
             !------------------------------------------------------------


### PR DESCRIPTION
Use a flux criteria for iterative calculation of atmocn flux.   This is introduced in a backward compatible way.   Clean up some unused variables and unnecessary if blocks.

Test suite:  ERS_Ld7.f19_g17.B1850.hobart_pgi.allactive-defaultio 
Test baseline: 
Test namelist changes: 
Test status: roundoff

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
