### PR TITLE
Update ACME cime management

### DIFF
--- a/scripts/Tools/acme_cime_merge
+++ b/scripts/Tools/acme_cime_merge
@@ -28,22 +28,30 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("repo", nargs="?",
                         help="Location of repo to use, default is based on current location")
 
-    parser.add_argument("--resume", action="store_true",
+    parser.add_argument("-r", "--resume", action="store_true",
                         help="Resume merge after fixing conflicts")
+
+    parser.add_argument("-a", "--abort", action="store_true",
+                        help="Resume split after fixing conflicts")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.repo, args.resume
+    expect(not (args.resume and args.abort), "Makes no sense to abort and resume")
+
+    return args.repo, args.resume, args.abort
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    repo, resume = parse_command_line(sys.argv, description)
+    repo, resume, abort = parse_command_line(sys.argv, description)
 
     if repo is not None:
         os.chdir(repo)
 
-    acme_cime_merge(resume)
+    if abort:
+        abort_merge()
+    else:
+        acme_cime_merge(resume)
 
 ###############################################################################
 

--- a/scripts/Tools/acme_cime_split
+++ b/scripts/Tools/acme_cime_split
@@ -29,27 +29,22 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("repo", nargs="?",
                         help="Location of repo to use, default is based on current location")
 
-    parser.add_argument("--resume-one", action="store_true",
-                        help="Resume split after fixing conflicts at point one")
-
-    parser.add_argument("--resume-two", action="store_true",
-                        help="Resume split after fixing conflicts at point two")
+    parser.add_argument("--resume", action="store_true",
+                        help="Resume split after fixing conflicts")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    expect(not (args.resume_one and args.resume_two), "Makes no sense to have two resume points")
-
-    return args.repo, args.resume_one, args.resume_two
+    return args.repo, args.resume
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    repo, resume_one, resume_two = parse_command_line(sys.argv, description)
+    repo, resume = parse_command_line(sys.argv, description)
 
     if repo is not None:
         os.chdir(repo)
 
-    acme_cime_split(resume_one, resume_two)
+    acme_cime_split(resume)
 
 ###############################################################################
 

--- a/scripts/Tools/acme_cime_split
+++ b/scripts/Tools/acme_cime_split
@@ -29,22 +29,30 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("repo", nargs="?",
                         help="Location of repo to use, default is based on current location")
 
-    parser.add_argument("--resume", action="store_true",
+    parser.add_argument("-r", "--resume", action="store_true",
+                        help="Resume split after fixing conflicts")
+
+    parser.add_argument("-a", "--abort", action="store_true",
                         help="Resume split after fixing conflicts")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.repo, args.resume
+    expect(not (args.resume and args.abort), "Makes no sense to abort and resume")
+
+    return args.repo, args.resume, args.abort
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    repo, resume = parse_command_line(sys.argv, description)
+    repo, resume, abort = parse_command_line(sys.argv, description)
 
     if repo is not None:
         os.chdir(repo)
 
-    acme_cime_split(resume)
+    if abort:
+        abort_split()
+    else:
+        acme_cime_split(resume)
 
 ###############################################################################
 

--- a/scripts/lib/acme_cime_mgmt.py
+++ b/scripts/lib/acme_cime_mgmt.py
@@ -12,14 +12,14 @@ MERGE_TAG_PREFIX = "to-acme-"
 def setup():
 ###############################################################################
     run_cmd_no_fail("git config merge.renameLimit 999999")
-    run_cmd_no_fail("git checkout master && git pull && git submodule update --init")
+    run_cmd_no_fail("git checkout master && git pull", verbose=True)
 
     remotes = run_cmd_no_fail("git remote")
     if ESMCI_REMOTE_NAME not in remotes:
-        run_cmd_no_fail("git remote add {} {}".format(ESMCI_REMOTE_NAME, ESMCI_URL))
+        run_cmd_no_fail("git remote add {} {}".format(ESMCI_REMOTE_NAME, ESMCI_URL), verbose=True)
 
-    run_cmd_no_fail("git fetch --prune {}".format(ESMCI_REMOTE_NAME))
-    run_cmd_no_fail("git fetch --prune {} --tags".format(ESMCI_REMOTE_NAME))
+    run_cmd_no_fail("git fetch --prune {}".format(ESMCI_REMOTE_NAME), verbose=True)
+    run_cmd_no_fail("git fetch --prune {} --tags".format(ESMCI_REMOTE_NAME), verbose=True)
 
 ###############################################################################
 def get_tag(prefix, expected_num=1):
@@ -50,8 +50,8 @@ def make_new_tag(prefix, old_tag, remote="origin", commit="HEAD"):
     new_tag = "{}{}".format(prefix, get_timestamp(timestamp_format="%m-%d-%Y"))
     expect(old_tag != new_tag, "New tag must have different name than old tag")
 
-    run_cmd_no_fail("git tag {} {}".format(new_tag, commit))
-    run_cmd_no_fail("git push {} {}".format(remote, new_tag))
+    run_cmd_no_fail("git tag {} {}".format(new_tag, commit), verbose=True)
+    run_cmd_no_fail("git push {} {}".format(remote, new_tag), verbose=True)
 
     return new_tag
 
@@ -77,13 +77,13 @@ def do_subtree_split(old_split_tag, new_split_tag, merge_tag):
 ###############################################################################
     subtree_branch = get_branch_from_tag(new_split_tag)
     run_cmd_no_fail("git subtree split {}.. --prefix=cime --onto={} --ignore-joins -b {}".\
-                        format(old_split_tag, merge_tag, subtree_branch))
+                        format(old_split_tag, merge_tag, subtree_branch), verbose=True)
     return subtree_branch
 
 ###############################################################################
 def do_subtree_pull():
 ###############################################################################
-    stat = run_cmd("git subtree pull --prefix=cime {} master".format(ESMCI_REMOTE_NAME))[0]
+    stat = run_cmd("git subtree pull --prefix=cime {} master".format(ESMCI_REMOTE_NAME), verbose=True)[0]
     if stat != 0:
         logging.info("There are merge conflicts. Please fix, commit, and re-run this tool with --resume")
         sys.exit(1)
@@ -92,14 +92,14 @@ def do_subtree_pull():
 def make_pr_branch(branch, branch_head):
 ###############################################################################
     pr_branch = "{}-pr".format(branch)
-    run_cmd_no_fail("git checkout --no-track -b {} {}".format(pr_branch, branch_head))
+    run_cmd_no_fail("git checkout --no-track -b {} {}".format(pr_branch, branch_head), verbose=True)
 
     return pr_branch
 
 ###############################################################################
 def merge_branch(branch, resume_count):
 ###############################################################################
-    stat = run_cmd("git merge -m 'Merge {}' -X rename-threshold=25 {}".format(branch, branch))[0]
+    stat = run_cmd("git merge -m 'Merge {}' -X rename-threshold=25 {}".format(branch, branch), verbose=True)[0]
     if stat != 0:
         logging.info("There are merge conflicts. Please fix, commit, and re-run this tool with --resume-{}".format(resume_count))
         sys.exit(1)
@@ -117,8 +117,8 @@ def merge_pr_branch_2():
 ###############################################################################
 def delete_tag(tag, remote="origin"):
 ###############################################################################
-    run_cmd_no_fail("git tag -d {}".format(tag))
-    run_cmd_no_fail("git push {} :refs/tags/{}".format(remote, tag))
+    run_cmd_no_fail("git tag -d {}".format(tag), verbose=True)
+    run_cmd_no_fail("git push {} :refs/tags/{}".format(remote, tag), verbose=True)
 
 ###############################################################################
 def acme_cime_split(resume_one, resume_two):
@@ -150,7 +150,7 @@ def acme_cime_split(resume_one, resume_two):
         merge_pr_branch_2()
 
     try:
-        run_cmd_no_fail("git push -u {} {}".format(ESMCI_REMOTE_NAME, pr_branch))
+        run_cmd_no_fail("git push -u {} {}".format(ESMCI_REMOTE_NAME, pr_branch), verbose=True)
     except:
         delete_tag(old_split_tag)
         raise
@@ -180,7 +180,7 @@ def acme_cime_merge(resume):
         pr_branch = "{}-pr".format(get_branch_from_tag(new_merge_tag))
 
     try:
-        run_cmd_no_fail("git push -u origin {}".format(pr_branch))
+        run_cmd_no_fail("git push -u origin {}".format(pr_branch), verbose=True)
     except:
         delete_tag(old_merge_tag, remote=ESMCI_REMOTE_NAME)
         raise

--- a/scripts/lib/acme_cime_mgmt.py
+++ b/scripts/lib/acme_cime_mgmt.py
@@ -91,28 +91,17 @@ def do_subtree_pull():
 ###############################################################################
 def make_pr_branch(branch, branch_head):
 ###############################################################################
-    pr_branch = "{}-pr".format(branch)
-    run_cmd_no_fail("git checkout --no-track -b {} {}".format(pr_branch, branch_head), verbose=True)
+    run_cmd_no_fail("git checkout --no-track -b {} {}".format(branch, branch_head), verbose=True)
 
-    return pr_branch
+    return branch
 
 ###############################################################################
-def merge_branch(branch, resume_count):
+def merge_branch(branch):
 ###############################################################################
     stat = run_cmd("git merge -m 'Merge {}' -X rename-threshold=25 {}".format(branch, branch), verbose=True)[0]
     if stat != 0:
-        logging.info("There are merge conflicts. Please fix, commit, and re-run this tool with --resume-{}".format(resume_count))
+        logging.info("There are merge conflicts. Please fix, commit, and re-run this tool with --resume")
         sys.exit(1)
-
-###############################################################################
-def merge_pr_branch_1(subtree_branch):
-###############################################################################
-    merge_branch(subtree_branch, "one")
-
-###############################################################################
-def merge_pr_branch_2():
-###############################################################################
-    merge_branch("{}/master".format(ESMCI_REMOTE_NAME), "two")
 
 ###############################################################################
 def delete_tag(tag, remote="origin"):
@@ -121,9 +110,9 @@ def delete_tag(tag, remote="origin"):
     run_cmd_no_fail("git push {} :refs/tags/{}".format(remote, tag), verbose=True)
 
 ###############################################################################
-def acme_cime_split(resume_one, resume_two):
+def acme_cime_split(resume):
 ###############################################################################
-    if not resume_one and not resume_two:
+    if not resume:
         setup()
 
         old_split_tag = get_split_tag()
@@ -133,22 +122,21 @@ def acme_cime_split(resume_one, resume_two):
 
             merge_tag = get_merge_tag()
 
-            subtree_branch = do_subtree_split(old_split_tag, new_split_tag, merge_tag)
+            pr_branch = do_subtree_split(old_split_tag, new_split_tag, merge_tag)
 
-            pr_branch = make_pr_branch(subtree_branch, merge_tag)
+            run_cmd_no_fail("git checkout {}".format(pr_branch), verbose=True)
         except:
             # If unexpected failure happens, delete new split tag
             delete_tag(new_split_tag)
             raise
 
-        merge_pr_branch_1(subtree_branch)
+        # potential conflicts
+        merge_branch("{}/master".format(ESMCI_REMOTE_NAME))
+
     else:
         old_split_tag, new_split_tag = get_split_tag(expected_num=2)
         logging.info("Resuming split with old tag {} and new tag {}".format(old_split_tag, new_split_tag))
-        pr_branch = "{}-pr".format(get_branch_from_tag(new_split_tag))
-
-    if not resume_two:
-        merge_pr_branch_2()
+        pr_branch = get_branch_from_tag(new_split_tag)
 
     try:
         run_cmd_no_fail("git push -u {} {}".format(ESMCI_REMOTE_NAME, pr_branch), verbose=True)
@@ -174,12 +162,13 @@ def acme_cime_merge(resume):
             delete_tag(new_merge_tag, remote=ESMCI_REMOTE_NAME)
             raise
 
+        # potential conflicts
         do_subtree_pull()
 
     else:
         old_merge_tag, new_merge_tag = get_merge_tag(expected_num=2)
         logging.info("Resuming merge with old tag {} and new tag {}".format(old_merge_tag, new_merge_tag))
-        pr_branch = "{}-pr".format(get_branch_from_tag(new_merge_tag))
+        pr_branch = get_branch_from_tag(new_merge_tag)
 
     try:
         run_cmd_no_fail("git push -u origin {}".format(pr_branch), verbose=True)

--- a/scripts/lib/acme_cime_mgmt.py
+++ b/scripts/lib/acme_cime_mgmt.py
@@ -47,7 +47,7 @@ def get_merge_tag(expected_num=1):
 ###############################################################################
 def make_new_tag(prefix, old_tag, remote="origin", commit="HEAD"):
 ###############################################################################
-    new_tag = "{}{}".format(prefix, get_timestamp(timestamp_format="%m-%d-%Y"))
+    new_tag = "{}{}".format(prefix, get_timestamp(timestamp_format="%Y-%m-%d"))
     expect(old_tag != new_tag, "New tag must have different name than old tag")
 
     run_cmd_no_fail("git tag {} {}".format(new_tag, commit), verbose=True)
@@ -144,6 +144,7 @@ def acme_cime_split(resume_one, resume_two):
         merge_pr_branch_1(subtree_branch)
     else:
         old_split_tag, new_split_tag = get_split_tag(expected_num=2)
+        logging.info("Resuming split with old tag {} and new tag {}".format(old_split_tag, new_split_tag))
         pr_branch = "{}-pr".format(get_branch_from_tag(new_split_tag))
 
     if not resume_two:
@@ -177,6 +178,7 @@ def acme_cime_merge(resume):
 
     else:
         old_merge_tag, new_merge_tag = get_merge_tag(expected_num=2)
+        logging.info("Resuming merge with old tag {} and new tag {}".format(old_merge_tag, new_merge_tag))
         pr_branch = "{}-pr".format(get_branch_from_tag(new_merge_tag))
 
     try:


### PR DESCRIPTION
Update acme cime management

1) Simplify split process, only one merge is needed
2) Add abort capability to both operations
3) Remove --ignore-joins from subtree split
4) Tag dates need to sort correctly
5) Add some additional logging info when resuming.
6) Make all commands that modify things verbose

Test suite: code_checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Yes, some minor changes to acme_cime_mgt tools

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
