### PR TITLE
Fix some misuses of MAX_(MPI)TASKS...

### DIFF
--- a/scripts/lib/CIME/SystemTests/pet.py
+++ b/scripts/lib/CIME/SystemTests/pet.py
@@ -46,6 +46,7 @@ class PET(SystemTestsCompareTwo):
         # to the batch submission, things break. Setting MAX_TASKS_PER_NODE to half of
         # it original value prevents this.
         self._case.set_value("MAX_TASKS_PER_NODE", int(self._case.get_value("MAX_TASKS_PER_NODE") / 2))
+        self._case.set_value("MAX_MPITASKS_PER_NODE", int(self._case.get_value("MAX_MPITASKS_PER_NODE") / 2))
 
         # Need to redo case_setup because we may have changed the number of threads
         case_setup(self._case, reset=True)

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -157,7 +157,7 @@ class TestScheduler(object):
 
         if parallel_jobs is None:
             self._parallel_jobs = min(len(test_names),
-                                      self._machobj.get_value("MAX_TASKS_PER_NODE"))
+                                      self._machobj.get_value("MAX_MPITASKS_PER_NODE"))
         else:
             self._parallel_jobs = parallel_jobs
 
@@ -203,7 +203,7 @@ class TestScheduler(object):
 
         # Oversubscribe by 1/4
         if proc_pool is None:
-            pes = int(self._machobj.get_value("MAX_MPITASKS_PER_NODE"))
+            pes = int(self._machobj.get_value("MAX_TASKS_PER_NODE"))
             self._proc_pool = int(pes * 1.25)
         else:
             self._proc_pool = int(proc_pool)


### PR DESCRIPTION
PET test needed to halve MAX_MPITASKS in addition to MAX_TASKS.

test_scheduler needed to use MAX_MPITASKS to set degree of task-level parallelism
and use MAX_TASKS to compute the proc/thread pool.

Test suite: code_checker, PET test by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2151 

User interface changes?: N

Update gh-pages html (Y/N)?:N

Code review: @jedwards4b 
