### PR TITLE
Fix create_test --help dump for CESM

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -172,7 +172,7 @@ OR
                             help="Use this testlist to lookup tests, default specified in config_files.xml")
 
         parser.add_argument("testargs", nargs="*",
-                            help="Tests or test suites to run."
+                            help="Tests to run."
                             " Testname form is TEST.GRID.COMPSET[.MACHINE_COMPILER]")
 
     else:


### PR DESCRIPTION
Test suites are not acceptible positional arguments for CESM.

Test suite: None
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2094 

User interface changes?: --help dump changes for create_test

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
