### PR TITLE
Add symlink to testmod used in cime_developer

### DIFF
--- a/config/acme/testmods_dirs/allactive/drv/y100k
+++ b/config/acme/testmods_dirs/allactive/drv/y100k
@@ -1,0 +1,1 @@
+../../../../../src/drivers/mct/cime_config/testdefs/testmods_dirs/drv/y100k


### PR DESCRIPTION
So that ACME machines can find it.

Test suite: FullSystemTest
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?:n

Code review: @jedwards4b 
