### PR TITLE
reducing warnings in fortran

### DIFF
--- a/src/components/xcpl_comps/xshare/dead_mod.F90
+++ b/src/components/xcpl_comps/xshare/dead_mod.F90
@@ -48,10 +48,9 @@ subroutine dead_setNewGrid(decomp_type,nxg,nyg,totpe,mype,lsize,gbuf,seg_len,npr
 !EOP
 
    !--- local ---
-   integer(IN)            :: ierr            ! error code
    logical                :: found
    integer(IN)            :: i,j,ig,jg
-   integer(IN)            :: n,ng,is,ie,js,je,nx,ny      ! indices
+   integer(IN)            :: n,is,ie,js,je,nx,ny      ! indices
    integer(IN)            :: npesx,npesy,mypex,mypey,nxp,nyp
    real   (R8)            :: hscore,bscore
    real   (R8)            :: dx,dy,deg2rad,ys,yc,yn,area,re

--- a/src/share/streams/shr_stream_mod.F90
+++ b/src/share/streams/shr_stream_mod.F90
@@ -257,7 +257,11 @@ contains
     !--- read data ---
     read(nUnit,'(a)',END=999) str
     call shr_string_leftalign_and_convert_tabs(str)
-    strm%dataSource = str(1:SHR_KIND_CS)
+    if(len_trim(str)<= len(strm%dataSource)) then
+       strm%dataSource = str(1:len(strm%dataSource))
+    else
+       call shr_sys_abort('dataSource too long for variable ' // errMsg(sourcefile, __LINE__))
+    endif
     if (debug>0 .and. s_loglev>0) write(s_logunit,F00) '  * format = ', trim(strm%dataSource)
 
     close(nUnit)
@@ -492,7 +496,11 @@ contains
           call shr_stream_abort(subName//"ERROR: no time variable name")
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domTvarName = subStr(1:SHR_KIND_CS)
+          if(len_trim(substr) <= len(strm%domTVarName)) then
+             strm%domTvarName = subStr(1:len(strm%domTVarName))
+          else
+             call shr_stream_abort(subName//"ERROR: string too long for variable name")
+          endif
        endif
        !--- get longitude variable name ---
        n = shr_string_listGetIndexF(fldListModel,"lon")
@@ -502,7 +510,11 @@ contains
           call shr_stream_abort(subName//"ERROR: no lon variable name")
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domXvarName = subStr(1:SHR_KIND_CS)
+          if(len_trim(substr) <= len(strm%domXVarName)) then
+             strm%domXvarName = subStr(1:len(strm%domXVarName))
+          else
+             call shr_stream_abort(subName//"ERROR: string too long for variable name")
+          endif
        endif
        !--- get latitude variable name ---
        n = shr_string_listGetIndexF(fldListModel,"lat")
@@ -512,7 +524,11 @@ contains
           call shr_stream_abort(subName//"ERROR: no lat variable name")
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domYvarName = subStr(1:SHR_KIND_CS)
+          if(len_trim(substr) <= len(strm%domYVarName)) then
+             strm%domYvarName = subStr(1:len(strm%domYVarName))
+          else
+             call shr_stream_abort(subName//"ERROR: string too long for variable name")
+          endif
        endif
        !--- get vertical variable name ---
        n = shr_string_listGetIndexF(fldListModel,"hgt")
@@ -523,7 +539,11 @@ contains
           strm%domZvarName = 'unknownname'
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domZvarName = subStr(1:SHR_KIND_CS)
+          if(len_trim(substr) <= len(strm%domZVarName)) then
+             strm%domZvarName = subStr(1:len(strm%domZVarName))
+          else
+             call shr_stream_abort(subName//"ERROR: string too long for variable name")
+          endif
        endif
        !--- get area variable name ---
        n = shr_string_listGetIndexF(fldListModel,"area")
@@ -534,7 +554,11 @@ contains
           strm%domAreaName = 'unknownname'
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domAreaName = subStr(1:SHR_KIND_CS)
+          if(len_trim(substr) <= len(strm%domAreaName)) then
+             strm%domAreaName = subStr(1:len(strm%domAreaName))
+          else
+             call shr_stream_abort(subName//"ERROR: string too long for variable name")
+          endif
        endif
        !--- get mask variable name ---
        n = shr_string_listGetIndexF(fldListModel,"mask")
@@ -545,7 +569,11 @@ contains
           strm%domMaskName = 'unknownname'
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domMaskName = subStr(1:SHR_KIND_CS)
+          if(len_trim(substr) <= len(strm%domMaskName)) then
+             strm%domMaskName = subStr(1:len(strm%domMaskName))
+          else
+             call shr_stream_abort(subName//"ERROR: string too long for variable name")
+          endif
        endif
     end if
 

--- a/src/share/streams/shr_stream_mod.F90
+++ b/src/share/streams/shr_stream_mod.F90
@@ -35,6 +35,7 @@ module shr_stream_mod
   use shr_log_mod, only : s_loglev   => shr_log_Level
   use shr_log_mod, only : s_logunit  => shr_log_Unit
   use shr_log_mod, only : OOBMsg => shr_log_OOBMsg
+  use shr_log_mod, only: errMsg => shr_log_errMsg
   use pio, only : file_desc_t
   use perf_mod
 
@@ -159,7 +160,9 @@ module shr_stream_mod
   integer(SHR_KIND_IN),parameter :: initarr_size = 3     ! size of initarr
   integer(SHR_KIND_IN),save :: debug = 0        ! edit/turn-on for debug write statements
   logical             ,save :: doabort = .true. ! flag if abort on error
-
+  character(len=*), parameter :: sourcefile = &
+       __FILE__
+!===============================================================================
   !===============================================================================
 contains
   !===============================================================================

--- a/src/share/streams/shr_stream_mod.F90
+++ b/src/share/streams/shr_stream_mod.F90
@@ -257,7 +257,7 @@ contains
     !--- read data ---
     read(nUnit,'(a)',END=999) str
     call shr_string_leftalign_and_convert_tabs(str)
-    strm%dataSource = str
+    strm%dataSource = str(1:SHR_KIND_CS)
     if (debug>0 .and. s_loglev>0) write(s_logunit,F00) '  * format = ', trim(strm%dataSource)
 
     close(nUnit)
@@ -492,7 +492,7 @@ contains
           call shr_stream_abort(subName//"ERROR: no time variable name")
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domTvarName = subStr
+          strm%domTvarName = subStr(1:SHR_KIND_CS)
        endif
        !--- get longitude variable name ---
        n = shr_string_listGetIndexF(fldListModel,"lon")
@@ -502,7 +502,7 @@ contains
           call shr_stream_abort(subName//"ERROR: no lon variable name")
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domXvarName = subStr
+          strm%domXvarName = subStr(1:SHR_KIND_CS)
        endif
        !--- get latitude variable name ---
        n = shr_string_listGetIndexF(fldListModel,"lat")
@@ -512,7 +512,7 @@ contains
           call shr_stream_abort(subName//"ERROR: no lat variable name")
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domYvarName = subStr
+          strm%domYvarName = subStr(1:SHR_KIND_CS)
        endif
        !--- get vertical variable name ---
        n = shr_string_listGetIndexF(fldListModel,"hgt")
@@ -523,7 +523,7 @@ contains
           strm%domZvarName = 'unknownname'
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domZvarName = subStr
+          strm%domZvarName = subStr(1:SHR_KIND_CS)
        endif
        !--- get area variable name ---
        n = shr_string_listGetIndexF(fldListModel,"area")
@@ -534,7 +534,7 @@ contains
           strm%domAreaName = 'unknownname'
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domAreaName = subStr
+          strm%domAreaName = subStr(1:SHR_KIND_CS)
        endif
        !--- get mask variable name ---
        n = shr_string_listGetIndexF(fldListModel,"mask")
@@ -545,7 +545,7 @@ contains
           strm%domMaskName = 'unknownname'
        else
           call shr_string_listGetName (fldListFile,n,substr,rc)
-          strm%domMaskName = subStr
+          strm%domMaskName = subStr(1:SHR_KIND_CS)
        endif
     end if
 
@@ -800,7 +800,6 @@ contains
     !EOP
 
     !----- local -----
-    integer(SHR_KIND_IN) :: n
 
     !----- formats -----
     character(*),parameter :: subName = '(shr_stream_default) '
@@ -997,8 +996,6 @@ contains
     !EOP
 
     !----- local -----
-    character(SHR_KIND_CL) :: fileName      ! string
-    integer  (SHR_KIND_IN) :: nt            ! size of a time-coord dimension
     integer  (SHR_KIND_IN) :: dDateIn       ! model date mapped onto a data date
     integer  (SHR_KIND_IN) :: dDateF        ! first date
     integer  (SHR_KIND_IN) :: dDateL        ! last date
@@ -2602,7 +2599,6 @@ contains
     character(SHR_KIND_CS) :: str         ! generic text string
     integer(SHR_KIND_IN)   :: nUnit       ! a file unit number
     integer(SHR_KIND_IN)   :: inpi        ! input integer
-    real(SHR_KIND_R8)      :: inpr        ! input real
     character(SHR_KIND_CXX):: inpcx       ! input char
     character(SHR_KIND_CL) :: inpcl       ! input char
     character(SHR_KIND_CS) :: inpcs       ! input char

--- a/src/share/util/mct_mod.F90
+++ b/src/share/util/mct_mod.F90
@@ -1,9 +1,3 @@
-!===============================================================================
-! SVN $Id: mct_mod.F90 65614 2014-11-20 00:39:07Z santos@ucar.edu $
-! SVN $URL: https://svn-ccsm-models.cgd.ucar.edu/csm_share/trunk_tags/share3_150116/shr/mct_mod.F90 $
-!===============================================================================
-!BOP ===========================================================================
-!
 ! !MODULE: mct_mod -- provides a standard API naming convention for MCT code
 !
 ! !DESCRIPTION:
@@ -237,7 +231,7 @@ subroutine mct_aVect_info(flag,aVect,comm,pe,fld,istr)
 !EOP
 
    !--- local ---
-   integer(IN)          :: i,j,k,n      ! generic indicies
+   integer(IN)          :: k            ! generic indicies
    integer(IN)          :: ks,ke        ! start and stop k indices
    integer(IN)          :: nflds        ! number of flds in AV to diagnose
    integer(IN)          :: nsize        ! grid point size of AV
@@ -538,7 +532,6 @@ subroutine mct_aVect_getRAttr(aVect,str,data,rcode)
 
    !--- local ---
    integer(IN) :: k,n,m
-   integer(IN) :: aVsize
 
    !--- formats ---
    character(*),parameter :: subName = "(mct_aVect_getRAttr) "
@@ -605,7 +598,6 @@ subroutine mct_aVect_putRAttr(aVect,str,data,rcode)
 
    !--- local ---
    integer(IN) :: k,n,m
-   integer(IN) :: aVsize
 
    !--- formats ---
    character(*),parameter :: subName = "(mct_aVect_putRAttr) "
@@ -890,9 +882,7 @@ subroutine mct_avect_mult(av,av1,fld1,avlist)
    integer(IN) :: n,m            ! generic indicies
    integer(IN) :: npts           ! number of points (local) in an aVect field
    integer(IN) :: nfld           ! number of fields (local) in an aVect field
-   integer(IN) :: nfldi          ! number of fields (local) in an aVect field
    integer(IN) :: nptsx          ! number of points (local) in an aVect field
-   integer(IN) :: nptsi          ! number of points (local) in an aVect field
    integer(IN) :: kfld           ! field number of fld1 in av1
    integer(IN),dimension(:),allocatable :: kfldin   ! field numbers of avlist in av
    type(mct_list)   :: blist     ! avlist as a List
@@ -1001,9 +991,7 @@ subroutine mct_avect_vecmult(av,vec,avlist,mask_spval)
    integer(IN) :: n,m            ! generic indicies
    integer(IN) :: npts           ! number of points (local) in an aVect field
    integer(IN) :: nfld           ! number of fields (local) in an aVect field
-   integer(IN) :: nfldi          ! number of fields (local) in an aVect field
    integer(IN) :: nptsx          ! number of points (local) in an aVect field
-   integer(IN) :: nptsi          ! number of points (local) in an aVect field
    logical     :: lmspval        ! local mask spval
    integer(IN),dimension(:),allocatable :: kfldin   ! field numbers of avlist in av
    type(mct_list)   :: blist     ! avlist as a List

--- a/src/share/util/shr_cal_mod.F90
+++ b/src/share/util/shr_cal_mod.F90
@@ -435,7 +435,6 @@ contains
 
     !EOP
 
-    integer :: rc
     integer :: k
     character(*),parameter :: subName = "(shr_cal_elapsDaysStrtMonth)"
 
@@ -768,7 +767,7 @@ contains
     !-------------------------------------------------------------------------------
     ! NOTE:
     !-------------------------------------------------------------------------------
-
+    dSec = 0.0_SHR_KIND_R8
     !--- calculate delta-time in seconds ---
     if     (trim(units) == 'days'   ) then
        dSec = delta * SHR_CONST_CDAY
@@ -855,7 +854,7 @@ contains
     !-------------------------------------------------------------------------------
     ! NOTE:
     !-------------------------------------------------------------------------------
-
+    dSec = 0.0_SHR_KIND_R8
     !--- calculate delta-time in seconds ---
     if     (trim(units) == 'days'   ) then
        dSec = delta * SHR_CONST_CDAY

--- a/src/share/util/shr_file_mod.F90
+++ b/src/share/util/shr_file_mod.F90
@@ -379,7 +379,7 @@ CONTAINS
     !-------------------------------------------------------------------------------
     ! Notes:
     !-------------------------------------------------------------------------------
-
+    shr_file_getUnit = -1
     if (present (unit)) then
        inquire( unit, opened=opened )
        if (unit < 0 .or. unit > shr_file_maxUnit) then

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -358,6 +358,9 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
            tstar = rh * delt
            qstar = re * delq
         enddo
+        if (iter < 1) then
+           call shr_sys_abort('No iterations performed ' //  // errMsg(sourcefile, __LINE__))
+        end if
         !------------------------------------------------------------
         ! compute the fluxes
         !------------------------------------------------------------
@@ -846,7 +849,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             Hb = (Qdel/rcpocn)+(Fd*betaS/alphaT)
             Hb = min(Hb , 0.0_R8)
             lambdaV = lambdaC*(1.0_R8 + ( (0.0_R8-Hb)*16.0_R8*molvisc(tBulk(n))* &
-                 shr_const_g*alphaT*molPr(tBulk(n))**2/ustarw**4)**0.75)**(-1.0_R8/3.0_R8)
+                 shr_const_g*alphaT*molPr(tBulk(n))**2/ustarw**4)**0.75_R8)**(-1.0_R8/3.0_R8)
             cSkin(n) =  MIN(0.0_R8, lambdaV * molPr(tBulk(n)) * Qdel / ustarw / rcpocn )
 
             !--- REGIME ---
@@ -942,7 +945,9 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             qstar = re * delq
 
          ENDDO   ! end iteration loop
-
+         if (iter < 1) then
+            call shr_sys_abort('No iterations performed ' //  // errMsg(sourcefile, __LINE__))
+         end if
          !--- COMPUTE FLUXES TO ATMOSPHERE AND OCEAN ---
          tau = rbot(n) * ustar * ustar
 

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -278,7 +278,10 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
    else
       spval = shr_const_spval
    endif
-
+   u10n = spval
+   rh = spval
+   psixh = spval
+   hol=spval
    al2 = log(zref/ztref)
 
    DO n=1,nMax
@@ -581,7 +584,6 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    integer(IN) :: lsecs   ! local seconds elapsed
    integer(IN) :: lonsecs ! incrememnt due to lon offset
    real(R8)    :: vmag    ! surface wind magnitude   (m/s)
-   real(R8)    :: thvbot  ! virtual temperature      (K)
    real(R8)    :: ssq     ! sea surface humidity     (kg/kg)
    real(R8)    :: delt    ! potential T difference   (K)
    real(R8)    :: delq    ! humidity difference      (kg/kg)
@@ -638,7 +640,6 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8)    :: rhocn   !
    real(R8)    :: rcpocn  !
    real(R8)    :: Nreset  ! value for multiplicative reset factor
-   real(R8)    :: resec   ! reset offset value in seconds
    logical     :: lmidnight
    logical     :: ltwopm
    logical     :: ltwoam
@@ -698,9 +699,11 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
       write(s_logunit,F00) "ERROR: flux_diurnal must be true"
       call shr_sys_abort(subName//"flux diurnal must be true")
    endif
-
    spval = shr_const_spval
-
+   rh = spval
+   dviter = spval
+   dtiter = spval
+   dsiter = spval
    al2 = log(zref/ztref)
 
    ! equations 18 and 19
@@ -843,7 +846,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             Hb = (Qdel/rcpocn)+(Fd*betaS/alphaT)
             Hb = min(Hb , 0.0_R8)
             lambdaV = lambdaC*(1.0_R8 + ( (0.0_R8-Hb)*16.0_R8*molvisc(tBulk(n))* &
-                 shr_const_g*alphaT*molPr(tBulk(n))**2/ustarw**4)**0.75)**(-1/3)
+                 shr_const_g*alphaT*molPr(tBulk(n))**2/ustarw**4)**0.75)**(-1.0_R8/3.0_R8)
             cSkin(n) =  MIN(0.0_R8, lambdaV * molPr(tBulk(n)) * Qdel / ustarw / rcpocn )
 
             !--- REGIME ---
@@ -880,7 +883,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                      Kvisc = Prandtl* kappa0 + NUzero * FofRi
                   else
                      regime(n) = 4.0_R8
-                     Kdiff = shr_const_karman*ustarw*shr_const_zsrflyr *(1.0_R8-7.0_R8*doL)**(1/3)
+                     Kdiff = shr_const_karman*ustarw*shr_const_zsrflyr *(1.0_R8-7.0_R8*doL)**(1.0_R8/3.0_R8)
                      Kvisc = Kdiff
                   endif
                endif

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -24,6 +24,7 @@ module shr_flux_mod
    use shr_sys_mod     ! shared system routines
    use shr_log_mod, only: s_loglev  => shr_log_Level
    use shr_log_mod, only: s_logunit => shr_log_Unit
+   use shr_log_mod, only: errMsg => shr_log_errMsg
 
    implicit none
 
@@ -73,7 +74,8 @@ module shr_flux_mod
 ! These control convergence of the iterative flux calculation
    real(r8) :: flux_con_tol = 0.0_R8
    integer(IN) :: flux_con_max_iter = 2
-
+   character(len=*), parameter :: sourcefile = &
+     __FILE__
 !===============================================================================
 contains
 !===============================================================================
@@ -359,7 +361,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,  prec_gust, gust_
            qstar = re * delq
         enddo
         if (iter < 1) then
-           call shr_sys_abort('No iterations performed ' //  // errMsg(sourcefile, __LINE__))
+           call shr_sys_abort('No iterations performed ' // errMsg(sourcefile, __LINE__))
         end if
         !------------------------------------------------------------
         ! compute the fluxes
@@ -946,7 +948,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
 
          ENDDO   ! end iteration loop
          if (iter < 1) then
-            call shr_sys_abort('No iterations performed ' //  // errMsg(sourcefile, __LINE__))
+            call shr_sys_abort('No iterations performed ' // errMsg(sourcefile, __LINE__))
          end if
          !--- COMPUTE FLUXES TO ATMOSPHERE AND OCEAN ---
          tau = rbot(n) * ustar * ustar

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -849,7 +849,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             Hb = (Qdel/rcpocn)+(Fd*betaS/alphaT)
             Hb = min(Hb , 0.0_R8)
             lambdaV = lambdaC*(1.0_R8 + ( (0.0_R8-Hb)*16.0_R8*molvisc(tBulk(n))* &
-                 shr_const_g*alphaT*molPr(tBulk(n))**2/ustarw**4)**0.75_R8)**(-1.0_R8/3.0_R8)
+                 shr_const_g*alphaT*molPr(tBulk(n))**2/ustarw**4)**0.75_R8)**(-1/3)
             cSkin(n) =  MIN(0.0_R8, lambdaV * molPr(tBulk(n)) * Qdel / ustarw / rcpocn )
 
             !--- REGIME ---
@@ -886,7 +886,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                      Kvisc = Prandtl* kappa0 + NUzero * FofRi
                   else
                      regime(n) = 4.0_R8
-                     Kdiff = shr_const_karman*ustarw*shr_const_zsrflyr *(1.0_R8-7.0_R8*doL)**(1.0_R8/3.0_R8)
+                     Kdiff = shr_const_karman*ustarw*shr_const_zsrflyr *(1.0_R8-7.0_R8*doL)**(1/3)
                      Kvisc = Kdiff
                   endif
                endif

--- a/src/share/util/shr_frz_mod.F90.in
+++ b/src/share/util/shr_frz_mod.F90.in
@@ -89,7 +89,7 @@ contains
 #endif
 
     !----------------------------------------------------------------------------
-
+    shr_frz_freezetemp = -274.0_R8
     if (tfrz_option == TFREEZE_OPTION_MINUS1P8) then
        shr_frz_freezetemp = -1.8_R8
     elseif (tfrz_option == TFREEZE_OPTION_LINEAR_SALT) then

--- a/src/share/util/shr_map_mod.F90
+++ b/src/share/util/shr_map_mod.F90
@@ -1042,8 +1042,8 @@ contains
 
     !--- local ---
     integer(SHR_KIND_IN)   :: nis,njs,nid,njd
-    integer(SHR_KIND_IN)   :: nwts,n,n1,n2,ncnt,i,j,inn,jnn
-    integer(SHR_KIND_IN)   :: irc,lrc
+    integer(SHR_KIND_IN)   :: nwts,n,n1,ncnt,i,j,inn,jnn
+    integer(SHR_KIND_IN)   :: lrc
     real(SHR_KIND_R8) :: rmin,rmax                     ! min/max value
     real(SHR_KIND_R8) :: cang                          ! circle angle, deg or rad
     real(SHR_KIND_R8),allocatable    :: Xdst(:,:)      ! lon of dst grid, wrapped as needed
@@ -1524,8 +1524,8 @@ contains
 
     !--- local ---
     integer(SHR_KIND_IN)   :: nis,njs,nid,njd
-    integer(SHR_KIND_IN)   :: nwts,n,n1,n2,ncnt,i,j,inn,jnn
-    integer(SHR_KIND_IN)   :: irc,lrc
+    integer(SHR_KIND_IN)   :: nwts,n,n1,ncnt,i,j,inn,jnn
+    integer(SHR_KIND_IN)   :: lrc
     real(SHR_KIND_R8) :: rmin,rmax                     ! min/max value
     real(SHR_KIND_R8) :: cang                          ! circle angle, deg or rad
     real(SHR_KIND_R8),allocatable    :: Xdst(:)        ! lon of dst grid, wrapped as needed
@@ -1967,7 +1967,7 @@ contains
     integer(SHR_KIND_IN) :: nfi,nfo         ! number of fields in array, in/out
     integer(SHR_KIND_IN) :: nsi,nso         ! size of grid in array, in/out
     real(SHR_KIND_R8)    :: theta           ! angle difference
-    integer(SHR_KIND_IN),save      :: t0=-1,t1,t2,t3,t4,t5 ! timers
+    integer(SHR_KIND_IN),save      :: t0=-1,t1,t2,t4,t5 ! timers
     integer(SHR_KIND_IN),parameter :: timing=0        ! turn timers off/on (0/1)
     logical,pointer      :: initnew(:)      ! mask for initialization
 
@@ -2885,7 +2885,6 @@ contains
 
     !--- local ---
     integer(SHR_KIND_IN) :: isize,jsize   ! array sizes
-    integer(SHR_KIND_IN) :: i,j           ! indices
     integer(SHR_KIND_IN) :: n             ! do loop counter
     integer(SHR_KIND_IN) :: il,ir         ! index of i left/mid/right
     integer(SHR_KIND_IN) :: jl,ju         ! index of j lower/mid/upper
@@ -2895,7 +2894,6 @@ contains
     real(SHR_KIND_R8)    :: xd,yd         ! value of Xdst,Ydst
     real(SHR_KIND_R8)    :: dx,dy,dx1,dy1 ! some d_lengths for weights calc
     real(SHR_KIND_R8)    :: csize         ! circle angle/radians
-    real(SHR_KIND_R8)    :: rmin,rmax     ! min/max
     real(SHR_KIND_R8)    :: cpole         ! the r8 lat value of the pole
     integer(SHR_KIND_IN) :: pole          ! 0=no, 1=north, 2=south
 
@@ -2910,18 +2908,15 @@ contains
     !-------------------------------------------------------------------------------
 
     pmax = size(pti,1)
-
+    csize = 360._SHR_KIND_R8
     !--- is lat/lon degrees or radians?  needed for X wraparound ---
     if (present(units)) then
-       if (index(units,'degrees').ne.0) then
-          csize = 360._SHR_KIND_R8
-       elseif (trim(units) == 'radians') then
+       if (trim(units) == 'radians') then
           csize = c2*pi
-       else
+       elseif (index(units,'degrees').eq.0) then
           call shr_sys_abort(subName//' ERROR in optional units = '//trim(units))
        endif
     else
-       csize = 360._SHR_KIND_R8
        if (shr_map_checkRad(Ysrc)) csize = c2*pi
     endif
 

--- a/src/share/util/shr_mem_mod.F90
+++ b/src/share/util/shr_mem_mod.F90
@@ -31,8 +31,6 @@ CONTAINS
 
     ! --- Memory stats ---
     integer :: msize                   ! memory size (high water)
-    integer :: mrss                    ! resident size (current memory use)
-    integer :: msize0,msize1           ! temporary size
     integer :: mrss0,mrss1,mrss2       ! temporary rss
     integer :: mshare,mtext,mdatastack
     logical :: lprt

--- a/src/share/util/shr_ncread_mod.F90
+++ b/src/share/util/shr_ncread_mod.F90
@@ -1582,7 +1582,6 @@ contains
     !EOP
 
     !----- local -----
-    integer(SHR_KIND_IN)   :: n
     logical                :: exists
 
     !----- formats -----

--- a/src/share/util/shr_orb_mod.F90
+++ b/src/share/util/shr_orb_mod.F90
@@ -433,7 +433,7 @@ CONTAINS
     real   (SHR_KIND_R8) :: obsum   ! Obliquity series summation
     real   (SHR_KIND_R8) :: cossum  ! Cos series summation for eccentricity/fvelp
     real   (SHR_KIND_R8) :: sinsum  ! Sin series summation for eccentricity/fvelp
-    real   (SHR_KIND_R8) :: fvelp = 0.0_SHR_KIND_R8   ! Fixed vernal equinox long of perihelion
+    real   (SHR_KIND_R8) :: fvelp   ! Fixed vernal equinox long of perihelion
     real   (SHR_KIND_R8) :: mvsum   ! mvelp series summation
     real   (SHR_KIND_R8) :: beta    ! Intermediate argument for lambm0
     real   (SHR_KIND_R8) :: years   ! Years to time of interest ( pos <=> future)
@@ -565,7 +565,6 @@ CONTAINS
        eccen3 = eccen2*eccen
 
        ! A series of cases for fvelp, which is in radians.
-
        if (abs(cossum) .le. 1.0E-8_SHR_KIND_R8) then
           if (sinsum .eq. 0.0_SHR_KIND_R8) then
              fvelp = 0.0_SHR_KIND_R8
@@ -576,7 +575,7 @@ CONTAINS
           endif
        else if (cossum .lt. 0.0_SHR_KIND_R8) then
           fvelp = atan(sinsum/cossum) + pi
-       else if (cossum .gt. 0.0_SHR_KIND_R8) then
+       else ! cossum > 1.0e-8
           if (sinsum .lt. 0.0_SHR_KIND_R8) then
              fvelp = atan(sinsum/cossum) + 2.0_SHR_KIND_R8*pi
           else

--- a/src/share/util/shr_orb_mod.F90
+++ b/src/share/util/shr_orb_mod.F90
@@ -433,7 +433,7 @@ CONTAINS
     real   (SHR_KIND_R8) :: obsum   ! Obliquity series summation
     real   (SHR_KIND_R8) :: cossum  ! Cos series summation for eccentricity/fvelp
     real   (SHR_KIND_R8) :: sinsum  ! Sin series summation for eccentricity/fvelp
-    real   (SHR_KIND_R8) :: fvelp   ! Fixed vernal equinox long of perihelion
+    real   (SHR_KIND_R8) :: fvelp = 0.0_SHR_KIND_R8   ! Fixed vernal equinox long of perihelion
     real   (SHR_KIND_R8) :: mvsum   ! mvelp series summation
     real   (SHR_KIND_R8) :: beta    ! Intermediate argument for lambm0
     real   (SHR_KIND_R8) :: years   ! Years to time of interest ( pos <=> future)

--- a/src/share/util/shr_pcdf_mod.F90
+++ b/src/share/util/shr_pcdf_mod.F90
@@ -157,7 +157,6 @@ subroutine shr_pcdf_readwrite(type,iosystem,pio_iotype,filename,&
 
 
   type(file_desc_t)     :: fid
-  type(var_desc_t)      :: varid
   type(io_desc_t)       :: iodescd
   type(io_desc_t)       :: iodesci
   integer(IN), pointer  :: ldof(:)
@@ -602,24 +601,13 @@ subroutine shr_pcdf_readr1d(fid,fname,iodesc,r1d)
 
   !--- local ---
   type(var_desc_t) :: varid
-  integer(IN)      :: dimid(4),ndims
-  integer(IN)      :: vsize,fsize
+  integer(IN)      :: ndims
   integer(IN)      :: rcode
   character(len=*),parameter :: subname = '(shr_pcdf_readr1d) '
 
   !-------------
 
   rcode = pio_inq_varid(fid,trim(fname),varid)
-
-!--tcraig, here vsize is global, fsize is local, what check if any?
-!  rcode = pio_inq_varndims(fid, varid, ndims)
-!  rcode = pio_inq_vardimid(fid, varid, dimid(1:ndims))
-!  rcode = pio_inq_dimlen(fid, dimid(1), vsize)
-!  fsize = size(r1d)
-!  if (vsize /= fsize) then
-!     write(shr_log_unit,*) subname,' ERROR: vsize,fsize = ',vsize,fsize
-!     call shr_sys_abort(trim(subname)//' ERROR: vsize,fsize')
-!  endif
 
   call pio_read_darray(fid,varid,iodesc,r1d,rcode)
 
@@ -637,8 +625,6 @@ subroutine shr_pcdf_writer1d(fid,fname,iodesc,r1d)
 
   !--- local ---
   type(var_desc_t) :: varid
-  integer(IN)      :: dimid(4)
-  integer(IN)      :: vsize,fsize
   real(R8)         :: lfillvalue
   integer(IN)      :: rcode
   character(len=*),parameter :: subname = '(shr_pcdf_writer1d) '
@@ -665,24 +651,14 @@ subroutine shr_pcdf_readi1d(fid,fname,iodesc,i1d)
 
   !--- local ---
   type(var_desc_t) :: varid
-  integer(IN)      :: dimid(4),ndims
-  integer(IN)      :: vsize,fsize
+  integer(IN)      :: ndims
+  integer(IN)      :: vsize
   integer(IN)      :: rcode
   character(len=*),parameter :: subname = '(shr_pcdf_readi1d) '
 
   !-------------
 
   rcode = pio_inq_varid(fid,trim(fname),varid)
-
-!--tcraig, here vsize is global, fsize is local, what check if any?
-!  rcode = pio_inq_varndims(fid, varid, ndims)
-!  rcode = pio_inq_vardimid(fid, varid, dimid(1:ndims))
-!  rcode = pio_inq_dimlen(fid, dimid(1), vsize)
-!  fsize = size(i1d)
-!  if (vsize /= fsize) then
-!     write(shr_log_unit,*) subname,' ERROR: vsize,fsize = ',vsize,fsize
-!     call shr_sys_abort(trim(subname)//' ERROR: vsize,fsize')
-!  endif
 
   call pio_read_darray(fid,varid,iodesc,i1d,rcode)
 
@@ -700,8 +676,6 @@ subroutine shr_pcdf_writei1d(fid,fname,iodesc,i1d)
 
   !--- local ---
   type(var_desc_t) :: varid
-  integer(IN)      :: dimid(4)
-  integer(IN)      :: vsize,fsize
   integer(IN)      :: lfillvalue
   integer(IN)      :: rcode
   character(len=*),parameter :: subname = '(shr_pcdf_writei1d) '

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -155,9 +155,7 @@ contains
     character(len=*), intent(in) :: comp_name(:)
     integer, intent(in) ::  comp_comm(:), comp_comm_iam(:)
     integer :: i
-    integer :: ncomps
     character(len=shr_kind_cl) :: nlfilename, cname
-    type(iosystem_desc_t) :: iosys
     integer :: ret
     character(*), parameter :: subName = '(shr_pio_init2) '
 
@@ -208,7 +206,7 @@ contains
        do i=1,total_comps
           if(comp_iamin(i)) then
              cname = comp_name(i)
-	     if(len_trim(cname) <= 3) then
+             if(len_trim(cname) <= 3) then
                 nlfilename=trim(shr_string_toLower(cname))//'_modelio.nml'
              else
                 nlfilename=trim(shr_string_toLower(cname(1:3)))//'_modelio.nml_'//cname(4:8)
@@ -259,9 +257,7 @@ contains
   subroutine shr_pio_finalize(  )
     integer :: ierr
     integer :: i
-    logical :: active
     do i=1,total_comps
-!       print *,__FILE__,__LINE__,drank,i,iosystems(i)%iosysid
        call pio_finalize(iosystems(i), ierr)
     end do
 

--- a/src/share/util/shr_reprosum_mod.F90
+++ b/src/share/util/shr_reprosum_mod.F90
@@ -1263,6 +1263,7 @@ module shr_reprosum_mod
       exceeds_limit = 0
       max_rel_diff = 0.0_r8
       max_abs_diff = 0.0_r8
+      max_rel_diff_idx = 0
       do ifld=1,nflds
          if (rel_diff(1,ifld) > shr_reprosum_reldiffmax) then
             exceeds_limit = exceeds_limit + 1

--- a/src/share/util/shr_string_mod.F90
+++ b/src/share/util/shr_string_mod.F90
@@ -435,8 +435,6 @@ contains
     !EOP
 
     !----- local ----
-    integer(SHR_KIND_IN) :: index_first_non_blank
-    integer(SHR_KIND_IN) :: rCode ! return code
     integer(SHR_KIND_IN) :: t01 = 0 ! timer
     character, parameter :: tab_char = char(9)
 
@@ -488,8 +486,7 @@ contains
     !EOP
 
     !----- local ----
-    integer(SHR_KIND_IN) :: rCode              ! return code
-    integer(SHR_KIND_IN) :: index, inlength, i ! temporaries
+    integer(SHR_KIND_IN) :: inlength, i ! temporaries
 
     !----- formats -----
     character(*),parameter :: subName =   "(shr_string_remove_tabs) "
@@ -537,7 +534,6 @@ contains
     !EOP
 
     !----- local ----
-    integer(SHR_KIND_IN) :: rCode  ! return code
     integer(SHR_KIND_IN) :: n,icnt ! counters
     integer(SHR_KIND_IN) :: t01 = 0 ! timer
 
@@ -840,7 +836,6 @@ contains
     !EOP
 
     !----- local -----
-    integer(SHR_KIND_IN)   :: n       ! counter
     integer(SHR_KIND_IN)   :: rCode   ! return code
     integer(SHR_KIND_IN) :: t01 = 0 ! timer
 
@@ -959,7 +954,7 @@ contains
     !EOP
 
     !----- local -----
-    integer(SHR_KIND_IN)   :: i,j,n   ! generic indecies
+    integer(SHR_KIND_IN)   :: i,n,j   ! generic indecies
     integer(SHR_KIND_IN)   :: kFlds   ! number of fields in list
     integer(SHR_KIND_IN)   :: i0,i1   ! name = list(i0:i1)
     integer(SHR_KIND_IN)   :: rCode   ! return code

--- a/src/share/util/shr_sys_mod.F90
+++ b/src/share/util/shr_sys_mod.F90
@@ -160,10 +160,11 @@ SUBROUTINE shr_sys_getenv(name, val, rcode)
    integer(SHR_KIND_IN),intent(out) :: rcode   ! return code
 
    !----- local -----
+#ifndef HAVE_GET_ENVIRONMENT
    integer(SHR_KIND_IN)             :: lenname ! length of env var name
    integer(SHR_KIND_IN)             :: lenval  ! length of env var value
    character(SHR_KIND_CL)           :: tmpval  ! temporary env var value
-
+#endif
    !----- formats -----
    character(*),parameter :: subName =   '(shr_sys_getenv) '
    character(*),parameter :: F00     = "('(shr_sys_getenv) ',4a)"
@@ -248,9 +249,10 @@ SUBROUTINE shr_sys_sleep(sec)
 
    !----- local -----
    integer(SHR_KIND_IN) :: isec   ! integer number of seconds
+#ifndef HAVE_SLEEP
    integer(SHR_KIND_IN) :: rcode  ! return code
    character(90)        :: str    ! system call string
-
+#endif
    !----- formats -----
    character(*),parameter :: subName =   '(shr_sys_sleep) '
    character(*),parameter :: F00     = "('(shr_sys_sleep) ',4a)"
@@ -288,8 +290,6 @@ SUBROUTINE shr_sys_flush(unit)
    integer(SHR_KIND_IN) :: unit  ! flush output buffer for this unit
 
    !----- local -----
-   integer(SHR_KIND_IN) :: ierr  ! error code
-
    !----- formats -----
    character(*),parameter :: subName =   '(shr_sys_flush) '
    character(*),parameter :: F00     = "('(shr_sys_flush) ',4a)"

--- a/src/share/util/shr_timer_mod.F90
+++ b/src/share/util/shr_timer_mod.F90
@@ -153,7 +153,6 @@ contains
     integer(SHR_KIND_IN), intent(in) :: n  ! timer number
 
     !----- local -----
-    real (SHR_KIND_R8) :: elapse      ! elapsed time returned by system counter
 
     !----- i/o formats -----
     character(len=*),parameter :: F00 = "('(shr_timer_stop) ',a,i5)"

--- a/src/share/util/water_isotopes.F90
+++ b/src/share/util/water_isotopes.F90
@@ -1,4 +1,3 @@
-
 module water_isotopes
 !-----------------------------------------------------------------------
 !
@@ -9,7 +8,7 @@ module water_isotopes
 !
 ! This code works over species indices, rather than the constituent indices
 ! used in the water_tracers module. As such, MAKE SURE you call these
-! routines with species indicies! The tracer variable names do not need to 
+! routines with species indicies! The tracer variable names do not need to
 ! match the species names, which are privided just for diagnostic output.
 !
 ! * This module MUST be includable by CAM and CLM * (be careful with uses)
@@ -33,7 +32,7 @@ module water_isotopes
                            SHR_CONST_VSMOW_16O, &
                            SHR_CONST_VSMOW_18O, &
                            SHR_CONST_VSMOW_D , &
-                           SHR_CONST_VSMOW_H 
+                           SHR_CONST_VSMOW_H
 
   implicit none
 
@@ -60,13 +59,13 @@ module water_isotopes
 
   public :: wiso_get_roce        ! retrive ocean isotope ratio.
   public :: wiso_flxoce          ! calculate isotopic ocean evaporation.
-  public :: wiso_ssatf           ! supersaturation function        
+  public :: wiso_ssatf           ! supersaturation function
   public :: wiso_heff            ! effective humidity function
 
   !Data checking routines:
 
   public :: wiso_get_rstd        !retrive standard isotope ratio
-  public :: wiso_get_fisub       !retrive isotope subsitutions 
+  public :: wiso_get_fisub       !retrive isotope subsitutions
                                  !aka number of iso. atoms per molec.
   public :: wiso_ratio           !calculate mass ratio of isotope .
   public :: wiso_delta           !calculate the delta value for isotopes.
@@ -85,10 +84,10 @@ module water_isotopes
 
 ! Module parameters
   integer , parameter, public :: pwtspec = 4    ! number of water species (h2o,hdo,h218o,h216o)
-  
+
 ! Tunable prameters for fractionation scheme
   real(r8), parameter :: dkfac    = 0.58_r8           ! diffusive evap. kinetic power law
-!  real(r8), parameter :: tkini    = SHR_CONST_TKTRIP  ! min temp. for kinetic effects as ice appears 
+!  real(r8), parameter :: tkini    = SHR_CONST_TKTRIP  ! min temp. for kinetic effects as ice appears
 !  real(r8), parameter :: tkini    = 258.15_r8         !From Bony et. al., 2008
   real(r8), parameter :: tkini    = 253.15_r8         !From Jouzel and Merlivat, 1984
 
@@ -101,7 +100,7 @@ module water_isotopes
 !bTdegC (Hoffman)
   real(r8), parameter :: ssatmx   = 2.00_r8           ! maximum supersaturation
   real(r8), parameter :: fkhum    = 0.25_r8           ! effective humidity factor
-  real(r8), parameter :: tzero    = SHR_CONST_TKTRIP  ! supercooled water in stratiform  
+  real(r8), parameter :: tzero    = SHR_CONST_TKTRIP  ! supercooled water in stratiform
 
   character(len=8), dimension(pwtspec), parameter, public :: & ! species names
       spnam  = (/ 'H2O     ', 'H216O   ', 'HD16O   ', 'H218O   ' /)
@@ -115,12 +114,6 @@ module water_isotopes
   real(r8), dimension(pwtspec), parameter :: &  ! isotopic subs.
       fisub = (/ 1._r8, 1._r8, 2._r8, 1._r8 /)
 
-  real(r8), dimension(pwtspec), parameter :: &  ! molecular weights
-      mwisp = (/ 18._r8, 18._r8, 19._r8, 20._r8 /)
-
-  real(r8), dimension(pwtspec), parameter :: &  ! mol. weight ratio
-      epsmw = (/ 1._r8, 1._r8, 19._r8/18._r8, 20._r8/18._r8 /)
-
   ! TBD: Ideally this should be controlled by something like a namelist parameter,
   ! but it needs to be something that can be made consistent between models.
   real(r8), dimension(pwtspec), parameter :: &  ! diffusivity ratio (note D/H, not HDO/H2O)
@@ -129,11 +122,7 @@ module water_isotopes
 !      difrm = (/ 1._r8, 1._r8, 0.9836504_r8, 0.9686999_r8 /)   ! this with expk
 !      difrm = (/ 1._r8, 1._r8, 0.9755_r8, 0.9723_r8 /)         ! Merlivat 1978 (tuned for isoCAM3)
        difrm = (/ 1._r8, 1._r8, 0.9757_r8, 0.9727_r8 /)         ! Merlivat 1978 (direct from paper)
-!      difrm = (/ 1._r8, 1._r8, 0.9839_r8, 0.9691_r8 /)         ! Cappa etal 2003 
-
-! Isotopic ratios in natural abundance (SMOW)
-  real(r8), dimension(pwtspec), parameter :: &  ! SMOW isotope ratios
-      rnat  = (/ 1._r8, 0.9976_r8, 155.76e-6_r8, 2005.20e-6_r8 /)
+!      difrm = (/ 1._r8, 1._r8, 0.9839_r8, 0.9691_r8 /)         ! Cappa etal 2003
 
 ! Prescribed isotopic ratios (largely arbitrary and tunable)
   real(r8), dimension(pwtspec), parameter :: &  ! model standard isotope ratio
@@ -145,7 +134,7 @@ module water_isotopes
 !     rstd  = (/ SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV, SHR_CONST_RSTD_H2ODEV /)   !all 1.0
 
 ! Isotope enrichment at ocean surface (better to be computed or read from file)
-  real(r8), dimension(pwtspec), parameter :: &  ! mean ocean surface enrichent 
+  real(r8), dimension(pwtspec), parameter :: &  ! mean ocean surface enrichent
 !      boce  = (/ 1._r8, 1._r8, 1.004_r8, 1.0005_r8 /)
 !      boce  = (/ 1._r8, 1._r8, 1.0128_r8, 1.0016_r8, 1.0008_r8, 1.00671_r8 /)  ! LGM
       boce  = (/ 1._r8, 1._r8, 1._r8, 1._r8 /)
@@ -226,7 +215,7 @@ contains
     real(r8), parameter :: difair = 2.36e-5_r8          ! molecular diffusivity of air
     real(r8), parameter :: muair  = 1.7e-5_r8           ! dynamic viscosity of air
                                                      ! about 17 degC, 1.73 at STP (Salby)
-    real(r8), parameter :: gravit = shr_const_g      ! gravity 
+    real(r8), parameter :: gravit = shr_const_g      ! gravity
     real(r8), parameter :: karman = shr_const_karman ! Von Karman constant
 
 !---------------------------- Arguments --------------------------------
@@ -241,11 +230,11 @@ contains
     real(r8) z0                 ! roughness length (constant in cam 9.5e-5)
     real(r8) reno               ! surface reynolds number
     real(r8) tmr                ! ratio of turbulen to molecular resistance
-    real(r8) enn		! diffusive power
+    real(r8) enn	        ! diffusive power
     real(r8) sc                 ! Schmidt number (Prandtl number)
     real(r8) vmu                ! kinematic viscocity of air
     real(r8) difn               ! ratio of difusivities to the power of n
-    real(r8) difrmj		! isotopic diffusion with substitutions
+    real(r8) difrmj	        ! isotopic diffusion with substitutions
 
     real(r8) kmol               ! Merlivals k_mol
 !-----------------------------------------------------------------------
@@ -299,7 +288,7 @@ contains
 
     implicit none
 
-    real(r8), parameter :: gravit = shr_const_g      ! gravity 
+    real(r8), parameter :: gravit = shr_const_g      ! gravity
     real(r8), parameter :: karman = shr_const_karman ! Von Karman constant
 
 !---------------------------- Arguments --------------------------------
@@ -358,7 +347,7 @@ contains
       wiso_alpl = exp(alpal(isp)*tk**3 + alpbl(isp)*tk**2 + alpcl(isp)*tk + alpdl(isp) + alpel(isp)/tk**3)
     else
       wiso_alpl = exp(alpal(isp)/tk**3 + alpbl(isp)/tk**2 + alpcl(isp)/tk + alpdl(isp))
-    end if 
+    end if
 
 #ifdef NOFRAC
     wiso_alpl = 1._r8
@@ -551,8 +540,6 @@ end function wiso_akci
   real(r8) qstar                        ! spec. hum,. mixing scale
   real(r8) Roce                         ! water tracer ratio of ocean surface
   real(r8) alpha                        ! fractionation factor
-  real(r8) rh                           ! relative humidity
-  real(r8) rate                         ! tracer ratio in evaporation
   real(r8) R_std                        ! tracer ratio in evaporation
 !-----------------------------------------------------------------------
 !
@@ -590,14 +577,14 @@ end function wiso_akci
 !
 !         rh = qbot/ssq                                         !calculate relative humidity
 !
-!If RH is 100%, then assume no evaporation occurs (although isotopic equilibration does, which needs to be coded in) 
+!If RH is 100%, then assume no evaporation occurs (although isotopic equilibration does, which needs to be coded in)
 !
-!         if(rh /= 1) then                                     
+!         if(rh /= 1) then
 !           Rate = alpkn*(Roce/alpha - (rh*wtbot/qbot))/(1-rh)  !calculate ratio in flux
 !         else
 !           Rate = 0                                            !Assume no evaporation occurs if RH is 100%
 !         end if
-! 
+!
 !         qflx = Rate*qe                                        !convert to specific humidity (qi)
 
   return
@@ -726,4 +713,3 @@ end function wiso_ssatf
 
 !=========================================================================
 end module water_isotopes
-


### PR DESCRIPTION
This reduces the number of unused local variables and possibly uninitialized variables in the code.
My plan is to do several of these code clean up pr's in the hope that smaller pieces will be more manageable.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
