### PR TITLE
exp(1/3) is identically 1

### DIFF
--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -897,8 +897,8 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             Hb = (Qdel/rcpocn)+(Fd*betaS/alphaT)
             Hb = min(Hb , 0.0_R8)
 
-!            lambdaV = lambdaC*(1.0_R8/cuberoot(1.0_R8 + ( (0.0_R8-Hb)*16.0_R8*molvisc(tBulk(n))* &
-!                 shr_const_g*alphaT*molPr(tBulk(n))**2/ustarw**4)**0.75_R8))
+!            lambdaV = lambdaC*(1.0_R8 + ( (0.0_R8-Hb)*16.0_R8*molvisc(tBulk(n))* &
+!                 shr_const_g*alphaT*molPr(tBulk(n))**2/ustarw**4)**0.75)**(-1._R8/3._R8)
             lambdaV = 6.5_R8
             cSkin(n) =  MIN(0.0_R8, lambdaV * molPr(tBulk(n)) * Qdel / ustarw / rcpocn )
 


### PR DESCRIPTION
Correct equations of the form **(1/3) to be **(1.0_R8/3.0_R8) to evaluate correctly.   

Test suite:  Not sure what to do here - this code is not currently used.
Test baseline: 
Test namelist changes: 
Test status: roundoff

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
