### PR TITLE
Remove concept of RUN_WITH_SUBMIT

### DIFF
--- a/config/acme/machines/template.case.run
+++ b/config/acme/machines/template.case.run
@@ -7,6 +7,8 @@
 template to create a case run script. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
 batch directives. Use case.submit from the command line to run your case.
+
+DO NOT RUN THIS SCRIPT MANUALLY
 """
 
 import os, sys

--- a/config/acme/machines/template.case.test
+++ b/config/acme/machines/template.case.test
@@ -4,6 +4,8 @@
 This is the system test submit script for CIME. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
 batch directives. Use case.submit from the command line to run your case.
+
+DO NOT RUN THIS SCRIPT MANUALLY
 """
 import os, sys
 os.chdir( '{{ caseroot }}')

--- a/config/acme/machines/template.st_archive
+++ b/config/acme/machines/template.st_archive
@@ -7,6 +7,8 @@
 template to create a case short term archiving script. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
 batch directives. Use case.submit from the command line to run your case.
+
+DO NOT RUN THIS SCRIPT MANUALLY
 """
 
 import sys, os, time

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -8,6 +8,8 @@
 template to create a case run script. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
 batch directives. Use case.submit from the command line to run your case.
+
+DO NOT RUN THIS SCRIPT MANUALLY
 """
 
 import os, sys

--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -4,6 +4,8 @@
 This is the system test submit script for CIME. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
 batch directives. Use case.submit from the command line to run your case.
+
+DO NOT RUN THIS SCRIPT MANUALLY
 """
 import os, sys
 os.chdir( '{{ caseroot }}')

--- a/config/cesm/machines/template.st_archive
+++ b/config/cesm/machines/template.st_archive
@@ -6,6 +6,8 @@
 template to create a case short term archiving script. This should only ever be called
 by case.submit when on batch system. This script only exists as a way of providing
 batch directives. Use case.submit from the command line to run your case.
+
+DO NOT RUN THIS SCRIPT MANUALLY
 """
 
 import sys, os, time

--- a/scripts/Tools/case.st_archive
+++ b/scripts/Tools/case.st_archive
@@ -1,0 +1,8 @@
+#! /bin/bash -e
+
+if [ "$#" -ne 0 ]; then
+    echo "Usage: ./case.st_archive"
+    exit 1
+fi
+
+./case.submit --job case.st_archive --no-batch

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -35,9 +35,6 @@ class SystemTestsCommon(object):
         self._init_environment(caseroot)
         self._init_locked_files(caseroot, expected)
 
-    def __del__(self):
-        self._case.set_value("RUN_WITH_SUBMIT", False)
-
     def _init_environment(self, caseroot):
         """
         Do initializations of environment variables that are needed in __init__

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -233,7 +233,6 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 # we need to make sure run2 is properly staged.
                 if run_type != "startup":
                     check_case(self._case2)
-                self._force_case2_settings()
 
                 self._case_two_custom_prerun_action()
                 self.run_indv(suffix = self._run_two_suffix)
@@ -466,19 +465,6 @@ class SystemTestsCompareTwo(SystemTestsCommon):
 
         # Go back to case 1 to ensure that's where we are for any following code
         self._activate_case1()
-
-    def _force_case2_settings(self):
-        """
-        Sets some settings in case2 that are normally set automatically.
-
-        This is needed because we aren't running case2 via the normal mechanism
-        (i.e., via the submit script).
-        """
-
-        # RUN_WITH_SUBMIT is normally set when you run the case's submit script.
-        # Trick the scripts into thinking that we are running via the submit
-        # script, like we're supposed to
-        self._case2.set_value("RUN_WITH_SUBMIT",True)
 
     def _link_to_case2_output(self):
         """

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -4,7 +4,7 @@ Interface to the env_batch.xml file.  This class inherits from EnvBase
 
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_base import EnvBase
-from CIME.utils import transform_vars, get_cime_root, convert_to_seconds, format_time, get_cime_config
+from CIME.utils import transform_vars, get_cime_root, convert_to_seconds, format_time, get_cime_config, get_batch_script_for_job
 
 from copy import deepcopy
 from collections import OrderedDict
@@ -178,9 +178,10 @@ class EnvBatch(EnvBase):
         overrides["batchdirectives"] = self.get_batch_directives(case, job, overrides=overrides)
 
         output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)
-        with open(job, "w") as fd:
+        output_name = get_batch_script_for_job(job)
+        with open(output_name, "w") as fd:
             fd.write(output_text)
-        os.chmod(job, os.stat(job).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.chmod(output_name, os.stat(output_name).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     def set_job_defaults(self, batch_jobs, case):
         if self._batchtype is None:
@@ -466,7 +467,7 @@ class EnvBatch(EnvBase):
                "Unable to determine the correct command for batch submission.")
         batchredirect = self.get_value("batch_redirect", subgroup=None)
         submitcmd = ''
-        for string in (batchsubmit, submitargs, batchredirect, job):
+        for string in (batchsubmit, submitargs, batchredirect, get_batch_script_for_job(job)):
             if  string is not None:
                 submitcmd += string + " "
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -2,7 +2,7 @@
 functions for building CIME models
 """
 from CIME.XML.standard_module_setup  import *
-from CIME.utils                 import get_model, analyze_build_log, stringify_bool, run_and_log_case_status, get_timestamp, run_sub_or_cmd, run_cmd
+from CIME.utils                 import get_model, analyze_build_log, stringify_bool, run_and_log_case_status, get_timestamp, run_sub_or_cmd, run_cmd, get_batch_script_for_job
 from CIME.provenance            import save_build_provenance
 from CIME.preview_namelists     import create_namelists, create_dirs
 from CIME.check_lockedfiles     import check_lockedfiles, lock_file, unlock_file
@@ -379,7 +379,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
     expect(os.path.isdir(caseroot), "'{}' is not a valid directory".format(caseroot))
     os.chdir(caseroot)
 
-    expect(os.path.exists("case.run"),
+    expect(os.path.exists(get_batch_script_for_job("case.run")),
            "ERROR: must invoke case.setup script before calling build script ")
 
     cimeroot = case.get_value("CIMEROOT")

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1011,6 +1011,7 @@ class Case(object):
                     os.path.join(toolsdir, "case.build"),
                     os.path.join(toolsdir, "case.submit"),
                     os.path.join(toolsdir, "case.qstatus"),
+                    os.path.join(toolsdir, "case.st_archive"),
                     os.path.join(toolsdir, "case.cmpgen_namelists"),
                     os.path.join(toolsdir, "preview_namelists"),
                     os.path.join(toolsdir, "preview_run"),

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -257,17 +257,6 @@ def do_data_assimilation(da_script, caseroot, cycle, lid, rundir):
 def case_run(case, skip_pnl=False):
 ###############################################################################
     # Set up the run, run the model, do the postrun steps
-    run_with_submit = case.get_value("RUN_WITH_SUBMIT")
-    expect(run_with_submit,
-           "You are not calling the run script via the submit script. "
-           "As a result, short-term archiving will not be called automatically."
-           "Please submit your run using the submit script like so:"
-           " ./case.submit Time: {}".format(get_timestamp()))
-
-    # Forces user to use case.submit if they re-submit
-    if case.get_value("TESTCASE") is None:
-        case.set_value("RUN_WITH_SUBMIT", False)
-
     prerun_script = case.get_value("PRERUN_SCRIPT")
     postrun_script = case.get_value("POSTRUN_SCRIPT")
 

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,6 +1,6 @@
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, get_timestamp, run_sub_or_cmd
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, run_sub_or_cmd
 from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -9,7 +9,7 @@ from CIME.preview_namelists import create_dirs, create_namelists
 from CIME.XML.env_mach_pes  import EnvMachPes
 from CIME.XML.machines      import Machines
 from CIME.BuildTools.configure import configure
-from CIME.utils             import get_cime_root, run_and_log_case_status, get_model
+from CIME.utils             import get_cime_root, run_and_log_case_status, get_model, get_batch_script_for_job
 from CIME.test_status       import *
 
 import shutil, six
@@ -83,21 +83,18 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 
     # Remove batch scripts
     if reset or clean:
-        if os.path.exists("case.run"):
-            os.remove("case.run")
+        case_run, case_test = get_batch_script_for_job("case.run"), get_batch_script_for_job("case.test")
+        if os.path.exists(case_run):
+            os.remove(case_run)
 
         if not test_mode:
             # rebuild the models (even on restart)
             case.set_value("BUILD_COMPLETE", False)
 
             # backup and then clean test script
-            if os.path.exists("case.test"):
-                os.remove("case.test")
-                logger.info("Successfully cleaned test script case.test")
-
-            if os.path.exists("case.testdriver"):
-                os.remove("case.testdriver")
-                logger.info("Successfully cleaned test script case.testdriver")
+            if os.path.exists(case_test):
+                os.remove(case_test)
+                logger.info("Successfully cleaned test script {}".format(case_test))
 
         logger.info("Successfully cleaned batch script case.run")
 
@@ -148,7 +145,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         if nthrds > 1:
             case.set_value("BUILD_THREADED",True)
 
-        if os.path.exists("case.run"):
+        if os.path.exists(get_batch_script_for_job("case.run")):
             logger.info("Machine/Decomp/Pes configuration has already been done ...skipping")
 
             case.initialize_derived_attributes()

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -64,7 +64,6 @@ def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
     #Load Modules
     case.load_env()
 
-    case.set_value("RUN_WITH_SUBMIT", True)
     case.flush()
 
     logger.warning("submit_jobs {}".format(job))

--- a/scripts/lib/CIME/case_test.py
+++ b/scripts/lib/CIME/case_test.py
@@ -71,6 +71,4 @@ def case_test(case, testname=None, reset=False):
         return True
     success = test.run()
 
-    case.set_value("RUN_WITH_SUBMIT", False)
-
     return success

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1532,3 +1532,6 @@ def run_bld_cmd_ensure_logging(cmd, arg_logger, from_dir=None):
     arg_logger.info(output)
     arg_logger.info(errput)
     expect(stat == 0, filter_unicode(errput))
+
+def get_batch_script_for_job(job):
+    return "." + job

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -464,15 +464,6 @@
     </desc>
   </entry>
 
-  <entry id="RUN_WITH_SUBMIT">
-    <type>logical</type>
-    <group>run_begin_stop_restart</group>
-    <default_value>FALSE</default_value>
-    <valid_values>TRUE,FALSE</valid_values>
-    <file>env_run.xml</file>
-    <desc>Logical to determine whether CESM run has been submitted with the submit script or not</desc>
-  </entry>
-
  <entry id="JOB_IDS">
    <type>char</type>
    <default_value></default_value>


### PR DESCRIPTION
It added a good deal of complexity and broke some usecases just for
the sake of protecting the user from themself. Instead, make batch
script files hidden from user so that they don't need to be
protected in the first place.

Test suite: scripts_regression_tests (on skybridge, batch machine)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Y, renaming of batch scripts

Update gh-pages html (Y/N)?:N

Code review: @jedwards4b @billsacks 
