### PR TITLE
More atmocn flux

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -653,16 +653,16 @@
     </values>
   </entry>
 
-  <entry id="flux_diurnal">
+  <entry id="coldair_outbreak_mod">
     <type>logical</type>
     <category>control</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      If true, turn on diurnal cycle in computing atm/ocn fluxes
-      default: false
+      if true use  Mahrt and Sun 1995,MWR modification to surface flux calculation
     </desc>
     <values>
-      <value>.false.</value>
+      <value cime_model='acme'>.false.</value>
+      <value cime_model='cesm'>.true.</value>
     </values>
   </entry>
 
@@ -672,9 +672,10 @@
     <group>seq_infodata_inparm</group>
     <desc>
       Iterate atmocn flux calculation to this % difference
+      Setting this to zero will always do flux_max_iteration
     </desc>
     <values>
-      <value cime_model='cesm'>0.01</value>
+      <value cime_model='cesm'>0.0</value>
       <value cime_model='acme'>0.0</value>
     </values>
   </entry>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -666,6 +666,19 @@
     </values>
   </entry>
 
+  <entry id="flux_diurnal">
+     <type>logical</type>
+     <category>control</category>
+     <group>seq_infodata_inparm</group>
+     <desc>
+      If true, turn on diurnal cycle in computing atm/ocn fluxes
+      default: false
+     </desc>
+     <values>
+      <value>.false.</value>
+     </values>
+   </entry>
+
   <entry id="flux_convergence">
     <type>real</type>
     <category>control</category>

--- a/src/drivers/mct/main/seq_flux_mct.F90
+++ b/src/drivers/mct/main/seq_flux_mct.F90
@@ -1214,6 +1214,7 @@ contains
     logical     :: flux_diurnal    ! .true. => turn on diurnal cycle in atm/ocn fluxes
     real(r8)    :: flux_convergence ! convergence criteria for imlicit flux computation
     integer(in) :: flux_max_iteration ! maximum number of iterations for convergence
+    logical :: coldair_outbreak_mod !  cold air outbreak adjustment  (Mahrt & Sun 1995,MWR)
     !
     real(r8),parameter :: albdif = 0.06_r8 ! 60 deg reference albedo, diffuse
     real(r8),parameter :: albdir = 0.07_r8 ! 60 deg reference albedo, direct
@@ -1233,8 +1234,10 @@ contains
 
     if (first_call) then
        call seq_infodata_getData(infodata , &
+         coldair_outbreak_mod=coldair_outbreak_mod,  &
          flux_convergence=flux_convergence, &
          flux_max_iteration=flux_max_iteration)
+
        if (.not.read_restart) cold_start = .true.
        index_xao_So_tref   = mct_aVect_indexRA(xao,'So_tref')
        index_xao_So_qref   = mct_aVect_indexRA(xao,'So_qref')
@@ -1300,7 +1303,8 @@ contains
        index_o2x_So_roce_HDO = mct_aVect_indexRA(o2x,'So_roce_HDO', perrWith='quiet')
        index_o2x_So_roce_18O = mct_aVect_indexRA(o2x,'So_roce_18O', perrWith='quiet')
        call shr_flux_adjust_constants(flux_convergence_tolerance=flux_convergence, &
-            flux_convergence_max_iteration=flux_max_iteration)
+            flux_convergence_max_iteration=flux_max_iteration, &
+            coldair_outbreak_mod=coldair_outbreak_mod)
        first_call = .false.
     end if
 

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -118,6 +118,7 @@ MODULE seq_infodata_mod
      character(SHR_KIND_CL)  :: flux_epbal      ! selects E,P,R adjustment technique
      logical                 :: flux_albav      ! T => no diurnal cycle in ocn albedos
      logical                 :: flux_diurnal    ! T => diurnal cycle in atm/ocn fluxes
+     logical                 :: coldair_outbreak_mod ! (Mahrt & Sun 1995,MWR)
      real(SHR_KIND_R8)       :: flux_convergence   ! atmocn flux calc convergence value
      integer                 :: flux_max_iteration ! max number of iterations of atmocn flux loop
      real(SHR_KIND_R8)       :: gust_fac        ! wind gustiness factor
@@ -354,6 +355,7 @@ CONTAINS
     character(SHR_KIND_CL) :: flux_epbal         ! selects E,P,R adjustment technique
     logical                :: flux_albav         ! T => no diurnal cycle in ocn albedos
     logical                :: flux_diurnal       ! T => diurnal cycle in atm/ocn fluxes
+    logical                 :: coldair_outbreak_mod ! (Mahrt & Sun 1995,MWR)
     real(SHR_KIND_R8)       :: flux_convergence   ! atmocn flux calc convergence value
     integer                 :: flux_max_iteration ! max number of iterations of atmocn flux loop
     real(SHR_KIND_R8)      :: gust_fac           ! wind gustiness factor
@@ -422,6 +424,7 @@ CONTAINS
          restart_pfile, restart_file, run_barriers,        &
          single_column, scmlat, force_stop_at,             &
          scmlon, logFilePostFix, outPathRoot, flux_diurnal,&
+         coldair_outbreak_mod, &
          flux_convergence, flux_max_iteration, gust_fac   ,&
          perpetual, perpetual_ymd, flux_epbal, flux_albav, &
          orb_iyear_align, orb_mode, wall_time_limit,       &
@@ -498,6 +501,7 @@ CONTAINS
        flux_epbal            = 'off'
        flux_albav            = .false.
        flux_diurnal          = .false.
+       coldair_outbreak_mod = .false.
        flux_convergence      = 0.0_SHR_KIND_R8
        flux_max_iteration    = 2
        gust_fac              = huge(1.0_SHR_KIND_R8)
@@ -621,6 +625,7 @@ CONTAINS
        infodata%flux_albav            = flux_albav
        infodata%flux_diurnal          = flux_diurnal
        infodata%flux_convergence      = flux_convergence
+       infodata%coldair_outbreak_mod      = coldair_outbreak_mod
        infodata%flux_max_iteration    = flux_max_iteration
        infodata%gust_fac              = gust_fac
        infodata%glc_renormalize_smb   = glc_renormalize_smb
@@ -945,6 +950,7 @@ CONTAINS
        nextsw_cday, precip_fact, flux_epbal, flux_albav,                  &
        glc_g2lupdate, atm_aero, run_barriers, esmf_map_flag,              &
        do_budgets, do_histinit, drv_threading, flux_diurnal,              &
+       coldair_outbreak_mod, &
        flux_convergence, flux_max_iteration, gust_fac,                    &
        budget_inst, budget_daily, budget_month, wall_time_limit,          &
        budget_ann, budget_ltann, budget_ltend , force_stop_at,            &
@@ -1015,6 +1021,7 @@ CONTAINS
     logical,                optional, intent(OUT) :: flux_albav              ! T => no diurnal cycle in ocn albedos
     logical,                optional, intent(OUT) :: flux_diurnal            ! T => diurnal cycle in atm/ocn flux
     real(SHR_KIND_R8), optional, intent(out)      :: flux_convergence   ! atmocn flux calc convergence value
+    logical, optional, intent(out) :: coldair_outbreak_mod        ! (Mahrt & Sun 1995, MWR)
     integer, optional, intent(OUT)                :: flux_max_iteration ! max number of iterations of atmocn flux loop
 
     real(SHR_KIND_R8),      optional, intent(OUT) :: gust_fac                ! wind gustiness factor
@@ -1188,6 +1195,7 @@ CONTAINS
     if ( present(flux_epbal)     ) flux_epbal     = infodata%flux_epbal
     if ( present(flux_albav)     ) flux_albav     = infodata%flux_albav
     if ( present(flux_diurnal)   ) flux_diurnal   = infodata%flux_diurnal
+    if ( present(coldair_outbreak_mod)) coldair_outbreak_mod = infodata%coldair_outbreak_mod
     if ( present(flux_convergence)) flux_convergence = infodata%flux_convergence
     if ( present(flux_max_iteration)) flux_max_iteration = infodata%flux_max_iteration
     if ( present(gust_fac)       ) gust_fac       = infodata%gust_fac
@@ -1514,6 +1522,7 @@ CONTAINS
        nextsw_cday, precip_fact, flux_epbal, flux_albav,                  &
        glc_g2lupdate, atm_aero, esmf_map_flag, wall_time_limit,           &
        do_budgets, do_histinit, drv_threading, flux_diurnal,              &
+       coldair_outbreak_mod,                                                           &
        flux_convergence, flux_max_iteration, gust_fac,                    &
        budget_inst, budget_daily, budget_month, force_stop_at,            &
        budget_ann, budget_ltann, budget_ltend ,                           &
@@ -1583,6 +1592,7 @@ CONTAINS
     character(len=*),       optional, intent(IN)    :: flux_epbal              ! selects E,P,R adjustment technique
     logical,                optional, intent(IN)    :: flux_albav              ! T => no diurnal cycle in ocn albedos
     logical,                optional, intent(IN)    :: flux_diurnal            ! T => diurnal cycle in atm/ocn flux
+    logical, optional, intent(in) :: coldair_outbreak_mod
     real(SHR_KIND_R8),      optional, intent(IN)    :: flux_convergence   ! atmocn flux calc convergence value
     integer,                optional, intent(IN)    :: flux_max_iteration ! max number of iterations of atmocn flux loop
     real(SHR_KIND_R8),      optional, intent(IN)    :: gust_fac                ! wind gustiness factor
@@ -1755,6 +1765,7 @@ CONTAINS
     if ( present(flux_epbal)     ) infodata%flux_epbal     = flux_epbal
     if ( present(flux_albav)     ) infodata%flux_albav     = flux_albav
     if ( present(flux_diurnal)   ) infodata%flux_diurnal   = flux_diurnal
+    if ( present(coldair_outbreak_mod)   ) infodata%coldair_outbreak_mod  = coldair_outbreak_mod
     if ( present(flux_convergence)) infodata%flux_convergence  = flux_convergence
     if ( present(flux_max_iteration)) infodata%flux_max_iteration   = flux_max_iteration
     if ( present(gust_fac)       ) infodata%gust_fac       = gust_fac
@@ -2176,6 +2187,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%flux_epbal,              mpicom)
     call shr_mpi_bcast(infodata%flux_albav,              mpicom)
     call shr_mpi_bcast(infodata%flux_diurnal,            mpicom)
+    call shr_mpi_bcast(infodata%coldair_outbreak_mod,            mpicom)
     call shr_mpi_bcast(infodata%flux_convergence,        mpicom)
     call shr_mpi_bcast(infodata%flux_max_iteration,      mpicom)
     call shr_mpi_bcast(infodata%gust_fac,                mpicom)
@@ -2845,6 +2857,7 @@ CONTAINS
     write(logunit,F0A) subname,'flux_epbal               = ', trim(infodata%flux_epbal)
     write(logunit,F0L) subname,'flux_albav               = ', infodata%flux_albav
     write(logunit,F0L) subname,'flux_diurnal             = ', infodata%flux_diurnal
+    write(logunit,F0L) subname,'coldair_outbreak_mod            = ', infodata%coldair_outbreak_mod
     write(logunit,F0L) subname,'flux_convergence         = ', infodata%flux_convergence
     write(logunit,F0L) subname,'flux_max_iteration       = ', infodata%flux_max_iteration
     write(logunit,F0R) subname,'gust_fac                 = ', infodata%gust_fac

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -738,6 +738,8 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    dtiter = spval
    dsiter = spval
    al2 = log(zref/ztref)
+  !--- for cold air outbreak calc --------------------------------
+   tdiff= tbot - ts
 
    ! equations 18 and 19
    AMP = 1.0_R8/F0-1.0_R8


### PR DESCRIPTION
Add the Mahrt and Sun 1995 MWR coldair outbreak modification to the flux calculation in 
shr_flux_mod.F90.   Default is do not use - bfb in acme.  This also changes the default flux convergence for cesm to 0.0 which means that flux_max_iterations will always be done.

Test suite: scripts_regression_tests.py ERS_D_Ld5.f09_g17.B1850.cheyenne_intel.allactive-defaultio
Test baseline: 
Test namelist changes: 
Test status: roundoff

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 

  