### PR TITLE
Use caching to speed-up retrieval of complaint entries

### DIFF
--- a/config/xml_schemas/env_mach_specific.xsd
+++ b/config/xml_schemas/env_mach_specific.xsd
@@ -34,14 +34,34 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="header"/>
+        <xs:element ref="group"/>
         <xs:element ref="module_system"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="mpirun"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="entry"/>
       </xs:sequence>
       <xs:attribute ref="id" use="required"/>
       <xs:attribute ref="version" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="group">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="entry"/>
+      </xs:sequence>
+      <xs:attribute ref="id" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="entry">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="type"/>
+        <xs:element ref="desc"/>
+      </xs:sequence>
+      <xs:attribute ref="id" use="required" />
+      <xs:attribute ref="value" use="required"/>
     </xs:complexType>
   </xs:element>
 
@@ -142,14 +162,4 @@
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="entry">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="type"/>
-        <xs:element ref="desc"/>
-      </xs:sequence>
-      <xs:attribute ref="id" use="required" />
-      <xs:attribute ref="value" use="required"/>
-    </xs:complexType>
-  </xs:element>
 </xs:schema>

--- a/scripts/lib/CIME/XML/batch.py
+++ b/scripts/lib/CIME/XML/batch.py
@@ -112,11 +112,11 @@ class Batch(GenericXML):
         """
         jobs = []
         bnode = self.get_child("batch_jobs")
-        for jnode in self.get_children(root=bnode, no_validate=True):
+        for jnode in self.get_children(root=bnode):
             if self.name(jnode) == "job":
                 name = self.get(jnode, "name")
                 jdict = {}
-                for child in self.get_children(root=jnode, no_validate=True):
+                for child in self.get_children(root=jnode):
                     jdict[self.name(child)] = self.text(child)
 
             jobs.append((name, jdict))

--- a/scripts/lib/CIME/XML/compilerblock.py
+++ b/scripts/lib/CIME/XML/compilerblock.py
@@ -157,7 +157,7 @@ class CompilerBlock(object):
 
         logger.debug("First pass output={}".format(output))
 
-        for child in self._db.get_children(root=elem, no_validate=True):
+        for child in self._db.get_children(root=elem):
             if self._db.name(child) == "env":
                 # <env> tags just need to be expanded by the writer.
                 output += writer.environment_variable_string(self._db.text(child))
@@ -241,10 +241,10 @@ class CompilerBlock(object):
         value_lists - A dictionary of PossibleValues, containing the lists
                       of all settings for each variable.
         """
-        for elem in self._db.get_children(root=self._compiler_elem, no_validate=True):
+        for elem in self._db.get_children(root=self._compiler_elem):
             # Deal with "flag"-type variables.
             if self._db.name(elem) in flag_vars:
-                for child in self._db.get_children(root=elem, no_validate=True):
+                for child in self._db.get_children(root=elem):
                     self._add_elem_to_lists(self._db.name(elem), child, value_lists)
             else:
                 self._add_elem_to_lists(self._db.name(elem), elem, value_lists)

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -62,7 +62,7 @@ class Compilers(GenericXML):
             schema_db = GenericXML(infile=schema)
             compiler_vars = schema_db.get_child("{http://www.w3.org/2001/XMLSchema}group", attributes={"name":"compilerVars"})
             choice  = schema_db.get_child(name="{http://www.w3.org/2001/XMLSchema}choice", root=compiler_vars)
-            self.flag_vars = set(schema_db.get(elem, "name") for elem in schema_db.get_children(root=choice, attributes={"type":"flagsVar"}, no_validate=True))
+            self.flag_vars = set(schema_db.get(elem, "name") for elem in schema_db.get_children(root=choice, attributes={"type":"flagsVar"}))
 
     def get_compiler(self):
         """
@@ -237,7 +237,7 @@ class Compilers(GenericXML):
                 big_append_tree.write_out(writer)
 
 def _add_to_macros(db, node, macros):
-    for child in db.get_children(root=node, no_validate=True):
+    for child in db.get_children(root=node):
         name = db.name(child)
         attrib = db.attrib(child)
         value = db.text(child)

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -19,10 +19,58 @@ class EnvBase(EntryID):
             fullpath = os.path.join(case_root, infile)
 
         EntryID.__init__(self, fullpath, schema=schema)
+
+        self._id_map = {}    # map id directly to nodes
+        self._group_map = {} # map group name to entry id dict
         if not os.path.isfile(fullpath):
             headerobj = Headers()
             headernode = headerobj.get_header_node(os.path.basename(fullpath))
             self.add_child(headernode)
+        else:
+            # Setup cache
+            group_elems = self.get_children("group")
+            for group_elem in group_elems:
+                group_name = self.get(group_elem, "id")
+                expect(group_name not in self._group_map, "Repeat group '{}'".format(group_name))
+                group_map = {}
+                self._group_map[group_name] = group_map
+                entry_elems = self.get_children("entry", root=group_elem)
+                for entry_elem in entry_elems:
+                    entry_id = self.get(entry_elem, "id")
+                    expect(entry_id not in group_map, "Repeat entry '{}' in group '{}'".format(entry_id, group_name))
+                    group_map[entry_id] = entry_elem
+                    if entry_id in self._id_map:
+                        self._id_map[entry_id].append(entry_elem)
+                    else:
+                        self._id_map[entry_id] = [entry_elem]
+
+            self.lock()
+
+    def get_children(self, name=None, attributes=None, root=None, no_validate=False):
+        if self.locked and name == "entry" and attributes is not None and attributes.keys() == ["id"]:
+            entry_id = attributes["id"]
+            if root is None or self.name(root) == "file":
+                if entry_id in self._id_map:
+                    return self._id_map[entry_id]
+                else:
+                    return []
+            else:
+                expect(self.name(root) == "group", "Unexpected elem '{}' for {}, attrs {}".format(self.name(root), self.filename, self.attrib(root)))
+                group_id = self.get(root, "id")
+                if group_id in self._group_map and entry_id in self._group_map[group_id]:
+                        return [self._group_map[group_id][entry_id]]
+                else:
+                    return []
+
+        else:
+            # Non-compliant look up
+            return EntryID.get_children(self, name=name, attributes=attributes, root=root, no_validate=True)
+
+    def scan_children(self, name, attributes=None, root=None):
+        if self.locked and name == "entry" and attributes is not None and attributes.keys() == ["id"]:
+            return EnvBase.get_children(self, name=name, attributes=attributes, root=root)
+        else:
+            return EntryID.scan_children(self, name, attributes=attributes, root=root)
 
     def set_components(self, components):
         if hasattr(self, '_components'):

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -20,33 +20,44 @@ class EnvBase(EntryID):
 
         EntryID.__init__(self, fullpath, schema=schema)
 
-        self._id_map = {}    # map id directly to nodes
-        self._group_map = {} # map group name to entry id dict
+        self._id_map = None
+        self._group_map = None
+
         if not os.path.isfile(fullpath):
             headerobj = Headers()
             headernode = headerobj.get_header_node(os.path.basename(fullpath))
             self.add_child(headernode)
         else:
-            # Setup cache
-            group_elems = self.get_children("group")
-            for group_elem in group_elems:
-                group_name = self.get(group_elem, "id")
-                expect(group_name not in self._group_map, "Repeat group '{}'".format(group_name))
-                group_map = {}
-                self._group_map[group_name] = group_map
-                entry_elems = self.get_children("entry", root=group_elem)
-                for entry_elem in entry_elems:
-                    entry_id = self.get(entry_elem, "id")
-                    expect(entry_id not in group_map, "Repeat entry '{}' in group '{}'".format(entry_id, group_name))
-                    group_map[entry_id] = entry_elem
-                    if entry_id in self._id_map:
-                        self._id_map[entry_id].append(entry_elem)
-                    else:
-                        self._id_map[entry_id] = [entry_elem]
+            self._setup_cache()
 
-            self.lock()
+    def _setup_cache(self):
+        self._id_map = {}    # map id directly to nodes
+        self._group_map = {} # map group name to entry id dict
 
-    def get_children(self, name=None, attributes=None, root=None, no_validate=False):
+        group_elems = self.get_children("group")
+        for group_elem in group_elems:
+            group_name = self.get(group_elem, "id")
+            expect(group_name not in self._group_map, "Repeat group '{}'".format(group_name))
+            group_map = {}
+            self._group_map[group_name] = group_map
+            entry_elems = self.get_children("entry", root=group_elem)
+            for entry_elem in entry_elems:
+                entry_id = self.get(entry_elem, "id")
+                expect(entry_id not in group_map, "Repeat entry '{}' in group '{}'".format(entry_id, group_name))
+                group_map[entry_id] = entry_elem
+                if entry_id in self._id_map:
+                    self._id_map[entry_id].append(entry_elem)
+                else:
+                    self._id_map[entry_id] = [entry_elem]
+
+        self.lock()
+
+    def change_file(self, newfile, copy=False):
+        self.unlock()
+        EntryID.change_file(self, newfile, copy=copy)
+        self._setup_cache()
+
+    def get_children(self, name=None, attributes=None, root=None):
         if self.locked and name == "entry" and attributes is not None and attributes.keys() == ["id"]:
             entry_id = attributes["id"]
             if root is None or self.name(root) == "file":
@@ -64,7 +75,7 @@ class EnvBase(EntryID):
 
         else:
             # Non-compliant look up
-            return EntryID.get_children(self, name=name, attributes=attributes, root=root, no_validate=True)
+            return EntryID.get_children(self, name=name, attributes=attributes, root=root)
 
     def scan_children(self, name, attributes=None, root=None):
         if self.locked and name == "entry" and attributes is not None and attributes.keys() == ["id"]:

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -58,7 +58,7 @@ class EnvBase(EntryID):
                 expect(self.name(root) == "group", "Unexpected elem '{}' for {}, attrs {}".format(self.name(root), self.filename, self.attrib(root)))
                 group_id = self.get(root, "id")
                 if group_id in self._group_map and entry_id in self._group_map[group_id]:
-                        return [self._group_map[group_id][entry_id]]
+                    return [self._group_map[group_id][entry_id]]
                 else:
                     return []
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -579,7 +579,7 @@ class EnvBatch(EnvBase):
     def get_children(self, name=None, attributes=None, root=None):
         if name in ("JOB_WALLCLOCK_TIME", "PROJECT", "CHARGE_ACCOUNT",
                         "PROJECT_REQUIRED", "JOB_QUEUE", "BATCH_COMMAND_FLAGS"):
-            nodes = EnvBase.scan_children(self, "entry", attributes={"id":name}, root=root)
+            nodes = EnvBase.get_children(self, "entry", attributes={"id":name}, root=root)
         else:
             nodes = EnvBase.scan_children(self, name, attributes=attributes, root=root)
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -108,7 +108,7 @@ class EnvBatch(EnvBase):
 
         orig_group = self.get_child("group", {"id":"job_submission"},
                                     err_msg="Looks like job groups have already been created")
-        orig_group_children = EnvBase.get_children(self, root=orig_group, no_validate=True)
+        orig_group_children = EnvBase.get_children(self, root=orig_group)
 
         childnodes = []
         for child in reversed(orig_group_children):
@@ -144,7 +144,7 @@ class EnvBatch(EnvBase):
             self.set_batch_system_type(batch_system_type)
 
         if batchobj.batch_system_node is not None and batchobj.machine_node is not None:
-            for node in batchobj.get_children(root=batchobj.machine_node, no_validate=True):
+            for node in batchobj.get_children(root=batchobj.machine_node):
                 oldnode = batchobj.get_optional_child(self.name(node), root=batchobj.batch_system_node)
                 if oldnode is not None and self.name(oldnode) != "directives":
                     logger.debug( "Replacing {}".format(self.name(oldnode)))

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -232,7 +232,7 @@ class EnvMachSpecific(EnvBase):
         for action, argument in modules_to_load:
             if argument is None:
                 argument = ""
-            cmds.append("{} {} {}".format(mod_cmd, action, argument))
+            cmds.append("{} {} {}".format(mod_cmd, action, "" if argument is None else argument))
         return cmds
 
     def _load_module_modules(self, modules_to_load):
@@ -260,7 +260,7 @@ class EnvMachSpecific(EnvBase):
             cmd += " && source $SOFTENV_LOAD"
 
         for action,argument in modules_to_load:
-            cmd += " && {} {} {}".format(sh_mod_cmd, action, argument)
+            cmd += " && {} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument)
 
         cmd += " && env"
         output = run_cmd_no_fail(cmd)

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -30,6 +30,8 @@ class EnvMachSpecific(EnvBase):
         default_run_exe_node = machobj.get_child("default_run_exe", root=default_run_suffix)
         default_run_misc_suffix_node = machobj.get_child("default_run_misc_suffix", root=default_run_suffix)
 
+        group_node = self.make_child("group", {"id":"compliant_values"})
+
         for item in items:
             nodes = machobj.get_first_child_nodes(item)
             if item == "run_exe" or item == "run_misc_suffix":
@@ -38,7 +40,7 @@ class EnvMachSpecific(EnvBase):
                 else:
                     value = nodes[0].text
 
-                entity_node = self.make_child("entry", {"id":item, "value":value})
+                entity_node = self.make_child("entry", {"id":item, "value":value}, root=group_node)
 
                 self.make_child("type", root=entity_node, text="char")
                 self.make_child("desc", root=entity_node, text=("executable name" if item == "run_exe" else "redirect for job output"))
@@ -180,7 +182,7 @@ class EnvMachSpecific(EnvBase):
 
         for node in nodes:
             if (self._match_attribs(self.attrib(node), case)):
-                for child in self.get_children(root=node, no_validate=True):
+                for child in self.get_children(root=node):
                     expect(self.name(child) == child_tag, "Expected {} element".format(child_tag))
                     if (self._match_attribs(self.attrib(child), case)):
                         val = self.text(child)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -5,7 +5,7 @@ be used by other XML interface modules and not directly.
 from CIME.XML.standard_module_setup import *
 import xml.etree.ElementTree as ET
 from distutils.spawn import find_executable
-import getpass
+import getpass, shutil
 import six
 from copy import deepcopy
 
@@ -94,6 +94,20 @@ class GenericXML(object):
         """
         self.locked = True
 
+    def unlock(self):
+        self.locked = False
+
+    def change_file(self, newfile, copy=False):
+        if copy:
+            new_case = os.path.dirname(newfile)
+            if not os.path.exists(new_case):
+                os.makedirs(new_case)
+            shutil.copy(self.filename, newfile)
+
+        self.tree = None
+        self.filename = newfile
+        self.read(newfile)
+
     #
     # API for individual node operations
     #
@@ -159,7 +173,7 @@ class GenericXML(object):
 
         return node
 
-    def get_children(self, name=None, attributes=None, root=None, no_validate=False):
+    def get_children(self, name=None, attributes=None, root=None):
         """
         This is the critical function, its interface and performance are crucial.
 
@@ -191,15 +205,6 @@ class GenericXML(object):
                         continue
 
             children.append(_Element(child))
-
-        # Remove
-        #if not no_validate:
-            #validate = self.scan_children(name, attributes=attributes, root=root)
-            #assert validate == children, "Validation failed for {}, {}\nScan found {} elements, get_children found {}".format(name, attributes, len(validate), len(children))
-            # if validate != children:
-            #     import pdb
-            #     pdb.set_trace()
-            #     validate = self.scan_children(name, attributes=attributes, root=root)
 
         return children
 

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -67,7 +67,7 @@ class Machines(GenericXML):
         """
         Return the names of all the child nodes for the target machine
         """
-        nodes = self.get_children(root=self.machine_node, no_validate=True)
+        nodes = self.get_children(root=self.machine_node)
         node_names = []
         for node in nodes:
             node_names.append(self.name(node))

--- a/scripts/lib/CIME/XML/pes.py
+++ b/scripts/lib/CIME/XML/pes.py
@@ -33,7 +33,7 @@ class Pes(GenericXML):
             o_grid_nodes = self.get_children("grid", root = overrides)
             opes_ntasks, opes_nthrds, opes_rootpe, oother_settings = self._find_matches(o_grid_nodes, grid, compset, machine, pesize_opts, True)
         # Get all the nodes
-        grid_nodes = self.get_children("grid", no_validate=True)
+        grid_nodes = self.get_children("grid")
         if o_grid_nodes:
             gn_set = set(grid_nodes)
             ogn_set = set(o_grid_nodes)
@@ -89,17 +89,17 @@ class Pes(GenericXML):
                                 points = int(grid_match!="any")*3+int(mach_match!="any")*7+\
                                     int(compset_match!="any")*2+int(pesize_match!="any")
                                 if override and points > 0:
-                                    for node in self.get_children(root=pes_node, no_validate=True):
+                                    for node in self.get_children(root=pes_node):
                                         vid = self.name(node)
                                         logger.info("vid is {}".format(vid))
                                         if "ntasks" in vid:
-                                            for child in self.get_children(root=node, no_validate=True):
+                                            for child in self.get_children(root=node):
                                                 pes_ntasks[self.name(child).upper()] = int(self.text(child))
                                         elif "nthrds" in vid:
-                                            for child in self.get_children(root=node, no_validate=True):
+                                            for child in self.get_children(root=node):
                                                 pes_nthrds[self.name(child).upper()] = int(self.text(child))
                                         elif "rootpe" in vid:
-                                            for child in self.get_children(root=node, no_validate=True):
+                                            for child in self.get_children(root=node):
                                                 pes_rootpe[self.name(child).upper()] = int(self.text(child))
                                     # if the value is already upper case its something else we are trying to set
                                         elif vid == self.name(node):
@@ -121,17 +121,17 @@ class Pes(GenericXML):
                                         logger.warning("points = {:d}".format(points))
                                         expect(False, "More than one PE layout matches given PE specs")
         if not override:
-            for node in self.get_children(root=pe_select, no_validate=True):
+            for node in self.get_children(root=pe_select):
                 vid = self.name(node)
                 logger.debug("vid is {}".format(vid))
                 if "ntasks" in vid:
-                    for child in self.get_children(root=node, no_validate=True):
+                    for child in self.get_children(root=node):
                         pes_ntasks[self.name(child).upper()] = int(self.text(child))
                 elif "nthrds" in vid:
-                    for child in self.get_children(root=node, no_validate=True):
+                    for child in self.get_children(root=node):
                         pes_nthrds[self.name(child).upper()] = int(self.text(child))
                 elif "rootpe" in vid:
-                    for child in self.get_children(root=node, no_validate=True):
+                    for child in self.get_children(root=node):
                         pes_rootpe[self.name(child).upper()] = int(self.text(child))
             # if the value is already upper case its something else we are trying to set
                 elif vid == self.name(node) and vid != "comment":

--- a/scripts/lib/CIME/XML/testlist.py
+++ b/scripts/lib/CIME/XML/testlist.py
@@ -123,7 +123,7 @@ class Testlist(GenericXML):
                         this_test_node[key] = value
 
                 # Get options that apply to all machines/compilers for this test
-                options = self.get_children("options", root=tnode, no_validate=True)
+                options = self.get_children("options", root=tnode)
                 if len(options) > 0:
                     optionnodes = self.get_children("option", root=options[0])
                 else:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -217,7 +217,8 @@ class Case(object):
         newcase = deepcopy(self)
         for env_file in newcase._files: # pylint: disable=protected-access
             basename = os.path.basename(env_file.filename)
-            env_file.filename = os.path.join(newcaseroot,basename)
+            newfile = os.path.join(newcaseroot, basename)
+            env_file.change_file(newfile, copy=True)
 
         if newcimeroot is not None:
             newcase.set_value("CIMEROOT", newcimeroot)

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -77,9 +77,9 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
            "inputdata root is not a directory: {}".format(din_loc_root))
 
     # Check that userdefine settings are specified before expanding variable
-    for vid, value in case:
-        expect(not (isinstance(value, six.string_types) and "USERDEFINED_required_build" in value),
-               "Parameter '{}' must be defined".format(vid))
+    # for vid, value in case:
+    #     expect(not (isinstance(value, six.string_types) and "USERDEFINED_required_build" in value),
+    #            "Parameter '{}' must be defined".format(vid))
 
     # Remove batch scripts
     if reset or clean:

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -12,7 +12,7 @@ from CIME.BuildTools.configure import configure
 from CIME.utils             import get_cime_root, run_and_log_case_status, get_model, get_batch_script_for_job
 from CIME.test_status       import *
 
-import shutil, six
+import shutil
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -76,11 +76,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
     expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
            "inputdata root is not a directory: {}".format(din_loc_root))
 
-    # Check that userdefine settings are specified before expanding variable
-    # for vid, value in case:
-    #     expect(not (isinstance(value, six.string_types) and "USERDEFINED_required_build" in value),
-    #            "Parameter '{}' must be defined".format(vid))
-
     # Remove batch scripts
     if reset or clean:
         case_run, case_test = get_batch_script_for_job("case.run"), get_batch_script_for_job("case.test")


### PR DESCRIPTION
get_children and scan_children for EnvBase and it's subclasses has been dramatically optimized. When the XML object is constructed, it loads all the groups and entries into python dictionaries (caches) so that compliant data lookups are much faster.

Based on my profiling of case.setup on my laptop, this reduces the time spent in scan_children from about 50% of the total runtime to 2%.

This reduces case.setup time on my laptop from 10s to about 5s. It also reduces total scripts_regression_tests time on melvin from 124 minutes to 104 minutes.

Also:

1) Remove no_validate from generic_xml.get_children. That was for debugging the XML APL consolidation.
2) Change case_clone to a much safer implementation via the new change_file method. We should  never be modifying data members of an object from outside
3) Restructure env_mach_specific so at least a couple entries are compliant.
4) Minor robustness improvements for environment loading 
5) Remove very expensive USERDEFINED_required_build check

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 

  