### PR TITLE
fix modulo function args for xlf

### DIFF
--- a/src/share/util/shr_cal_mod.F90
+++ b/src/share/util/shr_cal_mod.F90
@@ -516,8 +516,8 @@ contains
     tdate = abs(date)
     year =int(     tdate       /10000)
     if (date < 0) year = -year
-    month=int( mod(tdate,10000)/  100)
-    day  =     mod(tdate,  100)
+    month=int( mod(tdate,10000_SHR_KIND_I8)/  100)
+    day  =     mod(tdate,  100_SHR_KIND_I8)
 
     if (debug > 1) write(s_logunit,*) trim(subname),'_b ',year,month,day
 


### PR DESCRIPTION
xlf wants both arguments of modulo to have the same type kind parameter

Test suite: built csm_share library with nag, intel and xlf
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #2210

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
