### PR TITLE
Correct bld output

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -477,7 +477,7 @@ class FakeTest(SystemTestsCommon):
 
             os.chmod(modelexe, 0o755)
 
-            build.post_build(self._case, [])
+            build.post_build(self._case, [], build_complete=True)
 
     def run_indv(self, suffix='base', st_archive=False):
         mpilib = self._case.get_value("MPILIB")
@@ -500,7 +500,7 @@ cp {}/scripts/tests/cpl.hi1.nc.test {}/{}.cpl.hi.0.nc
 """.format(rundir, cimeroot, rundir, case)
         self._set_script(script)
         FakeTest.build_phase(self,
-                       sharedlib_only=sharedlib_only, model_only=model_only)
+                             sharedlib_only=sharedlib_only, model_only=model_only)
 
 class TESTRUNDIFF(FakeTest):
     """

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -530,7 +530,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
             case.read_xml()
             # Note, doing buildlists will never result in the system thinking the build is complete
 
-    post_build(case, logs, build_complete=not buildlist or shared_lib_only)
+    post_build(case, logs, build_complete=not (buildlist or sharedlib_only))
 
     t3 = time.time()
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -529,18 +529,20 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
             # in case component build scripts updated the xml files, update the case object
             case.read_xml()
             # Note, doing buildlists will never result in the system thinking the build is complete
-            post_build(case, logs)
+
+    post_build(case, logs, build_complete=not buildlist or shared_lib_only)
 
     t3 = time.time()
 
-    logger.info("Time spent not building: {:f} sec".format(t2 - t1))
-    logger.info("Time spent building: {:f} sec".format(t3 - t2))
-    logger.info("MODEL BUILD HAS FINISHED SUCCESSFULLY")
+    if not sharedlib_only:
+        logger.info("Time spent not building: {:f} sec".format(t2 - t1))
+        logger.info("Time spent building: {:f} sec".format(t3 - t2))
+        logger.info("MODEL BUILD HAS FINISHED SUCCESSFULLY")
 
     return True
 
 ###############################################################################
-def post_build(case, logs):
+def post_build(case, logs, build_complete=False):
 ###############################################################################
 
     logdir = case.get_value("LOGDIR")
@@ -552,25 +554,28 @@ def post_build(case, logs):
             os.makedirs(bldlogdir)
 
     for log in logs:
-        logger.debug("Copying build log {} to {}".format(log, bldlogdir))
+        logger.info("Copying build log {} to {}".format(log, bldlogdir))
         with open(log, 'rb') as f_in:
             with gzip.open("{}.gz".format(log), 'wb') as f_out:
                 shutil.copyfileobj(f_in, f_out)
         if "sharedlibroot" not in log:
             shutil.copy("{}.gz".format(log), os.path.join(bldlogdir, "{}.gz".format(os.path.basename(log))))
+        os.remove(log)
 
-    # Set XML to indicate build complete
-    case.set_value("BUILD_COMPLETE", True)
-    case.set_value("BUILD_STATUS", 0)
-    if "SMP_VALUE" in os.environ:
-        case.set_value("SMP_BUILD", os.environ["SMP_VALUE"])
-    case.flush()
+    if build_complete:
 
-    lock_file("env_build.xml")
+        # Set XML to indicate build complete
+        case.set_value("BUILD_COMPLETE", True)
+        case.set_value("BUILD_STATUS", 0)
+        if "SMP_VALUE" in os.environ:
+            case.set_value("SMP_BUILD", os.environ["SMP_VALUE"])
+            case.flush()
 
-    # must ensure there's an lid
-    lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")
-    save_build_provenance(case, lid=lid)
+        lock_file("env_build.xml")
+
+        # must ensure there's an lid
+        lid = os.environ["LID"] if "LID" in os.environ else get_timestamp("%y%m%d-%H%M%S")
+        save_build_provenance(case, lid=lid)
 
 ###############################################################################
 def case_build(caseroot, case, sharedlib_only=False, model_only=False, buildlist=None):

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -82,4 +82,5 @@ def run_gmake(case, compclass, libroot, bldroot, libname="", user_cppdefs=""):
     if user_cppdefs:
         cmd = cmd + "USER_CPPDEFS='{}'".format(user_cppdefs )
 
-    run_cmd_no_fail(cmd, combine_output=True)
+    stat, out, _ = run_cmd(cmd, combine_output=True)
+    print(out)

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -82,5 +82,5 @@ def run_gmake(case, compclass, libroot, bldroot, libname="", user_cppdefs=""):
     if user_cppdefs:
         cmd = cmd + "USER_CPPDEFS='{}'".format(user_cppdefs )
 
-    stat, out, _ = run_cmd(cmd, combine_output=True)
+    _, out, _ = run_cmd(cmd, combine_output=True)
     print(out)

--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -125,15 +125,16 @@ def check_lockedfiles(case):
                     expect(False, "Cannot change file env_case.xml, please"
                            " recover the original copy from LockedFiles")
                 elif objname == "env_build":
-                    logging.warning("Setting build complete to False")
-                    case.set_value("BUILD_COMPLETE", False)
-                    if "PIO_VERSION" in diffs:
-                        case.set_value("BUILD_STATUS", 2)
-                        logging.critical("Changing PIO_VERSION requires running "
-                                         "case.build --clean-all and rebuilding")
-                    elif toggle_build_status:
-                        case.set_value("BUILD_STATUS", 1)
-                    f2obj.set_value("BUILD_COMPLETE", False)
+                    if toggle_build_status:
+                        logging.warning("Setting build complete to False")
+                        case.set_value("BUILD_COMPLETE", False)
+                        if "PIO_VERSION" in diffs:
+                            case.set_value("BUILD_STATUS", 2)
+                            logging.critical("Changing PIO_VERSION requires running "
+                                             "case.build --clean-all and rebuilding")
+                        else:
+                            case.set_value("BUILD_STATUS", 1)
+                        f2obj.set_value("BUILD_COMPLETE", False)
                 elif objname == "env_batch":
                     expect(False, "Batch configuration has changed, please run case.setup --reset")
                 else:

--- a/src/drivers/mct/cime_config/buildexe
+++ b/src/drivers/mct/cime_config/buildexe
@@ -49,8 +49,8 @@ def _main_func():
     cmd = "%s exec_se -j %d EXEC_SE=%s MODEL=%s LIBROOT=%s -f %s "\
         % (gmake, gmake_j, exename, "driver", libroot, makefile)
 
-    rc, out, err = run_cmd(cmd, combine_output=True)
-    expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
+    rc, out, _ = run_cmd(cmd, combine_output=True)
+    expect(rc==0,"Command %s failed rc=%d\nout=%s"%(cmd,rc,out))
     logger.info(out)
 
 ###############################################################################

--- a/src/drivers/mct/cime_config/buildexe
+++ b/src/drivers/mct/cime_config/buildexe
@@ -35,7 +35,7 @@ def _main_func():
         os.environ["PIO_VERSION"] = str(case.get_value("PIO_VERSION"))
 
     expect((num_esp is None) or (int(num_esp) == 1), "ESP component restricted to one instance")
-        
+
 
     with open('Filepath', 'w') as out:
         out.write(os.path.join(caseroot, "SourceMods", "src.drv") + "\n")
@@ -49,7 +49,7 @@ def _main_func():
     cmd = "%s exec_se -j %d EXEC_SE=%s MODEL=%s LIBROOT=%s -f %s "\
         % (gmake, gmake_j, exename, "driver", libroot, makefile)
 
-    rc, out, err = run_cmd(cmd)
+    rc, out, err = run_cmd(cmd, combine_output=True)
     expect(rc==0,"Command %s failed rc=%d\nout=%s\nerr=%s"%(cmd,rc,out,err))
     logger.info(out)
 


### PR DESCRIPTION
Fixes several issues in the build: stderr was suppressed for component and exe logs, uncompressed log files were left behind after compressing, library (mct, pio, csm_share) log files were not compressed.   

Test suite:  scripts_regression_test.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
