### PR TITLE
Fix print statements that were corrupted by py3 changes

### DIFF
--- a/scripts/Tools/preview_run
+++ b/scripts/Tools/preview_run
@@ -51,14 +51,14 @@ def _main_func(description):
     logging.disable(logging.CRITICAL)
 
     with Case(caseroot, read_only=False) as case:
-        print("BATCH SUBMIT:")
+        print("BATCH SUBMIT: (nodes {})".format(case.num_nodes))
         case.load_env()
         job = "case.test" if case.get_value("TEST") else "case.run"
         job_id_to_cmd = case.submit_jobs(dry_run=True, job=job)
         for job_id, cmd in job_id_to_cmd:
-            print("   ", job_id, "->", case.get_resolved_value(cmd))
-        print()
-        print("MPIRUN:", case.get_resolved_value(case.get_mpirun_cmd()))
+            print("    {} -> {}".format(job_id, case.get_resolved_value(cmd)))
+        print("")
+        print("MPIRUN: {}".format(case.get_resolved_value(case.get_mpirun_cmd())))
 
 if __name__ == "__main__":
     _main_func(__doc__)


### PR DESCRIPTION
Add num node information to output.

Test suite: code_checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:  N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
