### PR TITLE
Cpl user mods

### DIFF
--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2468,13 +2468,18 @@
     <desc>standard full pathname of the cprnc executable</desc>
   </entry>
 
-  <entry id="USER_MODS_FULLPATH">
+  <entry id="CPL_USER_MODS">
     <type>char</type>
-    <default_value>UNSET</default_value>
-    <group>user_mods</group>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <values match="last">
+      <value compset="1850_">$SRCROOT/cime_config/usermods_dirs/b1850</value>
+    </values>
+    <group>run_component_cpl</group>
     <file>env_case.xml</file>
-    <desc>path to user mods under TESTS_MODS_DIR or USER_MODS_DIR</desc>
+    <desc>User mods to apply to specific compset matches. </desc>
   </entry>
+
 
   <!-- ===================================================================== -->
   <!-- component coupling options and frequencies -->

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2468,19 +2468,6 @@
     <desc>standard full pathname of the cprnc executable</desc>
   </entry>
 
-  <entry id="CPL_USER_MODS">
-    <type>char</type>
-    <valid_values></valid_values>
-    <default_value></default_value>
-    <values match="last">
-      <value compset="1850_">$SRCROOT/cime_config/usermods_dirs/b1850</value>
-    </values>
-    <group>run_component_cpl</group>
-    <file>env_case.xml</file>
-    <desc>User mods to apply to specific compset matches. </desc>
-  </entry>
-
-
   <!-- ===================================================================== -->
   <!-- component coupling options and frequencies -->
   <!-- ===================================================================== -->

--- a/src/drivers/mct/cime_config/config_component_acme.xml
+++ b/src/drivers/mct/cime_config/config_component_acme.xml
@@ -204,7 +204,7 @@
 
     CO2A_OI: sets the driver namelist variable flds_co2a = .true.; this adds
     prognostic CO2 and diagnostic CO2 at the lowest model level to be sent from
-    the atmosphere to the land and ocean. Also sets the driver namelist variable 
+    the atmosphere to the land and ocean. Also sets the driver namelist variable
     flds_bgc_oi = .true.; this turns on the transfer of bgc fields between the
     ocean and seaice components via the coupler.
 
@@ -223,6 +223,17 @@
     The namelist variables flds_co2a, flds_co2b, flds_co2c and flds_co2_dmsa are
     in the namelist group cpl_flds_inparm.
     </desc>
+  </entry>
+
+  <entry id="CPL_USER_MODS">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <values match="last">
+    </values>
+    <group>run_component_cpl</group>
+    <file>env_case.xml</file>
+    <desc>User mods to apply to specific compset matches. </desc>
   </entry>
 
   <entry id="NCPL_BASE_PERIOD">

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -147,6 +147,18 @@
     </desc>
   </entry>
 
+  <entry id="CPL_USER_MODS">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value></default_value>
+    <values match="last">
+      <value compset="1850_">$SRCROOT/cime_config/usermods_dirs/b1850</value>
+    </values>
+    <group>run_component_cpl</group>
+    <file>env_case.xml</file>
+    <desc>User mods to apply to specific compset matches. </desc>
+  </entry>
+
   <entry id="NCPL_BASE_PERIOD">
     <type>char</type>
     <valid_values>hour,day,year,decade</valid_values>


### PR DESCRIPTION
We have _USER_MODS for components but neglected to add one for CPL, this adds it and removes
an unused xml variable USER_MODS_FULLPATH  

Test suite: scripts_regression_tests.py as well as SMS.f09_g17.B1850.cheyenne_intel.allactive-default
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
