### PR TITLE
Change grid in testlist schema to NMTOKEN

### DIFF
--- a/config/xml_schemas/testlist.xsd
+++ b/config/xml_schemas/testlist.xsd
@@ -17,7 +17,7 @@
         <xs:element minOccurs="0" ref="options"/>
       </xs:sequence>
       <xs:attribute name="compset" use="required" type="xs:NCName"/>
-      <xs:attribute name="grid" use="required" type="xs:NCName"/>
+      <xs:attribute name="grid" use="required" type="xs:NMTOKEN"/>
       <xs:attribute name="name" use="required" type="xs:NCName"/>
       <xs:attribute name="testmods" />
     </xs:complexType>


### PR DESCRIPTION
Change the grid in the testlist XSD schema to NMTOKEN from NCName, in order
to allow the CLM grids for single point such as 1x1_brazil. This allows
the CLM testlist to be upgraded to the version 2.0 format.

Test suite: regression test
Test status: bit for bit

Fixes: 2222