### PR TITLE
Implement walltime stash to support more-accurate walltimes

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -3,13 +3,14 @@ Base class for CIME system tests
 """
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_run import EnvRun
-from CIME.utils import append_testlog
+from CIME.utils import append_testlog, get_model
 from CIME.case_setup import case_setup
 from CIME.case_run import case_run
 from CIME.case_st_archive import case_st_archive
 from CIME.test_status import *
 from CIME.check_lockedfiles import *
 from CIME.hist_utils import *
+from CIME.provenance import save_test_time
 
 import CIME.build as build
 
@@ -168,6 +169,9 @@ class SystemTestsCommon(object):
         status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
         with self._test_status:
             self._test_status.set_status(RUN_PHASE, status, comments=("time={:d}".format(int(time_taken))))
+
+        if success and get_model() == "acme":
+            save_test_time(self._case.get_value("BASELINE_ROOT"), self._casebaseid, time_taken)
 
         # We return success if the run phase worked; memleaks, diffs will not be taken into account
         # with this return value.

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -82,4 +82,4 @@ def run_gmake(case, compclass, libroot, bldroot, libname="", user_cppdefs=""):
         cmd = cmd + "USER_CPPDEFS='{}'".format(user_cppdefs )
 
     _, out, _ = run_cmd(cmd, combine_output=True)
-    print(out)
+    print(out.encode('utf-8'))

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -381,6 +381,7 @@ def get_recommended_test_time_based_on_past(baseline_root, test):
                 for cutoff, tolerance in _WALLTIME_TOLERANCE:
                     if last_line <= cutoff:
                         best_walltime = int(float(last_line) * tolerance)
+                        break
 
                 return convert_to_babylonian_time(best_walltime)
         except:

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -372,19 +372,21 @@ _WALLTIME_FILE_NAME     = "walltimes"
 _WALLTIME_TOLERANCE     = 1.25
 
 def get_recommended_test_time_based_on_past(baseline_root, test):
-    the_path = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test, _WALLTIME_FILE_NAME)
-    if os.path.exists(the_path):
-        last_line = int(open(the_path, "r").readlines()[-1])
-        last_line = int(float(last_line) * _WALLTIME_TOLERANCE)
-        return convert_to_babylonian_time(last_line)
-    else:
-        return None
+    if baseline_root is not None:
+        the_path = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test, _WALLTIME_FILE_NAME)
+        if os.path.exists(the_path):
+            last_line = int(open(the_path, "r").readlines()[-1])
+            last_line = int(float(last_line) * _WALLTIME_TOLERANCE)
+            return convert_to_babylonian_time(last_line)
+
+    return None
 
 def save_test_time(baseline_root, test, time_seconds):
-    the_dir  = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test)
-    if not os.path.exists(the_dir):
-        os.makedirs(the_dir)
+    if baseline_root is not None:
+        the_dir  = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test)
+        if not os.path.exists(the_dir):
+            os.makedirs(the_dir)
 
-    the_path = os.path.join(the_dir, _WALLTIME_FILE_NAME)
-    with open(the_path, "a") as fd:
-        fd.write("{}\n".format(int(time_seconds)))
+        the_path = os.path.join(the_dir, _WALLTIME_FILE_NAME)
+        with open(the_path, "a") as fd:
+            fd.write("{}\n".format(int(time_seconds)))

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -7,7 +7,7 @@ Library for saving build/run provenance.
 from CIME.XML.standard_module_setup import *
 from CIME.utils import touch, gzip_existing_file, SharedArea, copy_umask, convert_to_babylonian_time
 
-import tarfile, getpass, signal, glob, shutil
+import tarfile, getpass, signal, glob, shutil, sys
 
 logger = logging.getLogger(__name__)
 
@@ -383,10 +383,14 @@ def get_recommended_test_time_based_on_past(baseline_root, test):
 
 def save_test_time(baseline_root, test, time_seconds):
     if baseline_root is not None:
-        the_dir  = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test)
-        if not os.path.exists(the_dir):
-            os.makedirs(the_dir)
+        try:
+            the_dir  = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test)
+            if not os.path.exists(the_dir):
+                os.makedirs(the_dir)
 
-        the_path = os.path.join(the_dir, _WALLTIME_FILE_NAME)
-        with open(the_path, "a") as fd:
-            fd.write("{}\n".format(int(time_seconds)))
+            the_path = os.path.join(the_dir, _WALLTIME_FILE_NAME)
+            with open(the_path, "a") as fd:
+                fd.write("{}\n".format(int(time_seconds)))
+        except:
+            # We NEVER want a failure here to kill the run
+            logger.warning("Failed to store test time: {}".format(sys.exc_info()[0]))

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -25,6 +25,7 @@ from CIME.XML.tests import Tests
 from CIME.case import Case
 from CIME.wait_for_tests import wait_for_tests
 from CIME.check_lockedfiles import lock_file
+from CIME.provenance import get_recommended_test_time_based_on_past
 import CIME.test_utils
 
 logger = logging.getLogger(__name__)
@@ -447,9 +448,14 @@ class TestScheduler(object):
         else:
             # model specific ways of setting time
             if get_model() == "acme":
-                recommended_time = get_recommended_test_time(test)
+                recommended_time = get_recommended_test_time_based_on_past(self._baseline_root, test)
+
+                if recommended_time is None:
+                    recommended_time = get_recommended_test_time(test)
+
                 if recommended_time is not None:
                     create_newcase_cmd += " --walltime {}".format(recommended_time)
+
             else:
                 if test in self._test_data and "options" in self._test_data[test] and \
                         "wallclock" in self._test_data[test]['options']:


### PR DESCRIPTION
This is for ACME only, but I'd still like feedback on the merits of the idea.

The idea is to make a "stash" of walltimes in the baseline area under a hardcoded baseline name "walltimes". Each time a test is run, store the time it took in a special file. This file will be used for more-accurate walltime requests on the batch system whenever the test is run again.

Test suite: scripts_regression_tests (anvil)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
