### PR TITLE
fix for broken hyperlink

### DIFF
--- a/doc/source/data_models/data-ocean.rst
+++ b/doc/source/data_models/data-ocean.rst
@@ -4,14 +4,20 @@
 Data Ocean (DOCN)
 ===================
 
-Data ocean can be run both as a prescribed component, simply reading in SST data from a stream, or as a prognostic slab ocean model component.
+Data ocean can be run both as a prescribed component, simply reading
+in SST data from a stream, or as a prognostic slab ocean model
+component.
 
-The data ocean component (DOCN) always returns SSTs to the driver. 
-The atmosphere/ocean fluxes are computed in the coupler. 
-Therefore, the data ocean model does not compute fluxes like the data ice (DICE) model. 
-DOCN has two distinct modes of operation. 
-DOCN can run as a pure data model, reading in ocean SSTs (normally climatological) from input datasets, performing time/spatial  interpolations, and passing these to the coupler. 
-Alternatively, DOCN can compute updated SSTs by running as a slab ocean model where bottom ocean heat flux convergence and boundary layer depths are read in and used with the atmosphere/ocean and ice/ocean fluxes obtained from the driver.
+The data ocean component (DOCN) always returns SSTs to the driver.
+The atmosphere/ocean fluxes are computed in the coupler.  Therefore,
+the data ocean model does not compute fluxes like the data ice (DICE)
+model.  DOCN has two distinct modes of operation.  DOCN can run as a
+pure data model, reading in ocean SSTs (normally climatological) from
+input datasets, performing time/spatial interpolations, and passing
+these to the coupler.  Alternatively, DOCN can compute updated SSTs by
+running as a slab ocean model where bottom ocean heat flux convergence
+and boundary layer depths are read in and used with the
+atmosphere/ocean and ice/ocean fluxes obtained from the driver.
 
 DOCN running in prescribed mode assumes that the only field in the
 input stream is SST and also that SST is in Celsius and must be
@@ -43,9 +49,7 @@ prognostic control runs.  For CESM, some of these are available in the
 The user then modifies the ``$DOCN_SOM_FILENAME`` variable in
 env_run.xml to point to the appropriate SOM forcing dataset.
 
-.. note:: A tool is available to derive valid `SOM forcing
-<http://www.cesm.ucar.edu/models/cesm1.2/data8/doc/SOM.pdf>`_ and more
-information on creating the SOM forcing is also available.
+.. note:: A tool is available to derive valid `SOM forcing <http://www.cesm.ucar.edu/models/cesm1.2/data8/doc/SOM.pdf>`_ and more information on creating the SOM forcing is also available.
 
 .. _docn-xml-vars:
 


### PR DESCRIPTION
Fixed a broken hyperlink in the data ocean model rst documentation. 

Test suite: N/A
Test baseline: N/A
Test namelist changes: N/A
Test status: [bit for bit, roundoff, climate changing] N/A

Fixes [CIME Github issue #]

User interface changes?: No

Update gh-pages html (Y/N)?: Y

Code review: 
