### PR TITLE
Cache file reads to avoid re-parsing XML files

### DIFF
--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -34,6 +34,11 @@ class GenericXML(object):
 
     _FILEMAP = {}
 
+    @classmethod
+    def invalidate_file(cls, filepath):
+        if filepath in cls._FILEMAP:
+            del cls._FILEMAP[filepath]
+
     def __init__(self, infile=None, schema=None, root_name_override=None, root_attrib_override=None):
         """
         Initialize an object

--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -7,6 +7,7 @@ from CIME.XML.env_build import EnvBuild
 from CIME.XML.env_case import EnvCase
 from CIME.XML.env_mach_pes import EnvMachPes
 from CIME.XML.env_batch import EnvBatch
+from CIME.XML.generic_xml import GenericXML
 from CIME.utils import run_cmd_no_fail
 
 logger = logging.getLogger(__name__)
@@ -23,7 +24,14 @@ def lock_file(filename, caseroot=None, newname=None):
     if not os.path.exists(fulllockdir):
         os.mkdir(fulllockdir)
     logging.debug("Locking file {} to {}".format(filename, newname))
+
+    # JGF: It is extremely dangerous to alter our database (xml files) without
+    # going through the standard API. The copy below invalidates all existing
+    # GenericXML instances that represent this file and all caching that may
+    # have involved this file. We should probably seek a safer way of locking
+    # files.
     shutil.copyfile(os.path.join(caseroot, filename), os.path.join(fulllockdir, newname))
+    GenericXML.invalidate_file(os.path.join(fulllockdir, newname))
 
 def unlock_file(filename, caseroot=None):
     expect("/" not in filename, "Please just provide basename of locked file")
@@ -36,18 +44,6 @@ def is_locked(filename, caseroot=None):
     expect("/" not in filename, "Please just provide basename of locked file")
     caseroot = os.getcwd() if caseroot is None else caseroot
     return os.path.exists(os.path.join(caseroot, LOCKED_DIR, filename))
-
-def restore(filename, caseroot=None, newname=None):
-    """
-    Restore the locked version of filename into main case dir
-    """
-    expect("/" not in filename, "Please just provide basename of locked file")
-    caseroot = os.getcwd() if caseroot is None else caseroot
-    newname = filename if newname is None else newname
-    shutil.copyfile(os.path.join(caseroot, LOCKED_DIR, filename), os.path.join(caseroot, newname))
-    # relock the restored file if names diffs
-    if newname != filename:
-        lock_file(newname, caseroot)
 
 def check_pelayouts_require_rebuild(case, models):
     """


### PR DESCRIPTION
Use a class member in GenericXML to store a map of filepath to xml etree. This way, XML files will only ever by read once in a CIME process.

This will further increase the performance of CIME. In my profiling, this increase performance of case.setup by 13%.

Remove extremely unsafe "restore" method in check_lockedfiles.

Test suite: scripts-regression-tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
