### PR TITLE
Turn off XML file caching in test scheduler

### DIFF
--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -33,6 +33,7 @@ class _Element(object): # private class, don't want users constructing directly 
 class GenericXML(object):
 
     _FILEMAP = {}
+    DISABLE_CACHING = False
 
     @classmethod
     def invalidate_file(cls, filepath):
@@ -77,7 +78,7 @@ class GenericXML(object):
         """
         Read and parse an xml file into the object
         """
-        if infile in self._FILEMAP:
+        if infile in self._FILEMAP and not self.DISABLE_CACHING:
             logger.debug("read (cached): " + infile)
             self.tree, self.root = self._FILEMAP[infile]
         else:

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -18,6 +18,7 @@ from update_acme_tests import get_recommended_test_time
 from CIME.utils import append_status, append_testlog, TESTS_FAILED_ERR_CODE, parse_test_name, get_full_test_name, get_model
 from CIME.test_status import *
 from CIME.XML.machines import Machines
+from CIME.XML.generic_xml import GenericXML
 from CIME.XML.env_test import EnvTest
 from CIME.XML.files import Files
 from CIME.XML.component import Component
@@ -880,7 +881,9 @@ class TestScheduler(object):
         # Setup cs files
         self._setup_cs_files()
 
+        GenericXML.DISABLE_CACHING = True
         self._producer()
+        GenericXML.DISABLE_CACHING = False
 
         expect(threading.active_count() == 1, "Leftover threads?")
 


### PR DESCRIPTION
Turn off XML file caching in test scheduler
    
The implementation is inherently thread-unsafe since the data
structure that does the caching is shared by all GenericXML
objects.

When I first tested a full acme suite without this fix, the result was complete disaster.