### PR TITLE
Revert file caching (pr #2243)

### DIFF
--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -31,15 +31,6 @@ class _Element(object): # private class, don't want users constructing directly 
         return _Element(deepcopy(self.xml_element))
 
 class GenericXML(object):
-
-    _FILEMAP = {}
-    DISABLE_CACHING = False
-
-    @classmethod
-    def invalidate_file(cls, filepath):
-        if filepath in cls._FILEMAP:
-            del cls._FILEMAP[filepath]
-
     def __init__(self, infile=None, schema=None, root_name_override=None, root_attrib_override=None):
         """
         Initialize an object
@@ -78,21 +69,16 @@ class GenericXML(object):
         """
         Read and parse an xml file into the object
         """
-        if infile in self._FILEMAP and not self.DISABLE_CACHING:
-            logger.debug("read (cached): " + infile)
-            self.tree, self.root = self._FILEMAP[infile]
-        else:
-            logger.debug("read: " + infile)
-            file_open = (lambda x: open(x, 'r', encoding='utf-8')) if six.PY3 else (lambda x: open(x, 'r'))
-            with file_open(infile) as fd:
-                self.read_fd(fd)
 
-            if schema is not None and self.get_version() > 1.0:
-                self.validate_xml_file(infile, schema)
+        logger.debug("read: " + infile)
+        file_open = (lambda x: open(x, 'r', encoding='utf-8')) if six.PY3 else (lambda x: open(x, 'r'))
+        with file_open(infile) as fd:
+            self.read_fd(fd)
 
-            logger.debug("File version is {}".format(str(self.get_version())))
+        if schema is not None and self.get_version() > 1.0:
+            self.validate_xml_file(infile, schema)
 
-            self._FILEMAP[infile] = (self.tree, self.root)
+        logger.debug("File version is {}".format(str(self.get_version())))
 
     def read_fd(self, fd):
         if self.tree:

--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -7,7 +7,6 @@ from CIME.XML.env_build import EnvBuild
 from CIME.XML.env_case import EnvCase
 from CIME.XML.env_mach_pes import EnvMachPes
 from CIME.XML.env_batch import EnvBatch
-from CIME.XML.generic_xml import GenericXML
 from CIME.utils import run_cmd_no_fail
 
 logger = logging.getLogger(__name__)
@@ -25,13 +24,8 @@ def lock_file(filename, caseroot=None, newname=None):
         os.mkdir(fulllockdir)
     logging.debug("Locking file {} to {}".format(filename, newname))
 
-    # JGF: It is extremely dangerous to alter our database (xml files) without
-    # going through the standard API. The copy below invalidates all existing
-    # GenericXML instances that represent this file and all caching that may
-    # have involved this file. We should probably seek a safer way of locking
-    # files.
     shutil.copyfile(os.path.join(caseroot, filename), os.path.join(fulllockdir, newname))
-    GenericXML.invalidate_file(os.path.join(fulllockdir, newname))
+
 
 def unlock_file(filename, caseroot=None):
     expect("/" not in filename, "Please just provide basename of locked file")


### PR DESCRIPTION
This reverts PR #2243 which was causing ERR test to fail and generally reducing confidence in the system tests.   I think that the ERR failure may be a race condition because it doesn't seem to happen every time. 
Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2249 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
