### PR TITLE
Change PET to be a multisubmit job

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -518,6 +518,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
+    <RESUBMIT>1</RESUBMIT>
   </test>
 
   <test NAME="PFS">

--- a/scripts/lib/CIME/SystemTests/pet.py
+++ b/scripts/lib/CIME/SystemTests/pet.py
@@ -20,6 +20,7 @@ class PET(SystemTestsCompareTwo):
         """
         SystemTestsCompareTwo.__init__(self, case,
                                        separate_builds = False,
+                                       multisubmit=True,
                                        run_two_suffix = 'single_thread',
                                        run_one_description = 'default threading',
                                        run_two_description = 'threads set to 1')
@@ -37,16 +38,6 @@ class PET(SystemTestsCompareTwo):
         #Do a run with all threads set to 1
         for comp in self._case.get_values("COMP_CLASSES"):
             self._case.set_value("NTHRDS_{}".format(comp), 1)
-
-        # The need for this is subtle. On batch systems, the entire PET test runs
-        # under a single submission and that submission is configured based on
-        # the case settings for case 1, IE 2 threads for all components. This causes
-        # the procs-per-node to be half of what it would be for single thread. On some
-        # machines, if the mpiexec tries to exceed the procs-per-node that were given
-        # to the batch submission, things break. Setting MAX_TASKS_PER_NODE to half of
-        # it original value prevents this.
-        self._case.set_value("MAX_TASKS_PER_NODE", int(self._case.get_value("MAX_TASKS_PER_NODE") / 2))
-        self._case.set_value("MAX_MPITASKS_PER_NODE", int(self._case.get_value("MAX_MPITASKS_PER_NODE") / 2))
 
         # Need to redo case_setup because we may have changed the number of threads
         case_setup(self._case, reset=True)

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -49,7 +49,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
 
     def __init__(self,
                  case,
-                 separate_builds,
+                 separate_builds = False,
                  run_two_suffix = 'test',
                  run_one_description = '',
                  run_two_description = '',
@@ -213,6 +213,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         """
         first_phase = self._case1.get_value("RESUBMIT") == 1 # Only relevant for multi-submit tests
         run_type = self._case1.get_value("RUN_TYPE")
+
         # First run
         if not self._multisubmit or first_phase:
             logger.info('Doing first run: ' + self._run_one_description)

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -231,7 +231,7 @@ def resubmit_check(case):
         run_cmd(cmd, verbose=True)
 
     if resubmit:
-        if testcase is not None and testcase in ['ERR']:
+        if testcase is not None and testcase in ['ERR', 'PET']:
             job = "case.test"
         else:
             job = "case.run"

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -231,10 +231,11 @@ def resubmit_check(case):
         run_cmd(cmd, verbose=True)
 
     if resubmit:
-        if testcase is not None and testcase in ['ERR', 'PET']:
+        if testcase is not None:
             job = "case.test"
         else:
             job = "case.run"
+
         submit(case, job=job, resubmit=True)
 
 ###############################################################################


### PR DESCRIPTION
Changing all the threading makes it hacky to try to do both runs
under a single submission.

Test suite: by hand, melvin and skybridve
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?:N

Code review: @jedwards4b 
