### PR TITLE
Second fix for user compsets 

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -457,7 +457,6 @@ class Case(object):
                 match, compset_alias, science_support = compsets.get_compset_match(name=compset_name)
                 if match is not None:
                     self._compsetname = match
-                    self.set_lookup_value("COMPSETS_SPEC_FILE", compsets_filename)
                     logger.info("Compset longname is {}".format(match))
                     logger.info("Compset specification file is {}".format(compsets_filename))
                     return compset_alias, science_support


### PR DESCRIPTION
Retested #2253 with this line removed as @billsacks suggested, all tests pass.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
