### PR TITLE
Improve python interface to environment modules

### DIFF
--- a/config/acme/machines/config_machines.xml
+++ b/config/acme/machines/config_machines.xml
@@ -1350,7 +1350,7 @@
          <mpirun mpilib="default">
            <executable>srun</executable>
          </mpirun>
-	 <module_system type="module_lmod">
+	 <module_system type="module">
 	      <init_path lang="python">/usr/share/lmod/lmod/init/env_modules_python.py</init_path>
  	      <init_path lang="perl">/usr/share/lmod/lmod/init/perl</init_path>
 	      <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
@@ -2772,7 +2772,7 @@
 		 <arg name="show-processmap"> display-map </arg>
 		-->
 
-    <module_system type="module_lmod">
+    <module_system type="module">
       <!-- list of init_path elements, one per supported language e.g. sh, perl, python-->
       <init_path lang="sh">/sw/summitdev/lmod/7.4.0/rhel7.2_gnu4.8.5/lmod/7.4/init/sh</init_path>
       <init_path lang="csh">/sw/summitdev/lmod/7.4.0/rhel7.2_gnu4.8.5/lmod/7.4/init/csh</init_path>
@@ -2780,7 +2780,7 @@
       <init_path lang="perl">/sw/summitdev/lmod/7.4.0/rhel7.2_gnu4.8.5/lmod/7.4/init/perl</init_path>
       <!-- list of cmd_path elements, one for every supported language, e.g. sh, perl, python -->
       <cmd_path lang="perl">module</cmd_path>
-      <cmd_path lang="python">module</cmd_path>
+      <cmd_path lang="python">/sw/summitdev/lmod/7.4.0/rhel7.2_gnu4.8.5/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
 


### PR DESCRIPTION
1) Get rid of module_lmod concept. All versions of module are capable of
python mode, they just need to be configured correctly in config_machines.xml
2) Fix module config for summitdev
3) Make internal methods load_modules and load_env private
4) Optimize module interation by bundling N commands doing the same action
into a single command with multiple arguments. This will greatly reduce the
number of subprocess forks and improve the speed of loading env.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2091 

User interface changes?: Yes, module_lmod no longer a support module type

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @vanroekel 
