### PR TITLE
Separate post-DA from pause/resume and add resume signal at init

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -213,7 +213,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
 <config_test>
 
   <test NAME="DAE">
-    <DESC>data assimilation test, default 1 day, two DA cycles, no data modification</DESC>
+    <DESC>data assimilation test, default two 2-day DA cycles, no data modification</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>4</STOP_N>

--- a/scripts/data_assimilation/da_no_data_mod.sh
+++ b/scripts/data_assimilation/da_no_data_mod.sh
@@ -17,6 +17,53 @@ else
   cycle=$2
   echo "caseroot: ${caseroot}"
   echo "cycle: ${cycle}"
+  cd ${caseroot}
+  res=$?
+  if [ $res -ne 0 ]; then
+    echo "ERROR: Unable to cd to caseroot, ${caseroot}"
+    errcode=$(( errcode + 1 ))
+  else
+    dval="`./xmlquery --value COMPSET 2> /dev/null | grep DWAV`"
+    ./xmlchange DATA_ASSIMILATION_WAV=TRUE
+    res=$?
+    if [ $res -ne 0 ]; then
+      echo "ERROR: Unable to change DATA_ASSIMILATION_WAV to TRUE"
+      errcode=$(( errcode + 1 ))
+    fi
+    if [ $cycle -gt 0 -a -n "${dval}" ]; then
+      rundir="`./xmlquery --value RUNDIR`"
+      if [ -n "${rundir}" -a -d "${rundir}" ]; then
+        cd ${rundir}
+        res=$?
+        if [ $res -ne 0 ]; then
+          echo "ERROR: Unable to cd to caseroot, ${caseroot}"
+          errcode=$(( errcode + 1 ))
+        else
+          # Check the latest log file for a resume signal
+          lfile="`ls -t wav.log.* | head -1`"
+          if [ -n "${lfile}" -a -f "${lfile}" ]; then
+            if [ -n "`echo ${lfile} | grep 'gz$'`" ]; then
+              sig="`zcat ${lfile} | grep 'Resume signal, TRUE' 2> /dev/null`"
+            else
+              sig="`cat ${lfile} | grep 'Resume signal, TRUE' 2> /dev/null`"
+            fi
+            if [ -n "${sig}" ]; then
+              echo "Post-DA resume signal found for cycle ${cycle}"
+            else
+              echo "ERROR: No post-DA resume signal found for cycle ${cycle}"
+              errcode=$(( errcode + 1 ))
+            fi
+          else
+            echo "ERROR: Unable to find wav log file in `pwd -P`"
+            errcode=$(( errcode + 1 ))
+          fi
+        fi
+      else
+        echo "ERROR: RUNDIR (${rundir}) is not a valid directory"
+        errcode=$(( errcode + 1 ))
+      fi
+    fi
+  fi
 fi
 
 exit $errcode

--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -1,6 +1,8 @@
 """
-Implementation of the CIME data assimilation test: Tests simple DA script
-which does not change the CAM input. Compares answers to non-DA run.
+Implementation of the CIME data assimilation test:
+Compares standard run with run broken into two data assimilation cycles.
+Runs a simple DA script on each cycle which performs checks but does not
+change any model state (restart files). Compares answers of two runs.
 
 """
 
@@ -18,8 +20,10 @@ from CIME.case_setup import case_setup
 class DAE(SystemTestsCompareTwo):
 ###############################################################################
     """
-    Implementation of the CIME data assimilation test: Tests simple DA script
-    which does not change the CAM input. Compares answers to non-DA run.
+    Implementation of the CIME data assimilation test:
+    Compares standard run with a run broken into two data assimilation cycles.
+    Runs a simple DA script on each cycle which performs checks but does not
+    change any model state (restart files). Compares answers of two runs.
     Refers to a faux data assimilation script in the
     cime/scripts/data_assimilation directory
     """

--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -95,7 +95,12 @@ class DAE(SystemTestsCompareTwo):
         for fname in da_files:
             found_caseroot = False
             found_cycle = False
-            found_signal = not is_dwav
+            found_signal = 0
+            if is_dwav and (cycle_num > 0):
+                expected_signal = self._case.get_value("NINST_WAV")
+            else:
+                expected_signal = 0
+
             with gzip.open(fname, "r") as dfile:
                 for bline in dfile:
                     line = bline.decode("utf-8")
@@ -107,7 +112,7 @@ class DAE(SystemTestsCompareTwo):
                         expect(int(line[7:]) == cycle_num,
                                "ERROR: Wrong cycle ({:d}) found in {} (expected {:d})".format(int(line[7:]), fname, cycle_num))
                     elif 'resume signal' in line:
-                        found_signal = True
+                        found_signal = found_signal + 1
                         expect('Post-DA resume signal found' in line[0:27],
                                "ERROR: bad post-DA message found in {}".format(fname))
                     else:
@@ -116,7 +121,7 @@ class DAE(SystemTestsCompareTwo):
                 # End of for loop
                 expect(found_caseroot, "ERROR: No caseroot found in {}".format(fname))
                 expect(found_cycle, "ERROR: No cycle found in {}".format(fname))
-                expect((cycle_num == 0) or found_signal,
-                       "ERROR: No post-DA resume signal message found in {}".format(fname))
+                expect(found_signal == expected_signal,
+                       "ERROR: Expected {} post-DA resume signal message(s), {} found in {}".format(expected_signal, found_signal, fname))
             # End of with
             cycle_num = cycle_num + 1

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -1,9 +1,9 @@
 """
 Implementation of the CIME pause/resume test: Tests having driver
 'pause' (write cpl restart file) and 'resume' (read cpl restart file)
-without changing restart file. Compare to non-pause/resume run.
+possibly changing the restart file. Compared to non-pause/resume run.
 Test can also be run with other component combinations.
-
+Test requires DESP component to function correctly.
 """
 
 import os.path
@@ -21,7 +21,7 @@ class PRE(SystemTestsCompareTwo):
     """
     Implementation of the CIME pause/resume test: Tests having driver
     'pause' (write cpl and/or other restart file(s)) and 'resume'
-    (read cpl and/or other restart file(s)) without changing restart
+    (read cpl and/or other restart file(s)) possibly changing restart
     file. Compare to non-pause/resume run.
     """
 

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -59,11 +59,11 @@ class PRE(SystemTestsCompareTwo):
         self._case.set_value("PAUSE_OPTION", stopopt)
         self._case.set_value("PAUSE_N", pausen)
         comps = self._case.get_values("COMP_CLASSES")
-        data_assimilation = []
+        pause_active = []
         for comp in comps:
-            data_assimilation.append(self._case.get_value("DATA_ASSIMILATION_{}".format(comp)))
+            pause_active.append(self._case.get_value("PAUSE_ACTIVE_{}".format(comp)))
 
-        expect(any(data_assimilation), "No Data_Assimilation flag is set")
+        expect(any(pause_active), "No pause_active flag is set")
 
         self._case.flush()
 
@@ -83,7 +83,7 @@ class PRE(SystemTestsCompareTwo):
         multi_driver = self._case.get_value("MULTI_DRIVER")
         comps = self._case.get_values("COMP_CLASSES")
         for comp in comps:
-            if not self._case.get_value("DATA_ASSIMILATION_{}".format(comp)):
+            if not self._case.get_value("PAUSE_ACTIVE_{}".format(comp)):
                 continue
             if comp == "CPL":
                 if multi_driver:

--- a/src/components/data_comps/desp/cime_config/namelist_definition_desp.xml
+++ b/src/components/data_comps/desp/cime_config/namelist_definition_desp.xml
@@ -41,7 +41,8 @@
       The mode of operation for the DESP model.
       NOCHANGE: report  status of model 'pause' but make no changes
       DATATEST: make a roundoff change  to the restart files of the
-                components in the 'DATA_ASSIMILATION' XML variable.
+                components with their 'PAUSE_ACTIVE_XXX' XML variable
+                set to TRUE.
       Default: NOCHANGE
     </desc>
     <values>

--- a/src/components/data_comps/dwav/cime_config/namelist_definition_dwav.xml
+++ b/src/components/data_comps/dwav/cime_config/namelist_definition_dwav.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0"?>
 
 <?xml-stylesheet type="text/xsl" href="namelist_definition.xsl"?>

--- a/src/components/data_comps/dwav/dwav_comp_mod.F90
+++ b/src/components/data_comps/dwav/dwav_comp_mod.F90
@@ -348,7 +348,7 @@ CONTAINS
     if (write_restart) then
        call t_startf('dwav_restart')
        call shr_cal_ymdtod2string(date_str, yy,mm,dd,currentTOD)
-       write(rest_file,"(6aa)") &
+       write(rest_file,"(6a)") &
             trim(case_name), '.dwav',trim(inst_suffix),'.r.', &
             trim(date_str),'.nc'
        write(rest_file_strm,"(6a)") &

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -389,13 +389,34 @@
     </desc>
   </entry>
 
+  <entry id="PAUSE_ACTIVE">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <group>run_begin_stop_restart</group>
+    <file>env_run.xml</file>
+    <desc>
+      Pause the model at times specified by PAUSE_OPTION and PAUSE_N.
+      Components 'pause' by writing a restart file.
+    </desc>
+    <values>
+      <value compclass="ATM">FALSE</value>
+      <value compclass="CPL">FALSE</value>
+      <value compclass="OCN">FALSE</value>
+      <value compclass="WAV">FALSE</value>
+      <value compclass="GLC">FALSE</value>
+      <value compclass="ICE">FALSE</value>
+      <value compclass="ROF">FALSE</value>
+      <value compclass="LND">FALSE</value>
+    </values>
+  </entry>
+
   <entry id="BARRIER_N">
     <type>char</type>
     <default_value>1</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
     <desc>
-      sets periodic model barriers with BARRIER_OPTION and BARRIER_DATE for synchronization
+      Sets periodic model barriers with BARRIER_OPTION and BARRIER_DATE for synchronization
     </desc>
   </entry>
 
@@ -419,7 +440,7 @@
     <desc>
       ESP component runs after driver 'pause cycle' If any component
       'pauses' (see PAUSE_OPTION,
-      PAUSE_N and DATA_ASSIMILATION XML variables),
+      PAUSE_N and PAUSE_ACTIVE_XXX XML variables),
       the ESP component (if present) will be run to process the
       component 'pause' (restart) files and set any required 'resume'
       signals.  If true, esp_cpl_dt and esp_cpl_offset settings are

--- a/src/drivers/mct/cime_config/config_compsets.xml
+++ b/src/drivers/mct/cime_config/config_compsets.xml
@@ -99,7 +99,7 @@
   </compset>
 
   <entries>
-    <entry id="DATA_ASSIMILATION_CPL">
+    <entry id="PAUSE_ACTIVE_CPL">
       <values match="last">
 	<value compset="DESP">TRUE</value>
       </values>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -2101,6 +2101,102 @@
     </values>
   </entry>
 
+  <entry id="pause_active_atm" modify_via_xml="PAUSE_ACTIVE_ATM">
+    <type>logical</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      Whether Pause signals are active for component atm
+    </desc>
+    <values>
+      <value>$PAUSE_ACTIVE_ATM</value>
+    </values>
+  </entry>
+
+  <entry id="pause_active_cpl" modify_via_xml="PAUSE_ACTIVE_CPL">
+    <type>logical</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      Whether Pause signals are active for component CPL
+    </desc>
+    <values>
+      <value>$PAUSE_ACTIVE_CPL</value>
+    </values>
+  </entry>
+
+  <entry id="pause_active_ocn" modify_via_xml="PAUSE_ACTIVE_OCN">
+    <type>logical</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      Whether Pause signals are active for component ocn
+    </desc>
+    <values>
+      <value>$PAUSE_ACTIVE_OCN</value>
+    </values>
+  </entry>
+
+  <entry id="pause_active_wav" modify_via_xml="PAUSE_ACTIVE_WAV">
+    <type>logical</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      Whether Pause signals are active for component wav
+    </desc>
+    <values>
+      <value>$PAUSE_ACTIVE_WAV</value>
+    </values>
+  </entry>
+
+  <entry id="pause_active_glc" modify_via_xml="PAUSE_ACTIVE_GLC">
+    <type>logical</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      Whether Pause signals are active for component glc
+    </desc>
+    <values>
+      <value>$PAUSE_ACTIVE_GLC</value>
+    </values>
+  </entry>
+
+  <entry id="pause_active_rof" modify_via_xml="PAUSE_ACTIVE_ROF">
+    <type>logical</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      Whether Pause signals are active for component rof
+    </desc>
+    <values>
+      <value>$PAUSE_ACTIVE_ROF</value>
+    </values>
+  </entry>
+
+  <entry id="pause_active_ice" modify_via_xml="PAUSE_ACTIVE_ICE">
+    <type>logical</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      Whether Pause signals are active for component ice
+    </desc>
+    <values>
+      <value>$PAUSE_ACTIVE_ICE</value>
+    </values>
+  </entry>
+
+  <entry id="pause_active_lnd" modify_via_xml="PAUSE_ACTIVE_LND">
+    <type>logical</type>
+    <category>time</category>
+    <group>seq_timemgr_inparm</group>
+    <desc>
+      Whether Pause signals are active for component lnd
+    </desc>
+    <values>
+      <value>$PAUSE_ACTIVE_LND</value>
+    </values>
+  </entry>
+
   <entry id="logfilepostfix">
     <type>char</type>
     <category>driver</category>

--- a/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -614,12 +614,20 @@
       </machine>
     </machines>
   </test>
+  <test name="DAE" grid="ww3a" compset="ADWAV">
+    <machines>
+      <machine name="hobart" compiler="nag" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+    </options>
+  </test>
   <test name="PRE" grid="f09_f09" compset="ADESP">
     <machines>
       <machine name="hobart" compiler="nag" category="pauseresume"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
   <test name="PRE" grid="f09_f09" compset="ADESP_TEST">
@@ -629,7 +637,7 @@
       <machine name="hobart" compiler="nag" category="pauseresume"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
 </testlist>

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -1131,6 +1131,9 @@ contains
 
   subroutine cime_init()
 
+    character(CL), allocatable :: comp_resume(:)
+
+
 104 format( A, i10.8, i8)
 
   !-----------------------------------------------------------------------------
@@ -2019,6 +2022,22 @@ contains
           call prep_lnd_calc_g2x_lx(timer='CPL:init_gllndnd')
        endif
     endif
+
+    !----------------------------------------------------------
+    !| Clear all resume signals
+    !----------------------------------------------------------
+    allocate(comp_resume(num_inst_max))
+    comp_resume = ''
+    call seq_infodata_putData(infodata,          &
+         atm_resume=comp_resume(1:num_inst_atm), &
+         lnd_resume=comp_resume(1:num_inst_lnd), &
+         ocn_resume=comp_resume(1:num_inst_ocn), &
+         ice_resume=comp_resume(1:num_inst_ice), &
+         glc_resume=comp_resume(1:num_inst_glc), &
+         rof_resume=comp_resume(1:num_inst_rof), &
+         wav_resume=comp_resume(1:num_inst_wav), &
+         cpl_resume=comp_resume(1))
+    deallocate(comp_resume)
 
     !----------------------------------------------------------
     !| Write histinit output file

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -1974,7 +1974,7 @@ CONTAINS
     integer(SHR_KIND_IN),   optional, intent(IN)    :: comp_ny         ! nx,ny 2d grid size global
     integer(SHR_KIND_IN),   optional, intent(IN)    :: comp_phase
     logical,                optional, intent(IN)    :: histavg_comp
-    character(SHR_KIND_CL), optional, intent(IN) :: comp_resume(:)
+    character(SHR_KIND_CL), optional, intent(IN)    :: comp_resume(:)
 
     !EOP
 

--- a/src/drivers/mct/shr/seq_timemgr_mod.F90
+++ b/src/drivers/mct/shr/seq_timemgr_mod.F90
@@ -62,6 +62,9 @@ module seq_timemgr_mod
   public :: seq_timemgr_pause_component_index ! Index of named component
   public :: seq_timemgr_pause_component_active ! .true. is comp should pause
 
+  ! --- Alert components if they need to do post-data assimilation processing
+  public :: seq_timemgr_data_assimilation_active ! .true. do post-DA
+
   ! ! PUBLIC PARAMETERS:
 
   integer(SHR_KIND_IN),public :: seq_timemgr_histavg_type
@@ -214,6 +217,9 @@ module seq_timemgr_mod
   ! Active pause - resume components
   logical, private :: pause_active(max_clocks) = .false.
 
+  ! Active post-data assimilation components
+  logical, private :: data_assimilation_active(max_clocks) = .false.
+
   type EClock_pointer     ! needed for array of pointers
      type(ESMF_Clock),pointer :: EClock => null()
   end type EClock_pointer
@@ -306,6 +312,15 @@ contains
     character(SHR_KIND_CS)  :: pause_option          ! Pause option units
     integer(SHR_KIND_IN)    :: pause_n               ! Number between pause intervals
 
+    logical :: pause_active_atm
+    logical :: pause_active_cpl
+    logical :: pause_active_ocn
+    logical :: pause_active_wav
+    logical :: pause_active_glc
+    logical :: pause_active_ice
+    logical :: pause_active_rof
+    logical :: pause_active_lnd
+
     logical :: data_assimilation_atm
     logical :: data_assimilation_cpl
     logical :: data_assimilation_ocn
@@ -363,6 +378,14 @@ contains
          restart_option, restart_n, restart_ymd,                 &
          pause_option,   &
          pause_n,           &
+         pause_active_atm, &
+         pause_active_cpl, &
+         pause_active_ocn, &
+         pause_active_wav, &
+         pause_active_glc, &
+         pause_active_ice, &
+         pause_active_rof, &
+         pause_active_lnd, &
          data_assimilation_atm, &
          data_assimilation_cpl, &
          data_assimilation_ocn, &
@@ -416,6 +439,14 @@ contains
        restart_ymd      = -1
        pause_option     = seq_timemgr_optNever
        pause_n          = -1
+       pause_active_atm = .false.
+       pause_active_cpl = .false.
+       pause_active_ocn = .false.
+       pause_active_wav = .false.
+       pause_active_glc = .false.
+       pause_active_ice = .false.
+       pause_active_rof = .false.
+       pause_active_lnd = .false.
        data_assimilation_atm = .false.
        data_assimilation_cpl = .false.
        data_assimilation_ocn = .false.
@@ -660,14 +691,22 @@ contains
     call shr_mpi_bcast( restart_ymd,          mpicom )
     call shr_mpi_bcast( pause_n,              mpicom )
     call shr_mpi_bcast( pause_option,         mpicom )
-    call shr_mpi_bcast(data_assimilation_atm, mpicom)
-    call shr_mpi_bcast(data_assimilation_cpl, mpicom)
-    call shr_mpi_bcast(data_assimilation_ocn, mpicom)
-    call shr_mpi_bcast(data_assimilation_wav, mpicom)
-    call shr_mpi_bcast(data_assimilation_glc, mpicom)
-    call shr_mpi_bcast(data_assimilation_ice, mpicom)
-    call shr_mpi_bcast(data_assimilation_rof, mpicom)
-    call shr_mpi_bcast(data_assimilation_lnd, mpicom)
+    call shr_mpi_bcast(pause_active_atm,      mpicom )
+    call shr_mpi_bcast(pause_active_cpl,      mpicom )
+    call shr_mpi_bcast(pause_active_ocn,      mpicom )
+    call shr_mpi_bcast(pause_active_wav,      mpicom )
+    call shr_mpi_bcast(pause_active_glc,      mpicom )
+    call shr_mpi_bcast(pause_active_ice,      mpicom )
+    call shr_mpi_bcast(pause_active_rof,      mpicom )
+    call shr_mpi_bcast(pause_active_lnd,      mpicom )
+    call shr_mpi_bcast(data_assimilation_atm, mpicom )
+    call shr_mpi_bcast(data_assimilation_cpl, mpicom )
+    call shr_mpi_bcast(data_assimilation_ocn, mpicom )
+    call shr_mpi_bcast(data_assimilation_wav, mpicom )
+    call shr_mpi_bcast(data_assimilation_glc, mpicom )
+    call shr_mpi_bcast(data_assimilation_ice, mpicom )
+    call shr_mpi_bcast(data_assimilation_rof, mpicom )
+    call shr_mpi_bcast(data_assimilation_lnd, mpicom )
 
     call shr_mpi_bcast( history_n,            mpicom )
     call shr_mpi_bcast( history_option,       mpicom )
@@ -734,33 +773,27 @@ contains
     seq_timemgr_calendar             = shr_cal_calendarName(calendar)
     seq_timemgr_esp_run_on_pause     = esp_run_on_pause
     seq_timemgr_end_restart          = end_restart
-    ! --- Figure out which components (if any) are doing pause this run
     rc = 1
     i = 1
-    if (data_assimilation_atm) then
-       pause_active(seq_timemgr_nclock_atm) = .true.
-    endif
-    if (data_assimilation_cpl) then
-       pause_active(seq_timemgr_nclock_drv) = .true.
-    endif
-    if (data_assimilation_ocn) then
-       pause_active(seq_timemgr_nclock_ocn) = .true.
-    endif
-    if (data_assimilation_wav) then
-       pause_active(seq_timemgr_nclock_wav) = .true.
-    endif
-    if (data_assimilation_glc) then
-       pause_active(seq_timemgr_nclock_glc) = .true.
-    endif
-    if (data_assimilation_ice) then
-       pause_active(seq_timemgr_nclock_ice) = .true.
-    endif
-    if (data_assimilation_rof) then
-       pause_active(seq_timemgr_nclock_rof) = .true.
-    endif
-    if (data_assimilation_lnd) then
-       pause_active(seq_timemgr_nclock_lnd) = .true.
-    endif
+    ! --- Figure out which components (if any) are doing pause this run
+    pause_active(seq_timemgr_nclock_atm) = pause_active_atm
+    pause_active(seq_timemgr_nclock_drv) = pause_active_cpl
+    pause_active(seq_timemgr_nclock_ocn) = pause_active_ocn
+    pause_active(seq_timemgr_nclock_wav) = pause_active_wav
+    pause_active(seq_timemgr_nclock_glc) = pause_active_glc
+    pause_active(seq_timemgr_nclock_ice) = pause_active_ice
+    pause_active(seq_timemgr_nclock_rof) = pause_active_rof
+    pause_active(seq_timemgr_nclock_lnd) = pause_active_lnd
+
+    ! Figure out which compoments need to do post-data assimilation processing
+    data_assimilation_active(seq_timemgr_nclock_atm) = data_assimilation_atm
+    data_assimilation_active(seq_timemgr_nclock_drv) = data_assimilation_cpl
+    data_assimilation_active(seq_timemgr_nclock_ocn) = data_assimilation_ocn
+    data_assimilation_active(seq_timemgr_nclock_wav) = data_assimilation_wav
+    data_assimilation_active(seq_timemgr_nclock_glc) = data_assimilation_glc
+    data_assimilation_active(seq_timemgr_nclock_ice) = data_assimilation_ice
+    data_assimilation_active(seq_timemgr_nclock_rof) = data_assimilation_rof
+    data_assimilation_active(seq_timemgr_nclock_lnd) = data_assimilation_lnd
 
     if ( ANY(pause_active) .and.                                              &
          (trim(pause_option) /= seq_timemgr_optNONE)  .and.                   &
@@ -2124,6 +2157,56 @@ contains
     seq_timemgr_pause_component_active = pause_active(component_index)
 
   end function seq_timemgr_pause_component_active
+
+  !===============================================================================
+  !===============================================================================
+  ! !IROUTINE: seq_timemgr_data_assimilation_active -- Check if component paused
+  !
+  ! !DESCRIPTION:
+  !
+  !     Return .true. if component is active in driver pause
+  !
+  ! !INTERFACE: ------------------------------------------------------------------
+
+  logical function seq_timemgr_data_assimilation_active(component_ntype)
+
+    !    !INPUT/OUTPUT PARAMETERS:
+
+    character(len=3), intent(IN) :: component_ntype
+
+    !EOP
+
+    !----- local -----
+    character(len=*), parameter :: subname = '(seq_timemgr_data_assimilation_active) '
+
+    !-------------------------------------------------------------------------------
+    ! Notes:
+    !-------------------------------------------------------------------------------
+
+    select case(component_ntype)
+    case ('atm')
+       seq_timemgr_data_assimilation_active = data_assimilation_active(seq_timemgr_nclock_atm)
+    case ('cpl')
+       seq_timemgr_data_assimilation_active = data_assimilation_active(seq_timemgr_nclock_drv)
+    case ('ocn')
+       seq_timemgr_data_assimilation_active = data_assimilation_active(seq_timemgr_nclock_ocn)
+    case ('wav')
+       seq_timemgr_data_assimilation_active = data_assimilation_active(seq_timemgr_nclock_wav)
+    case ('glc')
+       seq_timemgr_data_assimilation_active = data_assimilation_active(seq_timemgr_nclock_glc)
+    case ('ice')
+       seq_timemgr_data_assimilation_active = data_assimilation_active(seq_timemgr_nclock_ice)
+    case ('rof')
+       seq_timemgr_data_assimilation_active = data_assimilation_active(seq_timemgr_nclock_rof)
+    case ('lnd')
+       seq_timemgr_data_assimilation_active = data_assimilation_active(seq_timemgr_nclock_lnd)
+    case ('esp')
+       seq_timemgr_data_assimilation_active = .FALSE.
+    case default
+       call shr_sys_abort(subname//': component_ntype, "'//component_ntype//'" not recognized"')
+    end select
+
+  end function seq_timemgr_data_assimilation_active
 
   !===============================================================================
   !===============================================================================


### PR DESCRIPTION
- MCT driver now uses `DATA_ASSIMILATION_XXX` XML variables to send resume
signal to components at initialization time. Components will use this signal to do
post-data-assimilation processing after reading restart files. 
  - DAE test now passes resume signal after DA via DATA_ASSIMILATION_WAV.
  - DWAV model was modified to look for and log resume signal during initialization.
Fixed some issues in DWAV model. If DAE test is used with the DWAV model then the DAE test will make sure that the signal was seen.
- Added `PAUSE_ACTIVE_XXX` XML variables to the MCT driver config_component.xml
to support pause/resume functionality. 
  - Changed PRE test to use these variables.

Test suite: scripts_regression_tests.py on Cheyenne
DAE_D_Ld4.ww3a.ADWAV.hobart_nag for PASS and also to hand check that
resume signal was found, logged, and checked by both the data assimilation
script (da_no_data_mod.sh) and by the DAE test.
DAE_N2_D_Ld4.ww3a.ADWAV.hobart_nag and
DAE_C2_D_Ld4.ww3a.ADWAV.hobart_nag (as above)
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes CIME Github issue #2266

User interface changes?: New XML variables, `PAUSE_ACTIVE_XXX`.

Update gh-pages html (Y/N)?: n

Code review: 
