### PR TITLE
Reinstate xml file caching, but only for read-only files

### DIFF
--- a/scripts/lib/CIME/SystemTests/err.py
+++ b/scripts/lib/CIME/SystemTests/err.py
@@ -30,7 +30,6 @@ class ERR(RestartTest):
         super(ERR, self)._case_two_setup()
         self._case.set_value("DOUT_S", False)
 
-
     def _case_two_custom_prerun_action(self):
         dout_s_root = self._case1.get_value("DOUT_S_ROOT")
         rest_root = os.path.abspath(os.path.join(dout_s_root,"rest"))

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -350,7 +350,7 @@ class SystemTestsCommon(object):
         Compare env_run file to original and warn about differences
         """
         components = self._case.get_values("COMP_CLASSES")
-        f1obj = EnvRun(self._caseroot, "env_run.xml", components=components)
+        f1obj = self._case.get_env("run")
         f2obj = EnvRun(self._caseroot, os.path.join(LOCKED_DIR, "env_run.orig.xml"), components=components)
         diffs = f1obj.compare_xml(f2obj)
         for key in diffs.keys():

--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 
 class EntryID(GenericXML):
 
-    def __init__(self, infile=None, schema=None):
-        GenericXML.__init__(self, infile, schema)
+    def __init__(self, infile=None, schema=None, read_only=True):
+        GenericXML.__init__(self, infile, schema, read_only=read_only)
         self.groups={}
 
     def get_default_value(self, node, attributes=None):

--- a/scripts/lib/CIME/XML/env_archive.py
+++ b/scripts/lib/CIME/XML/env_archive.py
@@ -1,38 +1,20 @@
 """
-Interface to the env_archive.xml file.  This class inherits from GenericXML
+Interface to the env_archive.xml file.  This class inherits from EnvBase
 """
 from CIME.XML.standard_module_setup import *
 
-from CIME.XML.generic_xml import GenericXML
-from CIME.XML.headers import Headers
+from CIME.XML.env_base import EnvBase
 
 logger = logging.getLogger(__name__)
 
-class EnvArchive(GenericXML):
+class EnvArchive(EnvBase):
 
     def __init__(self, case_root=None, infile="env_archive.xml"):
         """
         initialize an object interface to file env_archive.xml in the case directory
         """
-        logger.debug("Case_root = {}".format(case_root))
-
-        # Check/Build path to env_archive.xml
-        if case_root is None:
-            case_root = os.getcwd()
-
-        if os.path.isabs(infile):
-            fullpath = infile
-        else:
-            fullpath = os.path.join(case_root, infile)
-
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_archive.xsd")
-        GenericXML.__init__(self, fullpath, schema=schema)
-
-        # The following creates the CASEROOT/env_archive.xml contents in self.root
-        if not os.path.isfile(fullpath):
-            headerobj = Headers()
-            headernode = headerobj.get_header_node(os.path.basename(fullpath))
-            self.add_child(headernode)
+        EnvBase.__init__(self, case_root, infile, schema=schema)
 
     def get_entries(self):
         return self.get_children('comp_archive_spec')
@@ -74,3 +56,6 @@ class EnvArchive(GenericXML):
             content_node = self.get_child('rpointer_content', root=rpointer_node)
             rpointer_items.append([self.text(file_node),self.text(content_node)])
         return rpointer_items
+
+    def get_type_info(self, vid):
+        return "char"

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -18,7 +18,7 @@ class EnvBase(EntryID):
         else:
             fullpath = os.path.join(case_root, infile)
 
-        EntryID.__init__(self, fullpath, schema=schema)
+        EntryID.__init__(self, fullpath, schema=schema, read_only=False)
 
         self._id_map = None
         self._group_map = None

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -416,3 +416,6 @@ class EnvMachSpecific(EnvBase):
         executable = self.text(exec_node)
 
         return executable, args
+
+    def get_type_info(self, vid):
+        return "char"

--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -7,7 +7,6 @@ from CIME.XML.env_build import EnvBuild
 from CIME.XML.env_case import EnvCase
 from CIME.XML.env_mach_pes import EnvMachPes
 from CIME.XML.env_batch import EnvBatch
-from CIME.XML.generic_xml import GenericXML
 from CIME.utils import run_cmd_no_fail
 
 logger = logging.getLogger(__name__)
@@ -31,7 +30,6 @@ def lock_file(filename, caseroot=None, newname=None):
     # have involved this file. We should probably seek a safer way of locking
     # files.
     shutil.copyfile(os.path.join(caseroot, filename), os.path.join(fulllockdir, newname))
-    GenericXML.invalidate_file(os.path.join(fulllockdir, newname))
 
 def unlock_file(filename, caseroot=None):
     expect("/" not in filename, "Please just provide basename of locked file")

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -881,9 +881,7 @@ class TestScheduler(object):
         # Setup cs files
         self._setup_cs_files()
 
-        GenericXML.DISABLE_CACHING = True
         self._producer()
-        GenericXML.DISABLE_CACHING = False
 
         expect(threading.active_count() == 1, "Leftover threads?")
 


### PR DESCRIPTION
Introduces the concept of read-only files. Files being read out of
the repo should never be modified, only EnvBase subclasses are
eligible for modification. This means we can cache the read-only
files without having to worry about cache-coherence issues.

Change list:
1) EnvArchive needs to be a subclass of EnvBase since it's an env case file
2) Caching only for read only files, ensure read-only prevents modifications
3) Try to minimize the differences between env_entryid and env_generic files in Case

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: n

Code review: @jedwards4b 
