### PR TITLE
allow merge of xml files without extra child level

### DIFF
--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -164,7 +164,12 @@ class GenericXML(object):
         """
         expect(not self.locked, "locked")
         root = root if root is not None else self.root
-        root.xml_element.append(node.xml_element)
+        logger.debug("add_child node name is {} root name is {}".format(node.xml_element.tag, self.name(root)))
+        if node.xml_element.tag == self.name(root):
+            for child in node.xml_element:
+                root.xml_element.append(child)
+        else:
+            root.xml_element.append(node.xml_element)
 
     def copy(self, node):
         return deepcopy(node)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -98,7 +98,7 @@ class GenericXML(object):
         if self.tree:
             addroot = _Element(ET.parse(fd).getroot())
             if addroot.xml_element.tag == self.name(self.root):
-                for child in addroot.get_children():
+                for child in self.get_children(root=addroot):
                     self.add_child(child)
             else:
                 self.add_child(addroot)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -96,7 +96,12 @@ class GenericXML(object):
 
     def read_fd(self, fd):
         if self.tree:
-            self.add_child(_Element(ET.parse(fd).getroot()))
+            addroot = _Element(ET.parse(fd).getroot())
+            if addroot.xml_element.tag == self.name(self.root):
+                for child in addroot.get_children():
+                    self.add_child(child)
+            else:
+                self.add_child(addroot)
         else:
             self.tree = ET.parse(fd)
             self.root = _Element(self.tree.getroot())
@@ -164,12 +169,7 @@ class GenericXML(object):
         """
         expect(not self.locked, "locked")
         root = root if root is not None else self.root
-        logger.debug("add_child node name is {} root name is {}".format(node.xml_element.tag, self.name(root)))
-        if node.xml_element.tag == self.name(root):
-            for child in node.xml_element:
-                root.xml_element.append(child)
-        else:
-            root.xml_element.append(node.xml_element)
+        root.xml_element.append(node.xml_element)
 
     def copy(self, node):
         return deepcopy(node)


### PR DESCRIPTION
Merging of xml files such as those in .cime directory was creating an extra parent level, this 
removes that layer if it exists. 

Test suite: scripts_regression_tests.py, SSP_Ld10.f19_g17.I1850Clm50Bgc.cheyenne_gnu.clm-rtmColdSSP 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2221 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
