### PR TITLE
st_archive counting too many cpl.r files when MULTI_… 

### DIFF
--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -30,16 +30,10 @@ def _get_datenames(rundir, casename, case):
     """
     expect(isdir(rundir), 'Cannot open directory {} '.format(rundir))
 
-    # KDR
     # The MULTI_DRIVER option requires a more careful search for dates.
     # When True, each date has MULTI_DRIVER cpl_####.r files.
     ndriver = case.get_value('MULTI_DRIVER')
     logger.debug("_get_datenames:  ndriver = {} ".format(ndriver))
-   
-    # glob uses shell style wildcards:
-    #   [!chars], instead of [^chars]).
-    #   ? matches a single char, instead of .
-    #   * matches everything
     if ndriver :
        files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl_0001.r.*.nc')))
     else:


### PR DESCRIPTION
When the MULTI_COUPLER option is used to build a case,
_get_datenames was not accounting for there being NINST cpl*.r
files at each restart date (cpl_0001.r., cpl_0002.r.,...).  
So st_archive was repeatedly trying to archive the same set.
_get_datenames now gets 'case' as an argument, 
which it queries for MULTI_COUPLER, and then counts
the correct subset of cpl.r files.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #2275

User interface changes?: no

Update gh-pages html (Y/N)?:N

Code review: 
