### PR TITLE
Fix issues with read only xml 

### DIFF
--- a/scripts/lib/CIME/XML/archive.py
+++ b/scripts/lib/CIME/XML/archive.py
@@ -38,7 +38,7 @@ class Archive(GenericXML):
 
             if infile is not None and os.path.isfile(infile):
                 arch = Archive(infile=infile, files=files)
-                specs = arch.get_child(name="comp_archive_spec", attributes={"compname":comp})
+                specs = arch.get_optional_child(name="comp_archive_spec", attributes={"compname":comp})
             else:
                 if infile is None:
                     logger.debug("No archive file defined for component {}".format(comp))

--- a/scripts/lib/CIME/XML/files.py
+++ b/scripts/lib/CIME/XML/files.py
@@ -38,7 +38,8 @@ class Files(EntryID):
         if "COMP_ROOT_DIR" in vid:
             if vid in self.COMP_ROOT_DIR:
                 if attribute is not None:
-                    return self.COMP_ROOT_DIR[vid+attribute["component"]]
+                    if vid+attribute["component"] in self.COMP_ROOT_DIR:
+                        return self.COMP_ROOT_DIR[vid+attribute["component"]]
                 else:
                     return self.COMP_ROOT_DIR[vid]
 

--- a/scripts/lib/CIME/XML/files.py
+++ b/scripts/lib/CIME/XML/files.py
@@ -26,7 +26,7 @@ class Files(EntryID):
         EntryID.__init__(self, infile, schema=schema)
         config_files_override = os.path.join(os.path.dirname(cimeroot),".config_files.xml")
         # variables COMP_ROOT_DIR_{} are mutable, all other variables are read only
-        self.COMP_ROOTS = {}
+        self.COMP_ROOT_DIR = {}
 
         # .config_file.xml at the top level may overwrite COMP_ROOT_DIR_ nodes in config_files
 
@@ -36,25 +36,41 @@ class Files(EntryID):
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None):
         if "COMP_ROOT_DIR" in vid:
-            if vid in self.COMP_ROOTS:
-                return self.COMP_ROOTS[vid]
+            if vid in self.COMP_ROOT_DIR:
+                if attribute is not None:
+                    return self.COMP_ROOT_DIR[vid+attribute["component"]]
+                else:
+                    return self.COMP_ROOT_DIR[vid]
+
         value = super(Files, self).get_value(vid, attribute=attribute, resolved=False, subgroup=subgroup)
-        if "COMP_ROOT_DIR" not in vid and value is not None and resolved and "COMP_ROOT_DIR" in value:
+        if value is None and attribute is not None:
+            value = super(Files, self).get_value(vid, attribute=None, resolved=False, subgroup=subgroup)
+
+        if "COMP_ROOT_DIR" not in vid and value is not None and "COMP_ROOT_DIR" in value:
             m = re.search("(COMP_ROOT_DIR_[^/]+)/", value)
             comp_root_dir_var_name = m.group(1)
             comp_root_dir = self.get_value(comp_root_dir_var_name, attribute=attribute, resolved=False, subgroup=subgroup)
-            self.set_value(comp_root_dir_var_name, comp_root_dir)
+            self.set_value(comp_root_dir_var_name, comp_root_dir,subgroup=attribute)
+            if resolved:
+                value = value.replace("$"+comp_root_dir_var_name, comp_root_dir)
+
+
         if resolved and value is not None:
             value = self.get_resolved_value(value)
 
         return value
 
-    def set_value(self, vid, value):
+    def set_value(self, vid, value,subgroup=None,ignore_type=False):
         if "COMP_ROOT_DIR" in vid:
-            self.COMP_ROOTS[vid] = value
+            if subgroup is not None:
+                self.COMP_ROOT_DIR[vid+subgroup["component"]] = value
+            else:
+                self.COMP_ROOT_DIR[vid] = value
+                
         else:
             expect(False, "Attempt to set a nonmutable variable {}".format(vid))
         return value
+
 
     def get_schema(self, nodename, attributes=None):
         node = self.get_optional_child("entry", {"id":nodename})

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -93,11 +93,17 @@ class GenericXML(object):
     def read_fd(self, fd):
         if self.tree:
             addroot = _Element(ET.parse(fd).getroot())
+            read_only = self.read_only
+            # we need to override the read_only mechanism here to append the xml object
+            if read_only:
+                self.read_only = False
             if addroot.xml_element.tag == self.name(self.root):
                 for child in self.get_children(root=addroot):
                     self.add_child(child)
             else:
                 self.add_child(addroot)
+            if read_only:
+                self.read_only = True
         else:
             self.tree = ET.parse(fd)
             self.root = _Element(self.tree.getroot())

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -293,6 +293,7 @@ class Machines(GenericXML):
         return None
 
     def set_value(self, vid, value, subgroup=None, ignore_type=True):
+        expect(False, "This object is not mutable")
         tmproot = self.root
         self.root = self.machine_node
         result = super(Machines, self).set_value(vid, value, subgroup=subgroup,

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -616,7 +616,6 @@ class Case(object):
         comp_root_dir = files.get_value(root_dir_node_name,
                                         {"component":"drv"}, resolved=False)
         if comp_root_dir is not None:
-            files.set_value(root_dir_node_name, comp_root_dir)
             self.set_value(root_dir_node_name, comp_root_dir)
 
 
@@ -626,23 +625,20 @@ class Case(object):
             root_dir_node_name = 'COMP_ROOT_DIR_' + comp_class
             node_name = 'CONFIG_' + comp_class + '_FILE'
             comp_root_dir = files.get_value(root_dir_node_name, {"component":comp_name}, resolved=False)
-
             if comp_root_dir is not None:
-                # the set_value in files is needed for the archiver setup below
-                files.set_value(root_dir_node_name, comp_root_dir)
                 self.set_value(root_dir_node_name, comp_root_dir)
-                compatt = None
-            else:
-                compatt = {"component":comp_name}
+
+            compatt = {"component":comp_name}
             # Add the group and elements for the config_files.xml
             comp_config_file = files.get_value(node_name, compatt, resolved=False)
             expect(comp_config_file is not None,"No component {} found for class {}".format(comp_name, comp_class))
             self.set_value(node_name, comp_config_file)
-            comp_config_file = self.get_resolved_value(comp_config_file)
+            comp_config_file =  files.get_value(node_name, compatt)
             expect(comp_config_file is not None and os.path.isfile(comp_config_file),
                    "Config file {} for component {} not found.".format(comp_config_file, comp_name))
             compobj = Component(comp_config_file, comp_class)
             # For files following version 3 schema this also checks the compsetname validity
+            
             self._component_description[comp_class] = compobj.get_description(self._compsetname)
             expect(self._component_description[comp_class] is not None,"No description found in file {} for component {} in comp_class {}".format(comp_config_file, comp_name, comp_class))
             logger.info("{} component is {}".format(comp_class, self._component_description[comp_class]))

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -538,6 +538,18 @@ class J_TestCreateNewcase(unittest.TestCase):
 
         cls._do_teardown.append(testdir)
 
+    def test_k_append_config(self):
+        machlist_before = MACHINE.list_available_machines()
+        self.assertEqual(len(machlist_before)>1, True, msg="Problem reading machine list")
+
+        newmachfile = os.path.join(CIME.utils.get_cime_root(),"config",
+                                   "xml_schemas","config_machines_template.xml")
+        MACHINE.read(newmachfile)
+        machlist_after = MACHINE.list_available_machines()
+
+        self.assertEqual(len(machlist_after)-len(machlist_before), 1, msg="Not able to append config_machines.xml {} {}".format(len(machlist_after), len(machlist_before)))
+        self.assertEqual("mymachine" in machlist_after, True, msg="Not able to append config_machines.xml")
+
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Fix issues associated with read-only xml objects, add a test to append config_machines.xml

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2276  + CDASH

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
