### PR TITLE
another exception for read only in config files

### DIFF
--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -435,7 +435,11 @@ class EntryID(GenericXML):
             if len(samenodes) > 1:
                 expect(len(samenodes) == 2, "Too many matchs for id {} in file {}".format(vid, self.filename))
                 logger.debug("Overwriting node {}".format(vid))
+                read_only = self.read_only
+                if read_only:
+                    self.read_only = False
                 self.remove_child(samenodes[0])
+                self.read_only = read_only
 
     def __iter__(self):
         for node in self.scan_children("entry"):


### PR DESCRIPTION
An exception to the config read only policy - in this case rather than appending a config file we are 
overwriting an existing setting. 

Test suite: scripts_regression_tests.py / create_newcase in ctsm
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2280 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
