### PR TITLE
move orb year settings for 1850 out of user mods

### DIFF
--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -32,6 +32,10 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     #--------------------------------
     config = {}
     config['cime_model'] = get_model()
+
+    compset = case.get_value("COMPSET")
+    config['iyear'] = compset.split('_')[0]
+
     config['BGC_MODE'] = case.get_value("CCSM_BGC")
     config['CPL_I2O_PER_CAT'] = case.get_value('CPL_I2O_PER_CAT')
     config['COMP_RUN_BARRIERS'] = case.get_value('COMP_RUN_BARRIERS')

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -152,7 +152,7 @@
     <valid_values></valid_values>
     <default_value></default_value>
     <values match="last">
-      <value compset="1850_">$SRCROOT/cime_config/usermods_dirs/b1850</value>
+      <value/>
     </values>
     <group>run_component_cpl</group>
     <file>env_case.xml</file>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -442,6 +442,7 @@
     </desc>
     <values>
       <value>1990</value>
+      <value iyear="1850"> 1850 </value>
     </values>
   </entry>
 
@@ -454,6 +455,7 @@
     </desc>
     <values>
       <value>1990</value>
+      <value iyear="1850"> 1850 </value>
     </values>
   </entry>
 


### PR DESCRIPTION
Setting the orb_year and orb_year_align for 1850 should not be done via user mods for 1850 cases. 
Here it is set in the namelist_definition_drv.xml file.   These will be set for any 1850 compset - is there any reason this wouldn't be the case for an I1850 or F1850?

Test suite: tests by hand of 1850 compsets
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2282

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
