### PR TITLE
Refactor _get_datenames to count the correct number of cpl.r files

### DIFF
--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -37,10 +37,6 @@ def _build_usernl_files(case, model, comp):
     multi_driver = case.get_value("MULTI_DRIVER")
     if multi_driver:
         ninst_max = case.get_value("NINST_MAX")
-# KDR added ESP so that I can build with 1,
-#     which will make st_archive work with .dart.$string files,
-#     which have no instance number.
-#     Should ESP be considered a data component?
         if model not in ("DRV","CPL","ESP"):
             ninst_model = case.get_value("NINST_{}".format(model))
             expect(ninst_model==ninst_max,"MULTI_DRIVER mode, all components must have same NINST value.  NINST_{} != {}".format(model,ninst_max))

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -37,7 +37,11 @@ def _build_usernl_files(case, model, comp):
     multi_driver = case.get_value("MULTI_DRIVER")
     if multi_driver:
         ninst_max = case.get_value("NINST_MAX")
-        if model not in ("DRV","CPL"):
+# KDR added ESP so that I can build with 1,
+#     which will make st_archive work with .dart.$string files,
+#     which have no instance number.
+#     Should ESP be considered a data component?
+        if model not in ("DRV","CPL","ESP"):
             ninst_model = case.get_value("NINST_{}".format(model))
             expect(ninst_model==ninst_max,"MULTI_DRIVER mode, all components must have same NINST value.  NINST_{} != {}".format(model,ninst_max))
     if comp == "cpl":

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -21,20 +21,23 @@ def _get_archive_file_fn(copy_only):
     return shutil.copyfile if copy_only else shutil.move
 
 ###############################################################################
-def _get_datenames(rundir, casename, case):
+def _get_datenames(case):
 ###############################################################################
     """
     Returns the datetime objects specifying the times of each file
     Note we are assuming that the coupler restart files exist and are consistent with other component datenames
     Not doc-testable due to filesystem dependence
     """
+    rundir = case.get_value("RUNDIR")
     expect(isdir(rundir), 'Cannot open directory {} '.format(rundir))
 
     # The MULTI_DRIVER option requires a more careful search for dates.
-    # When True, each date has MULTI_DRIVER cpl_####.r files.
-    ndriver = case.get_value('MULTI_DRIVER')
-    logger.debug("_get_datenames:  ndriver = {} ".format(ndriver))
-    if ndriver :
+    # When True, each date has NINST cpl_####.r files.
+    multidriver = case.get_value('MULTI_DRIVER')
+    logger.debug("_get_datenames:  multidriver = {} ".format(multidriver))
+
+    casename = case.get_value("CASE")
+    if multidriver :
        files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl_0001.r.*.nc')))
     else:
        files = sorted(glob.glob(os.path.join(rundir, casename +      '.cpl.r.*.nc')))
@@ -555,7 +558,7 @@ def _archive_process(case, archive, last_date, archive_incomplete_logs, copy_onl
                        archive_incomplete_logs, archive_file_fn)
 
     # archive restarts and all necessary associated files (e.g. rpointer files)
-    datenames = _get_datenames(case.get_value("RUNDIR"), case.get_value("CASE"), case)
+    datenames = _get_datenames(case)
     histfiles_savein_rundir_by_compname = {}
     for datename in datenames:
         datename_is_last = False
@@ -619,7 +622,7 @@ def archive_last_restarts(case, archive_restdir, last_date=None, link_to_restart
     files that are associated with these restart files.)
     """
     archive = case.get_env('archive')
-    datenames = _get_datenames(case.get_value("RUNDIR"), case.get_value("CASE"), case)
+    datenames = _get_datenames(case)
     expect(len(datenames) >= 1, "No restart dates found")
     last_datename = datenames[-1]
 

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -30,16 +30,10 @@ def _get_datenames(rundir, casename, case):
     """
     expect(isdir(rundir), 'Cannot open directory {} '.format(rundir))
 
-    # KDR
     # The MULTI_DRIVER option requires a more careful search for dates.
     # When True, each date has MULTI_DRIVER cpl_####.r files.
     ndriver = case.get_value('MULTI_DRIVER')
     logger.debug("_get_datenames:  ndriver = {} ".format(ndriver))
-   
-    # glob uses shell style wildcards:
-    #   [!chars], instead of [^chars]).
-    #   ? matches a single char, instead of .
-    #   * matches everything
     if ndriver :
        files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl_0001.r.*.nc')))
     else:

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -333,10 +333,10 @@ def _archive_history_files(case, archive, archive_entry,
                                "history file {} does not exist ".format(srcfile))
                         destfile = join(archive_histdir, histfile)
                         if histfile in histfiles_savein_rundir:
-                            logger.info("histfiles_savein_rundir; copying \n  {} to \n  {} ".format(srcfile, destfile))
+                            logger.debug("histfiles_savein_rundir; copying \n  {} to \n  {} ".format(srcfile, destfile))
                             shutil.copy(srcfile, destfile)
                         else:
-                            logger.info("_archive_history_files; moving \n  {} to \n  {} ".format(srcfile, destfile))
+                            logger.debug("_archive_history_files; moving \n  {} to \n  {} ".format(srcfile, destfile))
                             archive_file_fn(srcfile, destfile)
 
 ###############################################################################
@@ -395,7 +395,7 @@ def _archive_restarts_date(case, archive,
     histfiles_savein_rundir_by_compname = {}
 
     for (archive_entry, compname, compclass) in _get_component_archive_entries(case, archive):
-        logger.info('Archiving restarts for {} ({})'.format(compname, compclass))
+        logger.debug('Archiving restarts for {} ({})'.format(compname, compclass))
 
         # archive restarts
         histfiles_savein_rundir = _archive_restarts_date_comp(case, archive, archive_entry,
@@ -500,7 +500,7 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
                     srcfile = os.path.join(rundir, restfile)
                     destfile = os.path.join(archive_restdir, restfile)
                     last_restart_file_fn(srcfile, destfile)
-                    logger.info("{} {} \n  {} to \n  {}".format(
+                    logger.debug("{} {} \n  {} to \n  {}".format(
                         "datename_is_last", last_restart_file_fn_msg, srcfile, destfile))
                     for histfile in histfiles_for_restart:
                         srcfile = os.path.join(rundir, histfile)
@@ -508,7 +508,7 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
                         expect(os.path.isfile(srcfile),
                                "history restart file {} for last date does not exist ".format(srcfile))
                         shutil.copy(srcfile, destfile)
-                        logger.info("datename_is_last + histfiles_for_restart copying \n  {} to \n  {}".format(srcfile, destfile))
+                        logger.debug("datename_is_last + histfiles_for_restart copying \n  {} to \n  {}".format(srcfile, destfile))
                 else:
                     # Only archive intermediate restarts if requested - otherwise remove them
                     if case.get_value('DOUT_S_SAVE_INTERIM_RESTART_FILES'):
@@ -517,7 +517,7 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
                         expect(os.path.isfile(srcfile),
                                "restart file {} does not exist ".format(srcfile))
                         archive_file_fn(srcfile, destfile)
-                        logger.info("_archive_restarts_date_comp; moving \n   {} to \n   {}".format(srcfile, destfile))
+                        logger.debug("_archive_restarts_date_comp; moving \n   {} to \n   {}".format(srcfile, destfile))
 
                         # need to copy the history files needed for interim restarts - since
                         # have not archived all of the history files yet
@@ -527,10 +527,10 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
                             expect(os.path.isfile(srcfile),
                                    "hist file {} does not exist ".format(srcfile))
                             shutil.copy(srcfile, destfile)
-                            logger.info("interim_restarts: copying \n  {} to \n  {}".format(srcfile, destfile))
+                            logger.debug("interim_restarts: copying \n  {} to \n  {}".format(srcfile, destfile))
                     else:
                         srcfile = os.path.join(rundir, restfile)
-                        logger.info("removing interim restart file {}".format(srcfile))
+                        logger.debug("removing interim restart file {}".format(srcfile))
                         if (os.path.isfile(srcfile)):
                             try:
                                 os.remove(srcfile)
@@ -577,7 +577,7 @@ def _archive_process(case, archive, last_date, archive_incomplete_logs, copy_onl
     for (archive_entry, compname, compclass) in _get_component_archive_entries(case, archive):
         logger.info('Archiving history files for {} ({})'.format(compname, compclass))
         histfiles_savein_rundir = histfiles_savein_rundir_by_compname.get(compname, [])
-        logger.info("_archive_process: histfiles_savein_rundir {} ".format(histfiles_savein_rundir))
+        logger.debug("_archive_process: histfiles_savein_rundir {} ".format(histfiles_savein_rundir))
         _archive_history_files(case, archive, archive_entry,
                                compclass, compname, histfiles_savein_rundir,
                                last_date, archive_file_fn)

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -28,6 +28,7 @@ def _get_datenames(case):
     Note we are assuming that the coupler restart files exist and are consistent with other component datenames
     Not doc-testable due to filesystem dependence
     """
+    casename = case.get_value("CASE")
     rundir = case.get_value("RUNDIR")
     expect(isdir(rundir), 'Cannot open directory {} '.format(rundir))
 
@@ -36,7 +37,6 @@ def _get_datenames(case):
     multidriver = case.get_value('MULTI_DRIVER')
     logger.debug("_get_datenames:  multidriver = {} ".format(multidriver))
 
-    casename = case.get_value("CASE")
     if multidriver :
        files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl_0001.r.*.nc')))
     else:

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -38,13 +38,15 @@ def _get_datenames(case):
     logger.debug("_get_datenames:  multidriver = {} ".format(multidriver))
 
     if multidriver :
-       files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl_0001.r.*.nc')))
+        files = sorted(glob.glob(os.path.join(rundir, casename + '.cpl_0001.r.*.nc')))
     else:
-       files = sorted(glob.glob(os.path.join(rundir, casename +      '.cpl.r.*.nc')))
+        files = sorted(glob.glob(os.path.join(rundir, casename +      '.cpl.r.*.nc')))
+
     logger.debug("  cpl files : {} ".format(files))
 
     if not files:
         expect(False, 'Cannot find a {}.cpl*.r.*.nc file in directory {} '.format(casename, rundir))
+
     datenames = []
     for filename in files:
         date = get_file_date(filename)


### PR DESCRIPTION
Replaced arguments to case_st_archive.py:_get_datenames
with 'case', which will be queried for needed information
in _get_datenames.

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2275

User interface changes?: no

Update gh-pages html (Y/N)?:N

Code review: @gold2718 @jedwards4b 
