### PR TITLE
Upgrade cime_bisect

### DIFF
--- a/scripts/Tools/cime_bisect
+++ b/scripts/Tools/cime_bisect
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
 """
-A script to help track down the commit that caused a test to fail. This
-script is intended to be run by git bisect.
+A script to help track down the commit that caused tests to fail.
 """
 
 from standard_script_setup import *
@@ -17,18 +16,26 @@ _MACHINE = Machines()
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n{0} <testargs> <last-known-good-commit> [<bad>] [--compare=<baseline-id>] [--no-batch]  [--verbose]
+        usage="""\n{0} <testargs> <last-known-good-commit> [--bad=<bad>] [--compare=<baseline-id>] [--no-batch]  [--verbose]
 OR
 {0} --help
 
 \033[1mEXAMPLES:\033[0m
     \033[1;32m# Bisect ERS.f45_g37.B1850C5 which got broken in the last 4 commits \033[0m
     > cd <root-of-broken-cime-repo>
-    > {0} ERS.f45_g37.B1850C5 HEAD~4 HEAD
+    > {0} HEAD~4 ERS.f45_g37.B1850C5
+
+    \033[1;32m# Bisect ERS.f45_g37.B1850C5 which started to DIFF in the last 4 commits \033[0m
+    > cd <root-of-broken-cime-repo>
+    > {0} HEAD~4 'ERS.f45_g37.B1850C5 -c -b master'
 
     \033[1;32m# Bisect a build error for ERS.f45_g37.B1850C5 which got broken in the last 4 commits \033[0m
     > cd <root-of-broken-cime-repo>
-    > {0} 'ERS.f45_g37.B1850C5 --no-run' HEAD~4 HEAD
+    > {0} HEAD~4 'ERS.f45_g37.B1850C5 --no-run'
+
+    \033[1;32m# Bisect two different failing tests which got broken in the last 4 commits \033[0m
+    > cd <root-of-broken-cime-repo>
+    > {0} HEAD~4 'ERS.f45_g37.B1850C5 --no-run' 'SMS.f45_g37.F'
 
 """.format(os.path.basename(args[0])),
 
@@ -37,28 +44,17 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
-    default_project  = CIME.utils.get_project()
-    default_compiler = _MACHINE.get_default_compiler()
-
     CIME.utils.setup_standard_logging_options(parser)
-
-    parser.add_argument("testargs", help="String to pass to create_test. Combine with single quotes if it includes multiple args.")
 
     parser.add_argument("good", help="Name of most recent known good commit.")
 
-    parser.add_argument("bad", nargs="?", default="HEAD", help="Name of bad commits, default is current commit.")
+    parser.add_argument("testargs", nargs="+", help="String to pass to create_test. Combine with single quotes if it includes multiple args.")
+
+    parser.add_argument("-B", "--bad", default="HEAD",
+                        help="Name of bad commit, default is current HEAD.")
 
     parser.add_argument("-r", "--test-root",
                         help="Path to testroot to use for testcases for bisect. WARNING. This will be cleared by this script.")
-
-    parser.add_argument("-c", "--compiler", default=default_compiler,
-                        help="What compiler to use to build CIME")
-
-    parser.add_argument("-p", "--project", default=default_project,
-                        help="Project to be given to create_test.")
-
-    parser.add_argument("-b", "--baseline-name",
-                        help="Baseline id for comparing baselines. Not specifying means no comparisons will be done.")
 
     parser.add_argument("-n", "--check-namelists", action="store_true",
                         help="Consider a commit to be broken if namelist check fails")
@@ -93,30 +89,19 @@ that you run this script from the cime direcory.
 
     expect(os.path.isdir(".git"), "Please run the root of a repo")
 
-    if not args.baseline_name:
-        expect(not args.check_namelists, "Makes no sense to check namelists without baselines")
-        expect(not args.check_throughput, "Makes no sense to check throughput without baselines")
-
-    return args.testargs, args.good, args.bad, args.test_root, args.compiler, args.project, args.baseline_name, \
+    return args.testargs, args.good, args.bad, args.test_root, \
         args.check_namelists, args.check_throughput, args.check_memory, args.check_memleak, args.all_commits
 
 ###############################################################################
-def cime_bisect(testargs, good, bad, testroot, compiler, project, baseline_name, check_namelists,
-                check_throughput, check_memory, check_memleak, all_commits):
+def cime_bisect(testargs, good, bad, testroot,
+                check_namelists, check_throughput, check_memory, check_memleak, commits_to_skip):
 ###############################################################################
+    print("####################################################")
+    print("TESTING WITH ARGS '{}'".format(testargs))
+    print("####################################################")
+
     create_test = os.path.join(CIME.utils.get_scripts_root(), "create_test")
     expect(os.path.exists(create_test), "Please run the root of a CIME repo")
-
-    # Important: we only want to test merges
-    if not all_commits:
-        commits_we_want_to_test = run_cmd_no_fail("git rev-list {}..{} --merges --first-parent".format(good, bad)).splitlines()
-        all_commits_            = run_cmd_no_fail("git rev-list {}..{}".format(good, bad)).splitlines()
-        commits_to_skip         = set(all_commits_) - set(commits_we_want_to_test)
-        print("Skipping these non-merge commits")
-        for item in commits_to_skip:
-            print(item)
-    else:
-        commits_to_skip = set()
 
     # Basic setup
     run_cmd_no_fail("git bisect start")
@@ -127,14 +112,7 @@ def cime_bisect(testargs, good, bad, testroot, compiler, project, baseline_name,
 
     # Formulate the create_test command, let create_test make the test-id, it will use
     # a timestamp that will allow us to avoid collisions
-    compare_args = "-c -b {}".format(baseline_name) if baseline_name is not None else ""
-    project_args = "-p {}".format(project) if project else ""
-    bisect_cmd = "{} {} --test-root {} --compiler {} {} {}".format(create_test,
-                                                                   testargs,
-                                                                   testroot,
-                                                                   compiler,
-                                                                   project_args,
-                                                                   compare_args)
+    bisect_cmd = "{} {} --test-root {}".format(create_test, testargs, testroot)
 
     is_batch = _MACHINE.has_batch_system()
     if (is_batch and "--no-run" not in testargs and "--no-build" not in testargs and "--no-setup" not in testargs):
@@ -163,7 +141,10 @@ def cime_bisect(testargs, good, bad, testroot, compiler, project, baseline_name,
         bad_commits_filtered = bad_commits - commits_to_skip
 
         expect(len(bad_commits_filtered) == 1, bad_commits_filtered)
-        print("Bad merge is:")
+
+        print("####################################################")
+        print("BAD MERGE IS:")
+        print("####################################################")
         print(run_cmd_no_fail("git show {}".format(bad_commits_filtered.pop())))
 
     finally:
@@ -172,10 +153,22 @@ def cime_bisect(testargs, good, bad, testroot, compiler, project, baseline_name,
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    testargs, good, bad, testroot, compiler, project, baseline_name, check_namelists, check_throughput, check_memory, check_memleak, all_commits = \
+    testargs, good, bad, testroot, check_namelists, check_throughput, check_memory, check_memleak, all_commits = \
         parse_command_line(sys.argv, description)
 
-    cime_bisect(testargs, good, bad, testroot, compiler, project, baseline_name, check_namelists, check_throughput, check_memory, check_memleak, all_commits)
+    # Important: we only want to test merges
+    if not all_commits:
+        commits_we_want_to_test = run_cmd_no_fail("git rev-list {}..{} --merges --first-parent".format(good, bad)).splitlines()
+        all_commits_            = run_cmd_no_fail("git rev-list {}..{}".format(good, bad)).splitlines()
+        commits_to_skip         = set(all_commits_) - set(commits_we_want_to_test)
+        print("Skipping these non-merge commits")
+        for item in commits_to_skip:
+            print(item)
+    else:
+        commits_to_skip = set()
+
+    for set_of_test_args in testargs:
+        cime_bisect(set_of_test_args, good, bad, testroot, check_namelists, check_throughput, check_memory, check_memleak, commits_to_skip)
 
 ###############################################################################
 

--- a/scripts/Tools/cime_bisect
+++ b/scripts/Tools/cime_bisect
@@ -100,7 +100,11 @@ def cime_bisect(testargs, good, bad, testroot,
     print("TESTING WITH ARGS '{}'".format(testargs))
     print("####################################################")
 
-    create_test = os.path.join(CIME.utils.get_scripts_root(), "create_test")
+    if os.path.exists("scripts/create_test"):
+        create_test = os.path.join(os.getcwd(), "scripts", "create_test")
+    else:
+        create_test = os.path.join(os.getcwd(), "cime", "scripts", "create_test")
+
     expect(os.path.exists(create_test), "Please run the root of a CIME repo")
 
     # Basic setup
@@ -143,7 +147,7 @@ def cime_bisect(testargs, good, bad, testroot,
         expect(len(bad_commits_filtered) == 1, bad_commits_filtered)
 
         print("####################################################")
-        print("BAD MERGE IS:")
+        print("BAD MERGE FOR ARGS '{}' IS:".format(testargs))
         print("####################################################")
         print(run_cmd_no_fail("git show {}".format(bad_commits_filtered.pop())))
 


### PR DESCRIPTION
Can now sequentially bisect several tests independently.

Also, decouple cime_bisect from the repo it's bisecting.

Test suite: code-checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: Y, cime_bisect changes

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
