### PR TITLE
Disable caching withing the main test_scheduler process.

### DIFF
--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -33,6 +33,7 @@ class _Element(object): # private class, don't want users constructing directly 
 class GenericXML(object):
 
     _FILEMAP = {}
+    DISABLE_CACHING = False
 
     def __init__(self, infile=None, schema=None, root_name_override=None, root_attrib_override=None, read_only=True):
         """
@@ -74,7 +75,7 @@ class GenericXML(object):
         """
         Read and parse an xml file into the object
         """
-        if infile in self._FILEMAP and self.read_only:
+        if not self.DISABLE_CACHING and infile in self._FILEMAP and self.read_only:
             logger.debug("read (cached): " + infile)
             self.tree, self.root = self._FILEMAP[infile]
         else:

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -18,6 +18,7 @@ from update_acme_tests import get_recommended_test_time
 from CIME.utils import append_status, append_testlog, TESTS_FAILED_ERR_CODE, parse_test_name, get_full_test_name, get_model
 from CIME.test_status import *
 from CIME.XML.machines import Machines
+from CIME.XML.generic_xml import GenericXML
 from CIME.XML.env_test import EnvTest
 from CIME.XML.files import Files
 from CIME.XML.component import Component
@@ -880,7 +881,9 @@ class TestScheduler(object):
         # Setup cs files
         self._setup_cs_files()
 
+        GenericXML.DISABLE_CACHING = True
         self._producer()
+        GenericXML.DISABLE_CACHING = False
 
         expect(threading.active_count() == 1, "Leftover threads?")
 


### PR DESCRIPTION
Subprocesses (shell calls) will still do caching.

For reasons I can't understand, caching breaks things when running
multiple tests in test_scheduler, even when I protect the cache
with a mutex.

Test suite: code-checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
