### PR TITLE
Leverage env command options to assist parsing

### DIFF
--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -278,21 +278,19 @@ class EnvMachSpecific(EnvBase):
         for action,argument in modules_to_load:
             cmd += " && {} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument)
 
-        cmd += " && env"
+        # Use null terminated lines to give us something more definitive to split on.
+        # Env vars can contain newlines, so splitting on newlines can be ambiguous
+        cmd += " && env -0"
         output = run_cmd_no_fail(cmd)
 
         ###################################################
         # Parse the output to set the os.environ dictionary
         ###################################################
         newenv = OrderedDict()
-        lastkey = None
-        for line in output.splitlines():
+        for line in output.split('\0'):
             if "=" in line:
                 key, val = line.split("=", 1)
                 newenv[key] = val
-                lastkey = key
-            elif lastkey is not None:
-                newenv[lastkey] += "\n" + line
 
         # resolve variables
         for key, val in newenv.items():


### PR DESCRIPTION
Newline was not a strong-enough split character for parsing
output of 'env' since newlines can occur in environment variables,
especially functions. Incorrect handling was causing all machines using
the 'soft' environment manager not to work.

This change causes a null character to be placed between env variables,
which should be a much more reliable way to split/parse this output.

Test suite: ./scripts_regression_tests.py K_TestCimeCase.test_env_loading
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
