### PR TITLE
Update components' communicator initialization

### DIFF
--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -180,10 +180,10 @@ module seq_comm_mct
   character(*), parameter :: layout_concurrent = 'concurrent'
   character(*), parameter :: layout_sequential = 'sequential'
 
-  character(*), parameter :: F11 = "(a,a,'(',i3,' ',a,')',a,   3i6,' (',a,i6,')',' (',a,i3,')','(',a,a,')')"
-  character(*), parameter :: F12 = "(a,a,'(',i3,' ',a,')',a,2i6,6x,' (',a,i6,')',' (',a,i3,')','(',a,2i6,')')"
-  character(*), parameter :: F13 = "(a,a,'(',i3,' ',a,')',a,2i6,6x,' (',a,i6,')',' (',a,i3,')')"
-  character(*), parameter :: F14 = "(a,a,'(',i3,' ',a,')',a,    6x,' (',a,i6,')',' (',a,i3,')')"
+  character(*), parameter :: F11 = "(a,a,'(',i3,' ',a,')',a,2i7,i3,'(',a,i7,')',' (',a,i3,')','(',a,a,')')"
+  character(*), parameter :: F12 = "(a,a,'(',i3,' ',a,')',a,2i7,3x,'(',a,i7,')',' (',a,i3,')','(',a,2i6,')')"
+  character(*), parameter :: F13 = "(a,a,'(',i3,' ',a,')',a,2i7,3x,'(',a,i7,')',' (',a,i3,')')"
+  character(*), parameter :: F14 = "(a,a,'(',i3,' ',a,')',a,    5x,'(',a,i7,')',' (',a,i3,')')"
 
   ! Exposed for use in the esp component, please don't use this elsewhere
   integer, public :: Global_Comm
@@ -710,7 +710,7 @@ contains
     endif
 
     if (seq_comms(ID)%iamroot) then
-       write(logunit,F11) trim(subname),'  initialize ID ',ID,seq_comms(ID)%name, &
+       write(logunit,F11) trim(subname),'  init ID ',ID,seq_comms(ID)%name, &
             ' pelist   =',pelist,' npes =',seq_comms(ID)%npes,' nthreads =',seq_comms(ID)%nthreads,&
             ' suffix =',trim(seq_comms(ID)%suffix)
     endif
@@ -826,12 +826,12 @@ contains
 
     if (seq_comms(ID)%iamroot) then
        if (loglevel > 1) then
-          write(logunit,F12) trim(subname),' initialize ID ',ID,seq_comms(ID)%name, &
+          write(logunit,F12) trim(subname),' init ID ',ID,seq_comms(ID)%name, &
                ' join IDs =',ID1,ID2,' npes =',seq_comms(ID)%npes, &
                ' nthreads =',seq_comms(ID)%nthreads, &
                ' cpl/cmp pes =',seq_comms(ID)%cplpe,seq_comms(ID)%cmppe
        else
-          write(logunit,F13) trim(subname),' initialize ID ',ID,seq_comms(ID)%name, &
+          write(logunit,F13) trim(subname),' init ID ',ID,seq_comms(ID)%name, &
                ' join IDs =',ID1,ID2,' npes =',seq_comms(ID)%npes, &
                ' nthreads =',seq_comms(ID)%nthreads
        endif
@@ -949,11 +949,11 @@ contains
 
     if (seq_comms(ID)%iamroot) then
        if (loglevel > 1) then
-          write(logunit,F14) trim(subname),' initialize ID ',ID,seq_comms(ID)%name, &
+          write(logunit,F14) trim(subname),' init ID ',ID,seq_comms(ID)%name, &
                ' join multiple comp IDs',' npes =',seq_comms(ID)%npes, &
                ' nthreads =',seq_comms(ID)%nthreads
        else
-          write(logunit,F14) trim(subname),' initialize ID ',ID,seq_comms(ID)%name, &
+          write(logunit,F14) trim(subname),' init ID ',ID,seq_comms(ID)%name, &
                ' join multiple comp IDs',' npes =',seq_comms(ID)%npes, &
                ' nthreads =',seq_comms(ID)%nthreads
        endif

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -405,7 +405,7 @@ contains
        pelist(3,1) = cpl_pestride
     end if
     call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, DRIVER_COMM, ierr)
-    call seq_comm_setcomm(CPLID,pelist,cpl_nthreads,'CPL')
+    call seq_comm_setcomm(CPLID,pelist,nthreads=cpl_nthreads,iname='CPL')
 
     call comp_comm_init(driver_comm, atm_rootpe, atm_nthreads, atm_layout, atm_ntasks, atm_pestride, num_inst_atm, &
          CPLID, ATMID, CPLATMID, ALLATMID, CPLALLATMID, 'ATM', count, drv_comm_id)
@@ -571,9 +571,9 @@ contains
        endif
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, DRIVER_COMM, ierr)
        if (present(drv_comm_id)) then
-          call seq_comm_setcomm(COMPID(n), pelist, comp_nthreads,name, drv_comm_id)
+          call seq_comm_setcomm(COMPID(n),pelist,nthreads=comp_nthreads,iname=name,drv_comm_id=drv_comm_id)
        else
-          call seq_comm_setcomm(COMPID(n), pelist, comp_nthreads,name, n, num_inst_comp)
+          call seq_comm_setcomm(COMPID(n),pelist,nthreads=comp_nthreads,iname=name,inst=n,tinst=num_inst_comp)
        endif
        call seq_comm_joincomm(CPLID, COMPID(n), CPLCOMPID(n), 'CPL'//name, n, num_inst_comp)
     enddo
@@ -619,7 +619,7 @@ contains
   end subroutine seq_comm_clean
 
   !---------------------------------------------------------
-  subroutine seq_comm_setcomm(ID,pelist,nthreads,iname,inst,tinst)
+  subroutine seq_comm_setcomm(ID,pelist,nthreads,iname,inst,tinst,drv_comm_id)
 
     implicit none
     integer,intent(IN) :: ID
@@ -628,6 +628,7 @@ contains
     character(len=*),intent(IN),optional :: iname  ! name of component
     integer,intent(IN),optional :: inst  ! instance of component
     integer,intent(IN),optional :: tinst ! total number of instances for this component
+    integer, intent(in), optional :: drv_comm_id
 
     integer :: mpigrp_world
     integer :: mpigrp

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -222,6 +222,7 @@ contains
     integer, pointer :: comps(:) ! array with component ids
     integer, pointer :: comms(:) ! array with mpicoms
     integer :: nu
+    character(len=seq_comm_namelen) :: valid_comps(ncomps)
 
     integer :: &
          atm_ntasks, atm_rootpe, atm_pestride, atm_nthreads, &
@@ -449,12 +450,17 @@ contains
 
     ! Initialize MCT
 
+    call mpi_barrier(DRIVER_COMM,ierr)
+    call shr_mpi_chkerr(ierr,subname//' mpi_barrier driver pre-mct-init')
+
     ! add up valid comps on local pe
 
+    valid_comps = '*'
     myncomps = 0
     do n = 1,ncomps
        if (seq_comms(n)%mpicom /= MPI_COMM_NULL) then
           myncomps = myncomps + 1
+          valid_comps(n) = seq_comms(n)%name
        endif
     enddo
 
@@ -477,7 +483,7 @@ contains
     enddo
 
     if (myncomps /= size(comps)) then
-       write(logunit,*) trim(subname),' ERROR in myncomps ',myncomps,size(comps)
+       write(logunit,*) trim(subname),' ERROR in myncomps ',myncomps,size(comps),comps,valid_comps
        call shr_sys_abort()
     endif
 

--- a/src/drivers/mct/shr/seq_comm_mct.F90
+++ b/src/drivers/mct/shr/seq_comm_mct.F90
@@ -450,6 +450,7 @@ contains
 
     ! Initialize MCT
 
+    ! ensure that all driver_comm processes initialized their comms
     call mpi_barrier(DRIVER_COMM,ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_barrier driver pre-mct-init')
 
@@ -577,7 +578,7 @@ contains
        endif
        call mpi_bcast(pelist, size(pelist), MPI_INTEGER, 0, DRIVER_COMM, ierr)
        if (present(drv_comm_id)) then
-          call seq_comm_setcomm(COMPID(n),pelist,nthreads=comp_nthreads,iname=name,drv_comm_id=drv_comm_id)
+          call seq_comm_setcomm(COMPID(n),pelist,nthreads=comp_nthreads,iname=name,inst=drv_comm_id)
        else
           call seq_comm_setcomm(COMPID(n),pelist,nthreads=comp_nthreads,iname=name,inst=n,tinst=num_inst_comp)
        endif
@@ -625,7 +626,7 @@ contains
   end subroutine seq_comm_clean
 
   !---------------------------------------------------------
-  subroutine seq_comm_setcomm(ID,pelist,nthreads,iname,inst,tinst,drv_comm_id)
+  subroutine seq_comm_setcomm(ID,pelist,nthreads,iname,inst,tinst)
 
     implicit none
     integer,intent(IN) :: ID
@@ -634,7 +635,6 @@ contains
     character(len=*),intent(IN),optional :: iname  ! name of component
     integer,intent(IN),optional :: inst  ! instance of component
     integer,intent(IN),optional :: tinst ! total number of instances for this component
-    integer, intent(in), optional :: drv_comm_id
 
     integer :: mpigrp_world
     integer :: mpigrp


### PR DESCRIPTION
* Add mpi_barrier prior to MCT initialization
* Update error message with more info about initialized comms
* Add names of optional parameters to seq_comm_setcomm calls
* Update write formatting for large PE layouts

Test suite:
* SMS.ne30_oECv3_ICG.A_WCYCL1850S.theta_intel
* SMS_P86400x4.ne120_oRRS18v3_ICG.A_WCYCL2000_H01AS.theta_intel.cam-cosplite

Test baseline: N/A
Test namelist changes: None
Test status: [bit for bit]

Fixes ESMCI/cime#2274

User interface changes?: None

Update gh-pages html (Y/N)?: N

Code review: 
