### PR TITLE
Catch more errors in the testlist schema, remove generic GSW DATM_MODE ignore scripts/cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ doc/build
 
 # ignore the JENKINS files created when make html is run
 scripts/Tools/JENKINS*
+
+# Ignore anything that are produced under scripts "cases" directory
+
+/scripts/cases/
+

--- a/config/xml_schemas/testlist.xsd
+++ b/config/xml_schemas/testlist.xsd
@@ -4,7 +4,7 @@
   <xs:element name="testlist">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="test"/>
+        <xs:element minOccurs="1" maxOccurs="unbounded" ref="test"/>
       </xs:sequence>
       <xs:attribute name="version" use="required" type="xs:decimal"/>
     </xs:complexType>
@@ -13,7 +13,7 @@
   <xs:element name="test">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="machines"/>
+        <xs:element minOccurs="1" maxOccurs="1" ref="machines"/>
         <xs:element minOccurs="0" ref="options"/>
       </xs:sequence>
       <xs:attribute name="compset" use="required" type="xs:NCName"/>
@@ -26,8 +26,7 @@
   <xs:element name="machines">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="machine"/>
-        <xs:element minOccurs="0" ref="options"/>
+        <xs:element maxOccurs="unbounded" minOccurs="1" ref="machine"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -10,12 +10,11 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSW][%GSWP3v1][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
     <desc option="CRUv7"> CLM CRU NCEP v7 data set </desc>
-    <desc option="GSW"> GSWP3 data set </desc>
     <desc option="GSWP3v1"> GSWP3v1 data set </desc>
     <desc option="CPLHIST"> Coupler hist data set (in this mode, it is strongly recommended that the model domain and the coupler history forcing are on the same domain)</desc>
     <desc option="1PT">single point tower site data set </desc>


### PR DESCRIPTION
Make testlist schema more strict so it will catch errors, instead of silently ignoring issues with how it was configured, especially for options.

Also remove generic GSW forcing option for DATM. Add scripts/cases to gitignore.

Test suite: scripts_regression_tests.py
Test namelist changes: None
Test status: bit for bit
Also made sure query_testlist works for components in cesm2_0_alpha10a
Fixes #2245, #2207 #1749

User interface changes?: no

Update gh-pages html (Y/N)?: no

Code review: 
