### PR TITLE
add support for provenance in cesm

### DIFF
--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -638,7 +638,7 @@ class Case(object):
                    "Config file {} for component {} not found.".format(comp_config_file, comp_name))
             compobj = Component(comp_config_file, comp_class)
             # For files following version 3 schema this also checks the compsetname validity
-            
+
             self._component_description[comp_class] = compobj.get_description(self._compsetname)
             expect(self._component_description[comp_class] is not None,"No description found in file {} for component {} in comp_class {}".format(comp_config_file, comp_name, comp_class))
             logger.info("{} component is {}".format(comp_class, self._component_description[comp_class]))
@@ -1256,16 +1256,8 @@ class Case(object):
     def set_model_version(self, model):
         version = "unknown"
         srcroot = self.get_value("SRCROOT")
-        if model == "cesm":
-            changelog = os.path.join(srcroot,"ChangeLog")
-            if os.path.isfile(changelog):
-                for line in open(changelog, "r"):
-                    m = re.search("Tag name: (cesm.*)$", line)
-                    if m is not None:
-                        version = m.group(1)
-                        break
-        elif model == "e3sm":
-            version = get_current_commit(True, srcroot)
+        version = get_current_commit(True, srcroot, tag=(model=="cesm"))
+
         self.set_value("MODEL_VERSION", version)
 
         if version != "unknown":

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -85,7 +85,7 @@ def _save_build_provenance_cesm(case, lid): # pylint: disable=unused-argument
         out = run_cmd_no_fail(manic + " --status --verbose", from_dir=srcroot)
     caseroot = case.get_value("CASEROOT")
     with open(os.path.join(caseroot, "README.case"), "a") as fd:
-        if version is not None:
+        if version is not None and version != "unknown":
             fd.write("CESM version is {}\n".format(version))
         if out is not None:
             fd.write("{}\n".format(out))

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -79,9 +79,16 @@ def _save_build_provenance_e3sm(case, lid):
 def _save_build_provenance_cesm(case, lid): # pylint: disable=unused-argument
     version = case.get_value("MODEL_VERSION")
     # version has already been recorded
+    srcroot = case.get_value("SRCROOT")
+    manic = os.path.join(srcroot, "manage_externals","checkout_externals")
+    if os.path.exists(manic):
+        out = run_cmd_no_fail(manic + " --status --verbose", from_dir=srcroot)
     caseroot = case.get_value("CASEROOT")
     with open(os.path.join(caseroot, "README.case"), "a") as fd:
-        fd.write("CESM version is {}\n".format(version))
+        if version is not None:
+            fd.write("CESM version is {}\n".format(version))
+        if out is not None:
+            fd.write("{}\n".format(out))
 
 def save_build_provenance(case, lid=None):
     with SharedArea():

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -604,14 +604,17 @@ def get_current_branch(repo=None):
         else:
             return output.replace("refs/heads/", "")
 
-def get_current_commit(short=False, repo=None):
+def get_current_commit(short=False, repo=None, tag=False):
     """
     Return the sha1 of the current HEAD commit
 
     >>> get_current_commit() is not None
     True
     """
-    rc, output, _ = run_cmd("git rev-parse {} HEAD".format("--short" if short else ""), from_dir=repo)
+    if tag:
+        rc, output, _ = run_cmd("git describe --tags $(git log -n1 --pretty='%h')", from_dir=repo)
+    else:
+        rc, output, _ = run_cmd("git rev-parse {} HEAD".format("--short" if short else ""), from_dir=repo)
     if rc == 0:
         return output
     else:


### PR DESCRIPTION
add provenance output to README.case by running the manage_externals/checkout_externals script with --verbose and --status - this gives the status of all cesm or related model externals

Test suite: by hand with cesm and ctsm
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2289 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
