### PR TITLE
Fix bug when providing -p PROJECT flag to create_test

### DIFF
--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -126,8 +126,6 @@ class TestScheduler(object):
                 self._project = self._machobj.get_value("PROJECT")
         else:
             self._project = project
-            # Needed in case default root depends on PROJECT
-            self._machobj.set_value("PROJECT", project)
 
         # We will not use batch system if user asked for no_batch or if current
         # machine is not a batch machine


### PR DESCRIPTION
Calling set_value on a machine_object is no longer allowed since
that's a read-only file. The PROJECT replacements later in the code
take care of the case where the user selects a non-default project
and it could impact test roots.

Test suite: by-hand on blues
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?:N

Code review: @jedwards4b 
