### PR TITLE
add xml support for inputdata server

### DIFF
--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -51,6 +51,15 @@
     <schema>$CIMEROOT/config/xml_schemas/config_batch.xsd</schema>
   </entry>
 
+  <entry id="INPUTDATA_SPEC_FILE">
+    <type>char</type>
+    <default_value>$CIMEROOT/config/$MODEL/config_inputdata.xml</default_value>
+    <group>case_last</group>
+    <file>env_case.xml</file>
+    <desc>file containing inputdata server descriptions  (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_inputdata.xsd</schema>
+  </entry>
+
   <entry id="COMPILERS_SPEC_FILE">
     <type>char</type>
     <default_value>$CIMEROOT/config/$MODEL/machines/config_compilers.xml</default_value>

--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<inputdata>
+<!-- server precidence is order in this file.  Highest preference at top -->
+  <server>
+    <protocal>svn</protocal>
+    <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
+  </server>
+  <server>
+    <protocal>svn</protocal>
+    <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata2</address>
+  </server>
+<!--
+  <server>
+    <protocal>grid-ftp</protocal>
+    <address>ftp://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
+  </server>
+-->
+</inputdata>

--- a/config/e3sm/config_files.xml
+++ b/config/e3sm/config_files.xml
@@ -33,6 +33,16 @@
     <schema>$CIMEROOT/config/xml_schemas/config_batch.xsd</schema>
   </entry>
 
+  <entry id="INPUTDATA_SPEC_FILE">
+    <type>char</type>
+    <default_value>$CIMEROOT/config/$MODEL/config_inputdata.xml</default_value>
+    <group>case_last</group>
+    <file>env_case.xml</file>
+    <desc>file containing inputdata server descriptions  (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_inputdata.xsd</schema>
+  </entry>
+
+
   <entry id="GRIDS_SPEC_FILE">
     <type>char</type>
     <default_value>$CIMEROOT/config/$MODEL/config_grids.xml</default_value>

--- a/config/e3sm/config_inputdata.xml
+++ b/config/e3sm/config_inputdata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<inputdata>
+<!-- server precidence is order in this file.  Highest preference at top -->
+  <server>
+    <protocal>svn</protocal>
+    <address>https://acme-svn2.ornl.gov/acme-repo/acme/inputdata</address>
+  </server>
+  <server>
+    <protocal>svn</protocal>
+    <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
+  </server>
+
+</inputdata>

--- a/config/xml_schemas/config_inputdata.xsd
+++ b/config/xml_schemas/config_inputdata.xsd
@@ -1,0 +1,19 @@
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="inputdata">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="server" maxOccurs="unbounded" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>server precidence is order in this file.  Highest preference at top</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element type="xs:string" name="protocal"/>
+              <xs:element type="xs:string" name="address"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -8,7 +8,7 @@ Should be run from case.
 from standard_script_setup import *
 
 from CIME.utils import get_model
-from CIME.check_input_data import check_input_data, SVN_LOCS
+from CIME.check_input_data import check_input_data, check_all_input_data
 from CIME.case import Case
 
 import argparse
@@ -33,7 +33,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    parser.add_argument("--svn-loc", default=SVN_LOCS[get_model()],
+    parser.add_argument("--svn-loc", default=None,
                         help="The input data repository from which to download data.")
 
 
@@ -58,11 +58,17 @@ def _main_func(description):
     svn_loc, input_data_root, data_list_dir, download = parse_command_line(sys.argv, description)
 
     with Case() as case:
-        sys.exit(0 if check_input_data(case,
-                                       svn_loc=svn_loc,
-                                       input_data_root=input_data_root,
-                                       data_list_dir=data_list_dir,
-                                       download=download) else 1)
+        if svn_loc is not None:
+            sys.exit(0 if check_input_data(case,
+                                           svn_loc=svn_loc,
+                                           input_data_root=input_data_root,
+                                           data_list_dir=data_list_dir,
+                                           download=download) else 1)
+        else:
+            sys.exit(0 if check_all_input_data(case,
+                                           input_data_root=input_data_root,
+                                           data_list_dir=data_list_dir,
+                                           download=download) else 1)
 
 ###############################################################################
 

--- a/scripts/lib/CIME/XML/inputdata.py
+++ b/scripts/lib/CIME/XML/inputdata.py
@@ -1,0 +1,45 @@
+"""
+Interface to the config_inputdata.xml file.  This class inherits from GenericXML.py
+"""
+from CIME.XML.standard_module_setup import *
+from CIME.XML.generic_xml import GenericXML
+from CIME.XML.files import Files
+from CIME.utils import expect
+
+logger = logging.getLogger(__name__)
+
+class Inputdata(GenericXML):
+
+    def __init__(self, infile=None, files=None):
+        """
+        initialize a files object given input pes specification file
+        """
+        if files is None:
+            files = Files()
+        if infile is None:
+            infile = files.get_value("INPUTDATA_SPEC_FILE")
+        schema = files.get_schema("INPUTDATA_SPEC_FILE")
+        logger.debug("DEBUG: infile is {}".format(infile))
+        GenericXML.__init__(self, infile, schema=schema)
+        self._servernode = None
+
+    def get_next_server(self):
+        protocal = None
+        address = None
+        servernodes = self.get_children("server")
+        if self._servernode is None:
+            self._servernode = servernodes[0]
+        else:
+            prevserver = self._servernode
+            for i, node in enumerate(servernodes):
+                if self._servernode == node and len(servernodes)>i+1:
+                    self._servernode = servernodes[i+1]
+                    break
+            if prevserver is not None and self._servernode == prevserver:
+                self._servernode = None
+
+        if self._servernode is not None:
+            protocal = self.text(self.get_child("protocal", root = self._servernode))
+            address =  self.text(self.get_child("address", root = self._servernode))
+
+        return protocal, address

--- a/scripts/lib/CIME/check_input_data.py
+++ b/scripts/lib/CIME/check_input_data.py
@@ -74,6 +74,8 @@ def check_all_input_data(case, input_data_root=None, data_list_dir="Buildconf", 
         if protocal == 'svn':
             success = check_input_data(case=case, svn_loc=address, download=download,
                                        input_data_root=input_data_root, data_list_dir=data_list_dir)
+        else:
+            expect(False,"Unknown inputdata server protocal {}".format(protocal))
 
     stage_refcase(case)
 


### PR DESCRIPTION
The inputdata sever is now defined in file config/$model/config_inputdata.xml 
which contains an ordered list of potential inputdata servers, each server will be attempted in turn. 
currently only svn protocal is supported but we are working on extending to grid-ftp and ftp protocals as well.   Partially addresses #2301 

Test suite:  tested by hand on cesm system
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
