### PR TITLE
Change subtree split method

### DIFF
--- a/scripts/lib/e3sm_cime_mgmt.py
+++ b/scripts/lib/e3sm_cime_mgmt.py
@@ -76,8 +76,8 @@ def get_branch_from_tag(tag):
 def do_subtree_split(old_split_tag, new_split_tag, merge_tag):
 ###############################################################################
     subtree_branch = get_branch_from_tag(new_split_tag)
-    run_cmd_no_fail("git subtree split {}.. --prefix=cime --squash --onto={} -b {}".\
-                        format(old_split_tag, merge_tag, subtree_branch), verbose=True)
+    run_cmd_no_fail("git subtree split --prefix=cime --onto={} -b {}".\
+                        format(merge_tag, subtree_branch), verbose=True)
     return subtree_branch
 
 ###############################################################################


### PR DESCRIPTION
Do not explicitly provide the commit range to subtree split.

Thanks to Bill Sacks for figuring out this was the source of our
history issues.

Test suite: Used this for most recent split
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @billsacks 
