### PR TITLE
New allow_error field for module system

### DIFF
--- a/config/e3sm/machines/config_machines.xml
+++ b/config/e3sm/machines/config_machines.xml
@@ -571,7 +571,7 @@
         <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to hwthread</arg>
       </arguments>
     </mpirun>
-    <module_system type="module">
+    <module_system type="module" allow_error="false">
       <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
       <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
       <init_path lang="sh">/usr/share/Modules/init/sh</init_path>

--- a/config/xml_schemas/env_mach_specific.xsd
+++ b/config/xml_schemas/env_mach_specific.xsd
@@ -73,6 +73,7 @@
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
       </xs:sequence>
       <xs:attribute name="type" use="required" type="xs:NCName"/>
+      <xs:attribute name="allow_error" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
 

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -273,7 +273,7 @@ class EnvMachSpecific(EnvBase):
         for cmd in self._get_module_commands(modules_to_load, "python"):
             logger.debug("module command is {}".format(cmd))
             stat, py_module_code, errout = run_cmd(cmd)
-            expect(stat==0 and len(errout) == 0,
+            expect(stat==0 and (len(errout) == 0 or self.allow_error()),
                    "module command {} failed with message:\n{}".format(cmd, errout))
             exec(py_module_code)
 
@@ -353,6 +353,17 @@ class EnvMachSpecific(EnvBase):
         """
         module_system = self.get_child("module_system")
         return self.get(module_system, "type")
+
+    def allow_error(self):
+        """
+        Return True if stderr output from module commands should be assumed
+        to be an error. Default False. This is necessary since implementations
+        of environment modules are highlty variable and some systems produce
+        stderr output even when things are working fine.
+        """
+        module_system = self.get_child("module_system")
+        value = self.get(module_system, "allow_error")
+        return value.upper() == "TRUE" if value is not None else False
 
     def get_module_system_init_path(self, lang):
         init_nodes = self.get_optional_child("init_path", attributes={"lang":lang}, root=self.get_child("module_system"))


### PR DESCRIPTION
This is necessary since implementations of environment modules are
highly variable and some systems produce stderr output even when
things are working fine.

Default this to false since we want to catch errors on standard
systems.

Test suite: code-checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #1625 

User interface changes?: Y, new allow_error attribute for module systems

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
