### PR TITLE
Auto-regen batch files in case_submit.

### DIFF
--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -175,16 +175,11 @@ class EnvBatch(EnvBase):
         output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)
         output_name = get_batch_script_for_job(job)
 
-        # make writable so we can modify here
-        if os.path.exists(output_name):
-            os.chmod(output_name, os.stat(output_name).st_mode | stat.S_IWUSR)
-
         with open(output_name, "w") as fd:
             fd.write(output_text)
 
-        # make it exectuble but remove write access. Users should never edit these
-        # files directly because those changes are too easily lost.
-        os.chmod(output_name, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+        # make sure batch script is exectuble
+        os.chmod(output_name, os.stat(output_name).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     def set_job_defaults(self, batch_jobs, case):
         if self._batchtype is None:

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -174,9 +174,17 @@ class EnvBatch(EnvBase):
 
         output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)
         output_name = get_batch_script_for_job(job)
+
+        # make writable so we can modify here
+        if os.path.exists(output_name):
+            os.chmod(output_name, os.stat(output_name).st_mode | stat.S_IWUSR)
+
         with open(output_name, "w") as fd:
             fd.write(output_text)
-        os.chmod(output_name, os.stat(output_name).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        # make it exectuble but remove write access. Users should never edit these
+        # files directly because those changes are too easily lost.
+        os.chmod(output_name, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 
     def set_job_defaults(self, batch_jobs, case):
         if self._batchtype is None:
@@ -625,7 +633,7 @@ class EnvBatch(EnvBase):
             f2bnode=None
             if len(f2bnodes):
                 f2bnode = f2bnodes[0]
-            f1batchnodes = self.get_children(root=bnode)            
+            f1batchnodes = self.get_children(root=bnode)
             for node in f1batchnodes:
                 name = self.name(node)
                 text1 = self.text(node)
@@ -649,3 +657,16 @@ class EnvBatch(EnvBase):
             xmldiffs.update(super(EnvBatch, self).compare_xml(other,
                                               root=node, otherroot=f2group))
         return xmldiffs
+
+    def make_all_batch_files(self, case, test_mode=False):
+        testcase = case.get_value("TESTCASE")
+        machdir  = case.get_value("MACHDIR")
+        logger.info("Creating batch script case.run")
+        for job in self.get_jobs():
+            input_batch_script = os.path.join(machdir,self.get_value('template', subgroup=job))
+            if job == "case.test" and testcase is not None and not test_mode:
+                logger.info("Writing {} script".format(job))
+                self.make_batch_script(input_batch_script, job, case)
+            elif job != "case.test":
+                logger.info("Writing {} script from input template {}".format(job, input_batch_script))
+                self.make_batch_script(input_batch_script, job, case)

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -632,6 +632,7 @@ class EnvBatch(EnvBase):
             for node in f1batchnodes:
                 name = self.name(node)
                 text1 = self.text(node)
+                text2 = ""
                 attribs = self.attrib(node)
                 f2matches = other.scan_children(name, attributes=attribs, root=f2bnode)
                 foundmatch=False

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -151,6 +151,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             check_pelayouts_require_rebuild(case, models)
 
             unlock_file("env_build.xml")
+            unlock_file("env_batch.xml")
 
             case.flush()
             check_lockedfiles(case)
@@ -172,10 +173,10 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 
             # Make a copy of env_mach_pes.xml in order to be able
             # to check that it does not change once case.setup is invoked
-            logger.info("Locking file env_mach_pes.xml")
             case.flush()
             logger.debug("at copy TOTALPES = {}".format(case.get_value("TOTALPES")))
             lock_file("env_mach_pes.xml")
+            lock_file("env_batch.xml")
 
         # Create user_nl files for the required number of instances
         if not os.path.exists("user_nl_cpl"):

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -151,7 +151,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             check_pelayouts_require_rebuild(case, models)
 
             unlock_file("env_build.xml")
-            unlock_file("env_batch.xml")
 
             case.flush()
             check_lockedfiles(case)
@@ -164,16 +163,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             case.set_value("SMP_PRESENT", case.get_build_threaded())
 
             # create batch files
-            logger.info("Creating batch script case.run")
             env_batch = case.get_env("batch")
-            for job in env_batch.get_jobs():
-                input_batch_script  = os.path.join(case.get_value("MACHDIR"), env_batch.get_value('template', subgroup=job))
-                if job == "case.test" and testcase is not None and not test_mode:
-                    logger.info("Writing {} script".format(job))
-                    env_batch.make_batch_script(input_batch_script, job, case)
-                elif job != "case.test":
-                    logger.info("Writing {} script from input template {}".format(job, input_batch_script))
-                    env_batch.make_batch_script(input_batch_script, job, case)
+            env_batch.make_all_batch_files(case, test_mode=test_mode)
 
             # May need to select new batch settings if pelayout changed (e.g. problem is now too big for prev-selected queue)
             env_batch.set_job_defaults([(("case.test" if case.get_value("TEST") else "case.run"), {})], case)
@@ -182,11 +173,9 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             # Make a copy of env_mach_pes.xml in order to be able
             # to check that it does not change once case.setup is invoked
             logger.info("Locking file env_mach_pes.xml")
-            logger.info("Locking file env_batch.xml")
             case.flush()
             logger.debug("at copy TOTALPES = {}".format(case.get_value("TOTALPES")))
             lock_file("env_mach_pes.xml")
-            lock_file("env_batch.xml")
 
         # Create user_nl files for the required number of instances
         if not os.path.exists("user_nl_cpl"):

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -48,10 +48,12 @@ def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
     if not resubmit:
         if case.get_value("TEST"):
             case.set_value("IS_FIRST_RUN", True)
+
         if no_batch:
             batch_system = "none"
         else:
             batch_system = env_batch.get_batch_system_type()
+
         case.set_value("BATCH_SYSTEM", batch_system)
     else:
         if env_batch.get_batch_system_type() == "none":
@@ -60,6 +62,10 @@ def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
         # This is a resubmission, do not reinitialize test values
         if case.get_value("TEST"):
             case.set_value("IS_FIRST_RUN", False)
+
+    if env_batch.get_batch_system_type() != "none":
+        # May need to regen batch files if user made walltime changes
+        env_batch.make_all_batch_files(case)
 
     #Load Modules
     case.load_env()

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -9,7 +9,7 @@ import socket
 from CIME.XML.standard_module_setup import *
 from CIME.utils                     import expect, run_and_log_case_status, verbatim_success_msg
 from CIME.preview_namelists         import create_namelists
-from CIME.check_lockedfiles         import check_lockedfiles
+from CIME.check_lockedfiles         import check_lockedfiles, check_lockedfile, unlock_file
 from CIME.check_input_data          import check_all_input_data
 from CIME.test_status               import *
 
@@ -28,25 +28,25 @@ def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
     expect(os.path.isdir(rundir) or not continue_run,
            " CONTINUE_RUN is true but RUNDIR {} does not exist".format(rundir))
 
+    # if case.submit is called with the no_batch flag then we assume that this
+    # flag will stay in effect for the duration of the RESUBMITs
+    env_batch = case.get_env("batch")
     if resubmit:
+        if env_batch.get_batch_system_type() == "none":
+            no_batch = True
+
+        # This is a resubmission, do not reinitialize test values
+        if job == "case.test":
+            case.set_value("IS_FIRST_RUN", False)
+
         resub = case.get_value("RESUBMIT")
         logger.info("Submitting job '{}', resubmit={:d}".format(job, resub))
         case.set_value("RESUBMIT", resub-1)
         if case.get_value("RESUBMIT_SETS_CONTINUE_RUN"):
             case.set_value("CONTINUE_RUN", True)
-    else:
-        if job in ("case.test","case.run"):
-            check_case(case)
-            check_DA_settings(case)
-            if case.get_value("MACH") == "mira":
-                with open(".original_host", "w") as fd:
-                    fd.write( socket.gethostname())
 
-    # if case.submit is called with the no_batch flag then we assume that this
-    # flag will stay in effect for the duration of the RESUBMITs
-    env_batch = case.get_env("batch")
-    if not resubmit:
-        if case.get_value("TEST"):
+    else:
+        if job == "case.test":
             case.set_value("IS_FIRST_RUN", True)
 
         if no_batch:
@@ -55,17 +55,30 @@ def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
             batch_system = env_batch.get_batch_system_type()
 
         case.set_value("BATCH_SYSTEM", batch_system)
-    else:
-        if env_batch.get_batch_system_type() == "none":
-            no_batch = True
 
-        # This is a resubmission, do not reinitialize test values
-        if case.get_value("TEST"):
-            case.set_value("IS_FIRST_RUN", False)
+        env_batch_has_changed = False
+        try:
+            check_lockedfile(case, os.path.basename(env_batch.filename))
+        except SystemExit:
+            env_batch_has_changed = True
 
-    if env_batch.get_batch_system_type() != "none":
-        # May need to regen batch files if user made walltime changes
-        env_batch.make_all_batch_files(case)
+        if env_batch.get_batch_system_type() != "none" and env_batch_has_changed:
+            # May need to regen batch files if user made batch setting changes (e.g. walltime, queue, etc)
+            logger.warning(\
+"""
+env_batch.xml appears to have changed, regenerating batch scripts
+manual edits to these file will be lost!
+""")
+            env_batch.make_all_batch_files(case)
+
+        unlock_file(os.path.basename(env_batch.filename))
+
+        if job in ("case.test","case.run"):
+            check_case(case)
+            check_DA_settings(case)
+            if case.get_value("MACH") == "mira":
+                with open(".original_host", "w") as fd:
+                    fd.write( socket.gethostname())
 
     #Load Modules
     case.load_env()


### PR DESCRIPTION
We continue to lock env_batch.xml at case.setup time. In case.submit, if env_batch.xml != locked/env_batch.xml, we regenerate batch scripts, otherwise, we accept them as-is.
This will allow the batch scripts to auto-regen if the user has made changes the "right" way via xmlchange. It will also allow and preserve hand-edits as long as the user had not made any xmlchanges to env_batch.

Test suite: scripts_regression_tests (on batch and non-batch)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2259 

User interface changes?: Yes, user edits to batch files are no longer supported

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @billsacks @jonbob 
