### PR TITLE
Cleanup xml

### DIFF
--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -65,8 +65,8 @@ class NamelistDefinition(EntryID):
         default_nodes = []
         for node in self.get_children("entry"):
             name = self.get(node, "id")
-            skip_default_entry = self.get(node, "skip_default_entry")
-            per_stream_entry = self.get(node, "per_stream_entry")
+            skip_default_entry = self.get(node, "skip_default_entry") == "true"
+            per_stream_entry = self.get(node, "per_stream_entry") == "true"
             set_node_values = False
             if skip_groups:
                 group_name = self._get_group_name(node)
@@ -131,7 +131,7 @@ class NamelistDefinition(EntryID):
         entries = []
         nodes = self.get_children("entry")
         for node in nodes:
-            per_stream_entry = self.get(node, "per_stream_entry")
+            per_stream_entry = self.get(node, "per_stream_entry") == "true"
             if per_stream_entry:
                 entries.append(self.get(node, "id"))
         return entries

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -580,37 +580,6 @@
     <desc>Perl 5 library directory</desc>
   </entry>
 
-  <entry id="mpirun">
-    <type>char</type>
-    <default_value></default_value>
-    <group>config_batch</group>
-    <file>env_case.xml</file>
-    <desc>The mpi run command associated with the machine configured batch system</desc>
-  </entry>
-
-  <entry id="module_system">
-    <type>char</type>
-    <default_value>UNSET</default_value>
-    <group>config_batch</group>
-    <file>env_case.xml</file>
-    <desc>The module system type defined for this machine</desc>
-  </entry>
-
-  <entry id="module_init_path">
-    <type>char</type>
-    <default_value>UNSET</default_value>
-    <group>config_batch</group>
-    <file>env_case.xml</file>
-    <desc>The module initialization path for module system defined for this machine</desc>
-  </entry>
-
-  <entry id="module_cmd_path">
-    <type>char</type>
-    <default_value>UNSET</default_value>
-    <group>config_batch</group>
-    <file>env_case.xml</file>
-    <desc>The module command path for module system defined for this machine</desc>
-  </entry>
 
 
   <!-- ===================================================================== -->


### PR DESCRIPTION
Attributes declared as boolean in xml are treated as string in python, here two variables were mistakenly treated as boolean in python and thus evaluated to true if present.   It turns out that both these variables are currently only present if set to true so there should be no expected impact of this change.  

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2322 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: gold2718
