### PR TITLE
Report lock file info as debug output

### DIFF
--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -23,7 +23,7 @@ def lock_file(filename, caseroot=None, newname=None):
     if not os.path.exists(fulllockdir):
         os.mkdir(fulllockdir)
 
-    logging.info("Locking file {}".format(filename))
+    logging.debug("Locking file {}".format(filename))
 
     # JGF: It is extremely dangerous to alter our database (xml files) without
     # going through the standard API. The copy below invalidates all existing
@@ -39,7 +39,7 @@ def unlock_file(filename, caseroot=None):
     if os.path.exists(locked_path):
         os.remove(locked_path)
 
-    logging.info("Unlocking file {}".format(filename))
+    logging.debug("Unlocking file {}".format(filename))
 
 def is_locked(filename, caseroot=None):
     expect("/" not in filename, "Please just provide basename of locked file")


### PR DESCRIPTION
Most users do not need to know the details of file locking. Also
this output clutters the output of create_test.

Test suite: None
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?:

Code review: @jedwards4b 
