### PR TITLE
Refactor handling of small jobs

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -556,6 +556,7 @@
     <job name="case.st_archive">
       <template>template.st_archive</template>
       <task_count>1</task_count>
+      <walltime>0:10:00</walltime>
       <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
       <dependency>case.run or case.test</dependency>
       <prereq>$DOUT_S</prereq>

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # Batch system directives
 {{ batchdirectives }}
-# PE Layout Documentation:
-{{ pedocumentation }}
 
 """
 template to create a case run script. This should only ever be called

--- a/config/e3sm/machines/config_batch.xml
+++ b/config/e3sm/machines/config_batch.xml
@@ -539,6 +539,7 @@
     <job name="case.st_archive">
       <template>template.st_archive</template>
       <task_count>1</task_count>
+      <walltime>0:10:00</walltime>
       <!-- If DOUT_S is true and case.run (or case.test) exits successfully then run st_archive-->
       <dependency>case.run case.test</dependency>
       <prereq>$DOUT_S</prereq>

--- a/config/e3sm/machines/template.case.run
+++ b/config/e3sm/machines/template.case.run
@@ -26,10 +26,6 @@ logger = logging.getLogger(__name__)
 
 import argparse
 
-
-# PE Layout Documentation:
-{{ pedocumentation }}
-
 ###############################################################################
 def parse_command_line(args, description):
 ###############################################################################

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -24,7 +24,7 @@
   <xs:element name="batch_mail_default" type="xs:string"/>
   <xs:element name="template" type="xs:NCName"/>
   <xs:element name="task_count" type="xs:integer"/>
-  <xs:element name="walltime" type="xs:integer"/>
+  <xs:element name="walltime" type="xs:string"/>
   <xs:element name="dependency" type="xs:string"/>
   <xs:element name="prereq" type="xs:string"/>
 

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -24,6 +24,7 @@
   <xs:element name="batch_mail_default" type="xs:string"/>
   <xs:element name="template" type="xs:NCName"/>
   <xs:element name="task_count" type="xs:integer"/>
+  <xs:element name="walltime" type="xs:integer"/>
   <xs:element name="dependency" type="xs:string"/>
   <xs:element name="prereq" type="xs:string"/>
 
@@ -180,6 +181,7 @@
       <xs:sequence>
         <xs:element ref="template"/>
         <xs:element minOccurs="0" ref="task_count"/>
+        <xs:element minOccurs="0" ref="walltime"/>
         <xs:element minOccurs="0" ref="dependency"/>
         <xs:element ref="prereq"/>
       </xs:sequence>

--- a/scripts/Tools/preview_run
+++ b/scripts/Tools/preview_run
@@ -39,26 +39,31 @@ OR
     parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
                         help="Case directory to build")
 
+    parser.add_argument("-j", "--job", default=None,
+                        help="The job you want to print")
+
     args = parser.parse_args(args[1:])
 
-    return args.caseroot
+    return args.caseroot, args.job
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    caseroot = parse_command_line(sys.argv, description)
+    caseroot, job = parse_command_line(sys.argv, description)
 
     logging.disable(logging.CRITICAL)
 
     with Case(caseroot, read_only=False) as case:
         print("BATCH SUBMIT: (nodes {})".format(case.num_nodes))
         case.load_env()
-        job = "case.test" if case.get_value("TEST") else "case.run"
+        if job is None:
+            job = "case.test" if case.get_value("TEST") else "case.run"
         job_id_to_cmd = case.submit_jobs(dry_run=True, job=job)
         for job_id, cmd in job_id_to_cmd:
             print("    {} -> {}".format(job_id, case.get_resolved_value(cmd)))
         print("")
-        print("MPIRUN: {}".format(case.get_resolved_value(case.get_mpirun_cmd())))
+        if job in ["case.test", "case.run"]:
+            print("MPIRUN: {}".format(case.get_resolved_value(case.get_mpirun_cmd())))
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -112,7 +112,7 @@ class EnvBatch(EnvBase):
 
         childnodes = []
         for child in reversed(orig_group_children):
-            childnodes.append(self.copy(child))
+            childnodes.append(child)
 
         self.remove_child(orig_group)
 
@@ -124,7 +124,7 @@ class EnvBatch(EnvBase):
                 self.make_child("type", root=node, text="char")
 
             for child in childnodes:
-                self.add_child(child, root=new_job_group)
+                self.add_child(self.copy(child), root=new_job_group)
 
     def cleanupnode(self, node):
         if self.get(node, "id") == "batch_system":
@@ -192,7 +192,7 @@ class EnvBatch(EnvBase):
             force_queue = case.get_value("USER_REQUESTED_QUEUE", subgroup=job) if case.get_value("USER_REQUESTED_QUEUE", subgroup=job) else None
             logger.info("job is {} USER_REQUESTED_WALLTIME {} USER_REQUESTED_QUEUE {}".format(job, walltime, force_queue))
             task_count = jsect["task_count"] if "task_count" in jsect else None
-            walltime = jsect["walltime"] if ("walltime" in jsect and walltime is None) else None
+            walltime = jsect["walltime"] if ("walltime" in jsect and walltime is None) else walltime
             if task_count is None:
                 node_count = case.num_nodes
             else:

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -164,7 +164,6 @@ class EnvBatch(EnvBase):
             overrides["total_tasks"] = int(task_count)
             overrides["num_nodes"]   = int(math.ceil(float(task_count)/float(case.tasks_per_node)))
 
-        overrides["pedocumentation"] = "" # TODO?
         overrides["job_id"] = case.get_value("CASE") + os.path.splitext(job)[1]
         if "pleiades" in case.get_value("MACH"):
             # pleiades jobname needs to be limited to 15 chars
@@ -193,6 +192,7 @@ class EnvBatch(EnvBase):
             force_queue = case.get_value("USER_REQUESTED_QUEUE", subgroup=job) if case.get_value("USER_REQUESTED_QUEUE", subgroup=job) else None
             logger.info("job is {} USER_REQUESTED_WALLTIME {} USER_REQUESTED_QUEUE {}".format(job, walltime, force_queue))
             task_count = jsect["task_count"] if "task_count" in jsect else None
+            walltime = jsect["walltime"] if ("walltime" in jsect and walltime is None) else None
             if task_count is None:
                 node_count = case.num_nodes
             else:

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -945,9 +945,9 @@ class Case(object):
         # batch system (must come after initialize_derived_attributes)
         #--------------------------------------------
         if walltime:
-            self.set_value("USER_REQUESTED_WALLTIME", walltime)
+            self.set_value("USER_REQUESTED_WALLTIME", walltime, subgroup=("case.test" if test else "case.run"))
         if queue:
-            self.set_value("USER_REQUESTED_QUEUE", queue)
+            self.set_value("USER_REQUESTED_QUEUE", queue, subgroup=("case.test" if test else "case.run"))
 
         env_batch = self.get_env("batch")
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -944,11 +944,6 @@ class Case(object):
         #--------------------------------------------
         # batch system (must come after initialize_derived_attributes)
         #--------------------------------------------
-        if walltime:
-            self.set_value("USER_REQUESTED_WALLTIME", walltime, subgroup=("case.test" if test else "case.run"))
-        if queue:
-            self.set_value("USER_REQUESTED_QUEUE", queue, subgroup=("case.test" if test else "case.run"))
-
         env_batch = self.get_env("batch")
 
         batch_system_type = machobj.get_value("BATCH_SYSTEM")
@@ -957,6 +952,12 @@ class Case(object):
 
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
         env_batch.create_job_groups(bjobs)
+
+        if walltime:
+            self.set_value("USER_REQUESTED_WALLTIME", walltime, subgroup=("case.test" if test else "case.run"))
+        if queue:
+            self.set_value("USER_REQUESTED_QUEUE", queue, subgroup=("case.test" if test else "case.run"))
+
         env_batch.set_job_defaults(bjobs, self)
         self.schedule_rewrite(env_batch)
 


### PR DESCRIPTION
Refactor how "non-core" jobs, like case.st_archive are handled by our system.

1) Since we allow a non-core job to specify num_tasks, we should also let it specify walltime
2) Remove unused pedocumentation
3) Allow --job argument to preview run
4) Fix significant bug in env_batch (remove aliasing of elements)
5) user-requested walltime/queue ONLY applies to "core" job.

With these changes, assuming a system has a well-configured batch system, this should allow intelligent selection of a "small job" queue for non-core jobs.

Test suite: by-hand, code_checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2209 

User interface changes?: Yes

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @billsacks 
