### PR TITLE
For Travis-CI build: kick off build on master whenever it's pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,9 @@ python:
 env:
   - CIME_MODEL=cesm
 script: cd scripts/tests; ./scripts_regression_tests.py --machine centos7-linux   A_RunUnitTests B_CheckCode
+
+# In addition to building PRs, also run the build on master whenever
+# it's pushed
+branches:
+  only:
+  - master


### PR DESCRIPTION
The Travis-CI build was already happening on master, but it was also
happening on ALL branches pushed to ESMCI, which was
overkill. @jedwards4b changed the configuration so that it wouldn't run
on pushed branches in general. This change (if I did it right) restores
its running on master, which seems like a good thing to have.

Test suite: none
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes: Addresses #2331 

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
