### PR TITLE
add queue attribute (small cheyenne jobs go to share queue)

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -292,12 +292,23 @@
   </batch_system>
 
   <batch_system MACH="cheyenne" type="pbs">
-    <directives>
+    <directives queue="regular">
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
       <directive> -l select={{ num_nodes }}:ncpus={{ max_tasks_per_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}</directive>
     </directives>
+
+    <directives queue="economy">
+      <directive default="/bin/bash" > -S {{ shell }}  </directive>
+      <directive> -l select={{ num_nodes }}:ncpus={{ max_tasks_per_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}</directive>
+    </directives>
+
+    <directives queue="share">
+      <directive default="/bin/bash" > -S {{ shell }}  </directive>
+      <directive> -l select=1:mpiprocs={{ total_tasks }}:ompthreads={{ thread_count }}</directive>
+    </directives>
     <queues>
-      <queue default="true" walltimemax="12:00" nodemin="1" nodemax="32">regular</queue>
+      <queue walltimemax="12:00" nodemin="1" nodemax="32">regular</queue>
+      <queue default="true" walltimemax="06:00" jobmin="1" jobmax="18">share</queue>
       <queue walltimemax="12:00" nodemin="1" nodemax="32">economy</queue>
     </queues>
   </batch_system>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -280,6 +280,14 @@
 	<arg name="zthreadplacement"> omplace -tm open64 </arg>
       </arguments>
     </mpirun>
+    <mpirun mpilib="mpt" queue="share">
+      <executable>mpirun `hostname`</executable>
+      <arguments>
+	<arg name="anum_tasks"> -np $TOTALPES</arg>
+	<!-- the omplace argument needs to be last -->
+	<arg name="zthreadplacement"> omplace -tm open64 </arg>
+      </arguments>
+    </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpirun</executable>
       <arguments>
@@ -363,6 +371,10 @@
       <!-- It's possible that we also need to set:
 	   LD_LIBRARY_PATH=/opt/sgi/mpt/mpt-2.15/lib:$LD_LIBRARY_PATH
       -->
+      <env name="MPI_USE_ARRAY">false</env>
+    </environment_variables>
+    <environment_variables queue="share">
+      <env name="TMPDIR">/glade/scratch/$USER</env>
       <env name="MPI_USE_ARRAY">false</env>
     </environment_variables>
     <resource_limits>

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -5,6 +5,7 @@
    version="2.0">
   <!-- attributes -->
   <xs:attribute name="version" type="xs:decimal"/>
+  <xs:attribute name="queue" type="xs:string"/>
   <xs:attribute name="MACH" type="xs:NCName"/>
   <xs:attribute name="type"  type="xs:NCName"/>
 
@@ -92,7 +93,7 @@
 
   <!-- directives: A list of fields to provide in the script directives section,
        be careful that these do not conflict with submit_args above -->
-        <xs:element minOccurs="0" ref="directives"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="directives"/>
 
   <!-- queues: The list of queue options for this machine, not all system queues need be listed
        attributes of this field include walltimemin, walltimemax, nodemin and nodemax and strict
@@ -134,6 +135,7 @@
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="directive"/>
       </xs:sequence>
+      <xs:attribute ref="queue"/>
     </xs:complexType>
   </xs:element>
 
@@ -192,4 +194,3 @@
   </xs:element>
 
 </xs:schema>
-

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -5,6 +5,7 @@
   <xs:attribute name="MACH" type="xs:NCName"/>
   <xs:attribute name="compiler" type="xs:string"/>
   <xs:attribute name="mpilib" type="xs:string"/>
+  <xs:attribute name="queue" type="xs:string"/>
   <xs:attribute name="DEBUG" type="upperBoolean"/>
   <xs:attribute name="threaded" type="xs:boolean"/>
   <xs:attribute name="unit_testing" type="xs:boolean"/>
@@ -155,6 +156,7 @@
 	<xs:element ref="arguments" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
+      <xs:attribute ref="queue"/>
       <xs:attribute ref="mpilib"/>
       <xs:attribute ref="threaded"/>
       <xs:attribute ref="unit_testing"/>

--- a/config/xml_schemas/env_batch.xsd
+++ b/config/xml_schemas/env_batch.xsd
@@ -56,4 +56,3 @@
   </xs:element>
 
 </xs:schema>
-

--- a/config/xml_schemas/env_mach_specific.xsd
+++ b/config/xml_schemas/env_mach_specific.xsd
@@ -10,6 +10,7 @@
 <xs:attribute name="SMP_PRESENT" type="xs:string"/>
 <xs:attribute name="value" type="xs:string"/>
 <xs:attribute name="unit_testing" type="xs:boolean"/>
+<xs:attribute name="queue" type="xs:string"/>
 
 <!-- simple elements -->
 <xs:element name="header" type="xs:string"/>
@@ -151,6 +152,7 @@
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="mpilib"/>
       <xs:attribute name="threaded" type="xs:boolean"/>
+      <xs:attribute ref="queue"/>
       <xs:attribute ref="unit_testing"/>
     </xs:complexType>
   </xs:element>

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1257,11 +1257,11 @@ class Case(object):
         else:
             logger.warning("WARNING: No {} Model version found.".format(model))
 
-    def load_env(self, reset=False):
+    def load_env(self, reset=False, job=None):
         if not self._is_env_loaded or reset:
             os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
             env_module = self.get_env("mach_specific")
-            env_module.load_env(self)
+            env_module.load_env(self, job=job)
             self._is_env_loaded = True
 
     def get_build_threaded(self):

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -41,7 +41,7 @@ def pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
     logger.debug("build complete is {} ".format(build_complete))
 
     # load the module environment...
-    case.load_env()
+    case.load_env(job="case.run")
 
     # set environment variables
     # This is a requirement for yellowstone only

--- a/scripts/lib/CIME/case_st_archive.py
+++ b/scripts/lib/CIME/case_st_archive.py
@@ -648,7 +648,7 @@ def case_st_archive(case, last_date_str=None, archive_incomplete_logs=True, copy
     Create archive object and perform short term archiving
     """
     caseroot = case.get_value("CASEROOT")
-
+    case.load_env(job="case.st_archive")
     if last_date_str is not None:
         try:
             last_date = datetime.datetime.strptime(last_date_str, '%Y-%m-%d')


### PR DESCRIPTION
The cheyenne system needs a different environment to run in the share queue, this implements that in a way that may prove useful for other systems as well.  Now environment variables and mpirun command as well as batch_system directives can all be tailored for a specific queue. 
On cheyenne, run jobs with <= 18 cores in the share queue

Test suite: scripts_regression_tests.py + hand testing SMS_P1x4.f19_g16.X
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2327 
Fixes #2328

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
