### PR TITLE
Env batch cleanup

### DIFF
--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -156,16 +156,20 @@ class EnvBatch(EnvBase):
             self.set_batch_system_type(batch_system_type)
 
         if batchobj.batch_system_node is not None and batchobj.machine_node is not None:
-            for node in batchobj.get_children(root=batchobj.machine_node):
-                oldnode = batchobj.get_optional_child(self.name(node), root=batchobj.batch_system_node)
-                if oldnode is not None and self.name(oldnode) != "directives":
-                    logger.debug( "Replacing {}".format(self.name(oldnode)))
-                    batchobj.remove_child(oldnode, root=batchobj.batch_system_node)
+            for node in batchobj.get_children("",root=batchobj.machine_node):
+                name = self.name(node)
+                if name != 'directives':
+                    oldnode = batchobj.get_optional_child(self.name(node), root=batchobj.batch_system_node)
+                    if oldnode is not None:
+                        logger.debug( "Replacing {}".format(self.name(oldnode)))
+                        batchobj.remove_child(oldnode, root=batchobj.batch_system_node)
 
         if batchobj.batch_system_node is not None:
             self.add_child(self.copy(batchobj.batch_system_node))
         if batchobj.machine_node is not None:
             self.add_child(self.copy(batchobj.machine_node))
+        self.set_value("BATCH_SYSTEM", batch_system_type)
+
 
     def make_batch_script(self, input_template, job, case):
         expect(os.path.exists(input_template), "input file '{}' does not exist".format(input_template))

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -159,7 +159,7 @@ class EnvBatch(EnvBase):
             for node in batchobj.get_children("",root=batchobj.machine_node):
                 name = self.name(node)
                 if name != 'directives':
-                    oldnode = batchobj.get_optional_child(self.name(node), root=batchobj.batch_system_node)
+                    oldnode = batchobj.get_optional_child(name, root=batchobj.batch_system_node)
                     if oldnode is not None:
                         logger.debug( "Replacing {}".format(self.name(oldnode)))
                         batchobj.remove_child(oldnode, root=batchobj.batch_system_node)

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -937,6 +937,7 @@ class Case(object):
         env_batch = self.get_env("batch")
 
         batch_system_type = machobj.get_value("BATCH_SYSTEM")
+        logger.info("Batch_system_type is {}".format(batch_system_type))
         batch = Batch(batch_system=batch_system_type, machine=machine_name)
         bjobs = batch.get_batch_jobs()
 
@@ -1170,10 +1171,11 @@ class Case(object):
                     mail_user=None, mail_type=None, batch_args=None,
                     dry_run=False):
         env_batch = self.get_env('batch')
-        return env_batch.submit_jobs(self, no_batch=no_batch, job=job, user_prereq=prereq,
+        result =  env_batch.submit_jobs(self, no_batch=no_batch, job=job, user_prereq=prereq,
                                      skip_pnl=skip_pnl, mail_user=mail_user,
                                      mail_type=mail_type, batch_args=batch_args,
                                      dry_run=dry_run)
+        return result
 
     def get_job_info(self):
         """

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -279,7 +279,7 @@ class Case(object):
                 if resolved and isinstance(result, six.string_types):
                     result = self.get_resolved_value(result)
                     vtype = env_file.get_type_info(item)
-                    if vtype is not None or vtype != "char":
+                    if vtype is not None and vtype != "char":
                         result = convert_to_type(result, vtype, item)
 
                 return result

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -9,7 +9,7 @@ import socket
 from CIME.XML.standard_module_setup import *
 from CIME.utils                     import expect, run_and_log_case_status, verbatim_success_msg
 from CIME.preview_namelists         import create_namelists
-from CIME.check_lockedfiles         import check_lockedfiles, check_lockedfile, unlock_file
+from CIME.check_lockedfiles         import check_lockedfiles, check_lockedfile, unlock_file, lock_file
 from CIME.check_input_data          import check_all_input_data
 from CIME.test_status               import *
 
@@ -72,6 +72,7 @@ manual edits to these file will be lost!
             env_batch.make_all_batch_files(case)
 
         unlock_file(os.path.basename(env_batch.filename))
+        lock_file(os.path.basename(env_batch.filename))
 
         if job in ("case.test","case.run"):
             check_case(case)

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -85,7 +85,7 @@ def _save_build_provenance_cesm(case, lid): # pylint: disable=unused-argument
     if os.path.exists(manic):
         out = run_cmd_no_fail(manic + " --status --verbose", from_dir=srcroot)
     caseroot = case.get_value("CASEROOT")
-    with open(os.path.join(caseroot, "README.case"), "a") as fd:
+    with open(os.path.join(caseroot, "CaseStatus"), "a") as fd:
         if version is not None and version != "unknown":
             fd.write("CESM version is {}\n".format(version))
         if out is not None:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1212,7 +1212,7 @@ def append_status(msg, sfile, caseroot='.'):
 
     with open(os.path.join(caseroot, sfile), "a") as fd:
         fd.write(ctime + msg + line_ending)
-        fd.write("\n ---------------------------------------------------\n" + line_ending)
+        fd.write(" ---------------------------------------------------" + line_ending)
 
 def append_testlog(msg, caseroot='.'):
     """

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1208,7 +1208,7 @@ def append_status(msg, sfile, caseroot='.'):
 
     # Reduce empty lines in CaseStatus. It's a very concise file
     # and does not need extra newlines for readability
-    line_ending = "" if sfile == "CaseStatus" else "\n"
+    line_ending = "\n"
 
     with open(os.path.join(caseroot, sfile), "a") as fd:
         fd.write(ctime + msg + line_ending)


### PR DESCRIPTION
Remove most usage of scan_children and replace with root discovery and get_children.
There are a couple of unrelated changes here that clean up README.case and move the cesm
version information to CaseStatus

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
