### PR TITLE
Provide infrastructure to allow SCM to run with SE dycore 

### DIFF
--- a/src/share/streams/shr_dmodel_mod.F90
+++ b/src/share/streams/shr_dmodel_mod.F90
@@ -451,29 +451,51 @@ CONTAINS
           lon     = mod(lon   +1440.0_r8,360.0_r8)
 
           !--- start with wraparound ---
-          ni = 1
-          mind = abs(lscmlon - (lon(1,1)+360.0_r8))
-          do i=1,nxg
-             dist = abs(lscmlon - lon(i,1))
-             if (dist < mind) then
+
+          !--- determine whether dealing with 2D input files (typical of Eulerian 
+          !--- dynamical core) or 1D files (typical of Spectral Element)
+          if (nyg .ne. 1) then
+            ni = 1
+            mind = abs(lscmlon - (lon(1,1)+360.0_r8))
+            do i=1,nxg
+              dist = abs(lscmlon - lon(i,1))
+              if (dist < mind) then
                 mind = dist
                 ni = i
-             endif
-          enddo
+              endif
+            enddo
 
-          nj = -1
-          mind = 1.0e20
-          do j=1,nyg
-             dist = abs(scmlat - lat(1,j))
-             if (dist < mind) then
+            nj = -1
+            mind = 1.0e20
+            do j=1,nyg
+              dist = abs(scmlat - lat(1,j))
+              if (dist < mind) then
                 mind = dist
                 nj = j
-             endif
-          enddo
+              endif
+            enddo
+
+            j = nj
+
+          else ! lat and lon are on 1D arrays
+
+            !--- to deal with spectral element grids
+            mind = 1.0e20
+            do i=1,nxg
+              dist=abs(lscmlon - lon(i,1)) + abs(scmlat - lat(i,1))
+              if (dist < mind) then
+                mind = dist
+                ni = i
+              endif
+            enddo
+
+            j = 1
+
+          endif
 
           n = 1
           i = ni
-          j = nj
+
           gGridRoot%data%rAttr(nlat ,n) = lat(i,j)
           gGridRoot%data%rAttr(nlon ,n) = lon(i,j)
           gGridRoot%data%rAttr(narea,n) = area(i,j)

--- a/src/share/util/shr_scam_mod.F90
+++ b/src/share/util/shr_scam_mod.F90
@@ -271,7 +271,7 @@ subroutine shr_scam_getCloseLatLonNC(ncid, targetLat,  targetLon, closeLat, clos
    if ( allocated(londimnames) ) deallocate(londimnames)
    if ( allocated(vars)        ) deallocate( vars )
 
-   if (latlen .eq. 1 .and. lonlen .gt. 1) then !-- Enforce for SE grids
+   if (londimnames(1) .eq. 'ncol') then !-- Enforce for SE grids
      closelatidx = 1
    endif
 
@@ -330,7 +330,8 @@ subroutine shr_scam_getCloseLatLonPIO(pioid, targetLat,  targetLon, closeLat, cl
    integer(IN)                      ::  ndimid
    integer(IN)                      ::  strt(nf90_max_var_dims),cnt(nf90_max_var_dims)
    integer(IN)                      ::  nlon = 0, nlat = 0
-   logical                          ::  lfound, islatitude        ! local version of found
+   logical                          ::  lfound
+   logical                          ::  is_segrid, islatitude        ! local version of found
    integer(IN), dimension(nf90_max_var_dims) :: dimids
    character(len=80), allocatable   ::  vars(:)
    character(len=80), allocatable   ::  latdimnames(:)
@@ -424,8 +425,10 @@ subroutine shr_scam_getCloseLatLonPIO(pioid, targetLat,  targetLon, closeLat, cl
      latlen=lonlen
      islatitude=.false. ! if spectral element lat and lon 
                         !   are on same array structure
+     is_segrid=.true.
    else
      islatitude=.true.
+     is_segrid=.false.
    endif
 
    !--- Loop through all variables until we find lat and lon ---
@@ -494,7 +497,7 @@ subroutine shr_scam_getCloseLatLonPIO(pioid, targetLat,  targetLon, closeLat, cl
    deallocate( vars )
 
    !--- If dealing with SE grids, set this to 1
-   if (latlen .eq. 1 .and. lonlen .gt. 1) then
+   if (is_segrid) then
      closelatidx = 1
    endif
 

--- a/src/share/util/shr_scam_mod.F90
+++ b/src/share/util/shr_scam_mod.F90
@@ -271,7 +271,7 @@ subroutine shr_scam_getCloseLatLonNC(ncid, targetLat,  targetLon, closeLat, clos
    if ( allocated(londimnames) ) deallocate(londimnames)
    if ( allocated(vars)        ) deallocate( vars )
 
-   if (nlat .eq. nlon) then !-- Enforce for SE grids
+   if (latlen .eq. 1 .and. lonlen .gt. 1) then !-- Enforce for SE grids
      closelatidx = 1
    endif
 
@@ -494,7 +494,7 @@ subroutine shr_scam_getCloseLatLonPIO(pioid, targetLat,  targetLon, closeLat, cl
    deallocate( vars )
 
    !--- If dealing with SE grids, set this to 1
-   if (nlat .eq. nlon) then
+   if (latlen .eq. 1 .and. lonlen .gt. 1) then
      closelatidx = 1
    endif
 


### PR DESCRIPTION
Changes to two files to allow the single column model (SCM) to be run with Spectral Element (SE) dynamical core.  The changes are necessary because the current infrastructure assumes a 2d grid compatability when determining the nearest longitude/latitude point to the SCM column.  However, SE input grids are 1D.   

Test suite: acme_developer tests
Test baseline:  test Eulerian SCM to ensure b4b
Test namelist changes: 
Test status: [bit for bit]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
