### PR TITLE
Improve create_test error message

### DIFF
--- a/scripts/lib/update_e3sm_tests.py
+++ b/scripts/lib/update_e3sm_tests.py
@@ -295,7 +295,13 @@ def get_full_test_names(testargs, machine, compiler):
         elif (testarg in e3sm_test_suites):
             tests_to_run.update(get_test_suite(testarg, machine, compiler))
         else:
-            tests_to_run.add(CIME.utils.get_full_test_name(testarg, machine=machine, compiler=compiler))
+            try:
+                tests_to_run.add(CIME.utils.get_full_test_name(testarg, machine=machine, compiler=compiler))
+            except:
+                if "." not in testarg:
+                    expect(False, "Unrecognized test suite '{}'".format(testarg))
+                else:
+                    raise
 
     for negation in negations:
         if (negation in e3sm_test_suites):


### PR DESCRIPTION
Assume that if the argument provided by the user has no dots in it,
and was not able to be resolved, that they intended the argument to be a test-suite.

Test suite: by-hand, code-checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2348 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @rljacob 
