### PR TITLE
modify regex for hobart to work on compute nodes

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -906,7 +906,7 @@
 
   <machine MACH="hobart">
     <DESC>NCAR CGD Linux Cluster 48 pes/node, batch system is PBS</DESC>
-    <NODENAME_REGEX>^hob.*</NODENAME_REGEX>
+    <NODENAME_REGEX>^h.*\.cgd\.ucar\.edu</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,pgi,nag,gnu</COMPILERS>
     <MPILIBS>mvapich2,openmpi</MPILIBS>


### PR DESCRIPTION
Modify regex to work on compute nodes as well as login nodes. 

Test suite: by hand, scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
