### PR TITLE
Add ability to xmlquery derived attributes

### DIFF
--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -85,6 +85,34 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     return args.caseroot, listofsettings, args.file, args.id, args.val, args.subgroup, args.append, args.noecho, args.force , args.dryrun
 
+def xmlchange_single_value(case, xmlid, xmlval, subgroup, append, force, dryrun):
+    if xmlid in ["THREAD_COUNT", "TOTAL_TASKS", "TASKS_PER_NODE", "NUM_NODES", "SPARE_NODES", "TASKS_PER_NUMA", "CORES_PER_TASK"]:
+        expect(False, "Cannot xmlchange derived attribute {}".format(xmlid))
+
+    type_str = case.get_type_info(xmlid)
+    if append:
+        value = case.get_value(xmlid, resolved=False,
+                               subgroup=subgroup)
+        xmlval = "%s %s" % (value, xmlval)
+
+    if type_str is not None and not force:
+        xmlval = convert_to_type(xmlval, type_str, xmlid)
+
+    if not dryrun:
+        newval = case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
+        expect(newval is not None,"No variable \"%s\" found"%xmlid)
+    else:
+        logger.warning("'%s' = '%s'" , xmlid , xmlval )
+
+    # Subtle: If the user is making specific requests for walltime and queue, we need to
+    # store these choices in USER_REQUESTED_WALLTIME and/or USER_REQUESTED_QUEUE so they
+    # are not lost if the user does a case.setup --reset.
+    if xmlid == "JOB_WALLCLOCK_TIME":
+        case.set_value("USER_REQUESTED_WALLTIME", xmlval, subgroup)
+
+    if xmlid == "JOB_QUEUE":
+        case.set_value("USER_REQUESTED_QUEUE", xmlval, subgroup)
+
 def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
               append, noecho, force, dryrun):
 
@@ -103,40 +131,10 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
                 pair = setting.split("=",1)
                 expect(len(pair) == 2 , "Expecting a key value pair in the form of key=value. Got %s" % (pair) )
                 (xmlid, xmlval) = pair
-                type_str = case.get_type_info(xmlid)
-                if append:
-                    value = case.get_value(xmlid, resolved=False,
-                                           subgroup=subgroup)
-                    xmlval = "%s %s" % (value, xmlval)
 
-                if type_str is not None and not force:
-                    xmlval = convert_to_type(xmlval, type_str, xmlid)
-
-                if not dryrun:
-                    newval = case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
-                    expect(newval is not None,"No variable \"%s\" found"%xmlid)
-                else:
-                    logger.warning("'%s' = '%s'" , xmlid , xmlval )
+                xmlchange_single_value(case, xmlid, xmlval, subgroup, append, force, dryrun)
         else:
-            if append:
-                value = case.get_value(xmlid, resolved=False, subgroup=subgroup)
-                xmlval = "%s %s" % (value, xmlval)
-
-            type_str = case.get_type_info(xmlid)
-            if type_str is not None and not force:
-                xmlval = convert_to_type(xmlval, type_str, xmlid)
-
-            newval = case.set_value(xmlid, xmlval, subgroup, ignore_type=force)
-            expect(newval is not None,"No variable '%s' found" % xmlid)
-
-        # Subtle: If the user is making specific requests for walltime and queue, we need to
-        # store these choices in USER_REQUESTED_WALLTIME and/or USER_REQUESTED_QUEUE so they
-        # are not lost if the user does a case.setup --reset.
-        if xmlid == "JOB_WALLCLOCK_TIME":
-            case.set_value("USER_REQUESTED_WALLTIME", xmlval, subgroup)
-
-        if xmlid == "JOB_QUEUE":
-            case.set_value("USER_REQUESTED_QUEUE", xmlval, subgroup)
+            xmlchange_single_value(case, xmlid, xmlval, subgroup, append, force, dryrun)
 
     if not noecho:
         argstr = ""

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -190,10 +190,14 @@ formatter_class=argparse.RawDescriptionHelpFormatter)
         args.type, args.valid_values, args.partial_match, args.file
 
 def get_value_as_string(case, var, attribute=None, resolved=False, subgroup=None):
-    thistype = case.get_type_info(var)
-    value = case.get_value(var, attribute=attribute, resolved=resolved, subgroup=subgroup)
-    if value is not None and thistype:
-        value = convert_to_string(value, thistype, var)
+    if var in ["THREAD_COUNT", "TOTAL_TASKS", "TASKS_PER_NODE", "NUM_NODES", "SPARE_NODES", "TASKS_PER_NUMA", "CORES_PER_TASK"]:
+        value = str(getattr(case, var.lower()))
+    else:
+        thistype = case.get_type_info(var)
+        value = case.get_value(var, attribute=attribute, resolved=resolved, subgroup=subgroup)
+        if value is not None and thistype:
+            value = convert_to_string(value, thistype, var)
+
     return value
 
 def xmlquery_sub(case, variables, subgroup=None, fileonly=False,

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -99,8 +99,11 @@ class Case(object):
         self._component_classes = []
         self._component_description = {}
         self._is_env_loaded = False
+
         # these are user_mods as defined in the compset
         # Command Line user_mods are handled seperately
+
+        # Derived attributes
         self.thread_count = None
         self.total_tasks = None
         self.tasks_per_node = None
@@ -108,6 +111,7 @@ class Case(object):
         self.spare_nodes = None
         self.tasks_per_numa = None
         self.cores_per_task = None
+
         # check if case has been configured and if so initialize derived
         if self.get_value("CASEROOT") is not None:
             self.initialize_derived_attributes()


### PR DESCRIPTION
Add ability to xmlquery derived attributes

Refactor xmlchange:
The code blocks that handled the two types of user input were diverging.
This commit encapsulates to core xmlchange operation. It also will cause
the user to be informed with a special error if they try to change a derived
attribute.

Test suite: code-checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2351 

User interface changes?: xmlquery will now accept derived attributes

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
