### PR TITLE
add stack size modifier to hobart

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -970,6 +970,9 @@
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
     </environment_variables>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
   </machine>
 
   <machine MACH="homebrew">


### PR DESCRIPTION
Modify stack size on hobart to unlimited, this is needed for MOM6 (and possibly other external components) 

Test suite: by hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
