### PR TITLE
Allow custom batch directive prefixes

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -39,7 +39,7 @@
     <batch_redirect></batch_redirect>
     <batch_directive></batch_directive>
     <directives>
-      <directive name=""></directive>
+      <directive></directive>
     </directives>
   </batch_system>
 
@@ -49,7 +49,7 @@
     <batch_redirect></batch_redirect>
     <batch_directive></batch_directive>
     <directives>
-      <directive name=""></directive>
+      <directive></directive>
     </directives>
   </batch_system>
 

--- a/config/e3sm/machines/config_batch.xml
+++ b/config/e3sm/machines/config_batch.xml
@@ -41,7 +41,7 @@
     <batch_redirect></batch_redirect>
     <batch_directive></batch_directive>
     <directives>
-      <directive name=""></directive>
+      <directive></directive>
     </directives>
   </batch_system>
 
@@ -52,7 +52,7 @@
     <batch_redirect></batch_redirect>
     <batch_directive></batch_directive>
     <directives>
-      <directive name=""></directive>
+      <directive></directive>
     </directives>
   </batch_system>
 

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -142,6 +142,7 @@
   <xs:element name="directive">
     <xs:complexType mixed="true">
       <xs:attribute name="default"/>
+      <xs:attribute name="prefix"/>
       <xs:attribute name="name"/>
     </xs:complexType>
   </xs:element>

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -143,7 +143,6 @@
     <xs:complexType mixed="true">
       <xs:attribute name="default"/>
       <xs:attribute name="prefix"/>
-      <xs:attribute name="name"/>
     </xs:complexType>
   </xs:element>
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -284,7 +284,10 @@ class EnvBatch(EnvBase):
                         else:
                             directive = transform_vars(directive, default=default)
 
-                        result.append("{} {}".format("" if directive_prefix is None else directive_prefix, directive))
+                        custom_prefix = self.get(node, "prefix")
+                        prefix = directive_prefix if custom_prefix is None else custom_prefix
+
+                        result.append("{}{}".format("" if not prefix else (prefix + " "), directive))
 
         return "\n".join(result)
 


### PR DESCRIPTION
Also, remove insertion of space if it's not needed.

Also, remove unsupported "name" attribute from directive.

Test suite: code-checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2358 

User interface changes?: Y, new prefix attribute available for batch directives

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
