### PR TITLE
Update hobart queue limits

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -258,11 +258,12 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemax="02:00:00" nodemin="1" nodemax="4" >short</queue>
-      <queue walltimemax="06:00:00" nodemin="1" nodemax="4" default="true">medium</queue>
-      <queue walltimemax="40:00:00" nodemin="1" nodemax="3" >long</queue>
-      <queue nodemax="16" nodemin="1" walltimemax="12:00:00">overnight</queue>
-      <queue nodemax="32" nodemin="1" walltimemax="3000:00:">monster</queue>
+      <queue walltimemax="02:00:00"   nodemin="1"  nodemax="8">short</queue>
+      <queue walltimemax="08:00:00"   nodemin="1"  nodemax="6" default="true">medium</queue>
+      <queue walltimemax="40:00:00"   nodemin="1"  nodemax="8">long</queue>
+      <queue walltimemax="80:00:00"   nodemin="1"  nodemax="8">verylong</queue>
+      <queue walltimemax="32:00:00"   nodemax="16" nodemin="1">overnight</queue>
+      <queue walltimemax="3000:00:00" nodemax="32" nodemin="1">monster</queue>
     </queues>
   </batch_system>
 

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -258,12 +258,12 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemax="02:00:00"   nodemin="1"  nodemax="8">short</queue>
-      <queue walltimemax="08:00:00"   nodemin="1"  nodemax="6" default="true">medium</queue>
-      <queue walltimemax="40:00:00"   nodemin="1"  nodemax="8">long</queue>
-      <queue walltimemax="80:00:00"   nodemin="1"  nodemax="8">verylong</queue>
-      <queue walltimemax="32:00:00"   nodemax="16" nodemin="1">overnight</queue>
-      <queue walltimemax="3000:00:00" nodemax="32" nodemin="1">monster</queue>
+      <queue walltimemax="02:00:00"   strict="true" nodemin="1"  nodemax="8">short</queue>
+      <queue walltimemax="08:00:00"   strict="true" nodemin="1"  nodemax="6" default="true">medium</queue>
+      <queue walltimemax="40:00:00"   strict="true" nodemin="1"  nodemax="8">long</queue>
+      <queue walltimemax="80:00:00"   strict="true" nodemin="1"  nodemax="8">verylong</queue>
+      <queue walltimemax="32:00:00"   strict="true" nodemax="16" nodemin="1">overnight</queue>
+      <queue walltimemax="3000:00:00" strict="true" nodemax="32" nodemin="1">monster</queue>
     </queues>
   </batch_system>
 


### PR DESCRIPTION
Queue limits have changed on hobart:

```
$ qstat -q

server: hobart.cgd.ucar.edu

Queue            Memory CPU Time Walltime Node  Run Que Lm  State
---------------- ------ -------- -------- ----  --- --- --  -----
short              --   16:00:00 02:00:00     8   0   0 50   E R
overnight          --   18432:00 32:00:00    16   0   0 10   E S
default            --      --       --      --    0   0 10   E R
monster            --   17280:00 3000:00:    32   1   0 10   E R
shared             --   12:00:00 12:00:00     1   0   0 16   E R
medium             --   72:00:00 08:00:00     6   2   1 50   E R
verylong           --   480:00:0 80:00:00     8   4   7 50   E R
long               --   240:00:0 40:00:00     8   0   0 50   E R
```

This PR updates CESM's `config_batch.xml` accordingly.

Test suite: Ran 10-day smoke tests and 3 hour walltime on {1,2,3,...,9} nodes to verify jobs were submitted to correct queue.
Test status: **ISSUE WITH THIS PR** The tests on 7 & 8 nodes were trying to use `short` even though the 3 hour walltime exceeded the limit

Update gh-pages html (Y/N)?: N

Code review: I think landing in the `short` queue instead of `long` for 7 or 8 tasks is indicative of an issue beyond the scope of this PR, but it should probably be fixed first (or "short" queue entry could be removed)
