### PR TITLE
Rename and reorg upper level contents

### DIFF
--- a/doc/source/build_cpl/index.rst
+++ b/doc/source/build_cpl/index.rst
@@ -6,7 +6,7 @@
    contain the root `toctree` directive.
 
 #######################################################################
-CIME User's Guide Part 3: Advanced - Building a Coupled Model with CIME
+Building a Coupled Model with CIME
 #######################################################################
 
 .. toctree::

--- a/doc/source/data_models/index.rst
+++ b/doc/source/data_models/index.rst
@@ -6,11 +6,11 @@
    contain the root `toctree` directive.
 
 ####################
- CIME Data Models
+ Data Models
 ####################
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :numbered:
 
    introduction.rst

--- a/doc/source/driver_cpl/index.rst
+++ b/doc/source/driver_cpl/index.rst
@@ -6,7 +6,7 @@
    contain the root `toctree` directive.
 
 #######################
-  CIME Driver/Coupler
+  Driver/Coupler
 #######################
 
 .. toctree::

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,19 +7,20 @@ CIME documentation
 ==================
 
 The Common Infrastructure for Modeling the Earth (CIME - pronounced
-"SEAM") provides a UNIX command-line-based interface for configuring,
-compiling and executing Earth system models.
+"SEAM") provides a Case Control System for configuring, compiling and executing
+Earth system models, data and stub model components, a driver and associated tools
+and libraries.
 
 Table of contents
 -----------------
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
       
    what_cime/index.rst
    users_guide/index.rst
-   build_cpl/index.rst
    data_models/index.rst
    driver_cpl/index.rst
+   build_cpl/index.rst
    misc_tools/index.rst
 
 Addendum

--- a/doc/source/users_guide/index.rst
+++ b/doc/source/users_guide/index.rst
@@ -5,9 +5,9 @@
 
 .. _users-guide1:
 
-#################################################
-CIME User's Guide Part 1: Beginner - Basic Usage
-#################################################
+#######################################
+Case Control System Part 1: Basic Usage
+#######################################
 
 .. toctree::
    :maxdepth: 3
@@ -26,7 +26,7 @@ CIME User's Guide Part 1: Beginner - Basic Usage
 .. _users-guide2:
 
 #######################################################################################
-CIME User's Guide Part 2: Intermediate - CIME Internals, Porting, Testing and Use Cases
+Case Control System Part 2: Configuration, Porting, Testing and Use Cases
 #######################################################################################
 
 .. toctree::

--- a/doc/source/what_cime/index.rst
+++ b/doc/source/what_cime/index.rst
@@ -29,26 +29,26 @@ Overview
 
 CIME is comprised of:
 
-1. A default coupled model architecture:
+1. A Case Control System to support configuration, compilation, execution, system testing and unit testing of a earth system model:
+
+    i. Scripts to enable simple generation of model executables and associated input files for different scientific cases, component resolutions and combinations of full, data and stub components with a handful of commands.
+    ii. Testing utilities to run defined system tests and report results for different configurations of the coupled system.
+
+2. A default coupled model architecture:
 
     i. A programmer interface and libraries to implement a hub-and-spoke inter-component coupling architecture.
-    ii. An implementation of a “hub” that needs 7 components (atm, ocn, lnd, sea-ice, land-ice, river, wave). a.k.a. “the driver”.
+    ii. An implementation of a "hub" that needs 7 components (atm, ocn, lnd, sea-ice, land-ice, river, wave). a.k.a. “the driver”.
     iii. The ability to allow active and data components to be mixed in any combination as long as each component implements the coupling programmer interface.
 
-2. Non-active Data and Stub components:
+3. Non-active Data and Stub components:
 
     i. “Data-only” versions of 6 of the 7 components that can replace active components at build-time.
     ii. “Stub” versions of all 7 components for building a complete system.
 
-3. Additional libraries useful in scientific applications in general and climate models in particular.
+4. Source code for externall libraries useful in scientific applications in general and climate models in particular.
     i.  Parallel I/O library.
     ii. The Model Coupling Toolkit.
     iii. Timing library.
-
-4. A system of scripts (python) to support case configuration, executable compilation, workflow, system testing and unit testing infrastructure:
-
-    i. Scripts to enable simple generation of model executables and associated input files for different scientific cases, component resolutions and combinations of full, data and stub components with a handful of commands.
-    ii. Testing utilities to run defined system tests and report results for different configurations of the coupled system.
 
 5. Additional stand-alone tools:
 
@@ -58,10 +58,10 @@ CIME is comprised of:
     iv. Netcdf file comparison program (for bit-for-bit).
 
 *************************
-Where is CIME developed?
+Development
 *************************
 
-CIME is an open-source, public repository hosted under the Earth
+CIME is developed in an open-source, public repository hosted under the Earth
 System Model Computational Infrastructure (ESMCI) organization on
 Github at http://github.com/ESMCI/cime.
 


### PR DESCRIPTION
Rename and reorg upper level contents.

Switch back to depth 2 at upper level because made it to hard to see all the content.
Expand the description of CIME in the top-most table of contents.
Reorganize the "what is cime" to put CCS first.
Remove multiple use of "CIME" from section headings.  We know its about CIME.
make part 1 and 2 about the Case Control System.
Move former part 3 on building a model with CIME to the end after data models and driver.

Test suite:  built docs locally

Update gh-pages html (Y/N)?: Y

