### PR TITLE
ignore files beginning in test_

### DIFF
--- a/scripts/Tools/mkSrcfiles
+++ b/scripts/Tools/mkSrcfiles
@@ -32,6 +32,7 @@ foreach $dir (@paths) {
     @filenames = (glob("$dir/*.[Ffc]"), glob("$dir/*.[Ff]90"), glob("$dir/*.cpp"));
     foreach $filename (@filenames) {
 	$filename =~ s!.*/!!;                   # remove part before last slash
+	next if ($filename =~ /^test_/);
 	$src{$filename} = 1;
     }
     @templates = glob("$dir/*.F90.in");

--- a/scripts/Tools/mkSrcfiles
+++ b/scripts/Tools/mkSrcfiles
@@ -32,7 +32,10 @@ foreach $dir (@paths) {
     @filenames = (glob("$dir/*.[Ffc]"), glob("$dir/*.[Ff]90"), glob("$dir/*.cpp"));
     foreach $filename (@filenames) {
 	$filename =~ s!.*/!!;                   # remove part before last slash
-	next if ($filename =~ /^test_/);
+	if ($filename =~ /^test_/){
+	    print "WARNING: Skipping file $dir/$filename Source files beginning in test_ are ignored\n";
+	    next;
+	}
 	$src{$filename} = 1;
     }
     @templates = glob("$dir/*.F90.in");


### PR DESCRIPTION
Using mkSrcfiles to build the FMS libraries requires ignoring files with name pattern test_* 
I checked all of cime and all of the cesm component models to assure that this name pattern was never used.

Test suite: by hand, build new FMS library
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes
User interface changes?:  Source code files beginning in test_ will be ignored in build

Update gh-pages html (Y/N)?:

Code review: 
