### PR TITLE
Fix skip-pnl for tests

### DIFF
--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -49,21 +49,24 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--reset", action="store_true",
                         help="Reset the case to its original state as defined by config_tests.xml")
 
+    parser.add_argument("--skip-preview-namelist", action="store_true",
+                        help="Skip calling preview-namelist during case.run")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)
 
-    return args.caseroot, args.testname, args.reset
+    return args.caseroot, args.testname, args.reset, args.skip_preview_namelist
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
-    caseroot, testname, reset = parse_command_line(sys.argv, description)
+    caseroot, testname, reset, skip_pnl = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        success = case_test(case, testname, reset)
+        success = case_test(case, testname=testname, reset=reset, skip_pnl=skip_pnl)
 
     sys.exit(0 if success else 1)
 

--- a/config/e3sm/machines/config_batch.xml
+++ b/config/e3sm/machines/config_batch.xml
@@ -60,7 +60,7 @@
     <batch_query>qstat</batch_query>
     <batch_submit>qsub</batch_submit>
     <batch_cancel>qdel</batch_cancel>
-    <batch_env>-v</batch_env>
+    <batch_env>--env</batch_env>
     <batch_directive></batch_directive>
     <jobid_pattern>(\d+)</jobid_pattern>
     <depend_string> --dependencies</depend_string>
@@ -82,7 +82,7 @@
     <batch_query>qstat</batch_query>
     <batch_submit>/projects/ccsm/acme/tools/cobalt/dsub</batch_submit>
     <batch_cancel>qdel</batch_cancel>
-    <batch_env>-v</batch_env>
+    <batch_env>--env</batch_env>
     <batch_directive>#COBALT</batch_directive>
     <jobid_pattern>(\d+)</jobid_pattern>
     <depend_string>--dependencies jobid</depend_string>

--- a/config/e3sm/machines/template.case.test
+++ b/config/e3sm/machines/template.case.test
@@ -49,21 +49,24 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--reset", action="store_true",
                         help="Reset the case to its original state as defined by config_tests.xml")
 
+    parser.add_argument("--skip-preview-namelist", action="store_true",
+                        help="Skip calling preview-namelist during case.run")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)
 
-    return args.caseroot, args.testname, args.reset
+    return args.caseroot, args.testname, args.reset, args.skip_preview_namelist
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
-    caseroot, testname, reset = parse_command_line(sys.argv, description)
+    caseroot, testname, reset, skip_pnl = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        success = case_test(case, testname, reset)
+        success = case_test(case, testname=testname, reset=reset, skip_pnl=skip_pnl)
 
     sys.exit(0 if success else 1)
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -35,6 +35,7 @@ class SystemTestsCommon(object):
         self._test_status = TestStatus(test_dir=caseroot, test_name=self._casebaseid)
         self._init_environment(caseroot)
         self._init_locked_files(caseroot, expected)
+        self._skip_pnl = False
 
     def _init_environment(self, caseroot):
         """
@@ -130,13 +131,14 @@ class SystemTestsCommon(object):
             comps = [x.lower() for x in self._case.get_values("COMP_CLASSES")]
         build.clean(self._case, cleanlist=comps)
 
-    def run(self):
+    def run(self, skip_pnl=False):
         """
         Do NOT override this method, this method is the framework that controls
         the run phase. run_phase is the extension point that subclasses should use.
         """
         success = True
         start_time = time.time()
+        self._skip_pnl = skip_pnl
         try:
             self._resetup_case(RUN_PHASE)
             with self._test_status:
@@ -223,7 +225,7 @@ class SystemTestsCommon(object):
 
         logger.info(infostr)
 
-        case_run(self._case)
+        case_run(self._case, skip_pnl=self._skip_pnl)
 
         if not self._coupler_log_indicates_run_complete():
             expect(False, "Coupler did not indicate run passed")

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -433,7 +433,10 @@ class EnvBatch(EnvBase):
 
             function_name = job.replace(".", "_")
             if not dry_run:
-                locals()[function_name](case)
+                if "archive" not in function_name:
+                    locals()[function_name](case, skip_pnl=skip_pnl)
+                else:
+                    locals()[function_name](case)
 
             return
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -496,19 +496,22 @@ class EnvBatch(EnvBase):
                "Unable to determine the correct command for batch submission.")
         batchredirect = self.get_value("batch_redirect", subgroup=None)
         submitcmd = ''
-        for string in (batchsubmit, submitargs):
-            if  string is not None:
-                submitcmd += string + " "
+        batch_env_flag = self.get_value("batch_env", subgroup=None)
+        if batch_env_flag:
+            sequence = (batchsubmit, submitargs, "skip_pnl", batchredirect, get_batch_script_for_job(job))
+        else:
+            sequence = (batchsubmit, submitargs, batchredirect, get_batch_script_for_job(job), "skip_pnl")
 
-        if job in ['case.run', 'case.test'] and skip_pnl:
-            batch_env_flag = self.get_value("batch_env", subgroup=None)
-            if not batch_env_flag:
-                submitcmd += " --skip-preview-namelist "
-            else:
-                submitcmd += " {} ARGS_FOR_SCRIPT='--skip-preview-namelist' ".format(batch_env_flag)
+        for string in sequence:
+            if string == "skip_pnl":
+                if job in ['case.run', 'case.test'] and skip_pnl:
+                    batch_env_flag = self.get_value("batch_env", subgroup=None)
+                    if not batch_env_flag:
+                        submitcmd += " --skip-preview-namelist "
+                    else:
+                        submitcmd += " {} ARGS_FOR_SCRIPT='--skip-preview-namelist' ".format(batch_env_flag)
 
-        for string in (batchredirect, get_batch_script_for_job(job)):
-            if  string is not None:
+            elif string is not None:
                 submitcmd += string + " "
 
         if dry_run:

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -496,16 +496,20 @@ class EnvBatch(EnvBase):
                "Unable to determine the correct command for batch submission.")
         batchredirect = self.get_value("batch_redirect", subgroup=None)
         submitcmd = ''
-        for string in (batchsubmit, submitargs, batchredirect, get_batch_script_for_job(job)):
+        for string in (batchsubmit, submitargs):
             if  string is not None:
                 submitcmd += string + " "
 
-        if job == 'case.run' and skip_pnl:
+        if job in ['case.run', 'case.test'] and skip_pnl:
             batch_env_flag = self.get_value("batch_env", subgroup=None)
             if not batch_env_flag:
-                submitcmd += " --skip-preview-namelist"
+                submitcmd += " --skip-preview-namelist "
             else:
-                submitcmd += " {} ARGS_FOR_SCRIPT='--skip-preview-namelist'".format(batch_env_flag)
+                submitcmd += " {} ARGS_FOR_SCRIPT='--skip-preview-namelist' ".format(batch_env_flag)
+
+        for string in (batchredirect, get_batch_script_for_job(job)):
+            if  string is not None:
+                submitcmd += string + " "
 
         if dry_run:
             return submitcmd

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -65,7 +65,9 @@ def pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
     # This needs to be done everytime the LID changes in order for log files to be set up correctly
     # The following also needs to be called in case a user changes a user_nl_xxx file OR an env_run.xml
     # variable while the job is in the queue
-    if not skip_pnl:
+    if skip_pnl:
+        create_namelists(case, component='cpl')
+    else:
         create_namelists(case)
 
     logger.info("-------------------------------------------------------------------------")
@@ -124,10 +126,11 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
 
                         case.set_value("CONTINUE_RUN",
                                        case.get_value("RESUBMIT_SETS_CONTINUE_RUN"))
-                        create_namelists(case)
 
                         lid = new_lid()
                         loop = True
+
+                        create_namelists(case)
 
                         case.spare_nodes -= num_fails
 

--- a/scripts/lib/CIME/case_test.py
+++ b/scripts/lib/CIME/case_test.py
@@ -42,7 +42,7 @@ def _set_up_signal_handlers():
         signum = getattr(signal, signame)
         signal.signal(signum, _signal_handler)
 
-def case_test(case, testname=None, reset=False):
+def case_test(case, testname=None, reset=False, skip_pnl=False):
     if testname is None:
         testname = case.get_value('TESTCASE')
 
@@ -69,6 +69,6 @@ def case_test(case, testname=None, reset=False):
         # pylint: disable=protected-access
         test._resetup_case(RUN_PHASE)
         return True
-    success = test.run()
+    success = test.run(skip_pnl=skip_pnl)
 
     return success

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1498,7 +1498,7 @@ class Z_FullSystemTest(TestCreateTestCommon):
                 with TestStatus(test_dir=casedir) as ts:
                     ts.set_status(MEMLEAK_PHASE, TEST_PEND_STATUS)
 
-            run_cmd_assert_result(self, "./case.submit --skip-preview-namelists", from_dir=casedir)
+            run_cmd_assert_result(self, "./case.submit --skip-preview-namelist", from_dir=casedir)
 
         self._wait_for_tests(self._baseline_name)
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1498,7 +1498,7 @@ class Z_FullSystemTest(TestCreateTestCommon):
                 with TestStatus(test_dir=casedir) as ts:
                     ts.set_status(MEMLEAK_PHASE, TEST_PEND_STATUS)
 
-            run_cmd_assert_result(self, "./case.submit", from_dir=casedir)
+            run_cmd_assert_result(self, "./case.submit --skip-preview-namelists", from_dir=casedir)
 
         self._wait_for_tests(self._baseline_name)
 


### PR DESCRIPTION
skip-pnl was being entirely ignored for case.test.

Also fixes argument passdown bug on some systems.

Test suite: scripts_regression_tests (both batch and desktop)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
