### PR TITLE
Update MCT to 2.10rc2

### DIFF
--- a/src/externals/mct/README
+++ b/src/externals/mct/README
@@ -1,6 +1,6 @@
 ######################################################################
 
- -- Mathematics + Computer Science Div. / Argonne National Laboratory
+ -- Argonne National Laboratory
 
     Model Coupling Toolkit (MCT)
 
@@ -15,7 +15,7 @@
 
 ######################################################################
 
-  This is version 2.9 of the Model Coupling Toolkit (MCT).
+  This is version 2.10 of the Model Coupling Toolkit (MCT).
 
   Our purpose in creating this toolkit is to support the construction
   of highly portable and extensible high-performance couplers
@@ -196,3 +196,4 @@ Optional Contents available
   12 Sep, 2012 -- version 2.8.2 (not released)
   16 Dec, 2012 -- version 2.8.3
   19 Jun, 2015 -- version 2.9.0
+  12 Mar, 2018 -- version 2.10.0

--- a/src/externals/mct/doc/mct_APIs.tex
+++ b/src/externals/mct/doc/mct_APIs.tex
@@ -44,7 +44,7 @@
 %%%
 %%% Enter your title below (after deleting mine)
 %%%
-The Model Coupling Toolkit API Reference Manual: MCT v. 2.9
+The Model Coupling Toolkit API Reference Manual: MCT v. 2.10
 \\ }                     %%% IMPORTANT: Keep this \\ before the }
 \end{sloppypar}
 
@@ -155,6 +155,8 @@ Version 2.8.2 & Sep 12, 2012      & 2.8.2 Version &
 Version 2.8.3 & Dec 17, 2012      & 2.8.3 Version &
 \\\hline
 Version 2.9.0 & Jun 19, 2015      & 2.9.0 Version &
+\\\hline
+Version 2.10.0 & Mar 12, 2018      & 2.10.0 Version &
 \\\hline
 \end{tabular}
 \end{center}

--- a/src/externals/mct/mct/m_Rearranger.F90
+++ b/src/externals/mct/mct/m_Rearranger.F90
@@ -732,11 +732,6 @@
    if(present(AlltoAll)) then
     if(AlltoAll) usealltoall=.true.
    endif
-!pw++
-   ! forcing use of alltoall protocol until additional tuning
-   ! capabilities are added to calling routines
-!pw   usealltoall=.true.
-!pw--
 
    useswapm=.false.
    if (usealltoall) then
@@ -761,12 +756,6 @@
      useswapm=.true.
     endif
 
-!pw++
-    ! forcing use of swapm variant of alltoall protocol
-    ! until additional tuning capabilities are added to
-    ! calling routines
-!pw    useswapm=.true.
-!pw--
    endif
 
    DoSum=.false.
@@ -792,69 +781,55 @@
 
   ! ALLOCATE DATA STRUCTURES !
 
-     ! IF SENDING INTEGER DATA
-     if(numi .ge. 1) then
+  ! IF SENDING OR RECEIVING INTEGER DATA
+  if (numi .ge. 1) then
 
-	! allocate buffer to hold all outgoing data
-        ISendSize = 1
-	do proc=1,SendRout%nprocs
-           ISendLoc(proc) = ISendSize
-           ISendSize = ISendSize + SendRout%locsize(proc)*numi
-	enddo
-        ISendSize = ISendSize - 1
-	allocate(ISendBuf(ISendSize),stat=ier)
-	if(ier/=0) call die(myname_,'allocate(ISendBuf)',ier)
+     ! allocate buffer to hold all outgoing data
+     ISendSize = 1
+     do proc=1,SendRout%nprocs
+        ISendLoc(proc) = ISendSize
+        ISendSize = ISendSize + SendRout%locsize(proc)*numi
+     enddo
+     if (ISendSize > 1) ISendSize = ISendSize - 1
+     allocate(ISendBuf(ISendSize),stat=ier)
+     if (ier/=0) call die(myname_,'allocate(ISendBuf)',ier)
 
-     endif
+     ! allocate buffer to hold all incoming data
+     IRecvSize = 1
+     do proc=1,RecvRout%nprocs
+        IRecvLoc(proc) = IRecvSize
+        IRecvSize = IRecvSize + RecvRout%locsize(proc)*numi
+     enddo
+     if (IRecvSize > 1) IRecvSize = IRecvSize - 1
+     allocate(IRecvBuf(IRecvSize),stat=ier)
+     if(ier/=0) call die(myname_,'allocate(IRecvBuf)',ier)
 
-     ! IF SENDING REAL DATA
-     if(numr .ge. 1) then
+  endif
 
-	! allocate buffer to hold all outgoing data
-        RSendSize = 1
-	do proc=1,SendRout%nprocs
-           RSendLoc(proc) = RSendSize
-           RSendSize = RSendSize + SendRout%locsize(proc)*numr
-	enddo
-        RSendSize = RSendSize - 1
-	allocate(RSendBuf(RSendSize),stat=ier)
-	if(ier/=0) call die(myname_,'allocate(RSendBuf)',ier)
+  ! IF SENDING OR RECEIVING REAL DATA
+  if (numr .ge. 1) then
 
+     ! allocate buffer to hold all outgoing data
+     RSendSize = 1
+     do proc=1,SendRout%nprocs
+        RSendLoc(proc) = RSendSize
+        RSendSize = RSendSize + SendRout%locsize(proc)*numr
+     enddo
+     if (RSendSize > 1) RSendSize = RSendSize - 1
+     allocate(RSendBuf(RSendSize),stat=ier)
+     if (ier/=0) call die(myname_,'allocate(RSendBuf)',ier)
 
-     endif
+     ! allocate buffer to hold all incoming data
+     RRecvSize = 1
+     do proc=1,RecvRout%nprocs
+        RRecvLoc(proc) = RRecvSize
+        RRecvSize = RRecvSize + RecvRout%locsize(proc)*numr
+     enddo
+     if (RRecvSize > 1) RRecvSize = RRecvSize - 1
+     allocate(RRecvBuf(RRecvSize),stat=ier)
+     if(ier/=0) call die(myname_,'allocate(RRecvBuf)',ier)
 
-  ! IF RECEVING DATA
-
-     ! IF RECEIVING INTEGER DATA
-     if(numi .ge. 1) then
-
-	! allocate buffer to hold all outgoing data
-        IRecvSize = 1
-	do proc=1,RecvRout%nprocs
-           IRecvLoc(proc) = IRecvSize
-           IRecvSize = IRecvSize + RecvRout%locsize(proc)*numi
-	enddo
-        IRecvSize = IRecvSize - 1
-	allocate(IRecvBuf(IRecvSize),stat=ier)
-	if(ier/=0) call die(myname_,'allocate(IRecvBuf)',ier)
-
-     endif
-
-     ! IF RECEIVING REAL DATA
-     if(numr .ge. 1) then
-
-	! allocate buffer to hold all outgoing data
-        RRecvSize = 1
-	do proc=1,RecvRout%nprocs
-           RRecvLoc(proc) = RRecvSize
-           RRecvSize = RRecvSize + RecvRout%locsize(proc)*numr
-	enddo
-        RRecvSize = RRecvSize - 1
-	allocate(RRecvBuf(RRecvSize),stat=ier)
-	if(ier/=0) call die(myname_,'allocate(RRecvBuf)',ier)
-
-
-     endif
+  endif
 
 !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -1325,29 +1300,29 @@ endif
 
   ! DEALLOCATE ALL STRUCTURES
 
-     if(numi .ge. 1) then
+  if (numi .ge. 1) then
 
-	! Deallocate the send buffer
-	deallocate(ISendBuf,stat=ier)
-	if(ier/=0) call die(myname_,'deallocate(ISendBuf)',ier)
+     ! Deallocate the send buffer
+     deallocate(ISendBuf,stat=ier)
+     if(ier/=0) call die(myname_,'deallocate(ISendBuf)',ier)
 
-	! Deallocate the receive buffer
-	deallocate(IRecvBuf,stat=ier)
-	if(ier/=0) call die(myname_,'deallocate(IRecvBuf)',ier)
+     ! Deallocate the receive buffer
+     deallocate(IRecvBuf,stat=ier)
+     if(ier/=0) call die(myname_,'deallocate(IRecvBuf)',ier)
 
-     endif
+  endif
 
-     if(numr .ge. 1) then
+  if (numr .ge. 1) then
 
-	! Deallocate the send buffer
-	deallocate(RSendBuf,stat=ier)
-	if(ier/=0) call die(myname_,'deallocate(RSendBuf)',ier)
+     ! Deallocate the send buffer
+     deallocate(RSendBuf,stat=ier)
+     if(ier/=0) call die(myname_,'deallocate(RSendBuf)',ier)
 
-	! Deallocate the receive buffer
-	deallocate(RRecvBuf,stat=ier)
-	if(ier/=0) call die(myname_,'deallocate(RRecvBuf)',ier)
+     ! Deallocate the receive buffer
+     deallocate(RRecvBuf,stat=ier)
+     if(ier/=0) call die(myname_,'deallocate(RRecvBuf)',ier)
 
-     endif
+  endif
 
   nullify(SendRout,RecvRout)
 


### PR DESCRIPTION
Update MCT with changes from the 2.10-rc2 tag.

Only significant diff is slight change to workaround for the mpi libs
that have trouble when arguments in MPI_alltoallv are not allocated.
Also update strings in docs from 2.9 to 2.10

Test suite:  e3sm_developer
Test baseline:  BFB using a low res E3SM fully coupled case
Test namelist changes:  None
Test status: BFB
