### PR TITLE
Compare two case setup

### DIFF
--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -14,7 +14,6 @@ import gzip
 import CIME.XML.standard_module_setup as sms
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.utils import expect
-from CIME.case_setup import case_setup
 
 ###############################################################################
 class DAE(SystemTestsCompareTwo):
@@ -40,7 +39,7 @@ class DAE(SystemTestsCompareTwo):
     ###########################################################################
     def _case_one_setup(self):
     ###########################################################################
-        case_setup(self._case, test_mode=True, reset=True)
+        pass
 
     ###########################################################################
     def _case_two_setup(self):

--- a/scripts/lib/CIME/SystemTests/eri.py
+++ b/scripts/lib/CIME/SystemTests/eri.py
@@ -4,6 +4,7 @@ CIME ERI test  This class inherits from SystemTestsCommon
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.check_input_data import check_all_input_data
+from CIME.case_setup import case_setup
 import shutil, glob, os
 
 logger = logging.getLogger(__name__)
@@ -92,6 +93,7 @@ class ERI(SystemTestsCommon):
         clone1.set_value("REST_N", rest_n1)
         clone1.set_value("HIST_OPTION", "never")
         clone1.flush()
+        case_setup(clone1, test_mode=True, reset=True)
 
         # if the initial case is hybrid this will put the reference data in the correct location
         check_all_input_data(clone1)
@@ -139,6 +141,7 @@ class ERI(SystemTestsCommon):
         clone2.set_value("HIST_OPTION",   stop_option)
         clone2.set_value("HIST_N",        hist_n)
         clone2.flush()
+        case_setup(clone2, test_mode=True, reset=True)
 
         rundir2 = clone2.get_value("RUNDIR")
         dout_sr2 = clone2.get_value("DOUT_S_ROOT")

--- a/scripts/lib/CIME/SystemTests/erp.py
+++ b/scripts/lib/CIME/SystemTests/erp.py
@@ -9,7 +9,6 @@ count are modified on retart.
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.case_setup import case_setup
 from CIME.SystemTests.restart_tests import RestartTest
 from CIME.check_lockedfiles import *
 
@@ -43,7 +42,6 @@ class ERP(RestartTest):
         # Note, some components, like CESM-CICE, have
         # decomposition information in env_build.xml that
         # needs to be regenerated for the above new tasks and thread counts
-        case_setup(self._case, test_mode=True, reset=True)
 
     def _case_one_custom_postrun_action(self):
         self.copy_case1_restarts_to_case2()

--- a/scripts/lib/CIME/SystemTests/mcc.py
+++ b/scripts/lib/CIME/SystemTests/mcc.py
@@ -6,7 +6,6 @@ This does two runs: In the first we run a three member ensemble using the
 """
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
-from CIME.case_setup import case_setup
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +26,6 @@ class MCC(SystemTestsCompareTwo):
         # number of requested couplers.
         self._case.set_value("MULTI_DRIVER",True)
         self._case.set_value("NINST", self._test_instances)
-        case_setup(self._case, test_mode=False, reset=True)
 
     def _case_two_setup(self):
         self._case.set_value("NINST", 1)
-        case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/nck.py
+++ b/scripts/lib/CIME/SystemTests/nck.py
@@ -10,7 +10,6 @@ Lay all of the components out sequentially
 
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
-from CIME.case_setup import case_setup
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +41,6 @@ class NCK(SystemTestsCompareTwo):
         for comp in self._comp_classes:
             self._case.set_value("NINST_{}".format(comp), 1)
 
-        case_setup(self._case, test_mode=True, reset=True)
 
     def _case_two_setup(self):
         for comp in self._comp_classes:
@@ -54,4 +52,3 @@ class NCK(SystemTestsCompareTwo):
             ntasks = self._case.get_value("NTASKS_{}".format(comp))
             self._case.set_value("NTASKS_{}".format(comp), ntasks*2)
 
-        case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/ncr.py
+++ b/scripts/lib/CIME/SystemTests/ncr.py
@@ -9,7 +9,6 @@ The second is a default build
 NOTE: This is currently untested, and may not be working properly
 """
 from CIME.XML.standard_module_setup import *
-from CIME.case_setup import case_setup
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.check_lockedfiles import *
 
@@ -60,10 +59,8 @@ class NCR(SystemTestsCompareTwo):
             self._case.set_value("NTASKS_{}".format(comp), ntasks)
         # test_mode must be False here so the case.test file is updated
         # This ensures that the correct number of nodes are used in case it's larger than in case 2
-        case_setup(self._case, test_mode = False, reset = True)
 
     def _case_two_setup(self):
         for comp in self._comp_classes():
             self._case.set_value("NINST_{}".format(comp), str(1))
             self._case.set_value("ROOTPE_{}".format(comp), 0)
-        case_setup(self._case, test_mode = True, reset = True)

--- a/scripts/lib/CIME/SystemTests/pea.py
+++ b/scripts/lib/CIME/SystemTests/pea.py
@@ -8,7 +8,6 @@ Builds runs and compares a single processor mpi model to a model built using mpi
 
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.XML.standard_module_setup import *
-from CIME.case_setup import case_setup
 from CIME.XML.machines import Machines
 
 logger = logging.getLogger(__name__)
@@ -29,7 +28,7 @@ class PEA(SystemTestsCompareTwo):
             self._case.set_value("ROOTPE_{}".format(comp), 0)
 
     def _case_one_setup(self):
-        case_setup(self._case, reset=True, test_mode=True)
+        pass
 
     def _case_two_setup(self):
         mach_name = self._case.get_value("MACH")
@@ -43,4 +42,3 @@ class PEA(SystemTestsCompareTwo):
 
         if os.path.isfile("Macros"):
             os.remove("Macros")
-        case_setup(self._case, reset=True, test_mode=True)

--- a/scripts/lib/CIME/SystemTests/pem.py
+++ b/scripts/lib/CIME/SystemTests/pem.py
@@ -9,7 +9,6 @@ are modified the second time.
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.case_setup import case_setup
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 
 logger = logging.getLogger(__name__)
@@ -31,4 +30,3 @@ class PEM(SystemTestsCompareTwo):
             ntasks = self._case.get_value("NTASKS_{}".format(comp))
             if ( ntasks > 1 ):
                 self._case.set_value("NTASKS_{}".format(comp), int(ntasks/2))
-        case_setup(self._case, reset=True)

--- a/scripts/lib/CIME/SystemTests/pet.py
+++ b/scripts/lib/CIME/SystemTests/pet.py
@@ -7,7 +7,6 @@ This is an openmp test to determine that changing thread counts does not change 
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.case_setup import case_setup
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 
 logger = logging.getLogger(__name__)
@@ -32,7 +31,7 @@ class PET(SystemTestsCompareTwo):
                 self._case.set_value("NTHRDS_{}".format(comp), 2)
 
         # Need to redo case_setup because we may have changed the number of threads
-        case_setup(self._case, reset=True)
+
 
     def _case_two_setup(self):
         #Do a run with all threads set to 1
@@ -40,4 +39,4 @@ class PET(SystemTestsCompareTwo):
             self._case.set_value("NTHRDS_{}".format(comp), 1)
 
         # Need to redo case_setup because we may have changed the number of threads
-        case_setup(self._case, reset=True)
+

--- a/scripts/lib/CIME/SystemTests/pre.py
+++ b/scripts/lib/CIME/SystemTests/pre.py
@@ -13,7 +13,6 @@ import glob
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.utils import expect
 from CIME.hist_utils import cprnc
-from CIME.case_setup import case_setup
 
 ###############################################################################
 class PRE(SystemTestsCompareTwo):
@@ -39,7 +38,7 @@ class PRE(SystemTestsCompareTwo):
     ###########################################################################
     def _case_one_setup(self):
     ###########################################################################
-        case_setup(self._case, test_mode=True, reset=True)
+        pass
 
     ###########################################################################
     def _case_two_setup(self):

--- a/scripts/lib/CIME/SystemTests/seq.py
+++ b/scripts/lib/CIME/SystemTests/seq.py
@@ -3,7 +3,6 @@ sequencing bfb test (10 day seq,conc tests)
 """
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
-from CIME.case_setup import case_setup
 from CIME.check_lockedfiles import *
 import shutil
 
@@ -49,4 +48,3 @@ class SEQ(SystemTestsCompareTwo):
                     rootpe += newntasks
 
         self._case.flush()
-        case_setup(self._case, test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -232,7 +232,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             with self._case2:
                 logger.info('Doing second run: ' + self._run_two_description)
                 self._activate_case2()
-               # we need to make sure run2 is properly staged.
+                # we need to make sure run2 is properly staged.
                 if run_type != "startup":
                     check_case(self._case2)
 
@@ -457,7 +457,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # caller of this method).
         self._case.flush()
         # This assures that case one namelists are populated
-        # and creates the case.test script 
+        # and creates the case.test script
         case_setup(self._case, test_mode=False, reset=True)
 
         # Set up case 2

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -40,7 +40,6 @@ from CIME.case import Case
 from CIME.case_submit import check_case
 from CIME.case_st_archive import archive_last_restarts
 from CIME.utils import get_model
-from CIME.case_setup import case_setup
 
 import shutil, os, glob
 
@@ -458,7 +457,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._case.flush()
         # This assures that case one namelists are populated
         # and creates the case.test script
-        case_setup(self._case, test_mode=False, reset=True)
+        self._case.case_setup(test_mode=False, reset=True)
 
         # Set up case 2
         self._activate_case2()
@@ -469,7 +468,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._case.flush()
 
         # This assures that case two namelists are populated
-        case_setup(self._case, test_mode=True, reset=True)
+        self._case.case_setup(test_mode=True, reset=True)
 
         # Go back to case 1 to ensure that's where we are for any following code
         self._activate_case1()

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -40,6 +40,7 @@ from CIME.case import Case
 from CIME.case_submit import check_case
 from CIME.case_st_archive import archive_last_restarts
 from CIME.utils import get_model
+from CIME.case_setup import case_setup
 
 import shutil, os, glob
 
@@ -231,7 +232,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             with self._case2:
                 logger.info('Doing second run: ' + self._run_two_description)
                 self._activate_case2()
-                # we need to make sure run2 is properly staged.
+               # we need to make sure run2 is properly staged.
                 if run_type != "startup":
                     check_case(self._case2)
 
@@ -455,6 +456,9 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # note that we print a warning to the log file if that happens, in the
         # caller of this method).
         self._case.flush()
+        # This assures that case one namelists are populated
+        # and creates the case.test script 
+        case_setup(self._case, test_mode=False, reset=True)
 
         # Set up case 2
         self._activate_case2()
@@ -463,6 +467,9 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # Flush the case so that, if errors occur later, then at least case2 is
         # in a correct, post-setup state
         self._case.flush()
+
+        # This assures that case two namelists are populated
+        case_setup(self._case, test_mode=True, reset=True)
 
         # Go back to case 1 to ensure that's where we are for any following code
         self._activate_case1()

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -36,6 +36,7 @@ from CIME.XML.generic_xml           import GenericXML
 from CIME.user_mod_support          import apply_user_mods
 from CIME.aprun import get_aprun_cmd_for_case
 from CIME.case_clone import create_case_clone
+from CIME.case_setup import case_setup
 
 logger = logging.getLogger(__name__)
 
@@ -1447,6 +1448,11 @@ class Case(object):
                                  project=project, cime_output_root=cime_output_root,
                                  exeroot=exeroot, rundir=rundir,
                                  user_mods_dir=user_mods_dir)
+
+
+    def case_setup(self, clean=False, test_mode=False, reset=False):
+        """ in case_setup """
+        return case_setup(self, clean, test_mod, reset)
 
     def is_save_timing_dir_project(self,project):
         """

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -1452,7 +1452,7 @@ class Case(object):
 
     def case_setup(self, clean=False, test_mode=False, reset=False):
         """ in case_setup """
-        return case_setup(self, clean, test_mod, reset)
+        return case_setup(self, clean, test_mode, reset)
 
     def is_save_timing_dir_project(self,project):
         """

--- a/scripts/lib/CIME/tests/case_fake.py
+++ b/scripts/lib/CIME/tests/case_fake.py
@@ -129,6 +129,9 @@ class CaseFake(object):
         """
         self.set_value('RUNDIR', os.path.join(self.get_value('CASEROOT'), 'run'))
 
+    def case_setup(self, clean=False, test_mode=False, reset=False):
+        pass
+
     def load_env(self, reset=False):
         pass
 


### PR DESCRIPTION
The PR #2373 causes some two test system test not to populate the case2 run directory with namelists.   This also occurs for the ERI test which clones ref1 and ref2 cases.   Fixed by explicitly running case_setup for both phases of comparetwo type tests and for each clone of the ERI test 

Test suite: cime_developer, 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2375 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
