### PR TITLE
make case tools part of the Case object

### DIFF
--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -5,8 +5,6 @@ case.setup - create the $caseroot/case.run script and user_nl_xxx component name
 """
 
 from standard_script_setup import *
-
-from CIME.case_setup import case_setup
 from CIME.case       import Case
 
 ###############################################################################
@@ -52,7 +50,7 @@ def _main_func(description):
 ###############################################################################
     caseroot, clean, test_mode, reset = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        case_setup(case, clean=clean, test_mode=test_mode, reset=reset)
+        case.case_setup(clean=clean, test_mode=test_mode, reset=reset)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -37,8 +37,6 @@ In addition, they MAY require the following methods:
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case import Case
-from CIME.case_submit import check_case
-from CIME.case_st_archive import archive_last_restarts
 from CIME.utils import get_model
 
 import shutil, os, glob
@@ -233,7 +231,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 self._activate_case2()
                 # we need to make sure run2 is properly staged.
                 if run_type != "startup":
-                    check_case(self._case2)
+                    self._case2.check_case()
 
                 self._case_two_custom_prerun_action()
                 self.run_indv(suffix = self._run_two_suffix)
@@ -254,9 +252,8 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         files.
         """
         rundir2 = self._case2.get_value("RUNDIR")
-        archive_last_restarts(case = self._case1,
-                              archive_restdir = rundir2,
-                              link_to_restart_files = True)
+        self._case1.archive_last_restarts(archive_restdir = rundir2,
+                                          link_to_restart_files = True)
 
     # ========================================================================
     # Private methods

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -68,6 +68,14 @@ class Case(object):
     """
     from CIME.case_setup import case_setup
     from CIME.case_clone import create_clone
+    from CIME.case_test  import case_test
+    from CIME.case_submit import check_DA_settings, check_case, submit
+    from CIME.case_st_archive import case_st_archive, restore_from_archive, \
+        archive_last_restarts
+    from CIME.case_run import case_run
+    from CIME.case_cmpgen_namelists import case_cmpgen_namelists
+    from CIME.check_lockedfiles import check_lockedfile, check_lockedfiles, check_pelayouts_require_rebuild
+    from CIME.preview_namelists import create_dirs, create_namelists
 
     def __init__(self, case_root=None, read_only=True):
 

--- a/scripts/lib/CIME/case.py
+++ b/scripts/lib/CIME/case.py
@@ -35,8 +35,6 @@ from CIME.XML.env_batch             import EnvBatch
 from CIME.XML.generic_xml           import GenericXML
 from CIME.user_mod_support          import apply_user_mods
 from CIME.aprun import get_aprun_cmd_for_case
-from CIME.case_clone import create_case_clone
-from CIME.case_setup import case_setup
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +63,12 @@ class Case(object):
     the case object creates and manipulates the Case env classes
     by reading and interpreting the CIME config classes.
 
+    This class extends across multiple files, class members external to this file
+    are listed in the following imports
     """
+    from CIME.case_setup import case_setup
+    from CIME.case_clone import create_clone
+
     def __init__(self, case_root=None, read_only=True):
 
         if case_root is None:
@@ -1439,20 +1442,6 @@ class Case(object):
                     logger.warning("Leaving broken case dir {}".format(self._caseroot))
 
             raise
-
-    def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None,
-                     cime_output_root=None, exeroot=None, rundir=None,
-                     user_mods_dir=None):
-        """ moved to case_clone """
-        return create_case_clone(self, newcase, keepexe=keepexe, mach_dir=mach_dir,
-                                 project=project, cime_output_root=cime_output_root,
-                                 exeroot=exeroot, rundir=rundir,
-                                 user_mods_dir=user_mods_dir)
-
-
-    def case_setup(self, clean=False, test_mode=False, reset=False):
-        """ in case_setup """
-        return case_setup(self, clean, test_mode, reset)
 
     def is_save_timing_dir_project(self,project):
         """

--- a/scripts/lib/CIME/case_clone.py
+++ b/scripts/lib/CIME/case_clone.py
@@ -1,5 +1,5 @@
 """
-case_clone is a member of the Case class from file case.py
+create_clone is a member of the Case class from file case.py
 """
 import os, glob, shutil
 from CIME.XML.standard_module_setup import *

--- a/scripts/lib/CIME/case_clone.py
+++ b/scripts/lib/CIME/case_clone.py
@@ -1,3 +1,6 @@
+"""
+case_clone is a member of the Case class from file case.py
+"""
 import os, glob, shutil
 from CIME.XML.standard_module_setup import *
 from CIME.utils import expect
@@ -9,7 +12,7 @@ from CIME.simple_compare            import compare_files
 logger = logging.getLogger(__name__)
 
 
-def create_case_clone(case, newcase, keepexe=False, mach_dir=None, project=None,
+def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None,
                       cime_output_root=None, exeroot=None, rundir=None,
                       user_mods_dir=None):
     """
@@ -20,7 +23,7 @@ def create_case_clone(case, newcase, keepexe=False, mach_dir=None, project=None,
     directories. It is an error to provide exeroot if keepexe is True.
     """
     if cime_output_root is None:
-        cime_output_root = case.get_value("CIME_OUTPUT_ROOT")
+        cime_output_root = self.get_value("CIME_OUTPUT_ROOT")
 
     newcaseroot = os.path.abspath(newcase)
     expect(not os.path.isdir(newcaseroot),
@@ -29,7 +32,7 @@ def create_case_clone(case, newcase, keepexe=False, mach_dir=None, project=None,
     newcase_cimeroot = os.path.abspath(get_cime_root())
 
     # create clone from case to case
-    clone_cimeroot = case.get_value("CIMEROOT")
+    clone_cimeroot = self.get_value("CIMEROOT")
     if newcase_cimeroot != clone_cimeroot:
         logger.warning(" case  CIMEROOT is {} ".format(newcase_cimeroot))
         logger.warning(" clone CIMEROOT is {} ".format(clone_cimeroot))
@@ -37,11 +40,11 @@ def create_case_clone(case, newcase, keepexe=False, mach_dir=None, project=None,
 
     # *** create case object as deepcopy of clone object ***
     srcroot = os.path.join(newcase_cimeroot,"..")
-    newcase = case.copy(newcasename, newcaseroot, newsrcroot=srcroot)
+    newcase = self.copy(newcasename, newcaseroot, newsrcroot=srcroot)
     newcase.set_value("CIMEROOT", newcase_cimeroot)
 
     # if we are cloning to a different user modify the output directory
-    olduser = case.get_value("USER")
+    olduser = self.get_value("USER")
     newuser = os.environ.get("USER")
     if olduser != newuser:
         cime_output_root = cime_output_root.replace(olduser, newuser)
@@ -63,10 +66,10 @@ def create_case_clone(case, newcase, keepexe=False, mach_dir=None, project=None,
 
     # determine if will use clone executable or not
     if keepexe:
-        orig_exeroot = case.get_value("EXEROOT")
+        orig_exeroot = self.get_value("EXEROOT")
         newcase.set_value("EXEROOT", orig_exeroot)
         newcase.set_value("BUILD_COMPLETE","TRUE")
-        orig_bld_complete = case.get_value("BUILD_COMPLETE")
+        orig_bld_complete = self.get_value("BUILD_COMPLETE")
         if not orig_bld_complete:
             logger.warning("\nWARNING: Creating a clone with --keepexe before building the original case may cause PIO_TYPENAME to be invalid in the clone")
             logger.warning("Avoid this message by building case one before you clone.\n")
@@ -91,7 +94,7 @@ def create_case_clone(case, newcase, keepexe=False, mach_dir=None, project=None,
     # user's case. However, note that, if a project is not given, the fallback will
     # be to copy it from the clone, just like other xml variables are copied.
     if project is None:
-        project = case.get_value("PROJECT", subgroup="case.run")
+        project = self.get_value("PROJECT", subgroup="case.run")
     if project is not None:
         newcase.set_value("PROJECT", project)
 
@@ -100,7 +103,7 @@ def create_case_clone(case, newcase, keepexe=False, mach_dir=None, project=None,
     newcase.flush(flushall=True)
 
     # copy user_ files
-    cloneroot = case.get_case_root()
+    cloneroot = self.get_case_root()
     files = glob.glob(cloneroot + '/user_*')
 
     for item in files:
@@ -151,7 +154,7 @@ def create_case_clone(case, newcase, keepexe=False, mach_dir=None, project=None,
     fnewcase.write("\n    *** original clone README follows ****")
     fnewcase.write("\n " +  fclone.read())
 
-    clonename = case.get_value("CASE")
+    clonename = self.get_value("CASE")
     logger.info(" Successfully created new case {} from clone case {} ".format(newcasename, clonename))
 
     case_setup(newcase)

--- a/scripts/lib/CIME/case_cmpgen_namelists.py
+++ b/scripts/lib/CIME/case_cmpgen_namelists.py
@@ -1,5 +1,6 @@
 """
 Library for case.cmpgen_namelists.
+case_cmpgen_namelists is a member of Class case from file case.py
 """
 
 from CIME.XML.standard_module_setup import *
@@ -82,15 +83,15 @@ def _do_full_nl_gen(case, test, generate_name, baseline_root=None):
         shutil.copy2(item, baseline_dir)
         os.chmod(preexisting_baseline, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
 
-def case_cmpgen_namelists(case, compare=False, generate=False, compare_name=None, generate_name=None, baseline_root=None, logfile_name="TestStatus.log"):
-    expect(case.get_value("TEST"), "Only makes sense to run this for a test case")
+def case_cmpgen_namelists(self, compare=False, generate=False, compare_name=None, generate_name=None, baseline_root=None, logfile_name="TestStatus.log"):
+    expect(self.get_value("TEST"), "Only makes sense to run this for a test case")
 
-    caseroot, casebaseid = case.get_value("CASEROOT"), case.get_value("CASEBASEID")
+    caseroot, casebaseid = self.get_value("CASEROOT"), self.get_value("CASEBASEID")
 
     if not compare:
-        compare = case.get_value("COMPARE_BASELINE")
+        compare = self.get_value("COMPARE_BASELINE")
     if not generate:
-        generate = case.get_value("GENERATE_BASELINE")
+        generate = self.get_value("GENERATE_BASELINE")
 
     if not compare and not generate:
         logging.debug("No namelists compares requested")
@@ -99,26 +100,26 @@ def case_cmpgen_namelists(case, compare=False, generate=False, compare_name=None
     # create namelists for case if they haven't been already
     casedocs = os.path.join(caseroot, "CaseDocs")
     if not os.path.exists(os.path.join(casedocs, "drv_in")):
-        create_namelists(case)
+        create_namelists(self)
 
-    test_name = casebaseid if casebaseid is not None else case.get_value("CASE")
+    test_name = casebaseid if casebaseid is not None else self.get_value("CASE")
     with TestStatus(test_dir=caseroot, test_name=test_name) as ts:
         try:
             # Inside this try are where we catch non-fatal errors, IE errors involving
             # baseline operations which may not directly impact the functioning of the viability of this case
             if compare and not compare_name:
-                compare_name = case.get_value("BASELINE_NAME_CMP")
+                compare_name = self.get_value("BASELINE_NAME_CMP")
                 expect(compare_name, "Was asked to do baseline compare but unable to determine baseline name")
                 logging.info("Comparing namelists with baselines '{}'".format(compare_name))
             if generate and not generate_name:
-                generate_name = case.get_value("BASELINE_NAME_GEN")
+                generate_name = self.get_value("BASELINE_NAME_GEN")
                 expect(generate_name, "Was asked to do baseline generation but unable to determine baseline name")
                 logging.info("Generating namelists to baselines '{}'".format(generate_name))
 
             success = True
             output = ""
             if compare:
-                success, output = _do_full_nl_comp(case, test_name, compare_name, baseline_root)
+                success, output = _do_full_nl_comp(self, test_name, compare_name, baseline_root)
                 if not success and ts.get_status(RUN_PHASE) is not None:
                     run_warn = \
 """NOTE: It is not necessarily safe to compare namelists after RUN
@@ -127,7 +128,7 @@ kept in the baselines are pre-RUN namelists."""
                     output += run_warn
                     logging.info(run_warn)
             if generate:
-                _do_full_nl_gen(case, test_name, generate_name, baseline_root)
+                _do_full_nl_gen(self, test_name, generate_name, baseline_root)
         except:
             ts.set_status(NAMELIST_PHASE, TEST_FAIL_STATUS)
             success = False
@@ -142,4 +143,3 @@ kept in the baselines are pre-RUN namelists."""
                 pass
 
         return success
-

--- a/scripts/lib/CIME/case_run.py
+++ b/scripts/lib/CIME/case_run.py
@@ -1,3 +1,6 @@
+"""
+case_run is a member of Class Case
+'"""
 from CIME.XML.standard_module_setup import *
 from CIME.case_submit               import submit
 from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, run_sub_or_cmd
@@ -5,14 +8,13 @@ from CIME.check_lockedfiles         import check_lockedfiles
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance
 from CIME.preview_namelists         import create_namelists
-from CIME.case_st_archive           import case_st_archive, restore_from_archive
 
 import shutil, time, sys, os, glob
 
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
+def _pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
 ###############################################################################
 
     # Pre run initialization code..
@@ -80,7 +82,7 @@ def pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
 def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
 ###############################################################################
 
-    pre_run_check(case, lid, skip_pnl=skip_pnl, da_cycle=da_cycle)
+    _pre_run_check(case, lid, skip_pnl=skip_pnl, da_cycle=da_cycle)
 
     model = case.get_value("MODEL")
 
@@ -121,8 +123,8 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
                         logger.warning("Detected model run failed due to node failure, restarting")
 
                         # Archive the last consistent set of restart files and restore them
-                        case_st_archive(case, no_resubmit=True)
-                        restore_from_archive(case)
+                        case.case_st_archive(no_resubmit=True)
+                        case.restore_from_archive()
 
                         case.set_value("CONTINUE_RUN",
                                        case.get_value("RESUBMIT_SETS_CONTINUE_RUN"))
@@ -140,18 +142,18 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
 
     logger.info("{} MODEL EXECUTION HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
 
-    post_run_check(case, lid)
+    _post_run_check(case, lid)
 
     return lid
 
 ###############################################################################
-def run_model(case, lid, skip_pnl=False, da_cycle=0):
+def _run_model(case, lid, skip_pnl=False, da_cycle=0):
 ###############################################################################
     functor = lambda: _run_model_impl(case, lid, skip_pnl=skip_pnl, da_cycle=da_cycle)
     return run_and_log_case_status(functor, "case.run", caseroot=case.get_value("CASEROOT"))
 
 ###############################################################################
-def post_run_check(case, lid):
+def _post_run_check(case, lid):
 ###############################################################################
 
     rundir = case.get_value("RUNDIR")
@@ -186,7 +188,7 @@ def post_run_check(case, lid):
             expect(False, "Model did not complete - see {} \n " .format(cpl_logfile))
 
 ###############################################################################
-def save_logs(case, lid):
+def _save_logs(case, lid):
 ###############################################################################
     logdir = case.get_value("LOGDIR")
     if logdir is not None and len(logdir) > 0:
@@ -203,7 +205,7 @@ def save_logs(case, lid):
                             os.path.join(caseroot, logdir, os.path.basename(logfile_gz)))
 
 ###############################################################################
-def resubmit_check(case):
+def _resubmit_check(case):
 ###############################################################################
 
     # check to see if we need to do resubmission from this particular job,
@@ -236,7 +238,7 @@ def resubmit_check(case):
         submit(case, job=job, resubmit=True)
 
 ###############################################################################
-def do_external(script_name, caseroot, rundir, lid, prefix):
+def _do_external(script_name, caseroot, rundir, lid, prefix):
 ###############################################################################
     expect(os.path.isfile(script_name), "External script {} not found".format(script_name))
     filename = "{}.external.log.{}".format(prefix, lid)
@@ -244,7 +246,7 @@ def do_external(script_name, caseroot, rundir, lid, prefix):
     run_sub_or_cmd(script_name, [caseroot], os.path.basename(script_name), [caseroot], logfile=outfile)
 
 ###############################################################################
-def do_data_assimilation(da_script, caseroot, cycle, lid, rundir):
+def _do_data_assimilation(da_script, caseroot, cycle, lid, rundir):
 ###############################################################################
     expect(os.path.isfile(da_script), "Data Assimilation script {} not found".format(da_script))
     filename = "da.log.{}".format(lid)
@@ -252,14 +254,14 @@ def do_data_assimilation(da_script, caseroot, cycle, lid, rundir):
     run_sub_or_cmd(da_script, [caseroot, cycle], os.path.basename(da_script), [caseroot, cycle], logfile=outfile)
 
 ###############################################################################
-def case_run(case, skip_pnl=False):
+def case_run(self, skip_pnl=False):
 ###############################################################################
     # Set up the run, run the model, do the postrun steps
-    prerun_script = case.get_value("PRERUN_SCRIPT")
-    postrun_script = case.get_value("POSTRUN_SCRIPT")
+    prerun_script = self.get_value("PRERUN_SCRIPT")
+    postrun_script = self.get_value("POSTRUN_SCRIPT")
 
-    data_assimilation_cycles = case.get_value("DATA_ASSIMILATION_CYCLES")
-    data_assimilation_script = case.get_value("DATA_ASSIMILATION_SCRIPT")
+    data_assimilation_cycles = self.get_value("DATA_ASSIMILATION_CYCLES")
+    data_assimilation_script = self.get_value("DATA_ASSIMILATION_SCRIPT")
     data_assimilation = (data_assimilation_cycles > 0 and
                          len(data_assimilation_script) > 0 and
                          os.path.isfile(data_assimilation_script))
@@ -267,42 +269,42 @@ def case_run(case, skip_pnl=False):
     lid = new_lid()
 
     if prerun_script:
-        case.flush()
-        do_external(prerun_script, case.get_value("CASEROOT"), case.get_value("RUNDIR"),
+        self.flush()
+        _do_external(prerun_script, self.get_value("CASEROOT"), self.get_value("RUNDIR"),
                     lid, prefix="prerun")
-        case.read_xml()
+        self.read_xml()
 
     for cycle in range(data_assimilation_cycles):
         # After the first DA cycle, runs are restart runs
         if cycle > 0:
             lid = new_lid()
-            case.set_value("CONTINUE_RUN",
-                           case.get_value("RESUBMIT_SETS_CONTINUE_RUN"))
+            self.set_value("CONTINUE_RUN",
+                           self.get_value("RESUBMIT_SETS_CONTINUE_RUN"))
 
-        lid = run_model(case, lid, skip_pnl, da_cycle=cycle)
+        lid = _run_model(self, lid, skip_pnl, da_cycle=cycle)
 
-        if case.get_value("CHECK_TIMING") or case.get_value("SAVE_TIMING"):
-            get_timing(case, lid)     # Run the getTiming script
+        if self.get_value("CHECK_TIMING") or self.get_value("SAVE_TIMING"):
+            get_timing(self, lid)     # Run the getTiming script
 
         if data_assimilation:
-            case.flush()
-            do_data_assimilation(data_assimilation_script, case.get_value("CASEROOT"), cycle, lid,
-                                 case.get_value("RUNDIR"))
-            case.read_xml()
+            self.flush()
+            _do_data_assimilation(data_assimilation_script, self.get_value("CASEROOT"), cycle, lid,
+                                 self.get_value("RUNDIR"))
+            self.read_xml()
 
-        save_logs(case, lid)       # Copy log files back to caseroot
+        _save_logs(self, lid)       # Copy log files back to caseroot
 
-        save_postrun_provenance(case)
+        save_postrun_provenance(self)
 
     if postrun_script:
-        case.flush()
-        do_external(postrun_script, case.get_value("CASEROOT"), case.get_value("RUNDIR"),
+        self.flush()
+        _do_external(postrun_script, self.get_value("CASEROOT"), self.get_value("RUNDIR"),
                     lid, prefix="postrun")
-        case.read_xml()
+        self.read_xml()
 
-    save_logs(case, lid)       # Copy log files back to caseroot
+    _save_logs(self, lid)       # Copy log files back to caseroot
 
     logger.warning("check for resubmit")
-    resubmit_check(case)
+    _resubmit_check(self)
 
     return True

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -210,14 +210,14 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         env_module.save_all_env_info("software_environment.txt")
 
 ###############################################################################
-def case_setup(case, clean=False, test_mode=False, reset=False):
+def case_setup(self, clean=False, test_mode=False, reset=False):
 ###############################################################################
-    caseroot, casebaseid = case.get_value("CASEROOT"), case.get_value("CASEBASEID")
+    caseroot, casebaseid = self.get_value("CASEROOT"), self.get_value("CASEBASEID")
     phase = "setup.clean" if clean else "case.setup"
-    functor = lambda: _case_setup_impl(case, caseroot, clean, test_mode, reset)
+    functor = lambda: _case_setup_impl(self, caseroot, clean, test_mode, reset)
 
-    if case.get_value("TEST") and not test_mode:
-        test_name = casebaseid if casebaseid is not None else case.get_value("CASE")
+    if self.get_value("TEST") and not test_mode:
+        test_name = casebaseid if casebaseid is not None else self.get_value("CASE")
         with TestStatus(test_dir=caseroot, test_name=test_name) as ts:
             try:
                 run_and_log_case_status(functor, phase, caseroot=caseroot)

--- a/scripts/lib/CIME/case_setup.py
+++ b/scripts/lib/CIME/case_setup.py
@@ -1,5 +1,6 @@
 """
 Library for case.setup.
+case_setup is a member of class Case from file case.py
 """
 
 from CIME.XML.standard_module_setup import *

--- a/scripts/lib/CIME/case_submit.py
+++ b/scripts/lib/CIME/case_submit.py
@@ -4,6 +4,7 @@
 case.submit - Submit a cesm workflow to the queueing system or run it
 if there is no queueing system.  A cesm workflow may include multiple
 jobs.
+submit, check_case and check_da_settings are members of class Case in file case.py
 """
 import socket
 from CIME.XML.standard_module_setup import *
@@ -103,11 +104,11 @@ manual edits to these file will be lost!
 
     return xml_jobid_text
 
-def submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
+def submit(self, job=None, no_batch=False, prereq=None, resubmit=False,
            skip_pnl=False, mail_user=None, mail_type=None, batch_args=None):
-    if case.get_value("TEST"):
-        caseroot = case.get_value("CASEROOT")
-        casebaseid = case.get_value("CASEBASEID")
+    if self.get_value("TEST"):
+        caseroot = self.get_value("CASEROOT")
+        casebaseid = self.get_value("CASEBASEID")
         # This should take care of the race condition where the submitted job
         # begins immediately and tries to set RUN phase. We proactively assume
         # a passed SUBMIT phase. If this state is already PASS, don't set it again
@@ -119,33 +120,33 @@ def submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
                 ts.set_status(SUBMIT_PHASE, TEST_PASS_STATUS)
 
     try:
-        functor = lambda: _submit(case, job=job, no_batch=no_batch, prereq=prereq,
+        functor = lambda: _submit(self, job=job, no_batch=no_batch, prereq=prereq,
                                   resubmit=resubmit, skip_pnl=skip_pnl,
                                   mail_user=mail_user, mail_type=mail_type,
                                   batch_args=batch_args)
-        run_and_log_case_status(functor, "case.submit", caseroot=case.get_value("CASEROOT"),
+        run_and_log_case_status(functor, "case.submit", caseroot=self.get_value("CASEROOT"),
                                 custom_success_msg_functor=verbatim_success_msg)
     except:
         # If something failed in the batch system, make sure to mark
         # the test as failed if we are running a test.
-        if case.get_value("TEST"):
+        if self.get_value("TEST"):
             with TestStatus(test_dir=caseroot, test_name=casebaseid) as ts:
                 ts.set_status(SUBMIT_PHASE, TEST_FAIL_STATUS)
 
         raise
 
-def check_case(case):
-    check_lockedfiles(case)
-    create_namelists(case) # Must be called before check_all_input_data
+def check_case(self):
+    check_lockedfiles(self)
+    create_namelists(self) # Must be called before check_all_input_data
     logger.info("Checking that inputdata is available as part of case submission")
-    check_all_input_data(case)
+    check_all_input_data(self)
 
-    expect(case.get_value("BUILD_COMPLETE"), "Build complete is "
+    expect(self.get_value("BUILD_COMPLETE"), "Build complete is "
            "not True please rebuild the model by calling case.build")
     logger.info("Check case OK")
 
-def check_DA_settings(case):
-    script = case.get_value("DATA_ASSIMILATION_SCRIPT")
-    cycles = case.get_value("DATA_ASSIMILATION_CYCLES")
+def check_DA_settings(self):
+    script = self.get_value("DATA_ASSIMILATION_SCRIPT")
+    cycles = self.get_value("DATA_ASSIMILATION_CYCLES")
     if len(script) > 0 and os.path.isfile(script) and cycles > 0:
         logger.info("Data Assimilation enabled using script {} with {:d} cycles".format(script,cycles))

--- a/scripts/lib/CIME/case_test.py
+++ b/scripts/lib/CIME/case_test.py
@@ -1,5 +1,6 @@
 """
 Run a testcase.
+case_test is a member of class Case from case.py
 """
 
 from CIME.XML.standard_module_setup import *
@@ -42,9 +43,9 @@ def _set_up_signal_handlers():
         signum = getattr(signal, signame)
         signal.signal(signum, _signal_handler)
 
-def case_test(case, testname=None, reset=False, skip_pnl=False):
+def case_test(self, testname=None, reset=False, skip_pnl=False):
     if testname is None:
-        testname = case.get_value('TESTCASE')
+        testname = self.get_value('TESTCASE')
 
     expect(testname is not None, "testname argument not resolved")
     logging.warning("Running test for {}".format(testname))
@@ -56,9 +57,9 @@ def case_test(case, testname=None, reset=False, skip_pnl=False):
         # not found or the test constructor throws. We need to be
         # sure to leave TestStatus in the appropriate state if that
         # happens.
-        test = find_system_test(testname, case)(case)
+        test = find_system_test(testname, self)(self)
     except:
-        caseroot = case.get_value("CASEROOT")
+        caseroot = self.get_value("CASEROOT")
         with TestStatus(test_dir=caseroot) as ts:
             ts.set_status(RUN_PHASE, TEST_FAIL_STATUS, comments="failed to initialize")
         append_testlog(str(sys.exc_info()[1]))

--- a/scripts/lib/CIME/check_lockedfiles.py
+++ b/scripts/lib/CIME/check_lockedfiles.py
@@ -1,5 +1,7 @@
 """
 API for checking locked files
+check_lockedfile, check_lockedfiles, check_pelayouts_require_rebuild are members
+of Class case.py from file case.py
 """
 
 from CIME.XML.standard_module_setup import *
@@ -46,7 +48,7 @@ def is_locked(filename, caseroot=None):
     caseroot = os.getcwd() if caseroot is None else caseroot
     return os.path.exists(os.path.join(caseroot, LOCKED_DIR, filename))
 
-def check_pelayouts_require_rebuild(case, models):
+def check_pelayouts_require_rebuild(self, models):
     """
     Create if we require a rebuild, expects cwd is caseroot
     """
@@ -54,45 +56,45 @@ def check_pelayouts_require_rebuild(case, models):
     if os.path.exists(locked_pes):
         # Look to see if $comp_PE_CHANGE_REQUIRES_REBUILD is defined
         # for any component
-        env_mach_pes_locked = EnvMachPes(infile=locked_pes, components=case.get_values("COMP_CLASSES"))
+        env_mach_pes_locked = EnvMachPes(infile=locked_pes, components=self.get_values("COMP_CLASSES"))
         for comp in models:
-            if case.get_value("{}_PE_CHANGE_REQUIRES_REBUILD".format(comp)):
+            if self.get_value("{}_PE_CHANGE_REQUIRES_REBUILD".format(comp)):
                 # Changing these values in env_mach_pes.xml will force
                 # you to clean the corresponding component
                 old_tasks   = env_mach_pes_locked.get_value("NTASKS_{}".format(comp))
                 old_threads = env_mach_pes_locked.get_value("NTHRDS_{}".format(comp))
                 old_inst    = env_mach_pes_locked.get_value("NINST_{}".format(comp))
 
-                new_tasks   = case.get_value("NTASKS_{}".format(comp))
-                new_threads = case.get_value("NTHRDS_{}".format(comp))
-                new_inst    = case.get_value("NINST_{}".format(comp))
+                new_tasks   = self.get_value("NTASKS_{}".format(comp))
+                new_threads = self.get_value("NTHRDS_{}".format(comp))
+                new_inst    = self.get_value("NINST_{}".format(comp))
 
                 if old_tasks != new_tasks or old_threads != new_threads or old_inst != new_inst:
                     logging.warning("{} pe change requires clean build {} {}".format(comp, old_tasks, new_tasks))
                     cleanflag = comp.lower()
                     run_cmd_no_fail("./case.build --clean {}".format(cleanflag))
 
-        unlock_file("env_mach_pes.xml", case.get_value("CASEROOT"))
+        unlock_file("env_mach_pes.xml", self.get_value("CASEROOT"))
 
-def check_lockedfile(case, filebase):
-    caseroot = case.get_value("CASEROOT")
+def check_lockedfile(self, filebase):
+    caseroot = self.get_value("CASEROOT")
 
     cfile = os.path.join(caseroot, filebase)
     lfile = os.path.join(caseroot, "LockedFiles", filebase)
-    components = case.get_values("COMP_CLASSES")
+    components = self.get_values("COMP_CLASSES")
     if os.path.isfile(cfile):
         objname = filebase.split('.')[0]
         if objname == "env_build":
-            f1obj = case.get_env('build')
+            f1obj = self.get_env('build')
             f2obj = EnvBuild(caseroot, lfile)
         elif objname == "env_mach_pes":
-            f1obj = case.get_env('mach_pes')
+            f1obj = self.get_env('mach_pes')
             f2obj = EnvMachPes(caseroot, lfile, components=components)
         elif objname == "env_case":
-            f1obj = case.get_env('case')
+            f1obj = self.get_env('case')
             f2obj = EnvCase(caseroot, lfile)
         elif objname == "env_batch":
-            f1obj = case.get_env('batch')
+            f1obj = self.get_env('batch')
             f2obj = EnvBatch(caseroot, lfile)
         else:
             logging.warning("Locked XML file '{}' is not current being handled".format(filebase))
@@ -116,26 +118,26 @@ def check_lockedfile(case, filebase):
             elif objname == "env_build":
                 if toggle_build_status:
                     logging.warning("Setting build complete to False")
-                    case.set_value("BUILD_COMPLETE", False)
+                    self.set_value("BUILD_COMPLETE", False)
                     if "PIO_VERSION" in diffs:
-                        case.set_value("BUILD_STATUS", 2)
+                        self.set_value("BUILD_STATUS", 2)
                         logging.critical("Changing PIO_VERSION requires running "
                                          "case.build --clean-all and rebuilding")
                     else:
-                        case.set_value("BUILD_STATUS", 1)
+                        self.set_value("BUILD_STATUS", 1)
                     f2obj.set_value("BUILD_COMPLETE", False)
             elif objname == "env_batch":
                 expect(False, "Batch configuration has changed, please run case.setup --reset")
             else:
                 expect(False, "'{}' diff was not handled".format(objname))
 
-def check_lockedfiles(case):
+def check_lockedfiles(self):
     """
     Check that all lockedfiles match what's in case
 
     If caseroot is not specified, it is set to the current working directory
     """
-    caseroot = case.get_value("CASEROOT")
+    caseroot = self.get_value("CASEROOT")
     lockedfiles = glob.glob(os.path.join(caseroot, "LockedFiles", "*.xml"))
     for lfile in lockedfiles:
         fpart = os.path.basename(lfile)
@@ -143,4 +145,4 @@ def check_lockedfiles(case):
         if fpart.count('.') > 1:
             continue
 
-        check_lockedfile(case, fpart)
+        self.check_lockedfile(fpart)

--- a/scripts/lib/CIME/preview_namelists.py
+++ b/scripts/lib/CIME/preview_namelists.py
@@ -1,5 +1,6 @@
 """
 API for preview namelist
+create_dirs and create_namelists are members of Class case from file case.py
 """
 
 from CIME.XML.standard_module_setup import *
@@ -8,20 +9,20 @@ from CIME.check_input_data import stage_refcase
 import glob, shutil
 logger = logging.getLogger(__name__)
 
-def create_dirs(case):
+def create_dirs(self):
     """
     Make necessary directories for case
     """
     # Get data from XML
-    exeroot  = case.get_value("EXEROOT")
-    libroot  = case.get_value("LIBROOT")
-    incroot  = case.get_value("INCROOT")
-    rundir   = case.get_value("RUNDIR")
-    caseroot = case.get_value("CASEROOT")
+    exeroot  = self.get_value("EXEROOT")
+    libroot  = self.get_value("LIBROOT")
+    incroot  = self.get_value("INCROOT")
+    rundir   = self.get_value("RUNDIR")
+    caseroot = self.get_value("CASEROOT")
 
     docdir = os.path.join(caseroot, "CaseDocs")
     dirs_to_make = []
-    models = case.get_values("COMP_CLASSES")
+    models = self.get_values("COMP_CLASSES")
     for model in models:
         dirname = model.lower()
         dirs_to_make.append(os.path.join(exeroot, dirname, "obj"))
@@ -41,24 +42,24 @@ def create_dirs(case):
         with open(os.path.join(dir_,"CASEROOT"),"w+") as fd:
             fd.write(caseroot+"\n")
 
-def create_namelists(case, component=None):
+def create_namelists(self, component=None):
     """
     Create component namelists
     """
-    case.flush()
+    self.flush()
 
-    create_dirs(case)
+    create_dirs(self)
 
-    casebuild = case.get_value("CASEBUILD")
-    caseroot = case.get_value("CASEROOT")
-    rundir = case.get_value("RUNDIR")
+    casebuild = self.get_value("CASEBUILD")
+    caseroot = self.get_value("CASEROOT")
+    rundir = self.get_value("RUNDIR")
 
     docdir = os.path.join(caseroot, "CaseDocs")
 
     # Load modules
-    case.load_env()
+    self.load_env()
 
-    stage_refcase(case)
+    stage_refcase(self)
 
 
     logger.info("Creating component namelists")
@@ -66,16 +67,16 @@ def create_namelists(case, component=None):
     # Create namelists - must have cpl last in the list below
     # Note - cpl must be last in the loop below so that in generating its namelist,
     # it can use xml vars potentially set by other component's buildnml scripts
-    models = case.get_values("COMP_CLASSES")
+    models = self.get_values("COMP_CLASSES")
     models += [models.pop(0)]
     for model in models:
         model_str = model.lower()
-        config_file = case.get_value("CONFIG_{}_FILE".format(model_str.upper()))
+        config_file = self.get_value("CONFIG_{}_FILE".format(model_str.upper()))
         config_dir = os.path.dirname(config_file)
         if model_str == "cpl":
             compname = "drv"
         else:
-            compname = case.get_value("COMP_{}".format(model_str.upper()))
+            compname = self.get_value("COMP_{}".format(model_str.upper()))
         if component is None or component == model_str:
             # first look in the case SourceMods directory
             cmd = os.path.join(caseroot, "SourceMods", "src."+compname, "buildnml")
@@ -85,7 +86,7 @@ def create_namelists(case, component=None):
                 # otherwise look in the component config_dir
                 cmd = os.path.join(config_dir, "buildnml")
             expect(os.path.isfile(cmd), "Could not find buildnml file for component {}".format(compname))
-            run_sub_or_cmd(cmd, (caseroot), "buildnml", (case, caseroot, compname), case=case)
+            run_sub_or_cmd(cmd, (caseroot), "buildnml", (self, caseroot, compname), case=self)
 
     logger.info("Finished creating component namelists")
 


### PR DESCRIPTION
This makes the create_clone and case_setup subroutines part of the case class without
requiring that they reside in the same source file.   

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
