### PR TITLE
Add an A and X compset test to aux_cime_baselines.

### DIFF
--- a/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -68,6 +68,11 @@
   </test>
   <test name="SMS" grid="f19_g16" compset="X">
     <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_cime_baselines">
+	<options>
+	  <option name="wallclock">00:10</option>
+	</options>
+      </machine>
       <machine name="cheyenne" compiler="intel" category="jim">
 	<options>
 	  <option name="wallclock">00:10</option>
@@ -611,6 +616,11 @@
         <options>
           <option name="wallclock">00:30:00</option>
          </options>
+      </machine>
+      <machine name="cheyenne" compiler="intel" category="aux_cime_baselines">
+        <options>
+          <option name="wallclock">00:30:00</option>
+        </options>
       </machine>
     </machines>
   </test>


### PR DESCRIPTION
Add an A and X compset test to aux_cime_baselines.

Test suite:  scripts_regression_tests, test_full_system was failing before
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:

Code review:
