### PR TITLE
cleanup acme -> e3sm references in rst documentation

### DIFF
--- a/doc/source/data_models/data-ocean.rst
+++ b/doc/source/data_models/data-ocean.rst
@@ -205,8 +205,8 @@ DOCN defines a set of pre-defined internal field names as well as mappings for h
    "dhdx", "So_dhdx" 
    "dhdy", "So_dhdy" 
    "s", "So_s" 
-   "h", "strm_h" (internal to docn_comp_mod only)
-   "qbot", "strm_qbot" (internal to docn_comp_mod only)
+   "h", "strm_h (internal to docn_comp_mod only)"
+   "qbot", "strm_qbot (internal to docn_comp_mod only)"
 
 .. _creating-sstdata-input-from-prognostic-run:
 

--- a/doc/source/users_guide/adding-cases.rst
+++ b/doc/source/users_guide/adding-cases.rst
@@ -134,7 +134,7 @@ The steps for adding a new component grid to the model system follow. gain, this
 
 7. Create grid file needed for create_newcase.
    The next step is to add the necessary new entries in the appropriate ``config_grids.xml`` file.
-   You will need to modify ``$CIMEROOT/config/cesm/config_grids.xml`` or ``$CIMEROOT/config/acme/config_grids.xml`` depending on the value of ``$CIME_MODEL``.
+   You will need to modify ``$CIMEROOT/config/cesm/config_grids.xml`` or ``$CIMEROOT/config/e3sm/config_grids.xml`` depending on the value of ``$CIME_MODEL``.
    You will need to:
 
    - add a single  ``<model_grid>`` entry

--- a/doc/source/users_guide/building-a-case.rst
+++ b/doc/source/users_guide/building-a-case.rst
@@ -54,7 +54,7 @@ Except for **intel/** and **lib/**, each directory contains an **obj/** subdirec
 
 The *mct*, *pio*, *gptl* and *csm_share* libraries are placed in a directory tree that reflects their dependencies. See the **bldlog** for a given component to locate the library.
 
-Special **include** modules are placed in **lib/include**. The model executable (**cesm.exe** or **acme.exe**, for example) is placed directly in ``$EXEROOT``.
+Special **include** modules are placed in **lib/include**. The model executable (**cesm.exe** or **e3sm.exe**, for example) is placed directly in ``$EXEROOT``.
 
 Component namelists, component logs, output data sets, and restart files are placed in ``$RUNDIR``.
 It is important to note that ``$RUNDIR`` and ``$EXEROOT`` are independent variables that are set in the **$CASEROOT/env_run.xml** file.

--- a/doc/source/users_guide/cime-internals.rst
+++ b/doc/source/users_guide/cime-internals.rst
@@ -4,7 +4,7 @@
 CIME internals
 ==============
 
-The file **$CIMEROOT/config/[cesm,acme]/config_files.xml** contains all model-specific information that CIME uses to determine compsets, compset component settings, model grids, machines, batch queue settings, and compiler settings. It contains the following xml nodes, which are discussed below or in subsequent sections of this guide.
+The file **$CIMEROOT/config/[cesm,e3sm]/config_files.xml** contains all model-specific information that CIME uses to determine compsets, compset component settings, model grids, machines, batch queue settings, and compiler settings. It contains the following xml nodes, which are discussed below or in subsequent sections of this guide.
 ::
 
    compset definitions:

--- a/doc/source/users_guide/porting-cime.rst
+++ b/doc/source/users_guide/porting-cime.rst
@@ -104,7 +104,7 @@ Each ``<machine>`` tag requires the following input:
 - ``MPILIBS``: mpilibs supported on the machine, in comma-separated list, default first
 - ``PROJECT``: a project or account number used for batch jobs; can be overridden in environment or in **$HOME/.cime/config**
 - ``SAVE_TIMING_DIR``: (E3SM only) target directory for archiving timing output
-- ``SAVE_TIMING_DIR_PROJECTS``: (ACME only) projects whose jobs archive timing output
+- ``SAVE_TIMING_DIR_PROJECTS``: (E3SM only) projects whose jobs archive timing output
 - ``CIME_OUTPUT_ROOT``: Base directory for case output; the **bld** and **run** directories are written below here
 - ``DIN_LOC_ROOT``: location of the input data directory
 - ``DIN_LOC_ROOT_CLMFORC``: optional input location for clm forcing data

--- a/doc/source/users_guide/testing.rst
+++ b/doc/source/users_guide/testing.rst
@@ -220,11 +220,11 @@ To run two tests::
 
 To run a test suite::
 
-  ./create_test acme_developer
+  ./create_test e3sm_developer
 
 To run a test suite excluding a specific test::
 
-  ./create_test acme_developer ^SMS.f19_f19.A
+  ./create_test e3sm_developer ^SMS.f19_f19.A
 
 See create_test -h for the full list of options
 
@@ -232,7 +232,7 @@ Interpreting test output is pretty easy, looking at an example::
 
   % ./create_test SMS.f19_f19.A
 
-  Creating test directory /home/jgfouca/acme/scratch/SMS.f19_f19.A.melvin_gnu.20170504_163152_31aahy
+  Creating test directory /home/jgfouca/e3sm/scratch/SMS.f19_f19.A.melvin_gnu.20170504_163152_31aahy
   RUNNING TESTS:
     SMS.f19_f19.A.melvin_gnu
   Starting CREATE_NEWCASE for test SMS.f19_f19.A.melvin_gnu with 1 procs
@@ -249,7 +249,7 @@ Interpreting test output is pretty easy, looking at an example::
   Finished RUN for test SMS.f19_f19.A.melvin_gnu in 35.068546 seconds (PASS). [COMPLETED 1 of 1]
   At test-scheduler close, state is:
   PASS SMS.f19_f19.A.melvin_gnu RUN
-    Case dir: /home/jgfouca/acme/scratch/SMS.f19_f19.A.melvin_gnu.20170504_163152_31aahy
+    Case dir: /home/jgfouca/e3sm/scratch/SMS.f19_f19.A.melvin_gnu.20170504_163152_31aahy
   test-scheduler took 154.780044079 seconds
 
 You can see that create_test informs the user of the case directory and of the progress and duration
@@ -271,12 +271,12 @@ results to a baseline area.
 Take a batch of results for the jenkins user for the testid 'mytest' and copy the results to
 baselines for 'master'::
 
-  ./bless_test_results -r /home/jenkins/acme/scratch/jenkins/ -t mytest -b master
+  ./bless_test_results -r /home/jenkins/e3sm/scratch/jenkins/ -t mytest -b master
 
 Take a batch of results for the jenkins user for the testid 'mytest' and compare the results to
 baselines for 'master'::
 
-  ./compare_test_results -r /home/jenkins/acme/scratch/jenkins/ -t mytest -b master
+  ./compare_test_results -r /home/jenkins/e3sm/scratch/jenkins/ -t mytest -b master
 
 ===================
 manage_testlists
@@ -286,7 +286,7 @@ manage_testlists
 Adding tests
 =============
 
-Open the update_acme_tests.py file, you'll see a python dict at the top
+Open the update_e3sm_tests.py file, you'll see a python dict at the top
 of the file called TEST_SUITES, find the test category you want to
 change in this dict and add your testcase to the list.  Note the
 comment at the top of this file indicating that you add a test with

--- a/doc/source/xml_files/drivers.rst
+++ b/doc/source/xml_files/drivers.rst
@@ -27,7 +27,7 @@ XML variables and component descriptions specific to the driver/coupler
 
 XML variables and component descriptions specific to the E3SM driver/coupler
 
-.. literalinclude:: ../../../src/drivers/mct/cime_config/config_component_acme.xml
+.. literalinclude:: ../../../src/drivers/mct/cime_config/config_component_e3sm.xml
 
 XML variables and component descriptions specific to the E3SM driver/coupler
 

--- a/doc/source/xml_files/e3sm.rst
+++ b/doc/source/xml_files/e3sm.rst
@@ -1,65 +1,65 @@
-.. _acme:
+.. _e3sm:
 
 #############################
 E3SM Coupled Model XML Files
 #############################
 
-XML files for E3SM in CIMEROOT/config/acme. 
+XML files for E3SM in CIMEROOT/config/e3sm. 
 
 .. toctree::
    :maxdepth: 1
 
 ********************
-CIMEROOT/config/acme
+CIMEROOT/config/e3sm
 ********************
 
 E3SM XML settings for short term archiver.
 
-.. literalinclude:: ../../../config/acme/config_archive.xml
+.. literalinclude:: ../../../config/e3sm/config_archive.xml
 
 E3SM XML settings for defining CASEROOT env_*.xml file entries.
 
-.. literalinclude:: ../../../config/acme/config_files.xml
+.. literalinclude:: ../../../config/e3sm/config_files.xml
 
 E3SM XML settings for defining supported grids.
 
-.. literalinclude:: ../../../config/acme/config_grids.xml
+.. literalinclude:: ../../../config/e3sm/config_grids.xml
 
 
 ******************************
-CIMEROOT/config/acme/allactive
+CIMEROOT/config/e3sm/allactive
 ******************************
 
 E3SM XML settings for all-active component set (compset) configurations.
 
-.. literalinclude:: ../../../config/acme/allactive/config_compsets.xml
+.. literalinclude:: ../../../config/e3sm/allactive/config_compsets.xml
 
 E3SM XML settings for all-active test configurations.
 
-.. literalinclude:: ../../../config/acme/allactive/testlist_allactive.xml
+.. literalinclude:: ../../../config/e3sm/allactive/testlist_allactive.xml
 
 E3SM XML settings for optimized processor elements (PEs) layout configurations.
 
-.. literalinclude:: ../../../config/acme/allactive/config_pesall.xml
+.. literalinclude:: ../../../config/e3sm/allactive/config_pesall.xml
 
 
 *****************************
-CIMEROOT/config/acme/machines
+CIMEROOT/config/e3sm/machines
 *****************************
 
 E3SM XML settings for supported batch queuing systems.
 
-.. literalinclude:: ../../../config/acme/machines/config_batch.xml
+.. literalinclude:: ../../../config/e3sm/machines/config_batch.xml
 
 E3SM XML settings for supported compilers.
 
-.. literalinclude:: ../../../config/acme/machines/config_compilers.xml
+.. literalinclude:: ../../../config/e3sm/machines/config_compilers.xml
 
 E3SM XML settings for supported machines.
 
-.. literalinclude:: ../../../config/acme/machines/config_machines.xml
+.. literalinclude:: ../../../config/e3sm/machines/config_machines.xml
 
 E3SM XML settings for Parallel Input/Output (PIO) library. 
 
-.. literalinclude:: ../../../config/acme/machines/config_pio.xml
+.. literalinclude:: ../../../config/e3sm/machines/config_pio.xml
 

--- a/doc/source/xml_files/index.rst
+++ b/doc/source/xml_files/index.rst
@@ -18,7 +18,7 @@ in the CIMEROOT/config/xml_schemas directory that can be used with
 .. toctree::
    :maxdepth: 2
 
-   acme.rst
+   e3sm.rst
    cesm.rst
    common.rst
    components.rst

--- a/doc/tools_autodoc.cfg
+++ b/doc/tools_autodoc.cfg
@@ -1,6 +1,6 @@
 [tools]
 tools_dir: ../scripts/Tools
-exclude_files: __init__.py load.awk standard_script_setup.py
+exclude_files: __init__.py load.awk standard_script_setup.py Makefile
 exclude_ext: ~ pyc
 exclude_prefix: JENKINS_
 


### PR DESCRIPTION
cleaned up old acme references in the doc/source rst files and scripts/Tools and replacing it with e3sm.

Test suite: N/A
Test baseline: N/A
Test namelist changes: N/A
Test status: [bit for bit, roundoff, climate changing] bit for bit

Fixes  #2379

User interface changes?: None

Update gh-pages html (Y/N)?: Y
