### PR TITLE
Cannot combine soft operations.

### DIFF
--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -141,12 +141,26 @@ class EnvMachSpecific(EnvBase):
         run_cmd_no_fail("echo -e '\n' && env", arg_stdout=filename)
 
     def make_env_mach_specific_file(self, shell, case):
+        module_system = self.get_module_system_type()
+        sh_init_cmd = self.get_module_system_init_path(shell)
+        sh_mod_cmd = self.get_module_system_cmd_path(shell)
+
+        lines = ["source {}".format(sh_init_cmd)]
+
+        if "SOFTENV_ALIASES" in os.environ:
+            lines.append("source $SOFTENV_ALIASES")
+        if "SOFTENV_LOAD" in os.environ:
+            lines.append("source $SOFTENV_LOAD")
+
         modules_to_load = self._get_modules_for_case(case)
         envs_to_set = self._get_envs_for_case(case)
         filename = ".env_mach_specific.{}".format(shell)
-        lines = []
         if modules_to_load is not None:
-            lines.extend(self._get_module_commands(modules_to_load, shell))
+            if module_system == "module":
+                lines.extend(self._get_module_commands(modules_to_load, shell))
+            else:
+                for action, argument in modules_to_load:
+                    lines.append("{} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument))
 
         if envs_to_set is not None:
             for env_name, env_value in envs_to_set:


### PR DESCRIPTION
env_mach_specific was coded to always try to combine module operations. Instead, it should only do that for "module" module systems.

Test suite: by-hand, both for module and soft system
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?:N

Code review: @jedwards4b 
