### PR TITLE
allow envvars to be unresolved

### DIFF
--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -203,7 +203,7 @@ class EnvBatch(EnvBase):
         overrides["mpirun"] = case.get_mpirun_cmd(job=job)
         output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)
         output_name = get_batch_script_for_job(job)
-
+        logger.info("Creating file {}".format(output_name))
         with open(output_name, "w") as fd:
             fd.write(output_text)
 

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -376,7 +376,7 @@ class GenericXML(object):
         for node in valnodes:
             self.set_text(node, value)
 
-    def get_resolved_value(self, raw_value):
+    def get_resolved_value(self, raw_value, allow_unresolved_envvars=False):
         """
         A value in the xml file may contain references to other xml
         variables or to environment variables. These are refered to in
@@ -411,8 +411,10 @@ class GenericXML(object):
             logger.debug("look for {} in env".format(item_data))
             env_var = m.groups()[0]
             env_var_exists = env_var in os.environ
-            expect(env_var_exists, "Undefined env var '{}'".format(env_var))
-            item_data = item_data.replace(m.group(), os.environ[env_var])
+            if not allow_unresolved_envvars:
+                expect(env_var_exists, "Undefined env var '{}'".format(env_var))
+            if env_var_exists:
+                item_data = item_data.replace(m.group(), os.environ[env_var])
 
         for s in shell_ref_re.finditer(item_data):
             logger.debug("execute {} in shell".format(item_data))

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1230,7 +1230,7 @@ class Case(object):
             if not success:
                 logger.warning("Failed to kill {}".format(jobid))
 
-    def get_mpirun_cmd(self, job=None):
+    def get_mpirun_cmd(self, job=None, allow_unresolved_envvars=True):
         if job is None:
             job = self.get_primary_job()
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -358,16 +358,18 @@ class Case(object):
 
         return result
 
-    def get_resolved_value(self, item, recurse=0):
+    def get_resolved_value(self, item, recurse=0, allow_unresolved_envvars=False):
         num_unresolved = item.count("$") if item else 0
         recurse_limit = 10
         if (num_unresolved > 0 and recurse < recurse_limit ):
             for env_file in self._env_entryid_files:
-                item = env_file.get_resolved_value(item)
+                item = env_file.get_resolved_value(item, 
+                                                   allow_unresolved_envvars=allow_unresolved_envvars)
             if ("$" not in item):
                 return item
             else:
-                item = self.get_resolved_value(item, recurse=recurse+1)
+                item = self.get_resolved_value(item, recurse=recurse+1, 
+                                               allow_unresolved_envvars=allow_unresolved_envvars)
 
         return item
 
@@ -1265,7 +1267,7 @@ class Case(object):
         if self.get_value("BATCH_SYSTEM") == "cobalt":
             mpi_arg_string += " : "
 
-        return self.get_resolved_value("{} {} {}".format(executable if executable is not None else "", mpi_arg_string, run_suffix))
+        return self.get_resolved_value("{} {} {}".format(executable if executable is not None else "", mpi_arg_string, run_suffix), allow_unresolved_envvars=True)
 
     def set_model_version(self, model):
         version = "unknown"

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -86,7 +86,7 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
     # Run the model
     logger.info("{} MODEL EXECUTION BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
 
-    cmd = case.get_mpirun_cmd()
+    cmd = case.get_mpirun_cmd(allow_unresolved_envvars=False)
     logger.info("run command is {} ".format(cmd))
 
     rundir = case.get_value("RUNDIR")


### PR DESCRIPTION
Some env vars in env_mach_specific.xml may only be defined on compute nodes, this change allows that to happen while resolving all cime xml vars. 

Test suite: scripts_regression_tests.py on hobart
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2411 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
