### PR TITLE
External script handling

### DIFF
--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -2,7 +2,8 @@
 case_run is a member of Class Case
 '"""
 from CIME.XML.standard_module_setup import *
-from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status, run_sub_or_cmd
+from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
+from CIME.utils                     import run_sub_or_cmd, append_status
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance
 
@@ -229,7 +230,9 @@ def _do_external(script_name, caseroot, rundir, lid, prefix):
     expect(os.path.isfile(script_name), "External script {} not found".format(script_name))
     filename = "{}.external.log.{}".format(prefix, lid)
     outfile = os.path.join(rundir, filename)
+    append_status("Starting script {}".format(script_name), "CaseStatus")
     run_sub_or_cmd(script_name, [caseroot], os.path.basename(script_name), [caseroot], logfile=outfile)
+    append_status("Completed script {}".format(script_name), "CaseStatus")
 
 ###############################################################################
 def _do_data_assimilation(da_script, caseroot, cycle, lid, rundir):

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -231,7 +231,7 @@ def _do_external(script_name, caseroot, rundir, lid, prefix):
     filename = "{}.external.log.{}".format(prefix, lid)
     outfile = os.path.join(rundir, filename)
     append_status("Starting script {}".format(script_name), "CaseStatus")
-    run_sub_or_cmd(script_name, [caseroot], os.path.basename(script_name), [caseroot], logfile=outfile)
+    run_sub_or_cmd(script_name, [caseroot], (os.path.basename(script_name).split('.',1))[0], [caseroot], logfile=outfile)
     append_status("Completed script {}".format(script_name), "CaseStatus")
 
 ###############################################################################

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -271,24 +271,33 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None, from
 
     # This code will try to import and run each buildnml as a subroutine
     # if that fails it will run it as a program in a seperate shell
-    do_run_cmd = False
+    do_run_cmd = True
     stat = 0
     output = ""
     errput = ""
-    try:
-        mod = imp.load_source(subname, cmd)
-        logger.info("   Calling {}".format(cmd))
-        if logfile:
-            with redirect_logger(open(logfile,"w"), subname):
+    # Before attempting to load the script make sure it contains the subroutine
+    # we are expecting
+    with open(cmd, 'r') as fd:
+        for line in fd.readlines():
+            if re.search(r"^def {}\(".format(subname), line):
+                do_run_cmd = False
+                break
+
+    if not do_run_cmd:
+        try:
+            mod = imp.load_source(subname, cmd)
+            logger.info("   Calling {}".format(cmd))
+            if logfile:
+                with redirect_stdout_stderr(open(logfile,"w")):
+                    getattr(mod, subname)(*subargs)
+            else:
                 getattr(mod, subname)(*subargs)
-        else:
-            getattr(mod, subname)(*subargs)
 
-    except SyntaxError:
-        do_run_cmd = True
+        except SyntaxError:
+            do_run_cmd = True
 
-    except AttributeError:
-        do_run_cmd = True
+        except AttributeError:
+            do_run_cmd = True
 
     if do_run_cmd:
         logger.info("   Running {} ".format(cmd))


### PR DESCRIPTION
If a python script was passed to run_sub_or_cmd subroutine in utils.py and it was not in the proper form to be called as a subroutine it would run twice, once as a subroutine and again as an external script.   This makes sure that the script is properly formed to call as a subroutine prior to calling it.
It also improves the redirect of logs and adds Documentation to the CaseStatus file for external scrpts called from case_run.py

Test suite: scripts_regression_tests.py + hand testing with POSTRUN_SCRIPT called as sub and as external
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
