### PR TITLE
St_archive the DART restart history files

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -112,9 +112,9 @@
     </rpointer>
     </comp_archive_spec>
     <comp_archive_spec compclass="esp" compname="dart">
-      <rest_file_extension>e\.\w+inf\w+</rest_file_extension>
+      <rest_file_extension>r</rest_file_extension>
       <hist_file_extension>[ei]</hist_file_extension>
-      <rest_history_varname>unset</rest_history_varname>
+      <rest_history_varname>restart_hist</rest_history_varname>
       <rpointer>
         <rpointer_file>rpointer.unset</rpointer_file>
         <rpointer_content>unset</rpointer_content>

--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -280,24 +280,27 @@ def get_histfiles_for_restarts(rundir, archive, archive_entry, restfile):
         cmd = "ncdump -v {} {} ".format(rest_hist_varname, os.path.join(rundir, restfile))
         rc, out, error = run_cmd(cmd)
         if rc != 0:
-            logger.debug(" WARNING: {} failed rc={:d}\nout={}\nerr={}".format(cmd, rc, out, error))
+            logger.info(" WARNING: {} failed rc={:d}\n    out={}\n    err={}".format(cmd, rc, out, error))
+        logger.debug(" get_histfiles_for_restarts: \n    out={}".format(out))
 
         searchname = "{} =".format(rest_hist_varname)
         if searchname in out:
             offset = out.index(searchname)
             items = out[offset:].split(",")
             for item in items:
-                # the following match has an option of having a './' at the beginning of
-                # the history filename
-                matchobj = re.search(r"\"(\.*\/*\w.*)\s?\"", item)
+                # the following match has an option of having any number of '.'s and '/'s 
+                # at the beginning of the history filename
+                matchobj = re.search(r"\"\S+\s*\"", item)
                 if matchobj:
-                    histfile = matchobj.group(1).strip()
+                    histfile = matchobj.group(0).strip('" ')
                     histfile = os.path.basename(histfile)
                     # append histfile to the list ONLY if it exists in rundir before the archiving
                     if histfile in histfiles:
                         logger.warning("WARNING, tried to add a duplicate file to histfiles")
                     if os.path.isfile(os.path.join(rundir,histfile)):
                         histfiles.add(histfile)
+                    else:
+                        logger.debug(" get_histfiles_for_restarts: histfile {} does not exist ".format(histfile))
     return histfiles
 
 ###############################################################################


### PR DESCRIPTION
Make config/cesm/config_archive.xml:dart handle the new dart.r. file,
which contains the ("inflation") restart history file names.
Suggested changes to case_st_archive.py to use a simpler and more robust
python regular expression when searching for restart history file names.

These changes pass my tests of st_archive of a directory 
filled with CAM+DART files.


Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2414

User interface changes?: env_archive.xml

Update gh-pages html (Y/N)?: no?

Code review: 
