### PR TITLE
improve cprnc build

### DIFF
--- a/tools/cprnc/Makefile
+++ b/tools/cprnc/Makefile
@@ -33,9 +33,12 @@ null  :=
 EXENAME = cprnc
 RM = rm
 
+NETCDF_PATH ?= $(NETCDF_FORTRAN_PATH)
+
 # Default for the netcdf library and include directories
 LIB_NETCDF := $(NETCDF_PATH)/lib
 INC_NETCDF := $(NETCDF_PATH)/include
+LDFLAGS = -L$(LIB_NETCDF) -lnetcdff
 
 # Determine platform
 UNAMES := $(shell uname -s)


### PR DESCRIPTION
Improve the cprnc build when netcdf c and fortran libraries are installed separately 

Test suite: hand tested build of cprnc with separate netcdf c and fortran builds 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2416 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
