### PR TITLE
Restore shell batch capability

### DIFF
--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -182,7 +182,7 @@ class EnvBatch(EnvBase):
             self.add_child(self.copy(batchobj.machine_node))
         self.set_value("BATCH_SYSTEM", batch_system_type)
 
-    def make_batch_script(self, input_template, job, case):
+    def make_batch_script(self, input_template, job, case, outfile=None):
         expect(os.path.exists(input_template), "input file '{}' does not exist".format(input_template))
         task_count = self.get_value("task_count", subgroup=job)
         overrides = {}
@@ -202,7 +202,7 @@ class EnvBatch(EnvBase):
         overrides["batchdirectives"] = self.get_batch_directives(case, job, overrides=overrides)
         overrides["mpirun"] = case.get_mpirun_cmd(job=job)
         output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)
-        output_name = get_batch_script_for_job(job)
+        output_name = get_batch_script_for_job(job) if outfile is None else outfile
         logger.info("Creating file {}".format(output_name))
         with open(output_name, "w") as fd:
             fd.write(output_text)

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -160,6 +160,9 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             # create batch files
             env_batch = case.get_env("batch")
             env_batch.make_all_batch_files(case)
+            if get_model() == "e3sm" and not case.get_value("TEST"):
+                input_batch_script = os.path.join(case.get_value("MACHDIR"), "template.case.run.sh")
+                env_batch.make_batch_script(input_batch_script, "case.run", case, outfile=get_batch_script_for_job("case.run.sh"))
 
             # May need to select new batch settings if pelayout changed (e.g. problem is now too big for prev-selected queue)
             env_batch.set_job_defaults([(case.get_primary_job(), {})], case)


### PR DESCRIPTION
A previous PR to simplify env_batch.xml broke this capability. 

Test suite: by-hand, code-checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
