### PR TITLE
more cesm testing changes

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -43,6 +43,7 @@
 
   <comp_archive_spec compname="rtm" compclass="rof">
     <rest_file_extension>r</rest_file_extension>
+    <rest_file_extension>rh\d*</rest_file_extension>
     <hist_file_extension>h\d*</hist_file_extension>
     <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>

--- a/scripts/lib/CIME/SystemTests/eri.py
+++ b/scripts/lib/CIME/SystemTests/eri.py
@@ -91,10 +91,6 @@ class ERI(SystemTestsCommon):
         clone1.set_value("REST_N", rest_n1)
         clone1.set_value("HIST_OPTION", "never")
         clone1.flush()
-        clone1.case_setup(test_mode=True, reset=True)
-
-        # if the initial case is hybrid this will put the reference data in the correct location
-        clone1.check_all_input_data()
 
         dout_sr1 = clone1.get_value("DOUT_S_ROOT")
 
@@ -103,6 +99,9 @@ class ERI(SystemTestsCommon):
             if "inithist" not in open("user_nl_cam", "r").read():
                 with open("user_nl_cam", "a") as fd:
                     fd.write("inithist = 'ENDOFRUN'\n")
+        clone1.case_setup(test_mode=True, reset=True)
+        # if the initial case is hybrid this will put the reference data in the correct location
+        clone1.check_all_input_data()
 
         self.run_indv(st_archive=True, suffix=None)
 

--- a/scripts/lib/CIME/SystemTests/ers.py
+++ b/scripts/lib/CIME/SystemTests/ers.py
@@ -37,16 +37,12 @@ class ERS(SystemTestsCommon):
         self._case.set_value("CONTINUE_RUN", True)
         self._case.set_value("REST_OPTION","never")
         self._case.flush()
-        logger.info("doing an {} {} restart test".format(str(stop_new), stop_option))
+        logger.info("doing an {} {} restart test, skip_pnl={}".format(str(stop_new), stop_option, self._skip_pnl))
+        self._case.create_namelists()
         self.run_indv(suffix="rest")
 
         # Compare restart file
         self._component_compare_test("base", "rest")
-
-    def build_phase(self, sharedlib_only=False, model_only=False):
-        if not model_only:
-            self._case.case_setup(test_mode=True, reset=True)
-        super(ERS, self).build_phase(sharedlib_only=sharedlib_only, model_only=model_only)
 
     def run_phase(self):
         self._ers_first_phase()


### PR DESCRIPTION
More fixes related to cesm testing

Test suite: scripts_regression_tests.py, ERI.f09_g17.B1850.cheyenne_intel.allactive-defaultio, ERS_Ld5.f09_g17.B1850.cheyenne_intel.allactive-defaultio
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
