### PR TITLE
fix skip_pnl issues

### DIFF
--- a/scripts/lib/CIME/SystemTests/eri.py
+++ b/scripts/lib/CIME/SystemTests/eri.py
@@ -147,7 +147,7 @@ class ERI(SystemTestsCommon):
 
         _helper(dout_sr1, refdate_2, refsec_2, rundir2)
 
-        clone2.case_setup(test_mode=True, reset=True)
+        self._skip_pnl = False
         # run ref2 case (all component history files will go to short term archiving)
 
         self.run_indv(suffix="hybrid", st_archive=True)

--- a/scripts/lib/CIME/SystemTests/ers.py
+++ b/scripts/lib/CIME/SystemTests/ers.py
@@ -37,8 +37,8 @@ class ERS(SystemTestsCommon):
         self._case.set_value("CONTINUE_RUN", True)
         self._case.set_value("REST_OPTION","never")
         self._case.flush()
-        logger.info("doing an {} {} restart test, skip_pnl={}".format(str(stop_new), stop_option, self._skip_pnl))
-        self._case.create_namelists()
+        logger.info("doing an {} {} restart test".format(str(stop_new), stop_option))
+        self._skip_pnl=False
         self.run_indv(suffix="rest")
 
         # Compare restart file


### PR DESCRIPTION
ERS and ERI tests need skip_pnl=False

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
