### PR TITLE
fix for eri test

### DIFF
--- a/scripts/lib/CIME/SystemTests/eri.py
+++ b/scripts/lib/CIME/SystemTests/eri.py
@@ -27,7 +27,6 @@ class ERI(SystemTestsCommon):
         """
         SystemTestsCommon.__init__(self, case)
         self._testname = "ERI"
-        self._skip_pnl = False
 
     def run_phase(self):
         caseroot = self._case.get_value("CASEROOT")
@@ -104,6 +103,7 @@ class ERI(SystemTestsCommon):
         # if the initial case is hybrid this will put the reference data in the correct location
         clone1.check_all_input_data()
 
+        self._skip_pnl = False
         self.run_indv(st_archive=True, suffix=None)
 
         #
@@ -148,6 +148,7 @@ class ERI(SystemTestsCommon):
         # run ref2 case (all component history files will go to short term archiving)
         clone2.case_setup(test_mode=True, reset=True)
 
+        self._skip_pnl = False
         self.run_indv(suffix="hybrid", st_archive=True)
 
         #
@@ -195,6 +196,7 @@ class ERI(SystemTestsCommon):
                 os.remove(dst)
             os.symlink(item, dst)
 
+        self._skip_pnl = False
         # run branch case (short term archiving is off)
         self.run_indv()
 

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -65,6 +65,7 @@ def _pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
     if skip_pnl:
         case.create_namelists(component='cpl')
     else:
+        logger.info("Generating namelists for {}".format(caseroot))
         case.create_namelists()
 
     logger.info("-------------------------------------------------------------------------")


### PR DESCRIPTION
Need to explicitly set skip_pnl = False for each of the three phases of this test. 

Test suite: ERI.f09_g17.B1850.cheyenne_intel.allactive-defaultio
Test baseline: 
Test namelist changes: 
Test status: bit for bit,
Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
