### PR TITLE
Fixes the potential leak reported by address sanitizer in PIO

### DIFF
--- a/src/externals/pio1/pio/piodarray.F90.in
+++ b/src/externals/pio1/pio/piodarray.F90.in
@@ -459,7 +459,7 @@ contains
 
     character(len=*), parameter :: subName=modName//'::write_darray_nf_{TYPE}'
     {VTYPE}, dimension(:), pointer ::  &
-         IOBUF                ! local IO buffer
+         IOBUF => null()                ! local IO buffer
 
     logical (log_kind) :: IOproc     ! true if IO processor
     integer (i4) ::  len,           &! length of IO decomp segmap
@@ -468,6 +468,7 @@ contains
 
     logical(log_kind) :: UseRearranger
 
+    logical(log_kind) :: is_iobuf_owned
 
 #if DEBUG_REARR
     {VTYPE}, dimension(:), pointer ::  array2
@@ -487,6 +488,7 @@ contains
     iotype     = File%iotype
     UseRearranger  = File%iosystem%UseRearranger
 
+    is_iobuf_owned = .false.
 
     ! ---------------------------------------------------------
     ! pull information out of the decomposition data structure
@@ -511,6 +513,7 @@ contains
                'Before call to allocate(IOBUF): ',len, iodesc%write%n_elemtype
 
           call alloc_check(IOBUF,len,' TYPE :IOBUF')
+          is_iobuf_owned = .true.
 
           if (present(fillval)) then
              IOBUF=fillval
@@ -527,6 +530,7 @@ contains
 
        else
           call alloc_check(IOBUF,0)
+          is_iobuf_owned = .true.
           IOBUF= -1.0_r8
        endif
 
@@ -535,7 +539,7 @@ contains
        !------------------------------------
        ! "array" is comp data
 
-       call rearrange_comp2io(File%iosystem,iodesc, array, iobuf)
+       call rearrange_comp2io(File%iosystem,iodesc, array, IOBUF)
 
 #if DEBUG_REARR
        call alloc_check(array2,size(array),'array2')
@@ -560,10 +564,11 @@ contains
        !--------------------------------------------
     else
        if(file%iotype==pio_iotype_pnetcdf) then
-          allocate(iobuf(size(array)))
-          iobuf=array
+          allocate(IOBUF(size(array)))
+          IOBUF=array
+          is_iobuf_owned = .true.
        else
-          iobuf=>array
+          IOBUF=>array
        end if
     endif   ! if(UseRearranger)
 #ifdef TIMING
@@ -610,7 +615,7 @@ contains
 
 
           if(Debug) print *, __PIO_FILE__,__LINE__,'start:',start, &
-           ' count:',count,' ndims:',ndims, minval(iobuf),maxval(iobuf)
+           ' count:',count,' ndims:',ndims, minval(IOBUF),maxval(IOBUF)
           ! this is a timedependent single value
        else if(vardesc%rec>=0) then
           call alloc_check(start,1)
@@ -655,13 +660,15 @@ contains
 #endif
        if(file%iotype==pio_iotype_pnetcdf) then
           call add_data_to_buffer(File, IOBUF, request)
-       else if(Userearranger) then
-          deallocate(iobuf)
+          is_iobuf_owned = .false.
        end if
 #ifdef TIMING
        call t_stopf("PIO:post_pio_write_nf")
 #endif
     end if
+    if(associated(IOBUF) .and. is_iobuf_owned) then
+       deallocate(IOBUF)
+    endif ! if(IOPROC)
 
     !   call MPI_Barrier(File%iosystem%comp_comm,ierr)
 
@@ -726,7 +733,7 @@ contains
     character(len=*), parameter :: subName=modName//'::write_darray_bin_{TYPE}'
 
     {VTYPE}, dimension(:), pointer ::  &
-         IOBUF                ! local IO buffer
+         IOBUF => null()                ! local IO buffer
 
 
 #if DEBUG_REARR


### PR DESCRIPTION
This fixes the potential memory leak reported by address sanitizer. This actually does look like one, so it should be fixed.

To test this, I did/am doing two things:
1) Run scripts_regression_tests on Anvil with gnu without address sanitizer. This is expected to pass, and ~~is currently in progress; I'll update this when it's finished~~ does complete successfully.
2) Run Z_FullSystemTest and most of scripts_regression_tests on Anvil with gnu with address sanitizer. This is expected to fail due to other reported "leaks", but should not contain any errors related to heap usage after freeing, or from IOBUF or the piodarray.F90 file.
These requirements were satisfied, so this looks to be correct. I'm not certain why the simpler method of checking the different cases to determine ownership wasn't working, just that the more general method used in this PR does. This should not have significant performance effects, so I don't think putting more effort to avoid the extra bool is worth it.

Test suite: scripts_regression_tests
Test status: BFB

Fixes #2154

Code review: @jedwards4b
