### PR TITLE
two more places we need to call case_setup

### DIFF
--- a/scripts/lib/CIME/SystemTests/pea.py
+++ b/scripts/lib/CIME/SystemTests/pea.py
@@ -42,3 +42,4 @@ class PEA(SystemTestsCompareTwo):
 
         if os.path.isfile("Macros"):
             os.remove("Macros")
+        self._case.case_setup(test_mode=True, reset=True)

--- a/scripts/lib/CIME/SystemTests/pem.py
+++ b/scripts/lib/CIME/SystemTests/pem.py
@@ -30,3 +30,4 @@ class PEM(SystemTestsCompareTwo):
             ntasks = self._case.get_value("NTASKS_{}".format(comp))
             if ( ntasks > 1 ):
                 self._case.set_value("NTASKS_{}".format(comp), int(ntasks/2))
+        self._case.case_setup(test_mode=True, reset=True)


### PR DESCRIPTION
PEA and PEM need to call case_setup for case2.

Test suite: PEA.f19_g16_rx1.A and PEM.f19_g16_rx1.A and scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
