### PR TITLE
Use --no-logging in call to checkout_externals

### DIFF
--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -83,7 +83,7 @@ def _save_build_provenance_cesm(case, lid): # pylint: disable=unused-argument
     manic = os.path.join(srcroot, "manage_externals","checkout_externals")
     out = None
     if os.path.exists(manic):
-        out = run_cmd_no_fail(manic + " --status --verbose", from_dir=srcroot)
+        out = run_cmd_no_fail(manic + " --status --verbose --no-logging", from_dir=srcroot)
     caseroot = case.get_value("CASEROOT")
     with open(os.path.join(caseroot, "CaseStatus"), "a") as fd:
         if version is not None and version != "unknown":


### PR DESCRIPTION
This is needed if you're running checkout_externals from a directory
where you don't have write permission.

Test suite: scripts_regression_tests - just A_RunUnitTests and B_CheckCode
   Also manual test of build from within a cesm checkout, so checkout_externals ran
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #2443 

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
