### PR TITLE
Add PEM test to cime developer

### DIFF
--- a/scripts/lib/get_tests.py
+++ b/scripts/lib/get_tests.py
@@ -63,6 +63,7 @@ _CIME_TESTS = {
                              "SMS_D_Ln9.f19_g16_rx1.A",
                              "DAE.f19_f19.A",
                              "PET_P4.f19_f19.A",
+                             "PEM_P4.f19_f19.A",
                              "SMS.T42_T42.S",
                              "PRE.f19_f19.ADESP",
                              "PRE.f19_f19.ADESP_TEST",


### PR DESCRIPTION
Recent cime update broke PEM for E3SM. Problems slipped through
due to lack of PEM testing.

Test suite: ./create_test PEM_P4.f19_f19.A
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:  N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
