### PR TITLE
Support renamed glimmer-cism directory; add README files to SourceMods directories

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -682,7 +682,7 @@ CMAKE_ENV_VARS += CC=$(CC) \
 .PHONY: $(GLC_DIR)/Makefile
 $(GLC_DIR)/Makefile:
 	cd $(GLC_DIR); \
-	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(GLCROOT)/glimmer-cism
+	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(GLCROOT)/source_cism
 
 $(PIO_LIBDIR)/Makefile:
 	cd $(PIO_LIBDIR); \

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1063,18 +1063,31 @@ class Case(object):
 
     def _create_caseroot_sourcemods(self):
         components = self.get_compset_components()
+        components.extend(['share', 'drv'])
+        readme_message = """Put source mods for the {component} library in this directory.
+
+WARNING: SourceMods are not kept under version control, and can easily
+become out of date if changes are made to the source code on which they
+are based. We only recommend using SourceMods for small, short-term
+changes that just apply to one or two cases. For larger or longer-term
+changes, including gradual, incremental changes towards a final
+solution, we highly recommend making changes in the main source tree,
+leveraging version control (git or svn).
+"""
+
         for component in components:
             directory = os.path.join(self._caseroot,"SourceMods","src.{}".format(component))
             if not os.path.exists(directory):
                 os.makedirs(directory)
-
-        directory = os.path.join(self._caseroot, "SourceMods", "src.share")
-        if not os.path.exists(directory):
-            os.makedirs(directory)
-
-        directory = os.path.join(self._caseroot,"SourceMods","src.drv")
-        if not os.path.exists(directory):
-            os.makedirs(directory)
+                # Besides giving some information on SourceMods, this
+                # README file serves one other important purpose: By
+                # putting a file inside each SourceMods subdirectory, we
+                # prevent aggressive scrubbers from scrubbing these
+                # directories due to being empty (which can cause builds
+                # to fail).
+                readme_file = os.path.join(directory, "README")
+                with open(readme_file, "w") as fd:
+                    fd.write(readme_message.format(component=component))
 
         if get_model() == "cesm":
         # Note: this is CESM specific, given that we are referencing cism explitly

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1079,18 +1079,17 @@ class Case(object):
         if get_model() == "cesm":
         # Note: this is CESM specific, given that we are referencing cism explitly
             if "cism" in components:
-                directory = os.path.join(self._caseroot, "SourceMods", "src.cism", "glimmer-cism")
+                directory = os.path.join(self._caseroot, "SourceMods", "src.cism", "source_cism")
                 if not os.path.exists(directory):
                     os.makedirs(directory)
-                readme_file = os.path.join(directory, "README")
+                    readme_file = os.path.join(directory, "README")
+                    str_to_write = """Put source mods for the source_cism library in this subdirectory.
+This includes any files from $COMP_ROOT_DIR_GLC/source_cism. Anything
+else (e.g., mods to source_glc or drivers) goes in the src.cism
+directory, NOT in this subdirectory."""
 
-                str_to_write = """
-                Put source mods for the glimmer-cism library in the glimmer-cism subdirectory
-                This includes any files that are in the glimmer-cism subdirectory of $cimeroot/../components/cism
-                Anything else (e.g., mods to source_glc or drivers) goes in this directory, NOT in glimmer-cism/"""
-
-                with open(readme_file, "w") as fd:
-                    fd.write(str_to_write)
+                    with open(readme_file, "w") as fd:
+                        fd.write(str_to_write)
 
     def create_caseroot(self, clone=False):
         if not os.path.exists(self._caseroot):


### PR DESCRIPTION
This PR includes two changes that are conceptually unrelated, but I have
combined them because they touch the same code:

(1) Support CISM's rename of the glimmer-cism directory to
    source_cism. Because the source files in this subdirectory are built
    into a separate library, a few updates are needed in cime, too. Note
    that, for CESM, this change must be coordinated with
    cism2_1_51 (for e3sm, there are no dependencies).

(2) Add README files in each subdirectory of SourceMods. The main point
    of this is to prevent SourceMods directories from being scrubbed due
    to being empty, which happens on hobart and possibly other systems
    (and then this breaks the build).

Test suite: scripts_regression_tests on hobart; also, aux_glc test suite
  for cism2_1_51 (with these cime changes rebased onto cime5.4.0-alpha.24)
Test baseline: For aux_glc test suite: cism2_1_50
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#2377
Fixes ESMCI/cime#2376

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
