### PR TITLE
add model doi url to seq_infodata and to cpl history global attributes

### DIFF
--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -27,6 +27,14 @@
     <desc option="BPRP"> with prognostic CO2 </desc>
   </description>
 
+  <entry id="MODEL_DOI_URL">
+    <type>char</type>
+    <default_value>https://doi.org/10.5065/D67H1H0V</default_value>
+    <group>run_metadata</group>
+    <file>env_case.xml</file>
+    <desc>run DOI</desc>
+  </entry> 
+
   <entry id="DRV_THREADING">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -2,6 +2,14 @@
 
 <entry_id version="2.0">
 
+  <entry id="MODEL_DOI_URL">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <group>run_metadata</group>
+    <file>env_case.xml</file>
+    <desc>run DOI</desc>
+  </entry> 
+
   <entry id="DRV_THREADING">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -306,6 +306,18 @@
   </entry>
 -->
 
+  <entry id="model_doi_url" modify_via_xml="MODEL_DOI_URL">
+    <type>char</type>
+    <category>expdef</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      model doi url
+    </desc>
+    <values>
+      <value>$MODEL_DOI_URL</value>
+    </values>
+  </entry>
+
   <entry id="username" modify_via_xml="USER">
     <type>char</type>
     <category>expdef</category>

--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -164,6 +164,7 @@ contains
     character(len=18) :: date_str
     type(mct_gsMap), pointer :: gsmap
     type(mct_gGrid), pointer :: dom    ! comp domain on cpl pes
+    character(CL) :: model_doi_url 
     !-------------------------------------------------------------------------------
     !
     !-------------------------------------------------------------------------------
@@ -200,7 +201,8 @@ contains
          glc_nx=glc_nx, glc_ny=glc_ny,        &
          wav_nx=wav_nx, wav_ny=wav_ny,        &
          ocn_nx=ocn_nx, ocn_ny=ocn_ny,        &
-         case_name=case_name)
+         case_name=case_name,                 &
+         model_doi_url=model_doi_url)
 
     !--- Get current date from clock needed to label the history pointer file ---
 
@@ -218,7 +220,7 @@ contains
     if (iamin_CPLID) then
 
        if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
-       call seq_io_wopen(hist_file,clobber=.true.)
+       call seq_io_wopen(hist_file,clobber=.true., model_doi_url=model_doi_url)
 
        ! loop twice, first time write header, second time write data for perf
 
@@ -446,6 +448,7 @@ contains
     type(mct_gGrid),  pointer :: dom    ! component domain on cpl pes
     type(mct_avect),  pointer :: c2x    ! component->coupler avs on cpl pes
     type(mct_avect),  pointer :: x2c    ! coupler->component avs on cpl pes
+    character(CL) :: model_doi_url
     !-------------------------------------------------------------------------------
     !
     !-------------------------------------------------------------------------------
@@ -489,7 +492,8 @@ contains
          histavg_rof=histavg_rof,             &
          histavg_glc=histavg_glc,             &
          histavg_wav=histavg_wav,             &
-         histavg_xao=histavg_xao)
+         histavg_xao=histavg_xao,             &
+         model_doi_url=model_doi_url)
 
     ! Get current date from clock needed to label the histavg pointer file
 
@@ -778,7 +782,7 @@ contains
        if (iamin_CPLID) then
 
           if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
-          call seq_io_wopen(hist_file, clobber=.true.)
+          call seq_io_wopen(hist_file, clobber=.true., model_doi_url=model_doi_url)
 
           ! loop twice,  first time write header,  second time write data for perf
 
@@ -1029,7 +1033,7 @@ contains
     type(mct_aVect)         :: avflds                  ! non-avg av for a subset of fields
 
     real(r8), parameter :: c0 = 0.0_r8 ! zero
-
+    character(CL) :: model_doi_url
     !-------------------------------------------------------------------------------
     !
     !-------------------------------------------------------------------------------
@@ -1052,7 +1056,8 @@ contains
          ice_present=ice_present,       &
          ocn_present=ocn_present,       &
          glc_present=glc_present,       &
-         wav_present=wav_present)
+         wav_present=wav_present,       &
+         model_doi_url=model_doi_url)
 
     lwrite_now = .true.
     useavg = .false.
@@ -1150,7 +1155,7 @@ contains
 
           if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
           if (fk1 == 1) then
-             call seq_io_wopen(hist_file(found), clobber=.true., file_ind=found)
+             call seq_io_wopen(hist_file(found), clobber=.true., file_ind=found, model_doi_url=model_doi_url)
           endif
 
           ! loop twice,  first time write header,  second time write data for perf
@@ -1289,7 +1294,7 @@ contains
     type(mct_aVect)         :: avflds                  ! non-avg av for a subset of fields
 
     real(r8),parameter :: c0 = 0.0_r8 ! zero
-
+    character(CL) :: model_doi_url
     !-------------------------------------------------------------------------------
     !
     !-------------------------------------------------------------------------------
@@ -1310,7 +1315,8 @@ contains
          ice_present=ice_present,       &
          ocn_present=ocn_present,       &
          glc_present=glc_present,       &
-         wav_present=wav_present)
+         wav_present=wav_present,       &
+         model_doi_url=model_doi_url)
 
     lwrite_now = .true.
     useavg = .false.
@@ -1379,9 +1385,9 @@ contains
 
           if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
           if (fk1 == 1) then
-             call seq_io_wopen(hist_file(found), clobber=.true.)
+             call seq_io_wopen(hist_file(found), clobber=.true. , model_doi_url=model_doi_url)
           else
-             call seq_io_wopen(hist_file(found), clobber=.false.)
+             call seq_io_wopen(hist_file(found), clobber=.false., model_doi_url=model_doi_url)
           endif
 
           ! loop twice,  first time write header,  second time write data for perf

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -975,7 +975,8 @@ CONTAINS
        reprosum_use_ddpdd, reprosum_diffmax, reprosum_recompute,          &
        atm_resume, lnd_resume, ocn_resume, ice_resume,                    &
        glc_resume, rof_resume, wav_resume, cpl_resume,                    &
-       mct_usealltoall, mct_usevector, max_cplstep_time, glc_valid_input)
+       mct_usealltoall, mct_usevector, max_cplstep_time, model_doi_url,   &
+       glc_valid_input)
 
 
     implicit none
@@ -1141,7 +1142,7 @@ CONTAINS
     logical,                optional, intent(OUT) :: atm_aero                ! atmosphere aerosols
     logical,                optional, intent(OUT) :: glc_g2lupdate           ! update glc2lnd fields in lnd model
     real(shr_kind_r8),      optional, intent(out) :: max_cplstep_time
-    character(SHR_KIND_CL)  optional, intent(OUT) :: model_doi_url
+    character(SHR_KIND_CL), optional, intent(OUT) :: model_doi_url
     logical,                optional, intent(OUT) :: glc_valid_input
     character(SHR_KIND_CL), optional, intent(OUT) :: atm_resume(:) ! atm read resume state
     character(SHR_KIND_CL), optional, intent(OUT) :: lnd_resume(:) ! lnd read resume state
@@ -1384,7 +1385,7 @@ CONTAINS
        end if
     end if
     if ( present(max_cplstep_time) ) max_cplstep_time = infodata%max_cplstep_time
-    if ( present(model_doi_url) ) model_doi_url = model_doi_url
+    if ( present(model_doi_url) ) model_doi_url = infodata%model_doi_url
 
     if ( present(glc_valid_input)) glc_valid_input = infodata%glc_valid_input
 
@@ -2308,6 +2309,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%atm_aero,                mpicom)
     call shr_mpi_bcast(infodata%glc_g2lupdate,           mpicom)
     call shr_mpi_bcast(infodata%glc_valid_input,         mpicom)
+    call shr_mpi_bcast(infodata%model_doi_url,           mpicom)
 
     call seq_infodata_pauseresume_bcast(infodata,        mpicom)
 

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -244,6 +244,7 @@ MODULE seq_infodata_mod
      character(SHR_KIND_CL)  :: rest_case_name  ! Short case identification
      !--- set by driver and may be time varying
      logical                 :: glc_valid_input  ! is valid accumulated data being sent to prognostic glc
+     character(SHR_KIND_CL)  :: model_doi_url
   end type seq_infodata_type
 
   ! --- public interfaces --------------------------------------------------------
@@ -414,7 +415,8 @@ CONTAINS
     ! if reprosum_diffmax is exceeded
     logical                :: mct_usealltoall    ! flag for mct alltoall
     logical                :: mct_usevector      ! flag for mct vector
-    real(shr_kind_r8) :: max_cplstep_time  ! abort if cplstep time exceeds this value
+    real(shr_kind_r8)      :: max_cplstep_time   ! abort if cplstep time exceeds this value
+    character(SHR_KIND_CL) :: model_doi_url
 
     namelist /seq_infodata_inparm/  &
          cime_model, case_desc, case_name, start_type, tchkpt_dir,     &
@@ -448,7 +450,7 @@ CONTAINS
          eps_agrid, eps_aarea, eps_omask, eps_ogrid,       &
          eps_oarea, esmf_map_flag,                         &
          reprosum_use_ddpdd, reprosum_diffmax, reprosum_recompute, &
-         mct_usealltoall, mct_usevector, max_cplstep_time
+         mct_usealltoall, mct_usevector, max_cplstep_time, model_doi_url
 
     !-------------------------------------------------------------------------------
 
@@ -559,6 +561,7 @@ CONTAINS
        mct_usealltoall       = .false.
        mct_usevector         = .false.
        max_cplstep_time      = 0.0
+       model_doi_url        = 'unset'
 
        !---------------------------------------------------------------------------
        ! Read in namelist
@@ -750,6 +753,7 @@ CONTAINS
        nullify(infodata%pause_resume)
 
        infodata%max_cplstep_time = max_cplstep_time
+       infodata%model_doi_url = model_doi_url
        !---------------------------------------------------------------
        ! check orbital mode, reset unused parameters, validate settings
        !---------------------------------------------------------------
@@ -1137,6 +1141,7 @@ CONTAINS
     logical,                optional, intent(OUT) :: atm_aero                ! atmosphere aerosols
     logical,                optional, intent(OUT) :: glc_g2lupdate           ! update glc2lnd fields in lnd model
     real(shr_kind_r8),      optional, intent(out) :: max_cplstep_time
+    character(SHR_KIND_CL)  optional, intent(OUT) :: model_doi_url
     logical,                optional, intent(OUT) :: glc_valid_input
     character(SHR_KIND_CL), optional, intent(OUT) :: atm_resume(:) ! atm read resume state
     character(SHR_KIND_CL), optional, intent(OUT) :: lnd_resume(:) ! lnd read resume state
@@ -1379,6 +1384,8 @@ CONTAINS
        end if
     end if
     if ( present(max_cplstep_time) ) max_cplstep_time = infodata%max_cplstep_time
+    if ( present(model_doi_url) ) model_doi_url = model_doi_url
+
     if ( present(glc_valid_input)) glc_valid_input = infodata%glc_valid_input
 
   END SUBROUTINE seq_infodata_GetData_explicit


### PR DESCRIPTION
add model doi url to seq_infodata and to cpl history global attributes

The CMIP6 protocol requires all output history files to contain a model doi url in the global attributes.
This is being implemented in CIME via
- adding a new drv xml variable MODEL_DOI_URL
- adding a cpl namelist variable model_doi_url in seq_infodata_inparm
- adding a call to retrieve this variable from seq_infodata_getdata
- outputting this url to the cpl history file

In CESM, the prognostic components will use infodata to extract this information and add it to their history file global attributes

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: add model_doi_url to seq_infodata_inparm
Test status: bit for bit
Fixes: none
User interface changes?: none
Update gh-pages html (Y/N)?:N
Code review: alice bertini
