### PR TITLE
Transition CIME to using a custom util for copying files.

### DIFF
--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -15,9 +15,8 @@ respectively. These can be changed by setting the environment variables
 COMPILER, MPILIB, and DEBUG, respectively.
 """
 
-import shutil
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
 from CIME.XML.compilers import Compilers
 from CIME.XML.env_mach_specific import EnvMachSpecific
 
@@ -58,13 +57,13 @@ def _copy_depends_files(machine_name, machines_dir, output_dir, compiler):
     outputdfile = os.path.join(output_dir, "Depends.{}.{}".format(machine_name,compiler))
     if os.path.isfile(dfile):
         if not os.path.isfile(outputdfile):
-            shutil.copyfile(dfile, outputdfile)
+            safe_copy(dfile, outputdfile)
     else:
         for dep in (machine_name, compiler):
             dfile = os.path.join(machines_dir, "Depends.{}".format(dep))
             outputdfile = os.path.join(output_dir, "Depends.{}".format(dep))
             if os.path.isfile(dfile) and not os.path.isfile(outputdfile):
-                shutil.copyfile(dfile, outputdfile)
+                safe_copy(dfile, outputdfile)
 
 class FakeCase(object):
 

--- a/scripts/lib/CIME/SystemTests/eri.py
+++ b/scripts/lib/CIME/SystemTests/eri.py
@@ -2,6 +2,7 @@
 CIME ERI test  This class inherits from SystemTestsCommon
 """
 from CIME.XML.standard_module_setup import *
+from CIME.utils import safe_copy
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 import shutil, glob, os
 
@@ -17,7 +18,7 @@ def _helper(dout_sr, refdate, refsec, rundir):
         os.symlink(item, dst)
 
     for item in glob.glob("{}/*rpointer*".format(rest_path)):
-        shutil.copy(item, rundir)
+        safe_copy(item, rundir)
 
 class ERI(SystemTestsCommon):
 

--- a/scripts/lib/CIME/SystemTests/err.py
+++ b/scripts/lib/CIME/SystemTests/err.py
@@ -2,10 +2,10 @@
 CIME ERR test  This class inherits from ERS
 ERR tests short term archiving and restart capabilities
 """
-import glob, os, shutil
+import glob, os
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.restart_tests import RestartTest
-from CIME.utils import ls_sorted_by_mtime
+from CIME.utils import ls_sorted_by_mtime, safe_copy
 
 logger = logging.getLogger(__name__)
 
@@ -46,4 +46,4 @@ class ERR(RestartTest):
                                                  "*.nc.{}".format(self._run_one_suffix))):
             orig_file = case_file[:-(1+len(self._run_one_suffix))]
             if not os.path.isfile(orig_file):
-                shutil.copyfile(case_file, orig_file)
+                safe_copy(case_file, orig_file)

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -3,14 +3,14 @@ Base class for CIME system tests
 """
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_run import EnvRun
-from CIME.utils import append_testlog, get_model
+from CIME.utils import append_testlog, get_model, safe_copy
 from CIME.test_status import *
 from CIME.hist_utils import *
 from CIME.provenance import save_test_time
 from CIME.locked_files import LOCKED_DIR, lock_file, is_locked
 import CIME.build as build
 
-import shutil, glob, gzip, time, traceback, six
+import glob, gzip, time, traceback, six
 
 logger = logging.getLogger(__name__)
 
@@ -453,8 +453,8 @@ class SystemTestsCommon(object):
                 m = re.search(r"/(cpl.*.log).*.gz",cpllog)
                 if m is not None:
                     baselog = os.path.join(basegen_dir, m.group(1))+".gz"
-                    shutil.copyfile(cpllog,
-                                    os.path.join(basegen_dir,baselog))
+                    safe_copy(cpllog,
+                              os.path.join(basegen_dir,baselog))
 
 class FakeTest(SystemTestsCommon):
     """

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -3,10 +3,12 @@ Common interface to XML files, this is an abstract class and is expected to
 be used by other XML interface modules and not directly.
 """
 from CIME.XML.standard_module_setup import *
+from CIME.utils import safe_copy
+
 import xml.etree.ElementTree as ET
 #pylint: disable=import-error
 from distutils.spawn import find_executable
-import getpass, shutil
+import getpass
 import six
 from copy import deepcopy
 
@@ -121,7 +123,7 @@ class GenericXML(object):
             new_case = os.path.dirname(newfile)
             if not os.path.exists(new_case):
                 os.makedirs(new_case)
-            shutil.copy(self.filename, newfile)
+            safe_copy(self.filename, newfile)
 
         self.tree = None
         self.filename = newfile

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -3,7 +3,7 @@ functions for building CIME models
 """
 import glob, shutil, time, threading, subprocess
 from CIME.XML.standard_module_setup  import *
-from CIME.utils                 import get_model, analyze_build_log, stringify_bool, run_and_log_case_status, get_timestamp, run_sub_or_cmd, run_cmd, get_batch_script_for_job, gzip_existing_file
+from CIME.utils                 import get_model, analyze_build_log, stringify_bool, run_and_log_case_status, get_timestamp, run_sub_or_cmd, run_cmd, get_batch_script_for_job, gzip_existing_file, safe_copy
 from CIME.provenance            import save_build_provenance
 from CIME.locked_files          import lock_file, unlock_file
 
@@ -94,7 +94,7 @@ def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
         expect(stat == 0, "BUILD FAIL: buildexe failed, cat {}".format(file_build))
 
         # Copy the just-built ${MODEL}.exe to ${MODEL}.exe.$LID
-        shutil.copy("{}/{}.exe".format(exeroot, cime_model), "{}/{}.exe.{}".format(exeroot, cime_model, lid))
+        safe_copy("{}/{}.exe".format(exeroot, cime_model), "{}/{}.exe.{}".format(exeroot, cime_model, lid))
 
         logs.append(file_build)
 
@@ -301,7 +301,7 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
         thread_bad_results.append("BUILD FAIL: {}.buildlib failed, cat {}".format(compname, file_build))
 
     for mod_file in glob.glob(os.path.join(bldroot, "*_[Cc][Oo][Mm][Pp]_*.mod")):
-        shutil.copy(mod_file, incroot)
+        safe_copy(mod_file, incroot)
 
     t2 = time.time()
     logger.info("{} built in {:f} seconds".format(compname, (t2 - t1)))

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -12,7 +12,7 @@ from six.moves import input
 from CIME.utils                     import expect, get_cime_root, append_status
 from CIME.utils                     import convert_to_type, get_model
 from CIME.utils                     import get_project, get_charge_account, check_name
-from CIME.utils                     import get_current_commit
+from CIME.utils                     import get_current_commit, safe_copy
 from CIME.locked_files         import LOCKED_DIR, lock_file
 from CIME.XML.machines              import Machines
 from CIME.XML.pes                   import Pes
@@ -1057,9 +1057,9 @@ class Case(object):
 
         if get_model() == "e3sm":
             if os.path.exists(os.path.join(machines_dir, "syslog.{}".format(machine))):
-                shutil.copy(os.path.join(machines_dir, "syslog.{}".format(machine)), os.path.join(casetools, "mach_syslog"))
+                safe_copy(os.path.join(machines_dir, "syslog.{}".format(machine)), os.path.join(casetools, "mach_syslog"))
             else:
-                shutil.copy(os.path.join(machines_dir, "syslog.noop"), os.path.join(casetools, "mach_syslog"))
+                safe_copy(os.path.join(machines_dir, "syslog.noop"), os.path.join(casetools, "mach_syslog"))
 
     def _create_caseroot_sourcemods(self):
         components = self.get_compset_components()

--- a/scripts/lib/CIME/case/case_clone.py
+++ b/scripts/lib/CIME/case/case_clone.py
@@ -3,7 +3,7 @@ create_clone is a member of the Case class from file case.py
 """
 import os, glob, shutil
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect, check_name
+from CIME.utils import expect, check_name, safe_copy
 from CIME.user_mod_support import apply_user_mods
 from CIME.locked_files         import lock_file
 from CIME.simple_compare            import compare_files
@@ -108,7 +108,7 @@ def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None,
     files = glob.glob(cloneroot + '/user_*')
 
     for item in files:
-        shutil.copy(item, newcaseroot)
+        safe_copy(item, newcaseroot)
 
     # copy SourceMod and Buildconf files
     # if symlinks exist, copy rather than follow links
@@ -126,8 +126,8 @@ def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None,
         if keepexe:
             # If keepexe CANNOT change any env_build.xml variables - so make a temporary copy of
             # env_build.xml and verify that it has not been modified
-            shutil.copy(os.path.join(newcaseroot, "env_build.xml"),
-                        os.path.join(newcaseroot, "LockedFiles", "env_build.xml"))
+            safe_copy(os.path.join(newcaseroot, "env_build.xml"),
+                      os.path.join(newcaseroot, "LockedFiles", "env_build.xml"))
 
         # Now apply contents of user_mods directory
         apply_user_mods(newcase_root, user_mods_dir, keepexe=keepexe)

--- a/scripts/lib/CIME/case/case_cmpgen_namelists.py
+++ b/scripts/lib/CIME/case/case_cmpgen_namelists.py
@@ -7,7 +7,7 @@ from CIME.XML.standard_module_setup import *
 
 from CIME.compare_namelists import is_namelist_file, compare_namelist_files
 from CIME.simple_compare import compare_files
-from CIME.utils import append_status
+from CIME.utils import append_status, safe_copy
 from CIME.test_status import *
 
 import os, shutil, traceback, stat, glob
@@ -79,7 +79,7 @@ def _do_full_nl_gen(case, test, generate_name, baseline_root=None):
         if (os.path.exists(preexisting_baseline)):
             os.remove(preexisting_baseline)
 
-        shutil.copy2(item, baseline_dir)
+        safe_copy(item, baseline_dir)
         os.chmod(preexisting_baseline, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
 
 def case_cmpgen_namelists(self, compare=False, generate=False, compare_name=None, generate_name=None, baseline_root=None, logfile_name="TestStatus.log"):

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -3,7 +3,7 @@ case_run is a member of Class Case
 '"""
 from CIME.XML.standard_module_setup import *
 from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
-from CIME.utils                     import run_sub_or_cmd, append_status
+from CIME.utils                     import run_sub_or_cmd, append_status, safe_copy
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance
 
@@ -28,7 +28,7 @@ def _pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
 
     if case.get_value("TESTCASE") == "PFS":
         env_mach_pes = os.path.join(caseroot,"env_mach_pes.xml")
-        shutil.copy(env_mach_pes,"{}.{}".format(env_mach_pes, lid))
+        safe_copy(env_mach_pes,"{}.{}".format(env_mach_pes, lid))
 
     # check for locked files.
     case.check_lockedfiles()

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -7,11 +7,9 @@ from CIME.XML.standard_module_setup import *
 
 from CIME.XML.machines      import Machines
 from CIME.BuildTools.configure import configure
-from CIME.utils             import get_cime_root, run_and_log_case_status, get_model, get_batch_script_for_job
+from CIME.utils             import get_cime_root, run_and_log_case_status, get_model, get_batch_script_for_job, safe_copy
 from CIME.test_status       import *
 from CIME.locked_files      import unlock_file, lock_file
-
-import shutil
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +39,7 @@ def _build_usernl_files(case, model, comp):
             expect(ninst_model==ninst_max,"MULTI_DRIVER mode, all components must have same NINST value.  NINST_{} != {}".format(model,ninst_max))
     if comp == "cpl":
         if not os.path.exists("user_nl_cpl"):
-            shutil.copy(os.path.join(model_dir, "user_nl_cpl"), ".")
+            safe_copy(os.path.join(model_dir, "user_nl_cpl"), ".")
     else:
         if ninst == 1:
             ninst = case.get_value("NINST_{}".format(model))
@@ -55,14 +53,14 @@ def _build_usernl_files(case, model, comp):
                     # to user_nl_foo_INST; otherwise, copy the original
                     # user_nl_foo from model_dir
                     if os.path.exists(nlfile):
-                        shutil.copy(nlfile, inst_nlfile)
+                        safe_copy(nlfile, inst_nlfile)
                     elif os.path.exists(model_nl):
-                        shutil.copy(model_nl, inst_nlfile)
+                        safe_copy(model_nl, inst_nlfile)
         else:
             # ninst = 1
             if not os.path.exists(nlfile):
                 if os.path.exists(model_nl):
-                    shutil.copy(model_nl, nlfile)
+                    safe_copy(model_nl, nlfile)
 
 ###############################################################################
 def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):

--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -7,7 +7,7 @@ are members of class Case from file case.py
 import shutil, glob, re, os
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils                     import run_and_log_case_status, ls_sorted_by_mtime, symlink_force
+from CIME.utils                     import run_and_log_case_status, ls_sorted_by_mtime, symlink_force, safe_copy
 from CIME.date                      import get_file_date
 from os.path                        import isdir, join
 
@@ -19,7 +19,7 @@ def _get_archive_file_fn(copy_only):
     """
     Returns the function to use for archiving some files
     """
-    return shutil.copyfile if copy_only else shutil.move
+    return safe_copy if copy_only else shutil.move
 
 ###############################################################################
 def _get_datenames(case):
@@ -134,7 +134,7 @@ def _archive_rpointer_files(casename, ninst_strings, rundir, save_interim_restar
         # Copy of all rpointer files for latest restart date
         rpointers = glob.glob(os.path.join(rundir, 'rpointer.*'))
         for rpointer in rpointers:
-            shutil.copy(rpointer, os.path.join(archive_restdir, os.path.basename(rpointer)))
+            safe_copy(rpointer, os.path.join(archive_restdir, os.path.basename(rpointer)))
     else:
         # Generate rpointer file(s) for interim restarts for the one datename and each
         # possible value of ninst_strings
@@ -263,7 +263,7 @@ def _archive_history_files(case, archive, archive_entry,
                         destfile = join(archive_histdir, histfile)
                         if histfile in histfiles_savein_rundir:
                             logger.debug("histfiles_savein_rundir; copying \n  {} to \n  {} ".format(srcfile, destfile))
-                            shutil.copy(srcfile, destfile)
+                            safe_copy(srcfile, destfile)
                         else:
                             logger.debug("_archive_history_files; moving \n  {} to \n  {} ".format(srcfile, destfile))
                             archive_file_fn(srcfile, destfile)
@@ -379,7 +379,7 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
         last_restart_file_fn = symlink_force
         last_restart_file_fn_msg = "linking"
     else:
-        last_restart_file_fn = shutil.copy
+        last_restart_file_fn = safe_copy
         last_restart_file_fn_msg = "copying"
 
     # the compname is drv but the files are named cpl
@@ -439,7 +439,7 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
                         destfile = os.path.join(archive_restdir, histfile)
                         expect(os.path.isfile(srcfile),
                                "history restart file {} for last date does not exist ".format(srcfile))
-                        shutil.copy(srcfile, destfile)
+                        safe_copy(srcfile, destfile)
                         logger.debug("datename_is_last + histfiles_for_restart copying \n  {} to \n  {}".format(srcfile, destfile))
                 else:
                     # Only archive intermediate restarts if requested - otherwise remove them
@@ -458,7 +458,7 @@ def _archive_restarts_date_comp(case, archive, archive_entry,
                             destfile = os.path.join(archive_restdir, histfile)
                             expect(os.path.isfile(srcfile),
                                    "hist file {} does not exist ".format(srcfile))
-                            shutil.copy(srcfile, destfile)
+                            safe_copy(srcfile, destfile)
                             logger.debug("interim_restarts: copying \n  {} to \n  {}".format(srcfile, destfile))
                     else:
                         srcfile = os.path.join(rundir, restfile)
@@ -536,7 +536,7 @@ def restore_from_archive(self, rest_dir=None):
         if os.path.exists(dst):
             os.remove(dst)
 
-        shutil.copy(item, rundir)
+        safe_copy(item, rundir)
 
 ###############################################################################
 def archive_last_restarts(self, archive_restdir, last_date=None, link_to_restart_files=False):

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -2,11 +2,11 @@
 API for checking input for testcase
 """
 from CIME.XML.standard_module_setup import *
-from CIME.utils import SharedArea, find_files
+from CIME.utils import SharedArea, find_files, safe_copy
 from CIME.XML.inputdata import Inputdata
 import CIME.Servers
 
-import glob, shutil
+import glob
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ and prestage the restart data to $RUNDIR manually
         # copy the refcases' rpointer files to the run directory
         for rpointerfile in glob.iglob(os.path.join("{}","*rpointer*").format(refdir)):
             logger.info("Copy rpointer {}".format(rpointerfile))
-            shutil.copy(rpointerfile, rundir)
+            safe_copy(rpointerfile, rundir)
 
         # link everything else
 

--- a/scripts/lib/CIME/case/preview_namelists.py
+++ b/scripts/lib/CIME/case/preview_namelists.py
@@ -4,8 +4,8 @@ create_dirs and create_namelists are members of Class case from file case.py
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import run_sub_or_cmd
-import glob, shutil
+from CIME.utils import run_sub_or_cmd, safe_copy
+import glob
 logger = logging.getLogger(__name__)
 
 def create_dirs(self):
@@ -102,9 +102,9 @@ def create_namelists(self, component=None):
                    "*streams*txt*", "*stxt", "*maps.rc", "*cism.config*"]:
         for file_to_copy in glob.glob(os.path.join(rundir, cpglob)):
             logger.debug("Copy file from '{}' to '{}'".format(file_to_copy, docdir))
-            shutil.copy2(file_to_copy, docdir)
+            safe_copy(file_to_copy, docdir)
 
     # Copy over chemistry mechanism docs if they exist
     if (os.path.isdir(os.path.join(casebuild, "camconf"))):
         for file_to_copy in glob.glob(os.path.join(casebuild, "camconf", "*chem_mech*")):
-            shutil.copy2(file_to_copy, docdir)
+            safe_copy(file_to_copy, docdir)

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -6,8 +6,9 @@ information from a run.
 """
 
 from CIME.XML.standard_module_setup import *
+from CIME.utils import safe_copy
 
-import datetime, shutil, re
+import datetime, re
 
 logger = logging.getLogger(__name__)
 
@@ -185,14 +186,7 @@ class _TimingParser:
         if not os.path.isdir(timingDir):
             os.makedirs(timingDir)
 
-        try:
-            shutil.copyfile(binfilename, finfilename)
-        except Exception as e:
-            if not os.path.isfile(binfilename):
-                logger.critical("File {} not found".format(binfilename))
-            else:
-                logger.critical("Unable to cp {} to {}".format(binfilename, finfilename))
-            raise e
+        safe_copy(binfilename, finfilename)
 
         os.chdir(self.caseroot)
         try:

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -5,9 +5,9 @@ Functions for actions pertaining to history files.
 from CIME.XML.standard_module_setup import *
 from CIME.test_status import TEST_NO_BASELINES_COMMENT
 
-from CIME.utils import get_current_commit, get_timestamp, get_model
+from CIME.utils import get_current_commit, get_timestamp, get_model, safe_copy
 
-import logging, glob, os, shutil, re, stat, filecmp
+import logging, glob, os, re, stat, filecmp
 logger = logging.getLogger(__name__)
 
 BLESS_LOG_NAME = "bless_log"
@@ -90,7 +90,7 @@ def copy(case, suffix):
             # because the test system will think that run1's files were output
             # by run2. But we live with that downside for the sake of the reason
             # noted above.)
-            shutil.copy(test_hist, new_file)
+            safe_copy(test_hist, new_file)
 
     expect(num_copied > 0, "copy failed: no hist files found in rundir '{}'".format(rundir))
 
@@ -219,7 +219,7 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
                 expected_log_file = os.path.join(casedir, os.path.basename(cprnc_log_file))
                 if not (os.path.exists(expected_log_file) and filecmp.cmp(cprnc_log_file, expected_log_file)):
                     try:
-                        shutil.copy(cprnc_log_file, casedir)
+                        safe_copy(cprnc_log_file, casedir)
                     except (OSError, IOError) as _:
                         logger.warning("Could not copy {} to {}".format(cprnc_log_file, casedir))
 
@@ -404,7 +404,7 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
             if os.path.exists(baseline):
                 os.remove(baseline)
 
-            shutil.copy(hist, baseline)
+            safe_copy(hist, baseline)
             comments += "    generating baseline '{}' from file {}\n".format(baseline, hist)
 
     # copy latest cpl log to baseline
@@ -413,8 +413,7 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
     if newestcpllogfile is None:
         logger.warning("No cpl.log file found in directory {}".format(case.get_value("RUNDIR")))
     else:
-        shutil.copyfile(newestcpllogfile,
-                    os.path.join(basegen_dir, "cpl.log.gz"))
+        safe_copy(newestcpllogfile, os.path.join(basegen_dir, "cpl.log.gz"))
 
     expect(num_gen > 0, "Could not generate any hist files for case '{}', something is seriously wrong".format(os.path.join(rundir, testcase)))
     #make sure permissions are open in baseline directory

--- a/scripts/lib/CIME/locked_files.py
+++ b/scripts/lib/CIME/locked_files.py
@@ -1,5 +1,5 @@
-import shutil
 from CIME.XML.standard_module_setup import *
+from CIME.utils import safe_copy
 logger = logging.getLogger(__name__)
 
 LOCKED_DIR = "LockedFiles"
@@ -19,7 +19,7 @@ def lock_file(filename, caseroot=None, newname=None):
     # GenericXML instances that represent this file and all caching that may
     # have involved this file. We should probably seek a safer way of locking
     # files.
-    shutil.copyfile(os.path.join(caseroot, filename), os.path.join(fulllockdir, newname))
+    safe_copy(os.path.join(caseroot, filename), os.path.join(fulllockdir, newname))
 
 def unlock_file(filename, caseroot=None):
     expect("/" not in filename, "Please just provide basename of locked file")

--- a/scripts/lib/CIME/user_mod_support.py
+++ b/scripts/lib/CIME/user_mod_support.py
@@ -3,8 +3,8 @@ user_mod_support.py
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect, run_cmd_no_fail
-import shutil, glob
+from CIME.utils import expect, run_cmd_no_fail, safe_copy
+import glob
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ def apply_user_mods(caseroot, user_mods_path, keepexe=None):
                     else:
                         logger.info("Adding SourceMod to case {}".format(case_source_mods))
                     try:
-                        shutil.copyfile(source_mods, case_source_mods)
+                        safe_copy(source_mods, case_source_mods)
                     except:
                         expect(False, "Could not write file {} in caseroot {}".format(case_source_mods,caseroot))
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -724,7 +724,47 @@ def match_any(item, re_list):
 
     return False
 
-def safe_copy(src_dir, tgt_dir, file_map):
+def safe_copy(src_path, tgt_path):
+    """
+    A flexbile and safe copy routine. Will try to copy file and metadata, but this
+    can fail if the current user doesn't own the tgt file. A fallback data-only copy is
+    attempted in this case. Works even if overwriting a read-only file.
+
+    tgt_path can be a directory, src_path must be a file
+
+    most of the complexity here is handling the case where the tgt_path file already
+    exists. This problem does not exist for the tree operations so we don't need to wrap those.
+    """
+
+    tgt_path = os.path.join(tgt_path, os.path.basename(src_path)) if os.path.isdir(tgt_path) else tgt_path
+
+    # Handle pre-existing file
+    if os.path.isfile(tgt_path):
+        st = os.stat(tgt_path)
+        owner_uid = st.st_uid
+
+        # Handle read-only files if possible
+        if not os.access(tgt_path, os.W_OK):
+            if owner_uid == os.getuid():
+                # I am the owner, make writeable
+                os.chmod(st.st_mode | statlib.S_IWRITE)
+            else:
+                # I won't be able to copy this file
+                raise OSError("Cannot copy over file {}, it is readonly and you are not the owner".format(tgt_path))
+
+        if owner_uid == os.getuid():
+            # I am the owner, copy file contents, permissions, and metadata
+            shutil.copy2(src_path, tgt_path)
+        else:
+            # I am not the owner, just copy file contents
+            shutil.copyfile(src_path, tgt_path)
+
+    else:
+        # We are making a new file, copy file contents, permissions, and metadata.
+        # This can fail if the underlying directory is not writable by current user.
+        shutil.copy2(src_path, tgt_path)
+
+def safe_recursive_copy(src_dir, tgt_dir, file_map):
     """
     Copies a set of files from one dir to another. Works even if overwriting a
     read-only file. Files can be relative paths and the relative path will be
@@ -734,9 +774,7 @@ def safe_copy(src_dir, tgt_dir, file_map):
         full_tgt = os.path.join(tgt_dir, tgt_file)
         full_src = src_file if os.path.isabs(src_file) else os.path.join(src_dir, src_file)
         expect(os.path.isfile(full_src), "Source dir '{}' missing file '{}'".format(src_dir, src_file))
-        if (os.path.isfile(full_tgt)):
-            os.remove(full_tgt)
-        shutil.copy2(full_src, full_tgt)
+        safe_copy(full_src, full_tgt)
 
 def symlink_force(target, link_name):
     """
@@ -1515,7 +1553,7 @@ def copy_umask(src, dst):
     Preserves all file metadata except making sure new file obeys umask
     """
     curr_umask = get_umask()
-    shutil.copy2(src, dst)
+    safe_copy(src, dst)
     octal_base = 0o777 if os.access(src, os.X_OK) else 0o666
     dst = os.path.join(dst, os.path.basename(src)) if os.path.isdir(dst) else dst
     os.chmod(dst, octal_base - curr_umask)
@@ -1574,7 +1612,7 @@ def resolve_mail_type_args(args):
 def copyifnewer(src, dest):
     """ if dest does not exist or is older than src copy src to dest """
     if not os.path.isfile(dest) or not filecmp.cmp(src, dest):
-        shutil.copy2(src, dest)
+        safe_copy(src, dest)
 
 class SharedArea(object):
     """

--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -7,7 +7,7 @@ import logging
 import xml.etree.ElementTree as xmlet
 
 import CIME.utils
-from CIME.utils import expect, Timeout, run_cmd_no_fail
+from CIME.utils import expect, Timeout, run_cmd_no_fail, safe_copy
 from CIME.XML.machines import Machines
 from CIME.test_status import *
 
@@ -175,9 +175,9 @@ def create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_ti
                     log_dst_dir = os.path.join(log_dir, "{}_{}_logs".format(test_name, param))
                     os.makedirs(log_dst_dir)
                     for log_file in glob.glob(os.path.join(log_src_dir, "*log*")):
-                        shutil.copy(log_file, log_dst_dir)
+                        safe_copy(log_file, log_dst_dir)
                     for log_file in glob.glob(os.path.join(log_src_dir, "*.cprnc.out*")):
-                        shutil.copy(log_file, log_dst_dir)
+                        safe_copy(log_file, log_dst_dir)
 
                     need_to_upload = True
 


### PR DESCRIPTION
The file-copy operation is very common in CIME and we were using
a smattering of shutil.copyfile, shutil.copy, and shutil.copy2.
This PR replaces these with safe_copy, a flexble and fault-tolerant
copying function. This should make it much easier for users to share
case directories and other common directories.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: n

Code review: @jedwards4b 
