### PR TITLE
Change the CESM inputdata server precedence order to gridftp, svn, ftp, wget.

### DIFF
--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -8,6 +8,12 @@
     <protocal>gftp</protocal>
     <address>ftp://gridanon.cgd.ucar.edu:2811/cesm/inputdata/</address>
   </server>
+
+  <server>
+    <protocal>svn</protocal>
+    <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
+  </server>
+
   <server>
     <comment> ftp requires the python package ftplib </comment>
     <protocal>ftp</protocal>
@@ -17,11 +23,6 @@
   <server>
     <protocal>wget</protocal>
     <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata</address>
-  </server>
-
-  <server>
-    <protocal>svn</protocal>
-    <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
   </server>
 
 </inputdata>


### PR DESCRIPTION
Change the CESM inputdata server precedence order to gridftp, svn, ftp, wget.

Test suite: scripts_regression_tests, ERP_D_Ln9.f19_f19_mg17.QPC6.cheyenne_intel.cam-outfrq9s
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:

Code review:
