### PR TITLE
Fix test_scheduler's computation of procs needed for a test

### DIFF
--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -676,16 +676,7 @@ class TestScheduler(object):
         if phase == RUN_PHASE and (self._no_batch or no_batch):
             test_dir = self._get_test_dir(test)
             total_pes = int(run_cmd_no_fail("./xmlquery TOTALPES --value", from_dir=test_dir))
-            threads = eval(run_cmd_no_fail("./xmlquery NTHRDS --value", from_dir=test_dir))
-            max_threads = 0
-            for item in threads:
-                _, comp_threads = item.split(":")
-                comp_threads = int(comp_threads)
-                if comp_threads > max_threads:
-                    max_threads = comp_threads
-
-            max_cores = total_pes * max_threads
-            return max_cores
+            return total_pes
 
         elif (phase == SHAREDLIB_BUILD_PHASE):
             if self._cime_model == "cesm":


### PR DESCRIPTION
TOTALPES now include threads, so there's no need for the thread
multiplier that was happening.

Test suite: code-checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2476 

User interface changes?:  N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
