### PR TITLE
Nodefail fix

### DIFF
--- a/scripts/lib/CIME/SystemTests/nodefail.py
+++ b/scripts/lib/CIME/SystemTests/nodefail.py
@@ -15,10 +15,6 @@ class NODEFAIL(ERS):
         """
         # we need to hard code the regular queue on cheyenne, otherwise this test
         # runs in the share queue and intermitently fails due to a lack of resources
-        if case.get_value("MACH") == "cheyenne":
-            if case.get_value("USER_REQUESTED_QUEUE", subgroup="case.test") != "regular":
-                case.set_value("USER_REQUESTED_QUEUE","regular", subgroup="case.test")
-                case.case_setup(reset=True)
         ERS.__init__(self, case)
 
         self._fail_sentinel = os.path.join(case.get_value("RUNDIR"), "FAIL_SENTINEL")

--- a/scripts/lib/CIME/SystemTests/nodefail.py
+++ b/scripts/lib/CIME/SystemTests/nodefail.py
@@ -17,6 +17,9 @@ class NODEFAIL(ERS):
 
         self._fail_sentinel = os.path.join(case.get_value("RUNDIR"), "FAIL_SENTINEL")
         self._fail_str      = case.get_value("NODE_FAIL_REGEX")
+        if case.get_value("MACH") == "cheyenne":
+            case.set_value("JOB_QUEUE","regular", subgroup="case.test")
+            case.case_setup(reset=True)
 
     def _restart_fake_phase(self):
         # Swap out model.exe for one that emits node failures

--- a/scripts/lib/CIME/SystemTests/nodefail.py
+++ b/scripts/lib/CIME/SystemTests/nodefail.py
@@ -13,8 +13,6 @@ class NODEFAIL(ERS):
         """
         initialize an object interface to the ERS system test
         """
-        # we need to hard code the regular queue on cheyenne, otherwise this test
-        # runs in the share queue and intermitently fails due to a lack of resources
         ERS.__init__(self, case)
 
         self._fail_sentinel = os.path.join(case.get_value("RUNDIR"), "FAIL_SENTINEL")

--- a/scripts/lib/CIME/SystemTests/nodefail.py
+++ b/scripts/lib/CIME/SystemTests/nodefail.py
@@ -13,13 +13,16 @@ class NODEFAIL(ERS):
         """
         initialize an object interface to the ERS system test
         """
+        # we need to hard code the regular queue on cheyenne, otherwise this test
+        # runs in the share queue and intermitently fails due to a lack of resources
+        if case.get_value("MACH") == "cheyenne":
+            if case.get_value("USER_REQUESTED_QUEUE", subgroup="case.test") != "regular":
+                case.set_value("USER_REQUESTED_QUEUE","regular", subgroup="case.test")
+                case.case_setup(reset=True)
         ERS.__init__(self, case)
 
         self._fail_sentinel = os.path.join(case.get_value("RUNDIR"), "FAIL_SENTINEL")
         self._fail_str      = case.get_value("NODE_FAIL_REGEX")
-        if case.get_value("MACH") == "cheyenne":
-            case.set_value("JOB_QUEUE","regular", subgroup="case.test")
-            case.case_setup(reset=True)
 
     def _restart_fake_phase(self):
         # Swap out model.exe for one that emits node failures

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -329,8 +329,8 @@ class EnvBatch(EnvBase):
                 dnodes = self.get_children("directives", root=root)
                 for dnode in dnodes:
                     nodes = self.get_children("directive", root=dnode)
-                    for node in nodes:
-                        if self._match_attribs(self.attrib(node), case, queue):
+                    if self._match_attribs(self.attrib(dnode), case, queue):
+                        for node in nodes:
                             directive = self.get_resolved_value("" if self.text(node) is None else self.text(node))
                             default = self.get(node, "default")
                             if default is None:

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -474,6 +474,14 @@ class TestScheduler(object):
 
         if self._queue is not None:
             create_newcase_cmd += " --queue={}".format(self._queue)
+        else:
+            # We need to hard code the queue for this test on cheyenne
+            # otherwise it runs in share and fails intermittently
+            test_case = CIME.utils.parse_test_name(test)[0]
+            if test_case == "NODEFAIL":
+                machine = machine if machine is not None else self._machobj.get_machine_name()
+                if machine == "cheyenne":
+                    create_newcase_cmd += " --queue=regular"
 
         if self._walltime is not None:
             create_newcase_cmd += " --walltime {}".format(self._walltime)


### PR DESCRIPTION
Because of the way the share queue is defined on cheyenne we need to force the NODEFAIL test to run on the regular queue.    There was also an error in parsing directives that left multiple repeats of the PBS directives in the derived .case.run and .case.test files. 

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2483 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
