### PR TITLE
Simple compare improvement

### DIFF
--- a/scripts/lib/CIME/case/case_cmpgen_namelists.py
+++ b/scripts/lib/CIME/case/case_cmpgen_namelists.py
@@ -29,8 +29,7 @@ def _do_full_nl_comp(case, test, compare_name, baseline_root=None):
                             if "README" not in os.path.basename(item)\
                             and not item.endswith("doc")\
                             and not item.endswith("prescribed")\
-                            and not os.path.basename(item).startswith(".")] + \
-                            glob.glob("{}/*user_nl*".format(test_dir))
+                            and not os.path.basename(item).startswith(".")]
 
     comments = "NLCOMP\n"
     for item in all_items_to_compare:

--- a/scripts/lib/CIME/simple_compare.py
+++ b/scripts/lib/CIME/simple_compare.py
@@ -102,9 +102,13 @@ def _compare_data(gold_lines, comp_lines, case):
         if (norm_gold_value != norm_comp_value):
             comments += "Inequivalent lines {} != {}\n".format(gold_value, comp_value)
             comments += "  NORMALIZED: {} != {}\n".format(norm_gold_value, norm_comp_value)
-
-        gidx += 1
-        cidx += 1
+            if gnum < cnum:
+                cidx += 1
+            elif cnum < gnum:
+                gidx += 1
+        else:
+            gidx += 1
+            cidx += 1
 
     return comments
 

--- a/scripts/lib/CIME/simple_compare.py
+++ b/scripts/lib/CIME/simple_compare.py
@@ -43,7 +43,7 @@ def _skip_comments_and_whitespace(lines, idx):
     return idx
 
 ###############################################################################
-def _compare_data(gold_lines, comp_lines, case):
+def _compare_data(gold_lines, comp_lines, case, offset_method=False):
 ###############################################################################
     """
     >>> teststr = '''
@@ -55,7 +55,7 @@ def _compare_data(gold_lines, comp_lines, case):
     ... data7 data8 data9 data10
     ... '''
     >>> _compare_data(teststr.splitlines(), teststr.splitlines(), None)
-    ''
+    ('', 0)
 
     >>> teststr2 = '''
     ... data1
@@ -64,15 +64,27 @@ def _compare_data(gold_lines, comp_lines, case):
     ... data7 data8 data9 data10
     ... data00
     ... '''
-    >>> results = _compare_data(teststr.splitlines(), teststr2.splitlines(), None)
+    >>> results,_ = _compare_data(teststr.splitlines(), teststr2.splitlines(), None)
     >>> print(results)
     Inequivalent lines data2 data3 != data2 data30
       NORMALIZED: data2 data3 != data2 data30
     Found extra lines
     data00
     <BLANKLINE>
+    >>> teststr3 = '''
+    ... data1
+    ... data4 data5 data6
+    ... data7 data8 data9 data10
+    ... data00
+    ... '''
+    >>> results,_ = _compare_data(teststr3.splitlines(), teststr2.splitlines(), None, offset_method=True)
+    >>> print(results)
+    Inequivalent lines data4 data5 data6 != data2 data30
+      NORMALIZED: data4 data5 data6 != data2 data30
+    <BLANKLINE>
     """
     comments = ""
+    cnt = 0
     gidx, cidx = 0, 0
     gnum, cnum = len(gold_lines), len(comp_lines)
     while (gidx < gnum or cidx < cnum):
@@ -81,15 +93,15 @@ def _compare_data(gold_lines, comp_lines, case):
 
         if (gidx == gnum):
             if (cidx == cnum):
-                return comments
+                return comments, cnt
             else:
                 comments += "Found extra lines\n"
                 comments += "\n".join(comp_lines[cidx:]) + "\n"
-                return comments
+                return comments, cnt
         elif (cidx == cnum):
             comments += "Missing lines\n"
             comments += "\n".join(gold_lines[gidx:1]) + "\n"
-            return comments
+            return comments, cnt
 
         gold_value = gold_lines[gidx].strip()
         gold_value = gold_value.replace('"',"'")
@@ -102,15 +114,17 @@ def _compare_data(gold_lines, comp_lines, case):
         if (norm_gold_value != norm_comp_value):
             comments += "Inequivalent lines {} != {}\n".format(gold_value, comp_value)
             comments += "  NORMALIZED: {} != {}\n".format(norm_gold_value, norm_comp_value)
-            if gnum < cnum:
-                cidx += 1
-            elif cnum < gnum:
+            cnt += 1
+        if offset_method and (norm_gold_value != norm_comp_value):
+            if gnum > cnum:
                 gidx += 1
+            else:
+                cidx += 1
         else:
             gidx += 1
             cidx += 1
 
-    return comments
+    return comments, cnt
 
 ###############################################################################
 def compare_files(gold_file, compare_file, case=None):
@@ -122,7 +136,14 @@ def compare_files(gold_file, compare_file, case=None):
     expect(os.path.exists(gold_file), "File not found: {}".format(gold_file))
     expect(os.path.exists(compare_file), "File not found: {}".format(compare_file))
 
-    comments = _compare_data(open(gold_file, "r").readlines(),
-                             open(compare_file, "r").readlines(),
-                             case)
+    comments, cnt = _compare_data(open(gold_file, "r").readlines(),
+                             open(compare_file, "r").readlines(), case)
+
+    if cnt > 0:
+        comments2, cnt2 = _compare_data(open(gold_file, "r").readlines(),
+                                        open(compare_file, "r").readlines(),
+                                        case, offset_method=True)
+        if cnt2 < cnt:
+            comments = comments2
+
     return comments == "", comments


### PR DESCRIPTION
Remove the direct comparison of user_nl_* files - this is already done in CaseDocs
Add an offset option to the simple_compare _compare_data method and if the default method shows differences, try the second method and keep the version with fewest differences.   Add a doctest
Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #2343 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
