### PR TITLE
Make st_archive handle DART's restart history files.

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -156,6 +156,7 @@
 
     <comp_archive_spec compclass="esp" compname="dart">
       <rest_file_extension>r</rest_file_extension>
+      <rest_file_extension>rh\d?</rest_file_extension>
       <hist_file_extension>[ei]</hist_file_extension>
       <rest_history_varname>restart_hist</rest_history_varname>
       <rpointer>
@@ -163,7 +164,14 @@
         <rpointer_content>unset</rpointer_content>
       </rpointer>
       <test_file_names>
-      <tfile disposition="move">casename.dart.e.pop_preassim_priorinf_mean.1976-01-01-00000.nc</tfile>
+        <!-- Copy the little restart file and the files it references -->
+        <tfile disposition="copy">casename.dart.r.1976-01-01-00000.nc</tfile>
+        <tfile disposition="copy">casename.dart.rh.pop_preassim_priorinf_mean.1976-01-01-00000.nc</tfile>
+        <tfile disposition="copy">casename.dart.rh.cam_preassim_priorinf_mean.1976-01-01-00000.nc</tfile>
+        <!-- Move all the rest -->
+        <tfile disposition="move">casename.dart.e.cam_postassim_mean.1976-01-01-00000.nc</tfile>
+        <tfile disposition="move">casename.dart.i.cam_output_mean.1976-01-01-00000.nc</tfile>
+        <tfile disposition="move">casename.dart.e.cam_obs_seq_final.1976-01-01-00000.nc</tfile>
       </test_file_names>
     </comp_archive_spec>
   </components>

--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -392,10 +392,10 @@ def _archive_restarts_date_comp(case, casename, rundir, archive, archive_entry,
             restfiles = [f for f in os.listdir(rundir) if pfile.search(f)]
             print ("HERE pfile {} restfiles {}".format(pfile, restfiles))
         else:
-            pattern = r"^{}.{}[\d_]*\..*".format(casename, compname)
+            pattern = r"^{}\.{}[\d_]*\.".format(casename, compname)
             pfile = re.compile(pattern)
             files = [f for f in os.listdir(rundir) if pfile.search(f)]
-            pattern =  r'_?' + r'\d*'  +  r'\.' + suffix + r'\.' + datename_str
+            pattern =  r'_?' + r'\d*' + r'\.' + suffix + r'\.' + r'[^\.]*' + r'\.?' + datename_str
             pfile = re.compile(pattern)
             restfiles = [f for f in files if pfile.search(f)]
             logger.debug("pattern is {} restfiles {}".format(pattern, restfiles))


### PR DESCRIPTION
case_st_archive.py:
   Enhance the 'restfiles' pattern in _archive_restarts_date_comp
   to find files which have a 'string' following the 'suffix'
   ($case.$comp.rh.$string.$date.nc).

   Improve the pattern used to find 'files' to be more selective
   (search for '\.' instead of '.' between $case and $comp) and to not
   search for '.*' at the end.

config/cesm/config_archive.xml:
   Add test file names into the dart section,
   including rh files.


Test suite: case.st_archive --test
Test baseline: 
Test namelist changes: none
Test status: bit for bit

Fixes  #2470

User interface changes?: none

Update gh-pages html (Y/N)?:

Code review: 
