### PR TITLE
Fix for testreporter.py

### DIFF
--- a/scripts/lib/CIME/XML/test_reporter.py
+++ b/scripts/lib/CIME/XML/test_reporter.py
@@ -19,7 +19,7 @@ class TestReporter(GenericXML):
         expect(get_model() == 'cesm', "testreport is only meant to populate the CESM test database." )
         self.root = None
 
-        GenericXML.__init__(self, root_name_override="testrecord")
+        GenericXML.__init__(self, root_name_override="testrecord", read_only=False, infile="TestRecord.xml")
 
     def setup_header(self, tagname,machine,compiler,mpilib,testroot,testtype,baseline):
         #


### PR DESCRIPTION
Fix for testreporter.py script.  Was getting "ERROR: locked",
and "AttributeError: 'NoneType' object has no attribute 'xml_element'",
error messages.

testreporter.py is only used to populate the CESM testing database.

Test suite: scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:

Code review:
