### PR TITLE
Match entire string for XML attribute selectors for env_mach_specific

### DIFF
--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -245,12 +245,12 @@ class EnvMachSpecific(EnvBase):
 
     def _match(self, my_value, xml_value):
         if xml_value.startswith("!"):
-            result = re.match(xml_value[1:],str(my_value)) is None
+            result = re.match(xml_value[1:] + "$",str(my_value)) is None
         elif isinstance(my_value, bool):
             if my_value: result = xml_value == "TRUE"
             else: result = xml_value == "FALSE"
         else:
-            result = re.match(xml_value,str(my_value)) is not None
+            result = re.match(xml_value + "$",str(my_value)) is not None
 
         logger.debug("(env_mach_specific) _match {} {} {}".format(my_value, xml_value, result))
         return result


### PR DESCRIPTION
If a machine has compilers "intel" and "intel18", we don't want to
match "intel" selectors when the user asks for "intel18" compiler.
If the user truly wants to express the concept "match any intel compiler",
they can use "intel.*" as the selector.

Looking over config_machines.xml for both e3sm and cesm, I don't think any machine was intentionally making-use of partial-string matching, except for maybe yellowstone.

Test suite: scripts_regression_tests, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2472 

User interface changes?: Yes, changes to matching behavior in env_mach_specific

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
