### PR TITLE
Check input logic fix

### DIFF
--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -46,7 +46,6 @@ def check_all_input_data(self, protocal=None, address=None, input_data_root=None
     else:
         success = self.check_input_data(protocal=protocal, address=address, download=False,
                                    input_data_root=input_data_root, data_list_dir=data_list_dir)
-        print ("HERE download {} success {}".format(download, success))
         if download and not success:
             success = _downloadfromserver(self, input_data_root, data_list_dir)
 

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -46,6 +46,7 @@ def check_all_input_data(self, protocal=None, address=None, input_data_root=None
     else:
         success = self.check_input_data(protocal=protocal, address=address, download=False,
                                    input_data_root=input_data_root, data_list_dir=data_list_dir)
+        print ("HERE download {} success {}".format(download, success))
         if download and not success:
             success = _downloadfromserver(self, input_data_root, data_list_dir)
 
@@ -177,7 +178,7 @@ def check_input_data(case, protocal="svn", address=None, input_data_root=None, d
                         # rel_path, and so cannot download the file. If it already exists, we can
                         # proceed
                         if not os.path.exists(full_path):
-                            logging.warning("  Model {} missing file {} = '{}'".format(model, description, full_path))
+                            logging.warning("Model {} missing file {} = '{}'".format(model, description, full_path))
                             if download:
                                 logging.warning("    Cannot download file since it lives outside of the input_data_root '{}'".format(input_data_root))
                             no_files_missing = False
@@ -193,12 +194,11 @@ def check_input_data(case, protocal="svn", address=None, input_data_root=None, d
                         # value and ignore it (perhaps with a warning)
                         if ("/" in rel_path and not os.path.exists(full_path)):
                             logging.warning("  Model {} missing file {} = '{}'".format(model, description, full_path))
+                            no_files_missing = False
 
                             if (download):
-                                success = _download_if_in_repo(server, input_data_root, rel_path.strip(os.sep),
+                                no_files_missing = _download_if_in_repo(server, input_data_root, rel_path.strip(os.sep),
                                                                isdirectory=rel_path.endswith(os.sep))
-                                if not success:
-                                    no_files_missing = False
                         else:
                             logging.debug("  Already had input file: '{}'".format(full_path))
 


### PR DESCRIPTION
A logic error in check_input_data causes missing data not to be downloaded unless check_input_data is run by hand. 
Test suite: hand tests of SMS.f19_g16.X.cheyenne_intel with DIN_LOC_ROOT changed to a temporary path. 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2497 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
