### PR TITLE
Testreporter fix.

### DIFF
--- a/scripts/lib/CIME/XML/test_reporter.py
+++ b/scripts/lib/CIME/XML/test_reporter.py
@@ -55,7 +55,7 @@ class TestReporter(GenericXML):
         #
         # Post test result XML to CESM test database
         #
-        xmlstr = self.to_string(self.root,method="xml",encoding="UTF-8")
+        xmlstr = self.get_raw_record()
         username=six.moves.input("Username:")
         os.system("stty -echo")
         password=six.moves.input("Password:")


### PR DESCRIPTION
Fix to allow testreporter.py to populate the test database.

Test suite: scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:

Code review:
