### PR TITLE
only check for rundir if not a test

### DIFF
--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -20,9 +20,10 @@ def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
         job = case.get_primary_job()
 
     rundir = case.get_value("RUNDIR")
-    continue_run = case.get_value("CONTINUE_RUN")
-    expect(os.path.isdir(rundir) or not continue_run,
-           " CONTINUE_RUN is true but RUNDIR {} does not exist".format(rundir))
+    if job != "case.test":
+        continue_run = case.get_value("CONTINUE_RUN")
+        expect(os.path.isdir(rundir) or not continue_run,
+               " CONTINUE_RUN is true but RUNDIR {} does not exist".format(rundir))
 
     # if case.submit is called with the no_batch flag then we assume that this
     # flag will stay in effect for the duration of the RESUBMITs


### PR DESCRIPTION
We simply need to avoid this check for rundir if this is a test. 

Test suite: scripts_regression_tests.py, hand rerun of system test SMS.f19_g16.X 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2507 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
