### PR TITLE
use nodefail code for cheyenne 

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -253,6 +253,7 @@
   <machine MACH="cheyenne">
     <DESC>NCAR SGI platform, os is Linux, 36 pes/node, batch system is PBS</DESC>
     <NODENAME_REGEX>.*.cheyenne.ucar.edu</NODENAME_REGEX>
+    <NODE_FAIL_REGEX>MPT ERROR: could not launch executable</NODE_FAIL_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu,pgi</COMPILERS>
     <MPILIBS compiler="intel" >mpt,openmpi</MPILIBS>

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -93,7 +93,10 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
 
     rundir = case.get_value("RUNDIR")
     loop = True
-
+    machine = case.get_value("MACH")
+    # special case of using the NODE_FAIL_REGEX code on cheyenne to avoid an mpt timeout issue on startup
+    if machine == "cheyenne":
+        case.spare_nodes = 2
     while loop:
         loop = False
 
@@ -115,8 +118,9 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
                         logger.warning("Detected model run failed due to node failure, restarting")
 
                         # Archive the last consistent set of restart files and restore them
-                        case.case_st_archive(no_resubmit=True)
-                        case.restore_from_archive()
+                        if not machine == "cheyenne":
+                            case.case_st_archive(no_resubmit=True)
+                            case.restore_from_archive()
 
                         case.set_value("CONTINUE_RUN",
                                        case.get_value("RESUBMIT_SETS_CONTINUE_RUN"))

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -93,9 +93,12 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
 
     rundir = case.get_value("RUNDIR")
     loop = True
-    machine = case.get_value("MACH")
+
     # special case of using the NODE_FAIL_REGEX code on cheyenne to avoid an mpt timeout issue on startup
-    if machine == "cheyenne":
+    # in this case no spare nodes are required, we simply try again on the same nodes.  We will make 2
+    # attempts to retry.
+    node_fail_re = case.get_value("NODE_FAIL_REGEX")
+    if node_fail_re and not case.get_value('ALLOCATE_SPARE_NODES'):
         case.spare_nodes = 2
     while loop:
         loop = False
@@ -107,7 +110,6 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
         model_logfile = os.path.join(rundir, model + ".log." + lid)
         # Determine if failure was due to a failed node, if so, try to restart
         if stat != 0:
-            node_fail_re = case.get_value("NODE_FAIL_REGEX")
             if node_fail_re:
                 node_fail_regex = re.compile(node_fail_re)
                 model_logfile = os.path.join(rundir, model + ".log." + lid)
@@ -118,7 +120,7 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
                         logger.warning("Detected model run failed due to node failure, restarting")
 
                         # Archive the last consistent set of restart files and restore them
-                        if not machine == "cheyenne":
+                        if case.get_value("ALLOCATE_SPARE_NODES"):
                             case.case_st_archive(no_resubmit=True)
                             case.restore_from_archive()
 


### PR DESCRIPTION
Use the nodefail code to retry jobs on cheyenne when MPT timeouts occur on startup.
NODE_FAIL_REGEX="MPT ERROR: could not launch executable"

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
