### PR TITLE
Enables submitting resubmits early and for prerequisites to fail when the user requests it

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -104,6 +104,7 @@
     <batch_directive>#BSUB</batch_directive>
     <jobid_pattern>&lt;(\d+)&gt;</jobid_pattern>
     <depend_string> -w 'done(jobid)'</depend_string>
+    <depend_allow_string> -w 'ended(jobid)'</depend_allow_string>
     <depend_separator>&amp;&amp;</depend_separator>
     <walltime_format>%H:%M</walltime_format>
     <batch_mail_flag>-u</batch_mail_flag>
@@ -133,6 +134,7 @@
     <batch_directive>#PBS</batch_directive>
     <jobid_pattern>^(\S+)$</jobid_pattern>
     <depend_string> -W depend=afterok:jobid</depend_string>
+    <depend_allow_string> -W depend=afterany:jobid</depend_allow_string>
     <depend_separator>:</depend_separator>
     <walltime_format>%H:%M:%S</walltime_format>
     <batch_mail_flag>-M</batch_mail_flag>
@@ -158,6 +160,7 @@
     <batch_directive>#SBATCH</batch_directive>
     <jobid_pattern>(\d+)$</jobid_pattern>
     <depend_string> --dependency=afterok:jobid</depend_string>
+    <depend_allow_string> --dependency=afterany:jobid</depend_allow_string>
     <depend_separator>,</depend_separator>
     <walltime_format>%H:%M:%S</walltime_format>
     <batch_mail_flag>--mail-user</batch_mail_flag>

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -48,6 +48,10 @@ OR
     parser.add_argument("--skip-preview-namelist", action="store_true",
                         help="Skip calling preview-namelist during case.run")
 
+    parser.add_argument("--completion-sets-continue-run", action="store_true",
+                        help="This is used to ensure CONTINUE_RUN is cleared for an initial run, "
+                        "but set for subsequent runs."
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
@@ -56,16 +60,16 @@ OR
     if args.skip_preview_namelist is None:
         args.skip_preview_namelist = False
 
-    return args.caseroot, args.skip_preview_namelist
+    return args.caseroot, args.skip_preview_namelist, args.set_continue_run
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
-    caseroot, skip_pnl = parse_command_line(sys.argv, description)
+    caseroot, skip_pnl, set_continue_run  = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        success = case.case_run(skip_pnl=skip_pnl)
+        success = case.case_run(skip_pnl=skip_pnl, set_continue_run=set_continue_run)
 
     sys.exit(0 if success else 1)
 

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -60,7 +60,7 @@ OR
     if args.skip_preview_namelist is None:
         args.skip_preview_namelist = False
 
-    return args.caseroot, args.skip_preview_namelist, args.set_continue_run
+    return args.caseroot, args.skip_preview_namelist, args.completion_sets_continue_run
 
 ###############################################################################
 def _main_func(description):

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -52,6 +52,9 @@ OR
                         help="This is used to ensure CONTINUE_RUN is cleared for an initial run, "
                         "but set for subsequent runs.")
 
+    parser.add_argument("--resubmit", default=False, action="store_true",
+                        help="If RESUBMIT is set, this performs the resubmissions.")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
@@ -60,16 +63,16 @@ OR
     if args.skip_preview_namelist is None:
         args.skip_preview_namelist = False
 
-    return args.caseroot, args.skip_preview_namelist, args.completion_sets_continue_run
+    return args.caseroot, args.skip_preview_namelist, args.completion_sets_continue_run, args.resubmit
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
-    caseroot, skip_pnl, set_continue_run  = parse_command_line(sys.argv, description)
+    caseroot, skip_pnl, set_continue_run, resubmit = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        success = case.case_run(skip_pnl=skip_pnl, set_continue_run=set_continue_run)
+        success = case.case_run(skip_pnl=skip_pnl, set_continue_run=set_continue_run, submit_resubmits=resubmit)
 
     sys.exit(0 if success else 1)
 

--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -50,7 +50,7 @@ OR
 
     parser.add_argument("--completion-sets-continue-run", action="store_true",
                         help="This is used to ensure CONTINUE_RUN is cleared for an initial run, "
-                        "but set for subsequent runs."
+                        "but set for subsequent runs.")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 

--- a/config/cesm/machines/template.st_archive
+++ b/config/cesm/machines/template.st_archive
@@ -64,6 +64,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--test", default=False, action="store_true",
                         help="Run tests of st_archiver functionality")
 
+    parser.add_argument("--resubmit", default=False, action="store_true",
+                        help="If RESUBMIT is set, this performs the resubmissions."
+                        "This is primarily meant for use by case.submit")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
@@ -75,20 +79,21 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     if args.force_move is True:
         args.copy_only = False
 
-    return args.caseroot, args.last_date, args.no_incomplete_logs, args.copy_only, args.test
+    return (args.caseroot, args.last_date, args.no_incomplete_logs, args.copy_only,
+            args.test, args.resubmit)
 
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    caseroot, last_date, no_incomplete_logs, copy_only, test = parse_command_line(sys.argv, description)
+    caseroot, last_date, no_incomplete_logs, copy_only, test, resubmit = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
         if test:
             success = case.test_st_archive()
         else:
             success = case.case_st_archive(last_date_str=last_date,
                                            archive_incomplete_logs=not no_incomplete_logs,
-                                           copy_only=copy_only)
+                                           copy_only=copy_only, no_resubmit=not resubmit)
 
     sys.exit(0 if success else 1)
 

--- a/config/e3sm/machines/config_batch.xml
+++ b/config/e3sm/machines/config_batch.xml
@@ -107,6 +107,7 @@
     <batch_directive>#BSUB</batch_directive>
     <jobid_pattern>&lt;(\d+)&gt;</jobid_pattern>
     <depend_string> -w 'done(jobid)'</depend_string>
+    <depend_allow_string> -w 'ended(jobid)'</depend_allow_string>
     <depend_separator>&amp;&amp;</depend_separator>
     <walltime_format>%H:%M</walltime_format>
     <batch_mail_flag>-u</batch_mail_flag>
@@ -133,6 +134,7 @@
     <batch_directive>#PBS</batch_directive>
     <jobid_pattern>^(\S+)$</jobid_pattern>
     <depend_string>-W depend=afterok:jobid</depend_string>
+    <depend_allow_string>-W depend=afterany:jobid</depend_allow_string>
     <depend_separator>:</depend_separator>
     <walltime_format>%H:%M:%S</walltime_format>
     <batch_mail_flag>-M</batch_mail_flag>
@@ -159,6 +161,7 @@
     <batch_directive>#MSUB</batch_directive>
     <jobid_pattern>(\d+)$</jobid_pattern>
     <depend_string>-W depend=afterok:jobid</depend_string>
+    <depend_allow_string>-W depend=afterany:jobid</depend_allow_string>
     <depend_separator>:</depend_separator>
     <walltime_format>%H:%M:%S</walltime_format>
     <batch_mail_flag>-M</batch_mail_flag>
@@ -213,6 +216,7 @@
     <batch_directive>#SBATCH</batch_directive>
     <jobid_pattern>(\d+)$</jobid_pattern>
     <depend_string>--dependency=afterok:jobid</depend_string>
+    <depend_allow_string>--dependency=afterany:jobid</depend_allow_string>
     <depend_separator>:</depend_separator>
     <walltime_format>%H:%M:%S</walltime_format>
     <batch_mail_flag>--mail-user</batch_mail_flag>

--- a/config/e3sm/machines/config_batch.xml
+++ b/config/e3sm/machines/config_batch.xml
@@ -238,6 +238,7 @@
     <batch_directive>#SBATCH</batch_directive>
     <jobid_pattern>(\d+)$</jobid_pattern>
     <depend_string>--dependency=afterok:jobid</depend_string>
+    <depend_allow_string>--dependency=afterany:jobid</depend_allow_string>
     <depend_separator>:</depend_separator>
     <walltime_format>%H:%M:%S</walltime_format>
     <batch_mail_flag>--mail-user</batch_mail_flag>

--- a/config/e3sm/machines/template.case.run
+++ b/config/e3sm/machines/template.case.run
@@ -53,6 +53,9 @@ OR
                         help="This is used to ensure CONTINUE_RUN is cleared for an initial run, "
                         "but set for subsequent runs.")
 
+    parser.add_argument("--resubmit", default=False, action="store_true",
+                        help="If RESUBMIT is set, this performs the resubmissions.")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
@@ -61,16 +64,16 @@ OR
     if args.skip_preview_namelist is None:
         args.skip_preview_namelist = False
 
-    return args.caseroot, args.skip_preview_namelist, args.completion_sets_continue_run
+    return args.caseroot, args.skip_preview_namelist, args.completion_sets_continue_run, args.resubmit
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
-    caseroot, skip_pnl, set_continue_run = parse_command_line(sys.argv, description)
+    caseroot, skip_pnl, set_continue_run, resubmit = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        success = case.case_run(skip_pnl=skip_pnl, set_continue_run=set_continue_run)
+        success = case.case_run(skip_pnl=skip_pnl, set_continue_run=set_continue_run, submit_resubmits=resubmit)
 
     sys.exit(0 if success else 1)
 

--- a/config/e3sm/machines/template.case.run
+++ b/config/e3sm/machines/template.case.run
@@ -51,7 +51,7 @@ OR
 
     parser.add_argument("--completion-sets-continue-run", action="store_true",
                         help="This is used to ensure CONTINUE_RUN is cleared for an initial run, "
-                        "but set for subsequent runs."
+                        "but set for subsequent runs.")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 

--- a/config/e3sm/machines/template.case.run
+++ b/config/e3sm/machines/template.case.run
@@ -49,6 +49,10 @@ OR
     parser.add_argument("--skip-preview-namelist", action="store_true",
                         help="Skip calling preview-namelist during case.run")
 
+    parser.add_argument("--completion-sets-continue-run", action="store_true",
+                        help="This is used to ensure CONTINUE_RUN is cleared for an initial run, "
+                        "but set for subsequent runs."
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
@@ -57,16 +61,16 @@ OR
     if args.skip_preview_namelist is None:
         args.skip_preview_namelist = False
 
-    return args.caseroot, args.skip_preview_namelist
+    return args.caseroot, args.skip_preview_namelist, args.completion_sets_continue_run
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
     sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
 
-    caseroot, skip_pnl = parse_command_line(sys.argv, description)
+    caseroot, skip_pnl, set_continue_run = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        success = case.case_run(skip_pnl=skip_pnl)
+        success = case.case_run(skip_pnl=skip_pnl, set_continue_run=set_continue_run)
 
     sys.exit(0 if success else 1)
 

--- a/config/e3sm/machines/template.st_archive
+++ b/config/e3sm/machines/template.st_archive
@@ -64,6 +64,10 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--test", default=False, action="store_true",
                         help="Run tests of st_archiver functionality")
 
+    parser.add_argument("--resubmit", default=False, action="store_true",
+                        help="If RESUBMIT is set, this performs the resubmissions."
+                        "This is primarily meant for use by case.submit")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.caseroot is not None:
@@ -75,20 +79,21 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     if args.force_move is True:
         args.copy_only = False
 
-    return args.caseroot, args.last_date, args.no_incomplete_logs, args.copy_only, args.test
+    return (args.caseroot, args.last_date, args.no_incomplete_logs, args.copy_only,
+            args.test, args.resubmit)
 
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    caseroot, last_date, no_incomplete_logs, copy_only, test = parse_command_line(sys.argv, description)
+    caseroot, last_date, no_incomplete_logs, copy_only, test, resubmit = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
         if test:
             success = case.test_st_archive()
         else:
             success = case.case_st_archive(last_date_str=last_date,
                                            archive_incomplete_logs=not no_incomplete_logs,
-                                           copy_only=copy_only)
+                                           copy_only=copy_only, no_resubmit=not resubmit)
 
     sys.exit(0 if success else 1)
 

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -17,6 +17,7 @@
   <xs:element name="batch_directive" type="xs:string"/>
   <xs:element name="jobid_pattern" type="xs:string"/>
   <xs:element name="depend_string" type="xs:string"/>
+  <xs:element name="depend_allow_string" type="xs:string"/>
   <xs:element name="depend_separator" type="xs:string"/>
   <xs:element name="walltime_format" type="xs:string"/>
   <xs:element name="batch_mail_flag" type="xs:string"/>
@@ -71,6 +72,7 @@
   <!-- depend_string: How to indicate to batch system that this job should not run until
        a previous job has completed successfully -->
         <xs:element minOccurs="0" ref="depend_string"/>
+	<xs:element minOccurs="0" ref="depend_allow_string"/>
 
   <!-- depend_separator: How to separate multiple batch job dependencies -->
         <xs:element minOccurs="0" ref="depend_separator"/>

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -39,8 +39,14 @@ OR
                         help="Do not submit jobs to batch system, run locally.")
 
     parser.add_argument("--prereq",
-                        help="Specify a prerequiset job id, this job will not start until the "
+                        help="Specify a prerequisite job id, this job will not start until the "
                         "job with this id is completed (batch mode only)")
+
+    parser.add_argument("--prereq-allow-failure", action="store_true",
+                        help="Allows starting the run even if the prerequisite fails."
+                        "This also allows resubmits to run if the original failed and the "
+                        "resubmit was submitted to the queue with the orginal as a dependency, "
+                        "as in the case of --resubmit-immediate")
 
     parser.add_argument("--resubmit", action="store_true",
                         help="Used with tests only, to continue rather than restart a test. ")
@@ -57,14 +63,14 @@ OR
 
     CIME.utils.resolve_mail_type_args(args)
 
-    return args.caseroot, args.job, args.no_batch, args.prereq, \
+    return args.caseroot, args.job, args.no_batch, args.prereq, args.prereq_allow_failure, \
         args.resubmit, args.skip_preview_namelist, args.mail_user, args.mail_type, \
         args.batch_args
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    caseroot, job, no_batch, prereq, resubmit, skip_pnl, \
+    caseroot, job, no_batch, prereq, allow_fail, resubmit, skip_pnl, \
         mail_user, mail_type, batch_args = parse_command_line(sys.argv, description)
 
     # save these options to a hidden file for use during resubmit
@@ -86,9 +92,9 @@ def _main_func(description):
         os.remove(config_file)
 
     with Case(caseroot, read_only=False) as case:
-        case.submit(job=job, no_batch=no_batch, prereq=prereq, resubmit=resubmit,
-               skip_pnl=skip_pnl, mail_user=mail_user, mail_type=mail_type,
-               batch_args=batch_args)
+        case.submit(job=job, no_batch=no_batch, prereq=prereq, allow_fail=allow_fail,
+                    resubmit=resubmit, skip_pnl=skip_pnl, mail_user=mail_user, mail_type=mail_type,
+                    batch_args=batch_args)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -51,6 +51,11 @@ OR
     parser.add_argument("--resubmit", action="store_true",
                         help="Used with tests only, to continue rather than restart a test. ")
 
+    parser.add_argument("--resubmit-immediate", action="store_true",
+                        help="This queues all of the resubmissions immediately after "
+                        "the first job is queued. These rely on the queue system to "
+                        "handle dependencies.")
+
     parser.add_argument("--skip-preview-namelist", action="store_true",
                         help="Skip calling preview-namelist during case.run")
 
@@ -63,14 +68,14 @@ OR
 
     CIME.utils.resolve_mail_type_args(args)
 
-    return args.caseroot, args.job, args.no_batch, args.prereq, args.prereq_allow_failure, \
-        args.resubmit, args.skip_preview_namelist, args.mail_user, args.mail_type, \
-        args.batch_args
+    return (args.caseroot, args.job, args.no_batch, args.prereq, args.prereq_allow_failure,
+            args.resubmit, args.resubmit_immediate, args.skip_preview_namelist, args.mail_user,
+            args.mail_type, args.batch_args)
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    caseroot, job, no_batch, prereq, allow_fail, resubmit, skip_pnl, \
+    caseroot, job, no_batch, prereq, allow_fail, resubmit, resubmit_immediate, skip_pnl, \
         mail_user, mail_type, batch_args = parse_command_line(sys.argv, description)
 
     # save these options to a hidden file for use during resubmit
@@ -93,8 +98,8 @@ def _main_func(description):
 
     with Case(caseroot, read_only=False) as case:
         case.submit(job=job, no_batch=no_batch, prereq=prereq, allow_fail=allow_fail,
-                    resubmit=resubmit, skip_pnl=skip_pnl, mail_user=mail_user, mail_type=mail_type,
-                    batch_args=batch_args)
+                    resubmit=resubmit, resubmit_immediate=resubmit_immediate, skip_pnl=skip_pnl,
+                    mail_user=mail_user, mail_type=mail_type, batch_args=batch_args)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -507,8 +507,8 @@ class EnvBatch(EnvBase):
             if allow_fail:
                 dep_string = self.get_value("depend_allow_string", subgroup=None)
                 if dep_string is None:
-                    logger.warn("'depend_allow_string' is not defined for this batch system, " +
-                                "falling back to the 'depend_string'")
+                    logger.warning("'depend_allow_string' is not defined for this batch system, " +
+                                   "falling back to the 'depend_string'")
                     dep_string = self.get_value("depend_string", subgroup=None)
             else:
                 dep_string = self.get_value("depend_string", subgroup=None)

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -484,11 +484,12 @@ class EnvBatch(EnvBase):
                                                  batch_args=batch_args,
                                                  dry_run=dry_run)
                 batch_job_id = str(alljobs.index(job)) if dry_run else result
-                prev_job = batch_job_id
                 depid[job] = batch_job_id
                 jobcmds.append( (job, result) )
                 if self._batchtype == "cobalt":
                     break
+            prev_job = batch_job_id
+
 
         if dry_run:
             return jobcmds

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -512,6 +512,8 @@ class EnvBatch(EnvBase):
             supported["skip_pnl"] = "--skip-preview-namelist"
         if job == "case.run":
             supported["set_continue_run"] = "--completion-sets-continue-run"
+        if job in ["case.st_archive", "case.run"]:
+            supported["submit_resubmits"] = "--resubmit"
         return supported
 
     @staticmethod
@@ -558,7 +560,8 @@ class EnvBatch(EnvBase):
             logger.info("Starting job script {}".format(job))
             function_name = job.replace(".", "_")
             if not dry_run:
-                args = self._build_run_args(job, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate)
+                args = self._build_run_args(job, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
+                                            submit_resubmits=not resubmit_immediate)
                 getattr(case, function_name)(**{k: v for k, (v, _) in args.items()})
             return
 
@@ -631,7 +634,8 @@ class EnvBatch(EnvBase):
                "Unable to determine the correct command for batch submission.")
         batchredirect = self.get_value("batch_redirect", subgroup=None)
         batch_env_flag = self.get_value("batch_env", subgroup=None)
-        run_args = self._build_run_args_str(job, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate)
+        run_args = self._build_run_args_str(job, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
+                                            submit_resubmits=not resubmit_immediate)
         if batch_env_flag:
             sequence = (batchsubmit, submitargs, run_args, batchredirect, get_batch_script_for_job(job))
         else:

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -472,7 +472,7 @@ class EnvBatch(EnvBase):
                 if prev_job is not None:
                     dep_jobs.append(prev_job)
 
-                logger.info("job {} depends on {}".format(job, dep_jobs))
+                logger.debug("job {} depends on {}".format(job, dep_jobs))
                 result = self._submit_single_job(case, job,
                                                  skip_pnl=skip_pnl,
                                                  resubmit_immediate=resubmit_immediate,
@@ -571,7 +571,7 @@ class EnvBatch(EnvBase):
             submitargs = args_override
 
         if dep_jobs is not None and len(dep_jobs) > 0:
-            logger.info("dependencies: {}".format(dep_jobs))
+            logger.debug("dependencies: {}".format(dep_jobs))
             if allow_fail:
                 dep_string = self.get_value("depend_allow_string", subgroup=None)
                 if dep_string is None:

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -637,8 +637,6 @@ class EnvBatch(EnvBase):
         else:
             sequence = (batchsubmit, submitargs, batchredirect, get_batch_script_for_job(job), run_args)
 
-        logger.info("sequence: {}".format(sequence))
-
         submitcmd = " ".join(s.strip() for s in sequence if s is not None)
 
         if dry_run:

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -415,7 +415,7 @@ class EnvBatch(EnvBase):
 
     def submit_jobs(self, case, no_batch=False, job=None, user_prereq=None, skip_pnl=False,
                     allow_fail=False, resubmit_immediate=False, mail_user=None, mail_type=None,
-                    batch_args=None, dry_run=False, run_args=None):
+                    batch_args=None, dry_run=False):
         alljobs = self.get_jobs()
         startindex = 0
         jobs = []
@@ -457,12 +457,12 @@ class EnvBatch(EnvBase):
 
         prev_job = None
 
-        for i in range(num_submit):
+        for _ in range(num_submit):
             for job, dependency in jobs:
                 if dependency is not None:
                     deps = dependency.split()
                 else:
-                        deps = []
+                    deps = []
                 dep_jobs = []
                 if user_prereq is not None:
                     dep_jobs.append(user_prereq)
@@ -504,7 +504,7 @@ class EnvBatch(EnvBase):
         >>> EnvBatch._get_supported_args("")
         {}
         >>> EnvBatch._get_supported_args("case.test")
-        {"skip_pnl": "--skip-preview-namelist"}
+        {'skip_pnl': '--skip-preview-namelist'}
         """
         supported = {}
         if job in ["case.run", "case.test"]:
@@ -520,7 +520,7 @@ class EnvBatch(EnvBase):
         as well as the values passed and the equivalent arguments for calling the script
 
         >>> EnvBatch._build_run_args("case.run", skip_pnl=True, cthulu="f'taghn")
-        {"skip_pnl": (True, "--skip-preview-namelist")}
+        {'skip_pnl': (True, '--skip-preview-namelist')}
         >>> EnvBatch._build_run_args("case.run", skip_pnl=False, cthulu="f'taghn")
         {}
         """
@@ -557,7 +557,7 @@ class EnvBatch(EnvBase):
             logger.info("Starting job script {}".format(job))
             function_name = job.replace(".", "_")
             if not dry_run:
-                args = _build_run_args(job, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate)
+                args = self._build_run_args(job, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate)
                 getattr(case, function_name)(**{k: v for k, (v, _) in args.items()})
             return
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1200,8 +1200,8 @@ directory, NOT in this subdirectory."""
                     resubmit_immediate=False, mail_user=None, mail_type=None, batch_args=None,
                     dry_run=False):
         env_batch = self.get_env('batch')
-        result =  env_batch.submit_jobs(self, no_batch=no_batch, job=job, user_prereq=prereq,
-                                        allow_fail=allow_fail,
+        result =  env_batch.submit_jobs(self, no_batch=no_batch, skip_pnl=skip_pnl,
+                                        job=job, user_prereq=prereq, allow_fail=allow_fail,
                                         resubmit_immediate=resubmit_immediate,
                                         mail_user=mail_user, mail_type=mail_type,
                                         batch_args=batch_args, dry_run=dry_run)

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1196,14 +1196,14 @@ directory, NOT in this subdirectory."""
         else:
             return comp_user_mods
 
-    def submit_jobs(self, no_batch=False, job=None, prereq=None, skip_pnl=False,
-                    mail_user=None, mail_type=None, batch_args=None,
+    def submit_jobs(self, no_batch=False, job=None, prereq=None, allow_fail=False,
+                    skip_pnl=False, mail_user=None, mail_type=None, batch_args=None,
                     dry_run=False):
         env_batch = self.get_env('batch')
         result =  env_batch.submit_jobs(self, no_batch=no_batch, job=job, user_prereq=prereq,
-                                     skip_pnl=skip_pnl, mail_user=mail_user,
-                                     mail_type=mail_type, batch_args=batch_args,
-                                     dry_run=dry_run)
+                                        allow_fail=allow_fail, skip_pnl=skip_pnl, mail_user=mail_user,
+                                        mail_type=mail_type, batch_args=batch_args,
+                                        dry_run=dry_run)
         return result
 
     def get_job_info(self):

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1197,13 +1197,12 @@ directory, NOT in this subdirectory."""
             return comp_user_mods
 
     def submit_jobs(self, no_batch=False, job=None, prereq=None, allow_fail=False,
-                    skip_pnl=False, mail_user=None, mail_type=None, batch_args=None,
-                    dry_run=False):
+                    mail_user=None, mail_type=None, batch_args=None, dry_run=False,
+                    run_args={}):
         env_batch = self.get_env('batch')
         result =  env_batch.submit_jobs(self, no_batch=no_batch, job=job, user_prereq=prereq,
-                                        allow_fail=allow_fail, skip_pnl=skip_pnl, mail_user=mail_user,
-                                        mail_type=mail_type, batch_args=batch_args,
-                                        dry_run=dry_run)
+                                        allow_fail=allow_fail, mail_user=mail_user, mail_type=mail_type,
+                                        batch_args=batch_args, dry_run=dry_run, run_args=run_args)
         return result
 
     def get_job_info(self):

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1196,13 +1196,15 @@ directory, NOT in this subdirectory."""
         else:
             return comp_user_mods
 
-    def submit_jobs(self, no_batch=False, job=None, prereq=None, allow_fail=False,
-                    mail_user=None, mail_type=None, batch_args=None, dry_run=False,
-                    run_args={}):
+    def submit_jobs(self, no_batch=False, job=None, skip_pnl=None, prereq=None, allow_fail=False,
+                    resubmit_immediate=False, mail_user=None, mail_type=None, batch_args=None,
+                    dry_run=False):
         env_batch = self.get_env('batch')
         result =  env_batch.submit_jobs(self, no_batch=no_batch, job=job, user_prereq=prereq,
-                                        allow_fail=allow_fail, mail_user=mail_user, mail_type=mail_type,
-                                        batch_args=batch_args, dry_run=dry_run, run_args=run_args)
+                                        allow_fail=allow_fail,
+                                        resubmit_immediate=resubmit_immediate,
+                                        mail_user=mail_user, mail_type=mail_type,
+                                        batch_args=batch_args, dry_run=dry_run)
         return result
 
     def get_job_info(self):

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -254,7 +254,7 @@ def _do_data_assimilation(da_script, caseroot, cycle, lid, rundir):
     run_sub_or_cmd(da_script, [caseroot, cycle], os.path.basename(da_script), [caseroot, cycle], logfile=outfile)
 
 ###############################################################################
-def case_run(self, skip_pnl=False):
+def case_run(self, skip_pnl=False, set_continue_run=False):
 ###############################################################################
     # Set up the run, run the model, do the postrun steps
     prerun_script = self.get_value("PRERUN_SCRIPT")
@@ -300,6 +300,9 @@ def case_run(self, skip_pnl=False):
                     lid, prefix="postrun")
         self.read_xml()
         _save_logs(self, lid)
+
+    if set_continue_run:
+        self.set_value("CONTINUE_RUN", True)
 
     logger.warning("check for resubmit")
     _resubmit_check(self)

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -254,7 +254,7 @@ def _do_data_assimilation(da_script, caseroot, cycle, lid, rundir):
     run_sub_or_cmd(da_script, [caseroot, cycle], os.path.basename(da_script), [caseroot, cycle], logfile=outfile)
 
 ###############################################################################
-def case_run(self, skip_pnl=False, set_continue_run=False):
+def case_run(self, skip_pnl=False, set_continue_run=False, submit_resubmits=False):
 ###############################################################################
     # Set up the run, run the model, do the postrun steps
     prerun_script = self.get_value("PRERUN_SCRIPT")
@@ -306,6 +306,7 @@ def case_run(self, skip_pnl=False, set_continue_run=False):
                        self.get_value("RESUBMIT_SETS_CONTINUE_RUN"))
 
     logger.warning("check for resubmit")
-    _resubmit_check(self)
+    if submit_resubmits:
+        _resubmit_check(self)
 
     return True

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -302,7 +302,8 @@ def case_run(self, skip_pnl=False, set_continue_run=False):
         _save_logs(self, lid)
 
     if set_continue_run:
-        self.set_value("CONTINUE_RUN", True)
+        self.set_value("CONTINUE_RUN",
+                       self.get_value("RESUBMIT_SETS_CONTINUE_RUN"))
 
     logger.warning("check for resubmit")
     _resubmit_check(self)

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -113,6 +113,10 @@ manual edits to these file will be lost!
 def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubmit=False,
            resubmit_immediate=False, skip_pnl=False, mail_user=None, mail_type=None,
            batch_args=None):
+    if resubmit_immediate and self.get_value("MACH") in ['mira', 'cetus']:
+        logger.warning("resubmit_immediate does not work on Mira/Cetus, submitting normally")
+        resubmit_immediate = False
+
     if self.get_value("TEST"):
         caseroot = self.get_value("CASEROOT")
         casebaseid = self.get_value("CASEBASEID")

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -15,7 +15,7 @@ from CIME.test_status               import *
 
 logger = logging.getLogger(__name__)
 
-def _submit(case, job=None, no_batch=False, prereq=None, resubmit=False,
+def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resubmit=False,
             skip_pnl=False, mail_user=None, mail_type=None, batch_args=None):
     if job is None:
         job = case.get_primary_job()
@@ -86,7 +86,7 @@ manual edits to these file will be lost!
 
     logger.warning("submit_jobs {}".format(job))
     job_ids = case.submit_jobs(no_batch=no_batch, job=job, skip_pnl=skip_pnl,
-                               prereq=prereq, mail_user=mail_user,
+                               prereq=prereq, allow_fail=allow_fail, mail_user=mail_user,
                                mail_type=mail_type, batch_args=batch_args)
 
     xml_jobids = []
@@ -101,7 +101,7 @@ manual edits to these file will be lost!
 
     return xml_jobid_text
 
-def submit(self, job=None, no_batch=False, prereq=None, resubmit=False,
+def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubmit=False,
            skip_pnl=False, mail_user=None, mail_type=None, batch_args=None):
     if self.get_value("TEST"):
         caseroot = self.get_value("CASEROOT")
@@ -134,7 +134,7 @@ def submit(self, job=None, no_batch=False, prereq=None, resubmit=False,
 
     try:
         functor = lambda: _submit(self, job=job, no_batch=no_batch, prereq=prereq,
-                                  resubmit=resubmit, skip_pnl=skip_pnl,
+                                  allow_fail=allow_fail, resubmit=resubmit, skip_pnl=skip_pnl,
                                   mail_user=mail_user, mail_type=mail_type,
                                   batch_args=batch_args)
         run_and_log_case_status(functor, "case.submit", caseroot=caseroot,

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1547,19 +1547,23 @@ class K_TestCimeCase(TestCreateTestCommon):
             # Test some test properties
             self.assertEqual(case.get_value("TESTCASE"), "TESTRUNPASS")
 
-    ###########################################################################
-    def test_cime_case_prereq(self):
-    ###########################################################################
+    def _batch_test_fixture(self, testcase_name):
         if not MACHINE.has_batch_system() or NO_BATCH:
             self.skipTest("Skipping testing user prerequisites without batch systems")
-        testcase_name = 'prereq_test'
         testdir = os.path.join(TEST_ROOT, testcase_name)
         if os.path.exists(testdir):
             shutil.rmtree(testdir)
-        run_cmd_assert_result(self, ("%s/create_newcase --case %s --script-root %s --compset X --res f19_g16 --output-root %s"
-                                     % (SCRIPT_DIR, testcase_name, testdir, testdir)),
+        run_cmd_assert_result(self, ("{}/create_newcase --case {} --script-root {} " +
+                                     "--compset X --res f19_g16 --output-root {}").format(
+                                         SCRIPT_DIR, testcase_name, testdir, testdir),
                               from_dir=SCRIPT_DIR)
+        return testdir
 
+    ###########################################################################
+    def test_cime_case_prereq(self):
+    ###########################################################################
+        testcase_name = 'prereq_test'
+        testdir = self._batch_test_fixture(testcase_name)
         with Case(testdir, read_only=False) as case:
             if case.get_value("depend_string") is None:
                 self.skipTest("Skipping prereq test, depend_string was not provided for this batch system")
@@ -1596,16 +1600,8 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_allow_failed_prereq(self):
     ###########################################################################
-        if not MACHINE.has_batch_system() or NO_BATCH:
-            self.skipTest("Skipping testing user prerequisites without batch systems")
-        testcase_name = 'failed_prereq_test'
-        testdir = os.path.join(TEST_ROOT, testcase_name)
-        if os.path.exists(testdir):
-            shutil.rmtree(testdir)
-        run_cmd_assert_result(self, ("%s/create_newcase --case %s --script-root %s --compset X --res f19_g16 --output-root %s"
-                                     % (SCRIPT_DIR, testcase_name, testdir, testdir)),
-                              from_dir=SCRIPT_DIR)
-
+        testcase_name = 'allow_failed_prereq_test'
+        testdir = self._batch_test_fixture(testcase_name)
         with Case(testdir, read_only=False) as case:
             depend_allow = case.get_value("depend_allow_string")
             if depend_allow is None:
@@ -1621,16 +1617,8 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_resubmit_immediate(self):
     ###########################################################################
-        if not MACHINE.has_batch_system() or NO_BATCH:
-            self.skipTest("Skipping testing user prerequisites without batch systems")
         testcase_name = 'resubmit_immediate_test'
-        testdir = os.path.join(TEST_ROOT, testcase_name)
-        if os.path.exists(testdir):
-            shutil.rmtree(testdir)
-        run_cmd_assert_result(self, ("%s/create_newcase --case %s --script-root %s --compset X --res f19_g16 --output-root %s"
-                                     % (SCRIPT_DIR, testcase_name, testdir, testdir)),
-                              from_dir=SCRIPT_DIR)
-
+        testdir = self._batch_test_fixture(testcase_name)
         with Case(testdir, read_only=False) as case:
             depend_string = case.get_value("depend_string")
             if depend_string is None:

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1634,6 +1634,22 @@ class K_TestCimeCase(TestCreateTestCommon):
                     self.assertTrue(depend_string in cmd[1])
 
     ###########################################################################
+    def test_cime_case_st_archive_resubmit(self):
+    ###########################################################################
+        testcase_name = "st_archive_resubmit_test"
+        testdir = self._batch_test_fixture(testcase_name)
+        with Case(testdir, read_only=False) as case:
+            case.case_setup(clean=False, test_mode=False, reset=True)
+            orig_resubmit = 2
+            case.set_value("RESUBMIT", orig_resubmit)
+            case.case_st_archive(no_resubmit=True)
+            new_resubmit = case.get_value("RESUBMIT")
+            self.assertTrue(orig_resubmit == new_resubmit, "st_archive resubmitted when told not to")
+            case.case_st_archive(no_resubmit=False)
+            new_resubmit = case.get_value("RESUBMIT")
+            self.assertTrue((orig_resubmit - 1) == new_resubmit, "st_archive did not resubmit when told to")
+
+    ###########################################################################
     def test_cime_case_build_threaded_1(self):
     ###########################################################################
         self._create_test(["--no-build", "TESTRUNPASS_P1x1.f19_g16_rx1.A"], test_id=self._baseline_name)

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1637,7 +1637,6 @@ class K_TestCimeCase(TestCreateTestCommon):
                 self.skipTest("Skipping resubmit_immediate test, depend_string was not provided for this batch system")
             depend_string = depend_string.replace("jobid", "")
             job_name = "case.run"
-            prereq_name = "resubmit_immediate_test"
             num_submissions = 6
             case.set_value("RESUBMIT", num_submissions - 1)
             batch_commands = case.submit_jobs(job=job_name, skip_pnl=True, dry_run=True, resubmit_immediate=True)

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1538,12 +1538,6 @@ class K_TestCimeCase(TestCreateTestCommon):
                             msg="Build complete had wrong value '%s'" %
                             build_complete)
 
-#            model_specific_val = case.get_value("CPL_SEQ_OPTION")
-#            if CIME.utils.get_model() == 'cesm':
-#                self.assertEqual(model_specific_val, "RASM_OPTION1")
-#            else:
-#                self.assertEqual(model_specific_val, "CESM1_MOD")
-
             # Test some test properties
             self.assertEqual(case.get_value("TESTCASE"), "TESTRUNPASS")
 
@@ -1611,7 +1605,10 @@ class K_TestCimeCase(TestCreateTestCommon):
             depend_allow = depend_allow.replace("jobid", prereq_name)
             batch_commands = case.submit_jobs(prereq=prereq_name, allow_fail=True, job=job_name, skip_pnl=True, dry_run=True)
             self.assertTrue(isinstance(batch_commands, collections.Sequence), "case.submit_jobs did not return a sequence for a dry run")
-            self.assertTrue(len(batch_commands) == 1, "case.submit_jobs did not return any job submission strings")
+            num_submissions = 1
+            if case.get_value("DOUT_S"):
+                num_submissions = 2
+            self.assertTrue(len(batch_commands) == num_submissions, "case.submit_jobs did not return any job submission strings")
             self.assertTrue(depend_allow in batch_commands[0][1])
 
     ###########################################################################
@@ -1629,6 +1626,8 @@ class K_TestCimeCase(TestCreateTestCommon):
             case.set_value("RESUBMIT", num_submissions - 1)
             batch_commands = case.submit_jobs(job=job_name, skip_pnl=True, dry_run=True, resubmit_immediate=True)
             self.assertTrue(isinstance(batch_commands, collections.Sequence), "case.submit_jobs did not return a sequence for a dry run")
+            if case.get_value("DOUT_S"):
+                num_submissions = 12
             self.assertTrue(len(batch_commands) == num_submissions, "case.submit_jobs did not return {} submitted jobs".format(num_submissions))
             for i, cmd in enumerate(batch_commands):
                 if i > 0:

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1561,6 +1561,8 @@ class K_TestCimeCase(TestCreateTestCommon):
                               from_dir=SCRIPT_DIR)
 
         with Case(testdir, read_only=False) as case:
+            if case.get_value("depend_string") is None:
+                self.skipTest("Skipping prereq test, depend_string was not provided for this batch system")
             job_name = "case.run"
             prereq_name = 'prereq_test'
             batch_commands = case.submit_jobs(prereq=prereq_name, job=job_name, skip_pnl=True, dry_run=True)
@@ -1576,7 +1578,7 @@ class K_TestCimeCase(TestCreateTestCommon):
                 self.assertTrue(isinstance(batch_cmd[1], six.string_types), "case.submit_jobs returned internal sequences without the batch command string as the second parameter: {}".format(batch_cmd[1]))
                 batch_cmd_args = batch_cmd[1]
 
-                jobid_ident = 'jobid'
+                jobid_ident = "jobid"
                 dep_str_fmt = case.get_env('batch').get_value('depend_string', subgroup=None)
                 self.assertTrue(jobid_ident in dep_str_fmt, "dependency string doesn't include the jobid identifier {}".format(jobid_ident))
                 dep_str = dep_str_fmt[:dep_str_fmt.index(jobid_ident)]
@@ -1590,6 +1592,60 @@ class K_TestCimeCase(TestCreateTestCommon):
                         break
 
                 self.assertTrue(prereq_name in prereq_substr, "Dependencies added, but not the user specified one")
+
+    ###########################################################################
+    def test_cime_case_allow_failed_prereq(self):
+    ###########################################################################
+        if not MACHINE.has_batch_system() or NO_BATCH:
+            self.skipTest("Skipping testing user prerequisites without batch systems")
+        testcase_name = 'failed_prereq_test'
+        testdir = os.path.join(TEST_ROOT, testcase_name)
+        if os.path.exists(testdir):
+            shutil.rmtree(testdir)
+        run_cmd_assert_result(self, ("%s/create_newcase --case %s --script-root %s --compset X --res f19_g16 --output-root %s"
+                                     % (SCRIPT_DIR, testcase_name, testdir, testdir)),
+                              from_dir=SCRIPT_DIR)
+
+        with Case(testdir, read_only=False) as case:
+            depend_allow = case.get_value("depend_allow_string")
+            if depend_allow is None:
+                self.skipTest("Skipping allow_failed_prereq test, depend_allow_string was not provided for this batch system")
+            job_name = "case.run"
+            prereq_name = "prereq_allow_fail_test"
+            depend_allow = depend_allow.replace("jobid", prereq_name)
+            batch_commands = case.submit_jobs(prereq=prereq_name, allow_fail=True, job=job_name, skip_pnl=True, dry_run=True)
+            self.assertTrue(isinstance(batch_commands, collections.Sequence), "case.submit_jobs did not return a sequence for a dry run")
+            self.assertTrue(len(batch_commands) == 1, "case.submit_jobs did not return any job submission strings")
+            self.assertTrue(depend_allow in batch_commands[0][1])
+
+    ###########################################################################
+    def test_cime_case_resubmit_immediate(self):
+    ###########################################################################
+        if not MACHINE.has_batch_system() or NO_BATCH:
+            self.skipTest("Skipping testing user prerequisites without batch systems")
+        testcase_name = 'resubmit_immediate_test'
+        testdir = os.path.join(TEST_ROOT, testcase_name)
+        if os.path.exists(testdir):
+            shutil.rmtree(testdir)
+        run_cmd_assert_result(self, ("%s/create_newcase --case %s --script-root %s --compset X --res f19_g16 --output-root %s"
+                                     % (SCRIPT_DIR, testcase_name, testdir, testdir)),
+                              from_dir=SCRIPT_DIR)
+
+        with Case(testdir, read_only=False) as case:
+            depend_string = case.get_value("depend_string")
+            if depend_string is None:
+                self.skipTest("Skipping resubmit_immediate test, depend_string was not provided for this batch system")
+            depend_string = depend_string.replace("jobid", "")
+            job_name = "case.run"
+            prereq_name = "resubmit_immediate_test"
+            num_submissions = 6
+            case.set_value("RESUBMIT", num_submissions - 1)
+            batch_commands = case.submit_jobs(job=job_name, skip_pnl=True, dry_run=True, resubmit_immediate=True)
+            self.assertTrue(isinstance(batch_commands, collections.Sequence), "case.submit_jobs did not return a sequence for a dry run")
+            self.assertTrue(len(batch_commands) == num_submissions, "case.submit_jobs did not return {} submitted jobs".format(num_submissions))
+            for i, cmd in enumerate(batch_commands):
+                if i > 0:
+                    self.assertTrue(depend_string in cmd[1])
 
     ###########################################################################
     def test_cime_case_build_threaded_1(self):


### PR DESCRIPTION
This implements two features:
1) Resubmitting regardless of the success of the preceding job(s). Note that this can be dangerous and waste significant computer time if done with restarts which are too far apart or if systematic errors cause the model to crash. This feature is used by running `case.submit` with the `--prereq-allow-failure` option.
2) Submitting the resubmitted jobs all at once, potentially significantly reducing the time spent in the queue on some HPC systems. This feature is used by running `case.submit` with the `--resubmit-immediate` option.

These options can (and are intended to) be used together; doing so will submit `$RESUBMIT` jobs which have a dependency on the job submitted immediately before, but does not require it to have completed successfully, only to have at least run.

Test suite: scripts_regression_tests
Test status: ok

Fixes #2510, Fixes #2547

User interface changes?: Adds the `--prereq-allow-failure` and the `--resubmit-immediate` option to case.submit.

Code review: @jgfouca @jedwards4b 
