### PR TITLE
refine cheyenne retry method

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -253,7 +253,7 @@
   <machine MACH="cheyenne">
     <DESC>NCAR SGI platform, os is Linux, 36 pes/node, batch system is PBS</DESC>
     <NODENAME_REGEX>.*.cheyenne.ucar.edu</NODENAME_REGEX>
-    <NODE_FAIL_REGEX>MPT ERROR: could not launch executable</NODE_FAIL_REGEX>
+    <NODE_FAIL_REGEX>MPT: xmpi_net_accept_timeo/accept() timeout</NODE_FAIL_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu,pgi</COMPILERS>
     <MPILIBS compiler="intel" >mpt,openmpi</MPILIBS>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -253,7 +253,10 @@
   <machine MACH="cheyenne">
     <DESC>NCAR SGI platform, os is Linux, 36 pes/node, batch system is PBS</DESC>
     <NODENAME_REGEX>.*.cheyenne.ucar.edu</NODENAME_REGEX>
+    <!-- MPT sometimes timesout at model start time, the next two lines cause
+    case_run.py to detect the timeout and retry FORCE_SPARE_NODES times -->
     <NODE_FAIL_REGEX>MPT: xmpi_net_accept_timeo/accept() timeout</NODE_FAIL_REGEX>
+    <FORCE_SPARE_NODES>2</FORCE_SPARE_NODES>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu,pgi</COMPILERS>
     <MPILIBS compiler="intel" >mpt,openmpi</MPILIBS>

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -23,6 +23,7 @@
   <xs:element name="NODENAME_REGEX" type="xs:string"/>
   <xs:element name="DESC" type="xs:string"/>
   <xs:element name="NODE_FAIL_REGEX" type="xs:string"/>
+  <xs:element name="FORCE_SPARE_NODES" type="xs:integer"/>
   <xs:element name="OS" type="xs:NCName"/>
   <xs:element name="PROXY" type="xs:string"/>
   <xs:element name="SAVE_TIMING_DIR" type="xs:string" />
@@ -83,6 +84,8 @@
         <xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
 	<!-- regex to look for in log files that will triger retry of mpirun command -->
         <xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
+	<!-- Number of retry attempts to make if NODE_FAIL_REGEX matches   -->
+        <xs:element ref="FORCE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
 	<!-- OS: the operating system of this machine. -->
         <xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
 	<!-- PROXY: optional http proxy for access to the internet-->

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -129,9 +129,9 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
 
                     case.spare_nodes -= num_fails
 
-                if stat != 0 and not loop:
-                    # We failed and we're not restarting
-                    expect(False, "RUN FAIL: Command '{}' failed\nSee log file for details: {}".format(cmd, model_logfile))
+        if stat != 0 and not loop:
+            # We failed and we're not restarting
+            expect(False, "RUN FAIL: Command '{}' failed\nSee log file for details: {}".format(cmd, model_logfile))
 
     logger.info("{} MODEL EXECUTION HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
 

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -98,8 +98,6 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
     # in this case no spare nodes are required, we simply try again on the same nodes.  We will make 2
     # attempts to retry.
     node_fail_re = case.get_value("NODE_FAIL_REGEX")
-    if node_fail_re and not case.get_value('ALLOCATE_SPARE_NODES'):
-        case.spare_nodes = 2
     while loop:
         loop = False
 
@@ -118,9 +116,8 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
                     logger.warning("Detected model run failed due to node failure, restarting")
 
                     # Archive the last consistent set of restart files and restore them
-                    if case.get_value("ALLOCATE_SPARE_NODES"):
-                        case.case_st_archive(no_resubmit=True)
-                        case.restore_from_archive()
+                    case.case_st_archive(no_resubmit=True)
+                    case.restore_from_archive()
 
                     case.set_value("CONTINUE_RUN",
                                    case.get_value("RESUBMIT_SETS_CONTINUE_RUN"))


### PR DESCRIPTION
Refining the retry code for cheyenne, it turns out that mpiexec may not return a non-zero stat on failure.  

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
