### PR TITLE
save submit options for resubmit

### DIFF
--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -6,6 +6,7 @@ case.submit - Submit a cesm workflow to the queueing system or run it if there i
 
 from standard_script_setup import *
 from CIME.case        import Case
+from ConfigParser import SafeConfigParser
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -65,6 +66,24 @@ def _main_func(description):
 ###############################################################################
     caseroot, job, no_batch, prereq, resubmit, skip_pnl, \
         mail_user, mail_type, batch_args = parse_command_line(sys.argv, description)
+
+    # save these options to a hidden file for use during resubmit
+    config_file = os.path.join(caseroot,".submit_options")
+    if skip_pnl or mail_user or mail_type or batch_args:
+        config = SafeConfigParser()
+        config.add_section("SubmitOptions")
+        if skip_pnl:
+            config.set("SubmitOptions", "skip_pnl", skip_pnl)
+        if mail_user:
+            config.set("SubmitOptions", "mail_user", mail_user)
+        if mail_type:
+            config.set("SubmitOptions", "mail_type", ",".join(mail_type))
+        if batch_args:
+            config.set("SubmitOptions", "batch_args", batch_args)
+        with open(config_file, "wb") as fd:
+            config.write(fd)
+    elif os.path.exists(config_file):
+        os.remove(config_file)
 
     with Case(caseroot, read_only=False) as case:
         case.submit(job=job, no_batch=no_batch, prereq=prereq, resubmit=resubmit,

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -6,7 +6,7 @@ case.submit - Submit a cesm workflow to the queueing system or run it if there i
 
 from standard_script_setup import *
 from CIME.case        import Case
-from ConfigParser import SafeConfigParser
+from six.moves import configparser
 
 ###############################################################################
 def parse_command_line(args, description):
@@ -70,7 +70,7 @@ def _main_func(description):
     # save these options to a hidden file for use during resubmit
     config_file = os.path.join(caseroot,".submit_options")
     if skip_pnl or mail_user or mail_type or batch_args:
-        config = SafeConfigParser()
+        config = configparser.SafeConfigParser()
         config.add_section("SubmitOptions")
         if skip_pnl:
             config.set("SubmitOptions", "skip_pnl", skip_pnl)

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -7,7 +7,7 @@ jobs.
 submit, check_case and check_da_settings are members of class Case in file case.py
 """
 import socket
-from ConfigParser                   import SafeConfigParser
+from six.moves                   import configparser
 from CIME.XML.standard_module_setup import *
 from CIME.utils                     import expect, run_and_log_case_status, verbatim_success_msg
 from CIME.locked_files              import unlock_file, lock_file
@@ -121,7 +121,7 @@ def submit(self, job=None, no_batch=False, prereq=None, resubmit=False,
     caseroot = self.get_value("CASEROOT")
     submit_options = os.path.join(caseroot, ".submit_options")
     if resubmit and os.path.exists(submit_options):
-        config = SafeConfigParser()
+        config = configparser.SafeConfigParser()
         config.read(submit_options)
         if not skip_pnl and config.has_option('SubmitOptions','skip_pnl'):
             skip_pnl = config.getboolean('SubmitOptions', 'skip_pnl')


### PR DESCRIPTION
Save the options used in the command line case.submit and use them in subsequent resubmits

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2512 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
