### PR TITLE
refine distinction of E vs Q compset

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -499,7 +499,7 @@ class Case(object):
             # this is a "J" compset
             primary_component = "allactive"
         elif progcomps["ATM"]:
-            if "DOCN%SOM" in self._compsetname:
+            if "DOCN%SOM" in self._compsetname and progcomps["LND"]:
                 # This is an "E" compset
                 primary_component = "allactive"
             else:
@@ -538,7 +538,6 @@ class Case(object):
                                             {"component":component}, resolved=False)
 
         self.set_lookup_value("COMPSETS_SPEC_FILE" ,compset_spec_file)
-
         if pesfile is None:
             self._pesfile = files.get_value("PES_SPEC_FILE", {"component":component})
             pesfile_unresolved = files.get_value("PES_SPEC_FILE", {"component":component}, resolved=False)


### PR DESCRIPTION
In a cam standalone case the Q compsets were incorrectly indentifying as E compsets. 

Test suite: hand tested create_newcase --case foo --compset QSC6 --res f19_f19_mg17 using cam sandbox
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
