### PR TITLE
add more checks for time settings

### DIFF
--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -277,9 +277,6 @@
       <value compset="_POP2" grid="oi%gx1v7">24</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
       <value compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
-      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">1</value>
-      <value compset="_DATM.*_CLM.*_SICE.*_SOCN">1</value>
-      <value compset="_SATM.*_SLND.*_SICE.*_SOCN">1</value>
       <value compset="_DLND.*_CISM\d">1</value>
     </values>
     <group>run_coupling</group>

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -278,6 +278,8 @@
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
       <value compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
       <value compset="_DLND.*_CISM\d">1</value>
+      <value compset="_XOCN">$ATM_NCPL</value>
+      <value compset="_SOCN">$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -288,9 +290,11 @@
 
   <entry id="GLC_NCPL">
     <type>integer</type>
-    <default_value>$ATM_NCPL</default_value>
+    <default_value>1</default_value>
     <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
+      <value compset="_SGLC">$ATM_NCPL</value>
+      <value compset="_XGLC">$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -320,7 +324,7 @@
 
   <entry id="ROF_NCPL">
     <type>integer</type>
-    <default_value>$ATM_NCPL</default_value>
+    <default_value>8</default_value>
     <values match="last">
       <value compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
@@ -328,6 +332,8 @@
       <value compset="_DATM%CPLHIST.+POP\d">8</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>
       <value compset="_DLND.*_CISM\d">1</value>
+      <value compset="_SROF">$ATM_NCPL</value>
+      <value compset="_XROF">$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -33,7 +33,7 @@
     <group>run_metadata</group>
     <file>env_case.xml</file>
     <desc>run DOI</desc>
-  </entry> 
+  </entry>
 
   <entry id="DRV_THREADING">
     <type>logical</type>
@@ -291,7 +291,7 @@
 
   <entry id="GLC_NCPL">
     <type>integer</type>
-    <default_value>1</default_value>
+    <default_value>$ATM_NCPL</default_value>
     <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
     </values>
@@ -323,7 +323,7 @@
 
   <entry id="ROF_NCPL">
     <type>integer</type>
-    <default_value>8</default_value>
+    <default_value>$ATM_NCPL</default_value>
     <values match="last">
       <value compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>

--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -8,7 +8,7 @@
     <group>run_metadata</group>
     <file>env_case.xml</file>
     <desc>run DOI</desc>
-  </entry> 
+  </entry>
 
   <entry id="DRV_THREADING">
     <type>logical</type>
@@ -393,7 +393,7 @@
 
   <entry id="GLC_NCPL">
     <type>integer</type>
-    <default_value>1</default_value>
+    <default_value>$ATM_NCPL</default_value>
     <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DLND.*_MALI">1</value>
@@ -428,7 +428,7 @@
 
   <entry id="ROF_NCPL">
     <type>integer</type>
-    <default_value>8</default_value>
+    <default_value>$ATM_NCPL</default_value>
     <values match="last">
       <value compset=".+" grid="a%ne4np4">6</value>
       <value compset=".+" grid="a%ne11np4">6</value>

--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -361,11 +361,16 @@
     <values match="last">
       <value compset="_POP2">1</value>
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
+      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN.*_SWAV">1</value>
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
+      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">1</value>
+      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
+      <value compset="_SATM.*_SLND.*_SICE.*_SOCN">1</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DLND.*_MALI">1</value>
+      <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">24</value>
       <value compset="_MPASO" grid="oi%oQU240">12</value>
       <value compset="_MPASO" grid="oi%oQU240wLI">12</value>
@@ -377,6 +382,7 @@
       <value compset="_MPASO" grid="oi%oRRS30to10wLI">48</value>
       <value compset="_MPASO" grid="oi%oRRS18to6v3">48</value>
       <value compset="_MPASO" grid="oi%oRRS15to5">96</value>
+
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -387,7 +393,7 @@
 
   <entry id="GLC_NCPL">
     <type>integer</type>
-    <default_value>$ATM_NCPL</default_value>
+    <default_value>1</default_value>
     <values match="last">
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DLND.*_MALI">1</value>
@@ -422,7 +428,7 @@
 
   <entry id="ROF_NCPL">
     <type>integer</type>
-    <default_value>$ATM_NCPL</default_value>
+    <default_value>8</default_value>
     <values match="last">
       <value compset=".+" grid="a%ne4np4">6</value>
       <value compset=".+" grid="a%ne11np4">6</value>
@@ -432,6 +438,8 @@
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN">$ATM_NCPL</value>
       <value compset="_DATM.*_SLND.*_DICE.*_DOCN">$ATM_NCPL</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>
+      <value compset="_SROF">$ATM_NCPL</value>
+      <value compset="_XROF">$ATM_NCPL</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DLND.*_MALI">1</value>
       <value compset="_SLND.*SOCN.*_MALI">1</value>

--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -361,16 +361,11 @@
     <values match="last">
       <value compset="_POP2">1</value>
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN.*_SWAV">1</value>
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
-      <value compset="_XATM.*_XLND.*_XICE.*_XOCN">1</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
-      <value compset="_SATM.*_SLND.*_SICE.*_SOCN">1</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DLND.*_MALI">1</value>
-      <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">24</value>
       <value compset="_MPASO" grid="oi%oQU240">12</value>
       <value compset="_MPASO" grid="oi%oQU240wLI">12</value>
@@ -382,7 +377,6 @@
       <value compset="_MPASO" grid="oi%oRRS30to10wLI">48</value>
       <value compset="_MPASO" grid="oi%oRRS18to6v3">48</value>
       <value compset="_MPASO" grid="oi%oRRS15to5">96</value>
-
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>

--- a/src/drivers/mct/shr/seq_timemgr_mod.F90
+++ b/src/drivers/mct/shr/seq_timemgr_mod.F90
@@ -857,7 +857,7 @@ contains
           write(logunit,*) trim(subname),' ERROR: dtime inconsistent = ',dtime
           call shr_sys_abort( subname//' :coupling intervals not compatible' )
        endif
-       if (pause_active(n) .and. (dtime(n) < min_dt)) then
+       if (pause_active(n) .and. (dtime(n) <= min_dt)) then
           min_dt = dtime(n)
           seq_timemgr_pause_sig_index = n
        end if
@@ -1024,7 +1024,8 @@ contains
        if(CurrTime + TimeStep > minStopTime ) then
           write(logunit,*) subname//" WARNING: Stop time too short, not all components will be advanced and restarts won't be written"
        endif
-       if (trim(restart_option) .ne. trim(seq_timemgr_optNone) .and. &
+       if (n /= seq_timemgr_nclock_esp .and. trim(restart_option) .ne. &
+            trim(seq_timemgr_optNone) .and. &
             trim(restart_option) .ne. trim(seq_timemgr_optNever)) then
              write(logunit,*) subname, 'RestInterval=',minRestInterval,&
                   ' Dtime=',dtime(n)


### PR DESCRIPTION
Add checks that stop_n is at least as long as the longest coupling interval and that atm_ncpl >= ocn_ncpl and atm_ncpl >= rof_ncpl

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit,

Fixes #1324 
Fixes #1707 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
