### PR TITLE
Convert more unsafe copies to safe.

### DIFF
--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-import shutil, glob, re
+import glob, re
 from standard_script_setup import *
-from CIME.utils import expect, run_bld_cmd_ensure_logging
+from CIME.utils import expect, run_bld_cmd_ensure_logging, safe_copy
 from CIME.case import Case
 
 logger = logging.getLogger(__name__)
@@ -81,10 +81,10 @@ def buildlib(bldroot, installpath, caseroot):
             newlib_time = os.path.getmtime(newlib)
             if newlib_time > installed_lib_time:
                 logger.info("Installing pio version 1")
-                shutil.copy2(newlib, installed_lib)
+                safe_copy(newlib, installed_lib)
                 for glob_to_copy in ("*.h", "*.mod"):
                     for item in glob.glob(os.path.join(pio_dir,"pio",glob_to_copy)):
-                        shutil.copy2(item, "{}/include".format(installpath))
+                        safe_copy(item, "{}/include".format(installpath))
             expect_string = "D_NETCDF;"
             pnetcdf_string = "D_PNETCDF"
             netcdf4_string = "D_NETCDF4"
@@ -105,7 +105,7 @@ def buildlib(bldroot, installpath, caseroot):
                     if os.path.isfile(installed_file):
                         installed_file_time = os.path.getmtime(installed_file)
                     if item_time  > installed_file_time:
-                        shutil.copy2(item, installed_file)
+                        safe_copy(item, installed_file)
             expect_string = "NetCDF_C_LIBRARY-ADVANCED"
             pnetcdf_string = "PnetCDF_C_LIBRARY-ADVANCED"
             netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"

--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob
+import os, sys, glob
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -17,7 +17,7 @@ sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect, get_model
+from CIME.utils import expect, get_model, safe_copy
 from CIME.buildnml import create_namelist_infile, parse_input
 from CIME.XML.files import Files
 
@@ -132,7 +132,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
-            shutil.copyfile(user_stream_path, stream_path)
+            safe_copy(user_stream_path, stream_path)
             config['stream'] = stream
             nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
@@ -218,8 +218,8 @@ def buildnml(case, caseroot, compname):
         rpointer = "rpointer." + compname
         if (os.path.isfile(os.path.join(rundir,rpointer)) and
             (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-            shutil.copy(os.path.join(rundir, rpointer),
-                        os.path.join(rundir, rpointer + inst_string))
+            safe_copy(os.path.join(rundir, rpointer),
+                      os.path.join(rundir, rpointer + inst_string))
 
         inst_string_label = inst_string
         if not inst_string_label:
@@ -243,10 +243,10 @@ def buildnml(case, caseroot, compname):
             file_dest = os.path.join(rundir, filename)
             if inst_string:
                 file_dest += inst_string
-            shutil.copy(file_src,file_dest)
+            safe_copy(file_src,file_dest)
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                shutil.copy(txtfile, rundir)
+                safe_copy(txtfile, rundir)
 
 ###############################################################################
 def _main_func():

--- a/src/components/data_comps/desp/cime_config/buildnml
+++ b/src/components/data_comps/desp/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import
 
-import os, shutil, sys, glob
+import os, sys, glob
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -17,7 +17,7 @@ sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
 from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
@@ -130,8 +130,8 @@ def buildnml(case, caseroot, compname):
         rpointer = "rpointer." + compname
         if (os.path.isfile(os.path.join(rundir,rpointer)) and
             (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-            shutil.copy(os.path.join(rundir, rpointer),
-                        os.path.join(rundir, rpointer + inst_string))
+            safe_copy(os.path.join(rundir, rpointer),
+                      os.path.join(rundir, rpointer + inst_string))
 
         inst_string_label = inst_string
         if not inst_string_label:
@@ -155,10 +155,10 @@ def buildnml(case, caseroot, compname):
             file_dest = os.path.join(rundir, filename)
             if inst_string:
                 file_dest += inst_string
-            shutil.copy(file_src,file_dest)
+            safe_copy(file_src,file_dest)
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                shutil.copy(txtfile, rundir)
+                safe_copy(txtfile, rundir)
 
 ###############################################################################
 def _main_func():

--- a/src/components/data_comps/dice/cime_config/buildnml
+++ b/src/components/data_comps/dice/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob
+import os, sys, glob
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -18,7 +18,7 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.XML.files import Files
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
 from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
-            shutil.copyfile(user_stream_path, stream_path)
+            safe_copy(user_stream_path, stream_path)
             config['stream'] = stream
             nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
@@ -176,8 +176,8 @@ def buildnml(case, caseroot, compname):
         rpointer = "rpointer." + compname
         if (os.path.isfile(os.path.join(rundir,rpointer)) and
             (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-            shutil.copy(os.path.join(rundir, rpointer),
-                        os.path.join(rundir, rpointer + inst_string))
+            safe_copy(os.path.join(rundir, rpointer),
+                      os.path.join(rundir, rpointer + inst_string))
 
         inst_string_label = inst_string
         if not inst_string_label:
@@ -201,10 +201,10 @@ def buildnml(case, caseroot, compname):
             file_dest = os.path.join(rundir, filename)
             if inst_string:
                 file_dest += inst_string
-            shutil.copy(file_src,file_dest)
+            safe_copy(file_src,file_dest)
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                shutil.copy(txtfile, rundir)
+                safe_copy(txtfile, rundir)
 
 ###############################################################################
 def _main_func():

--- a/src/components/data_comps/dlnd/cime_config/buildnml
+++ b/src/components/data_comps/dlnd/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob
+import os, sys, glob
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -17,7 +17,7 @@ sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
 from CIME.XML.files import Files
 from CIME.buildnml import create_namelist_infile, parse_input
 
@@ -99,7 +99,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
-            shutil.copyfile(user_stream_path, stream_path)
+            safe_copy(user_stream_path, stream_path)
             config['stream'] = stream
             nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
@@ -184,8 +184,8 @@ def buildnml(case, caseroot, compname):
         rpointer = "rpointer." + compname
         if (os.path.isfile(os.path.join(rundir,rpointer)) and
             (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-            shutil.copy(os.path.join(rundir, rpointer),
-                        os.path.join(rundir, rpointer + inst_string))
+            safe_copy(os.path.join(rundir, rpointer),
+                      os.path.join(rundir, rpointer + inst_string))
 
         inst_string_label = inst_string
         if not inst_string_label:
@@ -209,10 +209,10 @@ def buildnml(case, caseroot, compname):
             file_dest = os.path.join(rundir, filename)
             if inst_string:
                 file_dest += inst_string
-            shutil.copy(file_src,file_dest)
+            safe_copy(file_src,file_dest)
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                shutil.copy(txtfile, rundir)
+                safe_copy(txtfile, rundir)
 
 ###############################################################################
 def _main_func():

--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob, re
+import os, sys, glob, re
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -18,7 +18,7 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.XML.files import Files
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
 from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
-            shutil.copyfile(user_stream_path, stream_path)
+            safe_copy(user_stream_path, stream_path)
             config['stream'] = stream
             nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
@@ -189,8 +189,8 @@ def buildnml(case, caseroot, compname):
         rpointer = "rpointer." + compname
         if (os.path.isfile(os.path.join(rundir,rpointer)) and
             (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-            shutil.copy(os.path.join(rundir, rpointer),
-                        os.path.join(rundir, rpointer + inst_string))
+            safe_copy(os.path.join(rundir, rpointer),
+                      os.path.join(rundir, rpointer + inst_string))
 
         inst_string_label = inst_string
         if not inst_string_label:
@@ -214,10 +214,10 @@ def buildnml(case, caseroot, compname):
             file_dest = os.path.join(rundir, filename)
             if inst_string:
                 file_dest += inst_string
-            shutil.copy(file_src,file_dest)
+            safe_copy(file_src,file_dest)
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                shutil.copy(txtfile, rundir)
+                safe_copy(txtfile, rundir)
 
 ###############################################################################
 def _main_func():

--- a/src/components/data_comps/drof/cime_config/buildnml
+++ b/src/components/data_comps/drof/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob
+import os, sys, glob
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -18,7 +18,7 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.XML.files import Files
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
 from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
@@ -100,7 +100,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
-            shutil.copyfile(user_stream_path, stream_path)
+            safe_copy(user_stream_path, stream_path)
             config['stream'] = stream
             nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
@@ -184,8 +184,8 @@ def buildnml(case, caseroot, compname):
         rpointer = "rpointer." + compname
         if (os.path.isfile(os.path.join(rundir,rpointer)) and
             (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-            shutil.copy(os.path.join(rundir, rpointer),
-                        os.path.join(rundir, rpointer + inst_string))
+            safe_copy(os.path.join(rundir, rpointer),
+                      os.path.join(rundir, rpointer + inst_string))
 
         inst_string_label = inst_string
         if not inst_string_label:
@@ -209,10 +209,10 @@ def buildnml(case, caseroot, compname):
             file_dest = os.path.join(rundir, filename)
             if inst_string:
                 file_dest += inst_string
-            shutil.copy(file_src,file_dest)
+            safe_copy(file_src,file_dest)
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                shutil.copy(txtfile, rundir)
+                safe_copy(txtfile, rundir)
 
 ###############################################################################
 def _main_func():

--- a/src/components/data_comps/dwav/cime_config/buildnml
+++ b/src/components/data_comps/dwav/cime_config/buildnml
@@ -8,7 +8,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob
+import os, sys, glob
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -17,7 +17,7 @@ from standard_script_setup import *
 from CIME.case import Case
 from CIME.XML.files import Files
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
 from CIME.buildnml import create_namelist_infile, parse_input
 
 logger = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen):
 
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
-            shutil.copyfile(user_stream_path, stream_path)
+            safe_copy(user_stream_path, stream_path)
             config['stream'] = stream
             nmlgen.update_shr_strdata_nml(config, stream, stream_path)
         else:
@@ -175,8 +175,8 @@ def buildnml(case, caseroot, compname):
         rpointer = "rpointer." + compname
         if (os.path.isfile(os.path.join(rundir,rpointer)) and
             (not os.path.isfile(os.path.join(rundir,rpointer + inst_string)))):
-            shutil.copy(os.path.join(rundir, rpointer),
-                        os.path.join(rundir, rpointer + inst_string))
+            safe_copy(os.path.join(rundir, rpointer),
+                      os.path.join(rundir, rpointer + inst_string))
 
         inst_string_label = inst_string
         if not inst_string_label:
@@ -200,10 +200,10 @@ def buildnml(case, caseroot, compname):
             file_dest = os.path.join(rundir, filename)
             if inst_string:
                 file_dest += inst_string
-            shutil.copy(file_src,file_dest)
+            safe_copy(file_src,file_dest)
 
             for txtfile in glob.glob(os.path.join(confdir, "*txt*")):
-                shutil.copy(txtfile, rundir)
+                safe_copy(txtfile, rundir)
 
 ###############################################################################
 def _main_func():

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -7,7 +7,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob, itertools, re
+import os, sys, glob, itertools, re
 
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
@@ -15,7 +15,7 @@ sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 from standard_script_setup import *
 from CIME.case import Case
 from CIME.nmlgen import NamelistGenerator
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
 from CIME.utils import get_model, get_time_in_seconds, get_timestamp
 from CIME.buildnml import create_namelist_infile, parse_input
 from CIME.XML.files import Files
@@ -386,15 +386,15 @@ def buildnml(case, caseroot, component):
     # copy drv_in, drv_flds_in, seq_maps.rc and all *modio* fiels to rundir
     rundir = case.get_value("RUNDIR")
 
-    shutil.copy(os.path.join(confdir,"drv_in"), rundir)
+    safe_copy(os.path.join(confdir,"drv_in"), rundir)
     drv_flds_in = os.path.join(caseroot, "CaseDocs", "drv_flds_in")
     if os.path.isfile(drv_flds_in):
-        shutil.copy(drv_flds_in, rundir)
+        safe_copy(drv_flds_in, rundir)
 
-    shutil.copy(os.path.join(confdir,"seq_maps.rc"), rundir)
+    safe_copy(os.path.join(confdir,"seq_maps.rc"), rundir)
 
     for filename in glob.glob(os.path.join(confdir, "*modelio*")):
-        shutil.copy(filename, rundir)
+        safe_copy(filename, rundir)
 
 ###############################################################################
 def _main_func():


### PR DESCRIPTION
With this change, I appear to be able to use other people's cases (your mileage may vary , depending upon the implementations of the buildnml/buildlib scripts for the components in your compset).

Test suite: create_test cime_tiny --no-run
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2485 

User interface changes?:  N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
