### PR TITLE
Add ability to skip checks of some locked env files.

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -385,7 +385,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist):
 
     comp_classes = case.get_values("COMP_CLASSES")
 
-    case.check_lockedfiles()
+    case.check_lockedfiles(skip="env_batch")
 
     # Retrieve relevant case data
     # This environment variable gets set for cesm Make and


### PR DESCRIPTION
We need to lock env_batch in case.setup so that we know if we need to
regenerate submit scripts in case.submit, but we do not want case.build
barfing on env_batch.xml lock files. Thus, the concept of skipping certain
files in check_locked_files had to be added.

Test suite: code-checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2514 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
