### PR TITLE
Adds a reasonable error message for when there is no time dimension

### DIFF
--- a/tools/cprnc/compare_vars_mod.F90.in
+++ b/tools/cprnc/compare_vars_mod.F90.in
@@ -50,7 +50,8 @@ contains
     vnot_analyzed = 0
     vnotfound=0
     if(n==2 .and. .not.ignoretime) then
-       call checknf90(nf90_inq_varid(file(1)%fh, 'time', vid1))
+       call checknf90(nf90_inq_varid(file(1)%fh, 'time', vid1), &
+            err_str='These files don''t have a time dimension, use cprnc with -m')
 
        ns1 = file(1)%dim(file(1)%unlimdimid)%dimsize
        if(n==2) then

--- a/tools/cprnc/utils.F90
+++ b/tools/cprnc/utils.F90
@@ -54,13 +54,17 @@ end subroutine get_dim_str
 
 
 
-subroutine checknf90(ierr,returnflag)
+subroutine checknf90(ierr,returnflag,err_str)
   use netcdf, only : nf90_noerr, nf90_strerror
   integer, intent(in) :: ierr
   logical, optional, intent(in) :: returnflag
+  character(len=*), optional, intent(in) :: err_str
 
   if(ierr/=NF90_NOERR) then
      print *, trim(nf90_strerror(ierr))
+     if(present(err_str)) then
+        print *, trim(err_str)
+     end if
      if(present(returnflag)) then
         if(returnflag) return
      end if


### PR DESCRIPTION
but -m wasn't specified

Tested manually and with the `run_tests` script

Fixes #2523 

User interface changes?: CPRNC

Code review: @billsacks 
