### PR TITLE
clean should not look for mpilibs

### DIFF
--- a/tools/configure
+++ b/tools/configure
@@ -108,6 +108,19 @@ def parse_command_line(args):
            % compiler)
     opts['compiler'] = compiler
     opts['os'] = machobj.get_value('OS')
+
+    if args.clean:
+        files = ["Macros.make", "Macros.cmake", "env_mach_specific.xml", ".env_mach_specific.sh",
+                 ".env_mach_specific.csh", "Depends.%s"%compiler, "Depends.%s"%args.machine,
+                  "Depends.%s.%s"%(args.machine,compiler)]
+        for file_ in files:
+            if os.path.isfile(file_):
+                logger.warn("Removing file %s"%file_)
+                os.remove(file_)
+        if argcnt == 2:
+            opts['clean_only'] = True
+            return opts
+
     # Set MPI library.
     if args.mpilib is not None:
         mpilib = args.mpilib
@@ -133,17 +146,6 @@ def parse_command_line(args):
         os.environ["DEBUG"] = "FALSE"
     opts['debug'] = debug
 
-
-    if args.clean:
-        files = ["Macros.make", "Macros.cmake", "env_mach_specific.xml", ".env_mach_specific.sh",
-                 ".env_mach_specific.csh", "Depends.%s"%compiler, "Depends.%s"%args.machine,
-                  "Depends.%s.%s"%(args.machine,compiler)]
-        for file_ in files:
-            if os.path.isfile(file_):
-                logger.warn("Removing file %s"%file_)
-                os.remove(file_)
-        if argcnt == 2:
-            opts['clean_only'] = True
 
     return opts
 


### PR DESCRIPTION
configure --clean shouldn't need to figure out what mpi library it needs. 

Test suite: by hand configure --clean on cheyenne
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #2542 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
