### PR TITLE
Convert e3sm grids

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1229,7 +1229,8 @@
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to hwthread</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1242,24 +1243,38 @@
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">sems-env</command>
-	<command name="load">sems-git</command>
-	<command name="load">sems-python/2.7.9</command>
-	<command name="load">sems-gcc/5.1.0</command>
-	<command name="load">sems-openmpi/1.8.7</command>
-	<command name="load">sems-cmake/2.8.12</command>
-	<command name="load">sems-netcdf/4.3.2/parallel</command>
+        <command name="purge"/>
+        <command name="load">sems-env</command>
+        <command name="load">acme-env</command>
+        <command name="load">sems-git</command>
+        <command name="load">sems-python/2.7.9</command>
+        <command name="load">sems-cmake/2.8.12</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">sems-gcc/5.3.0</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">sems-intel/16.0.3</command>
+      </modules>
+      <modules mpilib="mpi-serial">
+        <command name="load">sems-netcdf/4.4.1/exo</command>
+        <command name="load">acme-pfunit/3.2.8/base</command>
+      </modules>
+      <modules mpilib="!mpi-serial">
+        <command name="load">sems-openmpi/1.8.7</command>
+        <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
       </modules>
     </module_system>
     <environment_variables>
       <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
+      <env name="OMP_STACKSIZE">64M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
       <env name="PNETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
     </environment_variables>
   </machine>
-
 
   <machine MACH="mira">
     <DESC>ANL IBM BG/Q, os is BGP, 16 pes/node, batch system is cobalt</DESC>

--- a/config/e3sm/allactive/config_compsets.xml
+++ b/config/e3sm/allactive/config_compsets.xml
@@ -288,25 +288,25 @@
 
   <entry id="RUN_REFDATE">
      <values match="first">
-       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_m%oEC60to30v3_g%null_w%null"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >0331-01-01</value>
+       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_g%null_w%null_m%oEC60to30v3"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >0331-01-01</value>
       </values>
   </entry>
 
   <entry id="RUN_TYPE">
      <values match="first">
-       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_m%oEC60to30v3_g%null_w%null"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >hybrid</value>
+       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_g%null_w%null_m%oEC60to30v3"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >hybrid</value>
       </values>
   </entry>
 
   <entry id="RUN_REFCASE">
      <values match="first">
-       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_m%oEC60to30v3_g%null_w%null"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >20171228.beta3rc13_1850.ne30_oECv3_ICG.edison</value>
+       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_g%null_w%null_m%oEC60to30v3"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >20171228.beta3rc13_1850.ne30_oECv3_ICG.edison</value>
       </values>
   </entry>
 
   <entry id="RUN_REFDIR">
      <values match="first">
-       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_m%oEC60to30v3_g%null_w%null"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >e3sm_init</value>
+       <value grid="a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_g%null_w%null_m%oEC60to30v3"      compset="1850_CAM5%CMIP6_CLM45%SPBC_MPASCICE%SPUNUP_MPASO%SPUNUP_MOSART_SGLC_SWAV"    >e3sm_init</value>
       </values>
   </entry>
 </entries>

--- a/config/e3sm/config_grids.xml
+++ b/config/e3sm/config_grids.xml
@@ -1,1262 +1,1611 @@
 <?xml version="1.0"?>
 
-<grid_data>
+<grid_data version="2.0">
 
   <help>
     =========================================
     GRID naming convention
     =========================================
-    The long grid name has the order atm,lnd,ocn/ice,river,mask,glc
-    The following shortname is used
-    a% => atm, l% => lnd, oi% => ocn/ice, r% => river, m% => mask, g% => glc, w% => wav
-    The notation is
+    The notation for the grid longname is
     a%name_l%name_oi%name_r%name_m%mask_g%name_w%name
-    Each grid is associated with three required elements and one optional element
-    longname      (a%name_l%name_oi%name_r%name_m%mask_g%name_w%name)
-    shortname     (for backwards compatibility)
-    alias         (even shorter notation than shortname) (optional)
-    support       (Description of the support level for this grid) (optional)
-    Each grid can also be associated with the following optional attributes
-    compset       (Regular expression for compsets that are required to match for this grid) (optional)
+    where
+    a% => atm, l% => lnd, oi% => ocn/ice, r% => river, m% => mask, g% => glc, w% => wav
+
+    Supported out of the box grid configurations are given via alias specification in
+    the file "config_grids.xml". Each grid alias can also be associated  with the
+    following optional attributes
+
+    compset       (Regular expression for compset matches that are required for this grid)
+    not_compset   (Regular expression for compset matches that are not permitted this grid)
+
+    Using the alias and the optional "compset" and "not_compset" attributes a grid longname is created
+    Note that the mask is for information only - and is not an attribute of the grid
+    By default, if the mask is not specified below, it will be set to the ocnice grid
+    And if there is no ocnice grid (such as for single column, the mask is null since it does not mean anything)
   </help>
 
   <grids>
-    <grid compset="DATM.+DROF">
-      <lname>a%gx1v6_l%gx1v6_oi%gx1v6_r%rx1_m%gx1v6_g%null_w%null</lname>
-      <sname>gx1v6_gx1v6</sname>
-      <alias>g16_g16</alias>
-      <support>Non-standard grid for testing of the interpolation in DATM rather than coupler</support>
-    </grid>
 
-    <grid compset="(DATM|SATM).+CLM">
-      <sname>CLM_USRDAT</sname>
-      <lname>a%CLM_USRDAT_l%CLM_USRDAT_oi%CLM_USRDAT_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid_defaults>
+      <grid name="atm"    compset="SATM"  >null</grid>
+      <grid name="lnd"    compset="SLND"  >null</grid>
+      <grid name="ocnice" compset="SOCN"  >null</grid>
+      <grid name="rof"    compset="SROF"  >null</grid>
+      <grid name="rof"    compset="DWAV"  >rx1</grid>
+      <grid name="rof"    compset="RTM"	  >r05</grid>
+      <grid name="rof"    compset="MOSART">r05</grid>
+      <grid name="rof"    compset="DROF"  >rx1</grid>
+      <grid name="rof"    compset="DROF%CPLHIST">r05</grid>
+      <grid name="rof"    compset="XROF"  >r05</grid>
+      <grid name="glc"	  compset="SGLC"  >null</grid>
+      <grid name="glc"	  compset="CISM1" >gland5UM</grid>
+      <grid name="glc"	  compset="CISM2" >gland4</grid>
+      <grid name="glc"    compset="XGLC"  >gland4</grid>
+      <grid name="wav"	  compset="SWAV"  >null</grid>
+      <grid name="wav"	  compset="DWAV"  >ww3a</grid>
+      <grid name="wav"	  compset="WW3"	  >ww3a</grid>
+      <grid name="wav"    compset="XWAV"  >ww3a</grid>
+    </model_grid_defaults>
 
-    <grid compset="DATM.+CLM">
-      <sname>1x1_numaIA</sname>
-      <lname>a%1x1_numaIA_l%1x1_numaIA_oi%1x1_numaIA_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="g16_g16" compset="DATM.+DROF">
+      <grid name="atm">gx1v6</grid>
+      <grid name="lnd">gx1v6</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="DATM.+CLM">
-      <sname>1x1_brazil</sname>
-      <lname>a%1x1_brazil_l%1x1_brazil_oi%1x1_brazil_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="CLM_USRDAT" compset="(DATM|SATM).+CLM">
+      <grid name="atm">CLMUSRDAT</grid>
+      <grid name="lnd">CLMUSRDAT</grid>
+      <grid name="ocnice">CLMUSRDAT</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
 
-    <grid compset="(DATM|SATM).+CLM">
-      <sname>1x1_smallvilleIA</sname>
-      <lname>a%1x1_smallvilleIA_l%1x1_smallvilleIA_oi%1x1_smallvilleIA_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="1x1_numaIA" compset="DATM.+CLM">
+      <grid name="atm">1x1numaIA</grid>
+      <grid name="lnd">1x1numaIA</grid>
+      <grid name="ocnice">1x1numaIA</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
 
-    <grid compset="DATM.+CLM">
-      <sname>1x1_camdenNJ</sname>
-      <lname>a%1x1_camdenNJ_l%1x1_camdenNJ_oi%1x1_camdenNJ_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="1x1_brazil" compset="DATM.+CLM">
+      <grid name="atm">1x1brazil</grid>
+      <grid name="lnd">1x1brazil</grid>
+      <grid name="ocnice">1x1brazil</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
 
-    <grid compset="DATM.+CLM">
-      <sname>1x1_mexicocityMEX</sname>
-      <lname>a%1x1_mexicocityMEX_l%1x1_mexicocityMEX_oi%1x1_mexicocityMEX_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="1x1_smallvilleIA" compset="(DATM|SATM).+CLM">
+      <grid name="atm">1x1smallvilleIA</grid>
+      <grid name="lnd">1x1smallvilleIA</grid>
+      <grid name="ocnice">1x1smallvilleIA</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
 
-    <grid compset="DATM.+CLM">
-      <sname>1x1_vancouverCAN</sname>
-      <lname>a%1x1_vancouverCAN_l%1x1_vancouverCAN_oi%1x1_vancouverCAN_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="1x1_camdenNJ" compset="DATM.+CLM">
+      <grid name="atm">1x1camdenNJ</grid>
+      <grid name="lnd">1x1camdenNJ</grid>
+      <grid name="ocnice">1x1camdenNJ</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
 
-    <grid compset="DATM.+CLM">
-      <sname>1x1_tropicAtl</sname>
-      <lname>a%1x1_tropicAtl_l%1x1_tropicAtl_oi%1x1_tropicAtl_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="1x1_mexicocityMEX" compset="DATM.+CLM">
+      <grid name="atm">1x1mexicocityMEX</grid>
+      <grid name="lnd">1x1mexicocityMEX</grid>
+      <grid name="ocnice">1x1mexicocityMEX</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
 
-    <grid compset="DATM.+CLM">
-      <sname>1x1_urbanc_alpha</sname>
-      <lname>a%1x1_urbanc_alpha_l%1x1_urbanc_alpha_oi%1x1_urbanc_alpha_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="1x1_vancouverCAN" compset="DATM.+CLM">
+      <grid name="atm">1x1vancouverCAN</grid>
+      <grid name="lnd">1x1vancouverCAN</grid>
+      <grid name="ocnice">1x1vancouverCAN</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
 
-    <grid compset="DATM.+CLM">
-      <sname>5x5_amazon</sname>
-      <alias>5amazon</alias>
-      <lname>a%5x5_amazon_l%5x5_amazon_oi%5x5_amazon_r%null_m%reg_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="1x1_tropicAtl" compset="DATM.+CLM">
+      <grid name="atm">1x1tropicAtl</grid>
+      <grid name="lnd">1x1tropicAtl</grid>
+      <grid name="ocnice">1x1tropicAtl</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
 
-    <grid compset="(DATM|SATM).+CLM">
-      <sname>hcru_hcru</sname>
-      <lname>a%360x720cru_l%360x720cru_oi%360x720cru_r%r05_m%360x720cru_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="1x1_urbanc_alpha" compset="DATM.+CLM">
+      <grid name="atm">1x1urbancalpha</grid>
+      <grid name="lnd">1x1urbancalpha</grid>
+      <grid name="ocnice">1x1urbancalpha</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
 
-    <grid compset="(DATM_SATM).+CLM">
-      <sname>NLDAS_NLDAS</sname>
-      <lname>a%NLDAS_l%NLDAS_oi%NLDAS_r%NLDAS_m%NLDAS_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="5amazon" compset="DATM.+CLM">
+      <grid name="atm">5x5amazon</grid>
+      <grid name="lnd">5x5amazon</grid>
+      <grid name="ocnice">5x5amazon</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>reg</mask>
+    </model_grid>
+
+    <model_grid alias="hcru_hcru" compset="(DATM|SATM).+CLM">
+      <grid name="atm">360x720cru</grid>
+      <grid name="lnd">360x720cru</grid>
+      <grid name="ocnice">360x720cru</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>360x720cru</mask>
+    </model_grid>
+
+    <model_grid alias="NLDAS_NLDAS" compset="(DATM_SATM).+CLM">
+      <grid name="atm">NLDAS</grid>
+      <grid name="lnd">NLDAS</grid>
+      <grid name="ocnice">NLDAS</grid>
+      <grid name="rof">NLDAS</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>NLDAS</mask>
+    </model_grid>
 
     <!-- eulerian grids -->
 
-    <grid>
-      <sname>T31_gx3v7</sname>
-      <alias>T31_g37</alias>
-      <lname>a%T31_l%T31_oi%gx3v7_r%r05_m%gx3v7_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T31_g37">
+      <grid name="atm">T31</grid>
+      <grid name="lnd">T31</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN)">
-      <sname>T31_T31</sname>
-      <lname>a%T31_l%T31_oi%T31_r%r05_m%gx3v7_g%null_w%null</lname>
-      <alias>T31_T31</alias>
-    </grid>
+    <model_grid alias="T31_T31" compset="(DOCN|XOCN|SOCN)">
+      <grid name="atm">T31</grid>
+      <grid name="lnd">T31</grid>
+      <grid name="ocnice">T31</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN)">
-      <sname>T42_T42</sname>
-      <alias>T42_T42</alias>
-      <lname>a%T42_l%T42_oi%T42_r%r05_m%usgs_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T42_T42" compset="(DOCN|XOCN|SOCN)">
+      <grid name="atm">T42</grid>
+      <grid name="lnd">T42</grid>
+      <grid name="ocnice">T42</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>usgs</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_gx3v7</sname>
-      <alias>T62_g37</alias>
-      <lname>a%T62_l%T62_oi%gx3v7_r%rx1_m%gx3v7_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_g37" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_gx1v6</sname>
-      <alias>T62_g16</alias>
-      <lname>a%T62_l%T62_oi%gx1v6_r%rx1_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_g16" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_mpas120</sname>
-      <alias>T62_m120</alias>
-      <lname>a%T62_l%T62_oi%mpas120_r%rx1_m%mpas120_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_m120" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">mpas120</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>mpas120</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_mpasgx1</sname>
-      <alias>T62_mgx1</alias>
-      <lname>a%T62_l%T62_oi%mpasgx1_r%rx1_m%mpasgx1_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_mgx1" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">mpasgx1</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>mpasgx1</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oEC60to30</sname>
-      <alias>T62_oEC60to30</alias>
-      <lname>a%T62_l%T62_oi%oEC60to30_r%rx1_m%oEC60to30_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_oEC60to30" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oEC60to30</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oEC60to30v3</sname>
-      <alias>T62_oEC60to30v3</alias>
-      <lname>a%T62_l%T62_oi%oEC60to30v3_r%rx1_m%oEC60to30v3_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_oEC60to30v3" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oEC60to30wLI</sname>
-      <alias>T62_oEC60to30wLI</alias>
-      <lname>a%T62_l%T62_oi%oEC60to30wLI_r%rx1_m%oEC60to30wLI_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_oEC60to30wLI" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oEC60to30wLI</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30wLI</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oEC60to30v3wLI</sname>
-      <alias>T62_oEC60to30v3wLI</alias>
-      <lname>a%T62_l%T62_oi%oEC60to30v3wLI_r%rx1_m%oEC60to30v3wLI_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_oEC60to30v3wLI" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oEC60to30v3wLI</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3wLI</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oRRS30to10</sname>
-      <alias>T62_oRRS30to10</alias>
-      <lname>a%T62_l%T62_oi%oRRS30to10_r%rx1_m%oRRS30to10_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_oRRS30to10" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oRRS30to10</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS30to10</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oRRS30to10wLI</sname>
-      <alias>T62_oRRS30to10wLI</alias>
-      <lname>a%T62_l%T62_oi%oRRS30to10wLI_r%rx1_m%oRRS30to10wLI_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_oRRS30to10wLI" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oRRS30to10wLI</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS30to10wLI</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oRRS30to10v3</sname>
-      <alias>T62_oRRS30to10v3</alias>
-      <lname>a%T62_l%T62_oi%oRRS30to10v3_r%rx1_m%oRRS30to10v3_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_oRRS30to10v3" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oRRS30to10v3</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS30to10v3</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oRRS30to10v3wLI</sname>
-      <alias>T62_oRRS30to10v3wLI</alias>
-      <lname>a%T62_l%T62_oi%oRRS30to10v3wLI_r%rx1_m%oRRS30to10v3wLI_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="T62_oRRS30to10v3wLI" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oRRS30to10v3wLI</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS30to10v3wLI</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oRRS18to6</sname>
-      <lname>a%T62_l%T62_oi%oRRS18to6_r%rx1_m%oRRS18to6_g%null_w%null</lname>
-      <alias>T62_oRRS18to6</alias>
-    </grid>
+    <model_grid alias="T62_oRRS18to6" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oRRS18to6</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oRRS18to6v3</sname>
-      <lname>a%T62_l%T62_oi%oRRS18to6v3_r%rx1_m%oRRS18to6v3_g%null_w%null</lname>
-      <alias>T62_oRRS18to6v3</alias>
-    </grid>
+    <model_grid alias="T62_oRRS18to6v3" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oRRS18to6v3</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6v3</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oRRS15to5</sname>
-      <lname>a%T62_l%T62_oi%oRRS15to5_r%rx1_m%oRRS15to5_g%null_w%null</lname>
-      <alias>T62_oRRS15to5</alias>
-    </grid>
+    <model_grid alias="T62_oRRS15to5" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oRRS15to5</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS15to5</mask>
+    </model_grid>
 
     <!-- finite volume grids -->
 
-    <grid>
-      <sname>0.23x0.31_gx1v6</sname>
-      <alias>f02_g16</alias>
-      <lname>a%0.23x0.31_l%0.23x0.31_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f02_g16">
+      <grid name="atm">0.23x0.31</grid>
+      <grid name="lnd">0.23x0.31</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>0.47x0.63_gx1v6</sname>
-      <alias>f05_g16</alias>
-      <lname>a%0.47x0.63_l%0.47x0.63_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f05_g16">
+      <grid name="atm">0.47x0.63</grid>
+      <grid name="lnd">0.47x0.63</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>0.9x1.25_gx1v6</sname>
-      <alias>f09_g16</alias>
-      <lname>a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f09_g16">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>0.9x1.25_mpas120</sname>
-      <alias>f09_m120</alias>
-      <lname>a%0.9x1.25_l%0.9x1.25_oi%mpas120_r%r05_m%mpas120_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f09_m120">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">mpas120</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>mpas120</mask>
+    </model_grid>
 
-    <grid compset="SGLC.+DWAV">
-      <sname>0.9x1.25_gx1v6</sname>
-      <alias>f09_g16</alias>
-      <lname>a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%null_w%ww3a</lname>
-    </grid>
+    <model_grid alias="f09_g16" compset="SGLC.+DWAV">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>1.9x2.5_gx1v6</sname>
-      <alias>f19_g16</alias>
-      <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f19_g16">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="SGLC.+DWAV">
-      <sname>1.9x2.5_gx1v6</sname>
-      <alias>f19_g16</alias>
-      <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%null_w%ww3a</lname>
-    </grid>
+    <model_grid alias="f19_g16" compset="SGLC.+DWAV">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>4x5_gx3v7</sname>
-      <alias>f45_g37</alias>
-      <lname>a%4x5_l%4x5_oi%gx3v7_r%r05_m%gx3v7_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f45_g37">
+      <grid name="atm">4x5</grid>
+      <grid name="lnd">4x5</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid>
-      <sname>1.9x2.5_gx1v6_r01</sname>
-      <alias>f19_g16_r01</alias>
-      <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r01_m%gx1v6_g%null_w%null</lname>
-      <support>Non-standard grid, for testing high resolution RTM grid</support>
-    </grid>
+    <model_grid alias="f19_g16_r01">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r01</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>0.23x0.31_0.23x0.31</sname>
-      <alias>f02_f02</alias>
-      <lname>a%0.23x0.31_l%0.23x0.31_oi%0.23x0.31_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f02_f02" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">0.23x0.31</grid>
+      <grid name="lnd">0.23x0.31</grid>
+      <grid name="ocnice">0.23x0.31</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>0.9x1.25_0.9x1.25</sname>
-      <lname>a%0.9x1.25_l%0.9x1.25_oi%0.9x1.25_r%r05_m%gx1v6_g%null_w%null</lname>
-      <alias>f09_f09</alias>
-    </grid>
+    <model_grid alias="f09_f09" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">0.9x1.25</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>1.9x2.5_1.9x2.5</sname>
-      <alias>f19_f19</alias>
-      <lname>a%1.9x2.5_l%1.9x2.5_oi%1.9x2.5_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f19_f19" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">1.9x2.5</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>2.5x3.33_2.5x3.33</sname>
-      <alias>f25_f25</alias>
-      <lname>a%2.5x3.33_l%2.5x3.33_oi%2.5x3.33_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f25_f25" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">2.5x3.33</grid>
+      <grid name="lnd">2.5x3.33</grid>
+      <grid name="ocnice">2.5x3.33</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>4x5_4x5</sname>
-      <alias>f45_f45</alias>
-      <lname>a%4x5_l%4x5_oi%4x5_r%r05_m%gx3v7_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f45_f45" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">4x5</grid>
+      <grid name="lnd">4x5</grid>
+      <grid name="ocnice">4x5</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>10x15_10x15</sname>
-      <alias>f10_f10</alias>
-      <lname>a%10x15_l%10x15_oi%10x15_r%r05_m%usgs_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="f10_f10" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">10x15</grid>
+      <grid name="lnd">10x15</grid>
+      <grid name="ocnice">10x15</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>usgs</mask>
+    </model_grid>
 
     <!--  spectral element grids -->
 
-   <grid>
-      <sname>ne4np4_oQU240</sname>
-      <lname>a%ne4np4_l%ne4np4_oi%oQU240_r%r05_m%oQU240_g%null_w%null</lname>
-      <alias>ne4_oQU240</alias>
-    </grid>
+    <model_grid alias="ne4_oQU240">
+      <grid name="atm">ne4np4</grid>
+      <grid name="lnd">ne4np4</grid>
+      <grid name="ocnice">oQU240</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240</mask>
+    </model_grid>
 
-   <grid>
-      <sname>ne4np4_oQU240wLI</sname>
-      <lname>a%ne4np4_l%ne4np4_oi%oQU240wLI_r%r05_m%oQU240wLI_g%null_w%null</lname>
-      <alias>ne4_oQU240wLI</alias>
-    </grid>
+    <model_grid alias="ne4_oQU240wLI">
+      <grid name="atm">ne4np4</grid>
+      <grid name="lnd">ne4np4</grid>
+      <grid name="ocnice">oQU240wLI</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240wLI</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne11np4_oQU240</sname>
-      <lname>a%ne11np4_l%ne11np4_oi%oQU240_r%r05_m%oQU240_g%null_w%null</lname>
-      <alias>ne11_oQU240</alias>
-    </grid>
+    <model_grid alias="ne11_oQU240">
+      <grid name="atm">ne11np4</grid>
+      <grid name="lnd">ne11np4</grid>
+      <grid name="ocnice">oQU240</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne16np4_gx3v7</sname>
-      <alias>ne16_g37</alias>
-      <lname>a%ne16np4_l%ne16np4_oi%gx3v7_r%r05_m%gx3v7_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne16_g37">
+      <grid name="atm">ne16np4</grid>
+      <grid name="lnd">ne16np4</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_gx1v6</sname>
-      <alias>ne30_g16</alias>
-      <lname>a%ne30np4_l%ne30np4_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne30_g16">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_mpas120</sname>
-      <alias>ne30_m120</alias>
-      <lname>a%ne30np4_l%ne30np4_oi%mpas120_r%r05_m%mpas120_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne30_m120">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">mpas120</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>mpas120</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_mpas120_gis20</sname>
-      <alias>ne30_m120_g</alias>
-      <lname>a%ne30np4_l%ne30np4_oi%mpas120_r%r05_m%mpas120_g%mpas.gis20km_w%null</lname>
-    </grid>
+    <model_grid alias="ne30_m120_g">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">mpas120</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.gis20km</grid>
+      <grid name="wav">null</grid>
+      <mask>mpas120</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_1.9x2.5_gx1v6</sname>
-      <alias>ne30_f19_g16</alias>
-      <lname>a%ne30np4_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-      <support>For testing tri-grid</support>
-    </grid>
+    <model_grid alias="ne30_f19_g16">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_0.9x1.25_gx1v6</sname>
-      <alias>ne30_f09_g16</alias>
-      <lname>a%ne30np4_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-      <support>For testing tri-grid</support>
-    </grid>
+    <model_grid alias="ne30_f09_g16">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne60np4_gx1v6</sname>
-      <alias>ne60_g16</alias>
-      <lname>a%ne60np4_l%ne60np4_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne60_g16">
+      <grid name="atm">ne60np4</grid>
+      <grid name="lnd">ne60np4</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne120np4_gx1v6</sname>
-      <alias>ne120_g16</alias>
-      <lname>a%ne120np4_l%ne120np4_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne120_g16">
+      <grid name="atm">ne120np4</grid>
+      <grid name="lnd">ne120np4</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne120np4_oRRS18to6</sname>
-      <lname>a%ne120np4_l%ne120np4_oi%oRRS18to6_r%r0125_m%oRRS18to6_g%null_w%null</lname>
-      <alias>ne120_oRRS18</alias>
-    </grid>
+    <model_grid alias="ne120_oRRS18">
+      <grid name="atm">ne120np4</grid>
+      <grid name="lnd">ne120np4</grid>
+      <grid name="ocnice">oRRS18to6</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne120np4_oRRS18to6v3</sname>
-      <lname>a%ne120np4_l%ne120np4_oi%oRRS18to6v3_r%r0125_m%oRRS18to6v3_g%null_w%null</lname>
-      <alias>ne120_oRRS18v3</alias>
-    </grid>
+    <model_grid alias="ne120_oRRS18v3">
+      <grid name="atm">ne120np4</grid>
+      <grid name="lnd">ne120np4</grid>
+      <grid name="ocnice">oRRS18to6v3</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6v3</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne120np4_oRRS15to5</sname>
-      <lname>a%ne120np4_l%ne120np4_oi%oRRS15to5_r%r0125_m%oRRS15to5_g%null_w%null</lname>
-      <alias>ne120_oRRS15</alias>
-    </grid>
+    <model_grid alias="ne120_oRRS15">
+      <grid name="atm">ne120np4</grid>
+      <grid name="lnd">ne120np4</grid>
+      <grid name="ocnice">oRRS15to5</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS15to5</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne240np4_0.23x0.31_gx1v6</sname>
-      <alias>ne240_f02_g16</alias>
-      <lname>a%ne240np4_l%0.23x0.31_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null</lname>
-      <support>For testing high resolution tri-grid</support>
-    </grid>
+    <model_grid alias="ne240_f02_g16">
+      <grid name="atm">ne240np4</grid>
+      <grid name="lnd">0.23x0.31</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne4np4_ne4np4</sname>
-      <lname>a%ne4np4_l%ne4np4_oi%ne4np4_r%r05_m%oQU240_g%null_w%null</lname>
-      <alias>ne4_ne4</alias>
-    </grid>
+    <model_grid alias="ne4_ne4" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne4np4</grid>
+      <grid name="lnd">ne4np4</grid>
+      <grid name="ocnice">ne4np4</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne11np4_ne11np4</sname>
-      <lname>a%ne11np4_l%ne11np4_oi%ne11np4_r%r05_m%oQU240_g%null_w%null</lname>
-      <alias>ne11_ne11</alias>
-    </grid>
+    <model_grid alias="ne11_ne11" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne11np4</grid>
+      <grid name="lnd">ne11np4</grid>
+      <grid name="ocnice">ne11np4</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne0np4_arm_x8v3_lowcon_ne0np4_arm_x8v3_lowcon</sname>
-      <lname>    a%ne0np4_arm_x8v3_lowcon_l%ne0np4_arm_x8v3_lowcon_oi%ne0np4_arm_x8v3_lowcon_r%null_m%gx1v6_g%null_w%null</lname>
-      <alias>armx8v3_armx8v3</alias>
-    </grid>
+    <model_grid alias="armx8v3_armx8v3" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne0np4armx8v3lowcon</grid>
+      <grid name="lnd">ne0np4armx8v3lowcon</grid>
+      <grid name="ocnice">ne0np4armx8v3lowcon</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne0np4_conus_x4v1_lowcon_ne0np4_conus_x4v1_lowcon</sname>
-      <lname>    a%ne0np4_conus_x4v1_lowcon_l%ne0np4_conus_x4v1_lowcon_oi%ne0np4_conus_x4v1_lowcon_r%null_m%tx0.1v2_g%null_w%null</lname>
-      <alias>conusx4v1_conusx4v1</alias>
-    </grid>
+    <model_grid alias="conusx4v1_conusx4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne0np4conusx4v1lowcon</grid>
+      <grid name="lnd">ne0np4conusx4v1lowcon</grid>
+      <grid name="ocnice">ne0np4conusx4v1lowcon</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>tx0.1v2</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne0np4_svalbard_x8v1_lowcon_ne0np4_svalbard_x8v1_lowcon</sname>
-      <lname>    a%ne0np4_svalbard_x8v1_lowcon_l%ne0np4_svalbard_x8v1_lowcon_oi%ne0np4_svalbard_x8v1_lowcon_r%null_m%tx0.1v2_g%null_w%null</lname>
-      <alias>svalbardx8v1_svalbardx8v1</alias>
-    </grid>
+    <model_grid alias="svalbardx8v1_svalbardx8v1" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne0np4svalbardx8v1lowcon</grid>
+      <grid name="lnd">ne0np4svalbardx8v1lowcon</grid>
+      <grid name="ocnice">ne0np4svalbardx8v1lowcon</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>tx0.1v2</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne0np4_sooberingoa_x4x8v1_lowcon_ne0np4_sooberingoa_x4x8v1_lowcon</sname>
-      <lname>    a%ne0np4_sooberingoa_x4x8v1_lowcon_l%ne0np4_sooberingoa_x4x8v1_lowcon_oi%ne0np4_sooberingoa_x4x8v1_lowcon_r%null_m%tx0.1v2_g%null_w%null</lname>
-      <alias>sooberingoax4x8v1_sooberingoax4x8v1</alias>
-    </grid>
+    <model_grid alias="sooberingoax4x8v1_sooberingoax4x8v1" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne0np4sooberingoax4x8v1lowcon</grid>
+      <grid name="lnd">ne0np4sooberingoax4x8v1lowcon</grid>
+      <grid name="ocnice">ne0np4sooberingoax4x8v1lowcon</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>tx0.1v2</mask>
+    </model_grid>
 
-    <!-- ENA RRM grid (all components) -->
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne0np4_enax4v1_ne0np4_enax4v1</sname>
-      <lname>a%ne0np4_enax4v1_l%ne0np4_enax4v1_oi%ne0np4_enax4v1_r%null_m%oRRS18to6_g%null_w%null</lname>
-      <alias>enax4v1_enax4v1</alias>
-    </grid>
+    <model_grid alias="enax4v1_enax4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne0np4enax4v1</grid>
+      <grid name="lnd">ne0np4enax4v1</grid>
+      <grid name="ocnice">ne0np4enax4v1</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6</mask>
+    </model_grid>
 
-    <!-- ENA RRM grid (land on ne30) -->
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne0np4_enax4v1_ne30np4_ne0np4_enax4v1</sname>
-      <lname>a%ne0np4_enax4v1_l%ne30np4_oi%ne0np4_enax4v1_r%null_m%oRRS18to6_g%null_w%null</lname>
-      <alias>enax4v1_ne30_enax4v1</alias>
-    </grid>
+    <model_grid alias="enax4v1_ne30_enax4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne0np4enax4v1</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">ne0np4enax4v1</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6</mask>
+    </model_grid>
 
-   <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne16np4_ne16np4</sname>
-      <alias>ne16_ne16</alias>
-      <lname>a%ne16np4_l%ne16np4_oi%ne16np4_r%r05_m%gx3v7_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne16_ne16" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne16np4</grid>
+      <grid name="lnd">ne16np4</grid>
+      <grid name="ocnice">ne16np4</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne30np4_ne30np4</sname>
-      <alias>ne30_ne30</alias>
-      <lname>a%ne30np4_l%ne30np4_oi%ne30np4_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne30_ne30" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">ne30np4</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(CAM5.+CLM.+MPASO%SPUNUP)">
-      <sname>ne30np4_oEC60to30_ICG</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oEC60to30_ICG_r%r05_m%oEC60to30_g%null_w%null</lname>
-      <alias>ne30_oEC_ICG</alias>
-    </grid>
+    <model_grid alias="ne30_oEC_ICG" compset="(CAM5.+CLM.+MPASO%SPUNUP)">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oEC60to30ICG</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30</mask>
+    </model_grid>
 
-    <grid compset="(CAM5.+CLM.+MPASO%SPUNUP)">
-      <sname>ne30np4_oEC60to30v3_ICG</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oEC60to30v3_ICG_r%r05_m%oEC60to30v3_g%null_w%null</lname>
-      <alias>ne30_oECv3_ICG</alias>
-    </grid>
+    <model_grid alias="ne30_oECv3_ICG" compset="(CAM5.+CLM.+MPASO%SPUNUP)">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oEC60to30v3ICG</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
 
-    <grid compset="(CAM5.+CLM.+MPASO%SPUNUP)">
-      <sname>ne30np4_oEC60to30v3wLI_ICG</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oEC60to30v3wLI_ICG_r%r05_m%oEC60to30v3wLI_g%null_w%null</lname>
-      <alias>ne30_oECv3wLI_ICG</alias>
-    </grid>
+    <model_grid alias="ne30_oECv3wLI_ICG" compset="(CAM5.+CLM.+MPASO%SPUNUP)">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oEC60to30v3wLIICG</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3wLI</mask>
+    </model_grid>
 
-    <grid compset="(CAM5.+CLM.+MPASO%SPUNUP)">
-      <sname>ne120np4_oRRS18to6v3_ICG</sname>
-      <lname>a%ne120np4_l%ne120np4_oi%oRRS18to6v3_ICG_r%r0125_m%oRRS18to6v3_g%null_w%null</lname>
-      <alias>ne120_oRRS18v3_ICG</alias>
-    </grid>
+    <model_grid alias="ne120_oRRS18v3_ICG" compset="(CAM5.+CLM.+MPASO%SPUNUP)">
+      <grid name="atm">ne120np4</grid>
+      <grid name="lnd">ne120np4</grid>
+      <grid name="ocnice">oRRS18to6v3ICG</grid>
+      <grid name="rof">r0125</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6v3</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne60np4_ne60np4</sname>
-      <alias>ne60_ne60</alias>
-      <lname>a%ne60np4_l%ne60np4_oi%ne60np4_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne60_ne60" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne60np4</grid>
+      <grid name="lnd">ne60np4</grid>
+      <grid name="ocnice">ne60np4</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne120np4_ne120np4</sname>
-      <alias>ne120_ne120</alias>
-      <lname>a%ne120np4_l%ne120np4_oi%ne120np4_r%r05_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne120_ne120" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne120np4</grid>
+      <grid name="lnd">ne120np4</grid>
+      <grid name="ocnice">ne120np4</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne240np4_ne240np4</sname>
-      <alias>ne240_ne240</alias>
-      <lname>a%ne240np4_l%ne240np4_oi%ne240np4_r%null_m%gx1v6_g%null_w%null</lname>
-    </grid>
+    <model_grid alias="ne240_ne240" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne240np4</grid>
+      <grid name="lnd">ne240np4</grid>
+      <grid name="ocnice">ne240np4</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
     <!--- mali grids -->
 
-    <grid compset="_MALI">
-      <sname>0.9x1.25_gx1v6_gis20</sname>
-      <alias>f09_g16_g</alias>
-      <lname>a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%mpas.gis20km_w%null</lname>
-    </grid> <!-- back compat -->
+    <model_grid alias="f09_g16_g" compset="_MALI">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.gis20km</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="_MALI">
-      <sname>0.9x1.25_gx1v6_ais20</sname>
-      <alias>f09_g16_a</alias>
-      <lname>a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%mpas.ais20km_w%null</lname>
-    </grid> <!-- back compat -->
+    <model_grid alias="f09_g16_a" compset="_MALI">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.ais20km</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
     <!-- mali + mpaso grids -->
 
-    <grid compset="MPASO.*_MALI">
-      <sname>T62_mpas120_gis20</sname>
-      <alias>T62_m120_g</alias>
-      <lname>a%T62_l%T62_oi%mpas120_r%rx1_m%mpas120_g%mpas.gis20km_w%null</lname>
-    </grid> <!-- back compat -->
+    <model_grid alias="T62_m120_g" compset="MPASO.*_MALI">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">mpas120</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">mpas.gis20km</grid>
+      <grid name="wav">null</grid>
+      <mask>mpas120</mask>
+    </model_grid>
 
-    <grid compset="MPASO.*_MALI">
-      <sname>0.9x1.25_oEC60to30_ais20</sname>
-      <alias>f09_oEC_a</alias>
-      <lname>a%0.9x1.25_l%0.9x1.25_oi%oEC60to30_r%r05_m%oEC60to30_g%mpas.ais20km_w%null</lname>
-    </grid> <!-- back compat -->
+    <model_grid alias="f09_oEC_a" compset="MPASO.*_MALI">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">oEC60to30</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.ais20km</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30</mask>
+    </model_grid>
 
     <!-- new runoff grids for data runoff model DROF -->
 
-    <grid compset="_DROF">
-      <sname>T31_gx3v7_rx1</sname>
-      <alias>T31_g37_rx1</alias>
-      <lname>a%T31_l%T31_oi%gx3v7_r%rx1_m%gx3v7_g%null_w%null</lname>
-    </grid> <!-- back compat -->
+    <model_grid alias="T31_g37_rx1" compset="_DROF">
+      <grid name="atm">T31</grid>
+      <grid name="lnd">T31</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid compset="_DROF">
-      <sname>4x5_gx3v7_rx1</sname>
-      <alias>f45_g37_rx1</alias>
-      <lname>a%4x5_l%4x5_oi%gx3v7_r%rx1_m%gx3v7_g%null_w%null</lname>
-    </grid> <!-- back compat -->
+    <model_grid alias="f45_g37_rx1" compset="_DROF">
+      <grid name="atm">4x5</grid>
+      <grid name="lnd">4x5</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid compset="_DROF">
-      <sname>1.9x2.5_gx1v6_rx1</sname>
-      <alias>f19_g16_rx1</alias>
-      <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%rx1_m%gx1v6_g%null_w%null</lname>
-    </grid> <!-- back compat -->
+    <model_grid alias="f19_g16_rx1" compset="_DROF">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="_DROF">
-      <sname>ne30np4_gx1v6_rx1</sname>
-      <alias>ne30_g16_rx1</alias>
-      <lname>a%ne30np4_l%ne30np4_oi%gx1v6_r%rx1_m%gx1v6_g%null_w%null</lname>
-    </grid> <!-- back compat -->
+    <model_grid alias="ne30_g16_rx1" compset="_DROF">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="_DROF">
-      <sname>ne30np4_1.9x2.5_gx1v6_rx1</sname>
-      <alias>ne30_f19_g16_rx1</alias>
-      <lname>a%ne30np4_l%1.9x2.5_oi%gx1v6_r%rx1_m%gx1v6_g%null_w%null</lname>
-    </grid><!-- back compat -->
+    <model_grid alias="ne30_f19_g16_rx1" compset="_DROF">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
     <!-- ww3 grids -->
 
-    <grid compset="_WW3">
-      <sname>ww3a_ww3a</sname>
-      <alias>ww3a_ww3a</alias>
-      <lname>a%ww3a_l%ww3a_oi%ww3a_r%null_m%ww3a_g%null_w%ww3a</lname>
-    </grid>
+    <model_grid alias="ww3a_ww3a" compset="_WW3">
+      <grid name="atm">ww3a</grid>
+      <grid name="lnd">ww3a</grid>
+      <grid name="ocnice">ww3a</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>ww3a</mask>
+    </model_grid>
 
+    <model_grid alias="f19_g16_r05_ww3" compset="(_DWAV|_XWAV|_WW3)">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <!-- QL, 150525, ww3 grids -->
-    <grid compset="(_DWAV|_XWAV|_WW3)">
-      <sname>1.9x2.5_gx1v6_r05_ww3a</sname>
-      <alias>f19_g16_r05_ww3</alias>
-      <lname>a%1.9x2.5_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%null_w%ww3a</lname>
-    </grid>
+    <model_grid alias="f09_g16_r05_ww3" compset="(_DWAV|_XWAV|_WW3)">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(_DWAV|_XWAV|_WW3)">
-      <sname>0.9x1.25_gx1v6_r05_ww3a</sname>
-      <alias>f09_g16_r05_ww3</alias>
-      <lname>a%0.9x1.25_l%1.9x2.5_oi%gx1v6_r%r05_m%gx1v6_g%null_w%ww3a</lname>
-    </grid>
+    <model_grid alias="T31_g37_r05_ww3" compset="(_DWAV|_XWAV|_WW3)">
+      <grid name="atm">T31</grid>
+      <grid name="lnd">T31</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid compset="(_DWAV|_XWAV|_WW3)">
-      <sname>T31_gx3v7_r05_ww3a</sname>
-      <alias>T31_g37_r05_ww3</alias>
-      <lname>a%T31_l%T31_oi%gx3v7_r%r05_m%gx3v7_g%null_w%ww3a</lname>
-    </grid>
+    <model_grid alias="T31_g37_rx1_ww3&gt;" compset="(_DROF.*_DWAV|_DROF.*_WW3)">
+      <grid name="atm">T31</grid>
+      <grid name="lnd">T31</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
 
-    <grid compset="(_DROF.*_DWAV|_DROF.*_WW3)">
-      <sname>T31_gx3v7_rx1_ww3a</sname>
-      <alias>T31_g37_rx1_ww3></alias>
-      <lname>a%T31_l%T31_oi%gx3v7_r%rx1_m%gx3v7_g%null_w%ww3a</lname>
-    </grid>
+    <model_grid alias="T62_g16_rx1_ww3" compset="(DATM.+DWAV|XATM.+XWAV|SATM.+SWAV)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
 
-    <grid compset="(DATM.+DWAV|XATM.+XWAV|SATM.+SWAV)">
-      <sname>T62_gx1v6_rx1_ww3a</sname>
-      <alias>T62_g16_rx1_ww3</alias>
-      <lname>a%T62_l%T62_oi%gx1v6_r%rx1_m%gx1v6_g%null_w%ww3a</lname>
-    </grid>
+    <model_grid alias="T62_oQU240" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oQU240</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oQU240</sname>
-      <lname>a%T62_l%T62_oi%oQU240_r%rx1_m%oQU240_g%null_w%null</lname>
-      <alias>T62_oQU240</alias>
-    </grid>
+    <model_grid alias="T62_oQU240wLI" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oQU240wLI</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240wLI</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oQU240wLI</sname>
-      <lname>a%T62_l%T62_oi%oQU240wLI_r%rx1_m%oQU240wLI_g%null_w%null</lname>
-      <alias>T62_oQU240wLI</alias>
-    </grid>
+    <model_grid alias="T62_oQU120" compset="(DATM|XATM|SATM)">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oQU120</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU120</mask>
+    </model_grid>
 
-    <grid compset="(DATM|XATM|SATM)">
-      <sname>T62_oQU120</sname>
-      <lname>a%T62_l%T62_oi%oQU120_r%rx1_m%oQU120_g%null_w%null</lname>
-      <alias>T62_oQU120</alias>
-    </grid>
+    <model_grid alias="ne16_oQU240">
+      <grid name="atm">ne16np4</grid>
+      <grid name="lnd">ne16np4</grid>
+      <grid name="ocnice">oQU240</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne16np4_oQU240</sname>
-      <lname>a%ne16np4_l%ne16np4_oi%oQU240_r%r05_m%oQU240_g%null_w%null</lname>
-      <alias>ne16_oQU240</alias>
-    </grid>
+    <model_grid alias="ne16_oQU240_a">
+      <grid name="atm">ne16np4</grid>
+      <grid name="lnd">ne16np4</grid>
+      <grid name="ocnice">oQU240</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.ais20km</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU240</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne16np4_oQU240_ais20</sname>
-      <lname>a%ne16np4_l%ne16np4_oi%oQU240_r%r05_m%oQU240_g%mpas.ais20km_w%null</lname>
-      <alias>ne16_oQU240_a</alias>
-    </grid>
+    <model_grid alias="ne30_oQU120">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oQU120</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU120</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oQU120</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oQU120_r%r05_m%oQU120_g%null_w%null</lname>
-      <alias>ne30_oQU120</alias>
-    </grid>
+    <model_grid alias="ne30_oQU120_a">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oQU120</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">mpas.ais20km</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU120</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oQU120_ais20</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oQU120_r%r05_m%oQU120_g%mpas.ais20km_w%null</lname>
-      <alias>ne30_oQU120_a</alias>
-    </grid>
+    <model_grid alias="ne30_oEC">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oEC60to30</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oEC60to30</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oEC60to30_r%r05_m%oEC60to30_g%null_w%null</lname>
-      <alias>ne30_oEC</alias>
-    </grid>
+    <model_grid alias="ne30_oECv3">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oEC60to30v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oEC60to30v3</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oEC60to30v3_r%r05_m%oEC60to30v3_g%null_w%null</lname>
-      <alias>ne30_oECv3</alias>
-    </grid>
+    <model_grid alias="ne30_oECwLI">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oEC60to30wLI</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30wLI</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oEC60to30wLI</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oEC60to30wLI_r%r05_m%oEC60to30wLI_g%null_w%null</lname>
-      <alias>ne30_oECwLI</alias>
-    </grid>
+    <model_grid alias="ne30_oECv3wLI">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oEC60to30v3wLI</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oEC60to30v3wLI</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oEC60to30v3wLI</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oEC60to30v3wLI_r%r05_m%oEC60to30v3wLI_g%null_w%null</lname>
-      <alias>ne30_oECv3wLI</alias>
-    </grid>
+    <model_grid alias="ne30_oRRS30">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oRRS30to10</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS30to10</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oRRS30to10</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oRRS30to10_r%r05_m%oRRS30to10_g%null_w%null</lname>
-      <alias>ne30_oRRS30</alias>
-    </grid>
+    <model_grid alias="ne30_oRRS30wLI">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oRRS30to10wLI</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS30to10wLI</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oRRS30to10wLI</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oRRS30to10wLI_r%r05_m%oRRS30to10wLI_g%null_w%null</lname>
-      <alias>ne30_oRRS30wLI</alias>
-    </grid>
+    <model_grid alias="ne30_oRRS30v3">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oRRS30to10v3</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS30to10v3</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oRRS30to10v3</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oRRS30to10v3_r%r05_m%oRRS30to10v3_g%null_w%null</lname>
-      <alias>ne30_oRRS30v3</alias>
-    </grid>
+    <model_grid alias="ne30_oRRS30v3wLI">
+      <grid name="atm">ne30np4</grid>
+      <grid name="lnd">ne30np4</grid>
+      <grid name="ocnice">oRRS30to10v3wLI</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS30to10v3wLI</mask>
+    </model_grid>
 
-    <grid>
-      <sname>ne30np4_oRRS30to10v3wLI</sname>
-      <lname>a%ne30np4_l%ne30np4_oi%oRRS30to10v3wLI_r%r05_m%oRRS30to10v3wLI_g%null_w%null</lname>
-      <alias>ne30_oRRS30v3wLI</alias>
-    </grid>
+    <model_grid alias="twpx4v1_twpx4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">ne0np4twpx4v1</grid>
+      <grid name="lnd">ne0np4twpx4v1</grid>
+      <grid name="ocnice">ne0np4twpx4v1</grid>
+      <grid name="rof">null</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>oRRS18to6v3</mask>
+    </model_grid>
 
-    <grid compset="(DOCN|XOCN|SOCN|AQP1)">
-      <sname>ne0np4_twpx4v1_ne0np4_twpx4v1</sname>
-      <lname>a%ne0np4_twpx4v1_l%ne0np4_twpx4v1_oi%ne0np4_twpx4v1_r%null_m%oRRS18to6v3_g%null_w%null</lname>
-      <alias>twpx4v1_twpx4v1</alias>
-    </grid>
-
-    <grid compset="MPASO.*_MALI">
-      <sname>T62_oQU120_ais20</sname>
-      <lname>a%T62_l%T62_oi%oQU120_r%rx1_m%oQU120_g%mpas.ais20km_w%null</lname>
-      <alias>T62_oQU120_a</alias>
-    </grid>
+    <model_grid alias="T62_oQU120_a" compset="MPASO.*_MALI">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">oQU120</grid>
+      <grid name="rof">rx1</grid>
+      <grid name="glc">mpas.ais20km</grid>
+      <grid name="wav">null</grid>
+      <mask>oQU120</mask>
+    </model_grid>
 
   </grids>
 
-  <!-- ======================================================== -->
-  <!-- Component grid domain specifications -->
-  <!-- ======================================================== -->
-
   <domains>
 
+    <!-- ======================================================== -->
+    <!-- Component grid domain specifications -->
+    <!-- ======================================================== -->
+
     <domain name="reg">
+      <nx/>
+      <ny/>
       <desc>regional grid mask: </desc>
-      <support>Only for DATM/CLM compsets</support>
     </domain>
 
     <domain name="usgs">
-      <!-- usgs grid - for used for mask specification-->
+      <nx/>
+      <ny/>
       <desc>USGS mask</desc>
     </domain>
 
     <domain name="null">
-      <!-- null grid -->
-      <nx>0</nx> <ny>0</ny>
+      <nx>0</nx>
+      <ny>0</ny>
       <desc>null is no grid: </desc>
     </domain>
 
     <domain name="CLM_USRDAT">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.${CLM_USRDAT_NAME}_navy.nc</file>
-      <file lnd_mask="reg">domain.lnd.${CLM_USRDAT_NAME}_navy.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.${CLM_USRDAT_NAME}_navy.nc</file>
       <desc>user specified domain - only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_numaIA">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.1x1pt-numaIA_navy.110106.nc</file>
-      <file lnd_mask="reg">domain.lnd.1x1pt-numaIA_navy.110106.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-numaIA_navy.110106.nc</file>
       <desc>1x1 Numa Iowa -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_brazil">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.1x1pt-brazil_navy.090715.nc</file>
-      <file lnd_mask="reg">domain.lnd.1x1pt-brazil_navy.090715.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-brazil_navy.090715.nc</file>
       <desc>1x1 Brazil -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_smallvilleIA">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.1x1pt-smallvilleIA_test.110106.nc</file>
-      <file lnd_mask="reg">domain.lnd.1x1pt-smallvilleIA_test.110106.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-smallvilleIA_test.110106.nc</file>
       <desc>1x1 Smallville Iowa Crop Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_camdenNJ">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.1x1pt-camdenNJ_navy.111004.nc</file>
-      <file lnd_mask="reg">domain.lnd.1x1pt-camdenNJ_navy.111004.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-camdenNJ_navy.111004.nc</file>
       <desc>1x1 Camden New Jersey -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_mexicocityMEX">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc</file>
-      <file lnd_mask="reg">domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc</file>
       <desc>1x1 Mexico City Mexico -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_vancouverCAN">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>
-      <file lnd_mask="reg">domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>
       <desc>1x1 Vancouver Canada -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_tropicAtl">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.1x1pt-tropicAtl_test.111004.nc</file>
-      <file lnd_mask="reg">domain.lnd.1x1pt-tropicAtl_test.111004.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-tropicAtl_test.111004.nc</file>
       <desc>1x1 Tropical Atlantic Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="1x1_urbanc_alpha">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.1x1pt-urbanc_alpha_test.110201.nc</file>
-      <file lnd_mask="reg">domain.lnd.1x1pt-urbanc_alpha_test.110201.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-urbanc_alpha_test.110201.nc</file>
       <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="5x5_amazon">
-      <nx>1</nx> <ny>1</ny>
-      <file atm_mask="reg">domain.lnd.5x5pt-amazon_navy.090715.nc</file>
-      <file lnd_mask="reg">domain.lnd.5x5pt-amazon_navy.090715.nc</file>
-      <path atm_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="reg">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>1</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.5x5pt-amazon_navy.090715.nc</file>
       <desc>5x5 Amazon regional case -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="360x720cru">
-      <nx>720</nx> <ny>360</ny>
-      <file atm_mask="360x720cru">domain.lnd.360x720_cruncep.100429.nc</file>
-      <file lnd_mask="360x720cru">domain.lnd.360x720_cruncep.100429.nc</file>
-      <path atm_mask="360x720cru">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="360x720cru">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>720</nx>
+      <ny>360</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.360x720_cruncep.100429.nc</file>
       <desc>Exact half-degree CRUNCEP datm forcing grid with CRUNCEP land-mask -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="NLDAS">
-      <nx>464</nx> <ny>224</ny>
-      <file atm_mask="NLDAS">domain.lnd.nldas2_0224x0464_c110415.nc</file>
-      <path atm_mask="NLDAS">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <file lnd_mask="NLDAS">domain.lnd.nldas2_0224x0464_c110415.nc</file>
-      <path lnd_mask="NLDAS">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>464</nx>
+      <ny>224</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.nldas2_0224x0464_c110415.nc</file>
       <desc>NLDAS US one eighth degree grid -- only valid for DATM/CLM compset</desc>
     </domain>
 
     <domain name="0.23x0.31">
-      <nx>1152</nx> <ny>768</ny>
-      <file atm_mask="gx1v6">domain.lnd.fv0.23x0.31_gx1v6.100517.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.0.23x0.31_gx1v6_101108.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.fv0.23x0.31_gx1v6.100517.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.0.23x0.31_gx1v6_101108.nc</file>
+      <nx>1152</nx>
+      <ny>768</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.fv0.23x0.31_gx1v6.100517.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.0.23x0.31_gx1v6_101108.nc</file>
       <desc>0.23x0.31 is FV 1/4-deg grid:</desc>
     </domain>
 
     <domain name="0.47x0.63">
-      <nx>576</nx>  <ny>384</ny>
-      <file atm_mask="gx1v6">domain.lnd.fv0.47x0.63_gx1v6.090407.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.0.47x0.63_gx1v6_090408.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.fv0.47x0.63_gx1v6.090407.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.0.47x0.63_gx1v6_090408.nc</file>
+      <nx>576</nx>
+      <ny>384</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.fv0.47x0.63_gx1v6.090407.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.0.47x0.63_gx1v6_090408.nc</file>
       <desc>0.47x0.63 is FV 1/2-deg grid:</desc>
     </domain>
 
     <domain name="0.9x1.25">
-      <nx>288</nx>  <ny>192</ny>
-      <file atm_mask="gx1v6">domain.lnd.fv0.9x1.25_gx1v6.090309.nc</file>
-      <file atm_mask="mp120v1">domain.lnd.fv0.9x1.25_mp120v1.111018.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.0.9x1.25_gx1v6_090403.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.fv0.9x1.25_gx1v6.090309.nc</file>
-      <file lnd_mask="mp120v1">domain.lnd.fv0.9x1.25_mp120v1.111018.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.0.9x1.25_gx1v6_090403.nc</file>
-      <!-- BUG: missing ocn domain file for mp120v1 mask -->
+      <nx>288</nx>
+      <ny>192</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.fv0.9x1.25_gx1v6.090309.nc</file>
+      <file grid="atm|lnd" mask="mp120v1">$DIN_LOC_ROOT/share/domains/domain.lnd.fv0.9x1.25_mp120v1.111018.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.0.9x1.25_gx1v6_090403.nc</file>
       <desc>0.9x1.25 is FV 1-deg grid:</desc>
     </domain>
 
     <domain name="1.9x2.5">
-      <nx>144</nx>  <ny>96</ny>
-      <file atm_mask="gx1v6">domain.lnd.fv1.9x2.5_gx1v6.090206.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.1.9x2.5_gx1v6_090403.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.fv1.9x2.5_gx1v6.090206.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.1.9x2.5_gx1v6_090403.nc</file>
+      <nx>144</nx>
+      <ny>96</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.fv1.9x2.5_gx1v6.090206.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.1.9x2.5_gx1v6_090403.nc</file>
       <desc>1.9x2.5 is FV 2-deg grid:</desc>
     </domain>
 
     <domain name="4x5">
-      <nx>72</nx> <ny>46</ny>
-      <file atm_mask="gx3v7">domain.lnd.fv4x5_gx3v7.091218.nc</file>
-      <file ice_mask="gx3v7">domain.ocn.4x5_gx3v7_100120.nc</file>
-      <file lnd_mask="gx3v7">domain.lnd.fv4x5_gx3v7.091218.nc</file>
-      <file ocn_mask="gx3v7">domain.ocn.4x5_gx3v7_100120.nc</file>
+      <nx>72</nx>
+      <ny>46</ny>
+      <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.fv4x5_gx3v7.091218.nc</file>
+      <file grid="ice|ocn" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.4x5_gx3v7_100120.nc</file>
       <desc>4x5 is FV 4-deg grid:</desc>
     </domain>
 
     <domain name="2.5x3.33">
-      <nx>108</nx>  <ny>72</ny>
-      <file atm_mask="gx3v7">domain.lnd.fv2.5x3.33_gx3v7.110223.nc</file>
-      <file ice_mask="gx3v7">domain.ocn.fv2.5x3.33_gx3v7_110223.nc</file>
-      <file lnd_mask="gx3v7">domain.lnd.fv2.5x3.33_gx3v7.110223.nc</file>
-      <file ocn_mask="gx3v7">domain.ocn.fv2.5x3.33_gx3v7_110223.nc</file>
+      <nx>108</nx>
+      <ny>72</ny>
+      <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.fv2.5x3.33_gx3v7.110223.nc</file>
+      <file grid="ice|ocn" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.fv2.5x3.33_gx3v7_110223.nc</file>
       <desc>2.5x3.33 is FV 3-deg grid:</desc>
     </domain>
 
     <domain name="10x15">
-      <nx>24</nx>   <ny>19</ny>
-      <file atm_mask="usgs">domain.lnd.fv10x15_USGS.110713.nc</file>
-      <file ice_mask="usgs">domain.camocn.10x15_USGS_070807.nc</file>
-      <file lnd_mask="usgs">domain.lnd.fv10x15_USGS.110713.nc</file>
-      <file ocn_mask="usgs">domain.camocn.10x15_USGS_070807.nc</file>
-      <path atm_mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path ice_mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path ocn_mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm</path>
+      <nx>24</nx>
+      <ny>19</ny>
+      <file grid="atm|lnd" mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.fv10x15_USGS.110713.nc</file>
+      <file grid="ice|ocn" mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.camocn.10x15_USGS_070807.nc</file>
       <desc>10x15 is FV 10-deg grid:</desc>
-      <support>For low resolution testing</support>
     </domain>
 
     <domain name="T341">
-      <nx>1024</nx> <ny>512</ny>
-      <!-- global spectral (eulerian dycore) grids-->
-      <!--- mask for atm is irrelevant -->
+      <nx>1024</nx>
+      <ny>512</ny>
       <desc>T341 is Gaussian grid:</desc>
-      <support>Backward compatible for very high resolution Spectral-dycore experiments</support>
     </domain>
 
     <domain name="T85">
-      <!-- global spectral (eulerian dycore) grids-->
-      <nx>256</nx>  <ny>128</ny>
+      <nx>256</nx>
+      <ny>128</ny>
       <desc>T85 is Gaussian grid:</desc>
-      <support>Backward compatible for high resolution Spectral-dycore experiments</support>
     </domain>
 
     <domain name="T62">
       <nx>192</nx>
       <ny>96</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx1v6.090320.nc</file>
+      <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx3v7.090911.nc</file>
+      <file grid="atm|lnd" mask="mpasgx1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_mpasgx1.150903.nc</file>
+      <file grid="atm|lnd" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240.151209.nc</file>
+      <file grid="atm|lnd" mask="oQU240wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU240wLI_mask.160929.nc</file>
+      <file grid="atm|lnd" mask="oQU120">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU120.151209.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30.150616.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30v3.161222.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30wLI_mask.160830.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oEC60to30v3wLI_mask.170328.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS30to10.150722.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS30to10wLI_mask.171109.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS30to10v3.171129.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS30to10v3wLI_mask.171109.nc</file>
+      <file grid="atm|lnd" mask="oRRS18to6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS18to6.160831.nc</file>
+      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS18to6v3.170111.nc</file>
+      <file grid="atm|lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oRRS15to5.150722.nc</file>
       <desc>T62 is Gaussian grid:</desc>
-      <file atm_mask="gx1v6">domain.lnd.T62_gx1v6.090320.nc</file>
-      <file atm_mask="gx3v7">domain.lnd.T62_gx3v7.090911.nc</file>
-      <file atm_mask="mpasgx1">domain.lnd.T62_mpasgx1.150903.nc</file>
-      <file atm_mask="oQU240">domain.lnd.T62_oQU240.151209.nc</file>
-      <file atm_mask="oQU240wLI">domain.lnd.T62_oQU240wLI_mask.160929.nc</file>
-      <file atm_mask="oQU120">domain.lnd.T62_oQU120.151209.nc</file>
-      <file atm_mask="oEC60to30">domain.lnd.T62_oEC60to30.150616.nc</file>
-      <file atm_mask="oEC60to30v3">domain.lnd.T62_oEC60to30v3.161222.nc</file>
-      <file atm_mask="oEC60to30wLI">domain.lnd.T62_oEC60to30wLI_mask.160830.nc</file>
-      <file atm_mask="oEC60to30v3wLI">domain.lnd.T62_oEC60to30v3wLI_mask.170328.nc</file>
-      <file atm_mask="oRRS30to10">domain.lnd.T62_oRRS30to10.150722.nc</file>
-      <file atm_mask="oRRS30to10wLI">domain.lnd.T62_oRRS30to10wLI_mask.171109.nc</file>
-      <file atm_mask="oRRS30to10v3">domain.lnd.T62_oRRS30to10v3.171129.nc</file>
-      <file atm_mask="oRRS30to10v3wLI">domain.lnd.T62_oRRS30to10v3wLI_mask.171109.nc</file>
-      <file atm_mask="oRRS18to6">domain.lnd.T62_oRRS18to6.160831.nc</file>
-      <file atm_mask="oRRS18to6v3">domain.lnd.T62_oRRS18to6v3.170111.nc</file>
-      <file atm_mask="oRRS15to5">domain.lnd.T62_oRRS15to5.150722.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.T62_gx1v6.090320.nc</file>
-      <file lnd_mask="gx3v7">domain.lnd.T62_gx3v7.090911.nc</file>
-      <file lnd_mask="mpasgx1">domain.lnd.T62_mpasgx1.150903.nc</file>
-      <file lnd_mask="oQU240">domain.lnd.T62_oQU240.151209.nc</file>
-      <file lnd_mask="oQU240wLI">domain.lnd.T62_oQU240wLI_mask.160929.nc</file>
-      <file lnd_mask="oQU120">domain.lnd.T62_oQU120.151209.nc</file>
-      <file lnd_mask="oEC60to30">domain.lnd.T62_oEC60to30.150616.nc</file>
-      <file lnd_mask="oEC60to30v3">domain.lnd.T62_oEC60to30v3.161222.nc</file>
-      <file lnd_mask="oEC60to30wLI">domain.lnd.T62_oEC60to30wLI_mask.160830.nc</file>
-      <file lnd_mask="oEC60to30v3wLI">domain.lnd.T62_oEC60to30v3wLI_mask.170328.nc</file>
-      <file lnd_mask="oRRS30to10">domain.lnd.T62_oRRS30to10.150722.nc</file>
-      <file lnd_mask="oRRS30to10v3">domain.lnd.T62_oRRS30to10v3.171129.nc</file>
-      <file lnd_mask="oRRS30to10wLI">domain.lnd.T62_oRRS30to10wLI_mask.171109.nc</file>
-      <file lnd_mask="oRRS30to10v3wLI">domain.lnd.T62_oRRS30to10v3wLI_mask.171109.nc</file>
-      <file lnd_mask="oRRS18to6">domain.lnd.T62_oRRS18to6.160831.nc</file>
-      <file lnd_mask="oRRS18to6v3">domain.lnd.T62_oRRS18to6v3.170111.nc</file>
-      <file lnd_mask="oRRS15to5">domain.lnd.T62_oRRS15to5.150722.nc</file>
     </domain>
 
     <domain name="T42">
-      <nx>128</nx> <ny>64</ny>
-      <file atm_mask="usgs">domain.lnd.T42_USGS.111004.nc</file>
-      <file lnd_mask="usgs">domain.lnd.T42_USGS.111004.nc</file>
-      <file ocn_mask="usgs">domain.camocn.64x128_USGS_070807.nc</file>
-      <path atm_mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path lnd_mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm</path>
-      <path ocn_mask="usgs">$DIN_LOC_ROOT/atm/cam/ocnfrac</path>
+      <nx>128</nx>
+      <ny>64</ny>
+      <file grid="atm|lnd" mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.T42_USGS.111004.nc</file>
+      <file grid="ocn" mask="usgs">$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.64x128_USGS_070807.nc</file>
       <desc>T42 is Gaussian grid:</desc>
     </domain>
 
     <domain name="T31">
-      <nx>96</nx> <ny>48</ny>
+      <nx>96</nx>
+      <ny>48</ny>
       <desc>T31 is Gaussian grid:</desc>
     </domain>
 
     <domain name="ne4np4">
       <nx>866</nx>
       <ny>1</ny>
+      <file grid="atm|lnd" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.lnd.ne4np4_oQU240.160614.nc</file>
+      <file grid="ice|ocn" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.ocn.ne4np4_oQU240.160614.nc</file>
       <desc>ne4np4 is Spectral Elem  7.5-deg grid:</desc>
-      <file atm_mask="gx3v7"/>
-      <file atm_mask="oQU240">domain.lnd.ne4np4_oQU240.160614.nc</file>
-      <file ice_mask="gx3v7"/>
-      <file ice_mask="oQU240">domain.ocn.ne4np4_oQU240.160614.nc</file>
-      <file lnd_mask="gx3v7"/>
-      <file lnd_mask="oQU240">domain.lnd.ne4np4_oQU240.160614.nc</file>
-      <file ocn_mask="gx3v7"/>
-      <file ocn_mask="oQU240">domain.ocn.ne4np4_oQU240.160614.nc</file>
     </domain>
 
     <domain name="ne11np4">
       <nx>6536</nx>
       <ny>1</ny>
+      <file grid="atm|lnd" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.lnd.ne11np4_oQU240.160614.nc</file>
+      <file grid="ice|ocn" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.ocn.ne11np4_oQU240.160614.nc</file>
       <desc>ne11np4 is Spectral Elem 2.7-deg grid:</desc>
-      <file atm_mask="gx3v7"/>
-      <file atm_mask="oQU240">domain.lnd.ne11np4_oQU240.160614.nc</file>
-      <file ice_mask="gx3v7"/>
-      <file ice_mask="oQU240">domain.ocn.ne11np4_oQU240.160614.nc</file>
-      <file lnd_mask="gx3v7"/>
-      <file lnd_mask="oQU240">domain.lnd.ne11np4_oQU240.160614.nc</file>
-      <file ocn_mask="gx3v7"/>
-      <file ocn_mask="oQU240">domain.ocn.ne11np4_oQU240.160614.nc</file>
     </domain>
 
     <domain name="ne16np4">
-      <nx>13826</nx> <ny>1</ny>
-      <file atm_mask="gx3v7">domain.lnd.ne16np4_gx3v7.120406.nc</file>
-      <file atm_mask="oQU240">domain.lnd.ne16np4_oQU240.151211.nc</file>
-      <file ice_mask="gx3v7">domain.ocn.ne16np4_gx3v7.121113.nc</file>
-      <file ice_mask="oQU240">domain.ocn.ne16np4_oQU240.151211.nc</file>
-      <file lnd_mask="gx3v7">domain.lnd.ne16np4_gx3v7.120406.nc</file>
-      <file lnd_mask="oQU240">domain.lnd.ne16np4_oQU240.151211.nc</file>
-      <file ocn_mask="gx3v7">domain.ocn.ne16np4_gx3v7.121113.nc</file>
-      <file ocn_mask="oQU240">domain.ocn.ne16np4_oQU240.151211.nc</file>
+      <nx>13826</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne16np4_gx3v7.120406.nc</file>
+      <file grid="atm|lnd" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.lnd.ne16np4_oQU240.151211.nc</file>
+      <file grid="ice|ocn" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne16np4_gx3v7.121113.nc</file>
+      <file grid="ice|ocn" mask="oQU240">$DIN_LOC_ROOT/share/domains/domain.ocn.ne16np4_oQU240.151211.nc</file>
       <desc>ne16np4 is Spectral Elem 2-deg grid:</desc>
-      <support>For low resolution spectral element grid testing</support>
     </domain>
 
     <domain name="ne30np4">
-      <nx>48602</nx> <ny>1</ny>
-      <file atm_mask="gx1v6">domain.lnd.ne30np4_gx1v6.110905.nc</file>
-      <file atm_mask="oQU120">domain.lnd.ne30np4_oQU120.160401.nc</file>
-      <file atm_mask="oEC60to30">domain.lnd.ne30np4_oEC60to30.20151214.nc</file>
-      <file atm_mask="oEC60to30v3">domain.lnd.ne30np4_oEC60to30v3.161222.nc</file>
-      <file atm_mask="oEC60to30wLI">domain.lnd.ne30np4_oEC60to30wLI_mask.160915.nc</file>
-      <file atm_mask="oEC60to30v3wLI">domain.lnd.ne30np4_oEC60to30v3wLI_mask.160915.nc</file>
-      <file atm_mask="oRRS30to10">domain.lnd.ne30np4_oRRS30to10.160419.nc</file>
-      <file atm_mask="oRRS30to10wLI">domain.lnd.ne30np4_oRRS30to10wLI.160930.nc</file>
-      <file atm_mask="oRRS30to10v3">domain.lnd.ne30np4_oRRS30to10v3.171101.nc</file>
-      <file atm_mask="oRRS30to10v3wLI">domain.lnd.ne30np4_oRRS30to10v3wLI_mask.171109.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.ne30np4_gx1v6_110217.nc</file>
-      <file ice_mask="oQU120">domain.ocn.ne30np4_oQU120.160401.nc</file>
-      <file ice_mask="oEC60to30">domain.ocn.ne30np4_oEC60to30.20151214.nc</file>
-      <file ice_mask="oEC60to30v3">domain.ocn.ne30np4_oEC60to30v3.161222.nc</file>
-      <file ice_mask="oEC60to30wLI">domain.ocn.ne30np4_oEC60to30wLI_mask.160915.nc</file>
-      <file ice_mask="oEC60to30v3wLI">domain.ocn.ne30np4_oEC60to30v3wLI_mask.160915.nc</file>
-      <file ice_mask="oRRS30to10">domain.ocn.ne30np4_oRRS30to10.160419.nc</file>
-      <file ice_mask="oRRS30to10wLI">domain.ocn.ne30np4_oRRS30to10wLI.160930.nc</file>
-      <file ice_mask="oRRS30to10v3">domain.ocn.ne30np4_oRRS30to10v3.171101.nc</file>
-      <file ice_mask="oRRS30to10v3wLI">domain.ocn.ne30np4_oRRS30to10v3wLI_mask.171109.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.ne30np4_gx1v6.110905.nc</file>
-      <file lnd_mask="oQU120">domain.lnd.ne30np4_oQU120.160401.nc</file>
-      <file lnd_mask="oEC60to30">domain.lnd.ne30np4_oEC60to30.20151214.nc</file>
-      <file lnd_mask="oEC60to30v3">domain.lnd.ne30np4_oEC60to30v3.161222.nc</file>
-      <file lnd_mask="oEC60to30wLI">domain.lnd.ne30np4_oEC60to30wLI_mask.160915.nc</file>
-      <file lnd_mask="oEC60to30v3wLI">domain.lnd.ne30np4_oEC60to30v3wLI_mask.170802.nc</file>
-      <file lnd_mask="oRRS30to10">domain.lnd.ne30np4_oRRS30to10.160419.nc</file>
-      <file lnd_mask="oRRS30to10wLI">domain.lnd.ne30np4_oRRS30to10wLI.160930.nc</file>
-      <file lnd_mask="oRRS30to10v3">domain.lnd.ne30np4_oRRS30to10v3.171101.nc</file>
-      <file lnd_mask="oRRS30to10v3wLI">domain.lnd.ne30np4_oRRS30to10v3wLI_mask.171109.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.ne30np4_gx1v6_110217.nc</file>
-      <file ocn_mask="oQU120">domain.ocn.ne30np4_oQU120.160401.nc</file>
-      <file ocn_mask="oEC60to30">domain.ocn.ne30np4_oEC60to30.20151214.nc</file>
-      <file ocn_mask="oEC60to30v3">domain.ocn.ne30np4_oEC60to30v3.161222.nc</file>
-      <file ocn_mask="oEC60to30wLI">domain.ocn.ne30np4_oEC60to30wLI_mask.160915.nc</file>
-      <file ocn_mask="oEC60to30v3wLI">domain.ocn.ne30np4_oEC60to30v3wLI_mask.160915.nc</file>
-      <file ocn_mask="oRRS30to10">domain.ocn.ne30np4_oRRS30to10.160419.nc</file>
-      <file ocn_mask="oRRS30to10wLI">domain.ocn.ne30np4_oRRS30to10wLI.160930.nc</file>
-      <file ocn_mask="oRRS30to10v3">domain.ocn.ne30np4_oRRS30to10v3.171101.nc</file>
-      <file ocn_mask="oRRS30to10v3wLI">domain.ocn.ne30np4_oRRS30to10v3wLI_mask.171109.nc</file>
+      <nx>48602</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_gx1v6.110905.nc</file>
+      <file grid="atm|lnd" mask="oQU120">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oQU120.160401.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oEC60to30.20151214.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oEC60to30v3.161222.nc</file>
+      <file grid="atm|lnd" mask="oEC60to30wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oEC60to30wLI_mask.160915.nc</file>
+      <file grid="atm" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oEC60to30v3wLI_mask.160915.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oRRS30to10.160419.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oRRS30to10wLI.160930.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oRRS30to10v3.171101.nc</file>
+      <file grid="atm|lnd" mask="oRRS30to10v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oRRS30to10v3wLI_mask.171109.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_gx1v6_110217.nc</file>
+      <file grid="ice|ocn" mask="oQU120">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_oQU120.160401.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_oEC60to30.20151214.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_oEC60to30v3.161222.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30wLI">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_oEC60to30wLI_mask.160915.nc</file>
+      <file grid="ice|ocn" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_oEC60to30v3wLI_mask.160915.nc</file>
+      <file grid="ice|ocn" mask="oRRS30to10">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_oRRS30to10.160419.nc</file>
+      <file grid="ice|ocn" mask="oRRS30to10wLI">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_oRRS30to10wLI.160930.nc</file>
+      <file grid="ice|ocn" mask="oRRS30to10v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_oRRS30to10v3.171101.nc</file>
+      <file grid="ice|ocn" mask="oRRS30to10v3wLI">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4_oRRS30to10v3wLI_mask.171109.nc</file>
+      <file grid="lnd" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4_oEC60to30v3wLI_mask.170802.nc</file>
       <desc>ne30np4 is Spectral Elem 1-deg grid:</desc>
     </domain>
 
     <domain name="ne60np4">
-      <nx>194402</nx> <ny>1</ny>
-      <file atm_mask="gx1v6">domain.lnd.ne60np4_gx1v6.120406.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.ne60np4_gx1v6.121113.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.ne60np4_gx1v6.120406.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.ne60np4_gx1v6.121113.nc</file>
+      <nx>194402</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne60np4_gx1v6.120406.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne60np4_gx1v6.121113.nc</file>
       <desc>ne60np4 is Spectral Elem 1/2-deg grid:</desc>
     </domain>
 
     <domain name="ne120np4">
       <nx>777602</nx>
       <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4_gx1v6.110502.nc</file>
+      <file grid="atm|lnd" mask="oRRS18to6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4_oRRS18to6.160831.nc</file>
+      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4_oRRS18to6v3.170111.nc</file>
+      <file grid="atm|lnd" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4_oRRS15to5.160207.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4_gx1v6.121113.nc</file>
+      <file grid="ice|ocn" mask="oRRS18to6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4_oRRS18to6.160831.nc</file>
+      <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4_oRRS18to6v3.170111.nc</file>
+      <file grid="ice|ocn" mask="oRRS15to5">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4_oRRS15to5.160207.nc</file>
       <desc>ne120np4 is Spectral Elem 1/4-deg grid:</desc>
-      <file atm_mask="gx1v6">domain.lnd.ne120np4_gx1v6.110502.nc</file>
-      <file atm_mask="oRRS18to6">domain.lnd.ne120np4_oRRS18to6.160831.nc</file>
-      <file atm_mask="oRRS18to6v3">domain.lnd.ne120np4_oRRS18to6v3.170111.nc</file>
-      <file atm_mask="oRRS15to5">domain.lnd.ne120np4_oRRS15to5.160207.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.ne120np4_gx1v6.121113.nc</file>
-      <file ice_mask="oRRS18to6">domain.ocn.ne120np4_oRRS18to6.160831.nc</file>
-      <file ice_mask="oRRS18to6v3">domain.ocn.ne120np4_oRRS18to6v3.170111.nc</file>
-      <file ice_mask="oRRS15to5">domain.ocn.ne120np4_oRRS15to5.160207.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.ne120np4_gx1v6.110502.nc</file>
-      <file lnd_mask="oRRS18to6">domain.lnd.ne120np4_oRRS18to6.160831.nc</file>
-      <file lnd_mask="oRRS18to6v3">domain.lnd.ne120np4_oRRS18to6v3.170111.nc</file>
-      <file lnd_mask="oRRS15to5">domain.lnd.ne120np4_oRRS15to5.160207.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.ne120np4_gx1v6.121113.nc</file>
-      <file ocn_mask="oRRS18to6">domain.ocn.ne120np4_oRRS18to6.160831.nc</file>
-      <file ocn_mask="oRRS18to6v3">domain.ocn.ne120np4_oRRS18to6v3.170111.nc</file>
-      <file ocn_mask="oRRS15to5">domain.ocn.ne120np4_oRRS15to5.160207.nc</file>
     </domain>
 
     <domain name="ne240np4">
-      <nx>3110402</nx> <ny>1</ny>
-      <file atm_mask="gx1v6">domain.lnd.ne240np4_gx1v6.111226.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.ne240np4_gx1v6.111226.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.ne240np4_gx1v6.111226.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.ne240np4_gx1v6.111226.nc</file>
+      <nx>3110402</nx>
+      <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.ne240np4_gx1v6.111226.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.ne240np4_gx1v6.111226.nc</file>
       <desc>ne240np4 is Spectral Elem 1/8-deg grid:</desc>
-      <support>Experimental for very high resolution experiments</support>
     </domain>
 
     <domain name="gx1v6">
-      <nx>320</nx>  <ny>384</ny>
-      <file atm_mask="gx1v6">domain.ocn.gx1v6.090206.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.gx1v6.090206.nc</file>
-      <file lnd_mask="gx1v6">domain.ocn.gx1v6.090206.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.gx1v6.090206.nc</file>
+      <nx>320</nx>
+      <ny>384</ny>
+      <file grid="atm|ice|lnd|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.gx1v6.090206.nc</file>
       <desc>gx1v6 is displaced Greenland pole v6 1-deg grid:</desc>
     </domain>
 
     <domain name="gx3v7">
-      <nx>100</nx> <ny>116</ny>
-      <file ice_mask="gx3v7">domain.ocn.gx3v7.120323.nc</file>
-      <file ocn_mask="gx3v7">domain.ocn.gx3v7.120323.nc</file>
+      <nx>100</nx>
+      <ny>116</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.gx3v7.120323.nc</file>
       <desc>gx3v7 is displaced Greenland pole v7 3-deg grid:</desc>
     </domain>
 
     <!-- MPAS grids -->
 
     <domain name="mpasgx1">
-      <nx>86354</nx>  <ny>1</ny>
-      <file ice_mask="mpasgx1">domain.ocn.mpasgx1.150903.nc</file>
-      <file ocn_mask="mpasgx1">domain.ocn.mpasgx1.150903.nc</file>
+      <nx>86354</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.mpasgx1.150903.nc</file>
       <desc>mpasgx1 is a MPAS seaice grid that is roughly 1 degree resolution:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="mpas120">
-      <nx>28574</nx>  <ny>1</ny>
-      <file  ocn_mask="mpas120">domain.ocn.mpas120.121116.nc</file>
+      <nx>28574</nx>
+      <ny>1</ny>
+      <file grid="ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.mpas120.121116.nc</file>
       <desc>mpas120 is a MPAS ocean grid that is roughly 1 degree resolution:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oEC60to30">
-      <nx>234988</nx>  <ny>1</ny>
-      <file ice_mask="oEC60to30">domain.ocn.oEC60to30.150616.nc</file>
-      <file ocn_mask="oEC60to30">domain.ocn.oEC60to30.150616.nc</file>
+      <nx>234988</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oEC60to30.150616.nc</file>
       <desc>oEC60to30 is a MPAS ocean grid generated with the eddy closure density function that is roughly comparable to the pop 1 degree resolution:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oEC60to30v3">
-      <nx>235160</nx>  <ny>1</ny>
-      <file ice_mask="oEC60to30v3">domain.ocn.oEC60to30v3.161222.nc</file>
-      <file ocn_mask="oEC60to30v3">domain.ocn.oEC60to30v3.161222.nc</file>
+      <nx>235160</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oEC60to30v3.161222.nc</file>
       <desc>oEC60to30v3 is a MPAS ocean grid generated with the eddy closure density function that is roughly comparable to the pop 1 degree resolution:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oEC60to30wLI">
-      <nx>236689</nx>  <ny>1</ny>
-      <file ice_mask="oEC60to30wLI">domain.ocn.oEC60to30wLI.160830.nc</file>
-      <file ocn_mask="oEC60to30wLI">domain.ocn.oEC60to30wLI.160830.nc</file>
+      <nx>236689</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oEC60to30wLI.160830.nc</file>
       <desc>oEC60to30wLI is a MPAS ocean grid generated with the eddy closure density function with 30 km gridcells at the equator, 60 km at mid-latitudes, and 35 km at high latitudes.  It is roughly comparable to the POP 1 degree resolution. Additionally, it has ocean under landice cavities:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oEC60to30v3wLI">
-      <nx>236358</nx>  <ny>1</ny>
-      <file ice_mask="oEC60to30v3wLI">domain.ocn.oEC60to30v3wLI_nomask.170328.nc</file>
-      <file ocn_mask="oEC60to30v3wLI">domain.ocn.oEC60to30v3wLI_nomask.170328.nc</file>
+      <nx>236358</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oEC60to30v3wLI_nomask.170328.nc</file>
       <desc>oEC60to30v3wLI is a MPAS ocean grid generated with the eddy closure density function with 30 km gridcells at the equator, 60 km at mid-latitudes, and 35 km at high latitudes.  It is roughly comparable to the POP 1 degree resolution. Additionally, it has ocean under landice cavities:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oRRS30to10">
-      <nx>1444565</nx>  <ny>1</ny>
-      <file ocn_mask="oRRS30to10">domain.ocn.oRRS30to10.150722.nc</file>
-      <file ice_mask="oRRS30to10">domain.ocn.oRRS30to10.150722.nc</file>
+      <nx>1444565</nx>
+      <ny>1</ny>
+      <file grid="ocn|ice">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS30to10.150722.nc</file>
       <desc>oRRS30to10 is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 30 km gridcells at low and 10 km gridcells at high latitudes:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oRRS30to10v3">
-      <nx>1445361</nx>  <ny>1</ny>
-      <file ocn_mask="oRRS30to10v3">domain.ocn.oRRS30to10v3.171129.nc</file>
-      <file ice_mask="oRRS30to10v3">domain.ocn.oRRS30to10v3.171129.nc</file>
+      <nx>1445361</nx>
+      <ny>1</ny>
+      <file grid="ocn|ice">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS30to10v3.171129.nc</file>
       <desc>oRRS30to10v3 is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 30 km gridcells at low and 10 km gridcells at high latitudes:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oRRS30to10wLI">
-      <nx>1462411</nx>  <ny>1</ny>
-      <file ocn_mask="oRRS30to10wLI">domain.ocn.oRRS30to10wLI.160930.nc</file>
-      <file ice_mask="oRRS30to10wLI">domain.ocn.oRRS30to10wLI.160930.nc</file>
+      <nx>1462411</nx>
+      <ny>1</ny>
+      <file grid="ocn|ice">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS30to10wLI.160930.nc</file>
       <desc>oRRS30to10wLI is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 30 km gridcells at low and 10 km gridcells at high latitudes: Additionally, it has ocean under landice cavities:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oRRS30to10v3wLI">
-      <nx>1460217</nx>  <ny>1</ny>
-      <file ocn_mask="oRRS30to10v3wLI">domain.ocn.oRRS30to10v3wLI.171109.nc</file>
-      <file ice_mask="oRRS30to10v3wLI">domain.ocn.oRRS30to10v3wLI.171109.nc</file>
+      <nx>1460217</nx>
+      <ny>1</ny>
+      <file grid="ocn|ice">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS30to10v3wLI.171109.nc</file>
       <desc>oRRS30to10v3wLI is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 30 km gridcells at low and 10 km gridcells at high latitudes: Additionally, it has ocean under landice cavities:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oEC60to30_ICG">
       <nx>234988</nx>
       <ny>1</ny>
+      <file grid="ice|ocn" mask="oEC60to30">$DIN_LOC_ROOT/share/domains/domain.ocn.oEC60to30.150616.nc</file>
       <desc>oEC60to30_ICG is a MPAS ocean grid with initial conditions, generated with the eddy closure density function with 30 km gridcells at the equator, 60 km at mid-latitudes, and 35 km at high latitudes.  It is roughly comparable to the POP 1 degree resolution.  This version of initial conditions is spun-up from a G compset run:</desc>
-      <file ice_mask="oEC60to30">domain.ocn.oEC60to30.150616.nc</file>
-      <file ocn_mask="oEC60to30">domain.ocn.oEC60to30.150616.nc</file>
     </domain>
 
     <domain name="oEC60to30v3_ICG">
       <nx>235160</nx>
       <ny>1</ny>
+      <file grid="ice|ocn" mask="oEC60to30v3">$DIN_LOC_ROOT/share/domains/domain.ocn.oEC60to30v3.161222.nc</file>
       <desc>oEC60to30v3_ICG is a MPAS ocean grid with initial conditions, generated with the eddy closure density function with 30 km gridcells at the equator, 60 km at mid-latitudes, and 35 km at high latitudes.  It is roughly comparable to the POP 1 degree resolution.  This version of initial conditions is spun-up from a G compset run:</desc>
-      <file ice_mask="oEC60to30v3">domain.ocn.oEC60to30v3.161222.nc</file>
-      <file ocn_mask="oEC60to30v3">domain.ocn.oEC60to30v3.161222.nc</file>
     </domain>
 
     <domain name="oEC60to30v3wLI_ICG">
-      <nx>236358</nx>  <ny>1</ny>
-      <file ice_mask="oEC60to30v3wLI">domain.ocn.oEC60to30v3wLI_nomask.170328.nc</file>
-      <file ocn_mask="oEC60to30v3wLI">domain.ocn.oEC60to30v3wLI_nomask.170328.nc</file>
+      <nx>236358</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn" mask="oEC60to30v3wLI">$DIN_LOC_ROOT/share/domains/domain.ocn.oEC60to30v3wLI_nomask.170328.nc</file>
       <desc>oEC60to30v3wLI is a MPAS ocean grid generated with the eddy closure density function with 30 km gridcells at the equator, 60 km at mid-latitudes, and 35 km at high latitudes.  It is roughly comparable to the POP 1 degree resolution. Additionally, it has ocean under landice cavities:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="oRRS18to6">
       <nx>3697425</nx>
       <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS18to6.160831.nc</file>
       <desc>oRRS18to6 is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 18 km gridcells at low and 6 km gridcells at high latitudes:</desc>
-      <file ice_mask="oRRS18to6">domain.ocn.oRRS18to6.160831.nc</file>
-      <file ocn_mask="oRRS18to6">domain.ocn.oRRS18to6.160831.nc</file>
     </domain>
 
     <domain name="oRRS18to6v3">
       <nx>3693225</nx>
       <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS18to6v3.170111.nc</file>
       <desc>oRRS18to6v3 is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 18 km gridcells at low and 6 km gridcells at high latitudes:</desc>
-      <file ice_mask="oRRS18to6v3">domain.ocn.oRRS18to6v3.170111.nc</file>
-      <file ocn_mask="oRRS18to6v3">domain.ocn.oRRS18to6v3.170111.nc</file>
     </domain>
 
     <domain name="oRRS18to6v3_ICG">
       <nx>3693225</nx>
       <ny>1</ny>
+      <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS18to6v3.170111.nc</file>
       <desc>oRRS18to6v3_ICG is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 18 km gridcells at low and 6 km gridcells at high latitudes.  This version of initial conditions is spun-up from a G compset run:</desc>
-      <file ice_mask="oRRS18to6v3">domain.ocn.oRRS18to6v3.170111.nc</file>
-      <file ocn_mask="oRRS18to6v3">domain.ocn.oRRS18to6v3.170111.nc</file>
     </domain>
 
     <!-- ROF (river) grids-->
 
     <domain name="rx1">
-      <nx>360</nx> <ny>180</ny>
+      <nx>360</nx>
+      <ny>180</ny>
       <desc>rx1 is 1 degree river routing grid (only valid for DROF):</desc>
-      <support>Can only be used by DROF</support>
     </domain>
 
     <domain name="r05">
-      <nx>720</nx> <ny>360</ny>
+      <nx>720</nx>
+      <ny>360</ny>
       <desc>r05 is 1/2 degree river routing grid:</desc>
     </domain>
 
     <domain name="r01">
-      <nx>3600</nx> <ny>1800</ny>
+      <nx>3600</nx>
+      <ny>1800</ny>
       <desc>r01 is 1/10 degree river routing grid:</desc>
-      <support>For experimental use by high resolution grids</support>
     </domain>
 
     <domain name="r0125">
@@ -1266,934 +1615,939 @@
     </domain>
 
     <domain name="mp120v1">
-      <nx>28993</nx>  <ny>1</ny>
-      <file ice_mask="mp120v1">domain.ocn.mp120v1.111018.nc</file>
-      <file ocn_mask="mp120v1">domain.ocn.mp120v1.111018.nc</file>
+      <nx>28993</nx>
+      <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.mp120v1.111018.nc</file>
       <desc>mp120v1 is a MPAS ocean grid that is roughly 1 degree resolution:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="mp120r10v1">
-      <nx>139734</nx> <ny>1</ny>
+      <nx>139734</nx>
+      <ny>1</ny>
       <desc>mp120r10v1 is a MPAS grid:</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <!-- GLC:MALI domains -->
 
     <domain name="mpas.gis20km">
-      <nx>7425</nx> <ny>1</ny>
+      <nx>7425</nx>
+      <ny>1</ny>
       <desc>mpas.gis20km is a uniform-resolution 20km MALI grid of the Greenland Ice Sheet.  It is primarily intended for testing.</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <domain name="mpas.ais20km">
-      <nx>45675</nx> <ny>1</ny>
+      <nx>45675</nx>
+      <ny>1</ny>
       <desc>mpas.ais20km is a uniform-resolution 20km MALI grid of the Antarctic Ice Sheet.  It is primarily intended for testing.</desc>
-      <support>Experimental, under development</support>
     </domain>
 
     <!-- WW3 domains-->
 
     <domain name="ww3a">
-      <nx>90</nx>  <ny>50</ny>
-      <file atm_mask="ww3a">domain.lnd.ww3a_ww3a.120222.nc</file>
-      <file ice_mask="ww3a">domain.ocn.ww3a_ww3a.120222.nc</file>
-      <file lnd_mask="ww3a">domain.lnd.ww3a_ww3a.120222.nc</file>
-      <file ocn_mask="ww3a">domain.ocn.ww3a_ww3a.120222.nc</file>
-      <path atm_mask="ww3a">$DIN_LOC_ROOT/share/domains</path>
-      <path ice_mask="ww3a">$DIN_LOC_ROOT/share/domains</path>
-      <path lnd_mask="ww3a">$DIN_LOC_ROOT/share/domains</path>
-      <path ocn_mask="ww3a">$DIN_LOC_ROOT/share/domains</path>
+      <nx>90</nx>
+      <ny>50</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.lnd.ww3a_ww3a.120222.nc</file>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.ww3a_ww3a.120222.nc</file>
       <desc>WW3 90 x 50 global grid</desc>
-      <support>For testing of the WAV model</support>
     </domain>
 
     <!-- RRM grids -->
+
     <domain name="ne0np4_arm_x8v3_lowcon">
       <nx>92558</nx>
       <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.armx8v3_gx1v6.140517.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.armx8v3_gx1v6.140517.nc</file>
       <desc>1-deg with 1/8-deg over U.S. (version 3):</desc>
-      <file atm_mask="gx1v6">domain.lnd.armx8v3_gx1v6.140517.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.armx8v3_gx1v6.140517.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.armx8v3_gx1v6.140517.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.armx8v3_gx1v6.140517.nc</file>
     </domain>
 
     <domain name="ne0np4_enax4v1">
       <nx>78788</nx>
       <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.enax4v1_gx1v6.170523.nc</file>
+      <file grid="atm|lnd" mask="oRRS18to6">$DIN_LOC_ROOT/share/domains/domain.lnd.enax4v1_oRRS18to6.170621.nc</file>
+      <file grid="ice|ocn" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.enax4v1_gx1v6.170523.nc</file>
+      <file grid="ice|ocn" mask="oRRS18to6">$DIN_LOC_ROOT/share/domains/domain.ocn.enax4v1_oRRS18to6.170621.nc</file>
       <desc>1-deg with 1/4-deg over Eastern North Atlantic (version 1):</desc>
-      <file atm_mask="gx1v6">domain.lnd.enax4v1_gx1v6.170523.nc</file>
-      <file ice_mask="gx1v6">domain.ocn.enax4v1_gx1v6.170523.nc</file>
-      <file lnd_mask="gx1v6">domain.lnd.enax4v1_gx1v6.170523.nc</file>
-      <file ocn_mask="gx1v6">domain.ocn.enax4v1_gx1v6.170523.nc</file>
-      <file atm_mask="oRRS18to6">domain.lnd.enax4v1_oRRS18to6.170621.nc</file>
-      <file ice_mask="oRRS18to6">domain.ocn.enax4v1_oRRS18to6.170621.nc</file>
-      <file lnd_mask="oRRS18to6">domain.lnd.enax4v1_oRRS18to6.170621.nc</file>
-      <file ocn_mask="oRRS18to6">domain.ocn.enax4v1_oRRS18to6.170621.nc</file>
     </domain>
 
     <domain name="ne0np4_twpx4v1">
       <nx>81434</nx>
       <ny>1</ny>
+      <file grid="atm|lnd" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.lnd.twpx4v1_oRRS18to6v3.170629.nc</file>
+      <file grid="ice|ocn" mask="oRRS18to6v3">$DIN_LOC_ROOT/share/domains/domain.ocn.twpx4v1_oRRS18to6v3.170629.nc</file>
       <desc>1-deg with 1/4-deg over Tropical West Pacific (version 1):</desc>
-      <file atm_mask="oRRS18to6v3">domain.lnd.twpx4v1_oRRS18to6v3.170629.nc</file>
-      <file ice_mask="oRRS18to6v3">domain.ocn.twpx4v1_oRRS18to6v3.170629.nc</file>
-      <file lnd_mask="oRRS18to6v3">domain.lnd.twpx4v1_oRRS18to6v3.170629.nc</file>
-      <file ocn_mask="oRRS18to6v3">domain.ocn.twpx4v1_oRRS18to6v3.170629.nc</file>
     </domain>
 
     <domain name="ne0np4_conus_x4v1_lowcon">
       <nx>89147</nx>
       <ny>1</ny>
+      <file grid="atm|lnd" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.lnd.conusx4v1_tx0.1v2.161129.nc</file>
+      <file grid="ice|ocn" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.ocn.conusx4v1_tx0.1v2.161129.nc</file>
       <desc>1-deg with 1/4-deg over CONUS (version 1):</desc>
-      <file atm_mask="tx0.1v2">domain.lnd.conusx4v1_tx0.1v2.161129.nc</file>
-      <file ice_mask="tx0.1v2">domain.ocn.conusx4v1_tx0.1v2.161129.nc</file>
-      <file lnd_mask="tx0.1v2">domain.lnd.conusx4v1_tx0.1v2.161129.nc</file>
-      <file ocn_mask="tx0.1v2">domain.ocn.conusx4v1_tx0.1v2.161129.nc</file>
     </domain>
 
-    <!-- Old mask for CONUS grid -->
     <domain name="tx0.1v2">
-      <nx>3600</nx>  <ny>2400</ny>
-      <file atm_mask="tx0.1v2">domain.ocn.tx0.1v2.090218.nc</file>
-      <file ice_mask="tx0.1v2">domain.ocn.tx0.1v2.090218.nc</file>
-      <file lnd_mask="tx0.1v2">domain.ocn.tx0.1v2.090218.nc</file>
-      <file ocn_mask="tx0.1v2">domain.ocn.tx0.1v2.090218.nc</file>
+      <nx>3600</nx>
+      <ny>2400</ny>
+      <file grid="atm|ice|lnd|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.tx0.1v2.090218.nc</file>
       <desc>tx0.1v2 is an old mask used for CONUS:</desc>
     </domain>
-
 
     <domain name="oQU240">
       <nx>7153</nx>
       <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oQU240.151209.nc</file>
       <desc>oQU240 is an MPAS ocean mesh with quasi-uniform 240 km grid cells, nominally 2 degree resolution:</desc>
-      <file ice_mask="oQU240">domain.ocn.oQU240.151209.nc</file>
-      <file ocn_mask="oQU240">domain.ocn.oQU240.151209.nc</file>
     </domain>
 
     <domain name="oQU240wLI">
       <nx>7268</nx>
       <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oQU240wLI.160929.nc</file>
       <desc>oQU240wLI is an MPAS ocean mesh with quasi-uniform 240 km grid cells, nominally 2 degree resolution. Additionally, it has ocean under landice cavities.:</desc>
-      <file ice_mask="oQU240wLI">domain.ocn.oQU240wLI.160929.nc</file>
-      <file ocn_mask="oQU240wLI">domain.ocn.oQU240wLI.160929.nc</file>
     </domain>
 
     <domain name="oQU120">
       <nx>28571</nx>
       <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oQU120.160401.nc</file>
       <desc>oQU120 is an MPAS ocean mesh with quasi-uniform 120 km grid cells, nominally 1 degree resolution:</desc>
-      <file ice_mask="oQU120">domain.ocn.oQU120.160401.nc</file>
-      <file ocn_mask="oQU120">domain.ocn.oQU120.160401.nc</file>
     </domain>
 
     <domain name="oRRS15to5">
       <nx>5778136</nx>
       <ny>1</ny>
+      <file grid="ice|ocn">$DIN_LOC_ROOT/share/domains/domain.ocn.oRRS15to5.160207.nc</file>
       <desc>oRRS15to5 is an MPAS ocean grid with a mesh density function that is roughly proportional to the Rossby radius of deformation, with 15 km gridcells at low and 5 km gridcells at high latitudes:</desc>
-      <file ice_mask="oRRS15to5">domain.ocn.oRRS15to5.160207.nc</file>
-      <file ocn_mask="oRRS15to5">domain.ocn.oRRS15to5.160207.nc</file>
     </domain>
 
   </domains>
 
-  <!-- ======================================================== -->
-  <!-- Mapping -->
-  <!-- ======================================================== -->
+  <!-- The following are the required grid maps that must not be idmap if the   -->
+  <!-- attributes grid1 and grid2 are not equal -->
+
+  <required_gridmaps>
+    <required_gridmap grid1="atm_grid" grid2="ocn_grid">ATM2OCN_FMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="ocn_grid">ATM2OCN_SMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="ocn_grid">ATM2OCN_VMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="ocn_grid">OCN2ATM_FMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="ocn_grid">OCN2ATM_SMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="lnd_grid">ATM2LND_FMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="lnd_grid">ATM2LND_SMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="lnd_grid">LND2ATM_FMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="lnd_grid">LND2ATM_SMAPNAME</required_gridmap>
+    <required_gridmap grid1="atm_grid" grid2="wav_grid">ATM2WAV_SMAPNAME</required_gridmap>
+    <required_gridmap grid1="ocn_grid" grid2="wav_grid">OCN2WAV_SMAPNAME</required_gridmap>
+    <required_gridmap grid1="ocn_grid" grid2="wav_grid">ICE2WAV_SMAPNAME</required_gridmap> <!-- ??? -->
+    <!-- <required_gridmap grid1="ocn_grid" grid2="rof_grid" not_compset="_POP">ROF2OCN_FMAPNAME</required_gridmap> ?? -->
+    <required_gridmap grid1="ocn_grid" grid2="rof_grid" >ROF2OCN_LIQ_RMAPNAME</required_gridmap>
+    <required_gridmap grid1="ocn_grid" grid2="rof_grid" >ROF2OCN_ICE_RMAPNAME</required_gridmap>
+    <required_gridmap grid1="lnd_grid" grid2="rof_grid">LND2ROF_FMAPNAME</required_gridmap>
+    <required_gridmap grid1="lnd_grid" grid2="rof_grid">ROF2LND_FMAPNAME</required_gridmap>
+  </required_gridmaps>
 
   <gridmaps>
+
+    <!-- ======================================================== -->
+    <!-- Mapping -->
+    <!-- ======================================================== -->
 
     <!--- atm to ocean and ocean to atm mapping files -->
 
     <gridmap atm_grid="0.23x0.31" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_fv0.23x0.31_to_gx1v6_aave_da_100423.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_fv0.23x0.31_to_gx1v6_bilin_da_100423.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_fv0.23x0.31_to_gx1v6_bilin_da_100423.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_gx1v6_to_fv0.23x0.31_aave_da_100423.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_gx1v6_to_fv0.23x0.31_aave_da_100423.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_fv0.23x0.31_to_gx1v6_aave_da_100423.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_fv0.23x0.31_to_gx1v6_bilin_da_100423.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_fv0.23x0.31_to_gx1v6_bilin_da_100423.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_gx1v6_to_fv0.23x0.31_aave_da_100423.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_gx1v6_to_fv0.23x0.31_aave_da_100423.nc</map>
     </gridmap>
 
     <gridmap atm_grid="0.47x0.63" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_fv0.47x0.63_to_gx1v6_aave_da_090407.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_fv0.47x0.63_to_gx1v6_patch_090401.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_fv0.47x0.63_to_gx1v6_patch_090401.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_gx1v6_to_fv0.47x0.63_aave_da_090407.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_gx1v6_to_fv0.47x0.63_aave_da_090407.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_fv0.47x0.63_to_gx1v6_aave_da_090407.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_fv0.47x0.63_to_gx1v6_patch_090401.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_fv0.47x0.63_to_gx1v6_patch_090401.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_gx1v6_to_fv0.47x0.63_aave_da_090407.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_gx1v6_to_fv0.47x0.63_aave_da_090407.nc</map>
     </gridmap>
 
     <gridmap atm_grid="0.9x1.25" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gx1v6_aave.130322.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gx1v6_blin.130322.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gx1v6_patc.130322.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_fv0.9x1.25_aave.130322.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_fv0.9x1.25_aave.130322.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gx1v6_aave.130322.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gx1v6_blin.130322.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gx1v6_patc.130322.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_fv0.9x1.25_aave.130322.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_fv0.9x1.25_aave.130322.nc</map>
     </gridmap>
 
     <gridmap atm_grid="0.9x1.25" ocn_grid="mpas120">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_0.9x1.25_TO_mpas120_aave.151109.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_0.9x1.25_TO_mpas120_bilin.151109.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/fv0.9x1.25/map_0.9x1.25_TO_mpas120_patc.151109.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/mpas120/map_mpas120_TO_0.9x1.25_aave.151109.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/mpas120/map_mpas120_TO_0.9x1.25_aave.151109.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_0.9x1.25_TO_mpas120_aave.151109.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_0.9x1.25_TO_mpas120_bilin.151109.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/fv0.9x1.25/map_0.9x1.25_TO_mpas120_patc.151109.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/mpas120/map_mpas120_TO_0.9x1.25_aave.151109.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/mpas120/map_mpas120_TO_0.9x1.25_aave.151109.nc</map>
     </gridmap>
 
     <gridmap atm_grid="0.9x1.25" ocn_grid="mp120v1">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_fv0.9x1.25_to_mp120v1_aave_da_111004.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_fv0.9x1.25_to_mp120v1_aave_da_111004.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_fv0.9x1.25_to_mp120v1_aave_da_111004.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_mp120v1_to_fv0.9x1.25_aave_da_111004.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_mp120v1_to_fv0.9x1.25_aave_da_111004.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_fv0.9x1.25_to_mp120v1_aave_da_111004.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_fv0.9x1.25_to_mp120v1_aave_da_111004.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_fv0.9x1.25_to_mp120v1_aave_da_111004.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_mp120v1_to_fv0.9x1.25_aave_da_111004.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_mp120v1_to_fv0.9x1.25_aave_da_111004.nc</map>
     </gridmap>
 
     <gridmap atm_grid="1.9x2.5" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v6_aave.130322.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v6_blin.130322.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v6_patc.130322.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_fv1.9x2.5_aave.130322.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_fv1.9x2.5_aave.130322.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v6_aave.130322.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v6_blin.130322.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v6_patc.130322.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_fv1.9x2.5_aave.130322.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_fv1.9x2.5_aave.130322.nc</map>
     </gridmap>
 
     <gridmap atm_grid="4x5" ocn_grid="gx3v7">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_fv4x5_to_gx3v7_aave_da_091218.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_fv4x5_to_gx3v7_bilin_da_091218.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_fv4x5_to_gx3v7_bilin_da_091218.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_gx3v7_to_fv4x5_aave_da_091218.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_gx3v7_to_fv4x5_aave_da_091218.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_fv4x5_to_gx3v7_aave_da_091218.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_fv4x5_to_gx3v7_bilin_da_091218.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_fv4x5_to_gx3v7_bilin_da_091218.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_gx3v7_to_fv4x5_aave_da_091218.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_gx3v7_to_fv4x5_aave_da_091218.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne4np4" ocn_grid="gx3v7">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne4np4/</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne4np4/</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne4np4/</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx3v7/</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx3v7/</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne4np4/</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne4np4/</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne4np4/</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx3v7/</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx3v7/</map>
     </gridmap>
 
     <gridmap atm_grid="ne4np4" ocn_grid="oQU240">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne4np4/map_ne4np4_to_oQU240_aave.160614.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne4np4/map_ne4np4_to_oQU240_aave.160614.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne4np4/map_ne4np4_to_oQU240_aave.160614.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oQU240/map_oQU240_to_ne4np4_aave.160614.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oQU240/map_oQU240_to_ne4np4_aave.160614.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne4np4/map_ne4np4_to_oQU240_aave.160614.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne4np4/map_ne4np4_to_oQU240_aave.160614.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne4np4/map_ne4np4_to_oQU240_aave.160614.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_ne4np4_aave.160614.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_ne4np4_aave.160614.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne11np4" ocn_grid="gx3v7">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne11np4/</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne11np4/</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne11np4/</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx3v7/</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx3v7/</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne11np4/</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne11np4/</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne11np4/</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx3v7/</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx3v7/</map>
     </gridmap>
 
     <gridmap atm_grid="ne16np4" ocn_grid="gx3v7">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne16np4/map_ne16np4_TO_gx3v7_aave.120406.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne16np4/map_ne16np4_TO_gx3v7_aave.120406.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne16np4/map_ne16np4_TO_gx3v7_aave.120406.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx3v7/map_gx3v7_TO_ne16np4_aave.120406.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx3v7/map_gx3v7_TO_ne16np4_aave.120406.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gx3v7_aave.120406.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gx3v7_aave.120406.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gx3v7_aave.120406.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx3v7/map_gx3v7_TO_ne16np4_aave.120406.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx3v7/map_gx3v7_TO_ne16np4_aave.120406.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne11np4" ocn_grid="oQU240">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne11np4/map_ne11np4_to_oQU240_aave.160614.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne11np4/map_ne11np4_to_oQU240_aave.160614.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne11np4/map_ne11np4_to_oQU240_aave.160614.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oQU240/map_oQU240_to_ne11np4_aave.160614.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oQU240/map_oQU240_to_ne11np4_aave.160614.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne11np4/map_ne11np4_to_oQU240_aave.160614.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne11np4/map_ne11np4_to_oQU240_aave.160614.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne11np4/map_ne11np4_to_oQU240_aave.160614.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_ne11np4_aave.160614.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_ne11np4_aave.160614.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_ne30np4_to_gx1v6_aave_110121.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_ne30np4_to_gx1v6_native_110328.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_ne30np4_to_gx1v6_native_110328.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_gx1v6_to_ne30np4_aave_110121.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_gx1v6_to_ne30np4_aave_110121.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_ne30np4_to_gx1v6_aave_110121.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_ne30np4_to_gx1v6_native_110328.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_ne30np4_to_gx1v6_native_110328.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_gx1v6_to_ne30np4_aave_110121.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_gx1v6_to_ne30np4_aave_110121.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oEC60to30_ICG">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_TO_oEC60to30_aave.151207.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30_conserve_151207.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30_conserve_151207.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_ne30np4_aave.151207.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_ne30np4_aave.151207.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_oEC60to30_aave.151207.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30_conserve_151207.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30_conserve_151207.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30/map_oEC60to30_TO_ne30np4_aave.151207.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30/map_oEC60to30_TO_ne30np4_aave.151207.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oEC60to30v3_ICG">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_aave.161222.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_conserve.161222.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_conserve.161222.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30np4_aave.161222.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30np4_aave.161222.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_aave.161222.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_conserve.161222.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_conserve.161222.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30np4_aave.161222.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30np4_aave.161222.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oEC60to30wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30wLI_mask_aave.160915.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30wLI_mask_aave.160915.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30wLI_nomask_aave.160915.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30wLI/map_oEC60to30wLI_mask_to_ne30np4_aave.160915.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30wLI/map_oEC60to30wLI_mask_to_ne30np4_aave.160915.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30wLI_mask_aave.160915.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30wLI_mask_aave.160915.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30wLI_nomask_aave.160915.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30wLI/map_oEC60to30wLI_mask_to_ne30np4_aave.160915.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30wLI/map_oEC60to30wLI_mask_to_ne30np4_aave.160915.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oEC60to30v3wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_mask_aave.170802.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_mask_conserve.170802.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_nomask_bilin.170802.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_to_ne30np4_aave.170802.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_to_ne30np4_bilin.170802.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_mask_aave.170802.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_mask_conserve.170802.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_nomask_bilin.170802.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_to_ne30np4_aave.170802.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_to_ne30np4_bilin.170802.nc</map>
     </gridmap>
+
     <gridmap atm_grid="ne30np4" ocn_grid="oEC60to30v3wLI_ICG">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_mask_aave.170802.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_mask_conserve.170802.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_nomask_bilin.170802.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_to_ne30np4_aave.170802.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_to_ne30np4_bilin.170802.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_mask_aave.170802.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_mask_conserve.170802.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3wLI_nomask_bilin.170802.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_to_ne30np4_aave.170802.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_to_ne30np4_bilin.170802.nc</map>
     </gridmap>
+
     <gridmap atm_grid="ne30np4" ocn_grid="oRRS30to10wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_mask_aave.160930.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_mask_aave.160930.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_nomask_aave.160930.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_to_ne30np4_aave.160930.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_to_ne30np4_aave.160930.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_mask_aave.160930.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_mask_aave.160930.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_nomask_aave.160930.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_to_ne30np4_aave.160930.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_to_ne30np4_aave.160930.nc</map>
     </gridmap>
+
     <gridmap atm_grid="ne30np4" ocn_grid="mpas120">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_ne30np4_TO_MPASO_QU120km_aave.151110.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_ne30np4_TO_MPASO_QU120km_bilin.151110.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_ne30np4_TO_MPASO_QU120km_bilin.151110.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_MPASO_QU120km_TO_ne30np4_aave.151110.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_MPASO_QU120km_TO_ne30np4_aave.151110.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_ne30np4_TO_MPASO_QU120km_aave.151110.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_ne30np4_TO_MPASO_QU120km_bilin.151110.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_ne30np4_TO_MPASO_QU120km_bilin.151110.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_MPASO_QU120km_TO_ne30np4_aave.151110.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_MPASO_QU120km_TO_ne30np4_aave.151110.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" lnd_grid="0.9x1.25">
-      <ATM2LND_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_TO_fv0.9x1.25_aave.120712.nc</ATM2LND_FMAPNAME>
-      <ATM2LND_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_TO_fv0.9x1.25_aave.120712.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_ne30np4_aave.120712.nc</LND2ATM_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_ne30np4_aave.120712.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_fv0.9x1.25_aave.120712.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_fv0.9x1.25_aave.120712.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_ne30np4_aave.120712.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_ne30np4_aave.120712.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" lnd_grid="1.9x2.5">
-      <ATM2LND_FMAPNAME>cpl/cpl6/map_ne30np4_to_fv1.9x2.5_aave_da_091230.nc</ATM2LND_FMAPNAME>
-      <ATM2LND_SMAPNAME>cpl/cpl6/map_ne30np4_to_fv1.9x2.5_aave_da_091230.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/cpl6/map_fv1.9x2.5_to_ne30np4_aave_da_091230.nc</LND2ATM_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/cpl6/map_fv1.9x2.5_to_ne30np4_aave_da_091230.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_FMAPNAME">cpl/cpl6/map_ne30np4_to_fv1.9x2.5_aave_da_091230.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/cpl6/map_ne30np4_to_fv1.9x2.5_aave_da_091230.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/cpl6/map_fv1.9x2.5_to_ne30np4_aave_da_091230.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/cpl6/map_fv1.9x2.5_to_ne30np4_aave_da_091230.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne60np4" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne60np4/map_ne60np4_TO_gx1v6_aave.120406.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne60np4/map_ne60np4_TO_gx1v6_blin.120406.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_ne60np4_aave.120406.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_ne60np4_aave.120406.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne60np4/map_ne60np4_TO_gx1v6_aave.120406.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne60np4/map_ne60np4_TO_gx1v6_blin.120406.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_ne60np4_aave.120406.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_ne60np4_aave.120406.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v6_aave_110428.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v6_bilin_110428.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v6_bilin_110428.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_to_ne120np4_aave_110428.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_to_ne120np4_aave_110428.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v6_aave_110428.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v6_bilin_110428.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_gx1v6_bilin_110428.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_to_ne120np4_aave_110428.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_to_ne120np4_aave_110428.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4" lnd_grid="0.9x1.25">
-      <ATM2LND_FMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_TO_fv0.9x1.25_aave.120712.nc</ATM2LND_FMAPNAME>
-      <ATM2LND_SMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_TO_fv0.9x1.25_aave.120712.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_ne120np4_aave.120712.nc</LND2ATM_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_ne120np4_aave.120712.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_fv0.9x1.25_aave.120712.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_fv0.9x1.25_aave.120712.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_ne120np4_aave.120712.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_ne120np4_aave.120712.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4" lnd_grid="0.23x0.31">
-      <ATM2LND_FMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_fv0.23x0.31_aave_110331.nc</ATM2LND_FMAPNAME>
-      <ATM2LND_SMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_fv0.23x0.31_aave_110331.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne120np4_aave_110331.nc</LND2ATM_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne120np4_aave_110331.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_fv0.23x0.31_aave_110331.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_fv0.23x0.31_aave_110331.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne120np4_aave_110331.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne120np4_aave_110331.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4" ocn_grid="oRRS18to6v3_ICG">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_aave.170111.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_conserve.170111.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_conserve.170111.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_aave.170111.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_conserve.170111.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_conserve.170111.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne240np4" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne240np4/map_ne240np4_to_gx1v6_aave_110428.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne240np4/map_ne240np4_to_gx1v6_aave_110428.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne240np4/map_ne240np4_to_gx1v6_aave_110428.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_to_ne240np4_aave_110428.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_to_ne240np4_aave_110428.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne240np4/map_ne240np4_to_gx1v6_aave_110428.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne240np4/map_ne240np4_to_gx1v6_aave_110428.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne240np4/map_ne240np4_to_gx1v6_aave_110428.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_to_ne240np4_aave_110428.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_to_ne240np4_aave_110428.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne240np4" lnd_grid="0.23x0.31">
-      <ATM2LND_FMAPNAME>cpl/gridmaps/ne240np4/map_ne240np4_to_fv0.23x0.31_aave_110428.nc</ATM2LND_FMAPNAME>
-      <ATM2LND_SMAPNAME>cpl/gridmaps/ne240np4/map_ne240np4_to_fv0.23x0.31_aave_110428.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</LND2ATM_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne240np4/map_ne240np4_to_fv0.23x0.31_aave_110428.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne240np4/map_ne240np4_to_fv0.23x0.31_aave_110428.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4_enax4v1" lnd_grid="ne30np4">
-      <ATM2LND_FMAPNAME>cpl/cpl6/map_enax4v1_TO_ne30np4_aave.170517.nc</ATM2LND_FMAPNAME>
-      <ATM2LND_SMAPNAME>cpl/cpl6/map_enax4v1_TO_ne30np4_aave.170517.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/cpl6/map_ne30np4_TO_enax4v1_aave.170517.nc</LND2ATM_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/cpl6/map_ne30np4_TO_enax4v1_aave.170517.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_FMAPNAME">cpl/cpl6/map_enax4v1_TO_ne30np4_aave.170517.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/cpl6/map_enax4v1_TO_ne30np4_aave.170517.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/cpl6/map_ne30np4_TO_enax4v1_aave.170517.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/cpl6/map_ne30np4_TO_enax4v1_aave.170517.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4_enax4v1" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_enax4v1_TO_gx1v6_aave.170523.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_enax4v1_TO_gx1v6_blin.170523.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_enax4v1_TO_gx1v6_patc.170523.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_gx1v6_TO_enax4v1_aave.170523.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_gx1v6_TO_enax4v1_aave.170523.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_enax4v1_TO_gx1v6_aave.170523.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_enax4v1_TO_gx1v6_blin.170523.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_enax4v1_TO_gx1v6_patc.170523.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_gx1v6_TO_enax4v1_aave.170523.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_gx1v6_TO_enax4v1_aave.170523.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4_enax4v1" ocn_grid="oRRS18to6">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_enax4v1_TO_oRRS18to6_aave.170620.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_enax4v1_TO_oRRS18to6_blin.170620.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_enax4v1_TO_oRRS18to6_patc.170620.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_oRRS18to6_TO_enax4v1_aave.170620.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_oRRS18to6_TO_enax4v1_aave.170620.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_enax4v1_TO_oRRS18to6_aave.170620.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_enax4v1_TO_oRRS18to6_blin.170620.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_enax4v1_TO_oRRS18to6_patc.170620.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_oRRS18to6_TO_enax4v1_aave.170620.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_oRRS18to6_TO_enax4v1_aave.170620.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="gx3v7">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_gx3v7_aave.130322.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_gx3v7_blin.130322.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_gx3v7_patc.130322.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx3v7/map_gx3v7_TO_T62_aave.130322.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx3v7/map_gx3v7_TO_T62_aave.130322.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_gx3v7_aave.130322.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_gx3v7_blin.130322.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_gx3v7_patc.130322.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx3v7/map_gx3v7_TO_T62_aave.130322.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx3v7/map_gx3v7_TO_T62_aave.130322.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_gx1v6_aave.130322.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_gx1v6_blin.130322.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_gx1v6_patc.130322.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_T62_aave.130322.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_T62_aave.130322.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_gx1v6_aave.130322.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_gx1v6_blin.130322.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_gx1v6_patc.130322.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_T62_aave.130322.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_T62_aave.130322.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="mpas120">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_mpas120_aave.121116.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_mpas120_aave.121116.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_mpas120_aave.121116.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/mpas120/map_mpas120_TO_T62_aave.121116.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/mpas120/map_mpas120_TO_T62_aave.121116.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_mpas120_aave.121116.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_mpas120_aave.121116.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_mpas120_aave.121116.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/mpas120/map_mpas120_TO_T62_aave.121116.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/mpas120/map_mpas120_TO_T62_aave.121116.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="mpasgx1">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_mpasgx1_aave.150827.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_mpasgx1_blin.150827.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_mpasgx1_blin.150827.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/mpasgx1/map_mpasgx1_TO_T62_aave.150827.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/mpasgx1/map_mpasgx1_TO_T62_aave.150827.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_mpasgx1_aave.150827.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_mpasgx1_blin.150827.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_mpasgx1_blin.150827.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/mpasgx1/map_mpasgx1_TO_T62_aave.150827.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/mpasgx1/map_mpasgx1_TO_T62_aave.150827.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oQU240">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU240_aave.151209.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU240_patc.151209.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU240_blin.151209.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oQU240/map_oQU240_TO_T62_aave.151209.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oQU240/map_oQU240_TO_T62_aave.151209.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240_aave.151209.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240_patc.151209.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240_blin.151209.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240/map_oQU240_TO_T62_aave.151209.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240/map_oQU240_TO_T62_aave.151209.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oQU240wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU240wLI_mask_aave.160929.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU240wLI_nomask_aave.160929.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU240wLI_mask_patc.160929.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oQU240wLI/map_oQU240wLI_mask_TO_T62_aave.160929.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oQU240wLI/map_oQU240wLI_mask_TO_T62_aave.160929.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240wLI_mask_aave.160929.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240wLI_nomask_aave.160929.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU240wLI_mask_patc.160929.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_mask_TO_T62_aave.160929.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240wLI/map_oQU240wLI_mask_TO_T62_aave.160929.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oQU120">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU120_aave.151209.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU120_patc.151209.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oQU120_blin.151209.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oQU120/map_oQU120_TO_T62_aave.151209.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oQU120/map_oQU120_TO_T62_aave.151209.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU120_aave.151209.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU120_patc.151209.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oQU120_blin.151209.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU120/map_oQU120_TO_T62_aave.151209.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU120/map_oQU120_TO_T62_aave.151209.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oEC60to30">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30_aave.150615.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30_bilin.150804.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30_patc.150804.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_T62_aave.150615.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_T62_aave.150615.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30_aave.150615.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30_bilin.150804.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30_patc.150804.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30/map_oEC60to30_TO_T62_aave.150615.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30/map_oEC60to30_TO_T62_aave.150615.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oEC60to30v3">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30v3_aave.161222.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30v3_blin.161222.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30v3_patc.161222.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_TO_T62_aave.161222.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_TO_T62_aave.161222.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3_aave.161222.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3_blin.161222.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3_patc.161222.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_TO_T62_aave.161222.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_TO_T62_aave.161222.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oEC60to30wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30wLI_aave.160830.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30wLI_nm_aave.160830.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30wLI_blin.160830.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30wLI/map_oEC60to30wLI_TO_T62_aave.160830.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30wLI/map_oEC60to30wLI_TO_T62_aave.160830.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30wLI_aave.160830.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30wLI_nm_aave.160830.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30wLI_blin.160830.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30wLI/map_oEC60to30wLI_TO_T62_aave.160830.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30wLI/map_oEC60to30wLI_TO_T62_aave.160830.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oEC60to30v3wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30v3wLI_mask_aave.170328.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30v3wLI_nomask_blin.170328.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oEC60to30v3wLI_mask_patc.170328.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_TO_T62_aave.170328.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_TO_T62_aave.170328.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3wLI_mask_aave.170328.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3wLI_nomask_blin.170328.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oEC60to30v3wLI_mask_patc.170328.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_TO_T62_aave.170328.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3wLI/map_oEC60to30v3wLI_mask_TO_T62_aave.170328.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oRRS30to10">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10_aave.150722.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10_blin.150722.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10_patc.150722.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS30to10/map_oRRS30to10_TO_T62_aave.150722.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS30to10/map_oRRS30to10_TO_T62_aave.150722.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10_aave.150722.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10_blin.150722.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10_patc.150722.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10/map_oRRS30to10_TO_T62_aave.150722.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10/map_oRRS30to10_TO_T62_aave.150722.nc</map>
     </gridmap>
+
     <gridmap atm_grid="T62" ocn_grid="oRRS30to10v3">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3_aave.171128.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3_blin.171128.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3_patc.171128.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_TO_T62_aave.171128.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_TO_T62_aave.171128.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3_aave.171128.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3_blin.171128.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3_patc.171128.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_TO_T62_aave.171128.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_TO_T62_aave.171128.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oRRS30to10wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10wLI_mask_aave.160930.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10wLI_nomask_aave.160930.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10wLI_mask_blin.160930.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_TO_T62_aave.160930.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_TO_T62_aave.160930.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10wLI_mask_aave.160930.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10wLI_nomask_aave.160930.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10wLI_mask_blin.160930.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_TO_T62_aave.160930.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_TO_T62_aave.160930.nc</map>
     </gridmap>
+
     <gridmap atm_grid="T62" ocn_grid="oRRS30to10v3wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3wLI_mask_aave.171109.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3wLI_nomask_blin.171109.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3wLI_mask_patc.171109.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_TO_T62_aave.171109.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_TO_T62_aave.171109.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3wLI_mask_aave.171109.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3wLI_nomask_blin.171109.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS30to10v3wLI_mask_patc.171109.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_TO_T62_aave.171109.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_TO_T62_aave.171109.nc</map>
     </gridmap>
+
     <gridmap atm_grid="T62" ocn_grid="oRRS18to6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6_aave.160831.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6_patch.160831.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6_bilin.160831.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_T62_aave.160831.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_T62_aave.160831.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6_aave.160831.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6_patch.160831.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6_bilin.160831.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_T62_aave.160831.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_T62_aave.160831.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oRRS18to6v3">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_aave.170111.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_patc.170111.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_blin.170111.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_T62_aave.170111.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_T62_aave.170111.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_aave.170111.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_patc.170111.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_to_oRRS18to6v3_blin.170111.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_T62_aave.170111.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_T62_aave.170111.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" ocn_grid="oRRS15to5">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS15to5_aave.150722.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS15to5_patc.150722.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_oRRS15to5_blin.150722.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS15to5/map_oRRS15to5_TO_T62_aave.150722.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS15to5/map_oRRS15to5_TO_T62_aave.150722.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS15to5_aave.150722.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS15to5_patc.150722.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_oRRS15to5_blin.150722.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_TO_T62_aave.150722.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_TO_T62_aave.150722.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T31" ocn_grid="gx3v7">
-      <!-- alias is used for gridname -->
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_T31_to_gx3v7_aave_da_090903.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_gx3v7_to_T31_aave_da_090903.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_gx3v7_to_T31_aave_da_090903.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_T31_to_gx3v7_aave_da_090903.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_gx3v7_to_T31_aave_da_090903.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_gx3v7_to_T31_aave_da_090903.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T85" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T85/map_T85_to_gx1v6_aave_110411.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</ATM2OCN_SMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</ATM2OCN_VMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_to_T85_aave_110411.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_to_T85_aave_110411.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T85/map_T85_to_gx1v6_aave_110411.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_to_T85_aave_110411.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_to_T85_aave_110411.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T85" lnd_grid="0.9x1.25">
-      <ATM2LND_FMAPNAME>cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_aave_110411.nc</ATM2LND_FMAPNAME>
-      <ATM2LND_SMAPNAME>cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_bilin_110411.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</LND2ATM_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_bilin_110411.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_aave_110411.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_bilin_110411.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_bilin_110411.nc</map>
     </gridmap>
 
     <gridmap atm_grid="128x256" lnd_grid="0.9x1.25">
-      <ATM2LND_SMAPNAME>cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_bilin_110411.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</LND2ATM_FMAPNAME>
-      <ATM2LND_FMAPNAME>cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_aave_110411.nc</ATM2LND_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_bilin_110411.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_bilin_110411.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</map>
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_aave_110411.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_bilin_110411.nc</map>
     </gridmap>
 
     <gridmap atm_grid="128x256" lnd_grid="0.9x1.25">
-      <ATM2LND_SMAPNAME>cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_bilin_110411.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</LND2ATM_FMAPNAME>
-      <ATM2LND_FMAPNAME>cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_aave_110411.nc</ATM2LND_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_bilin_110411.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</map>
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/T85/map_T85_to_fv0.9x1.25_aave_110411.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_to_T85_aave_110411.nc</map>
     </gridmap>
 
-    <gridmap atm_grid="512x1024" lnd_grid="0.23x0.31" >
-      <ATM2LND_FMAPNAME>cpl/gridmaps/T341/map_T341_to_fv0.23x0.31_aave_110413.nc</ATM2LND_FMAPNAME>
-      <ATM2LND_SMAPNAME>cpl/gridmaps/T341/map_T341_to_fv0.23x0.31_aave_110413.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_T341_aave_110413.nc</LND2ATM_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_T341_aave_110413.nc</LND2ATM_SMAPNAME>
+    <gridmap atm_grid="512x1024" lnd_grid="0.23x0.31">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/T341/map_T341_to_fv0.23x0.31_aave_110413.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/T341/map_T341_to_fv0.23x0.31_aave_110413.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_T341_aave_110413.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_T341_aave_110413.nc</map>
     </gridmap>
 
     <!--  QL, 150525, wav to ocn, atm, ice mapping files  -->
 
     <gridmap ocn_grid="gx3v7" wav_grid="ww3a">
-      <WAV2OCN_SMAPNAME>cpl/gridmaps/ww3a/map_ww3a_TO_gx3v7_splice_150428.nc</WAV2OCN_SMAPNAME>
-      <OCN2WAV_SMAPNAME>cpl/gridmaps/gx3v7/map_gx3v7_TO_ww3a_splice_150428.nc</OCN2WAV_SMAPNAME>
-      <ICE2WAV_SMAPNAME>cpl/gridmaps/gx3v7/map_gx3v7_TO_ww3a_splice_150428.nc</ICE2WAV_SMAPNAME>
+      <map name="WAV2OCN_SMAPNAME">cpl/gridmaps/ww3a/map_ww3a_TO_gx3v7_splice_150428.nc</map>
+      <map name="OCN2WAV_SMAPNAME">cpl/gridmaps/gx3v7/map_gx3v7_TO_ww3a_splice_150428.nc</map>
+      <map name="ICE2WAV_SMAPNAME">cpl/gridmaps/gx3v7/map_gx3v7_TO_ww3a_splice_150428.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="gx1v6" wav_grid="ww3a">
-      <WAV2OCN_SMAPNAME>cpl/gridmaps/ww3a/map_ww3a_TO_gx1v6_splice_150428.nc</WAV2OCN_SMAPNAME>
-      <OCN2WAV_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_ww3a_splice_150428.nc</OCN2WAV_SMAPNAME>
-      <ICE2WAV_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_TO_ww3a_splice_150428.nc</ICE2WAV_SMAPNAME>
+      <map name="WAV2OCN_SMAPNAME">cpl/gridmaps/ww3a/map_ww3a_TO_gx1v6_splice_150428.nc</map>
+      <map name="OCN2WAV_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_ww3a_splice_150428.nc</map>
+      <map name="ICE2WAV_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_ww3a_splice_150428.nc</map>
     </gridmap>
 
-
     <gridmap atm_grid="48x96" wav_grid="ww3a">
-      <ATM2WAV_SMAPNAME>cpl/gridmaps/T31/map_T31_TO_ww3a_bilin_131104.nc</ATM2WAV_SMAPNAME>
+      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/T31/map_T31_TO_ww3a_bilin_131104.nc</map>
     </gridmap>
 
     <gridmap atm_grid="T62" wav_grid="ww3a">
-      <ATM2WAV_SMAPNAME>cpl/gridmaps/T62/map_T62_TO_ww3a_bilin.150617.nc</ATM2WAV_SMAPNAME>
+      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/T62/map_T62_TO_ww3a_bilin.150617.nc</map>
     </gridmap>
 
     <gridmap atm_grid="1.9x2.5" wav_grid="ww3a">
-      <ATM2WAV_SMAPNAME>cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_ww3a_bilin_140702.nc</ATM2WAV_SMAPNAME>
+      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_ww3a_bilin_140702.nc</map>
     </gridmap>
 
     <!--- river to land and land to river mapping files    -->
 
     <gridmap lnd_grid="360x720cru" rof_grid="r01">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/0.1x0.1/map_360x720_nomask_to_0.1x0.1_nomask_aave_da_c130107.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/360x720/map_0.1x0.1_nomask_to_360x720_nomask_aave_da_c130104.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.1x0.1/map_360x720_nomask_to_0.1x0.1_nomask_aave_da_c130107.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/360x720/map_0.1x0.1_nomask_to_360x720_nomask_aave_da_c130104.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="1.9x2.5" rof_grid="r01">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/0.1x0.1/map_1.9x2.5_nomask_to_0.1x0.1_nomask_aave_da_c120709.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/1.9x2.5/map_0.1x0.1_nomask_to_1.9x2.5_nomask_aave_da_c120709.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.1x0.1/map_1.9x2.5_nomask_to_0.1x0.1_nomask_aave_da_c120709.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/1.9x2.5/map_0.1x0.1_nomask_to_1.9x2.5_nomask_aave_da_c120709.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne120np4" rof_grid="r01">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/0.1x0.1/map_ne120np4_nomask_to_0.1x0.1_nomask_aave_da_c120711.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne120np4/map_0.1x0.1_nomask_to_ne120np4_nomask_aave_da_c120706.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.1x0.1/map_ne120np4_nomask_to_0.1x0.1_nomask_aave_da_c120711.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_0.1x0.1_nomask_to_ne120np4_nomask_aave_da_c120706.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne120np4" rof_grid="r0125">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/ne120np4/map_ne120np4_to_0.125_nomask_aave.160613.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne120np4/map_0.125_to_ne120np4_nomask_aave.160613.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_ne120np4_to_0.125_nomask_aave.160613.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_0.125_to_ne120np4_nomask_aave.160613.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne240np4" rof_grid="r01">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/0.1x0.1/map_ne240np4_nomask_to_0.1x0.1_nomask_aave_da_c120711.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne240np4/map_0.1x0.1_nomask_to_ne240np4_nomask_aave_da_c120706.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.1x0.1/map_ne240np4_nomask_to_0.1x0.1_nomask_aave_da_c120711.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne240np4/map_0.1x0.1_nomask_to_ne240np4_nomask_aave_da_c120706.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="360x720cru" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/0.5x0.5/map_360x720_nomask_to_0.5x0.5_nomask_aave_da_c130103.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/360x720/map_0.5x0.5_nomask_to_360x720_nomask_aave_da_c120830.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.5x0.5/map_360x720_nomask_to_0.5x0.5_nomask_aave_da_c130103.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/360x720/map_0.5x0.5_nomask_to_360x720_nomask_aave_da_c120830.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne4np4" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/ne4np4/map_ne4np4_TO_r05_aave.160621.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne4np4/map_r05_TO_ne4np4_aave.160621.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne4np4/map_ne4np4_TO_r05_aave.160621.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne4np4/map_r05_TO_ne4np4_aave.160621.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne11np4" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/ne11np4/map_ne11np4_TO_r05_aave.160621.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne11np4/map_r05_TO_ne11np4_aave.160621.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne11np4/map_ne11np4_TO_r05_aave.160621.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne11np4/map_r05_TO_ne11np4_aave.160621.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne16np4" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/ne16np4/map_ne16np4_nomask_to_0.5x0.5_nomask_aave_da_c110922.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne16np4/map_0.5x0.5_nomask_to_ne16np4_nomask_aave_da_c110922.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne16np4/map_ne16np4_nomask_to_0.5x0.5_nomask_aave_da_c110922.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne16np4/map_0.5x0.5_nomask_to_ne16np4_nomask_aave_da_c110922.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne30np4" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/ne30np4/map_ne30np4_to_0.5x0.5rtm_aave_da_110320.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne30np4/map_0.5x0.5_nomask_to_ne30np4_nomask_aave_da_c121019.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne30np4/map_ne30np4_to_0.5x0.5rtm_aave_da_110320.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne30np4/map_0.5x0.5_nomask_to_ne30np4_nomask_aave_da_c121019.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne60np4" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/ne60np4/map_ne60np4_nomask_to_0.5x0.5_nomask_aave_da_c110922.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne60np4/map_0.5x0.5_nomask_to_ne60np4_nomask_aave_da_c110922.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne60np4/map_ne60np4_nomask_to_0.5x0.5_nomask_aave_da_c110922.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne60np4/map_0.5x0.5_nomask_to_ne60np4_nomask_aave_da_c110922.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne120np4" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/ne120np4/map_ne120np4_to_0.5x0.5rtm_aave_da_110320.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne120np4/map_0.5x0.5_nomask_to_ne120np4_nomask_aave_da_c121019.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_ne120np4_to_0.5x0.5rtm_aave_da_110320.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_0.5x0.5_nomask_to_ne120np4_nomask_aave_da_c121019.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne240np4" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/ne240np4/map_ne240np4_nomask_to_0.5x0.5_nomask_aave_da_c110922.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/ne240np4/map_0.5x0.5_nomask_to_ne240np4_nomask_aave_da_c121019.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne240np4/map_ne240np4_nomask_to_0.5x0.5_nomask_aave_da_c110922.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne240np4/map_0.5x0.5_nomask_to_ne240np4_nomask_aave_da_c121019.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="0.23x0.31" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/0.23x0.31/map_0.23x0.31_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/0.23x0.31/map_0.5x0.5_nomask_to_0.23x0.31_nomask_aave_da_c110920.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.23x0.31/map_0.23x0.31_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/0.23x0.31/map_0.5x0.5_nomask_to_0.23x0.31_nomask_aave_da_c110920.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="0.47x0.63" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/0.47x0.63/map_0.47x0.63_nomask_to_0.5x0.5_nomask_aave_da_c120306.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/0.47x0.63/map_0.5x0.5_nomask_to_0.47x0.63_nomask_aave_da_c120306.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.47x0.63/map_0.47x0.63_nomask_to_0.5x0.5_nomask_aave_da_c120306.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/0.47x0.63/map_0.5x0.5_nomask_to_0.47x0.63_nomask_aave_da_c120306.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="0.9x1.25" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/0.9x1.25/map_0.9x1.25_nomask_to_0.5x0.5_nomask_aave_da_c120522.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/0.9x1.25/map_0.5x0.5_nomask_to_0.9x1.25_nomask_aave_da_c121019.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.9x1.25/map_0.9x1.25_nomask_to_0.5x0.5_nomask_aave_da_c120522.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/0.9x1.25/map_0.5x0.5_nomask_to_0.9x1.25_nomask_aave_da_c121019.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="1.9x2.5" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/1.9x2.5/map_1.9x2.5_nomask_to_0.5x0.5_nomask_aave_da_c120522.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/1.9x2.5/map_0.5x0.5_nomask_to_1.9x2.5_nomask_aave_da_c120709.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/1.9x2.5/map_1.9x2.5_nomask_to_0.5x0.5_nomask_aave_da_c120522.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/1.9x2.5/map_0.5x0.5_nomask_to_1.9x2.5_nomask_aave_da_c120709.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="2.5x3.33" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/2.5x3.33/map_2.5x3.33_nomask_to_0.5x0.5_nomask_aave_da_c110823.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/2.5x3.33/map_0.5x0.5_nomask_to_2.5x3.33_nomask_aave_da_c110823.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/2.5x3.33/map_2.5x3.33_nomask_to_0.5x0.5_nomask_aave_da_c110823.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/2.5x3.33/map_0.5x0.5_nomask_to_2.5x3.33_nomask_aave_da_c110823.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="10x15" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/10x15/map_10x15_to_0.5x0.5rtm_aave_da_110307.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/10x15/map_0.5x0.5_nomask_to_10x15_nomask_aave_da_c121019.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_10x15_to_0.5x0.5rtm_aave_da_110307.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_0.5x0.5_nomask_to_10x15_nomask_aave_da_c121019.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="4x5" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/4x5/map_4x5_nomask_to_0.5x0.5_nomask_aave_da_c110822.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/4x5/map_0.5x0.5_nomask_to_4x5_nomask_aave_da_c110822.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/4x5/map_4x5_nomask_to_0.5x0.5_nomask_aave_da_c110822.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/4x5/map_0.5x0.5_nomask_to_4x5_nomask_aave_da_c110822.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="T341" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/512x1024/map_512x1024_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/512x1024/map_0.5x0.5_nomask_to_512x1024_nomask_aave_da_c110920.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/512x1024/map_512x1024_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/512x1024/map_0.5x0.5_nomask_to_512x1024_nomask_aave_da_c110920.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="T85" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/128x256/map_128x256_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/128x256/map_0.5x0.5_nomask_to_128x256_nomask_aave_da_c110920.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/128x256/map_128x256_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/128x256/map_0.5x0.5_nomask_to_128x256_nomask_aave_da_c110920.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="T31" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/48x96/map_48x96_nomask_to_0.5x0.5_nomask_aave_da_c110822.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/48x96/map_0.5x0.5_nomask_to_48x96_nomask_aave_da_c110822.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/48x96/map_48x96_nomask_to_0.5x0.5_nomask_aave_da_c110822.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/48x96/map_0.5x0.5_nomask_to_48x96_nomask_aave_da_c110822.nc</map>
     </gridmap>
 
     <!--- river to ocn area overlap -->
 
-    <gridmap rof_grid="r05" ocn_grid="gx1v6" >
-      <ROF2OCN_FMAPNAME>cpl/cpl6/map_r05_TO_g16_aave.120920.nc</ROF2OCN_FMAPNAME>
+    <gridmap ocn_grid="gx1v6" rof_grid="r05">
+      <map name="ROF2OCN_FMAPNAME">cpl/cpl6/map_r05_TO_g16_aave.120920.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="gx3v7" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="gx3v7" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_gx3v7_e1000r500_090903.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="gx1v6" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="gx1v6" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_gx1v6_e1000r300_090318.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="gx3v7" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="gx3v7" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_gx3v7_e1000r500_090903.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="gx1v6" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_gx1v6_e1000r300_090226.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_gx1v6_e1000r300_090226.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="gx1v6" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_gx1v6_e1000r300_090226.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_gx1v6_e1000r300_090226.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r01" ocn_grid="gx1v6" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r01_to_gx1v6_120711.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r01_to_gx1v6_120711.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="gx1v6" rof_grid="r01">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r01_to_gx1v6_120711.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r01_to_gx1v6_120711.nc</map>
     </gridmap>
 
     <!--- deprecated MPAS grids -->
-    <gridmap rof_grid="rx1" ocn_grid="mpasgx1" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_mpasgx1_nn_150910.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_mpasgx1_nn_150910.nc</ROF2OCN_LIQ_RMAPNAME>
+
+    <gridmap ocn_grid="mpasgx1" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_mpasgx1_nn_150910.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_mpasgx1_nn_150910.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="mpas120" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_mpas120_nn_131217.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_mpas120_nn_131217.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="mpas120" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_mpas120_nn_131217.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_mpas120_nn_131217.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="mpas120" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_QU120km_nn_151110.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_QU120km_nn_151110.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="mpas120" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_QU120km_nn_151110.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_QU120km_nn_151110.nc</map>
     </gridmap>
 
     <!--- current MPAS grids -->
-    <gridmap rof_grid="rx1" ocn_grid="oQU240" >
-      <ROF2OCN_ICE_RMAPNAME>cpl/cpl6/map_rx1_to_oQU240_nn.160527.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME>cpl/cpl6/map_rx1_to_oQU240_nn.160527.nc</ROF2OCN_LIQ_RMAPNAME>
+
+    <gridmap ocn_grid="oQU240" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oQU240_nn.160527.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oQU240_nn.160527.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oQU240wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oQU240wLI_nn.160929.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oQU240wLI_nn.160929.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oQU240wLI" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oQU240wLI_nn.160929.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oQU240wLI_nn.160929.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oQU120" >
-      <ROF2OCN_ICE_RMAPNAME>cpl/cpl6/map_rx1_to_oQU120_nn.160527.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME>cpl/cpl6/map_rx1_to_oQU120_nn.160527.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oQU120" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oQU120_nn.160527.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oQU120_nn.160527.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oEC60to30" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30_nn.160527.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30_nn.160527.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oEC60to30_nn.160527.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oEC60to30_nn.160527.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oEC60to30v3" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30v3" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oEC60to30v3_smoothed.r300e600.161222.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oEC60to30v3_smoothed.r300e600.161222.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oEC60to30wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30wLI_nn.160830.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30wLI_nn.160830.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30wLI" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oEC60to30wLI_nn.160830.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oEC60to30wLI_nn.160830.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oEC60to30v3wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30v3wLI_smoothed.r300e600.170328.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oEC60to30v3wLI_smoothed.r300e600.170328.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30v3wLI" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oEC60to30v3wLI_smoothed.r300e600.170328.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oEC60to30v3wLI_smoothed.r300e600.170328.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10_nn.160527.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10_nn.160527.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS30to10" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS30to10_nn.160527.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS30to10_nn.160527.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10v3" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10v3_smoothed.r150e300.171129.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10v3_smoothed.r150e300.171129.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS30to10v3" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS30to10v3_smoothed.r150e300.171129.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS30to10v3_smoothed.r150e300.171129.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10wLI_smoothed.r150e300.160930.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10wLI_smoothed.r150e300.160930.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS30to10wLI" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS30to10wLI_smoothed.r150e300.160930.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS30to10wLI_smoothed.r150e300.160930.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oRRS30to10v3wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10v3wLI-masked_smoothed.r150e300.171116.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS30to10v3wLI-masked_smoothed.r150e300.171116.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS30to10v3wLI" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS30to10v3wLI-masked_smoothed.r150e300.171116.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS30to10v3wLI-masked_smoothed.r150e300.171116.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oRRS18to6" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS18to6_nn.160830.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS18to6_nn.160830.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS18to6" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS18to6_nn.160830.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS18to6_nn.160830.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oRRS18to6v3" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS18to6v3_smoothed.r100e200.170111.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_rx1_to_oRRS18to6v3_smoothed.r100e200.170111.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS18to6v3" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS18to6v3_smoothed.r100e200.170111.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS18to6v3_smoothed.r100e200.170111.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="rx1" ocn_grid="oRRS15to5" >
-      <ROF2OCN_ICE_RMAPNAME>cpl/cpl6/map_rx1_to_oRRS15to5_nn.160527.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME>cpl/cpl6/map_rx1_to_oRRS15to5_nn.160527.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS15to5" rof_grid="rx1">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS15to5_nn.160527.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_oRRS15to5_nn.160527.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oQU240" >
-      <ROF2OCN_ICE_RMAPNAME>cpl/cpl6/map_r05_to_oQU240_nn.160714.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME>cpl/cpl6/map_r05_to_oQU240_nn.160714.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oQU240" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oQU240_nn.160714.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oQU240_nn.160714.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oQU240wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oQU240wLI_nn.160929.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oQU240wLI_nn.160929.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oQU240wLI" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oQU240wLI_nn.160929.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oQU240wLI_nn.160929.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oQU120" >
-      <ROF2OCN_ICE_RMAPNAME>cpl/cpl6/map_r05_to_oQU120_nn.160718.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME>cpl/cpl6/map_r05_to_oQU120_nn.160718.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oQU120" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oQU120_nn.160718.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oQU120_nn.160718.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30_ICG" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30_ICG" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30_smoothed.r175e350.160718.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30v3" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30v3" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30v3_ICG" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30v3_ICG" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30v3_smoothed.r300e600.161222.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30wLI_smoothed.r300e600.160926.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30wLI_smoothed.r300e600.160926.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30wLI" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30wLI_smoothed.r300e600.160926.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30wLI_smoothed.r300e600.160926.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30v3wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3wLI_smoothed.r300e600.170802.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3wLI_smoothed.r300e600.170802.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30v3wLI" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30v3wLI_smoothed.r300e600.170802.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30v3wLI_smoothed.r300e600.170802.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oEC60to30v3wLI_ICG" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3wLI_smoothed.r300e600.170802.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oEC60to30v3wLI_smoothed.r300e600.170802.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oEC60to30v3wLI_ICG" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30v3wLI_smoothed.r300e600.170802.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oEC60to30v3wLI_smoothed.r300e600.170802.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oRRS30to10" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10_nn.160718.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10_nn.160718.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS30to10" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10_nn.160718.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10_nn.160718.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oRRS30to10wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10wLI_nn.160930.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10wLI_nn.160930.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS30to10wLI" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10wLI_nn.160930.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10wLI_nn.160930.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oRRS30to10v3" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10v3_smoothed.r150e300.171109.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10v3_smoothed.r150e300.171109.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS30to10v3" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10v3_smoothed.r150e300.171109.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10v3_smoothed.r150e300.171109.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oRRS30to10v3wLI" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10v3wLI_smoothed.r150e300.171109.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r05_to_oRRS30to10v3wLI_smoothed.r150e300.171109.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS30to10v3wLI" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10v3wLI_smoothed.r150e300.171109.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oRRS30to10v3wLI_smoothed.r150e300.171109.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r05" ocn_grid="oRRS15to5" >
-      <ROF2OCN_ICE_RMAPNAME>cpl/cpl6/map_r05_to_oRRS15to5_nn.160203.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME>cpl/cpl6/map_r05_to_oRRS15to5_nn.160203.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS15to5" rof_grid="r05">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r05_to_oRRS15to5_nn.160203.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r05_to_oRRS15to5_nn.160203.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r0125" ocn_grid="oRRS18to6" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6_nn.160831.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6_nn.160831.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS18to6" rof_grid="r0125">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r0125_to_oRRS18to6_nn.160831.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_oRRS18to6_nn.160831.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r0125" ocn_grid="oRRS18to6v3" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS18to6v3" rof_grid="r0125">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r0125" ocn_grid="oRRS18to6v3_ICG" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS18to6v3_ICG" rof_grid="r0125">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_oRRS18to6v3_smoothed.r50e100.170111.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="r0125" ocn_grid="oRRS15to5" >
-      <ROF2OCN_ICE_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS15to5_nn.160720.nc</ROF2OCN_ICE_RMAPNAME>
-      <ROF2OCN_LIQ_RMAPNAME >cpl/cpl6/map_r0125_to_oRRS15to5_nn.160720.nc</ROF2OCN_LIQ_RMAPNAME>
+    <gridmap ocn_grid="oRRS15to5" rof_grid="r0125">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r0125_to_oRRS15to5_nn.160720.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r0125_to_oRRS15to5_nn.160720.nc</map>
     </gridmap>
 
     <!--- river flooding variables -->
@@ -2208,22 +2562,22 @@
     <!-- GLC: mpas.gis20km     -->
     <!-- ====================  -->
 
-    <gridmap lnd_grid="0.9x1.25" glc_grid="mpas.gis20km" >
-      <LND2GLC_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_mpas.gis20km_aave.150922.nc</LND2GLC_FMAPNAME>
-      <LND2GLC_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_mpas.gis20km_bilin.150922.nc</LND2GLC_SMAPNAME>
-      <GLC2LND_FMAPNAME>cpl/gridmaps/mpas.gis20km/map_mpas.gis20km_TO_fv0.9x1.25_aave.150922.nc</GLC2LND_FMAPNAME>
-      <GLC2LND_SMAPNAME>cpl/gridmaps/mpas.gis20km/map_mpas.gis20km_TO_fv0.9x1.25_aave.150922.nc</GLC2LND_SMAPNAME>
+    <gridmap glc_grid="mpas.gis20km" lnd_grid="0.9x1.25">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_mpas.gis20km_aave.150922.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_mpas.gis20km_bilin.150922.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.gis20km/map_mpas.gis20km_TO_fv0.9x1.25_aave.150922.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.gis20km/map_mpas.gis20km_TO_fv0.9x1.25_aave.150922.nc</map>
     </gridmap>
 
     <!-- ====================  -->
     <!-- GLC: mpas.ais20km     -->
     <!-- ====================  -->
 
-    <gridmap lnd_grid="0.9x1.25" glc_grid="mpas.ais20km">
-      <LND2GLC_FMAPNAME>cpl/gridmaps/fv0.9x1.25/map_f09_TO_ais20km_aave.151005.nc</LND2GLC_FMAPNAME>
-      <LND2GLC_SMAPNAME>cpl/gridmaps/fv0.9x1.25/map_f09_TO_ais20km_bilin.151005.nc</LND2GLC_SMAPNAME>
-      <GLC2LND_FMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_TO_f09_aave.151005.nc</GLC2LND_FMAPNAME>
-      <GLC2LND_SMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_TO_f09_aave.151005.nc</GLC2LND_SMAPNAME>
+    <gridmap glc_grid="mpas.ais20km" lnd_grid="0.9x1.25">
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_f09_TO_ais20km_aave.151005.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_f09_TO_ais20km_bilin.151005.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_TO_f09_aave.151005.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_TO_f09_aave.151005.nc</map>
     </gridmap>
 
     <!-- ======================================================== -->
@@ -2240,159 +2594,159 @@
     <!-- MPASO / MALI -->
 
     <gridmap glc_grid="mpas.gis20km" ocn_grid="mpas120">
-      <GLC2OCN_LIQ_RMAPNAME>cpl/gridmaps/mpas.gis20km/map_mpas.gis20km_to_mpas120_nnsmooth_150924.nc</GLC2OCN_LIQ_RMAPNAME>
-      <GLC2OCN_ICE_RMAPNAME>cpl/gridmaps/mpas.gis20km/map_mpas.gis20km_to_mpas120_nnsmooth_150924.nc</GLC2OCN_ICE_RMAPNAME>
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.gis20km/map_mpas.gis20km_to_mpas120_nnsmooth_150924.nc</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.gis20km/map_mpas.gis20km_to_mpas120_nnsmooth_150924.nc</map>
     </gridmap>
 
-    <gridmap ocn_grid="oEC60to30" glc_grid="mpas.ais20km">
-      <GLC2OCN_FMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oEC60to30_nearestdtos.151005.nc</GLC2OCN_FMAPNAME>
-      <GLC2OCN_SMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oEC60to30_nearestdtos.151005.nc</GLC2OCN_SMAPNAME>
-      <OCN2GLC_FMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_to_ais20km_nearestdtos.151005.nc</OCN2GLC_FMAPNAME>
-      <OCN2GLC_SMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_to_ais20km_nearestdtos.151005.nc</OCN2GLC_SMAPNAME>
+    <gridmap glc_grid="mpas.ais20km" ocn_grid="oEC60to30">
+      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oEC60to30_nearestdtos.151005.nc</map>
+      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oEC60to30_nearestdtos.151005.nc</map>
+      <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/oEC60to30/map_oEC60to30_to_ais20km_nearestdtos.151005.nc</map>
+      <map name="OCN2GLC_SMAPNAME">cpl/gridmaps/oEC60to30/map_oEC60to30_to_ais20km_nearestdtos.151005.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne16np4" ocn_grid="oQU240">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne16np4/map_ne16np4_to_oQU240_aave.151209.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne16np4/map_ne16np4_to_oQU240_conserve.151209.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne16np4/map_ne16np4_to_oQU240_conserve.151209.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oQU240/map_oQU240_to_ne16np4_aave.151209.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oQU240/map_oQU240_to_ne16np4_aave.151209.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_to_oQU240_aave.151209.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_to_oQU240_conserve.151209.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_to_oQU240_conserve.151209.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_ne16np4_aave.151209.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_ne16np4_aave.151209.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oQU120">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oQU120_aave.160322.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oQU120_conserve.160322.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oQU120_conserve.160322.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oQU120/map_oQU120_to_ne30np4_aave.160322.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oQU120/map_oQU120_to_ne30np4_aave.160322.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oQU120_aave.160322.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oQU120_conserve.160322.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oQU120_conserve.160322.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oQU120/map_oQU120_to_ne30np4_aave.160322.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oQU120/map_oQU120_to_ne30np4_aave.160322.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oEC60to30">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_TO_oEC60to30_aave.151207.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30_conserve_151207.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30_conserve_151207.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_ne30np4_aave.151207.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30/map_oEC60to30_TO_ne30np4_aave.151207.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_oEC60to30_aave.151207.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30_conserve_151207.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30_conserve_151207.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30/map_oEC60to30_TO_ne30np4_aave.151207.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30/map_oEC60to30_TO_ne30np4_aave.151207.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oEC60to30v3">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_aave.161222.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_conserve_161222.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_conserve_161222.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30np4_aave.161222.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30np4_aave.161222.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_aave.161222.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_conserve_161222.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oEC60to30v3_conserve_161222.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30np4_aave.161222.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oEC60to30v3/map_oEC60to30v3_to_ne30np4_aave.161222.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oRRS30to10">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10_aave.160419.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10_aave.160419.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10_aave.160419.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS30to10/map_oRRS30to10_to_ne30np4_aave.160419.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS30to10/map_oRRS30to10_to_ne30np4_aave.160419.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10_aave.160419.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10_aave.160419.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10_aave.160419.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10/map_oRRS30to10_to_ne30np4_aave.160419.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10/map_oRRS30to10_to_ne30np4_aave.160419.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oRRS30to10wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_mask_aave.160930.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_mask_aave.160930.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_nomask_aave.160930.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_to_ne30np4_aave.160930.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_to_ne30np4_aave.160930.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_mask_aave.160930.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_mask_aave.160930.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10wLI_nomask_aave.160930.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_to_ne30np4_aave.160930.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10wLI/map_oRRS30to10wLI_mask_to_ne30np4_aave.160930.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oRRS30to10v3">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3_aave.171218.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3_conserve.171218.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3_conserve.171218.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_to_ne30np4_aave.171218.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_to_ne30np4_aave.171218.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3_aave.171218.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3_conserve.171218.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3_conserve.171218.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_to_ne30np4_aave.171218.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10v3/map_oRRS30to10v3_to_ne30np4_aave.171218.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" ocn_grid="oRRS30to10v3wLI">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3wLI_mask_aave.171218.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3wLI_mask_conserve.171218.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3wLI_nomask_conserve.171218.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_to_ne30np4_aave.171218.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_to_ne30np4_aave.171218.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3wLI_mask_aave.171218.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3wLI_mask_conserve.171218.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_to_oRRS30to10v3wLI_nomask_conserve.171218.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_to_ne30np4_aave.171218.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS30to10v3wLI/map_oRRS30to10v3wLI_mask_to_ne30np4_aave.171218.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4" lnd_grid="1.9x1.25">
-      <ATM2LND_SMAPNAME>cpl/cpl6/map_ne30np4_to_fv1.9x2.5_aave_da_091230.nc</ATM2LND_SMAPNAME>
-      <LND2ATM_FMAPNAME>cpl/cpl6/map_fv1.9x2.5_to_ne30np4_aave_da_091230.nc</LND2ATM_FMAPNAME>
-      <ATM2LND_FMAPNAME>cpl/cpl6/map_ne30np4_to_fv1.9x2.5_aave_da_091230.nc</ATM2LND_FMAPNAME>
-      <LND2ATM_SMAPNAME>cpl/cpl6/map_fv1.9x2.5_to_ne30np4_aave_da_091230.nc</LND2ATM_SMAPNAME>
+      <map name="ATM2LND_SMAPNAME">cpl/cpl6/map_ne30np4_to_fv1.9x2.5_aave_da_091230.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/cpl6/map_fv1.9x2.5_to_ne30np4_aave_da_091230.nc</map>
+      <map name="ATM2LND_FMAPNAME">cpl/cpl6/map_ne30np4_to_fv1.9x2.5_aave_da_091230.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/cpl6/map_fv1.9x2.5_to_ne30np4_aave_da_091230.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4" ocn_grid="oRRS18to6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6_aave.160831.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6_bilin.160831.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6_bilin.160831.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_ne120np4_aave.160831.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_ne120np4_aave.160831.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6_aave.160831.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6_bilin.160831.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6_bilin.160831.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_ne120np4_aave.160831.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS18to6/map_oRRS18to6_to_ne120np4_aave.160831.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4" ocn_grid="oRRS18to6v3">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_aave.170111.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_conserve.170111.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_conserve.170111.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_aave.170111.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_conserve.170111.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS18to6v3_conserve.170111.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS18to6v3/map_oRRS18to6v3_to_ne120np4_aave.170111.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4" ocn_grid="oRRS15to5">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS15to5_aave.160203.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS15to5_bilin.160428.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS15to5_bilin.160428.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne120np4_aave.160203.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne120np4_aave.160203.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS15to5_aave.160203.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS15to5_bilin.160428.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_to_oRRS15to5_bilin.160428.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne120np4_aave.160203.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/oRRS15to5/map_oRRS15to5_to_ne120np4_aave.160203.nc</map>
     </gridmap>
 
     <gridmap atm_grid="48x96" ocn_grid="gx3v7">
-      <ATM2OCN_FMAPNAME>cpl/cpl6/map_T31_to_gx3v7_aave_da_090903.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/cpl6/map_gx3v7_to_T31_aave_da_090903.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/cpl6/map_gx3v7_to_T31_aave_da_090903.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_T31_to_gx3v7_aave_da_090903.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/cpl6/map_T31_to_gx3v7_patch_090903.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_gx3v7_to_T31_aave_da_090903.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_gx3v7_to_T31_aave_da_090903.nc</map>
     </gridmap>
 
     <gridmap atm_grid="128x256" ocn_grid="gx1v6">
-      <ATM2OCN_FMAPNAME>cpl/gridmaps/T85/map_T85_to_gx1v6_aave_110411.nc</ATM2OCN_FMAPNAME>
-      <ATM2OCN_VMAPNAME>cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</ATM2OCN_VMAPNAME>
-      <ATM2OCN_SMAPNAME>cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</ATM2OCN_SMAPNAME>
-      <OCN2ATM_FMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_to_T85_aave_110411.nc</OCN2ATM_FMAPNAME>
-      <OCN2ATM_SMAPNAME>cpl/gridmaps/gx1v6/map_gx1v6_to_T85_aave_110411.nc</OCN2ATM_SMAPNAME>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/T85/map_T85_to_gx1v6_aave_110411.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/T85/map_T85_to_gx1v6_bilin_110411.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_to_T85_aave_110411.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_to_T85_aave_110411.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="512x1024" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/512x1024/map_512x1024_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/512x1024/map_0.5x0.5_nomask_to_512x1024_nomask_aave_da_c110920.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/512x1024/map_512x1024_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/512x1024/map_0.5x0.5_nomask_to_512x1024_nomask_aave_da_c110920.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="128x256" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/128x256/map_128x256_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/128x256/map_0.5x0.5_nomask_to_128x256_nomask_aave_da_c110920.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/128x256/map_128x256_nomask_to_0.5x0.5_nomask_aave_da_c110920.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/128x256/map_0.5x0.5_nomask_to_128x256_nomask_aave_da_c110920.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="48x96" rof_grid="r05">
-      <LND2ROF_FMAPNAME>lnd/clm2/mappingdata/maps/48x96/map_48x96_nomask_to_0.5x0.5_nomask_aave_da_c110822.nc</LND2ROF_FMAPNAME>
-      <ROF2LND_FMAPNAME>lnd/clm2/mappingdata/maps/48x96/map_0.5x0.5_nomask_to_48x96_nomask_aave_da_c110822.nc</ROF2LND_FMAPNAME>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/48x96/map_48x96_nomask_to_0.5x0.5_nomask_aave_da_c110822.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/48x96/map_0.5x0.5_nomask_to_48x96_nomask_aave_da_c110822.nc</map>
     </gridmap>
 
     <gridmap glc_grid="mpas.ais20km" ocn_grid="oQU240">
-      <GLC2OCN_FMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240_aave.151209.nc</GLC2OCN_FMAPNAME>
-      <OCN2GLC_FMAPNAME>cpl/gridmaps/oQU240/map_oQU240_to_ais20km_aave.151209.nc</OCN2GLC_FMAPNAME>
-      <GLC2OCN_SMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240_nearestdtos.151209.nc</GLC2OCN_SMAPNAME>
-      <GLC2OCN_LIQ_RMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240_nearestdtos.151209.nc</GLC2OCN_LIQ_RMAPNAME>
-      <GLC2OCN_ICE_RMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240_nearestdtos.151209.nc</GLC2OCN_ICE_RMAPNAME>
-      <OCN2GLC_SMAPNAME>cpl/gridmaps/oQU240/map_oQU240_to_ais20km_nearestdtos.151209.nc</OCN2GLC_SMAPNAME>
+      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240_aave.151209.nc</map>
+      <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_ais20km_aave.151209.nc</map>
+      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240_nearestdtos.151209.nc</map>
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240_nearestdtos.151209.nc</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU240_nearestdtos.151209.nc</map>
+      <map name="OCN2GLC_SMAPNAME">cpl/gridmaps/oQU240/map_oQU240_to_ais20km_nearestdtos.151209.nc</map>
     </gridmap>
 
     <gridmap glc_grid="mpas.ais20km" ocn_grid="oQU120">
-      <GLC2OCN_FMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU120_aave.160331.nc</GLC2OCN_FMAPNAME>
-      <OCN2GLC_FMAPNAME>cpl/gridmaps/oQU120/map_oQU120_to_ais20km_aave.160331.nc</OCN2GLC_FMAPNAME>
-      <GLC2OCN_SMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU120_nearestdtos.160331.nc</GLC2OCN_SMAPNAME>
-      <GLC2OCN_LIQ_RMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU120_nearestdtos.160331.nc</GLC2OCN_LIQ_RMAPNAME>
-      <GLC2OCN_ICE_RMAPNAME>cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU120_nearestdtos.160331.nc</GLC2OCN_ICE_RMAPNAME>
-      <OCN2GLC_SMAPNAME>cpl/gridmaps/oQU120/map_oQU120_to_ais20km_nearestdtos.160331.nc</OCN2GLC_SMAPNAME>
+      <map name="GLC2OCN_FMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU120_aave.160331.nc</map>
+      <map name="OCN2GLC_FMAPNAME">cpl/gridmaps/oQU120/map_oQU120_to_ais20km_aave.160331.nc</map>
+      <map name="GLC2OCN_SMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU120_nearestdtos.160331.nc</map>
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU120_nearestdtos.160331.nc</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/mpas.ais20km/map_ais20km_to_oQU120_nearestdtos.160331.nc</map>
+      <map name="OCN2GLC_SMAPNAME">cpl/gridmaps/oQU120/map_oQU120_to_ais20km_nearestdtos.160331.nc</map>
     </gridmap>
 
   </gridmaps>

--- a/config/e3sm/config_grids.xml
+++ b/config/e3sm/config_grids.xml
@@ -27,24 +27,24 @@
   <grids>
 
     <model_grid_defaults>
-      <grid name="atm"    compset="SATM"  >null</grid>
-      <grid name="lnd"    compset="SLND"  >null</grid>
-      <grid name="ocnice" compset="SOCN"  >null</grid>
-      <grid name="rof"    compset="SROF"  >null</grid>
-      <grid name="rof"    compset="DWAV"  >rx1</grid>
-      <grid name="rof"    compset="RTM"	  >r05</grid>
+      <grid name="atm"    compset="SATM">null</grid>
+      <grid name="lnd"    compset="SLND">null</grid>
+      <grid name="ocnice" compset="SOCN">null</grid>
+      <grid name="rof"    compset="SROF">null</grid>
+      <grid name="rof"    compset="DWAV">rx1</grid>
+      <grid name="rof"    compset="RTM">r05</grid>
       <grid name="rof"    compset="MOSART">r05</grid>
-      <grid name="rof"    compset="DROF"  >rx1</grid>
+      <grid name="rof"    compset="DROF">rx1</grid>
       <grid name="rof"    compset="DROF%CPLHIST">r05</grid>
-      <grid name="rof"    compset="XROF"  >r05</grid>
-      <grid name="glc"	  compset="SGLC"  >null</grid>
-      <grid name="glc"	  compset="CISM1" >gland5UM</grid>
-      <grid name="glc"	  compset="CISM2" >gland4</grid>
-      <grid name="glc"    compset="XGLC"  >gland4</grid>
-      <grid name="wav"	  compset="SWAV"  >null</grid>
-      <grid name="wav"	  compset="DWAV"  >ww3a</grid>
-      <grid name="wav"	  compset="WW3"	  >ww3a</grid>
-      <grid name="wav"    compset="XWAV"  >ww3a</grid>
+      <grid name="rof"    compset="XROF">r05</grid>
+      <grid name="glc"    compset="SGLC">null</grid>
+      <grid name="glc"    compset="CISM1">gland5UM</grid>
+      <grid name="glc"    compset="CISM2">gland4</grid>
+      <grid name="glc"    compset="XGLC">gland4</grid>
+      <grid name="wav"    compset="SWAV">null</grid>
+      <grid name="wav"    compset="DWAV">ww3a</grid>
+      <grid name="wav"    compset="WW3">ww3a</grid>
+      <grid name="wav"    compset="XWAV">ww3a</grid>
     </model_grid_defaults>
 
     <model_grid alias="g16_g16" compset="DATM.+DROF">
@@ -58,9 +58,9 @@
     </model_grid>
 
     <model_grid alias="CLM_USRDAT" compset="(DATM|SATM).+CLM">
-      <grid name="atm">CLMUSRDAT</grid>
-      <grid name="lnd">CLMUSRDAT</grid>
-      <grid name="ocnice">CLMUSRDAT</grid>
+      <grid name="atm">CLM_USRDAT</grid>
+      <grid name="lnd">CLM_USRDAT</grid>
+      <grid name="ocnice">CLM_USRDAT</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -68,9 +68,9 @@
     </model_grid>
 
     <model_grid alias="1x1_numaIA" compset="DATM.+CLM">
-      <grid name="atm">1x1numaIA</grid>
-      <grid name="lnd">1x1numaIA</grid>
-      <grid name="ocnice">1x1numaIA</grid>
+      <grid name="atm">1x1_numaIA</grid>
+      <grid name="lnd">1x1_numaIA</grid>
+      <grid name="ocnice">1x1_numaIA</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -78,9 +78,9 @@
     </model_grid>
 
     <model_grid alias="1x1_brazil" compset="DATM.+CLM">
-      <grid name="atm">1x1brazil</grid>
-      <grid name="lnd">1x1brazil</grid>
-      <grid name="ocnice">1x1brazil</grid>
+      <grid name="atm">1x1_brazil</grid>
+      <grid name="lnd">1x1_brazil</grid>
+      <grid name="ocnice">1x1_brazil</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -88,9 +88,9 @@
     </model_grid>
 
     <model_grid alias="1x1_smallvilleIA" compset="(DATM|SATM).+CLM">
-      <grid name="atm">1x1smallvilleIA</grid>
-      <grid name="lnd">1x1smallvilleIA</grid>
-      <grid name="ocnice">1x1smallvilleIA</grid>
+      <grid name="atm">1x1_smallvilleIA</grid>
+      <grid name="lnd">1x1_smallvilleIA</grid>
+      <grid name="ocnice">1x1_smallvilleIA</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -98,9 +98,9 @@
     </model_grid>
 
     <model_grid alias="1x1_camdenNJ" compset="DATM.+CLM">
-      <grid name="atm">1x1camdenNJ</grid>
-      <grid name="lnd">1x1camdenNJ</grid>
-      <grid name="ocnice">1x1camdenNJ</grid>
+      <grid name="atm">1x1_camdenNJ</grid>
+      <grid name="lnd">1x1_camdenNJ</grid>
+      <grid name="ocnice">1x1_camdenNJ</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -108,9 +108,9 @@
     </model_grid>
 
     <model_grid alias="1x1_mexicocityMEX" compset="DATM.+CLM">
-      <grid name="atm">1x1mexicocityMEX</grid>
-      <grid name="lnd">1x1mexicocityMEX</grid>
-      <grid name="ocnice">1x1mexicocityMEX</grid>
+      <grid name="atm">1x1_mexicocityMEX</grid>
+      <grid name="lnd">1x1_mexicocityMEX</grid>
+      <grid name="ocnice">1x1_mexicocityMEX</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -118,9 +118,9 @@
     </model_grid>
 
     <model_grid alias="1x1_vancouverCAN" compset="DATM.+CLM">
-      <grid name="atm">1x1vancouverCAN</grid>
-      <grid name="lnd">1x1vancouverCAN</grid>
-      <grid name="ocnice">1x1vancouverCAN</grid>
+      <grid name="atm">1x1_vancouverCAN</grid>
+      <grid name="lnd">1x1_vancouverCAN</grid>
+      <grid name="ocnice">1x1_vancouverCAN</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -128,9 +128,9 @@
     </model_grid>
 
     <model_grid alias="1x1_tropicAtl" compset="DATM.+CLM">
-      <grid name="atm">1x1tropicAtl</grid>
-      <grid name="lnd">1x1tropicAtl</grid>
-      <grid name="ocnice">1x1tropicAtl</grid>
+      <grid name="atm">1x1_tropicAtl</grid>
+      <grid name="lnd">1x1_tropicAtl</grid>
+      <grid name="ocnice">1x1_tropicAtl</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -138,9 +138,9 @@
     </model_grid>
 
     <model_grid alias="1x1_urbanc_alpha" compset="DATM.+CLM">
-      <grid name="atm">1x1urbancalpha</grid>
-      <grid name="lnd">1x1urbancalpha</grid>
-      <grid name="ocnice">1x1urbancalpha</grid>
+      <grid name="atm">1x1_urbanc_alpha</grid>
+      <grid name="lnd">1x1_urbanc_alpha</grid>
+      <grid name="ocnice">1x1_urbanc_alpha</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -148,9 +148,9 @@
     </model_grid>
 
     <model_grid alias="5amazon" compset="DATM.+CLM">
-      <grid name="atm">5x5amazon</grid>
-      <grid name="lnd">5x5amazon</grid>
-      <grid name="ocnice">5x5amazon</grid>
+      <grid name="atm">5x5_amazon</grid>
+      <grid name="lnd">5x5_amazon</grid>
+      <grid name="ocnice">5x5_amazon</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -684,9 +684,9 @@
     </model_grid>
 
     <model_grid alias="armx8v3_armx8v3" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne0np4armx8v3lowcon</grid>
-      <grid name="lnd">ne0np4armx8v3lowcon</grid>
-      <grid name="ocnice">ne0np4armx8v3lowcon</grid>
+      <grid name="atm">ne0np4_arm_x8v3_lowcon</grid>
+      <grid name="lnd">ne0np4_arm_x8v3_lowcon</grid>
+      <grid name="ocnice">ne0np4_arm_x8v3_lowcon</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -694,9 +694,9 @@
     </model_grid>
 
     <model_grid alias="conusx4v1_conusx4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne0np4conusx4v1lowcon</grid>
-      <grid name="lnd">ne0np4conusx4v1lowcon</grid>
-      <grid name="ocnice">ne0np4conusx4v1lowcon</grid>
+      <grid name="atm">ne0np4_conus_x4v1_lowcon</grid>
+      <grid name="lnd">ne0np4_conus_x4v1_lowcon</grid>
+      <grid name="ocnice">ne0np4_conus_x4v1_lowcon</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -704,9 +704,9 @@
     </model_grid>
 
     <model_grid alias="svalbardx8v1_svalbardx8v1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne0np4svalbardx8v1lowcon</grid>
-      <grid name="lnd">ne0np4svalbardx8v1lowcon</grid>
-      <grid name="ocnice">ne0np4svalbardx8v1lowcon</grid>
+      <grid name="atm">ne0np4_svalbard_x8v1_lowcon</grid>
+      <grid name="lnd">ne0np4_svalbard_x8v1_lowcon</grid>
+      <grid name="ocnice">ne0np4_svalbard_x8v1_lowcon</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -714,9 +714,9 @@
     </model_grid>
 
     <model_grid alias="sooberingoax4x8v1_sooberingoax4x8v1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne0np4sooberingoax4x8v1lowcon</grid>
-      <grid name="lnd">ne0np4sooberingoax4x8v1lowcon</grid>
-      <grid name="ocnice">ne0np4sooberingoax4x8v1lowcon</grid>
+      <grid name="atm">ne0np4_sooberingoa_x4x8v1_lowcon</grid>
+      <grid name="lnd">ne0np4_sooberingoa_x4x8v1_lowcon</grid>
+      <grid name="ocnice">ne0np4_sooberingoa_x4x8v1_lowcon</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -724,9 +724,9 @@
     </model_grid>
 
     <model_grid alias="enax4v1_enax4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne0np4enax4v1</grid>
-      <grid name="lnd">ne0np4enax4v1</grid>
-      <grid name="ocnice">ne0np4enax4v1</grid>
+      <grid name="atm">ne0np4_enax4v1</grid>
+      <grid name="lnd">ne0np4_enax4v1</grid>
+      <grid name="ocnice">ne0np4_enax4v1</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -734,9 +734,9 @@
     </model_grid>
 
     <model_grid alias="enax4v1_ne30_enax4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne0np4enax4v1</grid>
+      <grid name="atm">ne0np4_enax4v1</grid>
       <grid name="lnd">ne30np4</grid>
-      <grid name="ocnice">ne0np4enax4v1</grid>
+      <grid name="ocnice">ne0np4_enax4v1</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -766,7 +766,7 @@
     <model_grid alias="ne30_oEC_ICG" compset="(CAM5.+CLM.+MPASO%SPUNUP)">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
-      <grid name="ocnice">oEC60to30ICG</grid>
+      <grid name="ocnice">oEC60to30_ICG</grid>
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -776,7 +776,7 @@
     <model_grid alias="ne30_oECv3_ICG" compset="(CAM5.+CLM.+MPASO%SPUNUP)">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
-      <grid name="ocnice">oEC60to30v3ICG</grid>
+      <grid name="ocnice">oEC60to30v3_ICG</grid>
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -786,7 +786,7 @@
     <model_grid alias="ne30_oECv3wLI_ICG" compset="(CAM5.+CLM.+MPASO%SPUNUP)">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
-      <grid name="ocnice">oEC60to30v3wLIICG</grid>
+      <grid name="ocnice">oEC60to30v3wLI_ICG</grid>
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -796,7 +796,7 @@
     <model_grid alias="ne120_oRRS18v3_ICG" compset="(CAM5.+CLM.+MPASO%SPUNUP)">
       <grid name="atm">ne120np4</grid>
       <grid name="lnd">ne120np4</grid>
-      <grid name="ocnice">oRRS18to6v3ICG</grid>
+      <grid name="ocnice">oRRS18to6v3_ICG</grid>
       <grid name="rof">r0125</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
@@ -1142,16 +1142,16 @@
     </model_grid>
 
     <model_grid alias="twpx4v1_twpx4v1" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">ne0np4twpx4v1</grid>
-      <grid name="lnd">ne0np4twpx4v1</grid>
-      <grid name="ocnice">ne0np4twpx4v1</grid>
+      <grid name="atm">ne0np4_twpx4v1</grid>
+      <grid name="lnd">ne0np4_twpx4v1</grid>
+      <grid name="ocnice">ne0np4_twpx4v1</grid>
       <grid name="rof">null</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>oRRS18to6v3</mask>
     </model_grid>
 
-    <model_grid alias="T62_oQU120_a" compset="MPASO.*_MALI">
+    <model_grid alias="T62_oQU120_ais20" compset="MPASO.*_MALI">
       <grid name="atm">T62</grid>
       <grid name="lnd">T62</grid>
       <grid name="ocnice">oQU120</grid>

--- a/scripts/Tools/xmlconvertors/convert-grid-v1-to-v2
+++ b/scripts/Tools/xmlconvertors/convert-grid-v1-to-v2
@@ -176,7 +176,7 @@ def convert_grids(v1file_obj, v2file_obj):
             if "%" in raw_piece:
                 pieces.append(raw_piece)
             else:
-                pieces[-1] += raw_piece
+                pieces[-1] += ("_" + raw_piece)
 
         ctype_map = {"a":"atm", "l":"lnd", "oi":"ocnice", "r":"rof", "m":"mask", "g":"glc", "w":"wav"}
         mask = None

--- a/scripts/Tools/xmlconvertors/convert-grid-v1-to-v2
+++ b/scripts/Tools/xmlconvertors/convert-grid-v1-to-v2
@@ -1,0 +1,217 @@
+#! /usr/bin/env python
+
+"""
+Convert a grid file from v1 to v2.
+"""
+
+import argparse, sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from standard_script_setup import *
+from CIME.utils import expect
+from CIME.XML.generic_xml import GenericXML
+import xml.etree.ElementTree as ET
+
+from collections import OrderedDict
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} <V1-GRID-FILE>
+OR
+{0} --help
+""".format(os.path.basename(args[0])),
+        description=description,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("v1file",
+                        help="v1 file path")
+
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    return args.v1file
+
+###############################################################################
+def convert_gridmaps(v1file_obj, v2file_obj):
+###############################################################################
+    gridmap_data = [] # (attribs, {name->file})
+
+    v1gridmaps = v1file_obj.get_child(name="gridmaps")
+    v1gridmap = v1file_obj.get_children(name="gridmap", root=v1gridmaps)
+    for gridmap_block in v1gridmap:
+        attribs = v1file_obj.attrib(gridmap_block)
+        children = []
+        for child in v1file_obj.get_children(root=gridmap_block):
+            children.append( (v1file_obj.name(child), v1file_obj.text(child)) )
+
+        gridmap_data.append( (attribs, children) )
+
+    v2gridmaps = v2file_obj.make_child("gridmaps")
+
+    for attribs, children in gridmap_data:
+        gridmap = v2file_obj.make_child("gridmap", attributes=attribs, root=v2gridmaps)
+        for name, text in children:
+            v2file_obj.make_child("map", attributes={"name": name}, root=gridmap, text=text)
+
+###############################################################################
+def convert_domains(v1file_obj, v2file_obj):
+###############################################################################
+    domain_data = [] # (name, nx, ny, {filemask->mask->file}, {pathmask->mask->path}, desc)
+
+    v1domains = v1file_obj.get_child(name="domains")
+    v1domain = v1file_obj.get_children(name="domain", root=v1domains)
+    for domain_block in v1domain:
+        attrib = v1file_obj.attrib(domain_block)
+        expect(attrib.keys() == ["name"],
+               "Unexpected attribs: {}".format(attrib))
+
+        name = attrib["name"]
+
+        desc = v1file_obj.get_element_text("desc", root=domain_block)
+        sup  = v1file_obj.get_element_text("support", root=domain_block)
+        nx   = v1file_obj.get_element_text("nx", root=domain_block)
+        ny   = v1file_obj.get_element_text("ny", root=domain_block)
+
+        if sup and not desc:
+            desc = sup
+
+        file_masks, path_masks = OrderedDict(), OrderedDict()
+
+        for child_name, masks in [("file", file_masks), ("path", path_masks)]:
+            children = v1file_obj.get_children(name=child_name, root=domain_block)
+            for child in children:
+                attrib = v1file_obj.attrib(child)
+                expect(len(attrib) == 1, "Bad {} attrib: {}".format(child_name, attrib))
+                mask_key, mask_value = attrib.items()[0]
+
+                component, _ = mask_key.split("_")
+                masks.setdefault(component, OrderedDict())[mask_value] = v1file_obj.text(child)
+
+        for child in v1file_obj.get_children(root=domain_block):
+            expect(v1file_obj.name(child) in ["nx", "ny", "file", "path", "desc", "support"],
+                   "Unhandled child of grid '{}'".format(v1file_obj.name(child)))
+
+        domain_data.append( (name, nx, ny, file_masks, path_masks, desc) )
+
+    v2domains = v2file_obj.make_child("domains")
+
+    for name, nx, ny, file_masks, path_masks, desc in domain_data:
+        attribs = {"name":name} if name else {}
+        domain_block = v2file_obj.make_child("domain", attributes=attribs, root=v2domains)
+
+        v2file_obj.make_child("nx", root=domain_block, text=nx)
+        v2file_obj.make_child("ny", root=domain_block, text=ny)
+
+        file_to_attrib = OrderedDict()
+        for component, mask_values in file_masks.iteritems():
+            for mask_value, filename in mask_values.iteritems():
+                if filename is None:
+                    continue
+
+                try:
+                    path = path_masks[component][mask_value]
+                except KeyError:
+                    path = "$DIN_LOC_ROOT/share/domains"
+
+                fullfile = os.path.join(path, filename)
+                mask_value = mask_value if mask_value not in ["reg", name] else ""
+                file_to_attrib.setdefault(fullfile, OrderedDict()).setdefault(mask_value, []).append(component)
+
+        for filename, masks in file_to_attrib.iteritems():
+            attrib = {}
+            expect(len(masks) == 1, "Bad mask")
+            for mask, components in masks.iteritems():
+                attrib["grid"] = "|".join(components)
+
+            if mask:
+                attrib["mask"] = mask
+
+            v2file_obj.make_child("file", attributes=attrib, root=domain_block, text=filename)
+
+        if desc:
+            v2file_obj.make_child("desc", root=domain_block, text=desc)
+
+###############################################################################
+def convert_grids(v1file_obj, v2file_obj):
+###############################################################################
+    grid_data = [] # (compset, lname, sname, alias, support)
+
+    v1grids = v1file_obj.get_child(name="grids")
+    v1grid = v1file_obj.get_children(name="grid", root=v1grids)
+    for grid_block in v1grid:
+        attrib = v1file_obj.attrib(grid_block)
+
+        compset = attrib["compset"] if "compset" in attrib else None
+        expect(attrib.keys() in [ ["compset"], [] ],
+               "Unexpected attribs: {}".format(attrib))
+
+        lname   = v1file_obj.get_element_text("lname", root=grid_block)
+        sname   = v1file_obj.get_element_text("sname", root=grid_block)
+        alias   = v1file_obj.get_element_text("alias", root=grid_block)
+        support = v1file_obj.get_element_text("support", root=grid_block)
+
+        for child in v1file_obj.get_children(root=grid_block):
+            expect(v1file_obj.name(child) in ["lname", "sname", "alias", "support"],
+                   "Unhandled child of grid '{}'".format(v1file_obj.name(child)))
+
+        grid_data.append((compset, lname, sname, alias, support))
+
+    v2grids = v2file_obj.make_child("grids")
+
+    # TODO: How to leverage model_grid_defaults
+
+    for compset, lname, sname, alias, support in grid_data:
+        v2_alias = alias if alias else sname
+        attribs = {"alias":v2_alias} if v2_alias else {}
+        attribs.update({"compset":compset} if compset else {})
+        v2grid = v2file_obj.make_child("model_grid", attributes=attribs, root=v2grids)
+
+        pieces_raw = lname.split("_")
+        pieces = []
+        for raw_piece in pieces_raw:
+            if "%" in raw_piece:
+                pieces.append(raw_piece)
+            else:
+                pieces[-1] += raw_piece
+
+        ctype_map = {"a":"atm", "l":"lnd", "oi":"ocnice", "r":"rof", "m":"mask", "g":"glc", "w":"wav"}
+        mask = None
+        for piece in pieces:
+            ctype, data = piece.split("%")
+            cname = ctype_map[ctype.strip()]
+            if cname == "mask":
+                expect(mask is None, "Multiple masks")
+                mask = data
+            else:
+                v2file_obj.make_child("grid", attributes={"name":cname}, text=data, root=v2grid)
+
+        if mask is not None:
+            v2file_obj.make_child("mask", text=mask, root=v2grid)
+
+###############################################################################
+def convert_to_v2(v1file):
+###############################################################################
+    v1file_obj = GenericXML(infile=v1file, read_only=True)
+    v2file_obj = GenericXML(infile="out.xml", read_only=False, root_name_override="grid_data", root_attrib_override={"version":"2.0"})
+
+    convert_grids(v1file_obj, v2file_obj)
+
+    convert_domains(v1file_obj, v2file_obj)
+
+    convert_gridmaps(v1file_obj, v2file_obj)
+
+    v2file_obj.write(outfile=sys.stdout)
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    v1file = parse_command_line(sys.argv, description)
+
+    convert_to_v2(v1file)
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -278,17 +278,18 @@ class GenericXML(object):
         if outfile is None:
             outfile = self.filename
 
-        # logger.debug("write: " + outfile)
+        logger.debug("write: " + (outfile if isinstance(outfile, six.string_types) else str(outfile)))
 
         xmlstr = self.get_raw_record()
 
         # xmllint provides a better format option for the output file
         xmllint = find_executable("xmllint")
         if xmllint is not None:
-            if outfile is sys.stdout:
-                print(run_cmd_no_fail("{} --format -".format(xmllint), input_str=xmlstr))
-            else:
+            if isinstance(outfile, six.string_types):
                 run_cmd_no_fail("{} --format --output {} -".format(xmllint, outfile), input_str=xmlstr)
+            else:
+                outfile.write(run_cmd_no_fail("{} --format -".format(xmllint), input_str=xmlstr))
+
         else:
             with open(outfile,'w') as xmlout:
                 xmlout.write(xmlstr)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -286,7 +286,7 @@ class GenericXML(object):
         xmllint = find_executable("xmllint")
         if xmllint is not None:
             if outfile is sys.stdout:
-                print run_cmd_no_fail("{} --format -".format(xmllint), input_str=xmlstr)
+                print(run_cmd_no_fail("{} --format -".format(xmllint), input_str=xmlstr))
             else:
                 run_cmd_no_fail("{} --format --output {} -".format(xmllint, outfile), input_str=xmlstr)
         else:

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -278,14 +278,17 @@ class GenericXML(object):
         if outfile is None:
             outfile = self.filename
 
-        logger.debug("write: " + outfile)
+        # logger.debug("write: " + outfile)
 
         xmlstr = self.get_raw_record()
 
         # xmllint provides a better format option for the output file
         xmllint = find_executable("xmllint")
         if xmllint is not None:
-            run_cmd_no_fail("{} --format --output {} -".format(xmllint, outfile), input_str=xmlstr)
+            if outfile is sys.stdout:
+                print run_cmd_no_fail("{} --format -".format(xmllint), input_str=xmlstr)
+            else:
+                run_cmd_no_fail("{} --format --output {} -".format(xmllint, outfile), input_str=xmlstr)
         else:
             with open(outfile,'w') as xmlout:
                 xmlout.write(xmlstr)

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -25,21 +25,16 @@ class Grids(GenericXML):
         self._comp_gridnames = self._get_grid_names()
 
     def _get_grid_names(self):
-        if self._version == 1.0:
-            gridnames = ["atm", "lnd", "ocnice", "rof", "mask", "glc", "wav"]
-        elif self._version >= 2.0:
-            grids = self.get_child("grids")
-            model_grid_defaults = self.get_child("model_grid_defaults", root=grids)
-            nodes = self.get_children("grid", root=model_grid_defaults)
-            gridnames = []
-            for node in nodes:
-                gn = self.get(node, "name")
-                if gn not in gridnames:
-                    gridnames.append(gn)
-            if "mask" not in gridnames:
-                gridnames.append("mask")
-        else:
-            expect(False,"Did not recognize config_grids.xml file version")
+        grids = self.get_child("grids")
+        model_grid_defaults = self.get_child("model_grid_defaults", root=grids)
+        nodes = self.get_children("grid", root=model_grid_defaults)
+        gridnames = []
+        for node in nodes:
+            gn = self.get(node, "name")
+            if gn not in gridnames:
+                gridnames.append(gn)
+        if "mask" not in gridnames:
+            gridnames.append("mask")
 
         return gridnames
 
@@ -75,53 +70,12 @@ class Grids(GenericXML):
         gridinfo.update(domains)
 
         # determine gridmaps given component_grids
-        gridmaps = self._get_gridmaps(component_grids, atmnlev, lndnlev)
+        gridmaps = self._get_gridmaps(component_grids)
         gridinfo.update(gridmaps)
 
         return gridinfo
 
     def _read_config_grids(self, name, compset, atmnlev, lndnlev):
-        if self._version == 1.0:
-            return self._read_config_grids_v1(name, compset)
-        elif self._version >= 2.0:
-            return self._read_config_grids_v2(name, compset, atmnlev, lndnlev)
-
-    def _read_config_grids_v1(self, name, compset):
-        """
-        read config_grids.xml with v1.0 schema
-        """
-        component_grids = {}
-        grid_list = self.get_child("grids")
-        nodes = self.get_children("grid", root=grid_list)
-        # first search for all grids that have a compset match - if one is found then return
-        for node in nodes:
-            if self.has(node, "compset"):
-                attrib = self.get(node, "compset")
-                compset_match = re.search(attrib,compset)
-                if compset_match is not None:
-                    alias = self.get_element_text("alias", root=node)
-                    sname = self.get_element_text("sname", root=node)
-                    lname = self.get_element_text("lname", root=node)
-                    if alias == name or lname == name or sname == name:
-                        logger.debug("Found node compset match: {} and lname: {}".format(attrib, lname))
-                        component_grids = self._get_component_grids(lname)
-                        return lname, component_grids
-
-        # if no matches were found for a possible compset match, then search for just a grid match with no
-        # compset attribute
-        for node in nodes:
-            if not self.has(node, "compset"):
-                sname = self.get_element_text("sname", root=node)
-                alias = self.get_element_text("alias", root=node)
-                lname = self.get_element_text("lname", root=node)
-                if alias == name or lname == name or sname == name:
-                    logger.debug("Found node compset match: {} and lname: {}".format(attrib, lname))
-                    component_grids = self._get_component_grids(lname)
-                    return lname, component_grids
-        expect (False,
-                "grid '{}'  is not supported, use query_config to determine supported grids ".format(name))
-
-    def _read_config_grids_v2(self, name, compset, atmnlev, lndnlev):
         """
         read config_grids.xml with version 2.0 schema
         """
@@ -225,7 +179,27 @@ class Grids(GenericXML):
         component_grids = self._get_component_grids_from_longname(lname)
         return lname, component_grids
 
-    def _get_domains_v2(self, component_grids, atmlevregex, lndlevregex):
+    def _get_component_grids_from_longname(self, name):
+        gridRE = re.compile(r"[_]{0,1}[a-z]{1,2}%")
+        grids = gridRE.split(name)[1:]
+        prefixes = re.findall("[a-z]+%",name)
+        component_grids = {}
+        i = 0
+        while i < len(grids):
+            prefix = prefixes[i]
+            grid = grids[i]
+            component_grids[prefix] = grid
+            i += 1
+        component_grids["i%"] = component_grids["oi%"]
+        component_grids["o%"] = component_grids["oi%"]
+        return component_grids
+
+    def _get_component_grids(self, name):
+        gridRE = re.compile(r"[_]{0,1}[a-z]{1,2}%")
+        component_grids = gridRE.split(name)[1:]
+        return component_grids
+
+    def _get_domains(self, component_grids, atmlevregex, lndlevregex):
         """ determine domains dictionary for config_grids.xml v2 schema"""
         # use component_grids to create grids dictionary
         # TODO: this should be in XML, not here
@@ -289,105 +263,7 @@ class Grids(GenericXML):
                             domains[path_name] = path
         return domains
 
-    def _get_component_grids_from_longname(self, name):
-        gridRE = re.compile(r"[_]{0,1}[a-z]{1,2}%")
-        grids = gridRE.split(name)[1:]
-        prefixes = re.findall("[a-z]+%",name)
-        component_grids = {}
-        i = 0
-        while i < len(grids):
-            prefix = prefixes[i]
-            grid = grids[i]
-            component_grids[prefix] = grid
-            i += 1
-        component_grids["i%"] = component_grids["oi%"]
-        component_grids["o%"] = component_grids["oi%"]
-        return component_grids
-
-    def _get_component_grids(self, name):
-        gridRE = re.compile(r"[_]{0,1}[a-z]{1,2}%")
-        component_grids = gridRE.split(name)[1:]
-        return component_grids
-
-    def _get_domains(self, component_grids, atmlevregex, lndlevregex):
-        if self._version == 1.0:
-            return self._get_domains_v1(component_grids)
-        elif self._version >= 2.0:
-            return self._get_domains_v2(component_grids, atmlevregex, lndlevregex)
-
-    def _get_domains_v1(self, component_grids):
-        # use component_grids to create grids dictionary
-        grids = [("ATM", component_grids[0]), \
-                 ("LND", component_grids[1]), \
-                 ("OCN", component_grids[2]), \
-                 ("ICE", component_grids[2]), \
-                 ("ROF", component_grids[3]), \
-                 ("MASK", component_grids[4]), \
-                 ("GLC", component_grids[5]), \
-                 ("WAV", component_grids[6])]
-        mask = component_grids[4]
-
-        domains_elem = self.get_child("domains")
-        domains = {}
-        mask_name = None
-        for grid in grids:
-            file_name = grid[0] + "_DOMAIN_FILE"
-            path_name = grid[0] + "_DOMAIN_PATH"
-            if grid[0] == "ATM" or grid[0] == "LND":
-                mask_name = "lnd_mask"
-            if grid[0] == "ICE" or grid[0] == "OCN":
-                mask_name = "ocn_mask"
-            root = self.get_optional_child("domain", attributes={"name":grid[1]}, root=domains_elem)
-            if root is not None:
-                if grid[0] != "MASK":
-                    domains[grid[0]+"_NX"] = int(self.get_element_text("nx", root=root))
-                    domains[grid[0]+"_NY"] = int(self.get_element_text("ny", root=root))
-                domains[grid[0] + "_GRID"] = grid[1]
-
-                if mask_name is not None:
-                    file_ = self.get_element_text("file", attributes={mask_name:mask}, root=root)
-                    path  = self.get_element_text("path", attributes={mask_name:mask}, root=root)
-                    if file_ is not None and grid[0] != "MASK":
-                        domains[file_name] = file_
-                    if path is not None:
-                        domains[path_name] = path
-        return domains
-
-    def _get_gridmaps(self, component_grids, atmnlev, lndnlev):
-        if self._version == 1.0:
-            return self._get_gridmaps_v1(component_grids, atmnlev, lndnlev)
-        elif self._version >= 2.0:
-            return self._get_gridmaps_v2(component_grids)
-
-    def _get_gridmaps_v1(self, component_grids, atmnlev=None, lndnlev=None):
-        # mapping files
-        grids = [("atm_grid", component_grids[0]), \
-                 ("lnd_grid", component_grids[1]), \
-                 ("ocn_grid", component_grids[2]), \
-                 ("rof_grid", component_grids[3]), \
-                 ("glc_grid", component_grids[5]), \
-                 ("wav_grid", component_grids[6]), \
-                 ("mask"    , component_grids[4])]
-        if atmnlev is not None:
-            grids[0] += "z"+atmnlev
-        if lndnlev is not None:
-            grids[1] += "z"+lndnlev
-
-        gridmaps_elem = self.get_child("gridmaps")
-        gridmaps = {}
-        for idx, grid in enumerate(grids):
-            for other_grid in grids[idx+1:]:
-                nodes = self.get_children("gridmap", attributes={grid[0]:grid[1], other_grid[0]:other_grid[1]}, root=gridmaps_elem)
-                for gridmap_node in nodes:
-                    for child in self.get_children(root=gridmap_node):
-                        gridmap = (self.name(child), self.text(child))
-                        if gridmap is not None:
-                            gridmaps[self.name(child)] = self.text(child)
-                            logger.debug(" {}: {}".format(*gridmap))
-
-        return gridmaps
-
-    def _get_gridmaps_v2(self, component_grids):
+    def _get_gridmaps(self, component_grids):
         """
         set all mapping files for config_grids.xml v2 schema
         """
@@ -448,13 +324,6 @@ class Grids(GenericXML):
         # write out help message
         helptext = self.get_element_text("help")
         logger.info("{} ".format(helptext))
-
-        if self._version == 1.0:
-            self._print_values_v1(long_output=long_output)
-        elif self._version >= 2.0:
-            self._print_values_v2(long_output=long_output)
-
-    def _print_values_v2(self, long_output=None):
 
         logger.info("{:5s}-------------------------------------------------------------".format(""))
         logger.info("{:10s}  default component grids:\n".format(""))
@@ -524,193 +393,3 @@ class Grids(GenericXML):
                 for gridname in gridnames:
                     if gridname != "null":
                         logger.info ("    {}".format(domains[gridname]))
-
-    def _print_values_v1(self, long_output=None):
-        # write out grid elements
-        grid_nodes = self.get_children("grid", root=self.get_child('grids'))
-        for grid_node in grid_nodes:
-            lname = self.get_element_text("lname",root=grid_node)
-            sname = self.get_element_text("sname",root=grid_node)
-            alias = self.get_element_text("alias",root=grid_node)
-            logger.info("------------------------------------------------")
-            logger.info("model grid: {}".format(lname))
-            logger.info("------------------------------------------------")
-            if sname is not None:
-                logger.info("   short name: {}".format(sname))
-            if alias is not None:
-                logger.info("   alias: {}".format(alias))
-            compset = self.get(grid_node, 'compset')
-            if compset is not None:
-                logger.info("   compset match: {}".format(compset))
-
-            # in long_output mode add domain description and mapping fiels
-            if long_output is not None:
-                # get component grids (will contain duplicates)
-                component_grids = self._get_component_grids(lname)
-
-                # write out out only unique non-null component grids
-                for domain in list(set(component_grids)):
-                    if domain != 'null':
-                        logger.info("   domain is {}".format(domain))
-                        domain_node = self.get_optional_child("domain", attributes={"name":domain}, root=self.get_child("domains"))
-                        if domain_node is None:
-                            continue
-                        dnode = self.get_optional_child("desc",root=domain_node)
-                        if dnode is not None:
-                            desc = self.text(dnode)
-                            logger.info("       Description: {}".format(desc))
-                        snode = self.get_optional_child("support",root=domain_node)
-                        if snode is not None:
-                            support = self.text(snode)
-                            logger.info("       Support: {}".format(support))
-
-                # write out mapping files
-                grids = [ ("atm_grid", component_grids[0]), ("lnd_grid", component_grids[1]), ("ocn_grid", component_grids[2]), \
-                          ("rof_grid", component_grids[3]), ("glc_grid", component_grids[5]), ("wav_grid", component_grids[6]) ]
-
-                for idx, grid in enumerate(grids):
-                    for other_grid in grids[idx+1:]:
-                        nodes = self.get_children("gridmap", attributes={grid[0]:grid[1], other_grid[0]:other_grid[1]})
-                        for gridmap_node in nodes:
-                            for child in gridmap_node:
-                                logger.info("    mapping file {}: {}".format(self.name(child), self.text(child)))
-
-                logger.info("   ")
-
-                # write out XROT_FLOOD_MODE element TODO: (why is this in there???)
-
-    def _get_all_values_v1(self):
-        # return a list of grid elements in long form
-        grid_list = list()
-        default_comp_grids = list()
-
-        grid_nodes = self.get_children("grid")
-        for grid_node in grid_nodes:
-            grid_info = dict()
-            lname = self.get_element_text("lname",root=grid_node)
-            sname = self.get_element_text("sname",root=grid_node)
-            alias = self.get_element_text("alias",root=grid_node)
-            grid_info = {
-                "lname" : lname,
-                "sname" : sname,
-                "alias" : alias,
-                }
-            compset_list = list()
-            for attr, value in grid_node.items():
-                if  attr == 'compset':
-                    compset_list.append(value)
-
-            grid_info.update({'compsets': compset_list})
-
-            # add domain description and mapping fiels
-            # get component grids (will contain duplicates)
-            component_grids = self._get_component_grids(lname)
-
-            # write out out only unique non-null component grids
-            for domain in list(set(component_grids)):
-                if domain != 'null':
-                    domain_list = list()
-                    domain_node = self.get_child("domain", attributes={"name":domain})
-                    for child in domain_node:
-                        domain_list.append({'domain':self.name(child), 'text':self.text(child)})
-
-            grid_info.update({'domains': domain_list})
-
-            # add mapping files
-            grids = [ ("atm_grid", component_grids[0]), ("lnd_grid", component_grids[1]), ("ocn_grid", component_grids[2]), \
-                          ("rof_grid", component_grids[3]), ("glc_grid", component_grids[5]), ("wav_grid", component_grids[6]) ]
-
-            for idx, grid in enumerate(grids):
-                map_list = list()
-                for other_grid in grids[idx+1:]:
-                    nodes = self.get_children("gridmap", attributes={grid[0]:grid[1], other_grid[0]:other_grid[1]})
-                    for gridmap_node in nodes:
-                        for child in gridmap_node:
-                            map_list.append({'map':self.name(child), 'file':self.text(child)})
-
-            grid_info.update({'maps': map_list})
-
-            grid_list.append(grid_info)
-
-        return default_comp_grids, grid_list
-
-    def _get_all_values_v2(self):
-
-        default_comp_grids = list()
-        grid_list = list()
-
-        default_nodes = self.get_children("model_grid_defaults")
-        for default_node in default_nodes:
-            grid_nodes = self.get_children("grid", root=default_node)
-            for grid_node in grid_nodes:
-                name = self.get(grid_node, "name")
-                compset = self.get(grid_node, "compset")
-                value = self.text(grid_node)
-                default_comp_grids.append({'component':name,
-                                           'compset':compset,
-                                           'value':value,})
-        domains = {}
-
-        domain_nodes = self.get_children("domain")
-        for domain_node in domain_nodes:
-            name = self.get(domain_node, "name")
-            if name == 'null':
-                continue
-            desc = self.text(self.get_child("desc", root=domain_node))
-            ##support = self.get_optional_child("support", root=domain_node).text
-            files = ""
-            file_nodes = self.get_children("file", root=domain_node)
-            for file_node in file_nodes:
-                filename = self.text(file_node)
-                mask_attrib = self.get(file_node, "mask")
-                grid_attrib = self.get(file_node, "grid")
-                files += "\n       " + filename
-                if mask_attrib or grid_attrib:
-                    files += " (only for"
-                if mask_attrib:
-                    files += " mask: " + mask_attrib
-                if grid_attrib:
-                    files += " grid match: " + grid_attrib
-                if mask_attrib or grid_attrib:
-                    files += ")"
-            domains[name] = "\n       %s with domain file(s): %s " %(desc, files)
-
-        grids_dict = dict()
-        model_grid_nodes = self.get_children("model_grid")
-        for model_grid_node in model_grid_nodes:
-            alias = self.get(model_grid_node, "alias")
-            compset = self.get(model_grid_node, "compset")
-            not_compset = self.get(model_grid_node, "not_compset")
-            restriction = ""
-            if compset:
-                restriction += "only for compsets that are %s " %compset
-            if not_compset:
-                restriction += "only for compsets that are not %s " %not_compset
-            if restriction:
-                aliases = "\n     alias: %s (%s)" % (alias,restriction)
-            else:
-                aliases = "\n     alias: %s" % (alias)
-
-            grid_nodes = self.get_children("grid", root=model_grid_node)
-            grids = ""
-            gridnames = []
-            for grid_node in grid_nodes:
-                gridnames.append(self.text(grid_node))
-                grids += self.get(grid_node, "name") + ":" + self.text(grid_node) + "  "
-            grids = "       non-default grids are: %s" %grids
-
-            mask = ""
-            mask_nodes = self.get_children("mask", root=model_grid_node)
-            for mask_node in mask_nodes:
-                mask += "\n       mask is: %s" %(self.text(mask_node))
-
-            grids_dict[alias] = {'aliases':aliases,
-                                 'grids':grids,
-                                 'mask':mask }
-
-            gridnames = set(gridnames)
-            for gridname in gridnames:
-                if gridname != "null":
-                    grid_list.append({gridname:(grids_dict[alias], domains[gridname])})
-
-        return default_comp_grids, grid_list

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -245,7 +245,7 @@ class Grids(GenericXML):
                         grid_match = re.search(comp_name.lower(), grid_attrib)
                         mask_match = None
                         if mask_name is not None:
-                            mask_match = re.search(mask_name, mask_attrib)
+                            mask_match = re.search(mask_name + "_", mask_attrib)
                         if grid_match is not None and mask_match is not None:
                             domain_name = self.text(file_node)
                     elif grid_attrib is not None:
@@ -253,7 +253,7 @@ class Grids(GenericXML):
                         if grid_match is not None:
                             domain_name = self.text(file_node)
                     elif mask_attrib is not None:
-                        mask_match = re.search(mask_name.lower(), mask_attrib)
+                        mask_match = re.search(mask_name.lower() + "_", mask_attrib)
                         if mask_match is not None:
                             domain_name = self.text(file_node)
                     if domain_name:

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -245,7 +245,7 @@ class Grids(GenericXML):
                         grid_match = re.search(comp_name.lower(), grid_attrib)
                         mask_match = None
                         if mask_name is not None:
-                            mask_match = re.search(mask_name + "_", mask_attrib)
+                            mask_match = re.search(mask_name, mask_attrib)
                         if grid_match is not None and mask_match is not None:
                             domain_name = self.text(file_node)
                     elif grid_attrib is not None:
@@ -253,7 +253,7 @@ class Grids(GenericXML):
                         if grid_match is not None:
                             domain_name = self.text(file_node)
                     elif mask_attrib is not None:
-                        mask_match = re.search(mask_name.lower() + "_", mask_attrib)
+                        mask_match = re.search(mask_name.lower(), mask_attrib)
                         if mask_match is not None:
                             domain_name = self.text(file_node)
                     if domain_name:


### PR DESCRIPTION
New tool for converting v1 to v2 grids.
Convert e3sm/config_grids.xml to v2.

Test suite: scripts_regression_tests, cime_developer with baseline comparison
Test baseline: 
Test namelist changes: 
Test status: bit for bi

Fixes [CIME Github issue #]

User interface changes?: Yes, e3sm grids are now v2

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @rljacob 
