### PR TITLE
avoid files whose description ends with datapath

### DIFF
--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -167,6 +167,8 @@ def check_input_data(case, protocal="svn", address=None, input_data_root=None, d
             if (line and not line.startswith("#")):
                 tokens = line.split('=')
                 description, full_path = tokens[0].strip(), tokens[1].strip()
+                if description.endswith('datapath'):
+                    continue
                 if(full_path):
                     # expand xml variables
                     full_path = case.get_resolved_value(full_path)


### PR DESCRIPTION
Cam sometimes lists both the directory and the file it needs separately in Buildconf/cam.input_data_list
until recently the path was ignored but now check_input_data wants to download the entire directory.
 
Test suite: hand testing 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2553 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
