### PR TITLE
do dt check in cime instead of timemgr

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -908,7 +908,7 @@ using a fortran linker.
     <append> -xCOMMON-AVX512 -no-fma </append>
   </CFLAGS>
   <FFLAGS>
-    <append> -xCOMMON-AVS512 -no-fma </append>
+    <append> -xCOMMON-AVX512 -no-fma </append>
     <append MPILIB="mpi-serial"> -mcmodel medium </append>
   </FFLAGS>
   <LDFLAGS>

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -107,6 +107,14 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
             nmlgen.add_default(comp.lower() + '_cpl_dt', value=cpl_dt)
             mindt = min(mindt, cpl_dt)
 
+    # sanity check
+    comp_atm = case.get_value("COMP_ATM")
+    if comp_atm is not None and comp_atm not in('datm', 'xatm', 'satm'):
+        atmdt = int(basedt / case.get_value('ATM_NCPL'))
+        expect(atmdt == mindt, 'Active atm should match shortest model timestep atmdt={} mindt={}'
+               .format(atmdt, mindt))
+            
+
     #--------------------------------
     # Overwrite: set start_ymd
     #--------------------------------

--- a/src/drivers/mct/shr/seq_timemgr_mod.F90
+++ b/src/drivers/mct/shr/seq_timemgr_mod.F90
@@ -657,10 +657,6 @@ contains
                rof_cpl_dt, wav_cpl_dt, esp_cpl_dt
           call shr_sys_abort( subname//': ERROR coupling intervals invalid' )
        end if
-       if ( atm_cpl_dt > rof_cpl_dt .or. atm_cpl_dt > ocn_cpl_dt ) then
-          call shr_sys_abort( subname//' ERROR: atm_cpl_dt must be <= rof_cpl_dt and ocn_cpl_dt')
-       endif
-
        ! --- Coupling offsets --------------------------------------------------
        if ( abs(atm_cpl_offset) > atm_cpl_dt .or. &
             abs(lnd_cpl_offset) > lnd_cpl_dt .or. &


### PR DESCRIPTION
This check was put in timemgr but should be in ccs.   There is also a minor typo fix for the stampede2 system.

Test suite: scripts_regression_tests.py, ERS.T62_g16.C.stampede2-skx_intel.pop-default 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
