### PR TITLE
change orbital parameters for all HIST compsets

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -442,6 +442,7 @@
     </desc>
     <values>
       <value>fixed_year</value>
+      <value iyear='HIST' cime_model='cesm'>variable_year</value>
     </values>
   </entry>
 
@@ -455,6 +456,7 @@
     <values>
       <value>1990</value>
       <value iyear="1850" cime_model="cesm">1850</value>
+      <value iyear='HIST' cime_model='cesm'>1850</value>
     </values>
   </entry>
 
@@ -468,6 +470,7 @@
     <values>
       <value>1990</value>
       <value iyear="1850" cime_model="cesm">1850</value>
+      <value iyear='HIST' cime_model='cesm'>1850</value>
     </values>
   </entry>
 


### PR DESCRIPTION
Change oribital parameters for historic compsets.  This affects CESM only. 

Test suite: B1850 and BHIST tested by hand (cesm only)
Test baseline: 
Test namelist changes: 
Test status: climate changing for HIST compsets

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
