### PR TITLE
correct run_refdir logic

### DIFF
--- a/scripts/lib/CIME/Servers/ftp.py
+++ b/scripts/lib/CIME/Servers/ftp.py
@@ -33,9 +33,8 @@ class FTP(GenericServer):
         except:
             logger.warning("ERROR from ftp server, trying next server")
             return False
-
         if rel_path not in stat:
-            if not stat[0].startswith(rel_path):
+            if not stat or not stat[0].startswith(rel_path):
                 logging.warning("FAIL: File {} not found.\nerror {}".format(rel_path, stat))
                 return False
         return True

--- a/scripts/lib/CIME/Servers/wget.py
+++ b/scripts/lib/CIME/Servers/wget.py
@@ -23,7 +23,7 @@ class WGET(GenericServer):
         full_url = os.path.join(self._server_loc, rel_path)
         stat, out, err = run_cmd("wget {} --spider {}".format(self._args, full_url))
         if (stat != 0):
-            logging.warning("FAIL: Repo '{}' does not have file '{}'\nReason:{}\n{}\n".format(self._server_loc, full_url, out, err))
+            logging.warning("FAIL: Repo '{}' does not have file '{}'\nReason:{}\n{}\n".format(self._server_loc, full_url, out.encode('utf-8'), err.encode('utf-8')))
             return False
         return True
 

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -48,7 +48,8 @@ def check_all_input_data(self, protocal=None, address=None, input_data_root=None
                                    input_data_root=input_data_root, data_list_dir=data_list_dir)
         if download and not success:
             success = _downloadfromserver(self, input_data_root, data_list_dir)
-
+    
+    expect(not download or (download and success), "Could not find all inputdata on any server")
     self.stage_refcase(input_data_root=input_data_root, data_list_dir=data_list_dir)
     return success
 

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -82,18 +82,20 @@ def stage_refcase(self, input_data_root=None, data_list_dir=None):
         run_refdir   = self.get_value("RUN_REFDIR")
         rundir       = self.get_value("RUNDIR")
 
-        refdir = os.path.join(din_loc_root, run_refdir, run_refcase, run_refdate)
-        if not os.path.isdir(refdir):
-            logger.warning("Refcase not found in {}, will attempt to download from inputdata".format(refdir))
-            with open(os.path.join("Buildconf","refcase.input_data_list"),"w") as fd:
-                fd.write("refdir = {}{}".format(refdir, os.sep))
-            if input_data_root is None:
-                input_data_root = din_loc_root
-            if data_list_dir is None:
-                data_list_dir = "Buildconf"
-            success = _downloadfromserver(self, input_data_root=input_data_root, data_list_dir=data_list_dir)
-            expect(success, "Could not download refcase from any server")
-
+        if os.path.isabs(run_refdir):
+            refdir = run_refdir
+        else:
+            refdir = os.path.join(din_loc_root, run_refdir, run_refcase, run_refdate)
+            if not os.path.isdir(refdir):
+                logger.warning("Refcase not found in {}, will attempt to download from inputdata".format(refdir))
+                with open(os.path.join("Buildconf","refcase.input_data_list"),"w") as fd:
+                    fd.write("refdir = {}{}".format(refdir, os.sep))
+                if input_data_root is None:
+                    input_data_root = din_loc_root
+                if data_list_dir is None:
+                    data_list_dir = "Buildconf"
+                success = _downloadfromserver(self, input_data_root=input_data_root, data_list_dir=data_list_dir)
+                expect(success, "Could not download refcase from any server")
 
         logger.info(" - Prestaging REFCASE ({}) to {}".format(refdir, rundir))
 


### PR DESCRIPTION
Run_refdir should only be relative to inputdata if it is a relative path, otherwise don't look for it in inputdata

Test suite: by hand , scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2546 
Fixes #2564 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
