### PR TITLE
update iyear for 2000 runs

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -468,6 +468,7 @@
     <values>
       <value>1990</value>
       <value iyear="1850" cime_model="cesm">1850</value>
+      <value iyear="2000" cime_model="cesm">2000</value>
       <value iyear='HIST' cime_model='cesm'>1850</value>
     </values>
   </entry>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -454,6 +454,7 @@
     <values>
       <value>1990</value>
       <value iyear="1850" cime_model="cesm">1850</value>
+      <value iyear="2000" cime_model="cesm">2000</value>
       <value iyear='HIST' cime_model='cesm'>1850</value>
     </values>
   </entry>


### PR DESCRIPTION
Sets the iorb_year for compsets with 2000 in the date.  I thought it best to set the iorb_year_align field even though it is not used in this compset to reduce confusion.

Test suite: hand tested with F2000_DEV
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
