### PR TITLE
multisubmit tests were not resubmitting.

### DIFF
--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -48,6 +48,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--reset", action="store_true",
                         help="Reset the case to its original state as defined by config_tests.xml")
 
+    parser.add_argument("--resubmit", action="store_true",
+                        help="Ignored in tests, but needed for all templates")
+
     parser.add_argument("--skip-preview-namelist", action="store_true",
                         help="Skip calling preview-namelist during case.run")
 

--- a/config/cesm/machines/template.st_archive
+++ b/config/cesm/machines/template.st_archive
@@ -86,6 +86,7 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def _main_func(description):
 ###############################################################################
+    sys.argv.extend([] if "ARGS_FOR_SCRIPT" not in os.environ else os.environ["ARGS_FOR_SCRIPT"].split())
     caseroot, last_date, no_incomplete_logs, copy_only, test, resubmit = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
         if test:

--- a/scripts/lib/CIME/SystemTests/pet.py
+++ b/scripts/lib/CIME/SystemTests/pet.py
@@ -19,7 +19,7 @@ class PET(SystemTestsCompareTwo):
         """
         SystemTestsCompareTwo.__init__(self, case,
                                        separate_builds = False,
-                                       multisubmit=True,
+                                       multisubmit=False,
                                        run_two_suffix = 'single_thread',
                                        run_one_description = 'default threading',
                                        run_two_description = 'threads set to 1')
@@ -39,4 +39,4 @@ class PET(SystemTestsCompareTwo):
             self._case.set_value("NTHRDS_{}".format(comp), 1)
 
         # Need to redo case_setup because we may have changed the number of threads
-
+        self._case.case_setup(reset=True, test_mode=True)

--- a/scripts/lib/CIME/SystemTests/pet.py
+++ b/scripts/lib/CIME/SystemTests/pet.py
@@ -19,7 +19,7 @@ class PET(SystemTestsCompareTwo):
         """
         SystemTestsCompareTwo.__init__(self, case,
                                        separate_builds = False,
-                                       multisubmit=False,
+                                       multisubmit=True,
                                        run_two_suffix = 'single_thread',
                                        run_one_description = 'default threading',
                                        run_two_description = 'threads set to 1')

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -223,7 +223,7 @@ class SystemTestsCommon(object):
 
         logger.info(infostr)
 
-        self._case.case_run(skip_pnl=self._skip_pnl)
+        self._case.case_run(skip_pnl=self._skip_pnl, submit_resubmits=True)
 
         if not self._coupler_log_indicates_run_complete():
             expect(False, "Coupler did not indicate run passed")
@@ -232,7 +232,7 @@ class SystemTestsCommon(object):
             self._component_compare_copy(suffix)
 
         if st_archive:
-            self._case.case_st_archive()
+            self._case.case_st_archive(resubmit=True)
 
     def _coupler_log_indicates_run_complete(self):
         newestcpllogfiles = self._get_latest_cpl_logs()

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -221,6 +221,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             self._case_one_custom_postrun_action()
 
         # Second run
+        logger.info("_multisubmit {} first phase {}".format(self._multisubmit, first_phase))
         if not self._multisubmit or not first_phase:
             # Subtle issue: case1 is already in a writeable state since it tends to be opened
             # with a with statement in all the API entrances in CIME. case2 was created via clone,

--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -630,10 +630,7 @@ def case_st_archive(self, last_date_str=None, archive_incomplete_logs=True, copy
 
     # resubmit case if appropriate
     resubmit_cnt = self.get_value("RESUBMIT")
-    logger.info("resubmit_cnt {} resubmit {}".format(resubmit_cnt, resubmit))
-    if not resubmit:
-        import traceback
-        traceback.print_stack()
+    logger.debug("resubmit_cnt {} resubmit {}".format(resubmit_cnt, resubmit))
     if resubmit_cnt > 0 and resubmit:
         logger.info("resubmitting from st_archive, resubmit={:d}".format(resubmit_cnt))
         if self.get_value("MACH") == "mira":

--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -630,6 +630,10 @@ def case_st_archive(self, last_date_str=None, archive_incomplete_logs=True, copy
 
     # resubmit case if appropriate
     resubmit_cnt = self.get_value("RESUBMIT")
+    logger.info("resubmit_cnt {} resubmit {}".format(resubmit_cnt, resubmit))
+    if not resubmit:
+        import traceback
+        traceback.print_stack()
     if resubmit_cnt > 0 and resubmit:
         logger.info("resubmitting from st_archive, resubmit={:d}".format(resubmit_cnt))
         if self.get_value("MACH") == "mira":


### PR DESCRIPTION
Tests with the multisubmit flag were not submitting the second phase.   Issue #2599 will be addressed separately. 

Test suite: scripts_regression_tests.py , PET_P36x2_Ln9.f10_f10_musgs.I1850Clm50BgcCrop.cheyenne_gnu.clm-default 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2597 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
