### PR TITLE
In datm, set orbital parameters in run loop

### DIFF
--- a/src/components/data_comps/datm/mct/atm_comp_mct.F90
+++ b/src/components/data_comps/datm/mct/atm_comp_mct.F90
@@ -219,6 +219,10 @@ CONTAINS
     integer(IN)                      :: shrlogunit     ! original log unit
     integer(IN)                      :: shrloglev      ! original log level
     character(CL)                    :: case_name      ! case name
+    real(R8)                         :: orbEccen       ! orb eccentricity (unit-less)
+    real(R8)                         :: orbMvelpp      ! orb moving vernal eq (radians)
+    real(R8)                         :: orbLambm0      ! orb mean long of perhelion (radians)
+    real(R8)                         :: orbObliqr      ! orb obliquity (radians)
     real(R8)                         :: nextsw_cday    ! calendar of next atm sw
     character(*), parameter :: subName = "(atm_run_mct) "
     !-------------------------------------------------------------------------------
@@ -233,11 +237,32 @@ CONTAINS
          dom=ggrid, &
          infodata=infodata)
 
-    call seq_infodata_GetData(infodata, case_name=case_name)
+    call seq_infodata_GetData(infodata, &
+         case_name=case_name, &
+         orb_eccen=orbEccen, &
+         orb_mvelpp=orbMvelpp, &
+         orb_lambm0=orbLambm0, &
+         orb_obliqr=orbObliqr)
 
-    call datm_comp_run(EClock, x2a, a2x, &
-         SDATM, gsmap, ggrid, mpicom, compid, my_task, master_task, &
-         inst_suffix, logunit, nextsw_cday, case_name)
+    call datm_comp_run( &
+         EClock = EClock, &
+         x2a = x2a, &
+         a2x = a2x, &
+         SDATM = SDATM, &
+         gsmap = gsmap, &
+         ggrid = ggrid, &
+         mpicom = mpicom, &
+         compid = compid, &
+         my_task = my_task, &
+         master_task = master_task, &
+         inst_suffix = inst_suffix, &
+         logunit = logunit, &
+         orbEccen = orbEccen, &
+         orbMvelpp = orbMvelpp, &
+         orbLambm0 = orbLambm0, &
+         orbObliqr = orbObliqr, &
+         nextsw_cday = nextsw_cday, &
+         case_name = case_name)
 
     call seq_infodata_PutData(infodata, nextsw_cday=nextsw_cday )
 


### PR DESCRIPTION
This is needed for datm to restart properly when using variable-year
orbital parameters.

Test suite:
- scripts_regression_tests on cheyenne
- These tests now pass in CTSM tag clm5.0.dev010 if I put in a hack in
  CTSM to fix a problem there:
  - ERS_D_P36x1.f10_f10_musgs.IHistClm50Bgc.cheyenne_intel.clm-decStart
  - ERP_D_P48x1.f10_f10_musgs.IHistClm50Bgc.hobart_nag.clm-decStart
- These tests are bit-for-bit with out-of-the-box clm5.0.dev010
  (confirming that these changes haven't completely broken datm; note
  that this includes a selection of 1850, 2000 and HIST tests, but
  deliberately does not include HIST tests that cross the year boundary):
  - ERP_D_P36x2_Ld3.f10_f10_musgs.I1850Clm50BgcCrop.cheyenne_intel.clm-default1850
  - ERP_D_Ld3_P36x2.f10_f10_musgs.I2000Clm50BgcCruGs.cheyenne_intel.clm-default
  - ERP_D_Ld5.f10_f10_musgs.I2000Clm50Sp.cheyenne_intel.clm-decStart
  - ERS_D_Ld10.f10_f10_musgs.IHistClm50SpG.cheyenne_intel.clm-glcMEC_decrease

Test baseline: clm5.0.dev010
Test namelist changes: none
Test status: potentially climate-changing for I compsets that use
variable_year orbital parameters (currently HIST compsets), and any
other compsets using datm with solar zenith angle-based interpolation (I
*think* that's the criteria determining if these changes change
answers): Previously, datm looked at orbital parameters at the start of
the run, and used those orbital parameters for its zenith angle-based
interpolations throughout the entire run (though re-checking this on
each restart). Now, datm re-checks the orbital parameters every time
step, so the zenith angle-based interpolations are kept in sync with the
current orbital parameters.

Fixes ESMCI/cime#2598

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
