### PR TITLE
add commas to output using --value

### DIFF
--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -330,10 +330,10 @@ def _main_func(description):
         wrapper=textwrap.TextWrapper()
         wrapper.subsequent_indent = "\t\t\t"
         wrapper.fix_sentence_endings = True
-
     for group in sorted(iter(results)):
-        if (len(variables) > 1 or len(results) > 1 or full) and not get_group:
+        if (len(variables) > 1 or len(results) > 1 or full) and not get_group and not value:
             print("\nResults in group {}".format(group))
+        cnt = 0
         for var in variables:
             if var in results[group]:
                 if raw:
@@ -341,6 +341,8 @@ def _main_func(description):
                 elif get_group:
                     print("\t{}: {}".format(var, results[group][var]['get_group']))
                 elif value:
+                    if cnt > 0:
+                        sys.stdout.write(",")
                     sys.stdout.write("{}".format(results[group][var]['value']))
                 elif description:
                     if results[group][var]['desc'][0] is not None:
@@ -364,7 +366,7 @@ def _main_func(description):
                     print("\t\tfile: {}".format(results[group][var]['file'][0]))
                 else:
                     print("\t{}: {}".format(var, results[group][var]['value']))
-
+            cnt += 1
 
 if (__name__ == "__main__"):
     _main_func(__doc__)


### PR DESCRIPTION
When using mutliple values and the --value flag comma separate output, this requires that the script used to illustrate this problem be modified a little to split the output on comma:
```
my ($d, $e, $f) = split /,/, `./xmlquery NTASKS_ATM,NTASKS_LND,NTASKS_OCN --value`;
```

Test suite:  scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2606 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
