### PR TITLE
move cam section out of config archive

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -1,30 +1,4 @@
 <components version="2.0">
-
-  <comp_archive_spec compname="cam" compclass="atm">
-    <rest_file_extension>[ri]</rest_file_extension>
-    <rest_file_extension>rh\d*</rest_file_extension>
-    <rest_file_extension>rs</rest_file_extension>
-    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
-    <hist_file_extension>e</hist_file_extension>
-    <rest_history_varname>nhfil</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>
-      <rpointer_content>$CASE.cam$NINST_STRING.r.$DATENAME.nc </rpointer_content>
-    </rpointer>
-    <test_file_names>
-      <tfile disposition="copy">rpointer.atm</tfile>
-      <tfile disposition="copy">rpointer.atm_9999</tfile>
-      <tfile disposition="copy">casename.cam.r.1976-01-01-00000.nc</tfile>
-      <tfile disposition="copy">casename.cam.rh4.1976-01-01-00000.nc</tfile>
-      <tfile disposition="move">casename.cam.h0.1976-01-01-00000.nc</tfile>
-      <tfile disposition="ignore">casename.cam.h0.1976-01-01-00000.nc.base</tfile>
-      <tfile disposition="move">casename.cam_0002.e.postassim.1976-01-01-00000.nc</tfile>
-      <tfile disposition="move">casename.cam_0002.e.preassim.1976-01-01-00000.nc</tfile>
-      <tfile disposition="copy">casename.cam.i.1976-01-01-00000.nc</tfile>
-      <tfile disposition="ignore">anothercasename.cam.i.1976-01-01-00000.nc</tfile>
-    </test_file_names>
-  </comp_archive_spec>
-
   <comp_archive_spec compname="clm" compclass="lnd">
     <rest_file_extension>r</rest_file_extension>
     <rest_file_extension>rh\d?</rest_file_extension>


### PR DESCRIPTION
The cam section of config_archive.xml was moved to cam in cam5_4_189

Test suite: case.st_archive --test 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
