### PR TITLE
Add support for f05_f05_mg17 resolutiion

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -419,6 +419,13 @@
       <mask>gx1v7</mask>
     </model_grid>
 
+    <model_grid alias="f05_f05_mg17" not_compset="_POP" >
+      <grid name="atm">0.47x0.63</grid>
+      <grid name="lnd">0.47x0.63</grid>
+      <grid name="ocnice">0.47x0.63</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
     <model_grid alias="f09_f09_gl5" compset="_CISM" not_compset="_POP">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
@@ -1044,6 +1051,8 @@
       <nx>576</nx>  <ny>384</ny>
       <file grid="atm|lnd" mask="gx1v6">domain.lnd.fv0.47x0.63_gx1v6.090407.nc</file>
       <file grid="ocnice"  mask="gx1v6">domain.ocn.0.47x0.63_gx1v6_090408.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">domain.lnd.fv0.47x0.63_gx1v7.180521.nc</file>
+      <file grid="ocnice"  mask="gx1v7">domain.ocn.fv0.47x0.63_gx1v7.180521.nc</file>
       <desc>0.47x0.63 is FV 1/2-deg grid:</desc>
     </domain>
 
@@ -1981,6 +1990,13 @@
     <!-- ====================  -->
     <!-- GLC: gland4           -->
     <!-- ====================  -->
+
+    <gridmap lnd_grid="0.47x0.63" glc_grid="gland4" >
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.47x0.63/map_fv0.47x0.63_TO_gland4km_aave.171105.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.47x0.63/map_fv0.47x0.63_TO_gland4km_blin.171105.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.47x0.63_aave.171105.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.47x0.63_aave.171105.nc</map>
+    </gridmap>
 
     <gridmap lnd_grid="0.9x1.25" glc_grid="gland4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland4km_aave.170429.nc</map>


### PR DESCRIPTION
        modified:   config/cesm/config_grids.xml

For running F compsets on half-degree horizontal resolution

Test suite: Smoke tests
 create_newcase --compset F2000climo --res f05_f05_mg17 --case ...
 SMS_Ld1.f09_g17.B1850.cheyenne_intel 
 SMS_Ld1.f09_f09_mg17.FHIST.cheyenne_intel
 SMS_Ld1.f09_f09_mg17.FWmaHIST.cheyenne_intel

Test status: expect bit-for-bit

Fixes CIME Github issue #2467
  Add support for half-degree CAM runs in CESM

User interface changes?: No

Update gh-pages html (Y/N)?:

Code review: 
