### PR TITLE
fix issues with mpi-serial build

### DIFF
--- a/src/externals/pio1/pio/box_rearrange.F90.in
+++ b/src/externals/pio1/pio/box_rearrange.F90.in
@@ -43,13 +43,7 @@ module box_rearrange
 
   use pio_kinds, only : pio_offset, r4, r8, i4, i8
   use pio_types
-#ifdef NO_MPI2
-  use pio_support, only : MPI_TYPE_CREATE_INDEXED_BLOCK, piodie, &
-                          Debug, DebugIO, CheckMPIReturn, pio_fc_gather_offset
-#else
   use pio_support, only : piodie, Debug, DebugIO, CheckMPIReturn, pio_fc_gather_offset
-
-#endif
 #ifdef TIMING
   use perf_mod, only : t_startf, t_stopf  !_EXTERNAL
 #endif

--- a/src/externals/pio1/pio/pio_support.F90
+++ b/src/externals/pio1/pio/pio_support.F90
@@ -42,9 +42,7 @@ module pio_support
   public :: pio_readdof
   public :: pio_writedof
   public :: pio_fc_gather_offset
-#ifdef NO_MPI2
-  public :: MPI_TYPE_CREATE_INDEXED_BLOCK
-#endif
+
 
 
   logical, public :: Debug=.FALSE.
@@ -370,25 +368,6 @@ contains
     endif
 
   end subroutine pio_readdof
-
-#ifdef NO_MPI2
-
-  subroutine MPI_TYPE_CREATE_INDEXED_BLOCK(count, blen, disp, oldtype, newtype, ierr)
-    integer, intent(in)  :: count
-    integer, intent(in)  :: blen
-    integer, intent(in)  :: disp(:)
-    integer, intent(in)  :: oldtype
-    integer, intent(out) :: newtype
-    integer :: ierr
-
-    integer :: dblens(count)
-
-    dblens = blen
-#ifndef _MPISERIAL
-    call mpi_type_indexed(count, dblens, disp, oldtype, newtype, ierr)
-#endif
-  end subroutine MPI_TYPE_CREATE_INDEXED_BLOCK
-#endif
 
 !
 !========================================================================

--- a/src/externals/pio1/pio/piolib_mod.F90
+++ b/src/externals/pio1/pio/piolib_mod.F90
@@ -1453,9 +1453,6 @@ contains
 
   subroutine genindexedblock(lenblocks,basetype,elemtype,filetype,displace)
     use pio_types, only : pio_double, pio_int, pio_real, pio_char
-#ifdef NO_MPI2
-    use pio_support, only : mpi_type_create_indexed_block
-#endif
     integer(i4), intent(in) :: lenblocks     ! length of blocks
     integer(i4), intent(in) :: basetype      ! base mpi type
     integer(i4), intent(inout) :: elemtype   ! elementary mpi type


### PR DESCRIPTION
This code is now provided by the mpi-serial library and some compilers complain about the duplicated subroutine.  Note that homebrew still fails due to the limit on stack space in mac-os.
Test suite:  tested SMS_Mmpi-serial.T42_T42.FSCAM on homebrew, centos7-linux and cheyenne
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
