### PR TITLE
Improve robustness of compare-two tests

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -208,6 +208,8 @@ class SystemTestsCommon(object):
         stop_option = self._case.get_value("STOP_OPTION")
         run_type    = self._case.get_value("RUN_TYPE")
         rundir      = self._case.get_value("RUNDIR")
+        is_batch    = self._case.get_value("BATCH_SYSTEM") != "none"
+
         # remove any cprnc output leftover from previous runs
         for compout in glob.iglob(os.path.join(rundir,"*.cprnc.out")):
             os.remove(compout)
@@ -223,7 +225,7 @@ class SystemTestsCommon(object):
 
         logger.info(infostr)
 
-        self._case.case_run(skip_pnl=self._skip_pnl, submit_resubmits=True)
+        self._case.case_run(skip_pnl=self._skip_pnl, submit_resubmits=is_batch)
 
         if not self._coupler_log_indicates_run_complete():
             expect(False, "Coupler did not indicate run passed")

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -38,6 +38,7 @@ from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.case import Case
 from CIME.utils import get_model
+from CIME.test_status import *
 
 import shutil, os, glob
 
@@ -108,6 +109,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._setup_cases_if_not_yet_done()
 
         self._multisubmit = multisubmit
+
     # ========================================================================
     # Methods that MUST be implemented by specific tests that inherit from this
     # base class
@@ -219,6 +221,11 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             self._case_one_custom_prerun_action()
             self.run_indv(suffix = self._run_one_suffix)
             self._case_one_custom_postrun_action()
+
+            # Add a PENDing compare phase so that we'll notice if the second part of compare two
+            # doesn't run.
+            with self._test_status:
+                self._test_status.set_status("{}_{}_{}".format(COMPARE_PHASE, self._run_one_suffix, self._run_two_suffix), TEST_PEND_STATUS)
 
         # Second run
         logger.info("_multisubmit {} first phase {}".format(self._multisubmit, first_phase))

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -108,7 +108,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
 
         self._setup_cases_if_not_yet_done()
 
-        self._multisubmit = multisubmit
+        self._multisubmit = multisubmit and self._case1.get_value("BATCH_SYSTEM") != "none"
 
     # ========================================================================
     # Methods that MUST be implemented by specific tests that inherit from this
@@ -217,15 +217,16 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # First run
         if not self._multisubmit or first_phase:
             logger.info('Doing first run: ' + self._run_one_description)
-            self._activate_case1()
-            self._case_one_custom_prerun_action()
-            self.run_indv(suffix = self._run_one_suffix)
-            self._case_one_custom_postrun_action()
 
             # Add a PENDing compare phase so that we'll notice if the second part of compare two
             # doesn't run.
             with self._test_status:
                 self._test_status.set_status("{}_{}_{}".format(COMPARE_PHASE, self._run_one_suffix, self._run_two_suffix), TEST_PEND_STATUS)
+
+            self._activate_case1()
+            self._case_one_custom_prerun_action()
+            self.run_indv(suffix = self._run_one_suffix)
+            self._case_one_custom_postrun_action()
 
         # Second run
         logger.info("_multisubmit {} first phase {}".format(self._multisubmit, first_phase))

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -960,8 +960,11 @@ class TestScheduler(object):
                     if ts_status not in [TEST_PASS_STATUS, TEST_PEND_STATUS]:
                         logger.info( "{} {} (phase {})".format(ts_status, test, phase))
                         rv = False
-                    elif nlfail:
+                    elif ts_status == TEST_PASS_STATUS and nlfail:
                         logger.info( "{} {} (but otherwise OK) {}".format(NAMELIST_FAIL_STATUS, test, phase))
+                        rv = False
+                    elif ts_status == TEST_PEND_STATUS and (not self._no_run and self._no_batch):
+                        logger.info( "{} {} (Some phases left in PEND)".format(TEST_FAIL_STATUS, test))
                         rv = False
                     else:
                         logger.info("{} {} {}".format(status, test, phase))

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -956,15 +956,16 @@ class TestScheduler(object):
                     ts = TestStatus(self._get_test_dir(test))
                     nlfail = ts.get_status(NAMELIST_PHASE) == TEST_FAIL_STATUS
                     ts_status = ts.get_overall_test_status(ignore_namelists=True, check_memory=False, check_throughput=False)
+                    local_run = not self._no_run and self._no_batch
 
                     if ts_status not in [TEST_PASS_STATUS, TEST_PEND_STATUS]:
                         logger.info( "{} {} (phase {})".format(ts_status, test, phase))
                         rv = False
-                    elif ts_status == TEST_PASS_STATUS and nlfail:
-                        logger.info( "{} {} (but otherwise OK) {}".format(NAMELIST_FAIL_STATUS, test, phase))
-                        rv = False
-                    elif ts_status == TEST_PEND_STATUS and (not self._no_run and self._no_batch):
+                    elif ts_status == TEST_PEND_STATUS and local_run:
                         logger.info( "{} {} (Some phases left in PEND)".format(TEST_FAIL_STATUS, test))
+                        rv = False
+                    elif nlfail:
+                        logger.info( "{} {} (but otherwise OK) {}".format(NAMELIST_FAIL_STATUS, test, phase))
                         rv = False
                     else:
                         logger.info("{} {} {}".format(status, test, phase))

--- a/scripts/lib/CIME/test_status.py
+++ b/scripts/lib/CIME/test_status.py
@@ -299,6 +299,10 @@ class TestStatus(object):
         'DIFF'
         >>> _test_helper2('FAIL ERS.foo.A BASELINE\nFAIL ERS.foo.A NLCOMP\nFAIL ERS.foo.A COMPARE_2\nPASS ERS.foo.A RUN')
         'FAIL'
+        >>> _test_helper2('PEND ERS.foo.A COMPARE_2\nFAIL ERS.foo.A RUN')
+        'FAIL'
+        >>> _test_helper2('PEND ERS.foo.A COMPARE_2\nPASS ERS.foo.A RUN')
+        'PEND'
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD')
         'PASS'
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD', wait_for_run=True)
@@ -320,7 +324,7 @@ class TestStatus(object):
                 run_phase_found = True
 
             if (status == TEST_PEND_STATUS):
-                return status
+                rv = TEST_PEND_STATUS
 
             elif (status == TEST_FAIL_STATUS):
                 if ( (not check_throughput and phase == THROUGHPUT_PHASE) or

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -444,7 +444,7 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
 
         # Also verify that comparison is NOT called:
         compare_phase_name = self.get_compare_phase_name(mytest)
-        self.assertIsNone(mytest._test_status.get_status(compare_phase_name))
+        self.assertEqual(test_status.TEST_PEND_STATUS, mytest._test_status.get_status(compare_phase_name))
 
     def test_run_phase_internal_calls_multisubmit_phase2(self):
         # Make sure that the correct calls are made to methods stubbed out by


### PR DESCRIPTION
1. Preemptively add a PEND for the comparison between the two runs. This should prevent relapsing into a situation where PET silently turns into SMS.
2. Multi-submit tests were broken on non-batching machines. Made changes so that no-batch runs will never be multisubmit runs.

Test suite: scripts_regression_tests (on both batch and non-batch machines)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2599 
Fixes #399 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @billsacks 
