### PR TITLE
Add and clarify pieces that describe adding a test to the prebeta testing.

### DIFF
--- a/doc/source/users_guide/testing.rst
+++ b/doc/source/users_guide/testing.rst
@@ -192,11 +192,7 @@ MODIFIERS    Description
 
    _D        XML variable DEBUG set to "TRUE"
 
-   _E        USE_ESMF_LIB set to "TRUE"
-
    _I        Marker to distinguish tests with same name - ignored.
-
-   _IOP      Turns on pnetcdf for the PIO backend.
 
    _Lo#      Run length set by o (STOP_OPTION) and # (STOP_N).
               | o = {"y":"nyears", "m":"nmonths",  "d":"ndays", 
@@ -273,10 +269,6 @@ current status of all your tests.
 Query_testlists
 ===================
 .. _query_testlists:
-
-.. KDR Will query_testlists be renamed query_tests?
-   And will ../Tools_user/query_tests.html then exist?
-   "To see the available tests for your model, call `query_tests <../Tools_user/query_tests.html>`_."
 
 **$CIMEROOT/scripts/query_testlists** gathers descriptions of the tests and testlists available 
 for CESM, the components, and projects.

--- a/doc/source/users_guide/testing.rst
+++ b/doc/source/users_guide/testing.rst
@@ -1,167 +1,240 @@
 .. _testing:
 
-**********
-Testing
-**********
+**************************
+Testing with create_test
+**************************
 
+`create_test <../Tools_user/create_test.html>`_ 
+is the tool we use to test both CIME and CIME-driven models. 
+It can be used as an easy way to run a single basic test or an entire suite of tests.  
+`create_test <../Tools_user/create_test.html>`_ runs a test suite in parallel for improved performance.  
+It is the driver behind the automated nightly testing of cime-driven models.
 
-`create_test <../Tools_user/create_test.html>`_ is the tool we use to test both CIME and CIME-driven models. It can be used as an easy way to
-run a single basic test or an entire suite of tests that are run in parallel for improved performance.
-`create_test <../Tools_user/create_test.html>`_  is the driver behind the automated nightly testing of CIME-driven models.
+Running create_test is generally resource intensive, so run it in a manner appropriate for your system,
+e.g. using 'nice', batch queues, nohup, the ``--parallel-jobs`` option to create_test, etc.
+It will create and submit additional jobs to the batch queue (if one is available).
+
+.. _individual:
+
+An individual test can be run as::
+
+  $CIMEROOT/scripts/create_test $test_name 
+
+Multiple tests can be run similarly, by listing all of the test names on the command line::
+
+  $CIMEROOT/scripts/create_test  $test_name  $test_name2
+
+or by putting the test names into a file, one name per line::
+
+  $CIMEROOT/scripts/create_test -f $file_of_test_names
+
+A pre-defined suite of tests can by run using the ``--xml`` options to create_test,
+which harvest test names from testlist*.xml files.
+As described in https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide,
+to determine what pre-defined test suites are available and what tests they contain, 
+you can run query_testlists_. 
+
+Test suites are retrieved in create_test via 3 selection attributes::
+
+    --xml-category your_category   The test category. 
+    --xml-machine  your_machine    The machine.
+    --xml-compiler your_compiler   The compiler.
+
+| If none of these 3 are used, the default values are 'none'.
+| If any of them are used, the default for the unused options is 'all'.
+| Existing values of these attributes can be seen by running query_testlists_.
+
+The search for test names can be restricted to a single test list using::
+
+    --xml-testlist your_testlist   
+
+Omitting this results in searching all testlists listed in::
+
+    cime/config/{cesm,e3sm}/config_files.xml
 
 =================
- Testname syntax
+Testname syntax
 =================
+.. _`Test naming`:
 
-Tests come in the forms:
-::
+Tests must be named with the following forms, [ ]=optional::
 
-  TESTTYPE[_MODIFIERS].GRID.COMPSET[.MACHINE_COMPILER[.TESTMODS]]
+  TESTTYPE[_MODIFIERS].GRID.COMPSET[.MACHINE_COMPILER][.GROUP-TESTMODS]
 
-Where
+=================  =====================================================================================
+NAME PART
+=================  =====================================================================================
+TESTTYPE_          the general type of test, e.g. SMS. Options are listed in the following table and config_tests.xml.
+MODIFIERS_         These are changes to the default settings for the test.
+                   See the following table and test_scheduler.py.
+GRID               The model grid (can be an alias).
+COMPSET            alias of the compset, or long name, if no ``--xml`` arguments are used.
+MACHINE            This is optional; if this value is not supplied, `create_test <../Tools_user/create_test.html>`_  
+                   will probe the underlying machine. 
+COMPILER           If this value is not supplied, use the default compiler for MACHINE.
+GROUP-TESTMODS_    This is optional. This points to a directory with  ``user_nl_xxx`` files or a ``shell_commands`` 
+                   that can be used to make namelist and ``XML`` modifications prior to running a test.
+                    |
 
-* ``TESTTYPE``
-   How you want to do the test. Options for this value are listed in config_tests.xml.
-   A common test type would be ERS which stands for exact restart, which means you want to test the
-   grid and compset to see if they reproduce the same result upon restart as they would if no restart
-   took place.
+=================  =====================================================================================
+   
+.. _TESTTYPE:
+   
+============ =====================================================================================
+TESTTYPE     Description
+============ =====================================================================================
+   ERS       Exact restart from startup (default 6 days + 5 days) 
+              | Do an 11 day initial test - write a restart at day 6.    (file suffix: base) 
+              | Do a 5 day restart test, starting from restart at day 6. (file suffix: rest) 
+              | Compare component history files '.base' and '.rest' at day 11.
+              |    They should be identical.
 
-* ``MODIFIERS``
-   These are changes to the default settings for the test.
+   ERS2      Exact restart from startup  (default 6 days + 5 days).
 
-   The currently accepted modifiers are:
+              | Do an 11 day initial test without making restarts. (file suffix: base)
+              | Do an 11 day restart test stopping at day 6 with a restart, 
+                then resuming from restart at day 6. (file suffix: rest)
+              | Compare component history files ".base" and ".rest" at day 11.
 
-   | ``_LdN``, ``_LnN``, ``_LyN`` - this changes the default length of the test.
-     ``N`` is an integer, ``d`` is day, ``n`` is timestep and ``y`` is year.  ``_Ld3`` would specify that the test is modified to be a 3 day test.
-   | ``_D`` - this sets the xml variable ``DEBUG`` to TRUE.
-   | ``_IOP`` - this turns on pnetcdf for the PIO backend.
+   ERT       Exact restart from startup, default 2 month + 1 month (ERS with info DBUG = 1).
 
-* ``GRID``
-   The model grid (can be an alias)
+   IRT       Exact restart from startup, (default 4 days + 7 days) with restart from interim file.
 
-* ``COMPSET``
-   The compset name (can be an alias)
+   ERIO      Exact restart from startup with different PIO methods, (default 6 days + 5 days).
 
-* ``MACHINE_COMPILER``
-    This is optional; `create_test <../Tools_user/create_test.html>`_  will probe
-    the underlying machine and use the default compiler for that machine if this value is not
-    supplied.
+   ERR       Exact restart from startup with resubmit, (default 4 days + 3 days).
 
-* ``TESTMODS``
-    This is optional. This points to a directory with  ``user_nl_xxx`` files or a ``shell_commands`` that can be used to provide test specific case modifications for the test.
+   ERRI      Exact restart from startup with resubmit, (default 4 days + 3 days). Tests incomplete logs option for st_archive.
 
-To see the available tests for your model, call `query_tests <../Tools_user/query_tests.html>`_.
+   ERI       hybrid/branch/exact restart test, default (by default STOP_N is 22 days) 
+              ref1case
+                Do an initial run for 3 days writing restarts at day 3.
+                ref1case is a clone of the main case.
+                Short term archiving is on.
+              ref2case (Suffix hybrid)
+                Do a hybrid run for default 19 days running with ref1 restarts from day 3,
+                and writing restarts at day 10. 
+                ref2case is a clone of the main case.
+                Short term archiving is on.
+              case
+                Do a branch run, starting from restarts written in ref2case,
+                for 9 days and writing restarts at day 5.
+                Short term archiving is off.
+              case (Suffix base)
+                Do a restart run from the branch run restarts for 4 days.
+                Compare component history files '.base' and '.hybrid' at day 19.
+                Short term archiving is off.
 
-==========
-Test Types
-==========
+   ERP       PES counts hybrid (OPENMP/MPI) restart bit for bit test from startup, (default 6 days + 5 days).
+              Initial PES set up out of the box
+              Do an 11 day initial test - write a restart at day 6.     (file suffix base)
+              Half the number of tasks and threads for each component.
+              Do a 5 day restart test starting from restart at day 6. (file suffix rest)
+              Compare component history files '.base' and '.rest' at day 11.
+              This is just like an ERS test but the tasks/threading counts are modified on restart
 
+   PEA       Single PE bit for bit test (default 5 days)
+              Do an initial run on 1 PE with mpi library.     (file suffix: base)
+              Do the same run on 1 PE with mpiserial library. (file suffix: mpiserial)
+              Compare base and mpiserial.
 
-The following are the type of tests that are supported by CIME:
+   PEM       Modified PE counts for MPI(NTASKS) bit for bit test (default 5 days)
+              Do an initial run with default PE layout                                     (file suffix: base)
+              Do another initial run with modified PE layout (NTASKS_XXX => NTASKS_XXX/2)  (file suffix: modpes)
+              Compare base and modpes
 
-* ``ERS``
-   | Exact restart from startup (default 6 days + 5 days).
-   | Do an 11 day initial test - write a restart at day 6.    (file suffix: base)
-   | Do a 5 day restart test, starting from restart at day 6. (file suffix: rest)
-   | Compare component history files '.base' and '.rest' at day 11.
+   PET       Modified threading OPENMP bit for bit test (default 5 days)
+              Do an initial run where all components are threaded by default. (file suffix: base)
+              Do another initial run with NTHRDS=1 for all components.        (file suffix: single_thread)
+              Compare base and single_thread.
 
-* ``ERS2``
-   | Exact restart from startup  (default 6 days + 5 days).
-   | Do an 11 day initial test without making restarts.     (file suffix: base)
-   | Do an 11 day restart test stopping at day 6 with a restart, then resuming from restart at day 6. (file suffix: rest)
-   | Compare component history files ".base" and ".rest" at day 11.
+   PFS       Performance test setup. History and restart output is turned off. (default 20 days)
 
-* ``ERT``
-   | Exact restart from startup, default 2 month + 1 month (ERS with info DBUG = 1).
+   ICP       CICE performance test.
 
-* ``IRT``
-   | Exact restart from startup, (default 4 days + 7 days) with restart from interim file.
+   OCP       POP performance test. (default 10 days)
 
-* ``ERIO``
-   | Exact restart from startup with different PIO methods, (default 6 days + 5 days).
+   MCC       Multi-driver validation vs single-driver (both multi-instance). (default 5 days)
 
-* ``ERR``
-   | Exact restart from startup with resubmit, (default 4 days + 3 days).
+   NCK       Multi-instance validation vs single instance - sequential PE for instances (default length)
+              Do an initial run test with NINST 1. (file suffix: base)
+              Do an initial run test with NINST 2. (file suffix: multiinst for both _0001 and _0002)
+              Compare base and _0001 and _0002.
 
-* ``ERRI``
-   | Exact restart from startup with resubmit, (default 4 days + 3 days). Tests incomplete logs option for st_archive.
+   REP       Reproducibility: Two identical runs are bit for bit. (default 5 days)
 
-* ``ERI``
-   | hybrid/branch/exact restart test, default (by default STOP_N is 22 days)
-   | ref1case: Do an initial run for 3 days writing restarts at day 3. ref1case is a clone of the main case. Short term archiving is on.
-   | ref2case (Suffix hybrid): Do a hybrid run for default 19 days running with ref1 restarts from day 3, and writing restarts at day 10.
-     ref2case is a clone of the main case. Short term archiving is on.
-   | case: Do a branch run, starting from restarts written in ref2case, for 9 days and writing restarts at day 5. Short term archiving is off.
-   | case (Suffix base): Do a restart run from the branch run restarts for 4 days. Then ompare component history files '.base' and '.hybrid' at day 19.
-     Short term archiving is off.
+   SBN       Smoke build-namelist test (just run preview_namelist and check_input_data).
 
-* ``ERP``
-   | PES counts hybrid (OPENMP/MPI) restart bit for bit test from startup, (default 6 days + 5 days).
-   | Initial PES set up out of the box.
-   | Do an 11 day initial test - write a restart at day 6.     (file suffix base)
-   | Half the number of tasks and threads for each component.
-   | Do a 5 day restart test starting from restart at day 6. (file suffix rest)
-   | Compare component history files '.base' and '.rest' at day 11.
-   | This is just like an ERS test but the tasks/threading counts are modified on restart.
+   SMS       Smoke startup test (default 5 days)
+              Do a 5 day initial test. (file suffix: base)
 
-* ``PEA``
-   | Single PE bit for bit test (default 5 days)
-   | Do an initial run on 1 PE with mpi library.     (file suffix: base)
-   | Do the same run on 1 PE with mpiserial library. (file suffix: mpiserial)
-   | Compare base and mpiserial.
+   SEQ       Different sequencing bit for bit test. (default 10 days)
+              Do an initial run test with out-of-box PE-layout. (file suffix: base)
+              Do a second run where all root pes are at pe-0.   (file suffix: seq)
+              Compare base and seq.
 
-* ``PEM``
-   | Modified PE counts for MPI(NTASKS) bit for bit test (default 5 days)
-   | Do an initial run with default PE layout                               (file suffix: base)
-   | Do another initial run with modified PE layout (NTASKS_XXX => NTASKS_XXX/2)  (file suffix: modpes)
-   | Compare base and modpes
+   DAE       Data assimilation test, default 1 day, two DA cycles, no data modification.
 
-* ``PET``
-   | Modified threading OPENMP bit for bit test (default 5 days)
-   | Do an initial run where all components are threaded by default. (file suffix: base)
-   | Do another initial run with NTHRDS=1 for all components.        (file suffix: single_thread)
-   | Compare base and single_thread.
+   PRE       Pause-resume test: by default a bit for bit test of pause-resume cycling.
+              Default 5 hours, five pause/resume cycles, no data modification.
+             |
 
-* ``PFS``
-   | Performance test setup. History and restart output is turned off. (default 20 days)
+============ =====================================================================================
 
-* ``ICP``
-   | CICE performance test.
+.. _MODIFIERS:
 
-* ``OCP``
-   | POP performance test. (default 10 days)
+============ =====================================================================================
+MODIFIERS    Description
+============ =====================================================================================
+   _C#       Set number of instances to # and use the multi driver (can't use with _N).
 
-* ``MCC``
-   | Multi-driver validation vs single-instance. (default 5 days)
+   _CG       CALENDAR set to "GREGORIAN"
 
-* ``NCK``
-   | Multi-instance validation vs single instance - sequential PE for instances (default length)
-   | Do an initial run test with NINST 1. (file suffix: base)
-   | Do an initial run test with NINST 2. (file suffix: multiinst for both _0001 and _0002)
-   | Compare base and _0001 and _0002.
+   _D        XML variable DEBUG set to "TRUE"
 
-* ``REP``
-   | Reproducibility: Two identical runs are bit for bit. (default 5 days)
+   _E        USE_ESMF_LIB set to "TRUE"
 
-* ``SBN``
-   | Smoke build-namelist test (just run preview_namelist and check_input_data).
+   _I        Marker to distinguish tests with same name - ignored.
 
-* ``SMS``
-   | Smoke startup test (default 5 days)
-   | Do a 5 day initial test. (file suffix: base)
+   _IOP      Turns on pnetcdf for the PIO backend.
 
-* ``SEQ``
-   | Different sequencing bit for bit test. (default 10 days)
-   | Do an initial run test with out-of-box PE-layout. (file suffix: base)
-   | Do a second run where all root pes are at pe-0.   (file suffix: seq)
-   | Compare base and seq.
+   _Lo#      Run length set by o (STOP_OPTION) and # (STOP_N).
+              | o = {"y":"nyears", "m":"nmonths",  "d":"ndays", 
+              |     \ "h":"nhours", "s":"nseconds", "n":"nsteps"}
 
-* ``DAE``
-   | Data assimilation test, default 1 day, two DA cycles, no data modification.
+   _Mx       Set MPI library to x.
 
-* ``PRE``
-   | Pause-resume test: by default a bit for bit test of pause-resume cycling.
-   | Default 5 hours, five pause/resume cycles, no data modification.
+   _N#       Set number of instances to # and use a single driver (can't use with _C).
+
+   _Px       Set create_newcase's ``--pecount`` to x, which is usually N (tasks) or NxM (tasks x threads per task).
+
+   _R        For testing in PTS_MODE or Single Column Model (SCM) mode.
+             For PTS_MODE, compile with mpi-serial.
+ 
+   _Vx       Set driver to x.
+              |
+
+============ =====================================================================================
+
+.. _GROUP-TESTMODS:
+
+============ =====================================================================================
+TESTMODS     Description
+============ =====================================================================================
+GROUP        A subdirectory of testmods_dirs and the parent directory of various testmods.
+`-`          Replaces '/' in the path name where the testmods are found.
+TESTMODS     A subdirectory of GROUP containing files which set non-default values
+             of the set-up and run-time variables via namelists or xml_change commands.
+             See "Adding tests": CESM_.  
+             Examples include
+
+              | GROUP-TESTMODS = cam-outfrq9s points to 
+              |    $cesm/components/cam/cime_config/testdefs/testmods_dirs/cam/outfrq9s
+              | while allactive-cesm2dev01 points to 
+              |    $cesm/cime_config/testmods_dirs/allactive/cesm2dev01
+
+============ =====================================================================================
+
 
 Each test run by `create_test <../Tools_user/create_test.html>`_  includes the following mandatory steps:
 
@@ -196,8 +269,32 @@ All output from the CIME infrastructure regarding this test will be put in the f
 A cs.status.$testid script will be put in the test root. This script will allow you to see the
 current status of all your tests.
 
+===================
+Query_testlists
+===================
+.. _query_testlists:
+
+.. KDR Will query_testlists be renamed query_tests?
+   And will ../Tools_user/query_tests.html then exist?
+   "To see the available tests for your model, call `query_tests <../Tools_user/query_tests.html>`_."
+
+**$CIMEROOT/scripts/query_testlists** gathers descriptions of the tests and testlists available 
+for CESM, the components, and projects.
+
+The ``--xml-{compiler,machine,category,testlist}`` arguments can be used 
+as in create_test (above) to focus the search.
+The 'category' descriptor of a test can be used to run a group of associated tests at the same time.
+The available categories, with the tests they encompass, can be listed by::
+
+   ./query_testlists --define-testtypes
+
+The ``--show-options`` argument does the same, but displays the 'options' defined for the tests,
+such as queue, walltime, etc..
+
+============================
 Using **create_test** (E3SM)
 ============================
+.. _`Using create_test (E3SM)`:
 
 Usage will differ slightly depending on if you're using E3SM or CESM.
 
@@ -280,8 +377,10 @@ Interpreting test output is pretty easy, looking at an example::
 You can see that `create_test <../Tools_user/create_test.html>`_  informs the user of the case directory and of the progress and duration
 of the various test phases.
 
+===================
 Managing baselines
-==================
+===================
+.. _`Managing baselines`:
 
 A big part of testing is managing your baselines (sometimes called gold results). We have provided
 tools to help the user do this without having to repeat full runs of test cases with `create_test <../Tools_user/create_test.html>`_ .
@@ -302,20 +401,65 @@ baselines for 'master'::
 
   ./compare_test_results -r /home/jenkins/e3sm/scratch/jenkins/ -t mytest -b master
 
+=============
 Adding tests
-============
+=============
+.. _`Adding tests`:
 
-Open the config/$model/tests.py file, you'll see a python dict at the top
+E3SM
+
+Open the config/e3sm/tests.py file, you'll see a python dict at the top
 of the file called _TESTS, find the test category you want to
 change in this dict and add your testcase to the list.  Note the
 comment at the top of this file indicating that you add a test with
 this format: test>.<grid>.<compset>, and then there is a second
 argument for mods.
 
-.. _scripts_regression_tests:
+CESM
 
-Scripts regression tests
-========================
+.. _CESM:
+
+Select a compset to test.  If you need to test a non-standard compset, 
+define an alias for it in the most appropriate config_compsets.xml in ::
+
+    $cesm/components/$component/cime_config
+    $cesm/cime/src/drivers/mct/cime_config
+    $cesm/cime_config
+
+If you want to test non-default namelist or xml variable values for your chosen compset,
+you might find them in a suitable existing testmods directory (see "branching", this section, for locations).
+If not, then populate a new testmods directory with the needed files (see "contents", below).
+Note; do not use '-' in the testmods directory name because it has a special meaning to create_test.
+Testlists and testmods live in different paths for cime, drv, and components. 
+The relevant directory branching looks like
+::
+
+    components/$component/cime_config/testdefs/
+       testlist_$component.xml
+       testmods_dirs/$component/{TESTMODS1,TESTMODS2,...}
+    cime/src/drivers/mct/cime_config/testdefs/
+       testlist_drv.xml
+       testmods_dirs/drv/{default,5steps,...}
+    cime_config/
+       testlist_allactive.xml
+       testmods_dirs/allactive/{default,cesm2dev01,cism,...}
+
+The contents of each testmods directory can include
+::
+
+    user_nl_$components    namelist variable=value pairs 
+    shell_commands         xmlchange commands
+    user_mods              a list of other GROUP-TESTMODS which should be imported
+                           but at a lower precedence than the local testmods.
+
+If this test will only be run as a single test, you can now create a test name
+and follow the individual_ test instructions for create_test.
+If you want this test to be part of a suite, then it must be described in the relevant testlists_YYY.xml file.
+
+===============================
+CIME's scripts regression tests
+===============================
+.. _`CIME's scripts regression tests`:
 
 **$CIMEROOT/scripts/tests/scripts_regression_tests.py** is the suite of internal tests we run
 for the stand-alone CIME testing. With no arguments, it will run the full suite. You can limit testing to a specific
@@ -338,3 +482,5 @@ won't print the output of the test until testing has completed. When there are f
 test, the case directories for that test will not be cleaned up so that the user can do a post-mortem
 analysis. The user will be notified of the specific directories that will be left for them to
 examine.
+
+More description can be found in https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide


### PR DESCRIPTION
1. Expand the introduction.
2. Expand the test name syntax description, using the same table format as the TESTTYPE table, instead of a bulleted list, for consistency.
3. Add a more complete table of MODIFIERS of TESTTYPE, replacing a brief text list.
4. Add a table of GROUP-TESTMODS, for completeness and clarity.
5. Expand descriptions of create_test and query_testlists.
6. Add a CESM subsection to the "Adding tests" section, since the E3SM instructions don't apply to CESM.

Test suite: make html
Test baseline: 
Test namelist changes: none
Test status: bit for bit

Fixes  #2556

User interface changes?: none

Update gh-pages html (Y/N)?: Y

Code review: 
