### PR TITLE
Add ability to handle tput_tolerance as option in test lists

### DIFF
--- a/config/xml_schemas/testlist.xsd
+++ b/config/xml_schemas/testlist.xsd
@@ -53,7 +53,11 @@
 
   <xs:element name="option">
     <xs:complexType mixed="true">
-      <xs:attribute name="name" use="required" type="xs:NCName"/>
+      <xs:attribute name="name"              use="required" type="xs:NCName"/>
+      <xs:attribute name="comment"           use="optional"/>
+      <xs:attribute name="wallclock"         use="optional"/>
+      <xs:attribute name="memleak_tolerance" use="optional"/>
+      <xs:attribute name="tput_tolerance"    use="optional"/>
     </xs:complexType>
   </xs:element>
 

--- a/config/xml_schemas/testlist.xsd
+++ b/config/xml_schemas/testlist.xsd
@@ -62,9 +62,10 @@
      <xs:restriction base="xs:NCName">
         <xs:enumeration value="wallclock"/>
         <xs:enumeration value="comment"/>
-        <xs:enumeration value="queue"/>
         <xs:enumeration value="memleak_tolerance"/>
         <xs:enumeration value="tput_tolerance"/>
+        <!-- Queue can't actually be set, but is currently in the CAM testlist -->
+        <xs:enumeration value="queue"/>
      </xs:restriction>
   </xs:simpleType>
 

--- a/config/xml_schemas/testlist.xsd
+++ b/config/xml_schemas/testlist.xsd
@@ -51,14 +51,21 @@
     </xs:complexType>
   </xs:element>
 
+
   <xs:element name="option">
     <xs:complexType mixed="true">
-      <xs:attribute name="name"              use="required" type="xs:NCName"/>
-      <xs:attribute name="comment"           use="optional"/>
-      <xs:attribute name="wallclock"         use="optional"/>
-      <xs:attribute name="memleak_tolerance" use="optional"/>
-      <xs:attribute name="tput_tolerance"    use="optional"/>
+      <xs:attribute name="name"              use="required" type="OptionType"/>
     </xs:complexType>
   </xs:element>
+
+  <xs:simpleType name="OptionType">
+     <xs:restriction base="xs:NCName">
+        <xs:enumeration value="wallclock"/>
+        <xs:enumeration value="comment"/>
+        <xs:enumeration value="queue"/>
+        <xs:enumeration value="memleak_tolerance"/>
+        <xs:enumeration value="tput_tolerance"/>
+     </xs:restriction>
+  </xs:simpleType>
 
 </xs:schema>

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -549,6 +549,11 @@ class TestScheduler(object):
         envtest.set_value("GENERATE_BASELINE", self._baseline_gen_name is not None)
         envtest.set_value("COMPARE_BASELINE", self._baseline_cmp_name is not None)
         envtest.set_value("CCSM_CPRNC", self._machobj.get_value("CCSM_CPRNC", resolved=False))
+
+        if test in self._test_data and "options" in self._test_data[test] and \
+                "tput_tolerance" in self._test_data[test]['options']:
+            envtest.set_value("TEST_TPUT_TOLERANCE", self._test_data[test]['options']['tput_tolerance'])
+
         tput_tolerance = self._machobj.get_value("TEST_TPUT_TOLERANCE", resolved=False)
         envtest.set_value("TEST_TPUT_TOLERANCE", 0.25 if tput_tolerance is None else tput_tolerance)
 

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -550,11 +550,11 @@ class TestScheduler(object):
         envtest.set_value("COMPARE_BASELINE", self._baseline_cmp_name is not None)
         envtest.set_value("CCSM_CPRNC", self._machobj.get_value("CCSM_CPRNC", resolved=False))
 
+        tput_tolerance = self._machobj.get_value("TEST_TPUT_TOLERANCE", resolved=False)
         if test in self._test_data and "options" in self._test_data[test] and \
                 "tput_tolerance" in self._test_data[test]['options']:
-            envtest.set_value("TEST_TPUT_TOLERANCE", self._test_data[test]['options']['tput_tolerance'])
+            tput_tolerance = self._test_data[test]['options']['tput_tolerance']
 
-        tput_tolerance = self._machobj.get_value("TEST_TPUT_TOLERANCE", resolved=False)
         envtest.set_value("TEST_TPUT_TOLERANCE", 0.25 if tput_tolerance is None else tput_tolerance)
 
         # Add the test instructions from config_test to env_test in the case


### PR DESCRIPTION
tput_tolerance is now an optional attribute that can be set in test lists.
Verified that it worked, for a simple test.

Also added the list of valid options to the XML schema and verified it validates
all CESM test lists. CAM has a setting that isn't implemented for queue, so I kept
it as a valid option even though it's inactive. This error checking helps to make sure
that test lists and any changes to test lists are valid.

Test suite:  ran scripts_regresson_tests.py
Test baseline: none
Test namelist changes: changes TEST_TPUT_TOLERANCE
Test status: bit-for-bit

Fixes #2640 

User interface changes?: none

Update gh-pages html (Y/N)?:N

Code review: 
