### PR TITLE
fix issue with stageing ww3 data

### DIFF
--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -169,6 +169,11 @@ def check_case(self):
     logger.info("Checking that inputdata is available as part of case submission")
     self.check_all_input_data()
 
+    if self.get_value('COMP_WAV') == 'ww':
+        # the ww3 buildnml has dependancies on inputdata so we must run it again
+        self.create_namelists(component='WAV')
+
+
     expect(self.get_value("BUILD_COMPLETE"), "Build complete is "
            "not True please rebuild the model by calling case.build")
     logger.info("Check case OK")


### PR DESCRIPTION
If inputdata is not present on the system when ww3 buildnml runs it fails to stage required startup data.  This fix runs the ww3 buildnml again after staging data. 

Test suite: SMS.T62_g37.C1850ECO.cheyenne_intel.pop-ecosys with empty inputdata dir
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2649 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
