### PR TITLE
Edit and cleanup parts of CCS users guide

### DIFF
--- a/doc/source/users_guide/building-a-case.rst
+++ b/doc/source/users_guide/building-a-case.rst
@@ -4,7 +4,10 @@
 Building a Case
 ******************
 
-The following describes the process of building the model executable.
+Once the case has been created and setup, its time to build the executable.
+Several directories full of source code must be built all with the same compiler and flags.
+**case.build** performs all build operations (setting dependecies, invoking Make,
+creating the executable).
 
 .. _building-the-model:
 
@@ -15,20 +18,20 @@ Calling **case.build**
 After calling `case.setup <../Tools_user/case.setup.html>`_ , run `case.build <../Tools_user/case.build.html>`_  to build the model executable. Running this will:
 
 1. Create the component namelists in ``$RUNDIR`` and ``$CASEROOT/CaseDocs``.
-2. Create the necessary compiled libraries ``mct``, ``pio``, ``gptl`` and ``csm_share``.
+2. Create the necessary compiled libraries used by coupler and component models ``mct``, ``pio``, ``gptl`` and ``csm_share``.
    The libraries will be placed in a path below ``$SHAREDLIBROOT``.
-3. Create the necessary compiled libraries. These are be placed in ``$EXEROOT/bld/lib``.
+3. Create the necessary compiled libraries for each component model. These are be placed in ``$EXEROOT/bld/lib``.
 4. Create the model executable (``$MODEL.exe``), which is placed in ``$EXEROOT``.
 
 You do not need to change the default build settings to create the executable, but it is useful to become familiar with them in order to make optimal use of the system. The CIME scripts provide you with a great deal of flexibility in customizing the build process.
 
 The **env_build.xml** variables control various aspects of building the executable. Most of the variables should not be modified, but users can modify these:
 
-- ``$BUILD_THREADED``
+- ``$BUILD_THREADED`` : if TRUE, the model will be built with OpenMP.
 
-- ``$DEBUG``
+- ``$DEBUG`` : if TRUE, the model is compiled with debugging instead of optimization flags.
 
-- ``$GMAKE_J``
+- ``$GMAKE_J`` : How many threads GNUMake should use while building.
 
 The best way to see what xml variables are in your ``$CASEROOT`` directory is to use the `xmlquery <../Tools_user/xmlquery.html>`_  command. For usage information, run:
 ::

--- a/doc/source/users_guide/cime-change-namelist.rst
+++ b/doc/source/users_guide/cime-change-namelist.rst
@@ -3,24 +3,29 @@
 Customizing your input variables
 ================================
 
-CIME and current CIME-compliant components currently primarily uses fortran namelists.
+CIME and CIME-compliant components currently use Fortran namelists to control runtime options.
 
-All CIME-compliant components generate their input variable settings using a **buildnml** file located in the component's **cime_config** directory.
+All CIME-compliant components generate their namelist file using a **buildnml** script located in the component's **cime_config** directory.  **buildnml** may call other scripts to complete the namelist.
 
 For example, the CIME data atmosphere model (DATM) generates namelists using the script **$CIMEROOT/components/data_comps/datm/cime_config/buildnml**.
 
-You can customize your namelists  in one of two ways:
+You can customize a model's namelists in one of two ways:
 
 1. by editing the **$CASEROOT/user_nl_xxx** files
 
-  These files should be modified via keyword-value pairs that correspond to new namelist or input data settings.
+  These files should be modified via keyword-value pairs that correspond to new namelist or input data settings.  They use the
+  syntax of Fortran namelists.
 
 2. by calling `xmlchange <../Tools_user/xmlchange.html>`_ to modify xml variables in your ``$CASEROOT``.
 
-You can preview the component namelists by running `preview_namelists <../Tools_user/preview_namelists.html>`_  from ``$CASEROOT``.
+   Many of these variables are converted to Fortran namelist values for input by the models.  Variables that have
+   to be coordinated between models in a coupled system (such as how many steps to run for) are usually in a CIME xml file.
+
+You can generate the component namelists by running `preview_namelists <../Tools_user/preview_namelists.html>`_  from ``$CASEROOT``.
 
 This results in the creation of component namelists (for example, atm_in, lnd_in, and so on) in ``$CASEROOT/CaseDocs/``.
-The namelist files are there only for user reference and **SHOULD NOT BE EDITED** since they are overwritten every time `preview_namelists <../Tools_user/preview_namelists.html>`_ and `case.submit <../Tools_user/case.submit.html>`_ are called.
+
+.. warning:: The namelist files in ``CaseDocs`` are  there only for user reference and **SHOULD NOT BE EDITED** since they are overwritten every time `preview_namelists <../Tools_user/preview_namelists.html>`_ and `case.submit <../Tools_user/case.submit.html>`_ are called and the files read at runtime are not the ones in ``CaseDocs``.
 
 .. _use-cases-modifying-driver-namelists:
 
@@ -50,10 +55,137 @@ On the hand, to change the driver namelist value of the starting year/month/day,
 Note that
 
 To see the result of change, call `preview_namelists <../Tools_user/preview_namelists.html>`_  and verify that the new value appears in **CaseDocs/drv_in**.
+
+Setting up a multi-year run
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This shows all of the steps necessary to do a multi-year simulation starting from a "cold start" for all components.  The
+compset and resolution in this example are for CESM but the steps are similar for other compets.
+
+1. Create a new case named EXAMPLE_CASE in your **$HOME** directory.
+
+   ::
+
+      > cd $CIME/scripts
+      > ./create_newcase --case ~/EXAMPLE_CASE --compset B1850 --res f09_g17
+
+2. Check the pe-layout by running **./pelayout**. Make sure it is suitable for your machine.
+   If it is not use `xmlchange <../Tools_user/xmlchange.html>`_ or  `pelayout <../Tools_user/pelayout.html>`_ to modify your pe-layout.
+   Then setup your case and build your executable.
+
+   ::
+
+      > cd ~/EXAMPLE_CASE
+      > ./case.setup
+      > ./case.build
+
+   .. warning:: The case.build script is can be compute intensive and may not be suitable to run on a login node. As an alternative you would submit this job to an interactive queue.
+                For example, on the NCAR cheyenne platform, you would use **qcmd -- ./case.build** to do this.
+
+3. In your case directory, set the job to run 12 model months, set the wallclock time, and submit the job.
+
+   ::
+
+      > ./xmlchange STOP_OPTION=nmonths
+      > ./xmlchange STOP_N=12
+      > ./xmlchange JOB_WALLCLOCK_TIME=06:00 --subgroup case.run
+      > ./case.submit
+
+4. Make sure the run succeeded.
+
+   You should see the following line or similar at the end of the **cpl.log** file in your run directory or your short term archiving directory, set by ``$DOUT_S_ROOT``.
+
+   ::
+
+      (seq_mct_drv): ===============       SUCCESSFUL TERMINATION OF CPL7-cesm ===============
+
+5. In the same case directory, Set the case to resubmit itself 10 times so it will run a total of 11 years (including the initial year), and resubmit the case. (Note that a resubmit will automatically change the run to be a continuation run).
+
+   ::
+
+      > ./xmlchange RESUBMIT=10
+      > ./case.submit
+
+   By default resubmitted runs are not submitted until the previous run is completed.  For 10 1-year runs as configured in this
+   example, CIME will first submit a job for one year, then when its finished submit a job for another year.  There will be
+   only one job in the queue at a time.
+   To change this behavior, and submit all jobs at once (with batch dependencies such that only one job is run at a time), use the command:
+
+   ::
+
+      > ./case.submit --resubmit-immediate
+
+Setting up a branch or hybrid run
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A branch or hybrid run uses initialization data from a previous run. Here is an example in which a valid load-balanced scenario is assumed.
+
+1. The first step in setting up a branch or hybrid run is to create a new case. A CESM compset and resolution is assumed below.
+
+   ::
+
+      > cd $CIMEROOT/scripts
+      > create_newcase --case ~/NEW_CASE --compset B1850 --res f09_g17
+      > cd ~/NEW_CASE
+
+
+2. For a branch run, use the following `xmlchange <../Tools_user/xmlchange.html>`_  commands to make **NEW_CASE** be a branch off of **EXAMPLE_CASE** at year 0001-02-01.
+
+   ::
+
+      > ./xmlchange RUN_TYPE=branch
+      > ./xmlchange RUN_REFCASE=EXAMPLE_CASE
+      > ./xmlchange RUN_REFDATE=0001-02-01
+
+3. For a hybrid run, use the following `xmlchange <../Tools_user/xmlchange.html>`_  command to start **NEW_CASE** from **EXAMPLE_CASE** at year 0001-02-01.
+
+   ::
+
+      > ./xmlchange RUN_TYPE=hybrid
+      > ./xmlchange RUN_REFCASE=EXAMPLE_CASE
+      > ./xmlchange RUN_REFDATE=0001-02-01
+
+   For a branch run, your **env_run.xml** file for **NEW_CASE** should be identical to the file for **EXAMPLE_CASE** except for the ``$RUN_TYPE`` setting.
+
+   Also, modifications introduced into **user_nl_** files in **EXAMPLE_CASE** should be reintroduced in **NEW_CASE**.
+
+4. Next, set up and build your case executable.
+   ::
+
+      > ./case.setup
+      > ./case.build
+
+5. Pre-stage the necessary restart/initial data in ``$RUNDIR``. Assume for this example that it was created in the **/rest/0001-02-01-00000** directory shown here:
+
+   ::
+      > cd $RUNDIR
+      > cp /user/archive/EXAMPLE_CASE/rest/0001-02-01-00000/* .
+
+   It is assumed that you already have a valid load-balanced scenario.
+   Go back to the case directory, set the job to run 12 model months, and submit the job.
+   ::
+
+      > cd ~/NEW_CASE
+      > ./xmlchange STOP_OPTION=nmonths
+      > ./xmlchange STOP_N=12
+      > ./xmlchange JOB_WALLCLOCK_TIME=06:00
+      > ./case.submit
+
+6.  Make sure the run succeeded (see above directions) and then change
+    the run to a continuation run. Set it to resubmit itself 10 times
+    so it will run a total of 11 years (including the initial year),
+    then resubmit the case.
+    ::
+
+       > ./xmlchange CONTINUE_RUN=TRUE
+       > ./xmlchange RESUMIT=10
+       > ./case.submit
+
 .. _changing-data-model-namelists:
 
 Customizing data model input variable and stream files
 ------------------------------------------------------
+
+Each data model can be runtime-configured with its own namelist.
 
 Data Atmosphere (DATM)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/users_guide/cime-change-namelist.rst
+++ b/doc/source/users_guide/cime-change-namelist.rst
@@ -56,6 +56,8 @@ Note that
 
 To see the result of change, call `preview_namelists <../Tools_user/preview_namelists.html>`_  and verify that the new value appears in **CaseDocs/drv_in**.
 
+.. _basic_example:
+
 Setting up a multi-year run
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/users_guide/cime-change-namelist.rst
+++ b/doc/source/users_guide/cime-change-namelist.rst
@@ -3,9 +3,12 @@
 Customizing your input variables
 ================================
 
-CIME and CIME-compliant components currently use Fortran namelists to control runtime options.
+CIME and CIME-compliant components primarily use Fortran namelists to control runtime options.  Some components use
+other text-based files for runtime options.
 
-All CIME-compliant components generate their namelist file using a **buildnml** script located in the component's **cime_config** directory.  **buildnml** may call other scripts to complete the namelist.
+All CIME-compliant components generate their input variable files using a **buildnml** script typically located in the
+component's **cime_config** directory (or other location as set in **config_file.xml**).
+**buildnml** may call other scripts to complete construction of the input file.
 
 For example, the CIME data atmosphere model (DATM) generates namelists using the script **$CIMEROOT/components/data_comps/datm/cime_config/buildnml**.
 
@@ -62,7 +65,7 @@ Setting up a multi-year run
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This shows all of the steps necessary to do a multi-year simulation starting from a "cold start" for all components.  The
-compset and resolution in this example are for CESM but the steps are similar for other compets.
+compset and resolution in this example are for a CESM fully-coupled case but the steps are similar for other models and cases.
 
 1. Create a new case named EXAMPLE_CASE in your **$HOME** directory.
 
@@ -81,7 +84,7 @@ compset and resolution in this example are for CESM but the steps are similar fo
       > ./case.setup
       > ./case.build
 
-   .. warning:: The case.build script is can be compute intensive and may not be suitable to run on a login node. As an alternative you would submit this job to an interactive queue.
+   .. warning:: The case.build script can be compute intensive and may not be suitable to run on a login node. As an alternative you would submit this job to an interactive queue.
                 For example, on the NCAR cheyenne platform, you would use **qcmd -- ./case.build** to do this.
 
 3. In your case directory, set the job to run 12 model months, set the wallclock time, and submit the job.
@@ -109,7 +112,7 @@ compset and resolution in this example are for CESM but the steps are similar fo
       > ./case.submit
 
    By default resubmitted runs are not submitted until the previous run is completed.  For 10 1-year runs as configured in this
-   example, CIME will first submit a job for one year, then when its finished submit a job for another year.  There will be
+   example, CIME will first submit a job for one year, then when that job completes it will submit a job for another year.  There will be
    only one job in the queue at a time.
    To change this behavior, and submit all jobs at once (with batch dependencies such that only one job is run at a time), use the command:
 

--- a/doc/source/users_guide/cime-dir.rst
+++ b/doc/source/users_guide/cime-dir.rst
@@ -1,0 +1,49 @@
+.. _cime-dir:
+
+******************
+Directory content
+******************
+
+If you use CIME as part of a climate model or standalone, the content of the **cime** directory is the same.
+
+If you are using it as part of a climate model, **cime** is usually one of the first subdirectories under the main directory.
+
+.. table:: **CIME directory in a climate model**
+
+   ====================== ===================================
+   Directory or Filename               Description
+   ====================== ===================================
+   README, etc.           typical top-level directory content
+   components/            source code for active models
+   cime/                  All of CIME code
+   ====================== ===================================
+
+CIME's content is split into several subdirectories. Users should start in the **scripts/** subdirectory.
+
+.. table::  **CIME directory content**
+
+   ========================== ==================================================================
+   Directory or Filename               Description
+   ========================== ==================================================================
+   CMakeLists.txt	      For building with CMake
+   ChangeLog		      Developer-maintained record of changes to CIME
+   ChangeLog_template	      Template for an entry in ChangeLog
+   LICENSE.TXT		      The CIME license
+   README		      Brief intro to CIME
+   README.md		      README in markdown language
+   README.unit_testing	      Instructions for running unit tests with CIME
+   **config/**		      **Shared and model-specific configuration files**
+   config/cesm/	              CESM-specific configuration options
+   config/e3sm/	              E3SM-specific configuration options
+   **scripts/**		      **The CIME user interface**
+   scripts/lib/  	      Infrastructure source code for CIME scripts and functions
+   scripts/Tools/	      Auxiliary tools; scripts and functions
+   **src/**		      **Model source code provided by CIME**
+   src/components/	      CIME-provided components including data and stub models
+   src/drivers/  	      CIME-provided main driver for a climate model
+   src/externals/	      Software provided with CIME for building a climate model
+   src/share/    	      Model source code provided by CIME and used by multiple components
+   **tests/**		      **Tests**
+   **tools/**		      **Standalone climate modeling tools**
+   utils/		      Some Perl source code needed by some prognostic components
+   ========================== ==================================================================

--- a/doc/source/users_guide/compsets.rst
+++ b/doc/source/users_guide/compsets.rst
@@ -36,6 +36,12 @@ In the case of CESM, this xml element has the contents shown here, where ``$SRCR
 
 Every file listed in COMPSETS_SPEC_FILE will be searched for the compset specified in the call to create_newcase.
 
+CIME will note which component's config_compsets.xml had the matching compset name and that component will be treated as
+the **primary component** As an example, the primary component for a compset that has a prognostic atmosphere,
+land and cice (in prescribed mode) and a data ocean is the atmosphere component (for cesm this is CAM) because the compset
+is defined, using the above example, in ``$SRCROOT/components/cam/cime_config/config_compsets.xml``
+In a compset where all components are prognostic, the primary component will be **allactive**.
+
 .. _defining-compsets:
 
 Compset longname

--- a/doc/source/users_guide/create-a-case.rst
+++ b/doc/source/users_guide/create-a-case.rst
@@ -4,7 +4,15 @@
 Creating a Case
 *********************************
 
-Creating a CIME experiment or *case* requires, at a minimum, specifying a compset and a model grid and a case directory.
+This and following sections provide more detail about the basic commands of the CIME Case Control System: **create_newcase**,
+**case.setup**, **case.build** and **case.submit**. On a supported system, you can configure, build and run many complex
+climate model configurations with only these 4 commands.
+
+To see if your machine is supported try::
+
+  > query_config --machines
+
+If you are not on an out-of-the box CIME-supported platform, you will need to :ref:`port <porting>` CIME to your system before proceeding.
 
 ===================================
 Calling **create_newcase**
@@ -12,26 +20,41 @@ Calling **create_newcase**
 
 The first step in creating a CIME-based experiment is to use `create_newcase  <../Tools_user/create_newcase.html>`_.
 
-If you are not on an out-of-the box CIME-supported platform, you will need to :ref:`port <porting>` CIME to your system before proceeding.
-
-Review the input options for `create_newcase  <../Tools_user/create_newcase.html>`_ in the  **help** text.::
+See the options for `create_newcase  <../Tools_user/create_newcase.html>`_ in the  **help** text.::
 
   > create_newcase --help
 
-The only required arguments to `create_newcase  <../Tools_user/create_newcase.html>`_ are shown here::
+The only required arguments to `create_newcase  <../Tools_user/create_newcase.html>`_ are::
 
   > create_newcase --case [CASE] --compset [COMPSET] --res [GRID]
 
+Creating a CIME experiment or *case* requires, at a minimum, specifying a compset and a model grid and a case directory.
 CIME supports out-of-the-box *component sets*, *model grids* and *hardware platforms* (machines).
 
-The [CASE] argument must be a string and may not contain any of the following special characters
-::
-
-   > + * ? < > / { } [ ] ~ ` @ :
+.. warning::
+   The [CASE] argument must be a string and may not contain any of the following special characters
+   ::
+      > + * ? < > / { } [ ] ~ ` @ :
 
 ======================================
 Results of calling **create_newcase**
 ======================================
+
+Suppose **create_newcase** was called as follows.
+Here, $CIMEROOT is the full pathname of the root directory of the CIME distribution::
+
+  > cd $CIMEROOT/scripts
+  > create_newcase --case ~/cime/example1 --compset A --res f09_g16_rx1
+
+In the example, the command creates a ``$CASEROOT`` directory: ``~/cime/example1``.
+If that directory already exists, a warning is printed and the command aborts.
+
+In the argument to ``--case``, the directory path is ignored and only the string after the last backslash is used as the [CASE].
+
+The output from create_newcase includes information such as.
+
+- The compset longname is ``2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV``
+- The model resolution is ``a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null``
 
 `create_newcase  <../Tools_user/create_newcase.html>`_ installs files in ``$CASEROOT`` that will build and run the model and to optionally archive the case on the target platform.
 

--- a/doc/source/users_guide/index.rst
+++ b/doc/source/users_guide/index.rst
@@ -44,6 +44,7 @@ Case Control System Part 2: Configuration, Porting, Testing and Use Cases
    unit_testing.rst
    multi-instance.rst
    workflows.rst
+   cime-dir.rst
 
 Indices and tables
 ==================

--- a/doc/source/users_guide/introduction-and-overview.rst
+++ b/doc/source/users_guide/introduction-and-overview.rst
@@ -118,7 +118,7 @@ For variables that can be set in more than one way, the order of precedence is:
 Quick start
 ==================
 
-To see an example of how a case is created, configured, built and run with CIME, execute the following commands for an example. (This assumes that CIME has been ported to your current machine).
+To see an example of how a case is created, configured, built and run with CIME, execute the following commands. (This assumes that CIME has been ported to your current machine).
 ::
 
    > cd cime/scripts
@@ -130,7 +130,7 @@ To see an example of how a case is created, configured, built and run with CIME,
 
 The output from each command is explained in the following sections.
 
-After you submit the case, you can follow the progress of your run by monitoring the ``CaseStatus`` file.
+After you submit the case, you can follow the progress of your run by monitoring the **CaseStatus** file.
 
 ::
 
@@ -142,6 +142,8 @@ Repeat the command until you see the message ``case.run success``.
 Discovering available cases with **query_config**
 =================================================
 
+Your CIME-driven model has many more possible cases besides the simple one in the above Quick Start.
+
 Use the utility `query_config <../Tools_user/query_config.html>`_  to see which out-of-the-box compsets, components, grids and machines are available for your model.
 
 If CIME is downloaded in standalone mode, only standalone CIME compsets can be queried.
@@ -151,6 +153,10 @@ If CIME is part of a CIME-driven model, `query_config <../Tools_user/query_confi
 To see lists of available compsets, components, grids and machines, look at the **help** text::
 
   > query_config --help
+
+To see all available component sets, try::
+
+  > query_config --compsets all
 
 **Usage examples**
 
@@ -172,9 +178,9 @@ The output will be similar to this::
    ADESP                : 2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_DESP
    AIAF                 : 2000_DATM%IAF_SLND_DICE%IAF_DOCN%IAF_DROF%IAF_SGLC_SWAV
 
-Each model component specifies its own definitions of what can appear after the ``%`` modifier in the compset longname (for example, ``DOM`` in ``DOCN%DOM``).
+Each model component specifies its own definitions of what can appear after the **%**  modifier in the compset longname (for example, **DOM** in **DOCN%DOM**).
 
-To see what supported modifiers are for ``DOCN``, run `query_config <../Tools_user/query_config.html>`_ as in this example::
+To see what supported modifiers are for **DOCN**, run `query_config <../Tools_user/query_config.html>`_ as in this example::
 
   > query_config --component docn
 
@@ -199,134 +205,6 @@ The output will be similar to this::
          _DOCN%NULL : docn null mode
           _DOCN%SOM : docn slab ocean mode
        _DOCN%SOMAQP : docn aquaplanet slab ocean mode
-    _DOCN%SST_AQUAP : docn aquaplanet mode:
+       _DOCN%SST_AQUAP : docn aquaplanet mode:
 
-.. _basic-examples:
-
-Setting up a multi-year run
-----------------------------
-
-This shows all of the steps necessary to do a CESM multi-year pre-industrial simulation starting from a "cold start" for all components.
-
-1. Create a new case named EXAMPLE_CASE in your **$HOME** directory. Use an 1850 control compset at 1-degree resolution (CESM components/resolution).
-
-   ::
-
-      > cd $CIME/scripts
-      > ./create_newcase --case ~/EXAMPLE_CASE --compset B1850 --res f09_g17
-
-2. Check the pe-layout by running **./pelayout**. Make sure it is suitable for your machine.
-   If it is not use `xmlchange <../Tools_user/xmlchange.html>`_ or  `pelayout <../Tools_user/pelayout.html>`_ to modify your pe-layout.
-   Then setup your case and build your executable.
-
-   ::
-
-      > cd ~/EXAMPLE_CASE
-      > ./case.setup
-      > ./case.build
-
-   .. warning:: The CESM2 case.build script is compute intensive and may not be suitable to run on a login node. As an alternative you would submit this job to an interactive queue.
-		For example, on the NCAR cheyenne platform, you would use **qcmd -- ./case.build** to do this.
-
-3. In your case directory, set the job to run 12 model months, set the wallclock time, and submit the job.
-
-   ::
-
-      > ./xmlchange STOP_OPTION=nmonths
-      > ./xmlchange STOP_N=12
-      > ./xmlchange JOB_WALLCLOCK_TIME=06:00 --subgroup case.run
-      > ./case.submit
-
-4. Make sure the run succeeded.
-
-   For cesm compsets, you should see the following line at the end of the **cpl.log** file in your run directory or your short term archiving directory, set by ``$DOUT_S_ROOT``.
-
-   ::
-
-      (seq_mct_drv): ===============       SUCCESSFUL TERMINATION OF CPL7-cesm ===============
-
-   For e3sm compsets, you should see the following line at the end of the **cpl.log** file in your run directory or your short term archiving directory, set by ``$DOUT_S_ROOT``.
-
-   ::
-
-      (seq_mct_drv): ===============       SUCCESSFUL TERMINATION OF CPL7-e3sm ===============
-
-5. In the same case directory, Set the case to resubmit itself 10 times so it will run a total of 11 years (including the initial year), and resubmit the case. (Note that a resubmit will automatically change the run to be a continuation run).
-
-   ::
-
-      > ./xmlchange RESUBMIT=10
-      > ./case.submit
-
-   By default resubmitted runs are not submitted until the previous run is completed.
-   To change this behavior, and submit all jobs at once (with batch dependencies such that only one job is run at a time), use the command:
-
-   ::
-
-      > ./case.submit --resubmit-immediate
-
-Setting up a branch or hybrid run
----------------------------------
-
-A branch or hybrid run uses initialization data from a previous run. Here is an example in which a valid load-balanced scenario is assumed.
-
-1. The first step in setting up a branch or hybrid run is to create a new case. A CESM compset and resolution is assumed below.
-
-   ::
-
-      > cd $CIMEROOT/scripts
-      > create_newcase --case ~/EXAMPLE_CASEp --compset B1850 --res f09_g17
-      > cd ~/EXAMPLE_CASEp
-
-
-2. For a branch run, use the following `xmlchange <../Tools_user/xmlchange.html>`_  commands to branch **EXAMPLE_CASE** at year 0001-02-01.
-
-   ::
-
-      > ./xmlchange RUN_TYPE=branch
-      > ./xmlchange RUN_REFCASE=EXAMPLE_CASE
-      > ./xmlchange RUN_REFDATE=0001-02-01
-
-3. For a hybrid run, use the following `xmlchange <../Tools_user/xmlchange.html>`_  command to start up from **EXAMPLE_CASE** at year 0001-02-01.
-
-   ::
-
-      > ./xmlchange RUN_TYPE=hybrid
-      > ./xmlchange RUN_REFCASE=EXAMPLE_CASE
-      > ./xmlchange RUN_REFDATE=0001-02-01
-
-   For a branch run, your **env_run.xml** file for **EXAMPLE_CASEp** should be identical to the file for **EXAMPLE_CASE** except for the ``$RUN_TYPE`` setting.
-
-   Also, modifications introduced into **user_nl_** files in **EXAMPLE_CASE** should be reintroduced in **EXAMPLE_CASEp**.
-
-4. Next, set up and build your case executable.
-   ::
-
-      > ./case.setup
-      > ./case.build
-
-5. Pre-stage the necessary restart/initial data in ``$RUNDIR``. Assume for this example that it was created in the **/rest/0001-02-01-00000** directory shown here:
-   ::
-
-      > cd $RUNDIR
-      > cp /user/archive/EXAMPLE_CASE/rest/0001-02-01-00000/* .
-
-   It is assumed that you already have a valid load-balanced scenario.
-   Go back to the case directory, set the job to run 12 model months, and submit the job.
-   ::
-
-      > cd ~/EXAMPLE_CASEp
-      > ./xmlchange STOP_OPTION=nmonths
-      > ./xmlchange STOP_N=12
-      > ./xmlchange JOB_WALLCLOCK_TIME=06:00
-      > ./case.submit
-
-6.  Make sure the run succeeded (see above directions) and then change
-    the run to a continuation run. Set it to resubmit itself 10 times
-    so it will run a total of 11 years (including the initial year),
-    then resubmit the case.
-    ::
-
-       > ./xmlchange CONTINUE_RUN=TRUE
-       > ./xmlchange RESUMIT=10
-       > ./case.submit
+For more details on how CIME determines the output for query_config, see :ref:`Component Sets<compsets>`.

--- a/doc/source/users_guide/introduction-and-overview.rst
+++ b/doc/source/users_guide/introduction-and-overview.rst
@@ -115,6 +115,30 @@ For variables that can be set in more than one way, the order of precedence is:
 
 - variable is set in a ``$CASEROOT`` xml file
 
+Quick start
+==================
+
+To see an example of how a case is created, configured, built and run with CIME, execute the following commands for an example. (This assumes that CIME has been ported to your current machine).
+::
+
+   > cd cime/scripts
+   > ./create_newcase --case mycase --compset X --res f19_g16
+   > cd mycase
+   > ./case.setup
+   > ./case.build
+   > ./case.submit
+
+The output from each command is explained in the following sections.
+
+After you submit the case, you can follow the progress of your run by monitoring the ``CaseStatus`` file.
+
+::
+
+   > tail CaseStatus
+
+Repeat the command until you see the message ``case.run success``.
+
+
 Discovering available cases with **query_config**
 =================================================
 
@@ -176,32 +200,6 @@ The output will be similar to this::
           _DOCN%SOM : docn slab ocean mode
        _DOCN%SOMAQP : docn aquaplanet slab ocean mode
     _DOCN%SST_AQUAP : docn aquaplanet mode:
-
-
-Quick start
-==================
-
-To see an example of how a case is created, configured, built and run with CIME, execute the following commands for an example. (This assumes that CIME has been ported to your current machine).
-::
-
-   > cd cime/scripts
-   > ./create_newcase --case mycase --compset X --res f19_g16
-   > cd mycase
-   > ./case.setup
-   > ./case.build
-   > ./case.submit
-
-The output from each command is explained in the following sections.
-
-After you submit the case, you can follow the progress of your run by monitoring the ``CaseStatus`` file.
-
-::
-
-   > tail CaseStatus
-
-Repeat the command until you see the message ``case.run success``.
-
-The following are two more detailed examples for how to setup and carry out basic runs.
 
 .. _basic-examples:
 

--- a/doc/source/users_guide/introduction-and-overview.rst
+++ b/doc/source/users_guide/introduction-and-overview.rst
@@ -14,7 +14,7 @@ Prerequisites
 =============
 
 Part 1 of this guide assumes that CIME or a CIME-driven model and the necessary input files
-have been installed on the computer you are using. If that is not the case, see Installing CIME.
+have been installed on the computer you are using. If that is not the case, see :ref:`Porting CIME<porting>`.
 
 Other prerequisites:
 
@@ -58,8 +58,7 @@ See the :ref:`glossary` for a more complete list of terms.
    For each of the 7 physical components (models), there can be three different implementations in a CIME-driven coupled model.
 
    *active*: Solve a complex set of equations to describe the model's behavior. Also called *prognostic* or *full* models.
-   Multiple active models might be available (for example POP and MPAS-ocean to represent the global ocean) but only one at a time
-   can be used in a component set.
+   These can be full General Circulation Models. Multiple active models might be available (for example POP and MPAS-ocean to represent the global ocean) but only one ocean or atmosphere model at a time can be used in a component set.
 
    *data*: For some climate problems, it is necessary to reduce feedbacks within the system by replacing an active model with a
    version that sends and receives the same variables to and from other models, but with the values read from files rather
@@ -72,7 +71,7 @@ See the :ref:`glossary` for a more complete list of terms.
 
 **component set** or **compset**:   The particular combination of active, data and stub versions of the 7 components is referred to
    as a *component set* or  *compset*.  The Case Control System allows one to define
-   several possible compsets and configure and run them on supported platforms.
+   several possible compsets and configure and run them on supported platforms. See :ref:`Component Sets<compsets>` for more information.
 
 **grid** or **model grid**:
    Each active model must solve its equations on a numerical grid. CIME allows models within the system to have
@@ -112,50 +111,9 @@ For variables that can be set in more than one way, the order of precedence is:
 
 - variable is set as an environment variable
 
-- variable is set in ``$HOME/.cime/config``
+- variable is set in ``$HOME/.cime/config`` as explained further :ref:`here<customizing-cime>`.
 
 - variable is set in a ``$CASEROOT`` xml file
-
-Directory content
-==================
-
-If you use CIME as part of a climate model or standalone, the content of the **cime** directory is the same.
-
-If you are using it as part of a climate model, **cime** is usually one of the first subdirectories under the main directory.
-
-The following is the directory structure of e3sm and cesm:
-
-    =============  ======================================
-    README, etc.   typical top-level directory content
-    components/    source code for active models
-    cime           All of CIME code"
-    =============  ======================================
-
-CIME's content is split into several subdirectories. Users should start in the **scripts/** subdirectory.
-
-   ===================== ==================================================================================
-   CMakeLists.txt	 For building with CMake
-   ChangeLog		 Developer-maintained record of changes to CIME
-   ChangeLog_template	 Template for an entry in ChangeLog
-   LICENSE.TXT		 The CIME license
-   README		 Brief intro to CIME
-   README.md		 README in markdown language
-   README.unit_testing	 Instructions for running unit tests with CIME
-   **config/**		 **Shared and model-specific configuration files**
-   config/cesm/	         CESM-specific configuration options
-   config/e3sm/	         E3SM-specific configuration options
-   **scripts/**		 **The CIME user interface**
-   scripts/lib/  	 Infrastructure source code for CIME scripts and functions
-   scripts/Tools/	 Auxiliary tools; scripts and functions
-   **src/**		 **Model source code provided by CIME**
-   src/components/	 CIME-provided components including data and stub models
-   src/drivers/  	 CIME-provided main driver for a climate model
-   src/externals/	 Software provided with CIME for building a climate model
-   src/share/    	 Model source code provided by CIME and used by multiple components
-   **tests/**		 **Tests**
-   **tools/**		 **Standalone climate modeling tools**
-   utils/		 Some Perl source code needed by some prognostic components
-   ===================== ==================================================================================
 
 Discovering available cases with **query_config**
 =================================================

--- a/doc/source/users_guide/pes-threads.rst
+++ b/doc/source/users_guide/pes-threads.rst
@@ -5,17 +5,7 @@ Controlling processors and threads
 ==================================
 
 Once a compset and resolution for a case has been defined, CIME
-provides ways to define the processor layout the case will use. A
-concept to first understand before reading the following is that of a
-**primary** component. The primary component is the component that
-defines the compset and the processor layout that will be
-created. CIME determines the primary component based on the
-combination of prognostic, data and stub components used in the
-requested compset. As an example, the primary component for a compset
-that has a prognostic atmosphere, land and cice (in prescribed mode)
-and a data ocean is the atmosphere component (for cesm this is CAM).
-In the case that all components are prognostic, the primary component
-is referred to as **allactive**.
+provides ways to define the processor layout the case will use.
 
 CIME cases have significant flexibility with respect to the layout of
 components across different hardware processors. There are up to eight
@@ -30,7 +20,7 @@ pe-settings for a case
 -------------------------
 
 CIME looks at the xml element ``PES_SPEC_FILE`` in the **$CIMEROOT/config/$model/config_files.xml** file to determine where
-to find the supported out-of-the-box model pe-settings for the primary component.
+to find the supported out-of-the-box model pe-settings for the primary component (See :ref:`Compsets<compsets>` for definition of primary component.)
 
 When your run `create_newcase  <../Tools_user/create_newcase.html>`_, CIME identifies the primary component and the setting of the ``PES_SPEC_FILE`` in the standard output.
 
@@ -98,44 +88,41 @@ instances of each component and the layout of the components across
 the hardware processors. The entries in **env_mach_pes.xml** have the
 following meanings:
 
-* ``MAX_MPITASKS_PER_NODE``
-   | The maximum number of MPI tasks per node. This is defined in **config_machines.xml** and therefore given a default setting, but can be user modified.
+.. list-table:: Entries in **env_mach_pes.xml**
+   :widths: 10 40
+   :header-rows: 1
 
-* ``MAX_TASKS_PER_NODE``
-   | The total number of (MPI tasks) * (OpenMP threads) allowed on a node. This is defined in **config_machines.xml** and therefore given a default setting, but can be user modified.
-   | Some computational platforms use a special software customized for the target hardware called symmetric multi-threading (SMT). This allows for over-subscription of the hardware cores. In cases where this is beneficial to model performance, the variable ``MAX_TASKS_PER_NODE`` will be greater than the hardware cores per node as specified by ``MAX_MPITASKS_PER_NODE``.
-
-* ``NTASKS``
-   | Total number of MPI tasks. A negative value indicates nodes rather than tasks, where *MAX_MPITASKS_PER_NODE \* -NTASKS* equals the number of MPI tasks.
-   | ``NTASKS`` can be positive or negative. If it is negative, this indicates nodes rather than tasks.
-
-* ``NTHRDS``
-   | Number of OpenMP threads per MPI task.
-   | ``NTHRDS`` must be greater than or equal to 1. If ``NTHRDS`` = 1, this generally means threading parallelization will be off for the given component.
-
-* ``ROOTPE``
-   | The global MPI task of the component root task; if negative, indicates nodes rather than tasks.
-   | The root processor for each component is set relative to the MPI global communicator.
-
-* ``PSTRID``
-   | The stride of MPI tasks across the global set of pes (for now set to 1). This variable is currently not used and is a placeholder for future development.
-
-* ``NINST``
-   | The number of component instances, which are spread evenly across NTASKS.
-
-* ``COST_PER_NODE``
-   | The numbers of cores/node used for accounting purposes. The user should not normally need to set this - but it is useful for understanding how you will be charged.
+   * - XML variable
+     - Description
+   * - MAX_MPITASKS_PER_NODE
+     - The maximum number of MPI tasks per node. This is defined in **config_machines.xml** and therefore given a default setting, but can be user modified.
+   * - MAX_TASKS_PER_NODE
+     - The total number of (MPI tasks) * (OpenMP threads) allowed on a node. This is defined in **config_machines.xml** and therefore given a default setting, but can be user modified. Some computational platforms use a special software customized for the target hardware called symmetric multi-threading (SMT). This allows for over-subscription of the hardware cores. In cases where this is beneficial to model performance, the variable ``MAX_TASKS_PER_NODE`` will be greater than the hardware cores per node as specified by ``MAX_MPITASKS_PER_NODE``.
+   * - NTASKS
+     - Total number of MPI tasks. A negative value indicates nodes rather than tasks, where *MAX_MPITASKS_PER_NODE \* -NTASKS* equals the number of MPI tasks.
+   * - NTHRDS
+     - Number of OpenMP threads per MPI task. ``NTHRDS`` must be greater than or equal to 1. If ``NTHRDS`` = 1, this generally means threading parallelization will be off for the given component.
+   * - ROOTPE
+     -  The global MPI task of the component root task; if negative, indicates nodes rather than tasks. The root processor for each component is set relative to the MPI global communicator.
+   * - PSTRID
+     - The stride of MPI tasks across the global set of pes (for now set to 1). This variable is currently not used and is a placeholder for future development.
+   * - NINST
+     -  The number of component instances, which are spread evenly across NTASKS.
+   * - COST_PER_NODE
+     -  The numbers of cores/node used for accounting purposes. The user should not normally need to set this - but it is useful for understanding how you will be charged.
 
 Each CIME component has corresponding entries for ``NTASKS``, ``NTHRDS``, ``ROOTPE`` and ``NINST`` in the **env_mach_pes.xml** file. The layout of components on processors has no impact on the science.
-If all components have identical ``NTASKS``, ``NTHRDS``, and ``ROOTPE`` settings, all components will run sequentially on the same hardware processors.
+If all components have identical ``NTASKS``, ``NTHRDS``, and ``ROOTPE`` settings, all components will exectute sequentially on the same hardware processors.
 
-The scientific sequencing is hardwired into the driver. Changing
+.. hint:: To view the current settings, use the `pelayout <../Tools_user/pelayout.html>`_ tool
+
+The time sequencing is hardwired into the driver. Changing
 processor layouts does not change intrinsic coupling lags or coupling
 sequencing.
 
-The coupler component has its own processor specification for doing
+The coupler component has its own processor set for doing
 computations such as mapping, merging, diagnostics, and flux
-calculation.  This is distinct from the driver, which automatically
+calculation.  This is distinct from the driver, which always
 runs on the union of all processors to manage model concurrency and
 sequencing.
 
@@ -148,7 +135,7 @@ with the land and ice components.  Beyond that constraint, the land,
 ice, coupler and ocean models can run concurrently, and the ocean
 model can also run concurrently with the atmosphere model.
 
-.. note:: if **env_mach_pes.xml** is modified after `case.setup <../Tools_user/case.setup.html>`_  has been called, then you must run `case.setup --reset <../Tools_user/case.setup.html>`_ and recompile using  `case.build <../Tools_user/case.build.html>`_.
+.. note:: if **env_mach_pes.xml** is modified after `case.setup <../Tools_user/case.setup.html>`_  has been called, then you must run `case.setup --reset <../Tools_user/case.setup.html>`_ and the call `case.build <../Tools_user/case.build.html>`_.  **case.build** will only recompile any source code that depends on values in **env_mach_pes.xml**
 
 Case Resource Allocation
 ------------------------
@@ -190,10 +177,10 @@ and job submit commands for your case.
 Optimizing processor layout
 ----------------------------
 
-Load balancing is the practice of specifying processor layout for a given model configuration
-(compset, grid, and so on) to optimize throughput and efficiency. For a fixed total number of
-processors, the goal of optimization to achieve maximum throughput. In contrast, for a given
-configuration across varied processor counts, the purpose is to find several "sweet spots" where
+Load balancing is the practice of specifying a processor layout for a given model configuration
+(compset, grid, and so on) to maximize simulation speed while minimizing processor idle time.
+For a fixed total number of processors, the goal of this optimization is to achieve maximum throughput.
+For a set of processor counts, the purpose is to find several "sweet spots" where
 the model is minimally idle, cost is relatively low, and the throughput is relatively high.
 
 As with most models, increasing total processors normally results in both increased throughput
@@ -210,7 +197,7 @@ internal load imbalance within a component.
 
 It is often best to load balance a system with all significant
 run-time I/O turned off because it occurs infrequently, typically just
-one timestep per month. It is best treated as a separate cost as it
+one timestep per simulated  month. It is best treated as a separate cost as it
 can otherwise bias interpretation of the overall balance.  Also, the
 use of OpenMP threading in some or all of the components is dependent
 on the hardware/OS support as well as whether the system supports
@@ -233,6 +220,8 @@ atmosphere model always run sequentially with the ice and land models
 for scientific reasons. As a result, running the atmosphere
 concurrently with the ice and land will result in idle processors at
 some point in the timestepping sequence.
+
+.. hint:: If you need to load balance a fully coupled case, use the :ref:`Load Balancing Tool<load_balancing_tool>`
 
 **One approach to load balancing**
 

--- a/doc/source/users_guide/running-a-case.rst
+++ b/doc/source/users_guide/running-a-case.rst
@@ -171,6 +171,8 @@ Below is an example of status messages:
   ``$REST_OPTION``, ``$REST_N`` and/or ``$REST_DATE``, and ``$RESUBMIT``
   before resubmitting.
 
+See the :ref:`basic example<basic_example>` for a complete example of how to run a case.
+
 ---------------------------------
 Troubleshooting a job that fails
 ---------------------------------
@@ -392,7 +394,7 @@ restart files that are required for restart.
 Archiving (referred to as short-term archiving here) is the phase of a model run when output data are
 moved from ``$RUNDIR`` to a local disk area (short-term archiving).
 It has no impact on the production run except to clean up disk space
-in the ``$RUNDIR`` and help manage user quotas.
+in the ``$RUNDIR`` which can help manage user disk quotas.
 
 Several variables in **env_run.xml** control the behavior of
 short-term archiving. This is an example of how to control the

--- a/doc/source/users_guide/setting-up-a-case.rst
+++ b/doc/source/users_guide/setting-up-a-case.rst
@@ -4,6 +4,10 @@
 Setting up a Case
 *********************************
 
+After creating a case, some aspects of the case are fixed (any variables in env_case.xml). Changing the pe-layout
+(see :ref:`Changing Pes<defining-pes>`) or some aspects of the batch system you may be using must be modified before running
+**case.setup**.
+
 ===================================
 Calling **case.setup**
 ===================================
@@ -12,9 +16,11 @@ After creating a case or changing aspects of a case, such as the pe-layout, call
 This creates the following additional files and directories in ``$CASEROOT``:
 
    =============================   ===============================================================================================================================
-   .case.run                       Run script containing the batch directives. The directives are generated using the contents
-                                   of **env_mach_pes.xml**. Running `case.setup --clean <../Tools_user/case.setup.html>`_  will remove this file. You should
-				   **never** run this script.
+   .case.run                       A (hidden) file with the commands that will be used to run the model (such as “mpirun”) and any batch directives needed. 
+                                   The directive values are generated using the contents
+                                   of **env_mach_pes.xml**. Running `case.setup --clean <../Tools_user/case.setup.html>`_  will remove this file. 
+				   This file should not be edited directly and instead controlled through XML variables in **env_batch.xml**. It should also
+				   *never* be run directly.
 
    Macros.make                     File containing machine-specific makefile directives for your target platform/compiler.
                                    This file is created if it does not already exist.
@@ -23,7 +29,7 @@ This creates the following additional files and directories in ``$CASEROOT``:
                                    Running `case.setup --clean <../Tools_user/case.setup.html>`_  will not remove the file once it has been created.
                                    However. if you remove or rename the Macros.make file, running `case.setup <../Tools_user/case.setup.html>`_ recreates it.
 
-   user_nl_xxx[_NNNN] files        Files where all user modifications to component namelists are made.
+   user_nl_xxx[_NNNN]              Files where all user modifications to component namelists are made.
 
                                    **xxx** is any one of the set of components targeted for the case.
                                    For example, for a full active CESM compset, **xxx** is cam, clm or rtm, and so on.


### PR DESCRIPTION

Edit and cleanup parts of the CCS users guide.
Further simplify the Introduction by moving the directory content description to Part 2 and the subsection on query_config to the end of the Intro.  Also move the long run and branch/hybrid examples to the "Cutomizing Your Input Variables" section.

Add/improve some content in the sections on case creation, setup, build and run.

In Part 2:  Make a few changes to the controlling pes section including converting a long list into a table, adding some references and some other minor edits.

Test suite: Built documents locally

Update gh-pages html (Y/N)?:  Y