### PR TITLE
E3sm st archive

### DIFF
--- a/config/e3sm/machines/config_machines.xml
+++ b/config/e3sm/machines/config_machines.xml
@@ -133,51 +133,45 @@
       <command name="load">cray-mpich/7.6.0</command>
     </modules>
 
-    <modules compiler="intel">
-      <command name="load">PrgEnv-intel/6.0.4</command>
-      <command name="rm">intel</command>
-      <command name="load">intel/17.0.2.174</command>
-      <command name="rm">cray-libsci</command>
-    </modules>
-
-    <modules compiler="intel18">
-      <command name="load">PrgEnv-intel/6.0.4</command>
-      <command name="rm">intel</command>
-      <command name="load">intel/18.0.2.199</command>
-      <command name="rm">cray-libsci</command>
-    </modules>
-
-    <modules compiler="gnu">
-      <command name="rm">PrgEnv-intel</command>
-      <command name="load">PrgEnv-gnu/6.0.4</command>
-      <command name="rm">gcc</command>
-      <command name="load">gcc/6.3.0</command>
-      <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/17.06.1</command>
-    </modules>
-
-    <modules compiler="gnu7">
-      <command name="rm">PrgEnv-intel</command>
-      <command name="load">PrgEnv-gnu/6.0.4</command>
-      <command name="rm">gcc</command>
-      <command name="load">gcc/7.2.0</command>
-      <command name="rm">cray-libsci</command>
-      <command name="load">cray-libsci/17.12.1</command>
-    </modules>
-
-    <modules mpilib="mpi-serial">
-      <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="rm">cray-hdf5-parallel</command>
-      <command name="rm">cray-parallel-netcdf</command>
-      <command name="load">cray-hdf5/1.8.16</command>
-      <command name="load">cray-netcdf/4.4.0</command>
-    </modules>
-    <modules mpilib="!mpi-serial">
-      <command name="rm">cray-netcdf-hdf5parallel</command>
-      <command name="load">cray-netcdf-hdf5parallel/4.4.0</command>
-      <command name="load">cray-hdf5-parallel/1.8.16</command>
-      <command name="load">cray-parallel-netcdf/1.6.1</command>
-    </modules>
+      <modules compiler="intel">
+	<command name="load">PrgEnv-intel</command>
+	<command name="switch">intel intel/18.0.1.163</command>
+	<command name="rm">cray-libsci</command>
+	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/edison</command>
+      </modules>
+      <modules compiler="intel" mpilib="!mpi-serial" >
+	<command name="load">esmf/6.3.0rp1-defio-intel17.0-mpi-O</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial" >
+	<command name="load">esmf/6.3.0rp1-defio-intel17.0-mpiuni-O</command>
+      </modules>
+      <modules compiler="cray">
+	<command name="load">PrgEnv-cray</command>
+	<command name="switch">cce cce/8.6.2</command>
+	<command name="switch">cray-libsci/17.09.1</command>
+      </modules>
+      <modules compiler="gnu">
+	<command name="load">PrgEnv-gnu</command>
+	<command name="switch">gcc gcc/7.1.0</command>
+	<command name="switch">cray-libsci/17.09.1</command>
+      </modules>
+      <modules>
+	<command name="load">papi/5.5.1.3</command>
+	<command name="swap">craype craype/2.5.12</command>
+	<command name="load">craype-ivybridge</command>
+      </modules>
+      <modules>
+	<command name="load">cray-mpich/7.6.2</command>
+      </modules>
+      <modules mpilib="mpi-serial">
+	<command name="load">cray-hdf5/1.10.0.3</command>
+	<command name="load">cray-netcdf/4.4.1.1.3</command>
+      </modules>
+      <modules mpilib="!mpi-serial">
+	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
+	<command name="load">cray-hdf5-parallel/1.10.0.3</command>
+	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
+      </modules>
   </module_system>
 
   <environment_variables>

--- a/config/e3sm/machines/config_machines.xml
+++ b/config/e3sm/machines/config_machines.xml
@@ -133,45 +133,51 @@
       <command name="load">cray-mpich/7.6.0</command>
     </modules>
 
-      <modules compiler="intel">
-	<command name="load">PrgEnv-intel</command>
-	<command name="switch">intel intel/18.0.1.163</command>
-	<command name="rm">cray-libsci</command>
-	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/edison</command>
-      </modules>
-      <modules compiler="intel" mpilib="!mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel17.0-mpi-O</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel17.0-mpiuni-O</command>
-      </modules>
-      <modules compiler="cray">
-	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.6.2</command>
-	<command name="switch">cray-libsci/17.09.1</command>
-      </modules>
-      <modules compiler="gnu">
-	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/7.1.0</command>
-	<command name="switch">cray-libsci/17.09.1</command>
-      </modules>
-      <modules>
-	<command name="load">papi/5.5.1.3</command>
-	<command name="swap">craype craype/2.5.12</command>
-	<command name="load">craype-ivybridge</command>
-      </modules>
-      <modules>
-	<command name="load">cray-mpich/7.6.2</command>
-      </modules>
-      <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.0.3</command>
-	<command name="load">cray-netcdf/4.4.1.1.3</command>
-      </modules>
-      <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
-	<command name="load">cray-hdf5-parallel/1.10.0.3</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
-      </modules>
+    <modules compiler="intel">
+      <command name="load">PrgEnv-intel/6.0.4</command>
+      <command name="rm">intel</command>
+      <command name="load">intel/17.0.2.174</command>
+      <command name="rm">cray-libsci</command>
+    </modules>
+
+    <modules compiler="intel18">
+      <command name="load">PrgEnv-intel/6.0.4</command>
+      <command name="rm">intel</command>
+      <command name="load">intel/18.0.2.199</command>
+      <command name="rm">cray-libsci</command>
+    </modules>
+
+    <modules compiler="gnu">
+      <command name="rm">PrgEnv-intel</command>
+      <command name="load">PrgEnv-gnu/6.0.4</command>
+      <command name="rm">gcc</command>
+      <command name="load">gcc/6.3.0</command>
+      <command name="rm">cray-libsci</command>
+      <command name="load">cray-libsci/17.06.1</command>
+    </modules>
+
+    <modules compiler="gnu7">
+      <command name="rm">PrgEnv-intel</command>
+      <command name="load">PrgEnv-gnu/6.0.4</command>
+      <command name="rm">gcc</command>
+      <command name="load">gcc/7.2.0</command>
+      <command name="rm">cray-libsci</command>
+      <command name="load">cray-libsci/17.12.1</command>
+    </modules>
+
+    <modules mpilib="mpi-serial">
+      <command name="rm">cray-netcdf-hdf5parallel</command>
+      <command name="rm">cray-hdf5-parallel</command>
+      <command name="rm">cray-parallel-netcdf</command>
+      <command name="load">cray-hdf5/1.8.16</command>
+      <command name="load">cray-netcdf/4.4.0</command>
+    </modules>
+    <modules mpilib="!mpi-serial">
+      <command name="rm">cray-netcdf-hdf5parallel</command>
+      <command name="load">cray-netcdf-hdf5parallel/4.4.0</command>
+      <command name="load">cray-hdf5-parallel/1.8.16</command>
+      <command name="load">cray-parallel-netcdf/1.6.1</command>
+    </modules>
   </module_system>
 
   <environment_variables>

--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -714,6 +714,8 @@ def test_env_archive(self, testdir="env_archive_test"):
         if (compname == 's'+comp.lower() or compname == 'x'+comp.lower()) and comp != 'ESP':
             logger.info("Not testing component {}".format(comp))
             components.remove(comp)
+        elif comp == 'ESP' and self.get_value('MODEL') == 'e3sm':
+            components.remove(comp)
         else:
             if compname == 'cpl':
                 compname = 'drv'


### PR DESCRIPTION
The ESP component is not used by e3sm and should not be tested in the case.st_archive tests
I also needed to update the e3sm modules for machine edison so that I could complete testing.

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: roundoff 

Fixes #2659 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
