### PR TITLE
Allow users to go up through the setup phase on non-local machines

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -137,6 +137,10 @@ def parse_command_line(args, cimeroot, description):
     # Select a driver. No selection implies mct driver
     parser.add_argument("--driver", help=argparse.SUPPRESS)
 
+    parser.add_argument("-n", "--non-local", action="store_true",
+                        help="Use when you've requested a machine that you aren't on. "
+                        "Will reduce errors for missing directories etc.")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.srcroot is not None:
@@ -173,7 +177,7 @@ def parse_command_line(args, cimeroot, description):
         args.user_mods_dir, args.pesfile, \
         args.user_grid, args.gridfile, args.srcroot, args.test, args.multi_driver, \
         args.ninst, args.walltime, args.queue, args.output_root, args.script_root, \
-        run_unsupported, args.answer, args.input_dir, args.driver
+        run_unsupported, args.answer, args.input_dir, args.driver, args.non_local
 
 ###############################################################################
 def _main_func(description):
@@ -185,7 +189,7 @@ def _main_func(description):
         user_mods_dir, pesfile, \
         user_grid, gridfile, srcroot, test, multi_driver, ninst, walltime, \
         queue, output_root, script_root, run_unsupported, \
-        answer, input_dir, driver = parse_command_line(sys.argv, cimeroot, description)
+        answer, input_dir, driver, non_local = parse_command_line(sys.argv, cimeroot, description)
 
     if script_root is None:
         caseroot = os.path.abspath(casename)
@@ -210,7 +214,7 @@ def _main_func(description):
                     multi_driver=multi_driver, ninst=ninst, test=test,
                     walltime=walltime, queue=queue, output_root=output_root,
                     run_unsupported=run_unsupported, answer=answer,
-                    input_dir=input_dir, driver=driver)
+                    input_dir=input_dir, driver=driver, non_local=non_local)
 
 ###############################################################################
 

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -279,6 +279,10 @@ def parse_command_line(args, description):
     parser.add_argument("--retry", type=int, default=default,
                         help="Automatically retry failed tests. >0 implies --wait")
 
+    parser.add_argument("-N", "--non-local", action="store_true",
+                        help="Use when you've requested a machine that you aren't on. "
+                        "Will reduce errors for missing directories etc.")
+
     CIME.utils.add_mail_type_args(parser)
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
@@ -328,6 +332,8 @@ def parse_command_line(args, description):
         args.no_build = True
         args.no_run   = True
         args.no_batch = True
+
+    expect(not (args.non_local and not args.no_build), "Cannot build on non-local machine")
 
     if args.single_submit:
         expect(not args.no_run, "Doesn't make sense to request single-submit if no-run is on")
@@ -436,7 +442,7 @@ def parse_command_line(args, description):
         args.namelists_only, args.project, \
         args.test_id, args.parallel_jobs, args.walltime, \
         args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue, \
-        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib, args.input_dir, args.pesfile, args.retry, args.mail_user, args.mail_type, args.wait_check_throughput, args.wait_check_memory, args.wait_ignore_namelists, args.wait_ignore_memleak, args.allow_pnl
+        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib, args.input_dir, args.pesfile, args.retry, args.mail_user, args.mail_type, args.wait_check_throughput, args.wait_check_memory, args.wait_ignore_namelists, args.wait_ignore_memleak, args.allow_pnl, args.non_local
 
 ###############################################################################
 def get_default_setting(config, varname, default_if_not_found, check_main=False):
@@ -544,7 +550,7 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
                 baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, project, test_id, parallel_jobs,
                 walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite, output_root, wait,
                 force_procs, force_threads, mpilib, input_dir, pesfile, mail_user, mail_type,
-                wait_check_throughput, wait_check_memory, wait_ignore_namelists, wait_ignore_memleak, allow_pnl):
+                wait_check_throughput, wait_check_memory, wait_ignore_namelists, wait_ignore_memleak, allow_pnl, non_local):
 ###############################################################################
     impl = TestScheduler(test_names, test_data=test_data,
                          no_run=no_run, no_build=no_build, no_setup=no_setup, no_batch=no_batch,
@@ -557,7 +563,7 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
                          proc_pool=proc_pool, use_existing=use_existing, save_timing=save_timing,
                          queue=queue, allow_baseline_overwrite=allow_baseline_overwrite,
                          output_root=output_root, force_procs=force_procs, force_threads=force_threads,
-                         mpilib=mpilib, input_dir=input_dir, pesfile=pesfile, mail_user=mail_user, mail_type=mail_type, allow_pnl=allow_pnl)
+                         mpilib=mpilib, input_dir=input_dir, pesfile=pesfile, mail_user=mail_user, mail_type=mail_type, allow_pnl=allow_pnl, non_local=non_local)
 
     success = impl.run_tests(wait=wait,
                              wait_check_throughput=wait_check_throughput,
@@ -596,7 +602,7 @@ def _main_func(description):
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \
     save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile, \
-    retry, mail_user, mail_type, wait_check_throughput, wait_check_memory, wait_ignore_namelists, wait_ignore_memleak, allow_pnl = \
+    retry, mail_user, mail_type, wait_check_throughput, wait_check_memory, wait_ignore_namelists, wait_ignore_memleak, allow_pnl, non_local = \
         parse_command_line(sys.argv, description)
 
     success = False
@@ -607,7 +613,7 @@ def _main_func(description):
                               baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only,
                               project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, save_timing,
                               queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile,
-                              mail_user, mail_type, wait_check_throughput, wait_check_memory, wait_ignore_namelists, wait_ignore_memleak, allow_pnl)
+                              mail_user, mail_type, wait_check_throughput, wait_check_memory, wait_ignore_namelists, wait_ignore_memleak, allow_pnl, non_local)
         run_count += 1
 
         # For testing only

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -224,32 +224,3 @@ class Compilers(GenericXML):
                 big_normal_tree.write_out(writer)
             if big_append_tree is not None:
                 big_append_tree.write_out(writer)
-
-def _add_to_macros(db, node, macros):
-    for child in db.get_children(root=node):
-        name = db.name(child)
-        attrib = db.attrib(child)
-        value = db.text(child)
-
-        if not attrib:
-            if name.startswith("ADD_"):
-                basename = name[4:]
-                if basename in macros:
-                    macros[basename] = "{} {}".format(macros[basename], value)
-                elif name in macros:
-                    macros[name] = "{} {}".format(macros[name], value)
-                else:
-                    macros[name] = value
-            else:
-                macros[name] = value
-
-        else:
-            cond_macros = macros["_COND_"]
-            for key, value2 in attrib.items():
-                if key not in cond_macros:
-                    cond_macros[key] = {}
-                if value2 not in cond_macros[key]:
-                    cond_macros[key][value2] = {}
-                cond_macros = cond_macros[key][value2]
-
-            cond_macros[name] = value

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -755,7 +755,7 @@ class Case(object):
                   multi_driver=False, ninst=1, test=False,
                   walltime=None, queue=None, output_root=None,
                   run_unsupported=False, answer=None,
-                  input_dir=None, driver=None):
+                  input_dir=None, driver=None, non_local=False):
 
         expect(check_name(compset_name, additional_chars='.'), "Invalid compset name {}".format(compset_name))
 
@@ -896,6 +896,10 @@ class Case(object):
         if output_root is None:
             output_root = self.get_value("CIME_OUTPUT_ROOT")
         self.set_value("CIME_OUTPUT_ROOT", output_root)
+        if non_local:
+            self.set_value("EXEROOT", os.path.join(output_root, "bld"))
+            self.set_value("RUNDIR", os.path.join(output_root, "run"))
+            self.set_value("NONLOCAL", True)
 
         # Overwriting an existing exeroot or rundir can cause problems
         exeroot = self.get_value("EXEROOT")
@@ -1412,7 +1416,7 @@ directory, NOT in this subdirectory."""
                multi_driver=False, ninst=1, test=False,
                walltime=None, queue=None, output_root=None,
                run_unsupported=False, answer=None,
-               input_dir=None, driver=None):
+               input_dir=None, driver=None, non_local=False):
         try:
             # Set values for env_case.xml
             self.set_lookup_value("CASE", os.path.basename(casename))
@@ -1428,7 +1432,7 @@ directory, NOT in this subdirectory."""
                            walltime=walltime, queue=queue,
                            output_root=output_root,
                            run_unsupported=run_unsupported, answer=answer,
-                           input_dir=input_dir, driver=driver)
+                           input_dir=input_dir, driver=driver, non_local=non_local)
 
             self.create_caseroot()
 

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -67,11 +67,14 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
 ###############################################################################
     os.chdir(caseroot)
 
+    non_local = case.get_value("NONLOCAL")
+
     # Check that $DIN_LOC_ROOT exists - and abort if not a namelist compare tests
-    din_loc_root = case.get_value("DIN_LOC_ROOT")
-    testcase     = case.get_value("TESTCASE")
-    expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
-           "inputdata root is not a directory: {}".format(din_loc_root))
+    if not non_local:
+        din_loc_root = case.get_value("DIN_LOC_ROOT")
+        testcase     = case.get_value("TESTCASE")
+        expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
+               "inputdata root is not a directory: {}".format(din_loc_root))
 
     # Remove batch scripts
     if reset or clean:
@@ -86,7 +89,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             case.set_value("BUILD_COMPLETE", False)
 
     if not clean:
-        case.load_env()
+        if not non_local:
+            case.load_env()
 
         models = case.get_values("COMP_CLASSES")
         mach = case.get_value("MACH")
@@ -156,7 +160,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
             else:
                 case.set_value("TOTALPES", case.total_tasks*case.thread_count)
 
-
             # May need to select new batch settings if pelayout changed (e.g. problem is now too big for prev-selected queue)
             env_batch = case.get_env("batch")
             env_batch.set_job_defaults([(case.get_primary_job(), {})], case)
@@ -195,7 +198,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         logger.info("If an old case build already exists, might want to run \'case.build --clean\' before building")
 
         # Some tests need namelists created here (ERP) - so do this if we are in test mode
-        if test_mode or get_model() == "e3sm":
+        if (test_mode or get_model() == "e3sm") and not non_local:
             logger.info("Generating component namelists as part of setup")
             case.create_namelists()
 
@@ -203,7 +206,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         env_module = case.get_env("mach_specific")
         env_module.make_env_mach_specific_file("sh", case)
         env_module.make_env_mach_specific_file("csh", case)
-        env_module.save_all_env_info("software_environment.txt")
+        if not non_local:
+            env_module.save_all_env_info("software_environment.txt")
 
         logger.info("You can now run './preview_run' to get more info on how your case will be run")
 

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -119,7 +119,7 @@ class TestScheduler(object):
                  use_existing=False, save_timing=False, queue=None,
                  allow_baseline_overwrite=False, output_root=None,
                  force_procs=None, force_threads=None, mpilib=None,
-                 input_dir=None, pesfile=None, mail_user=None, mail_type=None, allow_pnl=False):
+                 input_dir=None, pesfile=None, mail_user=None, mail_type=None, allow_pnl=False, non_local=False):
     ###########################################################################
         self._cime_root       = CIME.utils.get_cime_root()
         self._cime_model      = get_model()
@@ -132,6 +132,7 @@ class TestScheduler(object):
         self._pesfile         = pesfile
         self._allow_baseline_overwrite = allow_baseline_overwrite
         self._allow_pnl       = allow_pnl
+        self._non_local       = non_local
 
         self._mail_user = mail_user
         self._mail_type = mail_type
@@ -425,6 +426,8 @@ class TestScheduler(object):
             create_newcase_cmd += " --output-root {} ".format(self._output_root)
         if self._input_dir is not None:
             create_newcase_cmd += " --input-dir {} ".format(self._input_dir)
+        if self._non_local:
+            create_newcase_cmd += " --non-local"
 
         if self._pesfile is not None:
             create_newcase_cmd += " --pesfile {} ".format(self._pesfile)

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -52,6 +52,15 @@
     <desc>full pathname of case</desc>
   </entry>
 
+  <entry id="NONLOCAL">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>case_def</group>
+    <file>env_case.xml</file>
+    <desc>user is not on the requested machine</desc>
+  </entry>
+
   <entry id="CASETOOLS">
     <type>char</type>
     <default_value>$CASEROOT/Tools</default_value>


### PR DESCRIPTION
Also, remove a bit of unrelated dead code.

Test suite: scripts_regression_tests, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Addresses #2521 

User interface changes?: Yes, new --non-local flag for create_test/create_newcase

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
