### PR TITLE
XSD definitions did not match implementation

### DIFF
--- a/config/e3sm/machines/config_batch.xml
+++ b/config/e3sm/machines/config_batch.xml
@@ -496,8 +496,12 @@
    <batch_system MACH="summit" type="lsf" >
      <directives>
        <directive>-P {{ project }}</directive>
-       <directive compiler="!pgiacc">-alloc_flags smt2</directive>
-       <directive compiler="pgiacc">-alloc_flags "gpumps smt2"</directive>
+     </directives>
+     <directives compiler="!pgiacc">
+       <directive>-alloc_flags smt2</directive>
+     </directives>
+     <directives compiler="pgiacc">
+       <directive>-alloc_flags "gpumps smt2"</directive>
      </directives>
      <queues>
        <queue walltimemax="02:00" default="true">batch</queue>

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -138,6 +138,9 @@
         <xs:element maxOccurs="unbounded" ref="directive"/>
       </xs:sequence>
       <xs:attribute ref="queue"/>
+      <xs:attribute name="compiler"/>
+      <xs:attribute name="mpilib"/>
+      <xs:attribute name="threaded" type="xs:boolean"/>
     </xs:complexType>
   </xs:element>
 
@@ -145,10 +148,6 @@
     <xs:complexType mixed="true">
       <xs:attribute name="default"/>
       <xs:attribute name="prefix"/>
-      <xs:attribute name="compiler"/>
-      <xs:attribute name="mpilib"/>
-      <xs:attribute name="threaded" type="xs:boolean"/>
-      <xs:attribute name="queue"/>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
XSD expected selectors on the \<directive\> elements, but env_batch.py
is coded to expect these on the parent \<directives\> element. The latter
is more consistent with the rest of CIME.

Test suite: by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b 
