### PR TITLE
Bluewaters update

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -241,7 +241,7 @@ using a fortran linker.
   <FREEFLAGS>
     <base> -free </base>
   </FREEFLAGS>
-  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
+  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
     <append compile_threaded="true"> -qopenmp </append>
   </LDFLAGS>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -241,7 +241,7 @@ using a fortran linker.
   <FREEFLAGS>
     <base> -free </base>
   </FREEFLAGS>
-  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
+  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
   <LDFLAGS>
     <append compile_threaded="true"> -qopenmp </append>
   </LDFLAGS>
@@ -467,6 +467,9 @@ using a fortran linker.
     <append MODEL="gptl"> -DHAVE_PAPI </append>
   </CPPDEFS>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+</compiler>
+<compiler MACH="bluewaters" COMPILER="intel">
+  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
 </compiler>
 
 <compiler MACH="bluewaters" COMPILER="pgi">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -54,7 +54,7 @@
     <DESC>ORNL XE6, os is CNL, 32 pes/node, batch system is PBS</DESC>
     <NODENAME_REGEX>h2o</NODENAME_REGEX>
     <OS>CNL</OS>
-    <COMPILERS>pgi,cray,gnu</COMPILERS>
+    <COMPILERS>intel,pgi,cray,gnu</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <PROJECT>banu</PROJECT>
     <CIME_OUTPUT_ROOT>/scratch/sciteam/$USER</CIME_OUTPUT_ROOT>
@@ -89,10 +89,22 @@
       <cmd_path lang="csh">module</cmd_path>
       <modules>
 	<command name="rm">PrgEnv-pgi</command>
+	<command name="rm">PrgEnv-intel</command>
 	<command name="rm">PrgEnv-cray</command>
 	<command name="rm">PrgEnv-gnu</command>
 	<command name="rm">pgi</command>
 	<command name="rm">cray</command>
+	<command name="rm">intel</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">gcc</command>
+      </modules>
+      <modules compiler="intel">
+	<command name="load">PrgEnv-intel</command>
+	<command name="rm">intel</command>
+	<command name="load">intel/17.0.4.196</command>
+	<!-- the PrgEnv-intel loads a gcc compiler that causes several
+	problems -->
+	<command name="rm">gcc</command>
       </modules>
       <modules compiler="pgi">
 	<command name="load">PrgEnv-pgi</command>
@@ -128,6 +140,7 @@
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
+      <env name="PATH">$ENV{HOME}/bin:$ENV{PATH}</env>
     </environment_variables>
   </machine>
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -553,7 +553,7 @@ class EnvBatch(EnvBase):
         if not batch_env_flag:
             return run_args_str
         else:
-            return "{} ARGS_FOR_SCRIPT='{}'".format(batch_env_flag, run_args_str)
+            return "{} ARGS_FOR_SCRIPT=\'{}\'".format(batch_env_flag, run_args_str)
 
     def _submit_single_job(self, case, job, dep_jobs=None, allow_fail=False,
                            no_batch=False, skip_pnl=False, mail_user=None, mail_type=None,

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -285,6 +285,13 @@ class GenericXML(object):
         version = 1.0 if version is None else float(version)
         return version
 
+    def find_xmllint(self):
+        if "XMLLINT" in os.environ:
+            xmllint = os.environ["XMLLINT"]
+        else:
+            xmllint = find_executable("xmllint")
+        return xmllint
+
     def write(self, outfile=None, force_write=False):
         """
         Write an xml file from data in self
@@ -300,7 +307,7 @@ class GenericXML(object):
         xmlstr = self.get_raw_record()
 
         # xmllint provides a better format option for the output file
-        xmllint = find_executable("xmllint")
+        xmllint = self.find_xmllint()
         if xmllint is not None:
             if isinstance(outfile, six.string_types):
                 run_cmd_no_fail("{} --format --output {} -".format(xmllint, outfile), input_str=xmlstr)
@@ -476,7 +483,7 @@ class GenericXML(object):
         """
         expect(os.path.isfile(filename),"xml file not found {}".format(filename))
         expect(os.path.isfile(schema),"schema file not found {}".format(schema))
-        xmllint = find_executable("xmllint")
+        xmllint = self.find_xmllint()
         if xmllint is not None:
             logger.debug("Checking file {} against schema {}".format(filename, schema))
             run_cmd_no_fail("{} --noout --schema {} {}".format(xmllint, schema, filename))

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -285,13 +285,6 @@ class GenericXML(object):
         version = 1.0 if version is None else float(version)
         return version
 
-    def find_xmllint(self):
-        if "XMLLINT" in os.environ:
-            xmllint = os.environ["XMLLINT"]
-        else:
-            xmllint = find_executable("xmllint")
-        return xmllint
-
     def write(self, outfile=None, force_write=False):
         """
         Write an xml file from data in self
@@ -307,7 +300,7 @@ class GenericXML(object):
         xmlstr = self.get_raw_record()
 
         # xmllint provides a better format option for the output file
-        xmllint = self.find_xmllint()
+        xmllint = find_executable("xmllint")
         if xmllint is not None:
             if isinstance(outfile, six.string_types):
                 run_cmd_no_fail("{} --format --output {} -".format(xmllint, outfile), input_str=xmlstr)
@@ -483,7 +476,7 @@ class GenericXML(object):
         """
         expect(os.path.isfile(filename),"xml file not found {}".format(filename))
         expect(os.path.isfile(schema),"schema file not found {}".format(schema))
-        xmllint = self.find_xmllint()
+        xmllint = find_executable("xmllint")
         if xmllint is not None:
             logger.debug("Checking file {} against schema {}".format(filename, schema))
             run_cmd_no_fail("{} --noout --schema {} {}".format(xmllint, schema, filename))


### PR DESCRIPTION
Set bluewaters default compiler to intel, workaround gcc problem there. 

Test suite: scripts_regression_tests.py, ect uf test
Test baseline: 
Test namelist changes: 
Test status:  roundoff

Fixes
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
