### PR TITLE
Use ConfigParser rather than SafeConfigParser

### DIFF
--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -75,7 +75,7 @@ def parse_command_line(args, description):
             args.mail_type, args.batch_args)
 
 ###############################################################################
-def _main_func(description):
+def _main_func(description, test_args=False):
 ###############################################################################
     caseroot, job, no_batch, prereq, allow_fail, resubmit, resubmit_immediate, skip_pnl, \
         mail_user, mail_type, batch_args = parse_command_line(sys.argv, description)
@@ -98,10 +98,11 @@ def _main_func(description):
     elif os.path.exists(config_file):
         os.remove(config_file)
 
-    with Case(caseroot, read_only=False) as case:
-        case.submit(job=job, no_batch=no_batch, prereq=prereq, allow_fail=allow_fail,
-                    resubmit=resubmit, resubmit_immediate=resubmit_immediate, skip_pnl=skip_pnl,
-                    mail_user=mail_user, mail_type=mail_type, batch_args=batch_args)
+    if not test_args:
+        with Case(caseroot, read_only=False) as case:
+            case.submit(job=job, no_batch=no_batch, prereq=prereq, allow_fail=allow_fail,
+                        resubmit=resubmit, resubmit_immediate=resubmit_immediate, skip_pnl=skip_pnl,
+                        mail_user=mail_user, mail_type=mail_type, batch_args=batch_args)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -83,7 +83,7 @@ def _main_func(description):
     # save these options to a hidden file for use during resubmit
     config_file = os.path.join(caseroot,".submit_options")
     if skip_pnl or mail_user or mail_type or batch_args:
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config.add_section("SubmitOptions")
         if skip_pnl:
             config.set("SubmitOptions", "skip_pnl", "True")

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1972,6 +1972,21 @@ class K_TestCimeCase(TestCreateTestCommon):
 
             self.assertEqual(problems, "", msg=problems)
 
+    ###########################################################################
+    def test_case_submit_interface(self):
+    ###########################################################################
+        try:
+            import imp
+        except ImportError:
+            print("imp not found, skipping case.submit interface test")
+            return
+        sys.path.append(TOOLS_DIR)
+        case_submit_path = os.path.join(TOOLS_DIR, "case.submit")
+        submit_interface = imp.load_source("case_submit_interface", case_submit_path)
+        sys.argv = ["case.submit", "--batch-args", "'random_arguments_here.%j'",
+                    "--mail-type", "fail", "--mail-user", "'random_arguments_here.%j'"]
+        submit_interface._main_func(None, True)
+
 ###############################################################################
 class X_TestSingleSubmit(TestCreateTestCommon):
 ###############################################################################


### PR DESCRIPTION
This enables submitting jobs with batch arguments which substitute things like the job id into their strings. For an example, see E3SM-Project/E3SM#2395

Test suite: scripts_regression_tests B_CheckCode and Z_FullSystemTest
Test status: BFB

Fixes #2679

Code review: @jedwards4b 
