### PR TITLE
fix issue with e3sm mali file archiving

### DIFF
--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -227,7 +227,7 @@ def _archive_history_files(archive, archive_entry,
     # run directory are those that are needed for restarts
 
     for suffix in archive.get_hist_file_extensions(archive_entry):
-        if compname.find('mpas') == 0:
+        if compname.find('mpas') == 0 or compname == 'mali':
             newsuffix =                    compname + r'\d*'
         else:
             newsuffix = casename + r'\.' + compname + r'_?' + r'\d*'
@@ -385,7 +385,7 @@ def _archive_restarts_date_comp(case, casename, rundir, archive, archive_entry,
     for suffix in archive.get_rest_file_extensions(archive_entry):
 #        logger.debug("suffix is {} ninst {}".format(suffix, ninst))
         restfiles = ""
-        if compname.find("mpas") == 0:
+        if compname.find('mpas') == 0 or compname == 'mali':
             pattern = compname + r'\.' + suffix + r'\.' + '_'.join(datename_str.rsplit('-', 1))
             pfile = re.compile(pattern)
             restfiles = [f for f in os.listdir(rundir) if pfile.search(f)]


### PR DESCRIPTION
Fix the e3sm case.st_archive --test-all option by adding component mali to the list of mpas style 
non-conforming file names.   

Test suite: byhand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
