### PR TITLE
fix issue with rebuilding csm_share

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -30,6 +30,7 @@ CP    := cp
 exec_se: $(EXEC_SE)  Depends
 complib: $(COMPLIB)  Depends
 
+
 CIME_MODEL ?= $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) MODEL --value)
 EXEROOT ?= $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) EXEROOT --value)
 SMP_PRESENT ?= $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) SMP_PRESENT --value)
@@ -849,21 +850,23 @@ $(MCTLIBS)  : $(MPISERIAL)
 $(PIOLIB) : $(MPISERIAL) $(GPTLLIB)
 
 $(CSMSHARELIB):  $(MCTLIBS) $(PIOLIB) $(GPTLLIB)
+
 ifneq ($(MODEL),csm_share)
   $(OBJS):  $(CSMSHARELIB)
+else
+  complib: install_lib
 endif
+
+install_lib: $(COMPLIB)
+	$(CP) -p $(COMPLIB) $(CSMSHARELIB)
+	$(CP) -p *.$(MOD_SUFFIX) *.h $(INCLUDE_DIR)
+
 
 $(EXEC_SE): $(OBJS) $(ULIBDEP) $(CSMSHARELIB) $(MCTLIBS) $(PIOLIB) $(GPTLLIB)
 	$(LD) -o $(EXEC_SE) $(OBJS) $(CLIBS) $(ULIBS) $(SLIBS) $(MLIBS) $(LDFLAGS)
 
-ifdef INCLUDE_DIR
-  $(COMPLIB): $(OBJS)
+$(COMPLIB): $(OBJS)
 	$(AR) -r $(COMPLIB) $(OBJS)
-	$(CP) *.$(MOD_SUFFIX) *.h $(INCLUDE_DIR)
-else
-  $(COMPLIB): $(OBJS)
-	$(AR) -r $(COMPLIB) $(OBJS)
-endif
 
 .c.o:
 	$(CC) -c $(INCLDIR) $(INCS) $(CFLAGS)  $<

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -100,10 +100,10 @@ def buildlib(bldroot, installpath, caseroot):
         for _file in glob.iglob(os.path.join(cimeroot,"src","share","RandNum","include","*")):
             copyifnewer(_file, os.path.join(installdir, "include", os.path.basename(_file)))
 
-        # This runs the gptl make command
+        # This runs the make command
         gmake_opts = "-f {}/Makefile complib MODEL=csm_share ".format(os.path.join(caseroot,"Tools"))
         gmake_opts += "-j {} ".format(case.get_value("GMAKE_J"))
-        gmake_opts += " COMPLIB={} ".format(os.path.join(installdir,"lib","libcsm_share.a"))
+        gmake_opts += " COMPLIB=libcsm_share.a"
         gmake_opts += " USER_CPPDEFS=\"{}\" ".format(multiinst_cppdefs)
         gmake_opts += " CASEROOT={} ".format(caseroot)
         gmake_opts += " CIMEROOT={} ".format(cimeroot)


### PR DESCRIPTION
The ability to use shared builds to improve test performance was lost by a change in the way csm_share was built in tag cime5.4.0-alpha10, this reverts part of that change so that if the csm_share library is built it won't get built again.

Test suite: scripts_regression_tests.py, hand testing
Test baseline: 
Test namelist changes: 
Test status:bit for bit

Fixes #2681 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
