### PR TITLE
Fix for passing run arguments in LSF

### DIFF
--- a/config/e3sm/machines/config_batch.xml
+++ b/config/e3sm/machines/config_batch.xml
@@ -104,6 +104,7 @@
     <batch_query args=" -w" >bjobs</batch_query>
     <batch_submit>bsub</batch_submit>
     <batch_cancel>bkill</batch_cancel>
+    <batch_env>-env</batch_env>
     <batch_directive>#BSUB</batch_directive>
     <jobid_pattern>&lt;(\d+)&gt;</jobid_pattern>
     <depend_string> -w 'done(jobid)'</depend_string>

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -552,8 +552,15 @@ class EnvBatch(EnvBase):
         batch_env_flag = self.get_value("batch_env", subgroup=None)
         if not batch_env_flag:
             return run_args_str
+        elif len(run_args_str) > 0:
+            batch_system = self.get_value("BATCH_SYSTEM", subgroup=None)
+            logger.info("batch_system: {}: ".format(batch_system))
+            if batch_system == "lsf":
+                return "{} \"all, ARGS_FOR_SCRIPT={}\"".format(batch_env_flag, run_args_str)
+            else:
+                return "{} ARGS_FOR_SCRIPT='{}'".format(batch_env_flag, run_args_str)
         else:
-            return "{} ARGS_FOR_SCRIPT=\'{}\'".format(batch_env_flag, run_args_str)
+            return ""
 
     def _submit_single_job(self, case, job, dep_jobs=None, allow_fail=False,
                            no_batch=False, skip_pnl=False, mail_user=None, mail_type=None,


### PR DESCRIPTION
This detects when LSF is the queue being used, and then passes the arguments to .case.run in a way that it supports.
This should be superseded by a more general fix.
This is currently being tested with scripts_regression_tests on a machine with an LSF queue in addition to on Skybridge; I'll update this when finished.

Test suite: B_CheckCode, Z_FullSystemTest
Test status: ok

Code review: @jedwards4b 
