### PR TITLE
Make docs more consistent

### DIFF
--- a/doc/source/users_guide/create-a-case.rst
+++ b/doc/source/users_guide/create-a-case.rst
@@ -38,7 +38,7 @@ CIME supports out-of-the-box *component sets*, *model grids* and *hardware platf
 
 ``CASEROOT`` can be a full path specifying where the case should be created; the name of
 the case will be the last component of the path. If not a full path, then the case is
-created under the current working directory.
+created in a location relative to the current working directory.
 
 ======================================
 Results of calling **create_newcase**

--- a/doc/source/users_guide/create-a-case.rst
+++ b/doc/source/users_guide/create-a-case.rst
@@ -26,19 +26,23 @@ See the options for `create_newcase  <../Tools_user/create_newcase.html>`_ in th
 
 The only required arguments to `create_newcase  <../Tools_user/create_newcase.html>`_ are::
 
-  > create_newcase --case CASEROOT --compset COMPSET --res GRID
+  > create_newcase --case CASENAME --compset COMPSET --res GRID
 
 Creating a CIME experiment or *case* requires, at a minimum, specifying a compset and a model grid and a case directory.
 CIME supports out-of-the-box *component sets*, *model grids* and *hardware platforms* (machines).
 
 .. warning::
-   The ``CASEROOT`` argument must be a string and may not contain any of the following special characters
+   The ``--case`` argument must be a string and may not contain any of the following special characters
    ::
       > + * ? < > { } [ ] ~ ` @ :
 
-``CASEROOT`` can be a full path specifying where the case should be created; the name of
-the case will be the last component of the path. If not a full path, then the case is
-created in a location relative to the current working directory.
+The ``--case`` argument is used to define the name of your case, a very important piece of
+metadata that will be used in filenames, internal metadata and directory paths. The
+``CASEROOT`` is a directory create_newcase will create with the same name as the
+``CASENAME``. If ``CASENAME`` is simply a name (not a path), ``CASEROOT`` is created in
+the directory where you execute create_newcase. If ``CASENAME`` is a relative or absolute
+path, ``CASEROOT`` is created there, and the name of the case will be the last component
+of the path.
 
 ======================================
 Results of calling **create_newcase**
@@ -53,8 +57,8 @@ Here, $CIMEROOT is the full pathname of the root directory of the CIME distribut
 In the example, the command creates a ``$CASEROOT`` directory: ``~/cime/example1``.
 If that directory already exists, a warning is printed and the command aborts.
 
-In the argument to ``--case``, the directory path is ignored and only the string after the
-last slash is used as the case name --- so here the case name is ``example1``.
+In the argument to ``--case``, the case name is taken from the string after the last slash
+--- so here the case name is ``example1``.
 
 The output from create_newcase includes information such as.
 

--- a/doc/source/users_guide/create-a-case.rst
+++ b/doc/source/users_guide/create-a-case.rst
@@ -26,13 +26,13 @@ See the options for `create_newcase  <../Tools_user/create_newcase.html>`_ in th
 
 The only required arguments to `create_newcase  <../Tools_user/create_newcase.html>`_ are::
 
-  > create_newcase --case [CASE] --compset [COMPSET] --res [GRID]
+  > create_newcase --case CASE --compset COMPSET --res GRID
 
 Creating a CIME experiment or *case* requires, at a minimum, specifying a compset and a model grid and a case directory.
 CIME supports out-of-the-box *component sets*, *model grids* and *hardware platforms* (machines).
 
 .. warning::
-   The [CASE] argument must be a string and may not contain any of the following special characters
+   The ``CASE`` argument must be a string and may not contain any of the following special characters
    ::
       > + * ? < > / { } [ ] ~ ` @ :
 

--- a/doc/source/users_guide/create-a-case.rst
+++ b/doc/source/users_guide/create-a-case.rst
@@ -26,15 +26,19 @@ See the options for `create_newcase  <../Tools_user/create_newcase.html>`_ in th
 
 The only required arguments to `create_newcase  <../Tools_user/create_newcase.html>`_ are::
 
-  > create_newcase --case CASE --compset COMPSET --res GRID
+  > create_newcase --case CASEROOT --compset COMPSET --res GRID
 
 Creating a CIME experiment or *case* requires, at a minimum, specifying a compset and a model grid and a case directory.
 CIME supports out-of-the-box *component sets*, *model grids* and *hardware platforms* (machines).
 
 .. warning::
-   The ``CASE`` argument must be a string and may not contain any of the following special characters
+   The ``CASEROOT`` argument must be a string and may not contain any of the following special characters
    ::
-      > + * ? < > / { } [ ] ~ ` @ :
+      > + * ? < > { } [ ] ~ ` @ :
+
+``CASEROOT`` can be a full path specifying where the case should be created; the name of
+the case will be the last component of the path. If not a full path, then the case is
+created under the current working directory.
 
 ======================================
 Results of calling **create_newcase**

--- a/doc/source/users_guide/create-a-case.rst
+++ b/doc/source/users_guide/create-a-case.rst
@@ -53,7 +53,8 @@ Here, $CIMEROOT is the full pathname of the root directory of the CIME distribut
 In the example, the command creates a ``$CASEROOT`` directory: ``~/cime/example1``.
 If that directory already exists, a warning is printed and the command aborts.
 
-In the argument to ``--case``, the directory path is ignored and only the string after the last backslash is used as the [CASE].
+In the argument to ``--case``, the directory path is ignored and only the string after the
+last slash is used as the case name --- so here the case name is ``example1``.
 
 The output from create_newcase includes information such as.
 

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -31,7 +31,7 @@ def parse_command_line(args, cimeroot, description):
                         help="(required) Specify a compset. "
                         "\nTo see list of current compsets, use the utility ./query_config --compsets in this directory.\n")
 
-    parser.add_argument("--res", "-res", required=True,
+    parser.add_argument("--res", "-res", required=True, metavar="GRID",
                         help="(required) Specify a model grid resolution. "
                         "\nTo see list of current model resolutions, use the utility "
                         "\n./query_config --grids in this directory.")

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -23,9 +23,11 @@ def parse_command_line(args, cimeroot, description):
     except:
         cime_config = None
 
-    parser.add_argument("--case", "-case", required=True,
+    parser.add_argument("--case", "-case", required=True, metavar="CASEROOT",
                         help="(required) Specify the case name. "
-                        "\nIf not a full pathname, then the case is created under then current working directory.")
+                        "\nCan be a full path specifying where the case should be created; "
+                        "\nthe name of the case will be the last component of the path. "
+                        "\nIf not a full path, then the case is created under then current working directory.")
 
     parser.add_argument("--compset", "-compset", required=True,
                         help="(required) Specify a compset. "

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -23,11 +23,11 @@ def parse_command_line(args, cimeroot, description):
     except:
         cime_config = None
 
-    parser.add_argument("--case", "-case", required=True, metavar="CASEROOT",
+    parser.add_argument("--case", "-case", required=True, metavar="CASENAME",
                         help="(required) Specify the case name. "
-                        "\nCan be a full path specifying where the case should be created; "
-                        "\nthe name of the case will be the last component of the path. "
-                        "\nIf not a full path, then the case is created in a location relative to the current working directory.")
+                        "\nIf this is simply a name (not a path), the case directory is created in the current working directory."
+                        "\nThis can also be a relative or absolute path specifying where the case should be created;"
+                        "\nwith this usage, the name of the case will be the last component of the path.")
 
     parser.add_argument("--compset", "-compset", required=True,
                         help="(required) Specify a compset. "

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -27,7 +27,7 @@ def parse_command_line(args, cimeroot, description):
                         help="(required) Specify the case name. "
                         "\nCan be a full path specifying where the case should be created; "
                         "\nthe name of the case will be the last component of the path. "
-                        "\nIf not a full path, then the case is created under then current working directory.")
+                        "\nIf not a full path, then the case is created in a location relative to the current working directory.")
 
     parser.add_argument("--compset", "-compset", required=True,
                         help="(required) Specify a compset. "


### PR DESCRIPTION
Three small changes to create_newcase --help and sphinx-based
documentation:

(1) Remove square brackets around command-line arguments in sphinx-based
    documentation of create_newcase command.

   Square brackets usually suggest that an argument is optional. Here the
   argument is required. Removing the square brackets makes the
   documentation more consistent with the output from
   `./create_newcase --help`.

(2) Make the help for create_newcase use GRID instead of RES

   This makes the help output consistent with our documentation

(3) Refer to the --case argument as CASEROOT rather than CASE

   Elsewhere in the documentation, we distinguish between CASEROOT and
   CASE. So it is confusing that we were labeling the --case argument as
   CASE, when really this was giving CASEROOT.

   Also add a bit more documentation about this argument.

Test suite: code_checker on create_newcase; manually checked
   create_newcase --help
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes none

User interface changes?: none

Update gh-pages html (Y/N)?: Y
   I can do this update if this PR is approved

Code review: 
