### PR TITLE
add return_values to machines.py for XML to HTML machine script

### DIFF
--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -320,3 +320,30 @@ class Machines(GenericXML):
                 print("      pes/node       ",self.text(max_mpitasks_per_node))
             if max_tasks_per_node is not None:
                 print("      max_tasks/node ",self.text(max_tasks_per_node))
+
+    def return_values(self):
+        # return a dictionary of machine info
+        machines = self.get_children("machine")
+        mach_dict = dict()
+        logger.info("Machines return values")
+        for machine in machines:
+            name = self.get(machine, "MACH")
+            
+            desc = self.get_child("DESC", root=machine)
+            mach_dict[(name,"description")] = self.text(desc)
+            
+            os_  = self.get_child("OS", root=machine)
+            mach_dict[(name,"os")] = self.text(os_)
+            
+            compilers = self.get_child("COMPILERS", root=machine)
+            mach_dict[(name,"compilers")] = self.text(compilers)
+            
+            max_tasks_per_node = self.get_child("MAX_TASKS_PER_NODE", root=machine)
+            if max_tasks_per_node is not None:
+                mach_dict[(name,"max_tasks_per_node")] = self.text(max_tasks_per_node)
+
+            max_mpitasks_per_node = self.get_child("MAX_MPITASKS_PER_NODE", root=machine)
+            if max_mpitasks_per_node is not None:
+                mach_dict[(name,"max_mpitasks_per_node")] = self.text( max_mpitasks_per_node)
+
+        return mach_dict


### PR DESCRIPTION
Adding method called return_values to return a dictionary of values in order
to work with the machdef2html.py script. 

Test suite: N/A
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes [CIME Github issue #] None

User interface changes?: None

Update gh-pages html (Y/N)?: N

Code review: 
