### PR TITLE
Maint 5.6 nersc update

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -583,12 +583,12 @@
 	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.0.3</command>
+	<command name="load">cray-hdf5/1.10.1,1</command>
 	<command name="load">cray-netcdf/4.4.1.1.6</command>
       </modules>
       <modules mpilib="!mpi-serial">
 	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-	<command name="load">cray-hdf5-parallel/1.10.0.3</command>
+	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
 	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
       <modules>
@@ -597,6 +597,8 @@
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">256M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
     </environment_variables>
   </machine>
   <machine MACH="cori-knl">
@@ -686,12 +688,12 @@
 	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.0.3</command>
+	<command name="load">cray-hdf5/1.10.1.1</command>
 	<command name="load">cray-netcdf/4.4.1.1.6</command>
       </modules>
       <modules mpilib="!mpi-serial">
 	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-	<command name="load">cray-hdf5-parallel/1.10.0.3</command>
+	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
 	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
       <modules>
@@ -700,6 +702,8 @@
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">256M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
     </environment_variables>
   </machine>
 
@@ -844,18 +848,20 @@
 	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.0.3</command>
+	<command name="load">cray-hdf5/1.10.1.1</command>
 	<command name="load">cray-netcdf/4.4.1.1.6</command>
       </modules>
       <modules mpilib="!mpi-serial">
 	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-	<command name="load">cray-hdf5-parallel/1.10.0.3</command>
+	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
 	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
     </module_system>
 
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
+      <env name="OMP_PROC_BIND">spread</env>
+      <env name="OMP_PLACES">threads</env>
     </environment_variables>
 
   </machine>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -583,7 +583,7 @@
 	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.1,1</command>
+	<command name="load">cray-hdf5/1.10.1.1</command>
 	<command name="load">cray-netcdf/4.4.1.1.6</command>
       </modules>
       <modules mpilib="!mpi-serial">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -519,6 +519,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
+	<arg name="binding"> -c {{ srun_binding }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -552,7 +553,7 @@
 
       <modules compiler="intel">
 	<command name="load">PrgEnv-intel</command>
-	<command name="switch">intel intel/18.0.1.163</command>
+	<command name="switch">intel intel/18.0.2.199</command>
 	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
@@ -564,11 +565,11 @@
 
       <modules compiler="cray">
 	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.6.2</command>
+	<command name="switch">cce cce/8.6.5</command>
       </modules>
       <modules compiler="gnu">
 	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/7.1.0</command>
+	<command name="switch">gcc gcc/7.3.0</command>
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
@@ -576,17 +577,17 @@
 	<command name="swap">craype craype/2.5.12</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/17.09.1</command>
+	<command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.6.2</command>
+	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpi-serial">
 	<command name="load">cray-hdf5/1.10.0.3</command>
-	<command name="load">cray-netcdf/4.4.1.1.3</command>
+	<command name="load">cray-netcdf/4.4.1.1.6</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
 	<command name="load">cray-hdf5-parallel/1.10.0.3</command>
 	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
@@ -623,7 +624,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
-	<arg name="binding"> -c 4 --cpu_bind=cores</arg>
+	<arg name="binding"> -c {{ srun_binding }} --cpu_bind=cores</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -667,29 +668,29 @@
 
       <modules compiler="cray">
 	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.6.2</command>
+	<command name="switch">cce cce/8.6.5</command>
       </modules>
       <modules compiler="gnu">
 	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/7.1.0</command>
+	<command name="switch">gcc gcc/7.3.0</command>
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
 	<command name="load">craype-mic-knl</command>
-	<command name="swap">craype craype/2.5.12</command>
+	<command name="swap">craype craype/2.5.14</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/17.09.1</command>
+	<command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.6.2</command>
+	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpi-serial">
 	<command name="load">cray-hdf5/1.10.0.3</command>
-	<command name="load">cray-netcdf/4.4.1.1.3</command>
+	<command name="load">cray-netcdf/4.4.1.1.6</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
 	<command name="load">cray-hdf5-parallel/1.10.0.3</command>
 	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
@@ -780,7 +781,7 @@
       <arguments>
 	<arg name="label"> --label</arg>
 	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
-	<arg name="thread_count" > -c $ENV{OMP_NUM_THREADS}</arg>
+	<arg name="thread_count" > -c {{ srun_binding }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -826,28 +827,28 @@
       </modules>
       <modules compiler="cray">
 	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.6.2</command>
-	<command name="switch">cray-libsci/17.09.1</command>
+	<command name="switch">cce cce/8.6.5</command>
+	<command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules compiler="gnu">
 	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/7.1.0</command>
-	<command name="switch">cray-libsci/17.09.1</command>
+	<command name="switch">gcc gcc/7.3.0</command>
+	<command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules>
-	<command name="load">papi/5.5.1.3</command>
-	<command name="swap">craype craype/2.5.12</command>
+	<command name="load">papi/5.5.1.4</command>
+	<command name="swap">craype craype/2.5.14</command>
 	<command name="load">craype-ivybridge</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.6.2</command>
+	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpi-serial">
 	<command name="load">cray-hdf5/1.10.0.3</command>
-	<command name="load">cray-netcdf/4.4.1.1.3</command>
+	<command name="load">cray-netcdf/4.4.1.1.6</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.3</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
 	<command name="load">cray-hdf5-parallel/1.10.0.3</command>
 	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>

--- a/scripts/Tools/preview_run
+++ b/scripts/Tools/preview_run
@@ -68,6 +68,8 @@ def _main_func(description):
             print("  FOR JOB: {}".format(job_id))
             print("    ENV:")
             case.load_env(job=job_id, reset=True, verbose=True)
+            if "OMP_NUM_THREADS" in os.environ:
+                print("      Setting Environment OMP_NUM_THREADS={}".format(os.environ["OMP_NUM_THREADS"]))
             print("    SUBMIT CMD:")
             print("      {}".format(case.get_resolved_value(cmd)))
             print("")

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -123,6 +123,7 @@ class Case(object):
         self.spare_nodes = None
         self.tasks_per_numa = None
         self.cores_per_task = None
+        self.srun_binding = None
 
         # check if case has been configured and if so initialize derived
         if self.get_value("CASEROOT") is not None:
@@ -177,6 +178,8 @@ class Case(object):
         self.cores_per_task = self.thread_count / threads_per_core
 
         os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
+
+        self.srun_binding = max_mpitasks_per_node / self.tasks_per_node
 
     # Define __enter__ and __exit__ so that we can use this as a context manager
     # and force a flush on exit.

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -179,7 +179,7 @@ class Case(object):
 
         os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
 
-        self.srun_binding = max_mpitasks_per_node / self.tasks_per_node
+        self.srun_binding = smt_factor*max_mpitasks_per_node / self.tasks_per_node
 
     # Define __enter__ and __exit__ so that we can use this as a context manager
     # and force a flush on exit.


### PR DESCRIPTION
Updates modules for nersc, added new variable for srun -s option.

Test suite: prealpha on edison, cori-haswell, cori-knl 
Test baseline: 
Test namelist changes: 
Test status: roundoff

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
