### PR TITLE
dont adjust specificity if attribute on field

### DIFF
--- a/scripts/lib/CIME/XML/compilerblock.py
+++ b/scripts/lib/CIME/XML/compilerblock.py
@@ -191,7 +191,6 @@ class CompilerBlock(object):
         append = self._db.name(elem) == "append" or (self._db.name(elem) == "base" and self._compiler and self._db.compiler != self._compiler)
         setting = ValueSetting(value_text, append,
                                conditions, set_up, tear_down)
-
         return (setting, depends)
 
     def _add_elem_to_lists(self, name, elem, value_lists):
@@ -208,8 +207,8 @@ class CompilerBlock(object):
             value_lists[name] = PossibleValues(name, setting,
                                                self._specificity, depends)
         else:
-            value_lists[name].add_setting(setting, self._specificity,
-                                          depends)
+            specificity = 0 if len(elem.xml_element.attrib) else self._specificity
+            value_lists[name].add_setting(setting, specificity,depends)
 
     def add_settings_to_lists(self, flag_vars, value_lists):
         """Add all data in the <compiler> element to lists of settings.
@@ -229,7 +228,6 @@ class CompilerBlock(object):
 
     def matches_machine(self):
         """Check whether this block matches a machine/os.
-
         This also sets the specificity of the block, so this must be called
         before add_settings_to_lists if machine-specific output is needed.
         """


### PR DESCRIPTION
If a field in config_compilers contains attributes then it should not get specificity points in compilerblock.py

Test suite: scripts_regression_tests.py, hand testing
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
