### PR TITLE
Fix for cprnc on hobart

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -919,7 +919,7 @@
     <DIN_LOC_ROOT_CLMFORC>/project/tss</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/scratch/cluster/$USER/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/fs/cgd/csm/ccsm_baselines</BASELINE_ROOT>
-    <CCSM_CPRNC>/fs/cgd/csm/tools/cime/tools/cprnc/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/fs/cgd/csm/tools/cime/tools/cprnc/cprnc.$COMPILER</CCSM_CPRNC>
     <GMAKE>gmake --output-sync</GMAKE>
     <GMAKE_J>4</GMAKE_J>
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>


### PR DESCRIPTION
cprnc needs to be built for the different compiler.  configure_machines.xml was updated
to point to cprnc.$COMPILER

Test suite:  ERS_Ln9.f19_g17.X.hobart_intel , ERS_Ln9.f19_g17.X.hobart_gnu,
                     ERS_Ln9.f19_g17.X.hobart_nag
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2708 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
