### PR TITLE
Rework machine overrides in config_compilers.

### DIFF
--- a/scripts/lib/CIME/BuildTools/macroconditiontree.py
+++ b/scripts/lib/CIME/BuildTools/macroconditiontree.py
@@ -53,7 +53,7 @@ class MacroConditionTree(object): # pylint: disable=too-many-instance-attributes
                         "found after the ambiguity check was complete, " \
                         "or there is a mixture of appending and initial " \
                         "settings in the condition tree."
-                self._assignments.append((name, setting.value, setting.force_no_append))
+                self._assignments.append((name, setting.value))
                 self._set_up += setting.set_up
                 self._tear_down += setting.tear_down
         else:
@@ -138,8 +138,8 @@ class MacroConditionTree(object): # pylint: disable=too-many-instance-attributes
         if self._is_leaf:
             for line in self._set_up:
                 writer.write_line(line)
-            for (name, value, force_no_append) in self._assignments:
-                if self._do_append and not force_no_append:
+            for (name, value) in self._assignments:
+                if self._do_append:
                     writer.append_variable(name, value)
                 else:
                     writer.set_variable(name, value)

--- a/scripts/lib/CIME/BuildTools/possiblevalues.py
+++ b/scripts/lib/CIME/BuildTools/possiblevalues.py
@@ -22,12 +22,11 @@ class PossibleValues(object):
     append_settings - A dictionary of lists of possible appending settings
                       for the variable, with the specificity of each list
                       as the associated dictionary key.
-    depends - The current list of variables that this variable depends on
-              to get its value.
 
     Public methods:
     add_setting
     ambiguity_check
+    dependencies
     to_cond_trees
     """
 
@@ -38,17 +37,20 @@ class PossibleValues(object):
         arguments are the same as for append_match.
         """
         self.name = name
-        self.depends = depends
         # If this is an appending setting, its specificity can't cause it
-        # to overwrite other settings, but we want to keep track of it.
+        # to overwrite other settings.
         if setting.do_append:
             self.settings = []
-            self.append_settings = {specificity: [setting]}
-            self._specificity = 0
+            self.append_settings = [setting]
+            self._specificities = []
+            self._depends = []
+            self._append_depends = depends
         else:
             self.settings = [setting]
-            self.append_settings = {}
-            self._specificity = specificity
+            self.append_settings = []
+            self._specificities = [specificity]
+            self._depends = [depends]
+            self._append_depends = set()
 
     def add_setting(self, setting, specificity, depends):
         """Add a possible value for a variable.
@@ -56,48 +58,53 @@ class PossibleValues(object):
         Arguments:
         setting - A ValueSetting to start the list.
         specificity - An integer representing how specific the setting is.
-                      Only the initial settings with the highest
-                      specificity and appending settings with at least that
-                      specificity will actually be kept in the list. The
-                      lowest allowed specificity is 0.
+                      Low-specificity settings that will never be used will be
+                      dropped from the list. The lowest allowed specificity is
+                      0.
         depends - A set of variable names, specifying the variables that
                   have to be set before this setting can be used (e.g. if
                   SLIBS refers to NETCDF_PATH, then NETCDF_PATH has to be
                   set first).
 
+        >>> from CIME.BuildTools.valuesetting import ValueSetting
         >>> a = ValueSetting('foo', False, dict(), [], [])
         >>> b = ValueSetting('bar', False, dict(), [], [])
         >>> vals = PossibleValues('var', a, 0, {'dep1'})
         >>> vals.add_setting(b, 1, {'dep2'})
         >>> a not in vals.settings and b in vals.settings
         True
-        >>> 'dep1' not in vals.depends and 'dep2' in vals.depends
+        >>> 'dep1' not in vals.dependencies() and 'dep2' in vals.dependencies()
         True
         >>> vals.add_setting(a, 1, {'dep1'})
         >>> a in vals.settings and b in vals.settings
         True
-        >>> 'dep1' in vals.depends and 'dep2' in vals.depends
+        >>> 'dep1' in vals.dependencies() and 'dep2' in vals.dependencies()
         True
         """
         if setting.do_append:
-            # Appending settings with at least the current level of
-            # specificity should be kept.
-            if specificity >= self._specificity:
-                if specificity not in self.append_settings:
-                    self.append_settings[specificity] = []
-                self.append_settings[specificity].append(setting)
-                self.depends |= depends
+            self.append_settings.append(setting)
+            self._append_depends |= depends
         else:
-            # Add equally specific settings to the list.
-            if specificity == self._specificity:
-                self.settings.append(setting)
-                self.depends |= depends
-            # Replace the list if the setting is more specific.
-            elif specificity > self._specificity:
-                self.settings = [setting]
-                self._specificity = specificity
-                self.depends = depends
-        # Do nothing if the setting is less specific.
+            mark_deletion = []
+            for i in range(len(self.settings)):
+                other_setting = self.settings[i]
+                other_specificity = self._specificities[i]
+                # Ignore this case if it's less specific than one we have.
+                if other_specificity > specificity:
+                    if other_setting.has_special_case(setting):
+                        return
+                # Override cases that are less specific than this one.
+                elif other_specificity < specificity:
+                    if setting.has_special_case(other_setting):
+                        mark_deletion.append(i)
+            mark_deletion.reverse()
+            for i in mark_deletion:
+                del self.settings[i]
+                del self._specificities[i]
+                del self._depends[i]
+            self.settings.append(setting)
+            self._specificities.append(specificity)
+            self._depends.append(depends)
 
     def ambiguity_check(self):
         """Check the current list of settings for ambiguity.
@@ -105,12 +112,22 @@ class PossibleValues(object):
         This function raises an error if an ambiguity is found.
         """
         for i in range(len(self.settings)-1):
-            for other in self.settings[i+1:]:
+            for j in range(i+1, len(self.settings)):
+                if self._specificities[i] != self._specificities[j]:
+                    continue
+                other = self.settings[j]
                 expect(not self.settings[i].is_ambiguous_with(other),
                        "Variable "+self.name+" is set ambiguously in "
                        "config_compilers.xml. Check the file for these "
                        "conflicting settings: \n1: {}\n2: {}".format(
                            self.settings[i].conditions, other.conditions))
+
+    def dependencies(self):
+        """Returns a set of names of variables needed to set this variable."""
+        depends = self._append_depends.copy()
+        for other in self._depends:
+            depends |= other
+        return depends
 
     def to_cond_trees(self):
         """Convert this object to a pair of MacroConditionTree objects.
@@ -119,21 +136,24 @@ class PossibleValues(object):
         frozen and we're ready to convert it into an actual text file. This
         object is checked for ambiguities before conversion.
 
-        The return value is a tuple of two trees. The first contains all
-        initial settings, and the second contains all appending settings.
-        If either would be empty, None is returned instead.
+        The return value is a tuple of two items. The first is a dict of
+        condition trees containing all initial settings, with the specificities
+        as the dictionary keys. The second is a single tree containing all
+        appending settings. If the appending tree would be empty, None is
+        returned instead.
         """
         self.ambiguity_check()
-        if self.settings:
-            normal_tree = MacroConditionTree(self.name, self.settings)
-        else:
-            normal_tree = None
-        append_settings = []
-        for specificity in self.append_settings:
-            if specificity >= self._specificity:
-                append_settings += self.append_settings[specificity]
-        if append_settings:
-            append_tree = MacroConditionTree(self.name, append_settings)
+        # Get all values of specificity for which we need to make a tree.
+        specificities = sorted(list(set(self._specificities)))
+        # Build trees, starting from the least specific and working up.
+        normal_trees = {}
+        for specificity in specificities:
+            settings_for_tree = [self.settings[i]
+                                 for i in range(len(self.settings))
+                                 if self._specificities[i] == specificity]
+            normal_trees[specificity] = MacroConditionTree(self.name, settings_for_tree)
+        if self.append_settings:
+            append_tree = MacroConditionTree(self.name, self.append_settings)
         else:
             append_tree = None
-        return (normal_tree, append_tree)
+        return (normal_trees, append_tree)

--- a/scripts/lib/CIME/BuildTools/valuesetting.py
+++ b/scripts/lib/CIME/BuildTools/valuesetting.py
@@ -28,14 +28,13 @@ class ValueSetting(object):
     has_special_case
     """
 
-    def __init__(self, value, do_append, conditions, set_up, tear_down, force_no_append=False): #  pylint: disable=too-many-arguments
+    def __init__(self, value, do_append, conditions, set_up, tear_down): #  pylint: disable=too-many-arguments
         """Create a ValueSetting object by specifying all its data."""
         self.value = value
         self.do_append = do_append
         self.conditions = conditions
         self.set_up = set_up
         self.tear_down = tear_down
-        self.force_no_append = force_no_append
 
     def is_ambiguous_with(self, other):
         """Check to see if this setting conflicts with another one.

--- a/scripts/lib/CIME/BuildTools/valuesetting.py
+++ b/scripts/lib/CIME/BuildTools/valuesetting.py
@@ -25,6 +25,7 @@ class ValueSetting(object):
 
     Public methods:
     is_ambiguous_with
+    has_special_case
     """
 
     def __init__(self, value, do_append, conditions, set_up, tear_down, force_no_append=False): #  pylint: disable=too-many-arguments
@@ -98,11 +99,47 @@ class ValueSetting(object):
             if self.conditions[var_name] != other.conditions[var_name]:
                 return False
         # Specificity check.
-        # One setting being more specific than the other is equivalent to
-        # its set of conditions being a proper superset of the others.
         self_set = set(self.conditions.keys())
         other_set = set(other.conditions.keys())
-        if self_set < other_set or self_set > other_set:
+        if self_set < other_set or other_set < self_set:
             return False
         # Any situation we couldn't resolve is ambiguous.
+        return True
+
+    def has_special_case(self, other):
+        """Check to see if another setting is a special case of this one.
+
+        The purpose of this routine is to see if one of the settings requires
+        conditions that are a strict subset of another's conditions. This is
+        used to check whether a setting can be thrown out entirely in favor of a
+        more general, but machine-specific setting.
+
+        >>> a = ValueSetting('foo', False, {"DEBUG": "TRUE"}, [], [])
+        >>> b = ValueSetting('bar', False, {"DEBUG": "TRUE", "MPILIB": "mpich2"}, [], [])
+        >>> c = ValueSetting('bar', False, {"DEBUG": "TRUE", "compile_threaded": "false"}, [], [])
+        >>> d = ValueSetting('foo', False, {"DEBUG": "FALSE"}, [], [])
+        >>> a.has_special_case(b)
+        True
+        >>> b.has_special_case(a)
+        False
+        >>> a.has_special_case(c)
+        True
+        >>> c.has_special_case(a)
+        False
+        >>> b.has_special_case(c)
+        False
+        >>> c.has_special_case(b)
+        False
+        >>> a.has_special_case(a)
+        True
+        >>> d.has_special_case(a)
+        False
+        >>> d.has_special_case(b)
+        False
+        """
+        for var_name in self.conditions:
+            if var_name not in other.conditions:
+                return False
+            if self.conditions[var_name] != other.conditions[var_name]:
+                return False
         return True

--- a/scripts/lib/CIME/XML/compilerblock.py
+++ b/scripts/lib/CIME/XML/compilerblock.py
@@ -208,8 +208,7 @@ class CompilerBlock(object):
             value_lists[name] = PossibleValues(name, setting,
                                                self._specificity, depends)
         else:
-            specificity = 0 if len(elem.xml_element.attrib) else self._specificity
-            value_lists[name].add_setting(setting, specificity,depends)
+            value_lists[name].add_setting(setting, self._specificity,depends)
 
     def add_settings_to_lists(self, flag_vars, value_lists):
         """Add all data in the <compiler> element to lists of settings.

--- a/scripts/lib/CIME/XML/compilerblock.py
+++ b/scripts/lib/CIME/XML/compilerblock.py
@@ -188,9 +188,9 @@ class CompilerBlock(object):
         value_text = self._handle_references(elem, set_up,
                                              tear_down, depends)
         # Create the setting object.
-        append = self._db.name(elem) == "append" or (self._db.name(elem) == "base" and self._compiler and self._db.compiler != self._compiler)
+        append = self._db.name(elem) == "append"
         setting = ValueSetting(value_text, append,
-                               conditions, set_up, tear_down, force_no_append=self._db.name(elem) == "base")
+                               conditions, set_up, tear_down)
 
         return (setting, depends)
 

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -199,28 +199,33 @@ class Compilers(GenericXML):
             # Variables that are ready to be written.
             ready_variables = [
                 var_name for var_name in value_lists
-                if value_lists[var_name].depends <= vars_written
+                if value_lists[var_name].dependencies() <= vars_written
             ]
             expect(len(ready_variables) > 0,
                    "The file {} has bad $VAR references. "
                    "Check for circular references or variables that "
                    "are used in a $VAR but not actually defined.".format(self.filename))
-            big_normal_tree = None
+            big_normal_trees = {}
             big_append_tree = None
             for var_name in ready_variables:
                 # Note that we're writing this variable.
                 vars_written.add(var_name)
                 # Make the conditional trees and write them out.
-                normal_tree, append_tree = \
+                normal_trees, append_tree = \
                     value_lists[var_name].to_cond_trees()
-                big_normal_tree = merge_optional_trees(normal_tree,
-                                                        big_normal_tree)
+                for spec in normal_trees:
+                    if spec in big_normal_trees:
+                        big_normal_trees[spec] = merge_optional_trees(normal_trees[spec],
+                                                                      big_normal_trees[spec])
+                    else:
+                        big_normal_trees[spec] = normal_trees[spec]
                 big_append_tree = merge_optional_trees(append_tree,
                                                         big_append_tree)
                 # Remove this variable from the list of variables to handle
                 # next iteration.
                 del value_lists[var_name]
-            if big_normal_tree is not None:
-                big_normal_tree.write_out(writer)
+            specificities = sorted(list(big_normal_trees.keys()))
+            for spec in specificities:
+                big_normal_trees[spec].write_out(writer)
             if big_append_tree is not None:
                 big_append_tree.write_out(writer)


### PR DESCRIPTION
In the original design, machine-specific settings would completely
override all non-machine-specific settings. This led to two unintuitive
behaviors in particular:
 - A machine-specific setting that does *not* apply could override one
   that does (e.g. because the machine-specific setting only applies to
   cases with a particular MPI library, whereas the non-specific setting
   applies to all cases).
 - A machine-specific `<base>` tag causes all non-machine-specific
   `<append>` tags to be ignored.

This commit changes both behaviors. Now machine-specific settings will
only override non-specific settings if they actually apply to the
current case. Furthermore, `<append>` tags can never be overridden,
regardless of the `<base>` tags that are involved.

While this is expected to have minimal effect on existing
config_compilers.xml settings, it is quite possible, even likely, that a
small number of changes will have to be made for some machines.

Test suite: scripts_regression_tests, Python doctests for valuesetting and possiblevalues
Test baseline: N/A
Test namelist changes: None
Test status: N/A, but no reason this shouldn't be bit for bit

This fixes some bugs that @jgfouca encountered and others that I noticed after #2703, though there's no open bug report for those.

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
@jedwards4b when he gets back, if he wants?