### PR TITLE
Use RawConfigParser instead of ConfigParser

### DIFF
--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -83,7 +83,7 @@ def _main_func(description, test_args=False):
     # save these options to a hidden file for use during resubmit
     config_file = os.path.join(caseroot,".submit_options")
     if skip_pnl or mail_user or mail_type or batch_args:
-        config = configparser.ConfigParser()
+        config = configparser.RawConfigParser()
         config.add_section("SubmitOptions")
         if skip_pnl:
             config.set("SubmitOptions", "skip_pnl", "True")


### PR DESCRIPTION
To fix the python 3 test failure

Test suite: K_TestCimeCase, B_CheckCode
Test status: Ok

Code review: @jedwards4b 
