### PR TITLE
Hist utils use archive xml

### DIFF
--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -6,7 +6,7 @@ from CIME.XML.standard_module_setup import *
 from CIME.test_status import TEST_NO_BASELINES_COMMENT
 from CIME.utils import get_current_commit, get_timestamp, get_model, safe_copy
 
-import logging, glob, os, re, stat, filecmp
+import logging, os, re, stat, filecmp
 logger = logging.getLogger(__name__)
 
 BLESS_LOG_NAME = "bless_log"

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -17,7 +17,7 @@ def _iter_model_file_substrs(case):
     for model in models:
         yield model
 
-def _get_all_hist_files(model, from_dir, suffix="", file_extensions=None, ref_case=None):
+def _get_all_hist_files(model, from_dir, file_extensions, suffix="", ref_case=None):
     suffix = (".{}".format(suffix) if suffix else "")
 
     test_hists = []
@@ -27,7 +27,7 @@ def _get_all_hist_files(model, from_dir, suffix="", file_extensions=None, ref_ca
             continue
         if extension.endswith('$'):
             extension = extension[:-1]
-        string = model+r'\d?_?\d*\.'+extension+suffix+'$'
+        string = model+r'\d?_?(\d{4})?\.'+extension+suffix+'$'
         logger.debug ("Regex is {}".format(string))
         pfile = re.compile(string)
         test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
@@ -42,8 +42,8 @@ def _get_all_hist_files(model, from_dir, suffix="", file_extensions=None, ref_ca
     logger.debug("_get_all_hist_files returns {} for model {}".format(test_hists, model))
     return test_hists
 
-def _get_latest_hist_files(model, from_dir, suffix="", file_extensions=None, ref_case=None):
-    test_hists = _get_all_hist_files(model, from_dir, suffix=suffix, file_extensions=file_extensions, ref_case=ref_case)
+def _get_latest_hist_files(model, from_dir, file_extensions, suffix="", ref_case=None):
+    test_hists = _get_all_hist_files(model, from_dir, file_extensions, suffix=suffix, ref_case=ref_case)
     latest_files = {}
     histlist = []
     for hist in test_hists:
@@ -75,7 +75,7 @@ def copy(case, suffix):
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        test_hists = _get_latest_hist_files(model, rundir, file_extensions=file_extensions, ref_case=ref_case)
+        test_hists = _get_latest_hist_files(model, rundir, file_extensions, ref_case=ref_case)
         num_copied += len(test_hists)
         for test_hist in test_hists:
             new_file = "{}.{}".format(test_hist, suffix)
@@ -203,8 +203,8 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        hists1 = _get_latest_hist_files(model, from_dir1, suffix1, file_extensions, ref_case)
-        hists2 = _get_latest_hist_files(model, from_dir2, suffix2, file_extensions, ref_case)
+        hists1 = _get_latest_hist_files(model, from_dir1, file_extensions, suffix1, ref_case)
+        hists2 = _get_latest_hist_files(model, from_dir2, file_extensions, suffix2, ref_case)
         if len(hists1) == 0 and len(hists2) == 0:
             comments += "    no hist files found for model {}\n".format(model)
             continue
@@ -418,7 +418,7 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        hists =  _get_latest_hist_files(model, rundir, file_extensions=file_extensions, ref_case=ref_case)
+        hists =  _get_latest_hist_files(model, rundir, file_extensions, ref_case=ref_case)
         logger.debug("latest_files: {}".format(hists))
         num_gen += len(hists)
         for hist in hists:

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -23,9 +23,11 @@ def _get_all_hist_files(testcase, model, from_dir, suffix="", file_extensions=No
     test_hists = []
     # Match hist files produced by run
     for extension in file_extensions:
+        if 'initial' in extension:
+            continue
         if extension.endswith('$'):
             extension = extension[:-1]
-        string = model+r'\d?_?\d*\.'+extension+suffix+r'$'
+        string = model+'\d?_?\d*\.'+extension+suffix+'$'
         logger.debug ("Regex is {}".format(string))
         pfile = re.compile(string)
         test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
@@ -347,9 +349,9 @@ def get_extension(model, filepath):
     'hi'
     >>> get_extension("cpl", "cpl.h.nc")
     'h'
-    >>> get_extension("cpl", "cpl.h1.nc")
+    >>> get_extension("cpl", "cpl.h1.nc.base")
     'h1'
-    >>> get_extension("cpl", "TESTRUNDIFF_Mmpi-serial.f19_g16_rx1.A.melvin_gnu.C.fake_testing_only_20160816_164150-20160816_164240.cpl.hi.0.nc.base")
+    >>> get_extension("cpl", "TESTRUNDIFF.cpl.hi.0.nc.base")
     'hi'
     >>> get_extension("cpl", "TESTRUNDIFF_Mmpi-serial.f19_g16_rx1.A.melvin_gnu.C.fake_testing_only_20160816_164150-20160816_164240.cpl.h.nc")
     'h'
@@ -360,18 +362,12 @@ def get_extension(model, filepath):
     >>> get_extension("mom", "ga0xnw.mom6.frc._0001_001.nc")
     'frc'
     >>> get_extension("mom", "ga0xnw.mom6.sfc.day._0001_001.nc")
-    'sfc.day'
+    'sfc'
     """
     basename = os.path.basename(filepath)
-    if model == "mom":
-        ext_regex = re.compile(r'.*%s[^_]*_?([0-9]{4})?[.](frc.?)([.].*[^.])?[.]nc' % model)
-        m = ext_regex.match(basename)
-        if m is None:
-            ext_regex = re.compile(r'.*%s[^_]*_?([0-9]{4})?[.](sfc.day.?)([.].*[^.])?[.]nc' % model)
-            m = ext_regex.match(basename)
-    else:
-        ext_regex = re.compile(r'.*%s[^_]*_?([0-9]{4})?[.](h.?)([.].*[^.])?[.]nc' % model)
-        m = ext_regex.match(basename)
+    regex = model+r'\d?_?(\d{4})?\.(\w+)[-\w\.]*\.nc\.?'
+    ext_regex = re.compile(regex)
+    m = ext_regex.search(basename)
 
     expect(m is not None, "Failed to get extension for file '{}'".format(filepath))
 

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -193,7 +193,6 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        print "HERE model {} file_ext {}".format(model, file_extensions)
         hists1 = _get_latest_hist_files(testcase, model, from_dir1, suffix1, file_extensions)
         hists2 = _get_latest_hist_files(testcase, model, from_dir2, suffix2, file_extensions)
         if len(hists1) == 0 and len(hists2) == 0:
@@ -403,7 +402,6 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        print "HERE model {} file_ext {}".format(model, file_extensions)
         hists =  _get_latest_hist_files(testcase, model, rundir, file_extensions=file_extensions)
         logger.debug("latest_files: {}".format(hists))
         num_gen += len(hists)

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -25,7 +25,7 @@ def _get_all_hist_files(testcase, model, from_dir, suffix="", file_extensions=No
     for extension in file_extensions:
         if extension.endswith('$'):
             extension = extension[:-1]
-            
+
         pfile = re.compile(model+r'\d?_?\d*\.'+extension+suffix+r'$')
         test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
     test_hists = list(set(test_hists))

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -29,7 +29,7 @@ def _get_all_hist_files(testcase, model, from_dir, suffix="", file_extensions=No
         logger.debug ("Regex is {}".format(string))
         pfile = re.compile(string)
         test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
-        
+
     test_hists = list(set(test_hists))
     test_hists.sort()
     logger.debug("_get_all_hist_files returns {} for model {}".format(test_hists, model))

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -25,11 +25,14 @@ def _get_all_hist_files(testcase, model, from_dir, suffix="", file_extensions=No
     for extension in file_extensions:
         if extension.endswith('$'):
             extension = extension[:-1]
-
-        pfile = re.compile(model+r'\d?_?\d*\.'+extension+suffix+r'$')
+        string = model+r'\d?_?\d*\.'+extension+suffix+r'$'
+        logger.debug ("Regex is {}".format(string))
+        pfile = re.compile(string)
         test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
+        
     test_hists = list(set(test_hists))
     test_hists.sort()
+    logger.debug("_get_all_hist_files returns {} for model {}".format(test_hists, model))
     return test_hists
 
 def _get_latest_hist_files(testcase, model, from_dir, suffix="", file_extensions=None):

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -357,11 +357,22 @@ def get_extension(model, filepath):
     '0002.h0'
     >>> get_extension("pop","PFS.f09_g16.B1850.cheyenne_intel.allactive-default.GC.c2_0_b1f2_int.pop.h.ecosys.nday1.0001-01-02.nc")
     'h'
+    >>> get_extension("mom", "ga0xnw.mom6.frc._0001_001.nc")
+    'frc'
+    >>> get_extension("mom", "ga0xnw.mom6.sfc.day._0001_001.nc")
+    'sfc.day'
     """
     basename = os.path.basename(filepath)
-    ext_regex = re.compile(r'.*%s[^_]*_?([0-9]{4})?[.](h.?)([.].*[^.])?[.]nc' % model)
+    if model == "mom":
+        ext_regex = re.compile(r'.*%s[^_]*_?([0-9]{4})?[.](frc.?)([.].*[^.])?[.]nc' % model)
+        m = ext_regex.match(basename)
+        if m is None:
+            ext_regex = re.compile(r'.*%s[^_]*_?([0-9]{4})?[.](sfc.day.?)([.].*[^.])?[.]nc' % model)
+            m = ext_regex.match(basename)
+    else:
+        ext_regex = re.compile(r'.*%s[^_]*_?([0-9]{4})?[.](h.?)([.].*[^.])?[.]nc' % model)
+        m = ext_regex.match(basename)
 
-    m = ext_regex.match(basename)
     expect(m is not None, "Failed to get extension for file '{}'".format(filepath))
 
     if m.group(1) is not None:

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -24,15 +24,12 @@ def _get_all_hist_files(testcase, model, from_dir, suffix="", file_extensions=No
     # Match hist files produced by run
     for extension in file_extensions:
         if extension.endswith('$'):
-            pfile = re.compile(model+r"\."+extension[:-1]+suffix+r'$')
-            test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
-        else:
-            pfile = re.compile(model+r"\."+extension+suffix+r'$')
-            test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
-
+            extension = extension[:-1]
+            
+        pfile = re.compile(model+r'\d?_?\d*\.'+extension+suffix+r'$')
+        test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
     test_hists = list(set(test_hists))
     test_hists.sort()
-    print "test_hists {}".format(test_hists)
     return test_hists
 
 def _get_latest_hist_files(testcase, model, from_dir, suffix="", file_extensions=None):
@@ -60,11 +57,16 @@ def copy(case, suffix):
     testcase = case.get_value("CASE")
 
     # Loop over models
+    archive = case.get_env("archive")
     comments = "Copying hist files to suffix '{}'\n".format(suffix)
     num_copied = 0
     for model in _iter_model_file_substrs(case):
         comments += "  Copying hist files for model '{}'\n".format(model)
-        test_hists = _get_latest_hist_files(testcase, model, rundir)
+        if model == 'cpl':
+            file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
+        else:
+            file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
+        test_hists = _get_latest_hist_files(testcase, model, rundir, file_extensions=file_extensions)
         num_copied += len(test_hists)
         for test_hist in test_hists:
             new_file = "{}.{}".format(test_hist, suffix)

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -27,7 +27,7 @@ def _get_all_hist_files(model, from_dir, suffix="", file_extensions=None, ref_ca
             continue
         if extension.endswith('$'):
             extension = extension[:-1]
-        string = model+'\d?_?\d*\.'+extension+suffix+'$'
+        string = model+r'\d?_?\d*\.'+extension+suffix+'$'
         logger.debug ("Regex is {}".format(string))
         pfile = re.compile(string)
         test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
@@ -42,7 +42,7 @@ def _get_all_hist_files(model, from_dir, suffix="", file_extensions=None, ref_ca
     logger.debug("_get_all_hist_files returns {} for model {}".format(test_hists, model))
     return test_hists
 
-def _get_latest_hist_files(testcase, model, from_dir, suffix="", file_extensions=None, ref_case=None):
+def _get_latest_hist_files(model, from_dir, suffix="", file_extensions=None, ref_case=None):
     test_hists = _get_all_hist_files(model, from_dir, suffix=suffix, file_extensions=file_extensions, ref_case=ref_case)
     latest_files = {}
     histlist = []
@@ -64,7 +64,6 @@ def copy(case, suffix):
     suffix - The string suffix you want to add to saved files, this can be used to find them later.
     """
     rundir   = case.get_value("RUNDIR")
-    testcase = case.get_value("CASE")
     ref_case = case.get_value("RUN_REFCASE")
     # Loop over models
     archive = case.get_env("archive")
@@ -76,7 +75,7 @@ def copy(case, suffix):
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        test_hists = _get_latest_hist_files(testcase, model, rundir, file_extensions=file_extensions, ref_case=ref_case)
+        test_hists = _get_latest_hist_files(model, rundir, file_extensions=file_extensions, ref_case=ref_case)
         num_copied += len(test_hists)
         for test_hist in test_hists:
             new_file = "{}.{}".format(test_hist, suffix)
@@ -204,8 +203,8 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        hists1 = _get_latest_hist_files(testcase, model, from_dir1, suffix1, file_extensions, ref_case)
-        hists2 = _get_latest_hist_files(testcase, model, from_dir2, suffix2, file_extensions, ref_case)
+        hists1 = _get_latest_hist_files(model, from_dir1, suffix1, file_extensions, ref_case)
+        hists2 = _get_latest_hist_files(model, from_dir2, suffix2, file_extensions, ref_case)
         if len(hists1) == 0 and len(hists2) == 0:
             comments += "    no hist files found for model {}\n".format(model)
             continue
@@ -419,7 +418,7 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
             file_extensions = archive.get_hist_file_extensions(archive.get_entry('drv'))
         else:
             file_extensions = archive.get_hist_file_extensions(archive.get_entry(model))
-        hists =  _get_latest_hist_files(testcase, model, rundir, file_extensions=file_extensions, ref_case=ref_case)
+        hists =  _get_latest_hist_files(model, rundir, file_extensions=file_extensions, ref_case=ref_case)
         logger.debug("latest_files: {}".format(hists))
         num_gen += len(hists)
         for hist in hists:

--- a/src/drivers/mct/cime_config/config_archive.xml
+++ b/src/drivers/mct/cime_config/config_archive.xml
@@ -1,7 +1,9 @@
 <components version="2.0">
   <comp_archive_spec compname="drv" compclass="cpl">
     <rest_file_extension>r</rest_file_extension>
-    <hist_file_extension>hi?\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>hi\..*\.nc$</hist_file_extension>
+    <hist_file_extension>ha\..*\.nc$</hist_file_extension>
+    <hist_file_extension>h\w+\..*\.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer$NINST_STRING.drv</rpointer_file>
@@ -11,6 +13,10 @@
       <tfile disposition="move">cpl_0001.log.5548574.chadmin1.180228-124723.gz</tfile>
       <tfile disposition="copy">casename.cpl.r.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.cpl.hi.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cpl.ha.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cpl.ha2x1d.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cpl.ha2x1h.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cpl.hl2x1yr_glc.1976-01-01-00000.nc</tfile>
       <tfile disposition="copy">rpointer.drv_0001</tfile>
       <tfile disposition="copy">rpointer.drv</tfile>
       <tfile disposition="ignore">casenamenot.cpl.r.1976-01-01-00000.nc</tfile>

--- a/src/drivers/mct/cime_config/config_archive.xml
+++ b/src/drivers/mct/cime_config/config_archive.xml
@@ -10,6 +10,7 @@
     <test_file_names>
       <tfile disposition="move">cpl_0001.log.5548574.chadmin1.180228-124723.gz</tfile>
       <tfile disposition="copy">casename.cpl.r.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.cpl.hi.1976-01-01-00000.nc</tfile>
       <tfile disposition="copy">rpointer.drv_0001</tfile>
       <tfile disposition="copy">rpointer.drv</tfile>
       <tfile disposition="ignore">casenamenot.cpl.r.1976-01-01-00000.nc</tfile>


### PR DESCRIPTION
Use information from env_archive.xml to determine history files for baselines and compares.
This removes the need for changes in two places to support different history file name formats

Test suite: scripts_regression_tests.py, cesm prealpha tests on hobart
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2695 
Fixes #2735 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: sacks
