### PR TITLE
Add BFAIL in more contexts when doing baseline comparisons

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -483,6 +483,9 @@ class SystemTestsCommon(object):
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             baseline_name = self._case.get_value("BASECMP_CASE")
             ts_comments = (os.path.dirname(baseline_name) + ": " + comments) if "\n" not in comments else os.path.dirname(baseline_name)
+            if ts_comments == os.path.dirname(baseline_name) and TEST_NO_BASELINES_COMMENT in comments:
+                ts_comments += " {} some baseline files were missing".format(TEST_NO_BASELINES_COMMENT)
+
             self._test_status.set_status(BASELINE_PHASE, status, comments=ts_comments)
 
     def _generate_baseline(self):

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -482,10 +482,7 @@ class SystemTestsCommon(object):
             append_testlog(comments)
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             baseline_name = self._case.get_value("BASECMP_CASE")
-            ts_comments = (os.path.dirname(baseline_name) + ": " + comments) if "\n" not in comments else os.path.dirname(baseline_name)
-            if ts_comments == os.path.dirname(baseline_name) and TEST_NO_BASELINES_COMMENT in comments:
-                ts_comments += " {} some baseline files were missing".format(TEST_NO_BASELINES_COMMENT)
-
+            ts_comments = os.path.dirname(baseline_name) + ": " + get_ts_synopsis(comments)
             self._test_status.set_status(BASELINE_PHASE, status, comments=ts_comments)
 
     def _generate_baseline(self):

--- a/scripts/lib/CIME/compare_test_results.py
+++ b/scripts/lib/CIME/compare_test_results.py
@@ -1,7 +1,7 @@
 import CIME.compare_namelists, CIME.simple_compare
 from CIME.utils import expect, append_status, EnvironmentContext
 from CIME.test_status import *
-from CIME.hist_utils import compare_baseline
+from CIME.hist_utils import compare_baseline, get_ts_synopsis
 from CIME.case import Case
 
 import os, glob, logging
@@ -142,11 +142,7 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                             compare_result = TEST_FAIL_STATUS
                             all_pass_or_skip = False
 
-                        # Following the logic in SystemTestsCommon._compare_baseline:
-                        # We'll print the comment if it's a brief one-liner; otherwise
-                        # the comment will only appear in the log file
-                        if "\n" not in detailed_comments:
-                            compare_comment = detailed_comments
+                        compare_comment = get_ts_synopsis(detailed_comments)
 
             brief_result = ""
             if not hist_only:

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -463,7 +463,8 @@ def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
 def get_ts_synopsis(comments):
     r"""
     Reduce case diff comments down to a single line synopsis so that we can put
-    something in the TestStatus file
+    something in the TestStatus file. It's expected that the comments provided
+    to this function came from _compare_hists (compare_test or compare_baseline).
 
     >>> get_ts_synopsis('')
     ''

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -464,7 +464,7 @@ def get_ts_synopsis(comments):
     r"""
     Reduce case diff comments down to a single line synopsis so that we can put
     something in the TestStatus file. It's expected that the comments provided
-    to this function came from _compare_hists (compare_test or compare_baseline).
+    to this function came from compare_baseline, not compare_tests.
 
     >>> get_ts_synopsis('')
     ''

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -10,6 +10,9 @@ import logging, os, re, stat, filecmp
 logger = logging.getLogger(__name__)
 
 BLESS_LOG_NAME = "bless_log"
+NO_COMPARE     = "had no compare counterpart"
+NO_ORIGINAL    = "had no original counterpart"
+DIFF_COMMENT   = "did NOT match"
 
 def _iter_model_file_substrs(case):
     models = case.get_compset_components()
@@ -211,11 +214,11 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
 
         one_not_two, two_not_one, match_ups = _hists_match(model, hists1, hists2, suffix1, suffix2)
         for item in one_not_two:
-            comments += "    File '{}' had no compare counterpart in '{}' with suffix '{}'\n".format(item, from_dir2, suffix2)
+            comments += "    File '{}' {} in '{}' with suffix '{}'\n".format(item, NO_COMPARE, from_dir2, suffix2)
             all_success = False
 
         for item in two_not_one:
-            comments += "    File '{}' had no original counterpart in '{}' with suffix '{}'\n".format(item, from_dir1, suffix1)
+            comments += "    File '{}' {} in '{}' with suffix '{}'\n".format(item, NO_ORIGINAL, from_dir1, suffix1)
             all_success = False
 
         num_compared += len(match_ups)
@@ -227,7 +230,7 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
             if success:
                 comments += "    {} matched {}\n".format(hist1, hist2)
             else:
-                comments += "    {} did NOT match {}\n".format(hist1, hist2)
+                comments += "    {} {} {}\n".format(hist1, DIFF_COMMENT, hist2)
                 comments += "    cat " + cprnc_log_file + "\n"
                 expected_log_file = os.path.join(casedir, os.path.basename(cprnc_log_file))
                 if not (os.path.exists(expected_log_file) and filecmp.cmp(cprnc_log_file, expected_log_file)):
@@ -483,9 +486,9 @@ def get_ts_synopsis(comments):
         has_bfails = False
         has_real_fails = False
         for line in comments.splitlines():
-            if "no compare counterpart" in line:
+            if NO_COMPARE in line:
                 has_bfails = True
-            elif "did NOT match" in line:
+            elif DIFF_COMMENT in line:
                 has_real_fails = True
 
         if has_real_fails:

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -183,7 +183,7 @@ def _hists_match(model, hists1, hists2, suffix1="", suffix2=""):
 
     return one_not_two, two_not_one, match_ups
 
-def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_suffix=""):
+def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_suffix="", add_bfail=False):
     if from_dir1 == from_dir2:
         expect(suffix1 != suffix2, "Comparing files to themselves?")
 
@@ -211,8 +211,10 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
 
         one_not_two, two_not_one, match_ups = _hists_match(model, hists1, hists2, suffix1, suffix2)
         for item in one_not_two:
-            comments += "    File '{}' had no counterpart in '{}' with suffix '{}'\n".format(item, from_dir2, suffix2)
+            comments += "    {}File '{}' had no counterpart in '{}' with suffix '{}'\n".format(
+                (TEST_NO_BASELINES_COMMENT + " ") if add_bfail else "", item, from_dir2, suffix2)
             all_success = False
+
         for item in two_not_one:
             comments += "    File '{}' had no counterpart in '{}' with suffix '{}'\n".format(item, from_dir1, suffix1)
             all_success = False
@@ -334,7 +336,7 @@ def compare_baseline(case, baseline_dir=None, outfile_suffix=""):
         if not os.path.isdir(bdir):
             return False, "ERROR {} baseline directory '{}' does not exist".format(TEST_NO_BASELINES_COMMENT,bdir)
 
-    success, comments = _compare_hists(case, rundir, basecmp_dir, outfile_suffix=outfile_suffix)
+    success, comments = _compare_hists(case, rundir, basecmp_dir, outfile_suffix=outfile_suffix, add_bfail=True)
     if get_model() == "e3sm":
         bless_log = os.path.join(basecmp_dir, BLESS_LOG_NAME)
         if os.path.exists(bless_log):


### PR DESCRIPTION
The original implementation only produce BFAIL if a baseline directory
was entirely missing. Users are asking for BFAILs for individual baseline
files.

Test suite: code-checker, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #789 

User interface changes?: N

Update gh-pages html (Y/N)?:N

Code review: @jedwards4b @billsacks 
