### PR TITLE
Do a better job of handling exceptions in sub-phases of run

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -186,6 +186,10 @@ TESTRUNFAIL       Insta-fail run step. Used to confirm that model run
 TESTRUNFAILEXC    Insta-fail run step via exception. Used to test correct
                   correct behavior when exceptions are generated.
 
+TESTRUNSTARCFAIL  Insta-fail st_archive step via exception. Used to test correct
+                  correct behavior when exceptions are generated within in run_phase
+                  for phases other than RUN.
+
 TESTRUNPASS       Insta-pass run step. Used to test that run that work
                   are reported correctly.
 
@@ -391,6 +395,15 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
 
   <test NAME="TESTRUNFAIL" INFRASTRUCTURE_TEST="TRUE">
     <DESC>For testing infra only. Insta-fail run step.</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <STOP_OPTION>ndays</STOP_OPTION>
+    <STOP_N>11</STOP_N>
+    <CHECK_TIMING>FALSE</CHECK_TIMING>
+    <DOUT_S>FALSE</DOUT_S>
+  </test>
+
+  <test NAME="TESTRUNSTARCFAIL" INFRASTRUCTURE_TEST="TRUE">
+    <DESC>For testing infra only. Insta-fail st archive test with exception.</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>11</STOP_N>

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -187,7 +187,7 @@ TESTRUNFAILEXC    Insta-fail run step via exception. Used to test correct
                   correct behavior when exceptions are generated.
 
 TESTRUNSTARCFAIL  Insta-fail st_archive step via exception. Used to test correct
-                  correct behavior when exceptions are generated within in run_phase
+                  behavior when exceptions are generated within in run_phase
                   for phases other than RUN.
 
 TESTRUNPASS       Insta-pass run step. Used to test that run that work

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -145,15 +145,16 @@ class SystemTestsCommon(object):
             self.run_phase()
 
             if self._case.get_value("GENERATE_BASELINE"):
-                self._generate_baseline()
+                self._phase_modifying_call(GENERATE_PHASE, self._generate_baseline)
 
             if self._case.get_value("COMPARE_BASELINE"):
-                self._compare_baseline()
+                self._phase_modifying_call(BASELINE_PHASE,   self._compare_baseline)
+                self._phase_modifying_call(MEMCOMP_PHASE,    self._compare_memory)
+                self._phase_modifying_call(THROUGHPUT_PHASE, self._compare_throughput)
 
-            self._check_for_memleak()
+            self._phase_modifying_call(MEMLEAK_PHASE, self._check_for_memleak)
 
-            self._st_archive_case_test()
-
+            self._phase_modifying_call(STARCHIVE_PHASE, self._st_archive_case_test)
 
         except BaseException as e:
             success = False
@@ -290,7 +291,6 @@ class SystemTestsCommon(object):
             else:
                 self._test_status.set_status(STARCHIVE_PHASE, TEST_FAIL_STATUS)
 
-
     def _get_mem_usage(self, cpllog):
         """
         Examine memory usage as recorded in the cpl log file and look for unexpected
@@ -326,16 +326,33 @@ class SystemTestsCommon(object):
                     return float(m.group(1))
         return None
 
+    def _phase_modifying_call(self, phase, function):
+        """
+        Ensures that unexpected exceptions from phases will result in a FAIL result
+        in the TestStatus file for that phase.
+        """
+        try:
+            function()
+        except BaseException as e:
+            msg = e.__str__()
+            excmsg = "Exception during {}:\n{}\n{}".format(phase, msg, traceback.format_exc())
+
+            logger.warning(excmsg)
+            append_testlog(excmsg)
+
+            with self._test_status:
+                self._test_status.set_status(phase, TEST_FAIL_STATUS, comments="exception")
+
     def _check_for_memleak(self):
         """
         Examine memory usage as recorded in the cpl log file and look for unexpected
         increases.
         """
-        latestcpllogs = self._get_latest_cpl_logs()
-        for cpllog in latestcpllogs:
-            memlist = self._get_mem_usage(cpllog)
+        with self._test_status:
+            latestcpllogs = self._get_latest_cpl_logs()
+            for cpllog in latestcpllogs:
+                memlist = self._get_mem_usage(cpllog)
 
-            with self._test_status:
                 if len(memlist)<3:
                     self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS, comments="insuffiencient data for memleak test")
                 else:
@@ -396,21 +413,11 @@ class SystemTestsCommon(object):
 
         return lastcpllogs
 
-    def _compare_baseline(self):
-        """
-        compare the current test output to a baseline result
-        """
+    def _compare_memory(self):
         with self._test_status:
-            # compare baseline
-            success, comments = compare_baseline(self._case)
-            append_testlog(comments)
-            status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
-            baseline_name = self._case.get_value("BASECMP_CASE")
-            ts_comments = (os.path.dirname(baseline_name) + ": " + comments) if "\n" not in comments else os.path.dirname(baseline_name)
-            self._test_status.set_status(BASELINE_PHASE, status, comments=ts_comments)
-            basecmp_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), baseline_name)
-
             # compare memory usage to baseline
+            baseline_name = self._case.get_value("BASECMP_CASE")
+            basecmp_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), baseline_name)
             newestcpllogfiles = self._get_latest_cpl_logs()
             if len(newestcpllogfiles) > 0:
                 memlist = self._get_mem_usage(newestcpllogfiles[0])
@@ -433,6 +440,21 @@ class SystemTestsCommon(object):
                         self._test_status.set_status(MEMCOMP_PHASE, TEST_FAIL_STATUS, comments=comment)
                         append_testlog(comment)
 
+    def _compare_throughput(self):
+        with self._test_status:
+            # compare memory usage to baseline
+            baseline_name = self._case.get_value("BASECMP_CASE")
+            basecmp_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), baseline_name)
+            newestcpllogfiles = self._get_latest_cpl_logs()
+            for cpllog in newestcpllogfiles:
+                m = re.search(r"/(cpl.*.log).*.gz",cpllog)
+                if m is not None:
+                    baselog = os.path.join(basecmp_dir, m.group(1))+".gz"
+                if baselog is None or not os.path.isfile(baselog):
+                    # for backward compatibility
+                    baselog = os.path.join(basecmp_dir, "cpl.log")
+
+                if os.path.isfile(baselog):
                     # compare throughput to baseline
                     current = self._get_throughput(cpllog)
                     baseline = self._get_throughput(baselog)
@@ -450,6 +472,19 @@ class SystemTestsCommon(object):
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
                             append_testlog(comment)
 
+    def _compare_baseline(self):
+        """
+        compare the current test output to a baseline result
+        """
+        with self._test_status:
+            # compare baseline
+            success, comments = compare_baseline(self._case)
+            append_testlog(comments)
+            status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
+            baseline_name = self._case.get_value("BASECMP_CASE")
+            ts_comments = (os.path.dirname(baseline_name) + ": " + comments) if "\n" not in comments else os.path.dirname(baseline_name)
+            self._test_status.set_status(BASELINE_PHASE, status, comments=ts_comments)
+
     def _generate_baseline(self):
         """
         generate a new baseline case based on the current test
@@ -460,7 +495,7 @@ class SystemTestsCommon(object):
             append_testlog(comments)
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             baseline_name = self._case.get_value("BASEGEN_CASE")
-            self._test_status.set_status("{}".format(GENERATE_PHASE), status, comments=os.path.dirname(baseline_name))
+            self._test_status.set_status(GENERATE_PHASE, status, comments=os.path.dirname(baseline_name))
             basegen_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))
             # copy latest cpl log to baseline
             # drop the date so that the name is generic
@@ -593,6 +628,11 @@ class TESTRUNFAILEXC(TESTRUNPASS):
 
     def run_phase(self):
         raise RuntimeError("Exception from run_phase")
+
+class TESTRUNSTARCFAIL(TESTRUNPASS):
+
+    def _st_archive_case_test(self):
+        raise RuntimeError("Exception from st archive")
 
 class TESTBUILDFAIL(TESTRUNPASS):
 

--- a/scripts/lib/get_tests.py
+++ b/scripts/lib/get_tests.py
@@ -44,6 +44,7 @@ _CIME_TESTS = {
                    ("TESTBUILDFAIL_P1.f19_g16_rx1.A",
                     "TESTBUILDFAILEXC_P1.f19_g16_rx1.A",
                     "TESTRUNFAIL_P1.f19_g16_rx1.A",
+                    "TESTRUNSTARCFAIL_P1.f19_g16_rx1.A",
                     "TESTRUNFAILEXC_P1.f19_g16_rx1.A",
                     "TESTRUNPASS_P1.f19_g16_rx1.A",
                     "TESTTESTDIFF_P1.f19_g16_rx1.A",

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -973,6 +973,7 @@ class O_TestTestScheduler(TestCreateTestCommon):
         tests = get_tests.get_full_test_names(["cime_test_only",
                                                        "^TESTMEMLEAKFAIL_P1.f09_g16.X",
                                                        "^TESTMEMLEAKPASS_P1.f09_g16.X",
+                                                       "^TESTRUNSTARCFAIL_P1.f09_g16.X",
                                                        "^TESTTESTDIFF_P1.f19_g16_rx1.A",
                                                        "^TESTBUILDFAILEXC_P1.f19_g16_rx1.A",
                                                        "^TESTRUNFAILEXC_P1.f19_g16_rx1.A"],
@@ -1060,6 +1061,7 @@ class O_TestTestScheduler(TestCreateTestCommon):
         test_diff_test      = [item for item in tests if "TESTTESTDIFF" in item][0]
         mem_fail_test       = [item for item in tests if "TESTMEMLEAKFAIL" in item][0]
         mem_pass_test       = [item for item in tests if "TESTMEMLEAKPASS" in item][0]
+        st_arch_fail_test   = [item for item in tests if "TESTRUNSTARCFAIL" in item][0]
 
         log_lvl = logging.getLogger().getEffectiveLevel()
         logging.disable(logging.CRITICAL)
@@ -1104,6 +1106,9 @@ class O_TestTestScheduler(TestCreateTestCommon):
             elif (test_name == test_diff_test):
                 assert_test_status(self, test_name, ts, "COMPARE_base_rest", TEST_FAIL_STATUS)
                 assert_test_status(self, test_name, ts, RUN_PHASE, TEST_PASS_STATUS)
+            elif test_name == st_arch_fail_test:
+                assert_test_status(self, test_name, ts, RUN_PHASE, TEST_PASS_STATUS)
+                assert_test_status(self, test_name, ts, STARCHIVE_PHASE, TEST_FAIL_STATUS)
             else:
                 self.assertTrue(test_name in [pass_test, mem_pass_test])
                 assert_test_status(self, test_name, ts, RUN_PHASE, TEST_PASS_STATUS)

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -973,7 +973,7 @@ class O_TestTestScheduler(TestCreateTestCommon):
         tests = get_tests.get_full_test_names(["cime_test_only",
                                                        "^TESTMEMLEAKFAIL_P1.f09_g16.X",
                                                        "^TESTMEMLEAKPASS_P1.f09_g16.X",
-                                                       "^TESTRUNSTARCFAIL_P1.f09_g16.X",
+                                                       "^TESTRUNSTARCFAIL_P1.f19_g16_rx1.A",
                                                        "^TESTTESTDIFF_P1.f19_g16_rx1.A",
                                                        "^TESTBUILDFAILEXC_P1.f19_g16_rx1.A",
                                                        "^TESTRUNFAILEXC_P1.f19_g16_rx1.A"],


### PR DESCRIPTION
Exceptions coming from sub-phases of the run phase (phases that happen during
SystemTestCommon.run other than that RUN phase) were causing RUN to be
reported as FAIL instead of the sub-phase.

This PR introduces a pattern of handling such phases with more robust
exception handling.

Also, adds a test for this.

Also, splits the 3 phases that were happening under _compare_baseline to
their own functions.

This implementation allows subclasses of SystemTestCommon to override
these sub-phase functions without having to worry about exception
handling.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #2706 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @billsacks 
