### PR TITLE
NOT YET TESTED: Report BFAIL for missing baseline files if there were no baseline fails

### DIFF
--- a/scripts/Tools/component_compare_baseline
+++ b/scripts/Tools/component_compare_baseline
@@ -42,7 +42,7 @@ def _main_func(description):
 ###############################################################################
     caseroot, baseline_dir = parse_command_line(sys.argv, description)
     with Case(caseroot) as case:
-        success, comments = compare_baseline(case, baseline_dir)
+        success, comments, ts_comments = compare_baseline(case, baseline_dir)
         print(comments)
 
     sys.exit(0 if success else 1)

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -483,9 +483,6 @@ class SystemTestsCommon(object):
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             baseline_name = self._case.get_value("BASECMP_CASE")
             ts_comments = (os.path.dirname(baseline_name) + ": " + comments) if "\n" not in comments else os.path.dirname(baseline_name)
-            if ts_comments == os.path.dirname(baseline_name) and TEST_NO_BASELINES_COMMENT in comments:
-                ts_comments += " {} some baseline files were missing".format(TEST_NO_BASELINES_COMMENT)
-
             self._test_status.set_status(BASELINE_PHASE, status, comments=ts_comments)
 
     def _generate_baseline(self):

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -478,11 +478,14 @@ class SystemTestsCommon(object):
         """
         with self._test_status:
             # compare baseline
-            success, comments = compare_baseline(self._case)
+            success, comments, ts_comments = compare_baseline(self._case)
             append_testlog(comments)
             status = TEST_PASS_STATUS if success else TEST_FAIL_STATUS
             baseline_name = self._case.get_value("BASECMP_CASE")
-            ts_comments = (os.path.dirname(baseline_name) + ": " + comments) if "\n" not in comments else os.path.dirname(baseline_name)
+            if ts_comments:
+                ts_comments = os.path.dirname(baseline_name) + ": " + ts_comments
+            else:
+                ts_comments = os.path.dirname(baseline_name)
             self._test_status.set_status(BASELINE_PHASE, status, comments=ts_comments)
 
     def _generate_baseline(self):

--- a/scripts/lib/CIME/bless_test_results.py
+++ b/scripts/lib/CIME/bless_test_results.py
@@ -55,7 +55,7 @@ def bless_history(test_name, test_dir, baseline_name, baseline_root, report_only
 
             baseline_full_dir = os.path.join(baseline_root, baseline_name, case.get_value("CASEBASEID"))
 
-            cmp_result, cmp_comments = compare_baseline(case, baseline_dir=baseline_full_dir, outfile_suffix=None)
+            cmp_result, cmp_comments, cmp_ts_comments = compare_baseline(case, baseline_dir=baseline_full_dir, outfile_suffix=None)
             if cmp_result:
                 logger.info("Diff appears to have been already resolved.")
                 return True, None

--- a/scripts/lib/CIME/compare_test_results.py
+++ b/scripts/lib/CIME/compare_test_results.py
@@ -32,13 +32,13 @@ def compare_history(case, baseline_name, baseline_root, log_id):
 
         outfile_suffix = "{}.{}".format(baseline_name, log_id)
         try:
-            result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
-                                                outfile_suffix=outfile_suffix)
+            result, comments, ts_comments = compare_baseline(case, baseline_dir=baseline_full_dir,
+                                                             outfile_suffix=outfile_suffix)
         except IOError:
-            result, comments = compare_baseline(case, baseline_dir=baseline_full_dir,
-                                                outfile_suffix=None)
+            result, comments, ts_comments = compare_baseline(case, baseline_dir=baseline_full_dir,
+                                                             outfile_suffix=None)
 
-        return result, comments
+        return result, comments, ts_comments
 
 ###############################################################################
 def compare_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, compare_tests=None, namelists_only=False, hist_only=False):
@@ -135,18 +135,12 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                             all_pass_or_skip = False
 
                     if do_compare:
-                        success, detailed_comments = compare_history(case, baseline_name, baseline_root, log_id)
+                        success, detailed_comments, compare_comment = compare_history(case, baseline_name, baseline_root, log_id)
                         if success:
                             compare_result = TEST_PASS_STATUS
                         else:
                             compare_result = TEST_FAIL_STATUS
                             all_pass_or_skip = False
-
-                        # Following the logic in SystemTestsCommon._compare_baseline:
-                        # We'll print the comment if it's a brief one-liner; otherwise
-                        # the comment will only appear in the log file
-                        if "\n" not in detailed_comments:
-                            compare_comment = detailed_comments
 
             brief_result = ""
             if not hist_only:


### PR DESCRIPTION
@jgfouca I'm submitting this for your consideration.

THIS IS UNTESTED: I haven't done manual tests of this or added unit
tests for this yet. I wanted to add unit tests, but this seemed like a lot of work until https://github.com/ESMCI/cime/issues/2747 is addressed. The main thing I'd like to add tests for is the logic in _compare_hists, though I could imagine doing this via unit tests of the public function, compare_baseline - which would also allow testing the creation of test_status_comments in that function.

This implements the logic that used to be in
component_compgen_baseline.sh (as I note in
https://github.com/ESMCI/cime/pull/2744#issuecomment-412208219):

1. The given baseline directory exists, but there are no history files
   there. (What I'd like: BFAIL on the BASELINE line.)

2. The given baseline directory exists. There are some history files
   there, but not all that there should be. The history files there are
   bit-for-bit with the new test. (What I'd like: BFAIL on the BASELINE
   line.)

3. The given baseline directory exists. There are some history files
   there, but not all that there should be. At least one history file is
   _not_ bit-for-bit with the new test. (What I'd like: FAIL, but _no_
   BFAIL on the BASELINE line.)

I also cleaned up the creation of the test status line for BASELINE
failures, making this the responsibility of compare_baseline (in
hist_utils.py) rather than the previous checking for whether "\n" was in
the full comments. (This removes some duplication between
system_tests_common.py and compare_test_results.py.)