### PR TITLE
New resume method

### DIFF
--- a/src/components/data_comps/desp/desp_comp_mod.F90
+++ b/src/components/data_comps/desp/desp_comp_mod.F90
@@ -15,7 +15,6 @@ module desp_comp_mod
   use shr_strdata_mod, only: shr_strdata_pioinit
   use seq_timemgr_mod, only: seq_timemgr_EClockGetData
   use seq_timemgr_mod, only: seq_timemgr_RestartAlarmIsOn
-  use seq_comm_mct,    only: seq_comm_inst, seq_comm_name, seq_comm_suffix
   use seq_comm_mct,    only: num_inst_cpl => num_inst_driver
 
   ! Used to link esp components across multiple drivers
@@ -24,6 +23,8 @@ module desp_comp_mod
   implicit none
   private
 
+#include <mpif.h>
+
   !--------------------------------------------------------------------------
   ! Public interfaces
   !--------------------------------------------------------------------------
@@ -31,6 +32,7 @@ module desp_comp_mod
   public                     :: desp_comp_init
   public                     :: desp_comp_run
   public                     :: desp_comp_final
+  public                     :: desp_bcast_res_files
 
   !--------------------------------------------------------------------------
   ! Public module data
@@ -46,15 +48,18 @@ module desp_comp_mod
   character(len=CS)           :: myModelName = 'esp'    ! user defined model name
   integer(IN)                 :: mpicom
   integer(IN)                 :: COMPID                 ! mct comp id
-  integer(IN)                 :: my_task                ! my task in mpi communicator mpicom
+  integer(IN)                 :: my_task                ! my task in mpicom
   integer(IN)                 :: npes                   ! total number of tasks
   integer(IN),      parameter :: master_task=0          ! task number of master task
+  integer(IN)                 :: global_numpes          ! #PEs in global_commm
+  integer(IN)                 :: global_mype            ! My rank in global_comm
   integer(IN)                 :: logunit                ! logging unit number
   integer(IN)                 :: loglevel               ! logging level
-  integer                     :: inst_index             ! number of current instance (ie. 1)
-  character(len=16)           :: inst_name              ! fullname of current instance (ie. "lnd_0001")
+  integer(IN)                 :: inst_index             ! number of current instance (ie. 1)
+  character(len=16)           :: inst_name              ! fullname of current instance (ie. "esp_0001")
   character(len=16)           :: inst_suffix            ! char string associated with instance (ie. "_0001" or "")
   character(len=CL)           :: desp_mode              ! mode of operation
+  logical                     :: bcast_filenames = .false.
   character(len=*), parameter :: rpprefix  = 'rpointer.'
   character(len=*), parameter :: rpfile    = rpprefix//'esp'
   character(len=*), parameter :: nullstr   = 'undefined'
@@ -64,68 +69,59 @@ module desp_comp_mod
 
   integer,          parameter :: NOERR       =  0
   integer,          parameter :: BAD_ID      = -1
-  integer,          parameter :: NO_RPOINTER = -2
-  integer,          parameter :: NO_RFILE    = -3
-  integer,          parameter :: NO_RPREAD   = -4
   integer,          parameter :: NO_READ     = -5
   integer,          parameter :: NO_WRITE    = -6
 
   type(shr_strdata_type)      :: SDESP
 
-  !--------------------------------------------------------------------------
-  ! Private interface
-  !--------------------------------------------------------------------------
-  interface get_restart_filenames
-     module procedure get_restart_filenames_a
-     module procedure get_restart_filenames_s
-  end interface get_restart_filenames
-  
-  !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CONTAINS
-  !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  !===============================================================================
+  !============================================================================
   subroutine desp_comp_init(EClock, espid, mpicom_in, phase, read_restart,    &
-       esp_present, esp_prognostic)
+       inst_name_in, inst_index_in, inst_suffix_in, esp_present, esp_prognostic)
 
     ! !DESCRIPTION: initialize data esp model
 
     ! !INPUT/OUTPUT PARAMETERS:
-    type(ESMF_Clock), intent(in)  :: EClock
-    integer,          intent(in)  :: espid
-    integer,          intent(in)  :: mpicom_in
-    integer,          intent(in)  :: phase
-    logical,          intent(in)  :: read_restart
-    logical,          intent(out) :: esp_present    ! flag
-    logical,          intent(out) :: esp_prognostic ! flag
+    type(ESMF_Clock),  intent(in)  :: EClock
+    integer,           intent(in)  :: espid
+    integer,           intent(in)  :: mpicom_in
+    integer,           intent(in)  :: phase
+    logical,           intent(in)  :: read_restart
+    integer,           intent(in)  :: inst_index_in  ! (e.g., 1)
+    character(len=16), intent(in)  :: inst_name_in   ! (e.g. "exp_0001")
+    character(len=16), intent(in)  :: inst_suffix_in ! (e.g. "_0001" or "")
+    logical,           intent(out) :: esp_present    ! flag
+    logical,           intent(out) :: esp_prognostic ! flag
 
-    !--- local variables ---
-    integer(IN)                    :: ierr       ! error code
-    integer(IN)                    :: shrlogunit ! original log unit
-    integer(IN)                    :: shrloglev  ! original log level
-    integer(IN)                    :: nunit      ! unit number
+                                                     !--- local variables ---
+    integer(IN)                    :: ierr           ! error code
+    integer(IN)                    :: shrlogunit     ! original log unit
+    integer(IN)                    :: shrloglev      ! original log level
+    integer(IN)                    :: nunit          ! unit number
 
-    character(len=CL)              :: fileName   ! generic file name
+    character(len=CL)              :: fileName       ! generic file name
 
-    character(len=CL)              :: rest_file  ! restart filename
-    character(len=CL)              :: restfilm   ! model restart file namelist
-    logical                        :: exists     ! filename existance
-    integer(IN)                    :: nu         ! unit number
-    integer(IN)                    :: CurrentYMD ! model date
-    integer(IN)                    :: CurrentTOD ! model sec into model date
-    integer(IN)                    :: stepno     ! step number
-    character(len=CL)              :: calendar   ! calendar type
-    integer :: global_mype, global_numpes
+    character(len=CL)              :: rest_file      ! restart filename
+    character(len=CL)              :: restfilm       ! rest_file namelist entry
+    logical                        :: exists         ! filename existance
+    integer(IN)                    :: nu             ! unit number
+    integer(IN)                    :: CurrentYMD     ! model date
+    integer(IN)                    :: CurrentTOD     ! model sec into model date
+    integer(IN)                    :: stepno         ! step number
+    character(len=CL)              :: calendar       ! calendar type
 
     !----- define namelist -----
     namelist / desp_nml /                                                     &
          desp_mode, restfilm
 
     !--- formats ---
-    character(*), parameter :: subName = "(desp_comp_init) "
-    character(*), parameter :: F00     = "('"//subName//"',8a)"
-    character(*), parameter :: F01     = "('"//subName//"',a,5i8)"
-    character(*), parameter :: F04     = "('"//subName//"',2a,2i8,'s')"
+    character(len=*), parameter :: subName = "(desp_comp_init) "
+    character(len=*), parameter :: F00     = "('"//subName//"',8a)"
+    character(len=*), parameter :: F01     = "('"//subName//"',a,5i8)"
+    character(len=*), parameter :: F04     = "('"//subName//"',2(a,i0))"
     !-------------------------------------------------------------------------------
 
     call t_startf('DESP_INIT')
@@ -133,8 +129,11 @@ CONTAINS
     !------------------------------------------------------------------------
     ! Initialize module variables from inputs
     !------------------------------------------------------------------------
-    COMPID       = espid
-    mpicom       = mpicom_in
+    COMPID      = espid
+    mpicom      = mpicom_in
+    inst_name   = inst_name_in
+    inst_index  = inst_index_in
+    inst_suffix = inst_suffix_in
 
     !------------------------------------------------------------------------
     ! Initialize output variables
@@ -142,14 +141,12 @@ CONTAINS
     esp_present    = .false.
     esp_prognostic = .false.
 
-    inst_name   = seq_comm_name(COMPID)
-    inst_index  = seq_comm_inst(COMPID)
-    inst_suffix = seq_comm_suffix(COMPID)
-
     if (phase == 1) then
        ! Determine communicator groups and sizes
        call mpi_comm_rank(mpicom, my_task, ierr)
        call mpi_comm_size(mpicom, npes, ierr)
+       call mpi_comm_rank(global_comm, global_mype, ierr)
+       call mpi_comm_size(global_comm, global_numpes, ierr)
 
        !--- open log file ---
        if (my_task == master_task) then
@@ -190,6 +187,7 @@ CONTAINS
           write(logunit,F01) 'inst_index  = ',inst_index
           write(logunit,F00) 'inst_name   = ',trim(inst_name)
           write(logunit,F00) 'inst_suffix = ',trim(inst_suffix)
+          write(logunit,F04) 'root global rank ',global_mype,' of ',global_numpes
           call shr_sys_flush(logunit)
        end if
        call shr_mpi_bcast(desp_mode,  mpicom, 'desp_mode')
@@ -204,12 +202,6 @@ CONTAINS
        !------------------------------------------------------------------------
 
        call shr_strdata_pioinit(SDESP, COMPID)
-
-       call mpi_comm_rank(global_comm, global_mype, ierr)
-       call mpi_comm_size(global_comm, global_numpes, ierr)
-
-       write(logunit,*)'DESP: I am global rank ',global_mype,' of ',global_numpes
-
 
        !------------------------------------------------------------------------
        ! Validate mode
@@ -321,57 +313,46 @@ CONTAINS
 
     ! !INPUT/OUTPUT PARAMETERS:
 
-    type(ESMF_Clock),  intent(in)    :: EClock
-    character(len=*),  intent(in)    :: case_name
-    logical,           intent(in)    :: pause_sig(desp_num_comps)
-    character(len=CL), intent(inout) :: atm_resume(num_inst_atm)
-    character(len=CL), intent(inout) :: lnd_resume(num_inst_lnd)
-    character(len=CL), intent(inout) :: rof_resume(num_inst_rof)
-    character(len=CL), intent(inout) :: ocn_resume(num_inst_ocn)
-    character(len=CL), intent(inout) :: ice_resume(num_inst_ice)
-    character(len=CL), intent(inout) :: glc_resume(num_inst_glc)
-    character(len=CL), intent(inout) :: wav_resume(num_inst_wav)
-    character(len=CL), intent(inout) :: cpl_resume(num_inst_cpl)
+    type(ESMF_Clock), intent(in) :: EClock
+    character(len=*), intent(in) :: case_name
+    logical,          intent(in) :: pause_sig(desp_num_comps)
+    character(len=CL), pointer   :: atm_resume(:)
+    character(len=CL), pointer   :: lnd_resume(:)
+    character(len=CL), pointer   :: rof_resume(:)
+    character(len=CL), pointer   :: ocn_resume(:)
+    character(len=CL), pointer   :: ice_resume(:)
+    character(len=CL), pointer   :: glc_resume(:)
+    character(len=CL), pointer   :: wav_resume(:)
+    character(len=CL), pointer   :: cpl_resume(:)
 
     !--- local ---
-    integer(IN)                      :: CurrentYMD            ! model date
-    integer(IN)                      :: CurrentTOD            ! model sec into model date
-    integer(IN)                      :: yy,mm,dd              ! year month day
-    integer(IN)                      :: ind                   ! loop index
-    integer(IN)                      :: inst                  ! loop index
-    integer(IN)                      :: errcode               ! error return code
-    character(len=CL), allocatable   :: rfilenames(:)         ! Restart filenames
-    integer(IN)                      :: shrlogunit, shrloglev ! original log unit and level
-    integer(IN)                      :: idt                   ! integer timestep
-    real(R8)                         :: dt                    ! timestep
-    logical                          :: write_restart         ! restart now
-    logical                          :: var_found             ! var on file
-    character(len=CL)                :: rest_file             ! restart_file
-    integer(IN)                      :: nu                    ! unit number
-    integer(IN)                      :: stepno                ! step number
-    character(len=CL)                :: calendar              ! calendar type
+    integer(IN)                      :: CurrentYMD    ! model date
+    integer(IN)                      :: CurrentTOD    ! model sec into model date
+    integer(IN)                      :: yy,mm,dd      ! year month day
+    integer(IN)                      :: ind           ! loop index
+    integer(IN)                      :: inst          ! loop index
+    integer(IN)                      :: errcode       ! error return code
+    character(len=CL)                :: rfilename     ! Restart filenames
+    integer(IN)                      :: shrlogunit    ! original log unit
+    integer(IN)                      :: shrloglev     ! original log level
+    integer(IN)                      :: idt           ! integer timestep
+    real(R8)                         :: dt            ! timestep
+    logical                          :: write_restart ! restart now
+    logical                          :: var_found     ! var on file
+    character(len=CL)                :: rest_file     ! restart_file
+    integer(IN)                      :: nu            ! unit number
+    integer(IN)                      :: stepno        ! step number
+    character(len=CL)                :: calendar      ! calendar type
     character(len=CS)                :: varname
     character(len=18)                :: date_str
-    character(len=*), parameter      :: F00   = "('(desp_comp_run) ',8a)"
-    character(len=*), parameter      :: F04   = "('(desp_comp_run) ',2a,2i8,'s')"
     character(len=*), parameter      :: subName = "(desp_comp_run) "
+    character(len=*), parameter      :: F00   = "('"//subName//"',8a)"
+    character(len=*), parameter      :: F04   = "('"//subName//"',2a,2i8,'s')"
     !--------------------------------------------------------------------------
 
     call t_startf('DESP_RUN')
 
     call t_startf('desp_run1')
-
-    !--------------------------------------------------------------------------
-    ! Make sure output variables are set
-    !--------------------------------------------------------------------------
-    atm_resume(:) = ' '
-    lnd_resume(:) = ' '
-    rof_resume(:) = ' '
-    ocn_resume(:) = ' '
-    ice_resume(:) = ' '
-    glc_resume(:) = ' '
-    wav_resume(:) = ' '
-    cpl_resume(:)    = ' '
 
     !--------------------------------------------------------------------------
     ! Reset shr logging to my log file
@@ -413,6 +394,7 @@ CONTAINS
        end if
     end if
 
+    errcode = NOERR
     ! Find the active components and their restart files
     ! Note hard-coded variable names are just for testing. This could be
     !   changed if this feature comes to regular use
@@ -420,56 +402,34 @@ CONTAINS
        if (pause_sig(ind)) then
           select case (comp_names(ind))
           case('atm')
-             call get_restart_filenames(ind, atm_resume, errcode)
-             allocate(rfilenames(size(atm_resume)))
-             rfilenames = atm_resume
+             rfilename = atm_resume(inst_index)
              varname = 'T'
           case('lnd')
-             call get_restart_filenames(ind, lnd_resume, errcode)
-             allocate(rfilenames(size(lnd_resume)))
-             rfilenames = lnd_resume
+             rfilename = lnd_resume(inst_index)
              varname = 'T'
           case('ice')
-             call get_restart_filenames(ind, ice_resume, errcode)
-             allocate(rfilenames(size(ice_resume)))
-             rfilenames = ice_resume
+             rfilename = ice_resume(inst_index)
              varname = 'T'
           case('ocn')
-             call get_restart_filenames(ind, ocn_resume, errcode)
-             allocate(rfilenames(size(ocn_resume)))
-             rfilenames = ocn_resume
+             rfilename = ocn_resume(inst_index)
              varname = 'PSURF_CUR'
           case('glc')
-             call get_restart_filenames(ind, glc_resume, errcode)
-             allocate(rfilenames(size(glc_resume)))
-             rfilenames = glc_resume
+             rfilename = glc_resume(inst_index)
              varname = 'T'
           case('rof')
-             call get_restart_filenames(ind, rof_resume, errcode)
-             allocate(rfilenames(size(rof_resume)))
-             rfilenames = rof_resume
+             rfilename = rof_resume(inst_index)
              varname = 'T'
           case('wav')
-             call get_restart_filenames(ind, wav_resume, errcode)
-             allocate(rfilenames(size(wav_resume)))
-             rfilenames = wav_resume
+             rfilename = wav_resume(inst_index)
              varname = 'T'
           case('drv')
-             call get_restart_filenames(ind, cpl_resume, errcode)
-             allocate(rfilenames(size(cpl_resume)))
-             rfilenames = cpl_resume
+             rfilename = cpl_resume(inst_index)
              varname = 'x2oacc_ox_Foxx_swnet'
           case default
              call shr_sys_abort(subname//'Unrecognized ind')
           end select
           ! Just die on errors for now
           select case (errcode)
-          case(NO_RPOINTER)
-             call shr_sys_abort(subname//'Missing rpointer file for '//comp_names(ind))
-          case(NO_RPREAD)
-             call shr_sys_abort(subname//'Cannot read rpointer file for '//comp_names(ind))
-          case(NO_RFILE)
-             call shr_sys_abort(subname//'Missing restart file for '//comp_names(ind))
           case(NO_READ)
              call shr_sys_abort(subname//'No restart read access for '//comp_names(ind))
           case(NO_WRITE)
@@ -479,29 +439,22 @@ CONTAINS
           select case (trim(desp_mode))
           case(noop_mode)
              ! Find the correct restart files but do not change them.
-             do inst = 1, size(rfilenames)
-                if ((my_task == master_task) .and. (loglevel > 0)) then
-                   write(logunit, *) subname, 'Found restart file ',trim(rfilenames(inst))
-                end if
-             end do
+             if ((my_task == master_task) .and. (loglevel > 0)) then
+                write(logunit, *) subname, 'Found restart file ',trim(rfilename)
+             end if
           case(test_mode)
              ! Find the correct restart files and 'tweak' them
-             do inst = 1, size(rfilenames)
-                if ((my_task == master_task) .and. (loglevel > 0)) then
-                   write(logunit, *) subname, 'Found restart file ',trim(rfilenames(inst))
-                end if
-                call esp_pio_modify_variable(COMPID, mpicom, rfilenames(inst), varname, var_found)
-                if (.not. var_found) then
-                   call shr_sys_abort(subname//'Variable, '//trim(varname)//', not found on '//rfilenames(inst))
-                end if
-             end do
+             if ((my_task == master_task) .and. (loglevel > 0)) then
+                write(logunit, *) subname, 'Found restart file ',trim(rfilename)
+             end if
+             call esp_pio_modify_variable(COMPID, mpicom, rfilename, varname, var_found)
+             if (.not. var_found) then
+                call shr_sys_abort(subname//'Variable, '//trim(varname)//', not found on '//rfilename)
+             end if
           case (null_mode)
              ! Since DESP is not 'present' for this mode, we should not get here.
              call shr_sys_abort(subname//'DESP should not run in "NULL" mode')
           end select
-          if (allocated(rfilenames)) then
-             deallocate(rfilenames)
-          end if
        end if
     end do
 
@@ -557,9 +510,9 @@ CONTAINS
 
     ! !DESCRIPTION: finalize method for data esp model
     !--- formats ---
-    character(*), parameter :: F00   = "('(desp_comp_final) ',8a)"
-    character(*), parameter :: F91   = "('(desp_comp_final) ',73('-'))"
-    character(*), parameter :: subName = "(desp_comp_final) "
+    character(len=*), parameter :: subName = "(desp_comp_final) "
+    character(len=*), parameter :: F00   = "('"//subName//"',8a)"
+    character(len=*), parameter :: F91   = "('"//subName//"',73('-'))"
     !--------------------------------------------------------------------------
 
     call t_startf('DESP_FINAL')
@@ -575,118 +528,12 @@ CONTAINS
   end subroutine desp_comp_final
 
   !============================================================================
-  subroutine get_restart_filenames_a(comp_ind, filenames, retcode)
-    use seq_comm_mct, only: ATMID, LNDID, OCNID, ICEID, GLCID, ROFID
-    use seq_comm_mct, only: WAVID, CPLID, seq_comm_suffix, cpl_inst_tag
-    use shr_file_mod, only: shr_file_getUnit, shr_file_freeUnit
+  logical function desp_bcast_res_files(oneletterid)
+     character(len=1), intent(in) :: oneletterid
 
-    ! Dummy arguments
-    integer,           intent(in)    :: comp_ind ! Internal comp. type index
-    character(len=CL), intent(inout) :: filenames(:)
-    integer,           intent(out)   :: retcode
-
-    ! Local variables
-    integer                          :: num_inst
-    integer                          :: ind
-    integer                          :: ierr
-    integer                          :: unitn
-    integer,          allocatable    :: ids(:)
-    logical                          :: file_exists
-    character(len=8)                 :: file_read
-    character(len=CS)                :: rpointer_name
-    character(len=CL)                :: errmsg
-    character(len=*), parameter      :: subname = "(desp_restart_filenames) "
-
-    retcode = NOERR
-    filenames = ' '
-    num_inst = size(filenames)
-    allocate(ids(num_inst))
-    select case (comp_names(comp_ind))
-    case('atm')
-       ids = ATMID
-    case('lnd')
-       ids = LNDID
-    case('ice')
-       ids = ICEID
-    case('ocn')
-       ids = OCNID
-    case('glc')
-       ids = GLCID
-    case('rof')
-       ids = ROFID
-    case('wav')
-       ids = WAVID
-    case('drv')
-       ids = CPLID
-    case default
-       call shr_sys_abort(subname//'Unrecognized comp_ind')
-    end select
-    rpointer_name = rpprefix//comp_names(comp_ind)
-
-    do ind = 1, num_inst
-       if (num_inst_cpl > 1) then
-          rpointer_name = rpprefix//comp_names(comp_ind)//trim(cpl_inst_tag)
-       else
-          rpointer_name = rpprefix//comp_names(comp_ind)//trim(seq_comm_suffix(ids(ind)))
-       endif
-       if (my_task == master_task) then
-          inquire(file=rpointer_name, EXIST=file_exists)
-          ! POP decided to not follow the convention
-          if ((.not. file_exists) .and. (trim(comp_names(comp_ind)) == 'ocn')) then
-             rpointer_name = rpprefix//comp_names(comp_ind)//".restart"//trim(seq_comm_suffix(ids(ind)))
-             inquire(file=rpointer_name, EXIST=file_exists)
-          end if
-          if (.not. file_exists) then
-             retcode = NO_RPOINTER
-          else
-             unitn = shr_file_getUnit()
-             if (loglevel > 0) then
-                write(logunit,"(3A)") subname,"read rpointer file ", trim(rpointer_name)
-             end if
-             open(unitn, file=rpointer_name, form='FORMATTED', status='old',     &
-                  action='READ', iostat=ierr)
-             if (ierr /= 0) then
-                write(errmsg, '(a,i0)') 'rpointer file open returns error condition, ',ierr
-                call shr_sys_abort(subname//trim(errmsg))
-             end if
-             read(unitn,'(a)', iostat=ierr) filenames(ind)
-             if (ierr /= 0) then
-                write(errmsg, '(a,i0)') 'rpointer file read returns error condition, ',ierr
-                call shr_sys_abort(subname//trim(errmsg))
-             end if
-             close(unitn)
-             call shr_file_freeUnit(unitn)
-             inquire(file=filenames(ind), EXIST=file_exists)
-             if (.not. file_exists) then
-                retcode = NO_RFILE
-                ! No else
-             end if
-          end if
-       end if
-       ! Broadcast what we learned about files
-       call shr_mpi_bcast(retcode,  mpicom, 'rpointer status')
-       call shr_mpi_bcast(filenames(ind),  mpicom, 'filenames(ind)')
-    end do
-
-    if (allocated(ids)) then
-       deallocate(ids)
-    end if
-
-  end subroutine get_restart_filenames_a
+     desp_bcast_res_files = bcast_filenames
+  end function desp_bcast_res_files
 
   !============================================================================
-  subroutine get_restart_filenames_s(comp_ind, filename, retcode)
-
-    ! Dummy arguments
-    integer,           intent(in)    :: comp_ind ! Internal comp. type index
-    character(len=CL), intent(inout) :: filename
-    integer,           intent(out)   :: retcode
-
-    ! Local variable
-    character(len=CL)                :: filenames(1)
-
-    call get_restart_filenames(comp_ind, filenames, retcode)
-    filename = filenames(1)
-  end subroutine get_restart_filenames_s
 
 end module desp_comp_mod

--- a/src/components/data_comps/desp/desp_comp_mod.F90
+++ b/src/components/data_comps/desp/desp_comp_mod.F90
@@ -423,7 +423,8 @@ CONTAINS
              rfilename = wav_resume(inst_index)
              varname = 'T'
           case('drv')
-             rfilename = cpl_resume(inst_index)
+             ! The driver is special, there may only be one (not multi-driver)
+             rfilename = cpl_resume(min(inst_index,size(cpl_resume,1)))
              varname = 'x2oacc_ox_Foxx_swnet'
           case default
              call shr_sys_abort(subname//'Unrecognized ind')

--- a/src/components/data_comps/desp/mct/esp_comp_mct.F90
+++ b/src/components/data_comps/desp/mct/esp_comp_mct.F90
@@ -44,30 +44,33 @@ CONTAINS
   subroutine esp_init_mct(EClock, cdata, x2a, a2x, NLFilename)
     use desp_comp_mod,    only: desp_comp_init, comp_names
     use seq_cdata_mod,    only: seq_cdata_setptrs
+    use seq_comm_mct,     only: seq_comm_inst, seq_comm_name, seq_comm_suffix
     use seq_infodata_mod, only: seq_infodata_putData, seq_infodata_GetData
     use seq_timemgr_mod,  only: seq_timemgr_pause_component_index
 
 
     ! !INPUT/OUTPUT PARAMETERS:
 
-    type(ESMF_Clock),                  intent(inout) :: EClock
-    type(seq_cdata),                   intent(inout) :: cdata
-    type(mct_aVect),                   intent(inout) :: x2a, a2x   ! Not used
-    character(len=*),        optional, intent(in)    :: NLFilename ! Not used
+    type(ESMF_Clock),           intent(inout) :: EClock
+    type(seq_cdata),            intent(inout) :: cdata
+    type(mct_aVect),            intent(inout) :: x2a, a2x   ! Not used
+    character(len=*), optional, intent(in)    :: NLFilename ! Not used
 
-    !EOP
+                                                                   !EOP
 
-    integer                                          :: ind
-    integer                                          :: ESPID
-    integer                                          :: mpicom_esp
-    integer                                          :: esp_phase
-    logical                                          :: esp_present
-    logical                                          :: esp_prognostic
-    logical                                          :: read_restart
-    type(seq_infodata_type), pointer                 :: infodata
-    character(len=*),        parameter               :: subName = "(esp_init_mct) "
+    integer                            :: inst_index  ! (e.g., 1)
+    character(len=16)                  :: inst_name   ! (e.g. "exp_0001")
+    character(len=16)                  :: inst_suffix ! (e.g. "_0001" or "")
+    integer                            :: ind
+    integer                            :: ESPID
+    integer                            :: mpicom_esp
+    integer                            :: esp_phase
+    logical                            :: esp_present
+    logical                            :: esp_prognostic
+    logical                            :: read_restart
+    type(seq_infodata_type), pointer   :: infodata
+    character(len=*),        parameter :: subName = "(esp_init_mct) "
     !--------------------------------------------------------------------------
-
 
     ! Retrieve  info for init method
     call seq_cdata_setptrs(cdata, ID=ESPID, mpicom=mpicom_esp,                &
@@ -75,8 +78,12 @@ CONTAINS
     call seq_infodata_getData(infodata, esp_phase=esp_phase,                  &
          read_restart=read_restart)
 
+    inst_name   = seq_comm_name(ESPID)
+    inst_index  = seq_comm_inst(ESPID)
+    inst_suffix = seq_comm_suffix(ESPID)
+
     call desp_comp_init(EClock, ESPID, mpicom_esp, esp_phase, read_restart,   &
-         esp_present, esp_prognostic)
+         inst_name, inst_index, inst_suffix, esp_present, esp_prognostic)
 
     ! Set the ESP model state
     call seq_infodata_PutData(infodata,                                       &
@@ -102,14 +109,15 @@ CONTAINS
   ! !INTERFACE: ------------------------------------------------------------------
 
   subroutine esp_run_mct( EClock, cdata,  x2a, a2x)
-    use shr_kind_mod,     only: CL=>SHR_KIND_CL
-    use seq_comm_mct,     only: num_inst_atm, num_inst_lnd, num_inst_rof
-    use seq_comm_mct,     only: num_inst_ocn, num_inst_ice, num_inst_glc
-    use seq_comm_mct,     only: num_inst_wav
-    use desp_comp_mod,    only: desp_comp_run
-    use seq_cdata_mod,    only: seq_cdata_setptrs
-    use seq_infodata_mod, only: seq_infodata_putData, seq_infodata_GetData
-    use seq_timemgr_mod,  only: seq_timemgr_pause_component_active
+    use shr_kind_mod,        only: CL=>SHR_KIND_CL
+    use seq_comm_mct,        only: num_inst_atm, num_inst_lnd, num_inst_rof
+    use seq_comm_mct,        only: num_inst_ocn, num_inst_ice, num_inst_glc
+    use seq_comm_mct,        only: num_inst_wav, num_inst_max, num_inst_driver
+    use desp_comp_mod,       only: desp_comp_run, desp_bcast_res_files
+    use seq_cdata_mod,       only: seq_cdata_setptrs
+    use seq_infodata_mod,    only: seq_infodata_putData, seq_infodata_GetData
+    use seq_pauseresume_mod, only: seq_resume_get_files, seq_resume_store_comp
+    use seq_timemgr_mod,     only: seq_timemgr_pause_component_active
 
     ! !INPUT/OUTPUT PARAMETERS:
 
@@ -123,14 +131,14 @@ CONTAINS
     integer                            :: ind
     type(seq_infodata_type), pointer   :: infodata
     logical                            :: pause_sig(desp_num_comps)
-    character(len=CL)                  :: atm_resume(num_inst_atm)
-    character(len=CL)                  :: lnd_resume(num_inst_lnd)
-    character(len=CL)                  :: rof_resume(num_inst_rof)
-    character(len=CL)                  :: ocn_resume(num_inst_ocn)
-    character(len=CL)                  :: ice_resume(num_inst_ice)
-    character(len=CL)                  :: glc_resume(num_inst_glc)
-    character(len=CL)                  :: wav_resume(num_inst_wav)
-    character(len=CL)                  :: cpl_resume
+    character(len=CL),       pointer   :: atm_resume(:)
+    character(len=CL),       pointer   :: lnd_resume(:)
+    character(len=CL),       pointer   :: rof_resume(:)
+    character(len=CL),       pointer   :: ocn_resume(:)
+    character(len=CL),       pointer   :: ice_resume(:)
+    character(len=CL),       pointer   :: glc_resume(:)
+    character(len=CL),       pointer   :: wav_resume(:)
+    character(len=CL),       pointer   :: cpl_resume(:)
     character(len=CL)                  :: case_name
     character(len=*),        parameter :: subName = "(esp_run_mct) "
     !--------------------------------------------------------------------------
@@ -138,6 +146,15 @@ CONTAINS
     ! Grab infodata and case name
     call seq_cdata_setptrs(cdata, infodata=infodata)
     call seq_infodata_GetData(infodata, case_name=case_name)
+    ! Grab any active resume filenames
+    call seq_resume_get_files('a', atm_resume, bcast=desp_bcast_res_files('a'))
+    call seq_resume_get_files('l', lnd_resume, bcast=desp_bcast_res_files('l'))
+    call seq_resume_get_files('o', ocn_resume, bcast=desp_bcast_res_files('o'))
+    call seq_resume_get_files('i', ice_resume, bcast=desp_bcast_res_files('i'))
+    call seq_resume_get_files('r', rof_resume, bcast=desp_bcast_res_files('r'))
+    call seq_resume_get_files('g', glc_resume, bcast=desp_bcast_res_files('g'))
+    call seq_resume_get_files('w', wav_resume, bcast=desp_bcast_res_files('w'))
+    call seq_resume_get_files('x', cpl_resume, bcast=desp_bcast_res_files('x'))
     ! Find out if we should be running
     do ind = 1, desp_num_comps
        pause_sig(ind) = seq_timemgr_pause_component_active(comp_index(ind))
@@ -145,11 +162,6 @@ CONTAINS
     call desp_comp_run(EClock, case_name, pause_sig, atm_resume, lnd_resume,  &
          rof_resume, ocn_resume, ice_resume, glc_resume, wav_resume,          &
          cpl_resume)
-    ! Set any resume signals resulting from data ESP run
-    call seq_infodata_PutData(infodata, atm_resume=atm_resume,                &
-         lnd_resume=lnd_resume, ocn_resume=ocn_resume, ice_resume=ice_resume, &
-         glc_resume=glc_resume, rof_resume=rof_resume, wav_resume=wav_resume, &
-         cpl_resume=cpl_resume)
 
   end subroutine esp_run_mct
 

--- a/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -521,14 +521,6 @@
       </machine>
     </machines>
   </test>
-  <test name="PRE" grid="f19_f19" compset="ADESP_TEST">
-    <machines>
-      <machine name="hobart" compiler="nag" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
-    </options>
-  </test>
   <test name="SEQ_IOP_Ld3" grid="f19_g16" compset="X">
     <machines>
       <machine name="hobart" compiler="pgi" category="prebeta">
@@ -644,6 +636,22 @@
     <machines>
       <machine name="hobart" compiler="gnu" category="prealpha"/>
       <machine name="hobart" compiler="nag" category="prealpha"/>
+      <machine name="hobart" compiler="nag" category="pauseresume"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+    </options>
+  </test>
+  <test name="PRE_N2" grid="f19_f19" compset="ADESP_TEST">
+    <machines>
+      <machine name="hobart" compiler="nag" category="pauseresume"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:20:00 </option>
+    </options>
+  </test>
+  <test name="PRE_N2" grid="f19_f19" compset="ADESP_TEST" testmods="drv/multi_driver">
+    <machines>
       <machine name="hobart" compiler="nag" category="pauseresume"/>
     </machines>
     <options>

--- a/src/drivers/mct/cime_config/testdefs/testmods_dirs/drv/multi_driver/shell_commands
+++ b/src/drivers/mct/cime_config/testdefs/testmods_dirs/drv/multi_driver/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange MULTI_DRIVER="TRUE"

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -637,8 +637,6 @@ contains
          iam=comp_comm_iam(it))
     if (iamroot_CPLID) output_perf = .true.
 
-    if (iamin_CPLID) complist = trim(complist)//' cpl'
-
     comp_id(it)    = CPLID
     comp_comm(it)  = mpicom_CPLID
     iamin_CPLID    = seq_comm_iamin(CPLID)
@@ -652,9 +650,6 @@ contains
        comp_name(it)  = seq_comm_name(comp_id(it))
        call seq_comm_getinfo(ATMID(eai), mpicom=comp_comm(it), &
             nthreads=nthreads_ATMID, iam=comp_comm_iam(it))
-       if (seq_comm_iamin(ATMID(eai))) then
-          complist = trim(complist)//' '//trim(seq_comm_name(ATMID(eai)))
-       endif
        if (seq_comm_iamroot(ATMID(eai))) output_perf = .true.
     enddo
     call seq_comm_getinfo(CPLALLATMID, mpicom=mpicom_CPLALLATMID)
@@ -667,9 +662,6 @@ contains
        comp_name(it)  = seq_comm_name(comp_id(it))
        call seq_comm_getinfo(LNDID(eli), mpicom=comp_comm(it), &
             nthreads=nthreads_LNDID, iam=comp_comm_iam(it))
-       if (seq_comm_iamin(LNDID(eli))) then
-          complist = trim(complist)//' '//trim(seq_comm_name(LNDID(eli)))
-       endif
        if (seq_comm_iamroot(LNDID(eli))) output_perf = .true.
     enddo
     call seq_comm_getinfo(CPLALLLNDID, mpicom=mpicom_CPLALLLNDID)
@@ -682,9 +674,6 @@ contains
        comp_name(it)  = seq_comm_name(comp_id(it))
        call seq_comm_getinfo(OCNID(eoi), mpicom=comp_comm(it), &
             nthreads=nthreads_OCNID, iam=comp_comm_iam(it))
-       if (seq_comm_iamin (OCNID(eoi))) then
-          complist = trim(complist)//' '//trim(seq_comm_name(OCNID(eoi)))
-       endif
        if (seq_comm_iamroot(OCNID(eoi))) output_perf = .true.
     enddo
     call seq_comm_getinfo(CPLALLOCNID, mpicom=mpicom_CPLALLOCNID)
@@ -697,9 +686,6 @@ contains
        comp_name(it)  = seq_comm_name(comp_id(it))
        call seq_comm_getinfo(ICEID(eii), mpicom=comp_comm(it), &
             nthreads=nthreads_ICEID, iam=comp_comm_iam(it))
-       if (seq_comm_iamin (ICEID(eii))) then
-          complist = trim(complist)//' '//trim(seq_comm_name(ICEID(eii)))
-       endif
        if (seq_comm_iamroot(ICEID(eii))) output_perf = .true.
     enddo
     call seq_comm_getinfo(CPLALLICEID, mpicom=mpicom_CPLALLICEID)
@@ -711,9 +697,6 @@ contains
        comp_iamin(it) = seq_comm_iamin(comp_id(it))
        comp_name(it)  = seq_comm_name(comp_id(it))
        call seq_comm_getinfo(GLCID(egi), mpicom=comp_comm(it), nthreads=nthreads_GLCID, iam=comp_comm_iam(it))
-       if (seq_comm_iamin (GLCID(egi))) then
-          complist = trim(complist)//' '//trim(seq_comm_name(GLCID(egi)))
-       endif
        if (seq_comm_iamroot(GLCID(egi))) output_perf = .true.
     enddo
     call seq_comm_getinfo(CPLALLGLCID, mpicom=mpicom_CPLALLGLCID)
@@ -726,9 +709,6 @@ contains
        comp_name(it)  = seq_comm_name(comp_id(it))
        call seq_comm_getinfo(ROFID(eri), mpicom=comp_comm(it), &
             nthreads=nthreads_ROFID, iam=comp_comm_iam(it))
-       if (seq_comm_iamin(ROFID(eri))) then
-          complist = trim(complist)//' '//trim( seq_comm_name(ROFID(eri)))
-       endif
        if (seq_comm_iamroot(ROFID(eri))) output_perf = .true.
     enddo
     call seq_comm_getinfo(CPLALLROFID, mpicom=mpicom_CPLALLROFID)
@@ -741,9 +721,6 @@ contains
        comp_name(it)  = seq_comm_name(comp_id(it))
        call seq_comm_getinfo(WAVID(ewi), mpicom=comp_comm(it), &
             nthreads=nthreads_WAVID, iam=comp_comm_iam(it))
-       if (seq_comm_iamin(WAVID(ewi))) then
-          complist = trim(complist)//' '//trim(seq_comm_name(WAVID(ewi)))
-       endif
        if (seq_comm_iamroot(WAVID(ewi))) output_perf = .true.
     enddo
     call seq_comm_getinfo(CPLALLWAVID, mpicom=mpicom_CPLALLWAVID)
@@ -756,9 +733,6 @@ contains
        comp_name(it)  = seq_comm_name(comp_id(it))
        call seq_comm_getinfo(ESPID(eei), mpicom=comp_comm(it), &
             nthreads=nthreads_ESPID, iam=comp_comm_iam(it))
-       if (seq_comm_iamin (ESPID(eei))) then
-          complist = trim(complist)//' '//trim(seq_comm_name(ESPID(eei)))
-       endif
     enddo
     ! ESP components do not use the coupler (they are 'external')
 

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2048,6 +2048,7 @@ contains
     use seq_comm_mct,        only: atm_layout, lnd_layout, ice_layout
     use seq_comm_mct,        only: glc_layout, rof_layout, ocn_layout
     use seq_comm_mct,        only: wav_layout, esp_layout, num_inst_driver
+    use seq_comm_mct,        only: seq_comm_inst
     use seq_pauseresume_mod, only: seq_resume_store_comp, seq_resume_get_files
     use seq_pauseresume_mod, only: seq_resume_free
 
@@ -3775,37 +3776,37 @@ contains
           do eai = 1, num_inst_atm
              call seq_resume_store_comp(atm(eai)%oneletterid,                 &
                   atm(eai)%cdata_cc%resume_filename, num_inst_atm,            &
-                  atm(eai)%instn, component_get_iamroot_compid(atm(eai)))
+                  ATMID(eai), component_get_iamroot_compid(atm(eai)))
           end do
           do eli = 1, num_inst_lnd
              call seq_resume_store_comp(lnd(eli)%oneletterid,                 &
                   lnd(eli)%cdata_cc%resume_filename, num_inst_lnd,            &
-                  lnd(eli)%instn, component_get_iamroot_compid(lnd(eli)))
+                  LNDID(eli), component_get_iamroot_compid(lnd(eli)))
           end do
           do eoi = 1, num_inst_ocn
              call seq_resume_store_comp(ocn(eoi)%oneletterid,                 &
                   ocn(eoi)%cdata_cc%resume_filename, num_inst_ocn,            &
-                  ocn(eoi)%instn, component_get_iamroot_compid(ocn(eoi)))
+                  OCNID(eoi), component_get_iamroot_compid(ocn(eoi)))
           end do
           do eii = 1, num_inst_ice
              call seq_resume_store_comp(ice(eii)%oneletterid,                 &
                   ice(eii)%cdata_cc%resume_filename, num_inst_ice,            &
-                  ice(eii)%instn, component_get_iamroot_compid(ice(eii)))
+                  ICEID(eii), component_get_iamroot_compid(ice(eii)))
           end do
           do eri = 1, num_inst_rof
              call seq_resume_store_comp(rof(eri)%oneletterid,                 &
                   rof(eri)%cdata_cc%resume_filename, num_inst_rof,            &
-                  rof(eri)%instn, component_get_iamroot_compid(rof(eri)))
+                  ROFID(eri), component_get_iamroot_compid(rof(eri)))
           end do
           do egi = 1, num_inst_glc
              call seq_resume_store_comp(glc(egi)%oneletterid,                 &
                   glc(egi)%cdata_cc%resume_filename, num_inst_glc,            &
-                  glc(egi)%instn, component_get_iamroot_compid(glc(egi)))
+                  GLCID(egi), component_get_iamroot_compid(glc(egi)))
           end do
           do ewi = 1, num_inst_wav
              call seq_resume_store_comp(wav(ewi)%oneletterid,                 &
                   wav(ewi)%cdata_cc%resume_filename, num_inst_wav,            &
-                  wav(ewi)%instn, component_get_iamroot_compid(wav(ewi)))
+                  WAVID(ewi), component_get_iamroot_compid(wav(ewi)))
           end do
           ! Here we pass 1 as num_inst_driver as num_inst_driver is used inside
           call seq_resume_store_comp('x', drv_resume, 1,                      &
@@ -3820,43 +3821,43 @@ contains
           call seq_resume_get_files('a', resume_files)
           if (associated(resume_files)) then
              do eai = 1, num_inst_atm
-                atm(eai)%cdata_cc%resume_filename = resume_files(atm(eai)%instn)
+                atm(eai)%cdata_cc%resume_filename = resume_files(ATMID(eai))
              end do
           end if
           call seq_resume_get_files('l', resume_files)
           if (associated(resume_files)) then
              do eli = 1, num_inst_lnd
-                lnd(eli)%cdata_cc%resume_filename = resume_files(lnd(eli)%instn)
+                lnd(eli)%cdata_cc%resume_filename = resume_files(LNDID(eli))
              end do
           end if
           call seq_resume_get_files('o', resume_files)
           if (associated(resume_files)) then
              do eoi = 1, num_inst_ocn
-                ocn(eoi)%cdata_cc%resume_filename = resume_files(ocn(eoi)%instn)
+                ocn(eoi)%cdata_cc%resume_filename = resume_files(OCNID(eoi))
              end do
           end if
           call seq_resume_get_files('i', resume_files)
           if (associated(resume_files)) then
              do eii = 1, num_inst_ice
-                ice(eii)%cdata_cc%resume_filename = resume_files(ice(eii)%instn)
+                ice(eii)%cdata_cc%resume_filename = resume_files(ICEID(eii))
              end do
           end if
           call seq_resume_get_files('r', resume_files)
           if (associated(resume_files)) then
              do eri = 1, num_inst_rof
-                rof(eri)%cdata_cc%resume_filename = resume_files(rof(eri)%instn)
+                rof(eri)%cdata_cc%resume_filename = resume_files(ROFID(eri))
              end do
           end if
           call seq_resume_get_files('g', resume_files)
           if (associated(resume_files)) then
              do egi = 1, num_inst_glc
-                glc(egi)%cdata_cc%resume_filename = resume_files(glc(egi)%instn)
+                glc(egi)%cdata_cc%resume_filename = resume_files(GLCID(egi))
              end do
           end if
           call seq_resume_get_files('w', resume_files)
           if (associated(resume_files)) then
              do ewi = 1, num_inst_wav
-                wav(ewi)%cdata_cc%resume_filename = resume_files(wav(ewi)%instn)
+                wav(ewi)%cdata_cc%resume_filename = resume_files(WAVID(ewi))
              end do
           end if
           call seq_resume_get_files('x', resume_files)
@@ -4206,7 +4207,7 @@ contains
     call shr_mpi_commsize(comm_in, numpes, ' cime_cpl_init')
 
     num_inst_driver = 1
-    id    = 0
+    id    = 1 ! For compatiblity with component instance numbering
 
     if (mype == 0) then
        ! Read coupler namelist if it exists

--- a/src/drivers/mct/main/component_type_mod.F90
+++ b/src/drivers/mct/main/component_type_mod.F90
@@ -92,7 +92,6 @@ module component_type_mod
      logical                         :: iamroot_compid
      logical                         :: present ! true => component is present and not stub
      integer                         :: nthreads_compid
-     integer                         :: instn
      character(len=CL)               :: suffix
      character(len=1)                :: oneletterid
      character(len=3)                :: ntype

--- a/src/drivers/mct/main/seq_rest_mod.F90
+++ b/src/drivers/mct/main/seq_rest_mod.F90
@@ -287,7 +287,7 @@ contains
   subroutine seq_rest_write(EClock_d, seq_SyncClock, infodata, &
        atm, lnd, ice, ocn, rof, glc, wav, esp,                 &
        fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-       fractions_rx, fractions_gx, fractions_wx, tag)
+       fractions_rx, fractions_gx, fractions_wx, tag, rest_file)
 
     implicit none
 
@@ -295,13 +295,13 @@ contains
     type(seq_timemgr_type) , intent(inout) :: seq_SyncClock ! contains ptr to driver clock
     type(seq_infodata_type), intent(in)    :: infodata
     type (component_type)       , intent(inout) :: atm(:)
-    type (component_type)       , intent(inout) :: lnd(:)
-    type (component_type)       , intent(inout) :: ice(:)
-    type (component_type)       , intent(inout) :: ocn(:)
-    type (component_type)       , intent(inout) :: rof(:)
-    type (component_type)       , intent(inout) :: glc(:)
-    type (component_type)       , intent(inout) :: wav(:)
-    type (component_type)       , intent(inout) :: esp(:)
+    type (component_type)  , intent(inout) :: lnd(:)
+    type (component_type)  , intent(inout) :: ice(:)
+    type (component_type)  , intent(inout) :: ocn(:)
+    type (component_type)  , intent(inout) :: rof(:)
+    type (component_type)  , intent(inout) :: glc(:)
+    type (component_type)  , intent(inout) :: wav(:)
+    type (component_type)  , intent(inout) :: esp(:)
     type(mct_aVect)        , intent(inout) :: fractions_ax(:)   ! Fractions on atm grid/decomp
     type(mct_aVect)        , intent(inout) :: fractions_lx(:)   ! Fractions on lnd grid/decomp
     type(mct_aVect)        , intent(inout) :: fractions_ix(:)   ! Fractions on ice grid/decomp
@@ -309,7 +309,8 @@ contains
     type(mct_aVect)        , intent(inout) :: fractions_rx(:)   ! Fractions on rof grid/decomp
     type(mct_aVect)        , intent(inout) :: fractions_gx(:)   ! Fractions on glc grid/decomp
     type(mct_aVect)        , intent(inout) :: fractions_wx(:)   ! Fractions on wav grid/decomp
-    character(len=*)       , intent(in) :: tag
+    character(len=*)       , intent(in)    :: tag
+    character(len=CL)      , intent(out)   :: rest_file         ! Restart filename
 
     integer(IN)   :: n,n1,n2,n3,fk
     integer(IN)   :: curr_ymd         ! Current date YYYYMMDD
@@ -322,7 +323,6 @@ contains
     logical       :: whead,wdata      ! flags header/data writing
     logical       :: cplroot          ! root pe on cpl id
     integer(IN)   :: iun              ! unit number
-    character(CL) :: rest_file        ! Local path to restart filename
     type(mct_gsMap),pointer :: gsmap
     character(len=6) :: year_char
 

--- a/src/drivers/mct/shr/CMakeLists.txt
+++ b/src/drivers/mct/shr/CMakeLists.txt
@@ -4,6 +4,7 @@ list(APPEND drv_sources
   seq_comm_mct.F90
   seq_infodata_mod.F90
   seq_io_read_mod.F90
+  seq_pauseresume_mod.F90
   )
 
 sourcelist_to_parent(drv_sources)

--- a/src/drivers/mct/shr/seq_cdata_mod.F90
+++ b/src/drivers/mct/shr/seq_cdata_mod.F90
@@ -1,6 +1,7 @@
 module seq_cdata_mod
 
   use shr_kind_mod     , only: r8=> shr_kind_r8
+  use shr_kind_mod     , only: CL => SHR_KIND_CL
   use shr_sys_mod      , only: shr_sys_flush
   use shr_sys_mod      , only: shr_sys_abort
   use seq_infodata_mod , only: seq_infodata_type
@@ -15,7 +16,7 @@ module seq_cdata_mod
   ! Public interfaces
   !--------------------------------------------------------------------------
   public :: seq_cdata_setptrs
-  public :: seq_cdata_init    ! only used by xxx_comp_esm.F90 for data models
+  public :: seq_cdata_init
 
   !--------------------------------------------------------------------------
   ! Public data
@@ -29,6 +30,8 @@ module seq_cdata_mod
      type(mct_gGrid)         ,pointer :: dom => null()      ! domain info
      type(mct_gsMap)         ,pointer :: gsMap => null()    ! decomp info
      type(seq_infodata_type) ,pointer :: infodata => null() ! Input init object
+     character(len=CL)       ,pointer :: resume_filename => null() ! filename used by pause/resume processing
+     logical                          :: post_assim         ! post assimilation
   end type seq_cdata
 
   public seq_cdata
@@ -37,7 +40,7 @@ module seq_cdata_mod
 contains
   !==============================================================================
 
-  subroutine seq_cdata_setptrs(cdata, ID, mpicom, dom, gsMap, infodata, name)
+  subroutine seq_cdata_setptrs(cdata, ID, mpicom, dom, gsMap, infodata, name, post_assimilation, resume_filename)
 
     !-----------------------------------------------------------------------
     !
@@ -49,23 +52,27 @@ contains
     type(mct_gsMap)         ,optional,pointer :: gsMap      ! decomp
     type(seq_infodata_type) ,optional,pointer :: infodata   ! INIT object
     character(len=*)        ,optional         :: name       ! name
+    logical                 ,optional         :: post_assimilation ! Restart is post assimilation
+     character(len=*)       ,optional,pointer :: resume_filename ! filename used by pause/resume processing
     !
     ! Local variables
     character(*),parameter :: subName = '(seq_cdata_setptrs) '
     !-----------------------------------------------------------------------
 
-    if (present(name     )) name     =  cdata%name
-    if (present(ID       )) ID       =  cdata%ID
-    if (present(mpicom   )) mpicom   =  cdata%mpicom
-    if (present(dom      )) dom      => cdata%dom
-    if (present(gsMap    )) gsMap    => cdata%gsMap
-    if (present(infodata )) infodata => cdata%infodata
+    if (present(name              )) name              =  cdata%name
+    if (present(ID                )) ID                =  cdata%ID
+    if (present(mpicom            )) mpicom            =  cdata%mpicom
+    if (present(post_assimilation )) post_assimilation =  cdata%post_assim
+    if (present(resume_filename   )) resume_filename   => cdata%resume_filename
+    if (present(dom               )) dom               => cdata%dom
+    if (present(gsMap             )) gsMap             => cdata%gsMap
+    if (present(infodata          )) infodata          => cdata%infodata
 
   end subroutine seq_cdata_setptrs
 
-  !===============================================================================
+  !============================================================================
 
-  subroutine seq_cdata_init(cdata,ID,dom,gsMap,infodata,name)
+  subroutine seq_cdata_init(cdata,ID, name, dom, gsMap, infodata, post_assim)
 
     !-----------------------------------------------------------------------
     ! Description
@@ -73,13 +80,14 @@ contains
     ! xxx_comp_esmf.F90 interfaces
     !
     ! Arguments
-    implicit none
+
     type(seq_cdata)         ,intent(inout)       :: cdata      ! initialized
     integer                 ,intent(in)          :: ID         ! component id
+    character(len=*)        ,intent(in),optional :: name       ! component name
     type(mct_gGrid)         ,intent(in),target   :: dom        ! domain
     type(mct_gsMap)         ,intent(in),target   :: gsMap      ! decomp
     type(seq_infodata_type) ,intent(in),target   :: infodata   ! INIT object
-    character(len=*)        ,intent(in),optional :: name       ! user defined name
+    logical                 ,intent(in)          :: post_assim
     !
     ! Local variables
     !
@@ -95,11 +103,15 @@ contains
     else
        cdata%name   =  'undefined'
     endif
-    cdata%ID       =  ID
-    cdata%mpicom   =  mpicom
-    cdata%dom      => dom
-    cdata%gsMap    => gsMap
-    cdata%infodata => infodata
+    cdata%ID              =  ID
+    cdata%mpicom          =  mpicom
+    cdata%dom             => dom
+    cdata%gsMap           => gsMap
+    cdata%infodata        => infodata
+    cdata%post_assim      =  post_assim
+
+    allocate(cdata%resume_filename)
+    cdata%resume_filename =  ''
 
   end subroutine seq_cdata_init
 

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -59,19 +59,6 @@ MODULE seq_infodata_mod
   character(len=*), public, parameter :: seq_infodata_orb_variable_year    = 'variable_year'
   character(len=*), public, parameter :: seq_infodata_orb_fixed_parameters = 'fixed_parameters'
 
-  ! Type to hold pause/resume signaling information
-  type seq_pause_resume_type
-     private
-     character(SHR_KIND_CL) :: atm_resume(num_inst_atm) = ' ' ! atm resume file
-     character(SHR_KIND_CL) :: lnd_resume(num_inst_lnd) = ' ' ! lnd resume file
-     character(SHR_KIND_CL) :: ice_resume(num_inst_ice) = ' ' ! ice resume file
-     character(SHR_KIND_CL) :: ocn_resume(num_inst_ocn) = ' ' ! ocn resume file
-     character(SHR_KIND_CL) :: glc_resume(num_inst_glc) = ' ' ! glc resume file
-     character(SHR_KIND_CL) :: rof_resume(num_inst_rof) = ' ' ! rof resume file
-     character(SHR_KIND_CL) :: wav_resume(num_inst_wav) = ' ' ! wav resume file
-     character(SHR_KIND_CL) :: cpl_resume = ' '               ! cpl resume file
-  end type seq_pause_resume_type
-
   ! InputInfo derived type
 
   type seq_infodata_type
@@ -240,7 +227,6 @@ MODULE seq_infodata_mod
      integer(SHR_KIND_IN)    :: esp_phase       ! esp phase
      logical                 :: atm_aero        ! atmosphere aerosols
      logical                 :: glc_g2lupdate   ! update glc2lnd fields in lnd model
-     type(seq_pause_resume_type), pointer :: pause_resume => NULL()
      real(shr_kind_r8) :: max_cplstep_time  ! abort if cplstep time exceeds this value
      !--- set from restart file ---
      character(SHR_KIND_CL)  :: rest_case_name  ! Short case identification
@@ -757,10 +743,6 @@ CONTAINS
        infodata%atm_aero      = .false.
        infodata%glc_g2lupdate = .false.
        infodata%glc_valid_input = .true.
-       if (associated(infodata%pause_resume)) then
-          deallocate(infodata%pause_resume)
-       end if
-       nullify(infodata%pause_resume)
 
        infodata%max_cplstep_time = max_cplstep_time
        infodata%model_doi_url = model_doi_url
@@ -925,12 +907,6 @@ CONTAINS
     integer :: mpicom             ! MPI communicator
 
     call seq_comm_setptrs(ID, mpicom=mpicom)
-    !----------------------------------------------------------
-    !| If pause/resume is active, initialize the resume data
-    !----------------------------------------------------------
-    if (seq_timemgr_pause_active() .and. (.not. associated(infodata%pause_resume))) then
-       allocate(infodata%pause_resume)
-    end if
     call seq_infodata_bcast(infodata, mpicom)
 
   END SUBROUTINE seq_infodata_Init2
@@ -984,8 +960,6 @@ CONTAINS
        eps_agrid, eps_aarea, eps_omask, eps_ogrid, eps_oarea,             &
        reprosum_use_ddpdd, reprosum_allow_infnan,                         &
        reprosum_diffmax, reprosum_recompute,                              &
-       atm_resume, lnd_resume, ocn_resume, ice_resume,                    &
-       glc_resume, rof_resume, wav_resume, cpl_resume,                    &
        mct_usealltoall, mct_usevector, max_cplstep_time, model_doi_url,   &
        glc_valid_input)
 
@@ -1157,14 +1131,6 @@ CONTAINS
     real(shr_kind_r8),      optional, intent(out) :: max_cplstep_time
     character(SHR_KIND_CL), optional, intent(OUT) :: model_doi_url
     logical,                optional, intent(OUT) :: glc_valid_input
-    character(SHR_KIND_CL), optional, intent(OUT) :: atm_resume(:) ! atm read resume state
-    character(SHR_KIND_CL), optional, intent(OUT) :: lnd_resume(:) ! lnd read resume state
-    character(SHR_KIND_CL), optional, intent(OUT) :: ice_resume(:) ! ice read resume state
-    character(SHR_KIND_CL), optional, intent(OUT) :: ocn_resume(:) ! ocn read resume state
-    character(SHR_KIND_CL), optional, intent(OUT) :: glc_resume(:) ! glc read resume state
-    character(SHR_KIND_CL), optional, intent(OUT) :: rof_resume(:) ! rof read resume state
-    character(SHR_KIND_CL), optional, intent(OUT) :: wav_resume(:) ! wav read resume state
-    character(SHR_KIND_CL), optional, intent(OUT) :: cpl_resume ! cpl read resume state
 
     !----- local -----
     character(len=*), parameter :: subname = '(seq_infodata_GetData_explicit) '
@@ -1343,62 +1309,6 @@ CONTAINS
     if ( present(esp_phase)      ) esp_phase      = infodata%esp_phase
     if ( present(atm_aero)       ) atm_aero       = infodata%atm_aero
     if ( present(glc_g2lupdate)  ) glc_g2lupdate  = infodata%glc_g2lupdate
-    if ( present(atm_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          atm_resume(:)  = infodata%pause_resume%atm_resume(:)
-       else
-          atm_resume(:) = ' '
-       end if
-    end if
-    if ( present(lnd_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          lnd_resume(:)  = infodata%pause_resume%lnd_resume(:)
-       else
-          lnd_resume(:) = ' '
-       end if
-    end if
-    if ( present(ice_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          ice_resume(:)  = infodata%pause_resume%ice_resume(:)
-       else
-          ice_resume(:) = ' '
-       end if
-    end if
-    if ( present(ocn_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          ocn_resume(:)  = infodata%pause_resume%ocn_resume(:)
-       else
-          ocn_resume(:) = ' '
-       end if
-    end if
-    if ( present(glc_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          glc_resume(:)  = infodata%pause_resume%glc_resume(:)
-       else
-          glc_resume(:) = ' '
-       end if
-    end if
-    if ( present(rof_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          rof_resume(:)  = infodata%pause_resume%rof_resume(:)
-       else
-          rof_resume(:) = ' '
-       end if
-    end if
-    if ( present(wav_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          wav_resume(:)  = infodata%pause_resume%wav_resume(:)
-       else
-          wav_resume(:) = ' '
-       end if
-    end if
-    if ( present(cpl_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          cpl_resume     = infodata%pause_resume%cpl_resume
-       else
-          cpl_resume = ' '
-       end if
-    end if
     if ( present(max_cplstep_time) ) max_cplstep_time = infodata%max_cplstep_time
     if ( present(model_doi_url) ) model_doi_url = infodata%model_doi_url
 
@@ -1418,7 +1328,7 @@ CONTAINS
 
   SUBROUTINE seq_infodata_GetData_bytype( component_firstletter, infodata,      &
        comp_present, comp_prognostic, comp_gnam, histavg_comp,            &
-       comp_phase, comp_nx, comp_ny, comp_resume)
+       comp_phase, comp_nx, comp_ny)
 
 
     implicit none
@@ -1434,7 +1344,6 @@ CONTAINS
     integer(SHR_KIND_IN),   optional, intent(OUT) :: comp_ny         ! nx,ny 2d grid size global
     integer(SHR_KIND_IN),   optional, intent(OUT) :: comp_phase
     logical,                optional, intent(OUT) :: histavg_comp
-    character(SHR_KIND_CL), optional, intent(OUT) :: comp_resume(:)
 
     !----- local -----
     character(len=*), parameter :: subname = '(seq_infodata_GetData_bytype) '
@@ -1445,37 +1354,37 @@ CONTAINS
        call seq_infodata_GetData(infodata, atm_present=comp_present,           &
             atm_prognostic=comp_prognostic, atm_gnam=comp_gnam,                &
             atm_phase=comp_phase, atm_nx=comp_nx, atm_ny=comp_ny,              &
-            histavg_atm=histavg_comp, atm_resume=comp_resume)
+            histavg_atm=histavg_comp)
     else if (component_firstletter == 'l') then
        call seq_infodata_GetData(infodata, lnd_present=comp_present,           &
             lnd_prognostic=comp_prognostic, lnd_gnam=comp_gnam,                &
             lnd_phase=comp_phase, lnd_nx=comp_nx, lnd_ny=comp_ny,              &
-            histavg_lnd=histavg_comp, lnd_resume=comp_resume)
+            histavg_lnd=histavg_comp)
     else if (component_firstletter == 'i') then
        call seq_infodata_GetData(infodata, ice_present=comp_present,           &
             ice_prognostic=comp_prognostic, ice_gnam=comp_gnam,                &
             ice_phase=comp_phase, ice_nx=comp_nx, ice_ny=comp_ny,              &
-            histavg_ice=histavg_comp, ice_resume=comp_resume)
+            histavg_ice=histavg_comp)
     else if (component_firstletter == 'o') then
        call seq_infodata_GetData(infodata, ocn_present=comp_present,           &
             ocn_prognostic=comp_prognostic, ocn_gnam=comp_gnam,                &
             ocn_phase=comp_phase, ocn_nx=comp_nx, ocn_ny=comp_ny,              &
-            histavg_ocn=histavg_comp, ocn_resume=comp_resume)
+            histavg_ocn=histavg_comp)
     else if (component_firstletter == 'r') then
        call seq_infodata_GetData(infodata, rof_present=comp_present,           &
             rof_prognostic=comp_prognostic, rof_gnam=comp_gnam,                &
             rof_phase=comp_phase, rof_nx=comp_nx, rof_ny=comp_ny,              &
-            histavg_rof=histavg_comp, rof_resume=comp_resume)
+            histavg_rof=histavg_comp)
     else if (component_firstletter == 'g') then
        call seq_infodata_GetData(infodata, glc_present=comp_present,           &
             glc_prognostic=comp_prognostic, glc_gnam=comp_gnam,                &
             glc_phase=comp_phase, glc_nx=comp_nx, glc_ny=comp_ny,              &
-            histavg_glc=histavg_comp, glc_resume=comp_resume)
+            histavg_glc=histavg_comp)
     else if (component_firstletter == 'w') then
        call seq_infodata_GetData(infodata, wav_present=comp_present,           &
             wav_prognostic=comp_prognostic, wav_gnam=comp_gnam,                &
             wav_phase=comp_phase, wav_nx=comp_nx, wav_ny=comp_ny,              &
-            histavg_wav=histavg_comp, wav_resume=comp_resume)
+            histavg_wav=histavg_comp)
     else if (component_firstletter == 'e') then
        if (present(comp_gnam)) then
           comp_gnam = ''
@@ -1499,12 +1408,6 @@ CONTAINS
           histavg_comp = .false.
           if ((loglevel > 1) .and. seq_comm_iamroot(1)) then
              write(logunit,*) trim(subname),' Note: ESP type has no histavg property'
-          end if
-       end if
-       if (present(comp_resume)) then
-          comp_resume = ' '
-          if ((loglevel > 1) .and. seq_comm_iamroot(1)) then
-             write(logunit,*) trim(subname),' Note: ESP type has no resume property'
           end if
        end if
 
@@ -1565,8 +1468,6 @@ CONTAINS
        eps_agrid, eps_aarea, eps_omask, eps_ogrid, eps_oarea,             &
        reprosum_use_ddpdd, reprosum_allow_infnan,                         &
        reprosum_diffmax, reprosum_recompute,                              &
-       atm_resume, lnd_resume, ocn_resume, ice_resume,                    &
-       glc_resume, rof_resume, wav_resume, cpl_resume,                    &
        mct_usealltoall, mct_usevector, glc_valid_input)
 
 
@@ -1733,14 +1634,6 @@ CONTAINS
     logical,                optional, intent(IN) :: atm_aero              ! atm aerosols
     logical,                optional, intent(IN) :: glc_g2lupdate         ! update glc2lnd fields in lnd model
     logical,                optional, intent(IN) :: glc_valid_input
-    character(SHR_KIND_CL), optional, intent(IN) :: atm_resume(:)         ! atm resume
-    character(SHR_KIND_CL), optional, intent(IN) :: lnd_resume(:)         ! lnd resume
-    character(SHR_KIND_CL), optional, intent(IN) :: ice_resume(:)         ! ice resume
-    character(SHR_KIND_CL), optional, intent(IN) :: ocn_resume(:)         ! ocn resume
-    character(SHR_KIND_CL), optional, intent(IN) :: glc_resume(:)         ! glc resume
-    character(SHR_KIND_CL), optional, intent(IN) :: rof_resume(:)         ! rof resume
-    character(SHR_KIND_CL), optional, intent(IN) :: wav_resume(:)         ! wav resume
-    character(SHR_KIND_CL), optional, intent(IN) :: cpl_resume            ! cpl resume
 
     !EOP
 
@@ -1908,70 +1801,6 @@ CONTAINS
     if ( present(atm_aero)       ) infodata%atm_aero       = atm_aero
     if ( present(glc_g2lupdate)  ) infodata%glc_g2lupdate  = glc_g2lupdate
     if ( present(glc_valid_input) ) infodata%glc_valid_input = glc_valid_input
-    if ( present(atm_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          infodata%pause_resume%atm_resume(:) = atm_resume(:)
-       else if (ANY(len_trim(atm_resume(:)) > 0)) then
-          allocate(infodata%pause_resume)
-          infodata%pause_resume%atm_resume(:) = atm_resume(:)
-       end if
-    end if
-    if ( present(lnd_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          infodata%pause_resume%lnd_resume(:) = lnd_resume(:)
-       else if (ANY(len_trim(lnd_resume(:)) > 0)) then
-          allocate(infodata%pause_resume)
-          infodata%pause_resume%lnd_resume(:) = lnd_resume(:)
-       end if
-    end if
-    if ( present(ice_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          infodata%pause_resume%ice_resume(:) = ice_resume(:)
-       else if (ANY(len_trim(ice_resume(:)) > 0)) then
-          allocate(infodata%pause_resume)
-          infodata%pause_resume%ice_resume(:) = ice_resume(:)
-       end if
-    end if
-    if ( present(ocn_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          infodata%pause_resume%ocn_resume(:) = ocn_resume(:)
-       else if (ANY(len_trim(ocn_resume(:)) > 0)) then
-          allocate(infodata%pause_resume)
-          infodata%pause_resume%ocn_resume(:) = ocn_resume(:)
-       end if
-    end if
-    if ( present(glc_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          infodata%pause_resume%glc_resume(:) = glc_resume(:)
-       else if (ANY(len_trim(glc_resume(:)) > 0)) then
-          allocate(infodata%pause_resume)
-          infodata%pause_resume%glc_resume(:) = glc_resume(:)
-       end if
-    end if
-    if ( present(rof_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          infodata%pause_resume%rof_resume(:) = rof_resume(:)
-       else if (ANY(len_trim(rof_resume(:)) > 0)) then
-          allocate(infodata%pause_resume)
-          infodata%pause_resume%rof_resume(:) = rof_resume(:)
-       end if
-    end if
-    if ( present(wav_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          infodata%pause_resume%wav_resume(:) = wav_resume(:)
-       else if (ANY(len_trim(wav_resume(:)) > 0)) then
-          allocate(infodata%pause_resume)
-          infodata%pause_resume%wav_resume(:) = wav_resume(:)
-       end if
-    end if
-    if ( present(cpl_resume) ) then
-       if (associated(infodata%pause_resume)) then
-          infodata%pause_resume%cpl_resume = cpl_resume
-       else if (len_trim(cpl_resume) > 0) then
-          allocate(infodata%pause_resume)
-          infodata%pause_resume%cpl_resume = cpl_resume
-       end if
-    end if
 
   END SUBROUTINE seq_infodata_PutData_explicit
 
@@ -1987,7 +1816,7 @@ CONTAINS
 
   SUBROUTINE seq_infodata_PutData_bytype( component_firstletter, infodata,      &
        comp_present, comp_prognostic, comp_gnam,                          &
-       histavg_comp, comp_phase, comp_nx, comp_ny, comp_resume)
+       histavg_comp, comp_phase, comp_nx, comp_ny)
 
     implicit none
 
@@ -2002,7 +1831,6 @@ CONTAINS
     integer(SHR_KIND_IN),   optional, intent(IN)    :: comp_ny         ! nx,ny 2d grid size global
     integer(SHR_KIND_IN),   optional, intent(IN)    :: comp_phase
     logical,                optional, intent(IN)    :: histavg_comp
-    character(SHR_KIND_CL), optional, intent(IN)    :: comp_resume(:)
 
     !EOP
 
@@ -2015,37 +1843,37 @@ CONTAINS
        call seq_infodata_PutData(infodata, atm_present=comp_present,           &
             atm_prognostic=comp_prognostic, atm_gnam=comp_gnam,                &
             atm_phase=comp_phase, atm_nx=comp_nx, atm_ny=comp_ny,              &
-            histavg_atm=histavg_comp, atm_resume=comp_resume)
+            histavg_atm=histavg_comp)
     else if (component_firstletter == 'l') then
        call seq_infodata_PutData(infodata, lnd_present=comp_present,           &
             lnd_prognostic=comp_prognostic, lnd_gnam=comp_gnam,                &
             lnd_phase=comp_phase, lnd_nx=comp_nx, lnd_ny=comp_ny,              &
-            histavg_lnd=histavg_comp, lnd_resume=comp_resume)
+            histavg_lnd=histavg_comp)
     else if (component_firstletter == 'i') then
        call seq_infodata_PutData(infodata, ice_present=comp_present,           &
             ice_prognostic=comp_prognostic, ice_gnam=comp_gnam,                &
             ice_phase=comp_phase, ice_nx=comp_nx, ice_ny=comp_ny,              &
-            histavg_ice=histavg_comp, ice_resume=comp_resume)
+            histavg_ice=histavg_comp)
     else if (component_firstletter == 'o') then
        call seq_infodata_PutData(infodata, ocn_present=comp_present,           &
             ocn_prognostic=comp_prognostic, ocn_gnam=comp_gnam,                &
             ocn_phase=comp_phase, ocn_nx=comp_nx, ocn_ny=comp_ny,              &
-            histavg_ocn=histavg_comp, ocn_resume=comp_resume)
+            histavg_ocn=histavg_comp)
     else if (component_firstletter == 'r') then
        call seq_infodata_PutData(infodata, rof_present=comp_present,           &
             rof_prognostic=comp_prognostic, rof_gnam=comp_gnam,                &
             rof_phase=comp_phase, rof_nx=comp_nx, rof_ny=comp_ny,              &
-            histavg_rof=histavg_comp, rof_resume=comp_resume)
+            histavg_rof=histavg_comp)
     else if (component_firstletter == 'g') then
        call seq_infodata_PutData(infodata, glc_present=comp_present,           &
             glc_prognostic=comp_prognostic, glc_gnam=comp_gnam,                &
             glc_phase=comp_phase, glc_nx=comp_nx, glc_ny=comp_ny,              &
-            histavg_glc=histavg_comp, glc_resume=comp_resume)
+            histavg_glc=histavg_comp)
     else if (component_firstletter == 'w') then
        call seq_infodata_PutData(infodata, wav_present=comp_present,           &
             wav_prognostic=comp_prognostic, wav_gnam=comp_gnam,                &
             wav_phase=comp_phase, wav_nx=comp_nx, wav_ny=comp_ny,              &
-            histavg_wav=histavg_comp, wav_resume=comp_resume)
+            histavg_wav=histavg_comp)
     else if (component_firstletter == 'e') then
        if ((loglevel > 1) .and. seq_comm_iamroot(1)) then
           if (present(comp_gnam)) then
@@ -2060,9 +1888,6 @@ CONTAINS
           if (present(histavg_comp)) then
              write(logunit,*) trim(subname),' Note: ESP type has no histavg property'
           end if
-          if (present(comp_resume)) then
-             write(logunit,*) trim(subname),' Note: ESP type has no resume property'
-          end if
 
        end if
 
@@ -2075,74 +1900,6 @@ CONTAINS
   END SUBROUTINE seq_infodata_PutData_bytype
 #endif
   ! ^ ifndef CPRPGI
-
-  !===============================================================================
-  !BOP ===========================================================================
-  !
-  ! !IROUTINE: seq_infodata_pauseresume_bcast -- Broadcast pause/resume data from root pe
-  !
-  ! !DESCRIPTION:
-  !
-  ! Broadcast the pause_resume data from an infodata across pes
-  !
-  ! !INTERFACE: ------------------------------------------------------------------
-
-  subroutine seq_infodata_pauseresume_bcast(infodata, mpicom, pebcast)
-
-    use shr_mpi_mod, only : shr_mpi_bcast
-
-    ! !INPUT/OUTPUT PARAMETERS:
-
-    type(seq_infodata_type),        intent(INOUT) :: infodata ! assume valid on root pe
-    integer(SHR_KIND_IN),           intent(IN)    :: mpicom   ! MPI Communicator
-    integer(SHR_KIND_IN), optional, intent(IN)    :: pebcast  ! pe sending
-
-    !EOP
-
-    !----- local -----
-    integer                     :: ind
-    integer(SHR_KIND_IN)        :: pebcast_local
-    character(len=*), parameter :: subname = '(seq_infodata_pauseresume_bcast) '
-
-    if (present(pebcast)) then
-       pebcast_local = pebcast
-    else
-       pebcast_local = 0
-    end if
-
-    if (associated(infodata%pause_resume)) then
-       do ind = 1, num_inst_atm
-          call shr_mpi_bcast(infodata%pause_resume%atm_resume(ind), mpicom,       &
-               pebcast=pebcast_local)
-       end do
-       do ind = 1, num_inst_lnd
-          call shr_mpi_bcast(infodata%pause_resume%lnd_resume(ind), mpicom,       &
-               pebcast=pebcast_local)
-       end do
-       do ind = 1, num_inst_ice
-          call shr_mpi_bcast(infodata%pause_resume%ice_resume(ind), mpicom,       &
-               pebcast=pebcast_local)
-       end do
-       do ind = 1, num_inst_ocn
-          call shr_mpi_bcast(infodata%pause_resume%ocn_resume(ind), mpicom,       &
-               pebcast=pebcast_local)
-       end do
-       do ind = 1, num_inst_glc
-          call shr_mpi_bcast(infodata%pause_resume%glc_resume(ind), mpicom,       &
-               pebcast=pebcast_local)
-       end do
-       do ind = 1, num_inst_rof
-          call shr_mpi_bcast(infodata%pause_resume%rof_resume(ind), mpicom,       &
-               pebcast=pebcast_local)
-       end do
-       do ind = 1, num_inst_wav
-          call shr_mpi_bcast(infodata%pause_resume%wav_resume(ind), mpicom,       &
-               pebcast=pebcast_local)
-       end do
-       call shr_mpi_bcast(infodata%pause_resume%cpl_resume,        mpicom,       &
-            pebcast=pebcast_local)
-    end if
-  end subroutine seq_infodata_pauseresume_bcast
 
   !===============================================================================
   !BOP ===========================================================================
@@ -2333,8 +2090,6 @@ CONTAINS
     call shr_mpi_bcast(infodata%glc_valid_input,         mpicom)
     call shr_mpi_bcast(infodata%model_doi_url,           mpicom)
 
-    call seq_infodata_pauseresume_bcast(infodata,        mpicom)
-
   end subroutine seq_infodata_bcast
 
   !===============================================================================
@@ -2373,7 +2128,7 @@ CONTAINS
     logical :: ice2cpli,ice2cplr
     logical :: glc2cpli,glc2cplr
     logical :: wav2cpli,wav2cplr
-    logical :: esp2cpli,esp2cplr
+    logical :: esp2cpli
     logical :: cpl2i,cpl2r
     logical :: logset
     logical :: deads   ! local variable to hold info temporarily
@@ -2402,7 +2157,6 @@ CONTAINS
     wav2cpli = .false.
     wav2cplr = .false.
     esp2cpli = .false.
-    esp2cplr = .false.
     cpl2i = .false.
     cpl2r = .false.
 
@@ -2480,11 +2234,6 @@ CONTAINS
 
     if (trim(type) == 'esp2cpl_init') then
        esp2cpli = .true.
-       esp2cplr = .true.
-       logset = .true.
-    endif
-    if (trim(type) == 'esp2cpl_run') then
-       esp2cplr = .true.
        logset = .true.
     endif
 
@@ -2610,7 +2359,6 @@ CONTAINS
     if (esp2cpli) then
        call shr_mpi_bcast(infodata%esp_present,        mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%esp_prognostic,     mpicom, pebcast=cmppe)
-       call seq_infodata_pauseresume_bcast(infodata,   mpicom, pebcast=cmppe)
     endif
 
     if (cpl2i) then
@@ -2651,16 +2399,11 @@ CONTAINS
        call shr_mpi_bcast(infodata%precip_fact,        mpicom, pebcast=cmppe)
     endif
 
-    if (esp2cplr) then
-       call seq_infodata_pauseresume_bcast(infodata,   mpicom, pebcast=cmppe)
-    endif
-
     if (cpl2r) then
        call shr_mpi_bcast(infodata%nextsw_cday,        mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%precip_fact,        mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%glc_g2lupdate,      mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%glc_valid_input,    mpicom, pebcast=cplpe)
-       call seq_infodata_pauseresume_bcast(infodata,   mpicom, pebcast=cplpe)
     endif
 
   end subroutine seq_infodata_Exchange
@@ -3009,46 +2752,6 @@ CONTAINS
     write(logunit,F0S) subname,'wav_phase                = ', infodata%wav_phase
 
     write(logunit,F0L) subname,'glc_g2lupdate            = ', infodata%glc_g2lupdate
-    if (associated(infodata%pause_resume)) then
-       do ind = 1, num_inst_atm
-          if (len_trim(infodata%pause_resume%atm_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'atm_resume(',ind,')        = ', trim(infodata%pause_resume%atm_resume(ind))
-          end if
-       end do
-       do ind = 1, num_inst_lnd
-          if (len_trim(infodata%pause_resume%lnd_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'lnd_resume(',ind,')        = ', trim(infodata%pause_resume%lnd_resume(ind))
-          end if
-       end do
-       do ind = 1, num_inst_ocn
-          if (len_trim(infodata%pause_resume%ocn_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'ocn_resume(',ind,')        = ', trim(infodata%pause_resume%ocn_resume(ind))
-          end if
-       end do
-       do ind = 1, num_inst_ice
-          if (len_trim(infodata%pause_resume%ice_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'ice_resume(',ind,')        = ', trim(infodata%pause_resume%ice_resume(ind))
-          end if
-       end do
-       do ind = 1, num_inst_glc
-          if (len_trim(infodata%pause_resume%glc_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'glc_resume(',ind,')        = ', trim(infodata%pause_resume%glc_resume(ind))
-          end if
-       end do
-       do ind = 1, num_inst_rof
-          if (len_trim(infodata%pause_resume%rof_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'rof_resume(',ind,')        = ', trim(infodata%pause_resume%rof_resume(ind))
-          end if
-       end do
-       do ind = 1, num_inst_wav
-          if (len_trim(infodata%pause_resume%wav_resume(ind)) > 0) then
-             write(logunit,FIA) subname,'wav_resume(',ind,')        = ', trim(infodata%pause_resume%wav_resume(ind))
-          end if
-       end do
-       if (len_trim(infodata%pause_resume%cpl_resume) > 0) then
-          write(logunit,F0A) subname,'cpl_resume               = ', trim(infodata%pause_resume%cpl_resume)
-       end if
-    end if
     !     endif
 
   END SUBROUTINE seq_infodata_print

--- a/src/drivers/mct/shr/seq_pauseresume_mod.F90
+++ b/src/drivers/mct/shr/seq_pauseresume_mod.F90
@@ -1,0 +1,439 @@
+! !MODULE: seq_pauseresume_mod --- Module for managing pause/resume data for ESP components
+!
+! !DESCRIPTION:
+!
+!     A module to collect and distribute pause/resume information
+!
+!
+! !INTERFACE: ------------------------------------------------------------------
+
+module seq_pauseresume_mod
+
+   ! !USES:
+
+   use shr_kind_mod,       only: CL => SHR_KIND_CL
+   use shr_sys_mod,        only: shr_sys_flush, shr_sys_abort
+   use seq_comm_mct,       only: num_inst_driver
+
+   implicit none
+
+   private
+#include <mpif.h>
+
+   ! !PUBLIC INTERFACES:
+   public :: seq_resume_store_comp ! Store component resume filenames
+   public :: seq_resume_get_files  ! Retrieve pointer to resume filenames
+   public :: seq_resume_free       ! Free resume filename storage
+   public :: seq_resume_broadcast  ! Broadcast component filenames to all PEs
+
+   ! Type to hold resume filenames
+   type seq_resume_type
+      character(len=CL), pointer :: atm_resume(:) => NULL() ! atm resume file(s)
+      character(len=CL), pointer :: lnd_resume(:) => NULL() ! lnd resume file(s)
+      character(len=CL), pointer :: ice_resume(:) => NULL() ! ice resume file(s)
+      character(len=CL), pointer :: ocn_resume(:) => NULL() ! ocn resume file(s)
+      character(len=CL), pointer :: glc_resume(:) => NULL() ! glc resume file(s)
+      character(len=CL), pointer :: rof_resume(:) => NULL() ! rof resume file(s)
+      character(len=CL), pointer :: wav_resume(:) => NULL() ! wav resume file(s)
+      character(len=CL), pointer :: cpl_resume(:) => NULL() ! cpl resume file(s)
+   end type seq_resume_type
+
+   type(seq_resume_type), pointer :: resume => NULL() ! For storing pause/resume files
+
+   private :: seq_resume_broadcast_array
+
+CONTAINS
+
+   !===========================================================================
+
+   !BOP =======================================================================
+   !
+   ! !IROUTINE: seq_resume_store_comp - Allocate space & store resume filenames
+   !
+   ! !DESCRIPTION:
+   !
+   ! Allocate data for resume filenames from all component instances
+   ! Store resume filenames for requested component
+   !
+   ! Assumptions about instance numbers:
+   !   Multi-driver: num_inst_driver = total number of instances of each <comp>
+   !                 num_inst_<comp> = 1
+   !   Single-driver: num_inst_driver = 1
+   !                  num_inst_<comp> = total number of <comp> instances
+   !
+   ! Assumption about resume names: All <comp> PEs should have the same value
+   !                                for <comp>%cdata_cc%resume_filename
+   !
+   ! !INTERFACE: --------------------------------------------------------------
+
+   subroutine seq_resume_store_comp(oid, filename, num_inst_comp, ninst, iamroot)
+      character(len=1),      intent(in)    :: oid           ! 1 letter comp type
+      character(len=*),      intent(in)    :: filename      ! resume filename
+      integer,               intent(in)    :: num_inst_comp ! # comp instances
+      integer,               intent(in)    :: ninst         ! comp  instance #
+      logical,               intent(in)    :: iamroot       ! is comp root?
+
+      integer                              :: num_inst      ! # store instances
+      character(len=CL), pointer           :: fname_ptr(:)
+      character(len=*),  parameter         :: subname = 'seq_resume_store_comp'
+
+      nullify(fname_ptr)
+
+      if (.not. associated(resume)) then
+         allocate(resume)
+      end if
+
+      if (len_trim(filename) > 0) then
+         num_inst = num_inst_comp * num_inst_driver
+      else
+         num_inst = 0
+      end if
+
+      ! Make sure each comp field is allocated correctly
+      select case(oid)
+      case ('a')
+         if (associated(resume%atm_resume)) then
+            if ((num_inst == 0) .or. (size(resume%atm_resume) /= num_inst)) then
+               deallocate(resume%atm_resume)
+               nullify(resume%atm_resume)
+            end if
+         end if
+         if (num_inst > 0) then
+            if (.not. associated(resume%atm_resume)) then
+               allocate(resume%atm_resume(num_inst))
+            end if
+            fname_ptr => resume%atm_resume
+         end if
+      case ('l')
+         if (associated(resume%lnd_resume)) then
+            if ((num_inst == 0) .or. (size(resume%lnd_resume) /= num_inst)) then
+               deallocate(resume%lnd_resume)
+               nullify(resume%lnd_resume)
+            end if
+         end if
+         if (num_inst > 0) then
+            if (.not. associated(resume%lnd_resume)) then
+               allocate(resume%lnd_resume(num_inst))
+            end if
+            fname_ptr => resume%lnd_resume
+         end if
+      case ('o')
+         if (associated(resume%ocn_resume)) then
+            if ((num_inst == 0) .or. (size(resume%ocn_resume) /= num_inst)) then
+               deallocate(resume%ocn_resume)
+               nullify(resume%ocn_resume)
+            end if
+         end if
+         if (num_inst > 0) then
+            if (.not. associated(resume%ocn_resume)) then
+               allocate(resume%ocn_resume(num_inst))
+            end if
+            fname_ptr => resume%ocn_resume
+         end if
+      case ('i')
+         if (associated(resume%ice_resume)) then
+            if ((num_inst == 0) .or. (size(resume%ice_resume) /= num_inst)) then
+               deallocate(resume%ice_resume)
+               nullify(resume%ice_resume)
+            end if
+         end if
+         if (num_inst > 0) then
+            if (.not. associated(resume%ice_resume)) then
+               allocate(resume%ice_resume(num_inst))
+            end if
+            fname_ptr => resume%ice_resume
+         end if
+      case ('r')
+         if (associated(resume%rof_resume)) then
+            if ((num_inst == 0) .or. (size(resume%rof_resume) /= num_inst)) then
+               deallocate(resume%rof_resume)
+               nullify(resume%rof_resume)
+            end if
+         end if
+         if (num_inst > 0) then
+            if (.not. associated(resume%rof_resume)) then
+               allocate(resume%rof_resume(num_inst))
+            end if
+            fname_ptr => resume%rof_resume
+         end if
+      case ('g')
+         if (associated(resume%glc_resume)) then
+            if ((num_inst == 0) .or. (size(resume%glc_resume) /= num_inst)) then
+               deallocate(resume%glc_resume)
+               nullify(resume%glc_resume)
+            end if
+         end if
+         if (num_inst > 0) then
+            if (.not. associated(resume%glc_resume)) then
+               allocate(resume%glc_resume(num_inst))
+            end if
+            fname_ptr => resume%glc_resume
+         end if
+      case ('w')
+         if (associated(resume%wav_resume)) then
+            if ((num_inst == 0) .or. (size(resume%wav_resume) /= num_inst)) then
+               deallocate(resume%wav_resume)
+               nullify(resume%wav_resume)
+            end if
+         end if
+         if (num_inst > 0) then
+            if (.not. associated(resume%wav_resume)) then
+               allocate(resume%wav_resume(num_inst))
+            end if
+            fname_ptr => resume%wav_resume
+         end if
+      case ('x')
+         if (associated(resume%cpl_resume)) then
+            if ((num_inst == 0) .or. (size(resume%cpl_resume) /= num_inst)) then
+               deallocate(resume%cpl_resume)
+               nullify(resume%cpl_resume)
+            end if
+         end if
+         if (num_inst > 0) then
+            if (.not. associated(resume%cpl_resume)) then
+               allocate(resume%cpl_resume(num_inst))
+            end if
+            fname_ptr => resume%cpl_resume
+         end if
+      case default
+         call shr_sys_abort(subname//': Bad component id, '//oid)
+      end select
+
+      ! Copy in the resume filename if it exists
+      if (associated(fname_ptr)) then
+         fname_ptr(ninst) = filename
+      end if
+
+   end subroutine seq_resume_store_comp
+
+   !===========================================================================
+   !BOP =======================================================================
+   !
+   ! !IROUTINE: seq_resume_get_files -- Return resume filename info
+   !
+   ! !DESCRIPTION:
+   !
+   ! Return resume filename info
+   !
+   ! !INTERFACE: --------------------------------------------------------------
+   subroutine seq_resume_get_files(oneletterid, files, bcast)
+      character(len=1),           intent(in) :: oneletterid
+      character(len=*), pointer              :: files(:)
+      logical,          optional, intent(in) :: bcast
+
+      character(len=*), parameter  :: subname = 'seq_resume_get_files'
+
+      nullify(files)
+      if (present(bcast)) then
+         if (bcast) then
+            call seq_resume_broadcast(oneletterid)
+         end if
+      ! No else: if not present, assume false
+      end if
+      select case(oneletterid)
+      case ('a')
+         if (associated(resume%atm_resume)) then
+            files => resume%atm_resume
+         end if
+      case ('l')
+         if (associated(resume%lnd_resume)) then
+            files => resume%lnd_resume
+         end if
+      case ('o')
+         if (associated(resume%ocn_resume)) then
+            files => resume%ocn_resume
+         end if
+      case ('i')
+         if (associated(resume%ice_resume)) then
+            files => resume%ice_resume
+         end if
+      case ('r')
+         if (associated(resume%rof_resume)) then
+            files => resume%rof_resume
+         end if
+      case ('g')
+         if (associated(resume%glc_resume)) then
+            files => resume%glc_resume
+         end if
+      case ('w')
+         if (associated(resume%wav_resume)) then
+            files => resume%wav_resume
+         end if
+      case ('x')
+         if (associated(resume%cpl_resume)) then
+            files => resume%cpl_resume
+         end if
+      case default
+         call shr_sys_abort(subname//': Bad component id, '//oneletterid)
+      end select
+   end subroutine seq_resume_get_files
+
+   !===========================================================================
+   !BOP =======================================================================
+   !
+   ! !IROUTINE: seq_resume_free -- Free space for resume filenames
+   !
+   ! !DESCRIPTION:
+   !
+   ! Free data for resume filenames from all component instances
+   !
+   ! !INTERFACE: --------------------------------------------------------------
+
+   subroutine seq_resume_free()
+
+      if (associated(resume)) then
+         if (associated(resume%atm_resume)) then
+            deallocate(resume%atm_resume)
+            nullify(resume%atm_resume)
+         end if
+
+         if (associated(resume%lnd_resume)) then
+            deallocate(resume%lnd_resume)
+            nullify(resume%lnd_resume)
+         end if
+
+         if (associated(resume%ocn_resume)) then
+            deallocate(resume%ocn_resume)
+            nullify(resume%ocn_resume)
+         end if
+
+         if (associated(resume%ice_resume)) then
+            deallocate(resume%ice_resume)
+            nullify(resume%ice_resume)
+         end if
+
+         if (associated(resume%rof_resume)) then
+            deallocate(resume%rof_resume)
+            nullify(resume%rof_resume)
+         end if
+
+         if (associated(resume%glc_resume)) then
+            deallocate(resume%glc_resume)
+            nullify(resume%glc_resume)
+         end if
+
+         if (associated(resume%wav_resume)) then
+            deallocate(resume%wav_resume)
+            nullify(resume%wav_resume)
+         end if
+
+         if (associated(resume%cpl_resume)) then
+            deallocate(resume%cpl_resume)
+            nullify(resume%cpl_resume)
+         end if
+      end if
+   end subroutine seq_resume_free
+
+   !===========================================================================
+   !BOP =======================================================================
+   !
+   ! !IROUTINE: seq_resume_broadcast
+   !
+   ! !DESCRIPTION:
+   !
+   ! Broadcast a component type's resume filenames to all PEs
+   !
+   ! !INTERFACE: --------------------------------------------------------------
+
+   subroutine seq_resume_broadcast(oneletterid)
+      character(len=1), intent(in) :: oneletterid
+
+      character(len=CL), pointer   :: fname_ptr(:)
+      character(len=*),  parameter :: subname = 'seq_resume_broadcast'
+
+      ! This interface does a pointer dance. Because the array
+      ! passed to seq_resume_broadcast_array may be NULL on input
+      ! but allocated on output, we need to 'reconnect' it to the
+      ! resume structure
+      select case(oneletterid)
+      case ('a')
+         fname_ptr => resume%atm_resume
+         call seq_resume_broadcast_array(fname_ptr)
+         resume%atm_resume => fname_ptr
+      case ('l')
+         fname_ptr => resume%lnd_resume
+         call seq_resume_broadcast_array(fname_ptr)
+         resume%lnd_resume => fname_ptr
+      case ('o')
+         fname_ptr => resume%ocn_resume
+         call seq_resume_broadcast_array(fname_ptr)
+         resume%ocn_resume => fname_ptr
+      case ('i')
+         fname_ptr => resume%ice_resume
+         call seq_resume_broadcast_array(fname_ptr)
+         resume%ice_resume => fname_ptr
+      case ('r')
+         fname_ptr => resume%rof_resume
+         call seq_resume_broadcast_array(fname_ptr)
+         resume%rof_resume => fname_ptr
+      case ('g')
+         fname_ptr => resume%glc_resume
+         call seq_resume_broadcast_array(fname_ptr)
+         resume%glc_resume => fname_ptr
+      case ('w')
+         fname_ptr => resume%wav_resume
+         call seq_resume_broadcast_array(fname_ptr)
+         resume%wav_resume => fname_ptr
+      case ('x')
+         fname_ptr => resume%cpl_resume
+         call seq_resume_broadcast_array(fname_ptr)
+         resume%cpl_resume => fname_ptr
+      case default
+         call shr_sys_abort(subname//': Bad component id, '//oneletterid)
+      end select
+   end subroutine seq_resume_broadcast
+
+   subroutine seq_resume_broadcast_array(filename_array)
+     use shr_mpi_mod,  only: shr_mpi_bcast
+     ! Used to bcast component filenames across multiple drivers
+     use seq_comm_mct, only: global_comm
+
+     character(len=CL), pointer   :: filename_array(:)
+
+     integer, allocatable         :: active_entries(:)
+     integer                      :: global_numpes
+     integer                      :: num_entries
+     integer                      :: my_entry
+     integer                      :: index
+     integer                      :: ierr
+     character(len=128)           :: errmsg
+     character(len=*),  parameter :: subname = "(fill_array_pes)"
+
+     call MPI_comm_rank(global_comm, global_numpes, ierr)
+     allocate(active_entries(global_numpes))
+
+     ! Find filled array element (if any)
+     ! Note, it is an error to find more than one.
+     active_entries = 0
+     my_entry = 0
+     if (associated(filename_array)) then
+        do index = 1, size(filename_array)
+           if (len_trim(filename_array(index)) > 0) then
+              if (my_entry > 0) then
+                 write(errmsg, '(2(a,i0))') ': Bad entry, ', index,           &
+                      ', already have ',my_entry
+                 call shr_sys_abort(subname//trim(errmsg))
+              end if
+              my_entry = index
+           end if
+        end do
+     end if
+     ! Share my_entry with other PEs
+     call MPI_allgather(my_entry, 1, MPI_INTEGER, active_entries, 1, MPI_INTEGER, global_comm, ierr)
+     ! Allocate our array if needed
+     num_entries = MAXVAL(active_entries)
+     if ((num_entries > 0) .and. (.not. associated(filename_array))) then
+        allocate(filename_array(num_entries))
+     end if
+     do index = 1, global_numpes
+        my_entry = active_entries(index)
+        if (my_entry > 0) then
+           call shr_mpi_bcast(filename_array(my_entry), global_comm,          &
+                subname//': bcast', pebcast=index-1)
+        end if
+     end do
+
+     deallocate(active_entries)
+  end subroutine seq_resume_broadcast_array
+
+end module seq_pauseresume_mod


### PR DESCRIPTION
Re-implementation of pause/resume with a few features:

- Components specify a pause filename that does not have to be the same as the restart filename
- Components use of resume is now multi-driver friendly (no array of resume filenames)
- The post-assimilation check at initialization is now a simple logical

@ekluzek, @brian-eaton:  Note that this is an incompatible change for those components (CAM, CLM) that currently implement the post-assimilation check at initialization. The new check is included in a call to `seq_cdata_setptrs`:
```
call seq_cdata_setptrs(cdata, post_assimilation=foo)
```

After the call, `foo` is `.true.` if this restart is a post-data-assimilation run.

Test suite: scripts_regression_tests.py
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes #2739 

User interface changes?: No

Update gh-pages html (Y/N)?: N

Code review: 
