### PR TITLE
Pgi lapack

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1022,6 +1022,7 @@ using a fortran linker.
 <compiler MACH="cheyenne" COMPILER="pgi">
   <SLIBS>
     <append> -llapack -lblas </append>
+    <append MPILIB="mpi-serial"> -ldl </append>
   </SLIBS>
 </compiler>
 

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1019,6 +1019,12 @@ using a fortran linker.
   </SLIBS>
 </compiler>
 
+<compiler MACH="cheyenne" COMPILER="pgi">
+  <SLIBS>
+    <append> -llapack -lblas </append>
+  </SLIBS>
+</compiler>
+
 <compiler MACH="cheyenne">
   <CPPDEFS>
     <!-- these flags enable nano timers -->

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -378,7 +378,10 @@
       <modules compiler="gnu" mpilib="mpi-serial">
 	<command name="load">netcdf/4.6.1</command>
       </modules>
-      <modules compiler="!gnu" mpilib="mpi-serial">
+      <modules compiler="pgi" mpilib="mpi-serial">
+	<command name="load">netcdf/4.4.1.1</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial">
 	<command name="load">netcdf/4.5.0</command>
       </modules>
     </module_system>


### PR DESCRIPTION
Add lapack and blas libraries to pgi compile on cheyenne, also found that libdl.a was needed in serial build.  

Test suite:  SMS_D_P1x1_Mmpi-serial.1x1_numaIA.I2000Clm50BgcCropGs.cheyenne_pgi
                   SMS_D.f10_f10_musgs.I2000Clm50BgcCropGs.cheyenne_pgi.clm-crop

The build now completes for these tests.   

Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2752 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: Erik
