### PR TITLE
Extract code for creating a test suite-specific cs.status script

### DIFF
--- a/scripts/lib/CIME/cs_status_creator.py
+++ b/scripts/lib/CIME/cs_status_creator.py
@@ -1,0 +1,40 @@
+"""
+Creates a test suite-specific cs.status file from a template
+"""
+
+from CIME.XML.standard_module_setup import *
+import CIME.utils
+import os
+import stat
+
+def create_cs_status(test_root, test_id, filename=None):
+    """Create a test suite-specific cs.status file from the template
+
+    Arguments:
+    test_root (string): path to test root; the file will be put here. If
+        this directory doesn't exist, it is created.
+    test_id (string): test id for this test suite. This can contain
+        shell wildcards if you want this one cs.status file to work
+        across multiple test suites. However, be careful not to make
+        this too general: for example, ending this with '*' will pick up
+        the *.ref1 directories for ERI and other tests, which is NOT
+        what you want.
+    filename (string): name of the generated cs.status file. If not
+        given, this will be built from the test_id.
+    """
+    python_libs_root = CIME.utils.get_python_libs_root()
+    cime_root = CIME.utils.get_cime_root()
+    template_file = os.path.join(python_libs_root, "cs.status.template")
+    template = open(template_file, "r").read()
+    template = template.replace("<PATH>",
+                                os.path.join(cime_root,"scripts","Tools")).replace\
+                                ("<TESTID>", test_id).replace\
+                                ("<TESTROOT>", test_root)
+    if not os.path.exists(test_root):
+        os.makedirs(test_root)
+    if filename is None:
+        filename = "cs.status.{}".format(test_id)
+    cs_status_file = os.path.join(test_root, filename)
+    with open(cs_status_file, "w") as fd:
+        fd.write(template)
+    os.chmod(cs_status_file, os.stat(cs_status_file).st_mode | stat.S_IXUSR | stat.S_IXGRP)

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -27,6 +27,7 @@ from CIME.case import Case
 from CIME.wait_for_tests import wait_for_tests
 from CIME.provenance import get_recommended_test_time_based_on_past
 from CIME.locked_files import lock_file
+from CIME.cs_status_creator import create_cs_status
 import CIME.test_utils
 
 logger = logging.getLogger(__name__)
@@ -857,18 +858,9 @@ class TestScheduler(object):
     ###########################################################################
         try:
             python_libs_root = CIME.utils.get_python_libs_root()
-            template_file = os.path.join(python_libs_root, "cs.status.template")
-            template = open(template_file, "r").read()
-            template = template.replace("<PATH>",
-                                        os.path.join(self._cime_root,"scripts","Tools")).replace\
-                                        ("<TESTID>", self._test_id).replace\
-                                        ("<TESTROOT>", self._test_root)
-            if not os.path.exists(self._test_root):
-                os.makedirs(self._test_root)
-            cs_status_file = os.path.join(self._test_root, "cs.status.{}".format(self._test_id))
-            with open(cs_status_file, "w") as fd:
-                fd.write(template)
-            os.chmod(cs_status_file, os.stat(cs_status_file).st_mode | stat.S_IXUSR | stat.S_IXGRP)
+
+            create_cs_status(test_root=self._test_root,
+                             test_id=self._test_id)
 
             template_file = os.path.join(python_libs_root, "cs.submit.template")
             template = open(template_file, "r").read()


### PR DESCRIPTION
This will let us write a command-line utility that leverages this to
create custom versions of this script. I'll post an example of how I'm
planning to use this in a follow-up comment.

Test suite: scripts_regression_tests on cheyenne, B_CheckCode on my mac,
   and manual testing to ensure that the name and contents of the
   cs.status file are the same as before, with `./create_test --no-build
   SMS.f19_g16.X.roo2_gnu --test-root $scratch/test1 --test-id abc123`
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
