### PR TITLE
DAE test improve

### DIFF
--- a/scripts/data_assimilation/da_no_data_mod.sh
+++ b/scripts/data_assimilation/da_no_data_mod.sh
@@ -32,6 +32,7 @@ else
     fi
     if [ -n "${dval}" ]; then
       rundir="`./xmlquery --value RUNDIR`"
+      ninst=`./xmlquery --value NINST_WAV`
       if [ -n "${rundir}" -a -d "${rundir}" ]; then
         cd ${rundir}
         res=$?
@@ -40,14 +41,16 @@ else
           errcode=$(( errcode + 1 ))
         else
           # Check the latest log file for a resume signal
-          lfiles="`ls -t wav.log.* 2> /dev/null | head -1`"
-          if [ -z "${lfiles}" ]; then
-            # We did not find any wav.log*, look for wav_nnnn.log*
-            for inst in `seq 1 9999`; do
+          if [ $ninst -eq 1 ]; then
+            lfiles="`ls -t wav.log.* 2> /dev/null | head -1`"
+          else
+            # Multi-instance, look for wav_nnnn.log*
+            for inst in `seq 1 $ninst`; do
               ifilename="`printf "wav_%04d.log.*" $inst`"
               ifile="`ls -t ${ifilename} 2> /dev/null | head -1`"
               if [ -z "${ifile}" ]; then
-                break;
+                echo "No log files for instance $ninst found"
+                errcode=$(( errcode + 1 ))
               elif [ -z "${lfiles}" ]; then
                 lfiles="${ifile}"
               else
@@ -60,30 +63,25 @@ else
             errcode=$(( errcode + 1 ))
           else
             for wavfile in ${lfiles}; do
+              dasig="`zgrep 'Resume signal, TRUE' ${wavfile} 2> /dev/null`"
+              initsig="`zgrep 'Initial run' ${wavfile} 2> /dev/null`"
               if [ $cycle -gt 0 ]; then
-                if [ -n "`echo ${lfiles} | grep 'gz$'`" ]; then
-                  sig="`zcat ${lfiles} | grep 'Resume signal, TRUE' 2> /dev/null`"
-                else
-                  sig="`cat ${lfiles} | grep 'Resume signal, TRUE' 2> /dev/null`"
-                fi
-                if [ -n "${sig}" ]; then
+                if [ -n "${dasig}" ]; then
                   echo "Post-DA resume signal found for cycle ${cycle}"
                 else
-                  echo "ERROR: No post-DA resume signal found for cycle ${cycle}"
-                  errcode=$(( errcode + 1 ))
+                  echo "No post-DA resume signal for cycle ${cycle}"
                 fi
-              else
-                if [ -n "`echo ${lfiles} | grep 'gz$'`" ]; then
-                  sig="`zcat ${lfiles} | grep 'Initial run' 2> /dev/null`"
-                else
-                  sig="`cat ${lfiles} | grep 'Initial run' 2> /dev/null`"
-                fi
-                if [ -n "${sig}" ]; then
+              elif [ -n "${dasig}" ]; then
+                echo "Bad Post-DA resume signal found for cycle ${cycle}"
+              fi
+              if [ $cycle -eq 0 ]; then
+                if [ -n "${initsig}" ]; then
                   echo "Initial run signal found for cycle ${cycle}"
                 else
-                  echo "ERROR: No Initial run signal found for cycle ${cycle}"
-                  errcode=$(( errcode + 1 ))
+                  echo "No initial run signal found for cycle ${cycle}"
                 fi
+              elif [ -n "${initsig}" ]; then
+                echo "Bad initial run signal found for cycle ${cycle}"
               fi
             done
           fi

--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -110,20 +110,20 @@ class DAE(SystemTestsCompareTwo):
             found_signal = 0
             found_init = 0
             if is_dwav:
-                expected_signal = self._case.get_value("NINST_WAV")
+                expected_init = self._case.get_value("NINST_WAV")
             else:
                 # Expect a signal from every instance of every DA component
-                expected_signal = 0
+                expected_init = 0
                 for comp in self._case.get_values("COMP_CLASSES"):
                     if self._case.get_value("DATA_ASSIMILATION_{}".format(comp)):
-                        expected_signal = expected_signal + self._case.get_value("NINST_{}".format(comp))
+                        expected_init = expected_init + self._case.get_value("NINST_{}".format(comp))
 
             # Adjust expected initial run and post-DA numbers
-            if cycle_num > 0:
-                expected_init = 0
-            else:
-                expected_init = expected_signal
+            if cycle_num == 0:
                 expected_signal = 0
+            else:
+                expected_signal = expected_init
+                expected_init = 0
 
             with gzip.open(fname, "r") as dfile:
                 for bline in dfile:

--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -39,25 +39,33 @@ class DAE(SystemTestsCompareTwo):
     ###########################################################################
     def _case_one_setup(self):
     ###########################################################################
-        pass
+        # Even though there may be test mods turning on data assimilation,
+        #   case1 is the control so turn it off
+        self._case.set_value("DATA_ASSIMILATION_SCRIPT", "")
+        self._case.set_value("DATA_ASSIMILATION_CYCLES", 1)
 
     ###########################################################################
     def _case_two_setup(self):
     ###########################################################################
-        # Set up data assimilation in config_tests.xml once that's ready
-        # We need to find the scripts/data_assimilation directory
-        # LIB_DIR should be our parent dir
-        da_dir = os.path.join(os.path.dirname(sms.LIB_DIR), "data_assimilation")
-        expect(os.path.isdir(da_dir), "ERROR: da_dir, '{}', does not exist".format(da_dir))
-        da_file = os.path.join(da_dir, "da_no_data_mod.sh")
-        expect(os.path.isfile(da_file), "ERROR: da_file, '{}', does not exist".format(da_file))
+        # Allow testmods to set an assimilation script
+        if len(self._case.get_value("DATA_ASSIMILATION_SCRIPT")) == 0:
+            # We need to find the scripts/data_assimilation directory
+            # LIB_DIR should be our parent dir
+            da_dir = os.path.join(os.path.dirname(sms.LIB_DIR), "data_assimilation")
+            expect(os.path.isdir(da_dir), "ERROR: da_dir, '{}', does not exist".format(da_dir))
+            da_file = os.path.join(da_dir, "da_no_data_mod.sh")
+            expect(os.path.isfile(da_file), "ERROR: da_file, '{}', does not exist".format(da_file))
+            # Set up two data assimilation cycles each half of the full run
+            self._case.set_value("DATA_ASSIMILATION_SCRIPT", da_file)
 
-        # Set up two data assimilation cycles each half of the full run
-        self._case.set_value("DATA_ASSIMILATION_SCRIPT", da_file)
-        self._case.set_value("DATA_ASSIMILATION_CYCLES", 2)
+        # We need at least 2 DA cycles
+        da_cycles = self._case.get_value("DATA_ASSIMILATION_CYCLES")
+        if da_cycles < 2:
+            da_cycles = 2
+            self._case.set_value("DATA_ASSIMILATION_CYCLES", da_cycles)
         stopn = self._case.get_value("STOP_N")
-        expect((stopn % 2) == 0, "ERROR: DAE test requires that STOP_N be even")
-        stopn = int(stopn / 2)
+        expect((stopn % da_cycles) == 0, "ERROR: DAE test with {0} cycles requires that STOP_N be divisible by {0}".format(da_cycles))
+        stopn = int(stopn / da_cycles)
         self._case.set_value("STOP_N", stopn)
 
         self._case.flush()
@@ -94,14 +102,27 @@ class DAE(SystemTestsCompareTwo):
         da_files.sort()
         cycle_num = 0
         compset = self._case.get_value("COMPSET")
+        # Special case for DWAV so we can make sure other variables are set
         is_dwav = '_DWAV' in compset
         for fname in da_files:
             found_caseroot = False
             found_cycle = False
             found_signal = 0
-            if is_dwav and (cycle_num > 0):
+            found_init = 0
+            if is_dwav:
                 expected_signal = self._case.get_value("NINST_WAV")
             else:
+                # Expect a signal from every instance of every DA component
+                expected_signal = 0
+                for comp in self._case.get_values("COMP_CLASSES"):
+                    if self._case.get_value("DATA_ASSIMILATION_{}".format(comp)):
+                        expected_signal = expected_signal + self._case.get_value("NINST_{}".format(comp))
+
+            # Adjust expected initial run and post-DA numbers
+            if cycle_num > 0:
+                expected_init = 0
+            else:
+                expected_init = expected_signal
                 expected_signal = 0
 
             with gzip.open(fname, "r") as dfile:
@@ -118,6 +139,10 @@ class DAE(SystemTestsCompareTwo):
                         found_signal = found_signal + 1
                         expect('Post-DA resume signal found' in line[0:27],
                                "ERROR: bad post-DA message found in {}".format(fname))
+                    elif 'Initial run' in line:
+                        found_init = found_init + 1
+                        expect('Initial run signal found' in line[0:24],
+                               "ERROR: bad Initial run message found in {}".format(fname))
                     else:
                         expect(False, "ERROR: Unrecognized line ('{}') found in {}".format(line, fname))
 
@@ -126,5 +151,7 @@ class DAE(SystemTestsCompareTwo):
                 expect(found_cycle, "ERROR: No cycle found in {}".format(fname))
                 expect(found_signal == expected_signal,
                        "ERROR: Expected {} post-DA resume signal message(s), {} found in {}".format(expected_signal, found_signal, fname))
+                expect(found_init == expected_init,
+                       "ERROR: Expected {} Initial run message(s), {} found in {}".format(expected_init, found_init, fname))
             # End of with
             cycle_num = cycle_num + 1

--- a/src/components/data_comps/dwav/mct/wav_comp_mct.F90
+++ b/src/components/data_comps/dwav/mct/wav_comp_mct.F90
@@ -148,11 +148,15 @@ CONTAINS
 
     ! Diagnostic print statement to test DATA_ASSIMILATION_WAV XML variable
     !   usage (and therefore a proxy for other component types).
-    if (len_trim(wav_resume(inst_index)) > 0) then
-       if (my_task == master_task) then
+    if (my_task == master_task) then
+       if (len_trim(wav_resume(inst_index)) > 0) then
           write(logunit, *) subName//': Resume signal, '//trim(wav_resume(inst_index))
-          call shr_sys_flush(logunit)
+       else if (read_restart) then
+          write(logunit, *) subName//': Restart run'
+       else
+          write(logunit, *) subName//': Initial run'
        end if
+       call shr_sys_flush(logunit)
     end if
 
     !----------------------------------------------------------------------------

--- a/src/components/data_comps/dwav/mct/wav_comp_mct.F90
+++ b/src/components/data_comps/dwav/mct/wav_comp_mct.F90
@@ -149,8 +149,8 @@ CONTAINS
     ! Diagnostic print statement to test DATA_ASSIMILATION_WAV XML variable
     !   usage (and therefore a proxy for other component types).
     if (my_task == master_task) then
-       if (len_trim(wav_resume(inst_index)) > 0) then
-          write(logunit, *) subName//': Resume signal, '//trim(wav_resume(inst_index))
+       if (len_trim(wav_resume(min(num_inst_WAV,inst_index))) > 0) then
+          write(logunit, *) subName//': Resume signal, '//trim(wav_resume(min(num_inst_WAV,inst_index)))
        else if (read_restart) then
           write(logunit, *) subName//': Restart run'
        else


### PR DESCRIPTION
DAE test expanded to be able to test post-assimilation detection in any component.
DAE test expanded to explicitly look for an initial (post-assimilation not detected) run.
Note that each component will need to add its own DAE test 'data-assimilation' script to read component logs and report correctly to DAE test.

Test suite: scripts_regression_tests on Cheyenne
Also, hand tests of different configurations:

- DAE.ww3a.ADWAV.hobart_intel
- DAE_N2.ww3a.ADWAV.hobart_intel
- DAE_N2.ww3a.ADWAV.hobart_intel.drv-multi_driver
- DAE_D.ww3a.ADWAV.hobart_intel

Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes ESMCI CIME #2757

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 