### PR TITLE
Update DWAV model

### DIFF
--- a/scripts/data_assimilation/da_no_data_mod.sh
+++ b/scripts/data_assimilation/da_no_data_mod.sh
@@ -63,7 +63,7 @@ else
             errcode=$(( errcode + 1 ))
           else
             for wavfile in ${lfiles}; do
-              dasig="`zgrep 'Resume signal, TRUE' ${wavfile} 2> /dev/null`"
+              dasig="`zgrep 'Post data assimilation signal' ${wavfile} 2> /dev/null`"
               initsig="`zgrep 'Initial run' ${wavfile} 2> /dev/null`"
               if [ $cycle -gt 0 ]; then
                 if [ -n "${dasig}" ]; then

--- a/src/components/data_comps/dwav/mct/wav_comp_mct.F90
+++ b/src/components/data_comps/dwav/mct/wav_comp_mct.F90
@@ -8,7 +8,6 @@ module wav_comp_mct
   use seq_cdata_mod   , only: seq_cdata, seq_cdata_setptrs
   use seq_infodata_mod, only: seq_infodata_type, seq_infodata_putdata, seq_infodata_getdata
   use seq_comm_mct    , only: seq_comm_inst, seq_comm_name, seq_comm_suffix
-   use seq_comm_mct   , only: num_inst_wav
   use shr_kind_mod    , only: IN=>SHR_KIND_IN, R8=>SHR_KIND_R8, CS=>SHR_KIND_CS, CL=>SHR_KIND_CL
   use shr_strdata_mod , only: shr_strdata_type
   use shr_file_mod    , only: shr_file_getunit, shr_file_getlogunit, shr_file_getloglevel
@@ -77,24 +76,24 @@ CONTAINS
     logical           :: scmMode = .false.         ! single column mode
     real(R8)          :: scmLat  = shr_const_SPVAL ! single column lat
     real(R8)          :: scmLon  = shr_const_SPVAL ! single column lon
-    character (CL)    :: wav_resume(num_inst_wav) ! reset state from restart?
+    logical           :: post_assim = .false.      ! Run is post-DA
     character(*), parameter :: subName = "(wav_init_mct) "
     !-------------------------------------------------------------------------------
 
     ! Set cdata pointers
     call seq_cdata_setptrs(cdata, &
-         id=compid, &
-         mpicom=mpicom, &
-         gsMap=gsmap, &
-         dom=ggrid, &
-         infodata=infodata)
+         id=compid,               &
+         mpicom=mpicom,           &
+         gsMap=gsmap,             &
+         dom=ggrid,               &
+         infodata=infodata,       &
+         post_assimilation=post_assim)
 
     ! Obtain infodata variables
     call seq_infodata_getData(infodata, &
          single_column=scmMode, &
          scmlat=scmlat, scmlon=scmLon, &
-         read_restart=read_restart, &
-         wav_resume=wav_resume)
+         read_restart=read_restart)
 
     ! Determine instance information
     inst_name   = seq_comm_name(compid)
@@ -149,8 +148,8 @@ CONTAINS
     ! Diagnostic print statement to test DATA_ASSIMILATION_WAV XML variable
     !   usage (and therefore a proxy for other component types).
     if (my_task == master_task) then
-       if (len_trim(wav_resume(min(num_inst_WAV,inst_index))) > 0) then
-          write(logunit, *) subName//': Resume signal, '//trim(wav_resume(min(num_inst_WAV,inst_index)))
+       if (post_assim) then
+          write(logunit, *) subName//': Post data assimilation signal'
        else if (read_restart) then
           write(logunit, *) subName//': Restart run'
        else

--- a/src/drivers/mct/cime_config/testdefs/testmods_dirs/drv/multi_driver/shell_commands
+++ b/src/drivers/mct/cime_config/testdefs/testmods_dirs/drv/multi_driver/shell_commands
@@ -1,1 +1,0 @@
-./xmlchange MULTI_DRIVER="TRUE"


### PR DESCRIPTION
Update DWAV model to be compatible with the new post-data-assimilation functionality.
This update required an output change so the DAE DA test script was updated to match.

Test suite: note, Cheyenne down and scripts_regression_test does not currently test DWAV
Hand tests of:
- DAE.ww3a.ADWAV.hobart_intel
- DAE_N2.ww3a.ADWAV.hobart_intel
- DAE_C2.ww3a.ADWAV.hobart_intel
- DAE_D.ww3a.ADWAV.hobart_intel

Test baseline: NA
Test namelist changes: None
Test status: bit for bit

Fixes #2764 

User interface changes?: No

Update gh-pages html (Y/N)?:N

Code review: 
