### PR TITLE
Fix documentation for histaux_r2x namelist variable

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1161,7 +1161,7 @@
     <category>history</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      turns on coupler history stream for instantaneous runoff to coupler fields.
+      turns on coupler history stream for daily average runoff to coupler fields.
       default: false
     </desc>
     <values>

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -155,7 +155,7 @@ MODULE seq_infodata_mod
      logical                 :: histaux_a2x24hr ! cpl writes aux hist files: a2x daily all
      logical                 :: histaux_l2x1yrg ! cpl writes aux hist files: l2x annual glc forcings
      logical                 :: histaux_l2x     ! cpl writes aux hist files: l2x every c2l comm
-     logical                 :: histaux_r2x     ! cpl writes aux hist files: r2x every c2o comm
+     logical                 :: histaux_r2x     ! cpl writes aux hist files: r2x daily
      logical                 :: histaux_double_precision ! if true, use double-precision for cpl aux hist files
      logical                 :: histavg_atm     ! cpl writes atm fields in average history file
      logical                 :: histavg_lnd     ! cpl writes lnd fields in average history file
@@ -393,7 +393,7 @@ CONTAINS
     logical                :: histaux_a2x24hr    ! cpl writes aux hist files: a2x daily all
     logical                :: histaux_l2x1yrg    ! cpl writes aux hist files: l2x annual glc forcings
     logical                :: histaux_l2x        ! cpl writes aux hist files: l2x every c2l comm
-    logical                :: histaux_r2x        ! cpl writes aux hist files: r2x every c2o comm
+    logical                :: histaux_r2x        ! cpl writes aux hist files: r2x daily
     logical                :: histaux_double_precision ! if true, use double-precision for cpl aux hist files
     logical                :: histavg_atm        ! cpl writes atm fields in average history file
     logical                :: histavg_lnd        ! cpl writes lnd fields in average history file


### PR DESCRIPTION
Ideally, this would be named histaux_r2x24hr, but I'm worried that doing
that rename would break some scripts being used for CESM2/CMIP6 spinup.

Test suite: NONE
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #2773 

User interface changes?: none

Update gh-pages html (Y/N)?: Y

Code review: 
