### PR TITLE
Fix DAE test for scripts_regression_tests

### DIFF
--- a/scripts/data_assimilation/da_no_data_mod.sh
+++ b/scripts/data_assimilation/da_no_data_mod.sh
@@ -24,13 +24,13 @@ else
     errcode=$(( errcode + 1 ))
   else
     dval="`./xmlquery --value COMPSET 2> /dev/null | grep DWAV`"
-    ./xmlchange DATA_ASSIMILATION_WAV=TRUE
-    res=$?
-    if [ $res -ne 0 ]; then
-      echo "ERROR: Unable to change DATA_ASSIMILATION_WAV to TRUE"
-      errcode=$(( errcode + 1 ))
-    fi
     if [ -n "${dval}" ]; then
+      ./xmlchange DATA_ASSIMILATION_WAV=TRUE
+      res=$?
+      if [ $res -ne 0 ]; then
+        echo "ERROR: Unable to change DATA_ASSIMILATION_WAV to TRUE"
+        errcode=$(( errcode + 1 ))
+      fi
       rundir="`./xmlquery --value RUNDIR`"
       ninst=`./xmlquery --value NINST_WAV`
       if [ -n "${rundir}" -a -d "${rundir}" ]; then

--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -84,6 +84,12 @@ class DAE(SystemTestsCompareTwo):
 
         # CONTINUE_RUN ends up TRUE, set it back in case this is a re-run.
         self._case.set_value("CONTINUE_RUN", False)
+        # Turn off post DA in case this is a re-run
+        for comp in self._case.get_values("COMP_CLASSES"):
+            if comp == "ESP":
+                continue
+            else:
+                self._case.set_value("DATA_ASSIMILATION_{}".format(comp), False)
         # Start normal run here
         self._activate_case1()
         SystemTestsCompareTwo.run_phase(self)
@@ -115,7 +121,9 @@ class DAE(SystemTestsCompareTwo):
                 # Expect a signal from every instance of every DA component
                 expected_init = 0
                 for comp in self._case.get_values("COMP_CLASSES"):
-                    if self._case.get_value("DATA_ASSIMILATION_{}".format(comp)):
+                    if comp == "ESP":
+                        continue
+                    elif self._case.get_value("DATA_ASSIMILATION_{}".format(comp)):
                         expected_init = expected_init + self._case.get_value("NINST_{}".format(comp))
 
             # Adjust expected initial run and post-DA numbers
@@ -146,12 +154,13 @@ class DAE(SystemTestsCompareTwo):
                     else:
                         expect(False, "ERROR: Unrecognized line ('{}') found in {}".format(line, fname))
 
-                # End of for loop
+                # End for
                 expect(found_caseroot, "ERROR: No caseroot found in {}".format(fname))
                 expect(found_cycle, "ERROR: No cycle found in {}".format(fname))
                 expect(found_signal == expected_signal,
                        "ERROR: Expected {} post-DA resume signal message(s), {} found in {}".format(expected_signal, found_signal, fname))
                 expect(found_init == expected_init,
                        "ERROR: Expected {} Initial run message(s), {} found in {}".format(expected_init, found_init, fname))
-            # End of with
+            # End with
             cycle_num = cycle_num + 1
+        # End for

--- a/scripts/lib/get_tests.py
+++ b/scripts/lib/get_tests.py
@@ -65,7 +65,7 @@ _CIME_TESTS = {
                              "ERR.f45_g37_rx1.A",
                              "ERP.f45_g37_rx1.A",
                              "SMS_D_Ln9.f19_g16_rx1.A",
-                             "DAE.f19_f19.A",
+                             "DAE.f19_f19.ADWAV",
                              "PET_P4.f19_f19.A",
                              "PEM_P4.f19_f19.A",
                              "SMS.T42_T42.S",


### PR DESCRIPTION
Fix DAE test script so that an A compset can pass a DAE test.
Modify DAE test included in cime_developer to be ADWAV compset which actually tests the post assimilation signaling mechanism (the A compset is a NULL test as none of the models can process the signal).

Test suite: scripts_regression_tests.py
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes #2771 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
