### PR TITLE
Make a new grid to ensure ADWAV works with f19_f19

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -550,6 +550,14 @@
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="f19_f19_ww3a" not_compset="_POP">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">1.9x2.5</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+
     <model_grid alias="f19_f19_mnull" compset="_DOCN%SAQUAP|DOCN%DAQUAP" >
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -550,14 +550,6 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_ww3a" not_compset="_POP">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">1.9x2.5</grid>
-      <grid name="wav">ww3a</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
     <model_grid alias="f19_f19_mnull" compset="_DOCN%SAQUAP|DOCN%DAQUAP" >
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>

--- a/config/e3sm/config_grids.xml
+++ b/config/e3sm/config_grids.xml
@@ -481,16 +481,6 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_ww3a" compset="(DOCN|XOCN|SOCN|AQP1)">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">1.9x2.5</grid>
-      <grid name="rof">r05</grid>
-      <grid name="glc">null</grid>
-      <grid name="wav">ww3a</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
     <model_grid alias="f25_f25" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">2.5x3.33</grid>
       <grid name="lnd">2.5x3.33</grid>
@@ -1189,6 +1179,11 @@
       <grid name="glc">mpas.ais20km</grid>
       <grid name="wav">null</grid>
       <mask>oQU120</mask>
+    </model_grid>
+
+    <!-- The following grid is only used for ADWAV testing -->
+    <model_grid alias="ww3a" compset="_WW3|DWAV">
+      <grid name="wav">ww3a</grid>
     </model_grid>
 
   </grids>

--- a/config/e3sm/config_grids.xml
+++ b/config/e3sm/config_grids.xml
@@ -481,6 +481,16 @@
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="f19_f19_ww3a" compset="(DOCN|XOCN|SOCN|AQP1)">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">1.9x2.5</grid>
+      <grid name="rof">r05</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">ww3a</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+
     <model_grid alias="f25_f25" compset="(DOCN|XOCN|SOCN|AQP1)">
       <grid name="atm">2.5x3.33</grid>
       <grid name="lnd">2.5x3.33</grid>

--- a/scripts/lib/get_tests.py
+++ b/scripts/lib/get_tests.py
@@ -65,7 +65,7 @@ _CIME_TESTS = {
                              "ERR.f45_g37_rx1.A",
                              "ERP.f45_g37_rx1.A",
                              "SMS_D_Ln9.f19_g16_rx1.A",
-                             "DAE.f19_f19.ADWAV",
+                             "DAE.f19_f19_ww3a.ADWAV",
                              "PET_P4.f19_f19.A",
                              "PEM_P4.f19_f19.A",
                              "SMS.T42_T42.S",

--- a/scripts/lib/get_tests.py
+++ b/scripts/lib/get_tests.py
@@ -65,7 +65,7 @@ _CIME_TESTS = {
                              "ERR.f45_g37_rx1.A",
                              "ERP.f45_g37_rx1.A",
                              "SMS_D_Ln9.f19_g16_rx1.A",
-                             "DAE.f19_f19_ww3a.ADWAV",
+                             "DAE.ww3a.ADWAV",
                              "PET_P4.f19_f19.A",
                              "PEM_P4.f19_f19.A",
                              "SMS.T42_T42.S",


### PR DESCRIPTION
This grid is no different than f19_f19 for cesm, but it's still necessary because the special grid is needed for e3sm.

Test suite: by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2779 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
