### PR TITLE
Rewrite array code as loops to appease NAG

### DIFF
--- a/src/share/util/mct_mod.F90
+++ b/src/share/util/mct_mod.F90
@@ -988,7 +988,7 @@ subroutine mct_avect_vecmult(av,vec,avlist,mask_spval)
 !EOP
 
    !--- local ---
-   integer(IN) :: n,m            ! generic indicies
+   integer(IN) :: n,m,p          ! generic indicies
    integer(IN) :: npts           ! number of points (local) in an aVect field
    integer(IN) :: nfld           ! number of fields (local) in an aVect field
    integer(IN) :: nptsx          ! number of points (local) in an aVect field
@@ -1016,33 +1016,37 @@ subroutine mct_avect_vecmult(av,vec,avlist,mask_spval)
 
    if (present(avlist)) then
 
-     call mct_list_init(blist,avlist)
+      call mct_list_init(blist,avlist)
 
-     nfld=mct_list_nitem(blist)
+      nfld=mct_list_nitem(blist)
 
-     allocate(kfldin(nfld))
-     do m=1,nfld
-       call mct_list_get(tattr,m,blist)
-       kfldin(m) = mct_aVect_indexRA(av,mct_string_toChar(tattr))
-       call mct_string_clean(tattr)
-     enddo
-     call mct_list_clean(blist)
+      allocate(kfldin(nfld))
+      do m=1,nfld
+         call mct_list_get(tattr,m,blist)
+         kfldin(m) = mct_aVect_indexRA(av,mct_string_toChar(tattr))
+         call mct_string_clean(tattr)
+      enddo
+      call mct_list_clean(blist)
 
-     if (lmspval) then
+      if (lmspval) then
 
-        !$omp simd
-        do n=1,npts
-	   where (.not. shr_const_isspval(av%rAttr(kfldin(:),n)))
-              av%rAttr(kfldin(:),n) = av%rAttr(kfldin(:),n)*vec(n)
-           endwhere
-        enddo
+         !$omp simd
+         do n = 1, npts
+            do p = 1, nfld
+               if (.not. shr_const_isspval(av%rAttr(kfldin(p),n))) then
+                  av%rAttr(kfldin(p),n) = av%rAttr(kfldin(p),n)*vec(n)
+               end if
+            end do
+        end do
 
      else  ! lmspval
 
         !$omp simd
-        do n=1,npts
-           av%rAttr(kfldin(:),n) = av%rAttr(kfldin(:),n)*vec(n)
-        enddo
+        do n = 1, npts
+           do p = 1, nfld
+              av%rAttr(kfldin(p),n) = av%rAttr(kfldin(p),n)*vec(n)
+           end do
+        end do
 
      endif  ! lmspval
 


### PR DESCRIPTION
Changed array-syntax code in mct_avec_vecmult to simple loop syntax to avoid a NAG debug run time bug.

Test suite: scripts_regression_tests.py
Test baseline: NA
Test namelist changes: None
Test status: bit for bit

Fixes #2766 

User interface changes?:  No

Update gh-pages html (Y/N)?: N

Code review: 
