### PR TITLE
Fix use of test_utils

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -31,6 +31,7 @@ from CIME.test_scheduler import TestScheduler, RUN_PHASE
 from CIME.utils          import expect, convert_to_seconds, compute_total_time, convert_to_babylonian_time, run_cmd_no_fail, get_cime_config
 from CIME.XML.machines   import Machines
 from CIME.case           import Case
+from CIME.test_utils     import get_tests_from_xml
 from argparse            import RawTextHelpFormatter
 
 import argparse, math, glob
@@ -378,9 +379,9 @@ def parse_command_line(args, description):
                    "At least one of --xml-machine, --xml-testlist, "
                    "--xml-compiler, --xml-category or a valid test name must be provided.")
 
-            test_data = CIME.test_utils.get_tests_from_xml(args.xml_machine, args.xml_category,
-                                                           args.xml_compiler, args.xml_testlist,
-                                                           machine_name, args.compiler)
+            test_data = get_tests_from_xml(args.xml_machine, args.xml_category,
+                                           args.xml_compiler, args.xml_testlist,
+                                           machine_name, args.compiler)
             test_names = [item["name"] for item in test_data]
             for test_datum in test_data:
                 test_extra_data[test_datum["name"]] = test_datum


### PR DESCRIPTION
I can't tell why this code started to give problems, but this fixes it

Test suite: scripts_regression_tests - just A_RunUnitTests and B_CheckCode
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #2783 

User interface changes?:  none

Update gh-pages html (Y/N)?: N

Code review: 
