### PR TITLE
Fix pruning of test_hists with refcase in their name

### DIFF
--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -44,9 +44,7 @@ def _get_all_hist_files(model, from_dir, file_extensions, suffix="", ref_case=No
         test_hists.extend([os.path.join(from_dir,f) for f in os.listdir(from_dir) if pfile.search(f)])
 
     if ref_case:
-        for test in test_hists:
-            if ref_case in os.path.basename(test):
-                test_hists.remove(test)
+        test_hists = [h for h in test_hists if not (ref_case in os.path.basename(h))]
 
     test_hists = list(set(test_hists))
     test_hists.sort()


### PR DESCRIPTION
The previous code was problematic because it modified the list that was
being iterated over. This resulted in some entries not being removed
from the list when they should have been.

Fixes ESMCI/cime#2790

Test suite: scripts_regression_tests - just A_RunUnitTests and B_CheckCode so far,
    full test suite underway
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #2790 

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: 
