### PR TITLE
Add /cluster/torque/bin to path on hobart

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1009,6 +1009,8 @@
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
+      <!-- The following is needed to access qsub from the compute nodes -->
+      <env name="PATH">$ENV{PATH}:/cluster/torque/bin</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>


### PR DESCRIPTION
This is needed in order to submit jobs from the compute nodes, via
qsub. (I want to be able to do this so that we can build and submit
create_test jobs on the compute nodes.) Somehow we've been able to do
resubmits on hobart, but I can't figure out how that is working; Mark
Moore suggested simply adding this to our path.

Test suite: ./scripts_regression_tests on hobart
   Passes except for two failures in T_TestRunRestart, also failing on master (#2796)
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: 
