### PR TITLE
Fix for ESMF_LIB versions before 8, fixed #2801

### DIFF
--- a/src/drivers/mct/main/cime_driver.F90
+++ b/src/drivers/mct/main/cime_driver.F90
@@ -28,12 +28,13 @@ program cime_driver
   use ESMF,          only : ESMF_Initialize, ESMF_Finalize
   use ESMF,          only : ESMF_LogKind_Flag, ESMF_LOGKIND_NONE
   use ESMF,          only : ESMF_LOGKIND_SINGLE, ESMF_LOGKIND_MULTI
-  use ESMF,          only : ESMF_LOGKIND_MULTI_ON_ERROR
+  use ESMF
   use cime_comp_mod, only : cime_pre_init1
   use cime_comp_mod, only : cime_pre_init2
   use cime_comp_mod, only : cime_init
   use cime_comp_mod, only : cime_run
   use cime_comp_mod, only : cime_final
+  use seq_comm_mct,  only : logunit
 
   implicit none
 
@@ -67,14 +68,19 @@ program cime_driver
   !--------------------------------------------------------------------------
   beg_count = shr_sys_irtc(irtc_rate)
 
-
   select case(esmf_logfile_option)
   case('ESMF_LOGKIND_SINGLE')
      esmf_logfile_kind = ESMF_LOGKIND_SINGLE
   case('ESMF_LOGKIND_MULTI')
      esmf_logfile_kind = ESMF_LOGKIND_MULTI
   case('ESMF_LOGKIND_MULTI_ON_ERROR')
+#if (! defined(USE_ESMF_LIB) ) || (ESMF_VERSION_MAJOR > 7)
      esmf_logfile_kind = ESMF_LOGKIND_MULTI_ON_ERROR
+#else
+     write(logunit,*) 'ESMF library version being used: ', ESMF_VERSION_MAJOR
+     call shr_sys_abort('CIME ERROR: invalid ESMF logfile kind for this ESMF library version: ' &
+                        //trim(esmf_logfile_option) )
+#endif
   case('ESMF_LOGKIND_NONE')
      esmf_logfile_kind = ESMF_LOGKIND_NONE
   case default


### PR DESCRIPTION
Changes so that cime can build with an ESMF library before version 8

This uses the pre-processor to see if an ESMF library is being used and if so, if the version
is before version 8. If it is it won't allow ESMF_LOGFILE_KIND to be set to ESMF_LOGKIND_MULTI_ON_ERROR, and will abort with an error, otherwise it will run.

Test baseline: Test a couple cases make sure it works with USE_ESMF_LIB on and off
   as well as default and
./xmlchange ESMF_LOGFILE_KIND='ESMF_LOGKIND_MULTI_ON_ERROR'
Test namelist changes: N
Test status: bit for bit
Fixes #2801

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
