### PR TITLE
Don't exceed maximum MPI tag value

### DIFF
--- a/src/drivers/mct/main/component_mod.F90
+++ b/src/drivers/mct/main/component_mod.F90
@@ -332,6 +332,7 @@ contains
     type(mct_gGrid) :: dom_tmp   ! temporary
     character(*), parameter :: subname = '(component_init_cx)'
     character(*), parameter :: F0I = "('"//subname//" : ', A, 2i8 )"
+    character(*), parameter :: F1I = "('"//subname//" : ', A, I10, A, I10 )"
     !---------------------------------------------------------------
 
     ! Initialize driver rearrangers and AVs on driver
@@ -390,7 +391,7 @@ contains
 
                 mpi_tag = comp(1)%cplcompid*1000+1*10+1
                 if (mpi_tag > max_mpi_tag) then
-                   write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+                   write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
                    call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
                 end if
                 call seq_map_map_exchange(comp(1), flow='c2x', dom_flag=.true., msgtag=mpi_tag)
@@ -569,7 +570,7 @@ contains
     integer :: eci, num_inst
     integer :: mpi_tag
     character(*), parameter :: subname = '(component_init_areacor)'
-    character(*), parameter :: F0I = "('"//subname//" : ', A, 2i8 )"
+    character(*), parameter :: F1I = "('"//subname//" : ', A, I10, A, I10 )"
     !---------------------------------------------------------------
 
     num_inst = size(comp)
@@ -581,7 +582,7 @@ contains
           ! Map component domain from coupler to component processes
           mpi_tag = comp(eci)%cplcompid*1000+eci*10+5
           if (mpi_tag > max_mpi_tag) then
-             write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+             write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
              call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
           end if
           call seq_map_map(comp(eci)%mapper_Cx2c, comp(eci)%dom_cx%data, comp(eci)%dom_cc%data, msgtag=mpi_tag)
@@ -604,7 +605,7 @@ contains
           ! Map corrected initial component AVs from component to coupler pes
           mpi_tag = comp(eci)%cplcompid*1000+eci*10+7
           if (mpi_tag > max_mpi_tag) then
-             write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+             write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
              call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
           end if
           call seq_map_map(comp(eci)%mapper_cc2x, comp(eci)%c2x_cc, comp(eci)%c2x_cx, msgtag=mpi_tag)
@@ -843,7 +844,7 @@ contains
     integer :: ierr
     integer :: mpi_tag
     character(*), parameter :: subname = '(component_exch)'
-    character(*), parameter :: F0I = "('"//subname//" : ', A, 2i8 )" 
+    character(*), parameter :: F1I = "('"//subname//" : ', A, I10, A, I10 )"
     !---------------------------------------------------------------
 
     if (present(timer_barrier))  then
@@ -869,14 +870,14 @@ contains
           if (flow == 'x2c') then ! coupler to component
              mpi_tag = comp(eci)%cplcompid*1000+eci*10+2
              if (mpi_tag > max_mpi_tag) then
-                write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+                write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
                 call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
              end if
              call seq_map_map(comp(eci)%mapper_Cx2c, comp(eci)%x2c_cx, comp(eci)%x2c_cc, msgtag=mpi_tag)
           else if (flow == 'c2x') then ! component to coupler
              mpi_tag = comp(eci)%cplcompid*1000+eci*10+4
              if (mpi_tag > max_mpi_tag) then
-                write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+                write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
                 call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
              end if
              call seq_map_map(comp(eci)%mapper_Cc2x, comp(eci)%c2x_cc, comp(eci)%c2x_cx, msgtag=mpi_tag)

--- a/src/drivers/mct/main/component_mod.F90
+++ b/src/drivers/mct/main/component_mod.F90
@@ -386,10 +386,14 @@ contains
                 if (iamroot_CPLID) then
                    write(logunit,F0I) 'creating dom_cx'
                    call shr_sys_flush(logunit)
-                end if
+                end igit cof
                 call seq_mctext_gGridInit(comp(1))
 
-                mpi_tag = comp(1)%cplcompid*1000+1*10+1
+                if (size(comp) > 1) then
+                    mpi_tag = comp(eci)%cplcompid*100+eci*10+1
+                else
+                    mpi_tag = comp(eci)%cplcompid*10000+eci*10+1
+                end if
                 if (mpi_tag > max_mpi_tag) then
                    write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
                    call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
@@ -580,7 +584,11 @@ contains
        if (comp(eci)%iamin_cplcompid) then
 
           ! Map component domain from coupler to component processes
-          mpi_tag = comp(eci)%cplcompid*1000+eci*10+5
+          if ( num_inst > 1) then
+             mpi_tag = comp(eci)%cplcompid*100+eci*10+5
+          else
+             mpi_tag = comp(eci)%cplcompid*10000+eci*10+5
+          end if
           if (mpi_tag > max_mpi_tag) then
              write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
              call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
@@ -603,7 +611,11 @@ contains
           endif
 
           ! Map corrected initial component AVs from component to coupler pes
-          mpi_tag = comp(eci)%cplcompid*1000+eci*10+7
+          if (num_inst > 1) then
+              mpi_tag = comp(eci)%cplcompid*100+eci*10+7
+          else
+              mpi_tag = comp(eci)%cplcompid*10000+eci*10+7
+          end if
           if (mpi_tag > max_mpi_tag) then
              write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
              call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
@@ -868,14 +880,22 @@ contains
           end if
 
           if (flow == 'x2c') then ! coupler to component
-             mpi_tag = comp(eci)%cplcompid*1000+eci*10+2
+             if ( size(comp) > 1) then
+                mpi_tag = comp(eci)%cplcompid*100+eci*10+2
+             else
+                mpi_tag = comp(eci)%cplcompid*10000+eci*10+2
+             end if
              if (mpi_tag > max_mpi_tag) then
                 write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
                 call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
              end if
              call seq_map_map(comp(eci)%mapper_Cx2c, comp(eci)%x2c_cx, comp(eci)%x2c_cc, msgtag=mpi_tag)
           else if (flow == 'c2x') then ! component to coupler
-             mpi_tag = comp(eci)%cplcompid*1000+eci*10+4
+             if ( size(comp) > 1) then
+                mpi_tag = comp(eci)%cplcompid*100+eci*10+4
+             else
+                mpi_tag = comp(eci)%cplcompid*10000+eci*10+4
+             end if
              if (mpi_tag > max_mpi_tag) then
                 write(logunit, F1I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
                 call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')

--- a/src/drivers/mct/main/component_mod.F90
+++ b/src/drivers/mct/main/component_mod.F90
@@ -63,6 +63,8 @@ module component_mod
   integer  :: mpicom_GLOID, mpicom_CPLID           ! GLOID, CPLID mpi communicator
   integer  :: nthreads_GLOID, nthreads_CPLID
   logical  :: drv_threading
+  integer (kind=MPI_ADDRESS_KIND) :: max_mpi_tag
+
 
   !===============================================================================
 
@@ -91,6 +93,8 @@ contains
     character(len=3)         , intent(in)            :: ntype
     !
     ! Local Variables
+    logical :: flag
+    integer :: ierr
     integer  :: eci       ! index
     character(*), parameter :: subname = '(component_init_pre)'
     !---------------------------------------------------------------
@@ -101,6 +105,9 @@ contains
     call seq_comm_getinfo(GLOID, mpicom=mpicom_GLOID, iamroot=iamroot_GLOID, nthreads=nthreads_GLOID)
     call seq_comm_getinfo(CPLID, mpicom=mpicom_CPLID, iamroot=iamroot_CPLID, nthreads=nthreads_CPLID)
     iamin_CPLID = seq_comm_iamin(CPLID)
+
+    ! MPI spec. garuntees at least 32768 tags available, but most implementations will have more.
+    call mpi_attr_get(MPI_COMM_WORLD, MPI_TAG_UB, max_mpi_tag, flag, ierr)
 
     ! Initialize component type variables
     do eci = 1,size(comp)
@@ -321,6 +328,7 @@ contains
     ! Local Variables
     integer         :: eci
     integer         :: rc        ! return code
+    integer         :: mpi_tag
     type(mct_gGrid) :: dom_tmp   ! temporary
     character(*), parameter :: subname = '(component_init_cx)'
     character(*), parameter :: F0I = "('"//subname//" : ', A, 2i8 )"
@@ -379,7 +387,14 @@ contains
                    call shr_sys_flush(logunit)
                 end if
                 call seq_mctext_gGridInit(comp(1))
-                call seq_map_map_exchange(comp(1), flow='c2x', dom_flag=.true., msgtag=comp(1)%cplcompid*10000+1*10+1)
+
+                mpi_tag = comp(1)%cplcompid*1000+1*10+1
+                if (mpi_tag > max_mpi_tag) then
+                   write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+                   call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
+                end if
+                call seq_map_map_exchange(comp(1), flow='c2x', dom_flag=.true., msgtag=mpi_tag)
+
              else if (eci > 1) then
                 if (iamroot_CPLID) then
                    write(logunit,F0I) 'comparing comp domain ensemble number ',eci
@@ -552,7 +567,9 @@ contains
     !
     ! Local Variables
     integer :: eci, num_inst
+    integer :: mpi_tag
     character(*), parameter :: subname = '(component_init_areacor)'
+    character(*), parameter :: F0I = "('"//subname//" : ', A, 2i8 )"
     !---------------------------------------------------------------
 
     num_inst = size(comp)
@@ -562,8 +579,12 @@ contains
        if (comp(eci)%iamin_cplcompid) then
 
           ! Map component domain from coupler to component processes
-          call seq_map_map(comp(eci)%mapper_Cx2c, comp(eci)%dom_cx%data, &
-               comp(eci)%dom_cc%data, msgtag=comp(eci)%cplcompid*10000+eci*10+5)
+          mpi_tag = comp(eci)%cplcompid*1000+eci*10+5
+          if (mpi_tag > max_mpi_tag) then
+             write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+             call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
+          end if
+          call seq_map_map(comp(eci)%mapper_Cx2c, comp(eci)%dom_cx%data, comp(eci)%dom_cc%data, msgtag=mpi_tag)
 
           ! For only component pes
           if (comp(eci)%iamin_compid) then
@@ -581,8 +602,12 @@ contains
           endif
 
           ! Map corrected initial component AVs from component to coupler pes
-          call seq_map_map(comp(eci)%mapper_cc2x, comp(eci)%c2x_cc, &
-               comp(eci)%c2x_cx, msgtag=comp(eci)%cplcompid*10000+eci*10+7)
+          mpi_tag = comp(eci)%cplcompid*1000+eci*10+7
+          if (mpi_tag > max_mpi_tag) then
+             write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+             call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
+          end if
+          call seq_map_map(comp(eci)%mapper_cc2x, comp(eci)%c2x_cc, comp(eci)%c2x_cx, msgtag=mpi_tag)
 
        endif
     enddo
@@ -816,7 +841,9 @@ contains
     ! Local Variables
     integer :: eci
     integer :: ierr
+    integer :: mpi_tag
     character(*), parameter :: subname = '(component_exch)'
+    character(*), parameter :: F0I = "('"//subname//" : ', A, 2i8 )" 
     !---------------------------------------------------------------
 
     if (present(timer_barrier))  then
@@ -840,11 +867,19 @@ contains
           end if
 
           if (flow == 'x2c') then ! coupler to component
-             call seq_map_map(comp(eci)%mapper_Cx2c, comp(eci)%x2c_cx, comp(eci)%x2c_cc, &
-                  msgtag=comp(eci)%cplcompid*10000+eci*10+2)
+             mpi_tag = comp(eci)%cplcompid*1000+eci*10+2
+             if (mpi_tag > max_mpi_tag) then
+                write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+                call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
+             end if
+             call seq_map_map(comp(eci)%mapper_Cx2c, comp(eci)%x2c_cx, comp(eci)%x2c_cc, msgtag=mpi_tag)
           else if (flow == 'c2x') then ! component to coupler
-             call seq_map_map(comp(eci)%mapper_Cc2x, comp(eci)%c2x_cc, comp(eci)%c2x_cx, &
-                  msgtag=comp(eci)%cplcompid*10000+eci*10+4)
+             mpi_tag = comp(eci)%cplcompid*1000+eci*10+4
+             if (mpi_tag > max_mpi_tag) then
+                write(logunit, F0I) 'MPI message tag ',mpi_tag,' exceeds max ',max_mpi_tag
+                call shr_sys_abort(subname//' ERROR: Max mpi tag exceeded')
+             end if
+             call seq_map_map(comp(eci)%mapper_Cc2x, comp(eci)%c2x_cc, comp(eci)%c2x_cx, msgtag=mpi_tag)
           end if
 
           if (present(timer_map_exch)) then

--- a/src/drivers/mct/main/component_mod.F90
+++ b/src/drivers/mct/main/component_mod.F90
@@ -106,7 +106,7 @@ contains
     call seq_comm_getinfo(CPLID, mpicom=mpicom_CPLID, iamroot=iamroot_CPLID, nthreads=nthreads_CPLID)
     iamin_CPLID = seq_comm_iamin(CPLID)
 
-    ! MPI spec. garuntees at least 32768 tags available, but most implementations will have more.
+    ! MPI spec. guarantees at least 32768 tags available, but most implementations will have more.
     call mpi_attr_get(MPI_COMM_WORLD, MPI_TAG_UB, max_mpi_tag, flag, ierr)
 
     ! Initialize component type variables
@@ -386,7 +386,7 @@ contains
                 if (iamroot_CPLID) then
                    write(logunit,F0I) 'creating dom_cx'
                    call shr_sys_flush(logunit)
-                end igit cof
+                end if
                 call seq_mctext_gGridInit(comp(1))
 
                 if (size(comp) > 1) then


### PR DESCRIPTION
The MPI standard specifies that the MPI tag upper bound (MPI_TAG_UB) must
be at least 32767 and many implementations greatly exceed this number
(eg. cray-mpich/7.4.4 has MPI_TAG_UB == 2^21-1). However, in
multi-instance runs, this tag is quickly exceed (~30 instances).

This PR adds a check for tags larger than MPI_TAG_UB and reduces
msgtag so that it will take ~300 instances to exceed MPI_TAG_UB on cray
machines while still protecting against tag collisions out to ~100
instances (see ESMCI/cime#2397 and ESMCI/cime#2363).

This should be sufficient for any multi-instance runs not using
multi-driver (where this isn't a problem), and runs larger should be
using multi-driver.

Test suite: scripts_regression_tests.py on edison; MVK SystemTest on Titan (E3SM)
Test baseline: N/A
Test namelist changes: none
Test status: [bit for bit]

Fixes E3SM-Project/E3SM#2487

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
