### PR TITLE
CIME modification for CISM standalone

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -40,6 +40,7 @@
       <grid name="glc"	  compset="CISM1" >gland5UM</grid>
       <grid name="glc"	  compset="CISM2" >gland4</grid>
       <grid name="glc"    compset="XGLC"  >gland4</grid>
+      <grid name="glc"    compset="TMISMIP">MISMIPgrid</grid>
       <grid name="wav"	  compset="SWAV"  >null</grid>
       <grid name="wav"	  compset="DWAV"  >ww3a</grid>
       <grid name="wav"	  compset="WW3"	  >ww3a</grid>
@@ -156,6 +157,10 @@
       <grid name="ocnice">gx3v7</grid>
       <grid name="glc">gland5UM</grid>
       <mask>gx3v7</mask>
+    </model_grid>
+
+    <model_grid alias="mip1" compset="_CISM">
+      <grid name="glc">MISMIPgrid</grid>
     </model_grid>
 
     <model_grid alias="T42_T42_musgs" not_compset="_POP">
@@ -301,6 +306,7 @@
       <grid name="ocnice">oQU120</grid>
       <mask>oQU120</mask>
     </model_grid>
+
 
     <!-- finite volume grids -->
 
@@ -1438,6 +1444,11 @@
     <domain name="gland4">
       <nx>416</nx> <ny>704</ny>
       <desc>4-km Greenland grid, for use with the glissade dycore</desc>
+    </domain>
+
+    <domain name="MISMIPgrid">
+      <nx>324</nx> <ny>40</ny>
+      <desc>2-km MISMIP+ grid to use for idealized experiment</desc>
     </domain>
 
     <!-- WW3 domains-->

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1061,8 +1061,7 @@
 
   <entry id="GLC_GRID">
     <type>char</type>
-    <valid_values>gland20,gland10,gland5,gland5UM,gland4,mpas.gis20km,mpas.ais20km,null</valid_values>
-    <default_value>gland5UM</default_value>
+    <default_value>UNSET</default_value>
     <group>build_grid</group>
     <file>env_build.xml</file>
     <desc>glacier (glc) grid - DO NOT EDIT (for experts only)</desc>


### PR DESCRIPTION
[Modification to accommodate CISM stand alone and/or a new grid not supported in CESM at the moment. The changes are for the MISMIP+ experiment and will be used for the MISOMIP experiment, ice-ocean coupling scenario.]

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
