### PR TITLE
Improve continue run checks in case_submit

### DIFF
--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -6,12 +6,13 @@ if there is no queueing system.  A cesm workflow may include multiple
 jobs.
 submit, check_case and check_da_settings are members of class Case in file case.py
 """
-import socket
-from six.moves                   import configparser
+from six.moves                      import configparser
 from CIME.XML.standard_module_setup import *
 from CIME.utils                     import expect, run_and_log_case_status, verbatim_success_msg
 from CIME.locked_files              import unlock_file, lock_file
 from CIME.test_status               import *
+
+import socket, glob
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +29,15 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
     if job is None:
         job = case.get_primary_job()
 
-    rundir = case.get_value("RUNDIR")
+    # Check if CONTINUE_RUN value makes sense
     if job != "case.test":
         continue_run = case.get_value("CONTINUE_RUN")
-        expect(os.path.isdir(rundir) or not continue_run,
-               " CONTINUE_RUN is true but RUNDIR {} does not exist".format(rundir))
+        rundir = case.get_value("RUNDIR")
+        if continue_run:
+            expect(os.path.isdir(rundir),
+                   "CONTINUE_RUN is true but RUNDIR {} does not exist".format(rundir))
+            expect(len(glob.glob(os.path.join(rundir, "*.nc"))) > 0,
+                   "CONTINUE_RUN is true but this case does not appear to have been run before".format(rundir))
 
     # if case.submit is called with the no_batch flag then we assume that this
     # flag will stay in effect for the duration of the RESUBMITs
@@ -117,8 +122,8 @@ def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubm
         logger.warning("resubmit_immediate does not work on Mira/Cetus, submitting normally")
         resubmit_immediate = False
 
+    caseroot = self.get_value("CASEROOT")
     if self.get_value("TEST"):
-        caseroot = self.get_value("CASEROOT")
         casebaseid = self.get_value("CASEBASEID")
         # This should take care of the race condition where the submitted job
         # begins immediately and tries to set RUN phase. We proactively assume
@@ -132,7 +137,6 @@ def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubm
 
     # If this is a resubmit check the hidden file .submit_options for
     # any submit options used on the original submit and use them again
-    caseroot = self.get_value("CASEROOT")
     submit_options = os.path.join(caseroot, ".submit_options")
     if resubmit and os.path.exists(submit_options):
         config = configparser.SafeConfigParser()

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -37,7 +37,7 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
             expect(os.path.isdir(rundir),
                    "CONTINUE_RUN is true but RUNDIR {} does not exist".format(rundir))
             expect(len(glob.glob(os.path.join(rundir, "*.nc"))) > 0,
-                   "CONTINUE_RUN is true but this case does not appear to have been run before".format(rundir))
+                   "CONTINUE_RUN is true but this case does not appear to have been run before")
 
     # if case.submit is called with the no_batch flag then we assume that this
     # flag will stay in effect for the duration of the RESUBMITs

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1352,7 +1352,6 @@ def does_file_have_string(filepath, text):
     """
     return os.path.isfile(filepath) and text in open(filepath).read()
 
-
 def is_last_process_complete(filepath, expect_text, fail_text ):
     """
     Search the filepath in reverse order looking for expect_text
@@ -1656,6 +1655,8 @@ def indent_string(the_string, indent_level):
 def verbatim_success_msg(return_val):
     return return_val
 
+CASE_SUCCESS = "success"
+CASE_FAILURE = "error"
 def run_and_log_case_status(func, phase, caseroot='.', custom_success_msg_functor=None):
     append_case_status(phase, "starting", caseroot=caseroot)
     rv = None
@@ -1663,11 +1664,11 @@ def run_and_log_case_status(func, phase, caseroot='.', custom_success_msg_functo
         rv = func()
     except:
         e = sys.exc_info()[1]
-        append_case_status(phase, "error", msg=("\n{}".format(e)), caseroot=caseroot)
+        append_case_status(phase, CASE_FAILURE, msg=("\n{}".format(e)), caseroot=caseroot)
         raise
     else:
         custom_success_msg = custom_success_msg_functor(rv) if custom_success_msg_functor else None
-        append_case_status(phase, "success", msg=custom_success_msg, caseroot=caseroot)
+        append_case_status(phase, CASE_SUCCESS, msg=custom_success_msg, caseroot=caseroot)
 
     return rv
 


### PR DESCRIPTION
If there are no netcdf files, then the case was not run before
and CONTINUE_RUN=TRUE doesn't make sense.

Test suite: scripts_regression_tests --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #213 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b @billsacks 
