### PR TITLE
Update presaero and CO2 datasets for datm7 to new CMIP6 version

### DIFF
--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -57,10 +57,12 @@
 
   <entry id="DATM_PRESAERO">
     <type>char</type>
-    <valid_values>none,clim_1850,clim_2000,trans_1850-2000,rcp2.6,rcp4.5,rcp6.0,rcp8.5,cplhist</valid_values>
+    <valid_values>none,clim_1850,clim_2000,clim_2010,trans_1850-2000,rcp2.6,rcp4.5,rcp6.0,rcp8.5,cplhist</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
       <value compset="^1850_">clim_1850</value>
+      <value compset="^2000_">clim_2000</value>
+      <value compset="^2010_">clim_2010</value>
       <value compset="^RCP8_">rcp8.5</value>
       <value compset="^RCP6_">rcp6.0</value>
       <value compset="^RCP4_">rcp4.5</value>
@@ -91,7 +93,7 @@
 
   <entry id="DATM_CO2_TSERIES">
     <type>char</type>
-    <valid_values>none,20tr,rcp2.6,rcp4.5,rcp6.0,rcp8.5</valid_values>
+    <valid_values>none,20tr,20tr.latbnd,rcp2.6,rcp4.5,rcp6.0,rcp8.5</valid_values>
     <default_value>none</default_value>
     <values match="last">
       <value compset="^RCP8">rcp8.5</value>
@@ -203,8 +205,10 @@
       <value compset="1850.*_DATM%CRU">1</value>
       <value compset="2000.*_DATM%CRU">1</value>
       <value compset="2003.*_DATM%CRU">1</value>
+      <value compset="2010.*_DATM%CRU">1</value>
       <value compset="1850.*_DATM%GSW">1</value>
       <value compset="2000.*_DATM%GSW">1</value>
+      <value compset="2010.*_DATM%GSW">1</value>
       <value compset="2003.*_DATM%GSW">1</value>
     </values>
     <group>run_component_datm</group>
@@ -237,8 +241,10 @@
       <value compset="1850.*_DATM%CRU">1901</value>
       <value compset="2000.*_DATM%CRU">1991</value>
       <value compset="2003.*_DATM%CRU">2002</value>
+      <value compset="2010.*_DATM%CRU">2005</value>
       <value compset="1850.*_DATM%GSW">1901</value>
       <value compset="2000.*_DATM%GSW">1991</value>
+      <value compset="2010.*_DATM%GSW">2005</value>
       <value compset="2003.*_DATM%GSW">2002</value>
     </values>
     <group>run_component_datm</group>
@@ -271,8 +277,10 @@
       <value   compset="1850.*_DATM%CRU">1920</value>
       <value   compset="2000.*_DATM%CRU">2010</value>
       <value   compset="2003.*_DATM%CRU">2003</value>
+      <value   compset="2010.*_DATM%CRU">2015</value>
       <value   compset="1850.*_DATM%GSW">1920</value>
       <value   compset="2000.*_DATM%GSW">2010</value>
+      <value   compset="2010.*_DATM%GSW">2015</value>
       <value   compset="2003.*_DATM%GSW">2003</value>
     </values>
     <group>run_component_datm</group>

--- a/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -97,6 +97,7 @@
     CLMGSWP3v1.TPQW
 
     co2tseries.20tr
+    co2tseries.20tr.latbnd
     co2tseries.rcp2.6
     co2tseries.rcp4.5
     co2tseries.rcp6.0
@@ -247,7 +248,7 @@
     <category>streams</category>
     <group>streams_file</group>
     <desc>Stream domain file path(s).</desc>
-    <values>
+    <values match="first">
       <value>null</value>
       <value stream="CLM1PT.1x1_mexicocityMEX">domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc</value>
       <value stream="CLM1PT.1x1_vancouverCAN">domain.lnd.1x1pt-vancouverCAN_navy.090715.nc </value>
@@ -293,8 +294,8 @@
       <value stream="CORE_IAF_JRA.NCEP.U_10">domain.atm.TL319.151007.nc</value>
       <value stream="CORE_IAF_JRA.NCEP.V_10">domain.atm.TL319.151007.nc</value>
       <value stream="CORE_IAF_JRA.CORE2.ArcFactor">CORE2.t_10.ArcFactor.T62.1997-2004.nc</value>
-      <value stream="co2tseries.20tr">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
+      <value stream="co2tseries.20tr">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.rcp2.6">fco2_datm_rcp2.6_1765-2500_c130312.nc</value>
       <value stream="co2tseries.rcp4.5">fco2_datm_rcp4.5_1765-2500_c130312.nc</value>
       <value stream="co2tseries.rcp6.0">fco2_datm_rcp6.0_1765-2500_c130312.nc</value>
@@ -435,7 +436,7 @@
     <category>streams</category>
     <group>streams_file</group>
     <desc>Stream data file path(s).</desc>
-    <values>
+    <values match="first">
       <value>null</value>
       <value  stream="CLM1PT.1x1_mexicocityMEX">clm1pt-1993-12.nc</value>
       <value  stream="CLM1PT.1x1_vancouverCAN">clm1pt-1992-08.nc</value>
@@ -1624,7 +1625,8 @@
         JRA.v1.3.v_10.TL319.2016.171019.nc
       </value> 
       <value stream="CORE_IAF_JRA.CORE2.ArcFactor">CORE2.t_10.ArcFactor.T62.1997-2004.nc</value>
-      <value stream="co2tseries.20tr">fco2_datm_1765-2007_c100614.nc</value>
+      <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
+      <value stream="co2tseries.20tr">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.rcp2.6">fco2_datm_rcp2.6_1765-2500_c130312.nc</value>
       <value stream="co2tseries.rcp4.5">fco2_datm_rcp4.5_1765-2500_c130312.nc</value>
       <value stream="co2tseries.rcp6.0">fco2_datm_rcp6.0_1765-2500_c130312.nc</value>
@@ -2016,9 +2018,9 @@
       <value stream="BC.CRUNCEP.CMAP.Precip">1979</value>
       <value stream="Anomaly.Forcing">2006</value>
       <value stream="presaero.cplhist">$DATM_CPLHIST_YR_ALIGN</value>
-      <value stream="presaero.clim1850">1850</value>
-      <value stream="presaero.clim2000">2000</value>
-      <value stream="presaero.clim2010">2010</value>
+      <value stream="presaero.clim_1850">1</value>
+      <value stream="presaero.clim_2000">1</value>
+      <value stream="presaero.clim_2010">1</value>
       <value stream="presaero.trans_1850-2000">1849</value>
       <value stream="presaero.rcp">1849</value>
       <value stream="topo.observed">1</value>
@@ -2136,7 +2138,7 @@
       <value stream="CORE_IAF_JRA.NCEP.U_10">2016</value>
       <value stream="CORE_IAF_JRA.NCEP.V_10">2016</value>
       <value stream="CORE_IAF_JRA.CORE2.ArcFactor">2016</value>
-      <value stream="co2tseries.20tr">2007</value>
+      <value stream="co2tseries.20tr">2014</value>
       <value stream="co2tseries.rcp">2500</value>
       <value stream="BC.QIAN.Precip">2004</value>
       <value stream="BC.CRUNCEP.GPCP.Precip">2012</value>
@@ -2146,7 +2148,7 @@
       <value stream="presaero.clim_1850">1850</value>
       <value stream="presaero.clim_2000">2000</value>
       <value stream="presaero.clim_2010">2010</value>
-      <value stream="presaero.trans_1850-2000">2006</value>
+      <value stream="presaero.trans_1850-2000">2014</value>
       <value stream="presaero.rcp">2104</value>
       <value stream="topo.observed">1</value>
       <value stream="topo.cplhist">$DATM_CPLHIST_YR_END</value>

--- a/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -127,6 +127,7 @@
 
     presaero.clim_1850
     presaero.clim_2000
+    presaero.clim_2010
     presaero.trans_1850-2000
     presaero.rcp2.6
     presaero.rcp4.5
@@ -233,6 +234,7 @@
       <value stream="presaero.cplhist">null</value>
       <value stream="presaero.clim_1850">$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/aero </value>
       <value stream="presaero.clim_2000">$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/aero </value>
+      <value stream="presaero.clim_2010">$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/aero </value>
       <value stream="presaero.trans_1850-2000">$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/aero</value>
       <value stream="presaero.rcp">$DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/aero</value>
       <value stream="topo.observed">$DIN_LOC_ROOT/atm/datm7/topo_forcing</value>
@@ -291,7 +293,8 @@
       <value stream="CORE_IAF_JRA.NCEP.U_10">domain.atm.TL319.151007.nc</value>
       <value stream="CORE_IAF_JRA.NCEP.V_10">domain.atm.TL319.151007.nc</value>
       <value stream="CORE_IAF_JRA.CORE2.ArcFactor">CORE2.t_10.ArcFactor.T62.1997-2004.nc</value>
-      <value stream="co2tseries.20tr">fco2_datm_1765-2007_c100614.nc</value>
+      <value stream="co2tseries.20tr">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
+      <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.rcp2.6">fco2_datm_rcp2.6_1765-2500_c130312.nc</value>
       <value stream="co2tseries.rcp4.5">fco2_datm_rcp4.5_1765-2500_c130312.nc</value>
       <value stream="co2tseries.rcp6.0">fco2_datm_rcp6.0_1765-2500_c130312.nc</value>
@@ -306,9 +309,10 @@
       <value stream="presaero.rcp4.5" atm_grid="CLM_USRDAT">aerosoldep_rcp4.5_monthly_1849-2104_${CLM_USRDAT_NAME}.nc</value>
       <value stream="presaero.rcp6.0" atm_grid="CLM_USRDAT">aerosoldep_rcp6_monthly_1849-2104_${CLM_USRDAT_NAME}.nc</value>
 
-      <value stream="presaero.clim_1850">aerosoldep_monthly_1850_mean_1.9x2.5_c090421.nc</value>
-      <value stream="presaero.clim_2000">aerosoldep_monthly_2000_mean_1.9x2.5_c090421.nc</value>
-      <value stream="presaero.trans_1850-2000">aerosoldep_monthly_1849-2006_1.9x2.5_c090803.nc</value>
+      <value stream="presaero.clim_1850">aerosoldep_WACCM.ensmean_monthly_hist_1849-2015_0.9x1.25_CMIP6_c180926.nc</value>
+      <value stream="presaero.clim_2000">aerosoldep_WACCM.ensmean_monthly_hist_1849-2015_0.9x1.25_CMIP6_c180926.nc</value>
+      <value stream="presaero.clim_2010">aerosoldep_WACCM.ensmean_monthly_hist_1849-2015_0.9x1.25_CMIP6_c180926.nc</value>
+      <value stream="presaero.trans_1850-2000">aerosoldep_WACCM.ensmean_monthly_hist_1849-2015_0.9x1.25_CMIP6_c180926.nc</value>
       <value stream="presaero.rcp2.6">aerosoldep_rcp2.6_monthly_1849-2104_1.9x2.5_c100402.nc</value>
       <value stream="presaero.rcp4.5">aerosoldep_rcp4.5_monthly_1849-2104_1.9x2.5_c100402.nc</value>
       <value stream="presaero.rcp6.0">aerosoldep_rcp6.0_monthly_1849-2104_1.9x2.5_c100830.nc</value>
@@ -1637,9 +1641,10 @@
       <value stream="Anomaly.Forcing.Shortwave">af.rsds.ccsm4.rcp45.2006-2300.nc</value>
       <value stream="Anomaly.Forcing.Longwave">af.rlds.ccsm4.rcp45.2006-2300.nc</value>
 
-      <value stream="presaero.clim_1850">aerosoldep_monthly_1850_mean_1.9x2.5_c090421.nc</value>
-      <value stream="presaero.clim_2000">aerosoldep_monthly_2000_mean_1.9x2.5_c090421.nc</value>
-      <value stream="presaero.trans_1850-2000">aerosoldep_monthly_1849-2006_1.9x2.5_c090803.nc</value>
+      <value stream="presaero.clim_1850">aerosoldep_WACCM.ensmean_monthly_hist_1849-2015_0.9x1.25_CMIP6_c180926.nc</value>
+      <value stream="presaero.clim_2000">aerosoldep_WACCM.ensmean_monthly_hist_1849-2015_0.9x1.25_CMIP6_c180926.nc</value>
+      <value stream="presaero.clim_2010">aerosoldep_WACCM.ensmean_monthly_hist_1849-2015_0.9x1.25_CMIP6_c180926.nc</value>
+      <value stream="presaero.trans_1850-2000">aerosoldep_WACCM.ensmean_monthly_hist_1849-2015_0.9x1.25_CMIP6_c180926.nc</value>
       <value stream="presaero.rcp2.6">aerosoldep_rcp2.6_monthly_1849-2104_1.9x2.5_c100402.nc</value>
       <value stream="presaero.rcp2.6" atm_grid="CLM_USRDAT">aerosoldep_rcp2.6_monthly_1849-2104_${CLM_USRDAT_NAME}.nc</value>
       <value stream="presaero.rcp4.5">aerosoldep_rcp4.5_monthly_1849-2104_1.9x2.5_c100402.nc</value>
@@ -2011,7 +2016,9 @@
       <value stream="BC.CRUNCEP.CMAP.Precip">1979</value>
       <value stream="Anomaly.Forcing">2006</value>
       <value stream="presaero.cplhist">$DATM_CPLHIST_YR_ALIGN</value>
-      <value stream="presaero.clim">1</value>
+      <value stream="presaero.clim1850">1850</value>
+      <value stream="presaero.clim2000">2000</value>
+      <value stream="presaero.clim2010">2010</value>
       <value stream="presaero.trans_1850-2000">1849</value>
       <value stream="presaero.rcp">1849</value>
       <value stream="topo.observed">1</value>
@@ -2072,7 +2079,9 @@
       <value stream="BC.CRUNCEP">1979</value>
       <value stream="Anomaly.Forcing">2006</value>
       <value stream="presaero.cplhist">$DATM_CPLHIST_YR_START</value>
-      <value stream="presaero.clim">1</value>
+      <value stream="presaero.clim_1850">1850</value>
+      <value stream="presaero.clim_2000">2000</value>
+      <value stream="presaero.clim_2010">2010</value>
       <value stream="presaero.trans_1850-2000">1849</value>
       <value stream="presaero.rcp">1849</value>
       <value stream="topo.observed">1</value>
@@ -2134,7 +2143,9 @@
       <value stream="BC.CRUNCEP.CMAP.Precip">2010</value>
       <value stream="Anomaly.Forcing">2300</value>
       <value stream="presaero.cplhist">$DATM_CPLHIST_YR_END</value>
-      <value stream="presaero.clim">1</value>
+      <value stream="presaero.clim_1850">1850</value>
+      <value stream="presaero.clim_2000">2000</value>
+      <value stream="presaero.clim_2010">2010</value>
       <value stream="presaero.trans_1850-2000">2006</value>
       <value stream="presaero.rcp">2104</value>
       <value stream="topo.observed">1</value>


### PR DESCRIPTION
Update presaero and CO2 datasets for datm7 to new CMIP6 version

Update with new CMIP6 presaero historical for 1850, 20tr and 2000, and add CMIP6 CO2 20tr, and include 20tr.latbnds option as well, and add settings for 2010 compsets

Testing: Ran following cases, made sure ran with new datasets, and namelists appeared correct:

```
ERS_D_Ld7_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_intel.clm-decStart1851_noinitial
ERP_D_Ld10_P36x2.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-ciso_decStart
ERS_Ly3_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_intel.clm-cropMonthOutput
ERS_Ly3_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_gnu.clm-cropMonthOutput
ERS_Ly3_P72x2.f10_f10_musgs.IHistClm50BgcCropG.cheyenne_intel.clm-cropMonthOutput
ERP_Ly3_P72x2.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-cropMonthOutput
ERS_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_intel.clm-cropMonthOutput
ERS_Ly5_P144x1.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-cropMonthOutput
ERS_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropGs.cheyenne_gnu.clm-cropMonthOutput
SMS_Lm1_D.f10_f10_musgs.I2000Clm50BgcCrop.cheyenne_intel.clm-snowlayers_3_monthly
SMS_Ld5_D.f09_g16.I1850Clm50BgcCrop.cheyenne_intel.clm-cmip6
ERP_D_Ld5.f10_f10_musgs.IHistClm50BgcCrop.cheyenne_intel.clm-allActive
SMS_D_Ly2.1x1_numaIA.IHistClm50BgcCropGs.cheyenne_intel.clm-ciso_bombspike1963
```

Fixes [CIME Github issue #] #2687, #2688

User interface changes?: Yes!

Added clim_2010 option for DATM_PRESAERO
Added 20tr.latbnd option for DATM_CO2_TSERIES
GSWP3v1 and CRUNCEPv7 forcing sets appropriate years for compsets starting with 2010

Update gh-pages html (Y/N)?: N

Code review: asking for jedwards/mvertens
