### PR TITLE
hr2x at endofrun

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1165,10 +1165,9 @@
       (*despite 'aux' instead of 'avg' in the name).
       Files are written at time-of-day = 00000, and at the end of the forecast,
       even if that time is not 00000.
-      The averaging period will depend on the forecast length.
-      Forecast length < 24 hour -> averaging period is the forecast length,
-      Forecast length >= 24 hour -> averaging period is 24 hours for files before the last (partial) day
-                                    averaging period is the last (partial) day for the last file.
+      Forecast length less than 24 hours; averaging period is the forecast length,
+      Otherwise; averaging period is 24 hours for files before the last (partial) day,
+                 averaging period is the last (partial) day for the last file.
       default: false
     </desc>
     <values>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1162,10 +1162,10 @@
     <group>seq_infodata_inparm</group>
     <desc>
       turns on coupler history stream for average* runoff to coupler fields
-      (*despite 'aux' instead of 'avg' in the name).
-      Files are written at time-of-day = 00000, and at the end of the forecast,
+      (*despite the lack of an averaging time span in the name).
+      Files are written at time-of-day = 00000, and at the end of the run interval,
       even if that time is not 00000.
-      Forecast length less than 24 hours; averaging period is the forecast length,
+      Run length less than 24 hours; averaging period is the run length,
       Otherwise; averaging period is 24 hours for files before the last (partial) day,
                  averaging period is the last (partial) day for the last file.
       default: false

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1161,7 +1161,14 @@
     <category>history</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      turns on coupler history stream for daily average runoff to coupler fields.
+      turns on coupler history stream for average* runoff to coupler fields
+      (*despite 'aux' instead of 'avg' in the name).
+      Files are written at time-of-day = 00000, and at the end of the forecast,
+      even if that time is not 00000.
+      The averaging period will depend on the forecast length.
+      Forecast length < 24 hour -> averaging period is the forecast length,
+      Forecast length >= 24 hour -> averaging period is 24 hours for files before the last (partial) day
+                                    averaging period is the last (partial) day for the last file.
       default: false
     </desc>
     <values>

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -269,6 +269,7 @@ module cime_comp_mod
   logical  :: t24hr_alarm            ! alarm every twentyfour hours
   logical  :: t1yr_alarm             ! alarm every year, at start of year
   logical  :: pause_alarm            ! pause alarm
+  logical  :: write_hist_alarm       ! seq_timemgr index for driver
   integer  :: drv_index              ! seq_timemgr index for driver
 
   real(r8) :: days_per_year = 365.0  ! days per year
@@ -3087,11 +3088,12 @@ contains
              if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
              if (do_hist_r2x) then
                 call t_drvstartf ('driver_rofpost_histaux', barrier=mpicom_CPLID)
+                write_hist_alarm = t24hr_alarm .or. stop_alarm
                 do eri = 1,num_inst_rof
                    inst_suffix =  component_get_suffix(rof(eri))
                    call seq_hist_writeaux(infodata, EClock_d, rof(eri), flow='c2x', &
                         aname='r2x',dname='domrb',inst_suffix=trim(inst_suffix),  &
-                        nx=rof_nx, ny=rof_ny, nt=1, write_now=t24hr_alarm)
+                        nx=rof_nx, ny=rof_ny, nt=1, write_now=write_hist_alarm)
                 enddo
                 call t_drvstopf ('driver_rofpost_histaux')
              endif

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -269,7 +269,7 @@ module cime_comp_mod
   logical  :: t24hr_alarm            ! alarm every twentyfour hours
   logical  :: t1yr_alarm             ! alarm every year, at start of year
   logical  :: pause_alarm            ! pause alarm
-  logical  :: write_hist_alarm       ! seq_timemgr index for driver
+  logical  :: write_hist_alarm       ! alarm to write a history file under multiple conditions
   integer  :: drv_index              ! seq_timemgr index for driver
 
   real(r8) :: days_per_year = 365.0  ! days per year
@@ -3088,6 +3088,8 @@ contains
              if (drv_threading) call seq_comm_setnthreads(nthreads_CPLID)
              if (do_hist_r2x) then
                 call t_drvstartf ('driver_rofpost_histaux', barrier=mpicom_CPLID)
+                ! Write coupler's hr2x file at 24 hour marks, 
+                ! and at the end of the forecast, even if that's not at a 24 hour mark.
                 write_hist_alarm = t24hr_alarm .or. stop_alarm
                 do eri = 1,num_inst_rof
                    inst_suffix =  component_get_suffix(rof(eri))

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -3089,7 +3089,7 @@ contains
              if (do_hist_r2x) then
                 call t_drvstartf ('driver_rofpost_histaux', barrier=mpicom_CPLID)
                 ! Write coupler's hr2x file at 24 hour marks, 
-                ! and at the end of the forecast, even if that's not at a 24 hour mark.
+                ! and at the end of the run interval, even if that's not at a 24 hour mark.
                 write_hist_alarm = t24hr_alarm .or. stop_alarm
                 do eri = 1,num_inst_rof
                    inst_suffix =  component_get_suffix(rof(eri))


### PR DESCRIPTION
Write cpl.hr2x files at ENDOFRUN when forecast is < 24 hours. 
Write them every 24 hours for longer forecasts.

Test suite: scripts_regression_tests.py and cesm2_2 CAM forecasts from hours 12-18 and 18-24
Test baseline: 
Test namelist changes: none
Test status: bit for bit in the model run.  Answer changing in the cpl.hr2x files

Fixes #2831 

User interface changes?: None

Update gh-pages html (Y/N)?: possibly; to alert users to the actual contents of cpl.hr2x files

Code review: 
