### PR TITLE
Dont hide ctest output in run_tests.py

### DIFF
--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -405,9 +405,9 @@ def _main():
             if ctest_args is not None:
                 ctest_command.extend(ctest_args.split(" "))
 
-            logging.info("Running '{}'".format(" ".join(ctest_command)))
+            logger.info("Running '{}'".format(" ".join(ctest_command)))
             output = run_cmd_no_fail(" ".join(ctest_command), from_dir=label, combine_output=True)
-            logging.info(output)
+            logger.info(output)
 
 if __name__ == "__main__":
     _main()

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -405,7 +405,7 @@ def _main():
             if ctest_args is not None:
                 ctest_command.extend(ctest_args.split(" "))
 
-            logging.info(ctest_command)
+            logging.info("Running '{}'".format(" ".join(ctest_command)))
             output = run_cmd_no_fail(" ".join(ctest_command), from_dir=label, combine_output=True)
             logging.info(output)
 

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -405,7 +405,9 @@ def _main():
             if ctest_args is not None:
                 ctest_command.extend(ctest_args.split(" "))
 
-            run_cmd_no_fail(" ".join(ctest_command), from_dir=label, combine_output=True)
+            logging.info(ctest_command)
+            output = run_cmd_no_fail(" ".join(ctest_command), from_dir=label, combine_output=True)
+            logging.info(output)
 
 if __name__ == "__main__":
     _main()


### PR DESCRIPTION
Dont hide ctest output in run_tests.py

If the command worked, the output was totally lost.

Test suite: by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2792 

User interface changes?: N

Update gh-pages html (Y/N)?:

Code review: @billsacks 
