### PR TITLE
change default for flux_convergence for all but 1 degree case

### DIFF
--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -50,6 +50,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['timer_level'] = 'pos' if case.get_value('TIMER_LEVEL') >= 1 else 'neg'
     config['bfbflag'] = 'on' if case.get_value('BFBFLAG') else 'off'
     config['continue_run'] = '.true.' if case.get_value('CONTINUE_RUN') else '.false.'
+    config['atm_grid'] = case.get_value('ATM_GRID')
 
     if case.get_value('RUN_TYPE') == 'startup':
         config['run_type'] = 'startup'
@@ -113,7 +114,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         atmdt = int(basedt / case.get_value('ATM_NCPL'))
         expect(atmdt == mindt, 'Active atm should match shortest model timestep atmdt={} mindt={}'
                .format(atmdt, mindt))
-            
+
 
     #--------------------------------
     # Overwrite: set start_ymd

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -705,6 +705,8 @@
       Setting this to zero will always do flux_max_iteration
     </desc>
     <values>
+      <!-- the value for f09 grids is maintained as 0.0 for compatibility with cmip6 experiments
+           the 1% convergence criteria improves performance of the atm ocn flux calculation in shr_flux_mod.F90 -->
       <value cime_model='cesm'>0.01</value>
       <value cime_model='cesm' atm_grid="0.9x1.25">0.0</value>
       <value cime_model='e3sm'>0.0</value>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -705,7 +705,8 @@
       Setting this to zero will always do flux_max_iteration
     </desc>
     <values>
-      <value cime_model='cesm'>0.0</value>
+      <value cime_model='cesm'>0.01</value>
+      <value cime_model='cesm' atm_grid="0.9x1.25">0.0</value>
       <value cime_model='e3sm'>0.0</value>
     </values>
   </entry>


### PR DESCRIPTION
Changes the atm-ocn flux convergence criteria for all except the 1 degree case,  this changes increases performance considerably for f19_g17

Test suite:  PFS.f19_g17.B1850.cheyenne_intel.allactive-default I also made sure that
                    PFS.f09_g17.B1850.cheyenne_intel.allactive-default was not affected.  
                  This change is for cesm only.
Test baseline: 
Test namelist changes: 
Test status:  roundoff

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
