### PR TITLE
add ability for testfile to contain comments

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -337,7 +337,7 @@ def parse_command_line(args, description):
 
     if args.testfile is not None:
         with open(args.testfile, "r") as fd:
-            args.testargs.extend( [line.strip() for line in fd.read().splitlines() if line.strip()] )
+            args.testargs.extend( [line.strip() for line in fd.read().splitlines() if line.strip() and not line.startswith('#')] )
 
     # Compute list of fully-resolved test_names
     test_extra_data = {}


### PR DESCRIPTION
ascii testfiles can now have comment lines beginning with # character, the # must be at the beginning of the line. 

Test suite: tested create_test by hand with testfile comments
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #589 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
