### PR TITLE
remove overzelous debug code

### DIFF
--- a/src/share/streams/shr_stream_mod.F90
+++ b/src/share/streams/shr_stream_mod.F90
@@ -779,11 +779,6 @@ contains
        strm%filePath = trim(filePath)
     endif
     if (present(filename)) then
-       if (debug>1 .and. s_loglev > 0) then
-          write(s_logunit,F01) "size of filename = ",size(filename)
-          write(s_logunit,F00) "filename = ",filename
-       endif
-
        do n = 1,size(filename)
           ! Ignore null file names.
           if (trim(filename(n)) /= trim(shr_stream_file_null)) then


### PR DESCRIPTION
Remove a debug print statement that was in place for a very specific case that has since been resolved.

Test suite:  Z_FullSystemTest
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #785 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
