### PR TITLE
Improve idmap test

### DIFF
--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -572,7 +572,7 @@ class NamelistGenerator(object):
                         continue
                     file_path = character_literal_to_string(literal)
                     # NOTE - these are hard-coded here and a better way is to make these extensible
-                    if file_path == 'UNSET' or file_path == 'idmap':
+                    if file_path == 'UNSET' or file_path == 'idmap' or file_path == 'idmap_ignore':
                         continue
                     if file_path == 'null':
                         continue
@@ -623,7 +623,7 @@ class NamelistGenerator(object):
                         for literal in literals:
                             file_path = character_literal_to_string(literal)
                             # NOTE - these are hard-coded here and a better way is to make these extensible
-                            if file_path == 'UNSET' or file_path == 'idmap':
+                            if file_path == 'UNSET' or file_path == 'idmap' or file_path == 'idmap_ignore':
                                 continue
                             if input_pathname == 'abs':
                                 # No further mangling needed for absolute paths.

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -211,8 +211,6 @@ def write_seq_maps_file(case, nmlgen, confdir):
     # The following is only approriate for config_grids.xml version 2.0 or later
     grid_version = Grids().get_version()
     if grid_version >= 2.0:
-        ignore_idmaps = ["rof2ocn_fmapname", "glc2ice_rmapname",
-                         "glc2ocn_liq_rmapname", "glc2ocn_ice_rmapname"]
         group_variables = nmlgen.get_group_variables("seq_maps")
         for name in group_variables:
             value = group_variables[name]
@@ -222,16 +220,13 @@ def write_seq_maps_file(case, nmlgen, confdir):
                     component1 = name[0:3]
                     component2 = name[4:7]
                     if not ignore_component[component1]  and not ignore_component[component2]:
-                        if name in ignore_idmaps:
-                            logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
+                        if "rof2ocn_" in name:
+                            if case.get_value("COMP_OCN") == 'docn':
+                                logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
                         else:
-                            if "rof2ocn_" in name:
-                                if case.get_value("COMP_OCN") == 'docn':
-                                    logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
-                            else:
-                                expect(gridvalue[component1] == gridvalue[component2],
-                                       "Need to provide valid mapping file between {} and {} in xml variable {} ".\
-                                           format(component1, component2, name))
+                            expect(gridvalue[component1] == gridvalue[component2],
+                                   "Need to provide valid mapping file between {} and {} in xml variable {} ".\
+                                   format(component1, component2, name))
 
     # now write out the file
     seq_maps_file = os.path.join(confdir, "seq_maps.rc")

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1492,10 +1492,11 @@
 
   <entry id="ROF2OCN_FMAPNAME">
     <type>char</type>
-    <default_value>idmap</default_value>
+    <default_value>idmap_ignore</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>rof2ocn flux mapping file</desc>
+    <desc>rof2ocn flux mapping file - the default value idmap_ignore, if set, will be ignored by buildnml and
+    will generate a runtime error if in fact a file is required for the given compset</desc>
   </entry>
 
   <entry id="ROF2OCN_FMAPTYPE">
@@ -1577,10 +1578,11 @@
 
   <entry id="GLC2ICE_RMAPNAME">
     <type>char</type>
-    <default_value>idmap</default_value>
+    <default_value>idmap_ignore</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>glc2ice runoff mapping file</desc>
+    <desc>glc2ice runoff mapping file - the default value idmap_ignore, if set, will be ignored by buildnml and
+    will generate a runtime error if in fact a file is required for the given compset</desc>
   </entry>
 
   <entry id="GLC2ICE_RMAPTYPE">
@@ -1594,10 +1596,11 @@
 
   <entry id="GLC2OCN_LIQ_RMAPNAME">
     <type>char</type>
-    <default_value>idmap</default_value>
+    <default_value>idmap_ignore</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>glc2ocn runoff mapping file for liquid runoff</desc>
+    <desc>glc2ocn runoff mapping file for liquid runoff - the default value idmap_ignore, if set, will be ignored by buildnml and
+    will generate a runtime error if in fact a file is required for the given compset</desc>
   </entry>
 
   <entry id="GLC2OCN_LIQ_RMAPTYPE">
@@ -1611,10 +1614,11 @@
 
   <entry id="GLC2OCN_ICE_RMAPNAME">
     <type>char</type>
-    <default_value>idmap</default_value>
+    <default_value>idmap_ignore</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>glc2ocn runoff mapping file for ice runoff</desc>
+    <desc>glc2ocn runoff mapping file for ice runoff - the default value idmap_ignore, if set, will be ignored by buildnml and
+    will generate a runtime error if in fact a file is required for the given compset</desc>
   </entry>
 
   <entry id="GLC2OCN_ICE_RMAPTYPE">


### PR DESCRIPTION
Add a default value of idmap_ignore for certain mapping files - it can only be determined at runtime whether these files should or should not exists.   This PR doesn't really change anything except to move the list of files from hardcoded in the python to the xml file.    

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #1908 arguably 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
