### PR TITLE
Nuopc cmeps

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -5,7 +5,7 @@ Script to create a new CIME Case Control System (CSS) experimental case.
 """
 
 from Tools.standard_script_setup import *
-from CIME.utils         import expect, get_model, get_cime_config
+from CIME.utils         import expect, get_model, get_cime_config, get_cime_default_driver
 from CIME.case          import Case
 from argparse           import RawTextHelpFormatter
 
@@ -135,7 +135,7 @@ def parse_command_line(args, cimeroot, description):
 
     parser.add_argument("-i", "--input-dir",
                         help="Use a non-default location for input files. This will change the xml value of DIN_LOC_ROOT.")
-    parser.add_argument("--driver", default="mct",
+    parser.add_argument("--driver", default=get_cime_default_driver(),
                         choices=('mct','nuopc', 'moab'),
                         help=argparse.SUPPRESS)
 

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -134,7 +134,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                 if comp_interface != "nuopc":
                     expect(case.get_value("NINST_LAYOUT_{}".format(comp)) == "concurrent",
                            "If multi_driver is TRUE, NINST_LAYOUT_{} must be concurrent".format(comp))
-                    case.set_value("NTASKS_PER_INST_{}".format(comp), ntasks)
+                case.set_value("NTASKS_PER_INST_{}".format(comp), ntasks)
             else:
                 if ninst > ntasks:
                     if ntasks == 1:
@@ -142,7 +142,6 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
                         ntasks = ninst
                     else:
                         expect(False, "NINST_{} value {:d} greater than NTASKS_{} {:d}".format(comp, ninst, comp, ntasks))
-            if comp_interface != "nuopc":
                 case.set_value("NTASKS_PER_INST_{}".format(comp), max(1,int(ntasks / ninst)))
 
         if os.path.exists(get_batch_script_for_job(case.get_primary_job())):

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -705,5 +705,4 @@ class NamelistGenerator(object):
                              skip_comps=skip_comps, atm_cpl_dt=atm_cpl_dt, ocn_cpl_dt=ocn_cpl_dt)
         if data_list_path is not None:
             # append to input_data_list file
-            with open(data_list_path, "a") as input_data_list:
-                self._write_input_files(input_data_list)
+            self._write_input_files(data_list_path)

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -177,7 +177,7 @@ def _read_cime_config_file():
     allowed_sections = ("main", "create_test")
 
     allowed_in_main = ("cime_model", "project", "charge_account", "srcroot", "mail_type",
-                       "mail_user", "machine", "mpilib", "compiler", "input_dir")
+                       "mail_user", "machine", "mpilib", "compiler", "input_dir", "cime_driver")
     allowed_in_create_test = ("mail_type", "mail_user", "save_timing", "single_submit",
                               "test_root", "output_root", "baseline_root", "clean",
                               "machine", "mpilib", "compiler", "parallel_jobs", "proc_pool",
@@ -243,6 +243,21 @@ def get_cime_root(case=None):
 
     logger.debug( "CIMEROOT is " + cimeroot)
     return cimeroot
+
+def get_cime_default_driver():
+    driver = os.environ.get("CIME_DRIVER")
+    if driver:
+        logger.debug("Setting CIME_DRIVER={} from environment".format(driver))
+    else:
+        cime_config = get_cime_config()
+        if (cime_config.has_option('main','CIME_DRIVER')):
+            driver = cime_config.get('main','CIME_DRIVER')
+            if driver:
+                logger.debug("Setting CIME_driver={} from ~/.cime/config".format(driver))
+    if not driver:
+        driver = "mct"
+    expect(driver in ("mct", "nuopc", "moab"),"Attempt to set invalid driver {}".format(driver))
+    return driver
 
 def set_model(model):
     """

--- a/src/drivers/nuopc/cime_config/buildnml
+++ b/src/drivers/nuopc/cime_config/buildnml
@@ -201,7 +201,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     # (2) Write namelist file drv_in and initial input dataset list.
     #--------------------------------
     namelist_file = os.path.join(confdir, "drv_in")
-    drv_namelist_groups = ["cime_pes", "papi_inparm", "pio_default_inparm", "prof_inparm"]
+    drv_namelist_groups = ["papi_inparm", "pio_default_inparm", "prof_inparm"]
     nmlgen.write_output_file(namelist_file, data_list_path=data_list_path, groups=drv_namelist_groups)
 
     #--------------------------------

--- a/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/nuopc/cime_config/namelist_definition_drv.xml
@@ -2945,7 +2945,7 @@ n    </desc>
   <entry id="atm_ntasks" modify_via_xml="NTASKS_ATM">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of mpi tasks assigned to the atm components.
       set by NTASKS_ATM in env_configure.xml.
@@ -2958,7 +2958,7 @@ n    </desc>
   <entry id="atm_nthreads" modify_via_xml="NTHRDS_ATM">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of threads per mpi task for the atm component.
       set by NTHRDS_ATM in env_configure.xml.
@@ -2971,7 +2971,7 @@ n    </desc>
   <entry id="atm_rootpe" modify_via_xml="ROOTPE_ATM">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the global mpi task rank of the root processor assigned to the atm component.
       set by ROOTPE_ATM in env_configure.xml.
@@ -2984,7 +2984,7 @@ n    </desc>
   <entry id="atm_pestride" modify_via_xml="PSTRID_ATM">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the mpi global processors stride associated with the mpi tasks for the atm component.
       set by PSTRID_ATM in env_configure.xml.
@@ -2997,7 +2997,7 @@ n    </desc>
   <entry id="lnd_ntasks" modify_via_xml="NTASKS_LND">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of mpi tasks assigned to the lnd components.
       set by NTASKS_LND in env_configure.xml.
@@ -3010,7 +3010,7 @@ n    </desc>
   <entry id="lnd_nthreads" modify_via_xml="NTHRDS_LND">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of threads per mpi task for the lnd component.
       set by NTHRDS_LND in env_configure.xml.
@@ -3023,7 +3023,7 @@ n    </desc>
   <entry id="lnd_rootpe" modify_via_xml="ROOTPE_LND">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the global mpi task rank of the root processor assigned to the lnd component.
       set by ROOTPE_LND in env_configure.xml.
@@ -3036,7 +3036,7 @@ n    </desc>
   <entry id="lnd_pestride" modify_via_xml="PSTRID_LND">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the mpi global processors stride associated with the mpi tasks for the lnd component.
       set by PSTRID_LND in env_configure.xml.
@@ -3049,7 +3049,7 @@ n    </desc>
   <entry id="ice_ntasks" modify_via_xml="NTASKS_ICE">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of mpi tasks assigned to the ice components.
       set by NTASKS_ICE in env_configure.xml.
@@ -3062,7 +3062,7 @@ n    </desc>
   <entry id="ice_nthreads" modify_via_xml="NTHRDS_ICE">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of threads per mpi task for the ice component.
       set by NTHRDS_ICE in env_configure.xml.
@@ -3075,7 +3075,7 @@ n    </desc>
   <entry id="ice_rootpe" modify_via_xml="ROOTPE_ICE">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the global mpi task rank of the root processor assigned to the ice component.
       set by ROOTPE_ICE in env_configure.xml.
@@ -3088,7 +3088,7 @@ n    </desc>
   <entry id="ice_pestride" modify_via_xml="PSTRID_ICE">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the mpi global processors stride associated with the mpi tasks for the ice component.
       set by PSTRID_ICE in env_configure.xml.
@@ -3101,7 +3101,7 @@ n    </desc>
   <entry id="ocn_ntasks" modify_via_xml="NTASKS_OCN">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of mpi tasks assigned to the ocn components.
       set by NTASKS_OCN in env_configure.xml.
@@ -3114,7 +3114,7 @@ n    </desc>
   <entry id="ocn_nthreads" modify_via_xml="NTHRDS_OCN">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of threads per mpi task for the ocn component.
       set by NTHRDS_OCN in env_configure.xml.
@@ -3127,7 +3127,7 @@ n    </desc>
   <entry id="ocn_rootpe" modify_via_xml="ROOTPE_OCN">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the global mpi task rank of the root processor assigned to the ocn component.
       set by ROOTPE_OCN in env_configure.xml.
@@ -3140,7 +3140,7 @@ n    </desc>
   <entry id="ocn_pestride" modify_via_xml="PSTRID_OCN">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the mpi global processors stride associated with the mpi tasks for the ocn component.
       set by PSTRID_OCN in env_configure.xml.  default: 1
@@ -3153,7 +3153,7 @@ n    </desc>
   <entry id="glc_ntasks" modify_via_xml="NTASKS_GLC">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of mpi tasks assigned to the glc components.
       set by NTASKS_GLC in env_configure.xml.
@@ -3166,7 +3166,7 @@ n    </desc>
   <entry id="glc_nthreads" modify_via_xml="NTHRDS_GLC">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of threads per mpi task for the glc component.
       set by NTHRDS_GLC in env_configure.xml.
@@ -3179,7 +3179,7 @@ n    </desc>
   <entry id="glc_rootpe" modify_via_xml="ROOTPE_GLC">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the global mpi task rank of the root processor assigned to the glc component.
       set by ROOTPE_GLC in env_configure.xml.
@@ -3192,7 +3192,7 @@ n    </desc>
   <entry id="glc_pestride" modify_via_xml="PSTRID_GLC">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the mpi global processors stride associated with the mpi tasks for the glc component.
       set by PSTRID_GLC in env_configure.xml.
@@ -3205,7 +3205,7 @@ n    </desc>
   <entry id="wav_ntasks" modify_via_xml="NTASKS_WAV">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of mpi tasks assigned to the wav components.
       set by NTASKS_WAV in env_configure.xml.
@@ -3218,7 +3218,7 @@ n    </desc>
   <entry id="wav_nthreads" modify_via_xml="NTHRDS_WAV">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of threads per mpi task for the wav component.
       set by NTHRDS_WAV in env_configure.xml.
@@ -3231,7 +3231,7 @@ n    </desc>
   <entry id="wav_rootpe" modify_via_xml="ROOTPE_WAV">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the global mpi task rank of the root processor assigned to the wav component.
       set by ROOTPE_WAV in env_configure.xml.
@@ -3244,7 +3244,7 @@ n    </desc>
   <entry id="wav_pestride" modify_via_xml="PSTRID_WAV">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the mpi global processors stride associated with the mpi tasks for the wav component.
       set by PSTRID_WAV in env_configure.xml.
@@ -3257,7 +3257,7 @@ n    </desc>
   <entry id="rof_ntasks" modify_via_xml="NTASKS_ROF">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of mpi tasks assigned to the lnd components.
       set by NTASKS_LND in env_configure.xml.
@@ -3270,7 +3270,7 @@ n    </desc>
   <entry id="rof_nthreads" modify_via_xml="NTHRDS_ROF">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of threads per mpi task for the lnd component.
       set by NTHRDS_ROF in env_configure.xml.
@@ -3283,7 +3283,7 @@ n    </desc>
   <entry id="rof_rootpe" modify_via_xml="ROOTPE_ROF">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the global mpi task rank of the root processor assigned to the lnd component.
       set by ROOTPE_LND in env_configure.xml.
@@ -3296,7 +3296,7 @@ n    </desc>
   <entry id="rof_pestride" modify_via_xml="PSTRID_ROF">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the mpi global processors stride associated with the mpi tasks for the lnd component.
       set by PSTRID_LND in env_configure.xml.
@@ -3309,7 +3309,7 @@ n    </desc>
   <entry id="esp_ntasks" modify_via_xml="NTASKS_ESP">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of mpi tasks assigned to the esp components.
       set by NTASKS_ESP in env_configure.xml.
@@ -3322,7 +3322,7 @@ n    </desc>
   <entry  id="esp_nthreads" modify_via_xml="NTHRDS_ESP">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of threads per mpi task for the esp component.
       set by NTHRDS_ESP in env_configure.xml.
@@ -3335,7 +3335,7 @@ n    </desc>
   <entry  id="esp_rootpe" modify_via_xml="ROOTPE_ESP">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the global mpi task rank of the root processor assigned to the esp component.
       set by ROOTPE_ESP in env_configure.xml.
@@ -3348,7 +3348,7 @@ n    </desc>
   <entry  id="esp_pestride" modify_via_xml="PSTRID_ESP">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the mpi global processors stride associated with the mpi tasks for the esp component.
       set by PSTRID_ESP in env_configure.xml.
@@ -3361,7 +3361,7 @@ n    </desc>
   <entry  id="cpl_ntasks" modify_via_xml="NTASKS_CPL">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of mpi tasks assigned to the cpl components.
       set by NTASKS_CPL in env_configure.xml.
@@ -3374,7 +3374,7 @@ n    </desc>
   <entry id="cpl_nthreads" modify_via_xml="NTHRDS_CPL">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the number of threads per mpi task for the cpl component.
       set by NTHRDS_CPL in env_configure.xml.
@@ -3387,7 +3387,7 @@ n    </desc>
   <entry id="cpl_rootpe" modify_via_xml="ROOTPE_CPL">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the global mpi task rank of the root processor assigned to the cpl component.
       set by ROOTPE_CPL in env_configure.xml.
@@ -3400,7 +3400,7 @@ n    </desc>
   <entry id="cpl_pestride" modify_via_xml="PSTRID_CPL">
     <type>integer</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       the mpi global processors stride associated with the mpi tasks for the cpl component.
       set by PSTRID_CPL in env_configure.xml.
@@ -3413,7 +3413,7 @@ n    </desc>
   <entry id="esmf_logging" modify_via_xml="ESMF_LOGFILE_KIND">
     <type>char</type>
     <category>cime_pes</category>
-    <group>cime_pes</group>
+    <group>PELAYOUT_attributes</group>
     <desc>
       Determines what ESMF log files (if any) are generated when
           USE_ESMF_LIB is TRUE.

--- a/src/drivers/nuopc/cime_driver/esm.F90
+++ b/src/drivers/nuopc/cime_driver/esm.F90
@@ -1462,7 +1462,7 @@ module ESM
        endif
        cnt=1
 
-       do ntask = rootpe, rootpe+ntasks*stride, stride
+       do ntask = rootpe, (rootpe+ntasks*stride)-1, stride
           petlist(cnt) = ntask
           cnt=cnt+1
        enddo

--- a/src/drivers/nuopc/mediator/med_fraction_mod.F90
+++ b/src/drivers/nuopc/mediator/med_fraction_mod.F90
@@ -175,6 +175,7 @@ module med_fraction_mod
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_getFldPtr
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_FieldRegrid
     use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_diagnose
+    use shr_nuopc_methods_mod , only : shr_nuopc_methods_FB_fldChk
     use med_map_mod           , only : med_map_Fractions_init
     use med_internalstate_mod , only : InternalState
 
@@ -311,17 +312,14 @@ module med_fraction_mod
     !---------------------------------------
 
     if (is_local%wrap%comp_present(compglc)) then
-
-       call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compglc), 'gfrac', dataPtr1, rc=rc)
        ! If 'gfrac' and 'frac' exists, then copy 'frac' to 'gfrac'
        ! TODO: implement a more general scheme that hard-wiring the name 'frac'
-       if (.not. shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) then
+       if (shr_nuopc_methods_FB_FldChk(is_local%wrap%FBfrac(compglc), 'gfrac', rc=rc) .and. &
+            shr_nuopc_methods_FB_FldChk(is_local%wrap%FBImp(compglc, compglc), 'frac', rc=rc)) then
+          call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBfrac(compglc), 'gfrac', dataPtr1, rc=rc)
           call shr_nuopc_methods_FB_getFldPtr(is_local%wrap%FBImp(compglc,compglc), 'frac' , dataPtr2, rc=rc)
-          if (.not. shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) then
-             dataPtr1 = dataPtr2
-          endif
+          dataPtr1 = dataPtr2
        endif
-
     endif
 
     !---------------------------------------

--- a/src/drivers/nuopc/shr/seq_comm_mct.F90
+++ b/src/drivers/nuopc/shr/seq_comm_mct.F90
@@ -23,7 +23,7 @@ module seq_comm_mct
 ! Public interfaces
 !--------------------------------------------------------------------------
 
-  public seq_comm_init
+  public seq_comm_setcomm
   public seq_comm_iamin
   public seq_comm_iamroot
   public seq_comm_mpicom
@@ -747,7 +747,7 @@ contains
   end subroutine seq_comm_init
 
 !---------------------------------------------------------
-  subroutine seq_comm_setcomm(ID,pelist,nthreads,iname,inst,tinst)
+  subroutine seq_comm_setcomm(ID,pelist,nthreads,iname,inst,tinst, comm_in)
     use shr_sys_mod, only : shr_sys_abort
     use mpi, only : MPI_COMM_NULL, mpi_comm_group, mpi_comm_create, mpi_group_range_incl
     use mpi, only: mpi_comm_size, mpi_comm_rank
@@ -759,6 +759,7 @@ contains
     character(len=*),intent(IN),optional :: iname  ! name of component
     integer,intent(IN),optional :: inst  ! instance of component
     integer,intent(IN),optional :: tinst ! total number of instances for this component
+    integer,intent(in),optional :: comm_in
 
     integer :: mpigrp_world
     integer :: mpigrp
@@ -772,6 +773,9 @@ contains
     if (ID < 1 .or. ID > ncomps) then
        write(logunit,*) subname,' ID out of range, abort ',ID
        call shr_sys_abort()
+    endif
+    if(present(comm_in)) then
+       GLOBAL_COMM=comm_in
     endif
 
     call mpi_comm_group(GLOBAL_COMM, mpigrp_world, ierr)

--- a/src/drivers/nuopc/shr/shr_nuopc_time_mod.F90
+++ b/src/drivers/nuopc/shr/shr_nuopc_time_mod.F90
@@ -122,6 +122,7 @@ contains
     integer                 :: mpicom              ! MPI communicator
     integer                 :: tmp(6)              ! Array for Broadcast
     integer                 :: dbrc
+    logical                 :: isPresent
     character(len=*), parameter :: subname = '(shr_nuopc_time_clockInit): '
     !-------------------------------------------------------------------------------
 
@@ -202,9 +203,14 @@ contains
           call NUOPC_CompAttributeGet(esmdriver, name="restart_pfile", value=restart_pfile, rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
 
-          call NUOPC_CompAttributeGet(esmdriver, name="inst_suffix", value=inst_suffix, rc=rc)
+          call NUOPC_CompAttributeGet(esmdriver, name="inst_suffix", isPresent=isPresent, rc=rc)
           if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
-
+          if(isPresent) then
+             call NUOPC_CompAttributeGet(esmdriver, name="inst_suffix", value=inst_suffix, rc=rc)
+             if (shr_nuopc_methods_ChkErr(rc,__LINE__,u_FILE_u)) return
+          else
+             inst_suffix = ""
+          endif
           if ( len_trim(restart_pfile) == 0 ) then
              rc = ESMF_FAILURE
              call ESMF_LogWrite(trim(subname)//' ERROR restart_pfile must be defined', &


### PR DESCRIPTION
Merge latest nuopc-cmeps development into master.   Adds env var and config var CIME_DRIVER which allows a user to set the default driver used by create_newcase.   So running scripts_regression_tests.py with an alternate driver simply requires setting CIME_DRIVER=nuopc in the 
environment.   

Test suite: scripts_regression_tests.py on cheyenne with mct and nuopc drivers
mct result - ALL PASS
nuopc result - ALL PASS EXCEPT:
  test_j_createnewcase_user_compset_vs_alias (__main__.J_TestCreateNewcase) ... FAIL
  test_cime_case_build_threaded_1 (__main__.K_TestCimeCase) ... ERROR
  test_save_timings (__main__.L_TestSaveTimings) ... FAIL
  test_save_timings_manual (__main__.L_TestSaveTimings) ... FAIL
  test_b_full (__main__.O_TestTestScheduler) ... FAIL
  test_c_use_existing (__main__.O_TestTestScheduler) ... FAIL
  test_d_retry (__main__.O_TestTestScheduler) ... FAIL
  test_bless_test_results (__main__.Q_TestBlessTestResults) ... FAIL
  test_run_restart (__main__.T_TestRunRestart) ... FAIL
  test_run_restart_too_many_fails (__main__.T_TestRunRestart) ... FAIL
  FAIL DAE.ww3a.ADWAV.cheyenne_intel MODEL_BUILD
  FAIL ERI.f09_g16.X.cheyenne_intel RUN
  FAIL ERP.f45_g37_rx1.A.cheyenne_intel XML
  FAIL ERS.ne30_g16_rx1.A.cheyenne_intel.drv-y100k RUN
  FAIL IRT_N2.f19_g16_rx1.A.cheyenne_intel RUN
  FAIL MCC_P1.f19_g16_rx1.A.cheyenne_intel RUN
  FAIL NCK_Ld3.f45_g37_rx1.A.cheyenne_intel RUN
  FAIL PET_P4.f19_f19.A.cheyenne_intel XML
  FAIL PRE.f19_f19.ADESP_TEST.cheyenne_intel SHAREDLIB_BUILD
  

Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2814 

User interface changes?:  Adds CIME_DRIVER env and config variable to set the default driver.

Update gh-pages html (Y/N)?:

Code review: 
