### PR TITLE
Fix floating-point mpiprocs for Python 3

### DIFF
--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -103,7 +103,7 @@ class EnvMachPes(EnvBase):
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):
         expect(total_tasks > 0,"totaltasks > 0 expected, totaltasks = {}".format(total_tasks))
-        tasks_per_node = min(self.get_value("MAX_TASKS_PER_NODE")/ max_thread_count,
+        tasks_per_node = min(self.get_value("MAX_TASKS_PER_NODE")// max_thread_count,
                              self.get_value("MAX_MPITASKS_PER_NODE"), total_tasks)
         return tasks_per_node if tasks_per_node > 0 else 1
 


### PR DESCRIPTION
Compute ```tasks_per_node``` via floor division. Otherwise, with Python 3 (and with true division), tasks_per_node is computed as a float, which triggers an error when ./case.submit is called since
mpiprocs in .case.run is a floating point number, e.g., 36.0.

Test suite: scripts_regression_tests.py
Test baseline: n/a
Test namelist changes: n/a 
Test status: pass

Fixes #2738

User interface changes?: N

Update gh-pages html (Y/N)?:

Code review: 
