### PR TITLE
Renaming grid and compset for MISOMIP experiment

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -40,7 +40,7 @@
       <grid name="glc"	  compset="CISM1" >gland5UM</grid>
       <grid name="glc"	  compset="CISM2" >gland4</grid>
       <grid name="glc"    compset="XGLC"  >gland4</grid>
-      <grid name="glc"    compset="TMISMIP">MISMIPgrid</grid>
+      <grid name="glc"    compset="Tu"    >MISOMIPgrid</grid>
       <grid name="wav"	  compset="SWAV"  >null</grid>
       <grid name="wav"	  compset="DWAV"  >ww3a</grid>
       <grid name="wav"	  compset="WW3"	  >ww3a</grid>
@@ -159,8 +159,8 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="mip1" compset="_CISM">
-      <grid name="glc">MISMIPgrid</grid>
+    <model_grid alias="miso2k" compset="_CISM">
+      <grid name="glc">MISOMIPgrid</grid>
     </model_grid>
 
     <model_grid alias="T42_T42_musgs" not_compset="_POP">
@@ -1446,9 +1446,9 @@
       <desc>4-km Greenland grid, for use with the glissade dycore</desc>
     </domain>
 
-    <domain name="MISMIPgrid">
-      <nx>324</nx> <ny>40</ny>
-      <desc>2-km MISMIP+ grid to use for idealized experiment</desc>
+    <domain name="MISOMIPgrid">
+      <nx>402</nx> <ny>40</ny>
+      <desc>2-km MISOMIP grid to use for idealized experiment</desc>
     </domain>
 
     <!-- WW3 domains-->


### PR DESCRIPTION
Renamed the grid and alias to align with what MOM6 does.
Renamed compset to follow naming convention.

Note: in terms of naming convention we introduced the convention that lower case "u"
means uncoupled (not even data anything) so that Tu means ice sheet only and stub everything.

[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
