### PR TITLE
Strawman fix of #2832, which broke the non-r2x files.

### DIFF
--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -3765,14 +3765,15 @@ contains
           if (do_hist_a2x24hr) then
              do eai = 1,num_inst_atm
                 inst_suffix = component_get_suffix(atm(eai))
+                write_hist_alarm = t24hr_alarm .or. stop_alarm
                 if (trim(hist_a2x24hr_flds) == 'all') then
                    call seq_hist_writeaux(infodata, EClock_d, atm(eai), flow='c2x', &
                         aname='a2x1d',dname='doma',inst_suffix=trim(inst_suffix),  &
-                        nx=atm_nx, ny=atm_ny, nt=1, write_now=t24hr_alarm)
+                        nx=atm_nx, ny=atm_ny, nt=1, write_now=write_hist_alarm)
                 else
                    call seq_hist_writeaux(infodata, EClock_d, atm(eai), flow='c2x', &
                         aname='a2x1d',dname='doma',inst_suffix=trim(inst_suffix),  &
-                        nx=atm_nx, ny=atm_ny, nt=1, write_now=t24hr_alarm, flds=hist_a2x24hr_flds)
+                        nx=atm_nx, ny=atm_ny, nt=1, write_now=write_hist_alarm, flds=hist_a2x24hr_flds)
                 endif
              enddo
           endif


### PR DESCRIPTION
For runs shorter than 24 hours, the names of all of the
coupler history files need to use the ymd and tod of the end
of the run, instead of the current time.  And the correct
number of time slots in each file must be used.
The proposed fixes are not complete: they ignore
> other flows (l2x, x2a, ...)
> other forecast lengths that could divide the day; 1,2,3,4,12 hours
They also are coded in an inflexible way.


Test suite: Single instance test ran correctly for hours 6,12,18,0 of a day,
in a CAM6 build from cesm2.1-alphabranch
Test baseline: 
Test namelist changes: none
Test status: bit-level changes to cpl aux hist files due to averaging span changes.

Fixes #2831 (again)

User interface changes?: If they need to use cpl hist files from runs shorter than 24 hours.

Update gh-pages html (Y/N)?:probably, but not done

Code review: none yet
