### PR TITLE
FUNIT test: Fix path to run_tests.py if get_test_spec_dir is overridden

### DIFF
--- a/scripts/lib/CIME/SystemTests/funit.py
+++ b/scripts/lib/CIME/SystemTests/funit.py
@@ -45,7 +45,7 @@ class FUNIT(SystemTestsCommon):
             os.remove(log)
 
         test_spec_dir = self.get_test_spec_dir()
-        unit_test_tool = os.path.abspath(os.path.join(test_spec_dir,"scripts","fortran_unit_testing","run_tests.py"))
+        unit_test_tool = os.path.abspath(os.path.join(get_cime_root(),"scripts","fortran_unit_testing","run_tests.py"))
         args = "--build-dir {} --test-spec-dir {} --machine {}".format(exeroot, test_spec_dir, mach)
         stat = run_cmd("{} {} >& funit.log".format(unit_test_tool, args), from_dir=rundir)[0]
 


### PR DESCRIPTION
For CTSM, we're overriding get_test_spec_dir to give the path to
components/clm/src. So it doesn't work to also use get_test_spec_dir to
specify the path to run_tests.py.

Test suite: scripts_regression_tests: just A_RunUnitTests and B_CheckCode
Also: ./create_test FUNIT.f09_g17.X.roo2_gnu
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
