### PR TITLE
Allow CHARGE_ACCOUNT to use subprojects and default to command line given project

### DIFF
--- a/doc/source/users_guide/cime-config.rst
+++ b/doc/source/users_guide/cime-config.rst
@@ -16,15 +16,15 @@ CIME recognizes a user-created custom configuration directory, ``$HOME/.cime``. 
 
   * ``PROJECT=<account number>``
 
-    This is your project account code for batch submission and/or directory priveleges
+    Used to specify a project id for compute accounting and directory permissions when on a batch system.
 
   * ``CHARGE_ACCOUNT=<account number>``
 
-    An alternative to PROJECT for batch charging>
+    Used to override the accounting (only) aspect of PROJECT
 
   * ``MAIL_USER=<email address>``
 
-    Used request a non-default email for batch summary output
+    Used to request a non-default email for batch summary output
 
   * ``MAIL_TYPE=[never,all,begin,fail,end]``
 

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -42,8 +42,10 @@ def parse_command_line(args):
                         "\nThe default is CIMEROOT/machines.")
 
     parser.add_argument("--project", "-project",
-                        help="Specify a project id. The default is the user-specified environment variable"
-			"\nvariable PROJECT or ACCOUNT or read from ~/.cesm_proj.")
+                        help="Specify a project id for the case (optional)."
+                        "\nUsed for accounting and directory permissions when on a batch system."
+                        "\nThe default is user or machine specified by PROJECT."
+                        "\nAccounting (only) may be overridden by user or machine specified CHARGE_ACCOUNT.")
 
     parser.add_argument("--cime-output-root",
                         help="Specify the root output directory. The default is the setting in the original"

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -64,7 +64,10 @@ def parse_command_line(args, cimeroot, description):
                         "\nThe default is the first listing in MPILIBS in config_machines.xml.\n")
 
     parser.add_argument("--project", "-project",
-                        help="Specify a project id as used in batch system accounting.")
+                        help="Specify a project id for the case (optional)."
+                        "\nUsed for accounting and directory permissions when on a batch system."
+                        "\nThe default is user or machine specified by PROJECT."
+                        "\nAccounting (only) may be overridden by user or machine specified CHARGE_ACCOUNT.")
 
     parser.add_argument("--pecount", "-pecount",  default="M",
                         help="Specify a target size description for the number of cores. "

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -183,8 +183,9 @@ def parse_command_line(args, description):
 
     parser.add_argument("-p", "--project",
                         help="Specify a project id for the case (optional)."
-                        "\nUsed for accounting when on a batch system."
-                        "\nThe default is user-specified environment variable PROJECT")
+                        "\nUsed for accounting and directory permissions when on a batch system."
+                        "\nThe default is user or machine specified by PROJECT."
+                        "\nAccounting (only) may be overridden by user or machine specified CHARGE_ACCOUNT.")
 
     parser.add_argument("-t", "--test-id",
                         help="Specify an 'id' for the test. This is simply a string that is appended "

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -885,19 +885,16 @@ class Case(object):
         self.set_value("REALUSER", os.environ["USER"])
 
         # Set project id
+        if project is None:
+            project = get_project(machobj)
         if project is not None:
             self.set_value("PROJECT", project)
-            self.set_value("CHARGE_ACCOUNT", project)
-        else:
-            project = get_project(machobj)
-            if project is not None:
-                self.set_value("PROJECT", project)
-            elif machobj.get_value("PROJECT_REQUIRED"):
-                expect(project is not None, "PROJECT_REQUIRED is true but no project found")
-            # Get charge_account id if it exists
-            charge_account = get_charge_account(machobj)
-            if charge_account is not None:
-                self.set_value("CHARGE_ACCOUNT", charge_account)
+        elif machobj.get_value("PROJECT_REQUIRED"):
+            expect(project is not None, "PROJECT_REQUIRED is true but no project found")
+        # Get charge_account id if it exists
+        charge_account = get_charge_account(machobj)
+        if charge_account is not None:
+            self.set_value("CHARGE_ACCOUNT", charge_account)
 
         # Resolve the CIME_OUTPUT_ROOT variable, other than this
         # we don't want to resolve variables until we need them

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -892,7 +892,7 @@ class Case(object):
         elif machobj.get_value("PROJECT_REQUIRED"):
             expect(project is not None, "PROJECT_REQUIRED is true but no project found")
         # Get charge_account id if it exists
-        charge_account = get_charge_account(machobj)
+        charge_account = get_charge_account(machobj, project)
         if charge_account is not None:
             self.set_value("CHARGE_ACCOUNT", charge_account)
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -936,7 +936,7 @@ def get_project(machobj=None):
     logger.info("No project info available")
     return None
 
-def get_charge_account(machobj=None):
+def get_charge_account(machobj=None, project=None):
     """
     Hierarchy for choosing CHARGE_ACCOUNT:
     1. Environment variable CHARGE_ACCOUNT
@@ -975,7 +975,7 @@ def get_charge_account(machobj=None):
             return charge_account
 
     logger.info("No charge_account info available, using value from PROJECT")
-    return get_project(machobj)
+    return project
 
 def find_files(rootdir, pattern):
     """


### PR DESCRIPTION
CHARGE_ACCOUNT was not falling back to the project value given on the command line in  #2676 and was fixed in #2763 . However, #2763 no longer allowed for subprojects to be charged on OLCF machines. This reverts #2763 and fixes both #2676 and #2886. 

Test suite: scripts_regression_tests.py on Titan
Test baseline: N/A
Test namelist changes: N/A
Test status: [bit for bit]

Fixes #2676 and #2886

User interface changes?: None

Update gh-pages html (Y/N)?: Y

Code review: 
