### PR TITLE
Remove redundant check of mpi-tag values

### DIFF
--- a/scripts/lib/get_tests.py
+++ b/scripts/lib/get_tests.py
@@ -64,7 +64,6 @@ _CIME_TESTS = {
                              "IRT_N2.f19_g16_rx1.A",
                              "ERR.f45_g37_rx1.A",
                              "ERP.f45_g37_rx1.A",
-                             "SMS_D_Ln9.f19_g16_rx1.A",
                              "SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A",
                              "DAE.ww3a.ADWAV",
                              "PET_P4.f19_f19.A",

--- a/scripts/lib/get_tests.py
+++ b/scripts/lib/get_tests.py
@@ -65,6 +65,7 @@ _CIME_TESTS = {
                              "ERR.f45_g37_rx1.A",
                              "ERP.f45_g37_rx1.A",
                              "SMS_D_Ln9.f19_g16_rx1.A",
+                             "SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A",
                              "DAE.ww3a.ADWAV",
                              "PET_P4.f19_f19.A",
                              "PEM_P4.f19_f19.A",


### PR DESCRIPTION
Because MPI-serial doesn't have the `MPI_attr_get` function,  PR #2804 broke MP-serial builds as discussed in #2890 . This removes a redundant exception that uses `MPI_attr_get` to determine the max MPI tag value, and report it and when it is exceed. MPI will still throw an exception when it is exceeded, but doesn't report the maximum value. I also added an MPI-serial test to cime_developer test suite. 

Test suite: ./scripts_regression_tests on titan, ./create_test cime_developer (with new SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A test) on anvil
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2890 

User interface changes?: N

Update gh-pages html (Y/N)?: N/A

Code review: 
