### PR TITLE
Fix regex matches in hist_utils: get_extension

### DIFF
--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -434,7 +434,7 @@ def get_extension(model, filepath):
     ext_regexes.append(r'\w+')
 
     for ext_regex in ext_regexes:
-        full_regex_str = model+r'\d?_?(\d{4})?\.('+ext_regex+')[-\w\.]*\.nc\.?'
+        full_regex_str = model+r'\d?_?(\d{4})?\.('+ext_regex+r')[-\w\.]*\.nc\.?'
         full_regex = re.compile(full_regex_str)
         m = full_regex.search(basename)
         if m is not None:

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -422,19 +422,16 @@ def get_extension(model, filepath):
     basename = os.path.basename(filepath)
     m = None
     if model == "mom":
-        for ext in ('frc', 'sfc.day', 'prog', 'hmz', 'hm'):
-            regex_str = r'.*' + model + r'[^_]*_?([0-9]{4})?[.](' + ext + r'.?)([.].*[^.])?[.]nc'
-            ext_regex = re.compile(regex_str)
-            m = ext_regex.match(basename)
-            if m is not None:
-                break
-    elif model == 'cice':
-        ext_regex = re.compile(r'.*%s[^_]*_?([0-9]{4})?[.](h_inst.?)([.].*[^.])?[.]nc' % model)
-        m = ext_regex.match(basename)
+        # Need to check 'sfc.day' specially: the embedded '.' messes up the general-purpose regex
+        ext = r'sfc\.day'
+        regex = model+r'\d?_?(\d{4})?\.('+ext+')[-\w\.]*\.nc\.?'
+        ext_regex = re.compile(regex)
+        m = ext_regex.search(basename)
 
     if m is None:
-        ext_regex = re.compile(r'.*%s[^_]*_?([0-9]{4})?[.](h.?)([.].*[^.])?[.]nc' % model)
-        m = ext_regex.match(basename)
+        regex = model+r'\d?_?(\d{4})?\.(\w+)[-\w\.]*\.nc\.?'
+        ext_regex = re.compile(regex)
+        m = ext_regex.search(basename)
 
 
     expect(m is not None, "Failed to get extension for file '{}'".format(filepath))

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -421,18 +421,24 @@ def get_extension(model, filepath):
     """
     basename = os.path.basename(filepath)
     m = None
+    ext_regexes = []
+
+    # First add any model-specific extension regexes; these will be checked before the
+    # general regex
     if model == "mom":
-        # Need to check 'sfc.day' specially: the embedded '.' messes up the general-purpose regex
-        ext = r'sfc\.day'
-        regex = model+r'\d?_?(\d{4})?\.('+ext+')[-\w\.]*\.nc\.?'
-        ext_regex = re.compile(regex)
-        m = ext_regex.search(basename)
+        # Need to check 'sfc.day' specially: the embedded '.' messes up the
+        # general-purpose regex
+        ext_regexes.append(r'sfc\.day')
 
-    if m is None:
-        regex = model+r'\d?_?(\d{4})?\.(\w+)[-\w\.]*\.nc\.?'
-        ext_regex = re.compile(regex)
-        m = ext_regex.search(basename)
+    # Now add the general-purpose extension regex
+    ext_regexes.append(r'\w+')
 
+    for ext_regex in ext_regexes:
+        full_regex_str = model+r'\d?_?(\d{4})?\.('+ext_regex+')[-\w\.]*\.nc\.?'
+        full_regex = re.compile(full_regex_str)
+        m = full_regex.search(basename)
+        if m is not None:
+            break
 
     expect(m is not None, "Failed to get extension for file '{}'".format(filepath))
 


### PR DESCRIPTION
PR ESMCI/cime#2811 (the big nuopc merge) accidentally reverted a regex
change in hist_utils.py:get_extension that was made in
ESMCI/cime#2728. This PR brings back the intended, more general regex,
and consolidates some near-duplicate regular expressions into a single
expression with a variable.

Test suite: scripts_regression_tests on cheyenne
Also ran the test that caused the failure noted in #2896
(ERS_Ly3.f10_f10_musgs.I1850Clm50BgcCropCmip6.cheyenne_intel.clm-basic
from a CTSM branch)
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#2896

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
