### PR TITLE
Fix 2010 period for datm GSWP3v1

### DIFF
--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -277,10 +277,10 @@
       <value   compset="1850.*_DATM%CRU">1920</value>
       <value   compset="2000.*_DATM%CRU">2010</value>
       <value   compset="2003.*_DATM%CRU">2003</value>
-      <value   compset="2010.*_DATM%CRU">2015</value>
+      <value   compset="2010.*_DATM%CRU">2014</value>
       <value   compset="1850.*_DATM%GSW">1920</value>
       <value   compset="2000.*_DATM%GSW">2010</value>
-      <value   compset="2010.*_DATM%GSW">2015</value>
+      <value   compset="2010.*_DATM%GSW">2014</value>
       <value   compset="2003.*_DATM%GSW">2003</value>
     </values>
     <group>run_component_datm</group>


### PR DESCRIPTION
Fix the end year for DATM_MODE=GSWP3v1 for a 2010 period.

Long compset names that start with 2010_*)

Testing:
  Ran testing with ctsm by hand
Test status: Fixes a bug for a CTSM test

Fixes [CIME Github issue #] #2907

User interface changes?: For compsets with datm that start with 2010_ period.

Update gh-pages html (Y/N)?: N

