### PR TITLE
Do not include time of day in cpl auxiliary hist file names

### DIFF
--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -1164,7 +1164,7 @@ contains
              if (present(yr_offset)) then
                 yy = yy + yr_offset
              end if
-             call shr_cal_ymdtod2string(date_str, yy, mm, dd, curr_tod)
+             call shr_cal_ymdtod2string(date_str, yy, mm, dd)
              write(hist_file(found), "(8a)") &
                   trim(case_name),'.cpl',trim(inst_suffix),'.h',trim(aname),'.',trim(date_str), '.nc'
           else


### PR DESCRIPTION
Having the time of day in these file names is incompatible with the file
naming assumption in dlnd. In talking with @mvertens, we felt it best to
back out this change for now (which was made in ESMCI/cime#2782), rather
than changing the convention in dlnd - partly because the old convention
may be assumed elsewhere, too.

Test suite: ./create_test cime_developer on cheyenne
Also manual testing: ran a 5-day test with the following, and checked file names:
```
  histaux_a2x = .true.
  histaux_a2x1hr = .true.
  histaux_a2x1hri = .true.
  histaux_a2x24hr = .true.
  histaux_a2x3hr = .true.
  histaux_a2x3hrp = .true.
  histaux_r2x = .true.
```
as well as a 1-year test with:
```
histaux_l2x1yrg = .true.
```
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#2912

User interface changes?: Changes names of cpl auxiliary history files

Update gh-pages html (Y/N)?: N

Code review: 
