### PR TITLE
Update addmetadata for POP-ECT tests

### DIFF
--- a/tools/statistical_ensemble_test/addmetadata.sh
+++ b/tools/statistical_ensemble_test/addmetadata.sh
@@ -52,6 +52,8 @@ stop_option=`./xmlquery --value STOP_OPTION`
 test_type="UF-ECT"
 if [ "$stop_option" = "nmonths" ]; then
     test_type="ECT"
+elif [ "$stop_option" = "nyears" ]; then
+    test_type="POP-ECT"
 fi
 
 if hash ncks 2>/dev/null; then


### PR DESCRIPTION
Update addmetadata script to be able to set testtype to POP-ECT when
doing the POP CECT test.

Test suite:   Ran addmetadata.sh by hand for POP ensemble test.
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
