### PR TITLE
Big improvement to robustness of CIME's XML handling

### DIFF
--- a/scripts/lib/CIME/XML/env_archive.py
+++ b/scripts/lib/CIME/XML/env_archive.py
@@ -9,12 +9,12 @@ logger = logging.getLogger(__name__)
 # pylint: disable=super-init-not-called
 class EnvArchive(ArchiveBase,EnvBase):
 
-    def __init__(self, case_root=None, infile="env_archive.xml"):
+    def __init__(self, case_root=None, infile="env_archive.xml", read_only=False):
         """
         initialize an object interface to file env_archive.xml in the case directory
         """
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_archive.xsd")
-        EnvBase.__init__(self, case_root, infile, schema=schema)
+        EnvBase.__init__(self, case_root, infile, schema=schema, read_only=read_only)
 
     def get_entries(self):
         return self.get_children('comp_archive_spec')

--- a/scripts/lib/CIME/XML/env_base.py
+++ b/scripts/lib/CIME/XML/env_base.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class EnvBase(EntryID):
 
-    def __init__(self, case_root, infile, schema=None):
+    def __init__(self, case_root, infile, schema=None, read_only=False):
         if case_root is None:
             case_root = os.getcwd()
 
@@ -18,7 +18,7 @@ class EnvBase(EntryID):
         else:
             fullpath = os.path.join(case_root, infile)
 
-        EntryID.__init__(self, fullpath, schema=schema, read_only=False)
+        EntryID.__init__(self, fullpath, schema=schema, read_only=read_only)
 
         self._id_map = None
         self._group_map = None

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class EnvBatch(EnvBase):
 
-    def __init__(self, case_root=None, infile="env_batch.xml"):
+    def __init__(self, case_root=None, infile="env_batch.xml", read_only=False):
         """
         initialize an object interface to file env_batch.xml in the case directory
         """
@@ -23,7 +23,7 @@ class EnvBatch(EnvBase):
         # This arbitrary setting should always be overwritten
         self._default_walltime = "00:20:00"
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_batch.xsd")
-        super(EnvBatch,self).__init__(case_root, infile, schema=schema)
+        super(EnvBatch,self).__init__(case_root, infile, schema=schema, read_only=read_only)
 
     # pylint: disable=arguments-differ
     def set_value(self, item, value, subgroup=None, ignore_type=False):

--- a/scripts/lib/CIME/XML/env_build.py
+++ b/scripts/lib/CIME/XML/env_build.py
@@ -9,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 class EnvBuild(EnvBase):
     # pylint: disable=unused-argument
-    def __init__(self, case_root=None, infile="env_build.xml",components=None):
+    def __init__(self, case_root=None, infile="env_build.xml",components=None, read_only=False):
         """
         initialize an object interface to file env_build.xml in the case directory
         """
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_entry_id.xsd")
-        EnvBase.__init__(self, case_root, infile, schema=schema)
+        EnvBase.__init__(self, case_root, infile, schema=schema, read_only=read_only)

--- a/scripts/lib/CIME/XML/env_case.py
+++ b/scripts/lib/CIME/XML/env_case.py
@@ -9,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 class EnvCase(EnvBase):
     # pylint: disable=unused-argument
-    def __init__(self, case_root=None, infile="env_case.xml", components=None):
+    def __init__(self, case_root=None, infile="env_case.xml", components=None, read_only=False):
         """
         initialize an object interface to file env_case.xml in the case directory
         """
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_entry_id.xsd")
-        EnvBase.__init__(self, case_root, infile, schema=schema)
+        EnvBase.__init__(self, case_root, infile, schema=schema, read_only=read_only)

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -9,13 +9,13 @@ logger = logging.getLogger(__name__)
 
 class EnvMachPes(EnvBase):
 
-    def __init__(self, case_root=None, infile="env_mach_pes.xml", components=None):
+    def __init__(self, case_root=None, infile="env_mach_pes.xml", components=None, read_only=False):
         """
         initialize an object interface to file env_mach_pes.xml in the case directory
         """
         self._components = components
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_pes.xsd")
-        EnvBase.__init__(self, case_root, infile, schema=schema)
+        EnvBase.__init__(self, case_root, infile, schema=schema, read_only=read_only)
 
     def add_comment(self, comment):
         if comment is not None:

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -15,12 +15,12 @@ logger = logging.getLogger(__name__)
 class EnvMachSpecific(EnvBase):
     # pylint: disable=unused-argument
     def __init__(self, caseroot=None, infile="env_mach_specific.xml",
-                 components=None, unit_testing=False):
+                 components=None, unit_testing=False, read_only=False):
         """
         initialize an object interface to file env_mach_specific.xml in the case directory
         """
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_specific.xsd")
-        EnvBase.__init__(self, caseroot, infile, schema=schema)
+        EnvBase.__init__(self, caseroot, infile, schema=schema, read_only=read_only)
         self._allowed_mpi_attributes = ("compiler", "mpilib", "threaded", "unit_testing", "queue")
         self._unit_testing = unit_testing
 

--- a/scripts/lib/CIME/XML/env_run.py
+++ b/scripts/lib/CIME/XML/env_run.py
@@ -9,11 +9,11 @@ logger = logging.getLogger(__name__)
 
 class EnvRun(EnvBase):
 
-    def __init__(self, case_root=None, infile="env_run.xml", components=None):
+    def __init__(self, case_root=None, infile="env_run.xml", components=None, read_only=False):
         """
         initialize an object interface to file env_run.xml in the case directory
         """
         self._components = components
         schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_entry_id.xsd")
 
-        EnvBase.__init__(self, case_root, infile, schema=schema)
+        EnvBase.__init__(self, case_root, infile, schema=schema, read_only=read_only)

--- a/scripts/lib/CIME/XML/env_test.py
+++ b/scripts/lib/CIME/XML/env_test.py
@@ -10,11 +10,11 @@ logger = logging.getLogger(__name__)
 
 class EnvTest(EnvBase):
     # pylint: disable=unused-argument
-    def __init__(self, case_root=None, infile="env_test.xml", components=None):
+    def __init__(self, case_root=None, infile="env_test.xml", components=None, read_only=False):
         """
         initialize an object interface to file env_test.xml in the case directory
         """
-        EnvBase.__init__(self, case_root, infile)
+        EnvBase.__init__(self, case_root, infile, read_only=read_only)
 
     def add_test(self,testnode):
         self.add_child(testnode)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -38,6 +38,11 @@ class GenericXML(object):
     _FILEMAP = {}
     DISABLE_CACHING = False
 
+    @classmethod
+    def invalidate(cls, filename):
+        if filename in cls._FILEMAP:
+            del cls._FILEMAP[filename]
+
     def __init__(self, infile=None, schema=None, root_name_override=None, root_attrib_override=None, read_only=True):
         """
         Initialize an object
@@ -71,17 +76,25 @@ class GenericXML(object):
 
             self.tree = ET.ElementTree(root)
 
+            self._FILEMAP[infile] = (self.tree, self.root, 0.0)
+
     def read(self, infile, schema=None):
         """
         Read and parse an xml file into the object
         """
-        if not self.DISABLE_CACHING and infile in self._FILEMAP and self.read_only:
-            logger.debug("read (cached): " + infile)
-            expect(self.read_only or not self.filename or not self.needsrewrite, "Reading into object marked for rewrite, file {}"
-                   .format(self.filename))
-            self.tree, self.root = self._FILEMAP[infile]
-        else:
-            logger.debug("read: " + infile)
+        cached_read = False
+        if not self.DISABLE_CACHING and infile in self._FILEMAP:
+            timestamp_cache = self._FILEMAP[infile][2]
+            timestamp_file  = os.path.getmtime(infile)
+            if timestamp_file == timestamp_cache:
+                logger.debug("read (cached): {}".format(infile))
+                expect(self.read_only or not self.filename or not self.needsrewrite, "Reading into object marked for rewrite, file {}"
+                       .format(self.filename))
+                self.tree, self.root, _ = self._FILEMAP[infile]
+                cached_read = True
+
+        if not cached_read:
+            logger.debug("read: {}".format(infile))
             file_open = (lambda x: open(x, 'r', encoding='utf-8')) if six.PY3 else (lambda x: open(x, 'r'))
             with file_open(infile) as fd:
                 self.read_fd(fd)
@@ -91,7 +104,7 @@ class GenericXML(object):
 
             logger.debug("File version is {}".format(str(self.get_version())))
 
-            self._FILEMAP[infile] = (self.tree, self.root)
+            self._FILEMAP[infile] = (self.tree, self.root, os.path.getmtime(infile))
 
     def read_fd(self, fd):
         expect(self.read_only or not self.filename or not self.needsrewrite, "Reading into object marked for rewrite, file {}"               .format(self.filename))
@@ -289,6 +302,12 @@ class GenericXML(object):
         """
         Write an xml file from data in self
         """
+        timestamp_cache = self._FILEMAP[self.filename][2]
+        if timestamp_cache != 0.0:
+            timestamp_file  = os.path.getmtime(self.filename)
+            expect(timestamp_file == timestamp_cache,
+                   "File {} appears to have changed without a corresponding invalidation, modtimes {:0.2f} != {:0.2f}".format(self.filename, timestamp_cache, timestamp_file))
+
         if not (self.needsrewrite or force_write):
             return
 
@@ -310,6 +329,9 @@ class GenericXML(object):
         else:
             with open(outfile,'w') as xmlout:
                 xmlout.write(xmlstr)
+
+        self._FILEMAP[self.filename] = (self.tree, self.root, os.path.getmtime(self.filename))
+
         self.needsrewrite = False
 
     def scan_child(self, nodename, attributes=None, root=None):

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -240,7 +240,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
         logger.info("Building {} with output to file {}".format(lib,file_build))
 
         run_sub_or_cmd(my_file, [full_lib_path, os.path.join(exeroot, sharedpath), caseroot], 'buildlib',
-                       [full_lib_path, os.path.join(exeroot, sharedpath), caseroot], logfile=file_build)
+                       [full_lib_path, os.path.join(exeroot, sharedpath), case], logfile=file_build)
 
         analyze_build_log(lib, file_build, compiler)
         logs.append(file_build)

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -195,17 +195,17 @@ class Case(object):
 
     def read_xml(self):
         self._env_entryid_files = []
-        self._env_entryid_files.append(EnvCase(self._caseroot, components=None))
+        self._env_entryid_files.append(EnvCase(self._caseroot, components=None, read_only=self._force_read_only))
         components = self._env_entryid_files[0].get_values("COMP_CLASSES")
-        self._env_entryid_files.append(EnvRun(self._caseroot, components=components))
-        self._env_entryid_files.append(EnvBuild(self._caseroot, components=components))
-        self._env_entryid_files.append(EnvMachPes(self._caseroot, components=components))
-        self._env_entryid_files.append(EnvBatch(self._caseroot))
+        self._env_entryid_files.append(EnvRun(self._caseroot, components=components, read_only=self._force_read_only))
+        self._env_entryid_files.append(EnvBuild(self._caseroot, components=components, read_only=self._force_read_only))
+        self._env_entryid_files.append(EnvMachPes(self._caseroot, components=components, read_only=self._force_read_only))
+        self._env_entryid_files.append(EnvBatch(self._caseroot, read_only=self._force_read_only))
         if os.path.isfile(os.path.join(self._caseroot,"env_test.xml")):
-            self._env_entryid_files.append(EnvTest(self._caseroot, components=components))
+            self._env_entryid_files.append(EnvTest(self._caseroot, components=components, read_only=self._force_read_only))
         self._env_generic_files = []
-        self._env_generic_files.append(EnvMachSpecific(self._caseroot))
-        self._env_generic_files.append(EnvArchive(self._caseroot))
+        self._env_generic_files.append(EnvMachSpecific(self._caseroot, read_only=self._force_read_only))
+        self._env_generic_files.append(EnvArchive(self._caseroot, read_only=self._force_read_only))
         self._files = self._env_entryid_files + self._env_generic_files
 
     def get_case_root(self):

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -248,7 +248,7 @@ def _do_external(script_name, caseroot, rundir, lid, prefix):
     filename = "{}.external.log.{}".format(prefix, lid)
     outfile = os.path.join(rundir, filename)
     append_status("Starting script {}".format(script_name), "CaseStatus")
-    run_sub_or_cmd(script_name, [caseroot], (os.path.basename(script_name).split('.',1))[0], [caseroot], logfile=outfile)
+    run_sub_or_cmd(script_name, [caseroot], (os.path.basename(script_name).split('.',1))[0], [caseroot], logfile=outfile) # For sub, use case?
     append_status("Completed script {}".format(script_name), "CaseStatus")
 
 ###############################################################################
@@ -257,7 +257,7 @@ def _do_data_assimilation(da_script, caseroot, cycle, lid, rundir):
     expect(os.path.isfile(da_script), "Data Assimilation script {} not found".format(da_script))
     filename = "da.log.{}".format(lid)
     outfile = os.path.join(rundir, filename)
-    run_sub_or_cmd(da_script, [caseroot, cycle], os.path.basename(da_script), [caseroot, cycle], logfile=outfile)
+    run_sub_or_cmd(da_script, [caseroot, cycle], os.path.basename(da_script), [caseroot, cycle], logfile=outfile) # For sub, use case?
 
 ###############################################################################
 def case_run(self, skip_pnl=False, set_continue_run=False, submit_resubmits=False):

--- a/scripts/lib/CIME/case/check_lockedfiles.py
+++ b/scripts/lib/CIME/case/check_lockedfiles.py
@@ -53,16 +53,16 @@ def check_lockedfile(self, filebase):
         objname = filebase.split('.')[0]
         if objname == "env_build":
             f1obj = self.get_env('build')
-            f2obj = EnvBuild(caseroot, lfile)
+            f2obj = EnvBuild(caseroot, lfile, read_only=True)
         elif objname == "env_mach_pes":
             f1obj = self.get_env('mach_pes')
-            f2obj = EnvMachPes(caseroot, lfile, components=components)
+            f2obj = EnvMachPes(caseroot, lfile, components=components, read_only=True)
         elif objname == "env_case":
             f1obj = self.get_env('case')
-            f2obj = EnvCase(caseroot, lfile)
+            f2obj = EnvCase(caseroot, lfile, read_only=True)
         elif objname == "env_batch":
             f1obj = self.get_env('batch')
-            f2obj = EnvBatch(caseroot, lfile)
+            f2obj = EnvBatch(caseroot, lfile, read_only=True)
         else:
             logging.warning("Locked XML file '{}' is not current being handled".format(filebase))
             return
@@ -92,7 +92,7 @@ def check_lockedfile(self, filebase):
                                          "case.build --clean-all and rebuilding")
                     else:
                         self.set_value("BUILD_STATUS", 1)
-                    f2obj.set_value("BUILD_COMPLETE", False)
+
             elif objname == "env_batch":
                 expect(False, "Batch configuration has changed, please run case.setup --reset")
             else:

--- a/scripts/lib/CIME/locked_files.py
+++ b/scripts/lib/CIME/locked_files.py
@@ -1,5 +1,7 @@
 from CIME.XML.standard_module_setup import *
 from CIME.utils import safe_copy
+from CIME.XML.generic_xml import GenericXML
+
 logger = logging.getLogger(__name__)
 
 LOCKED_DIR = "LockedFiles"
@@ -20,6 +22,7 @@ def lock_file(filename, caseroot=None, newname=None):
     # have involved this file. We should probably seek a safer way of locking
     # files.
     safe_copy(os.path.join(caseroot, filename), os.path.join(fulllockdir, newname))
+    GenericXML.invalidate(os.path.join(fulllockdir, newname))
 
 def unlock_file(filename, caseroot=None):
     expect("/" not in filename, "Please just provide basename of locked file")

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -20,6 +20,7 @@ from CIME.test_status import *
 from CIME.XML.machines import Machines
 from CIME.XML.generic_xml import GenericXML
 from CIME.XML.env_test import EnvTest
+from CIME.XML.env_mach_pes import EnvMachPes
 from CIME.XML.files import Files
 from CIME.XML.component import Component
 from CIME.XML.tests import Tests
@@ -444,9 +445,6 @@ class TestScheduler(object):
                 self._log_output(test, error)
                 return False, error
 
-            comp_root_dir_cpl = files.get_value( "COMP_ROOT_DIR_CPL", resolved=False)
-            files.set_value("COMP_ROOT_DIR_CPL", comp_root_dir_cpl)
-
             testmods_dir = files.get_value("TESTS_MODS_DIR", {"component": component})
             test_mod_file = os.path.join(testmods_dir, component, modspath)
             if not os.path.exists(test_mod_file):
@@ -705,7 +703,7 @@ class TestScheduler(object):
     ###########################################################################
         if phase == RUN_PHASE and (self._no_batch or no_batch):
             test_dir = self._get_test_dir(test)
-            total_pes = int(run_cmd_no_fail("./xmlquery TOTALPES --value", from_dir=test_dir))
+            total_pes = EnvMachPes(test_dir, read_only=True).get_value("TOTALPES")
             return total_pes
 
         elif (phase == SHAREDLIB_BUILD_PHASE):

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -7,7 +7,7 @@ to confirm overall CIME correctness.
 
 import glob, os, re, shutil, signal, sys, tempfile, \
     threading, time, logging, unittest, getpass, \
-    filecmp
+    filecmp, time
 
 from xml.etree.ElementTree import ParseError
 
@@ -19,14 +19,14 @@ subprocess.call('/bin/rm -f $(find . -name "*.pyc")', shell=True, cwd=LIB_DIR)
 import six
 from six import assertRaisesRegex
 
-
 import collections
 
-from CIME.utils import run_cmd, run_cmd_no_fail, get_lids, get_current_commit
+from CIME.utils import run_cmd, run_cmd_no_fail, get_lids, get_current_commit, safe_copy, touch
 import get_tests
 import CIME.test_scheduler, CIME.wait_for_tests
 from  CIME.test_scheduler import TestScheduler
 from  CIME.XML.compilers import Compilers
+from  CIME.XML.env_run import EnvRun
 from  CIME.XML.machines import Machines
 from  CIME.XML.files import Files
 from  CIME.case import Case
@@ -1434,6 +1434,24 @@ class P_TestJenkinsGenericJob(TestCreateTestCommon):
         assert_dashboard_has_build(self, build_name)
 
 ###############################################################################
+class M_TestCimePerformance(TestCreateTestCommon):
+###############################################################################
+
+    ###########################################################################
+    def test_cime_case_ctrl_performance(self):
+    ###########################################################################
+
+        ts = time.time()
+
+        num_repeat = 5
+        for i in xrange(num_repeat):
+            self._create_test(["cime_tiny --no-build"])
+
+        elapsed = time.time() - ts
+
+        print("Perf test result: {:0.2f}".format(elapsed))
+
+###############################################################################
 class T_TestRunRestart(TestCreateTestCommon):
 ###############################################################################
 
@@ -2124,6 +2142,71 @@ class K_TestCimeCase(TestCreateTestCommon):
         sys.argv = ["case.submit", "--batch-args", "'random_arguments_here.%j'",
                     "--mail-type", "fail", "--mail-user", "'random_arguments_here.%j'"]
         submit_interface._main_func(None, True)
+
+    ###########################################################################
+    def test_xml_caching(self):
+    ###########################################################################
+        self._create_test(["--no-build", "TESTRUNPASS.f19_g16_rx1.A"], test_id=self._baseline_name)
+
+        casedir = os.path.join(self._testroot,
+                               "%s.%s" % (CIME.utils.get_full_test_name("TESTRUNPASS.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
+        self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
+
+        active = os.path.join(casedir, "env_run.xml")
+        backup = os.path.join(casedir, "env_run.xml.bak")
+
+        safe_copy(active, backup)
+
+        with Case(casedir, read_only=False) as case:
+            env_run = EnvRun(casedir, read_only=True)
+            self.assertEqual(case.get_value("RUN_TYPE"), "startup")
+            case.set_value("RUN_TYPE", "branch")
+            self.assertEqual(case.get_value("RUN_TYPE"), "branch")
+            self.assertEqual(env_run.get_value("RUN_TYPE"), "branch")
+
+        with Case(casedir) as case:
+            self.assertEqual(case.get_value("RUN_TYPE"), "branch")
+
+        time.sleep(0.2)
+        safe_copy(backup, active)
+
+        with Case(casedir, read_only=False) as case:
+            self.assertEqual(case.get_value("RUN_TYPE"), "startup")
+            case.set_value("RUN_TYPE", "branch")
+
+        with Case(casedir, read_only=False) as case:
+            self.assertEqual(case.get_value("RUN_TYPE"), "branch")
+            time.sleep(0.2)
+            safe_copy(backup, active)
+            case.read_xml() # Manual re-sync
+            self.assertEqual(case.get_value("RUN_TYPE"), "startup")
+            case.set_value("RUN_TYPE", "branch")
+            self.assertEqual(case.get_value("RUN_TYPE"), "branch")
+
+        with Case(casedir) as case:
+            self.assertEqual(case.get_value("RUN_TYPE"), "branch")
+            time.sleep(0.2)
+            safe_copy(backup, active)
+            env_run = EnvRun(casedir, read_only=True)
+            self.assertEqual(env_run.get_value("RUN_TYPE"), "startup")
+
+        with Case(casedir, read_only=False) as case:
+            self.assertEqual(case.get_value("RUN_TYPE"), "startup")
+            case.set_value("RUN_TYPE", "branch")
+
+        # behind the back detection
+        with self.assertRaises(SystemExit) as context:
+            with Case(casedir, read_only=False) as case:
+                time.sleep(0.2)
+                safe_copy(backup, active)
+
+        with Case(casedir, read_only=False) as case:
+            case.set_value("RUN_TYPE", "branch")
+
+        with self.assertRaises(SystemExit) as context:
+            with Case(casedir) as case:
+                time.sleep(0.2)
+                safe_copy(backup, active)
 
 ###############################################################################
 class X_TestSingleSubmit(TestCreateTestCommon):

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -41,94 +41,95 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     return args.buildroot, args.installpath, args.caseroot
 
 
-def buildlib(bldroot, installpath, caseroot):
+def buildlib(bldroot, installpath, case):
 ###############################################################################
-    with Case(caseroot, read_only=False) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        comp_interface = case.get_value("COMP_INTERFACE")
-        filepath = [os.path.join(caseroot,"SourceMods","src.share"),
-                    os.path.join(cimeroot,"src","drivers",comp_interface,"shr"),
-                    os.path.join(cimeroot,"src","share","streams"),
-                    os.path.join(cimeroot,"src","share","util"),
-                    os.path.join(cimeroot,"src","share","RandNum","src"),
-                    os.path.join(cimeroot,"src","share","RandNum","src","dsfmt_f03"),
-                    os.path.join(cimeroot,"src","share","RandNum","src","kissvec"),
-                    os.path.join(cimeroot,"src","share","RandNum","src","mt19937")]
+    caseroot = case.get_value("CASEROOT")
+    cimeroot = case.get_value("CIMEROOT")
+    comp_interface = case.get_value("COMP_INTERFACE")
+    filepath = [os.path.join(caseroot,"SourceMods","src.share"),
+                os.path.join(cimeroot,"src","drivers",comp_interface,"shr"),
+                os.path.join(cimeroot,"src","share","streams"),
+                os.path.join(cimeroot,"src","share","util"),
+                os.path.join(cimeroot,"src","share","RandNum","src"),
+                os.path.join(cimeroot,"src","share","RandNum","src","dsfmt_f03"),
+                os.path.join(cimeroot,"src","share","RandNum","src","kissvec"),
+                os.path.join(cimeroot,"src","share","RandNum","src","mt19937")]
 
-        # Append path for driver - currently only values of 'mct' and 'nuopc' are accepted
-        driver = case.get_value("COMP_INTERFACE")
-        if driver == "mct":
-            filepath.append(os.path.join(cimeroot,"src","drivers","mct","shr"))
-        elif driver == "nuopc":
-            filepath.append(os.path.join(cimeroot,"src","drivers","nuopc","shr"))
-            filepath.append(os.path.join(cimeroot,"src","drivers","nuopc","cime_flds"))
+    # Append path for driver - currently only values of 'mct' and 'nuopc' are accepted
+    driver = case.get_value("COMP_INTERFACE")
+    if driver == "mct":
+        filepath.append(os.path.join(cimeroot,"src","drivers","mct","shr"))
+    elif driver == "nuopc":
+        filepath.append(os.path.join(cimeroot,"src","drivers","nuopc","shr"))
+        filepath.append(os.path.join(cimeroot,"src","drivers","nuopc","cime_flds"))
+    else:
+        expect(False, "driver value of {} not supported".format(driver))
+
+    if case.get_value("USE_ESMF_LIB"):
+        use_esmf = "esmf"
+    else:
+        use_esmf = "noesmf"
+        filepath.append(os.path.join(cimeroot, "src", "share", "esmf_wrf_timemgr"))
+
+    ninst_value = case.get_value("NINST_VALUE")
+
+    libdir = os.path.join(bldroot,comp_interface,use_esmf, ninst_value,"csm_share")
+    if not os.path.isdir(libdir):
+        os.makedirs(libdir)
+
+    filepathfile = os.path.join(libdir, "Filepath")
+    # if the filepathfile has a different number of lines than filepath, replace it
+    file_len = 0
+    if os.path.isfile(filepathfile):
+        file_len = len(open(filepathfile).readlines())
+
+    if len(filepath) != file_len:
+        with open(filepathfile, "w") as fd:
+            for path in filepath:
+                fd.write("{}\n".format(path))
+
+    components = case.get_values("COMP_CLASSES")
+    multiinst_cppdefs = ""
+    multi_driver = case.get_value("MULTI_DRIVER")
+    for comp in components:
+        if comp == "CPL":
+            continue
+        if multi_driver:
+            ninst_comp = 1
         else:
-            expect(False, "driver value of {} not supported".format(driver))
+            ninst_comp = case.get_value("NINST_{}".format(comp))
+        multiinst_cppdefs += " -DNUM_COMP_INST_{}={}".format(comp, ninst_comp)
 
-        if case.get_value("USE_ESMF_LIB"):
-            use_esmf = "esmf"
-        else:
-            use_esmf = "noesmf"
-            filepath.append(os.path.join(cimeroot, "src", "share", "esmf_wrf_timemgr"))
+    installdir = os.path.join(installpath, comp_interface,
+                              use_esmf, ninst_value)
+    for ndir in ("lib", "include"):
+        if not os.path.isdir(os.path.join(installdir,ndir)):
+            os.makedirs(os.path.join(installdir,ndir))
+    # copy some header files
+    for _file in glob.iglob(os.path.join(cimeroot,"src","share","include","*")):
+        copyifnewer(_file, os.path.join(installdir, "include", os.path.basename(_file)))
+    for _file in glob.iglob(os.path.join(cimeroot,"src","share","RandNum","include","*")):
+        copyifnewer(_file, os.path.join(installdir, "include", os.path.basename(_file)))
 
-        ninst_value = case.get_value("NINST_VALUE")
+    # This runs the make command
+    gmake_opts = "-f {}/Makefile complib MODEL=csm_share ".format(os.path.join(caseroot,"Tools"))
+    gmake_opts += "-j {} ".format(case.get_value("GMAKE_J"))
+    gmake_opts += " COMPLIB=libcsm_share.a"
+    gmake_opts += ' USER_CPPDEFS="{} -DTIMING" '.format(multiinst_cppdefs)
+    gmake_opts += " CASEROOT={} ".format(caseroot)
+    gmake_opts += " CIMEROOT={} ".format(cimeroot)
+    gmake_opts += "INCLUDE_DIR={} ".format(os.path.join(installdir, "include"))
+    gmake_opts += " -C {}".format(libdir)
 
-        libdir = os.path.join(bldroot,comp_interface,use_esmf, ninst_value,"csm_share")
-        if not os.path.isdir(libdir):
-            os.makedirs(libdir)
+    gmake_cmd = case.get_value("GMAKE")
 
-        filepathfile = os.path.join(libdir, "Filepath")
-        # if the filepathfile has a different number of lines than filepath, replace it
-        file_len = 0
-        if os.path.isfile(filepathfile):
-            file_len = len(open(filepathfile).readlines())
-
-        if len(filepath) != file_len:
-            with open(filepathfile, "w") as fd:
-                for path in filepath:
-                    fd.write("{}\n".format(path))
-
-        components = case.get_values("COMP_CLASSES")
-        multiinst_cppdefs = ""
-        multi_driver = case.get_value("MULTI_DRIVER")
-        for comp in components:
-            if comp == "CPL":
-                continue
-            if multi_driver:
-                ninst_comp = 1
-            else:
-                ninst_comp = case.get_value("NINST_{}".format(comp))
-            multiinst_cppdefs += " -DNUM_COMP_INST_{}={}".format(comp, ninst_comp)
-
-        installdir = os.path.join(installpath, comp_interface,
-                                  use_esmf, ninst_value)
-        for ndir in ("lib", "include"):
-            if not os.path.isdir(os.path.join(installdir,ndir)):
-                os.makedirs(os.path.join(installdir,ndir))
-        # copy some header files
-        for _file in glob.iglob(os.path.join(cimeroot,"src","share","include","*")):
-            copyifnewer(_file, os.path.join(installdir, "include", os.path.basename(_file)))
-        for _file in glob.iglob(os.path.join(cimeroot,"src","share","RandNum","include","*")):
-            copyifnewer(_file, os.path.join(installdir, "include", os.path.basename(_file)))
-
-        # This runs the make command
-        gmake_opts = "-f {}/Makefile complib MODEL=csm_share ".format(os.path.join(caseroot,"Tools"))
-        gmake_opts += "-j {} ".format(case.get_value("GMAKE_J"))
-        gmake_opts += " COMPLIB=libcsm_share.a"
-        gmake_opts += ' USER_CPPDEFS="{} -DTIMING" '.format(multiinst_cppdefs)
-        gmake_opts += " CASEROOT={} ".format(caseroot)
-        gmake_opts += " CIMEROOT={} ".format(cimeroot)
-        gmake_opts += "INCLUDE_DIR={} ".format(os.path.join(installdir, "include"))
-        gmake_opts += " -C {}".format(libdir)
-
-        gmake_cmd = case.get_value("GMAKE")
-
-        cmd = "{} {}".format(gmake_cmd, gmake_opts)
-        run_bld_cmd_ensure_logging(cmd, logger)
+    cmd = "{} {}".format(gmake_cmd, gmake_opts)
+    run_bld_cmd_ensure_logging(cmd, logger)
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)
-    buildlib(bldroot, installpath, caseroot)
+    with Case(caseroot) as case:
+        buildlib(bldroot, installpath, case)
 
 if (__name__ == "__main__"):
     _main(sys.argv, __doc__)

--- a/src/build_scripts/buildlib.gptl
+++ b/src/build_scripts/buildlib.gptl
@@ -39,27 +39,28 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     return args.buildroot, args.installpath, args.caseroot
 
-def buildlib(bldroot, installpath, caseroot):
+def buildlib(bldroot, installpath, case):
 ###############################################################################
-    with Case(caseroot, read_only=False) as case:
-        gptl_dir = os.path.join(case.get_value("CIMEROOT"), "src", "share", "timing")
-        gmake_opts = "-f {gptl}/Makefile install -C {bldroot} MACFILE={macfile} MODEL=gptl GPTL_DIR={gptl} GPTL_LIBDIR={bldroot}"\
-            " SHAREDPATH={install}"\
-            .format(gptl=gptl_dir, bldroot=bldroot, macfile=os.path.join(caseroot,"Macros.make"),
-                    install=installpath)
-        build_threaded = case.get_build_threaded()
-        if build_threaded:
-            gmake_opts += " compile_threaded=true "
+    caseroot = case.get_value("CASEROOT")
+    gptl_dir = os.path.join(case.get_value("CIMEROOT"), "src", "share", "timing")
+    gmake_opts = "-f {gptl}/Makefile install -C {bldroot} MACFILE={macfile} MODEL=gptl GPTL_DIR={gptl} GPTL_LIBDIR={bldroot}"\
+        " SHAREDPATH={install}"\
+        .format(gptl=gptl_dir, bldroot=bldroot, macfile=os.path.join(caseroot,"Macros.make"),
+                install=installpath)
+    build_threaded = case.get_build_threaded()
+    if build_threaded:
+        gmake_opts += " compile_threaded=true "
 
-        gmake_cmd = case.get_value("GMAKE")
+    gmake_cmd = case.get_value("GMAKE")
 
-        # This runs the gptl make command
-        cmd = "{} {}".format(gmake_cmd, gmake_opts)
-        run_bld_cmd_ensure_logging(cmd, logger)
+    # This runs the gptl make command
+    cmd = "{} {}".format(gmake_cmd, gmake_opts)
+    run_bld_cmd_ensure_logging(cmd, logger)
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)
-    buildlib(bldroot, installpath, caseroot)
+    with Case(caseroot) as case:
+        buildlib(bldroot, installpath, case)
 
 if (__name__ == "__main__"):
     _main(sys.argv, __doc__)

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -14,22 +14,21 @@ from standard_script_setup import *
 from CIME.buildlib import build_cime_component_lib, parse_input
 from CIME.case import Case
 
-def buildlib(caseroot, libroot, bldroot, compname=None):
-    with Case(caseroot) as case:
-        if compname is None:
-            thisdir = os.path.dirname(os.path.abspath(__file__))
-            path, dir1 = os.path.split(thisdir)
-            _, dir2 = os.path.split(path)
-            if dir1 == "cime_config":
-                compname = dir2
-            else:
-                compname = dir1.split('.')[1]
-        build_cime_component_lib(case, compname, libroot, bldroot)
+def buildlib(case, libroot, bldroot, compname=None):
+    if compname is None:
+        thisdir = os.path.dirname(os.path.abspath(__file__))
+        path, dir1 = os.path.split(thisdir)
+        _, dir2 = os.path.split(path)
+        if dir1 == "cime_config":
+            compname = dir2
+        else:
+            compname = dir1.split('.')[1]
+    build_cime_component_lib(case, compname, libroot, bldroot)
 
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)
-    buildlib(caseroot, libroot, bldroot)
-
+    with Case(caseroot) as case:
+        buildlib(case, libroot, bldroot)
 
 if __name__ == "__main__":
     _main_func(sys.argv)

--- a/src/build_scripts/buildlib.mct
+++ b/src/build_scripts/buildlib.mct
@@ -40,48 +40,49 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     return args.buildroot, args.installpath, args.caseroot
 
-def buildlib(bldroot, installpath, caseroot):
+def buildlib(bldroot, installpath, case):
 ###############################################################################
-    with Case(caseroot, read_only=False) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        mct_dir = os.path.join(cimeroot,"src","externals","mct")
-        for _dir in ("mct", "mpeu"):
-            if not os.path.isdir(os.path.join(bldroot,_dir)):
-                os.makedirs(os.path.join(bldroot,_dir))
-            copyifnewer(os.path.join(mct_dir,_dir,"Makefile"),
-                        os.path.join(bldroot,_dir,"Makefile"))
+    caseroot = case.get_value("CASEROOT")
+    cimeroot = case.get_value("CIMEROOT")
+    mct_dir = os.path.join(cimeroot,"src","externals","mct")
+    for _dir in ("mct", "mpeu"):
+        if not os.path.isdir(os.path.join(bldroot,_dir)):
+            os.makedirs(os.path.join(bldroot,_dir))
+        copyifnewer(os.path.join(mct_dir,_dir,"Makefile"),
+                    os.path.join(bldroot,_dir,"Makefile"))
 
-        gmake_opts = "-f {} ".format(os.path.join(caseroot,"Tools","Makefile"))
-        gmake_opts += " -C {} ".format(bldroot)
-        gmake_opts += " CASEROOT={} ".format(caseroot)
-        gmake_opts += "MODEL=mct {}".format(os.path.join(bldroot,"Makefile.conf"))
+    gmake_opts = "-f {} ".format(os.path.join(caseroot,"Tools","Makefile"))
+    gmake_opts += " -C {} ".format(bldroot)
+    gmake_opts += " CASEROOT={} ".format(caseroot)
+    gmake_opts += "MODEL=mct {}".format(os.path.join(bldroot,"Makefile.conf"))
 
-        gmake_cmd = case.get_value("GMAKE")
+    gmake_cmd = case.get_value("GMAKE")
 
-        # This runs the mpi-serial configure command
-        cmd = "{} {}".format(gmake_cmd, gmake_opts)
-        run_bld_cmd_ensure_logging(cmd, logger)
+    # This runs the mpi-serial configure command
+    cmd = "{} {}".format(gmake_cmd, gmake_opts)
+    run_bld_cmd_ensure_logging(cmd, logger)
 
-        # Now we run the mct make command
-        gmake_opts = "-f {} ".format(os.path.join(mct_dir,"Makefile"))
-        gmake_opts += " -C {} ".format(bldroot)
-        gmake_opts += " -j {} ".format(case.get_value("GMAKE_J"))
-        gmake_opts += " SRCDIR={} ".format(os.path.join(mct_dir))
+    # Now we run the mct make command
+    gmake_opts = "-f {} ".format(os.path.join(mct_dir,"Makefile"))
+    gmake_opts += " -C {} ".format(bldroot)
+    gmake_opts += " -j {} ".format(case.get_value("GMAKE_J"))
+    gmake_opts += " SRCDIR={} ".format(os.path.join(mct_dir))
 
-        cmd = "{} {}".format(gmake_cmd, gmake_opts)
-        run_bld_cmd_ensure_logging(cmd, logger)
+    cmd = "{} {}".format(gmake_cmd, gmake_opts)
+    run_bld_cmd_ensure_logging(cmd, logger)
 
-        for _dir in ("mct", "mpeu"):
-            for _file in glob.iglob(os.path.join(bldroot,_dir,"*.a")):
-                logger.info("Installing {} to {}".format(_file,installpath))
-                copyifnewer(_file, os.path.join(installpath, "lib", os.path.basename(_file)))
-            for _file in glob.iglob(os.path.join(bldroot,_dir,"*.mod")):
-                logger.info("Installing {} to {}".format(_file,installpath))
-                copyifnewer(_file, os.path.join(installpath, "include", os.path.basename(_file)))
+    for _dir in ("mct", "mpeu"):
+        for _file in glob.iglob(os.path.join(bldroot,_dir,"*.a")):
+            logger.info("Installing {} to {}".format(_file,installpath))
+            copyifnewer(_file, os.path.join(installpath, "lib", os.path.basename(_file)))
+        for _file in glob.iglob(os.path.join(bldroot,_dir,"*.mod")):
+            logger.info("Installing {} to {}".format(_file,installpath))
+            copyifnewer(_file, os.path.join(installpath, "include", os.path.basename(_file)))
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)
-    buildlib(bldroot, installpath, caseroot)
+    with Case(caseroot) as case:
+        buildlib(bldroot, installpath, case)
 
 if (__name__ == "__main__"):
     _main(sys.argv, __doc__)

--- a/src/build_scripts/buildlib.mpi-serial
+++ b/src/build_scripts/buildlib.mpi-serial
@@ -40,42 +40,43 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     return args.buildroot, args.installpath, args.caseroot
 
-def buildlib(bldroot, installpath, caseroot):
+def buildlib(bldroot, installpath, case):
 ###############################################################################
-    with Case(caseroot, read_only=False) as case:
-        cimeroot = case.get_value("CIMEROOT")
-        mct_dir = os.path.join(cimeroot,"src","externals","mct")
-        for _file in glob.iglob(os.path.join(mct_dir, "mpi-serial","*.h")):
-            copyifnewer(_file, os.path.join(bldroot,os.path.basename(_file)))
+    caseroot = case.get_value("CASEROOT")
+    cimeroot = case.get_value("CIMEROOT")
+    mct_dir = os.path.join(cimeroot,"src","externals","mct")
+    for _file in glob.iglob(os.path.join(mct_dir, "mpi-serial","*.h")):
+        copyifnewer(_file, os.path.join(bldroot,os.path.basename(_file)))
 
-        gmake_opts = "-f {} ".format(os.path.join(caseroot,"Tools","Makefile"))
-        gmake_opts += " -C {} ".format(bldroot)
-        gmake_opts += " CASEROOT={} ".format(caseroot)
-        gmake_opts += "MODEL=mpi-serial {}".format(os.path.join(bldroot,"Makefile.conf"))
+    gmake_opts = "-f {} ".format(os.path.join(caseroot,"Tools","Makefile"))
+    gmake_opts += " -C {} ".format(bldroot)
+    gmake_opts += " CASEROOT={} ".format(caseroot)
+    gmake_opts += "MODEL=mpi-serial {}".format(os.path.join(bldroot,"Makefile.conf"))
 
-        gmake_cmd = case.get_value("GMAKE")
+    gmake_cmd = case.get_value("GMAKE")
 
-        # This runs the mpi-serial configure command
-        cmd = "{} {}".format(gmake_cmd, gmake_opts)
-        run_bld_cmd_ensure_logging(cmd, logger)
+    # This runs the mpi-serial configure command
+    cmd = "{} {}".format(gmake_cmd, gmake_opts)
+    run_bld_cmd_ensure_logging(cmd, logger)
 
-        # Now we run the mpi-serial make command
-        gmake_opts = "-f {} ".format(os.path.join(mct_dir,"mpi-serial","Makefile"))
-        gmake_opts += " -C {} ".format(bldroot)
-        gmake_opts += " -j {} ".format(case.get_value("GMAKE_J"))
-        gmake_opts += " SRCDIR={} ".format(os.path.join(mct_dir))
+    # Now we run the mpi-serial make command
+    gmake_opts = "-f {} ".format(os.path.join(mct_dir,"mpi-serial","Makefile"))
+    gmake_opts += " -C {} ".format(bldroot)
+    gmake_opts += " -j {} ".format(case.get_value("GMAKE_J"))
+    gmake_opts += " SRCDIR={} ".format(os.path.join(mct_dir))
 
-        cmd = "{} {}".format(gmake_cmd, gmake_opts)
-        run_bld_cmd_ensure_logging(cmd, logger)
+    cmd = "{} {}".format(gmake_cmd, gmake_opts)
+    run_bld_cmd_ensure_logging(cmd, logger)
 
-        copyifnewer(os.path.join(bldroot, "libmpi-serial.a"), os.path.join(installpath, "lib", "libmpi-serial.a"))
-        for _file in ("mpi.h", "mpif.h", "mpi.mod", "MPI.mod"):
-            if os.path.isfile(os.path.join(bldroot,_file)):
-                copyifnewer(os.path.join(bldroot, _file), os.path.join(installpath, "include", _file))
+    copyifnewer(os.path.join(bldroot, "libmpi-serial.a"), os.path.join(installpath, "lib", "libmpi-serial.a"))
+    for _file in ("mpi.h", "mpif.h", "mpi.mod", "MPI.mod"):
+        if os.path.isfile(os.path.join(bldroot,_file)):
+            copyifnewer(os.path.join(bldroot, _file), os.path.join(installpath, "include", _file))
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)
-    buildlib(bldroot, installpath, caseroot)
+    with Case(caseroot) as case:
+        buildlib(bldroot, installpath, case)
 
 if (__name__ == "__main__"):
     _main(sys.argv, __doc__)

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -41,113 +41,115 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     return args.buildroot, args.installpath, args.caseroot
 
-def buildlib(bldroot, installpath, caseroot):
 ###############################################################################
-    with Case(caseroot, read_only=False) as case:
-        pio_version = case.get_value("PIO_VERSION")
-        mpilib = case.get_value("MPILIB")
-        exeroot = case.get_value("EXEROOT")
-        pio_model = "pio{}".format(pio_version)
-        pio_dir = os.path.join(bldroot, pio_model)
-        compiler = case.get_value("COMPILER")
-        build_threaded = case.get_build_threaded()
-        if not os.path.isdir(pio_dir):
-            os.makedirs(pio_dir)
-        casetools = case.get_value("CASETOOLS")
-        cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/genf90 \""
-        gmake_opts = "{pio_dir}/Makefile -C {pio_dir} CASEROOT={caseroot} MODEL={pio_model} USER_CMAKE_OPTS={cmake_opts} "\
-            "PIO_LIBDIR={pio_dir} CASETOOLS={casetools} PIO_VERSION={pio_version} MPILIB={mpilib} "\
-            "SHAREDLIBROOT={bldroot} EXEROOT={exeroot} COMPILER={compiler} BUILD_THREADED={bt} "\
-            "USER_CPPDEFS=-DTIMING -f {casetools}/Makefile"\
-            .format(pio_dir=pio_dir, caseroot=caseroot, pio_model=pio_model, cmake_opts=cmake_opts,
-                    casetools=casetools, pio_version=pio_version, mpilib=mpilib, bldroot=bldroot,
-                    exeroot=exeroot, compiler=compiler, bt=build_threaded)
+def buildlib(bldroot, installpath, case):
+###############################################################################
+    pio_version = case.get_value("PIO_VERSION")
+    mpilib = case.get_value("MPILIB")
+    caseroot = case.get_value("CASEROOT")
+    exeroot = case.get_value("EXEROOT")
+    pio_model = "pio{}".format(pio_version)
+    pio_dir = os.path.join(bldroot, pio_model)
+    compiler = case.get_value("COMPILER")
+    build_threaded = case.get_build_threaded()
+    if not os.path.isdir(pio_dir):
+        os.makedirs(pio_dir)
+    casetools = case.get_value("CASETOOLS")
+    cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/genf90 \""
+    gmake_opts = "{pio_dir}/Makefile -C {pio_dir} CASEROOT={caseroot} MODEL={pio_model} USER_CMAKE_OPTS={cmake_opts} "\
+        "PIO_LIBDIR={pio_dir} CASETOOLS={casetools} PIO_VERSION={pio_version} MPILIB={mpilib} "\
+        "SHAREDLIBROOT={bldroot} EXEROOT={exeroot} COMPILER={compiler} BUILD_THREADED={bt} "\
+        "USER_CPPDEFS=-DTIMING -f {casetools}/Makefile"\
+        .format(pio_dir=pio_dir, caseroot=caseroot, pio_model=pio_model, cmake_opts=cmake_opts,
+                casetools=casetools, pio_version=pio_version, mpilib=mpilib, bldroot=bldroot,
+                exeroot=exeroot, compiler=compiler, bt=build_threaded)
 
-        gmake_cmd = case.get_value("GMAKE")
+    gmake_cmd = case.get_value("GMAKE")
 
-        # This runs the pio cmake command from the cime case Makefile
-        cmd = "{} {}".format(gmake_cmd, gmake_opts)
-        run_bld_cmd_ensure_logging(cmd, logger, from_dir=pio_dir)
+    # This runs the pio cmake command from the cime case Makefile
+    cmd = "{} {}".format(gmake_cmd, gmake_opts)
+    run_bld_cmd_ensure_logging(cmd, logger, from_dir=pio_dir)
 
-        # This runs the pio make command from the cmake generated Makefile
-        run_bld_cmd_ensure_logging("{} -j {}".format(gmake_cmd, case.get_value("GMAKE_J")), logger, from_dir=pio_dir)
+    # This runs the pio make command from the cmake generated Makefile
+    run_bld_cmd_ensure_logging("{} -j {}".format(gmake_cmd, case.get_value("GMAKE_J")), logger, from_dir=pio_dir)
 
-        if pio_version == 1:
-            installed_lib = os.path.join(installpath,"lib","libpio.a")
-            installed_lib_time = 0
-            if os.path.isfile(installed_lib):
-                installed_lib_time = os.path.getmtime(installed_lib)
-            newlib = os.path.join(pio_dir,"pio","libpio.a")
-            newlib_time = os.path.getmtime(newlib)
-            if newlib_time > installed_lib_time:
-                logger.info("Installing pio version 1")
-                safe_copy(newlib, installed_lib)
-                for glob_to_copy in ("*.h", "*.mod"):
-                    for item in glob.glob(os.path.join(pio_dir,"pio",glob_to_copy)):
-                        safe_copy(item, "{}/include".format(installpath))
-            expect_string = "D_NETCDF;"
-            pnetcdf_string = "D_PNETCDF"
-            netcdf4_string = "D_NETCDF4"
-        else:
-            globs_to_copy = (os.path.join("src","clib","libpioc.*"),
-                             os.path.join("src","flib","libpiof.*"),
-                             os.path.join("src","clib","*.h"),
-                             os.path.join("src","flib","*.mod"))
-            for glob_to_copy in globs_to_copy:
-                installed_file_time = 0
-                for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
-                    if item.endswith(".a") or item.endswith(".so"):
-                        installdir = "lib"
-                    else:
-                        installdir = "include"
-                    installed_file = os.path.join(installpath,installdir,os.path.basename(item))
-                    item_time = os.path.getmtime(item)
-                    if os.path.isfile(installed_file):
-                        installed_file_time = os.path.getmtime(installed_file)
-                    if item_time  > installed_file_time:
-                        safe_copy(item, installed_file)
-            expect_string = "NetCDF_C_LIBRARY-ADVANCED"
-            pnetcdf_string = "PnetCDF_C_LIBRARY-ADVANCED"
-            netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
+    if pio_version == 1:
+        installed_lib = os.path.join(installpath,"lib","libpio.a")
+        installed_lib_time = 0
+        if os.path.isfile(installed_lib):
+            installed_lib_time = os.path.getmtime(installed_lib)
+        newlib = os.path.join(pio_dir,"pio","libpio.a")
+        newlib_time = os.path.getmtime(newlib)
+        if newlib_time > installed_lib_time:
+            logger.info("Installing pio version 1")
+            safe_copy(newlib, installed_lib)
+            for glob_to_copy in ("*.h", "*.mod"):
+                for item in glob.glob(os.path.join(pio_dir,"pio",glob_to_copy)):
+                    safe_copy(item, "{}/include".format(installpath))
+        expect_string = "D_NETCDF;"
+        pnetcdf_string = "D_PNETCDF"
+        netcdf4_string = "D_NETCDF4"
+    else:
+        globs_to_copy = (os.path.join("src","clib","libpioc.*"),
+                         os.path.join("src","flib","libpiof.*"),
+                         os.path.join("src","clib","*.h"),
+                         os.path.join("src","flib","*.mod"))
+        for glob_to_copy in globs_to_copy:
+            installed_file_time = 0
+            for item in glob.glob(os.path.join(pio_dir,glob_to_copy)):
+                if item.endswith(".a") or item.endswith(".so"):
+                    installdir = "lib"
+                else:
+                    installdir = "include"
+                installed_file = os.path.join(installpath,installdir,os.path.basename(item))
+                item_time = os.path.getmtime(item)
+                if os.path.isfile(installed_file):
+                    installed_file_time = os.path.getmtime(installed_file)
+                if item_time  > installed_file_time:
+                    safe_copy(item, installed_file)
+        expect_string = "NetCDF_C_LIBRARY-ADVANCED"
+        pnetcdf_string = "PnetCDF_C_LIBRARY-ADVANCED"
+        netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
 
 
-        # make sure case pio_typename valid_values is set correctly
-        expect_string_found = False
-        pnetcdf_found = False
-        netcdf4_parallel_found = False
+    # make sure case pio_typename valid_values is set correctly
+    expect_string_found = False
+    pnetcdf_found = False
+    netcdf4_parallel_found = False
 
-        cache_file = open(os.path.join(pio_dir,"CMakeCache.txt"), "r")
-        for line in cache_file:
-            if re.search(expect_string, line):
-                expect_string_found = True
-            if re.search(pnetcdf_string, line):
-                pnetcdf_found = True
-            if re.search(netcdf4_string, line):
-                netcdf4_parallel_found = True
+    cache_file = open(os.path.join(pio_dir,"CMakeCache.txt"), "r")
+    for line in cache_file:
+        if re.search(expect_string, line):
+            expect_string_found = True
+        if re.search(pnetcdf_string, line):
+            pnetcdf_found = True
+        if re.search(netcdf4_string, line):
+            netcdf4_parallel_found = True
 
-        expect(expect_string_found, "CIME models require NETCDF in PIO build")
-        valid_values = "netcdf"
-        if pnetcdf_found:
-            valid_values += ",pnetcdf"
-        if netcdf4_parallel_found:
-            valid_values += ",netcdf4p,netcdf4c"
-        logger.warning("Updating valid_values for PIO_TYPENAME: {}".format(valid_values))
+    expect(expect_string_found, "CIME models require NETCDF in PIO build")
+    valid_values = "netcdf"
+    if pnetcdf_found:
+        valid_values += ",pnetcdf"
+    if netcdf4_parallel_found:
+        valid_values += ",netcdf4p,netcdf4c"
+    logger.warning("Updating valid_values for PIO_TYPENAME: {}".format(valid_values))
 
-        case.set_valid_values("PIO_TYPENAME",valid_values)
-        # nothing means use the general default
-        valid_values += ",nothing"
+    case.set_valid_values("PIO_TYPENAME",valid_values)
+    # nothing means use the general default
+    valid_values += ",nothing"
 
-        for comp in case.get_values("COMP_CLASSES"):
-            comp_pio_typename = "{}_PIO_TYPENAME".format(comp)
-            case.set_valid_values(comp_pio_typename,valid_values)
-            current_value = case.get_value(comp_pio_typename)
-            if current_value not in valid_values:
-                logger.warning("Resetting PIO_TYPENAME to netcdf for component {}".format(comp))
-                case.set_value(comp_pio_typename,"netcdf")
+    for comp in case.get_values("COMP_CLASSES"):
+        comp_pio_typename = "{}_PIO_TYPENAME".format(comp)
+        case.set_valid_values(comp_pio_typename,valid_values)
+        current_value = case.get_value(comp_pio_typename)
+        if current_value not in valid_values:
+            logger.warning("Resetting PIO_TYPENAME to netcdf for component {}".format(comp))
+            case.set_value(comp_pio_typename,"netcdf")
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)
-    buildlib(bldroot, installpath, caseroot)
+    with Case(caseroot, read_only=False) as case:
+        buildlib(bldroot, installpath, case)
 
 if (__name__ == "__main__"):
     _main(sys.argv, __doc__)

--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -171,7 +171,7 @@ def buildnml(case, caseroot, compname):
     ninst = case.get_value("NINST_ATM")
     if ninst is None:
         ninst = case.get_value("NINST")
-    
+
     # Determine configuration directory
     confdir = os.path.join(caseroot,"Buildconf",compname + "conf")
     if not os.path.isdir(confdir):


### PR DESCRIPTION
Change list:
* Propagate Case read_only to its XML objects
* Cache all files, but use file mod-time to detect changes.
* Try to pass Case, not caseroot, to run_sub_or_cmd
* Add a CIME performance test
* Add tests for CIME XML handling

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2161 
Fixes #2850 

User interface changes?: GenericXML will now throw an error if XML files are changed behind its back without a re-read/invalidate.

Update gh-pages html (Y/N)?:

Code review: @jedwards4b @billsacks 
