### PR TITLE
do not allow trailing / in filename

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -151,11 +151,15 @@ def check_name(fullname, additional_chars=None, fullpath=False):
     False
     >>> check_name("mycase*mods")
     False
+    >>> check_name("/some/full/path/name/")
+    False
     """
 
     chars = '+*?<>/{}[\]~`@:' # pylint: disable=anomalous-backslash-in-string
     if additional_chars is not None:
         chars += additional_chars
+    if fullname.endswith('/'):
+        return False
     if fullpath:
         _, name = os.path.split(fullname)
     else:


### PR DESCRIPTION
Disallow trailing / character in filename
Test suite: scripts_regression_tests.py, hand testing
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2937 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
