### PR TITLE
Mlevy/update esmf in mapping master

### DIFF
--- a/tools/mapping/gen_mapping_files/gen_ESMF_mapping_file/create_ESMF_map.sh
+++ b/tools/mapping/gen_mapping_files/gen_ESMF_mapping_file/create_ESMF_map.sh
@@ -218,13 +218,13 @@ if [ $MACH == "UNSET" ]; then
       MACH="cheyenne"
     ;;
     geyser* )
-      MACH="geyser"
+      MACH="dav"
     ;;
     caldera* )
-      MACH="caldera"
+      MACH="dav"
     ;;
     pronghorn* )
-      MACH="pronghorn"
+      MACH="dav"
     ;;
     *)
       echo "Can not determine machine name from hostname '$hostname'"
@@ -296,48 +296,44 @@ fi
 #-------------------------------------------------------------------------------
 
 case $MACH in
-  ## cheyenne, geyser, caldera, or pronghorn
-  "cheyenne" |  "geyser" | "caldera" | "pronghorn" )
+  ## cheyenne
+  "cheyenne" )
+    module purge
+    module load intel/17.0.1 esmf_libs/7.0.0
     if [ "$serial" == "TRUE" ]; then
       # No MPIEXEC
       if [ -z "$MPIEXEC" ]; then
         MPIEXEC=""
       fi
-
-      # run configure in same directory as this script
-      CWD=`pwd -P`
-      cd $SDIR
-      ../../../configure --clean
-      ../../../configure --mpilib mpi-serial
-      . .env_mach_specific.sh
-      cd $CWD
+      module load esmf-7.1.0r-ncdfio-uni-O
     else
-      if [ "$MACH" == "cheyenne" ]; then
-        # MPIEXEC should be mpirun -np
+      # MPIEXEC should be mpirun -np
       if [ -z "$MPIEXEC" ]; then
         if [ -z "$NCPUS" ]; then
           NCPUS=1
         fi
         MPIEXEC="mpirun -np $NCPUS"
       fi
-
-      # run configure in same directory as this script
-      CWD=`pwd -P`
-      cd $SDIR
-      ../../../configure --clean
-      ../../../configure --mpilib mpt
-      . .env_mach_specific.sh
-      module swap mpt mpt/2.15f
-      module swap esmf-7.0.0-defio-mpi-O esmf-7.0.0-ncdfio-mpi-O
-      cd $CWD
-      else # geyser and caldera still don't work
-        echo "ERROR: Must use serial implementation of ESMF because module"
-        echo "       changes have made it difficult to run in parallel."
-        echo "       Rerun with --serial"
-        exit 1
-      fi
+      module load esmf-7.1.0r-ncdfio-mpi-O
+      module load mpt/2.15f
     fi
-
+    # need to load module to access ncatted
+    module load nco
+  ;;
+## geyser, caldera, or pronghorn
+  "dav" )
+    module purge
+    module load intel/17.0.1 esmflibs/7.1.0r
+    if [ "$serial" == "TRUE" ]; then
+      # No MPIEXEC
+      if [ -z "$MPIEXEC" ]; then
+        MPIEXEC=""
+      fi
+      module load esmf-7.1.0r-ncdfio-uni-O
+    else
+      echo "ERROR: Parallel ESMF tools are not available on $MACH, use --serial"
+      exit 1
+    fi
     # need to load module to access ncatted
     module load nco
   ;;


### PR DESCRIPTION


Update the version of ESMF used by the mapping tools on cheyenne
from 7.0.0 to 7.1.0r (this addresses a known-issue in ESMF where
bilinear maps made when one grid has cell centers at 90 N or 90 S
have incorrect weights).

Also, cleaned up how these tools are called from the NCAR DAV
cluster. Note at this time that CISL has not installed parallel versions
of the ESMF tools on DAV, so running there requires the --serial
flag. I'll submit another pull request if / when CISL installs the mpi
versions.

In doing this, I moved away from relying on tools/configure to set
up the environment properly -- I wanted these tools to work on DAV
and never found the time to add a DAV entry to config_machines.xml.
And on cheyenne, I did not want to test the ramifications of changing
the ESMF versions in config_machines.xml.

Testing: the mapping tools are not called by any of the automated
testing, but I did generate maps with create_ESMF_map.sh exercising
each path through the code (cheyenne-serial, cheyenne-parallel, and
DAV-serial).
