### PR TITLE
Update fv1.9x2.5,gx1v7 grids

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1071,8 +1071,8 @@
       <nx>144</nx>  <ny>96</ny>
       <file grid="atm|lnd" mask="gx1v6">domain.lnd.fv1.9x2.5_gx1v6.090206.nc</file>
       <file grid="ocnice"  mask="gx1v6">domain.ocn.1.9x2.5_gx1v6_090403.nc</file>
-      <file grid="atm|lnd" mask="gx1v7">domain.lnd.fv1.9x2.5_gx1v7.170518.nc</file>
-      <file grid="ocnice"  mask="gx1v7">domain.ocn.fv1.9x2.5_gx1v7.170518.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">domain.lnd.fv1.9x2.5_gx1v7.181205.nc</file>
+      <file grid="ocnice"  mask="gx1v7">domain.ocn.fv1.9x2.5_gx1v7.181205.nc</file>
       <file grid="ocnice"  mask="null">domain.aqua.fv1.9x2.5.nc</file>
       <desc>1.9x2.5 is FV 2-deg grid:</desc>
     </domain>
@@ -1521,11 +1521,11 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_fv1.9x2.5_aave.130322.nc</map>
     </gridmap>
     <gridmap atm_grid="1.9x2.5" ocn_grid="gx1v7">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v7_aave.170518.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v7_blin.170518.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v7_patc.170518.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_fv1.9x2.5_aave.170518.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_fv1.9x2.5_aave.170518.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v7_aave.181205.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v7_blin.181205.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gx1v7_patc.181205.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_fv1.9x2.5_aave.181205.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_fv1.9x2.5_aave.181205.nc</map>
     </gridmap>
     <gridmap atm_grid="1.9x2.5" ocn_grid="tx1v1">
       <map name="ATM2OCN_FMAPNAME">cpl/cpl6/map_fv1.9x2.5_to_tx1v1_aave_da_090710.nc</map>


### PR DESCRIPTION
Older versions of the fv1.9x2.5,gx1v7 files were generated with ESMF 7.0.0, which had a bug.  The
new mappings files were generated with the ESMF7.1.0r, which fixed the bug.

Test suite: scripts_regression_tests.py,ERS_Ld5.f19_g17.BWma1850
Test baseline: 
Test namelist changes: 
Test status: answer changing for g19_g17 grids

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
