### PR TITLE
Improve error/exception handling throughout CIME

### DIFF
--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -128,7 +128,7 @@ def _main_func(description):
                 # sure to leave TestStatus in the appropriate state if that
                 # happens.
                 test = find_system_test(testname, case)(case)
-            except:
+            except BaseException:
                 phase_to_fail = MODEL_BUILD_PHASE if model_only else SHAREDLIB_BUILD_PHASE
                 with TestStatus(test_dir=caseroot) as ts:
                     ts.set_status(phase_to_fail, TEST_FAIL_STATUS, comments="failed to initialize")

--- a/scripts/Tools/case_diff
+++ b/scripts/Tools/case_diff
@@ -131,11 +131,12 @@ def _main_func(description):
                 repls[os.path.normpath(val2)] = os.path.normpath(val1)
             else:
                 repls[val2] = val1
-        except SystemExit:
-            print("Warning, failed to normalize on " + xml_normalize_field)
+        except Exception:
+            logging.warning("Warning, failed to normalize on " + xml_normalize_field)
+            repls = {}
 
     num_differing_files = recursive_diff(case1, case2, repls, show_binary, skip_list)
-    print (num_differing_files, "files are different")
+    logging.info(num_differing_files, "files are different")
     sys.exit(0 if num_differing_files == 0 else 1)
 
 ###############################################################################

--- a/scripts/Tools/testreporter.py
+++ b/scripts/Tools/testreporter.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 
 """
-
 Simple script to populate CESM test database with test results.
-
 """
 
 from standard_script_setup import *
@@ -15,10 +13,7 @@ from CIME.XML.test_reporter         import TestReporter
 from CIME.utils                     import expect
 from CIME.XML.generic_xml import GenericXML
 
-
 import glob
-
-
 
 ###############################################################################
 def parse_command_line(args):
@@ -29,7 +24,7 @@ def parse_command_line(args):
 
     # Parse command line options
 
-#    parser = argparse.ArgumentParser(description='Arguements for testreporter')
+    #parser = argparse.ArgumentParser(description='Arguements for testreporter')
     parser.add_argument("--tagname",
                         help="Name of the tag being tested.")
     parser.add_argument("--testid",
@@ -44,7 +39,6 @@ def parse_command_line(args):
                         help="Dump XML test results to sceen.")
     args = parser.parse_args()
     CIME.utils.parse_args_and_handle_standard_logging_options(args)
-
 
     return args.testroot, args.testid, args.tagname, args.testtype, args.dryrun, args.dumpxml
 
@@ -107,7 +101,7 @@ def get_testreporter_xml(testroot, testid, tagname, testtype):
         #
         try:
             lines = [line.rstrip('\n') for line in open(test_name+"/TestStatus")]
-        except:
+        except (IOError, OSError):
             test_status['STATUS']="FAIL"
             test_status['COMMENT']="TestStatus missing. "
             continue
@@ -208,7 +202,7 @@ def get_testreporter_xml(testroot, testid, tagname, testtype):
                         test_status['COMMENT']+=line.split(' ',3)[3]+' '
                     else:
                         test_status['COMMENT']+=line.split(' ',4)[4]+' '
-            except:
+            except Exception: # Probably want to be more specific here
                 pass
 
         #
@@ -217,7 +211,6 @@ def get_testreporter_xml(testroot, testid, tagname, testtype):
         testxml.add_result(test_name,test_status)
 
     return testxml
-
 
 ##############################################################################
 def _main_func():

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -248,7 +248,7 @@ def xmlquery_sub(case, variables, subgroup=None, fileonly=False,
                     for comp in comp_classes:
                         try:
                             nextval = get_value_as_string(case,var, attribute={"compclass" : comp}, resolved=resolved, subgroup=group)
-                        except:
+                        except Exception: # probably want to be more specific
                             nextval = get_value_as_string(case,var, attribute={"compclass" : comp}, resolved=False, subgroup=group)
 
                         if nextval is not None:

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -20,7 +20,7 @@ def parse_command_line(args, cimeroot, description):
     CIME.utils.setup_standard_logging_options(parser)
     try:
         cime_config = get_cime_config()
-    except:
+    except Exception:
         cime_config = None
 
     parser.add_argument("--case", "-case", required=True, metavar="CASENAME",

--- a/scripts/lib/CIME/Servers/ftp.py
+++ b/scripts/lib/CIME/Servers/ftp.py
@@ -5,6 +5,7 @@ FTP Server class.  Interact with a server using FTP protocol
 from CIME.XML.standard_module_setup import *
 from CIME.Servers.generic_server import GenericServer
 from ftplib import FTP as FTPpy
+from ftplib import all_errors as all_ftp_errors
 
 logger = logging.getLogger(__name__)
 # I think that multiple inheritence would be useful here, but I couldnt make it work
@@ -31,9 +32,10 @@ class FTP(GenericServer):
     def fileexists(self, rel_path):
         try:
             stat = self.ftp.nlst(rel_path)
-        except:
+        except all_ftp_errors:
             logger.warning("ERROR from ftp server, trying next server")
             return False
+
         if rel_path not in stat:
             if not stat or not stat[0].startswith(rel_path):
                 logging.warning("FAIL: File {} not found.\nerror {}".format(rel_path, stat))
@@ -43,7 +45,7 @@ class FTP(GenericServer):
     def getfile(self, rel_path, full_path):
         try:
             stat = self.ftp.retrbinary('RETR {}'.format(rel_path), open(full_path, "wb").write)
-        except:
+        except all_ftp_errors:
             logger.warning("ERROR from ftp server, trying next server")
             return False
 
@@ -56,7 +58,7 @@ class FTP(GenericServer):
     def getdirectory(self, rel_path, full_path):
         try:
             stat = self.ftp.nlst(rel_path)
-        except:
+        except all_ftp_errors:
             logger.warning("ERROR from ftp server, trying next server")
             return False
 

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -363,7 +363,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                     rundir = self._get_case2_rundir())
                 self._write_info_to_case2_output_root()
                 self._setup_cases()
-            except:
+            except BaseException:
                 # If a problem occurred in setting up the test cases, it's
                 # important to remove the case2 directory: If it's kept around,
                 # that would signal that test setup was done successfully, and

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -216,11 +216,11 @@ class Component(EntryID):
         (False, None)
         >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "?")
         (True, ['DATM'])
-        >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1")
+        >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1") # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
         CIMEError: ERROR: Expected exactly one modifer found 0 in ['DATM']
-        >>> obj._get_description_match("1850_DATM%CRU%HSI_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1")
+        >>> obj._get_description_match("1850_DATM%CRU%HSI_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1") # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
         CIMEError: ERROR: Expected exactly one modifer found 2 in ['DATM', 'CRU', 'HSI']

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -219,11 +219,11 @@ class Component(EntryID):
         >>> obj._get_description_match("1850_DATM_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1")
         Traceback (most recent call last):
         ...
-        SystemExit: ERROR: Expected exactly one modifer found 0 in ['DATM']
+        CIMEError: ERROR: Expected exactly one modifer found 0 in ['DATM']
         >>> obj._get_description_match("1850_DATM%CRU%HSI_Barn",set(["DATM"]), set(["DATM","CRU","HSI"]), "1")
         Traceback (most recent call last):
         ...
-        SystemExit: ERROR: Expected exactly one modifer found 2 in ['DATM', 'CRU', 'HSI']
+        CIMEError: ERROR: Expected exactly one modifer found 2 in ['DATM', 'CRU', 'HSI']
         >>> obj._get_description_match("1850_CAM50%WCCM%RCO2_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "*")
         (True, ['CAM50', 'WCCM', 'RCO2'])
 

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -393,7 +393,7 @@ class EnvBatch(EnvBase):
                     if " " in val:
                         try:
                             rval = eval(val)
-                        except:
+                        except Exception:
                             rval = val
                     else:
                         rval = val
@@ -435,7 +435,7 @@ class EnvBatch(EnvBase):
                 else:
                     prereq = case.get_resolved_value(prereq)
                     prereq = eval(prereq)
-            except:
+            except Exception:
                 expect(False,"Unable to evaluate prereq expression '{}' for job '{}'".format(self.get_value('prereq',subgroup=job), job))
 
             if prereq:

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -575,7 +575,11 @@ class EnvBatch(EnvBase):
             if not dry_run:
                 args = self._build_run_args(job, True, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
                                             submit_resubmits=not resubmit_immediate)
-                getattr(case, function_name)(**{k: v for k, (v, _) in args.items()})
+                try:
+                    getattr(case, function_name)(**{k: v for k, (v, _) in args.items()})
+                except Exception as e:
+                    # We don't want exception from the run phases getting into submit phase
+                    logger.warning("Exception from {}: {}".format(function_name, str(e)))
 
             return
 

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -493,7 +493,7 @@ class GenericXML(object):
         if math_re.search(item_data):
             try:
                 tmp = eval(item_data)
-            except:
+            except Exception:
                 tmp = item_data
             item_data = str(tmp)
 

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -162,7 +162,7 @@ class Machines(GenericXML):
         >>> machobj.set_machine("trump")
         Traceback (most recent call last):
         ...
-        SystemExit: ERROR: No machine trump found
+        CIMEError: ERROR: No machine trump found
         """
         if machine == "Query":
             self.machine = machine

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -159,7 +159,7 @@ class Machines(GenericXML):
         >>> machobj = Machines(machine="melvin")
         >>> machobj.get_machine_name()
         'melvin'
-        >>> machobj.set_machine("trump")
+        >>> machobj.set_machine("trump") # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
         CIMEError: ERROR: No machine trump found

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -561,7 +561,6 @@ def post_build(case, logs, build_complete=False, save_build_provenance=True):
 
         lock_file("env_build.xml")
 
-
 ###############################################################################
 def case_build(caseroot, case, sharedlib_only=False, model_only=False, buildlist=None, save_build_provenance=True):
 ###############################################################################

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1059,7 +1059,6 @@ class Case(object):
             except Exception as e:
                 logger.warning("FAILED to set up exefiles: {}".format(str(e)))
 
-
     def _create_caseroot_sourcemods(self):
         components = self.get_compset_components()
         components.extend(['share', 'drv'])
@@ -1461,7 +1460,7 @@ directory, NOT in this subdirectory."""
 
             # Lock env_case.xml
             lock_file("env_case.xml", self._caseroot)
-        except:
+        except Exception:
             if os.path.exists(self._caseroot):
                 if not logger.isEnabledFor(logging.DEBUG) and not test:
                     logger.warning("Failed to setup case, removing {}\nUse --debug to force me to keep caseroot".format(self._caseroot))

--- a/scripts/lib/CIME/case/case_clone.py
+++ b/scripts/lib/CIME/case/case_clone.py
@@ -10,7 +10,6 @@ from CIME.simple_compare            import compare_files
 
 logger = logging.getLogger(__name__)
 
-
 def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None,
                       cime_output_root=None, exeroot=None, rundir=None,
                       user_mods_dir=None):
@@ -59,11 +58,8 @@ def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None,
                "by this user.  Use the --cime-output-root flag to provide a writable "
                "scratch directory".format(cime_output_root))
     else:
-        try:
+        if not os.path.isdir(cime_output_root):
             os.makedirs(cime_output_root)
-        except:
-            if not os.path.isdir(cime_output_root):
-                raise
 
     # determine if will use clone executable or not
     if keepexe:

--- a/scripts/lib/CIME/case/case_cmpgen_namelists.py
+++ b/scripts/lib/CIME/case/case_cmpgen_namelists.py
@@ -129,9 +129,9 @@ kept in the baselines are pre-RUN namelists."""
                     logging.info(run_warn)
             if generate:
                 _do_full_nl_gen(self, test_name, generate_name, baseline_root)
-        except:
-            ts.set_status(NAMELIST_PHASE, TEST_FAIL_STATUS)
+        except Exception:
             success = False
+            ts.set_status(NAMELIST_PHASE, TEST_FAIL_STATUS)
             warn = "Exception during namelist operations:\n{}\n{}".format(sys.exc_info()[1], traceback.format_exc())
             output += warn
             logging.warning(warn)

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -236,7 +236,7 @@ def case_setup(self, clean=False, test_mode=False, reset=False):
         with TestStatus(test_dir=caseroot, test_name=test_name) as ts:
             try:
                 run_and_log_case_status(functor, phase, caseroot=caseroot)
-            except:
+            except BaseException: # Want to catch KeyboardInterrupt too
                 ts.set_status(SETUP_PHASE, TEST_FAIL_STATUS)
                 raise
             else:

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -8,7 +8,7 @@ submit, check_case and check_da_settings are members of class Case in file case.
 """
 from six.moves                      import configparser
 from CIME.XML.standard_module_setup import *
-from CIME.utils                     import expect, run_and_log_case_status, verbatim_success_msg, CASE_SUCCESS, does_file_have_string
+from CIME.utils                     import expect, run_and_log_case_status, verbatim_success_msg, CASE_SUCCESS, does_file_have_string, CIMEError
 from CIME.locked_files              import unlock_file, lock_file
 from CIME.test_status               import *
 
@@ -71,7 +71,7 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
         env_batch_has_changed = False
         try:
             case.check_lockedfile(os.path.basename(env_batch.filename))
-        except SystemExit:
+        except CIMEError:
             env_batch_has_changed = True
 
         if env_batch.get_batch_system_type() != "none" and env_batch_has_changed:
@@ -159,7 +159,7 @@ def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubm
                                   batch_args=batch_args)
         run_and_log_case_status(functor, "case.submit", caseroot=caseroot,
                                 custom_success_msg_functor=verbatim_success_msg)
-    except:
+    except BaseException: # Want to catch KeyboardInterrupt too
         # If something failed in the batch system, make sure to mark
         # the test as failed if we are running a test.
         if self.get_value("TEST"):

--- a/scripts/lib/CIME/case/case_test.py
+++ b/scripts/lib/CIME/case/case_test.py
@@ -58,12 +58,12 @@ def case_test(self, testname=None, reset=False, skip_pnl=False):
         # sure to leave TestStatus in the appropriate state if that
         # happens.
         test = find_system_test(testname, self)(self)
-    except:
+    except BaseException:
         caseroot = self.get_value("CASEROOT")
         with TestStatus(test_dir=caseroot) as ts:
             ts.set_status(RUN_PHASE, TEST_FAIL_STATUS, comments="failed to initialize")
         append_testlog(str(sys.exc_info()[1]))
-        return False
+        raise
 
     if reset:
         logger.info("Reset test to initial conditions and exit")

--- a/scripts/lib/CIME/compare_namelists.py
+++ b/scripts/lib/CIME/compare_namelists.py
@@ -124,7 +124,7 @@ def _parse_namelists(namelist_lines, filename):
     >>> _parse_namelists(teststr.splitlines(), 'foo')
     OrderedDict([('fire_emis_nl', OrderedDict([('fire_emis_factors_file', "'fire_emis_factors_c140116.nc'"), ('fire_emis_specifier', ["'bc_a1 = BC'", "'pom_a1 = 1.4*OC'", "'pom_a2 = A*B*C'", "'SO2 = SO2'"])]))])
 
-    >>> _parse_namelists('blah', 'foo')
+    >>> _parse_namelists('blah', 'foo') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     CIMEError: ERROR: File 'foo' does not appear to be a namelist file, skipping
@@ -133,7 +133,7 @@ def _parse_namelists(namelist_lines, filename):
     ... val = 'one', 'two',
     ... val2 = 'three'
     ... /'''
-    >>> _parse_namelists(teststr.splitlines(), 'foo')
+    >>> _parse_namelists(teststr.splitlines(), 'foo') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     CIMEError: ERROR: In file 'foo', Incomplete multiline variable: 'val'
@@ -141,7 +141,7 @@ def _parse_namelists(namelist_lines, filename):
     >>> teststr = '''&nml
     ... val = 'one', 'two',
     ... /'''
-    >>> _parse_namelists(teststr.splitlines(), 'foo')
+    >>> _parse_namelists(teststr.splitlines(), 'foo') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     CIMEError: ERROR: In file 'foo', Incomplete multiline variable: 'val'
@@ -150,7 +150,7 @@ def _parse_namelists(namelist_lines, filename):
     ... val = 'one', 'two',
     ...       'three -> four'
     ... /'''
-    >>> _parse_namelists(teststr.splitlines(), 'foo')
+    >>> _parse_namelists(teststr.splitlines(), 'foo') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     CIMEError: ERROR: In file 'foo', multiline list variable 'val' had dict entries

--- a/scripts/lib/CIME/compare_namelists.py
+++ b/scripts/lib/CIME/compare_namelists.py
@@ -1,7 +1,7 @@
 import os, re, logging, six
 
 from collections import OrderedDict
-from CIME.utils  import expect
+from CIME.utils  import expect, CIMEError
 logger=logging.getLogger(__name__)
 
 # pragma pylint: disable=unsubscriptable-object
@@ -77,7 +77,7 @@ def _interpret_value(value_str, filename):
                     sub_tokens = [item.strip() for item in token.split("*")]
                     expect(len(sub_tokens) == 2, "Incorrect usage of multiplication in token '{}'".format(token))
                     new_tokens.extend([sub_tokens[1]] * int(sub_tokens[0]))
-                except:
+                except Exception:
                     # User probably did not intend to use the * operator as a namelist multiplier
                     new_tokens.append(token)
             else:
@@ -127,7 +127,7 @@ def _parse_namelists(namelist_lines, filename):
     >>> _parse_namelists('blah', 'foo')
     Traceback (most recent call last):
         ...
-    SystemExit: ERROR: File 'foo' does not appear to be a namelist file, skipping
+    CIMEError: ERROR: File 'foo' does not appear to be a namelist file, skipping
 
     >>> teststr = '''&nml
     ... val = 'one', 'two',
@@ -136,7 +136,7 @@ def _parse_namelists(namelist_lines, filename):
     >>> _parse_namelists(teststr.splitlines(), 'foo')
     Traceback (most recent call last):
         ...
-    SystemExit: ERROR: In file 'foo', Incomplete multiline variable: 'val'
+    CIMEError: ERROR: In file 'foo', Incomplete multiline variable: 'val'
 
     >>> teststr = '''&nml
     ... val = 'one', 'two',
@@ -144,7 +144,7 @@ def _parse_namelists(namelist_lines, filename):
     >>> _parse_namelists(teststr.splitlines(), 'foo')
     Traceback (most recent call last):
         ...
-    SystemExit: ERROR: In file 'foo', Incomplete multiline variable: 'val'
+    CIMEError: ERROR: In file 'foo', Incomplete multiline variable: 'val'
 
     >>> teststr = '''&nml
     ... val = 'one', 'two',
@@ -153,7 +153,7 @@ def _parse_namelists(namelist_lines, filename):
     >>> _parse_namelists(teststr.splitlines(), 'foo')
     Traceback (most recent call last):
         ...
-    SystemExit: ERROR: In file 'foo', multiline list variable 'val' had dict entries
+    CIMEError: ERROR: In file 'foo', multiline list variable 'val' had dict entries
 
     >>> teststr = '''&nml
     ... val = 2, 2*13
@@ -544,7 +544,7 @@ def is_namelist_file(file_path):
 ###############################################################################
     try:
         compare_namelist_files(file_path, file_path)
-    except SystemExit as e:
+    except CIMEError as e:
         assert "does not appear to be a namelist file" in str(e), str(e)
         return False
     return True

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -623,21 +623,21 @@ def literal_to_python_value(literal, type_=None):
     >>> literal_to_python_value("bacon")
     Traceback (most recent call last):
     ...
-    SystemExit: ERROR: 'bacon' is not a valid literal for any Fortran type.
+    CIMEError: ERROR: 'bacon' is not a valid literal for any Fortran type.
     >>> literal_to_python_value("1", type_="real")
     1.0
     >>> literal_to_python_value("bacon", type_="logical")
     Traceback (most recent call last):
     ...
-    SystemExit: ERROR: 'bacon' is not a valid literal of type 'logical'.
+    CIMEError: ERROR: 'bacon' is not a valid literal of type 'logical'.
     >>> literal_to_python_value("1", type_="booga")
     Traceback (most recent call last):
     ...
-    SystemExit: ERROR: Invalid Fortran type for a namelist: 'booga'
+    CIMEError: ERROR: Invalid Fortran type for a namelist: 'booga'
     >>> literal_to_python_value("2*1")
     Traceback (most recent call last):
     ...
-    SystemExit: ERROR: Cannot use repetition syntax in literal_to_python_value
+    CIMEError: ERROR: Cannot use repetition syntax in literal_to_python_value
     >>> literal_to_python_value("")
     >>> literal_to_python_value("-1.D+10")
     -10000000000.0
@@ -858,15 +858,13 @@ def shouldRaise(eclass, method, *args, **kw):
     """
     try:
         method(*args, **kw)
-    except:
+    except BaseException:
         e = sys.exc_info()[1]
         if not isinstance(e, eclass):
             raise
         return
     raise Exception("Expected exception %s not raised" %
                     str(eclass))
-
-
 
 class Namelist(object):
 
@@ -968,7 +966,7 @@ class Namelist(object):
         >>> parse(text='&foo bar=1 / &bazz bar=1 /').get_value('bar')  # doctest: +ELLIPSIS
         Traceback (most recent call last):
         ...
-        SystemExit: ERROR: Namelist.get_value: Variable {} is present in multiple groups: ...
+        CIMEError: ERROR: Namelist.get_value: Variable {} is present in multiple groups: ...
         >>> parse(text='&foo bar=1 / &bazz /').get_value('Bar')
         ['1']
         >>> parse(text='&foo bar(2)=1 / &bazz /').get_value('Bar(2)')
@@ -2065,7 +2063,7 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> _NamelistParser("foo(1:2)=1,2,3 ")._parse_name_and_values(allow_eof_end=True)
         Traceback (most recent call last):
         ...
-        SystemExit: ERROR: Too many values for array foo(1:2)
+        CIMEError: ERROR: Too many values for array foo(1:2)
         >>> _NamelistParser("foo=1,")._parse_name_and_values(allow_eof_end=True)
         ('foo', ['1', ''], False)
         >>> _NamelistParser("foo+=1")._parse_name_and_values(allow_eof_end=True)

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -620,21 +620,21 @@ def literal_to_python_value(literal, type_=None):
     True
     >>> literal_to_python_value("Fortune")
     False
-    >>> literal_to_python_value("bacon")
+    >>> literal_to_python_value("bacon") # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     CIMEError: ERROR: 'bacon' is not a valid literal for any Fortran type.
     >>> literal_to_python_value("1", type_="real")
     1.0
-    >>> literal_to_python_value("bacon", type_="logical")
+    >>> literal_to_python_value("bacon", type_="logical") # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     CIMEError: ERROR: 'bacon' is not a valid literal of type 'logical'.
-    >>> literal_to_python_value("1", type_="booga")
+    >>> literal_to_python_value("1", type_="booga") # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     CIMEError: ERROR: Invalid Fortran type for a namelist: 'booga'
-    >>> literal_to_python_value("2*1")
+    >>> literal_to_python_value("2*1") # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     CIMEError: ERROR: Cannot use repetition syntax in literal_to_python_value
@@ -963,7 +963,7 @@ class Namelist(object):
         not require a `group_name`, and it requires that the `variable_name` be
         unique across all groups.
 
-        >>> parse(text='&foo bar=1 / &bazz bar=1 /').get_value('bar')  # doctest: +ELLIPSIS
+        >>> parse(text='&foo bar=1 / &bazz bar=1 /').get_value('bar')  # doctest: +ELLIPSIS +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
         CIMEError: ERROR: Namelist.get_value: Variable {} is present in multiple groups: ...
@@ -2060,7 +2060,7 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         ('foo', ['2'], False)
         >>> _NamelistParser("foo=1,2")._parse_name_and_values(allow_eof_end=True)
         ('foo', ['1', '2'], False)
-        >>> _NamelistParser("foo(1:2)=1,2,3 ")._parse_name_and_values(allow_eof_end=True)
+        >>> _NamelistParser("foo(1:2)=1,2,3 ")._parse_name_and_values(allow_eof_end=True) # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
         CIMEError: ERROR: Too many values for array foo(1:2)

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -25,7 +25,7 @@ def _get_batch_job_id_for_syslog(case):
             return os.environ["COBALT_JOBID"]
         elif mach in ['summit']:
             return os.environ["LSB_JOBID"]
-    except:
+    except KeyError:
         pass
 
     return None
@@ -435,7 +435,7 @@ def get_recommended_test_time_based_on_past(baseline_root, test, raw=False):
                     best_walltime += _GLOBAL_WIGGLE
 
                 return convert_to_babylonian_time(best_walltime)
-        except:
+        except Exception:
             # We NEVER want a failure here to kill the run
             logger.warning("Failed to read test time: {}".format(sys.exc_info()[1]))
 
@@ -451,6 +451,6 @@ def save_test_time(baseline_root, test, time_seconds):
             the_path = os.path.join(the_dir, _WALLTIME_FILE_NAME)
             with open(the_path, "a") as fd:
                 fd.write("{}\n".format(int(time_seconds)))
-        except:
+        except Exception:
             # We NEVER want a failure here to kill the run
             logger.warning("Failed to store test time: {}".format(sys.exc_info()[1]))

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -691,7 +691,7 @@ class TestScheduler(object):
     ###########################################################################
         try:
             return run(test)
-        except (SystemExit, Exception) as e:
+        except Exception as e:
             exc_tb = sys.exc_info()[2]
             errput = "Test '{}' failed in phase '{}' with exception '{}'\n".format(test, phase, str(e))
             errput += ''.join(traceback.format_tb(exc_tb))

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -496,7 +496,10 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
                                            run_one_should_pass = False)
 
         # Exercise
-        mytest.run()
+        try:
+            mytest.run()
+        except Exception:
+            pass
 
         # Verify
         self.assertEqual(test_status.TEST_FAIL_STATUS,
@@ -512,7 +515,10 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
                                            run_two_should_pass = False)
 
         # Exercise
-        mytest.run()
+        try:
+            mytest.run()
+        except Exception:
+            pass
 
         # Verify
         self.assertEqual(test_status.TEST_FAIL_STATUS,

--- a/scripts/lib/CIME/tests/test_user_mod_support.py
+++ b/scripts/lib/CIME/tests/test_user_mod_support.py
@@ -5,7 +5,9 @@ import shutil
 import tempfile
 import os
 from CIME.user_mod_support import apply_user_mods
+from CIME.utils import CIMEError
 import six
+
 # ========================================================================
 # Define some parameters
 # ========================================================================
@@ -114,7 +116,7 @@ class TestUserModSupport(unittest.TestCase):
 
     def test_keepexe(self):
         self.createUserMod("foo")
-        with six.assertRaisesRegex(self, SystemExit, "cannot have any source mods"):
+        with six.assertRaisesRegex(self, CIMEError, "cannot have any source mods"):
             apply_user_mods(self._caseroot,
                             os.path.join(self._user_mods_parent_dir, "foo"), keepexe=True)
 

--- a/scripts/lib/CIME/user_mod_support.py
+++ b/scripts/lib/CIME/user_mod_support.py
@@ -67,7 +67,7 @@ def apply_user_mods(caseroot, user_mods_path, keepexe=None):
                         logger.info("Adding SourceMod to case {}".format(case_source_mods))
                     try:
                         safe_copy(source_mods, case_source_mods)
-                    except:
+                    except Exception:
                         expect(False, "Could not write file {} in caseroot {}".format(case_source_mods,caseroot))
 
         # create xmlchange_cmnds and shell_commands in caseroot

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -120,7 +120,7 @@ def expect(condition, error_msg, exc_type=CIMEError, error_prefix="ERROR:"):
     checking user error, not programming error.
 
     >>> expect(True, "error1")
-    >>> expect(False, "error2")
+    >>> expect(False, "error2") # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     CIMEError: ERROR: error2
@@ -489,7 +489,7 @@ def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
 
     >>> run_cmd_no_fail('echo foo') == 'foo'
     True
-    >>> run_cmd_no_fail('echo THE ERROR >&2; false') # doctest:+ELLIPSIS
+    >>> run_cmd_no_fail('echo THE ERROR >&2; false') # doctest:+ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     CIMEError: ERROR: Command: 'echo THE ERROR >&2; false' failed with error ...
@@ -574,11 +574,11 @@ def parse_test_name(test_name):
     ['ERS', None, 'fe12_123', 'JGF', 'machine', 'compiler', None]
     >>> parse_test_name('ERS.fe12_123.JGF.machine_compiler.test-mods')
     ['ERS', None, 'fe12_123', 'JGF', 'machine', 'compiler', 'test/mods']
-    >>> parse_test_name('SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods')
+    >>> parse_test_name('SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     CIMEError: ERROR: Expected 4th item of 'SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods' ('A_XLND_SICE_SOCN_XROF_XGLC_SWAV') to be in form machine_compiler
-    >>> parse_test_name('SMS.f19_g16.2000_DATM%QI/A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods')
+    >>> parse_test_name('SMS.f19_g16.2000_DATM%QI/A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     CIMEError: ERROR: Invalid compset name 2000_DATM%QI/A_XLND_SICE_SOCN_XROF_XGLC_SWAV

--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -7,7 +7,7 @@ import logging
 import xml.etree.ElementTree as xmlet
 
 import CIME.utils
-from CIME.utils import expect, Timeout, run_cmd_no_fail, safe_copy
+from CIME.utils import expect, Timeout, run_cmd_no_fail, safe_copy, CIMEError
 from CIME.XML.machines import Machines
 from CIME.test_status import *
 
@@ -189,7 +189,7 @@ def create_cdash_xml_fakes(results, cdash_build_name, cdash_build_group, utc_tim
     first_result_case = os.path.dirname(list(results.items())[0][1][0])
     try:
         srcroot = run_cmd_no_fail("./xmlquery --value CIMEROOT", from_dir=first_result_case)
-    except:
+    except CIMEError:
         # Use repo containing this script as last resort
         srcroot = CIME.utils.get_cime_root()
 
@@ -355,7 +355,7 @@ def wait_for_test(test_path, results, wait, check_throughput, check_memory, igno
     try:
         fd = open(test_log_path, "w")
         fd.close()
-    except:
+    except (IOError, OSError):
         test_log_path = "/dev/null"
 
     prior_ts = None
@@ -414,7 +414,7 @@ def wait_for_tests_impl(test_paths, no_wait=False, check_throughput=False, check
             if (test_status == prior_status):
                 logging.warning("Test name '{}' was found in both '{}' and '{}'".format(test_name, test_path, prior_path))
             else:
-                raise SystemExit("Test name '{}' was found in both '{}' and '{}' with different results".format(test_name, test_path, prior_path))
+                raise CIMEError("Test name '{}' was found in both '{}' and '{}' with different results".format(test_name, test_path, prior_path))
 
         test_results[test_name] = (test_path, test_status)
         completed_test_paths.append(test_path)

--- a/scripts/lib/e3sm_cime_mgmt.py
+++ b/scripts/lib/e3sm_cime_mgmt.py
@@ -1,4 +1,4 @@
-from CIME.utils import run_cmd, run_cmd_no_fail, expect, get_timestamp
+from CIME.utils import run_cmd, run_cmd_no_fail, expect, get_timestamp, CIMEError
 
 import getpass, logging, os
 
@@ -97,7 +97,7 @@ def reset_file(version, srcpath, dstpath):
     os.remove(dstpath)
     try:
         run_cmd_no_fail("git show {}:{} > {}".format(version, srcpath, dstpath))
-    except:
+    except CIMEError:
         # If the above failes, then the file was deleted
         run_cmd_no_fail("git rm -f {}".format(dstpath))
     else:
@@ -203,7 +203,7 @@ def e3sm_cime_split(resume, squash=False, auto_conf=False):
             pr_branch = do_subtree_split(new_split_tag, merge_tag)
 
             run_cmd_no_fail("git checkout {}".format(pr_branch), verbose=True)
-        except:
+        except BaseException:
             # If unexpected failure happens, delete new split tag
             logging.info("Abandoning split due to unexpected failure")
             delete_tag(new_split_tag)
@@ -231,7 +231,7 @@ def e3sm_cime_merge(resume, squash=False, auto_conf=False):
             new_merge_tag = make_new_merge_tag(old_merge_tag)
 
             pr_branch = make_pr_branch(get_branch_from_tag(new_merge_tag), "origin/master")
-        except:
+        except BaseException:
             logging.info("Abandoning merge due to unexpected failure")
             delete_tag(new_merge_tag, remote=ESMCI_REMOTE_NAME)
             raise

--- a/scripts/lib/get_tests.py
+++ b/scripts/lib/get_tests.py
@@ -11,7 +11,7 @@ _ALL_TESTS = {}
 try:
     from tests import _TESTS # pylint: disable=import-error
     _ALL_TESTS.update(_TESTS)
-except:
+except ImportError:
     pass
 
 # Here are the tests belonging to e3sm suites. Format is
@@ -201,7 +201,7 @@ def get_full_test_names(testargs, machine, compiler):
         else:
             try:
                 tests_to_run.add(CIME.utils.get_full_test_name(testarg, machine=machine, compiler=compiler))
-            except:
+            except Exception:
                 if "." not in testarg:
                     expect(False, "Unrecognized test suite '{}'".format(testarg))
                 else:

--- a/scripts/query_config
+++ b/scripts/query_config
@@ -195,7 +195,7 @@ def parse_command_line(args, description):
     for comp_interface in tmp_comp_interfaces:
         try:
             components = get_components(files[comp_interface])
-        except:
+        except Exception:
             supported_comp_interfaces.remove(comp_interface)
 
         for comp in components:

--- a/tools/load_balancing_tool/load_balancing_submit.py
+++ b/tools/load_balancing_tool/load_balancing_submit.py
@@ -205,15 +205,13 @@ def load_balancing_submit(compset, res, pesfile, mpilib, compiler, project, mach
                           extra_options_file, test_id, force_purge, test_root):
 ################################################################################
     # Read in list of pes from given file
-    if not os.access(pesfile, os.R_OK):
-        logger.critical('ERROR: File %s not found', pesfile)
-        raise SystemExit(1)
+    expect(os.access(pesfile, os.R_OK), 'ERROR: File %s not found', pesfile)
+
     logger.info('Reading XML file %s. Searching for pesize entries:', pesfile)
     try:
         pesobj = Pes(pesfile)
     except ParseError:
-        logger.critical('ERROR: File %s not parseable', pesfile)
-        raise SystemExit(1)
+        expect(False, 'ERROR: File %s not parseable', pesfile)
 
     pesize_list = []
     grid_nodes = pesobj.get_children("grid")
@@ -229,9 +227,7 @@ def load_balancing_submit(compset, res, pesfile, mpilib, compiler, project, mach
                     logger.critical('pesize %s duplicated in file %s', pesize, pesfile)
                 pesize_list.append(pesize)
 
-    if not pesize_list:
-        logger.critical('ERROR: No grid entries found in pes file %s', pesfile)
-        raise SystemExit(1)
+    expect(pesize_list, 'ERROR: No grid entries found in pes file {}'.format(pesfile))
 
     machobj = Machines(machine=machine)
     if test_root is None:


### PR DESCRIPTION
Our default CIME error was SystemExit, which was nice for
avoiding tracebacks, but very bad in that it's not a subclass of
Exception. This forced us to use bare excepts and catches for BaseException.

The new CIME error is CIMEError, which is both a SystemExit error and
an Exception.

There are still a few places where we catch BaseException, these are
places where we want to do cleanup, even in the presense of a KeyboardInterrupt.
These places should almost always re-raise after cleanup because keyboard
interrupts should not be swallowed.

Get rid of all bare excepts.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #2947 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b @billsacks 
