### PR TITLE
Fix nag & pgi CAM COSP build

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -483,8 +483,11 @@ FFLAGS_NOOPT += $(FPPDEFS)
 
 
 ifeq ($(findstring -cosp,$(CAM_CONFIG_OPTS)),-cosp)
-# The following is for the COSP simulator code:
-COSP_LIBDIR:=$(abspath $(EXEROOT)/atm/obj/cosp)
+  # The following is for the COSP simulator code:
+  COSP_LIBDIR:=$(abspath $(EXEROOT)/atm/obj/cosp)
+  ifeq ($(MODEL),driver)
+    INCLDIR+=-I$(COSP_LIBDIR)
+  endif
 endif
 
 ifeq ($(MODEL),cam)


### PR DESCRIPTION
The nag and pgi compilers were failing to include the COSP modules.  The Makefile was updated to
add the include path to COSP, as needed.

Test suite:  scripts_regression_tests, SMS_Ln9.f10_f10_mg37.F2000climo.hobart_intel.cam-cosp
                 SMS_Ln9.f10_f10_mg37.F2000climo.hobart_nag.cam-cosp
                 SMS_Ln9.f10_f10_mg37.F2000climo.hobart_pgi.cam-cosp
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
