### PR TITLE
improve the logic of the continue run check

### DIFF
--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -8,11 +8,11 @@ submit, check_case and check_da_settings are members of class Case in file case.
 """
 from six.moves                      import configparser
 from CIME.XML.standard_module_setup import *
-from CIME.utils                     import expect, run_and_log_case_status, verbatim_success_msg, CASE_SUCCESS, does_file_have_string, CIMEError
+from CIME.utils                     import expect, run_and_log_case_status, verbatim_success_msg, CIMEError
 from CIME.locked_files              import unlock_file, lock_file
 from CIME.test_status               import *
 
-import socket, glob
+import socket
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,6 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
     # Check if CONTINUE_RUN value makes sense
     if job != "case.test" and case.get_value("CONTINUE_RUN"):
         rundir = case.get_value("RUNDIR")
-        caseroot = case.get_value("CASEROOT")
         expect(os.path.isdir(rundir),
                "CONTINUE_RUN is true but RUNDIR {} does not exist".format(rundir))
         expect(os.path.exists(os.path.join(rundir,"rpointer.drv")),

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -35,10 +35,16 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
         caseroot = case.get_value("CASEROOT")
         expect(os.path.isdir(rundir),
                "CONTINUE_RUN is true but RUNDIR {} does not exist".format(rundir))
-        expect(len(glob.glob(os.path.join(rundir, "*.nc"))) > 0,
-               "CONTINUE_RUN is true but this case does not appear to have been run before (no .nc files in RUNDIR)")
-        expect(does_file_have_string(os.path.join(caseroot, "CaseStatus"), "case.run {}".format(CASE_SUCCESS)),
-               "CONTINUE_RUN is true but this case does not appear to have ever run successfully")
+        expect(os.path.exists(os.path.join(rundir,"rpointer.drv")),
+               "CONTINUE_RUN is true but this case does not appear to have restart files staged in {}".format(rundir))
+        # Finally we open the rpointer.drv file and check that it's correct
+        casename = case.get_value("CASE")
+        with open(os.path.join(rundir,"rpointer.drv"), "r") as fd:
+            ncfile = fd.readline().strip()
+            expect(ncfile.startswith(casename) and
+                   os.path.exists(os.path.join(rundir,ncfile)),
+                   "File {ncfile} not present or does not match case {casename}".
+                   format(ncfile=os.path.join(rundir,ncfile),casename=casename))
 
     # if case.submit is called with the no_batch flag then we assume that this
     # flag will stay in effect for the duration of the RESUBMITs


### PR DESCRIPTION
Improve the logic in case.submit for whether a run can be continued or not.  This test
looks for rpointer.drv which should always be present in the run directory for a restart run,
it then looks for the netcdf file listed in that rpointer file and makes sure that the case name matches and the file is present.  These are all necessary conditions for a restart, however the test is not exhaustive and some checks are still left for runtime.  

Test suite: scripts_regression_tests.py, hand testing of specific issue 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2954 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
