### PR TITLE
List mpi-serial's include directory before any system-level includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,11 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/mct/mpeu)
 link_directories(${CMAKE_CURRENT_BINARY_DIR}/mct/mct)
 link_directories(${CMAKE_CURRENT_BINARY_DIR}/mct/mpeu)
 if (USE_MPI_SERIAL)
-  include_directories(${CMAKE_CURRENT_BINARY_DIR}/mct/mpi-serial)
-  link_directories(${CMAKE_CURRENT_BINARY_DIR}/mct/mpi-serial)
+  # We need to list the mpi-serial include directory before system-level
+  # directories so that we're sure to use mpi-serial's mpif.h instead of
+  # an mpif.h from a system path.
+  include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/mct/mpi-serial)
+  link_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/mct/mpi-serial)
 endif()
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
Without this, I was getting runtime failures on my new mac, using
gcc/gfortran 8.2.0 and cmake 3.13.2. The problem was that it seemed to
be picking up /usr/local/include/mpif.h rather than the mpif.h from
mpi-serial.

I'm not sure why this problem suddenly appeared on my new machine: both
my new and old machines had -I/usr/local/include before the mpi-serial
include directory, and both had an mpif.h in /usr/local/include. So I'm
not sure why this issue didn't appear on my old machine, too. Similarly,
I can't understand why both the old and new versions work on both
cheyenne and hobart, but they do.

Test suite:
- In this version off of maint-5.6: Fortran unit tests on my new mac and
  cheyenne
- In version rebased onto master: Fortran unit tests on my new mac, my
  old mac, cheyenne and hobart
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
