### PR TITLE
case.cmpgen_namelists needs to be able to write to the case

### DIFF
--- a/scripts/Tools/case.cmpgen_namelists
+++ b/scripts/Tools/case.cmpgen_namelists
@@ -52,7 +52,7 @@ def _main_func(description):
 ###############################################################################
     caseroot, compare, generate, compare_name, generate_name, baseline_root \
         = parse_command_line(sys.argv, description)
-    with Case(caseroot, read_only=True) as case:
+    with Case(caseroot, read_only=False) as case:
         success = case.case_cmpgen_namelists(compare, generate, compare_name, generate_name, baseline_root)
 
     sys.exit(0 if success else CIME.utils.TESTS_FAILED_ERR_CODE)


### PR DESCRIPTION
case.cmpgen_namelists is expected to write case namelist files and so needs to have read_only=False

Test suite: scripts_regression_tests.py, hand testing of cesm cases
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2953 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
