### PR TITLE
Remove support for CLM4.0

### DIFF
--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -387,8 +387,7 @@
       <value component="cam"      >$COMP_ROOT_DIR_ATM/bld/namelist_files/namelist_definition.xml</value>
       <value component="cism"     >$COMP_ROOT_DIR_GLC/bld/namelist_files/namelist_definition_cism.xml</value>
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/namelist_definition_cice.xml</value>
-      <value component="clm"      >$COMP_ROOT_DIR_LND/bld/namelist_files/namelist_definition_clm4_5.xml</value>
-      <value component="clm"      >$COMP_ROOT_DIR_LND/bld/namelist_files/namelist_definition_clm4_0.xml</value>
+      <value component="clm"      >$COMP_ROOT_DIR_LND/bld/namelist_files/namelist_definition_ctsm.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_pop.xml</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_mom.xml</value>
       -->

--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -109,13 +109,6 @@
     </values>
   </entry>
   -->
-<!--  <entry id="LND_PIO_REARRANGER">
-    <values>
-      <value compset="_CLM40" >2</value>
-      <value compset="_CLM45" >1</value>
-      <value compset="_CLM50" >1</value>
-    </values>
-  </entry> -->
 
   <!--- uncomment and fill in relevant sections
   <entry id="LND_PIO_STRIDE">

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -813,9 +813,8 @@ test_esmf: test_esmf.o
 #-------------------------------------------------------------------------------
 # create list of component libraries - hard-wired for current ccsm components
 #-------------------------------------------------------------------------------
-CLMVER = $(filter $(CLM_CONFIG_OPTS), clm5_0 clm4_5)
 ifeq ($(CIME_MODEL),cesm)
-  ifneq ($(CLMVER),$(null))
+  ifeq ($(COMP_LND),clm)
     USE_SHARED_CLM=TRUE
   else
     USE_SHARED_CLM=FALSE
@@ -826,10 +825,10 @@ endif
 ifeq ($(USE_SHARED_CLM),FALSE)
   LNDOBJDIR = $(EXEROOT)/lnd/obj
   LNDLIBDIR=$(LIBROOT)
-  ifeq ($(CLMVER),$(null))
-    LNDLIB := liblnd.a
-  else
+  ifeq ($(COMP_LND),clm)
     LNDLIB := libclm.a
+  else
+    LNDLIB := liblnd.a
   endif
   INCLDIR += -I$(LNDOBJDIR)
 else

--- a/scripts/lib/CIME/SystemTests/README
+++ b/scripts/lib/CIME/SystemTests/README
@@ -140,7 +140,7 @@ ICP    cice performance test
     SPINUP tests
 ======================================================================
 
-SSP    smoke CLM spinup test (only valid for CLM compsets with CLM45 and CN or BGC)  (TODO - change to SPL)
+SSP    smoke CLM spinup test (only valid for CLM compsets with CN or BGC)  (TODO - change to SPL)
        do an initial spin test (setting CLM_BLDNML_OTPS to -bgc_spinup_on)
          write restarts at the end of the run
          short term archiving is on

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -10,7 +10,7 @@ from CIME.locked_files          import lock_file, unlock_file
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
+def _build_model(build_threaded, exeroot, incroot, complist,
                  lid, caseroot, cimeroot, compiler, buildlist, comp_interface):
 ###############################################################################
     logs = []
@@ -30,14 +30,10 @@ def _build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
             continue
 
         # special case for clm
-        # clm 4_0 is not a shared (as in sharedlibs, shared by all tests) library and must be built here
-        # clm 4_5 and newer is a shared library (but not in E3SM) and should be built in build_libraries
-        if get_model() != "e3sm":
-            if comp == "clm":
-                if "clm4_0" in clm_config_opts:
-                    logger.info("         - Building clm4_0 Library ")
-                else:
-                    continue
+        # clm 4_5 and newer is a shared (as in sharedlibs, shared by all tests) library
+        # (but not in E3SM) and should be built in build_libraries
+        if get_model() != "e3sm" and comp == "clm":
+            continue
         else:
             logger.info("         - Building {} Library ".format(model))
 
@@ -253,9 +249,8 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
     # clm not a shared lib for E3SM
     if get_model() != "e3sm" and (buildlist is None or "lnd" in buildlist):
         comp_lnd = case.get_value("COMP_LND")
-        clm_config_opts = case.get_value("CLM_CONFIG_OPTS")
-        if comp_lnd == "clm" and "clm4_0" not in clm_config_opts:
-            logging.info("         - Building clm4_5/clm5_0 Library ")
+        if comp_lnd == "clm":
+            logging.info("         - Building clm library ")
             esmfdir = "esmf" if case.get_value("USE_ESMF_LIB") else "noesmf"
             bldroot = os.path.join(sharedlibroot, sharedpath, comp_interface, esmfdir, "clm","obj" )
             libroot = os.path.join(exeroot, sharedpath, comp_interface, esmfdir, "lib")
@@ -331,7 +326,6 @@ def _clean_impl(case, cleanlist, clean_all, clean_depends):
         gmake           = case.get_value("GMAKE")
         caseroot        = os.path.abspath(case.get_value("CASEROOT"))
         casetools       = case.get_value("CASETOOLS")
-        clm_config_opts = case.get_value("CLM_CONFIG_OPTS")
 
         os.environ["DEBUG"]           = stringify_bool(debug)
         os.environ["USE_ESMF_LIB"]    = stringify_bool(use_esmf_lib)
@@ -339,7 +333,6 @@ def _clean_impl(case, cleanlist, clean_all, clean_depends):
         os.environ["CASEROOT"]        = caseroot
         os.environ["COMP_INTERFACE"]  = case.get_value("COMP_INTERFACE")
         os.environ["PIO_VERSION"]     = str(case.get_value("PIO_VERSION"))
-        os.environ["CLM_CONFIG_OPTS"] = clm_config_opts  if clm_config_opts is not None else ""
 
         cmd = gmake + " -f " + os.path.join(casetools, "Makefile")
         if cleanlist is not None:
@@ -433,7 +426,6 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
     cism_use_trilinos   = case.get_value("CISM_USE_TRILINOS")
     mali_use_albany     = case.get_value("MALI_USE_ALBANY")
     use_moab            = case.get_value("USE_MOAB")
-    clm_config_opts     = case.get_value("CLM_CONFIG_OPTS")
     cam_config_opts     = case.get_value("CAM_CONFIG_OPTS")
     pio_config_opts     = case.get_value("PIO_CONFIG_OPTS")
     ninst_value         = case.get_value("NINST_VALUE")
@@ -456,7 +448,6 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
     os.environ["MPILIB"]               = mpilib
     os.environ["DEBUG"]                = stringify_bool(debug)
     os.environ["OS"]                   = os_
-    os.environ["CLM_CONFIG_OPTS"]      = clm_config_opts     if clm_config_opts     is not None else ""
     os.environ["CAM_CONFIG_OPTS"]      = cam_config_opts     if cam_config_opts     is not None else ""
     os.environ["PIO_CONFIG_OPTS"]      = pio_config_opts     if pio_config_opts     is not None else ""
     os.environ["OCN_SUBMODEL"]         = ocn_submodel        if ocn_submodel        is not None else ""
@@ -521,7 +512,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
 
     if not sharedlib_only:
         os.environ["INSTALL_SHAREDPATH"] = os.path.join(exeroot, sharedpath) # for MPAS makefile generators
-        logs.extend(_build_model(build_threaded, exeroot, clm_config_opts, incroot, complist,
+        logs.extend(_build_model(build_threaded, exeroot, incroot, complist,
                                 lid, caseroot, cimeroot, compiler, buildlist, comp_interface))
 
         if not buildlist:

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -508,16 +508,11 @@
 
   <entry id="GLC_NEC">
     <type>integer</type>
-    <valid_values>0,1,3,5,10,36</valid_values>
+    <valid_values>1,3,5,10,36</valid_values>
     <default_value>10</default_value>
-    <values match="last">
-      <value compset="_CLM40.*_SGLC">0</value>
-    </values>
     <group>run_glc</group>
     <file>env_run.xml</file>
     <desc>Number of glacier elevation classes used in CLM.
-    0 implies no glacier_mec (glacier multiple elevation classes)
-    landunit in CLM. 0 is only valid for CLM40.
     Used by both CLM and the coupler (even if CISM is not running, and only SGLC is used).</desc>
   </entry>
 
@@ -526,8 +521,7 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values match="last">
-      <value compset="_CLM45.+CISM\d">TRUE</value>
-      <value compset="_CLM50.+CISM\d">TRUE</value>
+      <value compset="_CLM.+CISM\d">TRUE</value>
       <!-- Turn on two-way coupling for TG compsets - even though there are no
            feedbacks for a TG compset, this will give us additional diagnostics -->
       <value compset="_DLND.+CISM\d">TRUE</value>

--- a/src/drivers/nuopc/cime_config/config_component_cesm.xml
+++ b/src/drivers/nuopc/cime_config/config_component_cesm.xml
@@ -474,16 +474,11 @@
 
   <entry id="GLC_NEC">
     <type>integer</type>
-    <valid_values>0,1,3,5,10,36</valid_values>
+    <valid_values>1,3,5,10,36</valid_values>
     <default_value>10</default_value>
-    <values match="last">
-      <value compset="_CLM40.*_SGLC">0</value>
-    </values>
     <group>run_glc</group>
     <file>env_run.xml</file>
     <desc>Number of glacier elevation classes used in CLM.
-    0 implies no glacier_mec (glacier multiple elevation classes)
-    landunit in CLM. 0 is only valid for CLM40.
     Used by both CLM and the coupler (even if CISM is not running, and only SGLC is used).</desc>
   </entry>
 
@@ -492,8 +487,7 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values match="last">
-      <value compset="_CLM45.+CISM\d">TRUE</value>
-      <value compset="_CLM50.+CISM\d">TRUE</value>
+      <value compset="_CLM.+CISM\d">TRUE</value>
       <!-- Turn on two-way coupling for TG compsets - even though there are no
            feedbacks for a TG compset, this will give us additional diagnostics -->
       <value compset="_DLND.+CISM\d">TRUE</value>


### PR DESCRIPTION
CLM4.0 is being dropped in CESM, and has already been dropped in
E3SM. This commit removes some of the complexity related to supporting
that old version of CLM.

This commit completely removes support for CLM4.0 for CESM. For E3SM,
support is removed in files that are shared between CESM and E3SM, but I
have not made any changes to E3SM-specific files.

A key change was in the build: we no longer need to distinguish between
CLM4.0 vs. later versions of CLM in setting some build options (but I
think that we *do* still need to determine whether we're running with
CLM or some other land model, including dlnd/slnd/xlnd, so some
CLM-specific logic still remains in the Makefile).

This change is backwards-incompatible with respect to CLM4.0 support,
but should be backwards compatible for cases using later versions of
CLM, as well as cases using other land components.

Test suite: `scripts_regression_tests` on cheyenne
Also ran most of the `aux_clm` test suite in the context of
https://github.com/ESCOMP/ctsm/pull/609 (note that that used a version
of this cime branch rebased onto cime5.7.5)
Test baseline: For `aux_clm` test suite, used previous ctsm tag
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#2963

User interface changes?: Drops support for CLM4.0

Update gh-pages html (Y/N)?: N

Code review: 
