### PR TITLE
Fix Case context manager enforcement

### DIFF
--- a/scripts/lib/CIME/SystemTests/dae.py
+++ b/scripts/lib/CIME/SystemTests/dae.py
@@ -83,13 +83,15 @@ class DAE(SystemTestsCompareTwo):
         # End for
 
         # CONTINUE_RUN ends up TRUE, set it back in case this is a re-run.
-        self._case.set_value("CONTINUE_RUN", False)
-        # Turn off post DA in case this is a re-run
-        for comp in self._case.get_values("COMP_CLASSES"):
-            if comp == "ESP":
-                continue
-            else:
-                self._case.set_value("DATA_ASSIMILATION_{}".format(comp), False)
+        with self._case:
+            self._case.set_value("CONTINUE_RUN", False)
+            # Turn off post DA in case this is a re-run
+            for comp in self._case.get_values("COMP_CLASSES"):
+                if comp == "ESP":
+                    continue
+                else:
+                    self._case.set_value("DATA_ASSIMILATION_{}".format(comp), False)
+
         # Start normal run here
         self._activate_case1()
         SystemTestsCompareTwo.run_phase(self)

--- a/scripts/lib/CIME/SystemTests/eri.py
+++ b/scripts/lib/CIME/SystemTests/eri.py
@@ -85,13 +85,13 @@ class ERI(SystemTestsCommon):
         logger.info("  writing restarts at {} {}".format(rest_n1, stop_option))
         logger.info("  short term archiving is on ")
 
-        clone1.set_value("CONTINUE_RUN", False)
-        clone1.set_value("RUN_STARTDATE", start_1)
-        clone1.set_value("STOP_N", stop_n1)
-        clone1.set_value("REST_OPTION", stop_option)
-        clone1.set_value("REST_N", rest_n1)
-        clone1.set_value("HIST_OPTION", "never")
-        clone1.flush()
+        with clone1:
+            clone1.set_value("CONTINUE_RUN", False)
+            clone1.set_value("RUN_STARTDATE", start_1)
+            clone1.set_value("STOP_N", stop_n1)
+            clone1.set_value("REST_OPTION", stop_option)
+            clone1.set_value("REST_N", rest_n1)
+            clone1.set_value("HIST_OPTION", "never")
 
         dout_sr1 = clone1.get_value("DOUT_S_ROOT")
 
@@ -100,12 +100,14 @@ class ERI(SystemTestsCommon):
             if "inithist" not in open("user_nl_cam", "r").read():
                 with open("user_nl_cam", "a") as fd:
                     fd.write("inithist = 'ENDOFRUN'\n")
-        clone1.case_setup(test_mode=True, reset=True)
-        # if the initial case is hybrid this will put the reference data in the correct location
-        clone1.check_all_input_data()
 
-        self._skip_pnl = False
-        self.run_indv(st_archive=True, suffix=None)
+        with clone1:
+            clone1.case_setup(test_mode=True, reset=True)
+            # if the initial case is hybrid this will put the reference data in the correct location
+            clone1.check_all_input_data()
+
+            self._skip_pnl = False
+            self.run_indv(st_archive=True, suffix=None)
 
         #
         # (2) Test run:
@@ -127,19 +129,19 @@ class ERI(SystemTestsCommon):
         logger.info("  short term archiving is on ")
 
         # setup ref2 case
-        clone2.set_value("RUN_TYPE",      "hybrid")
-        clone2.set_value("RUN_STARTDATE", start_2)
-        clone2.set_value("RUN_REFCASE",   "{}.ref1".format(orig_casevar))
-        clone2.set_value("RUN_REFDATE",   refdate_2)
-        clone2.set_value("RUN_REFTOD",    refsec_2)
-        clone2.set_value("GET_REFCASE",   False)
-        clone2.set_value("CONTINUE_RUN",  False)
-        clone2.set_value("STOP_N",        stop_n2)
-        clone2.set_value("REST_OPTION",   stop_option)
-        clone2.set_value("REST_N",        rest_n2)
-        clone2.set_value("HIST_OPTION",   stop_option)
-        clone2.set_value("HIST_N",        hist_n)
-        clone2.flush()
+        with clone2:
+            clone2.set_value("RUN_TYPE",      "hybrid")
+            clone2.set_value("RUN_STARTDATE", start_2)
+            clone2.set_value("RUN_REFCASE",   "{}.ref1".format(orig_casevar))
+            clone2.set_value("RUN_REFDATE",   refdate_2)
+            clone2.set_value("RUN_REFTOD",    refsec_2)
+            clone2.set_value("GET_REFCASE",   False)
+            clone2.set_value("CONTINUE_RUN",  False)
+            clone2.set_value("STOP_N",        stop_n2)
+            clone2.set_value("REST_OPTION",   stop_option)
+            clone2.set_value("REST_N",        rest_n2)
+            clone2.set_value("HIST_OPTION",   stop_option)
+            clone2.set_value("HIST_N",        hist_n)
 
         rundir2 = clone2.get_value("RUNDIR")
         dout_sr2 = clone2.get_value("DOUT_S_ROOT")
@@ -147,10 +149,11 @@ class ERI(SystemTestsCommon):
         _helper(dout_sr1, refdate_2, refsec_2, rundir2)
 
         # run ref2 case (all component history files will go to short term archiving)
-        clone2.case_setup(test_mode=True, reset=True)
+        with clone2:
+            clone2.case_setup(test_mode=True, reset=True)
 
-        self._skip_pnl = False
-        self.run_indv(suffix="hybrid", st_archive=True)
+            self._skip_pnl = False
+            self.run_indv(suffix="hybrid", st_archive=True)
 
         #
         # (3a) Test run:

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -173,33 +173,37 @@ class SystemTestsCompareTwo(SystemTestsCommon):
     # ========================================================================
 
     def build_phase(self, sharedlib_only=False, model_only=False):
-        if self._separate_builds:
-            self._activate_case1()
-            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-            self._activate_case2()
-            # Although we're doing separate builds, it still makes sense
-            # to share the sharedlibroot area with case1 so we can reuse
-            # pieces of the build from there.
-            if get_model() != "e3sm":
-                # We need to turn off this change for E3SM because it breaks
-                # the MPAS build system
-                self._case2.set_value("SHAREDLIBROOT",
-                                      self._case1.get_value("SHAREDLIBROOT"))
+        # Subtle issue: case1 is already in a writeable state since it tends to be opened
+        # with a with statement in all the API entrances in CIME. case2 was created via clone,
+        # not a with statement, so it's not in a writeable state, so we need to use a with
+        # statement here to put it in a writeable state.
+        with self._case2:
+            if self._separate_builds:
+                self._activate_case1()
+                self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+                self._activate_case2()
+                # Although we're doing separate builds, it still makes sense
+                # to share the sharedlibroot area with case1 so we can reuse
+                # pieces of the build from there.
+                if get_model() != "e3sm":
+                    # We need to turn off this change for E3SM because it breaks
+                    # the MPAS build system
+                    self._case2.set_value("SHAREDLIBROOT",
+                                          self._case1.get_value("SHAREDLIBROOT"))
 
-            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-        else:
-            self._activate_case1()
-            self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-            # pio_typename may be changed during the build if the default is not a
-            # valid value for this build, update case2 to reflect this change
-            for comp in self._case1.get_values("COMP_CLASSES"):
-                comp_pio_typename = "{}_PIO_TYPENAME".format(comp)
-                self._case2.set_value(comp_pio_typename, self._case1.get_value(comp_pio_typename))
+                self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+            else:
+                self._activate_case1()
+                self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
+                # pio_typename may be changed during the build if the default is not a
+                # valid value for this build, update case2 to reflect this change
+                for comp in self._case1.get_values("COMP_CLASSES"):
+                    comp_pio_typename = "{}_PIO_TYPENAME".format(comp)
+                    self._case2.set_value(comp_pio_typename, self._case1.get_value(comp_pio_typename))
 
-            # The following is needed when _case_two_setup has a case_setup call
-            # despite sharing the build (e.g., to change NTHRDS)
-            self._case2.set_value("BUILD_COMPLETE",True)
-            self._case2.flush()
+                # The following is needed when _case_two_setup has a case_setup call
+                # despite sharing the build (e.g., to change NTHRDS)
+                self._case2.set_value("BUILD_COMPLETE",True)
 
     def run_phase(self, success_change=False):  # pylint: disable=arguments-differ
         """
@@ -464,12 +468,10 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._case.case_setup(test_mode=False, reset=True)
 
         # Set up case 2
-        self._activate_case2()
-        self._common_setup()
-        self._case_two_setup()
-        # Flush the case so that, if errors occur later, then at least case2 is
-        # in a correct, post-setup state
-        self._case.flush()
+        with self._case2:
+            self._activate_case2()
+            self._common_setup()
+            self._case_two_setup()
 
         # Go back to case 1 to ensure that's where we are for any following code
         self._activate_case1()

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -271,6 +271,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
             logs.append(file_build)
             expect(not thread_bad_results, "\n".join(thread_bad_results))
 
+    case.flush() # python sharedlib subs may have made XML modifications
     return logs
 
 ###############################################################################

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -681,7 +681,7 @@ class Case(object):
         expect(ftype == "env_mach_pes.xml" or ftype == "config_pes", " Do not recognize {} as a valid CIME pes file {}".format(self._pesfile, ftype))
         if ftype == "env_mach_pes.xml":
             new_mach_pes_obj = EnvMachPes(infile=self._pesfile, components=self._component_classes)
-            self.update_env(new_mach_pes_obj, "mach_pes")
+            self.update_env(new_mach_pes_obj, "mach_pes", blow_away=True)
             return new_mach_pes_obj.get_value("TOTALPES")
 
         pesobj = Pes(self._pesfile)
@@ -1410,12 +1410,14 @@ directory, NOT in this subdirectory."""
         expect(new_env_file is not None, "No match found for file type {}".format(ftype))
         self._files = [new_env_file]
 
-    def update_env(self, new_object, env_file):
+    def update_env(self, new_object, env_file, blow_away=False):
         """
         Replace a case env object file
         """
         old_object = self.get_env(env_file)
-        expect(not old_object.needsrewrite, "Potential loss of unflushed changes in {}".format(env_file.filename))
+        if not blow_away:
+            expect(not old_object.needsrewrite, "Potential loss of unflushed changes in {}".format(env_file))
+
         new_object.filename = old_object.filename
         if old_object in self._env_entryid_files:
             self._env_entryid_files.remove(old_object)

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -245,7 +245,7 @@ class Case(object):
         # Important, and subtle: Writability should NOT be copied because
         # this allows the copy to be modified without needing a "with" statement
         # which opens the door to tricky errors such as unflushed writes.
-        newcase._read_only_mode = True
+        newcase._read_only_mode = True # pylint: disable=protected-access
 
         return newcase
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1415,7 +1415,7 @@ directory, NOT in this subdirectory."""
         Replace a case env object file
         """
         old_object = self.get_env(env_file)
-        expect(not old_object.needsrewrite, "Potential loss of unflushed changes in {}".format(env_file))
+        expect(not old_object.needsrewrite, "Potential loss of unflushed changes in {}".format(env_file.filename))
         new_object.filename = old_object.filename
         if old_object in self._env_entryid_files:
             self._env_entryid_files.remove(old_object)

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -194,6 +194,9 @@ class Case(object):
         return False
 
     def read_xml(self):
+        for env_file in self._files:
+            expect(not env_file.needsrewrite, "Potential loss of unflushed changes in {}".format(env_file.filename))
+
         self._env_entryid_files = []
         self._env_entryid_files.append(EnvCase(self._caseroot, components=None, read_only=self._force_read_only))
         components = self._env_entryid_files[0].get_values("COMP_CLASSES")
@@ -238,6 +241,12 @@ class Case(object):
         newcase.set_value("CASEROOT",newcaseroot)
         newcase.set_value("CONTINUE_RUN","FALSE")
         newcase.set_value("RESUBMIT",0)
+
+        # Important, and subtle: Writability should NOT be copied because
+        # this allows the copy to be modified without needing a "with" statement
+        # which opens the door to tricky errors such as unflushed writes.
+        newcase._read_only_mode = True
+
         return newcase
 
     def flush(self, flushall=False):
@@ -369,6 +378,9 @@ class Case(object):
         is returned unless return_file is True, in which case (resolved_value, filename)
         is returned where filename is the name of the modified file.
         """
+        expect(not self._read_only_mode, "Cannot modify case, read_only. "
+               "Case must be opened with read_only=False and can only be modified within a context manager")
+
         if item == "CASEROOT":
             self._caseroot = value
         result = None
@@ -390,6 +402,9 @@ class Case(object):
         """
         Update or create a valid_values entry for item and populate it
         """
+        expect(not self._read_only_mode, "Cannot modify case, read_only. "
+               "Case must be opened with read_only=False and can only be modified within a context manager")
+
         result = None
         for env_file in self._env_entryid_files:
             result = env_file.set_valid_values(item, valid_values)
@@ -1361,7 +1376,7 @@ directory, NOT in this subdirectory."""
         logger.warning("setting case file to {}".format(xmlfile))
         components = self.get_value("COMP_CLASSES")
         new_env_file = None
-        for env_file in self._env_entryid_files:
+        for env_file in self._files:
             if os.path.basename(env_file.filename) == ftype:
                 if ftype == "env_run.xml":
                     new_env_file = EnvRun(infile=xmlfile, components=components)
@@ -1375,33 +1390,32 @@ directory, NOT in this subdirectory."""
                     new_env_file = EnvBatch(infile=xmlfile)
                 elif ftype == "env_test.xml":
                     new_env_file = EnvTest(infile=xmlfile)
+                elif ftype == "env_archive.xml":
+                    new_env_file = EnvArchive(infile=xmlfile)
+                elif ftype == "env_mach_specific.xml":
+                    new_env_file = EnvMachSpecific(infile=xmlfile)
+                else:
+                    expect(False, "No match found for file type {}".format(ftype))
+
             if new_env_file is not None:
                 self._env_entryid_files = []
                 self._env_generic_files = []
-                self._env_entryid_files.append(new_env_file)
-                break
-        if new_env_file is None:
-            for env_file in self._env_generic_files:
-                if os.path.basename(env_file.filename) == ftype:
-                    if ftype == "env_archive.xml":
-                        new_env_file = EnvArchive(infile=xmlfile)
-                    elif ftype == "env_mach_specific.xml":
-                        new_env_file = EnvMachSpecific(infile=xmlfile)
-                    else:
-                        expect(False, "No match found for file type {}".format(ftype))
-                if new_env_file is not None:
-                    self._env_entryid_files = []
-                    self._env_generic_files = []
-                    self._env_generic_files.append(new_env_file)
-                    break
+                if ftype in ["env_archive.xml", "env_mach_specific.xml"]:
+                    self._env_generic_files = [new_env_file]
+                else:
+                    self._env_entryid_files = [new_env_file]
 
-        self._files = self._env_entryid_files + self._env_generic_files
+                break
+
+        expect(new_env_file is not None, "No match found for file type {}".format(ftype))
+        self._files = [new_env_file]
 
     def update_env(self, new_object, env_file):
         """
         Replace a case env object file
         """
         old_object = self.get_env(env_file)
+        expect(not old_object.needsrewrite, "Potential loss of unflushed changes in {}".format(env_file))
         new_object.filename = old_object.filename
         if old_object in self._env_entryid_files:
             self._env_entryid_files.remove(old_object)

--- a/scripts/lib/CIME/case/case_clone.py
+++ b/scripts/lib/CIME/case/case_clone.py
@@ -41,131 +41,133 @@ def create_clone(self, newcaseroot, keepexe=False, mach_dir=None, project=None,
     # *** create case object as deepcopy of clone object ***
     srcroot = os.path.join(newcase_cimeroot,"..")
     newcase = self.copy(newcasename, newcaseroot, newsrcroot=srcroot)
-    newcase.set_value("CIMEROOT", newcase_cimeroot)
+    with newcase:
+        newcase.set_value("CIMEROOT", newcase_cimeroot)
 
-    # if we are cloning to a different user modify the output directory
-    olduser = self.get_value("USER")
-    newuser = os.environ.get("USER")
-    if olduser != newuser:
-        cime_output_root = cime_output_root.replace(olduser, newuser)
-        newcase.set_value("USER", newuser)
-    newcase.set_value("CIME_OUTPUT_ROOT", cime_output_root)
+        # if we are cloning to a different user modify the output directory
+        olduser = self.get_value("USER")
+        newuser = os.environ.get("USER")
+        if olduser != newuser:
+            cime_output_root = cime_output_root.replace(olduser, newuser)
+            newcase.set_value("USER", newuser)
+        newcase.set_value("CIME_OUTPUT_ROOT", cime_output_root)
 
-    # try to make the new output directory and raise an exception
-    # on any error other than directory already exists.
-    if os.path.isdir(cime_output_root):
-        expect(os.access(cime_output_root, os.W_OK), "Directory {} is not writable "
-               "by this user.  Use the --cime-output-root flag to provide a writable "
-               "scratch directory".format(cime_output_root))
-    else:
-        if not os.path.isdir(cime_output_root):
-            os.makedirs(cime_output_root)
+        # try to make the new output directory and raise an exception
+        # on any error other than directory already exists.
+        if os.path.isdir(cime_output_root):
+            expect(os.access(cime_output_root, os.W_OK), "Directory {} is not writable "
+                   "by this user.  Use the --cime-output-root flag to provide a writable "
+                   "scratch directory".format(cime_output_root))
+        else:
+            if not os.path.isdir(cime_output_root):
+                os.makedirs(cime_output_root)
 
-    # determine if will use clone executable or not
-    if keepexe:
-        orig_exeroot = self.get_value("EXEROOT")
-        newcase.set_value("EXEROOT", orig_exeroot)
-        newcase.set_value("BUILD_COMPLETE","TRUE")
-        orig_bld_complete = self.get_value("BUILD_COMPLETE")
-        if not orig_bld_complete:
-            logger.warning("\nWARNING: Creating a clone with --keepexe before building the original case may cause PIO_TYPENAME to be invalid in the clone")
-            logger.warning("Avoid this message by building case one before you clone.\n")
-    else:
-        newcase.set_value("BUILD_COMPLETE","FALSE")
-
-    # set machdir
-    if mach_dir is not None:
-        newcase.set_value("MACHDIR", mach_dir)
-
-    # set exeroot and rundir if requested
-    if exeroot is not None:
-        expect(not keepexe, "create_case_clone: if keepexe is True, "
-               "then exeroot cannot be set")
-        newcase.set_value("EXEROOT", exeroot)
-    if rundir is not None:
-        newcase.set_value("RUNDIR", rundir)
-
-    # Set project id
-    # Note: we do not just copy this from the clone because it seems likely that
-    # users will want to change this sometimes, especially when cloning another
-    # user's case. However, note that, if a project is not given, the fallback will
-    # be to copy it from the clone, just like other xml variables are copied.
-    if project is None:
-        project = self.get_value("PROJECT", subgroup=self.get_primary_job())
-    if project is not None:
-        newcase.set_value("PROJECT", project)
-
-    # create caseroot
-    newcase.create_caseroot(clone=True)
-
-    # Many files in the case will be links back to the source tree
-    # but users may have broken links to modify files locally.  In this case
-    # copy the locally modified file.   We only want to do this for files that
-    # already exist in the clone.
-    #pylint: disable=protected-access
-    self._copy_user_modified_to_clone(self.get_value("CASEROOT"), newcase.get_value("CASEROOT"))
-    self._copy_user_modified_to_clone(self.get_value("CASETOOLS"), newcase.get_value("CASETOOLS"))
-
-    newcase.flush(flushall=True)
-
-    # copy user_ files
-    cloneroot = self.get_case_root()
-    files = glob.glob(cloneroot + '/user_*')
-
-    for item in files:
-        safe_copy(item, newcaseroot)
-
-    # copy SourceMod and Buildconf files
-    # if symlinks exist, copy rather than follow links
-    for casesub in ("SourceMods", "Buildconf"):
-        shutil.copytree(os.path.join(cloneroot, casesub),
-                        os.path.join(newcaseroot, casesub),
-                        symlinks=True)
-
-    # lock env_case.xml in new case
-    lock_file("env_case.xml", newcaseroot)
-
-    # apply user_mods if appropriate
-    newcase_root = newcase.get_value("CASEROOT")
-    if user_mods_dir is not None:
+        # determine if will use clone executable or not
         if keepexe:
-            # If keepexe CANNOT change any env_build.xml variables - so make a temporary copy of
-            # env_build.xml and verify that it has not been modified
-            safe_copy(os.path.join(newcaseroot, "env_build.xml"),
-                      os.path.join(newcaseroot, "LockedFiles", "env_build.xml"))
+            orig_exeroot = self.get_value("EXEROOT")
+            newcase.set_value("EXEROOT", orig_exeroot)
+            newcase.set_value("BUILD_COMPLETE","TRUE")
+            orig_bld_complete = self.get_value("BUILD_COMPLETE")
+            if not orig_bld_complete:
+                logger.warning("\nWARNING: Creating a clone with --keepexe before building the original case may cause PIO_TYPENAME to be invalid in the clone")
+                logger.warning("Avoid this message by building case one before you clone.\n")
+        else:
+            newcase.set_value("BUILD_COMPLETE","FALSE")
 
-        # Now apply contents of user_mods directory
-        apply_user_mods(newcase_root, user_mods_dir, keepexe=keepexe)
+        # set machdir
+        if mach_dir is not None:
+            newcase.set_value("MACHDIR", mach_dir)
 
-        # Determine if env_build.xml has changed
+        # set exeroot and rundir if requested
+        if exeroot is not None:
+            expect(not keepexe, "create_case_clone: if keepexe is True, "
+                   "then exeroot cannot be set")
+            newcase.set_value("EXEROOT", exeroot)
+        if rundir is not None:
+            newcase.set_value("RUNDIR", rundir)
+
+        # Set project id
+        # Note: we do not just copy this from the clone because it seems likely that
+        # users will want to change this sometimes, especially when cloning another
+        # user's case. However, note that, if a project is not given, the fallback will
+        # be to copy it from the clone, just like other xml variables are copied.
+        if project is None:
+            project = self.get_value("PROJECT", subgroup=self.get_primary_job())
+        if project is not None:
+            newcase.set_value("PROJECT", project)
+
+        # create caseroot
+        newcase.create_caseroot(clone=True)
+
+        # Many files in the case will be links back to the source tree
+        # but users may have broken links to modify files locally.  In this case
+        # copy the locally modified file.   We only want to do this for files that
+        # already exist in the clone.
+        #pylint: disable=protected-access
+        self._copy_user_modified_to_clone(self.get_value("CASEROOT"), newcase.get_value("CASEROOT"))
+        self._copy_user_modified_to_clone(self.get_value("CASETOOLS"), newcase.get_value("CASETOOLS"))
+
+        newcase.flush(flushall=True)
+
+        # copy user_ files
+        cloneroot = self.get_case_root()
+        files = glob.glob(cloneroot + '/user_*')
+
+        for item in files:
+            safe_copy(item, newcaseroot)
+
+        # copy SourceMod and Buildconf files
+        # if symlinks exist, copy rather than follow links
+        for casesub in ("SourceMods", "Buildconf"):
+            shutil.copytree(os.path.join(cloneroot, casesub),
+                            os.path.join(newcaseroot, casesub),
+                            symlinks=True)
+
+        # lock env_case.xml in new case
+        lock_file("env_case.xml", newcaseroot)
+
+        # apply user_mods if appropriate
+        newcase_root = newcase.get_value("CASEROOT")
+        if user_mods_dir is not None:
+            if keepexe:
+                # If keepexe CANNOT change any env_build.xml variables - so make a temporary copy of
+                # env_build.xml and verify that it has not been modified
+                safe_copy(os.path.join(newcaseroot, "env_build.xml"),
+                          os.path.join(newcaseroot, "LockedFiles", "env_build.xml"))
+
+            # Now apply contents of user_mods directory
+            apply_user_mods(newcase_root, user_mods_dir, keepexe=keepexe)
+
+            # Determine if env_build.xml has changed
+            if keepexe:
+                success, comment = compare_files(os.path.join(newcaseroot, "env_build.xml"),
+                                                 os.path.join(newcaseroot, "LockedFiles", "env_build.xml"))
+                if not success:
+                    logger.warning(comment)
+                    shutil.rmtree(newcase_root)
+                    expect(False, "env_build.xml cannot be changed via usermods if keepexe is an option: \n "
+                               "Failed to clone case, removed {}\n".format(newcase_root))
+
+        # if keep executable, then remove the new case SourceMods directory and link SourceMods to
+        # the clone directory
         if keepexe:
-            success, comment = compare_files(os.path.join(newcaseroot, "env_build.xml"),
-                                             os.path.join(newcaseroot, "LockedFiles", "env_build.xml"))
-            if not success:
-                logger.warning(comment)
-                shutil.rmtree(newcase_root)
-                expect(False, "env_build.xml cannot be changed via usermods if keepexe is an option: \n "
-                           "Failed to clone case, removed {}\n".format(newcase_root))
+            shutil.rmtree(os.path.join(newcase_root, "SourceMods"))
+            os.symlink(os.path.join(cloneroot, "SourceMods"),
+                       os.path.join(newcase_root, "SourceMods"))
 
-    # if keep executable, then remove the new case SourceMods directory and link SourceMods to
-    # the clone directory
-    if keepexe:
-        shutil.rmtree(os.path.join(newcase_root, "SourceMods"))
-        os.symlink(os.path.join(cloneroot, "SourceMods"),
-                   os.path.join(newcase_root, "SourceMods"))
+        # Update README.case
+        fclone   = open(cloneroot + "/README.case", "r")
+        fnewcase = open(newcaseroot  + "/README.case", "a")
+        fnewcase.write("\n    *** original clone README follows ****")
+        fnewcase.write("\n " +  fclone.read())
 
-    # Update README.case
-    fclone   = open(cloneroot + "/README.case", "r")
-    fnewcase = open(newcaseroot  + "/README.case", "a")
-    fnewcase.write("\n    *** original clone README follows ****")
-    fnewcase.write("\n " +  fclone.read())
+        clonename = self.get_value("CASE")
+        logger.info(" Successfully created new case {} from clone case {} ".format(newcasename, clonename))
 
-    clonename = self.get_value("CASE")
-    logger.info(" Successfully created new case {} from clone case {} ".format(newcasename, clonename))
-
-    newcase.case_setup()
+        newcase.case_setup()
 
     return newcase
+
 # pylint: disable=unused-argument
 def _copy_user_modified_to_clone(self, origpath, newpath):
     """

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -304,7 +304,7 @@ class J_TestCreateNewcase(unittest.TestCase):
             case.set_value("CHARGE_ACCOUNT", "fred")
 
         # this should not fail with a locked file issue
-        run_cmd_assert_result(self, "./case.build",from_dir=testdir, expected_stat=0)
+        run_cmd_assert_result(self, "./case.build", from_dir=testdir)
 
         run_cmd_assert_result(self, "./case.st_archive --test-all", from_dir=testdir)
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -293,6 +293,7 @@ class J_TestCreateNewcase(unittest.TestCase):
         with Case(testdir, read_only=False) as case:
             ntasks = case.get_value("NTASKS_ATM")
             case.set_value("NTASKS_ATM", ntasks+1)
+
         # this should fail with a locked file issue
         run_cmd_assert_result(self, "./case.build",
                               from_dir=testdir, expected_stat=1)
@@ -301,10 +302,22 @@ class J_TestCreateNewcase(unittest.TestCase):
         run_cmd_assert_result(self, "./case.build", from_dir=testdir)
         with Case(testdir, read_only=False) as case:
             case.set_value("CHARGE_ACCOUNT", "fred")
+
         # this should not fail with a locked file issue
         run_cmd_assert_result(self, "./case.build",from_dir=testdir, expected_stat=0)
 
         run_cmd_assert_result(self, "./case.st_archive --test-all", from_dir=testdir)
+
+        # Trying to set values outside of context manager should fail
+        case = Case(testdir, read_only=False)
+        with self.assertRaises(CIMEError):
+            case.set_value("NTASKS_ATM", 42)
+
+        # Trying to read_xml with pending changes should fail
+        with self.assertRaises(CIMEError):
+            with Case(testdir, read_only=False) as case:
+                case.set_value("CHARGE_ACCOUNT", "fouc")
+                case.read_xml()
 
         cls._do_teardown.append(testdir)
 
@@ -404,6 +417,20 @@ class J_TestCreateNewcase(unittest.TestCase):
                               (SCRIPT_DIR, prevtestdir, testdir, cls._testroot),from_dir=SCRIPT_DIR)
 
         cls._do_teardown.append(testdir)
+
+    def test_dd_create_clone_not_writable(self):
+        cls = self.__class__
+
+        testdir = os.path.join(cls._testroot, 'test_create_clone_not_writable')
+        if os.path.exists(testdir):
+            shutil.rmtree(testdir)
+        prevtestdir = cls._testdirs[0]
+        cls._testdirs.append(testdir)
+
+        with Case(prevtestdir, read_only=False) as case1:
+            case2 = case1.create_clone(testdir)
+            with self.assertRaises(CIMEError):
+                case2.set_value("CHARGE_ACCOUNT", "fouc")
 
     def test_e_xmlquery(self):
         # Set script and script path


### PR DESCRIPTION
This is a significant change and needs a close review. The code will be easier to examine if whitespace changes are ignored.

A bug slipped-in some time ago that allowed cases to be
modified outside a context manager. This was allowing errors
to slip in, such as unflushed writes in SystemTestCompareTwo.

This PR also adds tests to ensure this doesn't happen again.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b @billsacks 
