### PR TITLE
update default run_refdir

### DIFF
--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -226,7 +226,7 @@
 
   <entry id="RUN_REFDIR">
     <type>char</type>
-    <default_value>ccsm4_init</default_value>
+    <default_value>cesm2_init</default_value>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
     <desc>


### PR DESCRIPTION
Change the default RUN_REFDIR from ccsm4_init to cesm2_init

Test suite: by hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit,

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
