### PR TITLE
Changes for PGI 18.4

### DIFF
--- a/src/externals/pio1/pio/pionfput_mod.F90.in
+++ b/src/externals/pio1/pio/pionfput_mod.F90.in
@@ -696,9 +696,11 @@ contains
 #endif
 #endif
 #ifdef _NETCDF
+#ifdef _NETCDF4
        case(pio_iotype_netcdf4p)
           ierr=nf90_var_par_access(File%fh, varid, NF90_COLLECTIVE)
           ierr = nf90_put_var(File%fh, varid, ival, start=int(pstart), count=int(pcount))
+#endif
        case(pio_iotype_netcdf, pio_iotype_netcdf4c)
           ! Only io proc 0 will do writing
           if (Ios%io_rank == 0) then

--- a/src/externals/pio1/pio/pionfput_mod.F90.in
+++ b/src/externals/pio1/pio/pionfput_mod.F90.in
@@ -696,11 +696,9 @@ contains
 #endif
 #endif
 #ifdef _NETCDF
-#ifdef _NETCDF4
        case(pio_iotype_netcdf4p)
           ierr=nf90_var_par_access(File%fh, varid, NF90_COLLECTIVE)
           ierr = nf90_put_var(File%fh, varid, ival, start=int(pstart), count=int(pcount))
-#endif
        case(pio_iotype_netcdf, pio_iotype_netcdf4c)
           ! Only io proc 0 will do writing
           if (Ios%io_rank == 0) then

--- a/src/share/util/shr_wv_sat_mod.F90
+++ b/src/share/util/shr_wv_sat_mod.F90
@@ -321,7 +321,7 @@ contains
   subroutine shr_wv_sat_make_one_table(table_spec, svp_function, table)
     type(ShrWVSatTableSpec), intent(in) :: table_spec
     interface
-       function svp_function(t, idx) result(es)
+       pure function svp_function(t, idx) result(es)
          import :: rk
          real(rk), intent(in) :: t
          integer, intent(in) :: idx


### PR DESCRIPTION
        modified:   src/externals/pio1/pio/pionfput_mod.F90.in
        modified:   src/share/util/shr_wv_sat_mod.F90

These are changes needed to compile with PGI 18.4 on ACOM machine.  Have yet to test these changes on other machines/compilers.  Would like to know if these changes make sense to others.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
