### PR TITLE
Better handling of file permissions when copying files

### DIFF
--- a/scripts/lib/CIME/SystemTests/homme.py
+++ b/scripts/lib/CIME/SystemTests/homme.py
@@ -4,9 +4,11 @@ CIME HOMME test. This class inherits from SystemTestsCommon
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.build import post_build
-from CIME.utils import append_testlog
+from CIME.utils import append_testlog, SharedArea
 from CIME.test_status import *
+
 import shutil
+from distutils import dir_util
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +69,8 @@ class HOMME(SystemTestsCommon):
                 if os.path.isdir(full_baseline_dir):
                     shutil.rmtree(full_baseline_dir)
 
-                shutil.copytree(os.path.join(exeroot, "tests", "baseline"), full_baseline_dir)
+                with SharedArea():
+                    dir_util.copy_tree(os.path.join(exeroot, "tests", "baseline"), full_baseline_dir, preserve_mode=False)
 
         elif compare:
             stat = run_cmd("{} -j 4 check".format(gmake), arg_stdout=log, combine_output=True, from_dir=exeroot)[0]

--- a/scripts/lib/CIME/case/case_cmpgen_namelists.py
+++ b/scripts/lib/CIME/case/case_cmpgen_namelists.py
@@ -7,10 +7,11 @@ from CIME.XML.standard_module_setup import *
 
 from CIME.compare_namelists import is_namelist_file, compare_namelist_files
 from CIME.simple_compare import compare_files, compare_runconfigfiles
-from CIME.utils import append_status, safe_copy
+from CIME.utils import append_status, safe_copy, SharedArea
 from CIME.test_status import *
 
 import os, shutil, traceback, stat, glob
+from distutils import dir_util
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ def _do_full_nl_comp(case, test, compare_name, baseline_root=None):
     logging.info(comments)
     return all_match, comments
 
-def _do_full_nl_gen(case, test, generate_name, baseline_root=None):
+def _do_full_nl_gen_impl(case, test, generate_name, baseline_root=None):
     test_dir       = case.get_value("CASEROOT")
     casedoc_dir    = os.path.join(test_dir, "CaseDocs")
     baseline_root  = case.get_value("BASELINE_ROOT") if baseline_root is None else baseline_root
@@ -70,18 +71,18 @@ def _do_full_nl_gen(case, test, generate_name, baseline_root=None):
     if os.path.isdir(baseline_casedocs):
         shutil.rmtree(baseline_casedocs)
 
-    shutil.copytree(casedoc_dir, baseline_casedocs)
-    os.chmod(baseline_casedocs, stat.S_IRWXU | stat.S_IRWXG | stat.S_IXOTH | stat.S_IROTH)
-    for item in glob.glob("{}/*".format(baseline_casedocs)):
-        os.chmod(item, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
+    dir_util.copy_tree(casedoc_dir, baseline_casedocs, preserve_mode=False)
 
     for item in glob.glob(os.path.join(test_dir, "user_nl*")):
         preexisting_baseline = os.path.join(baseline_dir, os.path.basename(item))
         if (os.path.exists(preexisting_baseline)):
             os.remove(preexisting_baseline)
 
-        safe_copy(item, baseline_dir)
-        os.chmod(preexisting_baseline, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
+        safe_copy(item, baseline_dir, preserve_meta=False)
+
+def _do_full_nl_gen(case, test, generate_name, baseline_root=None):
+    with SharedArea():
+        _do_full_nl_gen_impl(case, test, generate_name, baseline_root=baseline_root)
 
 def case_cmpgen_namelists(self, compare=False, generate=False, compare_name=None, generate_name=None, baseline_root=None, logfile_name="TestStatus.log"):
     expect(self.get_value("TEST"), "Only makes sense to run this for a test case")

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -444,13 +444,15 @@ def get_recommended_test_time_based_on_past(baseline_root, test, raw=False):
 def save_test_time(baseline_root, test, time_seconds):
     if baseline_root is not None:
         try:
-            the_dir  = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test)
-            if not os.path.exists(the_dir):
-                os.makedirs(the_dir)
+            with SharedArea():
+                the_dir  = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test)
+                if not os.path.exists(the_dir):
+                    os.makedirs(the_dir)
 
-            the_path = os.path.join(the_dir, _WALLTIME_FILE_NAME)
-            with open(the_path, "a") as fd:
-                fd.write("{}\n".format(int(time_seconds)))
+                the_path = os.path.join(the_dir, _WALLTIME_FILE_NAME)
+                with open(the_path, "a") as fd:
+                    fd.write("{}\n".format(int(time_seconds)))
+
         except Exception:
             # We NEVER want a failure here to kill the run
             logger.warning("Failed to store test time: {}".format(sys.exc_info()[1]))

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -84,19 +84,19 @@ def verify_perms(test_obj, root_dir):
         for filename in files:
             full_path = os.path.join(root, filename)
             st = os.stat(full_path)
-            test_obj.assertTrue(st.st_mode & osstat.S_IWGRP)
-            test_obj.assertTrue(st.st_mode & osstat.S_IRGRP)
-            test_obj.assertTrue(st.st_mode & osstat.S_IROTH)
+            test_obj.assertTrue(st.st_mode & osstat.S_IWGRP, msg="file {} is not group writeable".format(full_path))
+            test_obj.assertTrue(st.st_mode & osstat.S_IRGRP, msg="file {} is not group readable".format(full_path))
+            test_obj.assertTrue(st.st_mode & osstat.S_IROTH, msg="file {} is not world readable".format(full_path))
 
         for dirname in dirs:
             full_path = os.path.join(root, dirname)
             st = os.stat(full_path)
 
-            test_obj.assertTrue(st.st_mode & osstat.S_IWGRP)
-            test_obj.assertTrue(st.st_mode & osstat.S_IRGRP)
-            test_obj.assertTrue(st.st_mode & osstat.S_IXGRP)
-            test_obj.assertTrue(st.st_mode & osstat.S_IROTH)
-            test_obj.assertTrue(st.st_mode & osstat.S_IXOTH)
+            test_obj.assertTrue(st.st_mode & osstat.S_IWGRP, msg="dir {} is not group writable".format(full_path))
+            test_obj.assertTrue(st.st_mode & osstat.S_IRGRP, msg="dir {} is not group readable".format(full_path))
+            test_obj.assertTrue(st.st_mode & osstat.S_IXGRP, msg="dir {} is not group executable".format(full_path))
+            test_obj.assertTrue(st.st_mode & osstat.S_IROTH, msg="dir {} is not world readable".format(full_path))
+            test_obj.assertTrue(st.st_mode & osstat.S_IXOTH, msg="dir {} is not world executable".format(full_path))
 
 ###############################################################################
 class A_RunUnitTests(unittest.TestCase):
@@ -2336,7 +2336,7 @@ class L_TestSaveTimings(TestCreateTestCommon):
             provenance_dirs = glob.glob(os.path.join(timing_dir, "performance_archive", getpass.getuser(), casename, lids[0] + "*"))
             self.assertEqual(len(provenance_dirs), 1, msg="provenance dirs were missing")
 
-        self.verify_perms(self, timing_dir)
+        verify_perms(self, timing_dir)
 
     ###########################################################################
     def test_save_timings(self):


### PR DESCRIPTION
Technique is to make better-use of SharedArea context manager
and copying files such that the user's umask will determine
the permissions of the copy, not the original file's meta data.

distutils.file_util|dir_util allows for more control of file
perms than shutil, so use that instead.

Add preserve_metadata flag to our safe_copy.

Include special exe handling in our safe_copy.

Copies occurring in SharedAreas should almost always have
preserve_metadata set to False.

Add a test to confirm all the above.

Test suite: scripts_regression_tests --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2982 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @billsacks 
