### PR TITLE
Modifications to allow for E3SM developer tests for the SE SCM

### DIFF
--- a/config/e3sm/tests.py
+++ b/config/e3sm/tests.py
@@ -33,6 +33,7 @@ _TESTS = {
                              ("SMS_Ln9.ne4_ne4.FC5AV1C-L", "cam-outfrq9s"),
                              ("SMS.ne4_ne4.FC5AV1C-L", "cam-cosplite"),
                              "SMS_R_Ld5.T42_T42.FSCM5A97",
+                             "SMS_R_Ld5.ne4_ne4.FSCM5A97",
                              "SMS_D_Ln5.ne4_ne4.FC5AV1C-L")
                             ),
 

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -609,9 +609,9 @@ class TestScheduler(object):
                     # For PTS_MODE, set all tasks and threads to 1
                     comps=["ATM","LND","ICE","OCN","CPL","GLC","ROF","WAV"]
 
-                    for c in range(0,len(comps)):
-                        envtest.set_test_parameter("NTASKS_"+comps[c], "1")
-                        envtest.set_test_parameter("NTHRDS_"+comps[c], "1")
+                    for comp in comps:
+                        envtest.set_test_parameter("NTASKS_"+comp, "1")
+                        envtest.set_test_parameter("NTHRDS_"+comp, "1")
 
                 elif (opt.startswith('I') or # Marker to distinguish tests with same name - ignored
                       opt.startswith('M') or # handled in create_newcase

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -613,9 +613,6 @@ class TestScheduler(object):
                         envtest.set_test_parameter("NTASKS_"+comps[c], "1")
                         envtest.set_test_parameter("NTHRDS_"+comps[c], "1")
 
-                    envtest.set_test_parameter("HIST_OPTION", "never")
-                    envtest.set_test_parameter("HIST_N", "-999")
-
                 elif (opt.startswith('I') or # Marker to distinguish tests with same name - ignored
                       opt.startswith('M') or # handled in create_newcase
                       opt.startswith('P') or # handled in create_newcase

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -606,8 +606,15 @@ class TestScheduler(object):
                     #  (SCM) mode
                     envtest.set_test_parameter("PTS_MODE", "TRUE")
 
-                    # For PTS_MODE, compile with mpi-serial
-                    envtest.set_test_parameter("MPILIB", "mpi-serial")
+                    # For PTS_MODE, set all tasks and threads to 1
+                    comps=["ATM","LND","ICE","OCN","CPL","GLC","ROF","WAV"]
+
+                    for c in range(0,len(comps)):
+                        envtest.set_test_parameter("NTASKS_"+comps[c], "1")
+                        envtest.set_test_parameter("NTHRDS_"+comps[c], "1")
+
+                    envtest.set_test_parameter("HIST_OPTION", "never")
+                    envtest.set_test_parameter("HIST_N", "-999")
 
                 elif (opt.startswith('I') or # Marker to distinguish tests with same name - ignored
                       opt.startswith('M') or # handled in create_newcase

--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -100,6 +100,7 @@ module seq_hist_mod
   logical     :: histavg_wav            ! .true.  => write wav fields to average history file
   logical     :: histavg_xao            ! .true.  => write flux xao fields to average history file
 
+  logical     :: single_column
 
   !--- domain equivalent 2d grid size ---
   integer(IN) :: atm_nx, atm_ny         ! nx,ny of 2d grid, if known
@@ -201,6 +202,7 @@ contains
          glc_nx=glc_nx, glc_ny=glc_ny,        &
          wav_nx=wav_nx, wav_ny=wav_ny,        &
          ocn_nx=ocn_nx, ocn_ny=ocn_ny,        &
+         single_column=single_column,         &
          case_name=case_name,                 &
          model_doi_url=model_doi_url)
 
@@ -252,13 +254,17 @@ contains
              gsmap => component_get_gsmap_cx(atm(1))
              dom   => component_get_dom_cx(atm(1))
              call seq_io_write(hist_file, gsmap, dom%data, 'dom_ax',  &
-                  nx=atm_nx, ny=atm_ny, nt=1, whead=whead, wdata=wdata, pre='doma')
+                  nx=atm_nx, ny=atm_ny, nt=1, whead=whead, wdata=wdata, pre='doma', &
+                  scolumn=single_column)
              call seq_io_write(hist_file, gsmap, fractions_ax, 'fractions_ax',  &
-                  nx=atm_nx, ny=atm_ny, nt=1, whead=whead, wdata=wdata, pre='fraca')
+                  nx=atm_nx, ny=atm_ny, nt=1, whead=whead, wdata=wdata, pre='fraca', &
+                  scolumn=single_column)
              call seq_io_write(hist_file, atm, 'x2c', 'x2a_ax', &
-                  nx=atm_nx, ny=atm_ny, nt=1, whead=whead, wdata=wdata, pre='x2a')
+                  nx=atm_nx, ny=atm_ny, nt=1, whead=whead, wdata=wdata, pre='x2a', &
+                  scolumn=single_column)
              call seq_io_write(hist_file, atm, 'c2x', 'a2x_ax', &
-                  nx=atm_nx, ny=atm_ny, nt=1, whead=whead, wdata=wdata, pre='a2x')
+                  nx=atm_nx, ny=atm_ny, nt=1, whead=whead, wdata=wdata, pre='a2x', &
+                  scolumn=single_column)
              !call seq_io_write(hist_file, gsmap, l2x_ax, 'l2x_ax',  &
              !    nx=atm_nx, ny=atm_ny, nt=1, whead=whead, wdata=wdata, pre='l2x_ax')
              !call seq_io_write(hist_file, gsmap, o2x_ax, 'o2x_ax',  &

--- a/src/drivers/mct/main/seq_io_mod.F90
+++ b/src/drivers/mct/main/seq_io_mod.F90
@@ -376,7 +376,7 @@ contains
   ! !INTERFACE: ------------------------------------------------------------------
 
   subroutine seq_io_write_av(filename,gsmap,AV,dname,whead,wdata,nx,ny,nt,fillval,pre,tavg,&
-       use_float, file_ind)
+       use_float, file_ind, scolumn)
 
     ! !INPUT/OUTPUT PARAMETERS:
     implicit none
@@ -394,6 +394,7 @@ contains
     logical,optional,intent(in) :: tavg     ! is this a tavg
     logical,optional,intent(in) :: use_float ! write output as float rather than double
     integer,optional,intent(in) :: file_ind
+    logical,optional,intent(in) :: scolumn ! single column model flag
 
     !EOP
 
@@ -421,6 +422,7 @@ contains
     character(*),parameter :: subName = '(seq_io_write_av) '
     integer, pointer :: Dof(:)
     integer :: lfile_ind
+    logical :: lcolumn
 
     real(r8), allocatable :: tmpdata(:)
 
@@ -440,8 +442,10 @@ contains
 
     lwhead = .true.
     lwdata = .true.
+    lcolumn = .false.
     if (present(whead)) lwhead = whead
     if (present(wdata)) lwdata = wdata
+    if (present(scolumn)) lcolumn = scolumn
 
     if (.not.lwhead .and. .not.lwdata) then
        ! should we write a warning?
@@ -475,7 +479,7 @@ contains
     if (present(ny)) then
        if (ny /= 0) lny = ny
     endif
-    if (lnx*lny /= ng) then
+    if (lnx*lny /= ng .and. .not. lcolumn) then 
        if(iam==0) write(logunit,*) subname,' ERROR: grid2d size not consistent ',ng,lnx,lny,trim(dname)
        call shr_sys_abort(subname//'ERROR: grid2d size not consistent ')
     endif
@@ -562,7 +566,7 @@ contains
   ! !INTERFACE: ------------------------------------------------------------------
 
   subroutine seq_io_write_avs(filename,gsmap,AVS,dname,whead,wdata,nx,ny,nt,fillval,pre,tavg,&
-       use_float,file_ind)
+       use_float,file_ind,scolumn)
 
     ! !INPUT/OUTPUT PARAMETERS:
     implicit none
@@ -580,6 +584,7 @@ contains
     logical,optional,intent(in) :: tavg     ! is this a tavg
     logical,optional,intent(in) :: use_float ! write output as float rather than double
     integer,optional,intent(in) :: file_ind
+    logical,optional,intent(in) :: scolumn ! single column model flag
 
     !EOP
 
@@ -610,6 +615,7 @@ contains
     integer, pointer :: Dof(:)
     integer, pointer :: Dofn(:)
     integer :: lfile_ind
+    logical :: lcolumn
 
     !-------------------------------------------------------------------------------
     !
@@ -627,8 +633,10 @@ contains
 
     lwhead = .true.
     lwdata = .true.
+    lcolumn = .false. 
     if (present(whead)) lwhead = whead
     if (present(wdata)) lwdata = wdata
+    if (present(scolumn)) lcolumn = scolumn
 
     if (.not.lwhead .and. .not.lwdata) then
        ! should we write a warning?
@@ -666,7 +674,7 @@ contains
     if (present(ny)) then
        if (ny /= 0) lny = ny
     endif
-    if (lnx*lny /= ng) then
+    if (lnx*lny /= ng .and. .not. lcolumn) then 
        if(iam==0) write(logunit,*) subname,' ERROR: grid2d size not consistent ',ng,lnx,lny,trim(dname)
        call shr_sys_abort(subname//' ERROR: grid2d size not consistent ')
     endif
@@ -784,7 +792,7 @@ contains
   ! !INTERFACE: ------------------------------------------------------------------
 
   subroutine seq_io_write_avscomp(filename, comp, flow, dname, &
-       whead, wdata, nx, ny, nt, fillval, pre, tavg, use_float, file_ind)
+       whead, wdata, nx, ny, nt, fillval, pre, tavg, use_float, file_ind, scolumn)
 
     ! !INPUT/OUTPUT PARAMETERS:
     implicit none
@@ -802,6 +810,7 @@ contains
     logical          ,optional,intent(in) :: tavg      ! is this a tavg
     logical          ,optional,intent(in) :: use_float ! write output as float rather than double
     integer          ,optional,intent(in) :: file_ind
+    logical          ,optional,intent(in) :: scolumn    ! single column model flag 
 
     !EOP
 
@@ -835,6 +844,7 @@ contains
     integer, pointer         :: Dof(:)
     integer, pointer         :: Dofn(:)
     integer                  :: lfile_ind
+    logical                  :: lcolumn
 
     !-------------------------------------------------------------------------------
     !
@@ -852,8 +862,10 @@ contains
 
     lwhead = .true.
     lwdata = .true.
+    lcolumn = .false. 
     if (present(whead)) lwhead = whead
     if (present(wdata)) lwdata = wdata
+    if (present(scolumn)) lcolumn = scolumn
     frame = -1
     if (present(nt)) then
        frame = nt
@@ -893,7 +905,7 @@ contains
     if (present(ny)) then
        if (ny /= 0) lny = ny
     endif
-    if (lnx*lny /= ng) then
+    if (lnx*lny /= ng .and. .not. lcolumn) then
        if(iam==0) then
           write(logunit,*) subname,' ERROR: grid2d size not consistent ',&
                ng,lnx,lny,trim(dname)


### PR DESCRIPTION
This PR includes modifications to allow for E3SM developer tests for the Spectral Element (SE) version of the Single Column Model (SCM), which will be the default version of the SCM for E3SMv2.  This PR 1) adds the SE SCM test in config/e3sm/tests.py , 2) removes the restriction that the SCM be compiled with mpi-serial mode (will not compile with the SE SCM and no longer a requirement for the Eulerian SCM), and 3) add a single_column logical check in src/drivers/mct/main/seq_io_mod.F90.  In the E3SM SE SCM since the full dynamics grid is initialized but only one physics column is initialized, a shr_sys_abort is called when coupler diagnostics would otherwise be successfully written to history file.  Added a logical check to avoid this abort call when SCM is used.  

Note that required modifications to run the SE SCM test have also be made in a companion E3SM PR.  

Test suite: scripts/test/scripts_regression_tests.py
Along with modifications in the E3SM PR, my e3sm_developer tests for both SE SCM and Eulerian SCM pass (in addition to the full testing suite).  SCM runs using the official E3SM SCM scripts also pass for both dynamical cores.  
Test baseline: 
Test namelist changes: 
Test status: bit for bit 

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
