### PR TITLE
avoid confusing error for cesm

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -83,13 +83,13 @@ endif
 ifeq ($(strip $(USE_ALBANY)), TRUE)
    USE_CXX = true
 endif
-
-HOMME_TARGET ?= $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) CAM_TARGET --value)
-ifeq ($(strip $(HOMME_TARGET)), preqx_kokkos)
-   USE_CXX = true
-   USE_KOKKOS = TRUE
+ifeq ($(CIME_MODEL),e3sm)
+  HOMME_TARGET ?= $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) CAM_TARGET --value)
+  ifeq ($(strip $(HOMME_TARGET)), preqx_kokkos)
+     USE_CXX = true
+     USE_KOKKOS = TRUE
+  endif
 endif
-
 ifeq ($(strip $(USE_FMS)), TRUE)
   SLIBS += -lfms
 endif


### PR DESCRIPTION
Avoid an error message when CIME_MODEL is cesm - CAM_TARGET is not defined. 

Test suite: by hand SMS_D_Ln9.T42_T42.FSCAM.cheyenne_intel.cam-scam_mpace_outfrq9s
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #2991 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
