### PR TITLE
Allow specifying directives to use for an unknown queue

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -201,6 +201,10 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
       <directive> -l select=1:mpiprocs={{ total_tasks }}:ompthreads={{ thread_count }}</directive>
     </directives>
+
+    <!-- Unknown queues use the batch directives for the regular queue -->
+    <unknown_queue_directives>regular</unknown_queue_directives>
+
     <queues>
       <queue walltimemax="12:00" nodemin="1" nodemax="4032">regular</queue>
       <queue walltimemax="12:00" nodemin="1" nodemax="4032">premium</queue>

--- a/config/xml_schemas/config_batch.xsd
+++ b/config/xml_schemas/config_batch.xsd
@@ -29,6 +29,7 @@
   <xs:element name="walltime" type="xs:string"/>
   <xs:element name="dependency" type="xs:string"/>
   <xs:element name="prereq" type="xs:string"/>
+  <xs:element name="unknown_queue_directives" type="xs:string"/>
 
   <!-- complex elements -->
 
@@ -96,6 +97,14 @@
   <!-- directives: A list of fields to provide in the script directives section,
        be careful that these do not conflict with submit_args above -->
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="directives"/>
+
+  <!-- unknown_queue_directives: If the queue is not a known queue on
+       this machine, this specifies the queue name for which directives
+       are taken. i.e., assume that all unknown queues use the same
+       directives as this queue. (If this element is not present then
+       unknown queues use directives for the default queue on this
+       machine.) -->
+        <xs:element minOccurs="0" ref="unknown_queue_directives"/>
 
   <!-- queues: The list of queue options for this machine, not all system queues need be listed
        attributes of this field include walltimemin, walltimemax, nodemin and nodemax and strict

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -326,13 +326,24 @@ class EnvBatch(EnvBase):
         roots = self.get_children("batch_system")
         queue = self.get_value("JOB_QUEUE", subgroup=job)
         if self._batchtype != "none" and not queue in self._get_all_queue_names():
+            unknown_queue = True
             qnode = self.get_default_queue()
-            queue = self.text(qnode)
+            default_queue = self.text(qnode)
+        else:
+            unknown_queue = False
 
         for root in roots:
             if root is not None:
                 if directive_prefix is None:
                     directive_prefix = self.get_element_text("batch_directive", root=root)
+
+                if unknown_queue:
+                    unknown_queue_directives = self.get_element_text("unknown_queue_directives",
+                                                                     root=root)
+                    if unknown_queue_directives is None:
+                        queue = default_queue
+                    else:
+                        queue = unknown_queue_directives
 
                 dnodes = self.get_children("directives", root=root)
                 for dnode in dnodes:


### PR DESCRIPTION
Previously, when using an unknown queue, the batch directives would come
from the default queue for the machine. This is a problem on cheyenne,
for which the default queue is the share queue. It looks like we need to
keep the share queue as the default queue for other purposes, though (in
particular: if the default is the regular queue, then the share queue
won't get selected for small - e.g., single-processor - jobs, since
small jobs also satisfy the requirements of the regular queue), so the
solution is to provide a different mechanism for specifying the queue to
use for the sake of choosing directives.

For machines that don't use this new mechanism, we maintain the previous
behavior of using the directives for the machine's default queue.

Note: I chose this mechanism of pointing to a different queue's
directives section rather than explicitly listing the directives for an
unknown queue, partly because this was easy to implement and partly
because I thought the latter would likely lead to the two getting
accidentally out-of-sync (because people may not think to update the
directives for an unknown queue, and this would likely go untested and
undiscovered for a long time).

Test suite: scripts_regression_tests on cheyenne;
also manual testing on a version off of master,
and on this version off of maint-5.6 (all tests were
with compset A, res f45_g37 on cheyenne, with NTASKS changed to 144):
- Checked .case.run with regular queue: same as before
- Checked .case.run with share queue: same as before
- Checked .case.run with an unknown queue: now same as regular queue
- Checked .case.run with an unknown queue, but with the new
  <unknown_queue_directives> block temporarily removed: same as share
  queue, as before (demonstrating that this change is backwards
  compatible)

Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#2994

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: 