### PR TITLE
update for stand-alone CMIP6 query outside of a caseroot

### DIFF
--- a/scripts/Tools/archive_metadata
+++ b/scripts/Tools/archive_metadata
@@ -1429,13 +1429,6 @@ def main_func(options):
 
     (case_dict, username, password) = initialize_main(options)
 
-    # loop through the _xml_vars gathering values
-    with Case(case_dict['CASEROOT'], read_only=True) as case:
-        if case_dict['dryrun']:
-            logger.info('Dryrun - calling get_case_vars')
-        else:
-            case_dict = get_case_vars(case_dict, case)
-
     # check if query_cmip6 argument is specified
     if options.query_cmip6:
         if case_dict['dryrun']:
@@ -1443,10 +1436,10 @@ def main_func(options):
         else:
             if query_expdb_cmip6(case_dict, username, password):
                 logger.info('Casename "%s" CMIP6 global attribute '\
-                            'metadata written to "./archive_files/%s" ' \
+                            'metadata written to "%s/archive_files/%s" ' \
                             'from "%s"',
-                            case_dict['q_casename'], case_dict['q_outfile'],
-                            case_dict['query_expdb_url'])
+                            case_dict['workdir'], case_dict['q_casename'],
+                            case_dict['q_outfile'], case_dict['query_expdb_url'])
                 logger.info('Successful completion of archive_metadata')
                 sys.exit(0)
             else:
@@ -1454,6 +1447,13 @@ def main_func(options):
                             'in experiments database at "%s".',
                             case_dict['q_casename'], case_dict['query_expdb_url'])
                 sys.exit(1)
+
+    # loop through the _xml_vars gathering values
+    with Case(case_dict['CASEROOT'], read_only=True) as case:
+        if case_dict['dryrun']:
+            logger.info('Dryrun - calling get_case_vars')
+        else:
+            case_dict = get_case_vars(case_dict, case)
 
     # check reserved casename expdb for CMIP6 experiments
     if case_dict['expType'].lower() == 'cmip6':


### PR DESCRIPTION
update to archive_metadata stand-alone functionality so that a Case object is not incorrectly instantiated when the --query_cmip6 command line option is called outside of a caseroot.

Test suite: manual
./archive_metadata --user aliceb@ucar.edu --password --expType CMIP6 --query_cmip6 b.e21.B1PCT.f09_g17.CMIP6-1pctCO2-bgc.001 db.json --workdir $tests/b.e21.B1PCT.f09_g17.CMIP6-1pctCO2-bgc.001_am

Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes [CIME Github issue #] N/A

User interface changes?: None

Update gh-pages html (Y/N)?:N

Code review: 
