### PR TITLE
changes to fix cdash testing

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -552,6 +552,11 @@ using a fortran linker.
     <append> -L/project/s824/edavin/OASIS3-MCT_2.0/build.cray/lib -lpsmile.MPI1 -lscrip -lmct_oasis -lmpeu_oasis </append>
   </SLIBS>
 </compiler>
+<compiler MACH="centos7-linux">
+  <SLIBS>
+    <append> -Wl,-rpath,$(NETCDF_PATH)/lib -lnetcdff -lnetcdf </append>
+  </SLIBS>
+</compiler>
 
 <compiler MACH="cheyenne">
   <CPPDEFS>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -276,7 +276,6 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">compiler/gnu/7.2.0</command>
 	<command name="load">mpi/gcc/mpich-3.2</command>
 	<command name="load">tool/netcdf/4.4.1.1/gcc</command>
-	<command name="load">tool/parallel-netcdf/mpich</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
Fix issues with centos7-linux build 
Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
