### PR TITLE
Checksum inputdata

### DIFF
--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -16,14 +16,6 @@
 
   <server>
     <protocol>wget</protocol>
-    <address>ftp://ftp.cgd.ucar.edu/pub/jedwards/inputdata</address>
-    <user>anonymous</user>
-    <password>user@example.edu</password>
-    <checksum>../inputdata_checksum.dat</checksum>
-  </server>
-
-  <server>
-    <protocol>wget</protocol>
     <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata</address>
     <user>anonymous</user>
     <password>user@example.edu</password>

--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -11,19 +11,23 @@
   </server>
 
   <server>
-    <protocol>svn</protocol>
-    <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
-  </server>
-
-  <server>
     <protocol>wget</protocol>
     <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata</address>
+    <user>anonymous</user>
+    <password>user@example.edu</password>
   </server>
 
   <server>
     <comment> ftp requires the python package ftplib </comment>
     <protocol>ftp</protocol>
     <address>ftp.cgd.ucar.edu/cesm/inputdata</address>
+    <user>anonymous</user>
+    <password>user@example.edu</password>
+  </server>
+
+  <server>
+    <protocol>svn</protocol>
+    <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
   </server>
 
 </inputdata>

--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -4,7 +4,6 @@
   <!-- server precidence is order in this file.  Highest preference at top -->
   <!-- If the client doesn't have the protocol it will be skipped -->
 
-
   <server>
     <comment>grid ftp requires the globus-url-copy tool on the client side </comment>
     <protocol>gftp</protocol>
@@ -17,14 +16,14 @@
   </server>
 
   <server>
-    <comment> ftp requires the python package ftplib </comment>
-    <protocol>ftp</protocol>
-    <address>ftp.cgd.ucar.edu/cesm/inputdata</address>
+    <protocol>wget</protocol>
+    <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata</address>
   </server>
 
   <server>
-    <protocol>wget</protocol>
-    <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata</address>
+    <comment> ftp requires the python package ftplib </comment>
+    <protocol>ftp</protocol>
+    <address>ftp.cgd.ucar.edu/cesm/inputdata</address>
   </server>
 
 </inputdata>

--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -11,6 +11,15 @@
     <comment>grid ftp requires the globus-url-copy tool on the client side </comment>
     <protocol>gftp</protocol>
     <address>ftp://gridanon.cgd.ucar.edu:2811/cesm/inputdata/</address>
+    <checksum>../inputdata_checksum.dat</checksum>
+  </server>
+
+  <server>
+    <protocol>wget</protocol>
+    <address>ftp://ftp.cgd.ucar.edu/pub/jedwards/inputdata</address>
+    <user>anonymous</user>
+    <password>user@example.edu</password>
+    <checksum>../inputdata_checksum.dat</checksum>
   </server>
 
   <server>
@@ -18,6 +27,7 @@
     <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata</address>
     <user>anonymous</user>
     <password>user@example.edu</password>
+    <checksum>../inputdata_checksum.dat</checksum>
   </server>
 
   <server>
@@ -26,6 +36,7 @@
     <address>ftp.cgd.ucar.edu/cesm/inputdata</address>
     <user>anonymous</user>
     <password>user@example.edu</password>
+    <checksum>../inputdata_checksum.dat</checksum>
   </server>
 
   <server>

--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -3,7 +3,10 @@
 <inputdata>
   <!-- server precidence is order in this file.  Highest preference at top -->
   <!-- If the client doesn't have the protocol it will be skipped -->
-
+  <!-- chksum verification of inputfiles is possible.  If a file with name -->
+  <!-- inputdata_chksum.dat is found on the server in the directory above inputdata -->
+  <!-- it will be searched for filename and chksum of each downloaded file.  -->
+  <!-- see the file ftp://ftp.cgd.ucar.edu/cesm/inputdata_chksum.dat for proper format. -->
   <server>
     <comment>grid ftp requires the globus-url-copy tool on the client side </comment>
     <protocol>gftp</protocol>

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -50,21 +50,25 @@ def parse_command_line(args, description):
     parser.add_argument("--download", action="store_true",
                         help="Attempt to download missing input files")
 
+    parser.add_argument("--chksum", action="store_true",
+                        help="chksum inputfiles against inputdata_chksum.dat (if available)")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.protocol, args.server, args.input_data_root, args.data_list_dir, args.download
+    return args.protocol, args.server, args.input_data_root, args.data_list_dir, args.download, args.chksum
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    protocol, address, input_data_root, data_list_dir, download = parse_command_line(sys.argv, description)
+    protocol, address, input_data_root, data_list_dir, download, chksum = parse_command_line(sys.argv, description)
 
     with Case() as case:
         sys.exit(0 if case.check_all_input_data(protocol=protocol,
                                                 address=address,
                                                 input_data_root=input_data_root,
                                                 data_list_dir=data_list_dir,
-                                                download=download) else 1)
+                                                download=download,
+                                                chksum=chksum) else 1)
 
 ###############################################################################
 

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -32,7 +32,7 @@ def parse_command_line(args, description):
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    parser.add_argument("--protocol", default='svn',
+    parser.add_argument("--protocol", default=None,
                         help="The input data protocol to download data.")
 
     parser.add_argument("--server", default=None,

--- a/scripts/Tools/check_input_data
+++ b/scripts/Tools/check_input_data
@@ -32,7 +32,7 @@ def parse_command_line(args, description):
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    parser.add_argument("--protocol", default=None,
+    parser.add_argument("--protocol", default='svn',
                         help="The input data protocol to download data.")
 
     parser.add_argument("--server", default=None,

--- a/scripts/lib/CIME/Servers/ftp.py
+++ b/scripts/lib/CIME/Servers/ftp.py
@@ -14,6 +14,10 @@ class FTP(GenericServer):
         ftp_server, root_address = address.split('/', 1)
         logger.info("server address {} root path {}".format(ftp_server, root_address))
         self.ftp = FTPpy(ftp_server)
+        if not user:
+            user = ''
+        if not passwd:
+            passwd = ''
 
         stat = self.ftp.login(user, passwd)
         logger.debug("login stat {}".format(stat))

--- a/scripts/lib/CIME/Servers/wget.py
+++ b/scripts/lib/CIME/Servers/wget.py
@@ -4,17 +4,15 @@ WGET Server class.  Interact with a server using WGET protocol
 # pylint: disable=super-init-not-called
 from CIME.XML.standard_module_setup import *
 from CIME.Servers.generic_server import GenericServer
-
 logger = logging.getLogger(__name__)
 
 class WGET(GenericServer):
     def __init__(self, address, user='', passwd=''):
         self._args = ''
         if user:
-            self._args += "--user {}".format(user)
+            self._args += "--user {} ".format(user)
         if passwd:
-            self._args += "--password {}".format(passwd)
-
+            self._args += "--password {} ".format(passwd)
         err = run_cmd("wget {} --spider {}".format(self._args, address))[0]
         expect(err == 0,"Could not connect to repo '{0}'\nThis is most likely either a proxy, or network issue .")
         self._server_loc = address

--- a/scripts/lib/CIME/XML/inputdata.py
+++ b/scripts/lib/CIME/XML/inputdata.py
@@ -27,6 +27,8 @@ class Inputdata(GenericXML):
     def get_next_server(self):
         protocol = None
         address = None
+        user = ''
+        passwd = ''
         servernodes = self.get_children("server")
         if self._servernode is None:
             self._servernode = servernodes[0]
@@ -42,8 +44,6 @@ class Inputdata(GenericXML):
         if self._servernode is not None:
             protocol = self.text(self.get_child("protocol", root = self._servernode))
             address =  self.text(self.get_child("address", root = self._servernode))
-            user = None
-            passwd = None
             unode = self.get_optional_child("user", root = self._servernode)
             if unode:
                 user =  self.text(unode)

--- a/scripts/lib/CIME/XML/inputdata.py
+++ b/scripts/lib/CIME/XML/inputdata.py
@@ -29,7 +29,7 @@ class Inputdata(GenericXML):
         address = None
         user = ''
         passwd = ''
-        chksum = None
+        chksum_file = None
         servernodes = self.get_children("server")
         if self._servernode is None:
             self._servernode = servernodes[0]

--- a/scripts/lib/CIME/XML/inputdata.py
+++ b/scripts/lib/CIME/XML/inputdata.py
@@ -42,5 +42,12 @@ class Inputdata(GenericXML):
         if self._servernode is not None:
             protocol = self.text(self.get_child("protocol", root = self._servernode))
             address =  self.text(self.get_child("address", root = self._servernode))
-
-        return protocol, address
+            user = None
+            passwd = None
+            unode = self.get_optional_child("user", root = self._servernode)
+            if unode:
+                user =  self.text(unode)
+            pnode = self.get_optional_child("password", root = self._servernode)
+            if pnode:
+                passwd =  self.text(pnode)
+        return protocol, address, user, passwd

--- a/scripts/lib/CIME/XML/inputdata.py
+++ b/scripts/lib/CIME/XML/inputdata.py
@@ -29,6 +29,7 @@ class Inputdata(GenericXML):
         address = None
         user = ''
         passwd = ''
+        chksum = None
         servernodes = self.get_children("server")
         if self._servernode is None:
             self._servernode = servernodes[0]
@@ -50,4 +51,7 @@ class Inputdata(GenericXML):
             pnode = self.get_optional_child("password", root = self._servernode)
             if pnode:
                 passwd =  self.text(pnode)
-        return protocol, address, user, passwd
+            csnode = self.get_optional_child("checksum", root = self._servernode)
+            if csnode:
+                chksum_file =  self.text(csnode)
+        return protocol, address, user, passwd, chksum_file

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -217,13 +217,13 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
     expect(data_list_files, "No .input_data_list files found in dir '{}'".format(data_list_dir))
 
     no_files_missing = True
-    user = case.get_value('USER')
+    local_user = case.get_value('USER')
     if download:
         chksum_hash.clear()
         if protocol not in vars(CIME.Servers):
             logger.warning("Client protocol {} not enabled".format(protocol))
             return False
-
+        logger.info("Using protocol {} with user {} and passwd {}".format(protocol, user, passwd))
         if protocol == "svn":
             server = CIME.Servers.SVN(address, user, passwd)
         elif protocol == "gftp":
@@ -281,12 +281,12 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
                             if (download):
                                 if chksum_file and firstdownload:
                                     # Get the md5 checksum file
-                                    got_chksum = _download_checksum_file(server, input_data_root, chksum_file, user)
+                                    got_chksum = _download_checksum_file(server, input_data_root, chksum_file, local_user)
                                     firstdownload = False
                                 isdirectory=rel_path.endswith(os.sep)
                                 no_files_missing = _download_if_in_repo(server,
                                                                         input_data_root, rel_path.strip(os.sep),
-                                                                        user, isdirectory=isdirectory)
+                                                                        local_user, isdirectory=isdirectory)
                                 if got_chksum and no_files_missing and not isdirectory:
                                     verify_chksum(input_data_root,chksum_file, rel_path.strip(os.sep))
                         else:

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -19,7 +19,11 @@ def _download_checksum_file(server, input_data_root):
     """
     rel_path = "../inputdata_checksum.dat"
     full_path = os.path.join(input_data_root, "inputdata_checksum.dat")
-    logging.info("Trying to download file: '{}' to path '{}' using {} protocal.".format(rel_path, full_path, type(server).__name__))
+    protocol = type(server).__name__
+    if protocol == 'svn':
+        # svn server does not have this file
+        return False
+    logging.info("Trying to download file: '{}' to path '{}' using {} protocal.".format(rel_path, full_path, protocol))
     tmpfile = None
     if os.path.isfile(full_path):
         tmpfile = full_path+".tmp"
@@ -95,8 +99,7 @@ def _downloadfromserver(case, input_data_root, data_list_dir):
         protocol, address, user, passwd = inputdata.get_next_server()
         logger.info("Checking server {} with protocol {}".format(address, protocol))
         success = case.check_input_data(protocol=protocol, address=address, download=True,
-#        input_data_root=input_data_root, data_list_dir=data_list_dir, user=user, passwd=passwd)
-        input_data_root=input_data_root, data_list_dir=data_list_dir)
+        input_data_root=input_data_root, data_list_dir=data_list_dir, user=user, passwd=passwd)
     return success
 
 def stage_refcase(self, input_data_root=None, data_list_dir=None):

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -20,7 +20,7 @@ def _download_checksum_file(server, input_data_root, chksum_file, user):
     success = False
     rel_path = chksum_file
     full_path = os.path.join(input_data_root, local_chksum_file)
-    lockfile = _check_permissions_and_lock_inputdata(input_data_root, user)
+    lockfile = _check_permissions_and_lock_inputdata_file(input_data_root, user)
     new_file = full_path + '.raw'
     protocol = type(server).__name__
     logging.info("Trying to download file: '{}' to path '{}' using {} protocol.".format(rel_path, new_file, protocol))
@@ -82,7 +82,7 @@ def _download_if_in_repo(server, input_data_root, rel_path, user, isdirectory=Fa
         return False
 
     full_path = os.path.join(input_data_root, rel_path)
-    lockfile = _check_permissions_and_lock_inputdata(full_path, user)
+    lockfile = _check_permissions_and_lock_inputdata_file(full_path, user)
     logging.info("Trying to download file: '{}' to path '{}' using {} protocol.".format(rel_path, full_path, type(server).__name__))
     # Make sure local path exists, create if it does not
     if isdirectory or full_path.endswith(os.sep):
@@ -302,7 +302,6 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
 
 def _check_permissions_and_lock_inputdata_file(file_path, user):
     basedir = os.path.dirname(file_path)
-    fname = os.path.basename(file_path)
     if not os.path.exists(basedir):
         try:
             os.makedirs(basedir)

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -281,8 +281,7 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
 
     no_files_missing = True
     local_user = case.get_value('USER')
-    if download or chksum:
-        chksum_hash.clear()
+    if download:
         if protocol not in vars(CIME.Servers):
             logger.warning("Client protocol {} not enabled".format(protocol))
             return False

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -136,7 +136,7 @@ def check_all_input_data(self, protocol=None, address=None, input_data_root=None
     success = False
     if protocol is not None and address is not None:
         success = self.check_input_data(protocol=protocol, address=address, download=download,
-                                        input_data_root=input_data_root, data_list_dir=data_list_dir, chksum=chksum)
+                                        input_data_root=input_data_root, data_list_dir=data_list_dir)
     else:
         if chksum or download:
             inputdata = Inputdata()
@@ -164,7 +164,7 @@ def check_all_input_data(self, protocol=None, address=None, input_data_root=None
                                                   chksum_file, self.get_value("USER"))
 
         success = self.check_input_data(protocol=protocol, address=address, download=False,
-                                        input_data_root=input_data_root, data_list_dir=data_list_dir, chksum=chksum)
+                                        input_data_root=input_data_root, data_list_dir=data_list_dir)
         if download and not success:
             success = _downloadfromserver(self, input_data_root, data_list_dir)
 
@@ -183,12 +183,12 @@ def _downloadfromserver(case, input_data_root, data_list_dir):
         input_data_root = case.get_value('DIN_LOC_ROOT')
 
     while not success and protocol is not None:
-        protocol, address, user, passwd, chksum_file = inputdata.get_next_server()
+        protocol, address, user, passwd, _ = inputdata.get_next_server()
         logger.info("Checking server {} with protocol {}".format(address, protocol))
         success = case.check_input_data(protocol=protocol, address=address, download=True,
                                         input_data_root=input_data_root,
                                         data_list_dir=data_list_dir,
-                                        user=user, passwd=passwd, chksum_file=chksum_file)
+                                        user=user, passwd=passwd)
     return success
 
 def stage_refcase(self, input_data_root=None, data_list_dir=None):
@@ -261,7 +261,7 @@ def stage_refcase(self, input_data_root=None, data_list_dir=None):
     return True
 
 def check_input_data(case, protocol="svn", address=None, input_data_root=None, data_list_dir="Buildconf",
-                     download=False, chksum=False, user=None, passwd=None, chksum_file=None):
+                     download=False, user=None, passwd=None):
     """
     For a given case check for the relevant input data as specified in data_list_dir/*.input_data_list
     in the directory input_data_root, if not found optionally download it using the servers specified

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -6,14 +6,14 @@ from CIME.utils import SharedArea, find_files, safe_copy, expect
 from CIME.XML.inputdata import Inputdata
 import CIME.Servers
 
-import glob, hashlib, time
+import glob, hashlib
 
 logger = logging.getLogger(__name__)
 # The inputdata_checksum.dat file will be read into this hash if it's available
 chksum_hash = dict()
 local_chksum_file = 'inputdata_checksum.dat'
 
-def _download_checksum_file(server, rundir, chksum_file, user):
+def _download_checksum_file(server, rundir, chksum_file):
     """
     Return True if successfully downloaded
     server is an object handle of type CIME.Servers
@@ -84,7 +84,7 @@ def _merge_chksum_files(new_file, old_file):
 
 
 
-def _download_if_in_repo(server, input_data_root, rel_path, user, isdirectory=False):
+def _download_if_in_repo(server, input_data_root, rel_path, isdirectory=False):
     """
     Return True if successfully downloaded
     server is an object handle of type CIME.Servers
@@ -156,7 +156,7 @@ def check_all_input_data(self, protocol=None, address=None, input_data_root=None
 
 
                 success = _download_checksum_file(server, self.get_value("RUNDIR"),
-                                                  chksum_file, self.get_value("USER"))
+                                                  chksum_file)
 
         success = self.check_input_data(protocol=protocol, address=address, download=False,
                                         input_data_root=input_data_root, data_list_dir=data_list_dir)
@@ -275,7 +275,6 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
     expect(data_list_files, "No .input_data_list files found in dir '{}'".format(data_list_dir))
 
     no_files_missing = True
-    local_user = case.get_value('USER')
     if download:
         if protocol not in vars(CIME.Servers):
             logger.warning("Client protocol {} not enabled".format(protocol))
@@ -338,7 +337,7 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
                             if (download):
                                 no_files_missing = _download_if_in_repo(server,
                                                                         input_data_root, rel_path.strip(os.sep),
-                                                                        local_user, isdirectory=isdirectory)
+                                                                        isdirectory=isdirectory)
                                 if no_files_missing:
                                     verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)
                         else:


### PR DESCRIPTION
Add checksum support for inputdata:  When files are downloaded the data is checksummed against the file inputdata_chksum.dat which has a format:
```  
 df9a88f7dd33ea7451307e2b3b68cea5             1445  eaton            1661657404  Feb  20   2010 inputdata/atm/cam/chem/1850-2000_emis/IPCC_emissions_aircraft_BC_1850-2000_1.9x2.5.c090729.nc
```
the first and last fields read into a hash and as files are downloaded the file check sum is compared to the hash in the file.  


Test suite: by hand, scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #2910 

User interface changes?: adds a --chksum option to check_input_data, files downloaded are always checked, the option is to check files already on local disk for a given case

Update gh-pages html (Y/N)?:

Code review: 
