### PR TITLE
update NYF CORE2 DROF data stream file.

### DIFF
--- a/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -89,10 +89,10 @@
     <group>streams_file</group>
     <desc>Stream domain file path(s).</desc>
     <values>
-      <value stream="rof.diatren_ann_rx1"      >runoff.daitren.annual.090225.nc</value>
-      <value stream="rof.diatren_ann_ais00_rx1">runoff.daitren.annual.090225.nc</value>
-      <value stream="rof.diatren_ann_ais45_rx1">runoff.daitren.annual.090225.nc</value>
-      <value stream="rof.diatren_ann_ais55_rx1">runoff.daitren.annual.090225.nc</value>
+      <value stream="rof.diatren_ann_rx1"      >runoff.daitren.annual.20190226.nc</value>
+      <value stream="rof.diatren_ann_ais00_rx1">runoff.daitren.annual.20190226.nc</value>
+      <value stream="rof.diatren_ann_ais45_rx1">runoff.daitren.annual.20190226.nc</value>
+      <value stream="rof.diatren_ann_ais55_rx1">runoff.daitren.annual.20190226.nc</value>
       <value stream="rof.diatren_iaf_rx1"      >runoff.daitren.iaf.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais00_rx1">runoff.daitren.iaf-AISx00.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais45_rx1">runoff.daitren.iaf-AISx45.20120419.nc</value>
@@ -179,10 +179,10 @@
     <group>streams_file</group>
     <desc>Stream data file path(s).</desc>
     <values>
-      <value stream="rof.diatren_ann_rx1"      >runoff.daitren.annual.090225.nc</value>
-      <value stream="rof.diatren_ann_ais00_rx1">runoff.daitren.annual.090225.nc</value>
-      <value stream="rof.diatren_ann_ais45_rx1">runoff.daitren.annual.090225.nc</value>
-      <value stream="rof.diatren_ann_ais55_rx1">runoff.daitren.annual.090225.nc</value>
+      <value stream="rof.diatren_ann_rx1"      >runoff.daitren.annual.20190226.nc</value>
+      <value stream="rof.diatren_ann_ais00_rx1">runoff.daitren.annual.20190226.nc</value>
+      <value stream="rof.diatren_ann_ais45_rx1">runoff.daitren.annual.20190226.nc</value>
+      <value stream="rof.diatren_ann_ais55_rx1">runoff.daitren.annual.20190226.nc</value>
       <value stream="rof.diatren_iaf_rx1"      >runoff.daitren.iaf.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais00_rx1">runoff.daitren.iaf-AISx00.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais45_rx1">runoff.daitren.iaf-AISx45.20120419.nc</value>


### PR DESCRIPTION
Updates core2 NYF data runoff stream file. The area and runoff units of the old file (*090225.nc) were incorrect and were leading to very large area correction factors within mct driver. This also fixes the erroneous drof fluxes in noupc driver for NYF-forced cases.

Test suite: aux_pop
Test baseline: cesm2.2_alpha01d-pop_2_1_20190118
Test namelist changes: n/a
Test status: roundoff differences and namelist changes in NYF forced cases for mct. 

Fixes [CIME Github issue #] n/a

User interface changes?: n/a

Update gh-pages html (Y/N)?: n/a

Code review: 
