### PR TITLE
Update CAM-SE grids

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -856,9 +856,9 @@
     </model_grid>
 
     <model_grid alias="ne30pg3_ne30pg3_mg17" not_compset="_POP">
-      <grid name="atm">ne30np4</grid>
-      <grid name="lnd">ne30np4</grid>
-      <grid name="ocnice">ne30np4</grid>
+      <grid name="atm">ne30pg3</grid>
+      <grid name="lnd">ne30pg3</grid>
+      <grid name="ocnice">ne30pg3</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
@@ -907,6 +907,13 @@
     </model_grid>
 
    <!-- VR-CESM grids with CAM-SE -->
+
+    <model_grid alias="ne0CONUSne30x8_g17">
+      <grid name="atm">ne0np4CONUS.ne30x8</grid>
+      <grid name="lnd">ne0np4CONUS.ne30x8</grid>
+      <grid name="ocnice">gx1v7</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
 
     <model_grid alias="ne0TESTONLYne5x4_ne0TESTONLYne5x4_mg37" not_compset="_POP">
       <grid name="atm">ne0np4TESTONLY.ne5x4</grid>
@@ -1353,6 +1360,8 @@
 
     <domain name="ne0np4CONUS.ne30x8">
       <nx>174098</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne0CONUSne30x8_gx1v7.190304.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne0CONUSne30x8_gx1v7_190304.nc</file>
       <desc>ne0np4CONUS.ne30x8 is a Spectral Elem 1-deg grid with a 1/8 deg refined region over the continental United States:</desc>
       <support>Test support only</support>
     </domain>

--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -15,6 +15,11 @@
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/1.9x2.5/map_0.1x0.1_nomask_to_1.9x2.5_nomask_aave_da_c120709.nc</map>
     </gridmap>
 
+    <gridmap lnd_grid="ne30pg3" rof_grid="r05">
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne30pg3/map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne30pg3/map_0.5x0.5_nomask_to_ne30pg3_aave_da_c180515.nc</map>
+    </gridmap>
+
     <gridmap lnd_grid="ne120np4" rof_grid="r01">
       <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.1x0.1/map_ne120np4_nomask_to_0.1x0.1_nomask_aave_da_c120711.nc</map>
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne120np4/map_0.1x0.1_nomask_to_ne120np4_nomask_aave_da_c120706.nc</map>
@@ -23,6 +28,11 @@
     <gridmap lnd_grid="ne240np4" rof_grid="r01">
       <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/0.1x0.1/map_ne240np4_nomask_to_0.1x0.1_nomask_aave_da_c120711.nc</map>
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne240np4/map_0.1x0.1_nomask_to_ne240np4_nomask_aave_da_c120706.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="ne0np4CONUS.ne30x8" rof_grid="r05">
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_0.5x0.5_nomask_aave.190227.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_0.5x0.5_nomask_TO_ne0CONUSne30x8_aave.190227.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="360x720cru" rof_grid="r05">
@@ -267,6 +277,20 @@
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30np4_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30np4_aave.170429.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="ne30pg3" glc_grid="gland4" >
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_gland4km_aave.180515.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_gland4km_blin.180515.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30pg3_aave.180510.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30pg3_aave.180510.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="ne0np4CONUS.ne30x8" glc_grid="gland4" >
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gland4km_aave.190227.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gland4km_blin.190227.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne0CONUSne30x8_aave.190227.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne0CONUSne30x8_aave.190227.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne120np4" glc_grid="gland4" >

--- a/config/cesm/config_grids_mct.xml
+++ b/config/cesm/config_grids_mct.xml
@@ -113,6 +113,7 @@
       <map name="OCN2ATM_FMAPNAME">cpl/cpl6/map_gx1v6_to_ne30np4_aave_110121.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/cpl6/map_gx1v6_to_ne30np4_aave_110121.nc</map>
     </gridmap>
+
     <gridmap atm_grid="ne30np4" lnd_grid="0.9x1.25">
       <map name="ATM2LND_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_fv0.9x1.25_aave.120712.nc</map>
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_fv0.9x1.25_aave.120712.nc</map>
@@ -202,6 +203,18 @@
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/ne240np4/map_ne240np4_to_fv0.23x0.31_aave_110428.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/fv0.23x0.31/map_fv0.23x0.31_to_ne240np4_aave_110428.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne0np4CONUS.ne30x8" ocn_grid="gx1v7">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_aave.190227.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_blin.190227.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_patc.190227.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190227.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190227.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne0np4CONUS.ne30x8" wav_grid="ww3a">
+      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_ww3a_blin.190213.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="gx1v7">


### PR DESCRIPTION
Update support for CAM-SE grids.  Add ne0np4CONUS.ne30x8 and replaced
missing ne30pg3.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
