### PR TITLE
deal with issues of downloading checksum file

### DIFF
--- a/scripts/lib/CIME/Servers/svn.py
+++ b/scripts/lib/CIME/Servers/svn.py
@@ -35,9 +35,11 @@ To check connection and store your credential run 'svn ls {0}' and permanently s
         return True
 
     def getfile(self, rel_path, full_path):
+        if not rel_path:
+            return False
         full_url = os.path.join(self._svn_loc, rel_path)
         stat, output, errput = \
-            run_cmd("svn --non-interactive --trust-server-cert {} export {} {}".format(self._args, full_url, full_path))
+                               run_cmd("svn --non-interactive --trust-server-cert {} export {} {}".format(self._args, full_url, full_path))
         if (stat != 0):
             logging.warning("svn export failed with output: {} and errput {}\n".format(output, errput))
             return False

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -93,7 +93,7 @@ def _download_if_in_repo(server, input_data_root, rel_path, isdirectory=False):
     user is the user name of the person running the script
     isdirectory indicates that this is a directory download rather than a single file
     """
-    if not server.fileexists(rel_path):
+    if not (rel_path or server.fileexists(rel_path)):
         return False
 
     full_path = os.path.join(input_data_root, rel_path)
@@ -137,7 +137,8 @@ def check_all_input_data(self, protocol=None, address=None, input_data_root=None
             inputdata = Inputdata()
             protocol = "svn"
             success = False
-            while not success and protocol is not None:
+            # download and merge all available chksum files.
+            while protocol is not None:
                 protocol, address, user, passwd, chksum_file = inputdata.get_next_server()
                 if protocol not in vars(CIME.Servers):
                     logger.warning("Client protocol {} not enabled".format(protocol))


### PR DESCRIPTION
Should only download chksum file if chksum option is specified or download is specified.
Fix error when trying to download existent checksum file.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit,
Fixes #3033 
Fixes #3034 
Fixes #3036

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
