### PR TITLE
fix issue with PET and ERP tests

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -18,6 +18,7 @@ def get_standard_makefile_args(case):
                  "OCN_SUBMODEL", "CISM_USE_TRILINOS", "USE_ALBANY", "USE_PETSC"]
 
     make_args = "CIME_MODEL={} ".format(case.get_value("MODEL"))
+    make_args += " compile_threaded={} ".format(case.get_build_threaded())
     for var in variables:
         make_args+=xml_to_make_variable(case, var)
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1328,7 +1328,7 @@ directory, NOT in this subdirectory."""
         Returns True if current settings require a threaded build/run.
         """
         force_threaded = self.get_value("FORCE_BUILD_SMP")
-        smp_present = bool(force_threaded) or self.thread_count > 1
+        smp_present = force_threaded or self.thread_count > 1
         return smp_present
 
     def _check_testlists(self, compset_alias, grid_name, files):

--- a/src/build_scripts/buildlib.gptl
+++ b/src/build_scripts/buildlib.gptl
@@ -44,15 +44,10 @@ def buildlib(bldroot, installpath, case):
 ###############################################################################
     caseroot = case.get_value("CASEROOT")
     gptl_dir = os.path.join(case.get_value("CIMEROOT"), "src", "share", "timing")
-    debug = case.get_value("DEBUG")
     gmake_opts = "-f {gptl}/Makefile install -C {bldroot} MACFILE={macfile} MODEL=gptl GPTL_DIR={gptl} GPTL_LIBDIR={bldroot}"\
         " SHAREDPATH={install} {stdargs} "\
         .format(gptl=gptl_dir, bldroot=bldroot, macfile=os.path.join(caseroot,"Macros.make"),
                 install=installpath, stdargs=get_standard_makefile_args(case))
-    if debug:
-        gmake_opts += " DEBUG=True"
-    if case.get_build_threaded():
-        gmake_opts += " compile_threaded=true "
 
     gmake_cmd = case.get_value("GMAKE")
 


### PR DESCRIPTION
PET and ERP tests were not setting compile_threaded correctly.

Test suite: ERP.f45_g37_rx1.A.centos7-linux_gnu ,  PET_P4.f19_f19.A.centos7-linux_gnu 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #3041 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
