### PR TITLE
Fix ./case.build --clean.

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -347,7 +347,7 @@ def _clean_impl(case, cleanlist, clean_all, clean_depends):
         casetools       = case.get_value("CASETOOLS")
 
         cmd = gmake + " -f " + os.path.join(casetools, "Makefile")
-        cmd += get_standard_makefile_args(case)
+        cmd += " {}".format(get_standard_makefile_args(case))
         if cleanlist is not None:
             for item in cleanlist:
                 tcmd = cmd + " clean" + item


### PR DESCRIPTION
Need a whitespace between make args.

I copied this fix over from e3sm.

Test suite: None
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
