### PR TITLE
Update mpt library version for pgi on cheyenne

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -305,9 +305,9 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">pnetcdf/1.11.0</command>
       </modules>
       <modules mpilib="mpt" compiler="pgi">
-	<command name="load">mpt/2.15f</command>
-	<command name="load">netcdf-mpi/4.5.0</command>
-	<command name="load">pnetcdf/1.9.0</command>
+	<command name="load">mpt/2.19</command>
+	<command name="load">netcdf-mpi/4.6.1</command>
+	<command name="load">pnetcdf/1.11.0</command>
       </modules>
       <modules mpilib="openmpi">
 	<command name="load">openmpi/3.0.1</command>


### PR DESCRIPTION
Update pgi's mpt, netcdf-mpi, and pnetcdf software stack for cheyenne.

Test suite: scripts_regression_tests with pgi
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
