### PR TITLE
Add NLDAS grid for CTSM and MOSART

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -122,11 +122,11 @@
 
     <!-- Regional NLDAS-2 grid over the U.S. (0.125 degree resolution;
          25-53N, 235-293E), with mask from NLDAS-2 atmospheric drivers -->
-    <model_grid alias="nldas2_mnldas2" compset="DATM.+CLM">
+    <model_grid alias="nldas2_rnldas2_mnldas2" compset="DATM.+CLM">
       <grid name="atm">0.125nldas2</grid>
       <grid name="lnd">0.125nldas2</grid>
       <grid name="ocnice">0.125nldas2</grid>
-      <grid name="rof">null</grid>
+      <grid name="rof">0.125nldas2</grid>
       <mask>nldas2</mask>
     </model_grid>
 
@@ -1103,6 +1103,7 @@
       <desc>5x5 Amazon regional case -- only valid for DATM/CLM compset</desc>
     </domain>
 
+    <!-- This grid is also used by ROF -->
     <domain name="0.125nldas2">
       <nx>464</nx> <ny>224</ny>
       <file grid="atm|lnd" mask="nldas2">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.0.125nldas2_0.125nldas2.190410.nc</file>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -121,7 +121,7 @@
     </model_grid>
 
     <!-- Regional, 12km NLDAS grid over the U.S., with the standard NLDAS mask -->
-    <model_grid alias="224x464_nldas_mnldas" compset="DATM.+CLM">
+    <model_grid alias="nldas_mnldas" compset="DATM.+CLM">
       <grid name="atm">224x464_nldas</grid>
       <grid name="lnd">224x464_nldas</grid>
       <grid name="ocnice">224x464_nldas</grid>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -121,13 +121,13 @@
     </model_grid>
 
     <!-- Regional NLDAS-2 grid over the U.S. (0.125 degree resolution;
-         25-53N, 235-293E), with the standard NLDAS-2 mask -->
+         25-53N, 235-293E), with mask from NLDAS-2 atmospheric drivers -->
     <model_grid alias="nldas2_mnldas2" compset="DATM.+CLM">
       <grid name="atm">0.125nldas2</grid>
       <grid name="lnd">0.125nldas2</grid>
       <grid name="ocnice">0.125nldas2</grid>
       <grid name="rof">null</grid>
-      <mask>nldas</mask>
+      <mask>nldas2</mask>
     </model_grid>
 
     <model_grid alias="hcru_hcru" compset="DATM.+CLM">

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -120,6 +120,15 @@
       <grid name="rof">null</grid>
     </model_grid>
 
+    <!-- Regional, 12km NLDAS grid over the U.S., with the standard NLDAS mask -->
+    <model_grid alias="224x464_nldas_mnldas" compset="DATM.+CLM">
+      <grid name="atm">224x464_nldas</grid>
+      <grid name="lnd">224x464_nldas</grid>
+      <grid name="ocnice">224x464_nldas</grid>
+      <grid name="rof">null</grid>
+      <mask>nldas</mask>
+    </model_grid>
+
     <model_grid alias="hcru_hcru" compset="DATM.+CLM">
       <grid name="atm">360x720cru</grid>
       <grid name="lnd">360x720cru</grid>
@@ -1091,6 +1100,13 @@
       <nx>1</nx> <ny>1</ny>
       <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.5x5pt-amazon_navy.090715.nc</file>
       <desc>5x5 Amazon regional case -- only valid for DATM/CLM compset</desc>
+    </domain>
+
+    <domain name="224x464_nldas">
+      <nx>464</nx> <ny>224</ny>
+      <file grid="atm|lnd" mask="nldas">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.224x464_nldas_224x464_nldas.190403.nc</file>
+      <file grid="ocnice"  mask="nldas">$DIN_LOC_ROOT/share/domains/domain.clm/domain.ocn.224x464_nldas.190403.nc</file>
+      <desc>Regional, 12km NLDAS grid over the U.S.</desc>
     </domain>
 
     <!-- ATM/LND domains global -->

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1105,9 +1105,8 @@
 
     <domain name="0.125nldas2">
       <nx>464</nx> <ny>224</ny>
-      <!-- FIXME: Need to update these domain files (both their names and their masks) -->
-      <file grid="atm|lnd" mask="nldas2">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.224x464_nldas_224x464_nldas.190403.nc</file>
-      <file grid="ocnice"  mask="nldas2">$DIN_LOC_ROOT/share/domains/domain.clm/domain.ocn.224x464_nldas.190403.nc</file>
+      <file grid="atm|lnd" mask="nldas2">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.0.125nldas2_0.125nldas2.190410.nc</file>
+      <file grid="ocnice"  mask="nldas2">$DIN_LOC_ROOT/share/domains/domain.clm/domain.ocn.0.125nldas2.190410.nc</file>
       <desc>Regional NLDAS-2 grid over the U.S. (0.125 degree resolution; 25-53N, 235-293E)</desc>
     </domain>
 

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -120,11 +120,12 @@
       <grid name="rof">null</grid>
     </model_grid>
 
-    <!-- Regional NLDAS grid over the U.S. (roughly 12km resolution), with the standard NLDAS mask -->
-    <model_grid alias="nldas_mnldas" compset="DATM.+CLM">
-      <grid name="atm">224x464_nldas</grid>
-      <grid name="lnd">224x464_nldas</grid>
-      <grid name="ocnice">224x464_nldas</grid>
+    <!-- Regional NLDAS-2 grid over the U.S. (0.125 degree resolution;
+         25-53N, 235-293E), with the standard NLDAS-2 mask -->
+    <model_grid alias="nldas2_mnldas2" compset="DATM.+CLM">
+      <grid name="atm">0.125nldas2</grid>
+      <grid name="lnd">0.125nldas2</grid>
+      <grid name="ocnice">0.125nldas2</grid>
       <grid name="rof">null</grid>
       <mask>nldas</mask>
     </model_grid>
@@ -1102,11 +1103,12 @@
       <desc>5x5 Amazon regional case -- only valid for DATM/CLM compset</desc>
     </domain>
 
-    <domain name="224x464_nldas">
+    <domain name="0.125nldas2">
       <nx>464</nx> <ny>224</ny>
-      <file grid="atm|lnd" mask="nldas">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.224x464_nldas_224x464_nldas.190403.nc</file>
-      <file grid="ocnice"  mask="nldas">$DIN_LOC_ROOT/share/domains/domain.clm/domain.ocn.224x464_nldas.190403.nc</file>
-      <desc>Regional NLDAS grid over the U.S. (roughly 12km resolution)</desc>
+      <!-- FIXME: Need to update these domain files (both their names and their masks) -->
+      <file grid="atm|lnd" mask="nldas2">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.224x464_nldas_224x464_nldas.190403.nc</file>
+      <file grid="ocnice"  mask="nldas2">$DIN_LOC_ROOT/share/domains/domain.clm/domain.ocn.224x464_nldas.190403.nc</file>
+      <desc>Regional NLDAS-2 grid over the U.S. (0.125 degree resolution; 25-53N, 235-293E)</desc>
     </domain>
 
     <!-- ATM/LND domains global -->

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -120,7 +120,7 @@
       <grid name="rof">null</grid>
     </model_grid>
 
-    <!-- Regional, 12km NLDAS grid over the U.S., with the standard NLDAS mask -->
+    <!-- Regional NLDAS grid over the U.S. (roughly 12km resolution), with the standard NLDAS mask -->
     <model_grid alias="nldas_mnldas" compset="DATM.+CLM">
       <grid name="atm">224x464_nldas</grid>
       <grid name="lnd">224x464_nldas</grid>
@@ -1106,7 +1106,7 @@
       <nx>464</nx> <ny>224</ny>
       <file grid="atm|lnd" mask="nldas">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.224x464_nldas_224x464_nldas.190403.nc</file>
       <file grid="ocnice"  mask="nldas">$DIN_LOC_ROOT/share/domains/domain.clm/domain.ocn.224x464_nldas.190403.nc</file>
-      <desc>Regional, 12km NLDAS grid over the U.S.</desc>
+      <desc>Regional NLDAS grid over the U.S. (roughly 12km resolution)</desc>
     </domain>
 
     <!-- ATM/LND domains global -->


### PR DESCRIPTION
Adds a high-resolution regional grid over the U.S. for use in land-only
simulations.

(I haven't added the necessary files to the inputdata repository yet,
but will do so once this and the corresponding CTSM PRs are accepted.)

Test suite: SMS test using this new grid in the context of a CTSM branch
   with the necessary changes
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
