### PR TITLE
Remove master history from maint-5.6 branch

### DIFF
--- a/scripts/lib/CIME/XML/entry_id.py
+++ b/scripts/lib/CIME/XML/entry_id.py
@@ -184,8 +184,8 @@ class EntryID(GenericXML):
 
     def _get_valid_values(self, node):
         valid_values = self.get_element_text("valid_values", root=node)
-        valid_values_list = None
-        if valid_values is not None:
+        valid_values_list = []
+        if valid_values:
             valid_values_list = [item.lstrip() for item in valid_values.split(',')]
         return valid_values_list
 
@@ -234,7 +234,7 @@ class EntryID(GenericXML):
         type_str = self._get_type_info(node)
         str_value = convert_to_string(value, type_str, vid)
 
-        if valid_values is not None and not str_value.startswith('$'):
+        if valid_values and not str_value.startswith('$'):
             expect(str_value in valid_values, "Did not find {} in valid values for {}: {}".format(value, vid, valid_values))
         return str_value
 

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -274,7 +274,7 @@ class GenericXML(object):
         return None
 
     def to_string(self, node, method="xml", encoding="us-ascii"):
-        return ET.tostring(node, method=method, encoding=encoding)
+        return ET.tostring(node.xml_element, method=method, encoding=encoding)
 
     #
     # API for operations over the entire file

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -70,6 +70,7 @@
       <value compset="^HIST_">trans_1850-2000</value>
       <value compset="^20TR_">trans_1850-2000</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
+      <value compset="_DATM.*_DICE.*_DOCN.*_DROF">none</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Reset maint-5.6 branch to the commit before master history came in.  Then cherry-picked 
PR #3057 and #3053.  Tried this before, but needed to have the --force in the push.

git reset --hard 398df65a0
git cherry-pick -m 1 30f288c 4e37fe6
git push --force origin fischer/fix_maint-5.6

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
