### PR TITLE
Support optional components

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -546,7 +546,7 @@ class Case(object):
         # because we ignore CPL for finding model components.
         # Model components would normally start at zero but since we are
         # dealing with a compset, 0 is reserved for the time field
-        for comp_ind in xrange(1, len(comp_classes)):
+        for comp_ind in range(1, len(comp_classes)):
             comp = comp_classes[comp_ind]
             # Find list of models for component class
             # List can be in different locations, check CONFIG_XXX_FILE first
@@ -582,7 +582,7 @@ class Case(object):
             model_set[comp_ind] = model
 
         # Fill in missing components with stubs
-        for comp_ind in xrange(1, len(model_set)):
+        for comp_ind in range(1, len(model_set)):
             if model_set[comp_ind] is None:
                 comp_class = comp_classes[comp_ind]
                 stub = 'S' + comp_class

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -471,7 +471,7 @@ class Case(object):
             self._compsetname = compset_name
 
         # Fill in compset name
-        self._compsetname = self._valid_compset(files, self._compsetname)
+        self._compsetname, self._components = self.valid_compset(self._compsetname, files)
         # if this is a valiid compset longname there will be at least 7 components.
         components = self.get_compset_components()
         expect(len(components) > 6, "No compset alias {} found and this does not appear to be a compset longname.".format(compset_name))
@@ -532,56 +532,21 @@ class Case(object):
 
         return primary_component
 
-
-    # RE to match component type name without optional piece (stuff after %).
-    # Drop any tailing digits (e.g., the 60 in CAM60) to ensure match
-    # Note, this will also drop trailing digits such as in ww3 but since it
-    # is handled consistenly, this should not affect functionality.
-    __mod_match_re__ = re.compile(r"([^%]*[^0-9%]+)")
-    def _valid_compset(self, files, compset_name, model_hash=None):
-        """Fill in missing stub models, return full compset name
-        >>> Case(read_only=False)._valid_compset(None, '2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV', model_hash={'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
-        '2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP'
-        >>> Case(read_only=False)._valid_compset(None, '2000_DATM%NYF_DICE%SSMI_DOCN%DOM_DROF%NYF', model_hash={'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
-        '2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP'
-        >>> Case(read_only=False)._valid_compset(None, '2000_DICE%SSMI_DOCN%DOM_DATM%NYF_DROF%NYF', model_hash={'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
-        '2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP'
-        >>> Case(read_only=False)._valid_compset(None, '1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD', model_hash={'datm':1,'satm':1, 'cam':1,'dlnd':2,'clm':2,'slnd':2,'cice':3,'dice':3,'sice':3,'pop':4,'docn':4,'socn':4,'mosart':5,'drof':5,'srof':5,'cism':6,'sglc':6,'ww':7,'swav':7,'ww3':7,'sesp':8})
-        '1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_SESP_BGC%BDRD'
+    def _valid_compset_impl(self, compset_name, comp_classes, comp_hash):
+        """Add stub models missing in <compset_name>, return full compset name.
+        <comp_classes> is a list of all supported component classes.
+        <comp_hash> is a dictionary where each key is a supported component
+        (e.g., datm) and the associated value is the index in <comp_classes> of
+        that component's class (e.g., 1 for atm).
+        >>> Case(read_only=False)._valid_compset_impl('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
+        ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
+        >>> Case(read_only=False)._valid_compset_impl('2000_DATM%NYF_DICE%SSMI_DOCN%DOM_DROF%NYF', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
+        ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
+        >>> Case(read_only=False)._valid_compset_impl('2000_DICE%SSMI_DOCN%DOM_DATM%NYF_DROF%NYF', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
+        ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
+        >>> Case(read_only=False)._valid_compset_impl('1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD', ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1, 'cam':1,'dlnd':2,'clm':2,'slnd':2,'cice':3,'dice':3,'sice':3,'pop':4,'docn':4,'socn':4,'mosart':5,'drof':5,'srof':5,'cism':6,'sglc':6,'ww':7,'swav':7,'ww3':7,'sesp':8})
+        ('1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_SESP_BGC%BDRD', ['1850', 'CAM60', 'CLM50%BGC-CROP', 'CICE', 'POP2%ECO%ABIO-DIC', 'MOSART', 'CISM2%NOEVOLVE', 'WW3', 'SESP', 'BGC%BDRD'])
         """
-        if model_hash is None:
-            # First, create hash of model names
-            # A note about indexing. Relevant component classes start at 1
-            # because we ignore CPL for finding model components.
-            # Model components would normally start at zero but since we are
-            # dealing with a compset, 0 is reserved for the time field
-            drv_config_file = files.get_value("CONFIG_CPL_FILE")
-            drv_comp = Component(drv_config_file, "CPL")
-            comp_classes = drv_comp.get_valid_model_components()
-            model_hash = {} # Hash model name to component class index
-            for comp_ind in range(1, len(comp_classes)):
-                comp = comp_classes[comp_ind]
-                # Find list of models for component class
-                # List can be in different locations, check CONFIG_XXX_FILE
-                node_name = 'CONFIG_{}_FILE'.format(comp)
-                models = files.get_components(node_name)
-                if (models is None) or (None in models):
-                    # Backup, check COMP_ROOT_DIR_XXX
-                    node_name = 'COMP_ROOT_DIR_' + comp
-                    models = files.get_components(node_name)
-
-                expect((models is not None) and (None not in models),
-                       "Unable to find list of supported components")
-
-                for model in models:
-                    mod_match = Case.__mod_match_re__.match(model.lower()).group(1)
-                    model_hash[mod_match] = comp_ind
-
-        else:
-            # Note: this case is only used for testing, normal code should
-            #       not call with model_hash
-            comp_classes = ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP']
-
         # Find the models declared in the compset
         model_set = [None]*len(comp_classes)
         components = compset_name.split('_')
@@ -598,9 +563,9 @@ class Case(object):
             match = Case.__mod_match_re__.match(model.lower())
             expect(match is not None, "No model match for {}".format(model))
             mod_match = match.group(1)
-            expect(mod_match in model_hash,
+            expect(mod_match in comp_hash,
                    "Unknown model type, {}".format(model))
-            comp_ind = model_hash[mod_match]
+            comp_ind = comp_hash[mod_match]
             model_set[comp_ind] = model
 
         # Fill in missing components with stubs
@@ -615,9 +580,47 @@ class Case(object):
         if bgc is not None:
             model_set.append(bgc)
 
-        self._components = model_set
-        self._compsetname = '_'.join(model_set)
-        return self._compsetname
+        compsetname = '_'.join(model_set)
+        return compsetname, model_set
+
+    # RE to match component type name without optional piece (stuff after %).
+    # Drop any trailing digits (e.g., the 60 in CAM60) to ensure match
+    # Note, this will also drop trailing digits such as in ww3 but since it
+    # is handled consistenly, this should not affect functionality.
+    # Note: interstitial digits are included (e.g., in FV3GFS).
+    __mod_match_re__ = re.compile(r"([^%]*[^0-9%]+)")
+    def valid_compset(self, compset_name, files):
+        """Add stub models missing in <compset_name>, return full compset name.
+        <files> is used to collect set of all supported components.
+        """
+        # First, create hash of model names
+        # A note about indexing. Relevant component classes start at 1
+        # because we ignore CPL for finding model components.
+        # Model components would normally start at zero but since we are
+        # dealing with a compset, 0 is reserved for the time field
+        drv_config_file = files.get_value("CONFIG_CPL_FILE")
+        drv_comp = Component(drv_config_file, "CPL")
+        comp_classes = drv_comp.get_valid_model_components()
+        comp_hash = {} # Hash model name to component class index
+        for comp_ind in range(1, len(comp_classes)):
+            comp = comp_classes[comp_ind]
+            # Find list of models for component class
+            # List can be in different locations, check CONFIG_XXX_FILE
+            node_name = 'CONFIG_{}_FILE'.format(comp)
+            models = files.get_components(node_name)
+            if (models is None) or (None in models):
+                # Backup, check COMP_ROOT_DIR_XXX
+                node_name = 'COMP_ROOT_DIR_' + comp
+                models = files.get_components(node_name)
+
+            expect((models is not None) and (None not in models),
+                   "Unable to find list of supported components")
+
+            for model in models:
+                mod_match = Case.__mod_match_re__.match(model.lower()).group(1)
+                comp_hash[mod_match] = comp_ind
+
+        return self._valid_compset_impl(compset_name, comp_classes, comp_hash)
 
 
     def _set_info_from_primary_component(self, files, pesfile=None):

--- a/src/components/data_comps/desp/cime_config/config_component.xml
+++ b/src/components/data_comps/desp/cime_config/config_component.xml
@@ -14,7 +14,7 @@
   -->
 
   <description modifier_mode="1">
-    <desc esp="DESP[%NOOP][%TEST]">Data External System Processor (DESP)</desc>
+    <desc esp="DESP[%NOOP][%TEST]">Data External System Processor (DESP) </desc>
     <desc option="NOOP">no modification of any model data</desc>
     <desc option="TEST">test modification of any model data</desc>
   </description>


### PR DESCRIPTION
Support optional components by filling in stub models for any missing component class

Test suite: scripts_regression_tests.py + many tests of running `create_newcase` with mangled compset names (both on command line and by modifying `<lname>` field in `<compset>` definition). E.g.:
```
2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV
2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP
2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC
2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SWAV
2000_DATM%NYF_DICE%SSMI_DOCN%DOM_DROF%NYF
2000_DICE%SSMI_DOCN%DOM_DATM%NYF_DROF%NYF
2000_DROF%NYF_DICE%SSMI_DATM%NYF_DOCN%DOM
```
Test baseline:  NA
Test namelist changes: NA
Test status: bit for bit

Fixes #3067 

User interface changes?: Stub components are now optional in compset long names. Also there is less order dependency.

Update gh-pages html (Y/N)?: N

Code review: 
