### PR TITLE
 set DATM_PRESAREO=none for A compsets, add back #3053 after a hard reset for maint-5.6 

### DIFF
--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -70,6 +70,7 @@
       <value compset="^HIST_">trans_1850-2000</value>
       <value compset="^20TR_">trans_1850-2000</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
+      <value compset="_DATM.*_DICE.*_DOCN.*_DROF">none</value> 
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
The PR adds back  #3053 after a hard reset to maint-5.6 that removed master history that was
added after master was accidentally merged to maint-5.6.

Set DATM_PRESAREO=none for A compsets, this avoids needing a 6GB inputdata file for testing.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: Changes answers for A compset
Fixes

User interface changes?:

Update gh-pages html (Y/N)?:

Code review: