### PR TITLE
Update of cori modules

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -501,10 +501,10 @@ This allows using a different mpirun command to launch unit tests
 	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-haswell</command>
+	<command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-haswell</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" >
-        <command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-haswell</command>
+	<command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-haswell</command>
       </modules>
 
       <modules compiler="cray">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -501,10 +501,10 @@ This allows using a different mpirun command to launch unit tests
 	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel2016-mpi-O</command>
+        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-haswell</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel2016-mpiuni-O</command>
+        <command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-haswell</command>
       </modules>
 
       <modules compiler="cray">
@@ -517,8 +517,8 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
-	<command name="load">papi/5.5.1.3</command>
-	<command name="swap">craype craype/2.5.12</command>
+	<command name="load">papi/5.6.0.3</command>
+	<command name="swap">craype craype/2.5.15</command>
       </modules>
       <modules>
 	<command name="switch">cray-libsci/18.03.1</command>
@@ -606,10 +606,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel2016-mpi-O</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel2016-mpiuni-O</command>
+        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-knl</command>
       </modules>
 
       <modules compiler="cray">
@@ -623,7 +620,7 @@ This allows using a different mpirun command to launch unit tests
       <modules>
 	<command name="load">cray-memkind</command>
 	<command name="load">craype-mic-knl</command>
-	<command name="swap">craype craype/2.5.14</command>
+	<command name="swap">craype craype/2.5.15</command>
       </modules>
       <modules>
 	<command name="switch">cray-libsci/18.03.1</command>


### PR DESCRIPTION
Update of cori-haswell and cori-knl  esmf, papi, and craype modules.

Test suite: scripts_regression_tests, prealpha tests on cori-haswell and cori-knl
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
