### PR TITLE
fix issue with setting 2 io tasks

### DIFF
--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -693,6 +693,7 @@ contains
          (pio_iotype .eq. PIO_IOTYPE_PNETCDF .or. &
          pio_iotype .eq. PIO_IOTYPE_NETCDF4P)) then
        pio_numiotasks = 2
+       pio_stride = min(pio_stride, npes/2)
     endif
 
     !--------------------------------------------------------------------------


### PR DESCRIPTION
When using pio2 if the pio_numiotasks and pio_stride indicate processors above the model task count you will get an error.  This change prevents that happening. 

Test suite: by hand SMS_P45.f19_g16.X 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
