### PR TITLE
Remove ESMF modules on edison

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -793,12 +793,6 @@ This allows using a different mpirun command to launch unit tests
 	<command name="rm">cray-libsci</command>
 	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/edison</command>
       </modules>
-      <modules compiler="intel" mpilib="!mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel17.0-mpi-O</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel17.0-mpiuni-O</command>
-      </modules>
       <modules compiler="cray">
 	<command name="load">PrgEnv-cray</command>
 	<command name="switch">cce cce/8.6.5</command>


### PR DESCRIPTION
Remove ESMF modules from config/cesm/machines/config_machines.xml to fix
builds for the last month of edison's life.

Test suite:  SMS.f09_g17.B1850.edison_intel, SMS.f09_f09_mg17.F2000climo.edison_intel
Test baseline: 
Test namelist changes: 
Test status:bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
