### PR TITLE
Allow specific tests to ignore field list differences

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -263,13 +263,20 @@ class SystemTestsCommon(object):
         comments = copy(self._case, suffix)
         append_testlog(comments)
 
-    def _component_compare_test(self, suffix1, suffix2, success_change=False):
+    def _component_compare_test(self, suffix1, suffix2,
+                                success_change=False,
+                                ignore_fieldlist_diffs=False):
         """
         Return value is not generally checked, but is provided in case a custom
         run case needs indirection based on success.
-        If success_change is True, success requires some files to be different
+        If success_change is True, success requires some files to be different.
+        If ignore_fieldlist_diffs is True, then: If the two cases differ only in their
+            field lists (i.e., all shared fields are bit-for-bit, but one case has some
+            diagnostic fields that are missing from the other case), treat the two cases
+            as identical.
         """
-        success, comments = self._do_compare_test(suffix1, suffix2)
+        success, comments = self._do_compare_test(suffix1, suffix2,
+                                                  ignore_fieldlist_diffs=ignore_fieldlist_diffs)
         if success_change:
             success = not success
 
@@ -279,12 +286,13 @@ class SystemTestsCommon(object):
             self._test_status.set_status("{}_{}_{}".format(COMPARE_PHASE, suffix1, suffix2), status)
         return success
 
-    def _do_compare_test(self, suffix1, suffix2):
+    def _do_compare_test(self, suffix1, suffix2, ignore_fieldlist_diffs=False):
         """
         Wraps the call to compare_test to facilitate replacement in unit
         tests
         """
-        return compare_test(self._case, suffix1, suffix2)
+        return compare_test(self._case, suffix1, suffix2,
+                            ignore_fieldlist_diffs=ignore_fieldlist_diffs)
 
     def _st_archive_case_test(self):
         result = self._case.test_env_archive()

--- a/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_compare_two.py
@@ -52,7 +52,8 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                  run_two_suffix = 'test',
                  run_one_description = '',
                  run_two_description = '',
-                 multisubmit = False):
+                 multisubmit = False,
+                 ignore_fieldlist_diffs = False):
         """
         Initialize a SystemTestsCompareTwo object. Individual test cases that
         inherit from SystemTestsCompareTwo MUST call this __init__ method.
@@ -71,10 +72,16 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 when starting the second run. Defaults to ''.
             multisubmit (bool): Do first and second runs as different submissions.
                 Designed for tests with RESUBMIT=1
+            ignore_fieldlist_diffs (bool): If True, then: If the two cases differ only in
+                their field lists (i.e., all shared fields are bit-for-bit, but one case
+                has some diagnostic fields that are missing from the other case), treat
+                the two cases as identical. (This is needed for tests where one case
+                exercises an option that produces extra diagnostic fields.)
         """
         SystemTestsCommon.__init__(self, case)
 
         self._separate_builds = separate_builds
+        self._ignore_fieldlist_diffs = ignore_fieldlist_diffs
 
         # run_one_suffix is just used as the suffix for the netcdf files
         # produced by the first case; we may eventually remove this, but for now
@@ -250,7 +257,9 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             # Case1 is the "main" case, and we need to do the comparisons from there
             self._activate_case1()
             self._link_to_case2_output()
-            self._component_compare_test(self._run_one_suffix, self._run_two_suffix, success_change=success_change)
+            self._component_compare_test(self._run_one_suffix, self._run_two_suffix,
+                                         success_change=success_change,
+                                         ignore_fieldlist_diffs=self._ignore_fieldlist_diffs)
 
     def copy_case1_restarts_to_case2(self):
         """

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -237,7 +237,8 @@ def _hists_match(model, hists1, hists2, suffix1="", suffix2=""):
 
     return one_not_two, two_not_one, match_ups
 
-def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_suffix=""):
+def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_suffix="",
+                   ignore_fieldlist_diffs=False):
     if from_dir1 == from_dir2:
         expect(suffix1 != suffix2, "Comparing files to themselves?")
 
@@ -278,7 +279,8 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
         for hist1, hist2 in match_ups:
             success, cprnc_log_file, cprnc_comment = cprnc(model, hist1, hist2, case, from_dir1,
                                                            multiinst_driver_compare=multiinst_driver_compare,
-                                                           outfile_suffix=outfile_suffix)
+                                                           outfile_suffix=outfile_suffix,
+                                                           ignore_fieldlist_diffs=ignore_fieldlist_diffs)
             if success:
                 comments += "    {} matched {}\n".format(hist1, hist2)
             else:
@@ -304,21 +306,27 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
 
     return all_success, comments
 
-def compare_test(case, suffix1, suffix2):
+def compare_test(case, suffix1, suffix2, ignore_fieldlist_diffs=False):
     """
     Compares two sets of component history files in the testcase directory
 
     case - The case containing the hist files to compare
     suffix1 - The suffix that identifies the first batch of hist files
     suffix1 - The suffix that identifies the second batch of hist files
+    ignore_fieldlist_diffs (bool): If True, then: If the two cases differ only in their
+        field lists (i.e., all shared fields are bit-for-bit, but one case has some
+        diagnostic fields that are missing from the other case), treat the two cases as
+        identical.
 
     returns (SUCCESS, comments)
     """
     rundir   = case.get_value("RUNDIR")
 
-    return _compare_hists(case, rundir, rundir, suffix1, suffix2)
+    return _compare_hists(case, rundir, rundir, suffix1, suffix2,
+                          ignore_fieldlist_diffs=ignore_fieldlist_diffs)
 
-def cprnc(model, file1, file2, case, rundir, multiinst_driver_compare=False, outfile_suffix=""):
+def cprnc(model, file1, file2, case, rundir, multiinst_driver_compare=False, outfile_suffix="",
+          ignore_fieldlist_diffs=False):
     """
     Run cprnc to compare two individual nc files
 
@@ -329,6 +337,10 @@ def cprnc(model, file1, file2, case, rundir, multiinst_driver_compare=False, out
     outfile_suffix - if non-blank, then the output file name ends with this
         suffix (with a '.' added before the given suffix).
         Use None to avoid permissions issues in the case dir.
+    ignore_fieldlist_diffs (bool): If True, then: If the two cases differ only in their
+        field lists (i.e., all shared fields are bit-for-bit, but one case has some
+        diagnostic fields that are missing from the other case), treat the two cases as
+        identical.
 
     returns (True if the files matched, log_name, comment)
         where 'comment' is either an empty string or one of the module-level constants
@@ -376,8 +388,11 @@ def cprnc(model, file1, file2, case, rundir, multiinst_driver_compare=False, out
             elif "the two files seem to be DIFFERENT" in out:
                 files_match = False
             elif "the two files DIFFER only in their field lists" in out:
-                files_match = False
-                comment = CPRNC_FIELDLISTS_DIFFER
+                if ignore_fieldlist_diffs:
+                    files_match = True
+                else:
+                    files_match = False
+                    comment = CPRNC_FIELDLISTS_DIFFER
             else:
                 expect(False, "Did not find an expected summary string in cprnc output")
     else:

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -179,7 +179,7 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
         if caseroot not in self.run_pass_caseroot:
             raise RuntimeError('caseroot not in run_pass_caseroot')
 
-    def _do_compare_test(self, suffix1, suffix2):
+    def _do_compare_test(self, suffix1, suffix2, ignore_fieldlist_diffs=False):
         """
         This fake implementation allows controlling whether compare_test
         passes or fails


### PR DESCRIPTION
Due to recent changes to cprnc, differences in field lists (i.e., if one
case has some diagnostic fields that are missing from the other case)
are now treated as differences. However, this is a problem for some new
tests that are wanted, such as ensuring that turning on carbon isotopes
doesn't change answers.

This PR allows a particular test type to dictate that field list
differences should be ignored. For tests that use SystemTestsCompareTwo,
this is as simple as adding an argument to the SystemTestsCompareTwo
constructor. For other tests, a new argument can be added to the call to
self._component_compare_test. (Differences in the values in shared
fields are still treated as differences.)

Test suite: scripts_regression_tests on cheyenne; also manual testing as
    noted below
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Manual testing:

- Ran a PEM test where I put in place a different copy of the '.base'
  file as the test is running, which has an extra field: reported as
  DIFFER, as expected.

- Redid that test with this new flag: now reported as IDENTICAL; done
  via the following diffs:

```diff
diff --git a/scripts/lib/CIME/SystemTests/pem.py b/scripts/lib/CIME/SystemTests/pem.py
index 34bb67a..abe2546 100644
--- a/scripts/lib/CIME/SystemTests/pem.py
+++ b/scripts/lib/CIME/SystemTests/pem.py
@@ -20,7 +20,8 @@ class PEM(SystemTestsCompareTwo):
                                        separate_builds = True,
                                        run_two_suffix = 'modpes',
                                        run_one_description = 'default pe counts',
-                                       run_two_description = 'halved pe counts')
+                                       run_two_description = 'halved pe counts',
+                                       ignore_fieldlist_diffs = True)

     def _case_one_setup(self):
         pass
```

- If I instead put in place a file with diffs in one field along with
  the added field, this is still reported as DIFFER (i.e., I didn't
  break the reporting of true differences when adding
  ignore_fieldlist_diffs)

Fixes: none

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @jgfouca 

Thanks to @klindsay28 for the inspiration for this change. Also cc @ekluzek .
