### PR TITLE
Omit OMP_NUM_THREADS in MPI-only runs

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -177,7 +177,8 @@ class Case(object):
         threads_per_core = 1 if (threads_per_node <= max_mpitasks_per_node) else smt_factor
         self.cores_per_task = self.thread_count / threads_per_core
 
-        os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
+        if self.get_build_threaded():
+            os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
 
         self.srun_binding = smt_factor*max_mpitasks_per_node / self.tasks_per_node
 
@@ -1411,7 +1412,8 @@ directory, NOT in this subdirectory."""
         if not self._is_env_loaded or reset:
             if job is None:
                 job = self.get_primary_job()
-            os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
+            if self.get_build_threaded():
+                os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
             env_module = self.get_env("mach_specific")
             env_module.load_env(self, job=job, verbose=verbose)
             self._is_env_loaded = True

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -179,6 +179,8 @@ class Case(object):
 
         if self.get_build_threaded():
             os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
+        elif "OMP_NUM_THREADS" in os.environ:
+            del os.environ["OMP_NUM_THREADS"]
 
         self.srun_binding = smt_factor*max_mpitasks_per_node / self.tasks_per_node
 
@@ -1414,6 +1416,8 @@ directory, NOT in this subdirectory."""
                 job = self.get_primary_job()
             if self.get_build_threaded():
                 os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
+            elif "OMP_NUM_THREADS" in os.environ:
+                del os.environ["OMP_NUM_THREADS"]
             env_module = self.get_env("mach_specific")
             env_module.load_env(self, job=job, verbose=verbose)
             self._is_env_loaded = True

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -76,7 +76,8 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
     model = case.get_value("MODEL")
 
     # Set OMP_NUM_THREADS
-    os.environ["OMP_NUM_THREADS"] = str(case.thread_count)
+    if case.get_build_threaded():
+        os.environ["OMP_NUM_THREADS"] = str(case.thread_count)
 
     # Run the model
     cmd = case.get_mpirun_cmd(allow_unresolved_envvars=False)

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -78,6 +78,8 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
     # Set OMP_NUM_THREADS
     if case.get_build_threaded():
         os.environ["OMP_NUM_THREADS"] = str(case.thread_count)
+    elif "OMP_NUM_THREADS" in os.environ:
+        del os.environ["OMP_NUM_THREADS"]
 
     # Run the model
     cmd = case.get_mpirun_cmd(allow_unresolved_envvars=False)


### PR DESCRIPTION
Omit OMP_NUM_THREADS in MPI-only runs

Test suite: SMS.f19_g16.X
Test baseline: mpi-only vs. threaded
Test namelist changes: none
Test status: [bit for bit]

Fixes ESMCI/cime#3082

User interface changes?: none

Update gh-pages html (Y/N)?: N