### PR TITLE
Fix ne0CONUSne30x8 grids

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1392,8 +1392,8 @@
 
     <domain name="ne0np4CONUS.ne30x8">
       <nx>174098</nx> <ny>1</ny>
-      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne0CONUSne30x8_gx1v7.190304.nc</file>
-      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne0CONUSne30x8_gx1v7.190304.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne0CONUSne30x8_gx1v7.190322.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne0CONUSne30x8_gx1v7.190322.nc</file>
       <desc>ne0np4CONUS.ne30x8 is a Spectral Elem 1-deg grid with a 1/8 deg refined region over the continental United States:</desc>
       <support>Test support only</support>
     </domain>

--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -32,8 +32,8 @@
     </gridmap>
 
     <gridmap lnd_grid="ne0np4CONUS.ne30x8" rof_grid="r05">
-      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_0.5x0.5_nomask_aave.190227.nc</map>
-      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_0.5x0.5_nomask_TO_ne0CONUSne30x8_aave.190227.nc</map>
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_0.5x0.5_nomask_aave.190322.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_0.5x0.5_nomask_TO_ne0CONUSne30x8_aave.190322.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="360x720cru" rof_grid="r05">
@@ -288,10 +288,10 @@
     </gridmap>
 
     <gridmap lnd_grid="ne0np4CONUS.ne30x8" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gland4km_aave.190227.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gland4km_blin.190227.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne0CONUSne30x8_aave.190227.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne0CONUSne30x8_aave.190227.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gland4km_aave.190322.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gland4km_blin.190322.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne0CONUSne30x8_aave.190322.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne0CONUSne30x8_aave.190322.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne120np4" glc_grid="gland4" >

--- a/config/cesm/config_grids_mct.xml
+++ b/config/cesm/config_grids_mct.xml
@@ -208,15 +208,15 @@
     </gridmap>
 
     <gridmap atm_grid="ne0np4CONUS.ne30x8" ocn_grid="gx1v7">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_aave.190227.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_blin.190227.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_patc.190227.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190227.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190227.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_aave.190322.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_blin.190322.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gx1v7_patc.190322.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190322.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne0CONUSne30x8_aave.190322.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4CONUS.ne30x8" wav_grid="ww3a">
-      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_ww3a_blin.190213.nc</map>
+      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_ww3a_blin.190322.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="gx1v7">


### PR DESCRIPTION
Update the ne0CONUSne30x8 mapping files, since the original ones used the wrong
SCRIP grid files.


Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
