### PR TITLE
properly link nag f90

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -402,6 +402,7 @@
 
   <batch_system type="pbs" MACH="izumi" >
     <batch_submit>ssh izumi cd $CASEROOT ; qsub</batch_submit>
+    <jobid_pattern>(\d+.izumi.unified.ucar.edu)$</jobid_pattern>
     <directives>
       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
       <directive default="/bin/bash" > -S {{ shell }}  </directive>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -915,6 +915,15 @@ using a fortran linker.
   </SLIBS>
 </compiler>
 
+<compiler MACH="izumi" COMPILER="nag">
+  <LDFLAGS>
+    <append> -lpthread</append>
+  </LDFLAGS>
+  <SLIBS>
+    <append> -L$(COMPILER_PATH)/lib/NAG_Fortran -lf62rts </append>
+  </SLIBS>
+</compiler>
+
 <compiler MACH="hobart" COMPILER="pgi">
   <CFLAGS>
     <append DEBUG="FALSE"> -O0 </append>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -324,14 +324,11 @@ using a fortran linker.
   <LDFLAGS>
     <append> -lpthread </append>
   </LDFLAGS>
-  <SLIBS>
-    <append> -L$(COMPILER_PATH)/lib/NAG_Fortran -lf62rts </append>
-  </SLIBS>
   <CONFIG_ARGS>
-    <append> LIBS="-L$(COMPILER_PATH)/lib/NAG_Fortran -lf62rts" </append>
+    <append> FCLIBS="-Wl,--as-needed,--allow-shlib-undefined  -L$(COMPILER_PATH)/lib/NAG_Fortran -lf62rts" </append>
   </CONFIG_ARGS>
-
 </compiler>
+
 
 <compiler COMPILER="pgi">
   <CFLAGS>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -320,6 +320,17 @@ using a fortran linker.
   <MPIFC> mpif90 </MPIFC>
   <SCC> gcc </SCC>
   <SFC> nagfor </SFC>
+
+  <LDFLAGS>
+    <append> -lpthread </append>
+  </LDFLAGS>
+  <SLIBS>
+    <append> -L$(COMPILER_PATH)/lib/NAG_Fortran -lf62rts </append>
+  </SLIBS>
+  <CONFIG_ARGS>
+    <append> LIBS="-L$(COMPILER_PATH)/lib/NAG_Fortran -lf62rts" </append>
+  </CONFIG_ARGS>
+
 </compiler>
 
 <compiler COMPILER="pgi">
@@ -900,28 +911,6 @@ using a fortran linker.
     <append MPILIB="mvapich2"> -mkl=cluster </append>
   </SLIBS>
   <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="FALSE">/fs/cgd/csm/tools/pFUnit/pFUnit3.2.8_hobart_Intel15.0.2_noMPI_noOpenMP</PFUNIT_PATH>
-</compiler>
-
-<compiler MACH="hobart" COMPILER="nag">
-  <CPPDEFS>
-    <!-- needed for nag pio build.. -->
-    <append> -DNO_C_SIZEOF </append>
-  </CPPDEFS>
-  <LDFLAGS>
-    <append> -lpthread</append>
-  </LDFLAGS>
-  <SLIBS>
-    <append> -L/usr/local/nag/lib/NAG_Fortran </append>
-  </SLIBS>
-</compiler>
-
-<compiler MACH="izumi" COMPILER="nag">
-  <LDFLAGS>
-    <append> -lpthread</append>
-  </LDFLAGS>
-  <SLIBS>
-    <append> -L$(COMPILER_PATH)/lib/NAG_Fortran -lf62rts </append>
-  </SLIBS>
 </compiler>
 
 <compiler MACH="hobart" COMPILER="pgi">

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -439,31 +439,7 @@ endif
 
 ifeq ($(MODEL),driver)
   INCLDIR += -I$(EXEROOT)/atm/obj -I$(EXEROOT)/ice/obj -I$(EXEROOT)/ocn/obj -I$(EXEROOT)/glc/obj -I$(EXEROOT)/rof/obj -I$(EXEROOT)/wav/obj -I$(EXEROOT)/esp/obj -I$(EXEROOT)/iac/obj
-# nagfor and gcc have incompatible LDFLAGS.
-# nagfor requires the weird "-Wl,-Wl,," syntax.
-# If done in config_compilers.xml, we break MCT.
-  ifeq ($(strip $(COMPILER)),nag)
-     ifeq ($(NETCDF_SEPARATE), FALSE)
-       SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF)
-     else ifeq ($(NETCDF_SEPARATE), TRUE)
-       SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF_C)
-       SLIBS += -Wl,-Wl,,-rpath=$(LIB_NETCDF_FORTRAN)
-     endif
-  endif
-else
-  ifeq ($(strip $(COMPILER)),nag)
-    ifeq ($(DEBUG), TRUE)
-      ifeq ($(strip $(MACH)),hobart)
-       # GCC needs to be able to link to
-       # nagfor runtime to get autoconf
-       # tests to work.
-         CFLAGS += -Wl,--as-needed,--allow-shlib-undefined
-         SLIBS += -L$(COMPILER_PATH)/lib/NAG_Fortran -lf62rts
-       endif
-    endif
-  endif
 endif
-
 
 ifndef MCT_LIBDIR
   MCT_LIBDIR=$(INSTALL_SHAREDPATH)/lib
@@ -514,14 +490,8 @@ else ifeq ($(NETCDF_SEPARATE), TRUE)
   CONFIG_ARGS += NETCDF_PATH=$(NETCDF_C_PATH)
 endif
 
-ifeq ($(COMPILER),nag)
-  CONFIG_ARGS += LIBS="$(SLIBS)"
-endif
-
 FFLAGS += $(FPPDEFS)
 FFLAGS_NOOPT += $(FPPDEFS)
-
-
 
 ifeq ($(findstring -cosp,$(CAM_CONFIG_OPTS)),-cosp)
   # The following is for the COSP simulator code:

--- a/src/components/xcpl_comps/xshare/mct/dead_mod.F90
+++ b/src/components/xcpl_comps/xshare/mct/dead_mod.F90
@@ -47,6 +47,7 @@ contains
     !--- formats ---
     character(*), parameter :: F00   = "('(dead_read_inparms) ',8a)"
     character(*), parameter :: F01   = "('(dead_read_inparms) ',a,a,4i8)"
+    character(*), parameter :: F02   = "('(dead_read_inparms) ',a,L2)"
     character(*), parameter :: F03   = "('(dead_read_inparms) ',a,a,i8,a)"
     character(*), parameter :: subName = "(dead_read_inpamrs) "
     !-------------------------------------------------------------------------------
@@ -95,7 +96,7 @@ contains
        write(logunit,F00) model,'    inst_name   :  ',trim(inst_name)
        write(logunit,F00) model,'    inst_suffix :  ',trim(inst_suffix)
        if (model.eq.'rof') then
-          write(logunit,F01) ' Flood mode     :  ',flood
+          write(logunit,F02) ' Flood mode     :  ',flood
        endif
        write(logunit,F00) model
        call shr_sys_flush(logunit)


### PR DESCRIPTION
Fix an issue in mct configure by providing the correct link flags for nag f90.

Test suite: SMS_D.f45_g37.A.izumi_nag
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
