### PR TITLE
Change DATM_CLMNCEP_YR_ALIGN for present-day compsets

### DIFF
--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -187,30 +187,31 @@
     <valid_values></valid_values>
     <default_value>1</default_value>
     <values match="last">
-      <value compset="2000.*_DATM%1PT">1</value>
+      <value compset="2000.*_DATM%1PT">1972</value>
       <value compset="1850.*_DATM%QIA">1</value>
       <value compset="1850.*_DATM%CRU">1</value>
       <value compset="1850.*_DATM%GSW">1</value>
-      <value compset="2000.*_DATM%QIA">1</value>
+      <value compset="2000.*_DATM%WISOQIA">2000</value>
+      <value compset="2000.*_DATM%QIA">1972</value>
       <value compset="HIST.*_DATM%QIA">1895</value>
       <value compset="HIST.*_DATM%CRU">1901</value>
       <value compset="HIST.*_DATM%GSW">1901</value>
       <value compset="20TR.*_DATM%QIA">1895</value>
       <value compset="20TR.*_DATM%CRU">1901</value>
       <value compset="20TR.*_DATM%GSW">1901</value>
-      <value compset="4804.*_DATM%QIA">1</value>
+      <value compset="4804.*_DATM%QIA">1948</value>
       <value compset="RCP.*_DATM%QIA">2004</value>
       <value compset="RCP.*_DATM%CRU">2005</value>
       <value compset="RCP.*_DATM%GSW">2005</value>
-      <value compset="2003.*_DATM%QIA.*_TEST">1</value>
+      <value compset="2003.*_DATM%QIA.*_TEST">2002</value>
       <value compset="1850.*_DATM%CRU">1</value>
-      <value compset="2000.*_DATM%CRU">1</value>
-      <value compset="2003.*_DATM%CRU">1</value>
-      <value compset="2010.*_DATM%CRU">1</value>
+      <value compset="2000.*_DATM%CRU">1991</value>
+      <value compset="2003.*_DATM%CRU">2002</value>
+      <value compset="2010.*_DATM%CRU">2005</value>
       <value compset="1850.*_DATM%GSW">1</value>
-      <value compset="2000.*_DATM%GSW">1</value>
-      <value compset="2010.*_DATM%GSW">1</value>
-      <value compset="2003.*_DATM%GSW">1</value>
+      <value compset="2000.*_DATM%GSW">1991</value>
+      <value compset="2010.*_DATM%GSW">2005</value>
+      <value compset="2003.*_DATM%GSW">2002</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -187,31 +187,24 @@
     <valid_values></valid_values>
     <default_value>1</default_value>
     <values match="last">
-      <value compset="2000.*_DATM%1PT">1972</value>
       <value compset="1850.*_DATM%QIA">1</value>
       <value compset="1850.*_DATM%CRU">1</value>
       <value compset="1850.*_DATM%GSW">1</value>
-      <value compset="2000.*_DATM%WISOQIA">2000</value>
-      <value compset="2000.*_DATM%QIA">1972</value>
       <value compset="HIST.*_DATM%QIA">1895</value>
       <value compset="HIST.*_DATM%CRU">1901</value>
       <value compset="HIST.*_DATM%GSW">1901</value>
       <value compset="20TR.*_DATM%QIA">1895</value>
       <value compset="20TR.*_DATM%CRU">1901</value>
       <value compset="20TR.*_DATM%GSW">1901</value>
-      <value compset="4804.*_DATM%QIA">1948</value>
       <value compset="RCP.*_DATM%QIA">2004</value>
       <value compset="RCP.*_DATM%CRU">2005</value>
       <value compset="RCP.*_DATM%GSW">2005</value>
-      <value compset="2003.*_DATM%QIA.*_TEST">2002</value>
       <value compset="1850.*_DATM%CRU">1</value>
-      <value compset="2000.*_DATM%CRU">1991</value>
-      <value compset="2003.*_DATM%CRU">2002</value>
-      <value compset="2010.*_DATM%CRU">2005</value>
       <value compset="1850.*_DATM%GSW">1</value>
-      <value compset="2000.*_DATM%GSW">1991</value>
-      <value compset="2010.*_DATM%GSW">2005</value>
-      <value compset="2003.*_DATM%GSW">2002</value>
+      <value compset="2000.*_DATM">$DATM_CLMNCEP_YR_START</value>
+      <value compset="2003.*_DATM">$DATM_CLMNCEP_YR_START</value>
+      <value compset="2010.*_DATM">$DATM_CLMNCEP_YR_START</value>
+      <value compset="4804.*_DATM">$DATM_CLMNCEP_YR_START</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
For present-day compsets, the CESM land group wants
DATM_CLMNCEP_YR_ALIGN to match DATM_CLMNCEP_YR_START for present-day
compsets. This will make the model year align with the forcing year. For
example, if RUN_STARTDATE is set to 2000-01-01, then the model will use
year-2000 atmospheric forcing data in the first year, etc.

Test suite:
- Ran `SMS_D_Ld3.f10_f10_musgs.I2000Clm50SpGs.cheyenne_gnu`
  - Confirmed that DATM_CLMNCEP_YR_ALIGN is set correctly
  - With RUN_STARTDATE=2000-01-01, confirmed that it uses year-2000
    atmospheric forcing data for the first few days of the run
- scripts_regression_tests on cheyenne
Test baseline: n/a
Test namelist changes: Yes - changes settings in datm_in
Test status: climate changing: changes behavior significantly for
  present-day I compsets. Climatological averages should be the same,
  but year alignment changes.

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 