### PR TITLE
Allow custom run_exe and run_misc_suffix 

### DIFF
--- a/config/e3sm/machines/config_machines.xml
+++ b/config/e3sm/machines/config_machines.xml
@@ -1147,15 +1147,15 @@
     <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
-      <executable>sbcast ${EXEROOT}/e3sm.exe /tmp/e3sm.exe; srun</executable>
+      <executable>sbcast ${EXEROOT}/e3sm.exe /tmp/e3sm.exe; srun </executable>
       <arguments>
         <arg name="num_tasks"> -l -n {{ total_tasks }} </arg>
       </arguments>
+      <run_exe> /tmp/e3sm.exe </run_exe>
     </mpirun>
     <mpirun mpilib="mpi-serial">
       <executable/>
     </mpirun>
-    <run_exe> /tmp/e3sm.exe </run_exe>
     <module_system type="module">
       <init_path lang="sh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/sh;export MODULEPATH=/blues/gpfs/software/centos7/spack-0.12.1/share/spack/lmod/linux-centos7-x86_64/Core</init_path>
       <init_path lang="csh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/csh;setenv MODULEPATH /blues/gpfs/software/centos7/spack-0.12.1/share/spack/lmod/linux-centos7-x86_64/Core</init_path>

--- a/config/e3sm/machines/config_machines.xml
+++ b/config/e3sm/machines/config_machines.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<config_machines version="2.0">
+<config_machines version="2.1">
 
   <!--
 
@@ -1147,7 +1147,7 @@
     <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
-      <executable>srun</executable>
+      <executable>sbcast ${EXEROOT}/e3sm.exe /tmp/e3sm.exe; srun</executable>
       <arguments>
         <arg name="num_tasks"> -l -n {{ total_tasks }} </arg>
       </arguments>
@@ -1155,6 +1155,7 @@
     <mpirun mpilib="mpi-serial">
       <executable/>
     </mpirun>
+    <run_exe> /tmp/e3sm.exe </run_exe>
     <module_system type="module">
       <init_path lang="sh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/sh;export MODULEPATH=/blues/gpfs/software/centos7/spack-0.12.1/share/spack/lmod/linux-centos7-x86_64/Core</init_path>
       <init_path lang="csh">/home/software/spack-0.10.1/opt/spack/linux-centos7-x86_64/gcc-4.8.5/lmod-7.4.9-ic63herzfgw5u3na5mdtvp3nwxy6oj2z/lmod/lmod/init/csh;setenv MODULEPATH /blues/gpfs/software/centos7/spack-0.12.1/share/spack/lmod/linux-centos7-x86_64/Core</init_path>

--- a/config/e3sm/machines/config_machines.xml
+++ b/config/e3sm/machines/config_machines.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<config_machines version="2.1">
+<config_machines version="2.0">
 
   <!--
 
@@ -1147,11 +1147,10 @@
     <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
-      <executable>sbcast ${EXEROOT}/e3sm.exe /tmp/e3sm.exe; srun </executable>
+      <executable>srun</executable>
       <arguments>
         <arg name="num_tasks"> -l -n {{ total_tasks }} </arg>
       </arguments>
-      <run_exe> /tmp/e3sm.exe </run_exe>
     </mpirun>
     <mpirun mpilib="mpi-serial">
       <executable/>

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -159,8 +159,6 @@
         <!-- mpirun: The mpi exec to start a job on this machine
              see detail below-->
         <xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
-        <!-- run_exe: The run executable to use on this machine; overrides default_run_exe -->
-        <xs:element ref="run_exe" minOccurs="0"/>
         <!-- module_system: how and what modules to load on this system ,
              see detail below -->
         <xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
@@ -182,6 +180,8 @@
       <xs:sequence>
         <xs:element ref="executable"/>
         <xs:element ref="arguments" minOccurs="0"/>
+        <!-- run_exe: The run executable to use on this machine; overrides default_run_exe -->
+        <xs:element ref="run_exe" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="queue"/>

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -56,6 +56,7 @@
   <xs:element name="executable" type="xs:string"/>
   <xs:element name="default_run_exe" type="xs:string"/>
   <xs:element name="default_run_misc_suffix" type="xs:string"/>
+  <xs:element name="run_exe" type="xs:string"/>
   <xs:element name="RUNDIR" type="xs:string"/>
   <xs:element name="EXEROOT" type="xs:string"/>
   <xs:element name="TEST_TPUT_TOLERANCE" type="xs:string"/>
@@ -158,6 +159,8 @@
         <!-- mpirun: The mpi exec to start a job on this machine
              see detail below-->
         <xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- run_exe: The run executable to use on this machine; overrides default_run_exe -->
+        <xs:element ref="run_exe" minOccurs="0"/>
         <!-- module_system: how and what modules to load on this system ,
              see detail below -->
         <xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -57,6 +57,7 @@
   <xs:element name="default_run_exe" type="xs:string"/>
   <xs:element name="default_run_misc_suffix" type="xs:string"/>
   <xs:element name="run_exe" type="xs:string"/>
+  <xs:element name="run_misc_suffix" type="xs:string"/>
   <xs:element name="RUNDIR" type="xs:string"/>
   <xs:element name="EXEROOT" type="xs:string"/>
   <xs:element name="TEST_TPUT_TOLERANCE" type="xs:string"/>
@@ -180,8 +181,10 @@
       <xs:sequence>
         <xs:element ref="executable"/>
         <xs:element ref="arguments" minOccurs="0"/>
-        <!-- run_exe: The run executable to use on this machine; overrides default_run_exe -->
+        <!-- run_exe: The run executable to use; overrides default_run_exe -->
         <xs:element ref="run_exe" minOccurs="0"/>
+        <!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
+        <xs:element ref="run_misc_suffix" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="queue"/>

--- a/config/xml_schemas/env_mach_specific.xsd
+++ b/config/xml_schemas/env_mach_specific.xsd
@@ -152,6 +152,8 @@
       <xs:sequence>
         <xs:element ref="executable"/>
         <xs:element minOccurs="0" maxOccurs="1" ref="arguments"/>
+        <xs:element minOccurs="0" maxOccurs="1" name="run_exe" type="xs:string"/>
+        <xs:element minOccurs="0" maxOccurs="1" name="run_misc_suffix" type="xs:string"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="mpilib"/>

--- a/doc/source/users_guide/machine.rst
+++ b/doc/source/users_guide/machine.rst
@@ -57,6 +57,8 @@ Each ``<machine>`` tag requires the following input:
   * May have optional attributes of ``compiler``, ``mpilib`` and/or ``threaded``
   * May have an optional ``<arguments>`` element which in turn contains one or more ``<arg>`` elements.
     These specify the arguments to the mpi executable and are dependent on your mpi library implementation.
+  * May have an option ``<run_exe>`` element which overrides the ``default_run_exe``
+  * May have an option ``<run_misc_suffix>`` element which overrides the ``default_run_misc_suffix``
 
 
 * ``module_system``: How and what modules to load on this system. Module systems allow you to easily load multiple compiler environments on a machine. CIME provides support for two types of module tools: `module <http://www.tacc.utexas.edu/tacc-projects/mclay/lmod>`_ and `soft  <http://www.mcs.anl.gov/hs/software/systems/softenv/softenv-intro.html>`_. If neither of these is available on your machine, simply set ``<module_system type="none"\>``.

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -360,7 +360,7 @@ def _main():
         }
 
         # We can get away with specifying case=None since we're using exe_only=True
-        mpirun_command, _ = machspecific.get_mpirun(None, mpi_attribs, None, exe_only=True)
+        mpirun_command, _, _ = machspecific.get_mpirun(None, mpi_attribs, None, exe_only=True)
         mpirun_command = machspecific.get_resolved_value(mpirun_command)
         logger.info("mpirun command is '{}'".format(mpirun_command))
 

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -360,7 +360,7 @@ def _main():
         }
 
         # We can get away with specifying case=None since we're using exe_only=True
-        mpirun_command, _, _ = machspecific.get_mpirun(None, mpi_attribs, None, exe_only=True)
+        mpirun_command, _, _, _ = machspecific.get_mpirun(None, mpi_attribs, None, exe_only=True)
         mpirun_command = machspecific.get_resolved_value(mpirun_command)
         logger.info("mpirun command is '{}'".format(mpirun_command))
 

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -39,7 +39,7 @@ class EnvMachSpecific(EnvBase):
                 if len(nodes) == 0:
                     value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)
                 else:
-                    value = nodes[0].text
+                    value = self.text(nodes[0])
 
                 entity_node = self.make_child("entry", {"id":item, "value":value}, root=group_node)
 

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -478,7 +478,10 @@ class EnvMachSpecific(EnvBase):
         run_exe_node = self.get_optional_child('run_exe', root=the_match)
         run_exe = self.text(run_exe_node)
 
-        return executable, args, run_exe
+        run_misc_suffix_node = self.get_optional_child('run_misc_suffix', root=the_match)
+        run_misc_suffix = self.text(run_exe_node)
+
+        return executable, args, run_exe, run_misc_suffix
 
     def get_type_info(self, vid):
         return "char"

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -479,7 +479,7 @@ class EnvMachSpecific(EnvBase):
         run_exe = self.text(run_exe_node)
 
         run_misc_suffix_node = self.get_optional_child('run_misc_suffix', root=the_match)
-        run_misc_suffix = self.text(run_exe_node)
+        run_misc_suffix = self.text(run_misc_suffix_node)
 
         return executable, args, run_exe, run_misc_suffix
 

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -475,7 +475,10 @@ class EnvMachSpecific(EnvBase):
         expect(exec_node is not None,"No executable found")
         executable = self.text(exec_node)
 
-        return executable, args
+        run_exe_node = self.get_optional_child('run_exe', root=the_match)
+        run_exe = self.text(run_exe_node)
+
+        return executable, args, run_exe
 
     def get_type_info(self, vid):
         return "char"

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1364,7 +1364,6 @@ directory, NOT in this subdirectory."""
         run_exe = env_mach_specific.get_value("run_exe")
         run_misc_suffix = env_mach_specific.get_value("run_misc_suffix")
         run_misc_suffix = "" if run_misc_suffix is None else run_misc_suffix
-        run_suffix = run_exe + run_misc_suffix
 
         mpirun_cmd_override = self.get_value("MPI_RUN_COMMAND")
         if mpirun_cmd_override not in ["", None, "UNSET"]:
@@ -1379,7 +1378,11 @@ directory, NOT in this subdirectory."""
             "unit_testing" : False
             }
 
-        executable, mpi_arg_list = env_mach_specific.get_mpirun(self, mpi_attribs, job)
+        executable, mpi_arg_list, custom_run_exe = env_mach_specific.get_mpirun(self, mpi_attribs, job)
+        if custom_run_exe:
+            logger.info('Using a custom run_exe {}'.format(custom_run_exe))
+            run_exe = custom_run_exe
+
 
         # special case for aprun
         if executable is not None and "aprun" in executable and not "theta" in self.get_value("MACH"):
@@ -1393,7 +1396,7 @@ directory, NOT in this subdirectory."""
         if self.get_value("BATCH_SYSTEM") == "cobalt":
             mpi_arg_string += " : "
 
-        return self.get_resolved_value("{} {} {}".format(executable if executable is not None else "", mpi_arg_string, run_suffix), allow_unresolved_envvars=allow_unresolved_envvars)
+        return self.get_resolved_value("{} {} {} {}".format(executable if executable is not None else "", mpi_arg_string, run_exe, run_misc_suffix), allow_unresolved_envvars=allow_unresolved_envvars)
 
     def set_model_version(self, model):
         version = "unknown"

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1378,10 +1378,13 @@ directory, NOT in this subdirectory."""
             "unit_testing" : False
             }
 
-        executable, mpi_arg_list, custom_run_exe = env_mach_specific.get_mpirun(self, mpi_attribs, job)
+        executable, mpi_arg_list, custom_run_exe, custom_run_misc_suffix = env_mach_specific.get_mpirun(self, mpi_attribs, job)
         if custom_run_exe:
             logger.info('Using a custom run_exe {}'.format(custom_run_exe))
             run_exe = custom_run_exe
+        if custom_run_misc_suffix:
+            logger.info('Using a custom run_misc_suffix {}'.format(custom_run_misc_suffix))
+            run_misc_suffix = custom_run_misc_suffix
 
 
         # special case for aprun


### PR DESCRIPTION
This updates the `config_machines.xsd` schema to allow for a custom `run_exe` and `misc_run_suffix`, which can optionally be set inside a machine's `mpirun` definition. This allows, as shown in the updated E3SM config for machine `anvil`, to use the SLURM `sbcast` option which [can speed up the job start time](https://docs.nersc.gov/jobs/best-practices/#running-large-jobs-over-1500-mpi-tasks):

```sh
 sbcast ${EXEROOT}/e3sm.exe /tmp/e3sm.exe; srun [ARGS] /tmp/e3sm.exe  >> e3sm.log.$LID 2>&1
```

Note: I chose to define this inside the `mpirun` definition because changing the `default_run_exe` at the machine level would cause mpi-serial runs to be executed like: 
```sh
 /tmp/e3sm.exe >> e3sm.log.$LID 2>&1
```
instead of: 

```sh
 ${EXEROOT}/e3sm.exe >> e3sm.log.$LID 2>&1
```

Test suite: 
* `scripts_regression_tests.py` on Anvil (same tests pass as before these changes)

Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3081 

User interface changes?: None

Update gh-pages html (Y/N)?: Y

Code review: 
