### PR TITLE
Fix ConfigParser fails with some saved submit_options 

### DIFF
--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -175,7 +175,7 @@ def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubm
     # any submit options used on the original submit and use them again
     submit_options = os.path.join(caseroot, ".submit_options")
     if resubmit and os.path.exists(submit_options):
-        config = configparser.SafeConfigParser()
+        config = configparser.RawConfigParser()
         config.read(submit_options)
         if not skip_pnl and config.has_option('SubmitOptions','skip_pnl'):
             skip_pnl = config.getboolean('SubmitOptions', 'skip_pnl')


### PR DESCRIPTION
Automatic resubmit fails when `.submit_options` is present (see E3SM-Project/E3SM#2868) for some batch systems due to unescaped `%` symbols (which are used for magic interpolation) in the `batch_args`. This likely affects 
 * E3SM machines that use the batch systems `lfs`, `nersc_slurm`, or `slurm`
 * CESM machines that use the batch system `lfs`

This is fixed by using `RawConfigParser` to parse the `.submit_options` file and, because this file is written with the `RawConfigParser` ( since #2722), there should not be any magic interpolation used or expected. 

Test suite: scripts_regression_tests.py on Anvil
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
