### PR TITLE
dont require optional arguments

### DIFF
--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -474,12 +474,16 @@ class EnvMachSpecific(EnvBase):
         exec_node = self.get_child("executable", root=the_match)
         expect(exec_node is not None,"No executable found")
         executable = self.text(exec_node)
+        run_exe = None
+        run_misc_suffix = None
 
         run_exe_node = self.get_optional_child('run_exe', root=the_match)
-        run_exe = self.text(run_exe_node)
+        if run_exe_node:
+            run_exe = self.text(run_exe_node)
 
         run_misc_suffix_node = self.get_optional_child('run_misc_suffix', root=the_match)
-        run_misc_suffix = self.text(run_misc_suffix_node)
+        if run_misc_suffix_node:
+            run_misc_suffix = self.text(run_misc_suffix_node)
 
         return executable, args, run_exe, run_misc_suffix
 

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -452,7 +452,7 @@ class EnvMachSpecific(EnvBase):
 
         # if there are no special arguments required for mpi-serial it need not have an entry in config_machines.xml
         if "mpilib" in attribs and attribs["mpilib"] == "mpi-serial" and best_match is None:
-            return "",[]
+            return "",[],None,None
 
         expect(best_match is not None or default_match is not None,
                "Could not find a matching MPI for attributes: {}".format(attribs))


### PR DESCRIPTION
Optional arguments run_exe and run_misc_suffix were introduced by PR #3099 but if they are not there an error is generated.

Test suite: scripts_regression_tests on centos7-linux (congo)
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3102 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
