### PR TITLE
Updates for pleiades

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1035,7 +1035,7 @@ using a fortran linker.
   <SLIBS>
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
-  <ESMF_LIBDIR>/home6/fvitt/esmf_7_0_0/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
+  <ESMF_LIBDIR>/home6/fvitt/esmf_7_1_0r/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="pleiades-has">
@@ -1049,7 +1049,7 @@ using a fortran linker.
   <SLIBS>
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
-  <ESMF_LIBDIR>/home6/fvitt/esmf_7_0_0/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
+  <ESMF_LIBDIR>/home6/fvitt/esmf_7_1_0r/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="pleiades-ivy">
@@ -1063,7 +1063,7 @@ using a fortran linker.
   <SLIBS>
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
-  <ESMF_LIBDIR>/home6/fvitt/esmf_7_0_0/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
+  <ESMF_LIBDIR>/home6/fvitt/esmf_7_1_0r/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="pleiades-san">
@@ -1077,7 +1077,7 @@ using a fortran linker.
   <SLIBS>
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
-  <ESMF_LIBDIR>/home6/fvitt/esmf_7_0_0/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
+  <ESMF_LIBDIR>/home6/fvitt/esmf_7_1_0r/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="sandiatoss3" COMPILER="intel">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1786,7 +1786,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="purge"/>
 	<command name="load">nas</command>
 	<command name="load">pkgsrc</command>
-	<command name="load">comp-intel/2016.2.181</command>
+	<command name="load">comp-intel/2018.3.222</command>
 	<command name="load">mpi-sgi/mpt.2.15r20</command>
 	<command name="load">szip/2.1.1</command>
 	<command name="load">hdf4/4.2.12</command>
@@ -1840,7 +1840,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="purge"/>
 	<command name="load">nas</command>
 	<command name="load">pkgsrc</command>
-	<command name="load">comp-intel/2016.2.181</command>
+	<command name="load">comp-intel/2018.3.222</command>
 	<command name="load">mpi-sgi/mpt.2.15r20</command>
 	<command name="load">szip/2.1.1</command>
 	<command name="load">hdf4/4.2.12</command>
@@ -1894,7 +1894,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="purge"/>
 	<command name="load">nas</command>
 	<command name="load">pkgsrc</command>
-	<command name="load">comp-intel/2016.2.181</command>
+	<command name="load">comp-intel/2018.3.222</command>
 	<command name="load">mpi-sgi/mpt.2.15r20</command>
 	<command name="load">szip/2.1.1</command>
 	<command name="load">hdf4/4.2.12</command>
@@ -1948,7 +1948,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="purge"/>
 	<command name="load">nas</command>
 	<command name="load">pkgsrc</command>
-	<command name="load">comp-intel/2016.2.181</command>
+	<command name="load">comp-intel/2018.3.222</command>
 	<command name="load">mpi-sgi/mpt.2.15r20</command>
 	<command name="load">szip/2.1.1</command>
 	<command name="load">hdf4/4.2.12</command>


### PR DESCRIPTION
        modified:   config/cesm/machines/config_compilers.xml
        modified:   config/cesm/machines/config_machines.xml

Update intel compiler version and ESMF lib for pleiades.

Test suite: 

  SMS_D_Ln9.f19_f19_mg16.FX2000.pleiades-has_intel (Overall: PASS) details:
  SMS_D_Ln9.f19_f19_mg16.FX2000.pleiades-san_intel (Overall: PASS) details:
  SMS_Ld1.f19_f19_mg16.FX2000.pleiades-bro_intel (Overall: PASS) details:
  SMS_Ld1.f19_f19_mg16.FX2000.pleiades-has_intel (Overall: PASS) details:
  SMS_Ld1.f19_f19_mg16.FX2000.pleiades-ivy_intel (Overall: PASS) details:
  SMS_Ld1.f19_f19_mg16.FX2000.pleiades-san_intel (Overall: PASS) details:
