### PR TITLE
Bring changes to datm Present Day compsets from master to maint-5-6

### DIFF
--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -187,30 +187,24 @@
     <valid_values></valid_values>
     <default_value>1</default_value>
     <values match="last">
-      <value compset="2000.*_DATM%1PT">1</value>
       <value compset="1850.*_DATM%QIA">1</value>
       <value compset="1850.*_DATM%CRU">1</value>
       <value compset="1850.*_DATM%GSW">1</value>
-      <value compset="2000.*_DATM%QIA">1</value>
       <value compset="HIST.*_DATM%QIA">1895</value>
       <value compset="HIST.*_DATM%CRU">1901</value>
       <value compset="HIST.*_DATM%GSW">1901</value>
       <value compset="20TR.*_DATM%QIA">1895</value>
       <value compset="20TR.*_DATM%CRU">1901</value>
       <value compset="20TR.*_DATM%GSW">1901</value>
-      <value compset="4804.*_DATM%QIA">1</value>
       <value compset="RCP.*_DATM%QIA">2004</value>
       <value compset="RCP.*_DATM%CRU">2005</value>
       <value compset="RCP.*_DATM%GSW">2005</value>
-      <value compset="2003.*_DATM%QIA.*_TEST">1</value>
       <value compset="1850.*_DATM%CRU">1</value>
-      <value compset="2000.*_DATM%CRU">1</value>
-      <value compset="2003.*_DATM%CRU">1</value>
-      <value compset="2010.*_DATM%CRU">1</value>
       <value compset="1850.*_DATM%GSW">1</value>
-      <value compset="2000.*_DATM%GSW">1</value>
-      <value compset="2010.*_DATM%GSW">1</value>
-      <value compset="2003.*_DATM%GSW">1</value>
+      <value compset="2000.*_DATM">$DATM_CLMNCEP_YR_START</value>
+      <value compset="2003.*_DATM">$DATM_CLMNCEP_YR_START</value>
+      <value compset="2010.*_DATM">$DATM_CLMNCEP_YR_START</value>
+      <value compset="4804.*_DATM">$DATM_CLMNCEP_YR_START</value>
     </values>
     <group>run_component_datm</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Bring PR PR #3093 to maint-5.6

This changes present-day compsets with datm and CLM to change the forcing period run over.

Testing: Currently none (since was tested on master)
Fixes none

User interface changes?: Changes default settings for some compsets

Update gh-pages html (Y/N)?: N

Code review: 
