### PR TITLE
Use truncated division operator in SEQ SystemTest for py2+3 compatibility

### DIFF
--- a/scripts/lib/CIME/SystemTests/seq.py
+++ b/scripts/lib/CIME/SystemTests/seq.py
@@ -32,7 +32,7 @@ class SEQ(SystemTestsCompareTwo):
                 self._case.set_value("ROOTPE_{}".format(comp), 0)
         else:
             totalpes = self._case.get_value("TOTALPES")
-            newntasks = max(1, totalpes/len(comp_classes))
+            newntasks = max(1, totalpes//len(comp_classes))
             rootpe = newntasks
 
             for comp in comp_classes:


### PR DESCRIPTION
When using python 3, the SEQ test will fail to set `NTASKS_*` because the XML `set_value` expects an integer, but a float is produced. This is because of the change from the `/` operator using truncated division for integers in python 2 to using real division always in python 3. Simply replacing `/` with the truncated division operator `//` fixes the issue (available since python 2.2).


Test suite: ./scripts_regression_tests.py on cori-knl
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes E3SM-Project/E3SM#2940
User interface changes?: N
Update gh-pages html (Y/N)?: N
