### PR TITLE
update cheyenne intel compiler, add DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ CIME is free software made available under the BSD License. For details see the 
 
 # Digital Object Identifier
 
-doi:10.5065/WE0D-9K91
+DOI:[10.5065/WE0D-9K91](http://dx.doi.org/10.5065/WE0D-9K91)

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ of NSF's Division of Atmospheric and Geospace Sciences.
 # License
 
 CIME is free software made available under the BSD License. For details see the LICENSE file.
+
+# Digital Object Identifier
+
+doi:10.5065/WE0D-9K91

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -598,8 +598,8 @@ using a fortran linker.
   </CMAKE_OPTS>
   <PFUNIT_PATH MPILIB="mpi-serial" compile_threaded="FALSE">$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.2.8_cheyenne_Intel17.0.1_noMPI_noOpenMP</PFUNIT_PATH>
   <PFUNIT_PATH MPILIB="mpt" compile_threaded="TRUE">$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit3.2.8_cheyenne_Intel17.0.1_MPI_openMP</PFUNIT_PATH>
-  <!-- Bug in the intel/17.0.1 compiler requires this, remove this line when compiler is updated -->
-  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
+  <!-- SET to FALSE for intel 17 and 18 TRUE otherwise -->
+  <HAS_F2008_CONTIGUOUS>TRUE</HAS_F2008_CONTIGUOUS>
 </compiler>
 
 <compiler MACH="cheyenne" COMPILER="pgi">


### PR DESCRIPTION
Adds a DOI for CIME and updates the intel compiler flags for intel 19 on cheyenne

Test suite: scripts_regression_tests.py on cheyenne
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3113 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
