### PR TITLE
update archive_metadata strip to lstrip

### DIFF
--- a/scripts/Tools/archive_metadata
+++ b/scripts/Tools/archive_metadata
@@ -791,7 +791,7 @@ def get_trunk_tag(case_dict, username, password):
     if result:
         last_tag = [i for i in result.split('\n') if i][-1]
         last_tag = last_tag[:-1].split('_')[-1]
-        tag = int(last_tag.strip('0'))
+        tag = int(last_tag.lstrip('0'))
 
     return tag
 


### PR DESCRIPTION
fix problem when stripping 0's in a string to only strip leading 0's using lstrip

Test suite: Manually ran archive_metadata on all existing CMIP6 cases on cheyenne
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

Fixes [CIME Github issue #] N/A

User interface changes?: None

Update gh-pages html (Y/N)?: N

Code review: 
