### PR TITLE
Add test_release compsets as supported

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1324,8 +1324,9 @@ directory, NOT in this subdirectory."""
             #   called if run_unsupported is False.
             tests = Testlist(tests_spec_file, files)
             testlist = tests.get_tests(compset=compset_alias, grid=grid_name, supported_only=True)
+            test_categories = ["prealpha", "prebeta", "test_release"]
             for test in testlist:
-                if test["category"] == "prealpha" or test["category"] == "prebeta" or "aux_" in test["category"]:
+                if test["category"] in test_categories or "aux_" in test["category"]:
                     testcnt += 1
         if testcnt > 0:
             logger.warning("\n*********************************************************************************************************************************")


### PR DESCRIPTION
Add test_release as a test category consulted to determine if a compset -- grid combination is supported.

Test suite: scripts_regression_tests.py on Cheyenne
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes #3127 

User interface changes?: No

Update gh-pages html (Y/N)?: N

Code review: 
