### PR TITLE
py3 and centos7-linux update

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -176,7 +176,7 @@ This allows using a different mpirun command to launch unit tests
 	<arg name="ntasks"> -np {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
-    <module_system type="module">
+    <module_system type="module" allow_error="true">
       <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
       <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
       <init_path lang="csh">/usr/share/Modules/init/csh</init_path>
@@ -189,10 +189,9 @@ This allows using a different mpirun command to launch unit tests
 	<command name="purge"/>
       </modules>
       <modules compiler="gnu">
-	<command name="load">compiler/gnu/7.2.0</command>
-	<command name="load">mpi/gcc/mpich-3.2</command>
-	<command name="load">tool/netcdf/4.4.1.1/gcc</command>
-	<command name="load">tool/parallel-netcdf/mpich</command>
+	<command name="load">compiler/gnu/8.2.0</command>
+	<command name="load">mpi/3.3/gcc-8.2.0</command>
+	<command name="load">tool/netcdf/4.6.1/gcc-8.1.0</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -191,7 +191,7 @@ def _post_run_check(case, lid):
         for cpl_logfile in cpl_logs:
             if not os.path.isfile(cpl_logfile):
                 break
-            with open(cpl_logfile, 'r') as fd:
+            with open(cpl_logfile, 'r', encoding='utf-8') as fd:
                 if 'SUCCESSFUL TERMINATION' in fd.read():
                     count_ok += 1
         if count_ok != cpl_ninst:


### PR DESCRIPTION
Update modules for centos7-linux, fix py3 error in case_run.py

Test suite: scripts_regression_tests.py on centos7-linux and using python 3.6.5, also tested with python 2.7.9
Test baseline: 
Test namelist changes: 
Test status: roundoff on centos7-linux

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
