### PR TITLE
fix nuopc build, update for stamepede esmf lib

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -402,10 +402,10 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_USE_ARRAY"/>
     </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="FALSE">
-      <env name="ESMFMKFILE">/glade/u/home/dunlap/ESMF-INSTALL/intel19/8.0.0bs32/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="TRUE">
-      <env name="ESMFMKFILE">/glade/u/home/dunlap/ESMF-INSTALL/intel19/8.0.0bs32/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2293,7 +2293,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="OMP_STACKSIZE">256M</env>
      </environment_variables>
     <environment_variables comp_interface="nuopc" mpilib="impi">
-      <env name="ESMFMKFILE">/work/01118/tg803972/stampede2/ESMF-INSTALL/8.0.0bs36_fix_for_stampede2/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/work/01118/tg803972/stampede2/ESMF-INSTALL/8.0.0bs38/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -353,6 +353,58 @@ ifeq ($(USE_ESMF_LIB), TRUE)
   SLIBS  += $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
 endif
 
+# Stub libraries do not need to be built for nuopc driver
+# so it will override these settings on the command line
+ATM_PRESENT ?= TRUE
+ICE_PRESENT ?= TRUE
+LND_PRESENT ?= TRUE
+OCN_PRESENT ?= TRUE
+ROF_PRESENT ?= TRUE
+GLC_PRESENT ?= TRUE
+WAV_PRESENT ?= TRUE
+ESP_PRESENT ?= TRUE
+IAC_PRESENT ?= TRUE
+ifeq ($(ULIBDEP),$(null))
+  ifneq ($(LIBROOT),$(null))
+    ifeq ($(ATM_PRESENT),TRUE)
+      ULIBDEP += $(LIBROOT)/libatm.a
+      CPPDEFS += -DATM_PRESENT
+    endif
+    ifeq ($(ICE_PRESENT),TRUE)
+      ULIBDEP += $(LIBROOT)/libice.a
+      CPPDEFS += -DICE_PRESENT
+    endif
+    ifeq ($(LND_PRESENT),TRUE)
+      ULIBDEP += $(LNDLIBDIR)/$(LNDLIB)
+      INCLDIR += -I$(LNDOBJDIR)
+      CPPDEFS += -DLND_PRESENT
+    endif
+    ifeq ($(OCN_PRESENT),TRUE)
+      ULIBDEP += $(LIBROOT)/libocn.a
+      CPPDEFS += -DOCN_PRESENT
+    endif
+    ifeq ($(ROF_PRESENT),TRUE)
+      ULIBDEP += $(LIBROOT)/librof.a
+      CPPDEFS += -DROF_PRESENT
+    endif
+    ifeq ($(GLC_PRESENT),TRUE)
+      ULIBDEP += $(LIBROOT)/libglc.a
+      CPPDEFS += -DGLC_PRESENT
+    endif
+    ifeq ($(WAV_PRESENT),TRUE)
+      ULIBDEP += $(LIBROOT)/libwav.a
+      CPPDEFS += -DWAV_PRESENT
+    endif
+    ifeq ($(ESP_PRESENT),TRUE)
+      ULIBDEP += $(LIBROOT)/libesp.a
+      CPPDEFS += -DESP_PRESENT
+    endif
+    ifeq ($(IAC_PRESENT),TRUE)
+      ULIBDEP += $(LIBROOT)/libiac.a
+    endif
+  endif
+endif
+
 ifdef CPRE
   FPPDEFS := $(subst $(comma),\\$(comma),$(CPPDEFS))
   FPPDEFS := $(patsubst -D%,$(CPRE)%,$(FPPDEFS))
@@ -797,57 +849,7 @@ else
     INCLUDE_DIR = $(INSTALL_SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/include
   endif
 endif
-# Stub libraries do not need to be built for nuopc driver
-# so it will override these settings on the command line
-ATM_PRESENT:=TRUE
-ICE_PRESENT:=TRUE
-LND_PRESENT:=TRUE
-OCN_PRESENT:=TRUE
-ROF_PRESENT:=TRUE
-GLC_PRESENT:=TRUE
-WAV_PRESENT:=TRUE
-ESP_PRESENT:=TRUE
-IAC_PRESENT:=TRUE
-ifeq ($(ULIBDEP),$(null))
-  ifneq ($(LIBROOT),$(null))
-    ifeq ($(ATM_PRESENT),TRUE)
-      ULIBDEP += $(LIBROOT)/libatm.a
-      CPPDEFS += -DATM_PRESENT
-    endif
-    ifeq ($(ICE_PRESENT),TRUE)
-      ULIBDEP += $(LIBROOT)/libice.a
-      CPPDEFS += -DICE_PRESENT
-    endif
-    ifeq ($(LND_PRESENT),TRUE)
-      ULIBDEP += $(LNDLIBDIR)/$(LNDLIB)
-      INCLDIR += -I$(LNDOBJDIR)
-      CPPDEFS += -DLND_PRESENT
-    endif
-    ifeq ($(OCN_PRESENT),TRUE)
-      ULIBDEP += $(LIBROOT)/libocn.a
-      CPPDEFS += -DOCN_PRESENT
-    endif
-    ifeq ($(ROF_PRESENT),TRUE)
-      ULIBDEP += $(LIBROOT)/librof.a
-      CPPDEFS += -DROF_PRESENT
-    endif
-    ifeq ($(GLC_PRESENT),TRUE)
-      ULIBDEP += $(LIBROOT)/libglc.a
-      CPPDEFS += -DGLC_PRESENT
-    endif
-    ifeq ($(WAV_PRESENT),TRUE)
-      ULIBDEP += $(LIBROOT)/libwav.a
-      CPPDEFS += -DWAV_PRESENT
-    endif
-    ifeq ($(ESP_PRESENT),TRUE)
-      ULIBDEP += $(LIBROOT)/libesp.a
-      CPPDEFS += -DESP_PRESENT
-    endif
-    ifeq ($(IAC_PRESENT),TRUE)
-      ULIBDEP += $(LIBROOT)/libiac.a
-    endif
-  endif
-endif
+
 ifeq ($(COMP_GLC), cism)
   ULIBDEP += $(CISM_LIBDIR)/libglimmercismfortran.a
   ifeq ($(CISM_USE_TRILINOS), TRUE)


### PR DESCRIPTION
I made a dumb error in PR #3129 by defining the CPPDEFS in the Makefile after they are used, move the code up in the Makefile so that they are applied correctly. 

Test suite: scripts_regression_tests.py with CIME_DRIVER=nuopc, nuopc hash is 769538c
Test baseline: 
Test namelist changes: 
Test status: bit for bit,

Fixes 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
