### PR TITLE
move so that var is defined

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -376,7 +376,6 @@ ifeq ($(ULIBDEP),$(null))
     endif
     ifeq ($(LND_PRESENT),TRUE)
       ULIBDEP += $(LNDLIBDIR)/$(LNDLIB)
-      INCLDIR += -I$(LNDOBJDIR)
       CPPDEFS += -DLND_PRESENT
     endif
     ifeq ($(OCN_PRESENT),TRUE)
@@ -849,7 +848,9 @@ else
     INCLUDE_DIR = $(INSTALL_SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/include
   endif
 endif
-
+ifeq ($(LND_PRESENT),TRUE)
+  INCLDIR += -I$(LNDOBJDIR)
+endif
 ifeq ($(COMP_GLC), cism)
   ULIBDEP += $(CISM_LIBDIR)/libglimmercismfortran.a
   ifeq ($(CISM_USE_TRILINOS), TRUE)


### PR DESCRIPTION
Move an Include statement in the Makefile so that it is defined before use.  

Test suite: scripts_regression_tests.py, SMS_D_Ld5.f10_f10_musgs.I2000Clm50BgcCropRtm.izumi_nag.rtm-default
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #3142
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
