### PR TITLE
require ids in namelist definition files to be lower case

### DIFF
--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -65,6 +65,7 @@ class NamelistDefinition(EntryID):
         default_nodes = []
         for node in self.get_children("entry"):
             name = self.get(node, "id")
+            expect(name == name.lower(),"ERROR id field in this file must be lowercase, id={}".format(name))
             skip_default_entry = self.get(node, "skip_default_entry") == "true"
             per_stream_entry = self.get(node, "per_stream_entry") == "true"
             set_node_values = False


### PR DESCRIPTION
Due to issue #3144 inforce that namelist definition entries be lower case. 

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
