### PR TITLE
Build groups need to be hashable for cesm

### DIFF
--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -298,7 +298,7 @@ class TestScheduler(object):
             # Any test that's in a shared-enabled suite with other tests should share exes
             self._build_groups = get_build_groups(self._tests)
         else:
-            self._build_groups = [ [item] for item in self._tests ]
+            self._build_groups = [ (item,) for item in self._tests ]
 
         # Build group to exeroot map
         self._build_group_exeroots = {}


### PR DESCRIPTION
Use tuple, not list.

Test suite: code_checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b 
