### PR TITLE
Caseinsensitive user_nl

### DIFF
--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -25,6 +25,37 @@ logger = logging.getLogger(__name__)
 
 _array_size_re = re.compile(r'^(?P<type>[^(]+)\((?P<size>[^)]+)\)$')
 
+class CaseInsensitiveDict(dict):
+
+    """Basic case insensitive dict with strings only keys."""
+
+    proxy = {}
+
+    def __init__(self, data):
+        dict.__init__(self)
+        self.proxy = dict((k.lower(), k) for k in data)
+        for k in data:
+            self[k] = data[k]
+
+    def __contains__(self, k):
+        return k.lower() in self.proxy
+
+    def __delitem__(self, k):
+        key = self.proxy[k.lower()]
+        super(CaseInsensitiveDict, self).__delitem__(key)
+        del self.proxy[k.lower()]
+
+    def __getitem__(self, k):
+        key = self.proxy[k.lower()]
+        return super(CaseInsensitiveDict, self).__getitem__(key)
+
+    def get(self, k, default=None):
+        return self[k] if k in self else default
+
+    def __setitem__(self, k, v):
+        super(CaseInsensitiveDict, self).__setitem__(k, v)
+        self.proxy[k.lower()] = k
+
 class NamelistDefinition(EntryID):
 
     """Class representing variable definitions for a namelist.
@@ -54,7 +85,7 @@ class NamelistDefinition(EntryID):
         self._entry_ids = []
         self._valid_values = {}
         self._entry_types = {}
-        self._group_names = {}
+        self._group_names = CaseInsensitiveDict({})
         self._nodes = {}
 
     def set_nodes(self, skip_groups=None):
@@ -65,7 +96,7 @@ class NamelistDefinition(EntryID):
         default_nodes = []
         for node in self.get_children("entry"):
             name = self.get(node, "id")
-            expect(name == name.lower(),"ERROR id field in this file must be lowercase, id={}".format(name))
+#            expect(name == name.lower(),"ERROR id field in this file must be lowercase, id={}".format(name))
             skip_default_entry = self.get(node, "skip_default_entry") == "true"
             per_stream_entry = self.get(node, "per_stream_entry") == "true"
             set_node_values = False
@@ -305,8 +336,10 @@ class NamelistDefinition(EntryID):
         return True
 
     def _expect_variable_in_definition(self, name, variable_template):
-        """Used to get a better error message for an unexpected variable."""
-        expect(name in self._entry_ids,
+        """Used to get a better error message for an unexpected variable.
+             case insensitve match"""
+
+        expect(name.lower() in (en.lower() for en in self._entry_ids),
                (variable_template + " is not in the namelist definition.").format(str(name)))
 
     def _user_modifiable_in_variable_definition(self, name):

--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -96,7 +96,6 @@ class NamelistDefinition(EntryID):
         default_nodes = []
         for node in self.get_children("entry"):
             name = self.get(node, "id")
-#            expect(name == name.lower(),"ERROR id field in this file must be lowercase, id={}".format(name))
             skip_default_entry = self.get(node, "skip_default_entry") == "true"
             per_stream_entry = self.get(node, "per_stream_entry") == "true"
             set_node_values = False
@@ -339,7 +338,7 @@ class NamelistDefinition(EntryID):
         """Used to get a better error message for an unexpected variable.
              case insensitve match"""
 
-        expect(name.lower() in (en.lower() for en in self._entry_ids),
+        expect(name in self._entry_ids,
                (variable_template + " is not in the namelist definition.").format(str(name)))
 
     def _user_modifiable_in_variable_definition(self, name):

--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -27,7 +27,8 @@ _array_size_re = re.compile(r'^(?P<type>[^(]+)\((?P<size>[^)]+)\)$')
 
 class CaseInsensitiveDict(dict):
 
-    """Basic case insensitive dict with strings only keys."""
+    """Basic case insensitive dict with strings only keys.
+        From https://stackoverflow.com/a/27890005 """
 
     proxy = {}
 

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1575,7 +1575,7 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         >>> _NamelistParser('abc ')._parse_variable_name()
         'abc'
         >>> _NamelistParser('ABC ')._parse_variable_name()
-        'abc'
+        'ABC'
         >>> _NamelistParser('abc\n')._parse_variable_name()
         'abc'
         >>> _NamelistParser('abc%fred\n')._parse_variable_name()
@@ -1584,8 +1584,8 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
         'abc(2)@fred'
         >>> _NamelistParser('abc(1:2:3)\n')._parse_variable_name()
         'abc(1:2:3)'
-        >>> _NamelistParser('abc=')._parse_variable_name()
-        'abc'
+        >>> _NamelistParser('aBc=')._parse_variable_name()
+        'aBc'
         >>> try:
         ...     _NamelistParser('abc(1,2) ')._parse_variable_name()
         ...     raise AssertionError("_NamelistParseError not raised")
@@ -1630,9 +1630,9 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
             else:
                 err_str = "{!r} is not a valid variable name".format(str(text))
             raise _NamelistParseError(err_str)
-        name = text.lower()
-
-        return name
+        return text
+#        name = text.lower()
+#        return name
 
     def _parse_character_literal(self):
         """Parse and return a character literal (a string).

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -1631,8 +1631,6 @@ class _NamelistParser(object): # pylint:disable=too-few-public-methods
                 err_str = "{!r} is not a valid variable name".format(str(text))
             raise _NamelistParseError(err_str)
         return text
-#        name = text.lower()
-#        return name
 
     def _parse_character_literal(self):
         """Parse and return a character literal (a string).


### PR DESCRIPTION
We were downcasing all user_nl and namelist variables but not all inputs handled by this function are case insensitive - for example ESMF runconfig files used in nuopc.   So the input from namelist_definition.xml must be accepted in whatever case it is in the file and input from user_nl_* must match that input.   The solution is to use a case insensitive dict type in namelist_definition.xml 

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
