### PR TITLE
Adding optional PIO root

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -646,20 +646,28 @@ $(SHAREDLIBROOT)/$(SHAREDPATH)/mct/mpi-serial/Makefile.conf:
 	@echo "SHAREDLIBROOT |$(SHAREDLIBROOT)| SHAREDPATH |$(SHAREDPATH)|"; \
 	$(CONFIG_SHELL) $(CIMEROOT)/src/externals/mct/mpi-serial/configure $(CONFIG_ARGS) --srcdir $(CIMEROOT)/src/externals/mct/mpi-serial
 
+ifndef PIO_SRCROOT
+  PIO_SRCROOT = $(CIMEROOT)/src/externals
+endif
+
+ifeq ($(PIO_VERSION),2)
+  PIO_SRC_DIR = $(PIO_SRCROOT)/pio2
+else
+  ifneq ("$(wildcard $(PIO_SRCROOT)/pio1/pio)", "")
+    PIO_SRC_DIR = $(PIO_SRCROOT)/pio1
+  else
+    PIO_SRC_DIR = $(PIO_SRCROOT)/pio1/pio
+  endif
+endif
+
 ifeq ($(PIO_VERSION),2)
 # This is a pio2 library
   PIOLIB = $(PIO_LIBDIR)/libpiof.a $(PIO_LIBDIR)/libpioc.a
   PIOLIBNAME = -lpiof -lpioc
-  PIO_SRC_DIR = $(CIMEROOT)/src/externals/pio2
 else
 # This is a pio1 library
   PIOLIB = $(PIO_LIBDIR)/libpio.a
   PIOLIBNAME = -lpio
-  ifneq ("$(wildcard $(CIMEROOT)/src/externals/pio1/pio)", "")
-    PIO_SRC_DIR = $(CIMEROOT)/src/externals/pio1
-  else
-    PIO_SRC_DIR = $(CIMEROOT)/src/externals/pio1/pio
-  endif
 endif
 #endif
 

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -45,8 +45,19 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def buildlib(bldroot, installpath, case):
 ###############################################################################
+    cime_model = case.get_value("MODEL")
     caseroot = case.get_value("CASEROOT")
     pio_version = case.get_value("PIO_VERSION")
+    if cime_model == "e3sm":
+        srcroot = case.get_value("SRCROOT")
+        pio_src_root_dir = os.path.join(srcroot, "externals")
+        pio1_src_dir = os.path.join(pio_src_root_dir, "pio1")
+        pio2_src_dir = os.path.join(pio_src_root_dir, "pio2")
+        if (not os.path.isdir(pio_src_root_dir) or
+            not os.path.isdir(pio1_src_dir) or
+            not os.path.isdir(pio2_src_dir)):
+            pio_src_root_dir = None
+
     # If variable PIO_VERSION_MAJOR is defined in the environment then
     # we assume that PIO is installed on the system
     # and expect to find
@@ -68,11 +79,22 @@ def buildlib(bldroot, installpath, case):
     cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/genf90 \""
     stdargs = get_standard_makefile_args(case, shared_lib=True)
 
-    gmake_opts = "{pio_dir}/Makefile -C {pio_dir} CASEROOT={caseroot} MODEL={pio_model} USER_CMAKE_OPTS={cmake_opts} "\
-        "PIO_LIBDIR={pio_dir} CASETOOLS={casetools} "\
-        " USER_CPPDEFS=-DTIMING {stdargs} -f {casetools}/Makefile"\
-        .format(pio_dir=pio_dir, caseroot=caseroot, pio_model=pio_model, cmake_opts=cmake_opts,
-                casetools=casetools, stdargs=stdargs)
+    gmake_vars =  "CASEROOT={caseroot} MODEL={pio_model} "\
+                  "USER_CMAKE_OPTS={cmake_opts} "\
+                  "PIO_LIBDIR={pio_dir} CASETOOLS={casetools} "\
+                  "USER_CPPDEFS=-DTIMING"\
+                  .format(caseroot=caseroot, pio_model=pio_model,
+                          cmake_opts=cmake_opts, pio_dir=pio_dir,
+                          casetools=casetools)
+
+    if pio_src_root_dir is not None:
+        gmake_vars += " PIO_SRCROOT={pio_src_root_dir}"\
+                      .format(pio_src_root_dir=pio_src_root_dir)
+
+    gmake_opts =  "{pio_dir}/Makefile -C {pio_dir} "\
+                  " {gmake_vars} {stdargs} -f {casetools}/Makefile"\
+                  .format(pio_dir=pio_dir, gmake_vars=gmake_vars,
+                          casetools=casetools, stdargs=stdargs)
 
     gmake_cmd = case.get_value("GMAKE")
 


### PR DESCRIPTION
Adding a PIO root directory that can be modified by the user
to point to a directory containing PIO1 and PIO2 sources (by
default it points to the <CIMEROOT>/src/externals directory).

Also adding an optional PIO root directory for E3SM

Test suite: scripts-regression.py
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit

User interface changes?: None

Update gh-pages html (Y/N)?: N

Code review: Jim Foucar, Jim Edwards
