### PR TITLE
Jedwards/workflow development

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -172,6 +172,7 @@
   <batch_system MACH="aleph" type="pbs" >
     <directives>
       <directive>-l nodes={{ num_nodes }}</directive>
+      <directive>-q {{ queue }}</directive>
     </directives>
     <queues>
       <queue default="true" >iccp</queue>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -106,6 +106,8 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">cray-hdf5/1.10.2.0</command>
         <command name="load">cray-parallel-netcdf/1.8.1.3</command>
         <command name="load">papi/5.6.0.4</command>
+        <command name="load">gridftp/6.0</command>
+        <command name="load">cray-python/3.6.5.1</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -108,6 +108,10 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">papi/5.6.0.4</command>
       </modules>
     </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">256M</env>
+      <env name="POSTPROCESS_PATH">/home/jedwards/workflow/CESM_postprocessing</env>
+    </environment_variables>
   </machine>
 
   <machine MACH="athena">

--- a/config/cesm/machines/config_workflow.xml
+++ b/config/cesm/machines/config_workflow.xml
@@ -61,16 +61,6 @@
 	<walltime>0:20:00</walltime>
       </runtime_parameters>
     </job>
-    <job name="timeseriesL">
-      <template>$CASEROOT/postprocess/timeseriesL</template>
-      <dependency>case.st_archive</dependency>
-      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_TIMESERIES</prereq>
-      <runtime_parameters>
-	<task_count>1</task_count>
-	<tasks_per_node>1</tasks_per_node>
-	<walltime>0:20:00</walltime>
-      </runtime_parameters>
-    </job>
     <job name="timeseries_transfer">
       <template>$ENV{POSTPROCESS_PATH}/timeseries/template.timeseries_transfer</template>
       <dependency>timeseries</dependency>

--- a/config/cesm/machines/config_workflow.xml
+++ b/config/cesm/machines/config_workflow.xml
@@ -50,17 +50,40 @@
     </job>
   </workflow_jobs>
 
-  <workflow_jobs case="diagnostics" prepend="default">
+  <workflow_jobs case="timeseries" prepend="default">
     <job name="timeseries">
-      <template>$CASEROOT/postprocess/timeseries</template>
+      <template>$ENV{POSTPROCESS_PATH}/timeseries/template.timeseries</template>
       <dependency>case.st_archive</dependency>
-      <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_TIMESERIES</prereq>
+      <prereq>$TIMESERIES</prereq>
+      <runtime_parameters MACH="aleph">
+	<task_count>72</task_count>
+	<tasks_per_node>9</tasks_per_node>
+	<walltime>0:20:00</walltime>
+      </runtime_parameters>
     </job>
     <job name="timeseriesL">
       <template>$CASEROOT/postprocess/timeseriesL</template>
       <dependency>case.st_archive</dependency>
       <prereq>$CASEROOT/postprocess/pp_config -value --get GENERATE_TIMESERIES</prereq>
+      <runtime_parameters>
+	<task_count>1</task_count>
+	<tasks_per_node>1</tasks_per_node>
+	<walltime>0:20:00</walltime>
+      </runtime_parameters>
     </job>
+    <job name="timeseries_transfer">
+      <template>$ENV{POSTPROCESS_PATH}/timeseries/template.timeseries_transfer</template>
+      <dependency>timeseries</dependency>
+      <prereq>1</prereq>
+      <runtime_parameters>
+	<task_count>1</task_count>
+	<tasks_per_node>1</tasks_per_node>
+	<walltime>1:00:00</walltime>
+      </runtime_parameters>
+    </job>
+
+  </workflow_jobs>
+  <workflow_jobs case="diagnostics" prepend="timeseries">
     <job name="xconform">
       <template>$CASEROOT/postprocess/xconform</template>
       <dependency>timeseriesL</dependency>

--- a/config/cesm/machines/config_workflow.xml
+++ b/config/cesm/machines/config_workflow.xml
@@ -60,7 +60,14 @@
 	<tasks_per_node>9</tasks_per_node>
 	<walltime>0:20:00</walltime>
       </runtime_parameters>
+      <runtime_parameters MACH="cheyenne">
+	<task_count>72</task_count>
+	<tasks_per_node>9</tasks_per_node>
+	<walltime>0:20:00</walltime>
+      </runtime_parameters>
     </job>
+  </workflow_jobs>
+  <workflow_jobs case="timeseries_transfer" prepend="timeseries">
     <job name="timeseries_transfer">
       <template>$ENV{POSTPROCESS_PATH}/timeseries/template.timeseries_transfer</template>
       <dependency>timeseries</dependency>
@@ -71,7 +78,6 @@
 	<walltime>1:00:00</walltime>
       </runtime_parameters>
     </job>
-
   </workflow_jobs>
   <workflow_jobs case="diagnostics" prepend="timeseries">
     <job name="xconform">

--- a/config/cesm/machines/cylc_suite.rc.template
+++ b/config/cesm/machines/cylc_suite.rc.template
@@ -1,0 +1,22 @@
+[meta]
+  title = CESM CYLC workflow for case {{ casename }}
+  
+[scheduling]
+  cycling mode = integer
+  initial cycle point = 1
+  final cycle point = {{ cycles }}
+
+  [[dependencies]]
+    [[[R1]]]
+      graph = "set_external_workflow => run => st_archive "
+    [[[R/P1]]] # Integer Cycling
+      graph = """
+	     st_archive[-P1] => run
+             run => st_archive 
+	     """
+[runtime]
+  [[set_external_workflow]]
+    script = cd {{ caseroot }}; ./xmlchange EXTERNAL_WORKFLOW=TRUE
+  [[st_archive]]
+    script = cd {{ caseroot }}; ./case.submit --job case.st_archive; ./xmlchange CONTINUE_RUN=TRUE
+

--- a/scripts/Tools/generate_cylc_workflow.py
+++ b/scripts/Tools/generate_cylc_workflow.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+"""
+Generates a cylc workflow file for the case.  See https://cylc.github.io for details about cylc
+"""
+
+from standard_script_setup import *
+
+from CIME.case              import Case
+from CIME.utils             import expect, transform_vars
+
+import argparse, re
+logger = logging.getLogger(__name__)
+
+###############################################################################
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
+                        help="Case directory for which namelists are generated.\n"
+                        "Default is current directory.")
+
+    parser.add_argument('--cycles', default=1,
+                        help="The number of cycles to run, default is RESUBMIT")
+
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    return args.caseroot, args.cycles
+
+def cylc_batch_job_template(job, caseroot, batch_system_type):
+    return """
+  [[{job}]]
+    script = cd {caseroot}; ./case.submit --job {job}
+    [[[job]]]
+      batch_system = {batch_system_type}
+    [[[directives]]]
+""".format(job=job, caseroot=caseroot, batch_system_type=batch_system_type) + "{{ batchdirectives }}\n"
+
+
+def cylc_script_job_template(job, caseroot):
+    return """
+  [[{job}]]
+    script = cd {caseroot}; ./case.submit --job {job}
+""".format(job=job, caseroot=caseroot)
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    caseroot, cycles = parse_command_line(sys.argv, description)
+    
+    expect(os.path.isfile(os.path.join(caseroot, "CaseStatus")),
+           "case.setup must be run prior to running {}".format(__file__))
+    with Case(caseroot, read_only=True) as case:
+        if cycles == 1:
+            cycles = max(1, case.get_value('RESUBMIT'))
+        env_batch = case.get_env('batch')
+        env_workflow = case.get_env('workflow')
+        jobs = env_workflow.get_jobs()
+        casename = case.get_value('CASE')
+        input_template = os.path.join(case.get_value("MACHDIR"),"cylc_suite.rc.template")
+        batch_system_type = env_batch.get_batch_system_type()
+        overrides = {"cycles":cycles, 
+                     'casename':casename}
+        input_text = open(input_template).read()
+        for job in jobs:
+            jobname = job
+            if job == 'case.st_archive':
+                continue
+            if job == 'case.run':
+                jobname = 'run'
+                overrides.update(env_batch.get_job_overrides(job, case))
+                overrides.update({'job_id':'run.'+casename})
+                input_text = input_text + cylc_batch_job_template(jobname, caseroot, batch_system_type)
+            else:
+                depends_on = env_workflow.get_value('dependency', subgroup=job)
+                if depends_on.startswith('case.'):
+                    depends_on = depends_on[5:]
+                input_text = input_text.replace(' => '+depends_on,' => '+depends_on+' => '+job)
+                    
+
+                overrides.update(env_batch.get_job_overrides(job, case))
+                overrides.update({'job_id':job+'.'+casename})
+                if 'total_tasks' in overrides and overrides['total_tasks'] > 1:
+                    input_text = input_text + cylc_batch_job_template(jobname, caseroot, batch_system_type)
+                else:
+                    input_text = input_text + cylc_script_job_template(jobname, caseroot)
+
+
+            overrides.update({'batchdirectives':env_batch.get_batch_directives(case,job, overrides=overrides, 
+                                                                           output_format='cylc')})
+
+
+            input_text = transform_vars(input_text, case=case, subgroup=job, overrides=overrides)
+        with open("cylc_suite.rc", "w") as f:
+                    f.write(input_text)
+                
+
+
+if (__name__ == "__main__"):
+    _main_func(__doc__)

--- a/scripts/Tools/generate_cylc_workflow.py
+++ b/scripts/Tools/generate_cylc_workflow.py
@@ -32,14 +32,14 @@ def parse_command_line(args, description):
 
     return args.caseroot, args.cycles
 
-def cylc_batch_job_template(job, caseroot, batch_system_type):
+def cylc_batch_job_template(job, jobname, caseroot, batch_system_type):
     return """
-  [[{job}]]
+  [[{jobname}]]
     script = cd {caseroot}; ./case.submit --job {job}
     [[[job]]]
-      batch_system = {batch_system_type}
+      batch system = {batch_system_type}
     [[[directives]]]
-""".format(job=job, caseroot=caseroot, batch_system_type=batch_system_type) + "{{ batchdirectives }}\n"
+""".format(jobname=jobname, job=job, caseroot=caseroot, batch_system_type=batch_system_type) + "{{ batchdirectives }}\n"
 
 
 def cylc_script_job_template(job, caseroot):
@@ -75,7 +75,7 @@ def _main_func(description):
                 jobname = 'run'
                 overrides.update(env_batch.get_job_overrides(job, case))
                 overrides.update({'job_id':'run.'+casename})
-                input_text = input_text + cylc_batch_job_template(jobname, caseroot, batch_system_type)
+                input_text = input_text + cylc_batch_job_template(job, jobname, caseroot, batch_system_type)
             else:
                 depends_on = env_workflow.get_value('dependency', subgroup=job)
                 if depends_on.startswith('case.'):
@@ -86,7 +86,7 @@ def _main_func(description):
                 overrides.update(env_batch.get_job_overrides(job, case))
                 overrides.update({'job_id':job+'.'+casename})
                 if 'total_tasks' in overrides and overrides['total_tasks'] > 1:
-                    input_text = input_text + cylc_batch_job_template(jobname, caseroot, batch_system_type)
+                    input_text = input_text + cylc_batch_job_template(job, jobname, caseroot, batch_system_type)
                 else:
                     input_text = input_text + cylc_script_job_template(jobname, caseroot)
 
@@ -96,8 +96,8 @@ def _main_func(description):
 
 
             input_text = transform_vars(input_text, case=case, subgroup=job, overrides=overrides)
-        with open("cylc_suite.rc", "w") as f:
-                    f.write(input_text)
+        with open("suite.rc", "w") as f:
+                    f.write(case.get_resolved_value(input_text))
                 
 
 

--- a/scripts/Tools/generate_cylc_workflow.py
+++ b/scripts/Tools/generate_cylc_workflow.py
@@ -7,9 +7,9 @@ Generates a cylc workflow file for the case.  See https://cylc.github.io for det
 from standard_script_setup import *
 
 from CIME.case              import Case
-from CIME.utils             import expect, transform_vars, safe_copy
+from CIME.utils             import expect, transform_vars
 
-import argparse, re
+import argparse
 logger = logging.getLogger(__name__)
 
 ###############################################################################
@@ -105,7 +105,7 @@ def _main_func(description):
 
             input_text = transform_vars(input_text, case=case, subgroup=job, overrides=overrides)
         with open("suite.rc", "w") as f:
-                    f.write(case.get_resolved_value(input_text))
+            f.write(case.get_resolved_value(input_text))
 
 
 

--- a/scripts/Tools/generate_cylc_workflow.py
+++ b/scripts/Tools/generate_cylc_workflow.py
@@ -7,7 +7,7 @@ Generates a cylc workflow file for the case.  See https://cylc.github.io for det
 from standard_script_setup import *
 
 from CIME.case              import Case
-from CIME.utils             import expect, transform_vars
+from CIME.utils             import expect, transform_vars, safe_copy
 
 import argparse, re
 logger = logging.getLogger(__name__)
@@ -32,14 +32,22 @@ def parse_command_line(args, description):
 
     return args.caseroot, args.cycles
 
-def cylc_batch_job_template(job, jobname, caseroot, batch_system_type):
+def cylc_batch_job_template(job, jobname, case):
+    caseroot = case.get_value("CASEROOT")
+    env_batch = case.get_env("batch")
+    batch_system_type = env_batch.get_batch_system_type()
+    batchsubmit = env_batch.get_value("batch_submit")
+    submit_args = env_batch.get_submit_args(case, job)
+
     return """
   [[{jobname}]]
     script = cd {caseroot}; ./case.submit --job {job}
     [[[job]]]
       batch system = {batch_system_type}
+      batch submit command template = {batchsubmit} {submit_args}  '%(job)s'
     [[[directives]]]
-""".format(jobname=jobname, job=job, caseroot=caseroot, batch_system_type=batch_system_type) + "{{ batchdirectives }}\n"
+""".format(jobname=jobname, job=job, caseroot=caseroot, batch_system_type=batch_system_type,
+           batchsubmit=batchsubmit, submit_args=submit_args) + "{{ batchdirectives }}\n"
 
 
 def cylc_script_job_template(job, caseroot):
@@ -52,7 +60,7 @@ def cylc_script_job_template(job, caseroot):
 def _main_func(description):
 ###############################################################################
     caseroot, cycles = parse_command_line(sys.argv, description)
-    
+
     expect(os.path.isfile(os.path.join(caseroot, "CaseStatus")),
            "case.setup must be run prior to running {}".format(__file__))
     with Case(caseroot, read_only=True) as case:
@@ -63,8 +71,8 @@ def _main_func(description):
         jobs = env_workflow.get_jobs()
         casename = case.get_value('CASE')
         input_template = os.path.join(case.get_value("MACHDIR"),"cylc_suite.rc.template")
-        batch_system_type = env_batch.get_batch_system_type()
-        overrides = {"cycles":cycles, 
+
+        overrides = {"cycles":cycles,
                      'casename':casename}
         input_text = open(input_template).read()
         for job in jobs:
@@ -75,30 +83,30 @@ def _main_func(description):
                 jobname = 'run'
                 overrides.update(env_batch.get_job_overrides(job, case))
                 overrides.update({'job_id':'run.'+casename})
-                input_text = input_text + cylc_batch_job_template(job, jobname, caseroot, batch_system_type)
+                input_text = input_text + cylc_batch_job_template(job, jobname, case)
             else:
                 depends_on = env_workflow.get_value('dependency', subgroup=job)
                 if depends_on.startswith('case.'):
                     depends_on = depends_on[5:]
                 input_text = input_text.replace(' => '+depends_on,' => '+depends_on+' => '+job)
-                    
+
 
                 overrides.update(env_batch.get_job_overrides(job, case))
                 overrides.update({'job_id':job+'.'+casename})
                 if 'total_tasks' in overrides and overrides['total_tasks'] > 1:
-                    input_text = input_text + cylc_batch_job_template(job, jobname, caseroot, batch_system_type)
+                    input_text = input_text + cylc_batch_job_template(job, jobname, case)
                 else:
                     input_text = input_text + cylc_script_job_template(jobname, caseroot)
 
 
-            overrides.update({'batchdirectives':env_batch.get_batch_directives(case,job, overrides=overrides, 
+            overrides.update({'batchdirectives':env_batch.get_batch_directives(case,job, overrides=overrides,
                                                                            output_format='cylc')})
 
 
             input_text = transform_vars(input_text, case=case, subgroup=job, overrides=overrides)
         with open("suite.rc", "w") as f:
                     f.write(case.get_resolved_value(input_text))
-                
+
 
 
 if (__name__ == "__main__"):

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -346,11 +346,9 @@ class EnvBatch(EnvBase):
                             directive = self.get_resolved_value("" if self.text(node) is None else self.text(node))
                             if output_format == 'cylc':
                                 if self._batchtype == 'pbs':
-                                    m = re.match(r'\s*(-[^l])', directive)
+                                    m = re.match(r'\s*(-[\w])', directive)
                                     if m:
-                                        directive = re.sub(r'(-[^l]) ','{} = '.format(m.group(1)), directive)
-                                    else:
-                                        directive = re.sub(r':',r'\n      -l ',directive)
+                                        directive = re.sub(r'(-[\w]) ','{} = '.format(m.group(1)), directive)
 
                             default = self.get(node, "default")
                             if default is None:
@@ -499,7 +497,7 @@ class EnvBatch(EnvBase):
                 batch_job_id = str(alljobs.index(job)) if dry_run else result
                 depid[job] = batch_job_id
                 jobcmds.append( (job, result) )
-                
+
                 if self._batchtype == "cobalt" or external_workflow:
                     break
             if not external_workflow:
@@ -590,7 +588,7 @@ class EnvBatch(EnvBase):
                     getattr(case, function_name)(**{k: v for k, (v, _) in args.items()})
                 else:
                     expect(os.path.isfile(job_name),"Could not find file {}".format(job_name))
-                    run_cmd_no_fail(os.path.join(self._caseroot,job_name), combine_output=True, verbose=True, from_dir=self._caseroot)                  
+                    run_cmd_no_fail(os.path.join(self._caseroot,job_name), combine_output=True, verbose=True, from_dir=self._caseroot)
             return
 
         submitargs = self.get_submit_args(case, job)

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -307,10 +307,12 @@ def case_run(self, skip_pnl=False, set_continue_run=False, submit_resubmits=Fals
         self.set_value("CONTINUE_RUN",
                        self.get_value("RESUBMIT_SETS_CONTINUE_RUN"))
 
-    logger.warning("check for resubmit")
+    external_workflow = self.get_value("EXTERNAL_WORKFLOW")
+    if not external_workflow:
+        logger.warning("check for resubmit")
     
-    logger.debug("submit_resubmits is {}".format(submit_resubmits))
-    if submit_resubmits:
-        _resubmit_check(self)
-
+        logger.debug("submit_resubmits is {}".format(submit_resubmits))
+        if submit_resubmits:
+            _resubmit_check(self)
+        
     return True

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -31,7 +31,10 @@ def _pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
         safe_copy(env_mach_pes,"{}.{}".format(env_mach_pes, lid))
 
     # check for locked files.
-    case.check_lockedfiles()
+    skip = None
+    if case.get_value("EXTERNAL_WORKFLOW"):
+        skip = "env_batch"
+    case.check_lockedfiles(skip=skip)
     logger.debug("check_lockedfiles OK")
 
     # check that build is done

--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -745,18 +745,19 @@ def case_st_archive(self, last_date_str=None, archive_incomplete_logs=True, copy
     logger.info("st_archive completed")
 
     # resubmit case if appropriate
-    resubmit_cnt = self.get_value("RESUBMIT")
-    logger.debug("resubmit_cnt {} resubmit {}".format(resubmit_cnt, resubmit))
-    if resubmit_cnt > 0 and resubmit:
-        logger.info("resubmitting from st_archive, resubmit={:d}".format(resubmit_cnt))
-        if self.get_value("MACH") == "mira":
-            expect(os.path.isfile(".original_host"), "ERROR alcf host file not found")
-            with open(".original_host", "r") as fd:
-                sshhost = fd.read()
-            run_cmd("ssh cooleylogin1 ssh {} '{case}/case.submit {case} --resubmit' "\
+    if not self.get_value("EXTERNAL_WORKFLOW"):
+        resubmit_cnt = self.get_value("RESUBMIT")
+        logger.debug("resubmit_cnt {} resubmit {}".format(resubmit_cnt, resubmit))
+        if resubmit_cnt > 0 and resubmit:
+            logger.info("resubmitting from st_archive, resubmit={:d}".format(resubmit_cnt))
+            if self.get_value("MACH") == "mira":
+                expect(os.path.isfile(".original_host"), "ERROR alcf host file not found")
+                with open(".original_host", "r") as fd:
+                    sshhost = fd.read()
+                run_cmd("ssh cooleylogin1 ssh {} '{case}/case.submit {case} --resubmit' "\
                         .format(sshhost, case=caseroot), verbose=True)
-        else:
-            self.submit(resubmit=True)
+            else:
+                self.submit(resubmit=True)
 
     return True
 

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -37,8 +37,8 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
     # if case.submit is called with the no_batch flag then we assume that this
     # flag will stay in effect for the duration of the RESUBMITs
     env_batch = case.get_env("batch")
-
-    if resubmit and env_batch.get_batch_system_type() == "none":
+    external_workflow = case.get_value("EXTERNAL_WORKFLOW")
+    if resubmit and env_batch.get_batch_system_type() == "none" or external_workflow:
         no_batch = True
     if no_batch:
         batch_system = "none"
@@ -53,7 +53,7 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
     except:
         env_batch_has_changed = True
 
-    if batch_system != "none" and env_batch_has_changed:
+    if batch_system != "none" and env_batch_has_changed and not external_workflow:
         # May need to regen batch files if user made batch setting changes (e.g. walltime, queue, etc)
         logger.warning(\
 """

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2607,6 +2607,15 @@
     <desc>External script to be run after model completion</desc>
   </entry>
 
+ <entry id="EXTERNAL_WORKFLOW">
+   <type>logical</type>
+   <valid_values>TRUE,FALSE</valid_values>
+   <default_value>FALSE</default_value>
+   <group>external_tools</group>
+   <file>env_run.xml</file>
+   <desc>whether the case uses an external workflow driver </desc>
+ </entry>
+
  <!-- Job Submission stuff -->
  <entry id="USER_REQUESTED_QUEUE">
    <type>char</type>
@@ -2681,6 +2690,7 @@
    <file>env_batch.xml</file>
    <desc>whether the PROJECT value is required on this machine</desc>
  </entry>
+
 
  <help>
     =========================================


### PR DESCRIPTION
A new tool generate_cylc_workflow.py is added.  This tool will create a cylc 7.8.3 compatible suite.rc file in the case directory.  The user sets the parameters in the case for the span of a submitted run and the number of resubmits, sets up and builds the case and then generates the workflow file.  The user can either set the RESUBMIT variable using xmlchange or use --cycles argument to generate_cylc_workflow.py to set the number of times the workflow is repeated. 

cylc register _casename_ 
cylc run _casename_

See the cylc documentation for more details. 

Test suite: scripts_regression_tests.py on cheyenne
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?:  Adds support for external workflow engine cylc

Update gh-pages html (Y/N)?:

Code review: 
