### PR TITLE
Ensemble clone

### DIFF
--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -5,7 +5,7 @@ from Tools.standard_script_setup import *
 from CIME.utils import expect
 from CIME.case  import Case
 from argparse   import RawTextHelpFormatter
-
+import re
 logger = logging.getLogger(__name__)
 
 ###############################################################################
@@ -22,6 +22,9 @@ def parse_command_line(args):
     parser.add_argument("--clone", "-clone", required=True,
                         help="(required) Specify a case to be cloned. If not a full pathname, "
                         "\nthe case to be cloned is assumed to be under then current working directory.")
+
+    parser.add_argument("--ensemble", default=1,
+                        help="clone an ensemble of cases, the case name argument must end in an integer.")
 
     parser.add_argument("--user-mods-dir",
                         help="Full pathname to a directory containing any combination of user_nl_* files "
@@ -59,14 +62,21 @@ def parse_command_line(args):
         expect(False,
                "Must specify -clone as an input argument")
 
+    startval = 1
+    if int(args.ensemble) > 1:
+        m = re.search(r'(\d+)$', args.case)
+        expect(m, " case name must end in an integer to use this feature")
+        startval = m.group(1)
+
     return args.case, args.clone, args.keepexe, args.mach_dir, args.project, \
-        args.cime_output_root, args.user_mods_dir
+        args.cime_output_root, args.user_mods_dir, int(args.ensemble), startval
 
 ##############################################################################
 def _main_func():
 ###############################################################################
 
-    case, clone, keepexe, mach_dir, project, cime_output_root, user_mods_dir = parse_command_line(sys.argv)
+    case, clone, keepexe, mach_dir, project, cime_output_root, user_mods_dir, \
+        ensemble, startval = parse_command_line(sys.argv)
 
     cloneroot = os.path.abspath(clone)
     expect(os.path.isdir(cloneroot),
@@ -75,13 +85,16 @@ def _main_func():
     if user_mods_dir is not None:
         if os.path.isdir(user_mods_dir):
             user_mods_dir = os.path.abspath(user_mods_dir)
+    nint = len(startval)
 
-    with Case(cloneroot, read_only=False) as clone:
-        clone.create_clone(case, keepexe=keepexe, mach_dir=mach_dir,
-                           project=project,
-                           cime_output_root=cime_output_root,
-                           user_mods_dir=user_mods_dir)
-
+    for i in range(int(startval), int(startval)+ensemble):
+        case = case[:-nint] + '{{0:0{0:d}d}}'.format(nint).format(i)
+        with Case(cloneroot, read_only=False) as clone:
+            clone.create_clone(case, keepexe=keepexe, mach_dir=mach_dir,
+                               project=project,
+                               cime_output_root=cime_output_root,
+                               user_mods_dir=user_mods_dir)
+        
 ###############################################################################
 
 if __name__ == "__main__":

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -24,7 +24,9 @@ def parse_command_line(args):
                         "\nthe case to be cloned is assumed to be under then current working directory.")
 
     parser.add_argument("--ensemble", default=1,
-                        help="clone an ensemble of cases, the case name argument must end in an integer.")
+                        help="clone an ensemble of cases, the case name argument must end in an integer.\n"
+                        "for example: ./create_clone --clone case.template --case case.001 --ensemble 4 \n"
+                        "will create case.001, case.002, case.003, case.004 from existing case.template"  )
 
     parser.add_argument("--user-mods-dir",
                         help="Full pathname to a directory containing any combination of user_nl_* files "

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -62,7 +62,7 @@ def parse_command_line(args):
         expect(False,
                "Must specify -clone as an input argument")
 
-    startval = 1
+    startval = '1'
     if int(args.ensemble) > 1:
         m = re.search(r'(\d+)$', args.case)
         expect(m, " case name must end in an integer to use this feature")
@@ -88,7 +88,8 @@ def _main_func():
     nint = len(startval)
 
     for i in range(int(startval), int(startval)+ensemble):
-        case = case[:-nint] + '{{0:0{0:d}d}}'.format(nint).format(i)
+        if ensemble > 1:
+            case = case[:-nint] + '{{0:0{0:d}d}}'.format(nint).format(i)
         with Case(cloneroot, read_only=False) as clone:
             clone.create_clone(case, keepexe=keepexe, mach_dir=mach_dir,
                                project=project,


### PR DESCRIPTION
Adds a --ensemble option to create_clone allowing the user to generate an ensemble of cases cloned from --clone 
Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: Adds --ensemble to create_clone, to use this option the original case must end in one or more integers, so for example if the case is named case.001 and --ensemble 4 is used you will get case.002, case.003, case.004 created.  

Update gh-pages html (Y/N)?:

Code review: 
