### PR TITLE
Add ESMF modules for cheyenne

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -356,6 +356,18 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">esmf_libs</command>
 	<command name="load">mkl</command>
       </modules>
+      <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE" comp_interface="mct">
+        <command name="load">esmf-7.1.0r-defio-mpi-g</command>
+      </modules>
+      <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE" comp_interface="mct">
+        <command name="load">esmf-7.1.0r-defio-mpi-O</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE" comp_interface="mct">
+        <command name="load">esmf-7.1.0r-ncdfio-uni-g</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE" comp_interface="mct">
+        <command name="load">esmf-7.1.0r-ncdfio-uni-O</command>
+      </modules>
       <modules compiler="pgi">
 	<command name="load">pgi/17.9</command>
       </modules>


### PR DESCRIPTION
Needed to add back in the ESMF module loads for mct on cheyenne.
This fixes failing WACCM-X tests.

Test suite: scripts_regression_tests, SMS_Ld1.f19_f19_mg17.FXSD.cheyenne_intel.cam-outfrq1d
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3171

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
