### PR TITLE
Jedwards/more workflow

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -140,7 +140,7 @@
       <arg flag="-A" name="$PROJECT"/>
     </submit_args>
     <directives>
-      <directive> -N {{ job_id }}</directive>
+      <directive>-N {{ job_id }}</directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
       <!-- <directive> -j oe {{ job_id }} </directive> -->
       <directive> -j oe </directive>

--- a/config/cesm/machines/cylc_suite.rc.template
+++ b/config/cesm/machines/cylc_suite.rc.template
@@ -1,9 +1,9 @@
 [meta]
-  title = CESM CYLC workflow for case {{ casename }}
+  title = CESM CYLC workflow for {{ workflow_description }}
 [cylc]
   [[parameters]]
-    member = 1
-  
+    member = {{ members }}
+
 [scheduling]
   cycling mode = integer
   initial cycle point = 1
@@ -19,7 +19,6 @@
 	     """
 [runtime]
   [[set_external_workflow<member>]]
-    script = cd {{ caseroot }}; ./xmlchange EXTERNAL_WORKFLOW=TRUE
+    script = cd {{ case_path_string }} ./xmlchange EXTERNAL_WORKFLOW=TRUE
   [[st_archive<member>]]
-    script = cd {{ caseroot }}; ./case.submit --job case.st_archive; ./xmlchange CONTINUE_RUN=TRUE
-
+    script = cd {{ case_path_string }} ./case.submit --job case.st_archive; ./xmlchange CONTINUE_RUN=TRUE

--- a/config/cesm/machines/cylc_suite.rc.template
+++ b/config/cesm/machines/cylc_suite.rc.template
@@ -1,5 +1,8 @@
 [meta]
   title = CESM CYLC workflow for case {{ casename }}
+[cylc]
+  [[parameters]]
+    member = 1
   
 [scheduling]
   cycling mode = integer
@@ -8,15 +11,15 @@
 
   [[dependencies]]
     [[[R1]]]
-      graph = "set_external_workflow => run => st_archive "
+      graph = "set_external_workflow<member> => run<member> => st_archive<member> "
     [[[R/P1]]] # Integer Cycling
       graph = """
-	     st_archive[-P1] => run
-             run => st_archive 
+	     st_archive<member>[-P1] => run<member>
+             run<member> => st_archive<member>
 	     """
 [runtime]
-  [[set_external_workflow]]
+  [[set_external_workflow<member>]]
     script = cd {{ caseroot }}; ./xmlchange EXTERNAL_WORKFLOW=TRUE
-  [[st_archive]]
+  [[st_archive<member>]]
     script = cd {{ caseroot }}; ./case.submit --job case.st_archive; ./xmlchange CONTINUE_RUN=TRUE
 

--- a/scripts/Tools/generate_cylc_workflow.py
+++ b/scripts/Tools/generate_cylc_workflow.py
@@ -40,7 +40,7 @@ def parse_command_line(args, description):
 
 def cylc_get_ensemble_first_and_last(case, ensemble):
     if ensemble == 1:
-        return 1,None;
+        return 1,None
     casename = case.get_value("CASE")
     m = re.search(r"(.*[^\d])(\d+)$", casename)
     minval = int(m.group(2))

--- a/scripts/Tools/generate_cylc_workflow.py
+++ b/scripts/Tools/generate_cylc_workflow.py
@@ -9,7 +9,7 @@ from standard_script_setup import *
 from CIME.case              import Case
 from CIME.utils             import expect, transform_vars
 
-import argparse
+import argparse, re
 logger = logging.getLogger(__name__)
 
 ###############################################################################
@@ -28,38 +28,68 @@ def parse_command_line(args, description):
     parser.add_argument('--cycles', default=1,
                         help="The number of cycles to run, default is RESUBMIT")
 
+    parser.add_argument("--ensemble", default=1,
+                        help="generate suite.rc for an ensemble of cases, the case name argument must end in an integer.\n"
+                        "for example: ./generate_cylc_workflow.py --ensemble 4 \n"
+                        "will generate a workflow file in the current case, if that case is named case.01,"
+                        "the workflow will include case.01, case.02, case.03 and case.04")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.caseroot, args.cycles
+    return args.caseroot, args.cycles, int(args.ensemble)
 
-def cylc_batch_job_template(job, jobname, case):
+def cylc_get_ensemble_first_and_last(case, ensemble):
+    if ensemble == 1:
+        return 1,None;
+    casename = case.get_value("CASE")
+    m = re.search(r"(.*[^\d])(\d+)$", casename)
+    minval = int(m.group(2))
+    maxval = minval+ensemble-1
+    return minval,maxval
+
+def cylc_get_case_path_string(case, ensemble):
     caseroot = case.get_value("CASEROOT")
+    casename = case.get_value("CASE")
+    if ensemble == 1:
+        return "{};".format(caseroot)
+    basepath = os.path.abspath(caseroot+"/..")
+    m = re.search(r"(.*[^\d])(\d+)$", casename)
+
+    expect(m, "casename {} must end in an integer for ensemble method".format(casename))
+
+    return "{basepath}/{basename}$(printf \"%0{intlen}d\"".format(basepath=basepath, basename=m.group(1), intlen=len(m.group(2))) + " ${CYLC_TASK_PARAM_member});"
+
+
+def cylc_batch_job_template(job, jobname, case, ensemble):
+
     env_batch = case.get_env("batch")
     batch_system_type = env_batch.get_batch_system_type()
     batchsubmit = env_batch.get_value("batch_submit")
     submit_args = env_batch.get_submit_args(case, job)
+    case_path_string = cylc_get_case_path_string(case, ensemble)
 
     return """
-  [[{jobname}]]
-    script = cd {caseroot}; ./case.submit --job {job}
+    [[{jobname}<member>]]
+    script = cd {case_path_string} ./case.submit --job {job}
     [[[job]]]
       batch system = {batch_system_type}
       batch submit command template = {batchsubmit} {submit_args}  '%(job)s'
     [[[directives]]]
-""".format(jobname=jobname, job=job, caseroot=caseroot, batch_system_type=batch_system_type,
+""".format(jobname=jobname, job=job, case_path_string=case_path_string, batch_system_type=batch_system_type,
            batchsubmit=batchsubmit, submit_args=submit_args) + "{{ batchdirectives }}\n"
 
 
-def cylc_script_job_template(job, caseroot):
+def cylc_script_job_template(job, case, ensemble):
+    case_path_string = cylc_get_case_path_string(case, ensemble)
     return """
-  [[{job}]]
-    script = cd {caseroot}; ./case.submit --job {job}
-""".format(job=job, caseroot=caseroot)
+    [[{job}<member>]]
+    script = cd {case_path_string} ./case.submit --job {job}
+""".format(job=job, case_path_string=case_path_string)
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    caseroot, cycles = parse_command_line(sys.argv, description)
+    caseroot, cycles, ensemble = parse_command_line(sys.argv, description)
 
     expect(os.path.isfile(os.path.join(caseroot, "CaseStatus")),
            "case.setup must be run prior to running {}".format(__file__))
@@ -75,6 +105,19 @@ def _main_func(description):
         overrides = {"cycles":cycles,
                      'casename':casename}
         input_text = open(input_template).read()
+
+        first,last = cylc_get_ensemble_first_and_last(case, ensemble)
+        if ensemble == 1:
+            overrides.update({'members':"{}".format(first)})
+            overrides.update({"workflow_description":"case {}".format(case.get_value("CASE"))})
+        else:
+            overrides.update({'members':"{}..{}".format(first,last)})
+            firstcase = case.get_value("CASE")
+            intlen = len(str(last))
+            lastcase = firstcase[:-intlen]+str(last)
+            overrides.update({"workflow_description":"ensemble from {} to {}".format(firstcase,lastcase)})
+        overrides.update({"case_path_string":cylc_get_case_path_string(case, ensemble)})
+
         for job in jobs:
             jobname = job
             if job == 'case.st_archive':
@@ -83,27 +126,27 @@ def _main_func(description):
                 jobname = 'run'
                 overrides.update(env_batch.get_job_overrides(job, case))
                 overrides.update({'job_id':'run.'+casename})
-                input_text = input_text + cylc_batch_job_template(job, jobname, case)
+                input_text = input_text + cylc_batch_job_template(job, jobname, case, ensemble)
             else:
                 depends_on = env_workflow.get_value('dependency', subgroup=job)
                 if depends_on.startswith('case.'):
                     depends_on = depends_on[5:]
-                input_text = input_text.replace(' => '+depends_on,' => '+depends_on+' => '+job)
+                input_text = input_text.replace(' => '+depends_on,' => '+depends_on+'<member> => '+job)
 
 
                 overrides.update(env_batch.get_job_overrides(job, case))
                 overrides.update({'job_id':job+'.'+casename})
                 if 'total_tasks' in overrides and overrides['total_tasks'] > 1:
-                    input_text = input_text + cylc_batch_job_template(job, jobname, case)
+                    input_text = input_text + cylc_batch_job_template(job, jobname, case, ensemble)
                 else:
-                    input_text = input_text + cylc_script_job_template(jobname, caseroot)
+                    input_text = input_text + cylc_script_job_template(jobname, case, ensemble)
 
 
             overrides.update({'batchdirectives':env_batch.get_batch_directives(case,job, overrides=overrides,
                                                                            output_format='cylc')})
-
-
+            # we need to re-transform for each job to get job size correctly
             input_text = transform_vars(input_text, case=case, subgroup=job, overrides=overrides)
+
         with open("suite.rc", "w") as f:
             f.write(case.get_resolved_value(input_text))
 

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -24,7 +24,9 @@ def parse_command_line(args):
                         "\nthe case to be cloned is assumed to be under then current working directory.")
 
     parser.add_argument("--ensemble", default=1,
-                        help="clone an ensemble of cases, the case name argument must end in an integer.")
+                        help="clone an ensemble of cases, the case name argument must end in an integer.\n"
+                        "for example: ./create_clone --clone case.template --case case.001 --ensemble 4 \n"
+                        "will create case.001, case.002, case.003, case.004 from existing case.template"  )
 
     parser.add_argument("--user-mods-dir",
                         help="Full pathname to a directory containing any combination of user_nl_* files "
@@ -62,7 +64,7 @@ def parse_command_line(args):
         expect(False,
                "Must specify -clone as an input argument")
 
-    startval = 1
+    startval = '1'
     if int(args.ensemble) > 1:
         m = re.search(r'(\d+)$', args.case)
         expect(m, " case name must end in an integer to use this feature")
@@ -88,13 +90,14 @@ def _main_func():
     nint = len(startval)
 
     for i in range(int(startval), int(startval)+ensemble):
-        case = case[:-nint] + '{{0:0{0:d}d}}'.format(nint).format(i)
+        if ensemble > 1:
+            case = case[:-nint] + '{{0:0{0:d}d}}'.format(nint).format(i)
         with Case(cloneroot, read_only=False) as clone:
             clone.create_clone(case, keepexe=keepexe, mach_dir=mach_dir,
                                project=project,
                                cime_output_root=cime_output_root,
                                user_mods_dir=user_mods_dir)
-        
+
 ###############################################################################
 
 if __name__ == "__main__":

--- a/scripts/create_clone
+++ b/scripts/create_clone
@@ -5,7 +5,7 @@ from Tools.standard_script_setup import *
 from CIME.utils import expect
 from CIME.case  import Case
 from argparse   import RawTextHelpFormatter
-
+import re
 logger = logging.getLogger(__name__)
 
 ###############################################################################
@@ -22,6 +22,9 @@ def parse_command_line(args):
     parser.add_argument("--clone", "-clone", required=True,
                         help="(required) Specify a case to be cloned. If not a full pathname, "
                         "\nthe case to be cloned is assumed to be under then current working directory.")
+
+    parser.add_argument("--ensemble", default=1,
+                        help="clone an ensemble of cases, the case name argument must end in an integer.")
 
     parser.add_argument("--user-mods-dir",
                         help="Full pathname to a directory containing any combination of user_nl_* files "
@@ -59,14 +62,21 @@ def parse_command_line(args):
         expect(False,
                "Must specify -clone as an input argument")
 
+    startval = 1
+    if int(args.ensemble) > 1:
+        m = re.search(r'(\d+)$', args.case)
+        expect(m, " case name must end in an integer to use this feature")
+        startval = m.group(1)
+
     return args.case, args.clone, args.keepexe, args.mach_dir, args.project, \
-        args.cime_output_root, args.user_mods_dir
+        args.cime_output_root, args.user_mods_dir, int(args.ensemble), startval
 
 ##############################################################################
 def _main_func():
 ###############################################################################
 
-    case, clone, keepexe, mach_dir, project, cime_output_root, user_mods_dir = parse_command_line(sys.argv)
+    case, clone, keepexe, mach_dir, project, cime_output_root, user_mods_dir, \
+        ensemble, startval = parse_command_line(sys.argv)
 
     cloneroot = os.path.abspath(clone)
     expect(os.path.isdir(cloneroot),
@@ -75,13 +85,16 @@ def _main_func():
     if user_mods_dir is not None:
         if os.path.isdir(user_mods_dir):
             user_mods_dir = os.path.abspath(user_mods_dir)
+    nint = len(startval)
 
-    with Case(cloneroot, read_only=False) as clone:
-        clone.create_clone(case, keepexe=keepexe, mach_dir=mach_dir,
-                           project=project,
-                           cime_output_root=cime_output_root,
-                           user_mods_dir=user_mods_dir)
-
+    for i in range(int(startval), int(startval)+ensemble):
+        case = case[:-nint] + '{{0:0{0:d}d}}'.format(nint).format(i)
+        with Case(cloneroot, read_only=False) as clone:
+            clone.create_clone(case, keepexe=keepexe, mach_dir=mach_dir,
+                               project=project,
+                               cime_output_root=cime_output_root,
+                               user_mods_dir=user_mods_dir)
+        
 ###############################################################################
 
 if __name__ == "__main__":

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -346,6 +346,10 @@ class EnvBatch(EnvBase):
                             directive = self.get_resolved_value("" if self.text(node) is None else self.text(node))
                             if output_format == 'cylc':
                                 if self._batchtype == 'pbs':
+                                    # cylc includes the -N itself, no need to add
+                                    if directive.startswith("-N"):
+                                        directive=''
+                                        continue
                                     m = re.match(r'\s*(-[\w])', directive)
                                     if m:
                                         directive = re.sub(r'(-[\w]) ','{} = '.format(m.group(1)), directive)

--- a/scripts/lib/CIME/case/case_clone.py
+++ b/scripts/lib/CIME/case/case_clone.py
@@ -126,6 +126,14 @@ def create_clone(self, newcase, keepexe=False, mach_dir=None, project=None,
                         os.path.join(newcaseroot, casesub),
                         symlinks=True)
 
+    # copy the postprocessing directory if it exists
+    if os.path.isdir(os.path.join(cloneroot, "postprocess")):
+        shutil.copytree(os.path.join(cloneroot, "postprocess"),
+                        os.path.join(newcaseroot, "postprocess"),
+                        symlinks=True)
+
+
+
     # lock env_case.xml in new case
     lock_file("env_case.xml", newcaseroot)
 

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -48,10 +48,11 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
     case.set_value("BATCH_SYSTEM", batch_system)
 
     env_batch_has_changed = False
-    try:
-        case.check_lockedfile(os.path.basename(env_batch.filename))
-    except:
-        env_batch_has_changed = True
+    if not external_workflow:
+        try:
+            case.check_lockedfile(os.path.basename(env_batch.filename))
+        except:
+            env_batch_has_changed = True
 
     if batch_system != "none" and env_batch_has_changed and not external_workflow:
         # May need to regen batch files if user made batch setting changes (e.g. walltime, queue, etc)


### PR DESCRIPTION
Adds a --ensemble option to generate_cylc_workflow

Test suite: scripts_regression_tests.py, hand testing
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: Add --ensemble to generate_cylc_workflow generating an ensemble driver for cylc workflow, this driver is generated in the first ensemble member and controls all members from a single cylc suite. 

Update gh-pages html (Y/N)?:

Code review: 
