### PR TITLE
all stubs is not supported in nuopc

### DIFF
--- a/scripts/Tools/mkDepends
+++ b/scripts/Tools/mkDepends
@@ -34,8 +34,8 @@
 #
 # ChangeLog:
 # -----------------------------------------------------------------------------
-# Modifications to Brian Eaton's original to relax the restrictions on 
-# source file name matching module name and only one module per source 
+# Modifications to Brian Eaton's original to relax the restrictions on
+# source file name matching module name and only one module per source
 # file.  Also added a new "-d depfile" option which allows an additional
 # file to be added to every dependence.
 #
@@ -174,8 +174,8 @@ chomp @src;
 
 my %module_files = ();
 
-# Attempt to parse each file for /^\s*module/ and extract module names 
-# for each file.  
+# Attempt to parse each file for /^\s*module/ and extract module names
+# for each file.
 my ($f, $name, $path, $suffix, $mod);
 # include NEMO's *.h90 files
 my @suffixes = ('\.[fFh]90', '\.[fF]','\.F90\.in' );
@@ -188,7 +188,7 @@ foreach $f (@src) {
 	# Search for module definitions.
 	if ( /^\s*MODULE\s+(\w+)\s*(\!.*)?$/i ) {
 	    ($mod = $1) =~ tr/A-Z/a-z/;
-            if ( defined $module_files{$mod} ) { 
+            if ( defined $module_files{$mod} ) {
                 die "Duplicate definitions of module $mod in $module_files{$mod} and $name: $!\n";
             }
             $module_files{$mod} = $name;
@@ -199,7 +199,7 @@ foreach $f (@src) {
 
 # Now make a list of .mod files in the file_paths.  If a source dependency
 # can't be found based on the module_files list above, then maybe a .mod
-# module dependency can if the mod file is visible.  
+# module dependency can if the mod file is visible.
 my %trumod_files = ();
 my ($dir);
 my ($f, $name, $path, $suffix, $mod);
@@ -372,7 +372,7 @@ foreach $f (sort keys %file_modules) {
 	$file = $1;
     }
     $target = $obj_dir."$file.o";
-    print "$target : @{$file_modules{$f}} @{$file_includes{$f}} $additional_file \n";
+    print "$target : $f @{$file_modules{$f}} @{$file_includes{$f}} $additional_file \n";
 }
 
 print "# The following section relates each module to the corresponding file.\n";
@@ -414,11 +414,18 @@ sub find_dependencies {
     while ( <FH> ) {
 	# Search for CPP include and strip filename when found.
 	if ( /^#\s*include\s+[<"](.*)[>"]/ ) {
-	     push @incs, $1;
-	 } 
+	    $include = $1;
+	 }
 	# Search for Fortran include dependencies.
 	elsif ( /^\s*include\s+['"](.*)['"]/ ) {                   #" for emacs fontlock
-	     push @incs, $1;
+	    $include = $1;
+	}
+	if(defined($include)){
+	    if($include =~ /shr_assert.h/){
+		push @mods, "$obj_dir".mangle_modfile("shr_assert_mod");
+	    }
+	    push @incs, $include;
+	    undef $include;
 	}
 	# Search for module dependencies.
 	elsif ( /^\s*USE(?:\s+|\s*\:\:\s*|\s*,\s*non_intrinsic\s*\:\:\s*)(\w+)/i ) {
@@ -432,7 +439,7 @@ sub find_dependencies {
 		}
 	    }
             # If we already have a .mod file around.
-            elsif ( defined $trumod_files{$module} ) { 
+            elsif ( defined $trumod_files{$module} ) {
                 push @mods, "$obj_dir".mangle_modfile($trumod_files{$module});
             }
 	}
@@ -535,7 +542,7 @@ OPTIONS
           targets in the dependency rules have the form dir/file.o.
      -w   Print warnings to STDERR about files or dependencies not found.
 ARGUMENTS
-     Filepath is the name of a file containing the directories (one per 
+     Filepath is the name of a file containing the directories (one per
      line) to be searched for dependencies.  Srcfiles is the name of a
      file containing the names of files (one per line) for which
      dependencies will be generated.

--- a/scripts/lib/CIME/XML/env_workflow.py
+++ b/scripts/lib/CIME/XML/env_workflow.py
@@ -65,6 +65,7 @@ class EnvWorkflow(EnvBase):
 
     def get_type_info(self, vid):
         gnodes = self.get_children("group")
+        type_info = None
         for gnode in gnodes:
             nodes = self.get_children("entry",{"id":vid}, root=gnode)
             type_info = None

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1097,6 +1097,11 @@ class TestCreateTestCommon(unittest.TestCase):
     ###########################################################################
     def _create_test(self, extra_args, test_id=None, pre_run_errors=False, run_errors=False, env_changes=""):
     ###########################################################################
+        # All stub model not supported in nuopc driver
+        driver = CIME.utils.get_cime_default_driver()
+        if driver == 'nuopc':
+            extra_args.append(" ^SMS.T42_T42.S")
+
         test_id = CIME.utils.get_timestamp() if test_id is None else test_id
         extra_args.append("-t {}".format(test_id))
         extra_args.append("--baseline-root {}".format(self._baseline_area))
@@ -1114,6 +1119,8 @@ class TestCreateTestCommon(unittest.TestCase):
             expected_stat = 0 if not pre_run_errors else CIME.utils.TESTS_FAILED_ERR_CODE
         else:
             expected_stat = 0 if not pre_run_errors and not run_errors else CIME.utils.TESTS_FAILED_ERR_CODE
+
+
 
         run_cmd_assert_result(self, "{} {}/create_test {}".format(env_changes, SCRIPT_DIR, " ".join(extra_args)),
                               expected_stat=expected_stat)

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1120,8 +1120,6 @@ class TestCreateTestCommon(unittest.TestCase):
         else:
             expected_stat = 0 if not pre_run_errors and not run_errors else CIME.utils.TESTS_FAILED_ERR_CODE
 
-
-
         run_cmd_assert_result(self, "{} {}/create_test {}".format(env_changes, SCRIPT_DIR, " ".join(extra_args)),
                               expected_stat=expected_stat)
 


### PR DESCRIPTION
Remove test SMS.T42_T42.S when testing with nuopc driver, all stub cases are not supported.

Test suite: scripts_regression_tests.py with CIME_DRIVER=nuopc
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
