### PR TITLE
fix mkDepends issue with shr_assert_mod

### DIFF
--- a/scripts/Tools/mkDepends
+++ b/scripts/Tools/mkDepends
@@ -34,8 +34,8 @@
 #
 # ChangeLog:
 # -----------------------------------------------------------------------------
-# Modifications to Brian Eaton's original to relax the restrictions on 
-# source file name matching module name and only one module per source 
+# Modifications to Brian Eaton's original to relax the restrictions on
+# source file name matching module name and only one module per source
 # file.  Also added a new "-d depfile" option which allows an additional
 # file to be added to every dependence.
 #
@@ -174,8 +174,8 @@ chomp @src;
 
 my %module_files = ();
 
-# Attempt to parse each file for /^\s*module/ and extract module names 
-# for each file.  
+# Attempt to parse each file for /^\s*module/ and extract module names
+# for each file.
 my ($f, $name, $path, $suffix, $mod);
 # include NEMO's *.h90 files
 my @suffixes = ('\.[fFh]90', '\.[fF]','\.F90\.in' );
@@ -188,7 +188,7 @@ foreach $f (@src) {
 	# Search for module definitions.
 	if ( /^\s*MODULE\s+(\w+)\s*(\!.*)?$/i ) {
 	    ($mod = $1) =~ tr/A-Z/a-z/;
-            if ( defined $module_files{$mod} ) { 
+            if ( defined $module_files{$mod} ) {
                 die "Duplicate definitions of module $mod in $module_files{$mod} and $name: $!\n";
             }
             $module_files{$mod} = $name;
@@ -199,7 +199,7 @@ foreach $f (@src) {
 
 # Now make a list of .mod files in the file_paths.  If a source dependency
 # can't be found based on the module_files list above, then maybe a .mod
-# module dependency can if the mod file is visible.  
+# module dependency can if the mod file is visible.
 my %trumod_files = ();
 my ($dir);
 my ($f, $name, $path, $suffix, $mod);
@@ -372,7 +372,7 @@ foreach $f (sort keys %file_modules) {
 	$file = $1;
     }
     $target = $obj_dir."$file.o";
-    print "$target : @{$file_modules{$f}} @{$file_includes{$f}} $additional_file \n";
+    print "$target : $f @{$file_modules{$f}} @{$file_includes{$f}} $additional_file \n";
 }
 
 print "# The following section relates each module to the corresponding file.\n";
@@ -414,11 +414,18 @@ sub find_dependencies {
     while ( <FH> ) {
 	# Search for CPP include and strip filename when found.
 	if ( /^#\s*include\s+[<"](.*)[>"]/ ) {
-	     push @incs, $1;
-	 } 
+	    $include = $1;
+	 }
 	# Search for Fortran include dependencies.
 	elsif ( /^\s*include\s+['"](.*)['"]/ ) {                   #" for emacs fontlock
-	     push @incs, $1;
+	    $include = $1;
+	}
+	if(defined($include)){
+	    if($include =~ /shr_assert.h/){
+		push @mods, "$obj_dir".mangle_modfile("shr_assert_mod");
+	    }
+	    push @incs, $include;
+	    undef $include;
 	}
 	# Search for module dependencies.
 	elsif ( /^\s*USE(?:\s+|\s*\:\:\s*|\s*,\s*non_intrinsic\s*\:\:\s*)(\w+)/i ) {
@@ -432,7 +439,7 @@ sub find_dependencies {
 		}
 	    }
             # If we already have a .mod file around.
-            elsif ( defined $trumod_files{$module} ) { 
+            elsif ( defined $trumod_files{$module} ) {
                 push @mods, "$obj_dir".mangle_modfile($trumod_files{$module});
             }
 	}
@@ -535,7 +542,7 @@ OPTIONS
           targets in the dependency rules have the form dir/file.o.
      -w   Print warnings to STDERR about files or dependencies not found.
 ARGUMENTS
-     Filepath is the name of a file containing the directories (one per 
+     Filepath is the name of a file containing the directories (one per
      line) to be searched for dependencies.  Srcfiles is the name of a
      file containing the names of files (one per line) for which
      dependencies will be generated.


### PR DESCRIPTION
mkdepends last update broke some interaction with shr_assert_mod, this fixes it. 
Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit,
Fixes 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
