### PR TITLE
Point to new mapping files for r05 <-> f10 mapping

### DIFF
--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -97,8 +97,8 @@
     </gridmap>
 
     <gridmap lnd_grid="10x15" rof_grid="r05">
-      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_10x15_to_0.5x0.5rtm_aave_da_110307.nc</map>
-      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_0.5x0.5_nomask_to_10x15_nomask_aave_da_c121019.nc</map>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_10x15_to_0.5x0.5rtm_aave_da_c20190725.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/10x15/map_0.5x0.5_nomask_to_10x15_nomask_aave_da_c20190725.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="4x5" rof_grid="r05">


### PR DESCRIPTION
Point to new mapping files for r05 <-> f10 mapping

The new mapping files were generated by @mvertens with a recent version
of ESMF_RegridWeightGen, with '--ignore_unmapped -m conserve'.

The new rof -> lnd map should fix the issue with the old map, that
mapping a 1 field from rof -> lnd without normalization leads to non-1
values on the destination.

Test suite: Cherry-picked the change into the cime version used in ctsm master, then ran
`SMS_D_Ld3.f10_f10_musgs.I1850Clm50BgcCrop.cheyenne_intel.clm-default`
with comparison against master.
Test baseline: ctsm1.0.dev052
Test namelist changes: lnd2rof_fmapname, rof2lnd_fmapname
Test status: greater than roundoff, but probably not climate changing;
only changes cases using the f10 grid (just used for testing)

There are differences in the following CLM fields (these are either directly related to the mapped river volume, or depend on it via methane's dependence on total gridcell water volume):

```
 RMS CH4PROD                          8.0350E-13            NORMALIZED  2.0526E-05
 RMS CH4_SURF_AERE_SAT                3.2242E-11            NORMALIZED  7.6731E-04
 RMS CH4_SURF_DIFF_SAT                6.5698E-13            NORMALIZED  3.1933E-03
 RMS CH4_SURF_EBUL_SAT                1.2144E-29            NORMALIZED  8.1788E-20
 RMS CONC_O2_SAT                      1.8803E-03            NORMALIZED  2.7509E-02
 RMS FCH4                             8.8559E-14            NORMALIZED  3.3512E-03
 RMS FCH4TOCO2                        8.7528E-11            NORMALIZED  2.9232E-03
 RMS FCH4_DFSAT                       2.2487E-18            NORMALIZED  7.2389E-05
 RMS FINUNDATED                       2.5729E-07            NORMALIZED  8.6899E-06
 RMS NEM                              8.7506E-11            NORMALIZED  5.1107E-03
 RMS TOTCOLCH4                        9.8119E-08            NORMALIZED  2.0761E-07
 RMS TWS                              2.6250E-02            NORMALIZED  1.5426E-06
 RMS VOLR                             4.7216E+07            NORMALIZED  7.2529E-02
 RMS VOLRMCH                          1.9205E+07            NORMALIZED  7.6222E-02
```

and in the following cpl fields:

```
 RMS x2l_Flrr_volr                    3.0371E-05            NORMALIZED  6.2596E-02
 RMS x2l_Flrr_volrmch                 1.3830E-05            NORMALIZED  6.6570E-02
 RMS fracr_lfrac                      1.5987E-09            NORMALIZED  4.6844E-09
 RMS r2x_Forr_rofl                    2.2583E-15            NORMALIZED  2.3902E-09
 RMS r2x_Forr_rofi                    9.3629E-15            NORMALIZED  1.0087E-08
 RMS r2x_Flrr_volr                    4.6823E-13            NORMALIZED  1.4978E-09
 RMS r2x_Flrr_volrmch                 2.7486E-13            NORMALIZED  2.0522E-09
 RMS x2r_Flrl_rofsur                  1.0427E-15            NORMALIZED  2.9982E-09
 RMS x2r_Flrl_rofgwl                  2.7807E-16            NORMALIZED  1.4963E-09
 RMS x2r_Flrl_rofsub                  3.1541E-15            NORMALIZED  1.7387E-09
 RMS x2r_Flrl_rofi                    9.3625E-15            NORMALIZED  1.0212E-08
```

Fixes ESMCI/cime#3185

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
