### PR TITLE
Use correct mask for ne16pg3 resolution

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -926,11 +926,11 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16pg3_ne16pg3_mg37" not_compset="_POP|_CLM">
+    <model_grid alias="ne16pg3_ne16pg3_mg17" not_compset="_POP|_CLM">
       <grid name="atm">ne16np4.pg3</grid>
       <grid name="lnd">ne16np4.pg3</grid>
       <grid name="ocnice">ne16np4.pg3</grid>
-      <mask>gx3v7</mask>
+      <mask>gx1v7</mask>
     </model_grid>
 
     <model_grid alias="ne30pg3_ne30pg3_mg17" not_compset="_POP">


### PR DESCRIPTION
The ne16pg3 grid (alias ne16pg3_ne16pg3_mg37) used the incorrect mask, gx3v7 for which there are no domain files. This PR uses the correct mask, gx1v7 and updates the alias to match (ne16pg3_ne16pg3_mg17).

Test suite: scripts_regression_tests.py except for pylint
Hand test to make sure new resolution works correctly
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes #3189 

User interface changes?:  No

Update gh-pages html (Y/N)?: N

Code review: @gold2718 -- simple XML change
