### PR TITLE
update ncpl and cpl_seq_option for mom6

### DIFF
--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -226,10 +226,13 @@
       <value compset="_DATM%COPYALL_NPS">72</value>
       <value compset="_DATM.*_CLM">48</value>
       <value compset="_DATM.*_DICE.*_POP2">4</value>
+      <value compset="_DATM.*_DICE.*_MOM6">24</value>
       <value compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
+      <value compset="_DATM.*_SLND.*_CICE.*_MOM6">24</value>
       <value compset="_DATM.*_CICE.*_DOCN">24</value>
       <value compset="_DATM.*_DOCN%US20">24</value>
       <value compset="_DATM%CPLHIST.+POP\d">48</value>
+      <value compset="_DATM%CPLHIST.+MOM\d">48</value>
       <value compset="_MPAS">1</value>
       <value compset=".+" grid="a%0.23x0.31">96</value>
       <value compset=".+" grid="a%ne60np4">96</value>
@@ -252,7 +255,9 @@
       <value compset=".+" grid="1x1_vancou">24</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DATM.*_DICE.*_POP2.*_WW3">4</value>
+      <value compset="_DATM.*_DICE.*_MOM6.*_WW3">4</value>
       <value compset="_DATM.*_DICE.*_POP2.*_DWAV">4</value>
+      <value compset="_DATM.*_DICE.*_MOM6.*_DWAV">4</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -292,6 +297,7 @@
     <default_value>$ATM_NCPL</default_value>
     <values match="last">
       <value compset="_POP2">1</value>
+      <value compset="_MOM6">24</value>
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
       <value compset="_POP2" grid="oi%gx1v6">24</value>
       <value compset="_POP2" grid="oi%gx1v7">24</value>
@@ -316,6 +322,7 @@
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_SGLC">$ATM_NCPL</value>
       <value compset="_XGLC">$ATM_NCPL</value>
+      <value compset="_MOM6">1</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -348,9 +355,11 @@
     <default_value>8</default_value>
     <values match="last">
       <value compset="_DATM.*_POP2.*_DROF">$ATM_NCPL</value>
+      <value compset="_DATM.*_MOM6.*_DROF">$ATM_NCPL</value>
       <value compset="_DATM.*_DOCN%SOM">$ATM_NCPL</value>
       <value compset="_DATM.*_SLND.*_DICE.*_DOCN">$ATM_NCPL</value>
       <value compset="_DATM%CPLHIST.+POP\d">8</value>
+      <value compset="_DATM%CPLHIST.+MOM\d">8</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">$ATM_NCPL</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_SROF">$ATM_NCPL</value>
@@ -433,6 +442,7 @@
     <values match="last">
       <value compset="_DATM.*_DOCN%SOM"			>CESM1_MOD</value>
       <value compset="_POP2"				>CESM1_MOD</value>
+      <value compset="_MOM6"				>RASM_OPTION1</value>
       <value compset="_POP2" grid="oi%gx1v6"		>RASM_OPTION1</value>
       <value compset="_POP2" grid="oi%gx1v7"		>RASM_OPTION1</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN"	>CESM1_MOD</value>


### PR DESCRIPTION
Updates ATM_NCPL, OCN_NCPL, ROF_NCPL, and CPL_SEQ_OPTION for MOM6.

Test suite: aux_mom
Test baseline: /glade/scratch/altuntas/cesm.tests/cheyenne/aux_mom/190808
Test namelist changes: no changes (except mom6 cases)
Test status: : bit for bit (except mom6 cases)

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
