### PR TITLE
if filename is abspath use for filepath

### DIFF
--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -474,7 +474,9 @@ class NamelistGenerator(object):
             for i, filename in enumerate(domain_filenames.split("\n")):
                 if filename.strip() == '':
                     continue
-                filepath = os.path.join(domain_filepath, filename.strip())
+                filepath, filename = os.path.split(filename)
+                if not filepath:
+                    filepath = os.path.join(domain_filepath, os.path.dirname(filename.strip()))
                 string = "domain{:d} = {}\n".format(i+1, filepath)
                 hashValue = hashlib.md5(string.rstrip().encode('utf-8')).hexdigest()
                 if hashValue not in lines_hash:


### PR DESCRIPTION
If a stream filename (such as DOCN_AQP_FILENAME) is an absolute path then use it to set the filepath argument, otherwise use domain_filepath.

Test suite: scripts_regression_tests.py and 3199 by hand.  
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3199

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
