### PR TITLE
Compset aliascheck

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -439,7 +439,7 @@ class Case(object):
             if result is not None:
                 del self.lookups[key]
 
-    def _set_compset(self, compset_name, files, driver="mct"):
+    def _set_compset(self, compset_name, files, driver="mct", test=False):
         """
         Loop through all the compset files and find the compset
         specifation file that matches either the input 'compset_name'.
@@ -485,7 +485,7 @@ class Case(object):
         # Fill in compset name
         self._compsetname, self._components = self.valid_compset(self._compsetname, files)
         # if this is a valid compset longname there will be at least 7 components and at least one is not stub
-        components = self.get_compset_components()
+        components = self.get_compset_components(test=test)
         expect(len(components) > 6, "No compset alias {} found and this does not appear to be a compset longname.".format(compset_name))
 
         return compset_alias, science_support
@@ -668,7 +668,7 @@ class Case(object):
         self.set_lookup_value("USER_MODS_DIR"  , user_mods_dir)
 
 
-    def get_compset_components(self):
+    def get_compset_components(self, test=False):
         #If are doing a create_clone then, self._compsetname is not set yet
         components = []
         compset = self.get_value("COMPSET")
@@ -690,7 +690,8 @@ class Case(object):
                 components.append(element_component)
                 if not element_component.startswith('s'):
                     allstubs = False
-        expect(not allstubs, "Invalid compset name, all stub components generated")
+
+        expect(test or not allstubs, "Invalid compset name, all stub components generated {}".format(test))
         return components
 
 
@@ -898,9 +899,9 @@ class Case(object):
         #--------------------------------------------
         # find and/or fill out compset name
         #--------------------------------------------
-        compset_alias, science_support = self._set_compset(compset_name, files, driver)
+        compset_alias, science_support = self._set_compset(compset_name, files, driver, test=test)
 
-        self._components = self.get_compset_components()
+        self._components = self.get_compset_components(test)
 
         #--------------------------------------------
         # grid
@@ -1190,7 +1191,7 @@ class Case(object):
                 logger.warning("FAILED to set up exefiles: {}".format(str(e)))
 
     def _create_caseroot_sourcemods(self):
-        components = self.get_compset_components()
+        components = self.get_compset_components(test=self.get_value("TEST"))
         components.extend(['share', 'drv'])
         readme_message = """Put source mods for the {component} library in this directory.
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -484,7 +484,7 @@ class Case(object):
 
         # Fill in compset name
         self._compsetname, self._components = self.valid_compset(self._compsetname, files)
-        # if this is a valiid compset longname there will be at least 7 components.
+        # if this is a valid compset longname there will be at least 7 components and at least one is not stub
         components = self.get_compset_components()
         expect(len(components) > 6, "No compset alias {} found and this does not appear to be a compset longname.".format(compset_name))
 
@@ -678,6 +678,7 @@ class Case(object):
                "compset is not set")
         # the first element is always the date operator - skip it
         elements = compset.split('_')[1:] # pylint: disable=maybe-no-member
+        allstubs = True
         for element in elements:
             # ignore the possible BGC or TEST modifier
             if element.startswith("BGC%") or element.startswith("TEST"):
@@ -687,6 +688,9 @@ class Case(object):
                 if "ww" not in element_component and "fv3" not in element_component:
                     element_component = re.sub(r'[0-9]*',"",element_component)
                 components.append(element_component)
+                if not element_component.startswith('s'):
+                    allstubs = False
+        expect(not allstubs, "Invalid compset name, all stub components generated")
         return components
 
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1549,7 +1549,7 @@ def find_system_test(testname, case):
         system_test_path =  "CIME.SystemTests.system_tests_common.{}".format(testname)
     else:
         components = ["any"]
-        components.extend( case.get_compset_components())
+        components.extend( case.get_compset_components(test=case.get_value("TEST")))
         fdir = []
         for component in components:
             tdir = case.get_value("SYSTEM_TESTS_DIR",


### PR DESCRIPTION
If all components are stubs and this is not a test, then throw an error - this is not a valid compset name or alias. 

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3182 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
