### PR TITLE
Update config_machines to update pgi software stack on cheyenne

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -363,7 +363,7 @@ This allows using a different mpirun command to launch unit tests
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu,pgi</COMPILERS>
     <MPILIBS compiler="intel" >mpt,openmpi</MPILIBS>
-    <MPILIBS compiler="pgi" >mpt</MPILIBS>
+    <MPILIBS compiler="pgi" >openmpi,mpt</MPILIBS>
     <MPILIBS compiler="gnu" >openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/glade/scratch/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
@@ -427,7 +427,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">mkl</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/17.9</command>
+	<command name="load">pgi/19.3</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
 	<command name="load">esmf-7.1.0r-defio-mpi-g</command>
@@ -456,21 +456,25 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules mpilib="mpt" compiler="pgi">
 	<command name="load">mpt/2.19</command>
-	<command name="load">netcdf-mpi/4.6.1</command>
-	<command name="load">pnetcdf/1.11.0</command>
+	<command name="load">netcdf-mpi/4.6.3</command>
+	<command name="load">pnetcdf/1.11.1</command>
       </modules>
-      <modules mpilib="openmpi">
-	<command name="load">openmpi/3.0.1</command>
-	<command name="load">netcdf/4.6.1</command>
+      <modules mpilib="openmpi" compiler="pgi">
+	<command name="load">openmpi/3.1.4</command>
+	<command name="load">netcdf/4.6.3</command>
+      </modules>
+      <modules mpilib="openmpi" compiler="gnu">
+        <command name="load">openmpi/3.0.1</command>
+        <command name="load">netcdf/4.6.1</command>
       </modules>
       <modules>
-	<command name="load">ncarcompilers/0.4.1</command>
+	<command name="load">ncarcompilers/0.5.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial">
 	<command name="load">netcdf/4.6.1</command>
       </modules>
       <modules compiler="pgi" mpilib="mpi-serial">
-	<command name="load">netcdf/4.4.1.1</command>
+	<command name="load">netcdf/4.6.3</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
 	<command name="load">netcdf/4.5.0</command>


### PR DESCRIPTION
The OS update on cheyenne updated the pgi environment.  The old pgi software stack was 
removed in favor of a new one.  config_machines needed to be updated to use the new modules.
The ncarcompilers module also needed to be updated, so I ran an intel and gnu test to insure 
answer didn't change.

Test suite: scripts_regression_tests, IRT_Ld5.f09_g17.BHISTcmip6.cheyenne_gnu,
                  ERS_Ld7.f19_g17.B1850.cheyenne_intel
Test baseline: cesm2.1.1-rc.05
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
