### PR TITLE
Fix nag on izumi

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -417,7 +417,7 @@ ifeq ($(MODEL),driver)
 else
   ifeq ($(strip $(COMPILER)),nag)
     ifeq ($(DEBUG), TRUE)
-      ifeq ($(strip $(MACH)),hobart)
+      ifneq (,$(filter $(strip $(MACH)),hobart izumi))
        # GCC needs to be able to link to
        # nagfor runtime to get autoconf
        # tests to work.


### PR DESCRIPTION
This fixes failing nag debug builds on Izumi.

Test suite: scripts_regressions_tests on izumi, SMS_D_Ld3.f45_g37_rx1.A.hobart_nag
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
