### PR TITLE
Update for cori modules.

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -669,7 +669,7 @@ using a fortran linker.
     <append> -L$(NETCDF_DIR) -lnetcdff -Wl,--as-needed,-L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf </append>
   </SLIBS>
     <CPPDEFS>
-    <append MODEL="gptl"> -DHAVE_PAPI -DHAVE_SLASHPROC </append>
+    <append MODEL="gptl"> -DHAVE_SLASHPROC </append>
   </CPPDEFS>
   <LDFLAGS>
     <append>-mkl </append>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -671,26 +671,25 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
-	<command name="load">papi/5.6.0.3</command>
-	<command name="swap">craype craype/2.5.15</command>
+	<command name="swap">craype craype/2.5.18</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/18.03.1</command>
+	<command name="switch">cray-libsci/19.02.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.6</command>
+	<command name="load">cray-mpich/7.7.8</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.2.0</command>
-	<command name="load">cray-netcdf/4.6.1.3</command>
+	<command name="load">cray-hdf5/1.10.5.0</command>
+	<command name="load">cray-netcdf/4.6.3.0</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-	<command name="load">cray-hdf5-parallel/1.10.2.0</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.4</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.0</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.0</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.0</command>
       </modules>
       <modules>
-	<command name="load">cmake/3.8.2</command>
+	<command name="load">cmake/3.14.4</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -777,23 +776,23 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
-	<command name="swap">craype craype/2.5.15</command>
+	<command name="swap">craype craype/2.5.18</command>
 	<command name="load">craype-mic-knl</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/18.03.1</command>
+	<command name="switch">cray-libsci/19.02.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.6</command>
+	<command name="load">cray-mpich/7.7.8</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.2.0</command>
-	<command name="load">cray-netcdf/4.6.1.3</command>
+	<command name="load">cray-hdf5/1.10.5.0</command>
+	<command name="load">cray-netcdf/4.6.3.0</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.1.3</command>
-	<command name="load">cray-hdf5-parallel/1.10.2.0</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.4</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.0</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.0</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.0</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
After the cori OS update, the cori-haswell and cori-knl modules needed to be updated.
PAPI was removed for cori-haswell.

Test suite:  scripts_regression_tests on cori-haswell, SMS.f19_g17.A.cori-knl_intel
                   
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
