### PR TITLE
Update regex to match changing cheyenne login name

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -355,7 +355,7 @@ This allows using a different mpirun command to launch unit tests
 
   <machine MACH="cheyenne">
     <DESC>NCAR SGI platform, os is Linux, 36 pes/node, batch system is PBS</DESC>
-    <NODENAME_REGEX>.*.cheyenne.ucar.edu</NODENAME_REGEX>
+    <NODENAME_REGEX>.*.?cheyenne\d?.ucar.edu</NODENAME_REGEX>
     <!-- MPT sometimes timesout at model start time, the next two lines cause
     case_run.py to detect the timeout and retry FORCE_SPARE_NODES times -->
     <MPIRUN_RETRY_REGEX>MPT: xmpi_net_accept_timeo/accept() timeout</MPIRUN_RETRY_REGEX>


### PR DESCRIPTION
CISL changed the names of cheyenne login nodes.  This was causing the regex matches to
fail when doing a create_newcase.  The regex was updated to provide better matches, and will
also work if the login names are restored to the original names. 

Test suite:  ./create_newcase --compset A --res f19_g17 --case TEST
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
