### PR TITLE
Maint 5.6 user streamfix

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -1,27 +1,4 @@
 <components version="2.0">
-  <comp_archive_spec compname="clm" compclass="lnd">
-    <rest_file_extension>r</rest_file_extension>
-    <rest_file_extension>rh\d?</rest_file_extension>
-    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
-    <hist_file_extension>e</hist_file_extension>
-    <rest_history_varname>locfnh</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.lnd$NINST_STRING</rpointer_file>
-      <rpointer_content>./$CASE.clm2$NINST_STRING.r.$DATENAME.nc</rpointer_content>
-    </rpointer>
-    <test_file_names>
-      <tfile disposition="copy">rpointer.lnd</tfile>
-      <tfile disposition="copy">rpointer.lnd_9999</tfile>
-      <tfile disposition="copy">casename.clm2.r.1976-01-01-00000.nc</tfile>
-      <tfile disposition="copy">casename.clm2.rh4.1976-01-01-00000.nc</tfile>
-      <tfile disposition="move">casename.clm2.h0.1976-01-01-00000.nc</tfile>
-      <tfile disposition="ignore">casename.clm2.h0.1976-01-01-00000.nc.base</tfile>
-      <tfile disposition="move">casename.clm2_0002.e.postassim.1976-01-01-00000.nc</tfile>
-      <tfile disposition="move">casename.clm2_0002.e.preassim.1976-01-01-00000.nc</tfile>
-      <tfile disposition="ignore">anothercasename.clm2.i.1976-01-01-00000.nc</tfile>
-    </test_file_names>
-  </comp_archive_spec>
-
   <comp_archive_spec compname="cice" compclass="ice">
     <rest_file_extension>[ri]</rest_file_extension>
     <hist_file_extension>h\d*.*\.nc$</hist_file_extension>

--- a/scripts/lib/CIME/XML/stream.py
+++ b/scripts/lib/CIME/XML/stream.py
@@ -19,7 +19,6 @@ class Stream(GenericXML):
         if files is None:
             files = Files()
         schema = None
-        print("Reading file {}".format(infile))
         GenericXML.__init__(self, infile, schema=schema)
 
     def get_value(self, name, attribute=None, resolved=True, subgroup=None):

--- a/scripts/lib/CIME/XML/stream.py
+++ b/scripts/lib/CIME/XML/stream.py
@@ -1,0 +1,54 @@
+"""
+Interface to the streams.xml style files.  This class inherits from GenericXML.py
+
+stream files predate cime and so do not conform to entry id format
+"""
+from CIME.XML.standard_module_setup import *
+from CIME.XML.generic_xml import GenericXML
+from CIME.XML.files import Files
+from CIME.utils import expect
+
+logger = logging.getLogger(__name__)
+
+class Stream(GenericXML):
+
+    def __init__(self, infile=None, files=None):
+        """
+        initialize an object
+        """
+        if files is None:
+            files = Files()
+        schema = None
+        print("Reading file {}".format(infile))
+        GenericXML.__init__(self, infile, schema=schema)
+
+    def get_value(self, name, attribute=None, resolved=True, subgroup=None):
+        """
+        Get Value of fields in a stream.xml file
+        """
+        expect(subgroup is None, "This class does not support subgroups")
+        value = None
+        node = None
+        if name.startswith("domain"):
+            node = self.scan_child("domainInfo")
+        elif name.startswith("data"):
+            node = self.scan_child("fieldInfo")
+        if name.endswith("filepath"):
+            node = self.scan_child("filePath", root=node)
+        elif name.endswith("filenames"):
+            node = self.scan_child("fileNames", root=node)
+        if node is not None:
+            value = self.text(node)
+
+        if value is None:
+            # if all else fails
+            #pylint: disable=assignment-from-none
+            value = GenericXML.get_value(self, name, attribute, resolved, subgroup)
+
+        if resolved:
+            if value is not None:
+                value = self.get_resolved_value(value)
+            elif name in os.environ:
+                value = os.environ[name]
+
+        return value

--- a/scripts/lib/CIME/XML/stream.py
+++ b/scripts/lib/CIME/XML/stream.py
@@ -38,7 +38,7 @@ class Stream(GenericXML):
         elif name.endswith("filenames"):
             node = self.scan_child("fileNames", root=node)
         if node is not None:
-            value = self.text(node)
+            value = self.text(node).strip()
 
         if value is None:
             # if all else fails

--- a/scripts/lib/CIME/XML/stream.py
+++ b/scripts/lib/CIME/XML/stream.py
@@ -21,20 +21,20 @@ class Stream(GenericXML):
         schema = None
         GenericXML.__init__(self, infile, schema=schema)
 
-    def get_value(self, name, attribute=None, resolved=True, subgroup=None):
+    def get_value(self, item, attribute=None, resolved=True, subgroup=None):
         """
         Get Value of fields in a stream.xml file
         """
         expect(subgroup is None, "This class does not support subgroups")
         value = None
         node = None
-        if name.startswith("domain"):
+        if item.startswith("domain"):
             node = self.scan_child("domainInfo")
-        elif name.startswith("data"):
+        elif item.startswith("data"):
             node = self.scan_child("fieldInfo")
-        if name.endswith("filepath"):
+        if item.endswith("filepath"):
             node = self.scan_child("filePath", root=node)
-        elif name.endswith("filenames"):
+        elif item.endswith("filenames"):
             node = self.scan_child("fileNames", root=node)
         if node is not None:
             value = self.text(node).strip()
@@ -42,12 +42,12 @@ class Stream(GenericXML):
         if value is None:
             # if all else fails
             #pylint: disable=assignment-from-none
-            value = GenericXML.get_value(self, name, attribute, resolved, subgroup)
+            value = GenericXML.get_value(self, item, attribute, resolved, subgroup)
 
         if resolved:
             if value is not None:
                 value = self.get_resolved_value(value)
-            elif name in os.environ:
-                value = os.environ[name]
+            elif item in os.environ:
+                value = os.environ[item]
 
         return value

--- a/scripts/lib/CIME/XML/stream.py
+++ b/scripts/lib/CIME/XML/stream.py
@@ -28,14 +28,10 @@ class Stream(GenericXML):
         expect(subgroup is None, "This class does not support subgroups")
         value = None
         node = None
-        if item.startswith("domain"):
-            node = self.scan_child("domainInfo")
-        elif item.startswith("data"):
-            node = self.scan_child("fieldInfo")
-        if item.endswith("filepath"):
-            node = self.scan_child("filePath", root=node)
-        elif item.endswith("filenames"):
-            node = self.scan_child("fileNames", root=node)
+        names = item.split('/')
+        node = None
+        for name in names:
+            node = self.scan_child(name, root=node)
         if node is not None:
             value = self.text(node).strip()
 

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -71,7 +71,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
     din_loc_root = case.get_value("DIN_LOC_ROOT")
     testcase     = case.get_value("TESTCASE")
     expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
-           "inputdata root is not a directory: {}".format(din_loc_root))
+           "inputdata root is not a directory or is not readable: {}".format(din_loc_root))
 
     # Remove batch scripts
     if reset or clean:

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -435,10 +435,10 @@ class NamelistGenerator(object):
         # Stream-specific configuration.
         if os.path.isfile(stream_path):
             strmobj = Stream(infile=stream_path)
-            domain_filepath = strmobj.get_value("domain_filepath")
-            data_filepath = strmobj.get_value("data_filepath")
-            domain_filenames = strmobj.get_value("domain_filenames")
-            data_filenames = strmobj.get_value("data_filenames")
+            domain_filepath = strmobj.get_value("domainInfo/filePath")
+            data_filepath = strmobj.get_value("fieldInfo/filePath")
+            domain_filenames = strmobj.get_value("domainInfo/fileNames")
+            data_filenames = strmobj.get_value("fieldInfo/fileNames")
         else:
             # Figure out the details of this stream.
             if stream in ("prescribed", "copyall"):

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -15,7 +15,7 @@ from CIME.namelist import Namelist, parse, \
     character_literal_to_string, string_to_character_literal, \
     expand_literal_list, compress_literal_list, merge_literal_lists
 from CIME.XML.namelist_definition import NamelistDefinition
-from CIME.utils import expect
+from CIME.utils import expect, safe_copy
 from CIME.XML.stream import Stream
 
 logger = logging.getLogger(__name__)
@@ -415,7 +415,7 @@ class NamelistGenerator(object):
                     new_lines.append(new_line)
         return "\n".join(new_lines)
 
-    def create_stream_file_and_update_shr_strdata_nml(self, config, #pylint:disable=too-many-locals
+    def create_stream_file_and_update_shr_strdata_nml(self, config, caseroot, #pylint:disable=too-many-locals
                            stream, stream_path, data_list_path):
         """Write the pseudo-XML file corresponding to a given stream.
 
@@ -428,6 +428,15 @@ class NamelistGenerator(object):
         `stream_path` - Path to write the stream file to.
         `data_list_path` - Path of file to append input data information to.
         """
+
+        if os.path.exists(stream_path):
+            os.unlink(stream_path)
+        user_stream_path = os.path.join(caseroot, "user_"+os.path.basename(stream_path))
+
+        # Use the user's stream file, or create one if necessary.
+        if os.path.exists(user_stream_path):
+            safe_copy(user_stream_path, stream_path)
+
         config = config.copy()
         config["stream"] = stream
 

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -16,6 +16,7 @@ from CIME.namelist import Namelist, parse, \
     expand_literal_list, compress_literal_list, merge_literal_lists
 from CIME.XML.namelist_definition import NamelistDefinition
 from CIME.utils import expect
+from CIME.XML.stream import Stream
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,8 @@ _var_ref_re = re.compile(r"\$(\{)?(?P<name>\w+)(?(1)\})")
 
 _ymd_re = re.compile(r"%(?P<digits>[1-9][0-9]*)?y(?P<month>m(?P<day>d)?)?")
 
-_stream_file_template = """
+_stream_file_template = """<?xml version="1.0"?>
+<file id="stream" version="1.0">
 <dataSource>
    GENERIC
 </dataSource>
@@ -52,6 +54,7 @@ _stream_file_template = """
       {offset}
    </offset>
 </fieldInfo>
+</file>
 """
 
 class NamelistGenerator(object):
@@ -425,49 +428,56 @@ class NamelistGenerator(object):
         `stream_path` - Path to write the stream file to.
         `data_list_path` - Path of file to append input data information to.
         """
-
-        # Stream-specific configuration.
         config = config.copy()
         config["stream"] = stream
 
-        # Figure out the details of this stream.
-        if stream in ("prescribed", "copyall"):
-            # Assume only one file for prescribed mode!
-            grid_file = self.get_default("strm_grid_file", config)
-            domain_filepath, domain_filenames = os.path.split(grid_file)
-            data_file = self.get_default("strm_data_file", config)
-            data_filepath, data_filenames = os.path.split(data_file)
+
+        # Stream-specific configuration.
+        if os.path.isfile(stream_path):
+            strmobj = Stream(infile=stream_path)
+            domain_filepath = strmobj.get_value("domain_filepath")
+            data_filepath = strmobj.get_value("data_filepath")
+            domain_filenames = strmobj.get_value("domain_filenames")
+            data_filenames = strmobj.get_value("data_filenames")
         else:
-            domain_filepath = self.get_default("strm_domdir", config)
-            domain_filenames = self.get_default("strm_domfil", config)
-            data_filepath = self.get_default("strm_datdir", config)
-            data_filenames = self.get_default("strm_datfil", config)
+            # Figure out the details of this stream.
+            if stream in ("prescribed", "copyall"):
+                # Assume only one file for prescribed mode!
+                grid_file = self.get_default("strm_grid_file", config)
+                domain_filepath, domain_filenames = os.path.split(grid_file)
+                data_file = self.get_default("strm_data_file", config)
+                data_filepath, data_filenames = os.path.split(data_file)
+            else:
+                domain_filepath = self.get_default("strm_domdir", config)
+                domain_filenames = self.get_default("strm_domfil", config)
+                data_filepath = self.get_default("strm_datdir", config)
+                data_filenames = self.get_default("strm_datfil", config)
 
-        domain_varnames = self._sub_fields(self.get_default("strm_domvar", config))
-        data_varnames = self._sub_fields(self.get_default("strm_datvar", config))
-        offset = self.get_default("strm_offset", config)
-        year_start = int(self.get_default("strm_year_start", config))
-        year_end = int(self.get_default("strm_year_end", config))
-        data_filenames = self._sub_paths(data_filenames, year_start, year_end)
-        domain_filenames = self._sub_paths(domain_filenames, year_start, year_end)
+            domain_varnames = self._sub_fields(self.get_default("strm_domvar", config))
+            data_varnames = self._sub_fields(self.get_default("strm_datvar", config))
+            offset = self.get_default("strm_offset", config)
+            year_start = int(self.get_default("strm_year_start", config))
+            year_end = int(self.get_default("strm_year_end", config))
+            data_filenames = self._sub_paths(data_filenames, year_start, year_end)
+            domain_filenames = self._sub_paths(domain_filenames, year_start, year_end)
 
-        # Overwrite domain_file if should be set from stream data
-        if domain_filenames == 'null':
-            domain_filepath = data_filepath
-            domain_filenames = data_filenames.splitlines()[0]
+            # Overwrite domain_file if should be set from stream data
+            if domain_filenames == 'null':
+                domain_filepath = data_filepath
+                domain_filenames = data_filenames.splitlines()[0]
 
-        stream_file_text = _stream_file_template.format(
-            domain_varnames=domain_varnames,
-            domain_filepath=domain_filepath,
-            domain_filenames=domain_filenames,
-            data_varnames=data_varnames,
-            data_filepath=data_filepath,
-            data_filenames=data_filenames,
-            offset=offset,
-        )
+            stream_file_text = _stream_file_template.format(
+                domain_varnames=domain_varnames,
+                domain_filepath=domain_filepath,
+                domain_filenames=domain_filenames,
+                data_varnames=data_varnames,
+                data_filepath=data_filepath,
+                data_filenames=data_filenames,
+                offset=offset,
+            )
 
-        with open(stream_path, 'w') as stream_file:
-            stream_file.write(stream_file_text)
+            with open(stream_path, 'w') as stream_file:
+                stream_file.write(stream_file_text)
 
         lines_hash = self._get_input_file_hash(data_list_path)
         with open(data_list_path, 'a') as input_data_list:

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -434,15 +434,13 @@ class NamelistGenerator(object):
         user_stream_path = os.path.join(caseroot, "user_"+os.path.basename(stream_path))
 
         # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-
         config = config.copy()
         config["stream"] = stream
 
 
         # Stream-specific configuration.
-        if os.path.isfile(stream_path):
+        if os.path.exists(user_stream_path):
+            safe_copy(user_stream_path, stream_path)
             strmobj = Stream(infile=stream_path)
             domain_filepath = strmobj.get_value("domainInfo/filePath")
             data_filepath = strmobj.get_value("fieldInfo/filePath")

--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -125,10 +125,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -120,6 +120,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DATM stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "datm.streams.txt." + inst_stream)
+        if os.path.exists(stream_path):
+            os.unlink(stream_path)
         user_stream_path = os.path.join(case.get_case_root(), "user_datm.streams.txt." + inst_stream)
 
         # Use the user's stream file, or create one if necessary.

--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -120,14 +120,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DATM stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "datm.streams.txt." + inst_stream)
-        if os.path.exists(stream_path):
-            os.unlink(stream_path)
-        user_stream_path = os.path.join(case.get_case_root(), "user_datm.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"),stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/src/components/data_comps/dice/cime_config/buildnml
+++ b/src/components/data_comps/dice/cime_config/buildnml
@@ -89,15 +89,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DICE stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "dice.streams.txt." + inst_stream)
-        if os.path.exists(stream_path):
-            os.unlink(stream_path)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_dice.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"),stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/src/components/data_comps/dice/cime_config/buildnml
+++ b/src/components/data_comps/dice/cime_config/buildnml
@@ -95,10 +95,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/src/components/data_comps/dice/cime_config/buildnml
+++ b/src/components/data_comps/dice/cime_config/buildnml
@@ -89,6 +89,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DICE stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "dice.streams.txt." + inst_stream)
+        if os.path.exists(stream_path):
+            os.unlink(stream_path)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_dice.streams.txt." + inst_stream)
 

--- a/src/components/data_comps/dlnd/cime_config/buildnml
+++ b/src/components/data_comps/dlnd/cime_config/buildnml
@@ -86,6 +86,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DLND stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "dlnd.streams.txt." + inst_stream)
+        if os.path.exists(stream_path):
+            os.unlink(stream_path)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_dlnd.streams.txt." + inst_stream)
 

--- a/src/components/data_comps/dlnd/cime_config/buildnml
+++ b/src/components/data_comps/dlnd/cime_config/buildnml
@@ -86,15 +86,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DLND stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "dlnd.streams.txt." + inst_stream)
-        if os.path.exists(stream_path):
-            os.unlink(stream_path)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_dlnd.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"), stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/src/components/data_comps/dlnd/cime_config/buildnml
+++ b/src/components/data_comps/dlnd/cime_config/buildnml
@@ -92,10 +92,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -89,15 +89,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DOCN stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "docn.streams.txt." + inst_stream)
-        if os.path.exists(stream_path):
-            os.unlink(stream_path)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_docn.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"), stream, stream_path, data_list_path)
 
     # For aquaplanet prescribed have no streams
     match = re.match(r'^sst_aquap\d+',docn_mode)

--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -89,6 +89,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DOCN stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "docn.streams.txt." + inst_stream)
+        if os.path.exists(stream_path):
+            os.unlink(stream_path)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_docn.streams.txt." + inst_stream)
 

--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -95,10 +95,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 
     # For aquaplanet prescribed have no streams
     match = re.match(r'^sst_aquap\d+',docn_mode)

--- a/src/components/data_comps/drof/cime_config/buildnml
+++ b/src/components/data_comps/drof/cime_config/buildnml
@@ -87,6 +87,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DROF stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "drof.streams.txt." + inst_stream)
+        if os.path.exists(stream_path):
+            os.unlink(stream_path)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_drof.streams.txt." + inst_stream)
 

--- a/src/components/data_comps/drof/cime_config/buildnml
+++ b/src/components/data_comps/drof/cime_config/buildnml
@@ -93,10 +93,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/src/components/data_comps/drof/cime_config/buildnml
+++ b/src/components/data_comps/drof/cime_config/buildnml
@@ -87,15 +87,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DROF stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "drof.streams.txt." + inst_stream)
-        if os.path.exists(stream_path):
-            os.unlink(stream_path)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_drof.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"), stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.

--- a/src/components/data_comps/dwav/cime_config/buildnml
+++ b/src/components/data_comps/dwav/cime_config/buildnml
@@ -86,15 +86,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DWAV stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "dwav.streams.txt." + inst_stream)
-        if os.path.exists(stream_path):
-            os.unlink(stream_path)
-        user_stream_path = os.path.join(case.get_case_root(),
-                                        "user_dwav.streams.txt." + inst_stream)
-
-        # Use the user's stream file, or create one if necessary.
-        if os.path.exists(user_stream_path):
-            safe_copy(user_stream_path, stream_path)
-        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, case.get_value("CASEROOT"), stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create dwav_nml namelists group

--- a/src/components/data_comps/dwav/cime_config/buildnml
+++ b/src/components/data_comps/dwav/cime_config/buildnml
@@ -86,6 +86,8 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         inst_stream = stream + inst_string
         logger.debug("DWAV stream is {}".format(inst_stream))
         stream_path = os.path.join(confdir, "dwav.streams.txt." + inst_stream)
+        if os.path.exists(stream_path):
+            os.unlink(stream_path)
         user_stream_path = os.path.join(case.get_case_root(),
                                         "user_dwav.streams.txt." + inst_stream)
 

--- a/src/components/data_comps/dwav/cime_config/buildnml
+++ b/src/components/data_comps/dwav/cime_config/buildnml
@@ -92,10 +92,7 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
         # Use the user's stream file, or create one if necessary.
         if os.path.exists(user_stream_path):
             safe_copy(user_stream_path, stream_path)
-            config['stream'] = stream
-            nmlgen.update_shr_strdata_nml(config, stream, stream_path)
-        else:
-            nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
+        nmlgen.create_stream_file_and_update_shr_strdata_nml(config, stream, stream_path, data_list_path)
 
     #----------------------------------------------------
     # Create dwav_nml namelists group


### PR DESCRIPTION
Make the streams file legitiment xml files so that we can parse them, this initial offering creates a very limited interface to read filepath and filenames for domain and data files so that the input_data_list can be created correctly. 
Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #3155 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
