### PR TITLE
Add /cluster/torque/bin to path on izumi

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1516,6 +1516,8 @@ This allows using a different mpirun command to launch unit tests
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
+      <!-- The following is needed in order to run qsub from the compute nodes -->
+      <env name="PATH">$ENV{PATH}:/cluster/torque/bin</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>


### PR DESCRIPTION
This is needed in order to run qsub from the compute nodes, which we
need for CTSM's run_sys_tests (which builds and submits tests on the
compute nodes).

Test suite: Just ran SMS.f19_g16.X.izumi_nag via CTSM's run_sys_tests
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
