### PR TITLE
update DROF(JRA) to MOM6 mapping file

### DIFF
--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -214,8 +214,8 @@
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx0.66v1_e1000r300_190314.nc</map>
     </gridmap>
     <gridmap rof_grid="JRA025" ocn_grid="tx0.66v1" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190326.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190326.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190910.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190910.nc</map>
     </gridmap>
 
     <!-- ======================================================== -->


### PR DESCRIPTION
Update JRA DROF to MOM6 mapping file. This is needed because JRA DROF domain has changed with #3223.

Test suite: SMS_Ld2.TL319_t061.GMOM_JRA, SMS_Vnuopc.TL319_t061.GMOM_JRA
Test baseline: n/a
Test namelist changes: mapping file (JRA to MOM6)
Test status: bit for bit, except MOM6-JRA runs

User interface changes?: N

Update gh-pages html (Y/N)?: N
