### PR TITLE
Fix wallclocks in testlists.

### DIFF
--- a/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
+++ b/src/drivers/mct/cime_config/testdefs/testlist_drv.xml
@@ -70,22 +70,22 @@
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cime_baselines">
 	<options>
-	  <option name="wallclock">00:10</option>
+	  <option name="wallclock">00:10:00</option>
 	</options>
       </machine>
       <machine name="cheyenne" compiler="intel" category="jim">
 	<options>
-	  <option name="wallclock">00:10</option>
+	  <option name="wallclock">00:10:00</option>
 	</options>
       </machine>
       <machine name="cheyenne" compiler="gnu" category="jim">
 	<options>
-	  <option name="wallclock">00:10</option>
+	  <option name="wallclock">00:10:00</option>
 	</options>
       </machine>
       <machine name="cheyenne" compiler="pgi" category="jim">
 	<options>
-	  <option name="wallclock">00:10</option>
+	  <option name="wallclock">00:10:00</option>
 	</options>
       </machine>
     </machines>
@@ -526,7 +526,7 @@
       <machine name="hobart" compiler="nag" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:20:00 </option>
     </options>
   </test>
   <test name="SEQ_IOP_Ld3" grid="f19_g16" compset="X">


### PR DESCRIPTION
Some of the wallclocks in the testlist were formatted incorrectly.  They were in seconds
instead of minutes.

Test suite: PEA_P1_Ld3.T31_g37.X.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
