### PR TITLE
fix bug in SCAM

### DIFF
--- a/src/share/util/shr_scam_mod.F90
+++ b/src/share/util/shr_scam_mod.F90
@@ -641,12 +641,13 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, ocn_compid, ocn_mpicom, &
    character(*),parameter :: subname = "(shr_scam_checkSurface) "
    character(*),parameter :: F00   = "('(shr_scam_checkSurface) ',8a)"
    character(len=CL)      :: decomp = '1d' ! restart pointer file
+   real(r8)               :: fixed_sst 
    character(len=CL)      :: restfilm = 'unset'
    character(len=CL)      :: restfils = 'unset'
    integer(IN)   :: nfrac
    logical :: force_prognostic_true = .false.
    namelist /dom_inparm/ sstcyc, nrevsn, rest_pfile, bndtvs, focndomain
-   namelist / docn_nml / decomp, force_prognostic_true, &
+   namelist / docn_nml / decomp, fixed_sst, force_prognostic_true, &
         restfilm, restfils
 
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
FSCAM testing failed as it did not have the new fixed_sst namelist variable added to it.

Note - this change will need to be in when the CAM release tag containing RCE is brought in, but it can be put in immediately with no issues with older CAM release tags.

Test suite: 
Test baseline: 
Test namelist changes:  Ran FSCAM test and it passes
Test status:BFB

Fixes [CIME Github issue #]

User interface changes?: No

Update gh-pages html?: No

Code review: 
