### PR TITLE
update esmf paths on cheyenne for nuopc

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -486,11 +486,17 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_IB_CONGESTED">1</env>
       <env name="MPI_USE_ARRAY"/>
     </environment_variables>
+    <environment_variables comp_interface="nuopc" mpilib="mpi-serial" DEBUG="FALSE">
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
+    </environment_variables>
+    <environment_variables comp_interface="nuopc" mpilib="mpi-serial" DEBUG="TRUE">
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
+    </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="FALSE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="TRUE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs38/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>


### PR DESCRIPTION
This just updates the esmf build for nuopc driver on cheyenne and adds serial builds. 

Test suite: tested with nuopc on cheyenne
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
