### PR TITLE
fix case of workflow job prior to case.run or case.test

### DIFF
--- a/scripts/Tools/preview_run
+++ b/scripts/Tools/preview_run
@@ -59,9 +59,8 @@ def _main_func(description):
         print("")
 
         print("BATCH INFO:")
-        if job is None:
-            job = case.get_primary_job()
-
+        if not job:
+            job = case.get_first_job()
         set_logger_indent("      ")
         job_id_to_cmd = case.submit_jobs(dry_run=True, job=job)
         env_batch = case.get_env('batch')
@@ -76,11 +75,11 @@ def _main_func(description):
             print("    SUBMIT CMD:")
             print("      {}".format(case.get_resolved_value(cmd)))
             print("")
+            if job_id in ("case.run", "case.test"):
+                print("    MPIRUN (job={}):".format(job_id))
+                print ("      {}".format(overrides["mpirun"]))
+                print("")
 
-            print("    MPIRUN (job={}):".format(job_id))
-            print ("      {}".format(overrides["mpirun"]))
-            print("")
-            
 
 
 if __name__ == "__main__":

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -435,6 +435,7 @@ class EnvBatch(EnvBase):
         alljobs = env_workflow.get_jobs()
         alljobs = [j for j in alljobs
                    if os.path.isfile(os.path.join(self._caseroot,get_batch_script_for_job(j)))]
+
         startindex = 0
         jobs = []
         firstjob = job
@@ -459,6 +460,7 @@ class EnvBatch(EnvBase):
 
             if self._batchtype == "cobalt":
                 break
+
         depid = OrderedDict()
         jobcmds = []
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1484,3 +1484,8 @@ directory, NOT in this subdirectory."""
 
     def get_primary_job(self):
         return "case.test" if self.get_value("TEST") else "case.run"
+
+    def get_first_job(self):
+        env_workflow = self.get_env("workflow")
+        jobs = env_workflow.get_jobs()
+        return jobs[0]

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -26,7 +26,7 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
             resubmit_immediate=False, skip_pnl=False, mail_user=None, mail_type=None,
             batch_args=None):
     if job is None:
-        job = case.get_primary_job()
+        job = case.get_first_job()
 
     rundir = case.get_value("RUNDIR")
     if job != "case.test":


### PR DESCRIPTION
There was an assumption that case.run or case.test would always be the first job in a workflow, that was a poor assumption.   

Test suite: tested workflow by hand including RESUBMIT, scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #3240 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
