### PR TITLE
Add namelist for minimum wind speed for atmOcn fluxes

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -4266,4 +4266,17 @@
     </values>
   </entry>
 
+  <entry id="seq_flux_atmocn_minwind">
+    <type>real</type>
+    <category>seq_flux_mct</category>
+    <group>seq_flux_mct_inparm</group>
+    <desc>
+       minimum wind speed for atmOcn flux calculations
+    </desc>
+    <values>
+      <value>0.5</value>
+      <value aqua_planet_sst_type="sst_aquap11">1.0</value>
+    </values>
+  </entry>
+
 </entry_id>

--- a/src/drivers/mct/main/seq_flux_mct.F90
+++ b/src/drivers/mct/main/seq_flux_mct.F90
@@ -111,6 +111,7 @@ module seq_flux_mct
   ! albedo reference variables - set via namelist
   real(r8)  :: seq_flux_mct_albdif  ! albedo, diffuse
   real(r8)  :: seq_flux_mct_albdir  ! albedo, direct
+  real(r8)  :: seq_flux_atmocn_minwind ! minimum wind temperature for atmocn flux routines
 
   ! Coupler field indices
 
@@ -476,7 +477,7 @@ contains
 
     character(len=256) :: cime_model
 
-    namelist /seq_flux_mct_inparm/ seq_flux_mct_albdif, seq_flux_mct_albdir
+    namelist /seq_flux_mct_inparm/ seq_flux_mct_albdif, seq_flux_mct_albdir, seq_flux_atmocn_minwind
 
     character(len=*),parameter :: subname = '(seq_flux_readnl_mct) '
 
@@ -509,6 +510,7 @@ contains
 
      call shr_mpi_bcast(seq_flux_mct_albdif, mpicom)
      call shr_mpi_bcast(seq_flux_mct_albdir, mpicom)
+     call shr_mpi_bcast(seq_flux_atmocn_minwind, mpicom)
 
   end subroutine seq_flux_readnl_mct
 
@@ -1069,7 +1071,8 @@ contains
     if (flux_diurnal) then
        call shr_flux_atmocn_diurnal (nloc_a2o , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
-            tocn , emask, sen , lat , lwup , &
+            tocn , emask, seq_flux_atmocn_minwind, &
+            sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             uGust, lwdn , swdn , swup, prec, &
@@ -1084,7 +1087,8 @@ contains
     else
        call shr_flux_atmocn (nloc_a2o , zbot , ubot, vbot, thbot, prec_gust, gust_fac, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
-            tocn , emask, sen , lat , lwup , &
+            tocn , emask, seq_flux_atmocn_minwind, &
+            sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
             duu10n,ustar, re  , ssq , missval = 0.0_r8 )
@@ -1477,7 +1481,8 @@ contains
     if (flux_diurnal) then
        call shr_flux_atmocn_diurnal (nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
-            tocn , emask, sen , lat , lwup , &
+            tocn , emask, seq_flux_atmocn_minwind, &
+            sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             uGust, lwdn , swdn , swup, prec, &
@@ -1495,7 +1500,8 @@ contains
     else
        call shr_flux_atmocn (nloc , zbot , ubot, vbot, thbot, prec_gust, gust_fac, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
-            tocn , emask, sen , lat , lwup , &
+            tocn , emask, seq_flux_atmocn_minwind, &
+            sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             duu10n,ustar, re  , ssq)


### PR DESCRIPTION
Minimum wind speed for atmOcn fluxes had been hardwired up until this point.  Introduced a namelist variable and changed the default setting only for AQP11.  

Test suite:  all aux_cam tests, cime_developer tests
Test baseline: 
Test namelist changes: Ran the AQP11 test, and it's namelist has the new value of 1
Test status: [bit for bit, roundoff, climate changing] BFB

Fixes [CIME Github issue #]

User interface changes?: Added "seq_flux_atmocn_minwind" namelist.  The default for all jobs is 0.5, which is the previous jobs.  The only exception is AQP11, which now has the value of 1.0

Update gh-pages html (Y/N)?:n

Code review: 
