### PR TITLE
correct the way esmf is built to avoid library mismatch

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -496,7 +496,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="TRUE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/turuncu/ESMF/8.0.0b50/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>
@@ -504,6 +504,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="UGCSINPUTPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/2012010100/gfs/fcst</env>
       <env name="UGCSFIXEDFILEPATH">/glade/work/turuncu/FV3GFS/fix_am</env>
       <env name="UGCSADDONPATH">/glade/work/turuncu/FV3GFS/addon</env>
+      <env name="YAML">/glade/u/home/dunlap/YAML-INSTALL/</env>
     </environment_variables>
     <environment_variables unit_testing="true">
       <env name="MPI_USE_ARRAY">false</env>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -487,13 +487,13 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_USE_ARRAY"/>
     </environment_variables>
     <environment_variables comp_interface="nuopc" mpilib="mpi-serial" DEBUG="FALSE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/turuncu/ESMF/8.0.0b50/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" mpilib="mpi-serial" DEBUG="TRUE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/turuncu/ESMF/8.0.0b50/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="FALSE">
-      <env name="ESMFMKFILE">/glade/work/dunlap/ESMF-INSTALL/8.0.0bs48/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/glade/work/turuncu/ESMF/8.0.0bs50/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc" DEBUG="TRUE">
       <env name="ESMFMKFILE">/glade/work/turuncu/ESMF/8.0.0b50/lib/libg/Linux.intel.64.mpt.default/esmf.mk</env>
@@ -504,7 +504,6 @@ This allows using a different mpirun command to launch unit tests
       <env name="UGCSINPUTPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/2012010100/gfs/fcst</env>
       <env name="UGCSFIXEDFILEPATH">/glade/work/turuncu/FV3GFS/fix_am</env>
       <env name="UGCSADDONPATH">/glade/work/turuncu/FV3GFS/addon</env>
-      <env name="YAML">/glade/u/home/dunlap/YAML-INSTALL/</env>
     </environment_variables>
     <environment_variables unit_testing="true">
       <env name="MPI_USE_ARRAY">false</env>

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -106,6 +106,7 @@ endif
 
 ifeq ($(COMP_INTERFACE), nuopc)
    CPPDEFS += -DNUOPC_INTERFACE
+   SLIBS += -L$(YAML)/lib
 else
    CPPDEFS += -DMCT_INTERFACE
 endif
@@ -320,14 +321,14 @@ endif
 # For compiling and linking with external ESMF.
 # If linking to external ESMF library then include esmf.mk
 # ESMF_F90COMPILEPATHS
-# ESMF_F90LINKPATHS
+# ESMF_F90ESMFLINKPATHS
 # ESMF_F90LINKRPATHS
 # ESMF_F90ESMFLINKLIBS
 ifeq ($(USE_ESMF_LIB), TRUE)
   -include $(CIME_ESMFMKFILE)
   CPPDEFS += -DESMF_VERSION_MAJOR=$(ESMF_VERSION_MAJOR) -DESMF_VERSION_MINOR=$(ESMF_VERSION_MINOR)
   FFLAGS += $(ESMF_F90COMPILEPATHS)
-  SLIBS  += $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
+  SLIBS  += $(ESMF_F90ESMFLINKPATHS) $(ESMF_F90ESMFLINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
 endif
 
 # Stub libraries do not need to be built for nuopc driver
@@ -613,18 +614,6 @@ ifdef LIB_MPI
    else
       SLIBS += -L$(LIB_MPI) -l$(MPI_LIB_NAME)
    endif
-endif
-
-# For compiling and linking with external ESMF.
-# If linking to external ESMF library then include esmf.mk
-# ESMF_F90COMPILEPATHS
-# ESMF_F90LINKPATHS
-# ESMF_F90LINKRPATHS
-# ESMF_F90ESMFLINKLIBS
-ifeq ($(USE_ESMF_LIB), TRUE)
-  -include $(CCSM_ESMFMKFILE)
-  FFLAGS += $(ESMF_F90COMPILEPATHS)
-  SLIBS  += $(ESMF_F90LINKPATHS) $(ESMF_F90LINKRPATHS) $(ESMF_F90ESMFLINKLIBS)
 endif
 
 # Add PETSc libraries

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -106,7 +106,6 @@ endif
 
 ifeq ($(COMP_INTERFACE), nuopc)
    CPPDEFS += -DNUOPC_INTERFACE
-   SLIBS += -L$(YAML)/lib
 else
    CPPDEFS += -DMCT_INTERFACE
 endif


### PR DESCRIPTION
We found an issue when ESMF was built with a different version of netcdf than cesm was using, the esmf.mk was specifying a path to netcdf that was overwriting the cesm path.  Changing the ESMF link flags to only specify ESMF and not it's dependencies solves the problem.  Also the ESMF clause was repeated in the Makefile.

Test suite: Hand tested SMS_D_Vnuopc.f09_g17.X.cheyenne_intel + scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
