### PR TITLE
Additions for cam testing

### DIFF
--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -92,6 +92,7 @@
       <value>$CIMEROOT/config/config_tests.xml</value>
       <!-- component specific config_tests files -->
       <value component="clm">$COMP_ROOT_DIR_LND/cime_config/config_tests.xml</value>
+      <value component="cam">$COMP_ROOT_DIR_ATM/cime_config/config_tests.xml</value>
     </values>
     <group>test</group>
     <file>env_test.xml</file>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -197,6 +197,13 @@
       <mask>gx1v7</mask>
     </model_grid>
 
+    <model_grid alias="T5_T5_mg37" not_compset="_POP">
+      <grid name="atm">T5</grid>
+      <grid name="lnd">T5</grid>
+      <grid name="ocnice">T5</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+
     <model_grid alias="T85_T85_mg16" not_compset="_POP">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>


### PR DESCRIPTION
Add a T5_T5_mg37 grid needed for cam testing.  Add filepath to cam's config_tests.xml.

Test suite:  scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
