### PR TITLE
Change globally uniform SST mode from AQP11 to AQPCONST

### DIFF
--- a/src/components/data_comps/docn/cime_config/buildnml
+++ b/src/components/data_comps/docn/cime_config/buildnml
@@ -98,6 +98,12 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
             value = ['null']
             nmlgen.set_value("streams",value)
 
+    # globally uniform SST mode
+    if docn_mode=='sst_aquap_constant':
+        value = ['null']
+        nmlgen.set_value("streams",value)
+        value = [case.get_value('DOCN_AQPCONST_VALUE')]
+        nmlgen.set_value("sst_constant_value",value)
     #----------------------------------------------------
     # Create `shr_strdata_nml` namelist group.
     #----------------------------------------------------

--- a/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/src/components/data_comps/docn/cime_config/config_component.xml
@@ -13,7 +13,7 @@
        This file may have ocn desc entries.
   -->
   <description modifier_mode="1">
-    <desc ocn="DOCN[%NULL][%DOM][%SOM][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQP11][%AQPFILE]">DOCN </desc>
+    <desc ocn="DOCN[%NULL][%DOM][%SOM][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQPFILE][%AQPCONST]">DOCN </desc>
     <desc option="NULL">  null mode</desc>
     <desc option="DOM">  prescribed ocean mode</desc>
     <desc option="SOM">  slab ocean mode</desc>
@@ -30,8 +30,8 @@
     <desc option="AQP8">  analytic aquaplanet sst - option 8</desc>
     <desc option="AQP9">  analytic aquaplanet sst - option 9</desc>
     <desc option="AQP10">  analytic aquaplanet sst - option 10</desc>
-    <desc option="AQP11">  CONSTANT, UNIFORM aquaplanet sst - option 11</desc>
     <desc option="AQPFILE">  file input aquaplanet sst </desc>
+    <desc option="AQPCONST">  globally constant SST for idealized experiments, such as RCE </desc>
   </description>
 
   <entry id="COMP_OCN">
@@ -45,7 +45,7 @@
 
   <entry id="DOCN_MODE">
     <type>char</type>
-    <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,sst_aquap11,sst_aquapfile,som,som_aquap,interannual,null</valid_values>
+    <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,sst_aquapfile,som,som_aquap,sst_aquap_constant,interannual,null</valid_values>
     <default_value>prescribed</default_value>
     <values match="last">
       <value compset="_DOCN%NULL_">null</value>
@@ -63,8 +63,8 @@
       <value compset="_DOCN%AQP8_">sst_aquap8</value>
       <value compset="_DOCN%AQP9_">sst_aquap9</value>
       <value compset="_DOCN%AQP10_">sst_aquap10</value>
-      <value compset="_DOCN%AQP11_">sst_aquap11</value>
       <value compset="_DOCN%AQPFILE_">sst_aquapfile</value>
+      <value compset="_DOCN%AQPCONST_">sst_aquap_constant</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>
@@ -134,6 +134,18 @@
     <file>env_run.xml</file>
     <desc>Sets aquaplanet forcing filename instead of using an analytic form.
     This is only used when DOCN_MODE=sst_aquapfile.</desc>
+  </entry>
+
+   <entry id="DOCN_AQPCONST_VALUE">
+    <type>real</type>
+    <valid_values></valid_values>
+    <default_value>-1</default_value>
+    <values match="last">
+      <value compset="_DOCN%AQPCONST">300</value>
+    </values>
+    <group>run_component_docn</group>
+    <file>env_run.xml</file>
+    <desc>Sets globally constant SST value</desc>
   </entry>
 
   <entry id="SSTICE_STREAM">

--- a/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/src/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -56,8 +56,8 @@
       <value docn_mode="sst_aquap8">''</value>
       <value docn_mode="sst_aquap9">''</value>
       <value docn_mode="sst_aquap10">''</value>
-      <value docn_mode="sst_aquap11">''</value>
       <value docn_mode="sst_aquapfile">aquapfile</value>
+      <value docn_mode="sst_aquap_constant">''</value>
       <value docn_mode="som">som</value>
       <value docn_mode="som_aquap">som</value>
       <value docn_mode="interannual">interannual</value>
@@ -257,7 +257,7 @@
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>SSTDATA,SST_AQUAP1,SST_AQUAP2,SST_AQUAP3,SST_AQUAP4,SST_AQUAP5,SST_AQUAP6,SST_AQUAP7,SST_AQUAP8,SST_AQUAP9,SST_AQUAP10,SST_AQUAP11,SST_AQUAPFILE,SOM,SOM_AQUAP,IAF,NULL,COPYALL</valid_values>
+    <valid_values>SSTDATA,SST_AQUAP1,SST_AQUAP2,SST_AQUAP3,SST_AQUAP4,SST_AQUAP5,SST_AQUAP6,SST_AQUAP7,SST_AQUAP8,SST_AQUAP9,SST_AQUAP10,SST_AQUAPFILE,SST_AQUAP_CONSTANT,SOM,SOM_AQUAP,IAF,NULL,COPYALL</valid_values>
     <desc>
       General method that operates on the data. This is generally
       implemented in the data models but is set in the strdata method for
@@ -323,8 +323,8 @@
       <value docn_mode="sst_aquap8$">SST_AQUAP8</value>
       <value docn_mode="sst_aquap9$">SST_AQUAP9</value>
       <value docn_mode="sst_aquap10$">SST_AQUAP10</value>
-      <value docn_mode="sst_aquap11$">SST_AQUAP11</value>
       <value docn_mode="sst_aquapfile$">SST_AQUAPFILE</value>
+      <value docn_mode="sst_aquap_constant$">SST_AQUAP_CONSTANT</value>
       <value docn_mode="som$">SOM</value>
       <value docn_mode="som_aquap">SOM_AQUAP</value>
       <value docn_mode="interannual">IAF</value>
@@ -644,15 +644,16 @@
     </values>
   </entry>
 
-  <entry id="fixed_sst">
-    <type>real</type>
+  <entry id="sst_constant_value" per_stream_entry="true">
+    <type>real(30)</type>
     <category>docn</category>
     <group>docn_nml</group>
     <desc>
-      Sea Surface Temperature for RCE runs
+      Value of globally uniform SST (K) for idealized experiments 
+      when data ocean mode is sst_aquap_constant
     </desc>
     <values>
-      <value>26.85</value>
+      <value>-1.0</value>
     </values>
   </entry>
 

--- a/src/share/util/shr_scam_mod.F90
+++ b/src/share/util/shr_scam_mod.F90
@@ -641,13 +641,13 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, ocn_compid, ocn_mpicom, &
    character(*),parameter :: subname = "(shr_scam_checkSurface) "
    character(*),parameter :: F00   = "('(shr_scam_checkSurface) ',8a)"
    character(len=CL)      :: decomp = '1d' ! restart pointer file
-   real(r8)               :: fixed_sst 
+   real(r8)               :: sst_constant_value 
    character(len=CL)      :: restfilm = 'unset'
    character(len=CL)      :: restfils = 'unset'
    integer(IN)   :: nfrac
    logical :: force_prognostic_true = .false.
    namelist /dom_inparm/ sstcyc, nrevsn, rest_pfile, bndtvs, focndomain
-   namelist / docn_nml / decomp, fixed_sst, force_prognostic_true, &
+   namelist / docn_nml / decomp, sst_constant_value, force_prognostic_true, &
         restfilm, restfils
 
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
This changes the recent AQP11 mode to AQPCONST and changes the namelist variable from sst_fixed (degrees C) to sst_constant_value (degrees K). The namelist variable is set by a new XML variable "DOCN_AQPCONST_VALUE" so that value can be controlled by the compset name. This is motivated by the RCEMIP protocol which calls for multiple SST values, and so this approach allows corresponding compsets to be defined, such as RCE300 and RCE305. 