### PR TITLE
fix mpi_bcast in seq_flux_mct

### DIFF
--- a/src/drivers/mct/main/seq_flux_mct.F90
+++ b/src/drivers/mct/main/seq_flux_mct.F90
@@ -487,7 +487,7 @@ contains
     if (seq_comm_iamroot(ID)) then
 
        !---------------------------------------------------------------------------
-       ! Read in namelist 
+       ! Read in namelist
        !---------------------------------------------------------------------------
 
         unitn = shr_file_getUnit()
@@ -508,10 +508,11 @@ contains
 
      end if
 
-     call shr_mpi_bcast(seq_flux_mct_albdif, mpicom)
-     call shr_mpi_bcast(seq_flux_mct_albdir, mpicom)
-     call shr_mpi_bcast(seq_flux_atmocn_minwind, mpicom)
-
+     if (seq_comm_iamin(ID)) then
+        call shr_mpi_bcast(seq_flux_mct_albdif, mpicom)
+        call shr_mpi_bcast(seq_flux_mct_albdir, mpicom)
+        call shr_mpi_bcast(seq_flux_atmocn_minwind, mpicom)
+     endif
   end subroutine seq_flux_readnl_mct
 
   !===============================================================================


### PR DESCRIPTION
Make sure that mpi_bcast only uses valid comm.

Test suite: SMS_Ld1_D.f19_g17.I1850Clm50BgcCropCmip6.cheyenne_gnu.clm-default
Test baseline: 
Test namelist changes: 
Test status: bit for bit,

Fixes #3259

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
