### PR TITLE
Fix T5_T5_mg37 grid

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1309,6 +1309,13 @@
       <support>Backward compatible for very high resolution Spectral-dycore experiments</support>
     </domain>
 
+    <domain name="T5">
+      <nx>16</nx> <ny>8</ny>
+      <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T5_gx3v7.181009.nc</file>
+      <file grid="ocnice"  mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.T5_gx3v7.181009.nc</file>
+      <desc>T5 is Gaussian grid:</desc>
+    </domain>
+
     <domain name="T85">
       <!-- global spectral (eulerian dycore) grids-->
       <nx>256</nx>  <ny>128</ny>


### PR DESCRIPTION
Add missing domain files for T5_T5_mg37 grid.

Test suite: ERS.T5_T5_mg37.QPC4.izumi_pgi.cam-outfrq3s
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
