### PR TITLE
Add --only-job option to case.submit

### DIFF
--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -17,6 +17,7 @@ Other examples:
 
 from standard_script_setup import *
 from CIME.case        import Case
+from CIME.utils        import expect
 from six.moves import configparser
 
 ###############################################################################
@@ -35,6 +36,13 @@ def parse_command_line(args, description):
     parser.add_argument("--job", "-j",
                         help="Name of the job to be submitted;\n"
                         "can be any of the jobs listed in env_batch.xml.\n"
+                        "This will be the first job of any defined workflow.  "
+                        "Default is case.run.")
+
+    parser.add_argument("--only-job", 
+                        help="Name of the job to be submitted;\n"
+                        "can be any of the jobs listed in env_batch.xml.\n"
+                        "Only this job will be run, workflow and RESUBMIT are ignored.  "
                         "Default is case.run.")
 
     parser.add_argument("--no-batch", action="store_true",
@@ -70,6 +78,8 @@ def parse_command_line(args, description):
 
     CIME.utils.resolve_mail_type_args(args)
 
+    expect(args.job is None or args.only_job is None, "Cannot specify both --job and --only-job")
+    
     return (args.caseroot, args.job, args.no_batch, args.prereq, args.prereq_allow_failure,
             args.resubmit, args.resubmit_immediate, args.skip_preview_namelist, args.mail_user,
             args.mail_type, args.batch_args)

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -39,7 +39,7 @@ def parse_command_line(args, description):
                         "This will be the first job of any defined workflow.  "
                         "Default is case.run.")
 
-    parser.add_argument("--only-job", 
+    parser.add_argument("--only-job",
                         help="Name of the job to be submitted;\n"
                         "can be any of the jobs listed in env_batch.xml.\n"
                         "Only this job will be run, workflow and RESUBMIT are ignored.  "
@@ -79,16 +79,24 @@ def parse_command_line(args, description):
     CIME.utils.resolve_mail_type_args(args)
 
     expect(args.job is None or args.only_job is None, "Cannot specify both --job and --only-job")
-    
-    return (args.caseroot, args.job, args.no_batch, args.prereq, args.prereq_allow_failure,
+    job = None
+    workflow = True
+    if args.job:
+        job = args.job
+    elif args.only_job:
+        job = args.only_job
+        workflow = False
+
+
+    return (args.caseroot, job, args.no_batch, args.prereq, args.prereq_allow_failure,
             args.resubmit, args.resubmit_immediate, args.skip_preview_namelist, args.mail_user,
-            args.mail_type, args.batch_args)
+            args.mail_type, args.batch_args, workflow)
 
 ###############################################################################
 def _main_func(description, test_args=False):
 ###############################################################################
     caseroot, job, no_batch, prereq, allow_fail, resubmit, resubmit_immediate, skip_pnl, \
-        mail_user, mail_type, batch_args = parse_command_line(sys.argv, description)
+        mail_user, mail_type, batch_args, workflow = parse_command_line(sys.argv, description)
 
     # save these options to a hidden file for use during resubmit
     config_file = os.path.join(caseroot,".submit_options")
@@ -112,7 +120,7 @@ def _main_func(description, test_args=False):
         with Case(caseroot, read_only=False) as case:
             case.submit(job=job, no_batch=no_batch, prereq=prereq, allow_fail=allow_fail,
                         resubmit=resubmit, resubmit_immediate=resubmit_immediate, skip_pnl=skip_pnl,
-                        mail_user=mail_user, mail_type=mail_type, batch_args=batch_args)
+                        mail_user=mail_user, mail_type=mail_type, batch_args=batch_args, workflow=workflow)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -432,7 +432,17 @@ class EnvBatch(EnvBase):
 
     def submit_jobs(self, case, no_batch=False, job=None, user_prereq=None, skip_pnl=False,
                     allow_fail=False, resubmit_immediate=False, mail_user=None, mail_type=None,
-                    batch_args=None, dry_run=False):
+                    batch_args=None, dry_run=False, workflow=True):
+        """
+          no_batch indicates that the jobs should be run directly rather that submitted to a queueing system
+          job is the first job in the workflow sequence to start
+          user_prereq is a batch system prerequisite as requested by the user
+          skip_pnl indicates that the preview_namelist should not be run by this job
+          allow_fail indicates that the prereq job need only complete not nessasarily successfully to start the next job
+          resubmit_immediate indicates that all jobs indicated by the RESUBMIT option should be submitted at the same time instead of
+                waiting to resubmit at the end of the first sequence
+          workflow is a logical indicating whether only "job" is submitted or the workflow sequence starting with "job" is submitted
+        """
         env_workflow = case.get_env('workflow')
         external_workflow = case.get_value("EXTERNAL_WORKFLOW")
         alljobs = env_workflow.get_jobs()
@@ -467,7 +477,7 @@ class EnvBatch(EnvBase):
         depid = OrderedDict()
         jobcmds = []
 
-        if resubmit_immediate:
+        if workflow and resubmit_immediate:
             num_submit = case.get_value("RESUBMIT") + 1
             case.set_value("RESUBMIT", 0)
             if num_submit <= 0:
@@ -502,12 +512,13 @@ class EnvBatch(EnvBase):
                                                  mail_user=mail_user,
                                                  mail_type=mail_type,
                                                  batch_args=batch_args,
-                                                 dry_run=dry_run)
+                                                 dry_run=dry_run,
+                                                 workflow=workflow)
                 batch_job_id = str(alljobs.index(job)) if dry_run else result
                 depid[job] = batch_job_id
                 jobcmds.append( (job, result) )
 
-                if self._batchtype == "cobalt" or external_workflow:
+                if self._batchtype == "cobalt" or external_workflow or not workflow:
                     break
 
             if not external_workflow and not no_batch:
@@ -588,7 +599,7 @@ class EnvBatch(EnvBase):
 
     def _submit_single_job(self, case, job, dep_jobs=None, allow_fail=False,
                            no_batch=False, skip_pnl=False, mail_user=None, mail_type=None,
-                           batch_args=None, dry_run=False, resubmit_immediate=False):
+                           batch_args=None, dry_run=False, resubmit_immediate=False, workflow=True):
 
         if not dry_run:
             logger.warning("Submit job {}".format(job))
@@ -599,7 +610,7 @@ class EnvBatch(EnvBase):
             job_name = "."+job
             if not dry_run:
                 args = self._build_run_args(job, True, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
-                                            submit_resubmits=not resubmit_immediate)
+                                            submit_resubmits=workflow and not resubmit_immediate)
                 try:
                     if hasattr(case, function_name):
                         getattr(case, function_name)(**{k: v for k, (v, _) in args.items()})
@@ -682,7 +693,7 @@ class EnvBatch(EnvBase):
         batchredirect = self.get_value("batch_redirect", subgroup=None)
         batch_env_flag = self.get_value("batch_env", subgroup=None)
         run_args = self._build_run_args_str(job, False, skip_pnl=skip_pnl, set_continue_run=resubmit_immediate,
-                                            submit_resubmits=not resubmit_immediate)
+                                            submit_resubmits=workflow and not resubmit_immediate)
         if batch_system == 'lsf' and not batch_env_flag:
             sequence = (run_args, batchsubmit, submitargs, batchredirect, get_batch_script_for_job(job))
         elif batch_env_flag:

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1339,13 +1339,13 @@ directory, NOT in this subdirectory."""
 
     def submit_jobs(self, no_batch=False, job=None, skip_pnl=None, prereq=None, allow_fail=False,
                     resubmit_immediate=False, mail_user=None, mail_type=None, batch_args=None,
-                    dry_run=False):
+                    dry_run=False, workflow=True):
         env_batch = self.get_env('batch')
         result =  env_batch.submit_jobs(self, no_batch=no_batch, skip_pnl=skip_pnl,
                                         job=job, user_prereq=prereq, allow_fail=allow_fail,
                                         resubmit_immediate=resubmit_immediate,
                                         mail_user=mail_user, mail_type=mail_type,
-                                        batch_args=batch_args, dry_run=dry_run)
+                                        batch_args=batch_args, dry_run=dry_run, workflow=workflow)
         return result
 
     def get_job_info(self):

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -25,7 +25,7 @@ def _build_prereq_str(case, prev_job_ids):
 
 def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resubmit=False,
             resubmit_immediate=False, skip_pnl=False, mail_user=None, mail_type=None,
-            batch_args=None):
+            batch_args=None, workflow=True):
     if job is None:
         job = case.get_first_job()
 
@@ -139,7 +139,7 @@ manual edits to these file will be lost!
     job_ids = case.submit_jobs(no_batch=no_batch, job=job, prereq=prereq,
                                skip_pnl=skip_pnl, resubmit_immediate=resubmit_immediate,
                                allow_fail=allow_fail, mail_user=mail_user,
-                               mail_type=mail_type, batch_args=batch_args)
+                               mail_type=mail_type, batch_args=batch_args, workflow=workflow)
 
     xml_jobids = []
     for jobname, jobid in job_ids.items():
@@ -155,7 +155,7 @@ manual edits to these file will be lost!
 
 def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubmit=False,
            resubmit_immediate=False, skip_pnl=False, mail_user=None, mail_type=None,
-           batch_args=None):
+           batch_args=None, workflow=True):
     if resubmit_immediate and self.get_value("MACH") in ['mira', 'cetus']:
         logger.warning("resubmit_immediate does not work on Mira/Cetus, submitting normally")
         resubmit_immediate = False
@@ -193,7 +193,7 @@ def submit(self, job=None, no_batch=False, prereq=None, allow_fail=False, resubm
                                   allow_fail=allow_fail, resubmit=resubmit,
                                   resubmit_immediate=resubmit_immediate, skip_pnl=skip_pnl,
                                   mail_user=mail_user, mail_type=mail_type,
-                                  batch_args=batch_args)
+                                  batch_args=batch_args, workflow=workflow)
         run_and_log_case_status(functor, "case.submit", caseroot=caseroot,
                                 custom_success_msg_functor=verbatim_success_msg)
     except BaseException: # Want to catch KeyboardInterrupt too

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1579,6 +1579,9 @@ def _get_most_recent_lid_impl(files):
     >>> files = ['/foo/bar/e3sm.log.20160905_111212', '/foo/bar/e3sm.log.20160906_111212.gz']
     >>> _get_most_recent_lid_impl(files)
     ['20160905_111212', '20160906_111212']
+    >>> files = ['/foo/bar/e3sm.log.20160905_111212', '/foo/bar/e3sm.log.20160905_111212.gz']
+    >>> _get_most_recent_lid_impl(files)
+    ['20160905_111212']
     """
     results = []
     for item in files:
@@ -1589,7 +1592,7 @@ def _get_most_recent_lid_impl(files):
         else:
             logger.warning("Apparent model log file '{}' did not conform to expected name format".format(item))
 
-    return sorted(results)
+    return sorted(list(set(results)))
 
 def ls_sorted_by_mtime(path):
     ''' return list of path sorted by timestamp oldest first'''


### PR DESCRIPTION
The --job _jobname_ option tells case.submit to start the defined workflow with _jobname_.  New option --only-job _jobname_ tells case.submit to run only _jobname_ and ignore any defined workflow. 

Test suite: scripts_regression_tests.py, hand testing
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #3250 

User interface changes?: Adds option --only-job to case.submit

Update gh-pages html (Y/N)?:

Code review: 
