### PR TITLE
add a raw xml option to query_config, useful for gui development

### DIFF
--- a/scripts/query_config
+++ b/scripts/query_config
@@ -20,7 +20,7 @@ from argparse           import RawTextHelpFormatter
 logger = logging.getLogger(__name__)
 supported_comp_interfaces = ["mct", "nuopc", "moab"]
 
-def query_grids(files, long_output):
+def query_grids(files, long_output, xml=False):
     """
     query all grids.
     """
@@ -29,12 +29,14 @@ def query_grids(files, long_output):
            "Cannot find config_file {} on disk".format(config_file))
 
     grids = Grids(config_file)
-    if long_output:
+    if xml:
+        print("{}".format(grids.get_raw_record()))
+    elif long_output:
         grids.print_values(long_output=long_output)
     else:
         grids.print_values()
 
-def query_machines(files, machine_name='all'):
+def query_machines(files, machine_name='all', xml=False):
     """
     query machines. Defaule: all
     """
@@ -43,9 +45,16 @@ def query_machines(files, machine_name='all'):
            "Cannot find config_file {} on disk".format(config_file))
     # Provide a special machine name indicating no need for a machine name
     machines = Machines(config_file, machine="Query")
-    machines.print_values(machine_name=machine_name)
+    if xml:
+        if machine_name == 'all':
+            print("{}".format(machines.get_raw_record()))
+        else:
+            machines.set_machine(machine_name)
+            print("{}".format(machines.get_raw_record(root=machines.machine_node)))
+    else:
+        machines.print_values(machine_name=machine_name)
 
-def query_compsets(files, name):
+def query_compsets(files, name, xml=False):
     """
     query compset definition give a compset name
     """
@@ -69,11 +78,11 @@ def query_compsets(files, name):
     if all_components:  # print all compsets
         for component in components:
             # the all_components flag will only print available components
-            print_compset(component, files, all_components=all_components)
+            print_compset(component, files, all_components=all_components, xml=xml)
     else:
-        print_compset(name, files)
+        print_compset(name, files, xml=xml)
 
-def print_compset(name, files, all_components=False):
+def print_compset(name, files, all_components=False, xml=False):
     """
     print compsets associated with the component name, but if all_components is true only
     print the details if the associated component is available
@@ -97,9 +106,12 @@ def print_compset(name, files, all_components=False):
     # determine component xml content
     compsets = Compsets(config_file)
     # print compsets associated with component without help text
-    compsets.print_values(arg_help=False)
+    if xml:
+        print("{}".format(compsets.get_raw_record()))
+    else:
+        compsets.print_values(arg_help=False)
 
-def query_all_components(files):
+def query_all_components(files, xml=False):
     """
     query all components
     """
@@ -111,9 +123,9 @@ def query_all_components(files):
         # determine all components in string
         components = files.get_components(string)
         for item in components:
-            query_component(item, files, all_components=True)
+            query_component(item, files, all_components=True, xml=xml)
 
-def query_component(name, files, all_components=False):
+def query_component(name, files, all_components=False, xml=False):
     """
     query a component by name
     """
@@ -164,7 +176,10 @@ def query_component(name, files, all_components=False):
 
     # determine component xml content
     component = Component(config_file, "CPL")
-    component.print_values()
+    if xml:
+        print("{}".format(component.get_raw_record()))
+    else:
+        component.print_values()
 
 def parse_command_line(args, description):
     """
@@ -178,6 +193,10 @@ def parse_command_line(args, description):
     CIME.utils.setup_standard_logging_options(parser)
 
     valid_components = ['all']
+
+    parser.add_argument("--xml", action="store_true",
+                        help="Output in xml format.")
+
     files = {}
     for comp_interface in supported_comp_interfaces:
         files[comp_interface] = Files(comp_interface=comp_interface)
@@ -243,7 +262,7 @@ def parse_command_line(args, description):
         parser.print_help(sys.stderr)
 
     return args.grids, args.compsets, args.components, args.machines, \
-        args.long, files[args.comp_interface]
+        args.long, args.xml, files[args.comp_interface]
 
 def get_compsets(files):
     """
@@ -347,23 +366,23 @@ def _main_func(description):
     """
     main function
     """
-    grids, compsets, components, machines, long_output, files = parse_command_line(sys.argv, description)
+    grids, compsets, components, machines, long_output, xml, files = parse_command_line(sys.argv, description)
 
 
     if grids:
-        query_grids(files, long_output)
+        query_grids(files, long_output, xml=xml)
 
     if compsets is not None:
-        query_compsets(files, name=compsets)
+        query_compsets(files, name=compsets, xml=xml)
 
     if components is not None:
         if re.search("^all$", components):  # print all compsets
-            query_all_components(files)
+            query_all_components(files, xml=xml)
         else:
-            query_component(components, files)
+            query_component(components, files, xml=xml)
 
     if machines is not None:
-        query_machines(files, machine_name=machines)
+        query_machines(files, machine_name=machines, xml=xml)
 
 # main entry point
 if __name__ == "__main__":

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2886,7 +2886,11 @@
    <default_value></default_value>
    <group>job_submission</group>
    <file>env_workflow.xml</file>
-   <desc>The machine wallclock setting.  Default determined in config_machines.xml can be overwritten by testing</desc>
+   <desc>The machine wallclock setting.  Default determined in
+   config_machines.xml can be overwritten by testing.  Format is
+   DD:HH:MM with DD assumed 0 if not present, this is translated to
+   the format specified by walltime format defined in
+   config_batch.xml</desc>
  </entry>
 
   <entry id="BATCH_COMMAND_FLAGS">


### PR DESCRIPTION
Adds a raw xml option to the query_config interface.

Test suite: tested by hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: adds --xml to query_config 

Update gh-pages html (Y/N)?:

Code review: 
