### PR TITLE
fix glob for bless_test_results

### DIFF
--- a/scripts/lib/CIME/bless_test_results.py
+++ b/scripts/lib/CIME/bless_test_results.py
@@ -59,7 +59,7 @@ def bless_history(test_name, case, baseline_name, baseline_root, report_only, fo
 def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, namelists_only=False, hist_only=False,
                        report_only=False, force=False, bless_tests=None, no_skip_pass=False):
 ###############################################################################
-    test_id_glob = "*{}*".format(compiler) if test_id is None else "*{}*".format(test_id)
+    test_id_glob = "*{}[0-9][0-9]".format(compiler) if test_id is None else "*{}".format(test_id)
     test_status_files = glob.glob("{}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
     expect(test_status_files, "No matching test cases found in for {}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
 


### PR DESCRIPTION
Improved patern matching for bless_test_results.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #3278

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
