### PR TITLE
add a common get_test_status_files routine

### DIFF
--- a/scripts/lib/CIME/bless_test_results.py
+++ b/scripts/lib/CIME/bless_test_results.py
@@ -4,8 +4,8 @@ from CIME.utils import run_cmd, expect, get_scripts_root, get_model, Environment
 from CIME.test_status import *
 from CIME.hist_utils import generate_baseline, compare_baseline
 from CIME.case import Case
-
-import os, glob, time, six
+from CIME.test_utils import get_test_status_files
+import os,  time, six
 logger = logging.getLogger(__name__)
 
 ###############################################################################
@@ -59,9 +59,7 @@ def bless_history(test_name, case, baseline_name, baseline_root, report_only, fo
 def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_id=None, namelists_only=False, hist_only=False,
                        report_only=False, force=False, bless_tests=None, no_skip_pass=False):
 ###############################################################################
-    test_id_glob = "*{}*".format(compiler) if test_id is None else "*{}*".format(test_id)
-    test_status_files = glob.glob("{}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
-    expect(test_status_files, "No matching test cases found in for {}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
+    test_status_files = get_test_status_files(test_root, compiler, test_id=test_id)
 
     # auto-adjust test-id if multiple rounds of tests were matched
     timestamps = set()

--- a/scripts/lib/CIME/bless_test_results.py
+++ b/scripts/lib/CIME/bless_test_results.py
@@ -1,6 +1,6 @@
 import CIME.compare_namelists, CIME.simple_compare
 from CIME.test_scheduler import NAMELIST_PHASE
-from CIME.utils import run_cmd, expect, get_scripts_root, get_model, EnvironmentContext
+from CIME.utils import run_cmd, get_scripts_root, get_model, EnvironmentContext
 from CIME.test_status import *
 from CIME.hist_utils import generate_baseline, compare_baseline
 from CIME.case import Case

--- a/scripts/lib/CIME/compare_test_results.py
+++ b/scripts/lib/CIME/compare_test_results.py
@@ -1,5 +1,5 @@
 import CIME.compare_namelists, CIME.simple_compare
-from CIME.utils import expect, append_status, EnvironmentContext
+from CIME.utils import append_status, EnvironmentContext
 from CIME.test_status import *
 from CIME.hist_utils import compare_baseline, get_ts_synopsis
 from CIME.case import Case

--- a/scripts/lib/CIME/compare_test_results.py
+++ b/scripts/lib/CIME/compare_test_results.py
@@ -4,7 +4,7 @@ from CIME.test_status import *
 from CIME.hist_utils import compare_baseline, get_ts_synopsis
 from CIME.case import Case
 
-import os, glob, logging
+import os, logging
 
 ###############################################################################
 def append_status_cprnc_log(msg, logfile_name, test_dir):
@@ -58,9 +58,7 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
     Returns True if all tests generated either PASS or SKIP results, False if
     there was at least one FAIL result.
     """
-    test_id_glob = "*{}*".format(compiler) if test_id is None else "*{}*".format(test_id)
-    test_status_files = glob.glob("{}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
-    expect(test_status_files, "No matching test cases found in for {}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
+    test_status_files = get_test_status_files(test_root, compiler, test_id=test_id)
 
     # ID to use in the log file names, to avoid file name collisions with
     # earlier files that may exist.

--- a/scripts/lib/CIME/compare_test_results.py
+++ b/scripts/lib/CIME/compare_test_results.py
@@ -3,6 +3,7 @@ from CIME.utils import expect, append_status, EnvironmentContext
 from CIME.test_status import *
 from CIME.hist_utils import compare_baseline, get_ts_synopsis
 from CIME.case import Case
+from CIME.test_utils import get_test_status_files
 
 import os, logging
 

--- a/scripts/lib/CIME/test_utils.py
+++ b/scripts/lib/CIME/test_utils.py
@@ -6,6 +6,7 @@ get test lists.
 from CIME.XML.standard_module_setup import *
 from CIME.XML.testlist import Testlist
 from CIME.XML.files import Files
+from CIME.test_status import TEST_STATUS_FILENAME
 import CIME.utils
 
 logger = logging.getLogger(__name__)
@@ -103,3 +104,11 @@ def test_to_string(test, category_field_width=0, test_field_width=0, show_option
                 mystr += "  # {}: {}".format(one_opt, myopts[one_opt])
 
     return mystr
+
+def get_test_status_files(test_root, compiler, test_id=None):
+    test_id_glob = "*{}*".format(compiler) if test_id is None else "*{}*".format(test_id)
+    test_status_files = glob.glob("{}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
+    test_status_files = [item for item in test_status_files if not os.path.dirname(item).endswith('ref1') and not os.path.dirname(item).endswith('ref2')]
+
+    expect(test_status_files, "No matching test cases found in for {}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME))
+    return test_status_files

--- a/scripts/lib/CIME/test_utils.py
+++ b/scripts/lib/CIME/test_utils.py
@@ -2,7 +2,7 @@
 Utility functions used in test_scheduler.py, and by other utilities that need to
 get test lists.
 """
-
+import glob
 from CIME.XML.standard_module_setup import *
 from CIME.XML.testlist import Testlist
 from CIME.XML.files import Files


### PR DESCRIPTION
Exclude .ref1 and .ref2 from TestStatus files and move get_test_status_files to a common place

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3278

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
