### PR TITLE
omit broken netcdf4 on cheyenne with mpt

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -450,7 +450,8 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules mpilib="mpt" compiler="intel">
 	<command name="load">mpt/2.19</command>
-	<command name="load">netcdf-mpi/4.7.1</command>
+	<!-- known failure in parallel netcdf with mpt, use serial -->
+	<command name="load">netcdf/4.7.1</command>
 	<command name="load">pnetcdf/1.11.0</command>
       </modules>
       <modules mpilib="mpt" compiler="pgi">


### PR DESCRIPTION
The ERIO test has been failing on cheyenne for some time because netcdf4p is broken when built with mpt.   This PR removes the netcdf-mpi module and replaces it with netcdf serial so that the ERIO test works again.

Test suite: ERIO.f09_g16.X.cheyenne_intel 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
