### PR TITLE
cleanup env batch

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -539,7 +539,7 @@ def single_submit_impl(machine_name, test_id, proc_pool, _, args, job_cost_map, 
         "tasks_per_node": tasks_per_node,
         "totaltasks" : tasks_per_node * num_nodes,
         "job_wallclock_time": wall_time_bab,
-        "job_queue": queue
+        "job_queue": env_batch.text(queue)
         }
 
     directives = env_batch.get_batch_directives(case, "case.test", overrides=overrides)

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -752,8 +752,6 @@ class EnvBatch(EnvBase):
     def _get_all_queue_names(self):
         all_queues = []
         all_queues = self.get_all_queues()
-        # Default queue needs to be first
-        all_queues.insert(0, self.get_default_queue())
 
         queue_names = []
         for queue in all_queues:
@@ -811,6 +809,7 @@ class EnvBatch(EnvBase):
     def get_all_queues(self, name=None):
         bs_nodes = self.get_children("batch_system")
         nodes = []
+        default_idx = None
         for bsnode in bs_nodes:
             qsnode = self.get_optional_child("queues", root=bsnode)
             if qsnode is not None:
@@ -818,6 +817,14 @@ class EnvBatch(EnvBase):
                 for qnode in qnodes:
                     if name is None or self.text(qnode) == name:
                         nodes.append(qnode)
+                        if self.get(qnode, "default", default="false") == "true":
+                            default_idx = len(nodes) - 1
+
+        # Queues are selected by first match, so we want the queue marked
+        # as default to come first.
+        if default_idx is not None:
+            def_node = nodes.pop(default_idx)
+            nodes.insert(0, def_node)
 
         return nodes
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2220,6 +2220,27 @@ class K_TestCimeCase(TestCreateTestCommon):
                 self.assertEqual(result, "421:32:11")
 
     ###########################################################################
+    def test_cime_case_test_walltime_mgmt_8(self):
+    ###########################################################################
+        if CIME.utils.get_model() != "e3sm":
+            self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
+
+        test_name = "SMS_P25600.f19_g16_rx1.A"
+        machine, compiler = "theta", "gnu"
+        self._create_test(["--no-setup", "--machine={}".format(machine), "--compiler={}".format(compiler), "--project e3sm", test_name], test_id=self._baseline_name,
+                          env_changes="unset CIME_GLOBAL_WALLTIME &&")
+
+        casedir = os.path.join(self._testroot,
+                               "%s.%s" % (CIME.utils.get_full_test_name(test_name, machine=machine, compiler=compiler), self._baseline_name))
+        self.assertTrue(os.path.isdir(casedir), msg="Missing casedir '%s'" % casedir)
+
+        result = run_cmd_assert_result(self, "./xmlquery JOB_WALLCLOCK_TIME --subgroup=case.test --value", from_dir=casedir)
+        self.assertEqual(result, "09:00:00")
+
+        result = run_cmd_assert_result(self, "./xmlquery JOB_QUEUE --subgroup=case.test --value", from_dir=casedir)
+        self.assertEqual(result, "default")
+
+    ###########################################################################
     def test_cime_case_test_custom_project(self):
     ###########################################################################
         test_name = "ERS_P1.f19_g16_rx1.A"


### PR DESCRIPTION
Clean up env_batch
    
Try, wherever possible, to have our queue handle be a qnode object, not
just a queue name. This will result in much better handling of the case
where multiple entries have the same name.

Also, add a test specifically for testing the case where there are multiple queue entries with the same name.

Test suite: scripts_regression_tests.K_TestCimeCase
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b 
