### PR TITLE
initialize albdif and albdir in seq_flux_mct

### DIFF
--- a/src/drivers/mct/main/seq_flux_mct.F90
+++ b/src/drivers/mct/main/seq_flux_mct.F90
@@ -109,8 +109,8 @@ module seq_flux_mct
   real(r8),parameter :: const_deg2rad = const_pi/180.0_r8  ! deg to rads
 
   ! albedo reference variables - set via namelist
-  real(r8)  :: seq_flux_mct_albdif  ! albedo, diffuse
-  real(r8)  :: seq_flux_mct_albdir  ! albedo, direct
+  real(r8)  :: seq_flux_mct_albdif = 0.06_r8  ! albedo, diffuse
+  real(r8)  :: seq_flux_mct_albdir = 0.07_r8  ! albedo, direct
   real(r8)  :: seq_flux_atmocn_minwind ! minimum wind temperature for atmocn flux routines
 
   ! Coupler field indices


### PR DESCRIPTION
These variables should be initialized even if for some reason the namelist isn't read. 

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes (See issue) #3294 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
