### PR TITLE
Add blank spaces needed for gnu

### DIFF
--- a/src/components/data_comps/dlnd/mct/dlnd_comp_mod.F90
+++ b/src/components/data_comps/dlnd/mct/dlnd_comp_mod.F90
@@ -61,7 +61,7 @@ module dlnd_comp_mod
        "Sl_avsdf    ","Sl_anidf    ","Sl_snowh    ","Fall_taux   ","Fall_tauy   ", &
        "Fall_lat    ","Fall_sen    ","Fall_lwup   ","Fall_evap   ","Fall_swnet  ", &
        "Sl_landfrac ","Sl_fv       ","Sl_ram1     ","Flrl_demand ",                &
-        "Flrl_rofsur ","Flrl_rofgwl ","Flrl_rofsub ","Flrl_rofdto ","Flrl_rofi", &
+        "Flrl_rofsur ","Flrl_rofgwl ","Flrl_rofsub ","Flrl_rofdto ","Flrl_rofi   ", &
        "Fall_flxdst1","Fall_flxdst2","Fall_flxdst3","Fall_flxdst4"                 /)
 
   character(fld_len),parameter  :: avifld_nosnow(1:nflds_nosnow) = &


### PR DESCRIPTION
Some gnu tests were giving an error of different character lengths in dlnd.
gnu needs the extra blank spaces to get the character lengths to match.

Test suite:  scripts_regression_tests, 
                     ERS_Ly20_N2_P2.f09_g17_gl20.T1850G1.cheyenne_gnu
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
