### PR TITLE
Fix bug in #3257

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -4250,7 +4250,7 @@
     </desc>
     <values>
       <value>0.06</value>
-      <value aqua_planet_sst_type="sst_aquap11">0.07</value>
+      <value aqua_planet_sst_type="sst_aquap_constant">0.07</value>
     </values>
   </entry>
 
@@ -4275,7 +4275,7 @@
     </desc>
     <values>
       <value>0.5</value>
-      <value aqua_planet_sst_type="sst_aquap11">1.0</value>
+      <value aqua_planet_sst_type="sst_aquap_constant">1.0</value>
     </values>
   </entry>
 


### PR DESCRIPTION
In #3257, the namelist_definition_drv.xml also needed to be updated.  Change sst_aquap11 to sst_aquap_constant.  

Test suite: 
Test baseline: 
Test namelist changes:  Tested using QPRCEMIP compset
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]  none (issue was opened in ESCOMP/CAM as issue 39, but discovered the error was in cime)

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
