### PR TITLE
Implement automatic test traiging in e3sm test infrastructure

### DIFF
--- a/scripts/Tools/jenkins_generic_job
+++ b/scripts/Tools/jenkins_generic_job
@@ -54,6 +54,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--submit-to-cdash", action="store_true",
                         help="Send results to CDash")
 
+    parser.add_argument("--update-success", action="store_true",
+                        help="Record test success in baselines. Only the nightly process should use this in general.")
+
     parser.add_argument("--no-batch", action="store_true",
                         help="Do not use batch system even if on batch machine")
 
@@ -127,15 +130,15 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
         args.override_baseline_name = args.baseline_name
 
     return args.generate_baselines, args.submit_to_cdash, args.no_batch, args.baseline_name, args.cdash_build_name, \
-        args.cdash_project, args.test_suite, args.cdash_build_group, args.baseline_compare, args.scratch_root, args.parallel_jobs, args.walltime, args.machine, args.compiler, args.override_baseline_name, args.baseline_root
+        args.cdash_project, args.test_suite, args.cdash_build_group, args.baseline_compare, args.scratch_root, args.parallel_jobs, args.walltime, args.machine, args.compiler, args.override_baseline_name, args.baseline_root, args.update_success
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler, real_baseline_name, baseline_root = \
+    generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler, real_baseline_name, baseline_root, update_success = \
         parse_command_line(sys.argv, description)
 
-    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler, real_baseline_name, baseline_root)
+    sys.exit(0 if jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch, baseline_name, cdash_build_name, cdash_project, test_suite, cdash_build_group, baseline_compare, scratch_root, parallel_jobs, walltime, machine, compiler, real_baseline_name, baseline_root, update_success)
              else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/scripts/Tools/jenkins_script
+++ b/scripts/Tools/jenkins_script
@@ -13,4 +13,4 @@ export JENKINS_START_TIME=$(date "+%s")
 
 umask 002
 
-$SCRIPT_DIR/jenkins_generic_job --submit-to-cdash "$@" >& JENKINS_$DATE_STAMP
+$SCRIPT_DIR/jenkins_generic_job --submit-to-cdash --update-success "$@" >& JENKINS_$DATE_STAMP

--- a/scripts/Tools/wait_for_tests
+++ b/scripts/Tools/wait_for_tests
@@ -73,14 +73,17 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--timeout", type=int,
                         help="Timeout wait in seconds.")
 
+    parser.add_argument("--update-success", action="store_true",
+                        help="Record test success in baselines. Only the nightly process should use this in general.")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.paths, args.no_wait, args.check_throughput, args.check_memory, args.ignore_namelist_diffs, args.ignore_memleak, args.cdash_build_name, args.cdash_project, args.cdash_build_group, args.timeout, args.force_log_upload, args.no_run
+    return args.paths, args.no_wait, args.check_throughput, args.check_memory, args.ignore_namelist_diffs, args.ignore_memleak, args.cdash_build_name, args.cdash_project, args.cdash_build_group, args.timeout, args.force_log_upload, args.no_run, args.update_success
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, ignore_memleak, cdash_build_name, cdash_project, cdash_build_group, timeout, force_log_upload, no_run = \
+    test_paths, no_wait, check_throughput, check_memory, ignore_namelist_diffs, ignore_memleak, cdash_build_name, cdash_project, cdash_build_group, timeout, force_log_upload, no_run, update_success = \
         parse_command_line(sys.argv, description)
 
     sys.exit(0 if CIME.wait_for_tests.wait_for_tests(test_paths,
@@ -94,7 +97,8 @@ def _main_func(description):
                                                      cdash_build_group=cdash_build_group,
                                                      timeout=timeout,
                                                      force_log_upload=force_log_upload,
-                                                     no_run=no_run)
+                                                     no_run=no_run,
+                                                     update_success=update_success)
              else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -6,7 +6,7 @@ from CIME.XML.env_run import EnvRun
 from CIME.utils import append_testlog, get_model, safe_copy, get_timestamp, CIMEError
 from CIME.test_status import *
 from CIME.hist_utils import *
-from CIME.provenance import save_test_time
+from CIME.provenance import save_test_time, get_test_success
 from CIME.locked_files import LOCKED_DIR, lock_file, is_locked
 import CIME.build as build
 
@@ -173,14 +173,40 @@ class SystemTestsCommon(object):
             with self._test_status:
                 self._test_status.set_status(RUN_PHASE, status, comments=("time={:d}".format(int(time_taken))))
 
-            if success and get_model() == "e3sm":
-                save_test_time(self._case.get_value("BASELINE_ROOT"), self._casebaseid, time_taken)
+            if get_model() == "e3sm":
+                # If run phase worked, remember the time it took in order to improve later walltime ests
+                baseline_root = self._case.get_value("BASELINE_ROOT")
+                if success:
+                    save_test_time(baseline_root, self._casebaseid, time_taken)
+
+                # If overall things did not pass, offer the user some insight into what might have broken things
+                overall_status = self._test_status.get_overall_test_status(ignore_namelists=True)
+                if overall_status != TEST_PASS_STATUS:
+                    worked_before, last_pass, last_fail = \
+                        get_test_success(baseline_root, self._case.get_value("CIMEROOT"), self._casebaseid)
+
+                    if worked_before:
+                        if last_pass is not None:
+                            # commits between last_pass and now broke things
+                            stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, "HEAD"))
+                            if stat == 0:
+                                append_testlog("NEW FAIL: Potentially broken merges:\n{}".format(out), self._orig_caseroot)
+                            else:
+                                logger.warning("Unable to list potentially broken merges: {}\n{}".format(out, err))
+                    else:
+                        if last_pass is not None and last_fail is not None:
+                            # commits between last_pass and last_fail broke things
+                            stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, last_fail))
+                            if stat == 0:
+                                append_testlog("OLD FAIL: Potentially broken merges:\n{}".format(out), self._orig_caseroot)
+                            else:
+                                logger.warning("Unable to list potentially broken merges: {}\n{}".format(out, err))
 
             if get_model() == "cesm" and self._case.get_value("GENERATE_BASELINE"):
                 baseline_dir = os.path.join(self._case.get_value("BASELINE_ROOT"), self._case.get_value("BASEGEN_CASE"))
                 generate_teststatus(self._caseroot, baseline_dir)
 
-        # We return success if the run phase worked; memleaks, diffs will not be taken into account
+        # We return success if the run phase worked; memleaks, diffs will NOT be taken into account
         # with this return value.
         return success
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -182,23 +182,24 @@ class SystemTestsCommon(object):
                 # If overall things did not pass, offer the user some insight into what might have broken things
                 overall_status = self._test_status.get_overall_test_status(ignore_namelists=True)
                 if overall_status != TEST_PASS_STATUS:
+                    srcroot = self._case.get_value("CIMEROOT")
                     worked_before, last_pass, last_fail = \
-                        get_test_success(baseline_root, self._case.get_value("CIMEROOT"), self._casebaseid)
+                        get_test_success(baseline_root, srcroot, self._casebaseid)
 
                     if worked_before:
                         if last_pass is not None:
                             # commits between last_pass and now broke things
-                            stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, "HEAD"))
+                            stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, "HEAD"), from_dir=srcroot)
                             if stat == 0:
-                                append_testlog("NEW FAIL: Potentially broken merges:\n{}\n{}".format(out, err), self._orig_caseroot)
+                                append_testlog("NEW FAIL: Potentially broken merges:\n{}".format(out), self._orig_caseroot)
                             else:
                                 logger.warning("Unable to list potentially broken merges: {}\n{}".format(out, err))
                     else:
                         if last_pass is not None and last_fail is not None:
                             # commits between last_pass and last_fail broke things
-                            stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, last_fail))
+                            stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, last_fail), from_dir=srcroot)
                             if stat == 0:
-                                append_testlog("OLD FAIL: Potentially broken merges:\n{}\n{}".format(out, err), self._orig_caseroot)
+                                append_testlog("OLD FAIL: Potentially broken merges:\n{}".format(out), self._orig_caseroot)
                             else:
                                 logger.warning("Unable to list potentially broken merges: {}\n{}".format(out, err))
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -189,7 +189,7 @@ class SystemTestsCommon(object):
                     if worked_before:
                         if last_pass is not None:
                             # commits between last_pass and now broke things
-                            stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, "HEAD"), from_dir=srcroot)
+                            stat, out, err = run_cmd("git rev-list --first-parent {}..{}".format(last_pass, "HEAD"), from_dir=srcroot)
                             if stat == 0:
                                 append_testlog("NEW FAIL: Potentially broken merges:\n{}".format(out), self._orig_caseroot)
                             else:
@@ -197,7 +197,7 @@ class SystemTestsCommon(object):
                     else:
                         if last_pass is not None and last_fail is not None:
                             # commits between last_pass and last_fail broke things
-                            stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, last_fail), from_dir=srcroot)
+                            stat, out, err = run_cmd("git rev-list --first-parent {}..{}".format(last_pass, last_fail), from_dir=srcroot)
                             if stat == 0:
                                 append_testlog("OLD FAIL: Potentially broken merges:\n{}".format(out), self._orig_caseroot)
                             else:

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -190,7 +190,7 @@ class SystemTestsCommon(object):
                             # commits between last_pass and now broke things
                             stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, "HEAD"))
                             if stat == 0:
-                                append_testlog("NEW FAIL: Potentially broken merges:\n{}".format(out), self._orig_caseroot)
+                                append_testlog("NEW FAIL: Potentially broken merges:\n{}\n{}".format(out, err), self._orig_caseroot)
                             else:
                                 logger.warning("Unable to list potentially broken merges: {}\n{}".format(out, err))
                     else:
@@ -198,7 +198,7 @@ class SystemTestsCommon(object):
                             # commits between last_pass and last_fail broke things
                             stat, out, err = run_cmd("git rev-list --first-parent {} {}".format(last_pass, last_fail))
                             if stat == 0:
-                                append_testlog("OLD FAIL: Potentially broken merges:\n{}".format(out), self._orig_caseroot)
+                                append_testlog("OLD FAIL: Potentially broken merges:\n{}\n{}".format(out, err), self._orig_caseroot)
                             else:
                                 logger.warning("Unable to list potentially broken merges: {}\n{}".format(out, err))
 

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -445,7 +445,7 @@ def save_test_time(baseline_root, test, time_seconds):
     if baseline_root is not None:
         try:
             with SharedArea():
-                the_dir  = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test)
+                the_dir = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test)
                 if not os.path.exists(the_dir):
                     os.makedirs(the_dir)
 
@@ -456,3 +456,91 @@ def save_test_time(baseline_root, test, time_seconds):
         except Exception:
             # We NEVER want a failure here to kill the run
             logger.warning("Failed to store test time: {}".format(sys.exc_info()[1]))
+
+_SUCCESS_BASELINE_NAME = "success-history"
+_SUCCESS_FILE_NAME     = "last-transitions"
+
+def _read_success_data(baseline_root, test):
+    success_path = os.path.join(baseline_root, _SUCCESS_BASELINE_NAME, test, _SUCCESS_FILE_NAME)
+    if os.path.exists(success_path):
+        with open(success_path, "r") as fd:
+            prev_results_raw = fd.read().strip()
+            prev_results = prev_results_raw.split()
+            expect(len(prev_results) == 2, "Bad success data: '{}'".format(prev_results_raw))
+    else:
+        prev_results = ["None", "None"]
+
+    # Convert "None" to None
+    for idx, item in enumerate(prev_results):
+        if item == "None":
+            prev_results[idx] = None
+
+    return success_path, prev_results
+
+def _is_test_working(prev_results, src_root, testing=False):
+    # If there is no history of success, prev run could not have succeeded and vice versa for failures
+    if prev_results[0] is None:
+        return False
+    elif prev_results[1] is None:
+        return True
+    else:
+        if not testing:
+            stat, out, err = run_cmd("git merge-base --is-ancestor {}".format(" ".join(prev_results)), from_dir=src_root)
+            expect(stat in [0, 1], "Unexpected status from ancestor check:\n{}\n{}".format(out, err))
+        else:
+            # Hack for testing
+            stat = 0 if prev_results[0] < prev_results[1] else 1
+
+        # stat == 0 tells us that pass is older than fail, so we must have failed, otherwise we passed
+        return stat != 0
+
+def get_test_success(baseline_root, src_root, test, testing=False):
+    """
+    Returns (was prev run success, commit when test last transitioned from fail to pass, commit when test last transitioned from pass to fail)
+
+    Unknown transition history is expressed as None
+    """
+    if baseline_root is not None:
+        try:
+            prev_results = _read_success_data(baseline_root, test)[1]
+            prev_success = _is_test_working(prev_results, src_root, testing=testing)
+            return prev_success, prev_results[0], prev_results[1]
+
+        except Exception:
+            # We NEVER want a failure here to kill the run
+            logger.warning("Failed to read test success: {}".format(sys.exc_info()[1]))
+
+    return False, None, None
+
+def save_test_success(baseline_root, src_root, test, succeeded, force_commit_test=None):
+    """
+    Update success data accordingly based on succeeded flag
+    """
+    if baseline_root is not None:
+        try:
+            with SharedArea():
+                success_path, prev_results = _read_success_data(baseline_root, test)
+
+                the_dir = os.path.dirname(success_path)
+                if not os.path.exists(the_dir):
+                    os.makedirs(the_dir)
+
+                prev_succeeded = _is_test_working(prev_results, src_root, testing=(force_commit_test is not None))
+
+                # if no transition occurred then no update is needed
+                if succeeded != prev_succeeded or (prev_results[0] is None and succeeded) or (prev_results[1] is None and not succeeded):
+
+                    new_results = list(prev_results)
+                    my_commit = force_commit_test if force_commit_test else get_current_commit(repo=src_root)
+                    if succeeded:
+                        new_results[0] = my_commit # we transitioned to a passing state
+                    else:
+                        new_results[1] = my_commit # we transitioned to a failing state
+
+                    str_results = ["None" if item is None else item for item in new_results]
+                    with open(success_path, "w") as fd:
+                        fd.write("{}\n".format(" ".join(str_results)))
+
+        except Exception:
+            # We NEVER want a failure here to kill the run
+            logger.warning("Failed to store test success: {}".format(sys.exc_info()[1]))

--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -10,6 +10,8 @@ import CIME.utils
 from CIME.utils import expect, Timeout, run_cmd_no_fail, safe_copy, CIMEError
 from CIME.XML.machines import Machines
 from CIME.test_status import *
+from CIME.provenance import save_test_success
+from CIME.case.case import Case
 
 SIGNAL_RECEIVED           = False
 E3SM_MAIN_CDASH           = "ACME_Climate"
@@ -436,7 +438,8 @@ def wait_for_tests(test_paths,
                    cdash_build_group=CDASH_DEFAULT_BUILD_GROUP,
                    timeout=None,
                    force_log_upload=False,
-                   no_run=False):
+                   no_run=False,
+                   update_success=False):
 ###############################################################################
     # Set up signal handling, we want to print results before the program
     # is terminated
@@ -451,6 +454,13 @@ def wait_for_tests(test_paths,
         logging.info("Test '{}' finished with status '{}'".format(test_name, test_status))
         logging.info("    Path: {}".format(test_path))
         all_pass &= test_status == TEST_PASS_STATUS
+
+        if update_success:
+            caseroot = os.path.dirname(test_data[0])
+            with Case(caseroot, read_only=True) as case:
+                srcroot = case.get_value("CIMEROOT")
+                baseline_root = case.get_value("BASELINE_ROOT")
+                save_test_success(baseline_root, srcroot, test_name, test_status in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS])
 
     if cdash_build_name:
         create_cdash_xml(test_results, cdash_build_name, cdash_project, cdash_build_group, force_log_upload)

--- a/scripts/lib/jenkins_generic_job.py
+++ b/scripts/lib/jenkins_generic_job.py
@@ -136,7 +136,7 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
                         arg_test_suite,
                         cdash_build_group, baseline_compare,
                         scratch_root, parallel_jobs, walltime,
-                        machine, compiler, real_baseline_name, baseline_root):
+                        machine, compiler, real_baseline_name, baseline_root, update_success):
 ###############################################################################
     """
     Return True if all tests passed
@@ -226,13 +226,15 @@ def jenkins_generic_job(generate_baselines, submit_to_cdash, no_batch,
         logging.info("To resubmit to dashboard: wait_for_tests {}/*{}/TestStatus --no-wait -b {}".format(test_root, test_id, cdash_build_name))
 
     tests_passed = CIME.wait_for_tests.wait_for_tests(glob.glob("{}/*{}/TestStatus".format(test_root, test_id)),
-                                                 no_wait=not use_batch, # wait if using queue
-                                                 check_throughput=False, # don't check throughput
-                                                 check_memory=False, # don't check memory
-                                                 ignore_namelists=False, # don't ignore namelist diffs
-                                                 cdash_build_name=cdash_build_name,
-                                                 cdash_project=cdash_project,
-                                                 cdash_build_group=cdash_build_group)
+                                                      no_wait=not use_batch, # wait if using queue
+                                                      check_throughput=False, # don't check throughput
+                                                      check_memory=False, # don't check memory
+                                                      ignore_namelists=False, # don't ignore namelist diffs
+                                                      cdash_build_name=cdash_build_name,
+                                                      cdash_project=cdash_project,
+                                                      cdash_build_group=cdash_build_group,
+                                                      update_success=update_success)
+
 
     logging.info("TEST ARCHIVER: Waiting for archiver thread")
     archiver_thread.join()


### PR DESCRIPTION
Should have no impact on cesm, but I asked for a review anyway in case there was interest.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
