### PR TITLE
Convert user requested walltime to match walltime_format.

### DIFF
--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -221,7 +221,8 @@ class EnvBatch(EnvBase):
 
             walltime    = case.get_value("USER_REQUESTED_WALLTIME", subgroup=job) if case.get_value("USER_REQUESTED_WALLTIME", subgroup=job) else None
             force_queue = case.get_value("USER_REQUESTED_QUEUE", subgroup=job) if case.get_value("USER_REQUESTED_QUEUE", subgroup=job) else None
-            logger.info("job is {} USER_REQUESTED_WALLTIME {} USER_REQUESTED_QUEUE {}".format(job, walltime, force_queue))
+            walltime_format = case.get_value("walltime_format", subgroup=job) if case.get_value("walltime_format", subgroup=job) else None
+            logger.info("job is {} USER_REQUESTED_WALLTIME {} USER_REQUESTED_QUEUE {} WALLTIME_FORMAT {}".format(job, walltime, force_queue, walltime_format))
             task_count = int(jsect["task_count"]) if "task_count" in jsect else case.total_tasks
             walltime = jsect["walltime"] if ("walltime" in jsect and walltime is None) else walltime
             if "task_count" in jsect:
@@ -273,6 +274,18 @@ class EnvBatch(EnvBase):
                     walltime = specs[3]
 
                 walltime = self._default_walltime if walltime is None else walltime # last-chance fallback
+            else:
+                # Set the walltime to the correct walltime_format, if set.
+                # Assuming correct format is #H:#M or %H:%M:%S.
+                if walltime_format is not None:
+                    components=walltime.split(":")
+                    if len(components) > len(walltime_format.split(":")):
+                        walltime = components[0] + ":" + components[1]
+                        logger.info(" Changing USER_REQUESTED_WALLTIME to {} to match walltime_format {}".format(walltime,walltime_format))
+                    if len(components) < len(walltime_format.split(":")):
+                        walltime=walltime + ":00"
+                        logger.info(" Changing USER_REQUESTED_WALLTIME to {} to match walltime_format {}".format(walltime,walltime_format))
+
             env_workflow.set_value("JOB_QUEUE", queue, subgroup=job, ignore_type=specs is None)
             env_workflow.set_value("JOB_WALLCLOCK_TIME", walltime, subgroup=job)
             logger.debug("Job {} queue {} walltime {}".format(job, queue, walltime))

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -280,10 +280,10 @@ class EnvBatch(EnvBase):
                 if walltime_format is not None:
                     components=walltime.split(":")
                     if len(components) > len(walltime_format.split(":")):
-                        walltime = components[0] + ":" + components[1]
+                        walltime = ':'.join(components[:len(walltime_format.split(":"))])
                         logger.info(" Changing USER_REQUESTED_WALLTIME to {} to match walltime_format {}".format(walltime,walltime_format))
                     if len(components) < len(walltime_format.split(":")):
-                        walltime=walltime + ":00"
+                        walltime = walltime + ':' + ':'.join(["00"]*(len(walltime_format.split(":")) - len(components)))
                         logger.info(" Changing USER_REQUESTED_WALLTIME to {} to match walltime_format {}".format(walltime,walltime_format))
 
             env_workflow.set_value("JOB_QUEUE", queue, subgroup=job, ignore_type=specs is None)


### PR DESCRIPTION
If the user requested walltime format is different than the config_batch.xml walltime_format, convert
to the correct format.

If user requested walltime is %H:%M, and walltime_format is %H:%M:%S, then add :00 to user walltime.
If user requested walltime is %H:%M:%S, and walltime format is %H:%M, then remove %S from user walltime.
If user requested walltime is the same format at walltime_format, or walltime_format is None, then do
nothing.

Test suite:  scripts_regression_tests, create_test SMS.f09_g17.A.cheyenne_intel --walltime 00:35
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #] #3235

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
