### PR TITLE
Remove redundant logic in _get_extension

### DIFF
--- a/scripts/lib/CIME/XML/archive_base.py
+++ b/scripts/lib/CIME/XML/archive_base.py
@@ -165,14 +165,9 @@ def _get_extension(model, filepath):
     ext_regexes.append(r'\w+')
 
     for ext_regex in ext_regexes:
-        full_regex_str = model+r'\d?_?(\d{4})?\.('+ext_regex+r')[-\w\.]*\.nc\.?'
+        full_regex_str = model+r'\d?_?(\d{4})?\.('+ext_regex+r')[-\w\.]*'
         full_regex = re.compile(full_regex_str)
         m = full_regex.search(basename)
-        if m is None:
-            # try without .nc part
-            full_regex_str = model+r'\d?_?(\d{4})?\.('+ext_regex+r')[-\w\.]*'
-            full_regex = re.compile(full_regex_str)
-            m = full_regex.search(basename)
         if m is not None:
             if m.group(1) is not None:
                 result = m.group(1)+'.'+m.group(2)


### PR DESCRIPTION
Consider these cases:
- Search succeeds with .nc extension: then the search will succeed
  identically without the .nc extension
- Search fails with .nc extension: then my suggestion will be no
  different from the current behavior (we'll just skip the first, failed
  search)

So we don't need to do the search twice

(See also https://github.com/ESMCI/cime/pull/3346#pullrequestreview-341461981)

Test suite: scripts_regression_tests: underway
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes ESMCI/cime#3347

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
