### PR TITLE
Wpcoomb/fix misleading output casestatus

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -3,7 +3,7 @@ Base class for CIME system tests
 """
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_run import EnvRun
-from CIME.utils import append_testlog, get_model, safe_copy, get_timestamp, CIMEError, run_and_log_case_status
+from CIME.utils import append_testlog, get_model, safe_copy, get_timestamp, CIMEError
 from CIME.test_status import *
 from CIME.hist_utils import *
 from CIME.provenance import save_test_time
@@ -528,9 +528,9 @@ class FakeTest(SystemTestsCommon):
     """
     def _set_script(self, script):
         self._script = script # pylint: disable=attribute-defined-outside-init
-    
-    def _fake_case_build_impl(self, sharedlib_only=False, model_only=False):
-          if (not sharedlib_only):
+
+    def build_phase(self, sharedlib_only=False, model_only=False):
+        if (not sharedlib_only):
             exeroot = self._case.get_value("EXEROOT")
             cime_model = self._case.get_value("MODEL")
             modelexe = os.path.join(exeroot, "{}.exe".format(cime_model))
@@ -542,15 +542,6 @@ class FakeTest(SystemTestsCommon):
             os.chmod(modelexe, 0o755)
 
             build.post_build(self._case, [], build_complete=True)
-   
-    def build_phase(self, sharedlib_only=False, model_only=False):
-        functor = lambda: self._fake_case_build_impl(sharedlib_only=False, model_only=False)
-        cb = "case.build"
-        if (sharedlib_only == True):
-            cb = cb + " (SHAREDLIB_BUILD)"
-        if (model_only == True):
-            cb = cb + " (MODEL_BUILD)"
-        return run_and_log_case_status(functor, cb, caseroot=self._case.get_value("CASEROOT"))
 
     def run_indv(self, suffix="base", st_archive=False):
         mpilib = self._case.get_value("MPILIB")
@@ -656,7 +647,7 @@ class TESTRUNSTARCFAIL(TESTRUNPASS):
 
 class TESTBUILDFAIL(TESTRUNPASS):
 
-    def _fake_case_build_impl(self, sharedlib_only=False, model_only=False):
+    def build_phase(self, sharedlib_only=False, model_only=False):
         if "TESTBUILDFAIL_PASS" in os.environ:
             TESTRUNPASS.build_phase(self, sharedlib_only, model_only)
         else:
@@ -667,10 +658,6 @@ class TESTBUILDFAIL(TESTRUNPASS):
                     fd.write("BUILD FAIL: Intentional fail for testing infrastructure")
 
                 expect(False, "BUILD FAIL: Intentional fail for testing infrastructure")
-
-    def build_phase(self, sharedlib_only=False, model_only=False):
-        functor    = lambda: self._fake_case_build_impl(sharedlib_only=False, model_only=False)
-        return run_and_log_case_status(functor, "case.build", caseroot=self._case.get_value("CASEROOT"))
 
 class TESTBUILDFAILEXC(FakeTest):
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -3,7 +3,7 @@ Base class for CIME system tests
 """
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_run import EnvRun
-from CIME.utils import append_testlog, get_model, safe_copy, get_timestamp, CIMEError
+from CIME.utils import append_testlog, get_model, safe_copy, get_timestamp, CIMEError, run_and_log_case_status
 from CIME.test_status import *
 from CIME.hist_utils import *
 from CIME.provenance import save_test_time
@@ -528,9 +528,9 @@ class FakeTest(SystemTestsCommon):
     """
     def _set_script(self, script):
         self._script = script # pylint: disable=attribute-defined-outside-init
-
-    def build_phase(self, sharedlib_only=False, model_only=False):
-        if (not sharedlib_only):
+    
+    def _fake_case_build_impl(self, sharedlib_only=False, model_only=False):
+          if (not sharedlib_only):
             exeroot = self._case.get_value("EXEROOT")
             cime_model = self._case.get_value("MODEL")
             modelexe = os.path.join(exeroot, "{}.exe".format(cime_model))
@@ -542,6 +542,15 @@ class FakeTest(SystemTestsCommon):
             os.chmod(modelexe, 0o755)
 
             build.post_build(self._case, [], build_complete=True)
+   
+    def build_phase(self, sharedlib_only=False, model_only=False):
+        functor = lambda: self._fake_case_build_impl(sharedlib_only=False, model_only=False)
+        cb = "case.build"
+        if (sharedlib_only == True):
+            cb = cb + " (SHAREDLIB_BUILD)"
+        if (model_only == True):
+            cb = cb + " (MODEL_BUILD)"
+        return run_and_log_case_status(functor, cb, caseroot=self._case.get_value("CASEROOT"))
 
     def run_indv(self, suffix="base", st_archive=False):
         mpilib = self._case.get_value("MPILIB")
@@ -647,7 +656,7 @@ class TESTRUNSTARCFAIL(TESTRUNPASS):
 
 class TESTBUILDFAIL(TESTRUNPASS):
 
-    def build_phase(self, sharedlib_only=False, model_only=False):
+    def _fake_case_build_impl(self, sharedlib_only=False, model_only=False):
         if "TESTBUILDFAIL_PASS" in os.environ:
             TESTRUNPASS.build_phase(self, sharedlib_only, model_only)
         else:
@@ -658,6 +667,10 @@ class TESTBUILDFAIL(TESTRUNPASS):
                     fd.write("BUILD FAIL: Intentional fail for testing infrastructure")
 
                 expect(False, "BUILD FAIL: Intentional fail for testing infrastructure")
+
+    def build_phase(self, sharedlib_only=False, model_only=False):
+        functor    = lambda: self._fake_case_build_impl(sharedlib_only=False, model_only=False)
+        return run_and_log_case_status(functor, "case.build", caseroot=self._case.get_value("CASEROOT"))
 
 class TESTBUILDFAILEXC(FakeTest):
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -563,7 +563,12 @@ def case_build(caseroot, case, sharedlib_only=False, model_only=False, buildlist
 ###############################################################################
     functor = lambda: _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
                                        save_build_provenance)
-    return run_and_log_case_status(functor, "case.build", caseroot=caseroot)
+    cb = "case.build"
+    if (sharedlib_only == True):
+        cb = cb + " (SHAREDLIB_BUILD)"
+    if (model_only == True):
+        cb = cb + " (MODEL_BUILD)"
+    return run_and_log_case_status(functor, cb, caseroot=caseroot)
 
 ###############################################################################
 def clean(case, cleanlist=None, clean_all=False, clean_depends=None):

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -3,7 +3,7 @@ case_run is a member of Class Case
 '"""
 from CIME.XML.standard_module_setup import *
 from CIME.utils                     import gzip_existing_file, new_lid, run_and_log_case_status
-from CIME.utils                     import run_sub_or_cmd, append_status, safe_copy, model_log
+from CIME.utils                     import run_sub_or_cmd, append_status, safe_copy, model_log, CIMEError
 from CIME.get_timing                import get_timing
 from CIME.provenance                import save_prerun_provenance, save_postrun_provenance
 
@@ -109,13 +109,13 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
         model_log("e3sm", logger, "{} SAVE_PRERUN_PROVENANCE HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
 
         model_log("e3sm", logger, "{} MODEL EXECUTION BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
-        run_func = lambda: run_cmd_no_fail(cmd, from_dir=rundir)[0]
+        run_func = lambda: run_cmd_no_fail(cmd, from_dir=rundir)
         try:
             run_and_log_case_status(run_func, "model execution", caseroot=case.get_value("CASEROOT"))
             cmd_success = True
-        except BaseException:
+        except CIMEError:
             cmd_success = False
-            
+
         model_log("e3sm", logger, "{} MODEL EXECUTION HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
 
         model_logfile = os.path.join(rundir, model + ".log." + lid)


### PR DESCRIPTION
Fixed Misleading output in CaseStatus.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: [bit for bit]

Fixes #3073 

User interface changes?: N

Update gh-pages html (Y/N)?:

Code review: @jedwards4b