### PR TITLE
restore 2.1.1 behavior for JRA compsets

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -263,6 +263,14 @@
       <mask>tx0.1v3</mask>
     </model_grid>
 
+    <model_grid alias="TL319_g17" compset="DROF%JRA-1p4">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">gx1v7</grid>
+      <grid name="rof">JRA025v2</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
     <model_grid alias="TL319_g17" not_compset="_CAM">
       <grid name="atm">TL319</grid>
       <grid name="lnd">TL319</grid>
@@ -276,6 +284,13 @@
       <grid name="lnd">TL319</grid>
       <grid name="ocnice">tx0.1v2</grid>
       <grid name="rof">JRA025</grid>
+    </model_grid>
+
+    <model_grid alias="TL319_t13" compset="DROF%JRA-1p4">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">tx0.1v3</grid>
+      <grid name="rof">JRA025v2</grid>
     </model_grid>
 
     <model_grid alias="TL319_t13" not_compset="_CAM">
@@ -1451,6 +1466,11 @@
       <support>For experimental use by high resolution grids</support>
     </domain>
 
+    <domain name="JRA025v2">
+      <nx>1440</nx> <ny>720</ny>
+      <desc>JRA 0.25 degree runoff grid for use with JRA-55 runoff data</desc>
+    </domain>
+
     <domain name="JRA025">
       <nx>1440</nx> <ny>720</ny>
       <desc>JRA 0.25 degree runoff grid for use with JRA-55 runoff data</desc>
@@ -2094,17 +2114,25 @@
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r01_to_gx1v6_120711.nc</map>
     </gridmap>
 
-    <gridmap rof_grid="JRA025" ocn_grid="gx1v7" >
+    <gridmap rof_grid="JRA025v2" ocn_grid="gx1v7" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_gx1v7_nn_open_ocean_nnsm_e1000r300_marginal_sea_190214.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_gx1v7_e1000r300_190214.nc</map>
+    </gridmap>
+    <gridmap rof_grid="JRA025" ocn_grid="gx1v7" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_gx1v7_nn_open_ocean_nnsm_e1000r300_marginal_sea_170801.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_gx1v7_e1000r300_170801.nc</map>
     </gridmap>
     <gridmap rof_grid="JRA025" ocn_grid="tx0.1v2" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v2_e333r100_170619.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v2_e333r100_170619.nc</map>
     </gridmap>
-    <gridmap rof_grid="JRA025" ocn_grid="tx0.1v3" >
+    <gridmap rof_grid="JRA025v2" ocn_grid="tx0.1v3" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v3_nnsm_e333r100_190226.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v3_nnsm_e333r100_190226.nc</map>
+    </gridmap>
+    <gridmap rof_grid="JRA025" ocn_grid="tx0.1v3" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v3_e333r100_170830.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v3_e333r100_170830.nc</map>
     </gridmap>
 
     <!-- ======================================================== -->

--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -10,7 +10,7 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
@@ -21,6 +21,7 @@
     <desc option="NYF">COREv2 normal year forcing</desc>
     <desc option="IAF">COREv2 interannual forcing</desc>
     <desc option="JRA">interannual JRA55 forcing</desc>
+    <desc option="JRA-1p4-2018">interannual JRA55 forcing, v1.4, through 2018</desc>
   </description>
 
   <entry id="COMP_ATM">
@@ -34,7 +35,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CPLHIST,CORE_IAF_JRA</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -45,6 +46,7 @@
       <value compset="%NYF">CORE2_NYF</value>
       <value compset="%IAF">CORE2_IAF</value>
       <value compset="%JRA">CORE_IAF_JRA</value>
+      <value compset="%JRA-1p4-2018">CORE_IAF_JRA_1p4_2018</value>
       <value compset="%QIA">CLM_QIAN</value>
       <value compset="%WISOQIA">CLM_QIAN_WISO</value>
       <value compset="%CRU">CLMCRUNCEP</value>

--- a/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -39,7 +39,8 @@
     CLM1PT		= Run with supplied single point data (force CLM)
     CORE2_NYF		= CORE2 normal year forcing (for forcing POP and CICE)
     CORE2_IAF		= CORE2 intra-annual year forcing (for forcing POP and CICE)
-    CORE_IAF_JRA		= JRA55 intra-annual year forcing (for forcing POP and CICE)
+    CORE_IAF_JRA	= JRA55 intra-annual year forcing (for forcing POP and CICE)
+    CORE_IAF_JRA_1p4_2018 = JRA55 intra-annual year forcing, v1.4, through 2018 (for forcing POP and CICE)
     CPLHIST     	= Streams for lnd or ocn/ice forcing used for spinup
     presaero		= Prescribed aerosol forcing
     topo		= Surface topography
@@ -191,6 +192,7 @@
       <value datm_mode="CLMGSWP3v1">CLMGSWP3v1.Solar,CLMGSWP3v1.Precip,CLMGSWP3v1.TPQW</value>
       <value datm_mode="CORE2_NYF" >CORE2_NYF.GISS,CORE2_NYF.GXGXS,CORE2_NYF.NCEP</value>
       <value datm_mode="CORE2_IAF" >CORE2_IAF.GCGCS.PREC,CORE2_IAF.GISS.LWDN,CORE2_IAF.GISS.SWDN,CORE2_IAF.GISS.SWUP,CORE2_IAF.NCEP.DN10,CORE2_IAF.NCEP.Q_10,CORE2_IAF.NCEP.SLP_,CORE2_IAF.NCEP.T_10,CORE2_IAF.NCEP.U_10,CORE2_IAF.NCEP.V_10,CORE2_IAF.CORE2.ArcFactor</value>
+      <value datm_mode="CORE_IAF_JRA_1p4_2018" >CORE_IAF_JRA_1p4_2018.GCGCS.PREC,CORE_IAF_JRA_1p4_2018.GISS.LWDN,CORE_IAF_JRA_1p4_2018.GISS.SWDN,CORE_IAF_JRA_1p4_2018.NCEP.Q_10,CORE_IAF_JRA_1p4_2018.NCEP.SLP_,CORE_IAF_JRA_1p4_2018.NCEP.T_10,CORE_IAF_JRA_1p4_2018.NCEP.U_10,CORE_IAF_JRA_1p4_2018.NCEP.V_10</value>
       <value datm_mode="CORE_IAF_JRA" >CORE_IAF_JRA.GCGCS.PREC,CORE_IAF_JRA.GISS.LWDN,CORE_IAF_JRA.GISS.SWDN,CORE_IAF_JRA.NCEP.Q_10,CORE_IAF_JRA.NCEP.SLP_,CORE_IAF_JRA.NCEP.T_10,CORE_IAF_JRA.NCEP.U_10,CORE_IAF_JRA.NCEP.V_10</value>
       <value datm_mode="CORE2_IAF" atm_grid="01col" >CORE2_IAF.NCEP.DENS.SOFS,CORE2_IAF.NCEP.PSLV.SOFS,CORE2_IAF.PREC.SOFS.DAILY,CORE2_IAF.LWDN.SOFS.DAILY,CORE2_IAF.SWDN.SOFS.DAILY,CORE2_IAF.SWUP.SOFS.DAILY,CORE2_IAF.SHUM.SOFS.6HOUR,CORE2_IAF.TBOT.SOFS.6HOUR,CORE2_IAF.U.SOFS.6HOUR,CORE2_IAF.V.SOFS.6HOUR,CORE2_IAF.CORE2.ArcFactor</value>
       <value datm_mode="CPLHIST">CPLHISTForcing.Solar,CPLHISTForcing.nonSolarFlux,CPLHISTForcing.State3hr,CPLHISTForcing.State1hr</value>
@@ -236,14 +238,7 @@
       <value stream="CORE2_IAF.NCEP.T_10">$DIN_LOC_ROOT/atm/datm7</value>
       <value stream="CORE2_IAF.NCEP.U_10">$DIN_LOC_ROOT/atm/datm7</value>
       <value stream="CORE2_IAF.NCEP.V_10">$DIN_LOC_ROOT/atm/datm7</value>
-      <value stream="CORE_IAF_JRA.GCGCS.PREC">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
-      <value stream="CORE_IAF_JRA.GISS.LWDN">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
-      <value stream="CORE_IAF_JRA.GISS.SWDN">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
-      <value stream="CORE_IAF_JRA.NCEP.Q_10">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
-      <value stream="CORE_IAF_JRA.NCEP.SLP_">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
-      <value stream="CORE_IAF_JRA.NCEP.T_10">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
-      <value stream="CORE_IAF_JRA.NCEP.U_10">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
-      <value stream="CORE_IAF_JRA.NCEP.V_10">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
+      <value stream="CORE_IAF_JRA.*">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
       <value stream="co2tseries">$DIN_LOC_ROOT/atm/datm7/CO2 </value>
       <value stream="BC.QIAN.Precip">$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/gpcp/qian</value>
       <value stream="BC.CRUNCEP.GPCP.Precip">$DIN_LOC_ROOT/atm/datm7/clm_output/cruncep_precip_1deg/gpcp_1deg_bias_correction</value>
@@ -304,14 +299,7 @@
       <value stream="CORE2_IAF.NCEP.U_10">domain.T62.050609.nc</value>
       <value stream="CORE2_IAF.NCEP.V_10">domain.T62.050609.nc</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">CORE2.t_10.ArcFactor.T62.1997-2004.nc</value>
-      <value stream="CORE_IAF_JRA.GCGCS.PREC">domain.atm.TL319.151007.nc</value>
-      <value stream="CORE_IAF_JRA.GISS.LWDN">domain.atm.TL319.151007.nc</value>
-      <value stream="CORE_IAF_JRA.GISS.SWDN">domain.atm.TL319.151007.nc</value>
-      <value stream="CORE_IAF_JRA.NCEP.Q_10">domain.atm.TL319.151007.nc</value>
-      <value stream="CORE_IAF_JRA.NCEP.SLP_">domain.atm.TL319.151007.nc</value>
-      <value stream="CORE_IAF_JRA.NCEP.T_10">domain.atm.TL319.151007.nc</value>
-      <value stream="CORE_IAF_JRA.NCEP.U_10">domain.atm.TL319.151007.nc</value>
-      <value stream="CORE_IAF_JRA.NCEP.V_10">domain.atm.TL319.151007.nc</value>
+      <value stream="CORE_IAF_JRA.*">domain.atm.TL319.151007.nc</value>
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.omip">fco2_datm_global_ssp585_simyr_1750-2020_CMIP6_c190522.nc</value>
@@ -448,14 +436,7 @@
       <value stream="CORE2_NYF">$DIN_LOC_ROOT/atm/datm7/NYF</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">$DIN_LOC_ROOT/atm/datm7/CORE2</value>
       <value stream="CORE2_IAF">$DIN_LOC_ROOT/ocn/iaf</value>
-      <value stream="CORE_IAF_JRA.GCGCS.PREC">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
-      <value stream="CORE_IAF_JRA.GISS.LWDN">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
-      <value stream="CORE_IAF_JRA.GISS.SWDN">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
-      <value stream="CORE_IAF_JRA.NCEP.Q_10">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
-      <value stream="CORE_IAF_JRA.NCEP.SLP_">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
-      <value stream="CORE_IAF_JRA.NCEP.T_10">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
-      <value stream="CORE_IAF_JRA.NCEP.U_10">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
-      <value stream="CORE_IAF_JRA.NCEP.V_10">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
+      <value stream="CORE_IAF_JRA.*">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
       <value stream="co2tseries">$DIN_LOC_ROOT/atm/datm7/CO2</value>
       <value stream="BC.QIAN.Precip">$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/gpcp/qian</value>
       <value stream="BC.CRUNCEP.GPCP.Precip">$DIN_LOC_ROOT/atm/datm7/clm_output/cruncep_precip_1deg/gpcp_1deg_bias_correction</value>
@@ -1175,6 +1156,67 @@
       </value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">CORE2.t_10.ArcFactor.T62.1997-2004.nc</value>
       <value  stream="CORE_IAF_JRA.GCGCS.PREC">
+        JRA.v1.3.prec.TL319.1958.171019.nc
+        JRA.v1.3.prec.TL319.1959.171019.nc
+        JRA.v1.3.prec.TL319.1960.171019.nc
+        JRA.v1.3.prec.TL319.1961.171019.nc
+        JRA.v1.3.prec.TL319.1962.171019.nc
+        JRA.v1.3.prec.TL319.1963.171019.nc
+        JRA.v1.3.prec.TL319.1964.171019.nc
+        JRA.v1.3.prec.TL319.1965.171019.nc
+        JRA.v1.3.prec.TL319.1966.171019.nc
+        JRA.v1.3.prec.TL319.1967.171019.nc
+        JRA.v1.3.prec.TL319.1968.171019.nc
+        JRA.v1.3.prec.TL319.1969.171019.nc
+        JRA.v1.3.prec.TL319.1970.171019.nc
+        JRA.v1.3.prec.TL319.1971.171019.nc
+        JRA.v1.3.prec.TL319.1972.171019.nc
+        JRA.v1.3.prec.TL319.1973.171019.nc
+        JRA.v1.3.prec.TL319.1974.171019.nc
+        JRA.v1.3.prec.TL319.1975.171019.nc
+        JRA.v1.3.prec.TL319.1976.171019.nc
+        JRA.v1.3.prec.TL319.1977.171019.nc
+        JRA.v1.3.prec.TL319.1978.171019.nc
+        JRA.v1.3.prec.TL319.1979.171019.nc
+        JRA.v1.3.prec.TL319.1980.171019.nc
+        JRA.v1.3.prec.TL319.1981.171019.nc
+        JRA.v1.3.prec.TL319.1982.171019.nc
+        JRA.v1.3.prec.TL319.1983.171019.nc
+        JRA.v1.3.prec.TL319.1984.171019.nc
+        JRA.v1.3.prec.TL319.1985.171019.nc
+        JRA.v1.3.prec.TL319.1986.171019.nc
+        JRA.v1.3.prec.TL319.1987.171019.nc
+        JRA.v1.3.prec.TL319.1988.171019.nc
+        JRA.v1.3.prec.TL319.1989.171019.nc
+        JRA.v1.3.prec.TL319.1990.171019.nc
+        JRA.v1.3.prec.TL319.1991.171019.nc
+        JRA.v1.3.prec.TL319.1992.171019.nc
+        JRA.v1.3.prec.TL319.1993.171019.nc
+        JRA.v1.3.prec.TL319.1994.171019.nc
+        JRA.v1.3.prec.TL319.1995.171019.nc
+        JRA.v1.3.prec.TL319.1996.171019.nc
+        JRA.v1.3.prec.TL319.1997.171019.nc
+        JRA.v1.3.prec.TL319.1998.171019.nc
+        JRA.v1.3.prec.TL319.1999.171019.nc
+        JRA.v1.3.prec.TL319.2000.171019.nc
+        JRA.v1.3.prec.TL319.2001.171019.nc
+        JRA.v1.3.prec.TL319.2002.171019.nc
+        JRA.v1.3.prec.TL319.2003.171019.nc
+        JRA.v1.3.prec.TL319.2004.171019.nc
+        JRA.v1.3.prec.TL319.2005.171019.nc
+        JRA.v1.3.prec.TL319.2006.171019.nc
+        JRA.v1.3.prec.TL319.2007.171019.nc
+        JRA.v1.3.prec.TL319.2008.171019.nc
+        JRA.v1.3.prec.TL319.2009.171019.nc
+        JRA.v1.3.prec.TL319.2010.171019.nc
+        JRA.v1.3.prec.TL319.2011.171019.nc
+        JRA.v1.3.prec.TL319.2012.171019.nc
+        JRA.v1.3.prec.TL319.2013.171019.nc
+        JRA.v1.3.prec.TL319.2014.171019.nc
+        JRA.v1.3.prec.TL319.2015.171019.nc
+        JRA.v1.3.prec.TL319.2016.171019.nc
+      </value>
+      <value  stream="CORE_IAF_JRA_1p4_2018.GCGCS.PREC">
         JRA.v1.3.prec.TL319.1958.190528.nc
         JRA.v1.3.prec.TL319.1959.190528.nc
         JRA.v1.3.prec.TL319.1960.190528.nc
@@ -1238,6 +1280,67 @@
         JRA.v1.3.prec.TL319.2018.190528.nc
       </value>
       <value  stream="CORE_IAF_JRA.GISS.LWDN">
+        JRA.v1.3.lwdn.TL319.1958.171019.nc
+        JRA.v1.3.lwdn.TL319.1959.171019.nc
+        JRA.v1.3.lwdn.TL319.1960.171019.nc
+        JRA.v1.3.lwdn.TL319.1961.171019.nc
+        JRA.v1.3.lwdn.TL319.1962.171019.nc
+        JRA.v1.3.lwdn.TL319.1963.171019.nc
+        JRA.v1.3.lwdn.TL319.1964.171019.nc
+        JRA.v1.3.lwdn.TL319.1965.171019.nc
+        JRA.v1.3.lwdn.TL319.1966.171019.nc
+        JRA.v1.3.lwdn.TL319.1967.171019.nc
+        JRA.v1.3.lwdn.TL319.1968.171019.nc
+        JRA.v1.3.lwdn.TL319.1969.171019.nc
+        JRA.v1.3.lwdn.TL319.1970.171019.nc
+        JRA.v1.3.lwdn.TL319.1971.171019.nc
+        JRA.v1.3.lwdn.TL319.1972.171019.nc
+        JRA.v1.3.lwdn.TL319.1973.171019.nc
+        JRA.v1.3.lwdn.TL319.1974.171019.nc
+        JRA.v1.3.lwdn.TL319.1975.171019.nc
+        JRA.v1.3.lwdn.TL319.1976.171019.nc
+        JRA.v1.3.lwdn.TL319.1977.171019.nc
+        JRA.v1.3.lwdn.TL319.1978.171019.nc
+        JRA.v1.3.lwdn.TL319.1979.171019.nc
+        JRA.v1.3.lwdn.TL319.1980.171019.nc
+        JRA.v1.3.lwdn.TL319.1981.171019.nc
+        JRA.v1.3.lwdn.TL319.1982.171019.nc
+        JRA.v1.3.lwdn.TL319.1983.171019.nc
+        JRA.v1.3.lwdn.TL319.1984.171019.nc
+        JRA.v1.3.lwdn.TL319.1985.171019.nc
+        JRA.v1.3.lwdn.TL319.1986.171019.nc
+        JRA.v1.3.lwdn.TL319.1987.171019.nc
+        JRA.v1.3.lwdn.TL319.1988.171019.nc
+        JRA.v1.3.lwdn.TL319.1989.171019.nc
+        JRA.v1.3.lwdn.TL319.1990.171019.nc
+        JRA.v1.3.lwdn.TL319.1991.171019.nc
+        JRA.v1.3.lwdn.TL319.1992.171019.nc
+        JRA.v1.3.lwdn.TL319.1993.171019.nc
+        JRA.v1.3.lwdn.TL319.1994.171019.nc
+        JRA.v1.3.lwdn.TL319.1995.171019.nc
+        JRA.v1.3.lwdn.TL319.1996.171019.nc
+        JRA.v1.3.lwdn.TL319.1997.171019.nc
+        JRA.v1.3.lwdn.TL319.1998.171019.nc
+        JRA.v1.3.lwdn.TL319.1999.171019.nc
+        JRA.v1.3.lwdn.TL319.2000.171019.nc
+        JRA.v1.3.lwdn.TL319.2001.171019.nc
+        JRA.v1.3.lwdn.TL319.2002.171019.nc
+        JRA.v1.3.lwdn.TL319.2003.171019.nc
+        JRA.v1.3.lwdn.TL319.2004.171019.nc
+        JRA.v1.3.lwdn.TL319.2005.171019.nc
+        JRA.v1.3.lwdn.TL319.2006.171019.nc
+        JRA.v1.3.lwdn.TL319.2007.171019.nc
+        JRA.v1.3.lwdn.TL319.2008.171019.nc
+        JRA.v1.3.lwdn.TL319.2009.171019.nc
+        JRA.v1.3.lwdn.TL319.2010.171019.nc
+        JRA.v1.3.lwdn.TL319.2011.171019.nc
+        JRA.v1.3.lwdn.TL319.2012.171019.nc
+        JRA.v1.3.lwdn.TL319.2013.171019.nc
+        JRA.v1.3.lwdn.TL319.2014.171019.nc
+        JRA.v1.3.lwdn.TL319.2015.171019.nc
+        JRA.v1.3.lwdn.TL319.2016.171019.nc
+      </value>
+      <value  stream="CORE_IAF_JRA_1p4_2018.GISS.LWDN">
         JRA.v1.3.lwdn.TL319.1958.190528.nc
         JRA.v1.3.lwdn.TL319.1959.190528.nc
         JRA.v1.3.lwdn.TL319.1960.190528.nc
@@ -1301,6 +1404,67 @@
         JRA.v1.3.lwdn.TL319.2018.190528.nc
       </value>
       <value  stream="CORE_IAF_JRA.GISS.SWDN">
+        JRA.v1.3.swdn.TL319.1958.171019.nc
+        JRA.v1.3.swdn.TL319.1959.171019.nc
+        JRA.v1.3.swdn.TL319.1960.171019.nc
+        JRA.v1.3.swdn.TL319.1961.171019.nc
+        JRA.v1.3.swdn.TL319.1962.171019.nc
+        JRA.v1.3.swdn.TL319.1963.171019.nc
+        JRA.v1.3.swdn.TL319.1964.171019.nc
+        JRA.v1.3.swdn.TL319.1965.171019.nc
+        JRA.v1.3.swdn.TL319.1966.171019.nc
+        JRA.v1.3.swdn.TL319.1967.171019.nc
+        JRA.v1.3.swdn.TL319.1968.171019.nc
+        JRA.v1.3.swdn.TL319.1969.171019.nc
+        JRA.v1.3.swdn.TL319.1970.171019.nc
+        JRA.v1.3.swdn.TL319.1971.171019.nc
+        JRA.v1.3.swdn.TL319.1972.171019.nc
+        JRA.v1.3.swdn.TL319.1973.171019.nc
+        JRA.v1.3.swdn.TL319.1974.171019.nc
+        JRA.v1.3.swdn.TL319.1975.171019.nc
+        JRA.v1.3.swdn.TL319.1976.171019.nc
+        JRA.v1.3.swdn.TL319.1977.171019.nc
+        JRA.v1.3.swdn.TL319.1978.171019.nc
+        JRA.v1.3.swdn.TL319.1979.171019.nc
+        JRA.v1.3.swdn.TL319.1980.171019.nc
+        JRA.v1.3.swdn.TL319.1981.171019.nc
+        JRA.v1.3.swdn.TL319.1982.171019.nc
+        JRA.v1.3.swdn.TL319.1983.171019.nc
+        JRA.v1.3.swdn.TL319.1984.171019.nc
+        JRA.v1.3.swdn.TL319.1985.171019.nc
+        JRA.v1.3.swdn.TL319.1986.171019.nc
+        JRA.v1.3.swdn.TL319.1987.171019.nc
+        JRA.v1.3.swdn.TL319.1988.171019.nc
+        JRA.v1.3.swdn.TL319.1989.171019.nc
+        JRA.v1.3.swdn.TL319.1990.171019.nc
+        JRA.v1.3.swdn.TL319.1991.171019.nc
+        JRA.v1.3.swdn.TL319.1992.171019.nc
+        JRA.v1.3.swdn.TL319.1993.171019.nc
+        JRA.v1.3.swdn.TL319.1994.171019.nc
+        JRA.v1.3.swdn.TL319.1995.171019.nc
+        JRA.v1.3.swdn.TL319.1996.171019.nc
+        JRA.v1.3.swdn.TL319.1997.171019.nc
+        JRA.v1.3.swdn.TL319.1998.171019.nc
+        JRA.v1.3.swdn.TL319.1999.171019.nc
+        JRA.v1.3.swdn.TL319.2000.171019.nc
+        JRA.v1.3.swdn.TL319.2001.171019.nc
+        JRA.v1.3.swdn.TL319.2002.171019.nc
+        JRA.v1.3.swdn.TL319.2003.171019.nc
+        JRA.v1.3.swdn.TL319.2004.171019.nc
+        JRA.v1.3.swdn.TL319.2005.171019.nc
+        JRA.v1.3.swdn.TL319.2006.171019.nc
+        JRA.v1.3.swdn.TL319.2007.171019.nc
+        JRA.v1.3.swdn.TL319.2008.171019.nc
+        JRA.v1.3.swdn.TL319.2009.171019.nc
+        JRA.v1.3.swdn.TL319.2010.171019.nc
+        JRA.v1.3.swdn.TL319.2011.171019.nc
+        JRA.v1.3.swdn.TL319.2012.171019.nc
+        JRA.v1.3.swdn.TL319.2013.171019.nc
+        JRA.v1.3.swdn.TL319.2014.171019.nc
+        JRA.v1.3.swdn.TL319.2015.171019.nc
+        JRA.v1.3.swdn.TL319.2016.171019.nc
+      </value>
+      <value  stream="CORE_IAF_JRA_1p4_2018.GISS.SWDN">
         JRA.v1.3.swdn.TL319.1958.190528.nc
         JRA.v1.3.swdn.TL319.1959.190528.nc
         JRA.v1.3.swdn.TL319.1960.190528.nc
@@ -1364,6 +1528,67 @@
         JRA.v1.3.swdn.TL319.2018.190528.nc
       </value>
       <value  stream="CORE_IAF_JRA.NCEP.Q_10">
+        JRA.v1.3.q_10.TL319.1958.171019.nc
+        JRA.v1.3.q_10.TL319.1959.171019.nc
+        JRA.v1.3.q_10.TL319.1960.171019.nc
+        JRA.v1.3.q_10.TL319.1961.171019.nc
+        JRA.v1.3.q_10.TL319.1962.171019.nc
+        JRA.v1.3.q_10.TL319.1963.171019.nc
+        JRA.v1.3.q_10.TL319.1964.171019.nc
+        JRA.v1.3.q_10.TL319.1965.171019.nc
+        JRA.v1.3.q_10.TL319.1966.171019.nc
+        JRA.v1.3.q_10.TL319.1967.171019.nc
+        JRA.v1.3.q_10.TL319.1968.171019.nc
+        JRA.v1.3.q_10.TL319.1969.171019.nc
+        JRA.v1.3.q_10.TL319.1970.171019.nc
+        JRA.v1.3.q_10.TL319.1971.171019.nc
+        JRA.v1.3.q_10.TL319.1972.171019.nc
+        JRA.v1.3.q_10.TL319.1973.171019.nc
+        JRA.v1.3.q_10.TL319.1974.171019.nc
+        JRA.v1.3.q_10.TL319.1975.171019.nc
+        JRA.v1.3.q_10.TL319.1976.171019.nc
+        JRA.v1.3.q_10.TL319.1977.171019.nc
+        JRA.v1.3.q_10.TL319.1978.171019.nc
+        JRA.v1.3.q_10.TL319.1979.171019.nc
+        JRA.v1.3.q_10.TL319.1980.171019.nc
+        JRA.v1.3.q_10.TL319.1981.171019.nc
+        JRA.v1.3.q_10.TL319.1982.171019.nc
+        JRA.v1.3.q_10.TL319.1983.171019.nc
+        JRA.v1.3.q_10.TL319.1984.171019.nc
+        JRA.v1.3.q_10.TL319.1985.171019.nc
+        JRA.v1.3.q_10.TL319.1986.171019.nc
+        JRA.v1.3.q_10.TL319.1987.171019.nc
+        JRA.v1.3.q_10.TL319.1988.171019.nc
+        JRA.v1.3.q_10.TL319.1989.171019.nc
+        JRA.v1.3.q_10.TL319.1990.171019.nc
+        JRA.v1.3.q_10.TL319.1991.171019.nc
+        JRA.v1.3.q_10.TL319.1992.171019.nc
+        JRA.v1.3.q_10.TL319.1993.171019.nc
+        JRA.v1.3.q_10.TL319.1994.171019.nc
+        JRA.v1.3.q_10.TL319.1995.171019.nc
+        JRA.v1.3.q_10.TL319.1996.171019.nc
+        JRA.v1.3.q_10.TL319.1997.171019.nc
+        JRA.v1.3.q_10.TL319.1998.171019.nc
+        JRA.v1.3.q_10.TL319.1999.171019.nc
+        JRA.v1.3.q_10.TL319.2000.171019.nc
+        JRA.v1.3.q_10.TL319.2001.171019.nc
+        JRA.v1.3.q_10.TL319.2002.171019.nc
+        JRA.v1.3.q_10.TL319.2003.171019.nc
+        JRA.v1.3.q_10.TL319.2004.171019.nc
+        JRA.v1.3.q_10.TL319.2005.171019.nc
+        JRA.v1.3.q_10.TL319.2006.171019.nc
+        JRA.v1.3.q_10.TL319.2007.171019.nc
+        JRA.v1.3.q_10.TL319.2008.171019.nc
+        JRA.v1.3.q_10.TL319.2009.171019.nc
+        JRA.v1.3.q_10.TL319.2010.171019.nc
+        JRA.v1.3.q_10.TL319.2011.171019.nc
+        JRA.v1.3.q_10.TL319.2012.171019.nc
+        JRA.v1.3.q_10.TL319.2013.171019.nc
+        JRA.v1.3.q_10.TL319.2014.171019.nc
+        JRA.v1.3.q_10.TL319.2015.171019.nc
+        JRA.v1.3.q_10.TL319.2016.171019.nc
+      </value>
+      <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.Q_10">
         JRA.v1.3.q_10.TL319.1958.190528.nc
         JRA.v1.3.q_10.TL319.1959.190528.nc
         JRA.v1.3.q_10.TL319.1960.190528.nc
@@ -1427,6 +1652,67 @@
         JRA.v1.3.q_10.TL319.2018.190528.nc
       </value> 
       <value  stream="CORE_IAF_JRA.NCEP.SLP_">
+        JRA.v1.3.slp.TL319.1958.171019.nc
+        JRA.v1.3.slp.TL319.1959.171019.nc
+        JRA.v1.3.slp.TL319.1960.171019.nc
+        JRA.v1.3.slp.TL319.1961.171019.nc
+        JRA.v1.3.slp.TL319.1962.171019.nc
+        JRA.v1.3.slp.TL319.1963.171019.nc
+        JRA.v1.3.slp.TL319.1964.171019.nc
+        JRA.v1.3.slp.TL319.1965.171019.nc
+        JRA.v1.3.slp.TL319.1966.171019.nc
+        JRA.v1.3.slp.TL319.1967.171019.nc
+        JRA.v1.3.slp.TL319.1968.171019.nc
+        JRA.v1.3.slp.TL319.1969.171019.nc
+        JRA.v1.3.slp.TL319.1970.171019.nc
+        JRA.v1.3.slp.TL319.1971.171019.nc
+        JRA.v1.3.slp.TL319.1972.171019.nc
+        JRA.v1.3.slp.TL319.1973.171019.nc
+        JRA.v1.3.slp.TL319.1974.171019.nc
+        JRA.v1.3.slp.TL319.1975.171019.nc
+        JRA.v1.3.slp.TL319.1976.171019.nc
+        JRA.v1.3.slp.TL319.1977.171019.nc
+        JRA.v1.3.slp.TL319.1978.171019.nc
+        JRA.v1.3.slp.TL319.1979.171019.nc
+        JRA.v1.3.slp.TL319.1980.171019.nc
+        JRA.v1.3.slp.TL319.1981.171019.nc
+        JRA.v1.3.slp.TL319.1982.171019.nc
+        JRA.v1.3.slp.TL319.1983.171019.nc
+        JRA.v1.3.slp.TL319.1984.171019.nc
+        JRA.v1.3.slp.TL319.1985.171019.nc
+        JRA.v1.3.slp.TL319.1986.171019.nc
+        JRA.v1.3.slp.TL319.1987.171019.nc
+        JRA.v1.3.slp.TL319.1988.171019.nc
+        JRA.v1.3.slp.TL319.1989.171019.nc
+        JRA.v1.3.slp.TL319.1990.171019.nc
+        JRA.v1.3.slp.TL319.1991.171019.nc
+        JRA.v1.3.slp.TL319.1992.171019.nc
+        JRA.v1.3.slp.TL319.1993.171019.nc
+        JRA.v1.3.slp.TL319.1994.171019.nc
+        JRA.v1.3.slp.TL319.1995.171019.nc
+        JRA.v1.3.slp.TL319.1996.171019.nc
+        JRA.v1.3.slp.TL319.1997.171019.nc
+        JRA.v1.3.slp.TL319.1998.171019.nc
+        JRA.v1.3.slp.TL319.1999.171019.nc
+        JRA.v1.3.slp.TL319.2000.171019.nc
+        JRA.v1.3.slp.TL319.2001.171019.nc
+        JRA.v1.3.slp.TL319.2002.171019.nc
+        JRA.v1.3.slp.TL319.2003.171019.nc
+        JRA.v1.3.slp.TL319.2004.171019.nc
+        JRA.v1.3.slp.TL319.2005.171019.nc
+        JRA.v1.3.slp.TL319.2006.171019.nc
+        JRA.v1.3.slp.TL319.2007.171019.nc
+        JRA.v1.3.slp.TL319.2008.171019.nc
+        JRA.v1.3.slp.TL319.2009.171019.nc
+        JRA.v1.3.slp.TL319.2010.171019.nc
+        JRA.v1.3.slp.TL319.2011.171019.nc
+        JRA.v1.3.slp.TL319.2012.171019.nc
+        JRA.v1.3.slp.TL319.2013.171019.nc
+        JRA.v1.3.slp.TL319.2014.171019.nc
+        JRA.v1.3.slp.TL319.2015.171019.nc
+        JRA.v1.3.slp.TL319.2016.171019.nc
+      </value> 
+      <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.SLP_">
         JRA.v1.3.slp.TL319.1958.190528.nc
         JRA.v1.3.slp.TL319.1959.190528.nc
         JRA.v1.3.slp.TL319.1960.190528.nc
@@ -1490,6 +1776,67 @@
         JRA.v1.3.slp.TL319.2018.190528.nc
       </value> 
       <value  stream="CORE_IAF_JRA.NCEP.T_10">
+        JRA.v1.3.t_10.TL319.1958.171019.nc
+        JRA.v1.3.t_10.TL319.1959.171019.nc
+        JRA.v1.3.t_10.TL319.1960.171019.nc
+        JRA.v1.3.t_10.TL319.1961.171019.nc
+        JRA.v1.3.t_10.TL319.1962.171019.nc
+        JRA.v1.3.t_10.TL319.1963.171019.nc
+        JRA.v1.3.t_10.TL319.1964.171019.nc
+        JRA.v1.3.t_10.TL319.1965.171019.nc
+        JRA.v1.3.t_10.TL319.1966.171019.nc
+        JRA.v1.3.t_10.TL319.1967.171019.nc
+        JRA.v1.3.t_10.TL319.1968.171019.nc
+        JRA.v1.3.t_10.TL319.1969.171019.nc
+        JRA.v1.3.t_10.TL319.1970.171019.nc
+        JRA.v1.3.t_10.TL319.1971.171019.nc
+        JRA.v1.3.t_10.TL319.1972.171019.nc
+        JRA.v1.3.t_10.TL319.1973.171019.nc
+        JRA.v1.3.t_10.TL319.1974.171019.nc
+        JRA.v1.3.t_10.TL319.1975.171019.nc
+        JRA.v1.3.t_10.TL319.1976.171019.nc
+        JRA.v1.3.t_10.TL319.1977.171019.nc
+        JRA.v1.3.t_10.TL319.1978.171019.nc
+        JRA.v1.3.t_10.TL319.1979.171019.nc
+        JRA.v1.3.t_10.TL319.1980.171019.nc
+        JRA.v1.3.t_10.TL319.1981.171019.nc
+        JRA.v1.3.t_10.TL319.1982.171019.nc
+        JRA.v1.3.t_10.TL319.1983.171019.nc
+        JRA.v1.3.t_10.TL319.1984.171019.nc
+        JRA.v1.3.t_10.TL319.1985.171019.nc
+        JRA.v1.3.t_10.TL319.1986.171019.nc
+        JRA.v1.3.t_10.TL319.1987.171019.nc
+        JRA.v1.3.t_10.TL319.1988.171019.nc
+        JRA.v1.3.t_10.TL319.1989.171019.nc
+        JRA.v1.3.t_10.TL319.1990.171019.nc
+        JRA.v1.3.t_10.TL319.1991.171019.nc
+        JRA.v1.3.t_10.TL319.1992.171019.nc
+        JRA.v1.3.t_10.TL319.1993.171019.nc
+        JRA.v1.3.t_10.TL319.1994.171019.nc
+        JRA.v1.3.t_10.TL319.1995.171019.nc
+        JRA.v1.3.t_10.TL319.1996.171019.nc
+        JRA.v1.3.t_10.TL319.1997.171019.nc
+        JRA.v1.3.t_10.TL319.1998.171019.nc
+        JRA.v1.3.t_10.TL319.1999.171019.nc
+        JRA.v1.3.t_10.TL319.2000.171019.nc
+        JRA.v1.3.t_10.TL319.2001.171019.nc
+        JRA.v1.3.t_10.TL319.2002.171019.nc
+        JRA.v1.3.t_10.TL319.2003.171019.nc
+        JRA.v1.3.t_10.TL319.2004.171019.nc
+        JRA.v1.3.t_10.TL319.2005.171019.nc
+        JRA.v1.3.t_10.TL319.2006.171019.nc
+        JRA.v1.3.t_10.TL319.2007.171019.nc
+        JRA.v1.3.t_10.TL319.2008.171019.nc
+        JRA.v1.3.t_10.TL319.2009.171019.nc
+        JRA.v1.3.t_10.TL319.2010.171019.nc
+        JRA.v1.3.t_10.TL319.2011.171019.nc
+        JRA.v1.3.t_10.TL319.2012.171019.nc
+        JRA.v1.3.t_10.TL319.2013.171019.nc
+        JRA.v1.3.t_10.TL319.2014.171019.nc
+        JRA.v1.3.t_10.TL319.2015.171019.nc
+        JRA.v1.3.t_10.TL319.2016.171019.nc
+      </value> 
+      <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.T_10">
         JRA.v1.3.t_10.TL319.1958.190528.nc
         JRA.v1.3.t_10.TL319.1959.190528.nc
         JRA.v1.3.t_10.TL319.1960.190528.nc
@@ -1553,6 +1900,67 @@
         JRA.v1.3.t_10.TL319.2018.190528.nc
       </value> 
       <value  stream="CORE_IAF_JRA.NCEP.U_10">
+        JRA.v1.3.u_10.TL319.1958.171019.nc
+        JRA.v1.3.u_10.TL319.1959.171019.nc
+        JRA.v1.3.u_10.TL319.1960.171019.nc
+        JRA.v1.3.u_10.TL319.1961.171019.nc
+        JRA.v1.3.u_10.TL319.1962.171019.nc
+        JRA.v1.3.u_10.TL319.1963.171019.nc
+        JRA.v1.3.u_10.TL319.1964.171019.nc
+        JRA.v1.3.u_10.TL319.1965.171019.nc
+        JRA.v1.3.u_10.TL319.1966.171019.nc
+        JRA.v1.3.u_10.TL319.1967.171019.nc
+        JRA.v1.3.u_10.TL319.1968.171019.nc
+        JRA.v1.3.u_10.TL319.1969.171019.nc
+        JRA.v1.3.u_10.TL319.1970.171019.nc
+        JRA.v1.3.u_10.TL319.1971.171019.nc
+        JRA.v1.3.u_10.TL319.1972.171019.nc
+        JRA.v1.3.u_10.TL319.1973.171019.nc
+        JRA.v1.3.u_10.TL319.1974.171019.nc
+        JRA.v1.3.u_10.TL319.1975.171019.nc
+        JRA.v1.3.u_10.TL319.1976.171019.nc
+        JRA.v1.3.u_10.TL319.1977.171019.nc
+        JRA.v1.3.u_10.TL319.1978.171019.nc
+        JRA.v1.3.u_10.TL319.1979.171019.nc
+        JRA.v1.3.u_10.TL319.1980.171019.nc
+        JRA.v1.3.u_10.TL319.1981.171019.nc
+        JRA.v1.3.u_10.TL319.1982.171019.nc
+        JRA.v1.3.u_10.TL319.1983.171019.nc
+        JRA.v1.3.u_10.TL319.1984.171019.nc
+        JRA.v1.3.u_10.TL319.1985.171019.nc
+        JRA.v1.3.u_10.TL319.1986.171019.nc
+        JRA.v1.3.u_10.TL319.1987.171019.nc
+        JRA.v1.3.u_10.TL319.1988.171019.nc
+        JRA.v1.3.u_10.TL319.1989.171019.nc
+        JRA.v1.3.u_10.TL319.1990.171019.nc
+        JRA.v1.3.u_10.TL319.1991.171019.nc
+        JRA.v1.3.u_10.TL319.1992.171019.nc
+        JRA.v1.3.u_10.TL319.1993.171019.nc
+        JRA.v1.3.u_10.TL319.1994.171019.nc
+        JRA.v1.3.u_10.TL319.1995.171019.nc
+        JRA.v1.3.u_10.TL319.1996.171019.nc
+        JRA.v1.3.u_10.TL319.1997.171019.nc
+        JRA.v1.3.u_10.TL319.1998.171019.nc
+        JRA.v1.3.u_10.TL319.1999.171019.nc
+        JRA.v1.3.u_10.TL319.2000.171019.nc
+        JRA.v1.3.u_10.TL319.2001.171019.nc
+        JRA.v1.3.u_10.TL319.2002.171019.nc
+        JRA.v1.3.u_10.TL319.2003.171019.nc
+        JRA.v1.3.u_10.TL319.2004.171019.nc
+        JRA.v1.3.u_10.TL319.2005.171019.nc
+        JRA.v1.3.u_10.TL319.2006.171019.nc
+        JRA.v1.3.u_10.TL319.2007.171019.nc
+        JRA.v1.3.u_10.TL319.2008.171019.nc
+        JRA.v1.3.u_10.TL319.2009.171019.nc
+        JRA.v1.3.u_10.TL319.2010.171019.nc
+        JRA.v1.3.u_10.TL319.2011.171019.nc
+        JRA.v1.3.u_10.TL319.2012.171019.nc
+        JRA.v1.3.u_10.TL319.2013.171019.nc
+        JRA.v1.3.u_10.TL319.2014.171019.nc
+        JRA.v1.3.u_10.TL319.2015.171019.nc
+        JRA.v1.3.u_10.TL319.2016.171019.nc
+      </value> 
+      <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.U_10">
         JRA.v1.3.u_10.TL319.1958.190528.nc
         JRA.v1.3.u_10.TL319.1959.190528.nc
         JRA.v1.3.u_10.TL319.1960.190528.nc
@@ -1616,6 +2024,67 @@
         JRA.v1.3.u_10.TL319.2018.190528.nc
       </value> 
       <value  stream="CORE_IAF_JRA.NCEP.V_10">
+        JRA.v1.3.v_10.TL319.1958.171019.nc
+        JRA.v1.3.v_10.TL319.1959.171019.nc
+        JRA.v1.3.v_10.TL319.1960.171019.nc
+        JRA.v1.3.v_10.TL319.1961.171019.nc
+        JRA.v1.3.v_10.TL319.1962.171019.nc
+        JRA.v1.3.v_10.TL319.1963.171019.nc
+        JRA.v1.3.v_10.TL319.1964.171019.nc
+        JRA.v1.3.v_10.TL319.1965.171019.nc
+        JRA.v1.3.v_10.TL319.1966.171019.nc
+        JRA.v1.3.v_10.TL319.1967.171019.nc
+        JRA.v1.3.v_10.TL319.1968.171019.nc
+        JRA.v1.3.v_10.TL319.1969.171019.nc
+        JRA.v1.3.v_10.TL319.1970.171019.nc
+        JRA.v1.3.v_10.TL319.1971.171019.nc
+        JRA.v1.3.v_10.TL319.1972.171019.nc
+        JRA.v1.3.v_10.TL319.1973.171019.nc
+        JRA.v1.3.v_10.TL319.1974.171019.nc
+        JRA.v1.3.v_10.TL319.1975.171019.nc
+        JRA.v1.3.v_10.TL319.1976.171019.nc
+        JRA.v1.3.v_10.TL319.1977.171019.nc
+        JRA.v1.3.v_10.TL319.1978.171019.nc
+        JRA.v1.3.v_10.TL319.1979.171019.nc
+        JRA.v1.3.v_10.TL319.1980.171019.nc
+        JRA.v1.3.v_10.TL319.1981.171019.nc
+        JRA.v1.3.v_10.TL319.1982.171019.nc
+        JRA.v1.3.v_10.TL319.1983.171019.nc
+        JRA.v1.3.v_10.TL319.1984.171019.nc
+        JRA.v1.3.v_10.TL319.1985.171019.nc
+        JRA.v1.3.v_10.TL319.1986.171019.nc
+        JRA.v1.3.v_10.TL319.1987.171019.nc
+        JRA.v1.3.v_10.TL319.1988.171019.nc
+        JRA.v1.3.v_10.TL319.1989.171019.nc
+        JRA.v1.3.v_10.TL319.1990.171019.nc
+        JRA.v1.3.v_10.TL319.1991.171019.nc
+        JRA.v1.3.v_10.TL319.1992.171019.nc
+        JRA.v1.3.v_10.TL319.1993.171019.nc
+        JRA.v1.3.v_10.TL319.1994.171019.nc
+        JRA.v1.3.v_10.TL319.1995.171019.nc
+        JRA.v1.3.v_10.TL319.1996.171019.nc
+        JRA.v1.3.v_10.TL319.1997.171019.nc
+        JRA.v1.3.v_10.TL319.1998.171019.nc
+        JRA.v1.3.v_10.TL319.1999.171019.nc
+        JRA.v1.3.v_10.TL319.2000.171019.nc
+        JRA.v1.3.v_10.TL319.2001.171019.nc
+        JRA.v1.3.v_10.TL319.2002.171019.nc
+        JRA.v1.3.v_10.TL319.2003.171019.nc
+        JRA.v1.3.v_10.TL319.2004.171019.nc
+        JRA.v1.3.v_10.TL319.2005.171019.nc
+        JRA.v1.3.v_10.TL319.2006.171019.nc
+        JRA.v1.3.v_10.TL319.2007.171019.nc
+        JRA.v1.3.v_10.TL319.2008.171019.nc
+        JRA.v1.3.v_10.TL319.2009.171019.nc
+        JRA.v1.3.v_10.TL319.2010.171019.nc
+        JRA.v1.3.v_10.TL319.2011.171019.nc
+        JRA.v1.3.v_10.TL319.2012.171019.nc
+        JRA.v1.3.v_10.TL319.2013.171019.nc
+        JRA.v1.3.v_10.TL319.2014.171019.nc
+        JRA.v1.3.v_10.TL319.2015.171019.nc
+        JRA.v1.3.v_10.TL319.2016.171019.nc
+      </value> 
+      <value  stream="CORE_IAF_JRA_1p4_2018.NCEP.V_10">
         JRA.v1.3.v_10.TL319.1958.190528.nc
         JRA.v1.3.v_10.TL319.1959.190528.nc
         JRA.v1.3.v_10.TL319.1960.190528.nc
@@ -1957,28 +2426,28 @@
       <value  stream="CORE2_IAF.CORE2.ArcFactor">
         TarcFactor tarcf
       </value>
-      <value  stream="CORE_IAF_JRA.GCGCS.PREC">
+      <value  stream="CORE_IAF_JRA.*.GCGCS.PREC">
         prec  prec
       </value>
-      <value  stream="CORE_IAF_JRA.GISS.LWDN">
+      <value  stream="CORE_IAF_JRA.*.GISS.LWDN">
         lwdn  lwdn 
       </value>
-      <value  stream="CORE_IAF_JRA.GISS.SWDN">
+      <value  stream="CORE_IAF_JRA.*.GISS.SWDN">
         swdn  swdn
       </value>
-      <value  stream="CORE_IAF_JRA.NCEP.Q_10">
+      <value  stream="CORE_IAF_JRA.*.NCEP.Q_10">
         q_10  shum
       </value>
-      <value  stream="CORE_IAF_JRA.NCEP.SLP_">
+      <value  stream="CORE_IAF_JRA.*.NCEP.SLP_">
         slp  pslv
       </value>
-      <value  stream="CORE_IAF_JRA.NCEP.T_10">
+      <value  stream="CORE_IAF_JRA.*.NCEP.T_10">
         t_10  tbot
       </value>
-      <value  stream="CORE_IAF_JRA.NCEP.U_10">
+      <value  stream="CORE_IAF_JRA.*.NCEP.U_10">
         u_10  u
       </value>
-      <value  stream="CORE_IAF_JRA.NCEP.V_10">
+      <value  stream="CORE_IAF_JRA.*.NCEP.V_10">
         v_10  v
       </value>
       <value  stream="co2tseries.20tr">
@@ -2079,11 +2548,11 @@
       <value stream="CORE2_NYF">1</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1</value>
       <value stream="CORE2_IAF">1</value>
-      <value stream="CORE_IAF_JRA">1</value>
+      <value stream="CORE_IAF_JRA.*">1</value>
       <value stream="co2tseries.20tr">1850</value>
       <!-- ncycles*(year_end-year_start+1)-(year_end-co2_year_start) -->
       <value stream="co2tseries.omip" datm_mode="CORE2_IAF">213</value>    <!-- 6*(2009-1948+1)-(2009-1850) -->
-      <value stream="co2tseries.omip" datm_mode="CORE_IAF_JRA">198</value> <!-- 6*(2018-1958+1)-(2018-1850) -->
+      <value stream="co2tseries.omip" datm_mode="CORE_IAF_JRA.*2018">198</value> <!-- 6*(2018-1958+1)-(2018-1850) -->
       <value stream="co2tseries.SSP">2015</value>
       <value stream="BC.QIAN.Precip">1979</value>
       <value stream="BC.CRUNCEP.GPCP.Precip">1979</value>
@@ -2139,14 +2608,7 @@
       <value stream="CORE2_IAF.NCEP.U_10">1948</value>
       <value stream="CORE2_IAF.NCEP.V_10">1948</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1948</value>
-      <value stream="CORE_IAF_JRA.GCGCS.PREC">1958</value>
-      <value stream="CORE_IAF_JRA.GISS.LWDN">1958</value>
-      <value stream="CORE_IAF_JRA.GISS.SWDN">1958</value>
-      <value stream="CORE_IAF_JRA.NCEP.Q_10">1958</value>
-      <value stream="CORE_IAF_JRA.NCEP.SLP_">1958</value>
-      <value stream="CORE_IAF_JRA.NCEP.T_10">1958</value>
-      <value stream="CORE_IAF_JRA.NCEP.U_10">1958</value>
-      <value stream="CORE_IAF_JRA.NCEP.V_10">1958</value>
+      <value stream="CORE_IAF_JRA.*">1958</value>
       <value stream="co2tseries.20tr">1850</value>
       <value stream="co2tseries.omip">1850</value>
       <value stream="co2tseries.SSP">2015</value>
@@ -2161,7 +2623,7 @@
       <value stream="presaero.SSP">2015</value>
       <!-- year_start-(ncycles-1)*(year_end-year_start+1)-1 -->
       <value stream="presaero.cesm2_omip" datm_mode="CORE2_IAF">1637</value>    <!-- 1948-(6-1)*(2009-1948+1)-1 -->
-      <value stream="presaero.cesm2_omip" datm_mode="CORE_IAF_JRA">1652</value> <!-- 1958-(6-1)*(2018-1958+1)-1 -->
+      <value stream="presaero.cesm2_omip" datm_mode="CORE_IAF_JRA.*2018">1652</value> <!-- 1958-(6-1)*(2018-1958+1)-1 -->
       <value stream="topo.observed">1</value>
       <value stream="topo.cplhist">$DATM_CPLHIST_YR_START</value>
     </values									>
@@ -2205,14 +2667,8 @@
       <value stream="CORE2_IAF.NCEP.U_10">2009</value>
       <value stream="CORE2_IAF.NCEP.V_10">2009</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">2009</value>
-      <value stream="CORE_IAF_JRA.GCGCS.PREC">2018</value>
-      <value stream="CORE_IAF_JRA.GISS.LWDN">2018</value>
-      <value stream="CORE_IAF_JRA.GISS.SWDN">2018</value>
-      <value stream="CORE_IAF_JRA.NCEP.Q_10">2018</value>
-      <value stream="CORE_IAF_JRA.NCEP.SLP_">2018</value>
-      <value stream="CORE_IAF_JRA.NCEP.T_10">2018</value>
-      <value stream="CORE_IAF_JRA.NCEP.U_10">2018</value>
-      <value stream="CORE_IAF_JRA.NCEP.V_10">2018</value>
+      <value stream="CORE_IAF_JRA.*2018">2018</value>
+      <value stream="CORE_IAF_JRA.*">2016</value>
       <value stream="co2tseries.20tr">2014</value>
       <value stream="co2tseries.omip">2019</value>
       <value stream="co2tseries.SSP">2500</value>
@@ -2228,7 +2684,7 @@
       <value stream="presaero.SSP">2101</value>
       <!-- year_end+1 -->
       <value stream="presaero.cesm2_omip" datm_mode="CORE2_IAF">2010</value>    <!-- 2009+1 -->
-      <value stream="presaero.cesm2_omip" datm_mode="CORE_IAF_JRA">2019</value> <!-- 2018+1 -->
+      <value stream="presaero.cesm2_omip" datm_mode="CORE_IAF_JRA.*2018">2019</value> <!-- 2018+1 -->
       <value stream="topo.observed">1</value>
       <value stream="topo.cplhist">$DATM_CPLHIST_YR_END</value>
     </values>
@@ -2241,7 +2697,7 @@
     <desc>Stream offset.</desc>
     <values>
       <value>0</value>
-      <value stream="CORE_IAF_JRA.GISS.SWDN">-5400</value>
+      <value stream="CORE_IAF_JRA.*.GISS.SWDN">-5400</value>
       <value stream="CPLHISTForcing.Solar">2700</value>
       <value stream="CPLHISTForcing.nonSolarFlux">900</value>
       <value stream="CPLHISTForcing.State3hr">900</value>
@@ -2299,7 +2755,7 @@
       W.G.Large, S.G.Yeager (2008), The global climatology of an
       interannually varying air-sea flux data set.
       Clm Dyn doi 10.1007/s00382-008-0441-3.
-      datamode = "CORE_IAF_JRA"
+      datamode = "CORE_IAF_JRA*"
       JRA55 intra-annual year forcing
       datamode = "CLMNCEP"
       In conjunction with NCEP climatological atmosphere data, provides the
@@ -2314,7 +2770,7 @@
       <value datm_mode="CLM">CLMNCEP</value>
       <value datm_mode="CORE2_NYF">CORE2_NYF</value>
       <value datm_mode="CORE2_IAF">CORE2_IAF</value>
-      <value datm_mode="CORE_IAF_JRA">CORE_IAF_JRA</value>
+      <value datm_mode="CORE_IAF_JRA.*">CORE_IAF_JRA</value>
       <value datm_mode="CPLHIST">COPYALL</value>
     </values>
   </entry>
@@ -2516,7 +2972,7 @@
            between multiple input values -->
       <value stream="topo.observed">lower</value>
       <value stream="CORE2_IAF.GISS.SWDN">coszen</value>
-      <value stream="CORE_IAF_JRA.GISS.SWDN">coszen</value>
+      <value stream="CORE_IAF_JRA.*.GISS.SWDN">coszen</value>
     </values>
   </entry>
 
@@ -2609,7 +3065,7 @@
       <value>null</value>
       <value datm_mode="CORE2_NYF">u:v</value>
       <value datm_mode="CORE2_IAF">u:v</value>
-      <value datm_mode="CORE_IAF_JRA">u:v</value>
+      <value datm_mode="CORE_IAF_JRA.*">u:v</value>
     </values>
   </entry>
 

--- a/src/components/data_comps/drof/cime_config/config_component.xml
+++ b/src/components/data_comps/drof/cime_config/config_component.xml
@@ -13,12 +13,13 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%IAF][%CPLHIST][%JRA]">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%CPLHIST][%JRA][%JRA-1p4-2018]">Data runoff model</desc>
     <desc option="NULL">NULL mode</desc>
     <desc option="NYF" >COREv2 normal year forcing:</desc>
     <desc option="IAF" >COREv2 interannual year forcing:</desc>
     <desc option="CPLHIST">CPLHIST mode:</desc>
     <desc option="JRA">JRA55 interannual forcing</desc>
+    <desc option="JRA-1p4-2018">JRA55 interannual forcing, v1.4, through 2018</desc>
   </description>
 
   <entry id="COMP_ROF">
@@ -32,7 +33,7 @@
 
   <entry id="DROF_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,IAF_JRA,NULL</valid_values>
+    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,IAF_JRA,IAF_JRA_1p4_2018,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
     <values match="last">
       <value compset="_DROF%NULL">NULL</value>
@@ -40,6 +41,7 @@
       <value compset="_DROF%IAF" >DIATREN_IAF_RX1</value>
       <value compset="_DROF%CPLHIST">CPLHIST</value>
       <value compset="_DROF%JRA" >IAF_JRA</value>
+      <value compset="_DROF%JRA-1p4-2018" >IAF_JRA_1p4_2018</value>
       <value compset=".+" grid="r%null">NULL</value> <!-- overwrites above if runoff grid is null -->
     </values>
     <group>run_component_drof</group>

--- a/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -53,6 +53,7 @@
       <value drof_mode="CPLHIST"        >rof.cplhist</value>
       <value drof_mode="DIATREN_ANN_RX1">rof.diatren_ann_rx1</value>
       <value drof_mode="DIATREN_IAF_RX1">rof.diatren_iaf_rx1</value>
+      <value drof_mode="IAF_JRA_1p4_2018">rof.iaf_jra_1p4_2018</value>
       <value drof_mode="IAF_JRA"        >rof.iaf_jra</value>
     </values>
   </entry>
@@ -65,7 +66,7 @@
     <values>
       <value stream="rof.diatren_ann_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.diatren_iaf_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
-      <value stream="rof.iaf_jra">$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
+      <value stream="rof.iaf_jra.*">$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
       <value stream="rof.cplhist">null</value>
     </values>
   </entry>
@@ -78,7 +79,7 @@
     <values>
       <value stream="rof.diatren_ann_rx1">runoff.daitren.annual.090225.nc</value>
       <value stream="rof.diatren_iaf_rx1">runoff.daitren.iaf.20120419.nc</value>
-      <value stream="rof.iaf_jra">domain.roff.JRA025.170111.nc</value>
+      <value stream="rof.iaf_jra.*">domain.roff.JRA025.170111.nc</value>
       <value stream="rof.cplhist">null</value>
     </values>
   </entry>
@@ -121,7 +122,7 @@
     <values>
       <value stream="rof.diatren_ann_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.diatren_iaf_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
-      <value stream="rof.iaf_jra">$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
+      <value stream="rof.iaf_jra.*">$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_DIR</value>
     </values>
   </entry>
@@ -134,7 +135,7 @@
     <values>
       <value stream="rof.diatren_ann_rx1">runoff.daitren.annual.090225.nc</value>
       <value stream="rof.diatren_iaf_rx1">runoff.daitren.iaf.20120419.nc</value>
-      <value stream="rof.iaf_jra">
+      <value stream="rof.iaf_jra_1p4_2018">
            JRA.v1.4.runoff.1958.190214.nc
            JRA.v1.4.runoff.1959.190214.nc
            JRA.v1.4.runoff.1960.190214.nc
@@ -197,6 +198,67 @@
            JRA.v1.4.runoff.2017.190214.nc
            JRA.v1.4.runoff.2018.190214.nc
       </value>
+      <value stream="rof.iaf_jra">
+           JRA.v1.1.runoff.1958.170807.nc
+           JRA.v1.1.runoff.1959.170807.nc
+           JRA.v1.1.runoff.1960.170807.nc
+           JRA.v1.1.runoff.1961.170807.nc
+           JRA.v1.1.runoff.1962.170807.nc
+           JRA.v1.1.runoff.1963.170807.nc
+           JRA.v1.1.runoff.1964.170807.nc
+           JRA.v1.1.runoff.1965.170807.nc
+           JRA.v1.1.runoff.1966.170807.nc
+           JRA.v1.1.runoff.1967.170807.nc
+           JRA.v1.1.runoff.1968.170807.nc
+           JRA.v1.1.runoff.1969.170807.nc
+           JRA.v1.1.runoff.1970.170807.nc
+           JRA.v1.1.runoff.1971.170807.nc
+           JRA.v1.1.runoff.1972.170807.nc
+           JRA.v1.1.runoff.1973.170807.nc
+           JRA.v1.1.runoff.1974.170807.nc
+           JRA.v1.1.runoff.1975.170807.nc
+           JRA.v1.1.runoff.1976.170807.nc
+           JRA.v1.1.runoff.1977.170807.nc
+           JRA.v1.1.runoff.1978.170807.nc
+           JRA.v1.1.runoff.1979.170807.nc
+           JRA.v1.1.runoff.1980.170807.nc
+           JRA.v1.1.runoff.1981.170807.nc
+           JRA.v1.1.runoff.1982.170807.nc
+           JRA.v1.1.runoff.1983.170807.nc
+           JRA.v1.1.runoff.1984.170807.nc
+           JRA.v1.1.runoff.1985.170807.nc
+           JRA.v1.1.runoff.1986.170807.nc
+           JRA.v1.1.runoff.1987.170807.nc
+           JRA.v1.1.runoff.1988.170807.nc
+           JRA.v1.1.runoff.1989.170807.nc
+           JRA.v1.1.runoff.1990.170807.nc
+           JRA.v1.1.runoff.1991.170807.nc
+           JRA.v1.1.runoff.1992.170807.nc
+           JRA.v1.1.runoff.1993.170807.nc
+           JRA.v1.1.runoff.1994.170807.nc
+           JRA.v1.1.runoff.1995.170807.nc
+           JRA.v1.1.runoff.1996.170807.nc
+           JRA.v1.1.runoff.1997.170807.nc
+           JRA.v1.1.runoff.1998.170807.nc
+           JRA.v1.1.runoff.1999.170807.nc
+           JRA.v1.1.runoff.2000.170807.nc
+           JRA.v1.1.runoff.2001.170807.nc
+           JRA.v1.1.runoff.2002.170807.nc
+           JRA.v1.1.runoff.2003.170807.nc
+           JRA.v1.1.runoff.2004.170807.nc
+           JRA.v1.1.runoff.2005.170807.nc
+           JRA.v1.1.runoff.2006.170807.nc
+           JRA.v1.1.runoff.2007.170807.nc
+           JRA.v1.1.runoff.2008.170807.nc
+           JRA.v1.1.runoff.2009.170807.nc
+           JRA.v1.1.runoff.2010.170807.nc
+           JRA.v1.1.runoff.2011.170807.nc
+           JRA.v1.1.runoff.2012.170807.nc
+           JRA.v1.1.runoff.2013.170807.nc
+           JRA.v1.1.runoff.2014.170807.nc
+           JRA.v1.1.runoff.2015.170807.nc
+           JRA.v1.1.runoff.2016.170807.nc
+      </value>
       <value stream="rof.cplhist">$DROF_CPLHIST_CASE.cpl.hr2x.%ym.nc</value>
     </values>
   </entry>
@@ -213,7 +275,7 @@
       <value stream="rof.diatren_iaf_rx1">
         runoff rofl
       </value>
-      <value stream="rof.iaf_jra">
+      <value stream="rof.iaf_jra.*">
         rofl  rofl
         rofi  rofi
       </value>
@@ -243,7 +305,7 @@
     <values>
       <value stream="rof.diatren_ann_rx1">1</value>
       <value stream="rof.diatren_iaf_rx1">1</value>
-      <value stream="rof.iaf_jra">1</value>
+      <value stream="rof.iaf_jra.*">1</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_YR_ALIGN</value>
     </values>
   </entry>
@@ -256,7 +318,7 @@
     <values>
       <value stream="rof.diatren_ann_rx1">1</value>
       <value stream="rof.diatren_iaf_rx1">1948</value>
-      <value stream="rof.iaf_jra">1958</value>
+      <value stream="rof.iaf_jra.*">1958</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_YR_START</value>
     </values>
   </entry>
@@ -269,7 +331,8 @@
     <values>
       <value stream="rof.diatren_ann_rx1">1</value>
       <value stream="rof.diatren_iaf_rx1">2009</value>
-      <value stream="rof.iaf_jra">2018</value>
+      <value stream="rof.iaf_jra_1p4_2018">2018</value>
+      <value stream="rof.iaf_jra">2016</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_YR_END</value>
     </values>
   </entry>
@@ -463,7 +526,7 @@
       <value>linear</value>
       <value stream="rof.diatren_ann_rx1">upper</value>
       <value stream="rof.diatren_iaf_rx1">upper</value>
-      <value stream="rof.iaf_jra">upper</value>
+      <value stream="rof.iaf_jra.*">upper</value>
       <value stream="rof.cplhist">nearest</value>
     </values>
   </entry>


### PR DESCRIPTION
backwards compatible implementation of #3223 

Restore 2.1.1 behavior for compsets with
DATM%JRA, DROF%JRA in longname

Updated JRA forcing is now available with
DATM%JRA-1p4-2018, DROF%JRA-1p4-2018 in longname

POP compset GIAF_JRA from 2.1.1 renamed to GIAF_JRA-1p3-2016
GIAF_JRA compset in POP is now the latest version of JRA forcing

Testing:
examination of namelists of
A) GIAF_JRA with 2.1.1
B) GIAF_JRA-1p3-2016 with new code
C) GIAF_JRA with new code

A) and B) are the same
C) has indented updates to JRA
    (matches OMIP runs peformed for CMIP6)


User interface changes?:  no

Update gh-pages html (Y/N)?: no

Code review: 
