### PR TITLE
Stampede2 module update

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2276,19 +2276,19 @@ This allows using a different mpirun command to launch unit tests
         <command name="purge"></command>
         <command name="load">TACC</command>
         <command name="load">python/2.7.13</command>
-        <command name="load">intel/17.0.4</command>
-        <command name="load">cmake/3.10.2</command>
+        <command name="load">intel/18.0.2</command>
+        <command name="load">cmake/3.16.1</command>
       </modules>
       <modules mpilib="mvapich2">
-        <command name="load">mvapich2/2.3b</command>
-        <command name="load">pnetcdf/1.8.1</command>
-        <command name="load">parallel-netcdf/4.3.3.1</command>
+        <command name="load">mvapich2/2.3.1</command>
+        <command name="load">pnetcdf/1.11</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="impi">
         <command name="rm">mvapich2</command>
-        <command name="load">impi/17.0.3</command>
-        <command name="load">pnetcdf/1.8.1</command>
-        <command name="load">parallel-netcdf/4.3.3.1</command>
+        <command name="load">impi/18.0.2</command>
+        <command name="load">pnetcdf/1.11</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpi-serial">
         <command name="load">netcdf/4.3.3.1</command>


### PR DESCRIPTION
Update intel compiler to 18.0.2 in order to fix pop failures.

Test suite:  scripts_regression_tests kept hanging, B1850, F2000climo, C1850ECO,
                    G1850ECO, T1850G, A, X, DTEST
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
