### PR TITLE
Fix chmod command in safe_copy

### DIFF
--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -794,7 +794,7 @@ def safe_copy(src_path, tgt_path):
         if not os.access(tgt_path, os.W_OK):
             if owner_uid == os.getuid():
                 # I am the owner, make writeable
-                os.chmod(st.st_mode | statlib.S_IWRITE)
+                os.chmod(tgt_path, st.st_mode | statlib.S_IWRITE)
             else:
                 # I won't be able to copy this file
                 raise OSError("Cannot copy over file {}, it is readonly and you are not the owner".format(tgt_path))


### PR DESCRIPTION
Test suite: manual testing only (see below); did NOT run
  scripts_regression_tests, since it seems this line must not be covered
  by automated testing (otherwise tests would have failed)
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Manual testing:

I created a temporary refdir:

```
[/glade/p/cesmdata/cseg/inputdata/cesm2_init/bill.test]
$ ls 0501-01-01/
b.e21.B1850.f09_g17.CMIP6-piControl.001.clm2.r.0501-01-01-00000.nc  rpointer.lnd
```

Then did the following:

```
./create_newcase --case $scratch/test_refcase_baseline_0123a --res f09_g17 --compset X --run-unsupported
./xmlchange RUN_TYPE=hybrid,RUN_REFCASE=bill.test,RUN_REFDIR=cesm2_init,RUN_REFDATE=0501-01-01
./xmlchange GET_REFCASE=TRUE
./case.setup
./case.build
^C
# Changed rpointer.lnd file in the refdir
./case.build
# Verified that the run directory has the new rpointer.lnd
```

I first verified that the second case.build command failed from the
baseline code (i.e., that I could properly reproduce the problem). With
the new code, the safe_copy no longer fails and the new rpointer.lnd
file is copied as desired.

Fixes ESMCI/cime#3363

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 