### PR TITLE
Fixes domain filename in input_data_list

### DIFF
--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -493,7 +493,7 @@ class NamelistGenerator(object):
                     continue
                 filepath, filename = os.path.split(filename)
                 if not filepath:
-                    filepath = os.path.join(domain_filepath, os.path.dirname(filename.strip()))
+                    filepath = os.path.join(domain_filepath, filename.strip())
                 string = "domain{:d} = {}\n".format(i+1, filepath)
                 hashValue = hashlib.md5(string.rstrip().encode('utf-8')).hexdigest()
                 if hashValue not in lines_hash:


### PR DESCRIPTION
The domain filename was being truncated when it doesn't have a full path.  

The os.path.dirname isn't needed in nmlgen.py when the filename has no filepath in it.

Test suite:  scripts_regression_tests,  f19_g17.I1850Clm50BgcCropCmip6waccm, T62_g16.GIAF
Test baseline: 
Test namelist changes: 
Test status: bit-for-bit

Fixes #3376

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
