### PR TITLE
Add D0 to all namelist values added in PR 3231 and 3251

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -4732,8 +4732,8 @@
        Surface albedo for direct radiation
     </desc>
     <values>
-      <value>0.06</value>
-      <value aqua_planet_sst_type="sst_aquap11">0.07</value>
+      <value>0.06D0</value>
+      <value aqua_planet_sst_type="sst_aquap11">0.07D0</value>
     </values>
   </entry>
 
@@ -4745,7 +4745,7 @@
        Surface albedo for diffuse radiation
     </desc>
     <values>
-      <value>0.07</value>
+      <value>0.07D0</value>
     </values>
   </entry>
 
@@ -4757,8 +4757,8 @@
        minimum wind speed for atmOcn flux calculations
     </desc>
     <values>
-      <value>0.5</value>
-      <value aqua_planet_sst_type="sst_aquap11">1.0</value>
+      <value>0.5D0</value>
+      <value aqua_planet_sst_type="sst_aquap11">1.0D0</value>
     </values>
   </entry>
 


### PR DESCRIPTION
When namelist variables were introduced in #3231 and #3251 they did not have D0 on the default values to designate these values as double precision.  Regression testing for CESM2.1.2 have not indicated any answer changes due to this setting, though the values of 0.6 and 0.7 are subject to roundoff differences.    After discussion with Bill Sacks, it has been decided that we will fix the defaults on master, just to be cautious.  We do not see a need to change this on the maintenance branch, since it is partially through the testing cycle for the upcoming release.

Test suite:  (none run - per Bill's suggestion)
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #] #3231 and #3251

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
