### PR TITLE
more fix for UFS release

### DIFF
--- a/config/ufs/machines/config_batch.xml
+++ b/config/ufs/machines/config_batch.xml
@@ -266,7 +266,7 @@
   </batch_system>
 
   <batch_system MACH="stampede2-skx" type="slurm" >
-    <batch_submit>ssh stampede2.tacc.utexas.edu cd $CASEROOT ; sbatch</batch_submit>
+    <batch_submit>ssh login1.stampede2.tacc.utexas.edu cd $CASEROOT ; sbatch</batch_submit>
     <submit_args>
       <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
       <arg flag="-p" name="$JOB_QUEUE"/>
@@ -279,7 +279,7 @@
   </batch_system>
 
   <batch_system MACH="stampede2-knl" type="slurm" >
-    <batch_submit>ssh stampede2.tacc.utexas.edu cd $CASEROOT ; sbatch</batch_submit>
+    <batch_submit>ssh login1.stampede2.tacc.utexas.edu cd $CASEROOT ; sbatch</batch_submit>
     <submit_args>
       <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
       <arg flag="-p" name="$JOB_QUEUE"/>

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -398,16 +398,16 @@ This allows using a different mpirun command to launch unit tests
       <modules mpilib="mvapich2">
         <command name="load">mvapich2/2.3b</command>
         <command name="load">pnetcdf/1.11.0</command>
-        <command name="load">parallel-netcdf/4.3.3.1</command>
+        <command name="load">netcdf/4.6.2</command>
       </modules>
       <modules mpilib="impi">
         <command name="rm">mvapich2</command>
         <command name="load">impi/18.0.2</command>
         <command name="load">pnetcdf/1.11.0</command>
-        <command name="load">parallel-netcdf/4.3.3.1</command>
+        <command name="load">netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">netcdf/4.3.3.1</command>
+        <command name="load">netcdf/4.6.2</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/config/ufs/machines/template.chgres.run
+++ b/config/ufs/machines/template.chgres.run
@@ -4,14 +4,10 @@
 # Set environment variables
 if [ -z "${NCEP_LIBS}" ]; then
   echo "Set environment variables:"
-  echo "export `cat software_environment.txt | grep \"NCEP_LIBS\"`" > .env
-  echo "export `cat software_environment.txt | grep \"LD_LIBRARY_PATH\" | grep -v \"__LMOD\"`" >> .env
+  cat software_environment.txt | grep "=" | sed -e 's/^/export /' > .env
   source .env
-  cat .env
 else
   echo "Environment variables are already set:"
-  echo "NCEP_LIBS = $NCEP_LIBS"
-  echo "LD_LIBRARY_PATH = $LD_LIBRARY_PATH"
 fi
 
 # Query run directory

--- a/config/ufs/machines/template.chgres.run
+++ b/config/ufs/machines/template.chgres.run
@@ -1,7 +1,19 @@
 #!/bin/bash
 {{ batchdirectives }}
 
-module list
+# Set environment variables
+if [ -z "${NCEP_LIBS}" ]; then
+  echo "Set environment variables:"
+  echo "export `cat software_environment.txt | grep \"NCEP_LIBS\"`" > .env
+  echo "export `cat software_environment.txt | grep \"LD_LIBRARY_PATH\" | grep -v \"__LMOD\"`" >> .env
+  source .env
+  cat .env
+else
+  echo "Environment variables are already set:"
+  echo "NCEP_LIBS = $NCEP_LIBS"
+  echo "LD_LIBRARY_PATH = $LD_LIBRARY_PATH"
+fi
+
 # Query run directory
 rundir=`./xmlquery --value RUNDIR`
 echo "Run directory is $rundir"

--- a/config/ufs/machines/template.gfs_post.run
+++ b/config/ufs/machines/template.gfs_post.run
@@ -4,14 +4,10 @@
 # Set environment variables
 if [ -z "${NCEP_LIBS}" ]; then
   echo "Set environment variables:"
-  echo "export `cat software_environment.txt | grep \"NCEP_LIBS\"`" > .env
-  echo "export `cat software_environment.txt | grep \"LD_LIBRARY_PATH\" | grep -v \"__LMOD\"`" >> .env
+  cat software_environment.txt | grep "=" | sed -e 's/^/export /' > .env
   source .env
-  cat .env
 else
   echo "Environment variables are already set:"
-  echo "NCEP_LIBS = $NCEP_LIBS"
-  echo "LD_LIBRARY_PATH = $LD_LIBRARY_PATH"
 fi
 
 # Query run directory

--- a/config/ufs/machines/template.gfs_post.run
+++ b/config/ufs/machines/template.gfs_post.run
@@ -1,8 +1,20 @@
 #!/bin/bash
 {{ batchdirectives }}
 
-# Query run directory
+# Set environment variables
+if [ -z "${NCEP_LIBS}" ]; then
+  echo "Set environment variables:"
+  echo "export `cat software_environment.txt | grep \"NCEP_LIBS\"`" > .env
+  echo "export `cat software_environment.txt | grep \"LD_LIBRARY_PATH\" | grep -v \"__LMOD\"`" >> .env
+  source .env
+  cat .env
+else
+  echo "Environment variables are already set:"
+  echo "NCEP_LIBS = $NCEP_LIBS"
+  echo "LD_LIBRARY_PATH = $LD_LIBRARY_PATH"
+fi
 
+# Query run directory
 rundir=`./xmlquery --value RUNDIR`
 echo "run dir is $rundir"
 cd $rundir


### PR DESCRIPTION
This PR aims to fix couple of issues related to the TACC's Stampede2 platform:
- setting environment variables for pre- and post-processing scripts
- fix used netCDF module
- fix node that is used to resubmit the job

Test suite: export CIME_MODEL=cesm; ./scripts_regression_tests.py 
Test baseline: /work/02503/edwardsj/UFS/ufs_baselines/20200131-intel
Test namelist changes: No
Test status: [bit for bit, roundoff, climate changing] all pass (SMS, ERS and PET)

Fixes [CIME Github issue #] No

User interface changes?: No

Update gh-pages html (Y/N)?: No

Code review: 