### PR TITLE
Fix auto-triage

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -184,7 +184,7 @@ class SystemTestsCommon(object):
                 overall_status = self._test_status.get_overall_test_status(ignore_namelists=True)
                 if overall_status != TEST_PASS_STATUS:
                     srcroot = self._case.get_value("CIMEROOT")
-                    worked_before, last_pass, last_fail = \
+                    worked_before, last_pass, last_fail_transition = \
                         get_test_success(baseline_root, srcroot, self._casebaseid)
 
                     if worked_before:
@@ -196,9 +196,9 @@ class SystemTestsCommon(object):
                             else:
                                 logger.warning("Unable to list potentially broken merges: {}\n{}".format(out, err))
                     else:
-                        if last_pass is not None and last_fail is not None:
-                            # commits between last_pass and last_fail broke things
-                            stat, out, err = run_cmd("git rev-list --first-parent {}..{}".format(last_pass, last_fail), from_dir=srcroot)
+                        if last_pass is not None and last_fail_transition is not None:
+                            # commits between last_pass and last_fail_transition broke things
+                            stat, out, err = run_cmd("git rev-list --first-parent {}..{}".format(last_pass, last_fail_transition), from_dir=srcroot)
                             if stat == 0:
                                 append_testlog("OLD FAIL: Potentially broken merges:\n{}".format(out), self._orig_caseroot)
                             else:

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -496,9 +496,9 @@ def _is_test_working(prev_results, src_root, testing=False):
 
 def get_test_success(baseline_root, src_root, test, testing=False):
     """
-    Returns (was prev run success, commit when test last transitioned from fail to pass, commit when test last transitioned from pass to fail)
+    Returns (was prev run success, commit when test last passed, commit when test last transitioned from pass to fail)
 
-    Unknown transition history is expressed as None
+    Unknown history is expressed as None
     """
     if baseline_root is not None:
         try:
@@ -528,12 +528,12 @@ def save_test_success(baseline_root, src_root, test, succeeded, force_commit_tes
                 prev_succeeded = _is_test_working(prev_results, src_root, testing=(force_commit_test is not None))
 
                 # if no transition occurred then no update is needed
-                if succeeded != prev_succeeded or (prev_results[0] is None and succeeded) or (prev_results[1] is None and not succeeded):
+                if succeeded or succeeded != prev_succeeded or (prev_results[0] is None and succeeded) or (prev_results[1] is None and not succeeded):
 
                     new_results = list(prev_results)
                     my_commit = force_commit_test if force_commit_test else get_current_commit(repo=src_root)
                     if succeeded:
-                        new_results[0] = my_commit # we transitioned to a passing state
+                        new_results[0] = my_commit # we passed
                     else:
                         new_results[1] = my_commit # we transitioned to a failing state
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2472,6 +2472,17 @@ class L_TestSaveTimings(TestCreateTestCommon):
         self.simple_test(manual_timing=True)
 
     ###########################################################################
+    def _record_success(self, test_name, test_success, commit, exp_last_pass, exp_trans_fail, baseline_dir):
+    ###########################################################################
+        save_test_success(baseline_dir, None, test_name, test_success, force_commit_test=commit)
+        was_success, last_pass, trans_fail = get_test_success(baseline_dir, None, test_name, testing=True)
+        self.assertEqual(test_success, was_success, msg="Broken was_success {} {}".format(test_name, commit))
+        self.assertEqual(last_pass, exp_last_pass, msg="Broken last_pass {} {}".format(test_name, commit))
+        self.assertEqual(trans_fail, exp_trans_fail, msg="Broken trans_fail {} {}".format(test_name, commit))
+        if test_success:
+            self.assertEqual(exp_last_pass, commit, msg="Should never")
+
+    ###########################################################################
     def test_success_recording(self):
     ###########################################################################
         if CIME.utils.get_model() != "e3sm":
@@ -2482,75 +2493,40 @@ class L_TestSaveTimings(TestCreateTestCommon):
         baseline_dir = os.path.join(self._baseline_area, self._baseline_name)
 
         # Test initial state
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test1, testing=True)
-        self.assertFalse(was_success, msg="Broken was_success 1.0")
-        self.assertEqual(trans_pass, None, msg="Broken trans_pass 1.0")
-        self.assertEqual(trans_fail, None, msg="Broken trans_fail 1.0")
+        was_success, last_pass, trans_fail = get_test_success(baseline_dir, None, fake_test1, testing=True)
+        self.assertFalse(was_success, msg="Broken initial was_success")
+        self.assertEqual(last_pass, None, msg="Broken initial last_pass")
+        self.assertEqual(trans_fail, None, msg="Broken initial trans_fail")
 
-        # Test first result
-        save_test_success(baseline_dir, None, fake_test1, False, force_commit_test="AAA")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test1, testing=True)
-        self.assertFalse(was_success, msg="Broken was_success 1.1")
-        self.assertEqual(trans_pass, None, msg="Broken trans_pass 1.1")
-        self.assertEqual(trans_fail, "AAA", msg="Broken trans_fail 1.1")
+        # Test first result (test1 fails, test2 passes)
+        #                    test_name , success, commit , expP , expTF, baseline)
+        self._record_success(fake_test1, False  , "AAA"  , None , "AAA", baseline_dir)
+        self._record_success(fake_test2, True   , "AAA"  , "AAA", None , baseline_dir)
 
-        save_test_success(baseline_dir, None, fake_test2, True, force_commit_test="AAA")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test2, testing=True)
-        self.assertTrue(was_success, msg="Broken was_success 2.1")
-        self.assertEqual(trans_pass, "AAA", msg="Broken trans_pass 2.1")
-        self.assertEqual(trans_fail, None, msg="Broken trans_fail 2.1")
+        # Test second result matches first (no transition) (test1 fails, test2 passes)
+        #                    test_name , success, commit , expP , expTF, baseline)
+        self._record_success(fake_test1, False  , "BBB"  , None , "AAA", baseline_dir)
+        self._record_success(fake_test2, True   , "BBB"  , "BBB", None , baseline_dir)
 
-        # Test second result matches first (no transition)
-        save_test_success(baseline_dir, None, fake_test1, False, force_commit_test="BBB")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test1, testing=True)
-        self.assertFalse(was_success, msg="Broken was_success 1.2")
-        self.assertEqual(trans_pass, None, msg="Broken trans_pass 1.2")
-        self.assertEqual(trans_fail, "AAA", msg="Broken trans_fail 1.2")
+        # Test transition to new state (first real transition) (test1 passes, test2 fails)
+        #                    test_name , success, commit , expP , expTF, baseline)
+        self._record_success(fake_test1, True   , "CCC"  , "CCC", "AAA", baseline_dir)
+        self._record_success(fake_test2, False  , "CCC"  , "BBB", "CCC", baseline_dir)
 
-        save_test_success(baseline_dir, None, fake_test2, True, force_commit_test="BBB")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test2, testing=True)
-        self.assertTrue(was_success, msg="Broken was_success 2.2")
-        self.assertEqual(trans_pass, "AAA", msg="Broken trans_pass 2.2")
-        self.assertEqual(trans_fail, None, msg="Broken trans_fail 2.2")
+        # Test transition to new state (second real transition) (test1 fails, test2 passes)
+        #                    test_name , success, commit , expP , expTF, baseline)
+        self._record_success(fake_test1, False  , "DDD"  , "CCC", "DDD", baseline_dir)
+        self._record_success(fake_test2, True   , "DDD"  , "DDD", "CCC", baseline_dir)
 
-        # Test transition to new state (first real transition)
-        save_test_success(baseline_dir, None, fake_test1, True, force_commit_test="CCC")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test1, testing=True)
-        self.assertTrue(was_success, msg="Broken was_success 1.3")
-        self.assertEqual(trans_pass, "CCC", msg="Broken trans_pass 1.3")
-        self.assertEqual(trans_fail, "AAA", msg="Broken trans_fail 1.3")
+        # Test final repeat (test1 fails, test2 passes)
+        #                    test_name , success, commit , expP , expTF, baseline)
+        self._record_success(fake_test1, False  , "EEE"  , "CCC", "DDD", baseline_dir)
+        self._record_success(fake_test2, True   , "EEE"  , "EEE", "CCC", baseline_dir)
 
-        save_test_success(baseline_dir, None, fake_test2, False, force_commit_test="CCC")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test2, testing=True)
-        self.assertFalse(was_success, msg="Broken was_success 2.3")
-        self.assertEqual(trans_pass, "AAA", msg="Broken trans_pass 2.3")
-        self.assertEqual(trans_fail, "CCC", msg="Broken trans_fail 2.3")
-
-        # Test transition to new state (second real transition)
-        save_test_success(baseline_dir, None, fake_test1, False, force_commit_test="DDD")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test1, testing=True)
-        self.assertFalse(was_success, msg="Broken was_success 1.4")
-        self.assertEqual(trans_pass, "CCC", msg="Broken trans_pass 1.4")
-        self.assertEqual(trans_fail, "DDD", msg="Broken trans_fail 1.4")
-
-        save_test_success(baseline_dir, None, fake_test2, True, force_commit_test="DDD")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test2, testing=True)
-        self.assertTrue(was_success, msg="Broken was_success 2.4")
-        self.assertEqual(trans_pass, "DDD", msg="Broken trans_pass 2.4")
-        self.assertEqual(trans_fail, "CCC", msg="Broken trans_fail 2.4")
-
-        # Test final repeat
-        save_test_success(baseline_dir, None, fake_test1, False, force_commit_test="EEE")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test1, testing=True)
-        self.assertFalse(was_success, msg="Broken was_success 1.5")
-        self.assertEqual(trans_pass, "CCC", msg="Broken trans_pass 1.5")
-        self.assertEqual(trans_fail, "DDD", msg="Broken trans_fail 1.5")
-
-        save_test_success(baseline_dir, None, fake_test2, True, force_commit_test="EEE")
-        was_success, trans_pass, trans_fail = get_test_success(baseline_dir, None, fake_test2, testing=True)
-        self.assertTrue(was_success, msg="Broken was_success 2.5")
-        self.assertEqual(trans_pass, "DDD", msg="Broken trans_pass 2.5")
-        self.assertEqual(trans_fail, "CCC", msg="Broken trans_fail 2.5")
+        # Test final transition (test1 passes, test2 fails)
+        #                    test_name , success, commit , expP , expTF, baseline)
+        self._record_success(fake_test1, True   , "FFF"  , "FFF", "DDD", baseline_dir)
+        self._record_success(fake_test2, False  , "FFF"  , "EEE", "FFF", baseline_dir)
 
 # Machinery for Macros generation tests.
 


### PR DESCRIPTION
need to record most recent pass, not pass transition

Test suite: L_TestSaveTimings, pylint
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: None (e3sm only)
