### PR TITLE
hist_utils tests using cprnc doesnt work on binary files

### DIFF
--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -62,6 +62,9 @@ def copy_histfiles(case, suffix):
         num_copied += len(test_hists)
         for test_hist in test_hists:
             test_hist = os.path.join(rundir,test_hist)
+            if not test_hist.endswith('.nc'):
+                logger.info("Will not compare non-netcdf file {}".format(test_hist))
+                continue
             new_file = "{}.{}".format(test_hist, suffix)
             if os.path.exists(new_file):
                 os.remove(new_file)
@@ -246,6 +249,9 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
         num_compared += len(match_ups)
 
         for hist1, hist2 in match_ups:
+            if not '.nc.' in hist1:
+                logger.info("Ignoring non-netcdf file {}".format(hist1))
+                continue
             success, cprnc_log_file, cprnc_comment = cprnc(model, os.path.join(from_dir1,hist1),
                                                            os.path.join(from_dir2,hist2), case, from_dir1,
                                                            multiinst_driver_compare=multiinst_driver_compare,

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -249,7 +249,7 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
         num_compared += len(match_ups)
 
         for hist1, hist2 in match_ups:
-            if not '.nc.' in hist1:
+            if not '.nc' in hist1:
                 logger.info("Ignoring non-netcdf file {}".format(hist1))
                 continue
             success, cprnc_log_file, cprnc_comment = cprnc(model, os.path.join(from_dir1,hist1),


### PR DESCRIPTION
Non-netcdf files should not be compared with cprnc - look for the .nc extension on history files and only compare files that have that extension.

Test suite: scripts_regression_tests.py + hand testing of SMS.T62_g37.C.cheyenne_intel.pop-default
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3396 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
