### PR TITLE
add ic_filepath to config_inputdata

### DIFF
--- a/config/ufs/config_inputdata.xml
+++ b/config/ufs/config_inputdata.xml
@@ -14,18 +14,19 @@
     <address>ftp.emc.ncep.noaa.gov/EIB/UFS/</address>
     <user>anonymous</user>
     <password>user@example.edu</password>
-  </server>
-  <server>
-    <!-- needed for test input data on ftp server -->
-    <comment>ftp site for ufs release</comment>
-    <protocol>ftp</protocol>
-    <address>ftp.emc.ncep.noaa.gov/EIB/UFS/inputdata</address>
-    <user>anonymous</user>
-    <password>user@example.edu</password>
+    <ic_filepath>inputdata/prod</ic_filepath>
   </server>
   <server>
     <comment>NOMADS ftp site for initial conditions</comment>
     <protocol>wget</protocol>
-    <address>nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/</address>
+    <address>http://nomads.ncep.noaa.gov:/pub/data/nccf/com/gfs/prod</address>
+    <ic_filepath></ic_filepath>
   </server>
+  <server>
+    <comment>NOMADS ftp site for grib initial conditions</comment>
+    <protocol>wget</protocol>
+    <address>https://nomads.ncdc.noaa.gov:</address>
+    <ic_filepath>data/gfsanl/</ic_filepath>
+  </server>
+
 </inputdata>

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -367,7 +367,7 @@ This allows using a different mpirun command to launch unit tests
     </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="NETCDF">$ENV{TACC_NETCDF_DIR}</env>
-      <env name="NCEP_LIBS">/work/01118/tg803972/stampede2/UFS/NCEPLIBS/build-all/install</env>
+      <env name="NCEPLIBS_DIR">/work/01118/tg803972/stampede2/UFS/NCEPLIBS/build-all/install</env>
       <env name="NEMSIO_INC">/work/01118/tg803972/stampede2/UFS/NCEPLIBS/build-all/install/include</env>
       <env name="NEMSIO_LIB">/work/01118/tg803972/stampede2/UFS/NCEPLIBS/build-all/install/lib/libnemsio_v2.2.3.a</env>
       <env name="BACIO_LIB4">/work/01118/tg803972/stampede2/UFS/NCEPLIBS/build-all/install/lib/libbacio_v2.1.0_4.a</env>

--- a/config/ufs/machines/template.chgres.run
+++ b/config/ufs/machines/template.chgres.run
@@ -2,7 +2,7 @@
 {{ batchdirectives }}
 
 # Set environment variables
-if [ -z "${NCEP_LIBS}" ]; then
+if [ -z "${NCEPLIBS_DIR}" ]; then
   echo "Set environment variables:"
   cat software_environment.txt | grep "=" | sed -e 's/^/export /' > .env
   source .env
@@ -13,6 +13,14 @@ fi
 # Query run directory
 rundir=`./xmlquery --value RUNDIR`
 echo "Run directory is $rundir"
+
+# Query build directory
+blddir="$rundir/../bld"
+
+# Link chgres executable to build directory
+cd $blddir
+ln -sf $NCEPLIBS_DIR/bin/chgres_cube.exe .
+cd - 
 
 # Query resolution and date
 atm_grid=`./xmlquery --value ATM_GRID`
@@ -30,9 +38,10 @@ echo "FILE PREFIX = $prefix"
 isrestart=`./xmlquery --value CONTINUE_RUN`
 echo "Is this run restart? $isrestart"
 
-# make sure namelists are up to date
+# Make sure namelists are up to date
 ./preview_namelists
 
+# Query required number of task
 np=`./xmlquery task_count --subgroup case.chgres --value`
 
 # Goto run directory
@@ -43,17 +52,14 @@ if [ "$isrestart" != "TRUE" -a ! -f "$rundir/INPUT/${prefix}.gfs_ctrl.nc" ]; the
   # Link namelist file
   ln -sf config.nml fort.41
 
-  # Query build directory
-  blddir="$rundir/../bld"
-
   # Set environment variables
-  export LD_LIBRARY_PATH=$NCEP_LIBS/lib:$NCEP_LIBS/lib64:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=$NCEPLIBS_DIR/lib:$NCEPLIBS_DIR/lib64:$LD_LIBRARY_PATH
 
   LID=`date +%y%m%d-%H%M%S`
   # Run chgres
   runcmd='{{ mpirun }}'
   mpirun=`echo $runcmd | awk '{print $1}'`
-  eval "$mpirun -np $np $NCEP_LIBS/bin/chgres_cube.exe 1> chgres_cube.$LID.log 2>&1"
+  eval "$mpirun -np $np $blddir/chgres_cube.exe 1> chgres_cube.$LID.log 2>&1"
 
   # Move output files to input directory
   mv -f gfs_ctrl.nc INPUT/${prefix}.gfs_ctrl.nc

--- a/config/ufs/machines/template.gfs_post.run
+++ b/config/ufs/machines/template.gfs_post.run
@@ -2,7 +2,7 @@
 {{ batchdirectives }}
 
 # Set environment variables
-if [ -z "${NCEP_LIBS}" ]; then
+if [ -z "${NCEPLIBS_DIR}" ]; then
   echo "Set environment variables:"
   cat software_environment.txt | grep "=" | sed -e 's/^/export /' > .env
   source .env
@@ -18,14 +18,15 @@ cd $rundir
 # Query build directory
 blddir="$rundir/../bld"
 
-# Set environment variables
-export LD_LIBRARY_PATH=$NCEP_LIBS/lib:$NCEP_LIBS/lib64:$LD_LIBRARY_PATH
+# Link chgres executable to build directory
+cd $blddir
+ln -sf $NCEPLIBS_DIR/bin/ncep_post .
+cd -
 
-# Copy executable to build directory
-cp $NCEP_LIBS/bin/ncep_post $blddir/.
+# Set environment variables
+export LD_LIBRARY_PATH=$NCEPLIBS_DIR/lib:$NCEPLIBS_DIR/lib64:$LD_LIBRARY_PATH
 
 # Query mpirun command
-
 runcmd='{{ mpirun }}'
 mpirun=`echo $runcmd | awk '{print $1}'`
 

--- a/config/xml_schemas/config_inputdata.xsd
+++ b/config/xml_schemas/config_inputdata.xsd
@@ -11,6 +11,10 @@
 	      <xs:element type="xs:string" name="comment" minOccurs="0"/>
               <xs:element type="xs:string" name="protocol"/>
               <xs:element type="xs:string" name="address"/>
+              <xs:element type="xs:string" name="user" minOccurs="0"/>
+              <xs:element type="xs:string" name="password" minOccurs="0"/>
+              <xs:element type="xs:string" name="checksum" minOccurs="0"/>
+              <xs:element type="xs:string" name="ic_filepath" minOccurs="0"/>
             </xs:sequence>
           </xs:complexType>
         </xs:element>

--- a/scripts/lib/CIME/XML/inputdata.py
+++ b/scripts/lib/CIME/XML/inputdata.py
@@ -30,6 +30,7 @@ class Inputdata(GenericXML):
         user = ''
         passwd = ''
         chksum_file = None
+        ic_filepath = None
         servernodes = self.get_children("server")
         if self._servernode is None:
             self._servernode = servernodes[0]
@@ -54,4 +55,8 @@ class Inputdata(GenericXML):
             csnode = self.get_optional_child("checksum", root = self._servernode)
             if csnode:
                 chksum_file =  self.text(csnode)
-        return protocol, address, user, passwd, chksum_file
+            icnode = self.get_optional_child("ic_filepath", root = self._servernode)
+            if icnode:
+                ic_filepath =  self.text(icnode)
+
+        return protocol, address, user, passwd, chksum_file, ic_filepath

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -145,7 +145,7 @@ def _build_model(build_threaded, exeroot, incroot, complist,
     return logs
 
 ###############################################################################
-def _build_checks(case, build_threaded, comp_interface, 
+def _build_checks(case, build_threaded, comp_interface,
                   debug, compiler, mpilib, complist, ninst_build, smp_value,
                   model_only, buildlist):
 ###############################################################################
@@ -499,13 +499,13 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
     case.load_env()
 
     sharedpath = _build_checks(case, build_threaded, comp_interface,
-                               debug, compiler, mpilib, complist, ninst_build, smp_value, 
+                               debug, compiler, mpilib, complist, ninst_build, smp_value,
                                model_only, buildlist)
 
     t2 = time.time()
     logs = []
 
-    if not model_only and cime_model != "ufs":
+    if not model_only and 'CPL' in comp_classes:
         logs = _build_libraries(case, exeroot, sharedpath, caseroot,
                                 cimeroot, libroot, lid, compiler, buildlist, comp_interface)
 

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -130,8 +130,8 @@ manual edits to these file will be lost!
         unlock_file(os.path.basename(env_batch.filename))
         lock_file(os.path.basename(env_batch.filename))
 
+        case.check_case()
         if job == case.get_primary_job():
-            case.check_case()
             case.check_DA_settings()
             if case.get_value("MACH") == "mira":
                 with open(".original_host", "w") as fd:

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -355,7 +355,6 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
                             logger.warning("  Model {} missing file {} = '{}'".format(model, description, full_path))
                             no_files_missing = False
                             if (download):
-                                print "HERE input_ic_root {} rel_path {}".format(input_ic_root,rel_path)
                                 if use_ic_path:
                                     no_files_missing = _download_if_in_repo(server,
                                                                             input_ic_root, rel_path.strip(os.sep),

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -22,7 +22,7 @@ def _download_checksum_file(rundir):
     chksum_found = False
     # download and merge all available chksum files.
     while protocol is not None:
-        protocol, address, user, passwd, chksum_file = inputdata.get_next_server()
+        protocol, address, user, passwd, chksum_file,_ = inputdata.get_next_server()
         if protocol not in vars(CIME.Servers):
             logger.warning("Client protocol {} not enabled".format(protocol))
             continue
@@ -106,7 +106,7 @@ def _merge_chksum_files(new_file, old_file):
 
 
 
-def _download_if_in_repo(server, input_data_root, rel_path, isdirectory=False):
+def _download_if_in_repo(server, input_data_root, rel_path, isdirectory=False, ic_filepath=None):
     """
     Return True if successfully downloaded
     server is an object handle of type CIME.Servers
@@ -117,8 +117,9 @@ def _download_if_in_repo(server, input_data_root, rel_path, isdirectory=False):
     """
     if not (rel_path or server.fileexists(rel_path)):
         return False
-
     full_path = os.path.join(input_data_root, rel_path)
+    if ic_filepath:
+        full_path = full_path.replace(ic_filepath, "")
     logging.info("Trying to download file: '{}' to path '{}' using {} protocol.".format(rel_path, full_path, type(server).__name__))
     # Make sure local path exists, create if it does not
     if isdirectory or full_path.endswith(os.sep):
@@ -183,12 +184,12 @@ def _downloadfromserver(case, input_data_root, data_list_dir):
         input_data_root = case.get_value('DIN_LOC_ROOT')
 
     while not success and protocol is not None:
-        protocol, address, user, passwd, _ = inputdata.get_next_server()
+        protocol, address, user, passwd, _, ic_filepath = inputdata.get_next_server()
         logger.info("Checking server {} with protocol {}".format(address, protocol))
         success = case.check_input_data(protocol=protocol, address=address, download=True,
                                         input_data_root=input_data_root,
                                         data_list_dir=data_list_dir,
-                                        user=user, passwd=passwd)
+                                        user=user, passwd=passwd, ic_filepath=ic_filepath)
     return success
 
 def stage_refcase(self, input_data_root=None, data_list_dir=None):
@@ -263,7 +264,7 @@ def stage_refcase(self, input_data_root=None, data_list_dir=None):
     return True
 
 def check_input_data(case, protocol="svn", address=None, input_data_root=None, data_list_dir="Buildconf",
-                     download=False, user=None, passwd=None, chksum=False):
+                     download=False, user=None, passwd=None, chksum=False, ic_filepath=None):
     """
     For a given case check for the relevant input data as specified in data_list_dir/*.input_data_list
     in the directory input_data_root, if not found optionally download it using the servers specified
@@ -317,11 +318,15 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
                 if(full_path):
                     # expand xml variables
                     full_path = case.get_resolved_value(full_path)
-                    if input_data_root in full_path:
+                    if input_ic_root in full_path and ic_filepath:
+                        rel_path = full_path.replace(input_ic_root, ic_filepath)
+                        use_ic_path = True
+                    elif input_data_root in full_path:
                         rel_path  = full_path.replace(input_data_root, "")
                     elif input_ic_root and \
                          (input_ic_root not in input_data_root and input_ic_root in full_path):
-                        rel_path  = full_path.replace(input_ic_root, "prod")
+                        if ic_filepath:
+                            rel_path  = full_path.replace(input_ic_root, ic_filepath)
                         use_ic_path = True
 
                     model = os.path.basename(data_list_file).split('.')[0]
@@ -350,14 +355,15 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
                             logger.warning("  Model {} missing file {} = '{}'".format(model, description, full_path))
                             no_files_missing = False
                             if (download):
+                                print "HERE input_ic_root {} rel_path {}".format(input_ic_root,rel_path)
                                 if use_ic_path:
                                     no_files_missing = _download_if_in_repo(server,
-                                                                            input_ic_root[:-4], rel_path.strip(os.sep),
-                                                                            isdirectory=isdirectory)
+                                                                            input_ic_root, rel_path.strip(os.sep),
+                                                                            isdirectory=isdirectory, ic_filepath=ic_filepath)
                                 else:
                                     no_files_missing = _download_if_in_repo(server,
                                                                             input_data_root, rel_path.strip(os.sep),
-                                                                            isdirectory=isdirectory)
+                                                                            isdirectory=isdirectory, ic_filepath=ic_filepath)
                                 if no_files_missing and chksum:
                                     verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)
                         else:


### PR DESCRIPTION
The inputdata download tool has always expected the same directory structure on the data server and client.  However this may not be the case for initial condition files.  This change allows the user to configure a path for each inputdata server for the location of inputdata and always get it to the same location on the client side.

Test suite: scripts_regression_tests.py plus handtesting with ufs model ic data downloads
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
