### PR TITLE
Wpcoomb/improve cprnc build process

### DIFF
--- a/config/e3sm/machines/config_machines.xml
+++ b/config/e3sm/machines/config_machines.xml
@@ -533,7 +533,7 @@
     <DIN_LOC_ROOT_CLMFORC>/sems-data-store/ACME/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/sems-data-store/ACME/baselines/$COMPILER</BASELINE_ROOT>
-    <!--CCSM_CPRNC>/sems-data-store/ACME/cprnc/build.new/cprnc</CCSM_CPRNC-->
+    <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build.new/cprnc</CCSM_CPRNC>
     <GMAKE_J>32</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>

--- a/config/e3sm/machines/config_machines.xml
+++ b/config/e3sm/machines/config_machines.xml
@@ -533,7 +533,7 @@
     <DIN_LOC_ROOT_CLMFORC>/sems-data-store/ACME/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/sems-data-store/ACME/baselines/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/sems-data-store/ACME/cprnc/build.new/cprnc</CCSM_CPRNC>
+    <!--CCSM_CPRNC>/sems-data-store/ACME/cprnc/build.new/cprnc</CCSM_CPRNC-->
     <GMAKE_J>32</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -247,6 +247,10 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
     if uses_kokkos(case):
         libs.append("kokkos")
 
+    cprnc_loc = case.get_value("CCSM_CPRNC")
+    if not cprnc_loc or not os.path.exists(cprnc_loc):
+        libs.append("cprnc")
+
     logs = []
     sharedlibroot = os.path.abspath(case.get_value("SHAREDLIBROOT"))
     for lib in libs:

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -247,12 +247,10 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
     if uses_kokkos(case):
         libs.append("kokkos")
 
+    # Check if we need to build our own cprnc
     cprnc_loc = case.get_value("CCSM_CPRNC")
     if not cprnc_loc or not os.path.exists(cprnc_loc):
         libs.append("cprnc")
-    #libs.append("cprnc")
-    logger.info("wpc:: appending cprnc lib to the libs list")
-
 
     logs = []
     sharedlibroot = os.path.abspath(case.get_value("SHAREDLIBROOT"))
@@ -267,7 +265,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
             full_lib_path = os.path.join(sharedlibroot, sharedpath, "mct", lib)
         elif lib == "cprnc":
             full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
-            case.set_value("CCSM_CPRNC", os.path.join(full_lib_path, "/bin/cprnc"))
+            case.set_value("CCSM_CPRNC", os.path.join(full_lib_path, "cprnc"))
         else:
             full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
         # pio build creates its own directory

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -264,7 +264,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
         elif lib == "mpi-serial":
             full_lib_path = os.path.join(sharedlibroot, sharedpath, "mct", lib)
         elif lib == "cprnc":
-            full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
+            full_lib_path = sharedlibroot
             case.set_value("CCSM_CPRNC", os.path.join(full_lib_path, "cprnc"))
         else:
             full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -250,6 +250,9 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
     cprnc_loc = case.get_value("CCSM_CPRNC")
     if not cprnc_loc or not os.path.exists(cprnc_loc):
         libs.append("cprnc")
+    #libs.append("cprnc")
+    logger.info("wpc:: appending cprnc lib to the libs list")
+
 
     logs = []
     sharedlibroot = os.path.abspath(case.get_value("SHAREDLIBROOT"))
@@ -262,6 +265,9 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
             full_lib_path = os.path.join(sharedlibroot, sharedpath)
         elif lib == "mpi-serial":
             full_lib_path = os.path.join(sharedlibroot, sharedpath, "mct", lib)
+        elif lib == "cprnc":
+            full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
+            case.set_value("CCSM_CPRNC", os.path.join(full_lib_path, "/bin/cprnc"))
         else:
             full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
         # pio build creates its own directory

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -248,9 +248,10 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
         libs.append("kokkos")
 
     # Check if we need to build our own cprnc
-    cprnc_loc = case.get_value("CCSM_CPRNC")
-    if not cprnc_loc or not os.path.exists(cprnc_loc):
-        libs.append("cprnc")
+    if case.get_value("TEST"):
+        cprnc_loc = case.get_value("CCSM_CPRNC")
+        if not cprnc_loc or not os.path.exists(cprnc_loc):
+            libs.append("cprnc")
 
     logs = []
     sharedlibroot = os.path.abspath(case.get_value("SHAREDLIBROOT"))

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -266,7 +266,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
             full_lib_path = os.path.join(sharedlibroot, sharedpath, "mct", lib)
         elif lib == "cprnc":
             full_lib_path = os.path.join(sharedlibroot, compiler, "cprnc")
-            case.set_value("CCSM_CPRNC", os.path.join(full_lib_path))
+            case.set_value("CCSM_CPRNC", os.path.join(full_lib_path, "cprnc"))
         else:
             full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
         # pio build creates its own directory

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -265,8 +265,8 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
         elif lib == "mpi-serial":
             full_lib_path = os.path.join(sharedlibroot, sharedpath, "mct", lib)
         elif lib == "cprnc":
-            full_lib_path = sharedlibroot
-            case.set_value("CCSM_CPRNC", os.path.join(full_lib_path, "cprnc"))
+            full_lib_path = os.path.join(sharedlibroot, compiler, "cprnc")
+            case.set_value("CCSM_CPRNC", os.path.join(full_lib_path))
         else:
             full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
         # pio build creates its own directory

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1157,9 +1157,9 @@ class TestCreateTestCommon(unittest.TestCase):
             self._wait_for_tests(test_id, expect_works=(not pre_run_errors and not run_errors))
 
     ###########################################################################
-    def _wait_for_tests(self, test_id, expect_works=True):
+    def _wait_for_tests(self, test_id, expect_works=True, always_wait=False):
     ###########################################################################
-        if self._hasbatch:
+        if self._hasbatch or always_wait:
             timeout_arg = "--timeout={}".format(GLOBAL_TIMEOUT) if GLOBAL_TIMEOUT is not None else ""
             expected_stat = 0 if expect_works else CIME.utils.TESTS_FAILED_ERR_CODE
             run_cmd_assert_result(self, "{}/wait_for_tests {} *{}/TestStatus".format(TOOLS_DIR, timeout_arg, test_id),
@@ -2407,6 +2407,7 @@ class K_TestCimeCase(TestCreateTestCommon):
             man_env_contents = fd.read()
 
         self.assertEqual(case_env_contents, man_env_contents)
+
     ###########################################################################
     def test_self_build_cprnc(self):
     ###########################################################################
@@ -2420,7 +2421,7 @@ class K_TestCimeCase(TestCreateTestCommon):
         run_cmd_assert_result(self, "./case.build", from_dir=casedir)
         run_cmd_assert_result(self, "./case.submit", from_dir=casedir)
 
-        self._wait_for_tests(self._baseline_name)
+        self._wait_for_tests(self._baseline_name, always_wait=True)
 
 ###############################################################################
 class X_TestSingleSubmit(TestCreateTestCommon):

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2407,6 +2407,20 @@ class K_TestCimeCase(TestCreateTestCommon):
             man_env_contents = fd.read()
 
         self.assertEqual(case_env_contents, man_env_contents)
+    ###########################################################################
+    def test_self_build_cprnc(self):
+    ###########################################################################
+        self._create_test(["ERS.f19_g16_rx1.A", "--no-build"], test_id=self._baseline_name)
+
+        casedir = os.path.join(self._testroot,
+                               "{}.{}".format(CIME.utils.get_full_test_name("ERS.f19_g16_rx1.A", machine=self._machine, compiler=self._compiler), self._baseline_name))
+
+        run_cmd_assert_result(self, "./xmlchange CCSM_CPRNC=this_is_a_broken_cprnc",
+                              from_dir=casedir)
+        run_cmd_assert_result(self, "./case.build", from_dir=casedir)
+        run_cmd_assert_result(self, "./case.submit", from_dir=casedir)
+
+        self._wait_for_tests(self._baseline_name)
 
 ###############################################################################
 class X_TestSingleSubmit(TestCreateTestCommon):

--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -3,7 +3,7 @@
 from standard_script_setup import *
 from CIME.utils import expect, run_bld_cmd_ensure_logging, run_cmd_no_fail, run_cmd
 from CIME.case import Case
-from CIME.build import get_standard_makefile_args
+from CIME.build import get_standard_cmake_args
 
 logger = logging.getLogger(__name__)
 
@@ -44,15 +44,23 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def buildlib(bldroot, installpath, case):
 ###############################################################################
-    import pdb
-    pdb.set_trace()
-    make_args = get_standard_makefile_args(case, shared_lib=True)
-    sfc = run_cmd_no_fail("make -f Macros.make {} -p | grep SFC".format(make_args)).split(":=")[-1].strip()
-    np = run_cmd_no_fail("make -f Macros.make {} -p | grep NETCDF_PATH".format(make_args)).split(":=")[-1].strip()
+    caseroot = case.get_value("CASEROOT")
+    cimeroot = case.get_value("CIMEROOT")
+
+    # Generate macros and environment
+    run_bld_cmd_ensure_logging("{}/tools/configure --mpilib=mpi-serial --macros-format=CMake".format(cimeroot), logger, from_dir=bldroot)
+
+    cmake_args = get_standard_cmake_args(case, shared_lib=True)
     cr = "$CIMEROOT/tools/cprnc"
 
-    cmake_cmd = "cmake -DNETCDF_PATH={netcdf_path} -DCMAKE_Fortran_COMPILER_ID={sfc} {cr} -DCMAKE_PREFIX_PATH{dest_path}".format(netcdf_path=np, sfc=sfc, cr=cr, destpath=installpath)
+    cmake_cmd = "CIMEROOT={cimeroot} . .env_mach_specific.sh && cmake {cmake_args} -DMPILIB=mpi-serial -C Macros.cmake {cimeroot}/tools/cprnc -DCMAKE_PREFIX_PATH={dest_path}".\
+        format(cimeroot=cimeroot, dest_path=installpath, caseroot=caseroot, cmake_args=cmake_args)
     run_bld_cmd_ensure_logging(cmake_cmd, logger, from_dir=bldroot)
+
+    gmake_cmd = case.get_value("GMAKE")
+    gmake_j = case.get_value("GMAKE_J")
+
+    run_bld_cmd_ensure_logging("{} -j {}".format(gmake_cmd, gmake_j), logger, from_dir=bldroot)
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)

--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -51,7 +51,7 @@ def buildlib(bldroot, installpath, case):
 
     cmake_args = get_standard_cmake_args(case, shared_lib=True)
 
-    cmake_cmd = "CIMEROOT={cimeroot} . .env_mach_specific.sh && cmake {cmake_args} -DMPILIB=mpi-serial -DDEBUG=FALSE -C Macros.cmake {cimeroot}/tools/cprnc -DCMAKE_PREFIX_PATH={dest_path}".\
+    cmake_cmd = "CIMEROOT={cimeroot} . .env_mach_specific.sh && NETCDF=$(dirname $(dirname $(which nf-config))) CIMEROOT={cimeroot} cmake {cmake_args} -DMPILIB=mpi-serial -DDEBUG=FALSE -C Macros.cmake {cimeroot}/tools/cprnc -DCMAKE_PREFIX_PATH={dest_path}".\
         format(cimeroot=cimeroot, dest_path=installpath, cmake_args=cmake_args)
     run_bld_cmd_ensure_logging(cmake_cmd, logger, from_dir=bldroot)
 

--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from standard_script_setup import *
-from CIME.utils import expect, run_bld_cmd_ensure_logging, run_cmd_no_fail, run_cmd
+from CIME.utils import run_bld_cmd_ensure_logging
 from CIME.case import Case
 from CIME.build import get_standard_cmake_args
 
@@ -44,7 +44,6 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def buildlib(bldroot, installpath, case):
 ###############################################################################
-    caseroot = case.get_value("CASEROOT")
     cimeroot = case.get_value("CIMEROOT")
 
     # Generate macros and environment

--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -51,10 +51,9 @@ def buildlib(bldroot, installpath, case):
     run_bld_cmd_ensure_logging("{}/tools/configure --mpilib=mpi-serial --macros-format=CMake".format(cimeroot), logger, from_dir=bldroot)
 
     cmake_args = get_standard_cmake_args(case, shared_lib=True)
-    cr = "$CIMEROOT/tools/cprnc"
 
     cmake_cmd = "CIMEROOT={cimeroot} . .env_mach_specific.sh && cmake {cmake_args} -DMPILIB=mpi-serial -C Macros.cmake {cimeroot}/tools/cprnc -DCMAKE_PREFIX_PATH={dest_path}".\
-        format(cimeroot=cimeroot, dest_path=installpath, caseroot=caseroot, cmake_args=cmake_args)
+        format(cimeroot=cimeroot, dest_path=installpath, cmake_args=cmake_args)
     run_bld_cmd_ensure_logging(cmake_cmd, logger, from_dir=bldroot)
 
     gmake_cmd = case.get_value("GMAKE")

--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -51,7 +51,7 @@ def buildlib(bldroot, installpath, case):
 
     cmake_args = get_standard_cmake_args(case, shared_lib=True)
 
-    cmake_cmd = "CIMEROOT={cimeroot} . .env_mach_specific.sh && cmake {cmake_args} -DMPILIB=mpi-serial -C Macros.cmake {cimeroot}/tools/cprnc -DCMAKE_PREFIX_PATH={dest_path}".\
+    cmake_cmd = "CIMEROOT={cimeroot} . .env_mach_specific.sh && cmake {cmake_args} -DMPILIB=mpi-serial -DDEBUG=FALSE -C Macros.cmake {cimeroot}/tools/cprnc -DCMAKE_PREFIX_PATH={dest_path}".\
         format(cimeroot=cimeroot, dest_path=installpath, cmake_args=cmake_args)
     run_bld_cmd_ensure_logging(cmake_cmd, logger, from_dir=bldroot)
 

--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -58,7 +58,7 @@ def buildlib(bldroot, installpath, case):
     gmake_cmd = case.get_value("GMAKE")
     gmake_j = case.get_value("GMAKE_J")
 
-    run_bld_cmd_ensure_logging("{} -j {}".format(gmake_cmd, gmake_j), logger, from_dir=bldroot)
+    run_bld_cmd_ensure_logging("{} VERBOSE=1 -j {}".format(gmake_cmd, gmake_j), logger, from_dir=bldroot)
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)

--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -44,13 +44,15 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 ###############################################################################
 def buildlib(bldroot, installpath, case):
 ###############################################################################
-
+    import pdb
+    pdb.set_trace()
+    make_args = get_standard_makefile_args(case, shared_lib=True)
     sfc = run_cmd_no_fail("make -f Macros.make {} -p | grep SFC".format(make_args)).split(":=")[-1].strip()
     np = run_cmd_no_fail("make -f Macros.make {} -p | grep NETCDF_PATH".format(make_args)).split(":=")[-1].strip()
     cr = "$CIMEROOT/tools/cprnc"
 
-    cmake_cmd = "cmake -DNETCDF_PATH={netcdf_path} -DCMAKE_Fortran_COMPILER_ID={sfc} {cr}".format(netcdf_path=np, sfc=sfc, cr=cr)
-    Run_bld_cmd_ensure_logging(cmake_cmd, logger, from_dir=bldroot)
+    cmake_cmd = "cmake -DNETCDF_PATH={netcdf_path} -DCMAKE_Fortran_COMPILER_ID={sfc} {cr} -DCMAKE_PREFIX_PATH{dest_path}".format(netcdf_path=np, sfc=sfc, cr=cr, destpath=installpath)
+    run_bld_cmd_ensure_logging(cmake_cmd, logger, from_dir=bldroot)
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)

--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+from standard_script_setup import *
+from CIME.utils import expect, run_bld_cmd_ensure_logging, run_cmd_no_fail, run_cmd
+from CIME.case import Case
+from CIME.build import get_standard_makefile_args
+
+logger = logging.getLogger(__name__)
+
+def parse_command_line(args, description):
+###############################################################################
+    parser = argparse.ArgumentParser(
+        usage="""\n{0} [--debug]
+OR
+{0} --verbose
+OR
+{0} --help
+
+\033[1mEXAMPLES:\033[0m
+    \033[1;32m# Run \033[0m
+    > {0}
+""" .format (os.path.basename(args[0])),
+
+description=description,
+
+formatter_class=argparse.ArgumentDefaultsHelpFormatter
+)
+
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("buildroot",
+                        help="build path root")
+
+    parser.add_argument("installpath",
+                        help="install path ")
+
+    parser.add_argument("caseroot", nargs="?", default=os.getcwd(),
+                        help="Case directory to build")
+
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    return args.buildroot, args.installpath, args.caseroot
+
+###############################################################################
+def buildlib(bldroot, installpath, case):
+###############################################################################
+
+    sfc = run_cmd_no_fail("make -f Macros.make {} -p | grep SFC".format(make_args)).split(":=")[-1].strip()
+    np = run_cmd_no_fail("make -f Macros.make {} -p | grep NETCDF_PATH".format(make_args)).split(":=")[-1].strip()
+    cr = "$CIMEROOT/tools/cprnc"
+
+    cmake_cmd = "cmake -DNETCDF_PATH={netcdf_path} -DCMAKE_Fortran_COMPILER_ID={sfc} {cr}".format(netcdf_path=np, sfc=sfc, cr=cr)
+    Run_bld_cmd_ensure_logging(cmake_cmd, logger, from_dir=bldroot)
+
+def _main(argv, documentation):
+    bldroot, installpath, caseroot = parse_command_line(argv, documentation)
+    with Case(caseroot, read_only=False) as case:
+        buildlib(bldroot, installpath, case)
+
+if (__name__ == "__main__"):
+    _main(sys.argv, __doc__)

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2711,7 +2711,7 @@
     <default_value>UNSET</default_value>
     <group>test</group>
     <file>env_test.xml</file>
-    <desc>standard full pathname of the cprnc executable</desc>
+    <desc>standard full pathname of the cprnc executable. One can skip defining the xml entry, CCSM_CPRNC, and the sharedlib build system will automatically build cprnc</desc>
   </entry>
 
   <!-- ===================================================================== -->

--- a/tools/cprnc/CMakeLists.txt
+++ b/tools/cprnc/CMakeLists.txt
@@ -1,23 +1,18 @@
 PROJECT(CPRNC C Fortran)
 
- 	
-execute_process(COMMAND ../configure --macros-format=CMake WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "$ENV{CIMEROOT}/src/CMake")
+# Generate this with: $cimeroot/tools/configure --mpilib=mpi-serial --macros-format=CMake
+#   You'll also need to source the .env_mach_specific.sh file before trying to build cprnc
+include("${PROJECT_BINARY_DIR}/Macros.cmake")
 
-INCLUDE(Macros.cmake)
+if (NOT NETCDF_PATH)
+  message(FATAL_ERROR "Requires NETCDF_PATH either from Macros.cmake or argument")
+endif()
 
 ENABLE_LANGUAGE(Fortran)
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{CIMEROOT}/src/externals/pio2/cmake)
-
-# Defining NETCDF_LIBRARIES and NETCDF_INCLUDE_DIR enables bypassing
-#   the search for Netcdf
-IF (NOT DEFINED NETCDF_LIBRARIES OR NOT DEFINED NETCDF_INCLUDE_DIR)
-  SET(NETCDF_INCLUDE_DIR ${NETCDF_PATH}/include)
-  SET(NETCDF_LIBRARIES ${NETCDF_PATH}/lib/libnetcdff.a)
-ENDIF ()
 
 ADD_CUSTOM_COMMAND(
   OUTPUT ${PROJECT_BINARY_DIR}/compare_vars_mod.F90
@@ -37,7 +32,7 @@ ELSEIF (CMAKE_COMPILER_ID STREQUAL PathScale)
 ENDIF ()
 
 INCLUDE_DIRECTORIES(
-  ${NETCDF_INCLUDE_DIR}
+  ${NETCDF_PATH}/include
   ${PROJECT_SOURCE_DIR}
   ${PROJECT_BINARY_DIR}
 )
@@ -53,9 +48,6 @@ SET (CPRNC_SRCS
 ADD_EXECUTABLE(cprnc ${CPRNC_SRCS})
 ADD_DEPENDENCIES(cprnc COMPARE_VARS)
 
-TARGET_LINK_LIBRARIES(cprnc ${NETCDF_LIBRARIES})
-
-INSTALL(TARGETS cprnc
-        RUNTIME DESTINATION bin)
-
-execute_process(COMMAND ../configure --clean WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+# SLIBS comes from Macros.cmake
+separate_arguments(SLIBS_LIST UNIX_COMMAND "${SLIBS}")
+TARGET_LINK_LIBRARIES(cprnc ${SLIBS_LIST})

--- a/tools/cprnc/CMakeLists.txt
+++ b/tools/cprnc/CMakeLists.txt
@@ -20,9 +20,8 @@ ADD_CUSTOM_COMMAND(
   OUTPUT ${PROJECT_BINARY_DIR}/compare_vars_mod.F90
   COMMAND perl ${PROJECT_SOURCE_DIR}/../../src/externals/genf90/genf90.pl
     ${PROJECT_SOURCE_DIR}/compare_vars_mod.F90.in > ${PROJECT_BINARY_DIR}/compare_vars_mod.F90
+  DEPENDS ${PROJECT_SOURCE_DIR}/compare_vars_mod.F90.in ${PROJECT_SOURCE_DIR}/../../src/externals/genf90/genf90.pl
 )
-
-ADD_CUSTOM_TARGET(COMPARE_VARS DEPENDS ${PROJECT_BINARY_DIR}/compare_vars_mod.F90)
 
 INCLUDE_DIRECTORIES(
   ${NETCDF_PATH}/include

--- a/tools/cprnc/CMakeLists.txt
+++ b/tools/cprnc/CMakeLists.txt
@@ -3,6 +3,8 @@ PROJECT(CPRNC C Fortran)
 # Generate this with: $cimeroot/tools/configure --mpilib=mpi-serial --macros-format=CMake
 #   You'll also need to source the .env_mach_specific.sh file before trying to build cprnc
 include("${PROJECT_BINARY_DIR}/Macros.cmake")
+set(CMAKE_Fortran_Compiler "${SFC}")
+set(CMAKE_Fortran_FLAGS "${FFLAGS}")
 
 if (NOT NETCDF_PATH)
   message(FATAL_ERROR "Requires NETCDF_PATH either from Macros.cmake or argument")
@@ -21,15 +23,6 @@ ADD_CUSTOM_COMMAND(
 )
 
 ADD_CUSTOM_TARGET(COMPARE_VARS DEPENDS ${PROJECT_BINARY_DIR}/compare_vars_mod.F90)
-
-# Support extended line lengths
-IF (${CMAKE_Fortran_COMPILER_ID} STREQUAL GNU)
-  SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
-ELSEIF (CMAKE_COMPILER_ID STREQUAL PGI)
-  SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Mextend")
-ELSEIF (CMAKE_COMPILER_ID STREQUAL PathScale)
-  SET(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -extend-source")
-ENDIF ()
 
 INCLUDE_DIRECTORIES(
   ${NETCDF_PATH}/include

--- a/tools/cprnc/CMakeLists.txt
+++ b/tools/cprnc/CMakeLists.txt
@@ -6,15 +6,13 @@ include("${PROJECT_BINARY_DIR}/Macros.cmake")
 set(CMAKE_Fortran_Compiler "${SFC}")
 set(CMAKE_Fortran_FLAGS "${FFLAGS}")
 
-if (NOT NETCDF_PATH)
-  message(FATAL_ERROR "Requires NETCDF_PATH either from Macros.cmake or argument")
-endif()
-
 ENABLE_LANGUAGE(Fortran)
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
+# Find netcdf
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{CIMEROOT}/src/externals/pio2/cmake)
+find_package (NetCDF COMPONENTS Fortran REQUIRED)
 
 ADD_CUSTOM_COMMAND(
   OUTPUT ${PROJECT_BINARY_DIR}/compare_vars_mod.F90
@@ -24,7 +22,7 @@ ADD_CUSTOM_COMMAND(
 )
 
 INCLUDE_DIRECTORIES(
-  ${NETCDF_PATH}/include
+  ${NetCDF_Fortran_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}
   ${PROJECT_BINARY_DIR}
 )
@@ -40,6 +38,4 @@ SET (CPRNC_SRCS
 ADD_EXECUTABLE(cprnc ${CPRNC_SRCS})
 ADD_DEPENDENCIES(cprnc COMPARE_VARS)
 
-# SLIBS comes from Macros.cmake
-separate_arguments(SLIBS_LIST UNIX_COMMAND "${SLIBS}")
-TARGET_LINK_LIBRARIES(cprnc ${SLIBS_LIST})
+TARGET_LINK_LIBRARIES(cprnc ${NetCDF_Fortran_LIBRARIES})


### PR DESCRIPTION
Improved cprnc build process for 
better installs on new platforms.
This PR adds functionality to build cprnc on the fly as part of create_test if it doesn't already exist. One can skip defining the xml entry, CCSM_CPRNC, and the sharedlib build system will automatically build cprnc once for each compiler, with DEBUG set to FALSE.


Test suite:  scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: 

Fixes #3389
Fixes #2457

User interface changes?: N

Update gh-pages html (Y/N)?:

Code review: @jedwards4b @billsacks 
