### PR TITLE
add filename to input_data_list

### DIFF
--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -495,7 +495,7 @@ class NamelistGenerator(object):
                 filepath, filename = os.path.split(filename)
                 if not filepath:
                     filepath = os.path.join(domain_filepath, os.path.dirname(filename.strip()))
-                string = "domain{:d} = {}\n".format(i+1, filepath)
+                string = "domain{:d} = {}/{}\n".format(i+1, filepath, filename)
                 hashValue = hashlib.md5(string.rstrip().encode('utf-8')).hexdigest()
                 if hashValue not in lines_hash:
                     input_data_list.write(string)


### PR DESCRIPTION
I noticed that some file names were not in the input_data_list that should be. 

Test suite: scripts_regression_tests.py on laramie
Test baseline: 
Test namelist changes: 
Test status: bit for bit,

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
