### PR TITLE
Fix the -n parameter to mpirun in chgres workflow template

### DIFF
--- a/config/ufs/machines/template.chgres.run
+++ b/config/ufs/machines/template.chgres.run
@@ -60,7 +60,7 @@ if [ "$isrestart" != "TRUE" -a ! -f "$rundir/INPUT/${prefix}.gfs_ctrl.nc" ]; the
   runcmd='{{ mpirun }}'
   mpirun=`echo $runcmd | awk '{print $1}'`
 
-  eval "$mpirun -np $np $blddir/chgres_cube.exe 1> chgres_cube.$LID.log 2>&1"
+  eval "$mpirun -n $np $blddir/chgres_cube.exe 1> chgres_cube.$LID.log 2>&1"
 
   # Move output files to input directory
   mv -f gfs_ctrl.nc INPUT/${prefix}.gfs_ctrl.nc


### PR DESCRIPTION
The chgres workflow template was using "-np" for the mpirun number of tasks, but this should be corrected to "-n" so it works on slurm and other batch systems.