### PR TITLE
Port CIME to Hera

### DIFF
--- a/config/ufs/machines/config_batch.xml
+++ b/config/ufs/machines/config_batch.xml
@@ -217,7 +217,6 @@
       <queue walltimemax="24:00:00" nodemin="861" nodemax="4166" default="true">batch</queue>
     </queues>
   </batch_system>
-
   <batch_system MACH="hera" type="slurm" >
     <batch_submit>sbatch</batch_submit>
     <submit_args>
@@ -229,11 +228,10 @@
       <directive>--partition=hera</directive>
     </directives>
     <queues>
-      <queue walltimemax="08:00:00" nodemin="1" nodemax="210">batch</queue>
-      <queue default="true" walltimemax="00:30:00" nodemin="1" nodemax="210">debug</queue>
+      <queue default="true" walltimemax="08:00:00" nodemin="1" nodemax="210">batch</queue>
+      <queue walltimemax="00:30:00" nodemin="1" nodemax="210">debug</queue>
     </queues>
   </batch_system>
-
   <batch_system type="pbs" MACH="izumi" >
     <batch_submit>ssh izumi cd $CASEROOT ; qsub</batch_submit>
     <jobid_pattern>(\d+.izumi.unified.ucar.edu)$</jobid_pattern>

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -251,6 +251,64 @@ This allows using a different mpirun command to launch unit tests
     </resource_limits>
   </machine>
 
+  <machine MACH="hera">
+    <DESC>NOAA hera system</DESC>
+    <NODENAME_REGEX>hfe</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>impi</MPILIBS>
+    <PROJECT>nems</PROJECT>
+    <SAVE_TIMING_DIR/>
+    <CIME_OUTPUT_ROOT>/scratch1/NCEPDEV/nems/$USER</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/scratch1/NCEPDEV/nems/Rocky.Dunlap/INPUTDATA</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/scratch1/NCEPDEV/nems/Rocky.Dunlap/INPUTDATA/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/scratch1/NCEPDEV/nems/Rocky.Dunlap/BASELINES</BASELINE_ROOT>
+    <CCSM_CPRNC>/home/Rocky.Dunlap/bin/cprnc</CCSM_CPRNC>
+    <GMAKE>make</GMAKE>
+    <GMAKE_J>8</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>NCEP</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>80</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>40</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="num_tasks">-n $TOTALPES</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="mpi-serial">
+      <executable></executable>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="sh">/apps/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/apps/lmod/lmod/init/csh</init_path>
+      <init_path lang="python">/apps/lmod/lmod/init/env_modules_python.py</init_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <cmd_path lang="python">/apps/lmod/lmod/libexec/lmod python</cmd_path>
+      <modules compiler="intel">
+        <command name="purge"/>
+        <command name="load">intel/18.0.5.274</command>
+      </modules>
+      <modules mpilib="impi">
+        <command name="load">netcdf/4.7.0</command>
+        <command name="load">impi/2018.0.4</command>
+	<command name="use">/scratch1/BMC/gmtb/software/modulefiles/intel-18.0.5.274/impi-2018.0.4</command>
+	<command name="load">NCEPlibs/1.0.0alpha01</command>
+      </modules>
+      <modules>
+        <command name="use">/scratch1/BMC/gmtb/software/modulefiles/generic</command>
+        <command name="load">cmake/3.16.3</command>
+      </modules>
+    </module_system>
+    <environment_variables comp_interface="nuopc">
+      <env name="ESMF_RUNTIME_PROFILE">ON</env>
+      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
+    </environment_variables>
+  </machine>
+
   <machine MACH="macos">
     <DESC>
       Customize these fields as appropriate for your system,

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -260,10 +260,10 @@ This allows using a different mpirun command to launch unit tests
     <PROJECT>nems</PROJECT>
     <SAVE_TIMING_DIR/>
     <CIME_OUTPUT_ROOT>/scratch1/NCEPDEV/nems/$USER</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/scratch1/NCEPDEV/nems/Rocky.Dunlap/INPUTDATA</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/scratch1/NCEPDEV/nems/Rocky.Dunlap/INPUTDATA/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT>/scratch1/NCEPDEV/stmp2/CIME_UFSINPUT</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/scratch1/NCEPDEV/stmp2/CIME_UFSINPUT/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/scratch1/NCEPDEV/nems/Rocky.Dunlap/BASELINES</BASELINE_ROOT>
+    <BASELINE_ROOT>/scratch1/NCEPDEV/stmp2/CIME_UFSBASELINES</BASELINE_ROOT>
     <CCSM_CPRNC>/home/Rocky.Dunlap/bin/cprnc</CCSM_CPRNC>
     <GMAKE>make</GMAKE>
     <GMAKE_J>8</GMAKE_J>


### PR DESCRIPTION
Initial port of CIME to Hera for the UFS MR Weather App.
(Rework of previous PR which was getting out of date.)

Test suite:
./create_test --xml-machine cheyenne --xml-compiler intel --generate feb10 --baseline-root /scratch1/NCEPDEV/nems/Rocky.Dunlap/BASELINES --workflow ufs-mrweather_wo_post --machine hera

Test baseline: (new baselines generated)
/scratch1/NCEPDEV/nems/Rocky.Dunlap/BASELINES