### PR TITLE
qsub fix for izumi

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -412,7 +412,7 @@
   </batch_system>
 
   <batch_system type="pbs" MACH="izumi" >
-    <batch_submit>ssh izumi cd $CASEROOT ; qsub</batch_submit>
+    <batch_submit>qsub</batch_submit>
     <jobid_pattern>(\d+.izumi.unified.ucar.edu)$</jobid_pattern>
     <directives>
       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>

--- a/config/ufs/machines/config_batch.xml
+++ b/config/ufs/machines/config_batch.xml
@@ -233,7 +233,7 @@
     </queues>
   </batch_system>
   <batch_system type="pbs" MACH="izumi" >
-    <batch_submit>ssh izumi cd $CASEROOT ; qsub</batch_submit>
+    <batch_submit> qsub</batch_submit>
     <jobid_pattern>(\d+.izumi.unified.ucar.edu)$</jobid_pattern>
     <directives>
       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>


### PR DESCRIPTION
Fix issue with qsub on izumi - using ssh prevents environment inheritance. 

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit,

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
