### PR TITLE
UFS release: add generic Linux configuration

### DIFF
--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -345,6 +345,43 @@ This allows using a different mpirun command to launch unit tests
 -->
   </machine>
 
+  <machine MACH="linux">
+    <DESC>
+      Customize these fields as appropriate for your system,
+      particularly changing MAX_TASKS_PER_NODE and MAX_MPITASKS_PER_NODE to the
+      number of cores on your machine.
+    </DESC>
+    <NODENAME_REGEX> something.matching.your.machine.hostname </NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>mpich</MPILIBS>
+    <CIME_OUTPUT_ROOT>$ENV{UFS_SCRATCH}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>$ENV{UFS_INPUT}/ufs-inputdata</DIN_LOC_ROOT>
+    <DOUT_S_ROOT>$ENV{UFS_SCRATCH}/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$ENV{UFS_INPUT}/baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>$CIMEROOT/tools/cprnc/build/cprnc</CCSM_CPRNC>
+    <GMAKE>make</GMAKE>
+    <GMAKE_J>4</GMAKE_J>
+    <BATCH_SYSTEM>none</BATCH_SYSTEM>
+    <SUPPORTED_BY>__YOUR_NAME_HERE__</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>8</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>8</MAX_MPITASKS_PER_NODE>
+    <TOTAL_TASKS>8</TOTAL_TASKS>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="labelstdout">-prepend-rank</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="none"/>
+<!--
+     <environment_variables>
+       <env name="PATH">$ENV{PATH}:$ENV{NCEPLIBS_DIR}/bin</env>
+    </environment_variables>
+-->
+  </machine>
+
   <machine MACH="stampede2-skx">
     <DESC>Intel Xeon Platinum 8160 ("Skylake"),48 cores on two sockets (24 cores/socket) , batch system is SLURM</DESC>
     <NODENAME_REGEX>.*stampede2</NODENAME_REGEX>

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -366,7 +366,6 @@ This allows using a different mpirun command to launch unit tests
     <SUPPORTED_BY>__YOUR_NAME_HERE__</SUPPORTED_BY>
     <MAX_TASKS_PER_NODE>8</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>8</MAX_MPITASKS_PER_NODE>
-    <TOTAL_TASKS>8</TOTAL_TASKS>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>


### PR DESCRIPTION
I am targeting the ufs_release_v1.0 for this PR.

This PR adds a generic Linux configuration, identical to the macOS configuration, to CIME. provided that the setup instructions for the machine are followed (NCEPLIBS-external, NCEPLIBS; these are also very similar for macOS and Linux), the end-to-end workflow runs out of the box on a Ubuntu Linux platform and with exactly the same commands as on macOS (including Grib2 output from the post-processor).

This PR requires the issue https://github.com/ufs-community/ufs-mrweather-app/issues/98 to be solved. In order to test the PR, I added an entry for `linux` in `src/model/FV3/cime/cime_config/config_pes.xml` as what is in there for `macos`.
