### PR TITLE
fv3 cam port changes

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1101,7 +1101,21 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="C96_C96_mg17" compset="_CISM" not_compset="_POP" >
+    <model_grid alias="C24_C24_mg17" >
+      <grid name="atm">C24</grid>
+      <grid name="lnd">C24</grid>
+      <grid name="ocnice">C24</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="C48_C48_mg17" >
+      <grid name="atm">C48</grid>
+      <grid name="lnd">C48</grid>
+      <grid name="ocnice">C48</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="C96_C96_mg17" >
       <grid name="atm">C96</grid>
       <grid name="lnd">C96</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -1128,6 +1142,21 @@
       <grid name="lnd">C96</grid>
       <grid name="ocnice">tx0.25v1</grid>
       <mask>tx0.25v1</mask>
+    </model_grid>
+
+    <model_grid alias="C192_C192_mg17" >
+      <grid name="atm">C192</grid>
+      <grid name="lnd">C192</grid>
+      <grid name="ocnice">C192</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+
+
+    <model_grid alias="C384_C384_mg17" >
+      <grid name="atm">C384</grid>
+      <grid name="lnd">C384</grid>
+      <grid name="ocnice">C384</grid>
+      <mask>gx1v7</mask>
     </model_grid>
 
     <model_grid alias="C384_t025" not_compset="_POP" >
@@ -1729,10 +1758,34 @@
 
     <!-- fvcubed domains-->
 
+    <domain name="C24">
+      <nx>3456</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.C24_gx1v6.181018.nc</file>
+      <file grid="ocnice" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.C24_gx1v6.181018.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.C24_gx1v7.181018.nc</file>
+      <file grid="ocnice" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.C24_gx1v7.181018.nc</file>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/C24_181018_ESMFmesh.nc</mesh>
+      <desc>C24 is a fvcubed xx-deg grid:</desc>
+      <support>Experimental for fv3 dycore</support>
+    </domain>
+
+    <domain name="C48">
+      <nx>13824</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.C48_gx1v6.181018.nc</file>
+      <file grid="ocnice" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.C48_gx1v6.181018.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.C48_gx1v7.181018.nc</file>
+      <file grid="ocnice" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.C48_gx1v7.181018.nc</file>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/C48_181018_ESMFmesh.nc</mesh>
+      <desc>C48 is a fvcubed xx-deg grid:</desc>
+      <support>Experimental for fv3 dycore</support>
+    </domain>
+
     <domain name="C96">
       <nx>55296</nx> <ny>1</ny>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.C96_gx1v6.181018.nc</file>
       <file grid="ocnice"  mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.C96_gx1v6.181018.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.C96_gx1v7.181018.nc</file>
+      <file grid="ocnice" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.C96_gx1v7.181018.nc</file>
       <file grid="atm|lnd" mask="tx0.66v1">$DIN_LOC_ROOT/share/domains/domain.lnd.C96_tx0.66v1.181210.nc</file>
       <file grid="ocnice"  mask="tx0.66v1">$DIN_LOC_ROOT/share/domains/domain.ocn.C96_tx0.66v1.181210.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/C96_181018_ESMFmesh.nc</mesh>
@@ -1740,9 +1793,24 @@
       <support>Experimental for fv3 dycore</support>
     </domain>
 
+    <domain name="C192">
+      <nx>221184</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.C192_gx1v6.181018..nc</file>
+      <file grid="ocnice" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.C192_gx1v6.181018.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.C192_gx1v7.181018..nc</file>
+      <file grid="ocnice" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.C192_gx1v7.181018.nc</file>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/C192_181018_ESMFmesh.nc</mesh>
+      <desc>C192 is a fvcubed xx-deg grid:</desc>
+      <support>Experimental for fv3 dycore</support>
+    </domain>
+
     <domain name="C384">
-      <!-- The following nx is incorrect -->
-      <nx>100000</nx> <ny>1</ny>
+      <nx>884736</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.C384_gx1v6.181018.nc</file>
+      <file grid="ocnice" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.C384_gx1v6.181018.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.C384_gx1v7.181018.nc</file>
+      <file grid="ocnice" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.C384_gx1v7.181018.nc</file>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/C384_181018_ESMFmesh.nc</mesh>
       <desc>C384 is a fvcubed xx-deg grid:</desc>
       <support>Experimental for fv3 dycore</support>
     </domain>

--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -31,6 +31,31 @@
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne240np4/map_0.1x0.1_nomask_to_ne240np4_nomask_aave_da_c120706.nc</map>
     </gridmap>
 
+    <gridmap lnd_grid="C24" rof_grid="r05">
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/C24/map_C24_TO_0.5x0.5_aave.181018.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/C24/map_0.5x0.5_TO_C24_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="C48" rof_grid="r05">
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/C48/map_C48_TO_0.5x0.5_aave.181018.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/C48/map_0.5x0.5_TO_C48_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="C96" rof_grid="r05">
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/C96/map_C96_TO_0.5x0.5_aave.181018.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/C96/map_0.5x0.5_TO_C96_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="C192" rof_grid="r05">
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/C192/map_C192_TO_0.5x0.5_aave.181018.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/C192/map_0.5x0.5_TO_C192_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="C384" rof_grid="r05">
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/C384/map_C384_TO_0.5x0.5_aave.181018.nc</map>
+      <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/C384/map_0.5x0.5_TO_C384_aave.181018.nc</map>
+    </gridmap>
+
     <gridmap lnd_grid="ne0np4CONUS.ne30x8" rof_grid="r05">
       <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_0.5x0.5_nomask_aave.190322.nc</map>
       <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_0.5x0.5_nomask_TO_ne0CONUSne30x8_aave.190322.nc</map>
@@ -249,6 +274,41 @@
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv1.9x2.5_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv1.9x2.5_aave.170429.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="C24" glc_grid="gland4" >
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C24/map_C24_TO_gland4km_aave.181018.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C24/map_C24_TO_gland4km_blin.181018.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C24_aave.181018.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C24_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="C48" glc_grid="gland4" >
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C48/map_C48_TO_gland4km_aave.181018.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C48/map_C48_TO_gland4km_blin.181018.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C48_aave.181018.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C48_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="C96" glc_grid="gland4" >
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C96/map_C96_TO_gland4km_aave.181018.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C96/map_C96_TO_gland4km_blin.181018.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C96_aave.181018.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C96_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="C192" glc_grid="gland4" >
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C192/map_C192_TO_gland4km_aave.181018.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C192/map_C192_TO_gland4km_blin.181018.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C192_aave.181018.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C192_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap lnd_grid="C384" glc_grid="gland4" >
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C384/map_C384_TO_gland4km_aave.181018.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C384/map_C384_TO_gland4km_blin.181018.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C384_aave.181018.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C384_aave.181018.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="T31" glc_grid="gland4" >

--- a/config/cesm/config_grids_mct.xml
+++ b/config/cesm/config_grids_mct.xml
@@ -4,6 +4,86 @@
 
     <!--- atm to ocean and ocean to atm mapping files -->
 
+    <gridmap atm_grid="C24" ocn_grid="gx1v6">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C24/map_C24_TO_gx1v6_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C24/map_C24_TO_gx1v6_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C24/map_C24_TO_gx1v6_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_C24_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_C24_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="C24" ocn_grid="gx1v7">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C24/map_C24_TO_gx1v7_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C24/map_C24_TO_gx1v7_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C24/map_C24_TO_gx1v7_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_C24_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_C24_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="C48" ocn_grid="gx1v6">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C48/map_C48_TO_gx1v6_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C48/map_C48_TO_gx1v6_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C48/map_C48_TO_gx1v6_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_C48_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_C48_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="C48" ocn_grid="gx1v7">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C48/map_C48_TO_gx1v7_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C48/map_C48_TO_gx1v7_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C48/map_C48_TO_gx1v7_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_C48_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_C48_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="C96" ocn_grid="gx1v6">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C96/map_C96_TO_gx1v6_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C96/map_C96_TO_gx1v6_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C96/map_C96_TO_gx1v6_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_C96_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_gx1v6_TO_C96_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="C96" ocn_grid="gx1v7">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C96/map_C96_TO_gx1v7_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C96/map_C96_TO_gx1v7_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C96/map_C96_TO_gx1v7_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_C96_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_C96_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="C192" ocn_grid="gx1v6">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C192/map_am_C192_TO_pop_gx1v6_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C192/map_am_C192_TO_pop_gx1v6_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C192/map_am_C192_TO_pop_gx1v6_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_pop_gx1v6_TO_am_C192_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_pop_gx1v6_TO_am_C192_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="C192" ocn_grid="gx1v7">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C192/map_am_C192_TO_pop_gx1v7_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C192/map_am_C192_TO_pop_gx1v7_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C192/map_am_C192_TO_pop_gx1v7_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_pop_gx1v7_TO_am_C192_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_pop_gx1v7_TO_am_C192_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="C384" ocn_grid="gx1v6">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C384/map_am_C384_TO_pop_gx1v6_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C384/map_am_C384_TO_pop_gx1v6_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C384/map_am_C384_TO_pop_gx1v6_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v6/map_pop_gx1v6_TO_am_C384_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v6/map_pop_gx1v6_TO_am_C384_aave.181018.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="C384" ocn_grid="gx1v7">
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C384/map_am_C384_TO_pop_gx1v7_aave.181018.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C384/map_am_C384_TO_pop_gx1v7_blin.181018.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/C384/map_am_C384_TO_pop_gx1v7_patc.181018.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_pop_gx1v7_TO_am_C384_aave.181018.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_pop_gx1v7_TO_am_C384_aave.181018.nc</map>
+    </gridmap>
+
     <gridmap atm_grid="C96" ocn_grid="tx0.66v1">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C96/map_C96_TO_tx0.66v1_aave.181210.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/C96/map_C96_TO_tx0.66v1_blin.181210.nc</map>

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -573,6 +573,14 @@ ifeq ($(findstring -cosp,$(CAM_CONFIG_OPTS)),-cosp)
   endif
 endif
 
+CAM_DYCORE ?= $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) CAM_DYCORE --value)
+
+ifeq ($(CAM_DYCORE),fv3)
+FV3CORE_LIBDIR:=$(abspath $(EXEROOT)/atm/obj/atmos_cubed_sphere)
+INCLDIR+=-I$(FV3CORE_LIBDIR) -I$(FV3CORE_LIBDIR)/../ -I../$(INSTALL_SHAREDPATH)/include -I../$(CSM_SHR_INCLUDE) -I$(abspath $(EXEROOT)/FMS) -I$(CIMEROOT)/../libraries/FMS/src/include
+endif
+
+
 ifeq ($(MODEL),cam)
   # These RRTMG files take an extraordinarily long time to compile with optimization.
   # Until mods are made to read the data from files, just remove optimization from
@@ -594,6 +602,12 @@ $(COSP_LIBDIR)/libcosp.a: cam_abortutils.o
 cospsimulator_intr.o: $(COSP_LIBDIR)/libcosp.a
 endif
 
+ifdef FV3CORE_LIBDIR
+$(FV3CORE_LIBDIR)/libfv3core.a: $(EXEROOT)/FMS/libfms.a
+	$(MAKE) -C $(FV3CORE_LIBDIR) complib COMPLIB='$(FV3CORE_LIBDIR)/libfv3core.a' F90='$(FC)' CC='$(CC)' FFLAGS='$(FFLAGS) $(FC_AUTO_R8)'  CFLAGS='$(CFLAGS)' INCLDIR='$(INCLDIR)' FC_TYPE='$(COMPILER)'
+
+dyn_grid.o: $(FV3CORE_LIBDIR)/libfv3core.a
+endif
 endif
 
 
@@ -896,6 +910,10 @@ ifdef COSP_LIBDIR
   endif
 endif
 
+ifdef FV3CORE_LIBDIR
+  ULIBDEP += $(FV3CORE_LIBDIR)/libfv3core.a
+  ULIBDEP += $(EXEROOT)/FMS/libfms.a
+endif
 
 ifndef CLIBS
    ifdef ULIBDEP

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -246,6 +246,11 @@
       <value compset=".+" grid="a%ne240np4.pg2">384</value>
       <value compset=".+" grid="a%ne240np4.pg3">384</value>
       <value compset=".+" grid="a%ne0np4CONUS.ne30x8">144</value>
+      <value compset=".+" grid="a%C24">48</value>
+      <value compset=".+" grid="a%C48">48</value>
+      <value compset=".+" grid="a%C96">48</value>
+      <value compset=".+" grid="a%C192">96</value>
+      <value compset=".+" grid="a%C384">192</value>
       <value compset=".+" grid="a%T42">72</value>
       <value compset=".+" grid="a%T85">144</value>
       <value compset=".+" grid="a%T341">288</value>


### PR DESCRIPTION
Mods to complete CIME portion of FV3 port to CAM.  Added a minimally complete set of FV3 grid definitions for 2, 1, 0.5, 0.25 degree resolutions, created and tested new mapping files and modified the Makefile and CIME scripts to allow building the fv3 library.  Ran scripts_regression_tests and all passed.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
