### PR TITLE
update cprnc build to use correct machine

### DIFF
--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -47,7 +47,8 @@ def buildlib(bldroot, installpath, case):
     cimeroot = case.get_value("CIMEROOT")
 
     # Generate macros and environment
-    run_bld_cmd_ensure_logging("{}/tools/configure --mpilib=mpi-serial --macros-format=CMake".format(cimeroot), logger, from_dir=bldroot)
+    
+    run_bld_cmd_ensure_logging("{}/tools/configure --mpilib=mpi-serial --macros-format=CMake --machine={}".format(cimeroot, case.get_value("MACH")), logger, from_dir=bldroot)
 
     cmake_args = get_standard_cmake_args(case, shared_lib=True)
 


### PR DESCRIPTION
chgres needs to build on case system not use regex match
Test suite: test_self_build_cprnc (__main__.K_TestCimeCase)
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3423 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
