### PR TITLE
Update nuopc datm mesh consistency check tolerance

### DIFF
--- a/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
@@ -369,7 +369,7 @@ contains
     call t_stopf('datm_strdata_init')
 
     ! Check that mesh lats and lons correspond to those on the input domain file
-    call dshr_check_mesh(mesh, sdat, 'datm', rc=rc)
+    call dshr_check_mesh(mesh, sdat, 'datm', tolerance=1.e-5_r8, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     ! Realize the actively coupled fields, now that a mesh is established and


### PR DESCRIPTION
Changes mesh consistency check tolerance from 1.e-10 to 1.e-5 for nuopc datm. This change was needed for 0.25 deg MOM6 grid runs with nuopc. Note: Other data components already have a tolerance of around 1.e-5.

Test suite: aux_mom
Test baseline: 
Test namelist changes: n/a 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: 
