### PR TITLE
Add ne5pg2_ne5pg2_mg37 for cam testing

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -911,6 +911,13 @@
 
     <!--  spectral element grids with 2x2 FVM physics grid -->
 
+    <model_grid alias="ne5pg2_ne5pg2_mg37" not_compset="_POP">
+      <grid name="atm">ne5np4.pg2</grid>
+      <grid name="lnd">ne5np4.pg2</grid>
+      <grid name="ocnice">ne5np4.pg2</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg2_ne30pg2_mg17">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">ne30np4.pg2</grid>
@@ -1443,6 +1450,14 @@
       <file grid="ocnice"  mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne5np4_gx3v7.140810.nc</file>
       <desc>ne5np4 is Spectral Elem 6-deg grid:</desc>
       <support>For ultra-low resolution spectral element grid testing</support>
+    </domain>
+
+    <domain name="ne5np4.pg2">
+      <nx>1350</nx> <ny>1</ny>
+      <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne5np4.pg2_gx3v7.200311.nc</file>
+      <file grid="ocnice"  mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne5np4.pg2_gx3v7.200311.nc</file>
+      <desc>ne5np4 is Spectral Elem 6-deg grid with a 2x2 FVM physics grid:</desc>
+      <support>EXPERIMENTAL FVM physics grid</support>
     </domain>
 
     <domain name="ne5np4.pg3">


### PR DESCRIPTION
Add ne5pg2_ne5pg2_mg37 grid  that's needed for cam testing.

Test suite: scripts_regression_tests, SMS_D_Ln9.ne5pg2_ne5pg2_mg37.FADIAB.izumi_pgi
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
