### PR TITLE
fix issue with pop input files that should not be found

### DIFF
--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -332,7 +332,7 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
 
                     model = os.path.basename(data_list_file).split('.')[0]
 
-                    if ("/" in rel_path and rel_path == full_path):
+                    if ("/" in rel_path and rel_path == full_path and not full_path.startswith('unknown')):
                         # User pointing to a file outside of input_data_root, we cannot determine
                         # rel_path, and so cannot download the file. If it already exists, we can
                         # proceed
@@ -352,7 +352,7 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
                         # value and ignore it (perhaps with a warning)
                         isdirectory=rel_path.endswith(os.sep)
 
-                        if ("/" in rel_path and not os.path.exists(full_path)):
+                        if ("/" in rel_path and not os.path.exists(full_path) and not full_path.startswith('unknown')):
                             logger.warning("  Model {} missing file {} = '{}'".format(model, description, full_path))
                             no_files_missing = False
                             if (download):

--- a/scripts/lib/CIME/case/preview_namelists.py
+++ b/scripts/lib/CIME/case/preview_namelists.py
@@ -90,7 +90,7 @@ def create_namelists(self, component=None):
             run_sub_or_cmd(cmd, (caseroot), "buildnml",
                            (self, caseroot, compname), case=self)
 
-        logger.info("Finished creating component namelists, component {} models = {}".format(component, models))
+        logger.debug("Finished creating component namelists, component {} models = {}".format(component, models))
 
     # Save namelists to docdir
     if (not os.path.isdir(docdir)):

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -62,7 +62,7 @@ def copy_histfiles(case, suffix):
         num_copied += len(test_hists)
         for test_hist in test_hists:
             test_hist = os.path.join(rundir,test_hist)
-            if not test_hist.endswith('.nc'):
+            if not test_hist.endswith('.nc') or 'once' in os.path.basename(test_hist):
                 logger.info("Will not compare non-netcdf file {}".format(test_hist))
                 continue
             new_file = "{}.{}".format(test_hist, suffix)


### PR DESCRIPTION
The pop model generates some names for the inputdata list that are intended to indicate that there is no file there.  Ideally pop would not generate these things, but the names begin with 'unknown' so this prevents cime trying to download.  This restores functionality that I removed in 
the PR introducing DIN_LOC_IC

Test suite: scripts_regression_tests.py , ERS_Vnuopc_Ld5.T62_g17.G.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
