### PR TITLE
Ensure that api documentation is rebuilt whenever rebuilding documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -30,18 +30,16 @@ Tools_user:
 	rm -f $(SOURCEDIR)/$@/temp_files/*
 	./tools_autodoc.py
 
+# It's too easy to forget to run 'make api' before running 'make html',
+# so add a rule that ensures that the api documentation is regenerated
+# whenever regenerating the html.
+html: api
+
 clean: clean_api
 
-# The api documentation is built in the source tree. This leads to a
-# high potential for accidentally building the documentation using a
-# different version of the api documentation, if you have a build
-# already sitting around from a different branch and you forget to run
-# 'make api' before running 'make html'. We mitigate this risk by
-# ensuring that 'clean_api' is run whenever 'make clean' is run, and
-# having 'clean_api' remove any pre-existing generated api
-# documentation. (Note that all of the files removed here are built
-# using 'make api'; these are not - or at least, should not be - files
-# that exist in the repository.)
+# Note that all of the files removed here are built using 'make api';
+# these are not - or at least, should not be - files that exist in the
+# repository.
 clean_api:
 	rm -f $(SOURCEDIR)/CIME_api/*.rst
 	rm -f $(SOURCEDIR)/Tools_api/*.rst

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -27,10 +27,28 @@ Tools_api:
 
 Tools_user:
 	rm -f $(SOURCEDIR)/$@/*.rst
-	rm -f $(SOURCEDIR)/$@/temp_files/*.*
+	rm -f $(SOURCEDIR)/$@/temp_files/*
 	./tools_autodoc.py
 
-.PHONY: help Makefile CIME_api Tools_api Tools_user
+clean: clean_api
+
+# The api documentation is built in the source tree. This leads to a
+# high potential for accidentally building the documentation using a
+# different version of the api documentation, if you have a build
+# already sitting around from a different branch and you forget to run
+# 'make api' before running 'make html'. We mitigate this risk by
+# ensuring that 'clean_api' is run whenever 'make clean' is run, and
+# having 'clean_api' remove any pre-existing generated api
+# documentation. (Note that all of the files removed here are built
+# using 'make api'; these are not - or at least, should not be - files
+# that exist in the repository.)
+clean_api:
+	rm -f $(SOURCEDIR)/CIME_api/*.rst
+	rm -f $(SOURCEDIR)/Tools_api/*.rst
+	rm -f $(SOURCEDIR)/Tools_user/*.rst
+	rm -f $(SOURCEDIR)/Tools_user/temp_files/*
+
+.PHONY: help Makefile CIME_api Tools_api Tools_user clean_api
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
When going back and forth between branches and building the
documentation from each, I was running into problems with the api
documentation from one branch contaminating the documentation build for
a different branch. This was both due to user error on my part
(forgetting to run 'make api' before 'make html'), but it looks like
some small issues also arose from the fact that the api documentation
wasn't being completely cleaned out before being rebuilt, so some stale
files that didn't apply to the given branch were sticking around.

This commit mitigates these issues by:
- Cleaning the directories containing the api builds whenever 'make
  clean' is run
- Automatically rebuilding the api documentation whenever 'make html' is
  run

I considered going further and ensuring that 'make clean' is run
whenever 'make html' is run (or at least ensuring that 'make clean_api'
is run whenever 'make api' is run). That felt a little too extreme to
me, but I'd be open to doing that if others think that's a good
idea. (Currently, as noted in
https://github.com/ESMCI/cime/wiki/Working-with-Sphinx-and-reStructuredText,
it is highly recommended that you run 'make clean' manually before
rebuilding the documentation.)

Test suite: just manual testing of documentation builds
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: none

Update gh-pages html (Y/N)?: Y (already done)

Code review: 
