### PR TITLE
case.setup: Add --keep option

### DIFF
--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -47,16 +47,21 @@ def parse_command_line(args, description):
                         "This flag should be used when rerunning case.setup after it\n"
                         "has already been run for this case.")
 
+    parser.add_argument("-k", "--keep", action="append", default=[],
+                        help="When cleaning/resetting a case, do not remove/refresh files in this list. "
+                        "Choices are batch script, env_mach_specific.xml, Macros.make, Macros.cmake. "
+                        "Use should use this if you have local modifications to these files that you want to keep.")
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.caseroot, args.clean, args.test_mode, args.reset
+    return args.caseroot, args.clean, args.test_mode, args.reset, args.keep
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    caseroot, clean, test_mode, reset = parse_command_line(sys.argv, description)
+    caseroot, clean, test_mode, reset, keep = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
-        case.case_setup(clean=clean, test_mode=test_mode, reset=reset)
+        case.case_setup(clean=clean, test_mode=test_mode, reset=reset, keep=keep)
 
 if __name__ == "__main__":
     _main_func(__doc__)

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -67,7 +67,7 @@ def _build_usernl_files(case, model, comp):
                     safe_copy(model_nl, nlfile)
 
 ###############################################################################
-def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
+def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, keep=None):
 ###############################################################################
     os.chdir(caseroot)
 
@@ -86,7 +86,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         batch_script = get_batch_script_for_job(case.get_primary_job())
         files_to_clean = [batch_script, "env_mach_specific.xml", "Macros.make", "Macros.cmake"]
         for file_to_clean in files_to_clean:
-            if os.path.exists(file_to_clean):
+            if os.path.exists(file_to_clean) and not (keep and file_to_clean in keep):
                 os.remove(file_to_clean)
                 logger.info("Successfully cleaned {}".format(file_to_clean))
 
@@ -229,11 +229,11 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False):
         logger.info("You can now run './preview_run' to get more info on how your case will be run")
 
 ###############################################################################
-def case_setup(self, clean=False, test_mode=False, reset=False):
+def case_setup(self, clean=False, test_mode=False, reset=False, keep=None):
 ###############################################################################
     caseroot, casebaseid = self.get_value("CASEROOT"), self.get_value("CASEBASEID")
     phase = "setup.clean" if clean else "case.setup"
-    functor = lambda: _case_setup_impl(self, caseroot, clean, test_mode, reset)
+    functor = lambda: _case_setup_impl(self, caseroot, clean=clean, test_mode=test_mode, reset=reset, keep=keep)
 
     if self.get_value("TEST") and not test_mode:
         test_name = casebaseid if casebaseid is not None else self.get_value("CASE")


### PR DESCRIPTION
A convenient way to keep local changes to key generated files when
cleaning or resetting a case.

Test suite: scripts_regression_tests --fast
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3459 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
