### PR TITLE
Convert netcdf-4 file to cdf5, update datm default

### DIFF
--- a/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -302,7 +302,7 @@
       <value stream="CORE_IAF_JRA.*">domain.atm.TL319.151007.nc</value>
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
-      <value stream="co2tseries.omip">fco2_datm_global_ssp585_simyr_1750-2020_CMIP6_c190522.nc</value>
+      <value stream="co2tseries.omip">fco2_datm_global_ssp585_simyr_1750-2020_CMIP6_c200324.nc</value>
       <value stream="co2tseries.SSP1-1.9.latbnd">fco2_datm_lat-bandsSSP1-1.9_simyr_2014-2500_CMIP6_c190514.nc</value>
       <value stream="co2tseries.SSP1-2.6.latbnd">fco2_datm_lat-bandsSSP1-2.6__simyr_2014-2500_CMIP6_c190506.nc</value>
       <value stream="co2tseries.SSP2-4.5.latbnd">fco2_datm_lat-bandsSSP2-4.5__simyr_2014-2500_CMIP6_c190506.nc</value>
@@ -2149,7 +2149,7 @@
       </value> 
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
-      <value stream="co2tseries.omip">fco2_datm_global_ssp585_simyr_1750-2020_CMIP6_c190522.nc</value>
+      <value stream="co2tseries.omip">fco2_datm_global_ssp585_simyr_1750-2020_CMIP6_c200324.nc</value>
       <value stream="co2tseries.SSP1-1.9.latbnd">fco2_datm_lat-bandsSSP1-1.9_simyr_2014-2500_CMIP6_c190514.nc</value>
       <value stream="co2tseries.SSP1-2.6.latbnd">fco2_datm_lat-bandsSSP1-2.6__simyr_2014-2500_CMIP6_c190506.nc</value>
       <value stream="co2tseries.SSP2-4.5.latbnd">fco2_datm_lat-bandsSSP2-4.5__simyr_2014-2500_CMIP6_c190506.nc</value>


### PR DESCRIPTION
`fco2_datm_global_ssp585_simyr_1750-2020_CMIP6_c190522.nc` is netcdf-4,
`fco2_datm_global_ssp585_simyr_1750-2020_CMIP6_c200324.nc` is identical
except the format is cdf5. This file is `strm_domfil` and `strm_datfil` for
`co2tseries.omip`

Test suite: `aux_pop`, `aux_pop_MARBL`
Test baseline: head of `maint-5.6` (3bde85f)
Test namelist changes: `datm.streams.txt.co2tseries.omip` changes
Test status: bit for bit

Fixes N/A
User interface changes?: None

Update gh-pages html (Y/N)?: N

Code review: No sit-down review, but it's only two lines that are modified. This should be merged in after #3462 is approved, so `maint-5.6` and `master` are reading the same version of this file