### PR TITLE
Wpcoomb/user defined env variables

### DIFF
--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -37,10 +37,8 @@ class EnvMachSpecific(EnvBase):
             nodes = machobj.get_first_child_nodes(item)
             if item == "environment_variables":
                 if len(nodes) == 0:
-                    example_name = "E3SM_ENV_VAR_HELP"
-                    example_text = "User can add specific env vars in this xml section"
-                    empty_env_node = self.make_child("environment_variables")
-                    example_env_node = self.make_child("env", attributes={"name":example_name}, root=empty_env_node, text = example_text)
+                    example_text = """\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
+                    empty_env_node = self.make_child_comment(text = example_text)
             if item == "run_exe" or item == "run_misc_suffix":
                 if len(nodes) == 0:
                     value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -37,10 +37,8 @@ class EnvMachSpecific(EnvBase):
             nodes = machobj.get_first_child_nodes(item)
             if item == "environment_variables":
                 if len(nodes) == 0:
-                    example_name = "NAME"
-                    example_text = "ARGUMENT"
-                    empty_env_node = self.make_child("environment_variables")
-                    example_env_node = self.make_child("env", attributes={"name":example_name}, root=empty_env_node, text = example_text)
+                    example_text = """\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
+                    empty_env_node = self.make_child_comment(text = example_text)
             if item == "run_exe" or item == "run_misc_suffix":
                 if len(nodes) == 0:
                     value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -35,6 +35,12 @@ class EnvMachSpecific(EnvBase):
 
         for item in items:
             nodes = machobj.get_first_child_nodes(item)
+            if item == "environment_variables":
+                if len(nodes) == 0:
+                    example_name = "NAME"
+                    example_text = "ARGUMENT"
+                    empty_env_node = self.make_child("environment_variables", text = "" )
+                    example_env_node = self.make_child("env", attributes={"name":example_name}, root=empty_env_node, text = example_text)
             if item == "run_exe" or item == "run_misc_suffix":
                 if len(nodes) == 0:
                     value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -37,8 +37,8 @@ class EnvMachSpecific(EnvBase):
             nodes = machobj.get_first_child_nodes(item)
             if item == "environment_variables":
                 if len(nodes) == 0:
-                    example_text = """\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
-                    empty_env_node = self.make_child_comment(text = example_text)
+                    example_text = """This section is for the user to specify any additional machine-specific env var, or to overwite existing ones.\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
+                    example_env_node = self.make_child_comment(text = example_text)
             if item == "run_exe" or item == "run_misc_suffix":
                 if len(nodes) == 0:
                     value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -37,8 +37,8 @@ class EnvMachSpecific(EnvBase):
             nodes = machobj.get_first_child_nodes(item)
             if item == "environment_variables":
                 if len(nodes) == 0:
-                    example_name = "Fred"
-                    example_text = ""
+                    example_name = "E3SM_ENV_VAR_HELP"
+                    example_text = "User can add specific env vars in this xml section"
                     empty_env_node = self.make_child("environment_variables")
                     example_env_node = self.make_child("env", attributes={"name":example_name}, root=empty_env_node, text = example_text)
             if item == "run_exe" or item == "run_misc_suffix":

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -39,7 +39,7 @@ class EnvMachSpecific(EnvBase):
                 if len(nodes) == 0:
                     example_name = "NAME"
                     example_text = "ARGUMENT"
-                    empty_env_node = self.make_child("environment_variables", text = "" )
+                    empty_env_node = self.make_child("environment_variables" )
                     example_env_node = self.make_child("env", attributes={"name":example_name}, root=empty_env_node, text = example_text)
             if item == "run_exe" or item == "run_misc_suffix":
                 if len(nodes) == 0:

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -38,7 +38,7 @@ class EnvMachSpecific(EnvBase):
             if item == "environment_variables":
                 if len(nodes) == 0:
                     example_text = """This section is for the user to specify any additional machine-specific env var, or to overwite existing ones.\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
-                    example_env_node = self.make_child_comment(text = example_text)
+                    self.make_child_comment(text = example_text)
             if item == "run_exe" or item == "run_misc_suffix":
                 if len(nodes) == 0:
                     value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -39,7 +39,7 @@ class EnvMachSpecific(EnvBase):
                 if len(nodes) == 0:
                     example_name = "NAME"
                     example_text = "ARGUMENT"
-                    empty_env_node = self.make_child("environment_variables" )
+                    empty_env_node = self.make_child("environment_variables")
                     example_env_node = self.make_child("env", attributes={"name":example_name}, root=empty_env_node, text = example_text)
             if item == "run_exe" or item == "run_misc_suffix":
                 if len(nodes) == 0:

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -37,8 +37,10 @@ class EnvMachSpecific(EnvBase):
             nodes = machobj.get_first_child_nodes(item)
             if item == "environment_variables":
                 if len(nodes) == 0:
-                    example_text = """\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
-                    empty_env_node = self.make_child_comment(text = example_text)
+                    example_name = "Fred"
+                    example_text = ""
+                    empty_env_node = self.make_child("environment_variables")
+                    example_env_node = self.make_child("env", attributes={"name":example_name}, root=empty_env_node, text = example_text)
             if item == "run_exe" or item == "run_misc_suffix":
                 if len(nodes) == 0:
                     value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -241,6 +241,15 @@ class GenericXML(object):
 
         return node
 
+    def make_child_comment(self, root=None, text=None):
+        expect(not self.locked and not self.read_only, "{}: cannot make child {} in file {}".format("read_only" if self.read_only else "locked", text, self.filename))
+        root = root if root is not None else self.root
+        self.needsrewrite = True
+        et_comment = ET.Comment(text)
+        node = _Element(et_comment)
+        root.xml_element.append(node.xml_element)
+        return node
+
     def get_children(self, name=None, attributes=None, root=None):
         """
         This is the critical function, its interface and performance are crucial.


### PR DESCRIPTION
Implemented the feature to have the system recognize when 
a machine listed in config_machines.xml has no entries 
for "environment_variables",  and when the system 
recognizes this situation-- it inserts a commented out example 
entry into the generated env_mach_specific.xml file 
located in the case directory.
```
  <!--This section is for the user to specify any additional machine-specific env var, or to overwite existing ones.
  <environment_variables>
    <env name="NAME">ARGUMENT</env>
  </environment_variables>
  -->
```

Test suite: regression tests
Test baseline: 
Test namelist changes: 
Test status: [bit for bit]

Fixes #3448 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @bartgol 
