### PR TITLE
Change sst_aquap11 back to sst_aquap_constant

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -4733,7 +4733,7 @@
     </desc>
     <values>
       <value>0.06D0</value>
-      <value aqua_planet_sst_type="sst_aquap11">0.07D0</value>
+      <value aqua_planet_sst_type="sst_aquap_constant">0.07D0</value>
     </values>
   </entry>
 
@@ -4758,7 +4758,7 @@
     </desc>
     <values>
       <value>0.5D0</value>
-      <value aqua_planet_sst_type="sst_aquap11">1.0D0</value>
+      <value aqua_planet_sst_type="sst_aquap_constant">1.0D0</value>
     </values>
   </entry>
 


### PR DESCRIPTION
sst_aquap_constant was accidentally renamed sst_aquap11 during the maint5.6
merge.  This PR renames sst_aquap11 back to sst_aquap_constant. 

Test suite scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #] #3466 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
