### PR TITLE
use shrmap by reference instead of copy

### DIFF
--- a/src/share/streams/shr_dmodel_mod.F90
+++ b/src/share/streams/shr_dmodel_mod.F90
@@ -38,7 +38,7 @@ module shr_dmodel_mod
   end interface shr_dmodel_gsmapCreate
 
   interface shr_dmodel_mapSet; module procedure &
-       !shr_dmodel_mapSet_dest!, &
+       !shr_dmodel_mapSet_dest, &
        shr_dmodel_mapSet_global
   end interface shr_dmodel_mapSet
 

--- a/src/share/streams/shr_dmodel_mod.F90
+++ b/src/share/streams/shr_dmodel_mod.F90
@@ -38,7 +38,7 @@ module shr_dmodel_mod
   end interface shr_dmodel_gsmapCreate
 
   interface shr_dmodel_mapSet; module procedure &
-      !shr_dmodel_mapSet_dest, &
+       !shr_dmodel_mapSet_dest!, &
        shr_dmodel_mapSet_global
   end interface shr_dmodel_mapSet
 
@@ -196,7 +196,7 @@ CONTAINS
     use shr_file_mod  , only : shr_file_noprefix, shr_file_queryprefix, shr_file_get
     use shr_string_mod, only : shr_string_lastindex
     use shr_ncread_mod, only : shr_ncread_domain, shr_ncread_vardimsizes
-    use shr_ncread_mod, only : shr_ncread_varexists, shr_ncread_vardimnum,  shr_ncread_field4dG 
+    use shr_ncread_mod, only : shr_ncread_varexists, shr_ncread_vardimnum,  shr_ncread_field4dG
 
     !----- arguments -----
     type(mct_gGrid)  ,          intent(inout) :: gGrid
@@ -450,7 +450,7 @@ CONTAINS
 
           !--- start with wraparound ---
 
-          !--- determine whether dealing with 2D input files (typical of Eulerian 
+          !--- determine whether dealing with 2D input files (typical of Eulerian
           !--- dynamical core) or 1D files (typical of Spectral Element)
           if (nyg .ne. 1) then
             ni = 1
@@ -1395,7 +1395,6 @@ CONTAINS
     integer(IN), pointer :: idst(:)
     real(R8)   , pointer :: wgts(:)
     type(mct_sMat) :: sMat0
-
     character(*), parameter :: subname = '(shr_dmodel_mapSet_global) '
     character(*), parameter :: F00   = "('(shr_dmodel_mapSet_global) ',8a)"
     character(*), parameter :: F01   = "('(shr_dmodel_mapSet_global) ',a,5i8)"
@@ -1491,20 +1490,19 @@ CONTAINS
        lstrategy = trim(strategy)
     endif
 
+
     if (my_task == master_task) then
        call shr_map_get(shrmap,shr_map_fs_nsrc,nsrc)
        call shr_map_get(shrmap,shr_map_fs_ndst,ndst)
        call shr_map_get(shrmap,shr_map_fs_nwts,nwts)
-       allocate(isrc(nwts),idst(nwts),wgts(nwts))
-       call shr_map_get(shrmap,isrc,idst,wgts)
-       call shr_map_clean(shrmap)
 
+       call shr_map_getARptr(shrmap,isrc,idst,wgts)
        call mct_sMat_init(sMat0,ndst,nsrc,nwts)
 
        call mct_sMat_ImpGColI (sMat0,isrc,nwts)
        call mct_sMat_ImpGRowI (sMat0,idst,nwts)
        call mct_sMat_ImpMatrix(sMat0,wgts,nwts)
-       deallocate(isrc,idst,wgts)
+       call shr_map_clean(shrmap)
     endif
 
     call mct_sMatP_Init(sMatP,sMat0,gsmapS,gsmapD,lstrategy,master_task,mpicom,compid)
@@ -1576,7 +1574,6 @@ CONTAINS
 
     call MPI_COMM_RANK(mpicom,my_task,ierr)
     master_task = 0
-
     !--- get sizes and allocate for SRC ---
 
     lsizeS = mct_aVect_lsize(ggridS%data)

--- a/src/share/util/shr_map_mod.F90
+++ b/src/share/util/shr_map_mod.F90
@@ -110,6 +110,7 @@ module shr_map_mod
   public :: shr_map_checkFilled       ! check whether map wts are set
   public :: shr_map_put               ! put stuff into the datatype
   public :: shr_map_get               ! get stuff out of the datatype
+  public :: shr_map_getARptr          ! get ptrs out of the datatype
   public :: shr_map_mapSet            ! compute weights in map
   public :: shr_map_mapData           ! map data
   public :: shr_map_listValidOpts     ! list valid options
@@ -640,6 +641,43 @@ contains
     endif
 
   end subroutine shr_map_getAR
+
+  subroutine shr_map_getARptr(map,isrc,idst,wgts)
+
+    implicit none
+
+    ! !INPUT/OUTPUT PARAMETERS:
+
+    type(shr_map_mapType) ,intent(in) :: map
+    integer(SHR_KIND_IN),pointer,optional :: isrc(:)
+    integer(SHR_KIND_IN),pointer,optional :: idst(:)
+    real   (SHR_KIND_R8),pointer,optional :: wgts(:)
+
+    !EOP
+
+    !--- local ---
+    integer(SHR_KIND_IN) :: nwts
+
+    !--- formats ---
+    character(*),parameter :: subName = "('shr_map_getAR') "
+
+    !-------------------------------------------------------------------------------
+
+    nwts = map%nwts
+
+    if (present(isrc)) then
+       isrc(1:nwts) => map%isrc(1:nwts)
+    endif
+
+    if (present(idst)) then
+       idst(1:nwts) => map%idst(1:nwts)
+    endif
+
+    if (present(wgts)) then
+       wgts(1:nwts) => map%wgts(1:nwts)
+    endif
+
+  end subroutine shr_map_getARptr
 
   !===============================================================================
   !BOP ===========================================================================


### PR DESCRIPTION
This PR replaces a copy of three arrays in shr_dmodel_mod with a reference, thus reducing the memory footprint considerably and improving performance too. 

Test suite: scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
