### PR TITLE
Add SSP*EXT_ for DATM_PRESAERO and DATM_CO2_TSERIES

### DIFF
--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -62,19 +62,27 @@
     <valid_values>none,clim_1850,clim_2000,clim_2010,trans_1850-2000,SSP1-1.9,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP4-3.4,SSP4-6.0,SSP5-3.4,SSP5-8.5,cesm2_omip,cplhist</valid_values>
     <default_value>clim_2000</default_value>
     <values match="last">
-      <value compset="^1850_"   >clim_1850</value>
-      <value compset="^2000_"   >clim_2000</value>
-      <value compset="^2010_"   >clim_2010</value>
-      <value compset="^SSP119_" >SSP1-1.9</value>
-      <value compset="^SSP126_" >SSP1-2.6</value>
-      <value compset="^SSP245_" >SSP2-4.5</value>
-      <value compset="^SSP370_" >SSP3-7.0</value>
-      <value compset="^SSP434_" >SSP4-3.4</value>
-      <value compset="^SSP460_" >SSP4-6.0</value>
-      <value compset="^SSP534_" >SSP5-3.4</value>
-      <value compset="^SSP585_" >SSP5-8.5</value>
-      <value compset="^HIST_"   >trans_1850-2000</value>
-      <value compset="^20TR_"   >trans_1850-2000</value>
+      <value compset="^1850_"      >clim_1850</value>
+      <value compset="^2000_"      >clim_2000</value>
+      <value compset="^2010_"      >clim_2010</value>
+      <value compset="^SSP119_"    >SSP1-1.9</value>
+      <value compset="^SSP126_"    >SSP1-2.6</value>
+      <value compset="^SSP245_"    >SSP2-4.5</value>
+      <value compset="^SSP370_"    >SSP3-7.0</value>
+      <value compset="^SSP434_"    >SSP4-3.4</value>
+      <value compset="^SSP460_"    >SSP4-6.0</value>
+      <value compset="^SSP534_"    >SSP5-3.4</value>
+      <value compset="^SSP585_"    >SSP5-8.5</value>
+      <value compset="^SSP119EXT_" >SSP1-1.9</value>
+      <value compset="^SSP126EXT_" >SSP1-2.6</value>
+      <value compset="^SSP245EXT_" >SSP2-4.5</value>
+      <value compset="^SSP370EXT_" >SSP3-7.0</value>
+      <value compset="^SSP434EXT_" >SSP4-3.4</value>
+      <value compset="^SSP460EXT_" >SSP4-6.0</value>
+      <value compset="^SSP534EXT_" >SSP5-3.4</value>
+      <value compset="^SSP585EXT_" >SSP5-8.5</value>
+      <value compset="^HIST_"      >trans_1850-2000</value>
+      <value compset="^20TR_"      >trans_1850-2000</value>
       <value compset="^OMIP_DATM%IAF" cime_model="cesm">cesm2_omip</value>
       <value compset="^OMIP_DATM%JRA" cime_model="cesm">cesm2_omip</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
@@ -105,16 +113,24 @@
     <valid_values>none,20tr,20tr.latbnd,omip,SSP1-1.9,SSP1-2.6,SSP2-4.5,SSP3-7.0,SSP4-3.4,SSP4-6.0,SSP5-3.4,SSP5-8.5,SSP1-1.9.latbnd,SSP1-2.6.latbnd,SSP2-4.5.latbnd,SSP3-7.0.latbnd,SSP4-3.4.latbnd,SSP4-6.0.latbnd,SSP5-3.4.latbnd,SSP5-8.5.latbnd</valid_values>
     <default_value>none</default_value>
     <values match="last">
-      <value compset="^SSP119_">SSP1-1.9</value>
-      <value compset="^SSP126_">SSP1-2.6</value>
-      <value compset="^SSP245_">SSP2-4.5</value>
-      <value compset="^SSP370_">SSP3-7.0</value>
-      <value compset="^SSP434_">SSP4-3.4</value>
-      <value compset="^SSP460_">SSP4-6.0</value>
-      <value compset="^SSP534_">SSP5-3.4</value>
-      <value compset="^SSP585_">SSP5-8.5</value>
-      <value compset="^HIST"   >20tr</value>
-      <value compset="^20TR"   >20tr</value>
+      <value compset="^SSP119_"   >SSP1-1.9</value>
+      <value compset="^SSP126_"   >SSP1-2.6</value>
+      <value compset="^SSP245_"   >SSP2-4.5</value>
+      <value compset="^SSP370_"   >SSP3-7.0</value>
+      <value compset="^SSP434_"   >SSP4-3.4</value>
+      <value compset="^SSP460_"   >SSP4-6.0</value>
+      <value compset="^SSP534_"   >SSP5-3.4</value>
+      <value compset="^SSP585_"   >SSP5-8.5</value>
+      <value compset="^SSP119EXT_">SSP1-1.9</value>
+      <value compset="^SSP126EXT_">SSP1-2.6</value>
+      <value compset="^SSP245EXT_">SSP2-4.5</value>
+      <value compset="^SSP370EXT_">SSP3-7.0</value>
+      <value compset="^SSP434EXT_">SSP4-3.4</value>
+      <value compset="^SSP460EXT_">SSP4-6.0</value>
+      <value compset="^SSP534EXT_">SSP5-3.4</value>
+      <value compset="^SSP585EXT_">SSP5-8.5</value>
+      <value compset="^HIST"      >20tr</value>
+      <value compset="^20TR"      >20tr</value>
       <value compset="^OMIP_DATM%IAF.*_POP2%[^_]*ECO">omip</value>
       <value compset="^OMIP_DATM%JRA.*_POP2%[^_]*ECO">omip</value>
     </values>


### PR DESCRIPTION
Adds SSP extension compset names for  DATM_PRESAERO and DATM_CO2_TSERIES, so that CLM can run them.

Setup SMS_Ld5.f09_g17.ISSP534ExtClm50BgcCrop.cheyenne_intel.clm-default, but it's not able to run as expected.

Tests ran: SMS_Ld5.f09_g17.ISSP585ExtClm50BgcCrop.cheyenne_intel.clm-default and
                 SMS_Ld5.f09_g17.ISSP126ExtClm50BgcCrop.cheyenne_intel.clm-default
Test status: bit-for-bit

User interface changes?: No

Update gh-pages html (Y/N)?: N

Code review: 
