### PR TITLE
add ftp timeout, fix failover to svn

### DIFF
--- a/scripts/lib/CIME/Servers/ftp.py
+++ b/scripts/lib/CIME/Servers/ftp.py
@@ -4,6 +4,7 @@ FTP Server class.  Interact with a server using FTP protocol
 # pylint: disable=super-init-not-called
 from CIME.XML.standard_module_setup import *
 from CIME.Servers.generic_server import GenericServer
+from CIME.utils import Timeout
 from ftplib import FTP as FTPpy
 from ftplib import all_errors as all_ftp_errors
 import socket
@@ -38,11 +39,15 @@ class FTP(GenericServer):
         ftp_server, root_address = address.split('/', 1)
         logger.info("server address {} root path {}".format(ftp_server, root_address))
         try:
-            ftp = FTPpy(ftp_server)
+            with Timeout(60):
+                ftp = FTPpy(ftp_server)
+
         except socket.error as e:
             logger.warning("ftp login timeout! {} ".format(e))
             return None
-
+        except RuntimeError:
+            logger.warning("ftp login timeout!")
+            return None
         return cls(address, user=user, passwd=passwd, server=ftp)
 
     def fileexists(self, rel_path):

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -36,7 +36,8 @@ def _download_checksum_file(rundir):
             server = CIME.Servers.WGET.wget_login(address, user, passwd)
         else:
             expect(False, "Unsupported inputdata protocol: {}".format(protocol))
-
+        if server is None:
+            continue
 
         success = False
         rel_path = chksum_file
@@ -362,7 +363,8 @@ def verify_chksum(input_data_root, rundir, filename, isdirectory):
     hashfile = os.path.join(rundir, local_chksum_file)
     if not chksum_hash:
         if not os.path.isfile(hashfile):
-            expect(False, "Failed to find or download file {}".format(hashfile))
+            logger.warning("Failed to find or download file {}".format(hashfile))
+            return
 
         with open(hashfile) as fd:
             lines = fd.readlines()


### PR DESCRIPTION
Add an ftp timeout and fix issue with failing over to svn.
Test suite: scripts_regression_tests.py, hand testing of check_input_data
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
