### PR TITLE
initialize XML variable values to be empty 

### DIFF
--- a/scripts/Tools/archive_metadata
+++ b/scripts/Tools/archive_metadata
@@ -318,6 +318,7 @@ def get_diag_dates(comp, pp_dir):
     model_dates = ''
     pp_vars = _pp_diag_vars.get(comp)
     for pp_var in pp_vars:
+        pp_value = ''
         cmd = ['./pp_config', '--get', pp_var, '--value']
         try:
             pp_value = subprocess.check_output(cmd)


### PR DESCRIPTION
prior to calling pp_config with the --value option.

Test suite: N/A
Test baseline: N/A
Test namelist changes: N/A
Test status: [bit for bit, roundoff, climate changing] bit for bit

Fixes [CIME Github issue #] N/A

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
