### PR TITLE
Bring back the setting of dlnd strm_domdir and strm_domfil to null

### DIFF
--- a/src/components/data_comps_mct/dlnd/cime_config/namelist_definition_dlnd.xml
+++ b/src/components/data_comps_mct/dlnd/cime_config/namelist_definition_dlnd.xml
@@ -80,6 +80,7 @@
     <group>streams_file</group>
     <desc>Stream domain file directory.</desc>
     <values>
+      <value>null</value>
       <value stream="clm.nldas">$DLND_CPLHIST_DIR</value>
     </values>
   </entry>
@@ -90,6 +91,7 @@
     <group>streams_file</group>
     <desc>Stream domain file path(s).</desc>
     <values>
+      <value>null</value>
       <value stream="clm.nldas">mosart_nldas_hist_1975.clm2.h1.1975-01-01-00000.nc</value>
     </values>
   </entry>


### PR DESCRIPTION
When dlnd was changed to support a new mode for MOSART in
ESMCI/cime#3457, the default settings of null for strm_domdir and
strm_domfil were accidentally removed. It turns out that these explicit
settings to null are important for the logic in nmlgen.py:
create_stream_file_and_update_shr_strdata_nml.

This commit brings back these settings to null

Test suite: NONE!
Test baseline: n/a
Test namelist changes: Will change namelists for T compsets
(reverting to behavior prior to #3457 for these compsets)
Test status: bit for bit

Fixes #3485 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @fischer-ncar 
