### PR TITLE
allow for specification of vertical grid in ATM_GRID

### DIFF
--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -58,7 +58,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
         config['aqua_planet_sst_type'] = docn_mode
     else:
         config['aqua_planet_sst_type'] = 'none'
-        
+
     if case.get_value('RUN_TYPE') == 'startup':
         config['run_type'] = 'startup'
     elif case.get_value('RUN_TYPE') == 'hybrid':
@@ -210,6 +210,11 @@ def write_seq_maps_file(case, nmlgen, confdir):
                 ignore_component[comp_class.lower()] = True
             else:
                 ignore_component[comp_class.lower()] = False
+
+    # The ATM grid may contain vertical grid information ("zxx" where xx is a number of levels)
+    # it's not desirable here, remove it.
+    if 'atm' in gridvalue and 'z' in gridvalue['atm']:
+        gridvalue['atm'] = (gridvalue['atm'])[0:gridvalue['atm'].rfind('z')]
 
     # Currently, hard-wire values of mapping file names to ignore
     # TODO: for rof2ocn_fmapname -needs to be resolved since this is currently


### PR DESCRIPTION
The ATM_GRID may include a vertical level specifier, this was not working in matching mapping files for surface conditions
Test suite: scripts_regression_tests.py hand changes of ATM_GRID
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
