### PR TITLE
use esmf8.1.0b14 on cheyenne

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -428,42 +428,29 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">gnu/9.1.0</command>
         <command name="load">openblas/0.3.6</command>
       </modules>
-      <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE" comp_interface="mct">
-        <command name="load">esmf-8.0.0-defio-mpi-g</command>
-      </modules>
-      <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE" comp_interface="mct">
-        <command name="load">esmf-8.0.0-defio-mpi-O</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE" comp_interface="mct">
-        <command name="load">esmf-8.0.0-ncdfio-uni-g</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE" comp_interface="mct">
-        <command name="load">esmf-8.0.0-ncdfio-uni-O</command>
+      <modules compiler="pgi">
+	<command name="load">pgi/19.3</command>
       </modules>
 
-      <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE" comp_interface="nuopc">
+      <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
         <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.5</command>
         <command name="load">esmf-8.1.0b14-ncdfio-mpt-g</command>
       </modules>
-
-      <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="TRUE" comp_interface="nuopc">
-        <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/gnu/9.1.0</command>
-        <command name="load">esmf-8.1.0b14-ncdfio-mpt-g</command>
-      </modules>
-      <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE" comp_interface="nuopc">
+      <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
         <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.5</command>
         <command name="load">esmf-8.1.0b14-ncdfio-mpt-O</command>
       </modules>
-      <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE" comp_interface="nuopc">
+      <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
         <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.5</command>
         <command name="load">esmf-8.1.0b14-ncdfio-mpiuni-g</command>
       </modules>
-      <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE" comp_interface="nuopc">
+      <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
         <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.5</command>
         <command name="load">esmf-8.1.0b14-ncdfio-mpiuni-O</command>
       </modules>
-      <modules compiler="pgi">
-	<command name="load">pgi/19.3</command>
+      <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="TRUE">
+        <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/gnu/9.1.0</command>
+        <command name="load">esmf-8.1.0b14-ncdfio-mpt-g</command>
       </modules>
 
       <modules mpilib="mpt" compiler="gnu">


### PR DESCRIPTION
Updates the esmf library used for waccmx on cheyenne to 8.1.0b14 (same as CMEPS)

Test suite: SMS_D_Ln9.f19_f19_mg17.FX2000.cheyenne_intel.cam-outfrq9s
Test baseline: 
Test namelist changes: 
Test status: bit for bit, 

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
