### PR TITLE
fix issue with mpi-serial io

### DIFF
--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -17,13 +17,12 @@
     </values>
   </entry>
   -->
-  <!--
   <entry id="PIO_VERSION">
     <values>
-      <value mach="stampede2-skx">1</value>
+      <value mpilib="mpi-serial">2</value>
     </values>
   </entry>
-  -->
+
 
   <!--- uncomment and fill in relevant sections
   <entry id="PIO_ROOT">

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -127,6 +127,19 @@ ifeq (,$(SHAREDPATH))
   INSTALL_SHAREDPATH = $(EXEROOT)/$(SHAREDPATH)
 endif
 
+# Atleast on Titan+cray mpi, MPI_Irsends() are buggy, causing hangs during I/O
+# Force PIO to use MPI_Isends instead of the default, MPI_Irsends
+ifeq ($(PIO_VERSION),2)
+  EXTRA_PIO_CPPDEFS = -DUSE_MPI_ISEND_FOR_FC
+  ifneq ($(COMPILER),nag)
+    # Needed by SCORPIO not default PIO, does not work with NAG compiler
+    USE_CXX := TRUE
+  endif
+else
+  EXTRA_PIO_CPPDEFS = -D_NO_MPI_RSEND
+  CPPDEFS += -DPIO1
+endif
+
 ifeq ($(USE_CXX), TRUE)
   ifeq ($(SUPPORTS_CXX), FALSE)
     $(error Fatal attempt to include C++ code on a compiler/machine combo that has not been set up to support C++)
@@ -290,19 +303,6 @@ ifeq ($(findstring -DLINUX,$(CPPDEFS)),-DLINUX)
       CPPDEFS += -DHAVE_SLASHPROC
     endif
   endif
-endif
-
-# Atleast on Titan+cray mpi, MPI_Irsends() are buggy, causing hangs during I/O
-# Force PIO to use MPI_Isends instead of the default, MPI_Irsends
-ifeq ($(PIO_VERSION),2)
-  EXTRA_PIO_CPPDEFS = -DUSE_MPI_ISEND_FOR_FC
-  ifneq ($(COMPILER),nag)
-    # Needed by SCORPIO not default PIO, does not work with NAG compiler
-    SUPPORTS_CXX := TRUE
-  endif
-else
-  EXTRA_PIO_CPPDEFS = -D_NO_MPI_RSEND
-  CPPDEFS += -DPIO1
 endif
 
 ifdef LIB_PNETCDF

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -124,8 +124,6 @@ endif
 
 ifeq ($(strip $(PIO_VERSION)),1)
   CPPDEFS += -DPIO1
-else
-  USE_CXX = TRUE
 endif
 
 ifeq (,$(SHAREDPATH))

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -122,10 +122,6 @@ else
   CPPDEFS += -DHAVE_MPI
 endif
 
-ifeq ($(strip $(PIO_VERSION)),1)
-  CPPDEFS += -DPIO1
-endif
-
 ifeq (,$(SHAREDPATH))
   SHAREDPATH = $(COMPILER)/$(MPILIB)/$(DEBUGDIR)/$(THREADDIR)/$(COMP_INTERFACE)
   INSTALL_SHAREDPATH = $(EXEROOT)/$(SHAREDPATH)
@@ -300,8 +296,13 @@ endif
 # Force PIO to use MPI_Isends instead of the default, MPI_Irsends
 ifeq ($(PIO_VERSION),2)
   EXTRA_PIO_CPPDEFS = -DUSE_MPI_ISEND_FOR_FC
+  ifneq ($(COMPILER),nag)
+    # Needed by SCORPIO not default PIO, does not work with NAG compiler
+    SUPPORTS_CXX := TRUE
+  endif
 else
   EXTRA_PIO_CPPDEFS = -D_NO_MPI_RSEND
+  CPPDEFS += -DPIO1
 endif
 
 ifdef LIB_PNETCDF

--- a/src/externals/pio2/src/flib/piolib_mod.F90
+++ b/src/externals/pio2/src/flib/piolib_mod.F90
@@ -939,8 +939,8 @@ contains
     integer(i4), intent(in) :: rearr
     type (iosystem_desc_t), intent(out)  :: iosystem  ! io descriptor to initalize
     integer(i4), intent(in),optional :: base
-    type (pio_rearr_opt_t), intent(in), optional :: rearr_opts
-
+    type (pio_rearr_opt_t), intent(in), target, optional :: rearr_opts
+    
     integer :: lbase
     integer :: ierr
     interface
@@ -953,7 +953,7 @@ contains
          integer(C_INT), value :: stride
          integer(C_INT), value :: base
          integer(C_INT), value :: rearr
-         type(pio_rearr_opt_t) :: rearr_opts
+         type(C_PTR) :: rearr_opts
          integer(C_INT) :: iosysidp
        end function PIOc_Init_Intracomm_from_F90
     end interface
@@ -966,8 +966,11 @@ contains
 #endif
     lbase=0
     if(present(base)) lbase=base
-    ierr = PIOc_Init_Intracomm_from_F90(comp_comm,num_iotasks,stride,lbase,rearr,rearr_opts,iosystem%iosysid)
-
+    if(present(rearr_opts)) then
+       ierr = PIOc_Init_Intracomm_from_F90(comp_comm,num_iotasks,stride,lbase,rearr,C_LOC(rearr_opts),iosystem%iosysid)
+    else
+       ierr = PIOc_Init_Intracomm_from_F90(comp_comm,num_iotasks,stride,lbase,rearr,C_NULL_PTR,iosystem%iosysid)
+    endif
     call CheckMPIReturn("Bad Initialization in PIO_Init_Intracomm:  ", ierr,__FILE__,__LINE__)
 #ifdef TIMING
     call t_stopf("PIO:init")

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -506,12 +506,17 @@ contains
     call shr_mpi_bcast(pio_buffer_size_limit, Comm)
     call shr_mpi_bcast(pio_async_interface, Comm)
     call shr_mpi_bcast(pio_rearranger, Comm)
+    if (npes == 1) then
+       pio_rearr_comm_max_pend_req_comp2io = 0
+       pio_rearr_comm_max_pend_req_io2comp = 0
+    endif
 
-     call shr_pio_rearr_opts_set(Comm, pio_rearr_comm_type, pio_rearr_comm_fcd, &
-           pio_rearr_comm_max_pend_req_comp2io, pio_rearr_comm_enable_hs_comp2io, &
-           pio_rearr_comm_enable_isend_comp2io, &
-           pio_rearr_comm_max_pend_req_io2comp, pio_rearr_comm_enable_hs_io2comp, &
-           pio_rearr_comm_enable_isend_io2comp, pio_numiotasks)
+
+    call shr_pio_rearr_opts_set(Comm, pio_rearr_comm_type, pio_rearr_comm_fcd, &
+         pio_rearr_comm_max_pend_req_comp2io, pio_rearr_comm_enable_hs_comp2io, &
+         pio_rearr_comm_enable_isend_comp2io, &
+         pio_rearr_comm_max_pend_req_io2comp, pio_rearr_comm_enable_hs_io2comp, &
+         pio_rearr_comm_enable_isend_io2comp, pio_numiotasks)
 
   end subroutine shr_pio_read_default_namelist
 
@@ -807,7 +812,7 @@ contains
       end select
 
       ! buf(3) = max_pend_req_comp2io
-      if((pio_rearr_comm_max_pend_req_comp2io <= 0) .and. &
+      if((pio_rearr_comm_max_pend_req_comp2io < 0) .and. &
           (pio_rearr_comm_max_pend_req_comp2io /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
 
         ! Small multiple of pio_numiotasks has proven to perform
@@ -839,7 +844,7 @@ contains
       end if
 
       ! buf(6) = max_pend_req_io2comp
-      if((pio_rearr_comm_max_pend_req_io2comp <= 0) .and. &
+      if((pio_rearr_comm_max_pend_req_io2comp < 0) .and. &
           (pio_rearr_comm_max_pend_req_io2comp /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
         write(shr_log_unit, *) "Invalid PIO rearranger comm max pend req (io2comp), ", pio_rearr_comm_max_pend_req_io2comp
         write(shr_log_unit, *) "Resetting PIO rearranger comm max pend req (io2comp) to ", PIO_REARR_COMM_DEF_MAX_PEND_REQ


### PR DESCRIPTION
The mpi-serial library was not interpreting a derived mpi datatype correctly, I found that forcing the alltoall interface when using a single processor fixes the problem.  It also allows 0 as a valid value for pio_rearr_comm_max_pend_req_comp2io and pio_rearr_comm_max_pend_req_io2comp.

Test suite: scripts_regression_tests.py, SMS_D_Ln9_Mmpi-serial.ne5_ne5_mg37.FADIAB.cheyenne_intel 
Test baseline: 
Test namelist changes: 
Test status: bit for bit,

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
