### PR TITLE
remove code specific to ornl machine

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -127,16 +127,12 @@ ifeq (,$(SHAREDPATH))
   INSTALL_SHAREDPATH = $(EXEROOT)/$(SHAREDPATH)
 endif
 
-# Atleast on Titan+cray mpi, MPI_Irsends() are buggy, causing hangs during I/O
-# Force PIO to use MPI_Isends instead of the default, MPI_Irsends
 ifeq ($(PIO_VERSION),2)
-  EXTRA_PIO_CPPDEFS = -DUSE_MPI_ISEND_FOR_FC
   ifneq ($(COMPILER),nag)
     # Needed by SCORPIO not default PIO, does not work with NAG compiler
     USE_CXX := TRUE
   endif
 else
-  EXTRA_PIO_CPPDEFS = -D_NO_MPI_RSEND
   CPPDEFS += -DPIO1
 endif
 


### PR DESCRIPTION
Remove code meant to workaround a bug on titan - this code is more appropriate in the scorpio buildlib file. 
Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3500 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
