### PR TITLE
Highres jra bgc

### DIFF
--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -255,8 +255,8 @@
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v2_e333r100_170619.nc</map>
     </gridmap>
     <gridmap rof_grid="JRA025v2" ocn_grid="tx0.1v3" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v3_e333r100_190226.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v3_e333r100_190226.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v3_nnsm_e333r100_190226.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v3_nnsm_e333r100_190226.nc</map>
     </gridmap>
     <gridmap rof_grid="JRA025" ocn_grid="tx0.1v3" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.1v3_e333r100_170830.nc</map>

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -230,6 +230,7 @@
       <value compset="_DATM.*_DICE.*_POP2">4</value>
       <value compset="_DATM.*_DICE.*_MOM6">24</value>
       <value compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
+      <value compset="_DATM.*_SLND.*_CICE.*_POP2" grid="oi%tx0.1v3">144</value>
       <value compset="_DATM.*_SLND.*_CICE.*_MOM6">24</value>
       <value compset="_DATM.*_CICE.*_DOCN">24</value>
       <value compset="_DATM.*_DOCN%US20">24</value>
@@ -310,6 +311,7 @@
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
       <value compset="_POP2" grid="oi%gx1v6">24</value>
       <value compset="_POP2" grid="oi%gx1v7">24</value>
+      <value compset="_POP2" grid="oi%tx0.1v3">48</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
       <value compset="_DATM%NYF.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
       <value compset="_DLND.*_CISM\d">1</value>


### PR DESCRIPTION
Updates to CIME used for 0.1 degree JRA-forced G run with BGC enabled. So far that is just

1. Updating filename in `ROF2OCN_LIQ_RMAPNAME` and `ROF2OCN_ICE_RMAPNAME` because I got it wrong in f078f12
1. Updating `ATM_NCPL` and `OCN_NCPL` for 0.1 degree ocean grids (`ATM_NCPL` update only applies to `DATM` / `SLND` / `CICE` / `POP` runs)

Test suite: just testing by hand so far, will update in comments when more testing is available
Test baseline: N/A
Test namelist changes: N/A
Test status: all test suites should be bit-for-bit, I don't think there are high-res runs being tested

User interface changes?: No

Update gh-pages html (Y/N)?: No

Code review: setting up this draft PR to make code review a little simpler
