### PR TITLE
Add missing ROF2OCN grid for r05_TO_gx3v7

### DIFF
--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -175,6 +175,10 @@
     <!--- river to ocn area overlap -->
     <!-- ======================================================== -->
 
+    <gridmap rof_grid="r05" ocn_grid="gx3v7" >
+      <map name="ROF2OCN_FMAPNAME">cpl/gridmaps/r05/map_r05_TO_gx3v7_aave.200504.nc</map>
+    </gridmap>
+
     <gridmap rof_grid="r05" ocn_grid="gx1v6" >
       <map name="ROF2OCN_FMAPNAME">cpl/cpl6/map_r05_TO_g16_aave.120920.nc</map>
     </gridmap>


### PR DESCRIPTION
ROF2OCN_FMAPNAME was missing for r05_TO_gx3v7 for the T31_g37.X tests.

Test suite: SMS..T31_g37.X.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
