### PR TITLE
fix atm level spec so that it does not match 1x1_brazil

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -3567,6 +3567,8 @@ OR
     GLOBAL_TIMEOUT = ns.timeout
     NO_TEARDOWN    = ns.no_teardown
 
+    os.chdir(os.path.dirname(__file__))
+
     if ns.machine is not None:
         MACHINE = Machines(machine=ns.machine)
         os.environ["CIME_MACHINE"] = ns.machine

--- a/src/components/data_comps_nuopc/drof/cime_config/buildnml
+++ b/src/components/data_comps_nuopc/drof/cime_config/buildnml
@@ -38,8 +38,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     #----------------------------------------------------
     # Get a bunch of information from the case.
     #----------------------------------------------------
-    rof_domain_file = case.get_value("ROF_DOMAIN_FILE")
-    rof_domain_path = case.get_value("ROF_DOMAIN_PATH")
     drof_mode = case.get_value("DROF_MODE")
     rof_grid = case.get_value("ROF_GRID")
 

--- a/src/components/data_comps_nuopc/dwav/cime_config/buildnml
+++ b/src/components/data_comps_nuopc/dwav/cime_config/buildnml
@@ -37,8 +37,6 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     #----------------------------------------------------
     # Get a bunch of information from the case.
     #----------------------------------------------------
-    wav_domain_file = case.get_value("WAV_DOMAIN_FILE")
-    wav_domain_path = case.get_value("WAV_DOMAIN_PATH")
     dwav_mode = case.get_value("DWAV_MODE")
     wav_grid = case.get_value("WAV_GRID")
 

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -213,7 +213,7 @@ def write_seq_maps_file(case, nmlgen, confdir):
 
     # The ATM grid may contain vertical grid information ("zxx" where xx is a number of levels)
     # it's not desirable here, remove it.
-    if 'atm' in gridvalue and 'z' in gridvalue['atm']:
+    if 'atm' in gridvalue and re.match('z\d',gridvalue['atm']):
         gridvalue['atm'] = (gridvalue['atm'])[0:gridvalue['atm'].rfind('z')]
 
     # Currently, hard-wire values of mapping file names to ignore

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -213,7 +213,7 @@ def write_seq_maps_file(case, nmlgen, confdir):
 
     # The ATM grid may contain vertical grid information ("zxx" where xx is a number of levels)
     # it's not desirable here, remove it.
-    if 'atm' in gridvalue and re.match('z\d',gridvalue['atm']):
+    if 'atm' in gridvalue and re.match(r'z\d',gridvalue['atm']):
         gridvalue['atm'] = (gridvalue['atm'])[0:gridvalue['atm'].rfind('z')]
 
     # Currently, hard-wire values of mapping file names to ignore


### PR DESCRIPTION
PR #3492 was too general in matching grids, refine to only match z\d to a vertical grid. 

Test suite: scripts_regression_tests.phy 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3518 
Fixes #3510 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
