### PR TITLE
Fix div0s in cprnc comparisons

### DIFF
--- a/tools/cprnc/compare_vars_mod.F90.in
+++ b/tools/cprnc/compare_vars_mod.F90.in
@@ -364,10 +364,10 @@ contains
           ! can be sensitive to outliers).
           if (n1 > 0 .and. n2 > 0 .and. rms > 0) then
              rms_normalized_denom = (avgval(1) + avgval(2)) / 2.0
-             if(abs(rms_normalized_denom)>1.e-20_r8)then
+             if(abs(rms_normalized_denom)>0)then
                 rms_normalized = rms / rms_normalized_denom
              else
-                rms_normalized = 0
+                rms_normalized = huge(rms)
              end if
           else
              ! don't try to compute rms_normalized in any of the following conditions:

--- a/tools/cprnc/compare_vars_mod.F90.in
+++ b/tools/cprnc/compare_vars_mod.F90.in
@@ -364,7 +364,11 @@ contains
           ! can be sensitive to outliers).
           if (n1 > 0 .and. n2 > 0 .and. rms > 0) then
              rms_normalized_denom = (avgval(1) + avgval(2)) / 2.0
-             rms_normalized = rms / rms_normalized_denom
+             if(abs(rms_normalized_denom)>1.e-20_r8)then
+                rms_normalized = rms / rms_normalized_denom
+             else
+                rms_normalized = 0
+             end if
           else
              ! don't try to compute rms_normalized in any of the following conditions:
              ! n1 = 0 -- then we won't have avgval(1)


### PR DESCRIPTION

When comparing two arrays (base and test), if the base had only zeros in an array, but the test had non-zero values, it was enabling a comparison between the two. However, the normalization factor was using the zero value, and hence trying to calculate a div0.

Tests: I performed a build test on the final changes.  The changes, as per commit 
ceae267, were necessary in completing tests for this PR: https://github.com/NGEET/fates/pull/647

Test baseline: NA 
Test namelist changes: None
Test status: NA

Fixes #3525

User interface changes?: no

Update gh-pages html (Y/N)?: no

Code review: 
