### PR TITLE
fix cime_model to stdout issue

### DIFF
--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -1323,7 +1323,6 @@ contains
        write(logunit,F00) 'Initialize each component: atm, lnd, rof, ocn, ice, glc, wav, esp, iac'
        call shr_sys_flush(logunit)
     endif
-    call seq_infodata_GetData(infodata, cime_model=cime_model)
 
     call t_startf('CPL:comp_init_pre_all')
     call component_init_pre(atm, ATMID, CPLATMID, CPLALLATMID, infodata, ntype='atm')
@@ -3428,6 +3427,7 @@ contains
     character        :: date*8, time*10, zone*5
 
     !-------------------------------------------------------------------------------
+    call seq_infodata_GetData(infodata, cime_model=cime_model)
 
     call date_and_time (date, time, zone, values)
     cdate(1:2) = date(5:6)
@@ -3447,7 +3447,7 @@ contains
     write(logunit,F00) '          github: http://esmci.github.io/cime/)             '
     write(logunit,F00) '     License information is available as a link from above  '
     write(logunit,F00) '------------------------------------------------------------'
-    write(logunit,F00) '                     MODEL ',cime_model
+    write(logunit,F00) '                     MODEL ',trim(cime_model)
     write(logunit,F00) '------------------------------------------------------------'
     write(logunit,F00) '                DATE ',cdate, ' TIME ', ctime
     write(logunit,F00) '------------------------------------------------------------'
@@ -3899,7 +3899,7 @@ contains
 
        ! ocn prep-merge (cesm1_mod or cesm1_mod_tight)
        if (ocn_prognostic) then
-#if COMPARE_TO_NUOPC          
+#if COMPARE_TO_NUOPC
           !This is need to compare to nuopc
           if (.not. skip_ocean_run) then
              ! ocn prep-merge
@@ -3909,7 +3909,7 @@ contains
              ! Accumulate ocn inputs - form partial sum of tavg ocn inputs (virtual "send" to ocn)
              call prep_ocn_accum(timer='CPL:atmocnp_accum')
           end if
-#else 
+#else
           ! ocn prep-merge
           xao_ox => prep_aoflux_get_xao_ox()
           call prep_ocn_mrg(infodata, fractions_ox, xao_ox=xao_ox, timer_mrg='CPL:atmocnp_mrgx2o')
@@ -4189,7 +4189,7 @@ contains
 !----------------------------------------------------------------------------------
 
   subroutine cime_run_rof_setup_send()
-    
+
     !----------------------------------------------------
     ! rof prep-merge
     !----------------------------------------------------


### PR DESCRIPTION
The model name was being printed before being initialized.  Move the initialization.

Test suite: SMS.f19_g16.X
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3533 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
