### PR TITLE
Wpcoomb/improve cime buildlib function debug logging

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -425,9 +425,6 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
 
     if (check_for_python(cmd)):
         logging_options = get_logging_options()
-        logger.warn("wpc0.build.py get_logging_options() is {}. logger.getEffectLevel() is {} ".format(logging_options, logger.getEffectiveLevel()))
-        logger.debug("wpc3.build.py HERE I AM get_logging_options() is {}. logger.getEffectLevel() is {} ".format(logging_options, logger.getEffectiveLevel()))
-
         if (logging_options != ""):
             compile_cmd = compile_cmd + logging_options
 

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -3,7 +3,7 @@ functions for building CIME models
 """
 import glob, shutil, time, threading, subprocess, imp
 from CIME.XML.standard_module_setup  import *
-from CIME.utils                 import get_model, analyze_build_log, stringify_bool, run_and_log_case_status, get_timestamp, run_sub_or_cmd, run_cmd, get_batch_script_for_job, gzip_existing_file, safe_copy, check_for_python
+from CIME.utils                 import get_model, analyze_build_log, stringify_bool, run_and_log_case_status, get_timestamp, run_sub_or_cmd, run_cmd, get_batch_script_for_job, gzip_existing_file, safe_copy, check_for_python, get_logging_options
 from CIME.provenance            import save_build_provenance as save_build_provenance_sub
 from CIME.locked_files          import lock_file, unlock_file
 
@@ -424,8 +424,12 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
         compile_cmd = "SMP={} {}".format(stringify_bool(smp), compile_cmd)
 
     if (check_for_python(cmd)):
-        if (logger.getEffectiveLevel() == 10):
-            compile_cmd = compile_cmd + "--debug"
+        logging_options = get_logging_options()
+        logger.warn("wpc0.build.py get_logging_options() is {}. logger.getEffectLevel() is {} ".format(logging_options, logger.getEffectiveLevel()))
+        logger.debug("wpc3.build.py HERE I AM get_logging_options() is {}. logger.getEffectLevel() is {} ".format(logging_options, logger.getEffectiveLevel()))
+
+        if (logging_options != ""):
+            compile_cmd = compile_cmd + logging_options
 
     with open(file_build, "w") as fd:
         stat = run_cmd(compile_cmd,

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -423,9 +423,9 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
     if get_model() != "ufs":
         compile_cmd = "SMP={} {}".format(stringify_bool(smp), compile_cmd)
 
-    if (check_for_python(cmd)):
+    if check_for_python(cmd):
         logging_options = get_logging_options()
-        if (logging_options != ""):
+        if logging_options != "":
             compile_cmd = compile_cmd + logging_options
 
     with open(file_build, "w") as fd:

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -168,7 +168,6 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     gmake_j    = case.get_value("GMAKE_J")
     gmake      = case.get_value("GMAKE")
 
-    logger.info("wpc0cmake. Building {} with output to {}".format(complist, buildlist))
     # make sure bldroot and libroot exist
     for build_dir in [bldroot, libroot]:
         if not os.path.exists(build_dir):
@@ -411,7 +410,6 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
                         thread_bad_results, smp, compiler):
 ###############################################################################
     logger.info("Building {} with output to {}".format(compclass, file_build))
-    logger.info("wpc1. Building {} with output to {}".format(compclass, file_build))
     t1 = time.time()
     cmd = os.path.join(caseroot, "SourceMods", "src." + compname, "buildlib")
     if os.path.isfile(cmd):
@@ -424,17 +422,11 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
         format(compclass=compclass, compname=compname, cmd=cmd, caseroot=caseroot, libroot=libroot, bldroot=bldroot)
     if get_model() != "ufs":
         compile_cmd = "SMP={} {}".format(stringify_bool(smp), compile_cmd)
-    logger.info("wpc2. cmd is {} with compile_cmd is {}".format(cmd, compile_cmd))
-    helpfile2 = os.path.join(os.getcwd(),os.path.basename("{}.log".format(sys.argv[0])))
-    #logger = logging.getLogger(__name__)
-    logger.info("wpc3. helpfile for --debug flag is file {}. logger.getEffectLevel() is {} ".format(helpfile2, logger.getEffectiveLevel()))
+
     if (check_for_python(cmd)):
-        logger.info("wpc5. logger is {}. logger.getEffectLevel() is {} ".format(logger, logger.getEffectiveLevel()))
         if (logger.getEffectiveLevel() == 10):
             compile_cmd = compile_cmd + "--debug"
-        
-    else:
-        logger.info("wpc6. logger is {}. logger.getEffectLevel() is {} ".format(logger, logger.getEffectiveLevel()))
+
     with open(file_build, "w") as fd:
         stat = run_cmd(compile_cmd,
                        from_dir=bldroot,  arg_stdout=fd,

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -69,10 +69,6 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
     with open(os.path.join(confdir, "CCSM_cppdefs"), "w") as out:
         out.write("")
 
-    helpfile2 = os.path.join(os.getcwd(),os.path.basename("{}.log".format(sys.argv[0])))
-    #logger = logging.getLogger(__name__)
-    logger.info("wpc4.buildlib.py helpfile for --debug flag is file {}. logger.getEffectLevel() is {} ".format(helpfile2, logger.getEffectiveLevel()))
-    
     # Build the component
     if get_model() != "e3sm" or use_old:
         safe_copy(os.path.join(confdir, "Filepath"), bldroot)

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -69,6 +69,10 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
     with open(os.path.join(confdir, "CCSM_cppdefs"), "w") as out:
         out.write("")
 
+    helpfile2 = os.path.join(os.getcwd(),os.path.basename("{}.log".format(sys.argv[0])))
+    #logger = logging.getLogger(__name__)
+    logger.info("wpc4.buildlib.py helpfile for --debug flag is file {}. logger.getEffectLevel() is {} ".format(helpfile2, logger.getEffectiveLevel()))
+    
     # Build the component
     if get_model() != "e3sm" or use_old:
         safe_copy(os.path.join(confdir, "Filepath"), bldroot)

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -4,7 +4,7 @@ common utilities for buildlib
 
 from CIME.XML.standard_module_setup import *
 from CIME.case import Case
-from CIME.utils import parse_args_and_handle_standard_logging_options, setup_standard_logging_options, get_model, safe_copy
+from CIME.utils import parse_args_and_handle_standard_logging_options, setup_standard_logging_options, get_model, safe_copy, get_logging_options
 from CIME.build import get_standard_makefile_args
 
 import sys, os, argparse
@@ -68,6 +68,10 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
 
     with open(os.path.join(confdir, "CCSM_cppdefs"), "w") as out:
         out.write("")
+
+    logging_options = get_logging_options()
+    logger.warn("wpc1.buildlib.py get_logging_options() is {}. logger.getEffectLevel() is {} ".format(logging_options, logger.getEffectiveLevel()))
+    logger.debug("wpc2.buildlib.py HERE I AM get_logging_options() is {}. logger.getEffectLevel() is {} ".format(logging_options, logger.getEffectiveLevel()))
 
     # Build the component
     if get_model() != "e3sm" or use_old:

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -4,7 +4,7 @@ common utilities for buildlib
 
 from CIME.XML.standard_module_setup import *
 from CIME.case import Case
-from CIME.utils import parse_args_and_handle_standard_logging_options, setup_standard_logging_options, get_model, safe_copy, get_logging_options
+from CIME.utils import parse_args_and_handle_standard_logging_options, setup_standard_logging_options, get_model, safe_copy
 from CIME.build import get_standard_makefile_args
 
 import sys, os, argparse
@@ -68,10 +68,6 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
 
     with open(os.path.join(confdir, "CCSM_cppdefs"), "w") as out:
         out.write("")
-
-    logging_options = get_logging_options()
-    logger.warn("wpc1.buildlib.py get_logging_options() is {}. logger.getEffectLevel() is {} ".format(logging_options, logger.getEffectiveLevel()))
-    logger.debug("wpc2.buildlib.py HERE I AM get_logging_options() is {}. logger.getEffectLevel() is {} ".format(logging_options, logger.getEffectiveLevel()))
 
     # Build the component
     if get_model() != "e3sm" or use_old:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -384,7 +384,11 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
 
     # Before attempting to load the script make sure it contains the subroutine
     # we are expecting
-    do_run_cmd = not check_for_python(cmd, subname)
+    with open(cmd, 'r') as fd:
+        for line in fd.readlines():
+            if re.search(r"^def {}\(".format(subname), line):
+                do_run_cmd = False
+                break
 
     if not do_run_cmd:
         try:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1137,8 +1137,6 @@ def parse_args_and_handle_standard_logging_options(args, parser=None):
         root_logger.addHandler(debug_log_handler)
 
         root_logger.setLevel(logging.DEBUG)
-
-        logger.warn("wpc5.utils.py log_file is is {}. logger.getEffectLevel() is {} ".format(log_file, logger.getEffectiveLevel()))
     elif args.silent:
         root_logger.setLevel(logging.WARN)
     else:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -366,7 +366,7 @@ def check_for_python(filepath, funcname=None):
         has_function = False
         with open(filepath, 'r') as fd:
             for line in fd.readlines():
-                if re.search(r"^def\s*{}\(".format(funcname), line) or re.search(r"^from.*import.*\s{}".format(funcname), line):
+                if re.search(r"^def\s+{}\(".format(funcname), line) or re.search(r"^from.+import.+\s{}".format(funcname), line):
                     has_function = True
                     break
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -359,9 +359,7 @@ _hack=object()
 
 def check_for_python(filepath, funcname=None):
     is_python = is_python_executable(filepath)
-
     has_function = True
-
     if funcname is not None:
         has_function = False
         with open(filepath, 'r') as fd:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1137,6 +1137,8 @@ def parse_args_and_handle_standard_logging_options(args, parser=None):
         root_logger.addHandler(debug_log_handler)
 
         root_logger.setLevel(logging.DEBUG)
+
+        logger.warn("wpc5.utils.py log_file is is {}. logger.getEffectLevel() is {} ".format(log_file, logger.getEffectiveLevel()))
     elif args.silent:
         root_logger.setLevel(logging.WARN)
     else:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -357,6 +357,21 @@ def _convert_to_fd(filearg, from_dir, mode="a"):
 
 _hack=object()
 
+def check_for_python(filepath, funcname=None):
+    is_python = is_python_executable(filepath)
+
+    has_function = True
+
+    if funcname is not None:
+        has_function = False
+        with open(filepath, 'r') as fd:
+            for line in fd.readlines():
+                if re.search(r"^def\s*{}\(".format(funcname), line) or re.search(r"^from.*import.*\s{}".format(funcname), line):
+                    has_function = True
+                    break
+
+    return is_python and has_function
+
 def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
                    from_dir=None, timeout=None):
     """

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -384,11 +384,7 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
 
     # Before attempting to load the script make sure it contains the subroutine
     # we are expecting
-    with open(cmd, 'r') as fd:
-        for line in fd.readlines():
-            if re.search(r"^def {}\(".format(subname), line):
-                do_run_cmd = False
-                break
+    do_run_cmd = not check_for_python(cmd, subname)
 
     if not do_run_cmd:
         try:

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -14,6 +14,8 @@ from standard_script_setup import *
 from CIME.buildlib import build_cime_component_lib, parse_input
 from CIME.case import Case
 
+logger = logging.getLogger(__name__)
+
 def buildlib(case, libroot, bldroot, compname=None):
     if compname is None:
         thisdir = os.path.dirname(os.path.abspath(__file__))
@@ -23,6 +25,8 @@ def buildlib(case, libroot, bldroot, compname=None):
             compname = dir2
         else:
             compname = dir1.split('.')[1]
+    
+    logger.debug("wpc7.buildlib HERE I AM logger.getEffectiveLevel() is {}. logger.getEffectLevel() is {} ".format(logger.getEffectiveLevel(), logger.getEffectiveLevel()))
     build_cime_component_lib(case, compname, libroot, bldroot)
 
 def _main_func(args):

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -23,13 +23,11 @@ def buildlib(case, libroot, bldroot, compname=None):
             compname = dir2
         else:
             compname = dir1.split('.')[1]
-    print("hello world")
     build_cime_component_lib(case, compname, libroot, bldroot)
 
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)
     with Case(caseroot) as case:
-        print("hello world main func")
         buildlib(case, libroot, bldroot)
 
 if __name__ == "__main__":

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -25,8 +25,6 @@ def buildlib(case, libroot, bldroot, compname=None):
             compname = dir2
         else:
             compname = dir1.split('.')[1]
-    
-    logger.debug("wpc7.buildlib HERE I AM logger.getEffectiveLevel() is {}. logger.getEffectLevel() is {} ".format(logger.getEffectiveLevel(), logger.getEffectiveLevel()))
     build_cime_component_lib(case, compname, libroot, bldroot)
 
 def _main_func(args):

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -23,11 +23,13 @@ def buildlib(case, libroot, bldroot, compname=None):
             compname = dir2
         else:
             compname = dir1.split('.')[1]
+    print("hello world")
     build_cime_component_lib(case, compname, libroot, bldroot)
 
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)
     with Case(caseroot) as case:
+        print("hello world main func")
         buildlib(case, libroot, bldroot)
 
 if __name__ == "__main__":


### PR DESCRIPTION
The buildlib scripts for external components are called from subthreads.
We now forward the --debug option if used to the python buildlib scripts.
If a component's buildlib is called as a subprocess, then 
the logging options (eg. --debug or --silent) do get passed down now.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: [bit for bit]

Fixes #3532 

User interface changes?: N

Update gh-pages html (Y/N)?:

Code review: @jedwards4b @jgfouca 
