### PR TITLE
add mvsource script

### DIFF
--- a/scripts/Tools/mvsource
+++ b/scripts/Tools/mvsource
@@ -17,11 +17,10 @@ except:
     print("ERROR: {} does not appear to be a valid CIMEROOT directory\n".format(cimeroot))
     exit
 
-logger = logging.getLogger(__name__)
 
 # simple way to verify we are in a caseroot
 if not os.path.exists(os.path.join(caseroot,"env_case.xml")):
-    logger.critical("ERROR: {} does not appear to be a valid CASEROOT directory\n".format(caseroot))
+    print("ERROR: {} does not appear to be a valid CASEROOT directory\n".format(caseroot))
     exit
 
 for dirpath, dirnames, filenames in os.walk(caseroot):
@@ -35,12 +34,12 @@ for dirpath, dirnames, filenames in os.walk(caseroot):
                 index = oldpath.find(cr)+len(cr)-1
                 newpath = cimeroot + oldpath[index:]
             if os.path.exists(newpath):
-                logger.info("Updating link for {}".format(_file))
+                print("Updating link for {}".format(_file))
                 symlink_force(newpath, _file)
 os.chdir(caseroot)
 
 with Case(caseroot, read_only=False) as case:
-    logger.info("Updating case xml")
+    print("Updating case xml")
     case.set_value('CIMEROOT', cimeroot)
     case.set_value('SRCROOT', os.path.dirname(cimeroot))
     case.set_value('CASEROOT', caseroot)

--- a/scripts/Tools/mvsource
+++ b/scripts/Tools/mvsource
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# Expects two arguments, the caseroot and the new cimeroot
+#
+import os, sys, errno
+caseroot = sys.argv[1]
+cimeroot = sys.argv[2]
+
+_LIBDIR = os.path.join(cimeroot, "scripts", "Tools")
+sys.path.append(_LIBDIR)
+_LIBDIR = os.path.join(cimeroot, "scripts", "lib")
+sys.path.append(_LIBDIR)
+
+from CIME.case import Case
+from CIME.utils import symlink_force
+
+# simple way to verify we are in a caseroot
+if not os.path.exists(os.path.join(caseroot,"env_case.xml")):
+   print("ERROR: {} does not appear to be a valid CASEROOT directory\n".format(caseroot))
+   exit
+
+if not os.path.exists(os.path.join(cimeroot,"scripts")):
+   print("ERROR: {} does not appear to be a valid CIMEROOT directory\n".format(caseroot))
+   exit
+
+
+
+
+for dirpath, dirnames, filenames in os.walk(caseroot):
+   os.chdir(dirpath)
+   for _file in filenames:
+      if os.path.islink(_file):
+         oldpath = os.path.realpath(os.readlink(_file))
+         link_name = _file
+         cr = os.sep+'cime'+os.sep
+         if cr in oldpath:
+            index = oldpath.find(cr)+len(cr)-1
+            newpath = cimeroot + oldpath[index:]
+            if os.path.exists(newpath):
+               symlink_force(newpath, _file)
+   os.chdir(caseroot)
+
+   with Case(caseroot, read_only=False) as case:
+      case.set_value('CIMEROOT', cimeroot)
+      case.set_value('SRCROOT', os.path.dirname(cimeroot))
+      case.set_value('CASEROOT', caseroot)
+      model = case.get_value('MODEL')
+      case.set_value("MACHDIR", os.path.join(cimeroot,"config",model,"machines"))
+   os.system('cp env_case.xml LockedFiles/')

--- a/scripts/Tools/mvsource
+++ b/scripts/Tools/mvsource
@@ -32,13 +32,16 @@ for dirpath, dirnames, filenames in os.walk(caseroot):
             index = oldpath.find(cr)+len(cr)-1
             newpath = cimeroot + oldpath[index:]
             if os.path.exists(newpath):
+               print("Updating link for {}".format(_file))
                symlink_force(newpath, _file)
-   os.chdir(caseroot)
+os.chdir(caseroot)
 
-   with Case(caseroot, read_only=False) as case:
-      case.set_value('CIMEROOT', cimeroot)
-      case.set_value('SRCROOT', os.path.dirname(cimeroot))
-      case.set_value('CASEROOT', caseroot)
-      model = case.get_value('MODEL')
-      case.set_value("MACHDIR", os.path.join(cimeroot,"config",model,"machines"))
-   os.system('cp env_case.xml LockedFiles/')
+with Case(caseroot, read_only=False) as case:
+   print("Updating case xml")
+   case.set_value('CIMEROOT', cimeroot)
+   case.set_value('SRCROOT', os.path.dirname(cimeroot))
+   case.set_value('CASEROOT', caseroot)
+   model = case.get_value('MODEL')
+   case.set_value("MACHDIR", os.path.join(cimeroot,"config",model,"machines"))
+
+os.system('cp env_case.xml LockedFiles/')

--- a/scripts/Tools/mvsource
+++ b/scripts/Tools/mvsource
@@ -2,7 +2,7 @@
 # This tool expects two arguments, the caseroot and the new cimeroot
 # It is intended to fix links and update your case source if the caseroot or src is moved.
 #
-import os, sys, errno
+import os, sys
 caseroot = sys.argv[1]
 cimeroot = sys.argv[2]
 
@@ -16,13 +16,10 @@ try:
     from CIME.utils import symlink_force
 except:
     print("ERROR: {} does not appear to be a valid CIMEROOT directory\n".format(cimeroot))
-    exit
-
 
 # simple way to verify we are in a caseroot
 if not os.path.exists(os.path.join(caseroot,"env_case.xml")):
     print("ERROR: {} does not appear to be a valid CASEROOT directory\n".format(caseroot))
-    exit
 
 for dirpath, dirnames, filenames in os.walk(caseroot):
     os.chdir(dirpath)

--- a/scripts/Tools/mvsource
+++ b/scripts/Tools/mvsource
@@ -10,7 +10,7 @@ sys.path.append(_LIBDIR)
 _LIBDIR = os.path.join(cimeroot, "scripts", "lib")
 sys.path.append(_LIBDIR)
 try:
-    from Tools.standard_script_setup import *
+    from standard_script_setup import *
     from CIME.case import Case
     from CIME.utils import symlink_force
 except:
@@ -37,7 +37,7 @@ for dirpath, dirnames, filenames in os.walk(caseroot):
             if os.path.exists(newpath):
                 logger.info("Updating link for {}".format(_file))
                 symlink_force(newpath, _file)
-                os.chdir(caseroot)
+os.chdir(caseroot)
 
 with Case(caseroot, read_only=False) as case:
     logger.info("Updating case xml")

--- a/scripts/Tools/mvsource
+++ b/scripts/Tools/mvsource
@@ -13,7 +13,7 @@ try:
    from CIME.case import Case
    from CIME.utils import symlink_force
 except:
-   print("ERROR: {} does not appear to be a valid CIMEROOT directory\n".format(caseroot))
+   print("ERROR: {} does not appear to be a valid CIMEROOT directory\n".format(cimeroot))
    exit
 
 # simple way to verify we are in a caseroot

--- a/scripts/Tools/mvsource
+++ b/scripts/Tools/mvsource
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Expects two arguments, the caseroot and the new cimeroot
+# This tool expects two arguments, the caseroot and the new cimeroot
+# It is intended to fix links and update your case source if the caseroot or src is moved.
 #
 import os, sys, errno
 caseroot = sys.argv[1]

--- a/scripts/Tools/mvsource
+++ b/scripts/Tools/mvsource
@@ -10,38 +10,41 @@ sys.path.append(_LIBDIR)
 _LIBDIR = os.path.join(cimeroot, "scripts", "lib")
 sys.path.append(_LIBDIR)
 try:
-   from CIME.case import Case
-   from CIME.utils import symlink_force
+    from Tools.standard_script_setup import *
+    from CIME.case import Case
+    from CIME.utils import symlink_force
 except:
-   print("ERROR: {} does not appear to be a valid CIMEROOT directory\n".format(cimeroot))
-   exit
+    print("ERROR: {} does not appear to be a valid CIMEROOT directory\n".format(cimeroot))
+    exit
+
+logger = logging.getLogger(__name__)
 
 # simple way to verify we are in a caseroot
 if not os.path.exists(os.path.join(caseroot,"env_case.xml")):
-   print("ERROR: {} does not appear to be a valid CASEROOT directory\n".format(caseroot))
-   exit
+    logger.critical("ERROR: {} does not appear to be a valid CASEROOT directory\n".format(caseroot))
+    exit
 
 for dirpath, dirnames, filenames in os.walk(caseroot):
-   os.chdir(dirpath)
-   for _file in filenames:
-      if os.path.islink(_file):
-         oldpath = os.path.realpath(os.readlink(_file))
-         link_name = _file
-         cr = os.sep+'cime'+os.sep
-         if cr in oldpath:
-            index = oldpath.find(cr)+len(cr)-1
-            newpath = cimeroot + oldpath[index:]
+    os.chdir(dirpath)
+    for _file in filenames:
+        if os.path.islink(_file):
+            oldpath = os.path.realpath(os.readlink(_file))
+            link_name = _file
+            cr = os.sep+'cime'+os.sep
+            if cr in oldpath:
+                index = oldpath.find(cr)+len(cr)-1
+                newpath = cimeroot + oldpath[index:]
             if os.path.exists(newpath):
-               print("Updating link for {}".format(_file))
-               symlink_force(newpath, _file)
-os.chdir(caseroot)
+                logger.info("Updating link for {}".format(_file))
+                symlink_force(newpath, _file)
+                os.chdir(caseroot)
 
 with Case(caseroot, read_only=False) as case:
-   print("Updating case xml")
-   case.set_value('CIMEROOT', cimeroot)
-   case.set_value('SRCROOT', os.path.dirname(cimeroot))
-   case.set_value('CASEROOT', caseroot)
-   model = case.get_value('MODEL')
-   case.set_value("MACHDIR", os.path.join(cimeroot,"config",model,"machines"))
+    logger.info("Updating case xml")
+    case.set_value('CIMEROOT', cimeroot)
+    case.set_value('SRCROOT', os.path.dirname(cimeroot))
+    case.set_value('CASEROOT', caseroot)
+    model = case.get_value('MODEL')
+    case.set_value("MACHDIR", os.path.join(cimeroot,"config",model,"machines"))
 
 os.system('cp env_case.xml LockedFiles/')

--- a/scripts/Tools/mvsource
+++ b/scripts/Tools/mvsource
@@ -9,21 +9,17 @@ _LIBDIR = os.path.join(cimeroot, "scripts", "Tools")
 sys.path.append(_LIBDIR)
 _LIBDIR = os.path.join(cimeroot, "scripts", "lib")
 sys.path.append(_LIBDIR)
-
-from CIME.case import Case
-from CIME.utils import symlink_force
+try:
+   from CIME.case import Case
+   from CIME.utils import symlink_force
+except:
+   print("ERROR: {} does not appear to be a valid CIMEROOT directory\n".format(caseroot))
+   exit
 
 # simple way to verify we are in a caseroot
 if not os.path.exists(os.path.join(caseroot,"env_case.xml")):
    print("ERROR: {} does not appear to be a valid CASEROOT directory\n".format(caseroot))
    exit
-
-if not os.path.exists(os.path.join(cimeroot,"scripts")):
-   print("ERROR: {} does not appear to be a valid CIMEROOT directory\n".format(caseroot))
-   exit
-
-
-
 
 for dirpath, dirnames, filenames in os.walk(caseroot):
    os.chdir(dirpath)


### PR DESCRIPTION
Add script cime/scripts/Tools/movesrc which accepts two arguments caseroot and cimeroot
and updates a case directory with these paths.  If either the case directory or the code source is moved use this script to correct the case and keep it functional. 

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3542 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
