### PR TITLE
Changes to add NCAR's Casper/DAV systems to the machine lists

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -219,7 +219,6 @@
       <arg flag="--gres=gpu:v100:4"/>
       <arg flag="--account" name="$PROJECT"/>
       <arg flag="--mem=0"/>
-      <arg flag="--reservation=NTDD0002"/>
       <arg flag="--export=MODULEPATH=/glade/u/apps/dav/modulefiles/default/compilers:/glade/u/apps/dav/modulefiles/default/idep"/>
     </submit_args>
     <queues>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -218,8 +218,7 @@
       <arg flag="-p" name="$JOB_QUEUE"/>
       <arg flag="--gres=gpu:v100:4"/>
       <arg flag="--account" name="$PROJECT"/>
-      <arg flag="--mem=0"/>
-      <arg flag="--export=MODULEPATH=/glade/u/apps/dav/modulefiles/default/compilers:/glade/u/apps/dav/modulefiles/default/idep"/>
+      <arg flag="--mem=0"/> 
     </submit_args>
     <queues>
       <queue nodemin="1" nodemax="96" default="true">dav</queue>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -211,6 +211,22 @@
     </queues>
   </batch_system>
 
+  <batch_system type="slurm" MACH="casper">
+    <batch_submit>sbatch</batch_submit>
+    <submit_args>
+      <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-p" name="$JOB_QUEUE"/>
+      <arg flag="--gres=gpu:v100:4"/>
+      <arg flag="--account" name="$PROJECT"/>
+      <arg flag="--mem=0"/>
+      <arg flag="--reservation=NTDD0002"/>
+      <arg flag="--export=MODULEPATH=/glade/u/apps/dav/modulefiles/default/compilers:/glade/u/apps/dav/modulefiles/default/idep"/>
+    </submit_args>
+    <queues>
+      <queue nodemin="1" nodemax="96" default="true">dav</queue>
+    </queues>
+  </batch_system>
+
   <batch_system MACH="cheyenne" type="pbs">
     <directives queue="regular">
       <directive default="/bin/bash" > -S {{ shell }}  </directive>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -653,6 +653,23 @@ using a fortran linker.
   </SLIBS>
 </compiler>
 
+<compiler MACH="casper" COMPILER="pgi">
+  <FFLAGS>
+    <append> -Mnofma -acc -ta=tesla:cc70 -Minfo=accel </append>
+    <append> -I$(EXEROOT)/ocn/obj/FMS </append>
+  </FFLAGS>
+  <CFLAGS>
+    <append> -Mnofma -acc -ta=tesla:cc70 -Minfo=accel </append>
+  </CFLAGS>
+  <LDFLAGS>
+    <append> -acc -ta=tesla:cc70 -Minfo=accel </append>
+  </LDFLAGS>
+  <SLIBS>
+    <append> -llapack -lblas -ldl </append>
+    <append MPILIB="mpi-serial"> -ldl </append>
+  </SLIBS>
+</compiler>
+
 <compiler MACH="cheyenne">
   <CPPDEFS>
     <!-- these flags enable nano timers -->

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -377,7 +377,6 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="labelstdout">-p "%g:"</arg>
         <arg name="num_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
@@ -417,20 +416,10 @@ This allows using a different mpirun command to launch unit tests
     <environment_variables>
       <env name="MODULEPATH">/glade/u/apps/dav/modulefiles/default/compilers:/glade/u/apps/dav/modulefiles/default/idep</env>
       <env name="OMP_STACKSIZE">256M</env>
-      <env name="TMPDIR">/glade/scratch/$USER</env>
-      <env name="MPI_TYPE_DEPTH">16</env>
+      <env name="TMPDIR">/glade/scratch/$USER</env> 
       <env name="CESMDATAROOT">/glade/p/cesmdata/cseg</env>
       <env name="NETCDF_PATH">/glade/u/apps/dav/opt/netcdf-mpi/4.7.3/openmpi/3.1.4/pgi/19.9</env>
-      <env name="MPI_IB_CONGESTED">1</env>
-      <env name="MPI_USE_ARRAY"/>
-    </environment_variables>
-    <environment_variables unit_testing="true">
-      <env name="MPI_USE_ARRAY">false</env>
-    </environment_variables>
-    <environment_variables queue="share">
-      <env name="TMPDIR">/glade/scratch/$USER</env>
-      <env name="MPI_USE_ARRAY">false</env>
-    </environment_variables>
+    </environment_variables> 
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
     </resource_limits>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -353,7 +353,7 @@ This allows using a different mpirun command to launch unit tests
   </machine>
 
    <machine MACH="casper">
-    <DESC>NCAR GPU platform, os is Linux, 32 pes/node, batch system is slurm</DESC>
+    <DESC>NCAR GPU platform, os is Linux, 36 pes/node, batch system is slurm</DESC>
     <NODENAME_REGEX>casper*</NODENAME_REGEX>
     <!-- MPT sometimes timesout at model start time, the next two lines cause
     case_run.py to detect the timeout and retry FORCE_SPARE_NODES times -->
@@ -371,8 +371,8 @@ This allows using a different mpirun command to launch unit tests
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <!-- have not seen any performance benefit in smt -->
-    <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mpirun</executable>
@@ -402,7 +402,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">ncarenv/1.3</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">pgi/19.9</command>
+        <command name="load">pgi/20.4</command>
       </modules>
       <modules mpilib="openmpi" compiler="pgi">
         <command name="load">openmpi/3.1.4</command>
@@ -418,7 +418,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="OMP_STACKSIZE">256M</env>
       <env name="TMPDIR">/glade/scratch/$USER</env> 
       <env name="CESMDATAROOT">/glade/p/cesmdata/cseg</env>
-      <env name="NETCDF_PATH">/glade/u/apps/dav/opt/netcdf-mpi/4.7.3/openmpi/3.1.4/pgi/19.9</env>
+      <env name="NETCDF_PATH">/glade/u/apps/dav/opt/netcdf-mpi/4.7.3/openmpi/3.1.4/pgi/20.4</env>
     </environment_variables> 
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -352,6 +352,90 @@ This allows using a different mpirun command to launch unit tests
     </resource_limits>
   </machine>
 
+   <machine MACH="casper">
+    <DESC>NCAR GPU platform, os is Linux, 32 pes/node, batch system is slurm</DESC>
+    <NODENAME_REGEX>casper*</NODENAME_REGEX>
+    <!-- MPT sometimes timesout at model start time, the next two lines cause
+    case_run.py to detect the timeout and retry FORCE_SPARE_NODES times -->
+    <MPIRUN_RETRY_REGEX>openmpi: Launcher network accept (MPI_LAUNCH_TIMEOUT) timed out</MPIRUN_RETRY_REGEX>
+    <MPIRUN_RETRY_COUNT>10</MPIRUN_RETRY_COUNT>
+    <OS>LINUX</OS>
+    <COMPILERS>pgi</COMPILERS>
+    <MPILIBS compiler="pgi" >openmpi</MPILIBS>
+    <CIME_OUTPUT_ROOT>/glade/scratch/$USER</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/glade/p/cgd/tss/CTSM_datm_forcing_data</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
+    <GMAKE_J>8</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>cseg</SUPPORTED_BY>
+    <!-- have not seen any performance benefit in smt -->
+    <MAX_TASKS_PER_NODE>32</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>32</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="labelstdout">-p "%g:"</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="openmpi">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/glade/u/apps/dav/opt/lmod/7.7.29/init/perl</init_path>
+      <init_path lang="python">/glade/u/apps/dav/opt/lmod/7.7.29/init/env_modules_python.py</init_path>
+      <init_path lang="sh">/glade/u/apps/dav/opt/lmod/7.7.29/init/sh</init_path>
+      <init_path lang="csh">/glade/u/apps/dav/opt/lmod/7.7.29/init/csh</init_path>
+      <cmd_path lang="perl">/glade/u/apps/dav/opt/lmod/7.7.29/libexec/lmod perl</cmd_path>
+      <cmd_path lang="python">/glade/u/apps/dav/opt/lmod/7.7.29/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="purge"/>
+      </modules>
+      <modules>
+        <command name="load">ncarenv/1.3</command>
+      </modules>
+      <modules compiler="pgi">
+        <command name="load">pgi/19.9</command>
+      </modules>
+      <modules mpilib="openmpi" compiler="pgi">
+        <command name="load">openmpi/3.1.4</command>
+        <command name="load">netcdf-mpi/4.7.3</command>
+        <command name="load">pnetcdf/1.12.1</command>
+      </modules>
+      <modules>
+        <command name="load">ncarcompilers/0.5.0</command>
+      </modules>
+    </module_system>
+    <environment_variables>
+      <env name="MODULEPATH">/glade/u/apps/dav/modulefiles/default/compilers:/glade/u/apps/dav/modulefiles/default/idep</env>
+      <env name="OMP_STACKSIZE">256M</env>
+      <env name="TMPDIR">/glade/scratch/$USER</env>
+      <env name="MPI_TYPE_DEPTH">16</env>
+      <env name="CESMDATAROOT">/glade/p/cesmdata/cseg</env>
+      <env name="NETCDF_PATH">/glade/u/apps/dav/opt/netcdf-mpi/4.7.3/openmpi/3.1.4/pgi/19.9</env>
+      <env name="MPI_IB_CONGESTED">1</env>
+      <env name="MPI_USE_ARRAY"/>
+    </environment_variables>
+    <environment_variables unit_testing="true">
+      <env name="MPI_USE_ARRAY">false</env>
+    </environment_variables>
+    <environment_variables queue="share">
+      <env name="TMPDIR">/glade/scratch/$USER</env>
+      <env name="MPI_USE_ARRAY">false</env>
+    </environment_variables>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
+  </machine>
+
   <machine MACH="cheyenne">
     <DESC>NCAR SGI platform, os is Linux, 36 pes/node, batch system is PBS</DESC>
     <NODENAME_REGEX>.*.?cheyenne\d?.ucar.edu</NODENAME_REGEX>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -357,8 +357,6 @@ This allows using a different mpirun command to launch unit tests
     <NODENAME_REGEX>casper*</NODENAME_REGEX>
     <!-- MPT sometimes timesout at model start time, the next two lines cause
     case_run.py to detect the timeout and retry FORCE_SPARE_NODES times -->
-    <MPIRUN_RETRY_REGEX>openmpi: Launcher network accept (MPI_LAUNCH_TIMEOUT) timed out</MPIRUN_RETRY_REGEX>
-    <MPIRUN_RETRY_COUNT>10</MPIRUN_RETRY_COUNT>
     <OS>LINUX</OS>
     <COMPILERS>pgi</COMPILERS>
     <MPILIBS compiler="pgi" >openmpi</MPILIBS>
@@ -369,7 +367,7 @@ This allows using a different mpirun command to launch unit tests
     <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
     <GMAKE_J>8</GMAKE_J>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
-    <SUPPORTED_BY>cseg</SUPPORTED_BY>
+    <SUPPORTED_BY>CISL-STP</SUPPORTED_BY>
     <!-- have not seen any performance benefit in smt -->
     <MAX_TASKS_PER_NODE>36</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>36</MAX_MPITASKS_PER_NODE>
@@ -413,12 +411,12 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">ncarcompilers/0.5.0</command>
       </modules>
     </module_system>
-    <environment_variables>
+    <environment_variables> 
       <env name="MODULEPATH">/glade/u/apps/dav/modulefiles/default/compilers:/glade/u/apps/dav/modulefiles/default/idep</env>
       <env name="OMP_STACKSIZE">256M</env>
       <env name="TMPDIR">/glade/scratch/$USER</env> 
       <env name="CESMDATAROOT">/glade/p/cesmdata/cseg</env>
-      <env name="NETCDF_PATH">/glade/u/apps/dav/opt/netcdf-mpi/4.7.3/openmpi/3.1.4/pgi/20.4</env>
+      <env name="NETCDF_PATH">$ENV{NETCDF}</env>
     </environment_variables> 
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>


### PR DESCRIPTION
This setup defaults to adding "-acc -ta=tesla:cc70" to the build flags
with PGI compiler and utilizing the NTDD0002 reservation for jobs
submitted on Casper.

[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: No

Update gh-pages html (Y/N)?: N

Code review: 
