### PR TITLE
Allow gptl build to recognize ESMF_LIBDIR

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -306,7 +306,7 @@ ifdef LIB_PNETCDF
    SLIBS += -L$(LIB_PNETCDF) -lpnetcdf
 endif
 
-# Set esmf.mk location with ESMF_LIBDIR having precedent over ESMFMKFILE
+# Set esmf.mk location with ESMF_LIBDIR having precedence over ESMFMKFILE
 CIME_ESMFMKFILE := undefined_ESMFMKFILE
 ifdef ESMFMKFILE
    CIME_ESMFMKFILE := $(ESMFMKFILE)

--- a/src/share/timing/Makefile
+++ b/src/share/timing/Makefile
@@ -22,7 +22,15 @@ ifdef COMP_INTERFACE
   UPVAR := $(shell echo $(COMP_INTERFACE) | tr a-z A-Z)
   CPPDEFS+=-D$(UPVAR)_INTERFACE
   ifeq ("$(COMP_INTERFACE)", "nuopc")
-    -include $(ESMFMKFILE)
+    # Set esmf.mk location with ESMF_LIBDIR having precedence over ESMFMKFILE
+    CIME_ESMFMKFILE := undefined_ESMFMKFILE
+    ifdef ESMFMKFILE
+       CIME_ESMFMKFILE := $(ESMFMKFILE)
+    endif
+    ifdef ESMF_LIBDIR
+       CIME_ESMFMKFILE := $(ESMF_LIBDIR)/esmf.mk
+    endif
+    -include $(CIME_ESMFMKFILE)
     FFLAGS += $(ESMF_F90COMPILEPATHS)
   endif
 endif


### PR DESCRIPTION
Previously, it only considered ESMFMKFILE. I have copied the relevant
logic from scripts/Tools/Makefile to consider either ESMFMKFILE or
ESMF_LIBDIR. This is important on machines that define ESMF_LIBDIR in
config_compilers, but where the environment variable ESMFMKFILE is not
set.

Test suite: Manual test of build on a machine that sets ESMF_LIBDIR but not ESMFMKFILE
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #3550 

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
