### PR TITLE
When writing .env_mach_specific files, only write settings for main job

### DIFF
--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -97,7 +97,7 @@ def _generate_env_mach_specific(output_dir, machobj, compiler, mpilib, debug,
         logger.warning("{} already exists, delete to replace".format(ems_path))
         return
 
-    ems_file = EnvMachSpecific(output_dir, unit_testing=unit_testing)
+    ems_file = EnvMachSpecific(output_dir, unit_testing=unit_testing, standalone_configure=True)
     ems_file.populate(machobj)
     ems_file.write()
 

--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -107,7 +107,7 @@ def _generate_env_mach_specific(output_dir, machobj, compiler, mpilib, debug,
     fake_case = FakeCase(compiler, mpilib, debug, comp_interface)
     ems_file.load_env(fake_case)
     for shell in ('sh', 'csh'):
-        ems_file.make_env_mach_specific_file(shell, fake_case)
+        ems_file.make_env_mach_specific_file(shell, fake_case, output_dir=output_dir)
         shell_path = os.path.join(output_dir, ".env_mach_specific." + shell)
         with open(shell_path, 'a') as shell_file:
             if shell == 'sh':

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -150,7 +150,14 @@ class EnvMachSpecific(EnvBase):
             f.write(self.list_modules())
         run_cmd_no_fail("echo -e '\n' && env", arg_stdout=filename)
 
-    def make_env_mach_specific_file(self, shell, case):
+    def make_env_mach_specific_file(self, shell, case, output_dir=''):
+        """Writes .env_mach_specific.sh or .env_mach_specific.csh
+
+        Args:
+        shell: string - 'sh' or 'csh'
+        case: case object
+        output_dir: string - path to output directory (if empty string, uses current directory)
+        """
         module_system = self.get_module_system_type()
         sh_init_cmd = self.get_module_system_init_path(shell)
         sh_mod_cmd = self.get_module_system_cmd_path(shell)
@@ -190,7 +197,7 @@ class EnvMachSpecific(EnvBase):
                 else:
                     expect(False, "Unknown shell type: '{}'".format(shell))
 
-        with open(filename, "w") as fd:
+        with open(os.path.join(output_dir, filename), "w") as fd:
             fd.write("\n".join(lines))
 
     # Private API


### PR DESCRIPTION
The main change here is:

When writing .env_mach_specific files, only write settings for main job

Previously, the .env_mach_specific.sh and .env_mach_specific.csh files
had settings for all jobs. At least on cheyenne, this led to the
settings for the st_archive job being written after the settings for the
main job - in particular, setting MPI_USE_ARRAY=false. I typically want
the settings for the main job. This commit changes the behavior so that
the env_mach_specific files just contain the settings for the main job.

Note that this doesn't change the behavior when running the standalone
configure tool, because I'm not sure how to fix that case.

An additional fix is:

configure tool: honor --output-dir for .env_mach_specific files

Previously, these files were being written in the current working
directory, even if --output-dir was given.

Test suite: Manual testing: (1) ran configure tool before and after on cheyenne; (2) examined .env_mach_specific.sh files before and after on cheyenne (both for a non-test case and for a test case); (3) scripts_regression_tests on cheyenne
Test baseline: n/a
Test namelist changes: 
Test status: bit for bit

Fixes #3553 
Fixes #3554 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
