### PR TITLE
couples HYCOM with data atmosphere for UFS HAFS application

### DIFF
--- a/config/ufs/config_files.xml
+++ b/config/ufs/config_files.xml
@@ -122,7 +122,8 @@
   <entry id="COMP_ROOT_DIR_CPL">
     <type>char</type>
     <values>
-      <value>$SRCROOT/src/model/NEMS</value>
+      <!--<value>$SRCROOT/src/model/NEMS</value>-->
+      <value>$CIMEROOT/src/drivers/nuopc</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -137,6 +138,7 @@
       <value component="pop"       >$SRCROOT/components/pop/</value>
       <value component="mom"       >$SRCROOT/components/mom/</value>
       <value component="nemo"      >$SRCROOT/components/nemo/</value>
+      <value component="hycom"     >$SRCROOT/src/model/HYCOM/</value>
       <value component="docn"      >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/docn</value>
       <value component="socn"      >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/socn</value>
       <value component="xocn"      >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xocn</value>
@@ -254,7 +256,8 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/config_compsets.xml</value>
-      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/config_compsets.xml</value>
+      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/config_compsets.xml</value>-->
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_compsets.xml</value>
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/config_compsets.xml</value>
       <value component="ufsatm"   >$COMP_ROOT_DIR_ATM/cime/cime_config/config_compsets.xml</value>
       <value component="cism"     >$COMP_ROOT_DIR_GLC/cime_config/config_compsets.xml</value>
@@ -262,7 +265,8 @@
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
-      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
+      <value component="nemo"     >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
+      <value component="hycom"    >$COMP_ROOT_DIR_OCN/cime/cime_config/config_compsets.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -275,7 +279,8 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/config_pes.xml</value>
-      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/config_pes.xml</value>
+      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/config_pes.xml</value>-->
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_pes.xml</value>
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/config_pes.xml</value>
       <value component="ufsatm"   >$COMP_ROOT_DIR_ATM/cime/cime_config/config_pes.xml</value>
       <value component="cism"     >$COMP_ROOT_DIR_GLC/cime_config/config_pes.xml</value>
@@ -283,7 +288,8 @@
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
-      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
+      <value component="nemo"     >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
+      <value component="hycom"    >$COMP_ROOT_DIR_OCN/cime/cime_config/config_pes.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -295,7 +301,8 @@
     <type>char</type>
     <values>
       <value>$CIMEROOT/config/$MODEL/config_archive.xml</value>
-      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/config_archive.xml</value>
+      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/config_archive.xml</value>-->
+      <value component="drv" >$COMP_ROOT_DIR_CPL/cime_config/config_archive.xml</value>
       <!-- data model components -->
       <value component="drof">$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
       <value component="datm">$COMP_ROOT_DIR_ATM/cime_config/config_archive.xml</value>
@@ -310,7 +317,8 @@
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
-      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
+      <value component="nemo"     >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
+      <value component="hycom"    >$COMP_ROOT_DIR_OCN/cime/cime_config/config_archive.xml</value>
       <value component="rtm"      >$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
       <value component="ufsatm"   >$COMP_ROOT_DIR_ATM/cime/cime_config/config_archive.xml</value>
@@ -344,7 +352,8 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="ufsatm"   >$COMP_ROOT_DIR_ATM/cime/cime_config/testlist.xml</value>
+      <value component="ufsatm">$COMP_ROOT_DIR_ATM/cime/cime_config/testlist.xml</value>
+      <value component="hycom" >$COMP_ROOT_DIR_OCN/cime/cime_config/testlist.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -357,7 +366,8 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/testmods_dirs</value>
-      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/testdefs/testmods_dirs</value>
+      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/testdefs/testmods_dirs</value>-->
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/testdefs/testmods_dirs</value>
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
       <value component="cism"     >$COMP_ROOT_DIR_GLC/cime_config/testdefs/testmods_dirs</value>
       <value component="clm"      >$COMP_ROOT_DIR_LND/cime_config/testdefs/testmods_dirs</value>
@@ -366,7 +376,7 @@
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
       <value component="mom"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
-      <value component="nemo"   >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
+      <value component="nemo"     >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -378,7 +388,8 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/usermods_dirs</value>
-      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/usermods_dirs</value>
+      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/usermods_dirs</value>-->
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/usermods_dirs</value>
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/usermods_dirs</value>
       <value component="cism"     >$COMP_ROOT_DIR_GLC/cime_config/usermods_dirs</value>
       <value component="clm"      >$COMP_ROOT_DIR_LND/cime_config/usermods_dirs</value>
@@ -399,7 +410,8 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/namelist_definition_drv.xml</value>
+      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/namelist_definition_drv.xml</value>-->
+      <value component="drv" >$COMP_ROOT_DIR_CPL/cime_config/namelist_definition_drv.xml</value>
       <!-- data model components -->
       <value component="drof">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/drof/cime_config/namelist_definition_drof.xml</value>
       <value component="datm">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/datm/cime_config/namelist_definition_datm.xml</value>
@@ -431,7 +443,8 @@
   <entry id="CONFIG_CPL_FILE">
     <type>char</type>
     <values>
-      <value>$COMP_ROOT_DIR_CPL/cime/cime_config/config_component.xml</value>
+      <!--<value>$COMP_ROOT_DIR_CPL/cime/cime_config/config_component.xml</value>-->
+      <value>$COMP_ROOT_DIR_CPL/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -443,7 +456,8 @@
   <entry id="CONFIG_CPL_FILE_MODEL_SPECIFIC">
     <type>char</type>
     <values>
-      <value>$SRCROOT/src/model/NEMS/cime/cime_config/config_component_$MODEL.xml</value>
+      <!--<value>$SRCROOT/src/model/NEMS/cime/cime_config/config_component_$MODEL.xml</value>-->
+      <value>$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/config_component_$MODEL.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -506,6 +520,7 @@
     <type>char</type>
     <values>
       <value>$COMP_ROOT_DIR_OCN/cime_config/config_component.xml</value>
+      <value component="hycom">$COMP_ROOT_DIR_OCN/cime/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/config/ufs/config_files.xml
+++ b/config/ufs/config_files.xml
@@ -449,7 +449,7 @@
   <entry id="CONFIG_CPL_FILE_MODEL_SPECIFIC">
     <type>char</type>
     <values>
-      <value>$COMP_ROOT_DIR_CPL/cime/cime_config/config_component_$MODEL.xml</value>
+      <value>$COMP_ROOT_DIR_CPL/cime_config/config_component_$MODEL.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/config/ufs/config_files.xml
+++ b/config/ufs/config_files.xml
@@ -122,8 +122,8 @@
   <entry id="COMP_ROOT_DIR_CPL">
     <type>char</type>
     <values>
-      <!--<value>$SRCROOT/src/model/NEMS</value>-->
-      <value>$CIMEROOT/src/drivers/nuopc</value>
+      <value component="nems">$SRCROOT/src/model/NEMS/cime</value>
+      <value component="cpl" >$CIMEROOT/src/drivers/nuopc</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -256,7 +256,6 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/config_compsets.xml</value>
-      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/config_compsets.xml</value>-->
       <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_compsets.xml</value>
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/config_compsets.xml</value>
       <value component="ufsatm"   >$COMP_ROOT_DIR_ATM/cime/cime_config/config_compsets.xml</value>
@@ -279,7 +278,6 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/config_pes.xml</value>
-      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/config_pes.xml</value>-->
       <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_pes.xml</value>
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/config_pes.xml</value>
       <value component="ufsatm"   >$COMP_ROOT_DIR_ATM/cime/cime_config/config_pes.xml</value>
@@ -301,7 +299,6 @@
     <type>char</type>
     <values>
       <value>$CIMEROOT/config/$MODEL/config_archive.xml</value>
-      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/config_archive.xml</value>-->
       <value component="drv" >$COMP_ROOT_DIR_CPL/cime_config/config_archive.xml</value>
       <!-- data model components -->
       <value component="drof">$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
@@ -366,7 +363,6 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/testmods_dirs</value>
-      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/testdefs/testmods_dirs</value>-->
       <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/testdefs/testmods_dirs</value>
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
       <value component="cism"     >$COMP_ROOT_DIR_GLC/cime_config/testdefs/testmods_dirs</value>
@@ -388,7 +384,6 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/usermods_dirs</value>
-      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/usermods_dirs</value>-->
       <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/usermods_dirs</value>
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/usermods_dirs</value>
       <value component="cism"     >$COMP_ROOT_DIR_GLC/cime_config/usermods_dirs</value>
@@ -410,7 +405,6 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <!--<value component="drv"      >$COMP_ROOT_DIR_CPL/cime/cime_config/namelist_definition_drv.xml</value>-->
       <value component="drv" >$COMP_ROOT_DIR_CPL/cime_config/namelist_definition_drv.xml</value>
       <!-- data model components -->
       <value component="drof">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/drof/cime_config/namelist_definition_drof.xml</value>
@@ -443,7 +437,6 @@
   <entry id="CONFIG_CPL_FILE">
     <type>char</type>
     <values>
-      <!--<value>$COMP_ROOT_DIR_CPL/cime/cime_config/config_component.xml</value>-->
       <value>$COMP_ROOT_DIR_CPL/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
@@ -456,8 +449,7 @@
   <entry id="CONFIG_CPL_FILE_MODEL_SPECIFIC">
     <type>char</type>
     <values>
-      <!--<value>$SRCROOT/src/model/NEMS/cime/cime_config/config_component_$MODEL.xml</value>-->
-      <value>$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/config_component_$MODEL.xml</value>
+      <value>$COMP_ROOT_DIR_CPL/cime/cime_config/config_component_$MODEL.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/config/ufs/config_grids.xml
+++ b/config/ufs/config_grids.xml
@@ -43,6 +43,11 @@
       <grid name="atm">C768</grid>
     </model_grid>
 
+    <model_grid alias="T62_Atlantic8">
+      <grid name="atm">T62</grid>
+      <grid name="lnd">T62</grid>
+      <grid name="ocnice">Atlantic8</grid>      
+    </model_grid>
   </grids>
 
   <!-- ======================================================== -->
@@ -50,7 +55,6 @@
   <!-- ======================================================== -->
 
   <domains>
-
     <domain name="null">
       <!-- null grid -->
       <nx>0</nx> <ny>0</ny>
@@ -59,7 +63,6 @@
     </domain>
 
     <!-- fvcubed domains-->
-
     <domain name="C96">
       <nx>55296</nx> <ny>1</ny>
       <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.C96_gx1v6.181018.nc</file>
@@ -87,6 +90,24 @@
       <desc>C768 is a fvcubed 13 km resolution grid:</desc>
       <support>Experimental for fv3 dycore</support>
     </domain>
+
+    <!-- domains for data atmosphere -->
+    <domain name="T62">
+      <nx>192</nx>  <ny>94</ny>
+      <file grid="atm|lnd" mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/T62/domain.lnd.T62_Atlantic8.200423.nc</file>
+      <file grid="ocnice"  mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/T62/domain.ocn.T62_Atlantic8.200423.nc</file>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/T62_040121_ESMFmesh.nc</mesh>
+      <desc>T62 is Gaussian grid:</desc>
+    </domain>
+
+    <!-- domains for regional ocean (HYCOM) -->
+    <domain name="Atlantic8">
+      <nx>1135</nx> <ny>633</ny>
+      <file grid="ocnice">/glade/u/home/turuncu/UFS/Atlantic8/T62/domain.ocn.Atlantic8.2004123.nc</file>
+      <mesh driver="nuopc">/glade/u/home/turuncu/UFS/Atlantic8/T62/Atlantic8_SCRIP_230420_ESMFmesh.nc</mesh>
+      <desc>Atlantic8 is a Atlantic grid for Dorian case at 7-8 km HYCOM grid:</desc>
+      <support>For regional HYCOM experiments</support>
+    </domain>    
   </domains>
 
   <!-- ======================================================== -->
@@ -116,6 +137,12 @@
   </required_gridmaps>
 
   <gridmaps driver="nuopc">
+    <gridmap atm_grid="T62" ocn_grid="Atlantic8">
+    <map name="ATM2OCN_FMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_T62_TO_Atlantic8_aave.200423.nc</map>
+    <map name="ATM2OCN_SMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_T62_TO_Atlantic8_blin.200423.nc</map>
+    <map name="ATM2OCN_VMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_T62_TO_Atlantic8_blin.200423.nc</map>
+    <map name="OCN2ATM_FMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_Atlantic8_TO_T62_aave.200423.nc</map>
+    <map name="OCN2ATM_SMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_Atlantic8_TO_T62_aave.200423.nc</map>
+    </gridmap>
   </gridmaps>
-
 </grid_data>

--- a/config/ufs/config_grids.xml
+++ b/config/ufs/config_grids.xml
@@ -151,19 +151,5 @@
   </required_gridmaps>
 
   <gridmaps driver="nuopc">
-    <gridmap atm_grid="T62" ocn_grid="Atlantic8">
-    <map name="ATM2OCN_FMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_T62_TO_Atlantic8_aave.200423.nc</map>
-    <map name="ATM2OCN_SMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_T62_TO_Atlantic8_blin.200423.nc</map>
-    <map name="ATM2OCN_VMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_T62_TO_Atlantic8_blin.200423.nc</map>
-    <map name="OCN2ATM_FMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_Atlantic8_TO_T62_aave.200423.nc</map>
-    <map name="OCN2ATM_SMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_Atlantic8_TO_T62_aave.200423.nc</map>
-    </gridmap>
-    <gridmap atm_grid="TL319" ocn_grid="Atlantic8">
-    <map name="ATM2OCN_FMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_TL319_TO_Atlantic8_aave.200527.nc</map>
-    <map name="ATM2OCN_SMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_TL319_TO_Atlantic8_blin.200527.nc</map>
-    <map name="ATM2OCN_VMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_TL319_TO_Atlantic8_blin.200527.nc</map>
-    <map name="OCN2ATM_FMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_Atlantic8_TO_TL319_aave.200527.nc</map>
-    <map name="OCN2ATM_SMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_Atlantic8_TO_TL319_aave.200527.nc</map>
-    </gridmap>
   </gridmaps>
 </grid_data>

--- a/config/ufs/config_grids.xml
+++ b/config/ufs/config_grids.xml
@@ -100,16 +100,16 @@
     <!-- domains for data atmosphere -->
     <domain name="T62">
       <nx>192</nx> <ny>94</ny>
-      <file grid="atm|lnd" mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/T62/domain.lnd.T62_Atlantic8.200423.nc</file>
-      <file grid="ocnice"  mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/T62/domain.ocn.T62_Atlantic8.200423.nc</file>
+      <file grid="atm|lnd" mask="Atlantic8">$DIN_LOC_ROOT/hafs/share/domains/domain.lnd.T62_Atlantic8.200423.nc</file>
+      <file grid="ocnice"  mask="Atlantic8">$DIN_LOC_ROOT/hafs/share/domains/domain.ocn.T62_Atlantic8.200423.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/T62_040121_ESMFmesh.nc</mesh>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
     <domain name="TL319">
       <nx>640</nx> <ny>320</ny>
-      <file grid="atm|lnd" mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/TL319/domain.lnd.TL319_Atlantic8.200527.nc</file>
-      <file grid="ocnice"  mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/TL319/domain.ocn.TL319_Atlantic8.200527.nc</file>
+      <file grid="atm|lnd" mask="Atlantic8">$DIN_LOC_ROOT/hafs/share/domains/domain.lnd.TL319_Atlantic8.200527.nc</file>
+      <file grid="ocnice"  mask="Atlantic8">$DIN_LOC_ROOT/hafs/share/domains/domain.ocn.TL319_Atlantic8.200527.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/TL319_151007_ESMFmesh.nc</mesh>
       <desc>TL319 grid for JRA55</desc>
     </domain>
@@ -117,8 +117,8 @@
     <!-- domains for regional ocean (HYCOM) -->
     <domain name="Atlantic8">
       <nx>1135</nx> <ny>633</ny>
-      <file grid="ocnice">/glade/u/home/turuncu/UFS/Atlantic8/T62/domain.ocn.Atlantic8.2004123.nc</file>
-      <mesh driver="nuopc">/glade/u/home/turuncu/UFS/Atlantic8/T62/Atlantic8_SCRIP_230420_ESMFmesh.nc</mesh>
+      <file grid="ocnice">$DIN_LOC_ROOT/hafs/share/domains/domain.ocn.Atlantic8.2004123.nc</file>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/hafs/share/meshes/Atlantic8_SCRIP_230420_ESMFmesh.nc</mesh>
       <desc>Atlantic8 is a Atlantic grid for Dorian case at 7-8 km HYCOM grid:</desc>
       <support>For regional HYCOM experiments</support>
     </domain>    
@@ -152,18 +152,18 @@
 
   <gridmaps driver="nuopc">
     <gridmap atm_grid="T62" ocn_grid="Atlantic8">
-    <map name="ATM2OCN_FMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_T62_TO_Atlantic8_aave.200423.nc</map>
-    <map name="ATM2OCN_SMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_T62_TO_Atlantic8_blin.200423.nc</map>
-    <map name="ATM2OCN_VMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_T62_TO_Atlantic8_blin.200423.nc</map>
-    <map name="OCN2ATM_FMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_Atlantic8_TO_T62_aave.200423.nc</map>
-    <map name="OCN2ATM_SMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_Atlantic8_TO_T62_aave.200423.nc</map>
+    <map name="ATM2OCN_FMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_T62_TO_Atlantic8_aave.200423.nc</map>
+    <map name="ATM2OCN_SMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_T62_TO_Atlantic8_blin.200423.nc</map>
+    <map name="ATM2OCN_VMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_T62_TO_Atlantic8_blin.200423.nc</map>
+    <map name="OCN2ATM_FMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_Atlantic8_TO_T62_aave.200423.nc</map>
+    <map name="OCN2ATM_SMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_Atlantic8_TO_T62_aave.200423.nc</map>
     </gridmap>
     <gridmap atm_grid="TL319" ocn_grid="Atlantic8">
-    <map name="ATM2OCN_FMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_TL319_TO_Atlantic8_aave.200527.nc</map>
-    <map name="ATM2OCN_SMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_TL319_TO_Atlantic8_blin.200527.nc</map>
-    <map name="ATM2OCN_VMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_TL319_TO_Atlantic8_blin.200527.nc</map>
-    <map name="OCN2ATM_FMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_Atlantic8_TO_TL319_aave.200527.nc</map>
-    <map name="OCN2ATM_SMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_Atlantic8_TO_TL319_aave.200527.nc</map>
+    <map name="ATM2OCN_FMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_TL319_TO_Atlantic8_aave.200527.nc</map>
+    <map name="ATM2OCN_SMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_TL319_TO_Atlantic8_blin.200527.nc</map>
+    <map name="ATM2OCN_VMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_TL319_TO_Atlantic8_blin.200527.nc</map>
+    <map name="OCN2ATM_FMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_Atlantic8_TO_TL319_aave.200527.nc</map>
+    <map name="OCN2ATM_SMAPNAME">$DIN_LOC_ROOT/hafs/mapping/maps/map_Atlantic8_TO_TL319_aave.200527.nc</map>
     </gridmap>
   </gridmaps>
 </grid_data>

--- a/config/ufs/config_grids.xml
+++ b/config/ufs/config_grids.xml
@@ -48,6 +48,12 @@
       <grid name="lnd">T62</grid>
       <grid name="ocnice">Atlantic8</grid>      
     </model_grid>
+
+    <model_grid alias="TL319_Atlantic8">
+      <grid name="atm">TL319</grid>
+      <grid name="lnd">TL319</grid>
+      <grid name="ocnice">Atlantic8</grid>
+    </model_grid>
   </grids>
 
   <!-- ======================================================== -->
@@ -93,11 +99,19 @@
 
     <!-- domains for data atmosphere -->
     <domain name="T62">
-      <nx>192</nx>  <ny>94</ny>
+      <nx>192</nx> <ny>94</ny>
       <file grid="atm|lnd" mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/T62/domain.lnd.T62_Atlantic8.200423.nc</file>
       <file grid="ocnice"  mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/T62/domain.ocn.T62_Atlantic8.200423.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/T62_040121_ESMFmesh.nc</mesh>
       <desc>T62 is Gaussian grid:</desc>
+    </domain>
+
+    <domain name="TL319">
+      <nx>640</nx> <ny>320</ny>
+      <file grid="atm|lnd" mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/TL319/domain.lnd.TL319_Atlantic8.200527.nc</file>
+      <file grid="ocnice"  mask="Atlantic8">/glade/u/home/turuncu/UFS/Atlantic8/TL319/domain.ocn.TL319_Atlantic8.200527.nc</file>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/TL319_151007_ESMFmesh.nc</mesh>
+      <desc>TL319 grid for JRA55</desc>
     </domain>
 
     <!-- domains for regional ocean (HYCOM) -->
@@ -143,6 +157,13 @@
     <map name="ATM2OCN_VMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_T62_TO_Atlantic8_blin.200423.nc</map>
     <map name="OCN2ATM_FMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_Atlantic8_TO_T62_aave.200423.nc</map>
     <map name="OCN2ATM_SMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/T62/map_Atlantic8_TO_T62_aave.200423.nc</map>
+    </gridmap>
+    <gridmap atm_grid="TL319" ocn_grid="Atlantic8">
+    <map name="ATM2OCN_FMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_TL319_TO_Atlantic8_aave.200527.nc</map>
+    <map name="ATM2OCN_SMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_TL319_TO_Atlantic8_blin.200527.nc</map>
+    <map name="ATM2OCN_VMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_TL319_TO_Atlantic8_blin.200527.nc</map>
+    <map name="OCN2ATM_FMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_Atlantic8_TO_TL319_aave.200527.nc</map>
+    <map name="OCN2ATM_SMAPNAME">/glade/u/home/turuncu/UFS/Atlantic8/TL319/map_Atlantic8_TO_TL319_aave.200527.nc</map>
     </gridmap>
   </gridmaps>
 </grid_data>

--- a/config/ufs/machines/config_compilers.xml
+++ b/config/ufs/machines/config_compilers.xml
@@ -581,4 +581,10 @@ using a fortran linker.
   <TRILINOS_PATH>$ENV{TRILINOS_PATH}</TRILINOS_PATH>
   <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
 </compiler>
+
+<compiler>
+  <FFLAGS>
+    <append MODEL="hycom">$(FC_AUTO_R8)</append>
+  </FFLAGS>
+</compiler>
 </config_compilers>

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -144,11 +144,11 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules compiler="intel" mpilib="impi" DEBUG="FALSE" comp_interface="nuopc">
         <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.2</command>
-        <command name="load">esmf-8.1.0b15-ncdfio-intelmpi-O</command>
+        <command name="load">esmf-8.1.0-i3614950-ncdfio-intelmpi-O</command>
       </modules>
       <modules compiler="intel" mpilib="impi" DEBUG="TRUE" comp_interface="nuopc">
         <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.2</command>
-        <command name="load">esmf-8.1.0b15-ncdfio-intelmpi-g</command>
+        <command name="load">esmf-8.1.0-i3614950-ncdfio-intelmpi-g</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial">
 	<command name="load">netcdf/4.7.1</command>

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -58,7 +58,8 @@ This allows using a different mpirun command to launch unit tests
     <MPIRUN_RETRY_COUNT>10</MPIRUN_RETRY_COUNT>
     <OS>LINUX</OS>
     <COMPILERS>intel,gnu</COMPILERS>
-    <MPILIBS>mpt</MPILIBS>
+    <MPILIBS compiler="gnu">mpt</MPILIBS>
+    <MPILIBS compiler="intel">mpt,impi</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{UFS_SCRATCH}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{UFS_INPUT}/ufs_inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/glade/p/cgd/tss/CTSM_datm_forcing_data</DIN_LOC_ROOT_CLMFORC>
@@ -87,6 +88,12 @@ This allows using a different mpirun command to launch unit tests
 	<!-- the omplace argument needs to be last -->
 	<arg name="zthreadplacement"> omplace -tm open64 </arg>
       </arguments>
+    </mpirun>
+    <mpirun mpilib="impi" queue="regular">
+       <executable>mpirun</executable>
+       <arguments>
+         <arg name="num_tasks"> -np {{ total_tasks }} </arg>
+       </arguments>
     </mpirun>
     <module_system type="module">
       <init_path lang="perl">/glade/u/apps/ch/opt/lmod/8.1.7/lmod/lmod/init/perl</init_path>
@@ -119,6 +126,11 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">netcdf/4.7.3</command>
 	<command name="load">pnetcdf/1.12.1</command>
       </modules>
+      <modules mpilib="impi" compiler="intel">
+        <command name="load">impi/2019.6.154</command>
+        <command name="load">netcdf/4.7.3</command>
+        <command name="load">pnetcdf/1.12.1</command>
+      </modules>
       <modules>
 	<command name="load">ncarcompilers/0.5.0</command>
       </modules>
@@ -129,6 +141,14 @@ This allows using a different mpirun command to launch unit tests
       <modules mpilib="mpt" compiler="intel">
 	<command name="use">/glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.5/mpt-2.19</command>
 	<command name="load">NCEPlibs/1.0.0</command>
+      </modules>
+      <modules compiler="intel" mpilib="impi" DEBUG="FALSE" comp_interface="nuopc">
+        <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.2</command>
+        <command name="load">esmf-8.1.0b15-ncdfio-intelmpi-O</command>
+      </modules>
+      <modules compiler="intel" mpilib="impi" DEBUG="TRUE" comp_interface="nuopc">
+        <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.2</command>
+        <command name="load">esmf-8.1.0b15-ncdfio-intelmpi-g</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial">
 	<command name="load">netcdf/4.7.1</command>

--- a/scripts/lib/CIME/XML/files.py
+++ b/scripts/lib/CIME/XML/files.py
@@ -28,6 +28,7 @@ class Files(EntryID):
         # variables COMP_ROOT_DIR_{} are mutable, all other variables are read only
         self.COMP_ROOT_DIR = {}
         self._comp_interface = comp_interface
+        self._cpl_comp = {}
         # .config_file.xml at the top level may overwrite COMP_ROOT_DIR_ nodes in config_files
 
         if os.path.isfile(config_files_override):
@@ -35,6 +36,13 @@ class Files(EntryID):
             self.overwrite_existing_entries()
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None):
+        if vid == "COMP_ROOT_DIR_CPL":
+             if self._cpl_comp:
+                 attribute = self._cpl_comp
+             elif attribute:
+                 self._cpl_comp = attribute
+             else:
+                 self._cpl_comp['component'] = 'cpl'
         if "COMP_ROOT_DIR" in vid:
             if vid in self.COMP_ROOT_DIR:
                 if attribute is not None:

--- a/scripts/lib/CIME/XML/files.py
+++ b/scripts/lib/CIME/XML/files.py
@@ -37,12 +37,12 @@ class Files(EntryID):
 
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None):
         if vid == "COMP_ROOT_DIR_CPL":
-             if self._cpl_comp:
-                 attribute = self._cpl_comp
-             elif attribute:
-                 self._cpl_comp = attribute
-             else:
-                 self._cpl_comp['component'] = 'cpl'
+            if self._cpl_comp:
+                attribute = self._cpl_comp
+            elif attribute:
+                self._cpl_comp = attribute
+            else:
+                self._cpl_comp['component'] = 'cpl'
         if "COMP_ROOT_DIR" in vid:
             if vid in self.COMP_ROOT_DIR:
                 if attribute is not None:

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -458,9 +458,19 @@ class Case(object):
         logger.debug(" Possible components for COMPSETS_SPEC_FILE are {}".format(components))
 
         self.set_lookup_value("COMP_INTERFACE", driver)
+        if self._cime_model == 'ufs':
+             config = {}
+             if 'ufsatm' in compset_name:
+                 config['component']='nems'
+             else:
+                 config['component']='cpl'
+
+              comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL", attribute=config)
+
         if self._cime_model == 'cesm':
             comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL")
-            self.set_lookup_value("COMP_ROOT_DIR_CPL",comp_root_dir_cpl)
+        if self._cime_model in ('cesm','ufs'):
+             self.set_lookup_value("COMP_ROOT_DIR_CPL",comp_root_dir_cpl)
 
         # Loop through all of the files listed in COMPSETS_SPEC_FILE and find the file
         # that has a match for either the alias or the longname in that order

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -464,8 +464,7 @@ class Case(object):
                  config['component']='nems'
              else:
                  config['component']='cpl'
-
-              comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL", attribute=config)
+             comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL", attribute=config)
 
         if self._cime_model == 'cesm':
             comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL")

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -459,17 +459,17 @@ class Case(object):
 
         self.set_lookup_value("COMP_INTERFACE", driver)
         if self._cime_model == 'ufs':
-             config = {}
-             if 'ufsatm' in compset_name:
-                 config['component']='nems'
-             else:
-                 config['component']='cpl'
-             comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL", attribute=config)
+            config = {}
+            if 'ufsatm' in compset_name:
+                config['component']='nems'
+            else:
+                config['component']='cpl'
+            comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL", attribute=config)
 
         if self._cime_model == 'cesm':
             comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL")
         if self._cime_model in ('cesm','ufs'):
-             self.set_lookup_value("COMP_ROOT_DIR_CPL",comp_root_dir_cpl)
+            self.set_lookup_value("COMP_ROOT_DIR_CPL",comp_root_dir_cpl)
 
         # Loop through all of the files listed in COMPSETS_SPEC_FILE and find the file
         # that has a match for either the alias or the longname in that order

--- a/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
@@ -427,6 +427,10 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call t_stopf('datm_strdata_init')
 
+    ! Write mesh for debugging
+    call ESMF_MeshWrite(mesh, filename='datm_mesh', rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
     ! Realize the actively coupled fields, now that a mesh is established and
     ! initialize dfields data type (to map streams to export state fields)
     call datm_comp_realize(importState, exportState, rc=rc)

--- a/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
@@ -158,6 +158,7 @@ module atm_comp_nuopc
   real(r8), pointer :: Faxa_swvdr(:)        => null()
   real(r8), pointer :: Faxa_swvdf(:)        => null()
   real(r8), pointer :: Faxa_swnet(:)        => null()
+  real(r8), pointer :: Faxa_swdn(:)         => null()
   real(r8), pointer :: Sa_co2prog(:)        => null() ! co2
   real(r8), pointer :: Sa_co2diag(:)        => null() ! co2
   real(r8), pointer :: Faxa_bcph(:,:)       => null() ! prescribed aerosols
@@ -890,6 +891,7 @@ contains
     call dshr_fldList_add(fldsExport, 'Sa_pbot'    )
     call dshr_fldList_add(fldsExport, 'Sa_shum'    )
     call dshr_fldList_add(fldsExport, 'Faxa_lwdn'  )
+    call dshr_fldList_add(fldsExport, 'Faxa_swdn'  )
     if (flds_co2a .or. flds_co2b .or. flds_co2c) then
        call dshr_fldList_add(fldsExport, 'Sa_co2prog')
        call dshr_fldList_add(fldsExport, 'Sa_co2diag')
@@ -1098,6 +1100,10 @@ contains
     call dshr_dfield_add( dfields, sdat, state_fld='Faxa_lwdn' , strm_fld='lwdn', &
          state=exportState, state_ptr=Faxa_lwdn, strm_ptr=strm_lwdn, logunit=logunit, masterproc=masterproc, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    call dshr_dfield_add( dfields, sdat, state_fld='Faxa_swdn'  , strm_fld='swdn'  , &
+         state=exportState, state_ptr=Faxa_swdn, strm_ptr=strm_swdn, logunit=logunit, masterproc=masterproc, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
     if (flds_co2a .or. flds_co2b .or. flds_co2c) then
        call dshr_dfield_add( dfields, sdat, state_fld='Sa_co2prog', strm_fld='co2prog', &
             state=exportState, state_ptr=Sa_co2prog, logunit=logunit, masterproc=masterproc, rc=rc)

--- a/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
@@ -428,10 +428,6 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     call t_stopf('datm_strdata_init')
 
-    ! Write mesh for debugging
-    call ESMF_MeshWrite(mesh, filename='datm_mesh', rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
     ! Realize the actively coupled fields, now that a mesh is established and
     ! initialize dfields data type (to map streams to export state fields)
     call datm_comp_realize(importState, exportState, rc=rc)


### PR DESCRIPTION
It adds capability to couple active HYCOM with data atmosphere for UFS HAFS application. Also note that a follow-up PR for CMEPS mediator need to be done to run the application. 

Test suite: CIME_MODEL=cesm scripts/tests/scripts_regression_tests.py
Test baseline: N/A
Test namelist changes: No namelist change
Test status: [bit for bit, roundoff, climate changing] N/A

Fixes [CIME Github issue #]

User interface changes?: It adds extra variable (downwelling shortwave) to data atmosphere

Update gh-pages html (Y/N)?: N

Code review: 
