### PR TITLE
Machine configuration updates for izumi

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1492,35 +1492,32 @@ This allows using a different mpirun command to launch unit tests
 	<command name="purge"></command>
       </modules>
       <modules compiler="intel">
-	<command name="load">compiler/intel/19.0.2</command>
-	<command name="load">tool/netcdf/4.6.1/intel</command>
+	<command name="load">compiler/intel/20.0.1</command>
+	<command name="load">tool/netcdf/4.7.4/intel/20.0.1</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich2">
-	<command name="load">mvapich2/2.3/intel-cluster-19.0.1</command>
+	<command name="load">mpi/2.3.3/intel/20.0.1</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">compiler/pgi/18.10</command>
-	<command name="load">tool/netcdf/4.6.1/pgi</command>
+	<command name="load">compiler/pgi/20.1</command>
+	<command name="load">tool/netcdf/4.7.4/pgi/20.1</command>
       </modules>
       <modules compiler="nag">
-	<command name="load">compiler/nag/6.2</command>
-	<command name="load">tool/netcdf/4.6.1/nag</command>
+	<command name="load">compiler/nag/6.2-8.1.0</command>
+	<command name="load">tool/netcdf/c4.6.1-f4.4.4/nag-gnu/6.2-8.1.0</command>
       </modules>
       <modules compiler="nag" mpilib="mvapich2">
-	<command name="load">mvapich2/2.3/nag-6.2</command>
-      </modules>
-      <modules compiler="nag" mpilib="openmpi">
-	<command name="load">openmpi/4.0.0/nag-6.2</command>
+	<command name="load">mpi/2.3.3/nag/6.2</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">compiler/gnu/8.2.0</command>
-	<command name="load">tool/netcdf/4.6.1/gcc</command>
+	<command name="load">compiler/gnu/9.3.0</command>
+	<command name="load">tool/netcdf/4.7.4/gnu/9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-	<command name="load">openmpi/4.0.0/gnu-8.2.0</command>
+	<command name="load">openmpi/4.0.3/gnu-9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich2">
-	<command name="load">mvapich2/2.3/gnu-8.2.0</command>
+	<command name="load">mpi/2.3.3/gnu-9.3.0</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1514,10 +1514,10 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">tool/netcdf/4.7.4/gnu/9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-	<command name="load">openmpi/4.0.3/gnu-9.3.0</command>
+	<command name="load">openmpi/4.0.3/gnu/9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich2">
-	<command name="load">mpi/2.3.3/gnu-9.3.0</command>
+	<command name="load">mpi/2.3.3/gnu/9.3.0</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
Updates to machine configurations after Izumi upgrades.

Test suite:  SMS_Ln9.f19_g16.X for intel, nag, gnu, and pgi
                 ERS_Ld3.f45_g37_rx1.A for intel, nag, gnu, and pgi
                 Built B1850 for intel, nag, gnu, and pgi
                 prealpha tests on izumi, tests across multiple nodes failing.
                 
Test baseline: 
Test namelist changes: 
Test status: round off 

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
