### PR TITLE
Esmf datamodels restio

### DIFF
--- a/src/components/data_comps_nuopc/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps_nuopc/datm/cime_config/namelist_definition_datm.xml
@@ -86,10 +86,10 @@
     CORE2_NYF.NCEP
 
     ========================
-    datmode CORE2_IAF: 
+    datmode CORE2_IAF:
     ========================
     Note for CORE2_IAF:
-    The most current versions of forcing files(those recommended for use) 
+    The most current versions of forcing files(those recommended for use)
     are duplicated below and stored at /ccsm/ocn/iaf/):
       gcgcs.prec.T62.current, giss.lwdn.T62.current,
       giss.swdn.T62.current, giss.swup.T62.current,
@@ -254,7 +254,7 @@
       <value stream="Anomaly.Forcing">
         <!-- TODO: what is this mesh? -->
 	$DIN_LOC_ROOT/atm/datm7/anomaly_forcing/domain.permafrostRCN_P2.c2013.nc
-      </value> 
+      </value>
       <value stream="CLM1PT.1x1_mexicocityMEX">
 	<!-- TODO: generate_mesh_from: $DIN_LOC_ROOT/share/domains/domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc -->
       </value>
@@ -2646,21 +2646,7 @@
     <group>datm_nml</group>
     <desc>
       Model restart filename for the data atmosphere model data.  This is
-      optional.  If both restfils and restfilm are undefined, the restart
-      filename will be read from the DATM restart pointer file (or files for multiple instances).
-    </desc>
-    <values>
-      <value>undefined</value>
-    </values>
-  </entry>
-
-  <entry id="restfils">
-    <type>char</type>
-    <category>datm</category>
-    <group>datm_nml</group>
-    <desc>
-      stream restart filename for the data atmosphere stream data.  This is
-      optional.  If both restfils and restfilm are undefined, the restart
+      optional.  If restfilm is undefined, the restart
       filename will be read from the DATM restart pointer file (or files for multiple instances).
     </desc>
     <values>

--- a/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/datm/src/atm_comp_nuopc.F90
@@ -92,7 +92,6 @@ module atm_comp_nuopc
   logical                      :: force_prognostic_true = .false.     ! if true set prognostic true
   logical                      :: wiso_datm = .false.                 ! expect isotopic forcing from file?
   character(CL)                :: restfilm = nullstr                  ! model restart file namelist
-  character(CL)                :: restfils = nullstr                  ! stream restart file namelist
   integer                      :: nx_global
   integer                      :: ny_global
                                                                       ! config attribute intput
@@ -297,7 +296,7 @@ contains
     !-------------------------------------------------------------------------------
 
     namelist / datm_nml / datamode, model_meshfile, model_maskfile, model_createmesh_fromfile, &
-         nx_global, ny_global, restfilm, restfils, &
+         nx_global, ny_global, restfilm, &
          iradsw, factorFn_data, factorFn_mesh, presaero, bias_correct, &
          anomaly_forcing, force_prognostic_true, wiso_datm
 
@@ -335,7 +334,6 @@ contains
     call shr_mpi_bcast(factorFn_data             , mpicom, 'factorFn_data')
     call shr_mpi_bcast(factorFn_mesh             , mpicom, 'factorFn_mesh')
     call shr_mpi_bcast(restfilm                  , mpicom, 'restfilm')
-    call shr_mpi_bcast(restfils                  , mpicom, 'restfils')
     call shr_mpi_bcast(presaero                  , mpicom, 'presaero')
     call shr_mpi_bcast(wiso_datm                 , mpicom, 'wiso_datm')
     call shr_mpi_bcast(force_prognostic_true     , mpicom, 'force_prognostic_true')
@@ -352,13 +350,11 @@ contains
        write(logunit,F01)' nx_global = ',nx_global
        write(logunit,F01)' ny_global = ',ny_global
        write(logunit,F00)' restfilm = ',trim(restfilm)
-       write(logunit,F00)' restfils = ',trim(restfils)
        write(logunit,F02)' force_prognostic_true = ',force_prognostic_true
        write(logunit,F01)' iradsw = ',iradsw
        write(logunit,F00)' factorFn_data = ',trim(factorFn_data)
        write(logunit,F00)' factorFn_mesh = ',trim(factorFn_mesh)
        write(logunit,F00)' restfilm = ',trim(restfilm)
-       write(logunit,F00)' restfils = ',trim(restfils)
        write(logunit,F02)' presaero  = ',presaero
        write(logunit,F02)' wiso_datm = ',wiso_datm
     end if
@@ -485,7 +481,7 @@ contains
 
     ! Read restart if necessary
     if (read_restart) then
-       call dshr_restart_read(restfilm, restfils, rpfile, inst_suffix, nullstr, logunit, my_task, mpicom, sdat)
+       call dshr_restart_read(restfilm, rpfile, inst_suffix, nullstr, logunit, my_task, mpicom, sdat)
     end if
 
     ! Get the time to interpolate the stream data to

--- a/src/components/data_comps_nuopc/dice/cime_config/namelist_definition_dice.xml
+++ b/src/components/data_comps_nuopc/dice/cime_config/namelist_definition_dice.xml
@@ -24,7 +24,7 @@
       SSTDATA
 
       **********IMPORTANT NOTE: *************
-      In the value matches below, regular expressions are used **** 
+      In the value matches below, regular expressions are used ****
       If two matches are equivalent, the FIRST one will be used, so need to make sure
       that matches are not equivalent if possible
 
@@ -360,7 +360,7 @@
       Copies all fields directly from the input data streams Any required
       fields not found on an input stream will be set to zero.
       ==> dataMode = "ssmi"
-      Is a prognostic mode. It requires data be sent to the ice  model. 
+      Is a prognostic mode. It requires data be sent to the ice  model.
       Ice fraction (extent) data is read from an input stream,
       atmosphere state variables are received from the mediator, and then
       atmosphere-ice surface fluxes are computed and sent to the mediator.
@@ -489,23 +489,8 @@
     <group>dice_nml</group>
     <desc>
       Model restart filename for the data ice model data.  This is optional.
-      If both restfils and restfilm are undefined, the restart filename will
+      If restfilm is undefined, the restart filename will
       be read from the ICE restart pointer file (or files for multiple instances).
-    </desc>
-    <values>
-      <value>undefined</value>
-    </values>
-  </entry>
-
-  <entry id="restfils">
-    <type>char</type>
-    <category>dice</category>
-    <group>dice_nml</group>
-    <desc>
-      Stream restart filename for the data ice stream data.  This is
-      optional.  If both restfils and restfilm are undefined, the restart
-      filename will be read from the DICE restart pointer file (or files for
-      multiple instances).
     </desc>
     <values>
       <value>undefined</value>

--- a/src/components/data_comps_nuopc/dice/src/ice_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/dice/src/ice_comp_nuopc.F90
@@ -72,7 +72,6 @@ module ice_comp_nuopc
   logical                      :: flux_Qacc                           ! activates water accumulation/melt wrt Q
   real(R8)                     :: flux_Qacc0                          ! initial water accumulation value
   character(CL)                :: restfilm = nullstr                  ! model restart file namelist
-  character(CL)                :: restfils = nullstr                  ! stream restart file namelist
   integer                      :: nx_global
   integer                      :: ny_global
 
@@ -240,7 +239,7 @@ contains
     !-------------------------------------------------------------------------------
 
     namelist / dice_nml / datamode, model_meshfile, model_maskfile, model_createmesh_fromfile, &
-         restfilm, restfils, nx_global, ny_global, flux_swpf, flux_Qmin, flux_Qacc, flux_Qacc0
+         restfilm, nx_global, ny_global, flux_swpf, flux_Qmin, flux_Qacc, flux_Qacc0
 
     rc = ESMF_SUCCESS
 
@@ -282,7 +281,6 @@ contains
        write(logunit,F03)' flux_Qacc  = ',flux_Qacc
        write(logunit,F03)' flux_Qacc0 = ',flux_Qacc0
        write(logunit,F00)' restfilm = ',trim(restfilm)
-       write(logunit,F00)' restfils = ',trim(restfils)
 
        ! check that files exists
        if (model_createmesh_fromfile /= nullstr) then
@@ -316,7 +314,6 @@ contains
     call shr_mpi_bcast(nx_global                 , mpicom, 'nx_global')
     call shr_mpi_bcast(ny_global                 , mpicom, 'ny_global')
     call shr_mpi_bcast(restfilm                  , mpicom, 'restfilm')
-    call shr_mpi_bcast(restfils                  , mpicom, 'restfils')
     call shr_mpi_bcast(flux_swpf                 , mpicom, 'flux_swpf')
     call shr_mpi_bcast(flux_Qmin                 , mpicom, 'flux_Qmin')
     call shr_mpi_bcast(flux_Qacc                 , mpicom, 'flux_Qacc')
@@ -394,7 +391,7 @@ contains
 
     ! Read restart if necessary
     if (read_restart) then
-       call dshr_restart_read(restfilm, restfils, rpfile, inst_suffix, nullstr, &
+       call dshr_restart_read(restfilm, rpfile, inst_suffix, nullstr, &
             logunit, my_task, mpicom, sdat, fld=water, fldname='water')
     end if
 

--- a/src/components/data_comps_nuopc/dlnd/cime_config/namelist_definition_dlnd.xml
+++ b/src/components/data_comps_nuopc/dlnd/cime_config/namelist_definition_dlnd.xml
@@ -381,18 +381,6 @@
     </values>
   </entry>
 
-  <entry id="restfils">
-    <type>char</type>
-    <category>dlnd</category>
-    <group>dlnd_nml</group>
-    <desc>
-      Stream restart file name for dlnd model, needed for branch simulations
-    </desc>
-    <values>
-      <value>undefined</value>
-    </values>
-  </entry>
-
   <entry id="force_prognostic_true">
     <type>logical</type>
     <category>dlnd</category>

--- a/src/components/data_comps_nuopc/dlnd/src/lnd_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/dlnd/src/lnd_comp_nuopc.F90
@@ -69,7 +69,6 @@ module lnd_comp_nuopc
   character(CL)            :: nlfilename = nullstr                ! filename to obtain namelist info from
   logical                  :: force_prognostic_true = .false.     ! if true set prognostic true
   character(CL)            :: restfilm = nullstr                  ! model restart file namelist
-  character(CL)            :: restfils = nullstr                  ! stream restart file namelist
   integer                  :: nx_global                           ! global nx dimension of model mesh
   integer                  :: ny_global                           ! global ny dimension of model mesh
   character(CL)            :: stream_fracname = nullstr           ! name of fraction field in first stream file
@@ -160,7 +159,7 @@ contains
     !-------------------------------------------------------------------------------
 
     namelist / dlnd_nml / datamode, model_meshfile, model_maskfile, model_createmesh_fromfile, &
-         nx_global, ny_global, restfilm, restfils, force_prognostic_true, stream_fracname
+         nx_global, ny_global, restfilm, force_prognostic_true, stream_fracname
 
     rc = ESMF_SUCCESS
 
@@ -192,7 +191,6 @@ contains
     call shr_mpi_bcast(nx_global                 , mpicom, 'nx_global')
     call shr_mpi_bcast(ny_global                 , mpicom, 'ny_global')
     call shr_mpi_bcast(restfilm                  , mpicom, 'restfilm')
-    call shr_mpi_bcast(restfils                  , mpicom, 'restfils')
     call shr_mpi_bcast(force_prognostic_true     , mpicom, 'force_prognostic_true')
     call shr_mpi_bcast(stream_fracname           , mpicom, 'stream_fracname')
 
@@ -210,7 +208,6 @@ contains
        write(logunit ,*)' nx_global             = ',nx_global
        write(logunit ,*)' ny_global             = ',ny_global
        write(logunit ,*)' restfilm              = ',trim(restfilm)
-       write(logunit ,*)' restfils              = ',trim(restfils)
        write(logunit ,*)' force_prognostic_true = ',force_prognostic_true
     endif
 
@@ -301,7 +298,7 @@ contains
 
     ! Read restart if necessary
     if (read_restart) then
-       call dshr_restart_read(restfilm, restfils, rpfile, inst_suffix, nullstr, logunit, my_task, mpicom, sdat)
+       call dshr_restart_read(restfilm, rpfile, inst_suffix, nullstr, logunit, my_task, mpicom, sdat)
     end if
 
     ! get the time to interpolate the stream data to

--- a/src/components/data_comps_nuopc/docn/cime_config/namelist_definition_docn.xml
+++ b/src/components/data_comps_nuopc/docn/cime_config/namelist_definition_docn.xml
@@ -504,18 +504,6 @@
     </values>
   </entry>
 
-  <entry id="restfils">
-    <type>char</type>
-    <category>docn</category>
-    <group>docn_nml</group>
-    <desc>
-      Stream restart file name for docn model, needed for branch simulations
-    </desc>
-    <values>
-      <value>undefined</value>
-    </values>
-  </entry>
-
   <entry id="force_prognostic_true">
     <type>logical</type>
     <category>docn</category>

--- a/src/components/data_comps_nuopc/docn/src/ocn_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/docn/src/ocn_comp_nuopc.F90
@@ -75,7 +75,6 @@ module ocn_comp_nuopc
   real(R8)                     :: sst_constant_value                  ! sst constant value
   integer                      :: aquap_option                        ! if aqua-planet mode, option to use
   character(CL)                :: restfilm = nullstr                  ! model restart file namelist
-  character(CL)                :: restfils = nullstr                  ! stream restart file namelist
   logical                      :: force_prognostic_true = .false.     ! if true set prognostic true
   logical                      :: ocn_prognostic
   integer                      :: nx_global
@@ -201,7 +200,7 @@ contains
     !-------------------------------------------------------------------------------
 
     namelist / docn_nml / datamode, model_meshfile, model_maskfile, model_createmesh_fromfile, &
-         restfilm, restfils, force_prognostic_true, sst_constant_value, nx_global, ny_global
+         restfilm,  force_prognostic_true, sst_constant_value, nx_global, ny_global
 
     rc = ESMF_SUCCESS
 
@@ -239,7 +238,6 @@ contains
        write(logunit,F01)' nx_global = ',nx_global
        write(logunit,F01)' ny_global = ',ny_global
        write(logunit,F00)' restfilm = ',trim(restfilm)
-       write(logunit,F00)' restfils = ',trim(restfils)
        write(logunit,F02)' force_prognostic_true = ',force_prognostic_true
 
        ! check that files exists
@@ -272,7 +270,6 @@ contains
     call shr_mpi_bcast(model_createmesh_fromfile , mpicom, 'model_createmesh_fromfile')
     call shr_mpi_bcast(nx_global                 , mpicom, 'nx_global')
     call shr_mpi_bcast(ny_global                 , mpicom, 'ny_global')
-    call shr_mpi_bcast(restfils                  , mpicom, 'restfils')
     call shr_mpi_bcast(force_prognostic_true     , mpicom, 'force_prognostic_true')
     call shr_mpi_bcast(sst_constant_value        , mpicom, 'sst_constant_value')
 
@@ -372,7 +369,7 @@ contains
 
     ! Read restart if necessary
     if (read_restart) then
-       call dshr_restart_read(restfilm, restfils, rpfile, inst_suffix, nullstr, &
+       call dshr_restart_read(restfilm, rpfile, inst_suffix, nullstr, &
             logunit, my_task, mpicom, sdat, fld=somtp, fldname='somtp')
     end if
 
@@ -600,7 +597,7 @@ contains
     ! -------------------------------------
     ! Determine ocean fraction
     ! -------------------------------------
-    
+
     ! Set pointers to exportState fields that have no corresponding stream field
     call dshr_state_getfldptr(exportState, fldname='So_omask', fldptr1=So_omask, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/src/components/data_comps_nuopc/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps_nuopc/drof/cime_config/namelist_definition_drof.xml
@@ -66,7 +66,7 @@
 	TODO_FILL_THIS_IN
       </value>
       <value stream="rof.cplhist">
-	TODO_FILL_THIS_IN 
+	TODO_FILL_THIS_IN
       </value>
     </values>
   </entry>
@@ -459,16 +459,6 @@
     <category>drof</category>
     <group>drof_nml</group>
     <desc>Master restart file name for drof model</desc>
-    <values>
-      <value>undefined</value>
-    </values>
-  </entry>
-
-  <entry id="restfils">
-    <type>char</type>
-    <category>drof</category>
-    <group>drof_nml</group>
-    <desc>Stream restart file name for drof model, needed for branch simulations</desc>
     <values>
       <value>undefined</value>
     </values>

--- a/src/components/data_comps_nuopc/drof/src/rof_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/drof/src/rof_comp_nuopc.F90
@@ -67,7 +67,6 @@ module rof_comp_nuopc
   character(CL)                :: model_createmesh_fromfile = nullstr ! full pathname to obtain mask from
   logical                      :: force_prognostic_true = .false.     ! if true set prognostic true
   character(CL)                :: restfilm = nullstr                  ! model restart file namelist
-  character(CL)                :: restfils = nullstr                  ! stream restart file namelist
   integer                      :: nx_global
   integer                      :: ny_global
 
@@ -159,7 +158,7 @@ contains
     !-------------------------------------------------------------------------------
 
     namelist / drof_nml / datamode, model_meshfile, model_maskfile, model_createmesh_fromfile, &
-         restfilm, restfils, force_prognostic_true, nx_global, ny_global
+         restfilm, force_prognostic_true, nx_global, ny_global
 
     rc = ESMF_SUCCESS
 
@@ -195,7 +194,6 @@ contains
        write(logunit,F01)' nx_global = ',nx_global
        write(logunit,F01)' ny_global = ',ny_global
        write(logunit,F00)' restfilm = ',trim(restfilm)
-       write(logunit,F00)' restfils = ',trim(restfils)
        write(logunit,F02)' force_prognostic_true = ',force_prognostic_true
 
        ! check that files exists
@@ -229,7 +227,6 @@ contains
     call shr_mpi_bcast(nx_global                 , mpicom, 'nx_global')
     call shr_mpi_bcast(ny_global                 , mpicom, 'ny_global')
     call shr_mpi_bcast(restfilm                  , mpicom, 'restfilm')
-    call shr_mpi_bcast(restfils                  , mpicom, 'restfils')
     call shr_mpi_bcast(force_prognostic_true     , mpicom, 'force_prognostic_true')
 
     ! Validate datamode
@@ -291,7 +288,7 @@ contains
 
     ! Read restart if necessary
     if (read_restart) then
-       call dshr_restart_read(restfilm, restfils, rpfile, inst_suffix, nullstr, logunit, my_task, mpicom, sdat)
+       call dshr_restart_read(restfilm, rpfile, inst_suffix, nullstr, logunit, my_task, mpicom, sdat)
     end if
 
     ! Get the time to interpolate the stream data to

--- a/src/components/data_comps_nuopc/dshr_nuopc/dshr_mod.F90
+++ b/src/components/data_comps_nuopc/dshr_nuopc/dshr_mod.F90
@@ -37,7 +37,7 @@ module dshr_mod
   use shr_cal_mod      , only : shr_cal_datetod2string
   use shr_const_mod    , only : shr_const_spval
   use shr_pio_mod      , only : shr_pio_getiosys, shr_pio_getiotype, shr_pio_getioformat
-  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_init_from_xml
+  use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_init_from_xml, SHR_STRDATA_GET_STREAM_COUNT
   use dshr_methods_mod , only : chkerr
   use perf_mod         , only : t_startf, t_stopf
   use pio
@@ -1119,9 +1119,10 @@ contains
     type(io_desc_t)   :: pio_iodesc
     integer           :: rcode
     integer           :: yy, mm, dd
-    character(*), parameter :: F00   = "('(dshr_restart_write) ',8a,2(i0,2x))"
+    character(*), parameter :: F00   = "('(dshr_restart_write) ',2a,2(i0,2x))"
     !-------------------------------------------------------------------------------
-
+    ! no streams means no restart file is written.
+     if(shr_strdata_get_stream_count(sdat) <= 0) return
      call shr_cal_datetod2string(date_str, ymd, tod)
      write(rest_file_model ,"(7a)") trim(case_name),'.', trim(model_name),trim(inst_suffix),'.r.', trim(date_str),'.nc'
 
@@ -1130,7 +1131,7 @@ contains
         open(newunit=nu, file=trim(rpfile)//trim(inst_suffix), form='formatted')
         write(nu,'(a)') rest_file_model
         close(nu)
-        write(logunit,F00)' (dshr_restart_write) writing ',trim(rest_file_model), ymd, tod
+        write(logunit,F00)' writing ',trim(rest_file_model), ymd, tod
      endif
 
      ! write data model restart data

--- a/src/components/data_comps_nuopc/dshr_nuopc/dshr_mod.F90
+++ b/src/components/data_comps_nuopc/dshr_nuopc/dshr_mod.F90
@@ -38,7 +38,6 @@ module dshr_mod
   use shr_const_mod    , only : shr_const_spval
   use shr_pio_mod      , only : shr_pio_getiosys, shr_pio_getiotype, shr_pio_getioformat
   use dshr_strdata_mod , only : shr_strdata_type, shr_strdata_init_from_xml
-  use dshr_strdata_mod , only : shr_strdata_restWrite, shr_strdata_restRead
   use dshr_methods_mod , only : chkerr
   use perf_mod         , only : t_startf, t_stopf
   use pio
@@ -1025,12 +1024,12 @@ contains
   end subroutine dshr_time_init
 
   !===============================================================================
-  subroutine dshr_restart_read(rest_filem, rest_files, rpfile, inst_suffix, nullstr, &
+  subroutine dshr_restart_read(rest_filem, rpfile, inst_suffix, nullstr, &
        logunit, my_task, mpicom, sdat, fld, fldname)
+    use dshr_stream_mod, only : shr_stream_restIO
 
     ! input/output arguments
     character(len=*)            , intent(inout) :: rest_filem
-    character(len=*)            , intent(inout) :: rest_files
     character(len=*)            , intent(in)    :: rpfile
     character(len=*)            , intent(in)    :: inst_suffix
     character(len=*)            , intent(in)    :: nullstr
@@ -1052,9 +1051,9 @@ contains
     character(*), parameter :: subName = "(dshr_restart_read) "
     !-------------------------------------------------------------------------------
 
-    if (trim(rest_filem) == trim(nullstr) .and. trim(rest_files) == trim(nullstr)) then
+    if (trim(rest_filem) == trim(nullstr)) then
        if (my_task == master_task) then
-          write(logunit,F00) ' restart filenames from rpointer'
+          write(logunit,F00) ' restart filename from rpointer'
           inquire(file=trim(rpfile)//trim(inst_suffix), exist=exists)
           if (.not.exists) then
              write(logunit, F00) ' ERROR: rpointer file does not exist'
@@ -1062,33 +1061,33 @@ contains
           endif
           open(newunit=nu, file=trim(rpfile)//trim(inst_suffix), form='formatted')
           read(nu, '(a)') rest_filem
-          read(nu, '(a)') rest_files
           close(nu)
-          inquire(file=trim(rest_files), exist=exists)
+          inquire(file=trim(rest_filem), exist=exists)
        endif
        call shr_mpi_bcast(rest_filem, mpicom, 'rest_filem')
-       call shr_mpi_bcast(rest_files, mpicom, 'rest_files')
     else
        ! use namelist already read
        if (my_task == master_task) then
           write(logunit, F00) ' restart filenames from namelist '
-          inquire(file=trim(rest_files), exist=exists)
+          inquire(file=trim(rest_filem), exist=exists)
        endif
     endif
     call shr_mpi_bcast(exists, mpicom, 'exists')
     if (exists) then
        if (my_task == master_task) write(logunit, F00) ' reading data model restart ', trim(rest_filem)
+       rcode = pio_openfile(sdat%pio_subsystem, pioid, sdat%io_type, trim(rest_filem), pio_nowrite)
+       call shr_stream_restIO(pioid, sdat%stream, 'read')
        if (present(fld) .and. present(fldname)) then
-          rcode = pio_openfile(sdat%pio_subsystem, pioid, sdat%io_type, trim(rest_filem), pio_nowrite)
           call pio_initdecomp(sdat%pio_subsystem, pio_double, (/sdat%model_gsize/), sdat%model_gindex, pio_iodesc)
           rcode = pio_inq_varid(pioid, trim(fldname), varid)
           call pio_read_darray(pioid, varid, pio_iodesc, fld, rcode)
-          call pio_closefile(pioid)
-          call pio_freedecomp(sdat%pio_subsystem, pio_iodesc)
        end if
-       call shr_strdata_restRead(sdat, trim(rest_files))
+       call pio_closefile(pioid)
+       if (present(fld) .and. present(fldname)) then
+          call pio_freedecomp(sdat%pio_subsystem, pio_iodesc)
+       endif
     else
-       if (my_task == master_task) write(logunit, F00) ' file not found, skipping ',trim(rest_files)
+       if (my_task == master_task) write(logunit, F00) ' file not found, skipping ',trim(rest_filem)
     endif
   end subroutine dshr_restart_read
 
@@ -1113,7 +1112,6 @@ contains
     ! local variables
     integer           :: nu
     character(len=CL) :: rest_file_model
-    character(len=CL) :: rest_file_stream
     character(len=CS) :: date_str
     type(file_desc_t) :: pioid
     integer           :: dimid(1)
@@ -1125,16 +1123,14 @@ contains
     !-------------------------------------------------------------------------------
 
      call shr_cal_datetod2string(date_str, ymd, tod)
-     write(rest_file_model ,"(7a)") trim(case_name),'.', trim(model_name),trim(inst_suffix),'.rm.', trim(date_str),'.nc'
-     write(rest_file_stream,"(7a)") trim(case_name),'.', trim(model_name),trim(inst_suffix),'.rs.', trim(date_str),'.bin'
+     write(rest_file_model ,"(7a)") trim(case_name),'.', trim(model_name),trim(inst_suffix),'.r.', trim(date_str),'.nc'
 
      ! write restart info to rpointer file
      if (my_task == master_task) then
         open(newunit=nu, file=trim(rpfile)//trim(inst_suffix), form='formatted')
         write(nu,'(a)') rest_file_model
-        write(nu,'(a)') rest_file_stream
         close(nu)
-        write(logunit,F00)' (dshr_restart_write) writing ',trim(rest_file_stream), ymd, tod
+        write(logunit,F00)' (dshr_restart_write) writing ',trim(rest_file_model), ymd, tod
      endif
 
      ! write data model restart data

--- a/src/components/data_comps_nuopc/dshr_nuopc/dshr_mod.F90
+++ b/src/components/data_comps_nuopc/dshr_nuopc/dshr_mod.F90
@@ -1050,6 +1050,8 @@ contains
     character(*), parameter :: F00   = "('(dshr_restart_read) ',8a)"
     character(*), parameter :: subName = "(dshr_restart_read) "
     !-------------------------------------------------------------------------------
+    ! no streams means no restart file is read.
+    if(shr_strdata_get_stream_count(sdat) <= 0) return
 
     if (trim(rest_filem) == trim(nullstr)) then
        if (my_task == master_task) then

--- a/src/components/data_comps_nuopc/dwav/cime_config/namelist_definition_dwav.xml
+++ b/src/components/data_comps_nuopc/dwav/cime_config/namelist_definition_dwav.xml
@@ -354,18 +354,6 @@
     </values>
   </entry>
 
-  <entry id="restfils">
-    <type>char</type>
-    <category>dwav</category>
-    <group>dwav_nml</group>
-    <desc>
-      Stream restart file name for dwav model, needed for branch simulations
-    </desc>
-    <values>
-      <value>undefined</value>
-    </values>
-  </entry>
-
   <entry id="force_prognostic_true">
     <type>logical</type>
     <category>dwav</category>

--- a/src/components/data_comps_nuopc/dwav/src/wav_comp_nuopc.F90
+++ b/src/components/data_comps_nuopc/dwav/src/wav_comp_nuopc.F90
@@ -67,7 +67,6 @@ module wav_comp_nuopc
   character(CL)                :: model_createmesh_fromfile = nullstr ! full pathname to obtain mask from
   logical                      :: force_prognostic_true = .false.     ! if true set prognostic true
   character(CL)                :: restfilm = nullstr                  ! model restart file namelist
-  character(CL)                :: restfils = nullstr                  ! stream restart file namelist
   integer                      :: nx_global
   integer                      :: ny_global
                                                                       ! constants
@@ -154,7 +153,7 @@ contains
     !-------------------------------------------------------------------------------
 
     namelist / dwav_nml / datamode, model_meshfile, model_maskfile, model_createmesh_fromfile, &
-         restfilm, restfils, force_prognostic_true, nx_global, ny_global
+         restfilm, force_prognostic_true, nx_global, ny_global
 
     rc = ESMF_SUCCESS
 
@@ -190,7 +189,6 @@ contains
        write(logunit,F01)' nx_global = ',nx_global
        write(logunit,F01)' ny_global = ',ny_global
        write(logunit,F00)' restfilm = ',trim(restfilm)
-       write(logunit,F00)' restfils = ',trim(restfils)
        write(logunit,F02)' force_prognostic_true = ',force_prognostic_true
 
        ! check that files exists
@@ -224,7 +222,6 @@ contains
     call shr_mpi_bcast(nx_global                 , mpicom, 'nx_global')
     call shr_mpi_bcast(ny_global                 , mpicom, 'ny_global')
     call shr_mpi_bcast(restfilm                  , mpicom, 'restfilm')
-    call shr_mpi_bcast(restfils                  , mpicom, 'restfils')
     call shr_mpi_bcast(force_prognostic_true     , mpicom, 'force_prognostic_true')
 
     ! Call advertise phase
@@ -283,7 +280,7 @@ contains
 
     ! Read restart if necessary
     if (read_restart) then
-       call dshr_restart_read(restfilm, restfils, rpfile, inst_suffix, nullstr, &
+       call dshr_restart_read(restfilm, rpfile, inst_suffix, nullstr, &
             logunit, my_task, mpicom, sdat)
     end if
 

--- a/src/share/streams_nuopc/dshr_strdata_mod.F90
+++ b/src/share/streams_nuopc/dshr_strdata_mod.F90
@@ -19,7 +19,7 @@ module dshr_strdata_mod
   use dshr_stream_mod  , only : shr_stream_taxis_cycle, shr_stream_taxis_extend, shr_stream_findBounds
   use dshr_stream_mod  , only : shr_stream_getCurrFile, shr_stream_setCurrFile, shr_stream_getMeshFilename
   use dshr_stream_mod  , only : shr_stream_init_from_xml, shr_stream_init_from_inline
-  use dshr_stream_mod  , only : shr_stream_restWrite, shr_stream_restRead
+!  use dshr_stream_mod  , only : shr_stream_restWrite, shr_stream_restRead
   use dshr_stream_mod  , only : shr_stream_getnextfilename, shr_stream_getprevfilename, shr_stream_getData
   use dshr_tinterp_mod , only : shr_tInterp_getCosz, shr_tInterp_getAvgCosz, shr_tInterp_getFactors
   use dshr_methods_mod , only : dshr_fldbun_getfldptr, dshr_fldbun_getfieldN, dshr_fldbun_fldchk, chkerr
@@ -41,8 +41,8 @@ module dshr_strdata_mod
   public  :: shr_strdata_type
   public  :: shr_strdata_init_from_xml
   public  :: shr_strdata_init_from_inline
-  public  :: shr_strdata_restRead
-  public  :: shr_strdata_restWrite
+!  public  :: shr_strdata_restRead
+!  public  :: shr_strdata_restWrite
   public  :: shr_strdata_setOrbs
   public  :: shr_strdata_advance
   public  :: shr_strdata_get_stream_domain  ! public since needed by dshr_mod
@@ -938,29 +938,6 @@ contains
 
   !===============================================================================
 
-  subroutine shr_strdata_restWrite(sdat, filename, str1)
-
-    type(shr_strdata_type) ,intent(inout) :: sdat
-    character(len=*)       ,intent(in)    :: filename
-    character(len=*)       ,intent(in)    :: str1
-    !-------------------------------------------------------------------------------
-
-    call shr_stream_restWrite(sdat%stream, trim(filename), trim(str1), shr_strdata_get_stream_count(sdat))
-
-  end subroutine shr_strdata_restWrite
-
-  !===============================================================================
-  subroutine shr_strdata_restRead(sdat, filename)
-
-    type(shr_strdata_type) ,intent(inout) :: sdat
-    character(len=*)       ,intent(in)    :: filename
-    !-------------------------------------------------------------------------------
-
-    call shr_stream_restRead(sdat%stream, trim(filename), shr_strdata_get_stream_count(sdat))
-
-  end subroutine shr_strdata_restRead
-
-  !===============================================================================
   subroutine shr_strdata_setOrbs(sdat,eccen,mvelpp,lambm0,obliqr,modeldt)
 
     type(shr_strdata_type),intent(inout) :: sdat

--- a/src/share/streams_nuopc/dshr_strdata_mod.F90
+++ b/src/share/streams_nuopc/dshr_strdata_mod.F90
@@ -945,9 +945,7 @@ contains
     character(len=*)       ,intent(in)    :: str1
     !-------------------------------------------------------------------------------
 
-    if (sdat%masterproc) then
-       call shr_stream_restWrite(sdat%stream, trim(filename), trim(str1), shr_strdata_get_stream_count(sdat))
-    endif
+    call shr_stream_restWrite(sdat%stream, trim(filename), trim(str1), shr_strdata_get_stream_count(sdat))
 
   end subroutine shr_strdata_restWrite
 

--- a/src/share/streams_nuopc/dshr_stream_mod.F90
+++ b/src/share/streams_nuopc/dshr_stream_mod.F90
@@ -915,6 +915,7 @@ contains
     deallocate(dids)
 
     ! allocate memory for date and secs
+
     allocate(strm%file(k)%date(nt), strm%file(k)%secs(nt))
     strm%file(k)%nt = nt
 
@@ -1517,6 +1518,7 @@ contains
                    call shr_sys_abort('somethin is wrong')
              endif
              deallocate(tmp)
+             streams(k)%file(n)%havedata = .true.
           enddo
        enddo
     endif

--- a/src/share/util/shr_cal_mod.F90
+++ b/src/share/util/shr_cal_mod.F90
@@ -228,7 +228,7 @@ contains
   !
   ! !INTERFACE:  -----------------------------------------------------------------
 
-  subroutine shr_cal_timeSet_int(etime,ymd,sec,calendar)
+  subroutine shr_cal_timeSet_int(etime,ymd,sec,calendar, rc)
 
     implicit none
 
@@ -237,13 +237,13 @@ contains
     type(ESMF_Time),intent(out) :: etime
     integer(SHR_KIND_IN),intent(in ) :: ymd,sec   ! ymd, sec
     character(*)        ,intent(in)  :: calendar  ! calendar type
-
+    integer, intent(out), optional   :: rc
     !EOP
 
     integer(SHR_KIND_IN) :: year,month,day
     type(ESMF_CALKIND_FLAG) :: calkind
     character(len=shr_cal_calMaxLen) :: lcalendar
-    integer :: rc
+    integer :: lrc
     character(*),parameter :: subName = "(shr_cal_timeSet)"
 
     !-------------------------------------------------------------------------------
@@ -259,12 +259,15 @@ contains
     endif
 
     call shr_cal_date2ymd(ymd,year,month,day)
-    call ESMF_TimeSet(etime,yy=year,mm=month,dd=day,s=sec,calkindflag=calkind,rc=rc)
-    if(rc /= ESMF_SUCCESS) call ESMF_Finalize(rc=rc, endflag=ESMF_END_ABORT)
-
+    call ESMF_TimeSet(etime,yy=year,mm=month,dd=day,s=sec,calkindflag=calkind,rc=lrc)
+    if (present(rc)) then
+       rc = lrc
+    else if(lrc /= ESMF_SUCCESS) then
+       call ESMF_Finalize(rc=rc, endflag=ESMF_END_ABORT)
+    endif
   end subroutine shr_cal_timeSet_int
 
-  subroutine shr_cal_timeSet_long(etime,ymd,sec,calendar)
+  subroutine shr_cal_timeSet_long(etime,ymd,sec,calendar, rc)
 
     implicit none
 
@@ -274,13 +277,13 @@ contains
     integer(SHR_KIND_I8),intent(in ) :: ymd ! ymd
     integer(SHR_KIND_IN), intent(in) :: sec   ! ymd
     character(*)        ,intent(in)  :: calendar  ! calendar type
-
+    integer, intent(out), optional   :: rc
     !EOP
 
     integer(SHR_KIND_IN) :: year,month,day
     type(ESMF_CALKIND_FLAG) :: calkind
     character(len=shr_cal_calMaxLen) :: lcalendar
-    integer :: rc
+    integer :: lrc
     character(*),parameter :: subName = "(shr_cal_timeSet_long)"
 
     !-------------------------------------------------------------------------------
@@ -296,9 +299,12 @@ contains
     endif
 
     call shr_cal_date2ymd(ymd,year,month,day)
-    call ESMF_TimeSet(etime,yy=year,mm=month,dd=day,s=sec,calkindflag=calkind,rc=rc)
-    if(rc /= ESMF_SUCCESS) call ESMF_Finalize(rc=rc, endflag=ESMF_END_ABORT)
-
+    call ESMF_TimeSet(etime,yy=year,mm=month,dd=day,s=sec,calkindflag=calkind,rc=lrc)
+    if(present(rc)) then
+       rc = lrc
+    else if(rc /= ESMF_SUCCESS) then
+       call ESMF_Finalize(rc=rc, endflag=ESMF_END_ABORT)
+    endif
   end subroutine shr_cal_timeSet_long
   !===============================================================================
   !BOP ===========================================================================


### PR DESCRIPTION
Instead of writing a binary restart file for streams we combine the stream restart data into the netcdf restart files for the data models.

Test suite:  ./create_test --baseline-root /glade/p/cesmdata/cseg/nuopc_baselines/ --compare jun03.esmf_datamodels --generate jun05.esmf_datamodels --xml-machine cheyenne --xml-compiler intel --xml-testlist ../src/drivers/nuopc/cime_config/testdefs/testlist_drv.xml  
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 

Created new baselines in /glade/p/cesmdata/cseg/nuopc_baselines/jun05.esmf_datamodels

DTEST cases require a file which is still not in the system: /glade/scratch/mvertens/pop_frc.1x1d.SCRIP.030620_ESMFmesh.nc