### PR TITLE
Change grid alias for artic var-res grids

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1093,14 +1093,14 @@
       <mask>tx0.1v2</mask>
     </model_grid>
 
-    <model_grid alias="ne0np4.ARCTIC.ne30x4_mt12" not_compset="_POP">
+    <model_grid alias="ne0ARCTICne30x4_ne0ARCTICne30x4_mt12" not_compset="_POP">
       <grid name="atm">ne0np4.ARCTIC.ne30x4</grid>
       <grid name="lnd">ne0np4.ARCTIC.ne30x4</grid>
       <grid name="ocnice">ne0np4.ARCTIC.ne30x4</grid>
       <mask>tx0.1v2</mask>
     </model_grid>
 
-    <model_grid alias="ne0np4.ARCTICGRIS.ne30x8_mt12" not_compset="_POP">
+    <model_grid alias="ne0ARCTICGRISne30x8_ne0ARCTICGRISne30x8_mt12" not_compset="_POP">
       <grid name="atm">ne0np4.ARCTICGRIS.ne30x8</grid>
       <grid name="lnd">ne0np4.ARCTICGRIS.ne30x8</grid>
       <grid name="ocnice">ne0np4.ARCTICGRIS.ne30x8</grid>


### PR DESCRIPTION
Need to change the grid aliases for the arctic var-res grids to something that makes valid
test names.

Test suite:  SMS_Ln9.ne0ARCTICne30x4_ne0ARCTICne30x4_mt12.F2000climo.cheyenne_intel
               SMS_Ln9.ne0ARCTICGRISne30x8_ne0ARCTICGRISne30x8_mt12.F2000climo.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes [CIME Github issue #] #3564 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
