### PR TITLE
scorpio doesnt support short type

### DIFF
--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -82,7 +82,7 @@ def buildlib(bldroot, installpath, case):
     if not os.path.isdir(pio_dir):
         os.makedirs(pio_dir)
     casetools = case.get_value("CASETOOLS")
-    if pio_version == 1:
+    if pio_version == 1 or scorpio_src_root_dir:
         cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/genf90 \""
     else:
         cmake_opts = "\"-D GENF90_PATH=$CIMEROOT/src/externals/pio2/scripts/ \""


### PR DESCRIPTION
scorpio (e3sm pio2 version) does not support the PIO_SHORT type added to the pio2 library. 

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3574 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
