### PR TITLE
fix print format issue and turn off debug flags

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -132,7 +132,7 @@ else
 endif
 
 ifeq ($(PIO_VERSION),2)
-  ifneq ($(COMPILER),nag)
+  ifeq ($(CIME_MODEL),e3sm)
     # Needed by SCORPIO not default PIO, does not work with NAG compiler
     USE_CXX := TRUE
   endif
@@ -140,11 +140,11 @@ else
   CPPDEFS += -DPIO1
 endif
 
-ifeq ($(USE_CXX), TRUE)
-  ifeq ($(SUPPORTS_CXX), FALSE)
-    $(error Fatal attempt to include C++ code on a compiler/machine combo that has not been set up to support C++)
-  endif
-endif
+#ifeq ($(USE_CXX), TRUE)
+#  ifeq ($(SUPPORTS_CXX), FALSE)
+#    $(error Fatal attempt to include C++ code on a compiler/machine combo that has not been set up to support C++)
+#  endif
+#endif
 
 # Not clear how to escape commas for libraries with their own configure
 # script, and they don't need this defined anyway, so leave this out of

--- a/src/share/streams/shr_strdata_mod.F90
+++ b/src/share/streams/shr_strdata_mod.F90
@@ -64,7 +64,7 @@ module shr_strdata_mod
 
   ! !PRIVATE:
 
-  integer(IN)                          :: debug    = 10  ! local debug flag
+  integer(IN)                          :: debug    = 0  ! local debug flag
   integer(IN)      ,parameter          :: nStrMax = 30
   integer(IN)      ,parameter          :: nVecMax = 30
   character(len=*) ,parameter, public  :: shr_strdata_nullstr = 'null'

--- a/src/share/streams/shr_stream_mod.F90
+++ b/src/share/streams/shr_stream_mod.F90
@@ -159,7 +159,7 @@ module shr_stream_mod
   !----- parameters -----
   real(SHR_KIND_R8)   ,parameter :: spd = SHR_CONST_CDAY ! seconds per day
   integer(SHR_KIND_IN),parameter :: initarr_size = 3     ! size of initarr
-  integer(SHR_KIND_IN),save :: debug = 10        ! edit/turn-on for debug write statements
+  integer(SHR_KIND_IN),save :: debug = 0        ! edit/turn-on for debug write statements
   logical             ,save :: doabort = .true. ! flag if abort on error
   character(len=*), parameter :: sourcefile = &
        __FILE__
@@ -240,7 +240,7 @@ contains
     else
        call shr_sys_abort('dataSource too long for variable ' // errMsg(sourcefile, __LINE__))
     endif
-    if (debug>0 .and. s_loglev>0) write(s_logunit,F00) '  * format = ', trim(strm%dataSource)
+    if (debug>0 .and. s_loglev>0) write(s_logunit,*) '  * format = ', trim(strm%dataSource)
 
     close(nUnit)
     call shr_file_freeUnit(nUnit)
@@ -334,7 +334,7 @@ contains
     else
        strm%offset = 0
     end if
-    if (debug>0 .and. s_loglev>0) write(s_logunit,F00) '  * offset ',strm%offset
+    if (debug>0 .and. s_loglev>0) write(s_logunit,*) '  * offset ',strm%offset
 
     close(nUnit)
 


### PR DESCRIPTION
Fix a formatting issue runtime failure for nag compiler, turn off debug flags in stream code.


Test suite: hand tested SMS_D_Ld3.f45_g37_rx1.A.izumi_nag 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
