### PR TITLE
Use pio1 even for mpi-serial cases in CESM

### DIFF
--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -20,7 +20,7 @@
   <!--
   <entry id="PIO_VERSION">
     <values>
-      <value mach="stampede2-skx">1</value>
+      <value></value>
     </values>
   </entry>
   -->

--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -17,12 +17,13 @@
     </values>
   </entry>
   -->
+  <!--
   <entry id="PIO_VERSION">
     <values>
-      <value mpilib="mpi-serial">2</value>
+      <value mach="stampede2-skx">1</value>
     </values>
   </entry>
-
+  -->
 
   <!--- uncomment and fill in relevant sections
   <entry id="PIO_ROOT">


### PR DESCRIPTION
For the CESM2.2 release, we'll stick with pio1, with plans to transition to pio2 for CESM2.3. This PR backs out a change that had made pio2 the default for mpi-serial cases; that change was causing failures in CTSM.

Test suite: NONE! (but note that this effectively just reverts config_pio.xml to an earlier version)
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: 
