### PR TITLE
Give the file name that results in the "empty read-only file" error

### DIFF
--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -65,9 +65,9 @@ class GenericXML(object):
         else:
             # if file does not exist create a root xml element
             # and set it's id to file
-            expect(not self.read_only, "Makes no sense to have empty read-only file")
-            logger.debug("File {} does not exists.".format(infile))
-            expect("$" not in infile,"File path not fully resolved {}".format(infile))
+            expect(not self.read_only, "Makes no sense to have empty read-only file: {}".format(infile))
+            logger.debug("File {} does not exist.".format(infile))
+            expect("$" not in infile,"File path not fully resolved: {}".format(infile))
 
             root = _Element(ET.Element("xml"))
 


### PR DESCRIPTION
Printing the file name when this error appears could help with diagnosing issues (e.g., https://bb.cgd.ucar.edu/cesm/threads/creat-new-case-error.5309).

Test suite: scripts_regression_tests - JUST A_RunUnitTests and B_CheckCode
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
