### PR TITLE
ERA5 data stream related changes

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -332,6 +332,21 @@
       <grid name="rof">JRA025</grid>
     </model_grid>
 
+    <model_grid alias="TL639_g17" not_compset="_CAM">
+      <grid name="atm">TL639</grid>
+      <grid name="lnd">TL639</grid>
+      <grid name="ocnice">gx1v7</grid>
+      <!--<grid name="rof">JRA025</grid>-->
+      <mask>gx1v7</mask>
+    </model_grid>
+
+    <model_grid alias="TL639_t061" not_compset="_CAM">
+      <grid name="atm">TL639</grid>
+      <grid name="lnd">TL639</grid>
+      <grid name="ocnice">tx0.66v1</grid>
+      <!--<grid name="rof">JRA025</grid>-->
+    </model_grid>
+
     <model_grid alias="T62_t061" not_compset="_CAM">
       <grid name="atm">T62</grid>
       <grid name="lnd">T62</grid>
@@ -1671,6 +1686,16 @@
       <file grid="ocnice"  mask="tx0.1v3">$DIN_LOC_ROOT/share/domains/domain.ocn.tx0.1v3.170730.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/TL319_151007_ESMFmesh.nc</mesh>
       <desc>TL319 grid for JRA55</desc>
+    </domain>
+
+    <domain name="TL639">
+      <nx>1440</nx> <ny>721</ny>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.TL639_gx1v7.200619.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.TL639_gx1v7.200619.nc</file>
+      <file grid="atm|lnd" mask="tx0.66v1">$DIN_LOC_ROOT/share/domains/domain.lnd.TL639_tx0.66v1.200619.nc</file>
+      <file grid="ocnice"  mask="tx0.66v1">$DIN_LOC_ROOT/share/domains/domain.ocn.TL639_tx0.66v1.200619.nc</file>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/TL639_200618_ESMFmesh.nc</mesh>
+      <desc>TL639 grid for ERA5</desc>
     </domain>
 
     <domain name="ne240np4.pg2">

--- a/config/ufs/config_grids.xml
+++ b/config/ufs/config_grids.xml
@@ -54,6 +54,12 @@
       <grid name="lnd">TL319</grid>
       <grid name="ocnice">Atlantic8</grid>
     </model_grid>
+
+    <model_grid alias="TL639_Atlantic8">
+      <grid name="atm">TL639</grid>
+      <grid name="lnd">TL639</grid>
+      <grid name="ocnice">Atlantic8</grid>
+    </model_grid>
   </grids>
 
   <!-- ======================================================== -->
@@ -112,6 +118,14 @@
       <file grid="ocnice"  mask="Atlantic8">$DIN_LOC_ROOT/hafs/share/domains/domain.ocn.TL319_Atlantic8.200527.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/TL319_151007_ESMFmesh.nc</mesh>
       <desc>TL319 grid for JRA55</desc>
+    </domain>
+
+    <domain name="TL639">
+      <nx>1440</nx> <ny>721</ny>
+      <file grid="atm|lnd" mask="Atlantic8">$DIN_LOC_ROOT/hafs/share/domains/domain.lnd.TL639_Atlantic8.200618.nc</file>
+      <file grid="ocnice"  mask="Atlantic8">$DIN_LOC_ROOT/hafs/share/domains/domain.ocn.TL639_Atlantic8.200618.nc</file>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/TL639_200618_ESMFmesh.nc</mesh>
+      <desc>TL639 grid for ERA5</desc>
     </domain>
 
     <!-- domains for regional ocean (HYCOM) -->

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -110,7 +110,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">cmake</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/19.0.5</command>
+        <command name="load">intel/19.0.5</command>
 	<command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">
@@ -128,7 +128,7 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules mpilib="impi" compiler="intel">
         <command name="load">impi/2019.6.154</command>
-        <command name="load">netcdf/4.7.3</command>
+        <command name="load">netcdf-mpi/4.7.3</command>
         <command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules>
@@ -143,12 +143,12 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">NCEPlibs/1.0.0</command>
       </modules>
       <modules compiler="intel" mpilib="impi" DEBUG="FALSE" comp_interface="nuopc">
-        <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.2</command>
-        <command name="load">esmf-8.1.0-i3614950-ncdfio-intelmpi-O</command>
+      <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.5</command>
+      <command name="load">esmf-8.1.0-i3614950_sreconopts3-ncdfio-intelmpi-O</command>
       </modules>
       <modules compiler="intel" mpilib="impi" DEBUG="TRUE" comp_interface="nuopc">
-        <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.2</command>
-        <command name="load">esmf-8.1.0-i3614950-ncdfio-intelmpi-g</command>
+      <command name="use">/glade/work/turuncu/PROGS/modulefiles/esmfpkgs/intel/19.0.5</command>
+      <command name="load">esmf-8.1.0-i3614950_sreconopts3-ncdfio-intelmpi-g</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial">
 	<command name="load">netcdf/4.7.1</command>


### PR DESCRIPTION
This PR aims to bring new atmosphere data stream by using ECMWF's latest state-of-art reanalysis data called ERA5. The data is in TL639 horizontal and hourly temporal resolutions. This PR is also linked to the [PR in CDEPS side](https://github.com/ESCOMP/CDEPS/pull/2).

Test suite: scripts_regression_tests.py
Test baseline: N/A
Test namelist changes: N/A
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #] No

User interface changes?: No

Update gh-pages html (Y/N)?:

Code review: 
