### PR TITLE
Rename ne30pg3 grid name to ne30np4.pg3

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -779,8 +779,8 @@
     </model_grid>
 
     <model_grid alias="ne30pg3_g17">
-      <grid name="atm">ne30pg3</grid>
-      <grid name="lnd">ne30pg3</grid>
+      <grid name="atm">ne30np4.pg3</grid>
+      <grid name="lnd">ne30np4.pg3</grid>
       <grid name="ocnice">gx1v7</grid>
       <mask>gx1v7</mask>
     </model_grid>
@@ -985,9 +985,9 @@
     </model_grid>
 
     <model_grid alias="ne30pg3_ne30pg3_mg17" not_compset="_POP">
-      <grid name="atm">ne30pg3</grid>
-      <grid name="lnd">ne30pg3</grid>
-      <grid name="ocnice">ne30pg3</grid>
+      <grid name="atm">ne30np4.pg3</grid>
+      <grid name="lnd">ne30np4.pg3</grid>
+      <grid name="ocnice">ne30np4.pg3</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
@@ -1533,11 +1533,11 @@
       <support>EXPERIMENTAL FVM physics grid</support>
     </domain>
 
-    <domain name="ne30pg3">
+    <domain name="ne30np4.pg3">
       <nx>48600</nx> <ny>1</ny>
       <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4.pg3_gx1v7.170605.nc</file>
       <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4.pg3_gx1v7_170605.nc</file>
-      <desc>ne30pg3 is a Spectral Elem ne30 grid with a 3x3 FVM physics grid:</desc>
+      <desc>ne30np4.pg3 is a Spectral Elem ne30 grid with a 3x3 FVM physics grid:</desc>
       <support>EXPERIMENTAL FVM physics grid</support>
     </domain>
 

--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -86,7 +86,7 @@
       <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_r05_TO_ne30np4.pg2_aave.191023.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne30pg3" rof_grid="r05">
+    <gridmap lnd_grid="ne30np4.pg3" rof_grid="r05">
       <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/ne30pg3/map_ne30pg3_to_0.5x0.5_nomask_aave_da_c180515.nc</map>
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/ne30pg3/map_0.5x0.5_nomask_to_ne30pg3_aave_da_c180515.nc</map>
     </gridmap>
@@ -392,7 +392,7 @@
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gland4km_TO_ne30np4.pg2_aave.191023.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne30pg3" glc_grid="gland4" >
+    <gridmap lnd_grid="ne30np4.pg3" glc_grid="gland4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_gland4km_aave.180515.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_gland4km_blin.180515.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30pg3_aave.180510.nc</map>

--- a/config/cesm/config_grids_mct.xml
+++ b/config/cesm/config_grids_mct.xml
@@ -238,14 +238,14 @@
       <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_ww3a_blin.191023.nc</map>
     </gridmap>
 
-    <gridmap atm_grid="ne30pg3" ocn_grid="gx1v7">
+    <gridmap atm_grid="ne30np4.pg3" ocn_grid="gx1v7">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_gx1v7_aave.190215.nc</map>
       <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_gx1v7_blin.190215.nc</map>
       <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_gx1v7_blin.190215.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne30pg3_aave.190215.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ne30pg3_aave.190215.nc</map>
     </gridmap>
-    <gridmap atm_grid="ne30pg3" wav_grid="ww3a">
+    <gridmap atm_grid="ne30np4.pg3" wav_grid="ww3a">
       <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_ww3a_blin.190215.nc</map>
     </gridmap>
 


### PR DESCRIPTION
Rename ne30pg3 grid name to ne30np4.pg3 to be consistent with other Spectral Element grids.
This is a result of a discussion with @adamrher and @ekluzek.


Test suite: SMS.ne30pg3_ne30pg3_mg17.A.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status:bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
