### PR TITLE
Fix max pending requests default

### DIFF
--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -2400,10 +2400,10 @@
   <entry id="PIO_REARR_COMM_MAX_PEND_REQ_COMP2IO">
     <type>integer</type>
     <valid_values></valid_values>
-    <default_value>0</default_value>
+    <default_value>-2</default_value>
     <group>run_pio</group>
     <file>env_run.xml</file>
-    <desc>pio rearranger communication max pending requests (comp2io) : 0 implies that CIME internally calculates the value ( = max(64, 2 * PIO_NUMTASKS) ), -1 implies no bound on max pending requests </desc>
+    <desc>pio rearranger communication max pending requests (comp2io) : -2 implies that CIME internally calculates the value ( = max(64, 2 * PIO_NUMTASKS) ), -1 implies no bound on max pending requests </desc>
   </entry>
 
   <entry id="PIO_REARR_COMM_ENABLE_HS_COMP2IO">
@@ -2430,7 +2430,7 @@
     <default_value>64</default_value>
     <group>run_pio</group>
     <file>env_run.xml</file>
-    <desc>pio rearranger communication max pending requests (io2comp) : -1 implies no bound on max pending requests </desc>
+    <desc>pio rearranger communication max pending requests (io2comp) : -2 implies that CIME internally calculates the value ( = 64), -1 implies no bound on max pending requests </desc>
   </entry>
 
   <!-- Handshaking is a very bad idea for large process counts and for -->

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -872,17 +872,6 @@ contains
       else
         buf(8) = 0
       end if
-
-      ! Log the rearranger options
-      write(shr_log_unit, *) "PIO rearranger options:"
-      write(shr_log_unit, *) "  comm type     =", pio_rearr_comm_type
-      write(shr_log_unit, *) "  comm fcd      =", pio_rearr_comm_fcd
-      write(shr_log_unit, *) "  max pend req (comp2io)  =", pio_rearr_comm_max_pend_req_comp2io
-      write(shr_log_unit, *) "  enable_hs (comp2io)     =", pio_rearr_comm_enable_hs_comp2io
-      write(shr_log_unit, *) "  enable_isend (comp2io)  =", pio_rearr_comm_enable_isend_comp2io
-      write(shr_log_unit, *) "  max pend req (io2comp)  =", pio_rearr_comm_max_pend_req_io2comp
-      write(shr_log_unit, *) "  enable_hs (io2comp)    =", pio_rearr_comm_enable_hs_io2comp
-      write(shr_log_unit, *) "  enable_isend (io2comp)  =", pio_rearr_comm_enable_isend_io2comp
     end if
 
     call shr_mpi_bcast(buf, comm)
@@ -918,6 +907,27 @@ contains
       pio_rearr_opt_i2c_enable_isend = .false.
     else
       pio_rearr_opt_i2c_enable_isend = .true.
+    end if
+
+    if(rank == 0) then
+      ! Log the rearranger options
+      write(shr_log_unit, *) "PIO rearranger options:"
+      write(shr_log_unit, *) "  comm type     = ", trim(pio_rearr_comm_type)
+      write(shr_log_unit, *) "  comm fcd      = ", trim(pio_rearr_comm_fcd)
+      if(pio_rearr_opt_c2i_max_pend_req == PIO_REARR_COMM_UNLIMITED_PEND_REQ) then
+        write(shr_log_unit, *) "  max pend req (comp2io)  = PIO_REARR_COMM_UNLIMITED_PEND_REQ (-1)"
+      else
+        write(shr_log_unit, *) "  max pend req (comp2io)  = ", pio_rearr_opt_c2i_max_pend_req
+      end if
+      write(shr_log_unit, *) "  enable_hs (comp2io)     = ", pio_rearr_opt_c2i_enable_hs
+      write(shr_log_unit, *) "  enable_isend (comp2io)  = ", pio_rearr_opt_c2i_enable_isend
+      if(pio_rearr_opt_i2c_max_pend_req == PIO_REARR_COMM_UNLIMITED_PEND_REQ) then
+        write(shr_log_unit, *) "  max pend req (io2comp)  = PIO_REARR_COMM_UNLIMITED_PEND_REQ (-1)"
+      else
+        write(shr_log_unit, *) "  max pend req (io2comp)  = ", pio_rearr_opt_i2c_max_pend_req
+      end if
+      write(shr_log_unit, *) "  enable_hs (io2comp)    = ", pio_rearr_opt_i2c_enable_hs
+      write(shr_log_unit, *) "  enable_isend (io2comp)  = ", pio_rearr_opt_i2c_enable_isend
     end if
   end subroutine
 !===============================================================================

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -814,7 +814,7 @@ contains
         write(shr_log_unit, *) "Resetting PIO rearranger comm max pend req (comp2io) to 0. (Since"
         write(shr_log_unit, *) "we have only 1 MPI process for this component)"
         buf(3) = 0
-      else if((pio_rearr_comm_max_pend_req_comp2io <= 0) .and. &
+      else if((pio_rearr_comm_max_pend_req_comp2io < 0) .and. &
           (pio_rearr_comm_max_pend_req_comp2io /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
 
         ! Small multiple of pio_numiotasks has proven to perform
@@ -822,7 +822,7 @@ contains
         ! very large process count runs. Can improve this by
         ! communicating between iotasks first, and then non-iotasks
         ! to iotasks (TO DO)
-        write(shr_log_unit, *) "Invalid PIO rearranger comm max pend req (comp2io), ",&
+        write(shr_log_unit, *) "User-specified PIO rearranger comm max pend req (comp2io) = ",&
              pio_rearr_comm_max_pend_req_comp2io
         write(shr_log_unit, *) "Resetting PIO rearranger comm max pend req (comp2io) to ", &
              max(PIO_REARR_COMM_DEF_MAX_PEND_REQ, 2 * pio_numiotasks)
@@ -850,9 +850,9 @@ contains
         write(shr_log_unit, *) "Resetting PIO rearranger comm max pend req (io2comp) to 0. (Since"
         write(shr_log_unit, *) "we have only 1 MPI process for this component)"
         buf(6) = 0
-      else if((pio_rearr_comm_max_pend_req_io2comp <= 0) .and. &
+      else if((pio_rearr_comm_max_pend_req_io2comp < 0) .and. &
           (pio_rearr_comm_max_pend_req_io2comp /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
-        write(shr_log_unit, *) "Invalid PIO rearranger comm max pend req (io2comp), ", pio_rearr_comm_max_pend_req_io2comp
+        write(shr_log_unit, *) "User-specified PIO rearranger comm max pend req (io2comp) = ", pio_rearr_comm_max_pend_req_io2comp
         write(shr_log_unit, *) "Resetting PIO rearranger comm max pend req (io2comp) to ", PIO_REARR_COMM_DEF_MAX_PEND_REQ
         buf(6) = PIO_REARR_COMM_DEF_MAX_PEND_REQ
       else


### PR DESCRIPTION
Using a new default value, -2, for PIO_REARR_COMM_MAX_PEND_REQ_COMP2IO to indicate that CIME needs to set the value of maximum I/O pending requests, since 0 is now a valid value for the variable.

Also see related PR #3499 

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?: N

Code review: 
