### PR TITLE
set PIO_REARR_COMM_TYPE: coll for mpi-serial

### DIFF
--- a/config/cesm/machines/config_pio.xml
+++ b/config/cesm/machines/config_pio.xml
@@ -243,6 +243,11 @@
     </values>
   </entry>
 
+  <entry id="PIO_REARR_COMM_TYPE">
+    <values>
+      <value mpilib="mpi-serial">coll</value>
+    </values>
+  </entry>
 
   <!--- uncomment and fill in relevant sections
   <entry id="CPL_PIO_STRIDE">

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -506,11 +506,6 @@ contains
     call shr_mpi_bcast(pio_buffer_size_limit, Comm)
     call shr_mpi_bcast(pio_async_interface, Comm)
     call shr_mpi_bcast(pio_rearranger, Comm)
-    if (npes == 1) then
-       pio_rearr_comm_max_pend_req_comp2io = 0
-       pio_rearr_comm_max_pend_req_io2comp = 0
-    endif
-
 
     call shr_pio_rearr_opts_set(Comm, pio_rearr_comm_type, pio_rearr_comm_fcd, &
          pio_rearr_comm_max_pend_req_comp2io, pio_rearr_comm_enable_hs_comp2io, &
@@ -812,7 +807,7 @@ contains
       end select
 
       ! buf(3) = max_pend_req_comp2io
-      if((pio_rearr_comm_max_pend_req_comp2io < 0) .and. &
+      if((pio_rearr_comm_max_pend_req_comp2io <= 0) .and. &
           (pio_rearr_comm_max_pend_req_comp2io /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
 
         ! Small multiple of pio_numiotasks has proven to perform
@@ -844,7 +839,7 @@ contains
       end if
 
       ! buf(6) = max_pend_req_io2comp
-      if((pio_rearr_comm_max_pend_req_io2comp < 0) .and. &
+      if((pio_rearr_comm_max_pend_req_io2comp <= 0) .and. &
           (pio_rearr_comm_max_pend_req_io2comp /= PIO_REARR_COMM_UNLIMITED_PEND_REQ)) then
         write(shr_log_unit, *) "Invalid PIO rearranger comm max pend req (io2comp), ", pio_rearr_comm_max_pend_req_io2comp
         write(shr_log_unit, *) "Resetting PIO rearranger comm max pend req (io2comp) to ", PIO_REARR_COMM_DEF_MAX_PEND_REQ


### PR DESCRIPTION
Use PIO_REARR_COMM_TYPE=coll for mpi-serial .   This undoes some of the changes in #3499 and makes #3594 unnecessary
Test suite: scripts_regression_tests.py, hand testing with pio2 and mpi-serial
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3596 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
