### PR TITLE
Wpcoomb/improve error message for create newcase test option

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -224,7 +224,6 @@ def _main_func(description):
         expect(("FROM_CREATE_TEST" in os.environ and os.environ["FROM_CREATE_TEST"] == "True"),
            "The --test argument is intended to only be called from inside create_test. Invoking this option from the command line is not appropriate usage.")
 
-
     with Case(caseroot, read_only=False) as case:
         # Configure the Case
         case.create(casename, srcroot, compset, grid, user_mods_dir=user_mods_dir,

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -217,6 +217,14 @@ def _main_func(description):
     expect(not (os.path.exists(caseroot) and not test),
            "Case directory {} already exists".format(caseroot))
 
+    # create_newcase ... --test ... throws a CIMEError along with
+    # a very stern warning message to the user
+    # if it detects that it was invoked outside of create_test
+    if test:
+        expect(("FROM_CREATE_TEST" in os.environ and os.environ["FROM_CREATE_TEST"] == "True"),
+           "The --test argument is intended to only be called from inside create_test. Invoking this option from the command line is not appropriate usage.")
+
+
     with Case(caseroot, read_only=False) as case:
         # Configure the Case
         case.create(casename, srcroot, compset, grid, user_mods_dir=user_mods_dir,

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -223,6 +223,7 @@ def _main_func(description):
     if test:
         expect(("FROM_CREATE_TEST" in os.environ and os.environ["FROM_CREATE_TEST"] == "True"),
            "The --test argument is intended to only be called from inside create_test. Invoking this option from the command line is not appropriate usage.")
+        del os.environ['FROM_CREATE_TEST']
 
     with Case(caseroot, read_only=False) as case:
         # Configure the Case

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -633,6 +633,7 @@ def _main_func(description):
 
     success = False
     run_count = 0
+    os.environ["FROM_CREATE_TEST"] = "True"
     while not success and run_count <= retry:
         use_existing = use_existing if run_count == 0 else True
         success = create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,
@@ -647,6 +648,7 @@ def _main_func(description):
         os.environ["TESTBUILDFAIL_PASS"] = "True"
         os.environ["TESTRUNFAIL_PASS"] = "True"
 
+    del os.environ['FROM_CREATE_TEST']
     sys.exit(0 if success else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -648,7 +648,6 @@ def _main_func(description):
         os.environ["TESTBUILDFAIL_PASS"] = "True"
         os.environ["TESTRUNFAIL_PASS"] = "True"
 
-    del os.environ['FROM_CREATE_TEST']
     sys.exit(0 if success else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -633,7 +633,6 @@ def _main_func(description):
 
     success = False
     run_count = 0
-    os.environ["FROM_CREATE_TEST"] = "True"
     while not success and run_count <= retry:
         use_existing = use_existing if run_count == 0 else True
         success = create_test(test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, test_root,

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -448,6 +448,7 @@ class TestScheduler(object):
         _, case_opts, grid, compset,\
             machine, compiler, test_mods = parse_test_name(test)
 
+        os.environ["FROM_CREATE_TEST"] = "True"
         create_newcase_cmd = "{} --case {} --res {} --compset {}"\
                              " --test".format(os.path.join(self._cime_root, "scripts", "create_newcase"),
                                               test_dir, grid, compset)


### PR DESCRIPTION
Calling create_newcase ... --test ... from the command line
now throws a CIMEError along with a very stern warning message 
to the user when it detects that it was invoked outside of create_test.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: [bit for bit]
Fixes #3595
User interface changes?: N
Update gh-pages html (Y/N)?:
Code review: @jedwards4b @jgfouca