### PR TITLE
Revert "fix force_build_smp, did not work after case.setup"

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -19,7 +19,7 @@ _CMD_ARGS_FOR_BUILD = \
 
 def get_standard_makefile_args(case, shared_lib=False):
     make_args = "CIME_MODEL={} ".format(case.get_value("MODEL"))
-    make_args += " SMP={} ".format(stringify_bool(case.get_build_threaded()))
+    make_args += " compile_threaded={} ".format(stringify_bool(case.get_build_threaded()))
     if not shared_lib:
         make_args += " USE_KOKKOS={} ".format(stringify_bool(uses_kokkos(case)))
     for var in _CMD_ARGS_FOR_BUILD:


### PR DESCRIPTION
Reverts ESMCI/cime#3591

Apparently #3591 caused problems with the gptl build. #3600 is supposed to fix those problems, but I have some outstanding questions there, and @jedwards4b won't be able to help resolve those until next week. So, in order for us to move forward with CESM testing, I'd like to revert #3591 for now. In the next couple of weeks, we will revisit #3591 together with #3600 to determine the appropriate fix.