### PR TITLE
Mapping file updates

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -962,7 +962,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne120pg2_ne120pg2_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne120pg2_ne120pg2_mg17" not_compset="_POP">
       <grid name="atm">ne120np4.pg2</grid>
       <grid name="lnd">ne120np4.pg2</grid>
       <grid name="ocnice">ne120np4.pg2</grid>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1542,8 +1542,8 @@
 
     <domain name="ne30np4.pg2">
       <nx>21600</nx> <ny>1</ny>
-      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4.pg2_gx1v7.170628.nc</file>
-      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4.pg2_gx1v7.170628.nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne30np4.pg2_gx1v7.200626.nc</file>
+      <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne30np4.pg2_gx1v7.200626.nc</file>
       <desc>ne30np4.pg2 is a Spectral Elem 1-deg grid with a 2x2 FVM physics grid:</desc>
       <support>EXPERIMENTAL FVM physics grid</support>
     </domain>
@@ -1609,8 +1609,8 @@
       <nx>345600</nx> <ny>1</ny>
       <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg2_gx1v7.170629.nc</file>
       <file grid="ocnice"  mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg2_gx1v7.170629.nc</file>
-      <file grid="atm|lnd" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg2_tx0.1v2.200108.nc</file>
-      <file grid="ocnice"  mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg2_tx0.1v2.200108.nc</file>
+      <file grid="atm|lnd" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne120np4.pg2_tx0.1v2.200626.nc</file>
+      <file grid="ocnice"  mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne120np4.pg2_tx0.1v2.200626.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/ne120np4_pentagons_100310_ESMFmesh.nc</mesh>
       <desc>ne120np4.pg2 is a Spectral Elem 0.25-deg grid with a 2x2 FVM physics grid:</desc>
       <support>EXPERIMENTAL FVM physics grid</support>
@@ -1660,16 +1660,16 @@
 
     <domain name="ne0np4.ARCTIC.ne30x4">
       <nx>117398</nx> <ny>1</ny>
-      <file grid="atm|lnd" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne0np4.ARCTIC.ne30x4_tx0.1v2.191023.nc</file>
-      <file grid="ocnice"  mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne0np4.ARCTIC.ne30x4_tx0.1v2.191023.nc</file>
+      <file grid="atm|lnd" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne0np4.ARCTIC.ne30x4_tx0.1v2.200626.nc</file>
+      <file grid="ocnice"  mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne0np4.ARCTIC.ne30x4_tx0.1v2.200626.nc</file>
       <desc>ne0np4.ARCTIC.ne30x4 is a Spectral Elem 1-deg grid with a 1/4 deg refined region over Arctic:</desc>
       <support>Test support only</support>
     </domain>
 
     <domain name="ne0np4.ARCTICGRIS.ne30x8">
       <nx>152390</nx> <ny>1</ny>
-      <file grid="atm|lnd" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne0np4.ARCTICGRIS.ne30x8_tx0.1v2.191209.nc</file>
-      <file grid="ocnice"  mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne0np4.ARCTICGRIS.ne30x8_tx0.1v2.191209.nc</file>
+      <file grid="atm|lnd" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.lnd.ne0np4.ARCTICGRIS.ne30x8_tx0.1v2.200626.nc</file>
+      <file grid="ocnice"  mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.ocn.ne0np4.ARCTICGRIS.ne30x8_tx0.1v2.200626.nc</file>
       <desc>ne0np4.ARCTICGRIS.ne30x8 is a Spectral Elem 1-deg grid with a 1/8 deg refined region over Greenland:</desc>
       <support>Test support only</support>
     </domain>

--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -57,13 +57,13 @@
     </gridmap>
 
     <gridmap lnd_grid="ne0np4.ARCTIC.ne30x4" rof_grid="r05">
-      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_ne0np4.ARCTIC.ne30x4_TO_r05_aave.191023.nc</map>
-      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_r05_TO_ne0np4.ARCTIC.ne30x4_aave.191023.nc</map>
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_ne0np4.ARCTIC.ne30x4_TO_r05_aave.200626.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_r05_TO_ne0np4.ARCTIC.ne30x4_aave.200626.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne0np4.ARCTICGRIS.ne30x8" rof_grid="r05">
-      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_ne0np4.ARCTICGRIS.ne30x8_TO_r05_aave.191209.nc</map>
-      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_r05_TO_ne0np4.ARCTICGRIS.ne30x8_aave.191209.nc</map>
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_ne0np4.ARCTICGRIS.ne30x8_TO_r05_aave.200626.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_r05_TO_ne0np4.ARCTICGRIS.ne30x8_aave.200626.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="360x720cru" rof_grid="r05">
@@ -82,8 +82,8 @@
     </gridmap>
 
     <gridmap lnd_grid="ne30np4.pg2" rof_grid="r05">
-      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_r05_aave.191023.nc</map>
-      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_r05_TO_ne30np4.pg2_aave.191023.nc</map>
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_r05_aave.200626.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_r05_TO_ne30np4.pg2_aave.200626.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne30np4.pg3" rof_grid="r05">
@@ -102,8 +102,8 @@
     </gridmap>
 
     <gridmap lnd_grid="ne120np4.pg2" rof_grid="r05">
-      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_r05_aave.200108.nc</map>
-      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_r05_TO_ne120np4.pg2_aave.200108.nc</map>
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_r05_aave.200626.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_r05_TO_ne120np4.pg2_aave.200626.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne120np4.pg3" rof_grid="r05">
@@ -386,10 +386,10 @@
     </gridmap>
 
     <gridmap lnd_grid="ne30np4.pg2" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gland4km_aave.191023.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gland4km_blin.191023.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gland4km_TO_ne30np4.pg2_aave.191023.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gland4km_TO_ne30np4.pg2_aave.191023.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gland4km_aave.200626.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gland4km_blin.200626.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gland4km_TO_ne30np4.pg2_aave.200626.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gland4km_TO_ne30np4.pg2_aave.200626.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne30np4.pg3" glc_grid="gland4" >
@@ -407,17 +407,17 @@
     </gridmap>
 
     <gridmap lnd_grid="ne0np4.ARCTIC.ne30x4" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_ne0np4.ARCTIC.ne30x4_TO_gland4km_aave.191023.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_ne0np4.ARCTIC.ne30x4_TO_gland4km_blin.191023.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_gland4km_TO_ne0np4.ARCTIC.ne30x4_aave.191023.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_gland4km_TO_ne0np4.ARCTIC.ne30x4_aave.191023.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_ne0np4.ARCTIC.ne30x4_TO_gland4km_aave.200626.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_ne0np4.ARCTIC.ne30x4_TO_gland4km_blin.200626.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_gland4km_TO_ne0np4.ARCTIC.ne30x4_aave.200626.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_gland4km_TO_ne0np4.ARCTIC.ne30x4_aave.200626.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne0np4.ARCTICGRIS.ne30x8" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_ne0np4.ARCTICGRIS.ne30x8_TO_gland4km_aave.191209.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_ne0np4.ARCTICGRIS.ne30x8_TO_gland4km_blin.191209.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_gland4km_TO_ne0np4.ARCTICGRIS.ne30x8_aave.191209.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_gland4km_TO_ne0np4.ARCTICGRIS.ne30x8_aave.191209.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_ne0np4.ARCTICGRIS.ne30x8_TO_gland4km_aave.200626.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_ne0np4.ARCTICGRIS.ne30x8_TO_gland4km_blin.200626.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_gland4km_TO_ne0np4.ARCTICGRIS.ne30x8_aave.200626.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_gland4km_TO_ne0np4.ARCTICGRIS.ne30x8_aave.200626.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne120np4" glc_grid="gland4" >
@@ -428,10 +428,10 @@
     </gridmap>
 
     <gridmap lnd_grid="ne120np4.pg2" glc_grid="gland4" >
-      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_gland4km_aave.200108.nc</map>
-      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_gland4km_blin.200108.nc</map>
-      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_gland4km_TO_ne120np4.pg2_aave.200108.nc</map>
-      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_gland4km_TO_ne120np4.pg2_aave.200108.nc</map>
+      <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_gland4km_aave.200626.nc</map>
+      <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_gland4km_blin.200626.nc</map>
+      <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_gland4km_TO_ne120np4.pg2_aave.200626.nc</map>
+      <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_gland4km_TO_ne120np4.pg2_aave.200626.nc</map>
     </gridmap>
 
     <gridmap lnd_grid="ne120np4.pg3" glc_grid="gland4" >

--- a/config/cesm/config_grids_mct.xml
+++ b/config/cesm/config_grids_mct.xml
@@ -228,14 +228,14 @@
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg2" ocn_grid="gx1v7">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gx1v7_aave.191023.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gx1v7_blin.191023.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gx1v7_blin.191023.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gx1v7_TO_ne30np4.pg2_aave.191023.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gx1v7_TO_ne30np4.pg2_aave.191023.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gx1v7_aave.200626.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gx1v7_blin.200626.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gx1v7_blin.200626.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gx1v7_TO_ne30np4.pg2_aave.200626.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gx1v7_TO_ne30np4.pg2_aave.200626.nc</map>
     </gridmap>
     <gridmap atm_grid="ne30np4.pg2" wav_grid="ww3a">
-      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_ww3a_blin.191023.nc</map>
+      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_ww3a_blin.200626.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne30np4.pg3" ocn_grid="gx1v7">
@@ -276,14 +276,14 @@
     </gridmap>
 
     <gridmap atm_grid="ne120np4.pg2" ocn_grid="tx0.1v2">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_tx0.1v2_aave.200109.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_tx0.1v2_blin.200109.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_tx0.1v2_blin.200109.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_tx0.1v2_TO_ne120np4.pg2_aave.200108.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_tx0.1v2_TO_ne120np4.pg2_aave.200108.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_tx0.1v2_aave.200626.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_tx0.1v2_blin.200626.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_tx0.1v2_blin.200626.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_tx0.1v2_TO_ne120np4.pg2_aave.200626.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_tx0.1v2_TO_ne120np4.pg2_aave.200626.nc</map>
     </gridmap>
     <gridmap atm_grid="ne120np4.pg2" wav_grid="ww3a">
-      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_ww3a_blin.200108.nc</map>
+      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_ww3a_blin.200626.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne120np4.pg3" ocn_grid="gx1v7">
@@ -357,25 +357,25 @@
     </gridmap>
 
     <gridmap atm_grid="ne0np4.ARCTIC.ne30x4" ocn_grid="tx0.1v2">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_ne0np4.ARCTIC.ne30x4_TO_tx0.1v2_aave.191023.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_ne0np4.ARCTIC.ne30x4_TO_tx0.1v2_blin.191023.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_ne0np4.ARCTIC.ne30x4_TO_tx0.1v2_blin.191023.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_tx0.1v2_TO_ne0np4.ARCTIC.ne30x4_aave.191023.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_tx0.1v2_TO_ne0np4.ARCTIC.ne30x4_aave.191023.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_ne0np4.ARCTIC.ne30x4_TO_tx0.1v2_aave.200626.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_ne0np4.ARCTIC.ne30x4_TO_tx0.1v2_blin.200626.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_ne0np4.ARCTIC.ne30x4_TO_tx0.1v2_blin.200626.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_tx0.1v2_TO_ne0np4.ARCTIC.ne30x4_aave.200626.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_tx0.1v2_TO_ne0np4.ARCTIC.ne30x4_aave.200626.nc</map>
     </gridmap>
     <gridmap atm_grid="ne0np4.ARCTIC.ne30x4" wav_grid="ww3a">
-      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_ne0np4.ARCTIC.ne30x4_TO_ww3a_blin.191023.nc</map>
+      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/maps/map_ne0np4.ARCTIC.ne30x4_TO_ww3a_blin.200626.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4.ARCTICGRIS.ne30x8" ocn_grid="tx0.1v2">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_ne0np4.ARCTICGRIS.ne30x8_TO_tx0.1v2_aave.191209.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_ne0np4.ARCTICGRIS.ne30x8_TO_tx0.1v2_blin.191209.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_ne0np4.ARCTICGRIS.ne30x8_TO_tx0.1v2_blin.191209.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_tx0.1v2_TO_ne0np4.ARCTICGRIS.ne30x8_aave.191209.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_tx0.1v2_TO_ne0np4.ARCTICGRIS.ne30x8_aave.191209.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_ne0np4.ARCTICGRIS.ne30x8_TO_tx0.1v2_aave.200626.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_ne0np4.ARCTICGRIS.ne30x8_TO_tx0.1v2_blin.200626.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_ne0np4.ARCTICGRIS.ne30x8_TO_tx0.1v2_blin.200626.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_tx0.1v2_TO_ne0np4.ARCTICGRIS.ne30x8_aave.200626.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_tx0.1v2_TO_ne0np4.ARCTICGRIS.ne30x8_aave.200626.nc</map>
     </gridmap>
     <gridmap atm_grid="ne0np4.ARCTICGRIS.ne30x8" wav_grid="ww3a">
-      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_ne0np4.ARCTICGRIS.ne30x8_TO_ww3a_blin.191209.nc</map>
+      <map name="ATM2WAV_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/maps/map_ne0np4.ARCTICGRIS.ne30x8_TO_ww3a_blin.200626.nc</map>
     </gridmap>
 
     <gridmap atm_grid="TL319" ocn_grid="gx1v7">


### PR DESCRIPTION
Update domain files and LND2GLC and GLC2LND mapping files in config_grids* for
  ne30np4.pg2
  ne120np4.pg2
  ne0np4.ARCTIC.ne30x4
  ne0np4.ARCTICGRIS.ne30x8

Also allow ne120pg2_ne120pg2_mg17 to run with land.

New domain and mapping files were generated by @adamrher.

The ne120np4.pg2 test failed with a timestep too large error.  This is expected as the correct timestep is
still being determined.  But the test did initialize with the correct mapping and domain files.

Test suite:   SMS_Ln9.ne30pg2_ne30pg2_mg17.F2000climo.cheyenne_intel
                  SMS_Ln9.ne120pg2_ne120pg2_mt12.F2000climo.cheyenne_intel
                       ERROR: negative moist layer thickness. timestep or remap time too large.
                  SMS_Ln9.ne0ARCTICne30x4_ne0ARCTICne30x4_mt12.F2000climo.cheyenne_intel
                  SMS_Ln9.ne0ARCTICGRISne30x8_ne0ARCTICGRISne30x8_mt12.F2000climo.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status: Answer changing at given resolution

Fixes #3593 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
