### PR TITLE
Refactor ensemble.py and single_run.py for python3

### DIFF
--- a/tools/statistical_ensemble_test/ensemble.py
+++ b/tools/statistical_ensemble_test/ensemble.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import os, sys, getopt
 import random
 from single_run import process_args_dict, single_case
@@ -23,17 +24,17 @@ def get_pertlim_uf(rand_num):
     if i == 0:
        ptlim = 0
     else:
-       j = 2*((i - 1)/100) + 101
+       j = 2*int((i - 1)/100) + 101
        k = (i - 1)%100
        if i%2 != 0:
-          ll = j + (k/2)*18
-          ippt = '{0:03d}'.format(ll)
+          ll = j + int(k/2)*18
+          ippt = str(ll).zfill(3)
           ptlim = "0."+ippt+"d-13"
        else:
-          ll = j + ((k-1)/2)*18
-          ippt = '{0:03d}'.format(ll)
+          ll = j + int((k-1)/2)*18
+          ippt = str(ll).zfill(3)
           ptlim = "-0."+ippt+"d-13"
-    return ptlim 
+    return ptlim
 
 
 def main(argv):
@@ -61,7 +62,7 @@ def main(argv):
         run_type = 'ensemble'
         clone_count = ens_size - 1
         if ens_size > 999:
-            print 'Error: cannot have an ensemble size greater than 999.'
+            print('Error: cannot have an ensemble size greater than 999.')
             sys.exit()
         print('STATUS: ensemble size = ' + str(ens_size))
     
@@ -180,11 +181,11 @@ def main(argv):
         if opts_dict['ect'] == 'pop':
             print ("STATUS: ---POP-ECT VERIFICATION CASE COMPLETE---")
             print ("Set up one case using the following init_ts_perturb value:")
-            print get_pertlim_uf(rand_ints[0])
+            print (get_pertlim_uf(rand_ints[0]))
         else:
             print ("STATUS: ---CAM-ECT VERIFICATION CASES COMPLETE---")
             print ("Set up three cases using the following pertlim values:")
-            print get_pertlim_uf(rand_ints[0]) + '   ' + get_pertlim_uf(rand_ints[1]) + "   " + get_pertlim_uf(rand_ints[2])
+            print (get_pertlim_uf(rand_ints[0]) + '   ' + get_pertlim_uf(rand_ints[1]) + "   " + get_pertlim_uf(rand_ints[2]))
     else:
        print ("STATUS: --ENSEMBLE CASES COMPLETE---")
 

--- a/tools/statistical_ensemble_test/single_run.py
+++ b/tools/statistical_ensemble_test/single_run.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python 
+#! /usr/bin/env python
+from __future__ import print_function
 import sys, getopt, os 
 
 #
@@ -6,46 +7,46 @@ import sys, getopt, os
 #
 def disp_usage(callType):
     if callType == 'ensemble.py':
-        print '\nSets up multiple CESM cases for either an ensemble of runs or a small (CAM-ECT = 3, POP-ECT = 1)'
-        print 'test set (default). Then use pyCECT utilities to create an ensemble'
-        print 'summary file or to evaluate the small test set of runs against the ensemble.'
-        print '  '
-        print '----------------------------'
-        print 'ensemble.py :'
+        print('\nSets up multiple CESM cases for either an ensemble of runs or a small (CAM-ECT = 3, POP-ECT = 1)')
+        print('test set (default). Then use pyCECT utilities to create an ensemble')
+        print('summary file or to evaluate the small test set of runs against the ensemble.')
+        print('  ')
+        print('----------------------------')
+        print('ensemble.py :')
     else: 
-        print '\nSets up a single CESM case. '
-        print '  '
-        print '----------------------------'
-        print 'single_run.py :'
-    print '----------------------------'
-    print ' '
-    print 'Required flags:'
+        print('\nSets up a single CESM case. ')
+        print('  ')
+        print('----------------------------')
+        print('single_run.py :')
+    print('----------------------------')
+    print(' ')
+    print('Required flags:')
     if callType == 'single_run.py':
-        print '  --case <name>    Case name passed on to create_newcase (incl. full path AND same)'
+        print('  --case <name>    Case name passed on to create_newcase (incl. full path AND same)')
     else:
-        print '  --case <name>    Case name passed on to create_newcase (incl. full path AND must end in ".000")'
-    print '  --mach <name>    Machine name passed on to create_newcase'
-    print ' ' 
-    print 'Optional flags (+ all "--" options to create_newcase): '
-    print '  --project <num>    Project number to charge in job scripts'
-    print '  --ect <cam,pop>    Specify whether ensemble is for CAM-ECT or POP-ECT (default = cam)'
+        print('  --case <name>    Case name passed on to create_newcase (incl. full path AND must end in ".000")')
+    print('  --mach <name>    Machine name passed on to create_newcase')
+    print(' ')
+    print('Optional flags (+ all "--" options to create_newcase): ')
+    print('  --project <num>    Project number to charge in job scripts')
+    print('  --ect <cam,pop>    Specify whether ensemble is for CAM-ECT or POP-ECT (default = cam)')
     if callType == 'single_run.py':
-       print '  --pertlim <num>    Run (CAM or POP) with specified non-zero pertlim'
-    print '  --walltime <hr:mn> Amount of walltime requested (default = 4:30 (CAM-ECT) 2:00 (POP-ECT), or 0:10 with --uf enabled)'
-    print '  --compiler <name>  Compiler to use (default = same as Machine default) '
-    print '  --compset <name>   Compset to use (default = F2000climo (CAM-ECT) or G (POP-ECT))'
-    print '  --res <name>       Resolution to run (default = f19_f19 (CAM-ECT) or T62_g17 (POP-ECT))'
-    print '  --uf               Enable ninth time step runs (ultra-fast mode for CAM-ECT) - otherwise the default is 12-month runs'
+       print('  --pertlim <num>    Run (CAM or POP) with specified non-zero pertlim')
+    print('  --walltime <hr:mn> Amount of walltime requested (default = 4:30 (CAM-ECT) 2:00 (POP-ECT), or 0:10 with --uf enabled)')
+    print('  --compiler <name>  Compiler to use (default = same as Machine default) ')
+    print('  --compset <name>   Compset to use (default = F2000climo (CAM-ECT) or G (POP-ECT))')
+    print('  --res <name>       Resolution to run (default = f19_f19 (CAM-ECT) or T62_g17 (POP-ECT))')
+    print('  --uf               Enable ninth time step runs (ultra-fast mode for CAM-ECT) - otherwise the default is 12-month runs')
     if callType == 'ensemble.py': 
-       print '  --nb               Disables auto building the root case of the ensemble'
-       print '  --ns               Disables auto submitting any members of the ensemble'
-       print '  --ensemble <size>  Build the ensemble (instead of building case(s) with random pertlim values for verification),'
-       print '                     and specify the number of ensemble members to generate (e.g.: 151 for CAM-ECT annual averages '
-       print '                     or 350 for ultra-fast CAM-ECT mode or 40 for POP-ECT)'
+       print('  --nb               Disables auto building the root case of the ensemble')
+       print('  --ns               Disables auto submitting any members of the ensemble')
+       print('  --ensemble <size>  Build the ensemble (instead of building case(s) with random pertlim values for verification),')
+       print('                     and specify the number of ensemble members to generate (e.g.: 151 for CAM-ECT annual averages ')
+       print('                     or 350 for ultra-fast CAM-ECT mode or 40 for POP-ECT)')
     else:
-       print '  --nb               Disables building (and submitting) the single case'
-       print '  --ns               Disables submitting the single case'
-    print '  --help, -h         Prints out this usage message'
+       print('  --nb               Disables building (and submitting) the single case')
+       print('  --ns               Disables submitting the single case')
+    print('  --help, -h         Prints out this usage message')
 
 ########
 def process_args_dict(caller, caller_argv):
@@ -117,7 +118,7 @@ def process_args_dict(caller, caller_argv):
             s_case_flags += ' ' + opt + ' ' + arg
         elif opt == '--pertlim':
             if caller == 'ensemble.py':
-                print "WARNING: pertlim ignored for ensemble.py."
+                print("WARNING: pertlim ignored for ensemble.py.")
                 opts_dict['pertlim'] = "0"
             else:
                 opts_dict['pertlim'] = arg
@@ -278,7 +279,7 @@ def single_case(opts_dict, case_flags, stat_dir):
     command = './case.setup'
     ret = os.system(command)
     
-    print "STATUS: Adjusting user_nl_* files...."
+    print("STATUS: Adjusting user_nl_* files....")
 
     #POP-ECT
     if opts_dict['ect'] == 'pop':


### PR DESCRIPTION
Edit print statements in each script to use the print_function.
Include from __future__ import print_function to ensure uniform
behavior in both python2 and python3.

Assignments of j and ll within ensemble.get_pert_lim no longer
assume the python2 behavior in which integer division always
returns an integer. Integer division returns a float in python3
when the dividend is not evenly divisible by the divisor. Refactor
uses integer type conversion to ensure the assignments of j and ll
work identically in python2 and python3.

The assignment of ippt within ensemble.get_pert_lim no longer
returns a ValueError in python3. Refactor uses string type
conversion, the zfill method and concatenation to ensure the
assignment of ptlim works identically in python2 and python3.

User interface changes?: N
Update gh-pages html (Y/N)?: N