### PR TITLE
Make cprnc rpath system more robust

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2601,8 +2601,9 @@ class L_TestSaveTimings(TestCreateTestCommon):
         if manual_timing:
             run_cmd_assert_result(self, "cd %s && %s/save_provenance postrun" % (casedir, TOOLS_DIR))
         if CIME.utils.get_model() == "e3sm":
-            provenance_dirs = glob.glob(os.path.join(timing_dir, "performance_archive", getpass.getuser(), casename, lids[0] + "*"))
-            self.assertEqual(len(provenance_dirs), 1, msg="provenance dirs were missing")
+            provenance_glob = os.path.join(timing_dir, "performance_archive", getpass.getuser(), casename, lids[0] + "*")
+            provenance_dirs = glob.glob(provenance_glob)
+            self.assertEqual(len(provenance_dirs), 1, msg="wrong number of provenance dirs, expected 1, got {}, looked for {}".format(provenance_dirs, provenance_glob))
             verify_perms(self, ''.join(provenance_dirs))
 
     ###########################################################################

--- a/tools/cprnc/CMakeLists.txt
+++ b/tools/cprnc/CMakeLists.txt
@@ -50,10 +50,21 @@ else()
   set(NF_LIB_LIST ${NetCDF_Fortran_LIBRARIES})
 endif()
 
+message("lib list is: ${NF_LIB_LIST}")
+
 foreach(NF_LIB IN LISTS NF_LIB_LIST)
-  get_filename_component(NF_LIB_DIR ${NF_LIB} DIRECTORY)
-  list(APPEND NF_LIB_DIRS ${NF_LIB_DIR})
+  if (NF_LIB MATCHES "-l")
+    continue()
+  elseif (NF_LIB MATCHES "-L/")
+    string(REGEX REPLACE "^-L" "" NF_LIB_DIR "${NF_LIB}")
+    list(APPEND NF_LIB_DIRS ${NF_LIB_DIR})
+  else()
+    get_filename_component(NF_LIB_DIR ${NF_LIB} DIRECTORY)
+    list(APPEND NF_LIB_DIRS ${NF_LIB_DIR})
+  endif()
 endforeach()
+
+message("lib dirs are: ${NF_LIB_DIRS}")
 
 set(CMAKE_BUILD_RPATH ${NF_LIB_DIRS})
 


### PR DESCRIPTION
In some cases, nf-config was returning stuff that was not
being well-handled when converting to lib paths.

Also, improve error message from L_TestSaveTimings when dirs are missing.

Test suite: ./scripts_regression_tests.py K_TestCimeCase.test_self_build_cprnc
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @WesCoomber 
