### PR TITLE
Update TL319 -> tx0.1v3 ATM2OCN map

### DIFF
--- a/config/cesm/config_grids_mct.xml
+++ b/config/cesm/config_grids_mct.xml
@@ -400,9 +400,9 @@
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/tx0.1v2/map_tx0.1v2_TO_TL319_aave.161014.nc</map>
     </gridmap>
     <gridmap atm_grid="TL319" ocn_grid="tx0.1v3">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_TO_tx0.1v3_patc.170730.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_TO_tx0.1v3_patc.170730.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_TO_tx0.1v3_patc.170730.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/TL319/map_TL319_TO_tx0.1v3_patc_blin_merged.180705.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/TL319/map_TL319_TO_tx0.1v3_patc_blin_merged.180705.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/TL319/map_TL319_TO_tx0.1v3_patc_blin_merged.180705.nc</map>
       <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/tx0.1v3/map_tx0.1v3_TO_TL319_aave.170730.nc</map>
       <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/tx0.1v3/map_tx0.1v3_TO_TL319_aave.170730.nc</map>
     </gridmap>


### PR DESCRIPTION
Better `ATM2OCN` maps are available for `TL319_t13` runs

Tests: I modified the three maps and then ran `check_inputdata` to verify I got the path correct

Fixes #3623 

User interface changes?: None

Update gh-pages html (Y/N)?: N

Code review: 3 lines changed, easy to verify that all three maps use `map_TL319_TO_tx0.1v3_patc_blin_merged.180705.nc`

****

I'd like this to go into `cesm2_2_alpha06d` so maybe `master` isn't the right base to merge into? I'm happy to merge it into something else if need be.
