### PR TITLE
Modifications in MCT to support MOSART stratification

### DIFF
--- a/src/drivers/mct/main/prep_rof_mod.F90
+++ b/src/drivers/mct/main/prep_rof_mod.F90
@@ -447,6 +447,9 @@ contains
     integer, save :: index_x2r_Faxa_swvdr
     integer, save :: index_x2r_Faxa_swvdf
     integer, save :: index_x2r_Faxa_lwdn
+    
+    integer, save :: index_l2x_coszen_str
+    integer, save :: index_x2r_coszen_str
 
     integer, save :: index_lfrac
     logical, save :: first_time = .true.

--- a/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/src/drivers/mct/shr/seq_flds_mod.F90
@@ -2060,23 +2060,33 @@ contains
        units    = 'kg m-2 s-1'
        attname  = 'Flrl_demand'
        call metadata_set(attname, longname, stdname, units)
-    call seq_flds_add(l2x_fluxes,'Flrl_Tqsur')
-    call seq_flds_add(l2x_fluxes_to_rof,'Flrl_Tqsur')
-    call seq_flds_add(x2r_fluxes,'Flrl_Tqsur')
-    longname = 'Temperature of surface runoff'
-    stdname  = 'Temperature_of_surface_runoff'
-    units    = 'Kelvin'
-    attname  = 'Flrl_Tqsur'
-    call metadata_set(attname, longname, stdname, units)
 
-    call seq_flds_add(l2x_fluxes,'Flrl_Tqsub')
-    call seq_flds_add(l2x_fluxes_to_rof,'Flrl_Tqsub')
-    call seq_flds_add(x2r_fluxes,'Flrl_Tqsub')
-    longname = 'Temperature of subsurface runoff'
-    stdname  = 'Temperature_of_subsurface_runoff'
-    units    = 'Kelvin'
-    attname  = 'Flrl_Tqsub'
-    call metadata_set(attname, longname, stdname, units)
+       call seq_flds_add(l2x_fluxes,'Flrl_Tqsur')
+       call seq_flds_add(l2x_fluxes_to_rof,'Flrl_Tqsur')
+       call seq_flds_add(x2r_fluxes,'Flrl_Tqsur')
+       longname = 'Temperature of surface runoff'
+       stdname  = 'Temperature_of_surface_runoff'
+       units    = 'Kelvin'
+       attname  = 'Flrl_Tqsur'
+       call metadata_set(attname, longname, stdname, units)
+
+       call seq_flds_add(l2x_fluxes,'Flrl_Tqsub')
+       call seq_flds_add(l2x_fluxes_to_rof,'Flrl_Tqsub')
+       call seq_flds_add(x2r_fluxes,'Flrl_Tqsub')
+       longname = 'Temperature of subsurface runoff'
+       stdname  = 'Temperature_of_subsurface_runoff'
+       units    = 'Kelvin'
+       attname  = 'Flrl_Tqsub'
+       call metadata_set(attname, longname, stdname, units)
+
+       ! Cosine of Zenith angle (-)
+       call seq_flds_add(l2x_fluxes,'coszen_str')
+       call seq_flds_add(x2r_fluxes,'coszen_str')
+       longname = 'Cosine of Zenith angle'
+       stdname  = 'coszen'
+       units    = ' '
+       attname  = 'coszen_str'
+       call metadata_set(attname, longname, stdname, units)
     endif
 
     ! Currently only the CESM land and runoff models treat irrigation as a separate


### PR DESCRIPTION
Adds new fields for supporting MOSART river stratification in E3SM

Test suite: e3sm_land_developer
Test baseline: 
Test namelist changes: 
Test status: 

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jgfouca 
