### PR TITLE
add CLA --query-expType option to query the CESM2 experiment database…

### DIFF
--- a/scripts/Tools/archive_metadata
+++ b/scripts/Tools/archive_metadata
@@ -30,7 +30,7 @@ from six.moves      import configparser, urllib
 # define global constants
 logger = logging.getLogger(__name__)
 _svn_expdb_url = 'https://svn-cesm2-expdb.cgd.ucar.edu'
-_exp_types = ['CMIP6', 'production', 'tuning','lens','C1','C2','C3','C4','C5']
+#_exp_types = ['CMIP6', 'production', 'tuning','lens','C1','C2','C3','C4','C5']
 _xml_vars = ['CASE', 'COMPILER', 'COMPSET', 'CONTINUE_RUN', 'DOUT_S', 'DOUT_S_ROOT',
              'GRID', 'MACH', 'MPILIB', 'MODEL', 'MODEL_VERSION', 'REST_N', 'REST_OPTION',
              'RUNDIR', 'RUN_REFCASE', 'RUN_REFDATE', 'RUN_STARTDATE', 'RUN_TYPE',
@@ -156,11 +156,12 @@ def commandline_options(args):
                         'does not have write permission in the caseroot (optional). ' \
                         'Defaults to current working directory.'.format(_svn_expdb_url))
 
-    parser.add_argument('--expType', dest='expType', nargs=1, required=True, choices=_exp_types,
+    parser.add_argument('--expType', dest='expType', nargs=1, 
                         help='Experiment type. For CMIP6 experiments, the case must already ' \
                         'exist in the experiments database at URL ' \
-                        ' "http://csegweb.cgd.ucar.edu/expdb2.0" (required). ' \
-                        'Must be one of "{0}"'.format(_exp_types))
+                        ' "http://csegweb.cgd.ucar.edu/expdb2.0"  ' \
+                        'Run archive_metadata --query-expType to see a complete list ' \
+                        'of supported experiment types (required unless --query-expType is specified).')
 
     parser.add_argument('--title', nargs=1, required=False, default=None,
                         help='Title of experiment (optional).')
@@ -192,6 +193,10 @@ def commandline_options(args):
                         'for specified CMIP6 casename as argument 1. ' \
                         'Writes a json formatted output file, specified by argument 2, ' \
                         'to subdir archive_files (optional).')
+
+    parser.add_argument('--query-expType', dest='query_expType', action='store_true',
+                        help='Query the experiments database for supported ' \
+                        'experiment types (optional).')
 
     parser.add_argument('--test-post', dest='test_post', action='store_true',
                         help='Post metadata to the test expdb2.0 web application server ' \
@@ -611,9 +616,36 @@ def check_expdb_case(case_dict, username, password):
     return int(output['case_id'])
 
 # ---------------------------------------------------------------------
+def query_expdb_expType(case_dict, username, password):
+# ---------------------------------------------------------------------
+    """ query_expdb_expType
+    Query the expdb for a dictionary of supported experiment types.
+
+    Arguments:
+        case_dict (dict) - case dictionary to store XML variables
+        username (string) - SVN developer's username
+        password (string) - SVN developer's password
+
+    """
+    logger.debug('query_expdb_expType')
+    output = list()
+    data_dict = {'queryType':'expTypes'}
+    data = json.dumps(data_dict)
+    params = urllib.parse.urlencode(dict(username=username, password=password, data=data))
+    try:
+        response = urllib.request.urlopen(case_dict['query_expdb_url'], params, context=_context)
+        output = json.load(response)
+    except urllib.error.HTTPError as http_e:
+        logger.info('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
+    except urllib.error.URLError as url_e:
+        logger.info('ERROR archive_metadata URL failed "%s"', url_e.reason)
+
+    return output
+
+# ---------------------------------------------------------------------
 def query_expdb_cmip6(case_dict, username, password):
 # ---------------------------------------------------------------------
-    """ query_exp_case
+    """ query_expdb_cmip6
     Query the expdb for CMIP6 casename = case_dict['q_casename'] metadata.
     Write out a json file to case_dict['q_outfile'].
 
@@ -1429,6 +1461,23 @@ def main_func(options):
 
     (case_dict, username, password) = initialize_main(options)
 
+    # check if query-expType argument is specified
+    if options.query_expType:
+        if case_dict['dryrun']:
+            logger.info('Dryrun - calling query_expdb_expType for supported experiment types')
+        else:
+            exp_types = query_expdb_expType(case_dict, username, password)
+            if exp_types:
+                for exp_type in exp_types:
+                    logger.info('expType: %s', exp_type["name"])
+                    logger.info('description: %s', exp_type["description"])
+                    logger.info('')
+                logger.info('Successful completion of archive_metadata')
+                sys.exit(0)
+            else:
+                logger.info('ERROR archive_metadata failed to query experiment types')
+                sys.exit(1)
+
     # check if query_cmip6 argument is specified
     if options.query_cmip6:
         if case_dict['dryrun']:
@@ -1447,6 +1496,13 @@ def main_func(options):
                             'in experiments database at "%s".',
                             case_dict['q_casename'], case_dict['query_expdb_url'])
                 sys.exit(1)
+
+    # check if expType argument is specified
+    if not options.expType:
+        logger.info('ERROR archive_metadata requires a valid expType. '\
+                    'Run archive_metadata --exp-types to see a complete list '\
+                    'of supported experiment types.')
+        sys.exit(1)
 
     # loop through the _xml_vars gathering values
     with Case(case_dict['CASEROOT'], read_only=True) as case:

--- a/scripts/Tools/archive_metadata
+++ b/scripts/Tools/archive_metadata
@@ -639,8 +639,10 @@ def query_expdb_expType(case_dict, username, password):
         output = json.load(response)
     except urllib.error.HTTPError as http_e:
         logger.error('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
+        sys.exit(1)
     except urllib.error.URLError as url_e:
         logger.error('ERROR archive_metadata URL failed "%s"', url_e.reason)
+        sys.exit(1)
 
     return output
 
@@ -669,8 +671,10 @@ def query_expdb_cmip6(case_dict, username, password):
         output = json.load(response)
     except urllib.error.HTTPError as http_e:
         logger.error('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
+        sys.exit(1)
     except urllib.error.URLError as url_e:
         logger.error('ERROR archive_metadata URL failed "%s"', url_e.reason)
+        sys.exit(1)
 
     if output:
         if not os.path.exists('{0}/archive_files'.format(case_dict['workdir'])):
@@ -729,8 +733,10 @@ def post_json(case_dict, username, password):
         urllib.request.urlopen(case_dict['json_expdb_url'], params, context=_context)
     except urllib.error.HTTPError as http_e:
         logger.error('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
+        sys.exit(1)
     except urllib.error.URLError as url_e:
         logger.error('ERROR archive_metadata URL failed "%s"', url_e.reason)
+        sys.exit(1)
 
 # ---------------------------------------------------------------------
 def check_svn():
@@ -1474,11 +1480,10 @@ def main_func(options):
                     print('expType: {}'.format(exp_type["name"]))
                     print('description: {}'.format(exp_type["description"]))
                     print('')
-                logger.info('Successful completion of archive_metadata')
-                sys.exit(0)
             else:
                 logger.error('ERROR archive_metadata failed to query experiment types')
                 sys.exit(1)
+        return 0
 
     # check if expType argument is a valid expType
     if not any(exp_type["name"] == options.expType[0] for exp_type in exp_types):
@@ -1499,7 +1504,6 @@ def main_func(options):
                             case_dict['workdir'], case_dict['q_casename'],
                             case_dict['q_outfile'], case_dict['query_expdb_url'])
                 logger.info('Successful completion of archive_metadata')
-                sys.exit(0)
             else:
                 logger.error('ERROR archive_metadata failed to find "%s" '\
                             'in experiments database at "%s".',

--- a/scripts/Tools/archive_metadata
+++ b/scripts/Tools/archive_metadata
@@ -30,7 +30,6 @@ from six.moves      import configparser, urllib
 # define global constants
 logger = logging.getLogger(__name__)
 _svn_expdb_url = 'https://svn-cesm2-expdb.cgd.ucar.edu'
-#_exp_types = ['CMIP6', 'production', 'tuning','lens','C1','C2','C3','C4','C5']
 _xml_vars = ['CASE', 'COMPILER', 'COMPSET', 'CONTINUE_RUN', 'DOUT_S', 'DOUT_S_ROOT',
              'GRID', 'MACH', 'MPILIB', 'MODEL', 'MODEL_VERSION', 'REST_N', 'REST_OPTION',
              'RUNDIR', 'RUN_REFCASE', 'RUN_REFDATE', 'RUN_STARTDATE', 'RUN_TYPE',
@@ -134,6 +133,7 @@ def commandline_options(args):
             ' https://csesgweb.cgd.ucar.edu/expdb2.0 for details.')
 
     CIME.utils.setup_standard_logging_options(parser)
+    options_group = parser.add_mutually_exclusive_group(required=True)
 
     parser.add_argument('--user', dest='user', type=str, default=None, required=True,
                         help='User name for SVN CESM developer access (required)')
@@ -156,12 +156,18 @@ def commandline_options(args):
                         'does not have write permission in the caseroot (optional). ' \
                         'Defaults to current working directory.'.format(_svn_expdb_url))
 
-    parser.add_argument('--expType', dest='expType', nargs=1, 
-                        help='Experiment type. For CMIP6 experiments, the case must already ' \
-                        'exist in the experiments database at URL ' \
-                        ' "http://csegweb.cgd.ucar.edu/expdb2.0"  ' \
-                        'Run archive_metadata --query-expType to see a complete list ' \
-                        'of supported experiment types (required unless --query-expType is specified).')
+    options_group.add_argument('--expType', dest='expType', nargs=1, 
+                               help='Supported experiment type defined in the CESM2 experiment database. '\
+                               'Run archive_metadata --query-expType to see a complete list ' \
+                               'of supported experiment types. '\
+                               'Note: for CMIP6 experiments, the case must already ' \
+                               'exist in the experiments database at URL ' \
+                               ' "http://csegweb.cgd.ucar.edu/expdb2.0"  ' \
+                               '(required unless --query-expType is specified).')
+
+    options_group.add_argument('--query-expType', dest='query_expType', action='store_true',
+                               help='Query the experiments database for supported ' \
+                               'experiment types (optional).')
 
     parser.add_argument('--title', nargs=1, required=False, default=None,
                         help='Title of experiment (optional).')
@@ -193,10 +199,6 @@ def commandline_options(args):
                         'for specified CMIP6 casename as argument 1. ' \
                         'Writes a json formatted output file, specified by argument 2, ' \
                         'to subdir archive_files (optional).')
-
-    parser.add_argument('--query-expType', dest='query_expType', action='store_true',
-                        help='Query the experiments database for supported ' \
-                        'experiment types (optional).')
 
     parser.add_argument('--test-post', dest='test_post', action='store_true',
                         help='Post metadata to the test expdb2.0 web application server ' \
@@ -607,10 +609,10 @@ def check_expdb_case(case_dict, username, password):
         response = urllib.request.urlopen(case_dict['query_expdb_url'], params, context=_context)
         output = json.loads(response.read().decode())
     except urllib.error.HTTPError as http_e:
-        logger.info('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
+        logger.error('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
         sys.exit(1)
     except urllib.error.URLError as url_e:
-        logger.info('ERROR archive_metadata URL failed "%s"', url_e.reason)
+        logger.error('ERROR archive_metadata URL failed "%s"', url_e.reason)
         sys.exit(1)
 
     return int(output['case_id'])
@@ -636,9 +638,9 @@ def query_expdb_expType(case_dict, username, password):
         response = urllib.request.urlopen(case_dict['query_expdb_url'], params, context=_context)
         output = json.load(response)
     except urllib.error.HTTPError as http_e:
-        logger.info('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
+        logger.error('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
     except urllib.error.URLError as url_e:
-        logger.info('ERROR archive_metadata URL failed "%s"', url_e.reason)
+        logger.error('ERROR archive_metadata URL failed "%s"', url_e.reason)
 
     return output
 
@@ -666,9 +668,9 @@ def query_expdb_cmip6(case_dict, username, password):
         response = urllib.request.urlopen(case_dict['query_expdb_url'], params, context=_context)
         output = json.load(response)
     except urllib.error.HTTPError as http_e:
-        logger.info('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
+        logger.error('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
     except urllib.error.URLError as url_e:
-        logger.info('ERROR archive_metadata URL failed "%s"', url_e.reason)
+        logger.error('ERROR archive_metadata URL failed "%s"', url_e.reason)
 
     if output:
         if not os.path.exists('{0}/archive_files'.format(case_dict['workdir'])):
@@ -726,9 +728,9 @@ def post_json(case_dict, username, password):
     try:
         urllib.request.urlopen(case_dict['json_expdb_url'], params, context=_context)
     except urllib.error.HTTPError as http_e:
-        logger.info('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
+        logger.error('ERROR archive_metadata HTTP post failed "%s"', http_e.code)
     except urllib.error.URLError as url_e:
-        logger.info('ERROR archive_metadata URL failed "%s"', url_e.reason)
+        logger.error('ERROR archive_metadata URL failed "%s"', url_e.reason)
 
 # ---------------------------------------------------------------------
 def check_svn():
@@ -771,7 +773,7 @@ def create_temp_archive(case_dict):
     if not os.path.exists(archive_temp_dir):
         os.makedirs(archive_temp_dir)
     else:
-        logger.info('ERROR archive_metadata archive_temp_dir already exists. exiting...')
+        logger.error('ERROR archive_metadata archive_temp_dir already exists. exiting...')
         sys.exit(1)
 
     return archive_temp_dir
@@ -1462,21 +1464,28 @@ def main_func(options):
     (case_dict, username, password) = initialize_main(options)
 
     # check if query-expType argument is specified
+    exp_types = query_expdb_expType(case_dict, username, password)
     if options.query_expType:
         if case_dict['dryrun']:
             logger.info('Dryrun - calling query_expdb_expType for supported experiment types')
         else:
-            exp_types = query_expdb_expType(case_dict, username, password)
             if exp_types:
                 for exp_type in exp_types:
-                    logger.info('expType: %s', exp_type["name"])
-                    logger.info('description: %s', exp_type["description"])
-                    logger.info('')
+                    print('expType: {}'.format(exp_type["name"]))
+                    print('description: {}'.format(exp_type["description"]))
+                    print('')
                 logger.info('Successful completion of archive_metadata')
                 sys.exit(0)
             else:
-                logger.info('ERROR archive_metadata failed to query experiment types')
+                logger.error('ERROR archive_metadata failed to query experiment types')
                 sys.exit(1)
+
+    # check if expType argument is a valid expType
+    if not any(exp_type["name"] == options.expType[0] for exp_type in exp_types):
+        logger.error('ERROR archive_metadata requires a valid expType.')
+        logger.error('Run archive_metadata --query-expType to see a complete list '\
+                     'of supported experiment types.')
+        sys.exit(1)
 
     # check if query_cmip6 argument is specified
     if options.query_cmip6:
@@ -1492,17 +1501,10 @@ def main_func(options):
                 logger.info('Successful completion of archive_metadata')
                 sys.exit(0)
             else:
-                logger.info('ERROR archive_metadata failed to find "%s" '\
+                logger.error('ERROR archive_metadata failed to find "%s" '\
                             'in experiments database at "%s".',
                             case_dict['q_casename'], case_dict['query_expdb_url'])
                 sys.exit(1)
-
-    # check if expType argument is specified
-    if not options.expType:
-        logger.info('ERROR archive_metadata requires a valid expType. '\
-                    'Run archive_metadata --exp-types to see a complete list '\
-                    'of supported experiment types.')
-        sys.exit(1)
 
     # loop through the _xml_vars gathering values
     with Case(case_dict['CASEROOT'], read_only=True) as case:
@@ -1518,7 +1520,7 @@ def main_func(options):
         else:
             case_dict['case_id'] = check_expdb_case(case_dict, username, password)
             if case_dict['case_id'] < 1:
-                logger.info('Unable to archive CMIP6 metadata. '\
+                logger.error('ERROR Unable to archive CMIP6 metadata. '\
                             '"%s" casename does not exist in database. '\
                             'All CMIP6 experiments casenames must be '\
                             'reserved in the experiments database at URL: '\


### PR DESCRIPTION
… for a list of supported experiment types
Usage:
archive_metadata --query-expType --user [SVN username] --password

Only a supported expType can be specified with the --expType CLA. 

Test suite: manual 
Test baseline: N/A
Test namelist changes: N/A
Test status: [bit for bit, roundoff, climate changing] bit for bit

Fixes [CIME Github issue #] N/A

User interface changes?: added CLA --query-expType

Update gh-pages html (Y/N)?: Y with next release build

Code review: 
