### PR TITLE
Minor fix to 'wget' mode of downloading CESM input data - newer versions

### DIFF
--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -16,7 +16,7 @@
 
   <server>
     <protocol>wget</protocol>
-    <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata</address>
+    <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata/</address>
     <user>anonymous</user>
     <password>user@example.edu</password>
     <checksum>../inputdata_checksum.dat</checksum>


### PR DESCRIPTION
of wget require the tailing '/' on directory names, or return a non-zero
error code.  On Cheyenne (wget 1.14) it returns 0 with or without the
slash, but on wget 1.19.5, found on the container and cloud versions,
without the '/' the initial check fails with an error code 8, as seen
below:
[user@cesm2.1.3 ~]$ wget --no-check-certificate --user anonymous
--password user@example.edu  --spider
ftp://ftp.cgd.ucar.edu/cesm/inputdata &>/dev/null; echo $?
8
[user@cesm2.1.3 ~]$ wget --no-check-certificate --user anonymous
--password user@example.edu  --spider
ftp://ftp.cgd.ucar.edu/cesm/inputdata/ &>/dev/null; echo $?
0

[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
