### PR TITLE
stampede2 and cori machine updates

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -813,30 +813,30 @@ This allows using a different mpirun command to launch unit tests
 
       <modules compiler="cray">
 	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.6.5</command>
+	<command name="switch">cce cce/8.7.9</command>
       </modules>
       <modules compiler="gnu">
 	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/7.3.0</command>
+	<command name="switch">gcc gcc/8.3.0</command>
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
-	<command name="swap">craype craype/2.5.18</command>
+	<command name="swap">craype craype/2.6.2</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/19.02.1</command>
+	<command name="switch">cray-libsci/19.06.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.8</command>
+	<command name="load">cray-mpich/7.7.10</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.5.0</command>
-	<command name="load">cray-netcdf/4.6.3.0</command>
+	<command name="load">cray-hdf5/1.10.5.2</command>
+	<command name="load">cray-netcdf/4.6.3.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.3.0</command>
-	<command name="load">cray-hdf5-parallel/1.10.5.0</command>
-	<command name="load">cray-parallel-netcdf/1.11.1.0</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.2</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
       <modules>
 	<command name="load">cmake/3.14.4</command>
@@ -918,31 +918,31 @@ This allows using a different mpirun command to launch unit tests
 
       <modules compiler="cray">
 	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.6.5</command>
+	<command name="switch">cce cce/9.1.0</command>
       </modules>
       <modules compiler="gnu">
 	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/7.3.0</command>
+	<command name="switch">gcc gcc/8.3.0</command>
       </modules>
       <modules>
 	<command name="load">cray-memkind</command>
-	<command name="swap">craype craype/2.5.18</command>
+	<command name="swap">craype craype/2.6.2</command>
 	<command name="load">craype-mic-knl</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/19.02.1</command>
+	<command name="switch">cray-libsci/19.06.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.8</command>
+	<command name="load">cray-mpich/7.7.10</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.5.0</command>
-	<command name="load">cray-netcdf/4.6.3.0</command>
+	<command name="load">cray-hdf5/1.10.5.2</command>
+	<command name="load">cray-netcdf/4.6.3.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.3.0</command>
-	<command name="load">cray-hdf5-parallel/1.10.5.0</command>
-	<command name="load">cray-parallel-netcdf/1.11.1.0</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.2</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2393,7 +2393,6 @@ This allows using a different mpirun command to launch unit tests
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>impi,mvapich2</MPILIBS>
-    <PROJECT>TG-ATM180016</PROJECT>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/work/02503/edwardsj/CESM/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/work/02503/edwardsj/CESM/inputdata/lmwg</DIN_LOC_ROOT_CLMFORC>
@@ -2499,19 +2498,19 @@ This allows using a different mpirun command to launch unit tests
         <command name="purge"></command>
         <command name="load">TACC</command>
         <command name="load">python/2.7.13</command>
-        <command name="load">intel/17.0.4</command>
-        <command name="load">cmake/3.10.2</command>
+        <command name="load">intel/18.0.2</command>
+        <command name="load">cmake/3.16.1</command>
       </modules>
       <modules mpilib="mvapich2">
-        <command name="load">mvapich2/2.3b</command>
-        <command name="load">pnetcdf/1.11.0</command>
-        <command name="load">parallel-netcdf/4.3.3.1</command>
+        <command name="load">mvapich2/2.3.1</command>
+        <command name="load">pnetcdf/1.11</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="impi">
         <command name="rm">mvapich2</command>
-        <command name="load">impi/17.0.3</command>
-        <command name="load">pnetcdf/1.11.0</command>
-        <command name="load">parallel-netcdf/4.3.3.1</command>
+        <command name="load">impi/18.0.2</command>
+        <command name="load">pnetcdf/1.11</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpi-serial">
         <command name="load">netcdf/4.3.3.1</command>


### PR DESCRIPTION
Machine updates for stampede2 and cori.  Cray compiler still not working

Test suite:   ERS_Ld3.f45_g37_rx1.A.stampede2-skx_intel,  ERS_Ld3.f45_g37_rx1.A.stampede2-knl_intel,
ERS_Ld3.f45_g37_rx1.A.cori-haswell_intel, ERS_Ld3.f45_g37_rx1.A.cori-knl_intel, ERS_Ld3.f45_g37_rx1.A.cori-haswell_gnu
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
