### PR TITLE
Archive atm_chunk_costs with other performance data

### DIFF
--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -313,6 +313,12 @@ def _save_postrun_timing_e3sm(case, lid):
 
     shutil.rmtree(rundir_timing_dir)
 
+    atm_chunk_costs_src_path = os.path.join(rundir, "atm_chunk_costs.txt")
+    if os.path.exists(atm_chunk_costs_src_path):
+        atm_chunk_costs_dst_path = os.path.join(rundir, "atm_chunk_costs.{}".format(lid))
+        shutil.move(atm_chunk_costs_src_path, atm_chunk_costs_dst_path)
+        gzip_existing_file(atm_chunk_costs_dst_path)
+
     gzip_existing_file(os.path.join(caseroot, "timing", "e3sm_timing_stats.%s" % lid))
 
     # JGF: not sure why we do this
@@ -376,6 +382,7 @@ def _save_postrun_timing_e3sm(case, lid):
     globs_to_copy.append("logs/run_environment.txt.{}".format(lid))
     globs_to_copy.append(os.path.join(rundir, "e3sm.log.{}.gz".format(lid)))
     globs_to_copy.append(os.path.join(rundir, "cpl.log.{}.gz".format(lid)))
+    globs_to_copy.append(os.path.join(rundir, "atm_chunk_costs.{}.gz".format(lid)))
     globs_to_copy.append("timing/*.{}*".format(lid))
     globs_to_copy.append("CaseStatus")
 


### PR DESCRIPTION
At the end of the run, rename atm_chunk_costs.txt as
atm_chunk_costs.$lid, gzip it, and then copy it to the
performance archive.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
