### PR TITLE
Use SRCROOT instead of CIMEROOT in key places

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -189,7 +189,7 @@ class SystemTestsCommon(object):
                 # If overall things did not pass, offer the user some insight into what might have broken things
                 overall_status = self._test_status.get_overall_test_status(ignore_namelists=True)
                 if overall_status != TEST_PASS_STATUS:
-                    srcroot = self._case.get_value("CIMEROOT")
+                    srcroot = self._case.get_value("SRCROOT")
                     worked_before, last_pass, last_fail_transition = \
                         get_test_success(baseline_root, srcroot, self._casebaseid)
 

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -75,7 +75,6 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
         safe_copy(os.path.join(confdir, "CCSM_cppdefs"), bldroot)
         run_gmake(case, compclass, compname, libroot, bldroot)
 
-
 ###############################################################################
 def run_gmake(case, compclass, compname, libroot, bldroot, libname="", user_cppdefs=""):
 ###############################################################################

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -500,7 +500,7 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
     if get_model() == "e3sm":
         bless_log = os.path.join(basegen_dir, BLESS_LOG_NAME)
         with open(bless_log, "a") as fd:
-            fd.write("sha:{} date:{}\n".format(get_current_commit(repo=case.get_value("CIMEROOT")),
+            fd.write("sha:{} date:{}\n".format(get_current_commit(repo=case.get_value("SRCROOT")),
                                                get_timestamp(timestamp_format="%Y-%m-%d_%H:%M:%S")))
 
     return True, comments

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -31,18 +31,18 @@ def _get_batch_job_id_for_syslog(case):
     return None
 
 def _save_build_provenance_e3sm(case, lid):
-    cimeroot = case.get_value("CIMEROOT")
+    srcroot = case.get_value("SRCROOT")
     exeroot = case.get_value("EXEROOT")
     caseroot = case.get_value("CASEROOT")
 
     # Save git describe
     describe_prov = os.path.join(exeroot, "GIT_DESCRIBE.{}".format(lid))
-    desc = get_current_commit(tag=True, repo=cimeroot)
+    desc = get_current_commit(tag=True, repo=srcroot)
     with open(describe_prov, "w") as fd:
         fd.write(desc)
 
     # Save HEAD
-    headfile = os.path.join(cimeroot, ".git", "logs", "HEAD")
+    headfile = os.path.join(srcroot, ".git", "logs", "HEAD")
     headfile_prov = os.path.join(exeroot, "GIT_LOGS_HEAD.{}".format(lid))
     if os.path.exists(headfile_prov):
         os.remove(headfile_prov)
@@ -137,7 +137,7 @@ def _save_prerun_timing_e3sm(case, lid):
     rundir = case.get_value("RUNDIR")
     blddir = case.get_value("EXEROOT")
     caseroot = case.get_value("CASEROOT")
-    cimeroot = case.get_value("CIMEROOT")
+    srcroot = case.get_value("SRCROOT")
     base_case = case.get_value("CASE")
     full_timing_dir = os.path.join(timing_dir, "performance_archive", getpass.getuser(), base_case, lid)
     if os.path.exists(full_timing_dir):
@@ -239,7 +239,7 @@ def _save_prerun_timing_e3sm(case, lid):
             safe_copy(item, os.path.join(full_timing_dir, os.path.basename(item) + "." + lid), preserve_meta=False)
 
     # Save state of repo
-    from_repo = cimeroot if os.path.exists(os.path.join(cimeroot, ".git")) else os.path.dirname(cimeroot)
+    from_repo = srcroot if os.path.exists(os.path.join(srcroot, ".git")) else os.path.dirname(srcroot)
     desc = get_current_commit(tag=True, repo=from_repo)
     with open(os.path.join(full_timing_dir, "GIT_DESCRIBE.{}".format(lid)), "w") as fd:
         fd.write(desc)

--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -190,10 +190,10 @@ def create_cdash_xml_fakes(results, cdash_build_name, cdash_build_group, utc_tim
     # We assume all cases were created from the same code repo
     first_result_case = os.path.dirname(list(results.items())[0][1][0])
     try:
-        srcroot = run_cmd_no_fail("./xmlquery --value CIMEROOT", from_dir=first_result_case)
+        srcroot = run_cmd_no_fail("./xmlquery --value SRCROOT", from_dir=first_result_case)
     except CIMEError:
         # Use repo containing this script as last resort
-        srcroot = CIME.utils.get_cime_root()
+        srcroot = os.path.join(CIME.utils.get_cime_root(), "..")
 
     git_commit = CIME.utils.get_current_commit(repo=srcroot)
 
@@ -457,7 +457,7 @@ def wait_for_tests(test_paths,
         if update_success:
             caseroot = os.path.dirname(test_data[0])
             with Case(caseroot, read_only=True) as case:
-                srcroot = case.get_value("CIMEROOT")
+                srcroot = case.get_value("SRCROOT")
                 baseline_root = case.get_value("BASELINE_ROOT")
                 save_test_success(baseline_root, srcroot, test_name, test_status in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS])
 


### PR DESCRIPTION
Now that CIME is a submodule, we cannot assume cime and E3SM
are the same repo.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
