### PR TITLE
Better logic when compset is tested in aux_ test

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1507,9 +1507,9 @@ directory, NOT in this subdirectory."""
             #   called if run_unsupported is False.
             tests = Testlist(tests_spec_file, files)
             testlist = tests.get_tests(compset=compset_alias, grid=grid_name, supported_only=True)
-            test_categories = ["prealpha", "prebeta", "test_release", "aux_"]
+            test_categories = ["prealpha", "prebeta", "test_release"]
             for test in testlist:
-                if test["category"] in test_categories \
+                if test["category"] in test_categories or "aux_" in test["category"] \
                    or get_cime_default_driver() in test["category"]:
                     testcnt += 1
         if testcnt > 0:


### PR DESCRIPTION
Update the logic behind whether a compset / resolution pair
requires running with `--run-unsupported`. Pairs that are
only testing in an `aux` test were not registering as supported.

Test suite: None
Test baseline: None
Test namelist changes: None
Test status: bit-for-bit -- only difference is fewer compsets requiring `--run-supported`

Fixes #3637 

User interface changes?: no

Update gh-pages html (Y/N)?: no

Code review: none yet
