### PR TITLE
Adding support to the data runoff model for E3SM Cryosphere

### DIFF
--- a/src/components/data_comps_mct/drof/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/drof/cime_config/config_component.xml
@@ -13,7 +13,7 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018]">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF">Data runoff model</desc>
     <desc option="NULL"     >NULL mode</desc>
     <desc option="NYF"      >COREv2 normal year forcing:</desc>
     <desc option="IAF"      >COREv2 interannual year forcing:</desc>
@@ -22,6 +22,9 @@
     <desc option="IAFAIS55" >COREv2 interannual year forcing:</desc>
     <desc option="CPLHIST"  >CPLHIST mode:</desc>
     <desc option="JRA-1p4-2018">JRA55 interannual forcing, v1.4, through 2018</desc>
+    <desc option="JRA-1p4-2018-AIS0ICE">JRA55 interannual forcing, v1.4, through 2018, no rofi around AIS</desc>
+    <desc option="JRA-1p4-2018-AIS0LIQ">JRA55 interannual forcing, v1.4, through 2018, no rofl around AIS</desc>
+    <desc option="JRA-1p4-2018-AIS0ROF">JRA55 interannual forcing, v1.4, through 2018, no rofi or rofl around AIS</desc>
     <desc option="JRA"      >JRA55 interannual forcing</desc>
   </description>
 
@@ -36,7 +39,7 @@
 
   <entry id="DROF_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p4_2018,NULL</valid_values>
+    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
     <values match="last">
       <value compset="_DROF%NULL">NULL</value>
@@ -51,6 +54,9 @@
       <value compset="_DROF%CPLHIST">CPLHIST</value>
       <value compset="_DROF%JRA" >IAF_JRA</value>
       <value compset="_DROF%JRA-1p4-2018" >IAF_JRA_1p4_2018</value>
+      <value compset="_DROF%JRA-1p4-2018-AIS0ICE" >IAF_JRA_1p4_2018_AIS0ICE</value>
+      <value compset="_DROF%JRA-1p4-2018-AIS0LIQ" >IAF_JRA_1p4_2018_AIS0LIQ</value>
+      <value compset="_DROF%JRA-1p4-2018-AIS0ROF" >IAF_JRA_1p4_2018_AIS0ROF</value>
       <value compset=".+" grid="r%null">NULL</value> <!-- overwrites above if runoff grid is null -->
     </values>
     <group>run_component_drof</group>

--- a/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
@@ -60,6 +60,9 @@
       <value drof_mode="DIATREN_IAF_AIS45_RX1">rof.diatren_iaf_ais45_rx1</value>
       <value drof_mode="DIATREN_IAF_AIS55_RX1">rof.diatren_iaf_ais55_rx1</value>
       <value drof_mode="IAF_JRA_1p4_2018"     >rof.iaf_jra_1p4_2018</value>
+      <value drof_mode="IAF_JRA_1p4_2018_AIS0ICE">rof.iaf_jra_1p4_2018_ais0ice</value>
+      <value drof_mode="IAF_JRA_1p4_2018_AIS0LIQ">rof.iaf_jra_1p4_2018_ais0liq</value>
+      <value drof_mode="IAF_JRA_1p4_2018_AIS0ROF">rof.iaf_jra_1p4_2018_ais0rof</value>
       <value drof_mode="IAF_JRA"              >rof.iaf_jra</value>
     </values>
   </entry>
@@ -251,6 +254,195 @@
            JRA.v1.4.runoff.2017.190214.nc
            JRA.v1.4.runoff.2018.190214.nc
       </value>
+      <value stream="rof.iaf_jra_1p4_2018_ais0ice">
+           JRA.v1.4.runoff.1958.no_rofi.190214.nc
+           JRA.v1.4.runoff.1959.no_rofi.190214.nc
+           JRA.v1.4.runoff.1960.no_rofi.190214.nc
+           JRA.v1.4.runoff.1961.no_rofi.190214.nc
+           JRA.v1.4.runoff.1962.no_rofi.190214.nc
+           JRA.v1.4.runoff.1963.no_rofi.190214.nc
+           JRA.v1.4.runoff.1964.no_rofi.190214.nc
+           JRA.v1.4.runoff.1965.no_rofi.190214.nc
+           JRA.v1.4.runoff.1966.no_rofi.190214.nc
+           JRA.v1.4.runoff.1967.no_rofi.190214.nc
+           JRA.v1.4.runoff.1968.no_rofi.190214.nc
+           JRA.v1.4.runoff.1969.no_rofi.190214.nc
+           JRA.v1.4.runoff.1970.no_rofi.190214.nc
+           JRA.v1.4.runoff.1971.no_rofi.190214.nc
+           JRA.v1.4.runoff.1972.no_rofi.190214.nc
+           JRA.v1.4.runoff.1973.no_rofi.190214.nc
+           JRA.v1.4.runoff.1974.no_rofi.190214.nc
+           JRA.v1.4.runoff.1975.no_rofi.190214.nc
+           JRA.v1.4.runoff.1976.no_rofi.190214.nc
+           JRA.v1.4.runoff.1977.no_rofi.190214.nc
+           JRA.v1.4.runoff.1978.no_rofi.190214.nc
+           JRA.v1.4.runoff.1979.no_rofi.190214.nc
+           JRA.v1.4.runoff.1980.no_rofi.190214.nc
+           JRA.v1.4.runoff.1981.no_rofi.190214.nc
+           JRA.v1.4.runoff.1982.no_rofi.190214.nc
+           JRA.v1.4.runoff.1983.no_rofi.190214.nc
+           JRA.v1.4.runoff.1984.no_rofi.190214.nc
+           JRA.v1.4.runoff.1985.no_rofi.190214.nc
+           JRA.v1.4.runoff.1986.no_rofi.190214.nc
+           JRA.v1.4.runoff.1987.no_rofi.190214.nc
+           JRA.v1.4.runoff.1988.no_rofi.190214.nc
+           JRA.v1.4.runoff.1989.no_rofi.190214.nc
+           JRA.v1.4.runoff.1990.no_rofi.190214.nc
+           JRA.v1.4.runoff.1991.no_rofi.190214.nc
+           JRA.v1.4.runoff.1992.no_rofi.190214.nc
+           JRA.v1.4.runoff.1993.no_rofi.190214.nc
+           JRA.v1.4.runoff.1994.no_rofi.190214.nc
+           JRA.v1.4.runoff.1995.no_rofi.190214.nc
+           JRA.v1.4.runoff.1996.no_rofi.190214.nc
+           JRA.v1.4.runoff.1997.no_rofi.190214.nc
+           JRA.v1.4.runoff.1998.no_rofi.190214.nc
+           JRA.v1.4.runoff.1999.no_rofi.190214.nc
+           JRA.v1.4.runoff.2000.no_rofi.190214.nc
+           JRA.v1.4.runoff.2001.no_rofi.190214.nc
+           JRA.v1.4.runoff.2002.no_rofi.190214.nc
+           JRA.v1.4.runoff.2003.no_rofi.190214.nc
+           JRA.v1.4.runoff.2004.no_rofi.190214.nc
+           JRA.v1.4.runoff.2005.no_rofi.190214.nc
+           JRA.v1.4.runoff.2006.no_rofi.190214.nc
+           JRA.v1.4.runoff.2007.no_rofi.190214.nc
+           JRA.v1.4.runoff.2008.no_rofi.190214.nc
+           JRA.v1.4.runoff.2009.no_rofi.190214.nc
+           JRA.v1.4.runoff.2010.no_rofi.190214.nc
+           JRA.v1.4.runoff.2011.no_rofi.190214.nc
+           JRA.v1.4.runoff.2012.no_rofi.190214.nc
+           JRA.v1.4.runoff.2013.no_rofi.190214.nc
+           JRA.v1.4.runoff.2014.no_rofi.190214.nc
+           JRA.v1.4.runoff.2015.no_rofi.190214.nc
+           JRA.v1.4.runoff.2016.no_rofi.190214.nc
+           JRA.v1.4.runoff.2017.no_rofi.190214.nc
+           JRA.v1.4.runoff.2018.no_rofi.190214.nc
+      </value>
+      <value stream="rof.iaf_jra_1p4_2018_ais0liq">
+           JRA.v1.4.runoff.1958.no_rofl.190214.nc
+           JRA.v1.4.runoff.1959.no_rofl.190214.nc
+           JRA.v1.4.runoff.1960.no_rofl.190214.nc
+           JRA.v1.4.runoff.1961.no_rofl.190214.nc
+           JRA.v1.4.runoff.1962.no_rofl.190214.nc
+           JRA.v1.4.runoff.1963.no_rofl.190214.nc
+           JRA.v1.4.runoff.1964.no_rofl.190214.nc
+           JRA.v1.4.runoff.1965.no_rofl.190214.nc
+           JRA.v1.4.runoff.1966.no_rofl.190214.nc
+           JRA.v1.4.runoff.1967.no_rofl.190214.nc
+           JRA.v1.4.runoff.1968.no_rofl.190214.nc
+           JRA.v1.4.runoff.1969.no_rofl.190214.nc
+           JRA.v1.4.runoff.1970.no_rofl.190214.nc
+           JRA.v1.4.runoff.1971.no_rofl.190214.nc
+           JRA.v1.4.runoff.1972.no_rofl.190214.nc
+           JRA.v1.4.runoff.1973.no_rofl.190214.nc
+           JRA.v1.4.runoff.1974.no_rofl.190214.nc
+           JRA.v1.4.runoff.1975.no_rofl.190214.nc
+           JRA.v1.4.runoff.1976.no_rofl.190214.nc
+           JRA.v1.4.runoff.1977.no_rofl.190214.nc
+           JRA.v1.4.runoff.1978.no_rofl.190214.nc
+           JRA.v1.4.runoff.1979.no_rofl.190214.nc
+           JRA.v1.4.runoff.1980.no_rofl.190214.nc
+           JRA.v1.4.runoff.1981.no_rofl.190214.nc
+           JRA.v1.4.runoff.1982.no_rofl.190214.nc
+           JRA.v1.4.runoff.1983.no_rofl.190214.nc
+           JRA.v1.4.runoff.1984.no_rofl.190214.nc
+           JRA.v1.4.runoff.1985.no_rofl.190214.nc
+           JRA.v1.4.runoff.1986.no_rofl.190214.nc
+           JRA.v1.4.runoff.1987.no_rofl.190214.nc
+           JRA.v1.4.runoff.1988.no_rofl.190214.nc
+           JRA.v1.4.runoff.1989.no_rofl.190214.nc
+           JRA.v1.4.runoff.1990.no_rofl.190214.nc
+           JRA.v1.4.runoff.1991.no_rofl.190214.nc
+           JRA.v1.4.runoff.1992.no_rofl.190214.nc
+           JRA.v1.4.runoff.1993.no_rofl.190214.nc
+           JRA.v1.4.runoff.1994.no_rofl.190214.nc
+           JRA.v1.4.runoff.1995.no_rofl.190214.nc
+           JRA.v1.4.runoff.1996.no_rofl.190214.nc
+           JRA.v1.4.runoff.1997.no_rofl.190214.nc
+           JRA.v1.4.runoff.1998.no_rofl.190214.nc
+           JRA.v1.4.runoff.1999.no_rofl.190214.nc
+           JRA.v1.4.runoff.2000.no_rofl.190214.nc
+           JRA.v1.4.runoff.2001.no_rofl.190214.nc
+           JRA.v1.4.runoff.2002.no_rofl.190214.nc
+           JRA.v1.4.runoff.2003.no_rofl.190214.nc
+           JRA.v1.4.runoff.2004.no_rofl.190214.nc
+           JRA.v1.4.runoff.2005.no_rofl.190214.nc
+           JRA.v1.4.runoff.2006.no_rofl.190214.nc
+           JRA.v1.4.runoff.2007.no_rofl.190214.nc
+           JRA.v1.4.runoff.2008.no_rofl.190214.nc
+           JRA.v1.4.runoff.2009.no_rofl.190214.nc
+           JRA.v1.4.runoff.2010.no_rofl.190214.nc
+           JRA.v1.4.runoff.2011.no_rofl.190214.nc
+           JRA.v1.4.runoff.2012.no_rofl.190214.nc
+           JRA.v1.4.runoff.2013.no_rofl.190214.nc
+           JRA.v1.4.runoff.2014.no_rofl.190214.nc
+           JRA.v1.4.runoff.2015.no_rofl.190214.nc
+           JRA.v1.4.runoff.2016.no_rofl.190214.nc
+           JRA.v1.4.runoff.2017.no_rofl.190214.nc
+           JRA.v1.4.runoff.2018.no_rofl.190214.nc
+      </value>
+      <value stream="rof.iaf_jra_1p4_2018_ais0rof">
+           JRA.v1.4.runoff.1958.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1959.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1960.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1961.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1962.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1963.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1964.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1965.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1966.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1967.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1968.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1969.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1970.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1971.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1972.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1973.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1974.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1975.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1976.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1977.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1978.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1979.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1980.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1981.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1982.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1983.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1984.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1985.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1986.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1987.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1988.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1989.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1990.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1991.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1992.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1993.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1994.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1995.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1996.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1997.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1998.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.1999.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2000.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2001.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2002.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2003.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2004.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2005.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2006.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2007.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2008.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2009.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2010.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2011.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2012.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2013.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2014.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2015.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2016.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2017.no_rofi_no_rofl.190214.nc
+           JRA.v1.4.runoff.2018.no_rofi_no_rofl.190214.nc
+      </value>
       <value stream="rof.iaf_jra">
            JRA.v1.1.runoff.1958.170807.nc
            JRA.v1.1.runoff.1959.170807.nc
@@ -405,6 +597,9 @@
       <value stream="rof.diatren_iaf_ais45_rx1">2009</value>
       <value stream="rof.diatren_iaf_ais55_rx1">2009</value>
       <value stream="rof.iaf_jra_1p4_2018"     >2018</value>
+      <value stream="rof.iaf_jra_1p4_2018_ais0ice">2018</value>
+      <value stream="rof.iaf_jra_1p4_2018_ais0liq">2018</value>
+      <value stream="rof.iaf_jra_1p4_2018_ais0rof">2018</value>
       <value stream="rof.iaf_jra"              >2016</value>
       <value stream="rof.cplhist"              >$DROF_CPLHIST_YR_END</value>
     </values>


### PR DESCRIPTION
This PR adds support to the data runoff model for use in E3SM Cryosphere configurations, which use runoff files with modified solid/liquid runoff around Antarctica.

This should not change any existing functionality.

Adding "in progress" label while I test the new compsets with the necessary E3SM changes.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
