### PR TITLE
Fix G_TestBuildSystem test

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1254,7 +1254,7 @@ class TestCreateTestCommon(unittest.TestCase):
             extra_args.append("--mpilib={}".format(TEST_MPILIB))
         extra_args.append("--test-root={0} --output-root={0}".format(self._testroot))
 
-        full_run = (set(extra_args) & set(["-n", "--namelist-only", "--no-setup", "--no-build"])) == set()
+        full_run = (set(extra_args) & set(["-n", "--namelist-only", "--no-setup", "--no-build", "--no-run"])) == set()
 
         if self._hasbatch:
             expected_stat = 0 if not pre_run_errors else CIME.utils.TESTS_FAILED_ERR_CODE


### PR DESCRIPTION
The create_test wrapper should not wait_for_tests if --no-run is passed.

Test suite: scripts_regression_tests G_TestBuildSystem (on both batch and non-batch machines)
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3640 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
