### PR TITLE
Reorder drof options. Fixes bug in #3641

### DIFF
--- a/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
@@ -59,10 +59,10 @@
       <value drof_mode="DIATREN_IAF_AIS00_RX1">rof.diatren_iaf_ais00_rx1</value>
       <value drof_mode="DIATREN_IAF_AIS45_RX1">rof.diatren_iaf_ais45_rx1</value>
       <value drof_mode="DIATREN_IAF_AIS55_RX1">rof.diatren_iaf_ais55_rx1</value>
-      <value drof_mode="IAF_JRA_1p4_2018"     >rof.iaf_jra_1p4_2018</value>
       <value drof_mode="IAF_JRA_1p4_2018_AIS0ICE">rof.iaf_jra_1p4_2018_ais0ice</value>
       <value drof_mode="IAF_JRA_1p4_2018_AIS0LIQ">rof.iaf_jra_1p4_2018_ais0liq</value>
       <value drof_mode="IAF_JRA_1p4_2018_AIS0ROF">rof.iaf_jra_1p4_2018_ais0rof</value>
+      <value drof_mode="IAF_JRA_1p4_2018"     >rof.iaf_jra_1p4_2018</value>
       <value drof_mode="IAF_JRA"              >rof.iaf_jra</value>
     </values>
   </entry>
@@ -191,69 +191,6 @@
       <value stream="rof.diatren_iaf_ais00_rx1">runoff.daitren.iaf-AISx00.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais45_rx1">runoff.daitren.iaf-AISx45.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais55_rx1">runoff.daitren.iaf-AISx55.20120419.nc</value>
-      <value stream="rof.iaf_jra_1p4_2018">
-           JRA.v1.4.runoff.1958.190214.nc
-           JRA.v1.4.runoff.1959.190214.nc
-           JRA.v1.4.runoff.1960.190214.nc
-           JRA.v1.4.runoff.1961.190214.nc
-           JRA.v1.4.runoff.1962.190214.nc
-           JRA.v1.4.runoff.1963.190214.nc
-           JRA.v1.4.runoff.1964.190214.nc
-           JRA.v1.4.runoff.1965.190214.nc
-           JRA.v1.4.runoff.1966.190214.nc
-           JRA.v1.4.runoff.1967.190214.nc
-           JRA.v1.4.runoff.1968.190214.nc
-           JRA.v1.4.runoff.1969.190214.nc
-           JRA.v1.4.runoff.1970.190214.nc
-           JRA.v1.4.runoff.1971.190214.nc
-           JRA.v1.4.runoff.1972.190214.nc
-           JRA.v1.4.runoff.1973.190214.nc
-           JRA.v1.4.runoff.1974.190214.nc
-           JRA.v1.4.runoff.1975.190214.nc
-           JRA.v1.4.runoff.1976.190214.nc
-           JRA.v1.4.runoff.1977.190214.nc
-           JRA.v1.4.runoff.1978.190214.nc
-           JRA.v1.4.runoff.1979.190214.nc
-           JRA.v1.4.runoff.1980.190214.nc
-           JRA.v1.4.runoff.1981.190214.nc
-           JRA.v1.4.runoff.1982.190214.nc
-           JRA.v1.4.runoff.1983.190214.nc
-           JRA.v1.4.runoff.1984.190214.nc
-           JRA.v1.4.runoff.1985.190214.nc
-           JRA.v1.4.runoff.1986.190214.nc
-           JRA.v1.4.runoff.1987.190214.nc
-           JRA.v1.4.runoff.1988.190214.nc
-           JRA.v1.4.runoff.1989.190214.nc
-           JRA.v1.4.runoff.1990.190214.nc
-           JRA.v1.4.runoff.1991.190214.nc
-           JRA.v1.4.runoff.1992.190214.nc
-           JRA.v1.4.runoff.1993.190214.nc
-           JRA.v1.4.runoff.1994.190214.nc
-           JRA.v1.4.runoff.1995.190214.nc
-           JRA.v1.4.runoff.1996.190214.nc
-           JRA.v1.4.runoff.1997.190214.nc
-           JRA.v1.4.runoff.1998.190214.nc
-           JRA.v1.4.runoff.1999.190214.nc
-           JRA.v1.4.runoff.2000.190214.nc
-           JRA.v1.4.runoff.2001.190214.nc
-           JRA.v1.4.runoff.2002.190214.nc
-           JRA.v1.4.runoff.2003.190214.nc
-           JRA.v1.4.runoff.2004.190214.nc
-           JRA.v1.4.runoff.2005.190214.nc
-           JRA.v1.4.runoff.2006.190214.nc
-           JRA.v1.4.runoff.2007.190214.nc
-           JRA.v1.4.runoff.2008.190214.nc
-           JRA.v1.4.runoff.2009.190214.nc
-           JRA.v1.4.runoff.2010.190214.nc
-           JRA.v1.4.runoff.2011.190214.nc
-           JRA.v1.4.runoff.2012.190214.nc
-           JRA.v1.4.runoff.2013.190214.nc
-           JRA.v1.4.runoff.2014.190214.nc
-           JRA.v1.4.runoff.2015.190214.nc
-           JRA.v1.4.runoff.2016.190214.nc
-           JRA.v1.4.runoff.2017.190214.nc
-           JRA.v1.4.runoff.2018.190214.nc
-      </value>
       <value stream="rof.iaf_jra_1p4_2018_ais0ice">
            JRA.v1.4.runoff.1958.no_rofi.190214.nc
            JRA.v1.4.runoff.1959.no_rofi.190214.nc
@@ -442,6 +379,69 @@
            JRA.v1.4.runoff.2016.no_rofi_no_rofl.190214.nc
            JRA.v1.4.runoff.2017.no_rofi_no_rofl.190214.nc
            JRA.v1.4.runoff.2018.no_rofi_no_rofl.190214.nc
+      </value>
+      <value stream="rof.iaf_jra_1p4_2018">
+           JRA.v1.4.runoff.1958.190214.nc
+           JRA.v1.4.runoff.1959.190214.nc
+           JRA.v1.4.runoff.1960.190214.nc
+           JRA.v1.4.runoff.1961.190214.nc
+           JRA.v1.4.runoff.1962.190214.nc
+           JRA.v1.4.runoff.1963.190214.nc
+           JRA.v1.4.runoff.1964.190214.nc
+           JRA.v1.4.runoff.1965.190214.nc
+           JRA.v1.4.runoff.1966.190214.nc
+           JRA.v1.4.runoff.1967.190214.nc
+           JRA.v1.4.runoff.1968.190214.nc
+           JRA.v1.4.runoff.1969.190214.nc
+           JRA.v1.4.runoff.1970.190214.nc
+           JRA.v1.4.runoff.1971.190214.nc
+           JRA.v1.4.runoff.1972.190214.nc
+           JRA.v1.4.runoff.1973.190214.nc
+           JRA.v1.4.runoff.1974.190214.nc
+           JRA.v1.4.runoff.1975.190214.nc
+           JRA.v1.4.runoff.1976.190214.nc
+           JRA.v1.4.runoff.1977.190214.nc
+           JRA.v1.4.runoff.1978.190214.nc
+           JRA.v1.4.runoff.1979.190214.nc
+           JRA.v1.4.runoff.1980.190214.nc
+           JRA.v1.4.runoff.1981.190214.nc
+           JRA.v1.4.runoff.1982.190214.nc
+           JRA.v1.4.runoff.1983.190214.nc
+           JRA.v1.4.runoff.1984.190214.nc
+           JRA.v1.4.runoff.1985.190214.nc
+           JRA.v1.4.runoff.1986.190214.nc
+           JRA.v1.4.runoff.1987.190214.nc
+           JRA.v1.4.runoff.1988.190214.nc
+           JRA.v1.4.runoff.1989.190214.nc
+           JRA.v1.4.runoff.1990.190214.nc
+           JRA.v1.4.runoff.1991.190214.nc
+           JRA.v1.4.runoff.1992.190214.nc
+           JRA.v1.4.runoff.1993.190214.nc
+           JRA.v1.4.runoff.1994.190214.nc
+           JRA.v1.4.runoff.1995.190214.nc
+           JRA.v1.4.runoff.1996.190214.nc
+           JRA.v1.4.runoff.1997.190214.nc
+           JRA.v1.4.runoff.1998.190214.nc
+           JRA.v1.4.runoff.1999.190214.nc
+           JRA.v1.4.runoff.2000.190214.nc
+           JRA.v1.4.runoff.2001.190214.nc
+           JRA.v1.4.runoff.2002.190214.nc
+           JRA.v1.4.runoff.2003.190214.nc
+           JRA.v1.4.runoff.2004.190214.nc
+           JRA.v1.4.runoff.2005.190214.nc
+           JRA.v1.4.runoff.2006.190214.nc
+           JRA.v1.4.runoff.2007.190214.nc
+           JRA.v1.4.runoff.2008.190214.nc
+           JRA.v1.4.runoff.2009.190214.nc
+           JRA.v1.4.runoff.2010.190214.nc
+           JRA.v1.4.runoff.2011.190214.nc
+           JRA.v1.4.runoff.2012.190214.nc
+           JRA.v1.4.runoff.2013.190214.nc
+           JRA.v1.4.runoff.2014.190214.nc
+           JRA.v1.4.runoff.2015.190214.nc
+           JRA.v1.4.runoff.2016.190214.nc
+           JRA.v1.4.runoff.2017.190214.nc
+           JRA.v1.4.runoff.2018.190214.nc
       </value>
       <value stream="rof.iaf_jra">
            JRA.v1.1.runoff.1958.170807.nc


### PR DESCRIPTION
This PR reorders the new drof options and associated streams files added in #3641 . The original ordering let pattern matching identify the rof.iaf_jra_1p4_2018 streams file for all of the new drof options, as opposed to the intended rof.iaf_jra_1p4_2018_ais* streams files.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
