### PR TITLE
nag compiler does not do openmp

### DIFF
--- a/scripts/create_test
+++ b/scripts/create_test
@@ -391,6 +391,10 @@ def parse_command_line(args, description):
 
         mach_obj = Machines(machine=machine_name)
         if args.testargs:
+            for test in args.testargs:
+                testsplit = CIME.utils.parse_test_name(test)
+                if not args.compiler and testsplit[5]:
+                    args.compiler = testsplit[5]
             args.compiler = mach_obj.get_default_compiler() if args.compiler is None else args.compiler
             test_names = get_tests.get_full_test_names(args.testargs,
                                                             mach_obj.get_machine_name(), args.compiler)

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -187,7 +187,6 @@ class TestScheduler(object):
 
         self._test_root = os.path.abspath(self._test_root)
         self._test_id   = test_id if test_id is not None else get_timestamp()
-
         self._compiler = self._machobj.get_default_compiler() if compiler is None else compiler
 
         self._clean          = clean
@@ -606,6 +605,10 @@ class TestScheduler(object):
         config_test = Tests()
         testnode = config_test.get_test_node(test_case)
         envtest.add_test(testnode)
+        # nag compiler on izumi wont build openmp, it's the only known nag compiler usage
+        if self._compiler == 'nag':
+            envtest.set_value("FORCE_BUILD_SMP", "FALSE")
+
         # Determine the test_case from the test name
         test_case, case_opts = parse_test_name(test)[:2]
 


### PR DESCRIPTION
Recent changes to the SMP build were causing the gptl library to try to compile with threads using the nag compiler on izumi. This change turns off the FORCE_BUILD_SMP flag for tests using the nag compiler 

Test suite: ctsm aux_clm tests on izumi
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
