### PR TITLE
CIME changes to support upcoming addition of MALI gis1to10km configuration

### DIFF
--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1062,7 +1062,7 @@
 
   <entry id="GLC_GRID">
     <type>char</type>
-    <valid_values>gland20,gland10,gland5,gland5UM,gland4,mpas.aisgis20km,mpas.gis20km,mpas.ais20km,null</valid_values>
+    <valid_values>gland20,gland10,gland5,gland5UM,gland4,mpas.aisgis20km,mpas.gis20km,mpas.ais20km,mpas.gis1to10km,null</valid_values>
     <default_value>gland5UM</default_value>
     <group>build_grid</group>
     <file>env_build.xml</file>

--- a/src/externals/mct/mpeu/m_inpak90.F90
+++ b/src/externals/mct/mpeu/m_inpak90.F90
@@ -297,7 +297,7 @@
   character(len=*),parameter :: myname='MCT(MPEU)::m_inpak90'
 !-----------------------------------------------------------------------
 
-    integer,parameter :: i90_MXDEP = 4
+    integer,parameter :: i90_MXDEP = 5
     integer,save      :: i90_depth = 0
     type(inpak90),save,pointer :: i90_now
 


### PR DESCRIPTION
This PR makes two small changes in CIME that are necessary prior to an E3SM PR to bring in the MALI gis1to10km configuration. The two changes are:
* add mpas.gis1to10km as option for GLC_GRID; and
* increase i90_MXDEP from 4 to 5 in mpeu.

Neither change should have any impact on current configurations.

[BFB]