### PR TITLE
skip over namelist vars ending with "input_data" in check_input_data

### DIFF
--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -315,7 +315,7 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
             if (line and not line.startswith("#")):
                 tokens = line.split('=')
                 description, full_path = tokens[0].strip(), tokens[1].strip()
-                if description.endswith('datapath'):
+                if description.endswith('datapath') or description.endswith('data_path'):
                     continue
                 if(full_path):
                     # expand xml variables


### PR DESCRIPTION

        modified:   scripts/lib/CIME/case/check_input_data.py

The CAM SD compsets use "met_data_path" to indicate directory path containing input data files.  The change here will cause check_input_data to ignore namelist variables that end in "data_path" as well as "datapath".

Test suite: 

SMS_D_Ln9.f09_f09_mg17.FCSD.cheyenne_intel.cam-outfrq9s
SMS_D_Ln9.f09_f09_mg17.FCts2SD.cheyenne_intel.cam-outfrq9s
SMS_D_Ln9.f09_f09_mg17.FSD.cheyenne_intel.cam-outfrq9s
SMS_D_Ln9.f09_f09_mg17.FWSD.cheyenne_intel.cam-outfrq9s
SMS_D_Ln9.f19_f19_mg17.FW4madSD.cheyenne_intel.cam-outfrq9s
SMS_D_Ln9.f19_f19_mg17.FWmaSD.cheyenne_intel.cam-outfrq9s

Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
