### PR TITLE
Cmeps driver env var

### DIFF
--- a/config/ufs/config_inputdata.xml
+++ b/config/ufs/config_inputdata.xml
@@ -8,6 +8,7 @@
   <!-- it will be searched for filename and chksum of each downloaded file.  -->
   <!-- see the file ftp://ftp.cgd.ucar.edu/cesm/inputdata_chksum.dat for proper format. -->
 
+  <!-- server for sample data -->
   <server>
     <comment>ftp site for ufs release</comment>
     <protocol>ftp</protocol>
@@ -16,17 +17,30 @@
     <password>user@example.edu</password>
     <ic_filepath>/inputdata/</ic_filepath>
   </server>
-  <server>
-    <comment>NOMADS site for grib initial conditions (depricated)</comment>
-    <protocol>wget</protocol>
-    <address>https://nomads.ncdc.noaa.gov:</address>
-    <ic_filepath>data/gfs4/</ic_filepath>
-  </server>
-  <server>
-    <comment>NOMADS ftp site for grib initial conditions</comment>
-    <protocol>ftp</protocol>
-    <address>ftp://nomads.ncdc.noaa.gov</address>
-    <ic_filepath>GFS/Grid4</ic_filepath>
-  </server>
 
+  <!-- servers for GRIB2 data -->
+  <server>
+    <comment>NCEI Thredds server for historical 0.5 deg. GRIB2 initial conditions</comment>
+    <protocol>wget</protocol>
+    <address>https://www.ncei.noaa.gov</address>
+    <ic_filepath>thredds/fileServer/model-gfs-004-files-old/</ic_filepath>
+  </server>
+  <server>
+    <comment>NCEI Thredds server for 0.5 deg. GRIB2 initial conditions</comment>
+    <protocol>wget</protocol>
+    <address>https://www.ncei.noaa.gov</address>
+    <ic_filepath>thredds/fileServer/model-gfs-004-files/</ic_filepath>
+  </server>
+  <server>
+    <comment>NCEI Thredds server for historical 1.0 deg. GRIB2 initial conditions</comment>
+    <protocol>wget</protocol>
+    <address>https://www.ncei.noaa.gov</address>
+    <ic_filepath>thredds/fileServer/model-gfs-003-files-old/</ic_filepath>
+  </server>
+  <server>
+    <comment>NCEI Thredds server for 1.0 deg. GRIB2 initial conditions</comment>
+    <protocol>wget</protocol>
+    <address>https://www.ncei.noaa.gov</address>
+    <ic_filepath>thredds/fileServer/model-gfs-003-files/</ic_filepath>
+  </server>
 </inputdata>

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -136,11 +136,11 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules mpilib="mpt" compiler="gnu">
 	<command name="use">/glade/p/ral/jntp/GMTB/tools/modulefiles/gnu-8.3.0/mpt-2.19</command>
-	<command name="load">NCEPlibs/1.0.0</command>
+	<command name="load">NCEPlibs/1.1.0</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
 	<command name="use">/glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.5/mpt-2.19</command>
-	<command name="load">NCEPlibs/1.0.0</command>
+	<command name="load">NCEPlibs/1.1.0</command>
       </modules>
       <modules compiler="intel" mpilib="impi" DEBUG="FALSE" comp_interface="nuopc">
       <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5</command>

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -338,9 +338,9 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
             os.makedirs(shared_item)
 
     mpilib = case.get_value("MPILIB")
-    cmeps_driver = os.environ.get("CMEPS_DRIVER")
+    cmeps_driver = os.environ.get("UFS_DRIVER")
     if cmeps_driver:
-        logger.info("CMEPS_DRIVER is set to {}".format(cmeps_driver))
+        logger.info("UFS_DRIVER is set to {}".format(cmeps_driver))
     if cmeps_driver and 'nems' in cmeps_driver:
         libs = []
     else:

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -338,10 +338,12 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
             os.makedirs(shared_item)
 
     mpilib = case.get_value("MPILIB")
-    if 'CPL' in case.get_values("COMP_CLASSES"):
-        libs = ["gptl", "mct", "pio", "csm_share"]
-    else:
+    cmeps_driver = os.environ.get("CMEPS_DRIVER")
+    logger.info("CMEPS_DRIVER is set to {}".format(cmeps_driver))
+    if cmeps_driver and 'nems' in cmeps_driver:
         libs = []
+    else:
+        libs = ["gptl", "mct", "pio", "csm_share"]
 
     if mpilib == "mpi-serial":
         libs.insert(0, mpilib)
@@ -351,7 +353,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
 
     # Build shared code of CDEPS nuopc data models
     cdeps_build_script = None
-    if comp_interface == "nuopc":
+    if comp_interface == "nuopc" and cmeps_driver and not 'nems' in cmeps_driver: 
         libs.append("CDEPS")
         cdeps_build_script = os.path.join(cimeroot, "src", "components", "cdeps", "cime_config", "buildlib")
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -459,7 +459,7 @@ class Case(object):
 
         self.set_lookup_value("COMP_INTERFACE", driver)
         if self._cime_model == 'ufs':
-            cmeps_driver = os.environ.get("CMEPS_DRIVER")
+            cmeps_driver = os.environ.get("UFS_DRIVER")
             attribute = None
             if cmeps_driver:
                 attribute = {"component":cmeps_driver}

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -459,13 +459,11 @@ class Case(object):
 
         self.set_lookup_value("COMP_INTERFACE", driver)
         if self._cime_model == 'ufs':
-            config = {}
-            # this is not sustainable, need to come up with something better
-            if 'ufsatm' in compset_name or 'HAFS' in compset_name:
-                config['component']='nems'
-            else:
-                config['component']='cpl'
-            comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL", attribute=config)
+            cmeps_driver = os.environ.get("CMEPS_DRIVER")
+            attribute = None
+            if cmeps_driver:
+                attribute = {"component":cmeps_driver}
+            comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL", attribute=attribute)
 
         if self._cime_model == 'cesm':
             comp_root_dir_cpl = files.get_value("COMP_ROOT_DIR_CPL")

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -565,7 +565,12 @@ class TestScheduler(object):
         # Determine list of component classes that this coupler/driver knows how
         # to deal with. This list follows the same order as compset longnames follow.
         files = Files(comp_interface=self._cime_driver)
-        drv_config_file = files.get_value("CONFIG_CPL_FILE")
+        cmeps_driver = os.environ.get("CMEPS_DRIVER")
+        attribute = None
+        if cmeps_driver:
+            attribute = {"component":cmeps_driver}
+
+        drv_config_file = files.get_value("CONFIG_CPL_FILE", attribute=attribute)
 
         if self._cime_driver == "nuopc" and not os.path.exists(drv_config_file):
             drv_config_file = files.get_value("CONFIG_CPL_FILE", {"component":"cpl"})

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -565,7 +565,7 @@ class TestScheduler(object):
         # Determine list of component classes that this coupler/driver knows how
         # to deal with. This list follows the same order as compset longnames follow.
         files = Files(comp_interface=self._cime_driver)
-        cmeps_driver = os.environ.get("CMEPS_DRIVER")
+        cmeps_driver = os.environ.get("UFS_DRIVER")
         attribute = None
         if cmeps_driver:
             attribute = {"component":cmeps_driver}


### PR DESCRIPTION
We needed to add a way to differentiate between different drivers using the same coupler.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
