### PR TITLE
Revert dlnd source code to how it was prior to PR 3619

### DIFF
--- a/src/components/data_comps_mct/dlnd/src/dlnd_comp_mod.F90
+++ b/src/components/data_comps_mct/dlnd/src/dlnd_comp_mod.F90
@@ -170,11 +170,11 @@ CONTAINS
        if (my_task == master_task) &
             write(logunit,F05) ' scm lon lat = ',scmlon,scmlat
        call shr_strdata_init(SDLND,mpicom,compid,name='lnd', &
-            scmmode=scmmode,scmlon=scmlon,scmlat=scmlat, calendar=calendar)
-!            dmodel_domain_fracname_from_stream=domain_fracname)
+            scmmode=scmmode,scmlon=scmlon,scmlat=scmlat, calendar=calendar, &
+            dmodel_domain_fracname_from_stream=domain_fracname)
     else
-       call shr_strdata_init(SDLND,mpicom,compid,name='lnd', calendar=calendar)
-!            dmodel_domain_fracname_from_stream=domain_fracname)
+       call shr_strdata_init(SDLND,mpicom,compid,name='lnd', calendar=calendar, &
+            dmodel_domain_fracname_from_stream=domain_fracname)
     endif
 
     if (my_task == master_task) then


### PR DESCRIPTION
Resolves ESMCI/cime#3667

See that issue for more details

Test suite: NONE YET!
Test baseline: n/a
Test namelist changes: none
Test status: climate changing for T compsets (glc forced by dlnd)

Fixes ESMCI/cime#3667

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @fischer-ncar 
