### PR TITLE
Add cuda entries

### DIFF
--- a/config/xml_schemas/config_compilers_v2.xsd
+++ b/config/xml_schemas/config_compilers_v2.xsd
@@ -197,6 +197,8 @@
       <xs:element name="SLIBS" type="flagsVar"/>
       <xs:element name="SUPPORTS_CXX" type="upperBoolean"/>
       <xs:element name="TRILINOS_PATH" type="systemPath"/>
+      <xs:element name="CUDA_FLAGS" type="flagsVar"/>
+      <xs:element name="USE_CUDA" type="upperBoolean"/>
     </xs:choice>
   </xs:group>
 


### PR DESCRIPTION
Add two entries to xml scheme: USE_CUDA and CUDA_FLAGS. USE_CUDA determines if CUDA is desired, and CUDA_FLAGS needs to give, at minimum, the architecture to compile for (`-arch`).