### PR TITLE
Fix FV3 grid problem and end GSWP3 forcing by default in 2013 as 2014 is bad

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1923,9 +1923,9 @@
 
     <domain name="C192">
       <nx>221184</nx> <ny>1</ny>
-      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.C192_gx1v6.181018..nc</file>
+      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.C192_gx1v6.181018.nc</file>
       <file grid="ocnice" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.C192_gx1v6.181018.nc</file>
-      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.C192_gx1v7.181018..nc</file>
+      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.C192_gx1v7.181018.nc</file>
       <file grid="ocnice" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.C192_gx1v7.181018.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/C192_181018_ESMFmesh.nc</mesh>
       <desc>C192 is a fvcubed xx-deg grid:</desc>

--- a/config/cesm/config_grids_mct.xml
+++ b/config/cesm/config_grids_mct.xml
@@ -568,7 +568,7 @@
     </gridmap>
 
     <gridmap lnd_grid="C24" rof_grid="r05">
-      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/C24/map_C24_TO_0.5x0.5_aave.181018.nc</map>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/C24/map_C24_nomask_to_0.5x0.5_nomask_aave_da_c181018.nc</map>
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/C24/map_0.5x0.5_TO_C24_aave.181018.nc</map>
     </gridmap>
 
@@ -583,7 +583,7 @@
     </gridmap>
 
     <gridmap lnd_grid="C192" rof_grid="r05">
-      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/C192/map_C192_TO_0.5x0.5_aave.181018.nc</map>
+      <map name="LND2ROF_FMAPNAME">lnd/clm2/mappingdata/maps/C192/map_C192_nomask_to_0.5x0.5_nomask_aave_da_c181018.nc</map>
       <map name="ROF2LND_FMAPNAME">lnd/clm2/mappingdata/maps/C192/map_0.5x0.5_TO_C192_aave.181018.nc</map>
     </gridmap>
 

--- a/src/components/data_comps_mct/datm/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/datm/cime_config/config_component.xml
@@ -44,7 +44,10 @@
     <desc>Mode for data atmosphere component.
       CORE2_NYF (CORE2 normal year forcing) are modes used in forcing prognostic ocean/sea-ice components.
       CLM_QIAN, CLMCRUNCEP, CLMCRUNCEPv7, CLMGSWP3v1, CLMMOSARTTEST, CLMNLDAS2 and CLM1PT are modes using observational data for forcing prognostic land components.
-      WARNING for CLMNLDAS2: This is a regional forcing dataset over the U.S. (25-53N, 235-293E). Garbage data will be produced for runs extending beyond this regional domain. </desc>
+      WARNING for CLMNLDAS2: This is a regional forcing dataset over the U.S. (25-53N, 235-293E). Garbage data will be produced for runs extending beyond this regional domain. 
+      WARNING for CLMGSWP3v1: Humidity is identically zero for last time step in Dec/2013 and all of 2014 so you should NOT use 2014
+data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
+    </desc>
     <values match="last">
       <value compset="%NYF">CORE2_NYF</value>
       <value compset="%IAF">CORE2_IAF</value>
@@ -297,7 +300,7 @@
       <value   compset="4804.*_DATM%QIA">2004</value>
       <value   compset="SSP.*_DATM%QIA">2004</value>
       <value   compset="SSP.*_DATM%CRU">2016</value>
-      <value   compset="SSP.*_DATM%GSW">2014</value>
+      <value   compset="SSP.*_DATM%GSW">2013</value>   <!-- NOTE: 2014 data is bad so ending in 2013 see issue #3653 -->
       <value   compset="2003.*_DATM%QIA.*_TEST">2003</value>
       <value   compset="1850.*_DATM%CRU">1920</value>
       <value   compset="2000.*_DATM%CRU">2010</value>
@@ -305,7 +308,7 @@
       <value   compset="2010.*_DATM%CRU">2014</value>
       <value   compset="1850.*_DATM%GSW">1920</value>
       <value   compset="2000.*_DATM%GSW">2010</value>
-      <value   compset="2010.*_DATM%GSW">2014</value>
+      <value   compset="2010.*_DATM%GSW">2013</value>   <!-- NOTE: 2014 data is bad so ending in 2013 see issue #3653 -->
       <value   compset="2003.*_DATM%GSW">2003</value>
       <value   compset="2000.*_DATM%NLDAS2">2018</value>
       <value   compset="2010.*_DATM%NLDAS2">2014</value>


### PR DESCRIPTION
Fix two issues. The FV3 grid problem and by default end the GSWP3 forcing in 2013, as the 2014 data is bad (humidity is zeroed).

Test suite: Ran two tests:
   SMS_Ld5.f10_f10_musgs.ISSP585Clm50BgcCrop.cheyenne_intel.clm-ciso_dec2050Start
   SMS_D.f19_f19_mg17.I2010Clm50Sp.cheyenne_intel.clm-clm50cam6LndTuningMode (changes answers)
Test namelist changes: end year in datm namelist for GSWP3 forcing
Test status: Some I compsets may change answers because of change in end year (2010 and SSP compsets)

With version based off of cime5.8.30 ran these tests:
   SMS_Ld10.C192_C192_mg17.I1850Clm50Sp.cheyenne_intel.clm-decStart
   SMS_Ld10.C24_C24_mg17.I1850Clm50Sp.cheyenne_intel.clm-decStart

Fixes #3653 
Fixes #3668

User interface changes?:  N

Update gh-pages html (Y/N)?: N

Code review: 
