### PR TITLE
Add source file feature

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -68,12 +68,12 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
-        <arg name="hyperthreading" default="1"> -j {{ hyperthreading }}</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
-        <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
-        <arg name="env_thread_count">--mpmd-env OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
+	<arg name="hyperthreading" default="1"> -j {{ hyperthreading }}</arg>
+	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+	<arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
+	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
+	<arg name="env_thread_count">--mpmd-env OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -86,27 +86,27 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="rm">craype-x86-skylake</command>
-        <command name="rm">PrgEnv-pgi</command>
-        <command name="rm">PrgEnv-intel</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">cray-netcdf</command>
-        <command name="rm">cray-hdf5</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">papi</command>
+	<command name="rm">craype-x86-skylake</command>
+	<command name="rm">PrgEnv-pgi</command>
+	<command name="rm">PrgEnv-intel</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">cray-hdf5</command>
+	<command name="rm">cray-parallel-netcdf</command>
+	<command name="rm">papi</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel</command>
-        <command name="load">craype-x86-skylake</command>
-        <command name="load">craype-hugepages2M</command>
-        <command name="rm">perftools-base/7.0.4</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
-        <command name="load">papi/5.6.0.4</command>
-        <command name="load">gridftp/6.0</command>
-        <command name="load">cray-python/3.6.5.1</command>
+	<command name="load">PrgEnv-intel</command>
+	<command name="load">craype-x86-skylake</command>
+	<command name="load">craype-hugepages2M</command>
+	<command name="rm">perftools-base/7.0.4</command>
+	<command name="load">cray-netcdf/4.6.1.3</command>
+	<command name="load">cray-hdf5/1.10.2.0</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
+	<command name="load">papi/5.6.0.4</command>
+	<command name="load">gridftp/6.0</command>
+	<command name="load">cray-python/3.6.5.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -147,42 +147,42 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules compiler="intel">
-        <command name="load">ANACONDA2/python2.7</command>
-        <command name="load">INTEL/intel_xe_2015.3.187</command>
-        <command name="load">SZIP/szip-2.1_int15</command>
+	<command name="load">ANACONDA2/python2.7</command>
+	<command name="load">INTEL/intel_xe_2015.3.187</command>
+	<command name="load">SZIP/szip-2.1_int15</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-        <command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-g_int15</command>
+	<command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-g_int15</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-        <command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-O_int15</command>
+	<command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-O_int15</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-g_int15</command>
+	<command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-g_int15</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-O_int15</command>
+	<command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-O_int15</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">HDF5/hdf5-1.8.15-patch1</command>
-        <command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1</command>
+	<command name="load">HDF5/hdf5-1.8.15-patch1</command>
+	<command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">HDF5/hdf5-1.8.15-patch1_parallel</command>
-        <command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1_parallel</command>
-        <command name="load">PARALLEL_NETCDF/parallel-netcdf-1.6.1</command>
+	<command name="load">HDF5/hdf5-1.8.15-patch1_parallel</command>
+	<command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1_parallel</command>
+	<command name="load">PARALLEL_NETCDF/parallel-netcdf-1.6.1</command>
       </modules>
       <modules>
-        <command name="load">CMAKE/cmake-3.3.0-rc1</command>
+	<command name="load">CMAKE/cmake-3.3.0-rc1</command>
       </modules>
       <modules compiler="intel">
-        <command name="unload">INTEL/intel_xe_2013.5.192</command>
-        <command name="unload">INTEL/intel_xe_2013</command>
-        <command name="unload">HDF5/hdf5-1.8.10-patch1</command>
-        <command name="load">INTEL/intel_xe_2015.3.187</command>
+	<command name="unload">INTEL/intel_xe_2013.5.192</command>
+	<command name="unload">INTEL/intel_xe_2013</command>
+	<command name="unload">HDF5/hdf5-1.8.10-patch1</command>
+	<command name="load">INTEL/intel_xe_2015.3.187</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -222,10 +222,10 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
-        <!-- <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg> -->
-        <arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
+	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+	<!-- <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg> -->
+	<arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -238,55 +238,55 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="rm">PrgEnv-pgi</command>
-        <command name="rm">PrgEnv-intel</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">pgi</command>
-        <command name="rm">cray</command>
-        <command name="rm">intel</command>
-        <command name="rm">cray-netcdf</command>
-        <command name="rm">gcc</command>
+	<command name="rm">PrgEnv-pgi</command>
+	<command name="rm">PrgEnv-intel</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">pgi</command>
+	<command name="rm">cray</command>
+	<command name="rm">intel</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">gcc</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel</command>
-        <command name="rm">intel</command>
-        <command name="load">intel/18.0.3.222</command>
-        <!-- the PrgEnv-intel loads a gcc compiler that causes several
-        problems -->
-        <command name="rm">gcc</command>
+	<command name="load">PrgEnv-intel</command>
+	<command name="rm">intel</command>
+	<command name="load">intel/18.0.3.222</command>
+	<!-- the PrgEnv-intel loads a gcc compiler that causes several
+	problems -->
+	<command name="rm">gcc</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">PrgEnv-pgi</command>
-        <command name="switch">pgi pgi/18.7.0</command>
+	<command name="load">PrgEnv-pgi</command>
+	<command name="switch">pgi pgi/18.7.0</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu</command>
-        <command name="switch">gcc gcc/6.3.0</command>
+	<command name="load">PrgEnv-gnu</command>
+	<command name="switch">gcc gcc/6.3.0</command>
       </modules>
       <modules compiler="cray">
-        <command name="load">PrgEnv-cray</command>
-        <command name="switch">cce cce/8.5.8</command>
+	<command name="load">PrgEnv-cray</command>
+	<command name="switch">cce cce/8.5.8</command>
       </modules>
       <modules>
-        <command name="load">papi/5.5.1.1</command>
-        <command name="switch">cray-mpich cray-mpich/7.7.1</command>
-        <command name="switch">cray-libsci cray-libsci/18.04.1</command>
-        <command name="load">torque/6.0.4</command>
+	<command name="load">papi/5.5.1.1</command>
+	<command name="switch">cray-mpich cray-mpich/7.7.1</command>
+	<command name="switch">cray-libsci cray-libsci/18.04.1</command>
+	<command name="load">torque/6.0.4</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.6.1.0</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.3</command>
+	<command name="load">cray-hdf5-parallel/1.10.2.0</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.1.0</command>
+	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">cray-netcdf/4.6.1.0</command>
+	<command name="load">cray-netcdf/4.6.1.0</command>
       </modules>
       <modules>
-        <command name="load">cmake/3.1.3</command>
-        <command name="rm">darshan</command>
-        <command name="use">/sw/modulefiles/CESM</command>
-        <command name="load">CESM-ENV</command>
+	<command name="load">cmake/3.1.3</command>
+	<command name="rm">darshan</command>
+	<command name="use">/sw/modulefiles/CESM</command>
+	<command name="load">CESM-ENV</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -323,7 +323,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec</executable>
       <arguments>
-        <arg name="ntasks"> -np {{ total_tasks }} </arg>
+	<arg name="ntasks"> -np {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
@@ -336,12 +336,12 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules compiler="gnu">
-        <command name="load">compiler/gnu/8.2.0</command>
-        <command name="load">mpi/3.3/gcc-8.2.0</command>
-        <command name="load">tool/netcdf/4.6.1/gcc-8.1.0</command>
+	<command name="load">compiler/gnu/8.2.0</command>
+	<command name="load">mpi/3.3/gcc-8.2.0</command>
+	<command name="load">tool/netcdf/4.6.1/gcc-8.1.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -375,13 +375,13 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -394,21 +394,21 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules>
-        <command name="load">ncarenv/1.3</command>
+	<command name="load">ncarenv/1.3</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">pgi/20.4</command>
+	<command name="load">pgi/20.4</command>
       </modules>
       <modules mpilib="openmpi" compiler="pgi">
-        <command name="load">openmpi/3.1.4</command>
-        <command name="load">netcdf-mpi/4.7.3</command>
-        <command name="load">pnetcdf/1.12.1</command>
+	<command name="load">openmpi/3.1.4</command>
+	<command name="load">netcdf-mpi/4.7.3</command>
+	<command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules>
-        <command name="load">ncarcompilers/0.5.0</command>
+	<command name="load">ncarcompilers/0.5.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -451,30 +451,30 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-        <arg name="labelstdout">-p "%g:"</arg>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
-        <!-- the omplace argument needs to be last -->
-        <arg name="zthreadplacement"> omplace -tm open64 </arg>
+	<arg name="labelstdout">-p "%g:"</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<!-- the omplace argument needs to be last -->
+	<arg name="zthreadplacement"> omplace -tm open64 </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpt" queue="share">
       <executable>mpirun `hostname`</executable>
       <arguments>
-        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
-        <!-- the omplace argument needs to be last -->
-        <arg name="zthreadplacement"> omplace -tm open64 </arg>
+	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+	<!-- the omplace argument needs to be last -->
+	<arg name="zthreadplacement"> omplace -tm open64 </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="default" unit_testing="true">
       <!-- The only place we can build and run the unit tests is on cheyenne's
-           shared nodes. However, running mpi jobs on the shared nodes currently
-           requires some workarounds; these workarounds are implemented here -->
+	   shared nodes. However, running mpi jobs on the shared nodes currently
+	   requires some workarounds; these workarounds are implemented here -->
       <executable>/opt/sgi/mpt/mpt-2.15/bin/mpirun $ENV{UNIT_TEST_HOST} -np 1 </executable>
     </mpirun>
     <module_system type="module">
@@ -487,83 +487,83 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">ncarenv/1.3</command>
-        <command name="load">cmake</command>
+	<command name="purge"/>
+	<command name="load">ncarenv/1.3</command>
+	<command name="load">cmake</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/19.0.5</command>
-        <command name="load">esmf_libs</command>
-        <command name="load">mkl</command>
+	<command name="load">intel/19.0.5</command>
+	<command name="load">esmf_libs</command>
+	<command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gnu/9.1.0</command>
-        <command name="load">openblas/0.3.6</command>
+	<command name="load">gnu/9.1.0</command>
+	<command name="load">openblas/0.3.6</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">pgi/19.3</command>
+	<command name="load">pgi/19.3</command>
       </modules>
 
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpiuni-g</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpiuni-O</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpiuni-O</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
       </modules>
 
       <modules mpilib="mpt" compiler="gnu">
-        <command name="load">mpt/2.21</command>
-        <command name="load">netcdf-mpi/4.7.3</command>
-        <command name="load">pnetcdf/1.12.1</command>
+	<command name="load">mpt/2.21</command>
+	<command name="load">netcdf-mpi/4.7.3</command>
+	<command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
-        <command name="load">mpt/2.21</command>
-        <!-- known failure in parallel netcdf with mpt, use serial -->
-        <command name="load">netcdf/4.7.3</command>
-        <command name="load">pnetcdf/1.12.1</command>
+	<command name="load">mpt/2.21</command>
+	<!-- known failure in parallel netcdf with mpt, use serial -->
+	<command name="load">netcdf/4.7.3</command>
+	<command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules mpilib="mpt" compiler="pgi">
-        <command name="load">mpt/2.19</command>
-        <command name="load">netcdf-mpi/4.7.1</command>
-        <command name="load">pnetcdf/1.11.1</command>
+	<command name="load">mpt/2.19</command>
+	<command name="load">netcdf-mpi/4.7.1</command>
+	<command name="load">pnetcdf/1.11.1</command>
       </modules>
       <modules mpilib="openmpi" compiler="pgi">
-        <command name="load">openmpi/3.1.4</command>
-        <command name="load">netcdf/4.7.1</command>
+	<command name="load">openmpi/3.1.4</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules mpilib="openmpi" compiler="gnu">
-        <command name="load">openmpi/3.1.4</command>
-        <command name="load">netcdf/4.7.1</command>
+	<command name="load">openmpi/3.1.4</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules>
-        <command name="load">ncarcompilers/0.5.0</command>
+	<command name="load">ncarcompilers/0.5.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial">
-        <command name="load">netcdf/4.7.1</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
-        <command name="load">netcdf/4.7.1</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules compiler="pgi" mpilib="mpi-serial">
-        <command name="load">netcdf/4.7.1</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -572,7 +572,6 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_TYPE_DEPTH">16</env>
       <env name="MPI_IB_CONGESTED">1</env>
       <env name="MPI_USE_ARRAY"/>
-      <env source="sh">/glade/scratch/jedwards/dothis</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>
@@ -617,9 +616,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
       <arguments>
-        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
-        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
-        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+	<arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+	<arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -632,13 +631,13 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gcc-6.3.0</command>
-        <command name="load">mvapich2-2.2-psm/gcc-6.3.0</command>
-        <command name="load">General/netcdf/4.4.1.1/gcc-6.3.0</command>
-        <command name="load">Python/2.7.13/gcc-6.3.0</command>
+	<command name="load">gcc-6.3.0</command>
+	<command name="load">mvapich2-2.2-psm/gcc-6.3.0</command>
+	<command name="load">General/netcdf/4.4.1.1/gcc-6.3.0</command>
+	<command name="load">Python/2.7.13/gcc-6.3.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -670,30 +669,30 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
       <arguments>
-        <arg name="mpi">--mpi=none</arg>
-        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
-        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
-        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+	<arg name="mpi">--mpi=none</arg>
+	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+	<arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+	<arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mvapich">
       <executable>srun</executable>
       <arguments>
-        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
-        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
-        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+	<arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+	<arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="intelmpi">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+	<arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+	<arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -704,32 +703,32 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules>
-        <command name="load">perl/5.20.0</command>
-        <command name="load">cmake/2.8.12</command>
+	<command name="load">perl/5.20.0</command>
+	<command name="load">cmake/2.8.12</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/15.0.1</command>
-        <command name="load">netcdf/4.3.2</command>
-        <command name="load">mkl/15.0.1</command>
+	<command name="load">intel/15.0.1</command>
+	<command name="load">netcdf/4.3.2</command>
+	<command name="load">mkl/15.0.1</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">pgi/14.10</command>
-        <command name="load">netcdf/4.3.2</command>
+	<command name="load">pgi/14.10</command>
+	<command name="load">netcdf/4.3.2</command>
       </modules>
       <modules mpilib="mvapich">
-        <command name="load">mvapich2/2.1</command>
+	<command name="load">mvapich2/2.1</command>
       </modules>
       <modules mpilib="mvapich2">
-        <command name="load">mvapich2/2.1</command>
+	<command name="load">mvapich2/2.1</command>
       </modules>
       <modules mpilib="intelmpi">
-        <command name="load">intelmpi/5.0.1.035</command>
+	<command name="load">intelmpi/5.0.1.035</command>
       </modules>
       <modules mpilib="openmpi">
-        <command name="load">openmpi/1.8.3</command>
+	<command name="load">openmpi/1.8.3</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -766,9 +765,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-        <arg name="label"> --label</arg>
-        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
-        <arg name="binding"> -c {{ srun_binding }}</arg>
+	<arg name="label"> --label</arg>
+	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
+	<arg name="binding"> -c {{ srun_binding }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -781,66 +780,66 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="rm">PrgEnv-intel</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">intel</command>
-        <command name="rm">cce</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">cray-parallel-hdf5</command>
-        <command name="rm">pmi</command>
-        <command name="rm">cray-libsci</command>
-        <command name="rm">cray-mpich2</command>
-        <command name="rm">cray-mpich</command>
-        <command name="rm">cray-netcdf</command>
-        <command name="rm">cray-hdf5</command>
-        <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="rm">craype-sandybridge</command>
-        <command name="rm">craype-ivybridge</command>
-        <command name="rm">craype</command>
+	<command name="rm">PrgEnv-intel</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">intel</command>
+	<command name="rm">cce</command>
+	<command name="rm">cray-parallel-netcdf</command>
+	<command name="rm">cray-parallel-hdf5</command>
+	<command name="rm">pmi</command>
+	<command name="rm">cray-libsci</command>
+	<command name="rm">cray-mpich2</command>
+	<command name="rm">cray-mpich</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">cray-hdf5</command>
+	<command name="rm">cray-netcdf-hdf5parallel</command>
+	<command name="rm">craype-sandybridge</command>
+	<command name="rm">craype-ivybridge</command>
+	<command name="rm">craype</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel</command>
-        <command name="switch">intel intel/19.0.3.199</command>
-        <command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
+	<command name="load">PrgEnv-intel</command>
+	<command name="switch">intel intel/19.0.3.199</command>
+	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-haswell</command>
+	<command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-haswell</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" >
-        <command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-haswell</command>
+	<command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-haswell</command>
       </modules>
 
       <modules compiler="cray">
-        <command name="load">PrgEnv-cray</command>
-        <command name="switch">cce cce/8.7.9</command>
+	<command name="load">PrgEnv-cray</command>
+	<command name="switch">cce cce/8.7.9</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu</command>
-        <command name="switch">gcc gcc/8.3.0</command>
+	<command name="load">PrgEnv-gnu</command>
+	<command name="switch">gcc gcc/8.3.0</command>
       </modules>
       <modules>
-        <command name="load">cray-memkind</command>
-        <command name="swap">craype craype/2.6.2</command>
+	<command name="load">cray-memkind</command>
+	<command name="swap">craype craype/2.6.2</command>
       </modules>
       <modules>
-        <command name="switch">cray-libsci/19.06.1</command>
+	<command name="switch">cray-libsci/19.06.1</command>
       </modules>
       <modules>
-        <command name="load">cray-mpich/7.7.10</command>
+	<command name="load">cray-mpich/7.7.10</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">cray-hdf5/1.10.5.2</command>
-        <command name="load">cray-netcdf/4.6.3.2</command>
+	<command name="load">cray-hdf5/1.10.5.2</command>
+	<command name="load">cray-netcdf/4.6.3.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
-        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
-        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.2</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
       <modules>
-        <command name="load">cmake/3.14.4</command>
+	<command name="load">cmake/3.14.4</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -872,9 +871,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-        <arg name="label"> --label</arg>
-        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
-        <arg name="binding"> -c {{ srun_binding }} --cpu_bind=cores</arg>
+	<arg name="label"> --label</arg>
+	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
+	<arg name="binding"> -c {{ srun_binding }} --cpu_bind=cores</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -887,63 +886,63 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="rm">craype-mic-knl</command>
-        <command name="rm">craype-haswell</command>
-        <command name="rm">PrgEnv-intel</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">intel</command>
-        <command name="rm">cce</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">cray-parallel-hdf5</command>
-        <command name="rm">pmi</command>
-        <command name="rm">cray-libsci</command>
-        <command name="rm">cray-mpich2</command>
-        <command name="rm">cray-mpich</command>
-        <command name="rm">cray-netcdf</command>
-        <command name="rm">cray-hdf5</command>
-        <command name="rm">cray-netcdf-hdf5parallel</command>
+	<command name="rm">craype-mic-knl</command>
+	<command name="rm">craype-haswell</command>
+	<command name="rm">PrgEnv-intel</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">intel</command>
+	<command name="rm">cce</command>
+	<command name="rm">cray-parallel-netcdf</command>
+	<command name="rm">cray-parallel-hdf5</command>
+	<command name="rm">pmi</command>
+	<command name="rm">cray-libsci</command>
+	<command name="rm">cray-mpich2</command>
+	<command name="rm">cray-mpich</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">cray-hdf5</command>
+	<command name="rm">cray-netcdf-hdf5parallel</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel</command>
-        <command name="switch">intel intel/19.0.3.199</command>
-        <command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
+	<command name="load">PrgEnv-intel</command>
+	<command name="switch">intel intel/19.0.3.199</command>
+	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-knl</command>
+	<command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-knl</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" >
-        <command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-knl</command>
+	<command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-knl</command>
       </modules>
 
       <modules compiler="cray">
-        <command name="load">PrgEnv-cray</command>
-        <command name="switch">cce cce/9.1.0</command>
+	<command name="load">PrgEnv-cray</command>
+	<command name="switch">cce cce/9.1.0</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu</command>
-        <command name="switch">gcc gcc/8.3.0</command>
+	<command name="load">PrgEnv-gnu</command>
+	<command name="switch">gcc gcc/8.3.0</command>
       </modules>
       <modules>
-        <command name="load">cray-memkind</command>
-        <command name="swap">craype craype/2.6.2</command>
-        <command name="load">craype-mic-knl</command>
+	<command name="load">cray-memkind</command>
+	<command name="swap">craype craype/2.6.2</command>
+	<command name="load">craype-mic-knl</command>
       </modules>
       <modules>
-        <command name="switch">cray-libsci/19.06.1</command>
+	<command name="switch">cray-libsci/19.06.1</command>
       </modules>
       <modules>
-        <command name="load">cray-mpich/7.7.10</command>
+	<command name="load">cray-mpich/7.7.10</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">cray-hdf5/1.10.5.2</command>
-        <command name="load">cray-netcdf/4.6.3.2</command>
+	<command name="load">cray-hdf5/1.10.5.2</command>
+	<command name="load">cray-netcdf/4.6.3.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
-        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
-        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.2</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -972,8 +971,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
-        <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
+	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="none"/>
@@ -1001,20 +1000,20 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich">
       <executable>srun</executable>
       <arguments>
-        <arg name="num_tasks"> --ntasks={{ total_tasks }}</arg>
-        <arg name="cpubind"> --cpu_bind=sockets</arg>
-        <arg name="cpubind"> --cpu_bind=verbose</arg>
-        <arg name="killonbadexit"> --kill-on-bad-exit</arg>
+	<arg name="num_tasks"> --ntasks={{ total_tasks }}</arg>
+	<arg name="cpubind"> --cpu_bind=sockets</arg>
+	<arg name="cpubind"> --cpu_bind=verbose</arg>
+	<arg name="killonbadexit"> --kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
       <arguments>
-        <arg name="mpinone"> --mpi=none</arg>
-        <arg name="num_tasks"> --ntasks={{ total_tasks }}</arg>
-        <arg name="cpubind"> --cpu_bind=sockets</arg>
-        <arg name="cpubind"> --cpu_bind=verbose</arg>
-        <arg name="killonbadexit"> --kill-on-bad-exit</arg>
+	<arg name="mpinone"> --mpi=none</arg>
+	<arg name="num_tasks"> --ntasks={{ total_tasks }}</arg>
+	<arg name="cpubind"> --cpu_bind=sockets</arg>
+	<arg name="cpubind"> --cpu_bind=verbose</arg>
+	<arg name="killonbadexit"> --kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1025,12 +1024,12 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">perl/5.20.7</command>
-        <command name="load">cmake/3.0.0</command>
-        <command name="load">pgi/15.5</command>
-        <command name="load">mpi/mvapich2/1.5.1p1/pgi11.3</command>
-        <command name="load">netcdf/4.1.2/pgi</command>
+	<command name="purge"/>
+	<command name="load">perl/5.20.7</command>
+	<command name="load">cmake/3.0.0</command>
+	<command name="load">pgi/15.5</command>
+	<command name="load">mpi/mvapich2/1.5.1p1/pgi11.3</command>
+	<command name="load">netcdf/4.1.2/pgi</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1058,9 +1057,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-        <arg name="label"> --label</arg>
-        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
-        <arg name="thread_count" > -c {{ srun_binding }}</arg>
+	<arg name="label"> --label</arg>
+	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
+	<arg name="thread_count" > -c {{ srun_binding }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1073,63 +1072,63 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="rm">PrgEnv-intel</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">intel</command>
-        <command name="rm">cce</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">cray-parallel-hdf5</command>
-        <command name="rm">pmi</command>
-        <command name="rm">cray-libsci</command>
-        <command name="rm">cray-mpich2</command>
-        <command name="rm">cray-mpich</command>
-        <command name="rm">cray-netcdf</command>
-        <command name="rm">cray-hdf5</command>
-        <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="rm">craype-sandybridge</command>
-        <command name="rm">craype-ivybridge</command>
-        <command name="rm">craype</command>
+	<command name="rm">PrgEnv-intel</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">intel</command>
+	<command name="rm">cce</command>
+	<command name="rm">cray-parallel-netcdf</command>
+	<command name="rm">cray-parallel-hdf5</command>
+	<command name="rm">pmi</command>
+	<command name="rm">cray-libsci</command>
+	<command name="rm">cray-mpich2</command>
+	<command name="rm">cray-mpich</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">cray-hdf5</command>
+	<command name="rm">cray-netcdf-hdf5parallel</command>
+	<command name="rm">craype-sandybridge</command>
+	<command name="rm">craype-ivybridge</command>
+	<command name="rm">craype</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel</command>
-        <command name="switch">intel intel/18.0.1.163</command>
-        <command name="rm">cray-libsci</command>
-        <command name="use">/global/project/projectdirs/ccsm1/modulefiles/edison</command>
+	<command name="load">PrgEnv-intel</command>
+	<command name="switch">intel intel/18.0.1.163</command>
+	<command name="rm">cray-libsci</command>
+	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/edison</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O</command>
+	<command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" >
-        <command name="load">esmf/6.3.0rp1-defio-intel17.0-mpiuni-O</command>
+	<command name="load">esmf/6.3.0rp1-defio-intel17.0-mpiuni-O</command>
       </modules>
       <modules compiler="cray">
-        <command name="load">PrgEnv-cray</command>
-        <command name="switch">cce cce/8.6.5</command>
-        <command name="switch">cray-libsci/18.03.1</command>
+	<command name="load">PrgEnv-cray</command>
+	<command name="switch">cce cce/8.6.5</command>
+	<command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu</command>
-        <command name="switch">gcc gcc/7.3.0</command>
-        <command name="switch">cray-libsci/18.03.1</command>
+	<command name="load">PrgEnv-gnu</command>
+	<command name="switch">gcc gcc/7.3.0</command>
+	<command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules>
-        <command name="load">papi/5.5.1.4</command>
-        <command name="swap">craype craype/2.5.14</command>
-        <command name="load">craype-ivybridge</command>
+	<command name="load">papi/5.5.1.4</command>
+	<command name="swap">craype craype/2.5.14</command>
+	<command name="load">craype-ivybridge</command>
       </modules>
       <modules>
-        <command name="load">cray-mpich/7.7.0</command>
+	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">cray-hdf5/1.10.1.1</command>
-        <command name="load">cray-netcdf/4.4.1.1.6</command>
+	<command name="load">cray-hdf5/1.10.1.1</command>
+	<command name="load">cray-netcdf/4.4.1.1.6</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-        <command name="load">cray-hdf5-parallel/1.10.1.1</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.3</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
+	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
+	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
     </module_system>
 
@@ -1160,9 +1159,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mpich">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
-        <arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+	<arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
+	<arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
@@ -1178,25 +1177,25 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules>
-        <command name="load">new</command>
+	<command name="load">new</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/2018.1</command>
+	<command name="load">intel/2018.1</command>
       </modules>
       <modules>
-        <command name="load">netcdf/4.3.1</command>
+	<command name="load">netcdf/4.3.1</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">pgi/14.1</command>
+	<command name="load">pgi/14.1</command>
       </modules>
       <modules mpilib="mpich">
-        <command name="load">mvapich2/1.8.1</command>
+	<command name="load">mvapich2/1.8.1</command>
       </modules>
       <modules mpilib="openmpi">
-        <command name="load">open_mpi/1.6.5</command>
+	<command name="load">open_mpi/1.6.5</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1223,9 +1222,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mpich">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
-        <arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+	<arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
+	<arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
@@ -1241,28 +1240,28 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules>
-        <command name="load">new</command>
+	<command name="load">new</command>
       </modules>
       <modules>
-        <command name="load">interconnect/ethernet</command>
+	<command name="load">interconnect/ethernet</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/2018.1</command>
+	<command name="load">intel/2018.1</command>
       </modules>
       <modules>
-        <command name="load">netcdf/4.3.1</command>
+	<command name="load">netcdf/4.3.1</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">pgi/14.1</command>
+	<command name="load">pgi/14.1</command>
       </modules>
       <modules mpilib="mpich">
-        <command name="load">mvapich2/1.8.1</command>
+	<command name="load">mvapich2/1.8.1</command>
       </modules>
       <modules mpilib="openmpi">
-        <command name="load">open_mpi/1.6.5</command>
+	<command name="load">open_mpi/1.6.5</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1289,9 +1288,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mpich">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
-        <arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+	<arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
+	<arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
@@ -1307,13 +1306,13 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules>
-        <command name="load">new</command>
+	<command name="load">new</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/2018.1</command>
+	<command name="load">intel/2018.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1340,11 +1339,11 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
-        <arg name="hyperthreading" default="2"> -j {{ hyperthreading }}</arg>
-        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
-        <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
-        <arg name="tasks_per_node" > -N $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
+	<arg name="hyperthreading" default="2"> -j {{ hyperthreading }}</arg>
+	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
+	<arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
+	<arg name="tasks_per_node" > -N $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1355,28 +1354,28 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="rm">PrgEnv-pgi</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">pgi</command>
-        <command name="rm">cray</command>
+	<command name="rm">PrgEnv-pgi</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">pgi</command>
+	<command name="rm">cray</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">PrgEnv-pgi</command>
-        <command name="switch">pgi pgi/12.5.0</command>
+	<command name="load">PrgEnv-pgi</command>
+	<command name="switch">pgi pgi/12.5.0</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu</command>
-        <command name="load">torque</command>
+	<command name="load">PrgEnv-gnu</command>
+	<command name="load">torque</command>
       </modules>
       <modules compiler="cray">
-        <command name="load">PrgEnv-cray/4.0.36</command>
-        <command name="load">cce/8.0.2</command>
+	<command name="load">PrgEnv-cray/4.0.36</command>
+	<command name="load">cce/8.0.2</command>
       </modules>
       <modules>
-        <command name="load">torque/4.1.3</command>
-        <command name="load">netcdf-hdf5parallel/4.2.0</command>
-        <command name="load">parallel-netcdf/1.2.0</command>
+	<command name="load">torque/4.1.3</command>
+	<command name="load">netcdf-hdf5parallel/4.2.0</command>
+	<command name="load">parallel-netcdf/1.2.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1406,14 +1405,14 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>mpiexec</executable>
       <arguments>
-        <arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
+	<arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
+	<arg name="num_tasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpiexec</executable>
       <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
+	<arg name="num_tasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
@@ -1426,38 +1425,38 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"></command>
+	<command name="purge"></command>
       </modules>
       <modules compiler="intel">
-        <command name="load">compiler/intel/18.0.3</command>
-        <command name="load">tool/netcdf/4.6.1/intel</command>
+	<command name="load">compiler/intel/18.0.3</command>
+	<command name="load">tool/netcdf/4.6.1/intel</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich2">
-        <command name="load">mpi/intel/mvapich2-2.3rc2-intel-18.0.3</command>
+	<command name="load">mpi/intel/mvapich2-2.3rc2-intel-18.0.3</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">compiler/pgi/18.1</command>
-        <command name="load">tool/netcdf/4.6.1/pgi</command>
+	<command name="load">compiler/pgi/18.1</command>
+	<command name="load">tool/netcdf/4.6.1/pgi</command>
       </modules>
       <modules compiler="nag">
-        <command name="load">compiler/nag/6.2</command>
-        <command name="load">tool/netcdf/4.6.1/nag</command>
+	<command name="load">compiler/nag/6.2</command>
+	<command name="load">tool/netcdf/4.6.1/nag</command>
       </modules>
       <modules compiler="nag" mpilib="mvapich2">
-        <command name="load">mpi/nag/mvapich2-2.3rc2</command>
+	<command name="load">mpi/nag/mvapich2-2.3rc2</command>
       </modules>
       <modules compiler="nag" mpilib="openmpi">
-        <command name="load">mpi/nag/openmpi-3.1.0</command>
+	<command name="load">mpi/nag/openmpi-3.1.0</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">compiler/gnu/8.1.0</command>
-        <command name="load">tool/netcdf/4.6.1/gcc</command>
+	<command name="load">compiler/gnu/8.1.0</command>
+	<command name="load">tool/netcdf/4.6.1/gcc</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-        <command name="load">mpi/gcc/openmpi-3.1.0a</command>
+	<command name="load">mpi/gcc/openmpi-3.1.0a</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich2">
-        <command name="load">mpi/gcc/mvapich2-2.3rc2-qlc</command>
+	<command name="load">mpi/gcc/mvapich2-2.3rc2-qlc</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1511,8 +1510,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
-        <arg name="labelstdout">-prepend-rank</arg>
+	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="labelstdout">-prepend-rank</arg>
       </arguments>
     </mpirun>
     <module_system type="none"/>
@@ -1542,14 +1541,14 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>mpiexec</executable>
       <arguments>
-        <arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
+	<arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
+	<arg name="num_tasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpiexec</executable>
       <arguments>
-        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
+	<arg name="num_tasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
@@ -1562,35 +1561,35 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"></command>
+	<command name="purge"></command>
       </modules>
       <modules compiler="intel">
-        <command name="load">compiler/intel/20.0.1</command>
-        <command name="load">tool/netcdf/4.7.4/intel/20.0.1</command>
+	<command name="load">compiler/intel/20.0.1</command>
+	<command name="load">tool/netcdf/4.7.4/intel/20.0.1</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich2">
-        <command name="load">mpi/2.3.3/intel/20.0.1</command>
+	<command name="load">mpi/2.3.3/intel/20.0.1</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">compiler/pgi/20.1</command>
-        <command name="load">tool/netcdf/4.7.4/pgi/20.1</command>
+	<command name="load">compiler/pgi/20.1</command>
+	<command name="load">tool/netcdf/4.7.4/pgi/20.1</command>
       </modules>
       <modules compiler="nag">
-        <command name="load">compiler/nag/6.2-8.1.0</command>
-        <command name="load">tool/netcdf/c4.6.1-f4.4.4/nag-gnu/6.2-8.1.0</command>
+	<command name="load">compiler/nag/6.2-8.1.0</command>
+	<command name="load">tool/netcdf/c4.6.1-f4.4.4/nag-gnu/6.2-8.1.0</command>
       </modules>
       <modules compiler="nag" mpilib="mvapich2">
-        <command name="load">mpi/2.3.3/nag/6.2</command>
+	<command name="load">mpi/2.3.3/nag/6.2</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">compiler/gnu/9.3.0</command>
-        <command name="load">tool/netcdf/4.7.4/gnu/9.3.0</command>
+	<command name="load">compiler/gnu/9.3.0</command>
+	<command name="load">tool/netcdf/4.7.4/gnu/9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-        <command name="load">openmpi/4.0.3/gnu/9.3.0</command>
+	<command name="load">openmpi/4.0.3/gnu/9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich2">
-        <command name="load">mpi/2.3.3/gnu/9.3.0</command>
+	<command name="load">mpi/2.3.3/gnu/9.3.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1631,8 +1630,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-        <arg name="labelstdout">-p "%g:"</arg>
-        <arg name="threadplacement"> omplace </arg>
+	<arg name="labelstdout">-p "%g:"</arg>
+	<arg name="threadplacement"> omplace </arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1645,35 +1644,35 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">ncarenv/1.3</command>
-        <command name="load">cmake/3.16.4</command>
+	<command name="purge"/>
+	<command name="load">ncarenv/1.3</command>
+	<command name="load">cmake/3.16.4</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/19.0.5</command>
-        <command name="load">mkl</command>
+	<command name="load">intel/19.0.5</command>
+	<command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gnu/9.1.0</command>
-        <command name="load">openblas/0.3.6</command>
+	<command name="load">gnu/9.1.0</command>
+	<command name="load">openblas/0.3.6</command>
       </modules>
       <modules mpilib="mpt">
-        <command name="load">mpt/2.21</command>
-        <command name="load">netcdf-mpi/4.7.3</command>
+	<command name="load">mpt/2.21</command>
+	<command name="load">netcdf-mpi/4.7.3</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
-        <command name="load">pnetcdf/1.12.1</command>
-        <command name="load">pio/2.4.4</command>
+	<command name="load">pnetcdf/1.12.1</command>
+	<command name="load">pio/2.4.4</command>
       </modules>
       <modules mpilib="openmpi">
-        <command name="load">openmpi/3.1.4</command>
-        <command name="load">netcdf-mpi/4.7.3</command>
+	<command name="load">openmpi/3.1.4</command>
+	<command name="load">netcdf-mpi/4.7.3</command>
       </modules>
       <modules>
-        <command name="load">ncarcompilers/0.5.0</command>
+	<command name="load">ncarcompilers/0.5.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">netcdf/4.7.3</command>
+	<command name="load">netcdf/4.7.3</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1702,8 +1701,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks">-np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE </arg>
+	<arg name="num_tasks">-np {{ total_tasks }}</arg>
+	<arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE </arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1716,20 +1715,20 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
       <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">cmake</command>
-        <command name="load">perl xml-libxml switch python/2.7</command>
+	<command name="purge"/>
+	<command name="load">cmake</command>
+	<command name="load">perl xml-libxml switch python/2.7</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/2016.4.072</command>
-        <command name="load">mkl</command>
+	<command name="load">intel/2016.4.072</command>
+	<command name="load">mkl</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
-        <command name="load">netcdf/4.4.1.1-intel-s</command>
+	<command name="load">netcdf/4.4.1.1-intel-s</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial">
-        <command name="load">openmpi</command>
-        <command name="load">netcdf/4.4.1.1-intel-p</command>
+	<command name="load">openmpi</command>
+	<command name="load">netcdf/4.4.1.1-intel-p</command>
       </modules>
     </module_system>
   </machine>
@@ -1754,8 +1753,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1768,20 +1767,20 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
       <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">cmake</command>
-        <command name="load">perl xml-libxml switch python/2.7</command>
+	<command name="purge"/>
+	<command name="load">cmake</command>
+	<command name="load">perl xml-libxml switch python/2.7</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/2016.4.072</command>
-        <command name="load">mkl</command>
+	<command name="load">intel/2016.4.072</command>
+	<command name="load">mkl</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
-        <command name="load">netcdf/4.4.1.1-intel-s</command>
+	<command name="load">netcdf/4.4.1.1-intel-s</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial">
-        <command name="load">openmpi</command>
-        <command name="load">netcdf/4.4.1.1-intel-p</command>
+	<command name="load">openmpi</command>
+	<command name="load">netcdf/4.4.1.1-intel-p</command>
       </modules>
     </module_system>
   </machine>
@@ -1807,7 +1806,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <!-- allow ls5 modules to write to stderr without cime error -->
@@ -1822,21 +1821,21 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
 
       <modules>
-        <command name="reset"/>
-        <command name="load">cmake</command>
+	<command name="reset"/>
+	<command name="load">cmake</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/18.0.2</command>
+	<command name="load">intel/18.0.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">netcdf/4.6.2</command>
+	<command name="load">netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpich">
-        <command name="load">cray_mpich</command>
+	<command name="load">cray_mpich</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">pnetcdf/1.8.0</command>
-        <command name="load">parallel-netcdf/4.6.2</command>
+	<command name="load">pnetcdf/1.8.0</command>
+	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
     </module_system>
   </machine>
@@ -1866,8 +1865,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to hwthread</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to hwthread</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1880,26 +1879,26 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">sems-env</command>
-        <command name="load">acme-env</command>
-        <command name="load">sems-git</command>
-        <command name="load">sems-python/2.7.9</command>
-        <command name="load">sems-cmake/2.8.12</command>
+	<command name="purge"/>
+	<command name="load">sems-env</command>
+	<command name="load">acme-env</command>
+	<command name="load">sems-git</command>
+	<command name="load">sems-python/2.7.9</command>
+	<command name="load">sems-cmake/2.8.12</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">sems-gcc/5.3.0</command>
+	<command name="load">sems-gcc/5.3.0</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">sems-intel/16.0.3</command>
+	<command name="load">sems-intel/16.0.3</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">sems-netcdf/4.4.1/exo</command>
-        <command name="load">acme-pfunit/3.2.8/base</command>
+	<command name="load">sems-netcdf/4.4.1/exo</command>
+	<command name="load">acme-pfunit/3.2.8/base</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">sems-openmpi/1.8.7</command>
-        <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
+	<command name="load">sems-openmpi/1.8.7</command>
+	<command name="load">sems-netcdf/4.4.1/exo_parallel</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1934,15 +1933,15 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>/usr/bin/runjob</executable>
       <arguments>
-        <arg name="label"> --label short</arg>
-        <!-- Ranks per node!! -->
-        <arg name="tasks_per_node"> --ranks-per-node $MAX_MPITASKS_PER_NODE</arg>
-        <!-- Total MPI Tasks -->
-        <arg name="num_tasks"> --np {{ total_tasks }}</arg>
-        <arg name="locargs">--block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
-        <arg name="bg_threadlayout"> --envs BG_THREADLAYOUT=1</arg>
-        <arg name="omp_stacksize"> --envs OMP_STACKSIZE=32M</arg>
-        <arg name="thread_count"> --envs OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
+	<arg name="label"> --label short</arg>
+	<!-- Ranks per node!! -->
+	<arg name="tasks_per_node"> --ranks-per-node $MAX_MPITASKS_PER_NODE</arg>
+	<!-- Total MPI Tasks -->
+	<arg name="num_tasks"> --np {{ total_tasks }}</arg>
+	<arg name="locargs">--block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
+	<arg name="bg_threadlayout"> --envs BG_THREADLAYOUT=1</arg>
+	<arg name="omp_stacksize"> --envs OMP_STACKSIZE=32M</arg>
+	<arg name="thread_count"> --envs OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="soft">
@@ -1951,10 +1950,10 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">soft</cmd_path>
       <cmd_path lang="sh">soft</cmd_path>
       <modules>
-        <command name="add">+mpiwrapper-xl</command>
-        <command name="add">@ibm-compilers-2015-02</command>
-        <command name="add">+cmake</command>
-        <command name="add">+python</command>
+	<command name="add">+mpiwrapper-xl</command>
+	<command name="add">@ibm-compilers-2015-02</command>
+	<command name="add">+cmake</command>
+	<command name="add">+python</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1984,42 +1983,42 @@ This allows using a different mpirun command to launch unit tests
       <COSTPES_PER_NODE>12</COSTPES_PER_NODE>
       <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
       <mpirun mpilib="default">
-          <executable>mpirun</executable>
-          <arguments>
-              <arg name="num_tasks">-np {{ total_tasks }}</arg>
-              <arg name="tasks_per_node">-npernode $MAX_TASKS_PER_NODE</arg>
-          </arguments>
+	  <executable>mpirun</executable>
+	  <arguments>
+	      <arg name="num_tasks">-np {{ total_tasks }}</arg>
+	      <arg name="tasks_per_node">-npernode $MAX_TASKS_PER_NODE</arg>
+	  </arguments>
       </mpirun>
       <module_system type="module">
-          <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
-          <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
-          <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
-          <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
-          <cmd_path lang="sh">module</cmd_path>
-          <cmd_path lang="csh">module</cmd_path>
-          <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
-          <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
-          <modules>
-              <command name="purge"/>
-              <command name="load">perl/5.22.1</command>
-              <command name="load">libxml2/2.9.2</command>
-              <command name="load">maui/3.3.1</command>
-              <command name="load">python/2.7.13</command>
-          </modules>
-          <modules compiler="gnu">
-              <command name="load">gcc/5.4.0</command>
-              <command name="load">gfortran/5.4.0</command>
-              <command name="load">hdf5/1.8.19fates</command>
-              <command name="load">netcdf/4.4.1.1-gnu540-fates</command>
-              <command name="load">openmpi/2.1.1-gnu540</command>
-          </modules>
-          <modules compiler="gnu" mpilib="!mpi-serial">
-              <command name="load">openmpi/2.1.1-gnu540</command>
-          </modules>
+	  <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
+	  <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
+	  <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
+	  <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+	  <cmd_path lang="sh">module</cmd_path>
+	  <cmd_path lang="csh">module</cmd_path>
+	  <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+	  <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
+	  <modules>
+	      <command name="purge"/>
+	      <command name="load">perl/5.22.1</command>
+	      <command name="load">libxml2/2.9.2</command>
+	      <command name="load">maui/3.3.1</command>
+	      <command name="load">python/2.7.13</command>
+	  </modules>
+	  <modules compiler="gnu">
+	      <command name="load">gcc/5.4.0</command>
+	      <command name="load">gfortran/5.4.0</command>
+	      <command name="load">hdf5/1.8.19fates</command>
+	      <command name="load">netcdf/4.4.1.1-gnu540-fates</command>
+	      <command name="load">openmpi/2.1.1-gnu540</command>
+	  </modules>
+	  <modules compiler="gnu" mpilib="!mpi-serial">
+	      <command name="load">openmpi/2.1.1-gnu540</command>
+	  </modules>
       </module_system>
        <environment_variables>
-         <env name="HDF5_HOME">/data/software/hdf5/1.8.19fates</env>
-         <env name="NETCDF_PATH">/data/software/netcdf/4.4.1.1-gnu540-fates</env>
+	 <env name="HDF5_HOME">/data/software/hdf5/1.8.19fates</env>
+	 <env name="NETCDF_PATH">/data/software/netcdf/4.4.1.1-gnu540-fates</env>
        </environment_variables>
   </machine>
 
@@ -2043,9 +2042,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-        <arg name="mpi">--mpi=none</arg>
-        <arg name="num_tasks">-n={{ total_tasks }}</arg>
-        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+	<arg name="mpi">--mpi=none</arg>
+	<arg name="num_tasks">-n={{ total_tasks }}</arg>
+	<arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2056,11 +2055,11 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">precision/i4</command>
-        <command name="load">pgi/11.8</command>
-        <command name="load">mvapich2/1.7</command>
-        <command name="load">netcdf/4.1.3</command>
+	<command name="purge"/>
+	<command name="load">precision/i4</command>
+	<command name="load">pgi/11.8</command>
+	<command name="load">mvapich2/1.7</command>
+	<command name="load">netcdf/4.1.3</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2088,7 +2087,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+	<arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2101,15 +2100,15 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">nas</command>
-        <command name="load">pkgsrc</command>
-        <command name="load">comp-intel/2018.3.222</command>
-        <command name="load">mpi-sgi/mpt.2.15r20</command>
-        <command name="load">szip/2.1.1</command>
-        <command name="load">hdf4/4.2.12</command>
-        <command name="load">hdf5/1.8.18_mpt</command>
-        <command name="load">netcdf/4.4.1.1_mpt</command>
+	<command name="purge"/>
+	<command name="load">nas</command>
+	<command name="load">pkgsrc</command>
+	<command name="load">comp-intel/2018.3.222</command>
+	<command name="load">mpi-sgi/mpt.2.15r20</command>
+	<command name="load">szip/2.1.1</command>
+	<command name="load">hdf4/4.2.12</command>
+	<command name="load">hdf5/1.8.18_mpt</command>
+	<command name="load">netcdf/4.4.1.1_mpt</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2140,7 +2139,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+	<arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2153,15 +2152,15 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">nas</command>
-        <command name="load">pkgsrc</command>
-        <command name="load">comp-intel/2018.3.222</command>
-        <command name="load">mpi-sgi/mpt.2.15r20</command>
-        <command name="load">szip/2.1.1</command>
-        <command name="load">hdf4/4.2.12</command>
-        <command name="load">hdf5/1.8.18_mpt</command>
-        <command name="load">netcdf/4.4.1.1_mpt</command>
+	<command name="purge"/>
+	<command name="load">nas</command>
+	<command name="load">pkgsrc</command>
+	<command name="load">comp-intel/2018.3.222</command>
+	<command name="load">mpi-sgi/mpt.2.15r20</command>
+	<command name="load">szip/2.1.1</command>
+	<command name="load">hdf4/4.2.12</command>
+	<command name="load">hdf5/1.8.18_mpt</command>
+	<command name="load">netcdf/4.4.1.1_mpt</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2192,7 +2191,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+	<arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2205,15 +2204,15 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">nas</command>
-        <command name="load">pkgsrc</command>
-        <command name="load">comp-intel/2018.3.222</command>
-        <command name="load">mpi-sgi/mpt.2.15r20</command>
-        <command name="load">szip/2.1.1</command>
-        <command name="load">hdf4/4.2.12</command>
-        <command name="load">hdf5/1.8.18_mpt</command>
-        <command name="load">netcdf/4.4.1.1_mpt</command>
+	<command name="purge"/>
+	<command name="load">nas</command>
+	<command name="load">pkgsrc</command>
+	<command name="load">comp-intel/2018.3.222</command>
+	<command name="load">mpi-sgi/mpt.2.15r20</command>
+	<command name="load">szip/2.1.1</command>
+	<command name="load">hdf4/4.2.12</command>
+	<command name="load">hdf5/1.8.18_mpt</command>
+	<command name="load">netcdf/4.4.1.1_mpt</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2244,7 +2243,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+	<arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2257,15 +2256,15 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">nas</command>
-        <command name="load">pkgsrc</command>
-        <command name="load">comp-intel/2018.3.222</command>
-        <command name="load">mpi-sgi/mpt.2.15r20</command>
-        <command name="load">szip/2.1.1</command>
-        <command name="load">hdf4/4.2.12</command>
-        <command name="load">hdf5/1.8.18_mpt</command>
-        <command name="load">netcdf/4.4.1.1_mpt</command>
+	<command name="purge"/>
+	<command name="load">nas</command>
+	<command name="load">pkgsrc</command>
+	<command name="load">comp-intel/2018.3.222</command>
+	<command name="load">mpi-sgi/mpt.2.15r20</command>
+	<command name="load">szip/2.1.1</command>
+	<command name="load">hdf4/4.2.12</command>
+	<command name="load">hdf5/1.8.18_mpt</command>
+	<command name="load">netcdf/4.4.1.1_mpt</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2300,7 +2299,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2313,14 +2312,14 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">sems-env</command>
-        <command name="load">sems-git</command>
-        <command name="load">sems-python/2.7.9</command>
-        <command name="load">sems-gcc/5.1.0</command>
-        <command name="load">sems-openmpi/1.8.7</command>
-        <command name="load">sems-cmake/2.8.12</command>
-        <command name="load">sems-netcdf/4.3.2/parallel</command>
+	<command name="purge"/>
+	<command name="load">sems-env</command>
+	<command name="load">sems-git</command>
+	<command name="load">sems-python/2.7.9</command>
+	<command name="load">sems-gcc/5.1.0</command>
+	<command name="load">sems-openmpi/1.8.7</command>
+	<command name="load">sems-cmake/2.8.12</command>
+	<command name="load">sems-netcdf/4.3.2/parallel</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2354,8 +2353,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2368,21 +2367,21 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">sems-env</command>
-        <command name="load">sems-git</command>
-        <command name="load">sems-python/2.7.9</command>
-        <command name="load">gnu/4.9.2</command>
-        <command name="load">intel/intel-15.0.3.187</command>
-        <command name="load">libraries/intel-mkl-15.0.2.164</command>
-        <command name="load">libraries/intel-mkl-15.0.2.164</command>
+	<command name="purge"/>
+	<command name="load">sems-env</command>
+	<command name="load">sems-git</command>
+	<command name="load">sems-python/2.7.9</command>
+	<command name="load">gnu/4.9.2</command>
+	<command name="load">intel/intel-15.0.3.187</command>
+	<command name="load">libraries/intel-mkl-15.0.2.164</command>
+	<command name="load">libraries/intel-mkl-15.0.2.164</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load" >openmpi-intel/1.8</command>
-        <command name="load" >sems-hdf5/1.8.12/parallel</command>
-        <command name="load" >sems-netcdf/4.3.2/parallel</command>
-        <command name="load" >sems-hdf5/1.8.12/base</command>
-        <command name="load" >sems-netcdf/4.3.2/base</command>
+	<command name="load" >openmpi-intel/1.8</command>
+	<command name="load" >sems-hdf5/1.8.12/parallel</command>
+	<command name="load" >sems-netcdf/4.3.2/parallel</command>
+	<command name="load" >sems-hdf5/1.8.12/base</command>
+	<command name="load" >sems-netcdf/4.3.2/base</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2414,13 +2413,13 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="impi">
       <executable>ibrun</executable>
       <arguments>
-        <arg name="ntasks"> -n {{ total_tasks }} </arg>
+	<arg name="ntasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mvapich2">
       <executable>ibrun</executable>
       <arguments>
-        <arg name="ntasks"> -n {{ total_tasks }} </arg>
+	<arg name="ntasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2433,25 +2432,25 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"></command>
-        <command name="load">TACC</command>
-        <command name="load">python/2.7.13</command>
-        <command name="load">intel/18.0.2</command>
-        <command name="load">cmake/3.16.1</command>
+	<command name="purge"></command>
+	<command name="load">TACC</command>
+	<command name="load">python/2.7.13</command>
+	<command name="load">intel/18.0.2</command>
+	<command name="load">cmake/3.16.1</command>
       </modules>
       <modules mpilib="mvapich2">
-        <command name="load">mvapich2/2.3.1</command>
-        <command name="load">pnetcdf/1.11</command>
-        <command name="load">parallel-netcdf/4.6.2</command>
+	<command name="load">mvapich2/2.3.1</command>
+	<command name="load">pnetcdf/1.11</command>
+	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="impi">
-        <command name="rm">mvapich2</command>
-        <command name="load">impi/18.0.2</command>
-        <command name="load">pnetcdf/1.11</command>
-        <command name="load">parallel-netcdf/4.6.2</command>
+	<command name="rm">mvapich2</command>
+	<command name="load">impi/18.0.2</command>
+	<command name="load">pnetcdf/1.11</command>
+	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">netcdf/4.3.3.1</command>
+	<command name="load">netcdf/4.3.3.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2502,25 +2501,25 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"></command>
-        <command name="load">TACC</command>
-        <command name="load">python/2.7.13</command>
-        <command name="load">intel/18.0.2</command>
-        <command name="load">cmake/3.16.1</command>
+	<command name="purge"></command>
+	<command name="load">TACC</command>
+	<command name="load">python/2.7.13</command>
+	<command name="load">intel/18.0.2</command>
+	<command name="load">cmake/3.16.1</command>
       </modules>
       <modules mpilib="mvapich2">
-        <command name="load">mvapich2/2.3.1</command>
-        <command name="load">pnetcdf/1.11</command>
-        <command name="load">parallel-netcdf/4.6.2</command>
+	<command name="load">mvapich2/2.3.1</command>
+	<command name="load">pnetcdf/1.11</command>
+	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="impi">
-        <command name="rm">mvapich2</command>
-        <command name="load">impi/18.0.2</command>
-        <command name="load">pnetcdf/1.11</command>
-        <command name="load">parallel-netcdf/4.6.2</command>
+	<command name="rm">mvapich2</command>
+	<command name="load">impi/18.0.2</command>
+	<command name="load">pnetcdf/1.11</command>
+	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">netcdf/4.3.3.1</command>
+	<command name="load">netcdf/4.3.3.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2552,7 +2551,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-        <arg name="num_tasks">-n $TOTALPES</arg>
+	<arg name="num_tasks">-n $TOTALPES</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpi-serial">
@@ -2565,14 +2564,14 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="python">/apps/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="intel">
-        <command name="purge"/>
-        <command name="load">intel/15.1.133</command>
-        <command name="load">impi/5.1.1.109</command>
-        <command name="load">netcdf/4.3.0</command>
-        <command name="load">pnetcdf</command>
-        <command name="use">/scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles</command>
-        <command name="load">yaml-cpp</command>
-        <command name="load">esmf/8.0.0bs29g</command>
+	<command name="purge"/>
+	<command name="load">intel/15.1.133</command>
+	<command name="load">impi/5.1.1.109</command>
+	<command name="load">netcdf/4.3.0</command>
+	<command name="load">pnetcdf</command>
+	<command name="use">/scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles</command>
+	<command name="load">yaml-cpp</command>
+	<command name="load">esmf/8.0.0bs29g</command>
       </modules>
     </module_system>
     <environment_variables comp_interface="nuopc">
@@ -2606,11 +2605,11 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
-        <arg name="num_tasks" >-n {{ total_tasks }}</arg>
-        <arg name="tasks_per_node" >-N {{ tasks_per_node }} </arg>
-        <arg name="thread_count">--cc depth -d $OMP_NUM_THREADS</arg>
-        <arg name="env_omp_stacksize">-e OMP_STACKSIZE=64M</arg>
-        <arg name="env_thread_count">-e OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
+	<arg name="num_tasks" >-n {{ total_tasks }}</arg>
+	<arg name="tasks_per_node" >-N {{ tasks_per_node }} </arg>
+	<arg name="thread_count">--cc depth -d $OMP_NUM_THREADS</arg>
+	<arg name="env_omp_stacksize">-e OMP_STACKSIZE=64M</arg>
+	<arg name="env_thread_count">-e OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2623,52 +2622,52 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="rm">craype-mic-knl</command>
-        <command name="rm">PrgEnv-intel</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">intel</command>
-        <command name="rm">cce</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">cray-hdf5-parallel</command>
-        <command name="rm">pmi</command>
-        <command name="rm">cray-libsci</command>
-        <command name="rm">cray-mpich</command>
-        <command name="rm">cray-netcdf</command>
-        <command name="rm">cray-hdf5</command>
-        <command name="rm">cray-netcdf-hdf5parallel</command>
-        <command name="rm">craype</command>
-        <command name="rm">papi</command>
+	<command name="rm">craype-mic-knl</command>
+	<command name="rm">PrgEnv-intel</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">intel</command>
+	<command name="rm">cce</command>
+	<command name="rm">cray-parallel-netcdf</command>
+	<command name="rm">cray-hdf5-parallel</command>
+	<command name="rm">pmi</command>
+	<command name="rm">cray-libsci</command>
+	<command name="rm">cray-mpich</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">cray-hdf5</command>
+	<command name="rm">cray-netcdf-hdf5parallel</command>
+	<command name="rm">craype</command>
+	<command name="rm">papi</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/6.0.4</command>
-        <command name="switch">intel intel/18.0.0.128</command>
-        <command name="rm">cray-libsci</command>
+	<command name="load">PrgEnv-intel/6.0.4</command>
+	<command name="switch">intel intel/18.0.0.128</command>
+	<command name="rm">cray-libsci</command>
       </modules>
 
       <modules compiler="cray">
-        <command name="load">PrgEnv-cray/6.0.4</command>
-        <command name="switch">cce cce/8.7.0</command>
+	<command name="load">PrgEnv-cray/6.0.4</command>
+	<command name="switch">cce cce/8.7.0</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu/6.0.4</command>
-        <command name="switch">gcc gcc/7.3.0</command>
+	<command name="load">PrgEnv-gnu/6.0.4</command>
+	<command name="switch">gcc gcc/7.3.0</command>
       </modules>
       <modules>
-        <command name="load">papi/5.6.0.1</command>
-        <command name="swap">craype craype/2.5.14</command>
+	<command name="load">papi/5.6.0.1</command>
+	<command name="swap">craype craype/2.5.14</command>
       </modules>
       <modules compiler="!intel">
-        <command name="switch">cray-libsci/18.04.1</command>
+	<command name="switch">cray-libsci/18.04.1</command>
       </modules>
       <modules>
-        <command name="load">cray-mpich/7.7.0</command>
+	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpt">
-        <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-        <command name="load">cray-hdf5-parallel/1.10.1.1</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.3</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
+	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
+	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
     </module_system>
   </machine>
@@ -2694,8 +2693,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec</executable>
       <arguments>
-        <arg name="labelstdout">--tag-output</arg>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="labelstdout">--tag-output</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2708,38 +2707,38 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">ncarenv/1.3</command>
-        <command name="load">cmake/3.14.4</command>
+	<command name="purge"/>
+	<command name="load">ncarenv/1.3</command>
+	<command name="load">cmake/3.14.4</command>
       </modules>
       <modules compiler="arm">
-        <command name="load">arm/19.3</command>
+	<command name="load">arm/19.3</command>
       </modules>
       <modules compiler="armgcc">
-        <command name="load">armgcc/8.2.0</command>
+	<command name="load">armgcc/8.2.0</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gnu/9.1.0</command>
-        <command name="load">openblas/0.3.6</command>
-        <command name="load">esmf_libs/8.0.0</command>
+	<command name="load">gnu/9.1.0</command>
+	<command name="load">openblas/0.3.6</command>
+	<command name="load">esmf_libs/8.0.0</command>
       </modules>
       <!-- must load after compiler -->
       <modules>
-        <command name="load">ncarcompilers/0.5.0</command>
+	<command name="load">ncarcompilers/0.5.0</command>
       </modules>
       <modules mpilib="openmpi">
-        <command name="load">openmpi/4.0.3</command>
-        <command name="load">netcdf-mpi/4.7.1</command>
-        <command name="load">pnetcdf/1.12.1</command>
+	<command name="load">openmpi/4.0.3</command>
+	<command name="load">netcdf-mpi/4.7.1</command>
+	<command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">netcdf/4.7.1</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="load">esmf-8.0.0-ncdfio-uni-g</command>
+	<command name="load">esmf-8.0.0-ncdfio-uni-g</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="load">esmf-8.0.0-ncdfio-uni-O</command>
+	<command name="load">esmf-8.0.0-ncdfio-uni-O</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -68,12 +68,12 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
-	<arg name="hyperthreading" default="1"> -j {{ hyperthreading }}</arg>
-	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
-	<arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
-	<arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
-	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
-	<arg name="env_thread_count">--mpmd-env OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
+        <arg name="hyperthreading" default="1"> -j {{ hyperthreading }}</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
+        <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
+        <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
+        <arg name="env_thread_count">--mpmd-env OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -86,27 +86,27 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="rm">craype-x86-skylake</command>
-	<command name="rm">PrgEnv-pgi</command>
-	<command name="rm">PrgEnv-intel</command>
-	<command name="rm">PrgEnv-cray</command>
-	<command name="rm">PrgEnv-gnu</command>
-	<command name="rm">cray-netcdf</command>
-	<command name="rm">cray-hdf5</command>
-	<command name="rm">cray-parallel-netcdf</command>
-	<command name="rm">papi</command>
+        <command name="rm">craype-x86-skylake</command>
+        <command name="rm">PrgEnv-pgi</command>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">papi</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">PrgEnv-intel</command>
-	<command name="load">craype-x86-skylake</command>
-	<command name="load">craype-hugepages2M</command>
-	<command name="rm">perftools-base/7.0.4</command>
-	<command name="load">cray-netcdf/4.6.1.3</command>
-	<command name="load">cray-hdf5/1.10.2.0</command>
-	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
-	<command name="load">papi/5.6.0.4</command>
-	<command name="load">gridftp/6.0</command>
-	<command name="load">cray-python/3.6.5.1</command>
+        <command name="load">PrgEnv-intel</command>
+        <command name="load">craype-x86-skylake</command>
+        <command name="load">craype-hugepages2M</command>
+        <command name="rm">perftools-base/7.0.4</command>
+        <command name="load">cray-netcdf/4.6.1.3</command>
+        <command name="load">cray-hdf5/1.10.2.0</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
+        <command name="load">papi/5.6.0.4</command>
+        <command name="load">gridftp/6.0</command>
+        <command name="load">cray-python/3.6.5.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -147,42 +147,42 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
+        <command name="purge"/>
       </modules>
       <modules compiler="intel">
-	<command name="load">ANACONDA2/python2.7</command>
-	<command name="load">INTEL/intel_xe_2015.3.187</command>
-	<command name="load">SZIP/szip-2.1_int15</command>
+        <command name="load">ANACONDA2/python2.7</command>
+        <command name="load">INTEL/intel_xe_2015.3.187</command>
+        <command name="load">SZIP/szip-2.1_int15</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-	<command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-g_int15</command>
+        <command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-g_int15</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-	<command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-O_int15</command>
+        <command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-O_int15</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-	<command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-g_int15</command>
+        <command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-g_int15</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-	<command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-O_int15</command>
+        <command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-O_int15</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">HDF5/hdf5-1.8.15-patch1</command>
-	<command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1</command>
+        <command name="load">HDF5/hdf5-1.8.15-patch1</command>
+        <command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">HDF5/hdf5-1.8.15-patch1_parallel</command>
-	<command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1_parallel</command>
-	<command name="load">PARALLEL_NETCDF/parallel-netcdf-1.6.1</command>
+        <command name="load">HDF5/hdf5-1.8.15-patch1_parallel</command>
+        <command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1_parallel</command>
+        <command name="load">PARALLEL_NETCDF/parallel-netcdf-1.6.1</command>
       </modules>
       <modules>
-	<command name="load">CMAKE/cmake-3.3.0-rc1</command>
+        <command name="load">CMAKE/cmake-3.3.0-rc1</command>
       </modules>
       <modules compiler="intel">
-	<command name="unload">INTEL/intel_xe_2013.5.192</command>
-	<command name="unload">INTEL/intel_xe_2013</command>
-	<command name="unload">HDF5/hdf5-1.8.10-patch1</command>
-	<command name="load">INTEL/intel_xe_2015.3.187</command>
+        <command name="unload">INTEL/intel_xe_2013.5.192</command>
+        <command name="unload">INTEL/intel_xe_2013</command>
+        <command name="unload">HDF5/hdf5-1.8.10-patch1</command>
+        <command name="load">INTEL/intel_xe_2015.3.187</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -222,10 +222,10 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
-	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
-	<!-- <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg> -->
-	<arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
-	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+        <!-- <arg name="tasks_per_numa"> -S {{ tasks_per_numa }}</arg> -->
+        <arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
+        <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -238,55 +238,55 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="rm">PrgEnv-pgi</command>
-	<command name="rm">PrgEnv-intel</command>
-	<command name="rm">PrgEnv-cray</command>
-	<command name="rm">PrgEnv-gnu</command>
-	<command name="rm">pgi</command>
-	<command name="rm">cray</command>
-	<command name="rm">intel</command>
-	<command name="rm">cray-netcdf</command>
-	<command name="rm">gcc</command>
+        <command name="rm">PrgEnv-pgi</command>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">pgi</command>
+        <command name="rm">cray</command>
+        <command name="rm">intel</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">gcc</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">PrgEnv-intel</command>
-	<command name="rm">intel</command>
-	<command name="load">intel/18.0.3.222</command>
-	<!-- the PrgEnv-intel loads a gcc compiler that causes several
-	problems -->
-	<command name="rm">gcc</command>
+        <command name="load">PrgEnv-intel</command>
+        <command name="rm">intel</command>
+        <command name="load">intel/18.0.3.222</command>
+        <!-- the PrgEnv-intel loads a gcc compiler that causes several
+        problems -->
+        <command name="rm">gcc</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">PrgEnv-pgi</command>
-	<command name="switch">pgi pgi/18.7.0</command>
+        <command name="load">PrgEnv-pgi</command>
+        <command name="switch">pgi pgi/18.7.0</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/6.3.0</command>
+        <command name="load">PrgEnv-gnu</command>
+        <command name="switch">gcc gcc/6.3.0</command>
       </modules>
       <modules compiler="cray">
-	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.5.8</command>
+        <command name="load">PrgEnv-cray</command>
+        <command name="switch">cce cce/8.5.8</command>
       </modules>
       <modules>
-	<command name="load">papi/5.5.1.1</command>
-	<command name="switch">cray-mpich cray-mpich/7.7.1</command>
-	<command name="switch">cray-libsci cray-libsci/18.04.1</command>
-	<command name="load">torque/6.0.4</command>
+        <command name="load">papi/5.5.1.1</command>
+        <command name="switch">cray-mpich cray-mpich/7.7.1</command>
+        <command name="switch">cray-libsci cray-libsci/18.04.1</command>
+        <command name="load">torque/6.0.4</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-hdf5-parallel/1.10.2.0</command>
-	<command name="load">cray-netcdf-hdf5parallel/4.6.1.0</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
+        <command name="load">cray-hdf5-parallel/1.10.2.0</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.1.0</command>
+        <command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-netcdf/4.6.1.0</command>
+        <command name="load">cray-netcdf/4.6.1.0</command>
       </modules>
       <modules>
-	<command name="load">cmake/3.1.3</command>
-	<command name="rm">darshan</command>
-	<command name="use">/sw/modulefiles/CESM</command>
-	<command name="load">CESM-ENV</command>
+        <command name="load">cmake/3.1.3</command>
+        <command name="rm">darshan</command>
+        <command name="use">/sw/modulefiles/CESM</command>
+        <command name="load">CESM-ENV</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -323,7 +323,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec</executable>
       <arguments>
-	<arg name="ntasks"> -np {{ total_tasks }} </arg>
+        <arg name="ntasks"> -np {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
@@ -336,12 +336,12 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
+        <command name="purge"/>
       </modules>
       <modules compiler="gnu">
-	<command name="load">compiler/gnu/8.2.0</command>
-	<command name="load">mpi/3.3/gcc-8.2.0</command>
-	<command name="load">tool/netcdf/4.6.1/gcc-8.1.0</command>
+        <command name="load">compiler/gnu/8.2.0</command>
+        <command name="load">mpi/3.3/gcc-8.2.0</command>
+        <command name="load">tool/netcdf/4.6.1/gcc-8.1.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -375,13 +375,13 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -394,21 +394,21 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
+        <command name="purge"/>
       </modules>
       <modules>
-	<command name="load">ncarenv/1.3</command>
+        <command name="load">ncarenv/1.3</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/20.4</command>
+        <command name="load">pgi/20.4</command>
       </modules>
       <modules mpilib="openmpi" compiler="pgi">
-	<command name="load">openmpi/3.1.4</command>
-	<command name="load">netcdf-mpi/4.7.3</command>
-	<command name="load">pnetcdf/1.12.1</command>
+        <command name="load">openmpi/3.1.4</command>
+        <command name="load">netcdf-mpi/4.7.3</command>
+        <command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules>
-	<command name="load">ncarcompilers/0.5.0</command>
+        <command name="load">ncarcompilers/0.5.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -451,30 +451,30 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-	<arg name="labelstdout">-p "%g:"</arg>
-	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
-	<!-- the omplace argument needs to be last -->
-	<arg name="zthreadplacement"> omplace -tm open64 </arg>
+        <arg name="labelstdout">-p "%g:"</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <!-- the omplace argument needs to be last -->
+        <arg name="zthreadplacement"> omplace -tm open64 </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpt" queue="share">
       <executable>mpirun `hostname`</executable>
       <arguments>
-	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
-	<!-- the omplace argument needs to be last -->
-	<arg name="zthreadplacement"> omplace -tm open64 </arg>
+        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+        <!-- the omplace argument needs to be last -->
+        <arg name="zthreadplacement"> omplace -tm open64 </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="default" unit_testing="true">
       <!-- The only place we can build and run the unit tests is on cheyenne's
-	   shared nodes. However, running mpi jobs on the shared nodes currently
-	   requires some workarounds; these workarounds are implemented here -->
+           shared nodes. However, running mpi jobs on the shared nodes currently
+           requires some workarounds; these workarounds are implemented here -->
       <executable>/opt/sgi/mpt/mpt-2.15/bin/mpirun $ENV{UNIT_TEST_HOST} -np 1 </executable>
     </mpirun>
     <module_system type="module">
@@ -487,83 +487,83 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">ncarenv/1.3</command>
-	<command name="load">cmake</command>
+        <command name="purge"/>
+        <command name="load">ncarenv/1.3</command>
+        <command name="load">cmake</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/19.0.5</command>
-	<command name="load">esmf_libs</command>
-	<command name="load">mkl</command>
+        <command name="load">intel/19.0.5</command>
+        <command name="load">esmf_libs</command>
+        <command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">gnu/9.1.0</command>
-	<command name="load">openblas/0.3.6</command>
+        <command name="load">gnu/9.1.0</command>
+        <command name="load">openblas/0.3.6</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/19.3</command>
+        <command name="load">pgi/19.3</command>
       </modules>
 
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-	<command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+        <command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-	<command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+        <command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-	<command name="load">esmf-8.1.0b23-ncdfio-mpiuni-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+        <command name="load">esmf-8.1.0b23-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-	<command name="load">esmf-8.1.0b23-ncdfio-mpiuni-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+        <command name="load">esmf-8.1.0b23-ncdfio-mpiuni-O</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="TRUE">
-	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-	<command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+        <command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="FALSE">
-	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-	<command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+        <command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
       </modules>
 
       <modules mpilib="mpt" compiler="gnu">
-	<command name="load">mpt/2.21</command>
-	<command name="load">netcdf-mpi/4.7.3</command>
-	<command name="load">pnetcdf/1.12.1</command>
+        <command name="load">mpt/2.21</command>
+        <command name="load">netcdf-mpi/4.7.3</command>
+        <command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
-	<command name="load">mpt/2.21</command>
-	<!-- known failure in parallel netcdf with mpt, use serial -->
-	<command name="load">netcdf/4.7.3</command>
-	<command name="load">pnetcdf/1.12.1</command>
+        <command name="load">mpt/2.21</command>
+        <!-- known failure in parallel netcdf with mpt, use serial -->
+        <command name="load">netcdf/4.7.3</command>
+        <command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules mpilib="mpt" compiler="pgi">
-	<command name="load">mpt/2.19</command>
-	<command name="load">netcdf-mpi/4.7.1</command>
-	<command name="load">pnetcdf/1.11.1</command>
+        <command name="load">mpt/2.19</command>
+        <command name="load">netcdf-mpi/4.7.1</command>
+        <command name="load">pnetcdf/1.11.1</command>
       </modules>
       <modules mpilib="openmpi" compiler="pgi">
-	<command name="load">openmpi/3.1.4</command>
-	<command name="load">netcdf/4.7.1</command>
+        <command name="load">openmpi/3.1.4</command>
+        <command name="load">netcdf/4.7.1</command>
       </modules>
       <modules mpilib="openmpi" compiler="gnu">
-	<command name="load">openmpi/3.1.4</command>
-	<command name="load">netcdf/4.7.1</command>
+        <command name="load">openmpi/3.1.4</command>
+        <command name="load">netcdf/4.7.1</command>
       </modules>
       <modules>
-	<command name="load">ncarcompilers/0.5.0</command>
+        <command name="load">ncarcompilers/0.5.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial">
-	<command name="load">netcdf/4.7.1</command>
+        <command name="load">netcdf/4.7.1</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
-	<command name="load">netcdf/4.7.1</command>
+        <command name="load">netcdf/4.7.1</command>
       </modules>
       <modules compiler="pgi" mpilib="mpi-serial">
-	<command name="load">netcdf/4.7.1</command>
+        <command name="load">netcdf/4.7.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -572,6 +572,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_TYPE_DEPTH">16</env>
       <env name="MPI_IB_CONGESTED">1</env>
       <env name="MPI_USE_ARRAY"/>
+      <env source="sh">/glade/scratch/jedwards/dothis</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
       <env name="ESMF_RUNTIME_PROFILE">ON</env>
@@ -587,9 +588,6 @@ This allows using a different mpirun command to launch unit tests
       <env name="TMPDIR">/glade/scratch/$USER</env>
       <env name="MPI_USE_ARRAY">false</env>
     </environment_variables>
-    <source_files>
-      <filepath>/glade/scratch/jedwards/dothis</filepath>
-    </source_files>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
     </resource_limits>
@@ -619,9 +617,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
       <arguments>
-	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
-	<arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
-	<arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -634,13 +632,13 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
+        <command name="purge"/>
       </modules>
       <modules compiler="gnu">
-	<command name="load">gcc-6.3.0</command>
-	<command name="load">mvapich2-2.2-psm/gcc-6.3.0</command>
-	<command name="load">General/netcdf/4.4.1.1/gcc-6.3.0</command>
-	<command name="load">Python/2.7.13/gcc-6.3.0</command>
+        <command name="load">gcc-6.3.0</command>
+        <command name="load">mvapich2-2.2-psm/gcc-6.3.0</command>
+        <command name="load">General/netcdf/4.4.1.1/gcc-6.3.0</command>
+        <command name="load">Python/2.7.13/gcc-6.3.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -672,30 +670,30 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
       <arguments>
-	<arg name="mpi">--mpi=none</arg>
-	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
-	<arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
-	<arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+        <arg name="mpi">--mpi=none</arg>
+        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mvapich">
       <executable>srun</executable>
       <arguments>
-	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
-	<arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
-	<arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="intelmpi">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -706,32 +704,32 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
+        <command name="purge"/>
       </modules>
       <modules>
-	<command name="load">perl/5.20.0</command>
-	<command name="load">cmake/2.8.12</command>
+        <command name="load">perl/5.20.0</command>
+        <command name="load">cmake/2.8.12</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/15.0.1</command>
-	<command name="load">netcdf/4.3.2</command>
-	<command name="load">mkl/15.0.1</command>
+        <command name="load">intel/15.0.1</command>
+        <command name="load">netcdf/4.3.2</command>
+        <command name="load">mkl/15.0.1</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/14.10</command>
-	<command name="load">netcdf/4.3.2</command>
+        <command name="load">pgi/14.10</command>
+        <command name="load">netcdf/4.3.2</command>
       </modules>
       <modules mpilib="mvapich">
-	<command name="load">mvapich2/2.1</command>
+        <command name="load">mvapich2/2.1</command>
       </modules>
       <modules mpilib="mvapich2">
-	<command name="load">mvapich2/2.1</command>
+        <command name="load">mvapich2/2.1</command>
       </modules>
       <modules mpilib="intelmpi">
-	<command name="load">intelmpi/5.0.1.035</command>
+        <command name="load">intelmpi/5.0.1.035</command>
       </modules>
       <modules mpilib="openmpi">
-	<command name="load">openmpi/1.8.3</command>
+        <command name="load">openmpi/1.8.3</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -768,9 +766,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-	<arg name="label"> --label</arg>
-	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
-	<arg name="binding"> -c {{ srun_binding }}</arg>
+        <arg name="label"> --label</arg>
+        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
+        <arg name="binding"> -c {{ srun_binding }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -783,66 +781,66 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="rm">PrgEnv-intel</command>
-	<command name="rm">PrgEnv-cray</command>
-	<command name="rm">PrgEnv-gnu</command>
-	<command name="rm">intel</command>
-	<command name="rm">cce</command>
-	<command name="rm">cray-parallel-netcdf</command>
-	<command name="rm">cray-parallel-hdf5</command>
-	<command name="rm">pmi</command>
-	<command name="rm">cray-libsci</command>
-	<command name="rm">cray-mpich2</command>
-	<command name="rm">cray-mpich</command>
-	<command name="rm">cray-netcdf</command>
-	<command name="rm">cray-hdf5</command>
-	<command name="rm">cray-netcdf-hdf5parallel</command>
-	<command name="rm">craype-sandybridge</command>
-	<command name="rm">craype-ivybridge</command>
-	<command name="rm">craype</command>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">intel</command>
+        <command name="rm">cce</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">cray-parallel-hdf5</command>
+        <command name="rm">pmi</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">cray-mpich2</command>
+        <command name="rm">cray-mpich</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">craype-sandybridge</command>
+        <command name="rm">craype-ivybridge</command>
+        <command name="rm">craype</command>
       </modules>
 
       <modules compiler="intel">
-	<command name="load">PrgEnv-intel</command>
-	<command name="switch">intel intel/19.0.3.199</command>
-	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
+        <command name="load">PrgEnv-intel</command>
+        <command name="switch">intel intel/19.0.3.199</command>
+        <command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-	<command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-haswell</command>
+        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-haswell</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" >
-	<command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-haswell</command>
+        <command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-haswell</command>
       </modules>
 
       <modules compiler="cray">
-	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.7.9</command>
+        <command name="load">PrgEnv-cray</command>
+        <command name="switch">cce cce/8.7.9</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/8.3.0</command>
+        <command name="load">PrgEnv-gnu</command>
+        <command name="switch">gcc gcc/8.3.0</command>
       </modules>
       <modules>
-	<command name="load">cray-memkind</command>
-	<command name="swap">craype craype/2.6.2</command>
+        <command name="load">cray-memkind</command>
+        <command name="swap">craype craype/2.6.2</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/19.06.1</command>
+        <command name="switch">cray-libsci/19.06.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.10</command>
+        <command name="load">cray-mpich/7.7.10</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.5.2</command>
-	<command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
-	<command name="load">cray-hdf5-parallel/1.10.5.2</command>
-	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
       <modules>
-	<command name="load">cmake/3.14.4</command>
+        <command name="load">cmake/3.14.4</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -874,9 +872,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-	<arg name="label"> --label</arg>
-	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
-	<arg name="binding"> -c {{ srun_binding }} --cpu_bind=cores</arg>
+        <arg name="label"> --label</arg>
+        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
+        <arg name="binding"> -c {{ srun_binding }} --cpu_bind=cores</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -889,63 +887,63 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="rm">craype-mic-knl</command>
-	<command name="rm">craype-haswell</command>
-	<command name="rm">PrgEnv-intel</command>
-	<command name="rm">PrgEnv-cray</command>
-	<command name="rm">PrgEnv-gnu</command>
-	<command name="rm">intel</command>
-	<command name="rm">cce</command>
-	<command name="rm">cray-parallel-netcdf</command>
-	<command name="rm">cray-parallel-hdf5</command>
-	<command name="rm">pmi</command>
-	<command name="rm">cray-libsci</command>
-	<command name="rm">cray-mpich2</command>
-	<command name="rm">cray-mpich</command>
-	<command name="rm">cray-netcdf</command>
-	<command name="rm">cray-hdf5</command>
-	<command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">craype-mic-knl</command>
+        <command name="rm">craype-haswell</command>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">intel</command>
+        <command name="rm">cce</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">cray-parallel-hdf5</command>
+        <command name="rm">pmi</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">cray-mpich2</command>
+        <command name="rm">cray-mpich</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
       </modules>
 
       <modules compiler="intel">
-	<command name="load">PrgEnv-intel</command>
-	<command name="switch">intel intel/19.0.3.199</command>
-	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
+        <command name="load">PrgEnv-intel</command>
+        <command name="switch">intel intel/19.0.3.199</command>
+        <command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-	<command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-knl</command>
+        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O-cori-knl</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" >
-	<command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-knl</command>
+        <command name="load">esmf/7.1.0r-netcdf-intel18.0.1.163-mpiuni-O-knl</command>
       </modules>
 
       <modules compiler="cray">
-	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/9.1.0</command>
+        <command name="load">PrgEnv-cray</command>
+        <command name="switch">cce cce/9.1.0</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/8.3.0</command>
+        <command name="load">PrgEnv-gnu</command>
+        <command name="switch">gcc gcc/8.3.0</command>
       </modules>
       <modules>
-	<command name="load">cray-memkind</command>
-	<command name="swap">craype craype/2.6.2</command>
-	<command name="load">craype-mic-knl</command>
+        <command name="load">cray-memkind</command>
+        <command name="swap">craype craype/2.6.2</command>
+        <command name="load">craype-mic-knl</command>
       </modules>
       <modules>
-	<command name="switch">cray-libsci/19.06.1</command>
+        <command name="switch">cray-libsci/19.06.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.10</command>
+        <command name="load">cray-mpich/7.7.10</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.5.2</command>
-	<command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.10.5.2</command>
+        <command name="load">cray-netcdf/4.6.3.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
-	<command name="load">cray-hdf5-parallel/1.10.5.2</command>
-	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
+        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -974,8 +972,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
-	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+        <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="none"/>
@@ -1003,20 +1001,20 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich">
       <executable>srun</executable>
       <arguments>
-	<arg name="num_tasks"> --ntasks={{ total_tasks }}</arg>
-	<arg name="cpubind"> --cpu_bind=sockets</arg>
-	<arg name="cpubind"> --cpu_bind=verbose</arg>
-	<arg name="killonbadexit"> --kill-on-bad-exit</arg>
+        <arg name="num_tasks"> --ntasks={{ total_tasks }}</arg>
+        <arg name="cpubind"> --cpu_bind=sockets</arg>
+        <arg name="cpubind"> --cpu_bind=verbose</arg>
+        <arg name="killonbadexit"> --kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
       <arguments>
-	<arg name="mpinone"> --mpi=none</arg>
-	<arg name="num_tasks"> --ntasks={{ total_tasks }}</arg>
-	<arg name="cpubind"> --cpu_bind=sockets</arg>
-	<arg name="cpubind"> --cpu_bind=verbose</arg>
-	<arg name="killonbadexit"> --kill-on-bad-exit</arg>
+        <arg name="mpinone"> --mpi=none</arg>
+        <arg name="num_tasks"> --ntasks={{ total_tasks }}</arg>
+        <arg name="cpubind"> --cpu_bind=sockets</arg>
+        <arg name="cpubind"> --cpu_bind=verbose</arg>
+        <arg name="killonbadexit"> --kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1027,12 +1025,12 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">perl/5.20.7</command>
-	<command name="load">cmake/3.0.0</command>
-	<command name="load">pgi/15.5</command>
-	<command name="load">mpi/mvapich2/1.5.1p1/pgi11.3</command>
-	<command name="load">netcdf/4.1.2/pgi</command>
+        <command name="purge"/>
+        <command name="load">perl/5.20.7</command>
+        <command name="load">cmake/3.0.0</command>
+        <command name="load">pgi/15.5</command>
+        <command name="load">mpi/mvapich2/1.5.1p1/pgi11.3</command>
+        <command name="load">netcdf/4.1.2/pgi</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1060,9 +1058,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-	<arg name="label"> --label</arg>
-	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
-	<arg name="thread_count" > -c {{ srun_binding }}</arg>
+        <arg name="label"> --label</arg>
+        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
+        <arg name="thread_count" > -c {{ srun_binding }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1075,63 +1073,63 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="rm">PrgEnv-intel</command>
-	<command name="rm">PrgEnv-cray</command>
-	<command name="rm">PrgEnv-gnu</command>
-	<command name="rm">intel</command>
-	<command name="rm">cce</command>
-	<command name="rm">cray-parallel-netcdf</command>
-	<command name="rm">cray-parallel-hdf5</command>
-	<command name="rm">pmi</command>
-	<command name="rm">cray-libsci</command>
-	<command name="rm">cray-mpich2</command>
-	<command name="rm">cray-mpich</command>
-	<command name="rm">cray-netcdf</command>
-	<command name="rm">cray-hdf5</command>
-	<command name="rm">cray-netcdf-hdf5parallel</command>
-	<command name="rm">craype-sandybridge</command>
-	<command name="rm">craype-ivybridge</command>
-	<command name="rm">craype</command>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">intel</command>
+        <command name="rm">cce</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">cray-parallel-hdf5</command>
+        <command name="rm">pmi</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">cray-mpich2</command>
+        <command name="rm">cray-mpich</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">craype-sandybridge</command>
+        <command name="rm">craype-ivybridge</command>
+        <command name="rm">craype</command>
       </modules>
 
       <modules compiler="intel">
-	<command name="load">PrgEnv-intel</command>
-	<command name="switch">intel intel/18.0.1.163</command>
-	<command name="rm">cray-libsci</command>
-	<command name="use">/global/project/projectdirs/ccsm1/modulefiles/edison</command>
+        <command name="load">PrgEnv-intel</command>
+        <command name="switch">intel intel/18.0.1.163</command>
+        <command name="rm">cray-libsci</command>
+        <command name="use">/global/project/projectdirs/ccsm1/modulefiles/edison</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
-	<command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O</command>
+        <command name="load">esmf/7.1.0r-defio-intel18.0.1.163-mpi-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" >
-	<command name="load">esmf/6.3.0rp1-defio-intel17.0-mpiuni-O</command>
+        <command name="load">esmf/6.3.0rp1-defio-intel17.0-mpiuni-O</command>
       </modules>
       <modules compiler="cray">
-	<command name="load">PrgEnv-cray</command>
-	<command name="switch">cce cce/8.6.5</command>
-	<command name="switch">cray-libsci/18.03.1</command>
+        <command name="load">PrgEnv-cray</command>
+        <command name="switch">cce cce/8.6.5</command>
+        <command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">PrgEnv-gnu</command>
-	<command name="switch">gcc gcc/7.3.0</command>
-	<command name="switch">cray-libsci/18.03.1</command>
+        <command name="load">PrgEnv-gnu</command>
+        <command name="switch">gcc gcc/7.3.0</command>
+        <command name="switch">cray-libsci/18.03.1</command>
       </modules>
       <modules>
-	<command name="load">papi/5.5.1.4</command>
-	<command name="swap">craype craype/2.5.14</command>
-	<command name="load">craype-ivybridge</command>
+        <command name="load">papi/5.5.1.4</command>
+        <command name="swap">craype craype/2.5.14</command>
+        <command name="load">craype-ivybridge</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.0</command>
+        <command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.1.1</command>
-	<command name="load">cray-netcdf/4.4.1.1.6</command>
+        <command name="load">cray-hdf5/1.10.1.1</command>
+        <command name="load">cray-netcdf/4.4.1.1.6</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
+        <command name="load">cray-hdf5-parallel/1.10.1.1</command>
+        <command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
     </module_system>
 
@@ -1162,9 +1160,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mpich">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
-	<arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
-	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+        <arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
+        <arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
@@ -1180,25 +1178,25 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
+        <command name="purge"/>
       </modules>
       <modules>
-	<command name="load">new</command>
+        <command name="load">new</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/2018.1</command>
+        <command name="load">intel/2018.1</command>
       </modules>
       <modules>
-	<command name="load">netcdf/4.3.1</command>
+        <command name="load">netcdf/4.3.1</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/14.1</command>
+        <command name="load">pgi/14.1</command>
       </modules>
       <modules mpilib="mpich">
-	<command name="load">mvapich2/1.8.1</command>
+        <command name="load">mvapich2/1.8.1</command>
       </modules>
       <modules mpilib="openmpi">
-	<command name="load">open_mpi/1.6.5</command>
+        <command name="load">open_mpi/1.6.5</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1225,9 +1223,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mpich">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
-	<arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
-	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+        <arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
+        <arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
@@ -1243,28 +1241,28 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
+        <command name="purge"/>
       </modules>
       <modules>
-	<command name="load">new</command>
+        <command name="load">new</command>
       </modules>
       <modules>
-	<command name="load">interconnect/ethernet</command>
+        <command name="load">interconnect/ethernet</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/2018.1</command>
+        <command name="load">intel/2018.1</command>
       </modules>
       <modules>
-	<command name="load">netcdf/4.3.1</command>
+        <command name="load">netcdf/4.3.1</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/14.1</command>
+        <command name="load">pgi/14.1</command>
       </modules>
       <modules mpilib="mpich">
-	<command name="load">mvapich2/1.8.1</command>
+        <command name="load">mvapich2/1.8.1</command>
       </modules>
       <modules mpilib="openmpi">
-	<command name="load">open_mpi/1.6.5</command>
+        <command name="load">open_mpi/1.6.5</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1291,9 +1289,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mpich">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
-	<arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
-	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+        <arg name="machine_file">-hostfile $ENV{PBS_JOBID}</arg>
+        <arg name="tasks_per_node"> -ppn $MAX_MPITASKS_PER_NODE</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
@@ -1309,13 +1307,13 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
+        <command name="purge"/>
       </modules>
       <modules>
-	<command name="load">new</command>
+        <command name="load">new</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/2018.1</command>
+        <command name="load">intel/2018.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1342,11 +1340,11 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
-	<arg name="hyperthreading" default="2"> -j {{ hyperthreading }}</arg>
-	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
-	<arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
-	<arg name="tasks_per_node" > -N $MAX_MPITASKS_PER_NODE</arg>
-	<arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
+        <arg name="hyperthreading" default="2"> -j {{ hyperthreading }}</arg>
+        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
+        <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
+        <arg name="tasks_per_node" > -N $MAX_MPITASKS_PER_NODE</arg>
+        <arg name="thread_count" > -d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1357,28 +1355,28 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="rm">PrgEnv-pgi</command>
-	<command name="rm">PrgEnv-cray</command>
-	<command name="rm">PrgEnv-gnu</command>
-	<command name="rm">pgi</command>
-	<command name="rm">cray</command>
+        <command name="rm">PrgEnv-pgi</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">pgi</command>
+        <command name="rm">cray</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">PrgEnv-pgi</command>
-	<command name="switch">pgi pgi/12.5.0</command>
+        <command name="load">PrgEnv-pgi</command>
+        <command name="switch">pgi pgi/12.5.0</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">PrgEnv-gnu</command>
-	<command name="load">torque</command>
+        <command name="load">PrgEnv-gnu</command>
+        <command name="load">torque</command>
       </modules>
       <modules compiler="cray">
-	<command name="load">PrgEnv-cray/4.0.36</command>
-	<command name="load">cce/8.0.2</command>
+        <command name="load">PrgEnv-cray/4.0.36</command>
+        <command name="load">cce/8.0.2</command>
       </modules>
       <modules>
-	<command name="load">torque/4.1.3</command>
-	<command name="load">netcdf-hdf5parallel/4.2.0</command>
-	<command name="load">parallel-netcdf/1.2.0</command>
+        <command name="load">torque/4.1.3</command>
+        <command name="load">netcdf-hdf5parallel/4.2.0</command>
+        <command name="load">parallel-netcdf/1.2.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1408,14 +1406,14 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>mpiexec</executable>
       <arguments>
-	<arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
-	<arg name="num_tasks"> -n {{ total_tasks }} </arg>
+        <arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpiexec</executable>
       <arguments>
-	<arg name="num_tasks"> -n {{ total_tasks }} </arg>
+        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
@@ -1428,38 +1426,38 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"></command>
+        <command name="purge"></command>
       </modules>
       <modules compiler="intel">
-	<command name="load">compiler/intel/18.0.3</command>
-	<command name="load">tool/netcdf/4.6.1/intel</command>
+        <command name="load">compiler/intel/18.0.3</command>
+        <command name="load">tool/netcdf/4.6.1/intel</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich2">
-	<command name="load">mpi/intel/mvapich2-2.3rc2-intel-18.0.3</command>
+        <command name="load">mpi/intel/mvapich2-2.3rc2-intel-18.0.3</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">compiler/pgi/18.1</command>
-	<command name="load">tool/netcdf/4.6.1/pgi</command>
+        <command name="load">compiler/pgi/18.1</command>
+        <command name="load">tool/netcdf/4.6.1/pgi</command>
       </modules>
       <modules compiler="nag">
-	<command name="load">compiler/nag/6.2</command>
-	<command name="load">tool/netcdf/4.6.1/nag</command>
+        <command name="load">compiler/nag/6.2</command>
+        <command name="load">tool/netcdf/4.6.1/nag</command>
       </modules>
       <modules compiler="nag" mpilib="mvapich2">
-	<command name="load">mpi/nag/mvapich2-2.3rc2</command>
+        <command name="load">mpi/nag/mvapich2-2.3rc2</command>
       </modules>
       <modules compiler="nag" mpilib="openmpi">
-	<command name="load">mpi/nag/openmpi-3.1.0</command>
+        <command name="load">mpi/nag/openmpi-3.1.0</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">compiler/gnu/8.1.0</command>
-	<command name="load">tool/netcdf/4.6.1/gcc</command>
+        <command name="load">compiler/gnu/8.1.0</command>
+        <command name="load">tool/netcdf/4.6.1/gcc</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-	<command name="load">mpi/gcc/openmpi-3.1.0a</command>
+        <command name="load">mpi/gcc/openmpi-3.1.0a</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich2">
-	<command name="load">mpi/gcc/mvapich2-2.3rc2-qlc</command>
+        <command name="load">mpi/gcc/mvapich2-2.3rc2-qlc</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1513,8 +1511,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
-	<arg name="labelstdout">-prepend-rank</arg>
+        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="labelstdout">-prepend-rank</arg>
       </arguments>
     </mpirun>
     <module_system type="none"/>
@@ -1544,14 +1542,14 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>mpiexec</executable>
       <arguments>
-	<arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
-	<arg name="num_tasks"> -n {{ total_tasks }} </arg>
+        <arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
+        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpiexec</executable>
       <arguments>
-	<arg name="num_tasks"> -n {{ total_tasks }} </arg>
+        <arg name="num_tasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
@@ -1564,35 +1562,35 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"></command>
+        <command name="purge"></command>
       </modules>
       <modules compiler="intel">
-	<command name="load">compiler/intel/20.0.1</command>
-	<command name="load">tool/netcdf/4.7.4/intel/20.0.1</command>
+        <command name="load">compiler/intel/20.0.1</command>
+        <command name="load">tool/netcdf/4.7.4/intel/20.0.1</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich2">
-	<command name="load">mpi/2.3.3/intel/20.0.1</command>
+        <command name="load">mpi/2.3.3/intel/20.0.1</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">compiler/pgi/20.1</command>
-	<command name="load">tool/netcdf/4.7.4/pgi/20.1</command>
+        <command name="load">compiler/pgi/20.1</command>
+        <command name="load">tool/netcdf/4.7.4/pgi/20.1</command>
       </modules>
       <modules compiler="nag">
-	<command name="load">compiler/nag/6.2-8.1.0</command>
-	<command name="load">tool/netcdf/c4.6.1-f4.4.4/nag-gnu/6.2-8.1.0</command>
+        <command name="load">compiler/nag/6.2-8.1.0</command>
+        <command name="load">tool/netcdf/c4.6.1-f4.4.4/nag-gnu/6.2-8.1.0</command>
       </modules>
       <modules compiler="nag" mpilib="mvapich2">
-	<command name="load">mpi/2.3.3/nag/6.2</command>
+        <command name="load">mpi/2.3.3/nag/6.2</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">compiler/gnu/9.3.0</command>
-	<command name="load">tool/netcdf/4.7.4/gnu/9.3.0</command>
+        <command name="load">compiler/gnu/9.3.0</command>
+        <command name="load">tool/netcdf/4.7.4/gnu/9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
-	<command name="load">openmpi/4.0.3/gnu/9.3.0</command>
+        <command name="load">openmpi/4.0.3/gnu/9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich2">
-	<command name="load">mpi/2.3.3/gnu/9.3.0</command>
+        <command name="load">mpi/2.3.3/gnu/9.3.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1633,8 +1631,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-	<arg name="labelstdout">-p "%g:"</arg>
-	<arg name="threadplacement"> omplace </arg>
+        <arg name="labelstdout">-p "%g:"</arg>
+        <arg name="threadplacement"> omplace </arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1647,35 +1645,35 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">ncarenv/1.3</command>
-	<command name="load">cmake/3.16.4</command>
+        <command name="purge"/>
+        <command name="load">ncarenv/1.3</command>
+        <command name="load">cmake/3.16.4</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/19.0.5</command>
-	<command name="load">mkl</command>
+        <command name="load">intel/19.0.5</command>
+        <command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">gnu/9.1.0</command>
-	<command name="load">openblas/0.3.6</command>
+        <command name="load">gnu/9.1.0</command>
+        <command name="load">openblas/0.3.6</command>
       </modules>
       <modules mpilib="mpt">
-	<command name="load">mpt/2.21</command>
-	<command name="load">netcdf-mpi/4.7.3</command>
+        <command name="load">mpt/2.21</command>
+        <command name="load">netcdf-mpi/4.7.3</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
-	<command name="load">pnetcdf/1.12.1</command>
-	<command name="load">pio/2.4.4</command>
+        <command name="load">pnetcdf/1.12.1</command>
+        <command name="load">pio/2.4.4</command>
       </modules>
       <modules mpilib="openmpi">
-	<command name="load">openmpi/3.1.4</command>
-	<command name="load">netcdf-mpi/4.7.3</command>
+        <command name="load">openmpi/3.1.4</command>
+        <command name="load">netcdf-mpi/4.7.3</command>
       </modules>
       <modules>
-	<command name="load">ncarcompilers/0.5.0</command>
+        <command name="load">ncarcompilers/0.5.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">netcdf/4.7.3</command>
+        <command name="load">netcdf/4.7.3</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1704,8 +1702,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="num_tasks">-np {{ total_tasks }}</arg>
-	<arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE </arg>
+        <arg name="num_tasks">-np {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE </arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1718,20 +1716,20 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
       <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">cmake</command>
-	<command name="load">perl xml-libxml switch python/2.7</command>
+        <command name="purge"/>
+        <command name="load">cmake</command>
+        <command name="load">perl xml-libxml switch python/2.7</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/2016.4.072</command>
-	<command name="load">mkl</command>
+        <command name="load">intel/2016.4.072</command>
+        <command name="load">mkl</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
-	<command name="load">netcdf/4.4.1.1-intel-s</command>
+        <command name="load">netcdf/4.4.1.1-intel-s</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial">
-	<command name="load">openmpi</command>
-	<command name="load">netcdf/4.4.1.1-intel-p</command>
+        <command name="load">openmpi</command>
+        <command name="load">netcdf/4.4.1.1-intel-p</command>
       </modules>
     </module_system>
   </machine>
@@ -1756,8 +1754,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
-	<arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1770,20 +1768,20 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
       <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">cmake</command>
-	<command name="load">perl xml-libxml switch python/2.7</command>
+        <command name="purge"/>
+        <command name="load">cmake</command>
+        <command name="load">perl xml-libxml switch python/2.7</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/2016.4.072</command>
-	<command name="load">mkl</command>
+        <command name="load">intel/2016.4.072</command>
+        <command name="load">mkl</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
-	<command name="load">netcdf/4.4.1.1-intel-s</command>
+        <command name="load">netcdf/4.4.1.1-intel-s</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial">
-	<command name="load">openmpi</command>
-	<command name="load">netcdf/4.4.1.1-intel-p</command>
+        <command name="load">openmpi</command>
+        <command name="load">netcdf/4.4.1.1-intel-p</command>
       </modules>
     </module_system>
   </machine>
@@ -1809,7 +1807,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <!-- allow ls5 modules to write to stderr without cime error -->
@@ -1824,21 +1822,21 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
 
       <modules>
-	<command name="reset"/>
-	<command name="load">cmake</command>
+        <command name="reset"/>
+        <command name="load">cmake</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/18.0.2</command>
+        <command name="load">intel/18.0.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">netcdf/4.6.2</command>
+        <command name="load">netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpich">
-	<command name="load">cray_mpich</command>
+        <command name="load">cray_mpich</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">pnetcdf/1.8.0</command>
-	<command name="load">parallel-netcdf/4.6.2</command>
+        <command name="load">pnetcdf/1.8.0</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
     </module_system>
   </machine>
@@ -1868,8 +1866,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
-	<arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to hwthread</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to hwthread</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1882,26 +1880,26 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">sems-env</command>
-	<command name="load">acme-env</command>
-	<command name="load">sems-git</command>
-	<command name="load">sems-python/2.7.9</command>
-	<command name="load">sems-cmake/2.8.12</command>
+        <command name="purge"/>
+        <command name="load">sems-env</command>
+        <command name="load">acme-env</command>
+        <command name="load">sems-git</command>
+        <command name="load">sems-python/2.7.9</command>
+        <command name="load">sems-cmake/2.8.12</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">sems-gcc/5.3.0</command>
+        <command name="load">sems-gcc/5.3.0</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">sems-intel/16.0.3</command>
+        <command name="load">sems-intel/16.0.3</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">sems-netcdf/4.4.1/exo</command>
-	<command name="load">acme-pfunit/3.2.8/base</command>
+        <command name="load">sems-netcdf/4.4.1/exo</command>
+        <command name="load">acme-pfunit/3.2.8/base</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">sems-openmpi/1.8.7</command>
-	<command name="load">sems-netcdf/4.4.1/exo_parallel</command>
+        <command name="load">sems-openmpi/1.8.7</command>
+        <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1936,15 +1934,15 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>/usr/bin/runjob</executable>
       <arguments>
-	<arg name="label"> --label short</arg>
-	<!-- Ranks per node!! -->
-	<arg name="tasks_per_node"> --ranks-per-node $MAX_MPITASKS_PER_NODE</arg>
-	<!-- Total MPI Tasks -->
-	<arg name="num_tasks"> --np {{ total_tasks }}</arg>
-	<arg name="locargs">--block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
-	<arg name="bg_threadlayout"> --envs BG_THREADLAYOUT=1</arg>
-	<arg name="omp_stacksize"> --envs OMP_STACKSIZE=32M</arg>
-	<arg name="thread_count"> --envs OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
+        <arg name="label"> --label short</arg>
+        <!-- Ranks per node!! -->
+        <arg name="tasks_per_node"> --ranks-per-node $MAX_MPITASKS_PER_NODE</arg>
+        <!-- Total MPI Tasks -->
+        <arg name="num_tasks"> --np {{ total_tasks }}</arg>
+        <arg name="locargs">--block $COBALT_PARTNAME --envs OMP_WAIT_POLICY=active --envs BG_SMP_FAST_WAKEUP=yes $LOCARGS</arg>
+        <arg name="bg_threadlayout"> --envs BG_THREADLAYOUT=1</arg>
+        <arg name="omp_stacksize"> --envs OMP_STACKSIZE=32M</arg>
+        <arg name="thread_count"> --envs OMP_NUM_THREADS=$ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="soft">
@@ -1953,10 +1951,10 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">soft</cmd_path>
       <cmd_path lang="sh">soft</cmd_path>
       <modules>
-	<command name="add">+mpiwrapper-xl</command>
-	<command name="add">@ibm-compilers-2015-02</command>
-	<command name="add">+cmake</command>
-	<command name="add">+python</command>
+        <command name="add">+mpiwrapper-xl</command>
+        <command name="add">@ibm-compilers-2015-02</command>
+        <command name="add">+cmake</command>
+        <command name="add">+python</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1986,42 +1984,42 @@ This allows using a different mpirun command to launch unit tests
       <COSTPES_PER_NODE>12</COSTPES_PER_NODE>
       <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
       <mpirun mpilib="default">
-	  <executable>mpirun</executable>
-	  <arguments>
-	      <arg name="num_tasks">-np {{ total_tasks }}</arg>
-	      <arg name="tasks_per_node">-npernode $MAX_TASKS_PER_NODE</arg>
-	  </arguments>
+          <executable>mpirun</executable>
+          <arguments>
+              <arg name="num_tasks">-np {{ total_tasks }}</arg>
+              <arg name="tasks_per_node">-npernode $MAX_TASKS_PER_NODE</arg>
+          </arguments>
       </mpirun>
       <module_system type="module">
-	  <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
-	  <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
-	  <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
-	  <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
-	  <cmd_path lang="sh">module</cmd_path>
-	  <cmd_path lang="csh">module</cmd_path>
-	  <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
-	  <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
-	  <modules>
-	      <command name="purge"/>
-	      <command name="load">perl/5.22.1</command>
-	      <command name="load">libxml2/2.9.2</command>
-	      <command name="load">maui/3.3.1</command>
-	      <command name="load">python/2.7.13</command>
-	  </modules>
-	  <modules compiler="gnu">
-	      <command name="load">gcc/5.4.0</command>
-	      <command name="load">gfortran/5.4.0</command>
-	      <command name="load">hdf5/1.8.19fates</command>
-	      <command name="load">netcdf/4.4.1.1-gnu540-fates</command>
-	      <command name="load">openmpi/2.1.1-gnu540</command>
-	  </modules>
-	  <modules compiler="gnu" mpilib="!mpi-serial">
-	      <command name="load">openmpi/2.1.1-gnu540</command>
-	  </modules>
+          <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
+          <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
+          <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
+          <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+          <cmd_path lang="sh">module</cmd_path>
+          <cmd_path lang="csh">module</cmd_path>
+          <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+          <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
+          <modules>
+              <command name="purge"/>
+              <command name="load">perl/5.22.1</command>
+              <command name="load">libxml2/2.9.2</command>
+              <command name="load">maui/3.3.1</command>
+              <command name="load">python/2.7.13</command>
+          </modules>
+          <modules compiler="gnu">
+              <command name="load">gcc/5.4.0</command>
+              <command name="load">gfortran/5.4.0</command>
+              <command name="load">hdf5/1.8.19fates</command>
+              <command name="load">netcdf/4.4.1.1-gnu540-fates</command>
+              <command name="load">openmpi/2.1.1-gnu540</command>
+          </modules>
+          <modules compiler="gnu" mpilib="!mpi-serial">
+              <command name="load">openmpi/2.1.1-gnu540</command>
+          </modules>
       </module_system>
        <environment_variables>
-	 <env name="HDF5_HOME">/data/software/hdf5/1.8.19fates</env>
-	 <env name="NETCDF_PATH">/data/software/netcdf/4.4.1.1-gnu540-fates</env>
+         <env name="HDF5_HOME">/data/software/hdf5/1.8.19fates</env>
+         <env name="NETCDF_PATH">/data/software/netcdf/4.4.1.1-gnu540-fates</env>
        </environment_variables>
   </machine>
 
@@ -2045,9 +2043,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-	<arg name="mpi">--mpi=none</arg>
-	<arg name="num_tasks">-n={{ total_tasks }}</arg>
-	<arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+        <arg name="mpi">--mpi=none</arg>
+        <arg name="num_tasks">-n={{ total_tasks }}</arg>
+        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2058,11 +2056,11 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">precision/i4</command>
-	<command name="load">pgi/11.8</command>
-	<command name="load">mvapich2/1.7</command>
-	<command name="load">netcdf/4.1.3</command>
+        <command name="purge"/>
+        <command name="load">precision/i4</command>
+        <command name="load">pgi/11.8</command>
+        <command name="load">mvapich2/1.7</command>
+        <command name="load">netcdf/4.1.3</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2090,7 +2088,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-	<arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2103,15 +2101,15 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">nas</command>
-	<command name="load">pkgsrc</command>
-	<command name="load">comp-intel/2018.3.222</command>
-	<command name="load">mpi-sgi/mpt.2.15r20</command>
-	<command name="load">szip/2.1.1</command>
-	<command name="load">hdf4/4.2.12</command>
-	<command name="load">hdf5/1.8.18_mpt</command>
-	<command name="load">netcdf/4.4.1.1_mpt</command>
+        <command name="purge"/>
+        <command name="load">nas</command>
+        <command name="load">pkgsrc</command>
+        <command name="load">comp-intel/2018.3.222</command>
+        <command name="load">mpi-sgi/mpt.2.15r20</command>
+        <command name="load">szip/2.1.1</command>
+        <command name="load">hdf4/4.2.12</command>
+        <command name="load">hdf5/1.8.18_mpt</command>
+        <command name="load">netcdf/4.4.1.1_mpt</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2142,7 +2140,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-	<arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2155,15 +2153,15 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">nas</command>
-	<command name="load">pkgsrc</command>
-	<command name="load">comp-intel/2018.3.222</command>
-	<command name="load">mpi-sgi/mpt.2.15r20</command>
-	<command name="load">szip/2.1.1</command>
-	<command name="load">hdf4/4.2.12</command>
-	<command name="load">hdf5/1.8.18_mpt</command>
-	<command name="load">netcdf/4.4.1.1_mpt</command>
+        <command name="purge"/>
+        <command name="load">nas</command>
+        <command name="load">pkgsrc</command>
+        <command name="load">comp-intel/2018.3.222</command>
+        <command name="load">mpi-sgi/mpt.2.15r20</command>
+        <command name="load">szip/2.1.1</command>
+        <command name="load">hdf4/4.2.12</command>
+        <command name="load">hdf5/1.8.18_mpt</command>
+        <command name="load">netcdf/4.4.1.1_mpt</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2194,7 +2192,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-	<arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2207,15 +2205,15 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">nas</command>
-	<command name="load">pkgsrc</command>
-	<command name="load">comp-intel/2018.3.222</command>
-	<command name="load">mpi-sgi/mpt.2.15r20</command>
-	<command name="load">szip/2.1.1</command>
-	<command name="load">hdf4/4.2.12</command>
-	<command name="load">hdf5/1.8.18_mpt</command>
-	<command name="load">netcdf/4.4.1.1_mpt</command>
+        <command name="purge"/>
+        <command name="load">nas</command>
+        <command name="load">pkgsrc</command>
+        <command name="load">comp-intel/2018.3.222</command>
+        <command name="load">mpi-sgi/mpt.2.15r20</command>
+        <command name="load">szip/2.1.1</command>
+        <command name="load">hdf4/4.2.12</command>
+        <command name="load">hdf5/1.8.18_mpt</command>
+        <command name="load">netcdf/4.4.1.1_mpt</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2246,7 +2244,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec_mpt</executable>
       <arguments>
-	<arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2259,15 +2257,15 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">nas</command>
-	<command name="load">pkgsrc</command>
-	<command name="load">comp-intel/2018.3.222</command>
-	<command name="load">mpi-sgi/mpt.2.15r20</command>
-	<command name="load">szip/2.1.1</command>
-	<command name="load">hdf4/4.2.12</command>
-	<command name="load">hdf5/1.8.18_mpt</command>
-	<command name="load">netcdf/4.4.1.1_mpt</command>
+        <command name="purge"/>
+        <command name="load">nas</command>
+        <command name="load">pkgsrc</command>
+        <command name="load">comp-intel/2018.3.222</command>
+        <command name="load">mpi-sgi/mpt.2.15r20</command>
+        <command name="load">szip/2.1.1</command>
+        <command name="load">hdf4/4.2.12</command>
+        <command name="load">hdf5/1.8.18_mpt</command>
+        <command name="load">netcdf/4.4.1.1_mpt</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2302,7 +2300,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2315,14 +2313,14 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">sems-env</command>
-	<command name="load">sems-git</command>
-	<command name="load">sems-python/2.7.9</command>
-	<command name="load">sems-gcc/5.1.0</command>
-	<command name="load">sems-openmpi/1.8.7</command>
-	<command name="load">sems-cmake/2.8.12</command>
-	<command name="load">sems-netcdf/4.3.2/parallel</command>
+        <command name="purge"/>
+        <command name="load">sems-env</command>
+        <command name="load">sems-git</command>
+        <command name="load">sems-python/2.7.9</command>
+        <command name="load">sems-gcc/5.1.0</command>
+        <command name="load">sems-openmpi/1.8.7</command>
+        <command name="load">sems-cmake/2.8.12</command>
+        <command name="load">sems-netcdf/4.3.2/parallel</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2356,8 +2354,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
-	<arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2370,21 +2368,21 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">sems-env</command>
-	<command name="load">sems-git</command>
-	<command name="load">sems-python/2.7.9</command>
-	<command name="load">gnu/4.9.2</command>
-	<command name="load">intel/intel-15.0.3.187</command>
-	<command name="load">libraries/intel-mkl-15.0.2.164</command>
-	<command name="load">libraries/intel-mkl-15.0.2.164</command>
+        <command name="purge"/>
+        <command name="load">sems-env</command>
+        <command name="load">sems-git</command>
+        <command name="load">sems-python/2.7.9</command>
+        <command name="load">gnu/4.9.2</command>
+        <command name="load">intel/intel-15.0.3.187</command>
+        <command name="load">libraries/intel-mkl-15.0.2.164</command>
+        <command name="load">libraries/intel-mkl-15.0.2.164</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load" >openmpi-intel/1.8</command>
-	<command name="load" >sems-hdf5/1.8.12/parallel</command>
-	<command name="load" >sems-netcdf/4.3.2/parallel</command>
-	<command name="load" >sems-hdf5/1.8.12/base</command>
-	<command name="load" >sems-netcdf/4.3.2/base</command>
+        <command name="load" >openmpi-intel/1.8</command>
+        <command name="load" >sems-hdf5/1.8.12/parallel</command>
+        <command name="load" >sems-netcdf/4.3.2/parallel</command>
+        <command name="load" >sems-hdf5/1.8.12/base</command>
+        <command name="load" >sems-netcdf/4.3.2/base</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2416,13 +2414,13 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="impi">
       <executable>ibrun</executable>
       <arguments>
-	<arg name="ntasks"> -n {{ total_tasks }} </arg>
+        <arg name="ntasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mvapich2">
       <executable>ibrun</executable>
       <arguments>
-	<arg name="ntasks"> -n {{ total_tasks }} </arg>
+        <arg name="ntasks"> -n {{ total_tasks }} </arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2435,25 +2433,25 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"></command>
-	<command name="load">TACC</command>
-	<command name="load">python/2.7.13</command>
-	<command name="load">intel/18.0.2</command>
-	<command name="load">cmake/3.16.1</command>
+        <command name="purge"></command>
+        <command name="load">TACC</command>
+        <command name="load">python/2.7.13</command>
+        <command name="load">intel/18.0.2</command>
+        <command name="load">cmake/3.16.1</command>
       </modules>
       <modules mpilib="mvapich2">
-	<command name="load">mvapich2/2.3.1</command>
-	<command name="load">pnetcdf/1.11</command>
-	<command name="load">parallel-netcdf/4.6.2</command>
+        <command name="load">mvapich2/2.3.1</command>
+        <command name="load">pnetcdf/1.11</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="impi">
-	<command name="rm">mvapich2</command>
-	<command name="load">impi/18.0.2</command>
-	<command name="load">pnetcdf/1.11</command>
-	<command name="load">parallel-netcdf/4.6.2</command>
+        <command name="rm">mvapich2</command>
+        <command name="load">impi/18.0.2</command>
+        <command name="load">pnetcdf/1.11</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">netcdf/4.3.3.1</command>
+        <command name="load">netcdf/4.3.3.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2504,25 +2502,25 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"></command>
-	<command name="load">TACC</command>
-	<command name="load">python/2.7.13</command>
-	<command name="load">intel/18.0.2</command>
-	<command name="load">cmake/3.16.1</command>
+        <command name="purge"></command>
+        <command name="load">TACC</command>
+        <command name="load">python/2.7.13</command>
+        <command name="load">intel/18.0.2</command>
+        <command name="load">cmake/3.16.1</command>
       </modules>
       <modules mpilib="mvapich2">
-	<command name="load">mvapich2/2.3.1</command>
-	<command name="load">pnetcdf/1.11</command>
-	<command name="load">parallel-netcdf/4.6.2</command>
+        <command name="load">mvapich2/2.3.1</command>
+        <command name="load">pnetcdf/1.11</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="impi">
-	<command name="rm">mvapich2</command>
-	<command name="load">impi/18.0.2</command>
-	<command name="load">pnetcdf/1.11</command>
-	<command name="load">parallel-netcdf/4.6.2</command>
+        <command name="rm">mvapich2</command>
+        <command name="load">impi/18.0.2</command>
+        <command name="load">pnetcdf/1.11</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">netcdf/4.3.3.1</command>
+        <command name="load">netcdf/4.3.3.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2554,7 +2552,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>
-	<arg name="num_tasks">-n $TOTALPES</arg>
+        <arg name="num_tasks">-n $TOTALPES</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpi-serial">
@@ -2567,14 +2565,14 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="python">/apps/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="intel">
-	<command name="purge"/>
-	<command name="load">intel/15.1.133</command>
-	<command name="load">impi/5.1.1.109</command>
-	<command name="load">netcdf/4.3.0</command>
-	<command name="load">pnetcdf</command>
-	<command name="use">/scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles</command>
-	<command name="load">yaml-cpp</command>
-	<command name="load">esmf/8.0.0bs29g</command>
+        <command name="purge"/>
+        <command name="load">intel/15.1.133</command>
+        <command name="load">impi/5.1.1.109</command>
+        <command name="load">netcdf/4.3.0</command>
+        <command name="load">pnetcdf</command>
+        <command name="use">/scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles</command>
+        <command name="load">yaml-cpp</command>
+        <command name="load">esmf/8.0.0bs29g</command>
       </modules>
     </module_system>
     <environment_variables comp_interface="nuopc">
@@ -2608,11 +2606,11 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
-	<arg name="num_tasks" >-n {{ total_tasks }}</arg>
-	<arg name="tasks_per_node" >-N {{ tasks_per_node }} </arg>
-	<arg name="thread_count">--cc depth -d $OMP_NUM_THREADS</arg>
-	<arg name="env_omp_stacksize">-e OMP_STACKSIZE=64M</arg>
-	<arg name="env_thread_count">-e OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
+        <arg name="num_tasks" >-n {{ total_tasks }}</arg>
+        <arg name="tasks_per_node" >-N {{ tasks_per_node }} </arg>
+        <arg name="thread_count">--cc depth -d $OMP_NUM_THREADS</arg>
+        <arg name="env_omp_stacksize">-e OMP_STACKSIZE=64M</arg>
+        <arg name="env_thread_count">-e OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2625,52 +2623,52 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="rm">craype-mic-knl</command>
-	<command name="rm">PrgEnv-intel</command>
-	<command name="rm">PrgEnv-cray</command>
-	<command name="rm">PrgEnv-gnu</command>
-	<command name="rm">intel</command>
-	<command name="rm">cce</command>
-	<command name="rm">cray-parallel-netcdf</command>
-	<command name="rm">cray-hdf5-parallel</command>
-	<command name="rm">pmi</command>
-	<command name="rm">cray-libsci</command>
-	<command name="rm">cray-mpich</command>
-	<command name="rm">cray-netcdf</command>
-	<command name="rm">cray-hdf5</command>
-	<command name="rm">cray-netcdf-hdf5parallel</command>
-	<command name="rm">craype</command>
-	<command name="rm">papi</command>
+        <command name="rm">craype-mic-knl</command>
+        <command name="rm">PrgEnv-intel</command>
+        <command name="rm">PrgEnv-cray</command>
+        <command name="rm">PrgEnv-gnu</command>
+        <command name="rm">intel</command>
+        <command name="rm">cce</command>
+        <command name="rm">cray-parallel-netcdf</command>
+        <command name="rm">cray-hdf5-parallel</command>
+        <command name="rm">pmi</command>
+        <command name="rm">cray-libsci</command>
+        <command name="rm">cray-mpich</command>
+        <command name="rm">cray-netcdf</command>
+        <command name="rm">cray-hdf5</command>
+        <command name="rm">cray-netcdf-hdf5parallel</command>
+        <command name="rm">craype</command>
+        <command name="rm">papi</command>
       </modules>
 
       <modules compiler="intel">
-	<command name="load">PrgEnv-intel/6.0.4</command>
-	<command name="switch">intel intel/18.0.0.128</command>
-	<command name="rm">cray-libsci</command>
+        <command name="load">PrgEnv-intel/6.0.4</command>
+        <command name="switch">intel intel/18.0.0.128</command>
+        <command name="rm">cray-libsci</command>
       </modules>
 
       <modules compiler="cray">
-	<command name="load">PrgEnv-cray/6.0.4</command>
-	<command name="switch">cce cce/8.7.0</command>
+        <command name="load">PrgEnv-cray/6.0.4</command>
+        <command name="switch">cce cce/8.7.0</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">PrgEnv-gnu/6.0.4</command>
-	<command name="switch">gcc gcc/7.3.0</command>
+        <command name="load">PrgEnv-gnu/6.0.4</command>
+        <command name="switch">gcc gcc/7.3.0</command>
       </modules>
       <modules>
-	<command name="load">papi/5.6.0.1</command>
-	<command name="swap">craype craype/2.5.14</command>
+        <command name="load">papi/5.6.0.1</command>
+        <command name="swap">craype craype/2.5.14</command>
       </modules>
       <modules compiler="!intel">
-	<command name="switch">cray-libsci/18.04.1</command>
+        <command name="switch">cray-libsci/18.04.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.0</command>
+        <command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpt">
-	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
-	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
+        <command name="load">cray-hdf5-parallel/1.10.1.1</command>
+        <command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
     </module_system>
   </machine>
@@ -2696,8 +2694,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec</executable>
       <arguments>
-	<arg name="labelstdout">--tag-output</arg>
-	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="labelstdout">--tag-output</arg>
+        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -2710,38 +2708,38 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
-	<command name="load">ncarenv/1.3</command>
-	<command name="load">cmake/3.14.4</command>
+        <command name="purge"/>
+        <command name="load">ncarenv/1.3</command>
+        <command name="load">cmake/3.14.4</command>
       </modules>
       <modules compiler="arm">
-	<command name="load">arm/19.3</command>
+        <command name="load">arm/19.3</command>
       </modules>
       <modules compiler="armgcc">
-	<command name="load">armgcc/8.2.0</command>
+        <command name="load">armgcc/8.2.0</command>
       </modules>
       <modules compiler="gnu">
-	<command name="load">gnu/9.1.0</command>
-	<command name="load">openblas/0.3.6</command>
-	<command name="load">esmf_libs/8.0.0</command>
+        <command name="load">gnu/9.1.0</command>
+        <command name="load">openblas/0.3.6</command>
+        <command name="load">esmf_libs/8.0.0</command>
       </modules>
       <!-- must load after compiler -->
       <modules>
-	<command name="load">ncarcompilers/0.5.0</command>
+        <command name="load">ncarcompilers/0.5.0</command>
       </modules>
       <modules mpilib="openmpi">
-	<command name="load">openmpi/4.0.3</command>
-	<command name="load">netcdf-mpi/4.7.1</command>
-	<command name="load">pnetcdf/1.12.1</command>
+        <command name="load">openmpi/4.0.3</command>
+        <command name="load">netcdf-mpi/4.7.1</command>
+        <command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">netcdf/4.7.1</command>
+        <command name="load">netcdf/4.7.1</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial" DEBUG="TRUE">
-	<command name="load">esmf-8.0.0-ncdfio-uni-g</command>
+        <command name="load">esmf-8.0.0-ncdfio-uni-g</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial" DEBUG="FALSE">
-	<command name="load">esmf-8.0.0-ncdfio-uni-O</command>
+        <command name="load">esmf-8.0.0-ncdfio-uni-O</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -68,12 +68,12 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>aprun</executable>
       <arguments>
-        <arg name="hyperthreading" default="1"> -j {{ hyperthreading }}</arg>
-        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
-        <arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
-        <arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
-        <arg name="env_thread_count">--mpmd-env OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
+	<arg name="hyperthreading" default="1"> -j {{ hyperthreading }}</arg>
+	<arg name="num_tasks"> -n {{ total_tasks }}</arg>
+	<arg name="tasks_per_node"> -N $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="tasks_per_numa" > -S {{ tasks_per_numa }}</arg>
+	<arg name="thread_count"> -d $ENV{OMP_NUM_THREADS}</arg>
+	<arg name="env_thread_count">--mpmd-env OMP_NUM_THREADS=$OMP_NUM_THREADS</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -86,27 +86,27 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="rm">craype-x86-skylake</command>
-        <command name="rm">PrgEnv-pgi</command>
-        <command name="rm">PrgEnv-intel</command>
-        <command name="rm">PrgEnv-cray</command>
-        <command name="rm">PrgEnv-gnu</command>
-        <command name="rm">cray-netcdf</command>
-        <command name="rm">cray-hdf5</command>
-        <command name="rm">cray-parallel-netcdf</command>
-        <command name="rm">papi</command>
+	<command name="rm">craype-x86-skylake</command>
+	<command name="rm">PrgEnv-pgi</command>
+	<command name="rm">PrgEnv-intel</command>
+	<command name="rm">PrgEnv-cray</command>
+	<command name="rm">PrgEnv-gnu</command>
+	<command name="rm">cray-netcdf</command>
+	<command name="rm">cray-hdf5</command>
+	<command name="rm">cray-parallel-netcdf</command>
+	<command name="rm">papi</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel</command>
-        <command name="load">craype-x86-skylake</command>
-        <command name="load">craype-hugepages2M</command>
-        <command name="rm">perftools-base/7.0.4</command>
-        <command name="load">cray-netcdf/4.6.1.3</command>
-        <command name="load">cray-hdf5/1.10.2.0</command>
-        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
-        <command name="load">papi/5.6.0.4</command>
-        <command name="load">gridftp/6.0</command>
-        <command name="load">cray-python/3.6.5.1</command>
+	<command name="load">PrgEnv-intel</command>
+	<command name="load">craype-x86-skylake</command>
+	<command name="load">craype-hugepages2M</command>
+	<command name="rm">perftools-base/7.0.4</command>
+	<command name="load">cray-netcdf/4.6.1.3</command>
+	<command name="load">cray-hdf5/1.10.2.0</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
+	<command name="load">papi/5.6.0.4</command>
+	<command name="load">gridftp/6.0</command>
+	<command name="load">cray-python/3.6.5.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -147,42 +147,42 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules compiler="intel">
-        <command name="load">ANACONDA2/python2.7</command>
-        <command name="load">INTEL/intel_xe_2015.3.187</command>
-        <command name="load">SZIP/szip-2.1_int15</command>
+	<command name="load">ANACONDA2/python2.7</command>
+	<command name="load">INTEL/intel_xe_2015.3.187</command>
+	<command name="load">SZIP/szip-2.1_int15</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-        <command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-g_int15</command>
+	<command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-g_int15</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-        <command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-O_int15</command>
+	<command name="load">ESMF/esmf-6.3.0rp1-intelmpi-64-O_int15</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-g_int15</command>
+	<command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-g_int15</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-O_int15</command>
+	<command name="load">ESMF/esmf-6.3.0rp1-mpiuni-64-O_int15</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">HDF5/hdf5-1.8.15-patch1</command>
-        <command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1</command>
+	<command name="load">HDF5/hdf5-1.8.15-patch1</command>
+	<command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">HDF5/hdf5-1.8.15-patch1_parallel</command>
-        <command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1_parallel</command>
-        <command name="load">PARALLEL_NETCDF/parallel-netcdf-1.6.1</command>
+	<command name="load">HDF5/hdf5-1.8.15-patch1_parallel</command>
+	<command name="load">NETCDF/netcdf-C_4.3.3.1-F_4.4.2_C++_4.2.1_parallel</command>
+	<command name="load">PARALLEL_NETCDF/parallel-netcdf-1.6.1</command>
       </modules>
       <modules>
-        <command name="load">CMAKE/cmake-3.3.0-rc1</command>
+	<command name="load">CMAKE/cmake-3.3.0-rc1</command>
       </modules>
       <modules compiler="intel">
-        <command name="unload">INTEL/intel_xe_2013.5.192</command>
-        <command name="unload">INTEL/intel_xe_2013</command>
-        <command name="unload">HDF5/hdf5-1.8.10-patch1</command>
-        <command name="load">INTEL/intel_xe_2015.3.187</command>
+	<command name="unload">INTEL/intel_xe_2013.5.192</command>
+	<command name="unload">INTEL/intel_xe_2013</command>
+	<command name="unload">HDF5/hdf5-1.8.10-patch1</command>
+	<command name="load">INTEL/intel_xe_2015.3.187</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -375,13 +375,13 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="anum_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="anum_tasks"> -np {{ total_tasks }}</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -394,21 +394,21 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules>
-        <command name="load">ncarenv/1.3</command>
+	<command name="load">ncarenv/1.3</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">pgi/20.4</command>
+	<command name="load">pgi/20.4</command>
       </modules>
       <modules mpilib="openmpi" compiler="pgi">
-        <command name="load">openmpi/3.1.4</command>
-        <command name="load">netcdf-mpi/4.7.3</command>
-        <command name="load">pnetcdf/1.12.1</command>
+	<command name="load">openmpi/3.1.4</command>
+	<command name="load">netcdf-mpi/4.7.3</command>
+	<command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules>
-        <command name="load">ncarcompilers/0.5.0</command>
+	<command name="load">ncarcompilers/0.5.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -497,36 +497,36 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gnu/9.1.0</command>
-        <command name="load">openblas/0.3.6</command>
+	<command name="load">gnu/9.1.0</command>
+	<command name="load">openblas/0.3.6</command>
       </modules>
       <modules compiler="pgi">
 	<command name="load">pgi/19.3</command>
       </modules>
 
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpiuni-g</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpiuni-O</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpiuni-O</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+	<command name="load">esmf-8.1.0b23-ncdfio-mpt-O</command>
       </modules>
 
       <modules mpilib="mpt" compiler="gnu">
@@ -550,8 +550,8 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules mpilib="openmpi" compiler="gnu">
-        <command name="load">openmpi/3.1.4</command>
-        <command name="load">netcdf/4.7.1</command>
+	<command name="load">openmpi/3.1.4</command>
+	<command name="load">netcdf/4.7.1</command>
       </modules>
       <modules>
 	<command name="load">ncarcompilers/0.5.0</command>
@@ -587,6 +587,9 @@ This allows using a different mpirun command to launch unit tests
       <env name="TMPDIR">/glade/scratch/$USER</env>
       <env name="MPI_USE_ARRAY">false</env>
     </environment_variables>
+    <source_files>
+      <filepath>/glade/scratch/jedwards/dothis</filepath>
+    </source_files>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
     </resource_limits>
@@ -616,9 +619,9 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>srun</executable>
       <arguments>
-        <arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
-        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
-        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+	<arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+	<arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -631,13 +634,13 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"/>
+	<command name="purge"/>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gcc-6.3.0</command>
-        <command name="load">mvapich2-2.2-psm/gcc-6.3.0</command>
-        <command name="load">General/netcdf/4.4.1.1/gcc-6.3.0</command>
-        <command name="load">Python/2.7.13/gcc-6.3.0</command>
+	<command name="load">gcc-6.3.0</command>
+	<command name="load">mvapich2-2.2-psm/gcc-6.3.0</command>
+	<command name="load">General/netcdf/4.4.1.1/gcc-6.3.0</command>
+	<command name="load">Python/2.7.13/gcc-6.3.0</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1653,8 +1656,8 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gnu/9.1.0</command>
-        <command name="load">openblas/0.3.6</command>
+	<command name="load">gnu/9.1.0</command>
+	<command name="load">openblas/0.3.6</command>
       </modules>
       <modules mpilib="mpt">
 	<command name="load">mpt/2.21</command>
@@ -1715,20 +1718,20 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
       <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">cmake</command>
-        <command name="load">perl xml-libxml switch python/2.7</command>
+	<command name="purge"/>
+	<command name="load">cmake</command>
+	<command name="load">perl xml-libxml switch python/2.7</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/2016.4.072</command>
-        <command name="load">mkl</command>
+	<command name="load">intel/2016.4.072</command>
+	<command name="load">mkl</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
-        <command name="load">netcdf/4.4.1.1-intel-s</command>
+	<command name="load">netcdf/4.4.1.1-intel-s</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial">
-        <command name="load">openmpi</command>
-        <command name="load">netcdf/4.4.1.1-intel-p</command>
+	<command name="load">openmpi</command>
+	<command name="load">netcdf/4.4.1.1-intel-p</command>
       </modules>
     </module_system>
   </machine>
@@ -1753,8 +1756,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="tasks_per_node"> -npernode $MAX_MPITASKS_PER_NODE</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1767,20 +1770,20 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="perl">/usr/Modules/bin/modulecmd perl</cmd_path>
       <cmd_path lang="python">/usr/Modules/bin/modulecmd python</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">cmake</command>
-        <command name="load">perl xml-libxml switch python/2.7</command>
+	<command name="purge"/>
+	<command name="load">cmake</command>
+	<command name="load">perl xml-libxml switch python/2.7</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/2016.4.072</command>
-        <command name="load">mkl</command>
+	<command name="load">intel/2016.4.072</command>
+	<command name="load">mkl</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
-        <command name="load">netcdf/4.4.1.1-intel-s</command>
+	<command name="load">netcdf/4.4.1.1-intel-s</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial">
-        <command name="load">openmpi</command>
-        <command name="load">netcdf/4.4.1.1-intel-p</command>
+	<command name="load">openmpi</command>
+	<command name="load">netcdf/4.4.1.1-intel-p</command>
       </modules>
     </module_system>
   </machine>
@@ -1821,20 +1824,20 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
 
       <modules>
-        <command name="reset"/>
-        <command name="load">cmake</command>
+	<command name="reset"/>
+	<command name="load">cmake</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/18.0.2</command>
+	<command name="load">intel/18.0.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">netcdf/4.6.2</command>
+	<command name="load">netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpich">
 	<command name="load">cray_mpich</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">pnetcdf/1.8.0</command>
+	<command name="load">pnetcdf/1.8.0</command>
 	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
     </module_system>
@@ -1865,8 +1868,8 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpirun</executable>
       <arguments>
-        <arg name="num_tasks"> -np {{ total_tasks }}</arg>
-        <arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to hwthread</arg>
+	<arg name="num_tasks"> -np {{ total_tasks }}</arg>
+	<arg name="tasks_per_node"> --map-by ppr:{{ tasks_per_numa }}:socket:PE=$ENV{OMP_NUM_THREADS} --bind-to hwthread</arg>
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1879,26 +1882,26 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <modules>
-        <command name="purge"/>
-        <command name="load">sems-env</command>
-        <command name="load">acme-env</command>
-        <command name="load">sems-git</command>
-        <command name="load">sems-python/2.7.9</command>
-        <command name="load">sems-cmake/2.8.12</command>
+	<command name="purge"/>
+	<command name="load">sems-env</command>
+	<command name="load">acme-env</command>
+	<command name="load">sems-git</command>
+	<command name="load">sems-python/2.7.9</command>
+	<command name="load">sems-cmake/2.8.12</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">sems-gcc/5.3.0</command>
+	<command name="load">sems-gcc/5.3.0</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">sems-intel/16.0.3</command>
+	<command name="load">sems-intel/16.0.3</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">sems-netcdf/4.4.1/exo</command>
-        <command name="load">acme-pfunit/3.2.8/base</command>
+	<command name="load">sems-netcdf/4.4.1/exo</command>
+	<command name="load">acme-pfunit/3.2.8/base</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">sems-openmpi/1.8.7</command>
-        <command name="load">sems-netcdf/4.4.1/exo_parallel</command>
+	<command name="load">sems-openmpi/1.8.7</command>
+	<command name="load">sems-netcdf/4.4.1/exo_parallel</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1983,42 +1986,42 @@ This allows using a different mpirun command to launch unit tests
       <COSTPES_PER_NODE>12</COSTPES_PER_NODE>
       <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
       <mpirun mpilib="default">
-          <executable>mpirun</executable>
-          <arguments>
-              <arg name="num_tasks">-np {{ total_tasks }}</arg>
-              <arg name="tasks_per_node">-npernode $MAX_TASKS_PER_NODE</arg>
-          </arguments>
+	  <executable>mpirun</executable>
+	  <arguments>
+	      <arg name="num_tasks">-np {{ total_tasks }}</arg>
+	      <arg name="tasks_per_node">-npernode $MAX_TASKS_PER_NODE</arg>
+	  </arguments>
       </mpirun>
       <module_system type="module">
-          <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
-          <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
-          <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
-          <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
-          <cmd_path lang="sh">module</cmd_path>
-          <cmd_path lang="csh">module</cmd_path>
-          <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
-          <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
-          <modules>
-              <command name="purge"/>
-              <command name="load">perl/5.22.1</command>
-              <command name="load">libxml2/2.9.2</command>
-              <command name="load">maui/3.3.1</command>
-              <command name="load">python/2.7.13</command>
-          </modules>
-          <modules compiler="gnu">
-              <command name="load">gcc/5.4.0</command>
-              <command name="load">gfortran/5.4.0</command>
-              <command name="load">hdf5/1.8.19fates</command>
-              <command name="load">netcdf/4.4.1.1-gnu540-fates</command>
-              <command name="load">openmpi/2.1.1-gnu540</command>
-          </modules>
-          <modules compiler="gnu" mpilib="!mpi-serial">
-              <command name="load">openmpi/2.1.1-gnu540</command>
-          </modules>
+	  <init_path lang="sh">/etc/profile.d/modules.sh</init_path>
+	  <init_path lang="csh">/etc/profile.d/modules.csh</init_path>
+	  <init_path lang="perl">/usr/share/Modules/init/perl.pm</init_path>
+	  <init_path lang="python">/usr/share/Modules/init/python.py</init_path>
+	  <cmd_path lang="sh">module</cmd_path>
+	  <cmd_path lang="csh">module</cmd_path>
+	  <cmd_path lang="perl">/usr/bin/modulecmd perl</cmd_path>
+	  <cmd_path lang="python">/usr/bin/modulecmd python</cmd_path>
+	  <modules>
+	      <command name="purge"/>
+	      <command name="load">perl/5.22.1</command>
+	      <command name="load">libxml2/2.9.2</command>
+	      <command name="load">maui/3.3.1</command>
+	      <command name="load">python/2.7.13</command>
+	  </modules>
+	  <modules compiler="gnu">
+	      <command name="load">gcc/5.4.0</command>
+	      <command name="load">gfortran/5.4.0</command>
+	      <command name="load">hdf5/1.8.19fates</command>
+	      <command name="load">netcdf/4.4.1.1-gnu540-fates</command>
+	      <command name="load">openmpi/2.1.1-gnu540</command>
+	  </modules>
+	  <modules compiler="gnu" mpilib="!mpi-serial">
+	      <command name="load">openmpi/2.1.1-gnu540</command>
+	  </modules>
       </module_system>
        <environment_variables>
-         <env name="HDF5_HOME">/data/software/hdf5/1.8.19fates</env>
-         <env name="NETCDF_PATH">/data/software/netcdf/4.4.1.1-gnu540-fates</env>
+	 <env name="HDF5_HOME">/data/software/hdf5/1.8.19fates</env>
+	 <env name="NETCDF_PATH">/data/software/netcdf/4.4.1.1-gnu540-fates</env>
        </environment_variables>
   </machine>
 
@@ -2432,25 +2435,25 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"></command>
-        <command name="load">TACC</command>
-        <command name="load">python/2.7.13</command>
-        <command name="load">intel/18.0.2</command>
-        <command name="load">cmake/3.16.1</command>
+	<command name="purge"></command>
+	<command name="load">TACC</command>
+	<command name="load">python/2.7.13</command>
+	<command name="load">intel/18.0.2</command>
+	<command name="load">cmake/3.16.1</command>
       </modules>
       <modules mpilib="mvapich2">
-        <command name="load">mvapich2/2.3.1</command>
-        <command name="load">pnetcdf/1.11</command>
-        <command name="load">parallel-netcdf/4.6.2</command>
+	<command name="load">mvapich2/2.3.1</command>
+	<command name="load">pnetcdf/1.11</command>
+	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="impi">
-        <command name="rm">mvapich2</command>
-        <command name="load">impi/18.0.2</command>
-        <command name="load">pnetcdf/1.11</command>
-        <command name="load">parallel-netcdf/4.6.2</command>
+	<command name="rm">mvapich2</command>
+	<command name="load">impi/18.0.2</command>
+	<command name="load">pnetcdf/1.11</command>
+	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">netcdf/4.3.3.1</command>
+	<command name="load">netcdf/4.3.3.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2501,25 +2504,25 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="purge"></command>
-        <command name="load">TACC</command>
-        <command name="load">python/2.7.13</command>
-        <command name="load">intel/18.0.2</command>
-        <command name="load">cmake/3.16.1</command>
+	<command name="purge"></command>
+	<command name="load">TACC</command>
+	<command name="load">python/2.7.13</command>
+	<command name="load">intel/18.0.2</command>
+	<command name="load">cmake/3.16.1</command>
       </modules>
       <modules mpilib="mvapich2">
-        <command name="load">mvapich2/2.3.1</command>
-        <command name="load">pnetcdf/1.11</command>
-        <command name="load">parallel-netcdf/4.6.2</command>
+	<command name="load">mvapich2/2.3.1</command>
+	<command name="load">pnetcdf/1.11</command>
+	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="impi">
-        <command name="rm">mvapich2</command>
-        <command name="load">impi/18.0.2</command>
-        <command name="load">pnetcdf/1.11</command>
-        <command name="load">parallel-netcdf/4.6.2</command>
+	<command name="rm">mvapich2</command>
+	<command name="load">impi/18.0.2</command>
+	<command name="load">pnetcdf/1.11</command>
+	<command name="load">parallel-netcdf/4.6.2</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">netcdf/4.3.3.1</command>
+	<command name="load">netcdf/4.3.3.1</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2564,14 +2567,14 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="csh">module</cmd_path>
       <cmd_path lang="python">/apps/lmod/lmod/libexec/lmod python</cmd_path>
       <modules compiler="intel">
-        <command name="purge"/>
-        <command name="load">intel/15.1.133</command>
-        <command name="load">impi/5.1.1.109</command>
-        <command name="load">netcdf/4.3.0</command>
-        <command name="load">pnetcdf</command>
-        <command name="use">/scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles</command>
+	<command name="purge"/>
+	<command name="load">intel/15.1.133</command>
+	<command name="load">impi/5.1.1.109</command>
+	<command name="load">netcdf/4.3.0</command>
+	<command name="load">pnetcdf</command>
+	<command name="use">/scratch4/NCEPDEV/nems/noscrub/emc.nemspara/soft/modulefiles</command>
 	<command name="load">yaml-cpp</command>
-        <command name="load">esmf/8.0.0bs29g</command>
+	<command name="load">esmf/8.0.0bs29g</command>
       </modules>
     </module_system>
     <environment_variables comp_interface="nuopc">
@@ -2641,33 +2644,33 @@ This allows using a different mpirun command to launch unit tests
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/6.0.4</command>
-        <command name="switch">intel intel/18.0.0.128</command>
-        <command name="rm">cray-libsci</command>
+	<command name="load">PrgEnv-intel/6.0.4</command>
+	<command name="switch">intel intel/18.0.0.128</command>
+	<command name="rm">cray-libsci</command>
       </modules>
 
       <modules compiler="cray">
-        <command name="load">PrgEnv-cray/6.0.4</command>
-        <command name="switch">cce cce/8.7.0</command>
+	<command name="load">PrgEnv-cray/6.0.4</command>
+	<command name="switch">cce cce/8.7.0</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu/6.0.4</command>
-        <command name="switch">gcc gcc/7.3.0</command>
+	<command name="load">PrgEnv-gnu/6.0.4</command>
+	<command name="switch">gcc gcc/7.3.0</command>
       </modules>
       <modules>
-        <command name="load">papi/5.6.0.1</command>
-        <command name="swap">craype craype/2.5.14</command>
+	<command name="load">papi/5.6.0.1</command>
+	<command name="swap">craype craype/2.5.14</command>
       </modules>
       <modules compiler="!intel">
-        <command name="switch">cray-libsci/18.04.1</command>
+	<command name="switch">cray-libsci/18.04.1</command>
       </modules>
       <modules>
-        <command name="load">cray-mpich/7.7.0</command>
+	<command name="load">cray-mpich/7.7.0</command>
       </modules>
       <modules mpilib="mpt">
-        <command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
-        <command name="load">cray-hdf5-parallel/1.10.1.1</command>
-        <command name="load">cray-parallel-netcdf/1.8.1.3</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.4.1.1.6</command>
+	<command name="load">cray-hdf5-parallel/1.10.1.1</command>
+	<command name="load">cray-parallel-netcdf/1.8.1.3</command>
       </modules>
     </module_system>
   </machine>
@@ -2718,8 +2721,8 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">armgcc/8.2.0</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gnu/9.1.0</command>
-        <command name="load">openblas/0.3.6</command>
+	<command name="load">gnu/9.1.0</command>
+	<command name="load">openblas/0.3.6</command>
 	<command name="load">esmf_libs/8.0.0</command>
       </modules>
       <!-- must load after compiler -->

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -65,6 +65,7 @@
   <xs:element name="EXEROOT" type="xs:string"/>
   <xs:element name="TEST_TPUT_TOLERANCE" type="xs:string"/>
   <xs:element name="MAX_GB_OLD_TEST_DATA" type="xs:string"/>
+  <xs:element name="filepath" type="xs:anyURI"/>
 
 
   <!-- complex elements -->
@@ -72,8 +73,8 @@
   <xs:complexType name="AttrElement">
     <xs:simpleContent>
       <xs:extension base="xs:string">
-        <xs:attribute ref="compiler">
-        </xs:attribute>
+	<xs:attribute ref="compiler">
+	</xs:attribute>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -82,8 +83,8 @@
   <xs:element name="config_machines">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
-        <xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
+	<xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
+	<xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute ref="version"/>
     </xs:complexType>
@@ -91,95 +92,96 @@
   <xs:element name="machine">
     <xs:complexType>
       <xs:sequence>
-        <!-- DESC: a text description of the machine, this field is current not used-->
-        <xs:element ref="DESC" minOccurs="1" maxOccurs="1"/>
-        <!-- NODENAME_REGEX: a regular expression used to identify this machine
-          it must work on compute nodes as well as login nodes, use machine option
-          to create_test or create_newcase if this flag is not available -->
-        <xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
-        <!-- regex to look for in log files that will triger retry of mpirun
-             command on extra allocated nodes -->
-        <xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
-        <!-- regex to look for in log files that will triger retry of mpirun command -->
-        <xs:element ref="MPIRUN_RETRY_REGEX" minOccurs="0" maxOccurs="1"/>
-        <!-- Number of retry attempts to make if MPIRUN_RETRY_REGEX matches   -->
-        <xs:element ref="MPIRUN_RETRY_COUNT" minOccurs="0" maxOccurs="1"/>
-        <!-- OS: the operating system of this machine. -->
-        <xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
-        <!-- PROXY: optional http proxy for access to the internet-->
-        <xs:element ref="PROXY" minOccurs="0" maxOccurs="1"/>
-        <!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
-        <xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
-        <!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
-        <xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
-        <!-- PROJECT: A project or account number used for batch jobs
-          can be overridden in environment or $HOME/.cime/config -->
-        <xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>
-        <!-- CHARGE_ACCOUNT: The name of the account to charge for batch jobs
-          can be overridden in environment or $HOME/.cime/config -->
-        <xs:element ref="CHARGE_ACCOUNT" minOccurs="0" maxOccurs="1"/>
-        <!-- SAVE_TIMING_DIR: (Acme only) directory for archiving timing output -->
-        <xs:element ref="SAVE_TIMING_DIR" minOccurs="0" maxOccurs="1"/>
-        <!-- SAVE_TIMING_DIR_PROJECTS: (Acme only) projects whose jobs archive timing output -->
-        <xs:element ref="SAVE_TIMING_DIR_PROJECTS" minOccurs="0" maxOccurs="1"/>
-        <!-- CIME_OUTPUT_ROOT: Base directory for case output,
-             the bld and run directories are written below here -->
-        <xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
-        <!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
-        <xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
-        <!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
-        <xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
-        <!-- DIN_LOC_ROOT: location of the inputdata directory -->
-        <xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
-        <!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
-        <xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
-        <!-- DOUT_S_ROOT: root directory of short term archive files -->
-        <xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
-        <!-- BASELINE_ROOT:  Root directory for system test baseline files -->
-        <xs:element ref="BASELINE_ROOT" minOccurs="0" maxOccurs="1"/>
-        <!-- CCSM_CPRNC: location of the cprnc tool, compares model output in testing-->
-        <xs:element ref="CCSM_CPRNC" minOccurs="0" maxOccurs="1"/>
-        <!-- PERL5LIB: location of external PERL modules (this variable is deprecated) -->
-        <xs:element ref="PERL5LIB" minOccurs="0" maxOccurs="1"/>
-        <!-- GMAKE: gnu compatible make tool, default is 'gmake' -->
-        <xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
-        <!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
-        <xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
-        <!-- TESTS: (acme only) list of tests to run on this machine -->
-        <xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
-        <!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->
-        <xs:element ref="NTEST_PARALLEL_JOBS" minOccurs="0" maxOccurs="1"/>
-        <!-- BATCH_SYSTEM: batch system used on this machine (none is okay) -->
-        <xs:element ref="BATCH_SYSTEM" minOccurs="1" maxOccurs="1"/>
-        <!-- ALLOCATE_SPARE_NODES: allocate spare nodes when job is launched default False-->
-        <xs:element ref="ALLOCATE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
-        <!-- SUPPORTED_BY: contact information for support for this system -->
-        <xs:element ref="SUPPORTED_BY" minOccurs="1" maxOccurs="1"/>
-        <!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
-             shared memory node on this machine-->
-        <xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="4"/>
-        <!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
-             this machine, in practice the MPI tasks per node will not exceed this value -->
-        <xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="4"/>
-        <!-- Optional cost factor per node unit -->
-        <xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
-        <!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
-             the batch system?  See PROJECT above -->
-        <xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>
-        <!-- mpirun: The mpi exec to start a job on this machine
-             see detail below-->
-        <xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
-        <!-- module_system: how and what modules to load on this system ,
-             see detail below -->
-        <xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
-        <!-- environment_variables: environment_variables to set on this system,
-          see detail below-->
-        <xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
-        <xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
-        <xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
-        <xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
+	<!-- DESC: a text description of the machine, this field is current not used-->
+	<xs:element ref="DESC" minOccurs="1" maxOccurs="1"/>
+	<!-- NODENAME_REGEX: a regular expression used to identify this machine
+	  it must work on compute nodes as well as login nodes, use machine option
+	  to create_test or create_newcase if this flag is not available -->
+	<xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
+	<!-- regex to look for in log files that will triger retry of mpirun
+	     command on extra allocated nodes -->
+	<xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
+	<!-- regex to look for in log files that will triger retry of mpirun command -->
+	<xs:element ref="MPIRUN_RETRY_REGEX" minOccurs="0" maxOccurs="1"/>
+	<!-- Number of retry attempts to make if MPIRUN_RETRY_REGEX matches   -->
+	<xs:element ref="MPIRUN_RETRY_COUNT" minOccurs="0" maxOccurs="1"/>
+	<!-- OS: the operating system of this machine. -->
+	<xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
+	<!-- PROXY: optional http proxy for access to the internet-->
+	<xs:element ref="PROXY" minOccurs="0" maxOccurs="1"/>
+	<!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
+	<xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
+	<!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
+	<xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
+	<!-- PROJECT: A project or account number used for batch jobs
+	  can be overridden in environment or $HOME/.cime/config -->
+	<xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>
+	<!-- CHARGE_ACCOUNT: The name of the account to charge for batch jobs
+	  can be overridden in environment or $HOME/.cime/config -->
+	<xs:element ref="CHARGE_ACCOUNT" minOccurs="0" maxOccurs="1"/>
+	<!-- SAVE_TIMING_DIR: (Acme only) directory for archiving timing output -->
+	<xs:element ref="SAVE_TIMING_DIR" minOccurs="0" maxOccurs="1"/>
+	<!-- SAVE_TIMING_DIR_PROJECTS: (Acme only) projects whose jobs archive timing output -->
+	<xs:element ref="SAVE_TIMING_DIR_PROJECTS" minOccurs="0" maxOccurs="1"/>
+	<!-- CIME_OUTPUT_ROOT: Base directory for case output,
+	     the bld and run directories are written below here -->
+	<xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
+	<!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
+	<xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
+	<!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
+	<xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
+	<!-- DIN_LOC_ROOT: location of the inputdata directory -->
+	<xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
+	<!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
+	<xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
+	<!-- DOUT_S_ROOT: root directory of short term archive files -->
+	<xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
+	<!-- BASELINE_ROOT:  Root directory for system test baseline files -->
+	<xs:element ref="BASELINE_ROOT" minOccurs="0" maxOccurs="1"/>
+	<!-- CCSM_CPRNC: location of the cprnc tool, compares model output in testing-->
+	<xs:element ref="CCSM_CPRNC" minOccurs="0" maxOccurs="1"/>
+	<!-- PERL5LIB: location of external PERL modules (this variable is deprecated) -->
+	<xs:element ref="PERL5LIB" minOccurs="0" maxOccurs="1"/>
+	<!-- GMAKE: gnu compatible make tool, default is 'gmake' -->
+	<xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
+	<!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
+	<xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
+	<!-- TESTS: (acme only) list of tests to run on this machine -->
+	<xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
+	<!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->
+	<xs:element ref="NTEST_PARALLEL_JOBS" minOccurs="0" maxOccurs="1"/>
+	<!-- BATCH_SYSTEM: batch system used on this machine (none is okay) -->
+	<xs:element ref="BATCH_SYSTEM" minOccurs="1" maxOccurs="1"/>
+	<!-- ALLOCATE_SPARE_NODES: allocate spare nodes when job is launched default False-->
+	<xs:element ref="ALLOCATE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
+	<!-- SUPPORTED_BY: contact information for support for this system -->
+	<xs:element ref="SUPPORTED_BY" minOccurs="1" maxOccurs="1"/>
+	<!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
+	     shared memory node on this machine-->
+	<xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="4"/>
+	<!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
+	     this machine, in practice the MPI tasks per node will not exceed this value -->
+	<xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="4"/>
+	<!-- Optional cost factor per node unit -->
+	<xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
+	<!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
+	     the batch system?  See PROJECT above -->
+	<xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>
+	<!-- mpirun: The mpi exec to start a job on this machine
+	     see detail below-->
+	<xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
+	<!-- module_system: how and what modules to load on this system ,
+	     see detail below -->
+	<xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
+	<!-- environment_variables: environment_variables to set on this system,
+	  see detail below-->
+	<xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
+	<xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
+	<xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
+	<xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="source_files"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
       </xs:sequence>
       <xs:attribute ref="MACH" use="required"/>
     </xs:complexType>
@@ -188,12 +190,12 @@
   <xs:element name="mpirun">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="executable"/>
-        <xs:element ref="arguments" minOccurs="0"/>
-        <!-- run_exe: The run executable to use; overrides default_run_exe -->
-        <xs:element ref="run_exe" minOccurs="0"/>
-        <!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
-        <xs:element ref="run_misc_suffix" minOccurs="0"/>
+	<xs:element ref="executable"/>
+	<xs:element ref="arguments" minOccurs="0"/>
+	<!-- run_exe: The run executable to use; overrides default_run_exe -->
+	<xs:element ref="run_exe" minOccurs="0"/>
+	<!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
+	<xs:element ref="run_misc_suffix" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="queue"/>
@@ -205,7 +207,7 @@
   <xs:element name="arguments">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
+	<xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -213,9 +215,9 @@
   <xs:element name="module_system">
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
       </xs:sequence>
       <xs:attribute ref="type" use="required"/>
       <xs:attribute ref="allow_error"/>
@@ -234,7 +236,7 @@
   <xs:element name="modules">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="command"/>
+	<xs:element maxOccurs="unbounded" ref="command"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="DEBUG"/>
@@ -251,15 +253,26 @@
   <xs:element name="environment_variables">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="env"/>
+	<xs:element maxOccurs="unbounded" ref="env"/>
       </xs:sequence>
       <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="source_files">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element maxOccurs="unbounded" ref="filepath"/>
+      </xs:sequence>
+      <xs:attribute ref="DEBUG"/>
+      <xs:attribute ref="mpilib"/>
+      <xs:attribute ref="compiler"/>
+      <xs:attribute ref="unit_testing"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="resource_limits">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="resource"/>
+	<xs:element maxOccurs="unbounded" ref="resource"/>
       </xs:sequence>
       <xs:attribute ref="DEBUG"/>
       <xs:attribute ref="mpilib"/>
@@ -273,6 +286,7 @@
       <xs:attribute ref="name" use="required"/>
     </xs:complexType>
   </xs:element>
+
   <xs:element name="resource">
     <xs:complexType mixed="true">
       <xs:attribute ref="name" use="required"/>
@@ -281,8 +295,8 @@
   <xs:element name="default_run_suffix">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="default_run_exe"/>
-        <xs:element ref="default_run_misc_suffix"/>
+	<xs:element ref="default_run_exe"/>
+	<xs:element ref="default_run_misc_suffix"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -15,6 +15,7 @@
   <xs:attribute name="type" type="xs:NCName"/>
   <xs:attribute name="lang" type="xs:NCName"/>
   <xs:attribute name="name" type="xs:NCName"/>
+  <xs:attribute name="source" type="xs:NCName"/>
 
   <!-- simple elements -->
   <xs:simpleType name="upperBoolean">
@@ -65,7 +66,6 @@
   <xs:element name="EXEROOT" type="xs:string"/>
   <xs:element name="TEST_TPUT_TOLERANCE" type="xs:string"/>
   <xs:element name="MAX_GB_OLD_TEST_DATA" type="xs:string"/>
-  <xs:element name="filepath" type="xs:anyURI"/>
 
 
   <!-- complex elements -->
@@ -73,8 +73,8 @@
   <xs:complexType name="AttrElement">
     <xs:simpleContent>
       <xs:extension base="xs:string">
-	<xs:attribute ref="compiler">
-	</xs:attribute>
+        <xs:attribute ref="compiler">
+        </xs:attribute>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -83,8 +83,8 @@
   <xs:element name="config_machines">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
-	<xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute ref="version"/>
     </xs:complexType>
@@ -92,96 +92,95 @@
   <xs:element name="machine">
     <xs:complexType>
       <xs:sequence>
-	<!-- DESC: a text description of the machine, this field is current not used-->
-	<xs:element ref="DESC" minOccurs="1" maxOccurs="1"/>
-	<!-- NODENAME_REGEX: a regular expression used to identify this machine
-	  it must work on compute nodes as well as login nodes, use machine option
-	  to create_test or create_newcase if this flag is not available -->
-	<xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
-	<!-- regex to look for in log files that will triger retry of mpirun
-	     command on extra allocated nodes -->
-	<xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
-	<!-- regex to look for in log files that will triger retry of mpirun command -->
-	<xs:element ref="MPIRUN_RETRY_REGEX" minOccurs="0" maxOccurs="1"/>
-	<!-- Number of retry attempts to make if MPIRUN_RETRY_REGEX matches   -->
-	<xs:element ref="MPIRUN_RETRY_COUNT" minOccurs="0" maxOccurs="1"/>
-	<!-- OS: the operating system of this machine. -->
-	<xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
-	<!-- PROXY: optional http proxy for access to the internet-->
-	<xs:element ref="PROXY" minOccurs="0" maxOccurs="1"/>
-	<!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
-	<xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
-	<!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
-	<xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
-	<!-- PROJECT: A project or account number used for batch jobs
-	  can be overridden in environment or $HOME/.cime/config -->
-	<xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>
-	<!-- CHARGE_ACCOUNT: The name of the account to charge for batch jobs
-	  can be overridden in environment or $HOME/.cime/config -->
-	<xs:element ref="CHARGE_ACCOUNT" minOccurs="0" maxOccurs="1"/>
-	<!-- SAVE_TIMING_DIR: (Acme only) directory for archiving timing output -->
-	<xs:element ref="SAVE_TIMING_DIR" minOccurs="0" maxOccurs="1"/>
-	<!-- SAVE_TIMING_DIR_PROJECTS: (Acme only) projects whose jobs archive timing output -->
-	<xs:element ref="SAVE_TIMING_DIR_PROJECTS" minOccurs="0" maxOccurs="1"/>
-	<!-- CIME_OUTPUT_ROOT: Base directory for case output,
-	     the bld and run directories are written below here -->
-	<xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
-	<!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
-	<xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
-	<!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
-	<xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
-	<!-- DIN_LOC_ROOT: location of the inputdata directory -->
-	<xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
-	<!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
-	<xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
-	<!-- DOUT_S_ROOT: root directory of short term archive files -->
-	<xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
-	<!-- BASELINE_ROOT:  Root directory for system test baseline files -->
-	<xs:element ref="BASELINE_ROOT" minOccurs="0" maxOccurs="1"/>
-	<!-- CCSM_CPRNC: location of the cprnc tool, compares model output in testing-->
-	<xs:element ref="CCSM_CPRNC" minOccurs="0" maxOccurs="1"/>
-	<!-- PERL5LIB: location of external PERL modules (this variable is deprecated) -->
-	<xs:element ref="PERL5LIB" minOccurs="0" maxOccurs="1"/>
-	<!-- GMAKE: gnu compatible make tool, default is 'gmake' -->
-	<xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
-	<!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
-	<xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
-	<!-- TESTS: (acme only) list of tests to run on this machine -->
-	<xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
-	<!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->
-	<xs:element ref="NTEST_PARALLEL_JOBS" minOccurs="0" maxOccurs="1"/>
-	<!-- BATCH_SYSTEM: batch system used on this machine (none is okay) -->
-	<xs:element ref="BATCH_SYSTEM" minOccurs="1" maxOccurs="1"/>
-	<!-- ALLOCATE_SPARE_NODES: allocate spare nodes when job is launched default False-->
-	<xs:element ref="ALLOCATE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
-	<!-- SUPPORTED_BY: contact information for support for this system -->
-	<xs:element ref="SUPPORTED_BY" minOccurs="1" maxOccurs="1"/>
-	<!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
-	     shared memory node on this machine-->
-	<xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="4"/>
-	<!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
-	     this machine, in practice the MPI tasks per node will not exceed this value -->
-	<xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="4"/>
-	<!-- Optional cost factor per node unit -->
-	<xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
-	<!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
-	     the batch system?  See PROJECT above -->
-	<xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>
-	<!-- mpirun: The mpi exec to start a job on this machine
-	     see detail below-->
-	<xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
-	<!-- module_system: how and what modules to load on this system ,
-	     see detail below -->
-	<xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
-	<!-- environment_variables: environment_variables to set on this system,
-	  see detail below-->
-	<xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
-	<xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
-	<xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
-	<xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="source_files"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
+        <!-- DESC: a text description of the machine, this field is current not used-->
+        <xs:element ref="DESC" minOccurs="1" maxOccurs="1"/>
+        <!-- NODENAME_REGEX: a regular expression used to identify this machine
+          it must work on compute nodes as well as login nodes, use machine option
+          to create_test or create_newcase if this flag is not available -->
+        <xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
+        <!-- regex to look for in log files that will triger retry of mpirun
+             command on extra allocated nodes -->
+        <xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
+        <!-- regex to look for in log files that will triger retry of mpirun command -->
+        <xs:element ref="MPIRUN_RETRY_REGEX" minOccurs="0" maxOccurs="1"/>
+        <!-- Number of retry attempts to make if MPIRUN_RETRY_REGEX matches   -->
+        <xs:element ref="MPIRUN_RETRY_COUNT" minOccurs="0" maxOccurs="1"/>
+        <!-- OS: the operating system of this machine. -->
+        <xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
+        <!-- PROXY: optional http proxy for access to the internet-->
+        <xs:element ref="PROXY" minOccurs="0" maxOccurs="1"/>
+        <!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
+        <xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
+        <!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
+        <xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- PROJECT: A project or account number used for batch jobs
+          can be overridden in environment or $HOME/.cime/config -->
+        <xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>
+        <!-- CHARGE_ACCOUNT: The name of the account to charge for batch jobs
+          can be overridden in environment or $HOME/.cime/config -->
+        <xs:element ref="CHARGE_ACCOUNT" minOccurs="0" maxOccurs="1"/>
+        <!-- SAVE_TIMING_DIR: (Acme only) directory for archiving timing output -->
+        <xs:element ref="SAVE_TIMING_DIR" minOccurs="0" maxOccurs="1"/>
+        <!-- SAVE_TIMING_DIR_PROJECTS: (Acme only) projects whose jobs archive timing output -->
+        <xs:element ref="SAVE_TIMING_DIR_PROJECTS" minOccurs="0" maxOccurs="1"/>
+        <!-- CIME_OUTPUT_ROOT: Base directory for case output,
+             the bld and run directories are written below here -->
+        <xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
+        <xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
+        <xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- DIN_LOC_ROOT: location of the inputdata directory -->
+        <xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
+        <xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
+        <!-- DOUT_S_ROOT: root directory of short term archive files -->
+        <xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- BASELINE_ROOT:  Root directory for system test baseline files -->
+        <xs:element ref="BASELINE_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- CCSM_CPRNC: location of the cprnc tool, compares model output in testing-->
+        <xs:element ref="CCSM_CPRNC" minOccurs="0" maxOccurs="1"/>
+        <!-- PERL5LIB: location of external PERL modules (this variable is deprecated) -->
+        <xs:element ref="PERL5LIB" minOccurs="0" maxOccurs="1"/>
+        <!-- GMAKE: gnu compatible make tool, default is 'gmake' -->
+        <xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
+        <!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
+        <xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
+        <!-- TESTS: (acme only) list of tests to run on this machine -->
+        <xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
+        <!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->
+        <xs:element ref="NTEST_PARALLEL_JOBS" minOccurs="0" maxOccurs="1"/>
+        <!-- BATCH_SYSTEM: batch system used on this machine (none is okay) -->
+        <xs:element ref="BATCH_SYSTEM" minOccurs="1" maxOccurs="1"/>
+        <!-- ALLOCATE_SPARE_NODES: allocate spare nodes when job is launched default False-->
+        <xs:element ref="ALLOCATE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
+        <!-- SUPPORTED_BY: contact information for support for this system -->
+        <xs:element ref="SUPPORTED_BY" minOccurs="1" maxOccurs="1"/>
+        <!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
+             shared memory node on this machine-->
+        <xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="4"/>
+        <!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
+             this machine, in practice the MPI tasks per node will not exceed this value -->
+        <xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="4"/>
+        <!-- Optional cost factor per node unit -->
+        <xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
+        <!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
+             the batch system?  See PROJECT above -->
+        <xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>
+        <!-- mpirun: The mpi exec to start a job on this machine
+             see detail below-->
+        <xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- module_system: how and what modules to load on this system ,
+             see detail below -->
+        <xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
+        <!-- environment_variables: environment_variables to set on this system,
+          see detail below-->
+        <xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
       </xs:sequence>
       <xs:attribute ref="MACH" use="required"/>
     </xs:complexType>
@@ -190,12 +189,12 @@
   <xs:element name="mpirun">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="executable"/>
-	<xs:element ref="arguments" minOccurs="0"/>
-	<!-- run_exe: The run executable to use; overrides default_run_exe -->
-	<xs:element ref="run_exe" minOccurs="0"/>
-	<!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
-	<xs:element ref="run_misc_suffix" minOccurs="0"/>
+        <xs:element ref="executable"/>
+        <xs:element ref="arguments" minOccurs="0"/>
+        <!-- run_exe: The run executable to use; overrides default_run_exe -->
+        <xs:element ref="run_exe" minOccurs="0"/>
+        <!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
+        <xs:element ref="run_misc_suffix" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="queue"/>
@@ -207,7 +206,7 @@
   <xs:element name="arguments">
     <xs:complexType>
       <xs:sequence>
-	<xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -215,9 +214,9 @@
   <xs:element name="module_system">
     <xs:complexType>
       <xs:sequence>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
       </xs:sequence>
       <xs:attribute ref="type" use="required"/>
       <xs:attribute ref="allow_error"/>
@@ -236,7 +235,7 @@
   <xs:element name="modules">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="command"/>
+        <xs:element maxOccurs="unbounded" ref="command"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="DEBUG"/>
@@ -253,26 +252,15 @@
   <xs:element name="environment_variables">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="env"/>
+        <xs:element maxOccurs="unbounded" ref="env"/>
       </xs:sequence>
       <xs:anyAttribute processContents="skip"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="source_files">
-    <xs:complexType>
-      <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="filepath"/>
-      </xs:sequence>
-      <xs:attribute ref="DEBUG"/>
-      <xs:attribute ref="mpilib"/>
-      <xs:attribute ref="compiler"/>
-      <xs:attribute ref="unit_testing"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="resource_limits">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="resource"/>
+        <xs:element maxOccurs="unbounded" ref="resource"/>
       </xs:sequence>
       <xs:attribute ref="DEBUG"/>
       <xs:attribute ref="mpilib"/>
@@ -283,10 +271,10 @@
 
   <xs:element name="env">
     <xs:complexType mixed="true">
-      <xs:attribute ref="name" use="required"/>
+      <xs:attribute ref="name" />
+      <xs:attribute ref="source"/>
     </xs:complexType>
   </xs:element>
-
   <xs:element name="resource">
     <xs:complexType mixed="true">
       <xs:attribute ref="name" use="required"/>
@@ -295,8 +283,8 @@
   <xs:element name="default_run_suffix">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="default_run_exe"/>
-	<xs:element ref="default_run_misc_suffix"/>
+        <xs:element ref="default_run_exe"/>
+        <xs:element ref="default_run_misc_suffix"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/config/xml_schemas/env_mach_specific.xsd
+++ b/config/xml_schemas/env_mach_specific.xsd
@@ -19,11 +19,10 @@
 <xs:element name="executable" type="xs:string"/>
 <xs:element name="type" type="xs:NCName"/>
 <xs:element name="desc" type="xs:string"/>
-<xs:element name="filepath" type="xs:anyURI"/>
 
 <!--  simple types -->
 <!-- For historical and user-interface reasons, we have uppercase TRUE and
-	    FALSE all over the place. This means we have to define an enumeration
+            FALSE all over the place. This means we have to define an enumeration
      instead of using "xs:boolean". -->
 <xs:simpleType name="upperBoolean">
   <xs:restriction base="xs:token">
@@ -37,13 +36,12 @@
   <xs:element name="file">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="header"/>
-	<xs:element ref="group"/>
-	<xs:element ref="module_system"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="mpirun"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="source_files"/>
+        <xs:element ref="header"/>
+        <xs:element ref="group"/>
+        <xs:element ref="module_system"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="mpirun"/>
       </xs:sequence>
       <xs:attribute ref="id" use="required"/>
       <xs:attribute ref="version" use="required"/>
@@ -53,7 +51,7 @@
   <xs:element name="group">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="entry"/>
+        <xs:element maxOccurs="unbounded" ref="entry"/>
       </xs:sequence>
       <xs:attribute ref="id" use="required"/>
     </xs:complexType>
@@ -62,8 +60,8 @@
   <xs:element name="entry">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="type"/>
-	<xs:element ref="desc"/>
+        <xs:element ref="type"/>
+        <xs:element ref="desc"/>
       </xs:sequence>
       <xs:attribute ref="id" use="required" />
       <xs:attribute ref="value" use="required"/>
@@ -73,9 +71,9 @@
   <xs:element name="module_system">
     <xs:complexType>
       <xs:sequence>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
       </xs:sequence>
       <xs:attribute name="type" use="required" type="xs:NCName"/>
       <xs:attribute name="allow_error" type="xs:boolean"/>
@@ -97,7 +95,7 @@
   <xs:element name="modules">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="command"/>
+        <xs:element maxOccurs="unbounded" ref="command"/>
       </xs:sequence>
       <xs:attribute ref="compiler" />
       <xs:attribute ref="DEBUG" />
@@ -115,22 +113,22 @@
   <xs:element name="environment_variables">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="env"/>
+        <xs:element maxOccurs="unbounded" ref="env"/>
       </xs:sequence>
       <xs:anyAttribute processContents="skip"/>
     </xs:complexType>
   </xs:element>
-
   <xs:element name="env">
     <xs:complexType mixed="true">
-      <xs:attribute name="name" use="required" type="xs:NCName"/>
+      <xs:attribute name="name" type="xs:NCName"/>
+      <xs:attribute name="source" type="xs:NCName"/>
     </xs:complexType>
   </xs:element>
 
   <xs:element name="resource_limits">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="resource"/>
+        <xs:element maxOccurs="unbounded" ref="resource"/>
       </xs:sequence>
       <xs:attribute ref="DEBUG"/>
       <xs:attribute ref="mpilib"/>
@@ -153,10 +151,10 @@
   <xs:element name="mpirun">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="executable"/>
-	<xs:element minOccurs="0" maxOccurs="1" ref="arguments"/>
-	<xs:element minOccurs="0" maxOccurs="1" name="run_exe" type="xs:string"/>
-	<xs:element minOccurs="0" maxOccurs="1" name="run_misc_suffix" type="xs:string"/>
+        <xs:element ref="executable"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="arguments"/>
+        <xs:element minOccurs="0" maxOccurs="1" name="run_exe" type="xs:string"/>
+        <xs:element minOccurs="0" maxOccurs="1" name="run_misc_suffix" type="xs:string"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="mpilib"/>
@@ -165,18 +163,11 @@
       <xs:attribute ref="unit_testing"/>
     </xs:complexType>
   </xs:element>
-  <xs:element name="source_files">
-    <xs:complexType>
-      <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="filepath"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
 
   <xs:element name="arguments">
     <xs:complexType>
       <xs:sequence>
-	<xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/config/xml_schemas/env_mach_specific.xsd
+++ b/config/xml_schemas/env_mach_specific.xsd
@@ -19,10 +19,11 @@
 <xs:element name="executable" type="xs:string"/>
 <xs:element name="type" type="xs:NCName"/>
 <xs:element name="desc" type="xs:string"/>
+<xs:element name="filepath" type="xs:anyURI"/>
 
 <!--  simple types -->
 <!-- For historical and user-interface reasons, we have uppercase TRUE and
-            FALSE all over the place. This means we have to define an enumeration
+	    FALSE all over the place. This means we have to define an enumeration
      instead of using "xs:boolean". -->
 <xs:simpleType name="upperBoolean">
   <xs:restriction base="xs:token">
@@ -36,12 +37,13 @@
   <xs:element name="file">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="header"/>
-        <xs:element ref="group"/>
-        <xs:element ref="module_system"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="mpirun"/>
+	<xs:element ref="header"/>
+	<xs:element ref="group"/>
+	<xs:element ref="module_system"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="mpirun"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="source_files"/>
       </xs:sequence>
       <xs:attribute ref="id" use="required"/>
       <xs:attribute ref="version" use="required"/>
@@ -51,7 +53,7 @@
   <xs:element name="group">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="entry"/>
+	<xs:element maxOccurs="unbounded" ref="entry"/>
       </xs:sequence>
       <xs:attribute ref="id" use="required"/>
     </xs:complexType>
@@ -60,8 +62,8 @@
   <xs:element name="entry">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="type"/>
-        <xs:element ref="desc"/>
+	<xs:element ref="type"/>
+	<xs:element ref="desc"/>
       </xs:sequence>
       <xs:attribute ref="id" use="required" />
       <xs:attribute ref="value" use="required"/>
@@ -71,9 +73,9 @@
   <xs:element name="module_system">
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
       </xs:sequence>
       <xs:attribute name="type" use="required" type="xs:NCName"/>
       <xs:attribute name="allow_error" type="xs:boolean"/>
@@ -95,7 +97,7 @@
   <xs:element name="modules">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="command"/>
+	<xs:element maxOccurs="unbounded" ref="command"/>
       </xs:sequence>
       <xs:attribute ref="compiler" />
       <xs:attribute ref="DEBUG" />
@@ -113,11 +115,12 @@
   <xs:element name="environment_variables">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="env"/>
+	<xs:element maxOccurs="unbounded" ref="env"/>
       </xs:sequence>
       <xs:anyAttribute processContents="skip"/>
     </xs:complexType>
   </xs:element>
+
   <xs:element name="env">
     <xs:complexType mixed="true">
       <xs:attribute name="name" use="required" type="xs:NCName"/>
@@ -127,7 +130,7 @@
   <xs:element name="resource_limits">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="resource"/>
+	<xs:element maxOccurs="unbounded" ref="resource"/>
       </xs:sequence>
       <xs:attribute ref="DEBUG"/>
       <xs:attribute ref="mpilib"/>
@@ -150,16 +153,23 @@
   <xs:element name="mpirun">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="executable"/>
-        <xs:element minOccurs="0" maxOccurs="1" ref="arguments"/>
-        <xs:element minOccurs="0" maxOccurs="1" name="run_exe" type="xs:string"/>
-        <xs:element minOccurs="0" maxOccurs="1" name="run_misc_suffix" type="xs:string"/>
+	<xs:element ref="executable"/>
+	<xs:element minOccurs="0" maxOccurs="1" ref="arguments"/>
+	<xs:element minOccurs="0" maxOccurs="1" name="run_exe" type="xs:string"/>
+	<xs:element minOccurs="0" maxOccurs="1" name="run_misc_suffix" type="xs:string"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="mpilib"/>
       <xs:attribute name="threaded" type="xs:boolean"/>
       <xs:attribute ref="queue"/>
       <xs:attribute ref="unit_testing"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="source_files">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element maxOccurs="unbounded" ref="filepath"/>
+      </xs:sequence>
     </xs:complexType>
   </xs:element>
 

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -194,7 +194,7 @@ class EnvMachSpecific(EnvBase):
                     if env_name:
                         lines.append("export {}={}".format(env_name, env_value))
                     else:
-                        lines.append("source {}".format(env_name, env_value))
+                        lines.append("source {}".format(env_value))
 
                 elif shell == "csh":
                     if env_name:

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -200,7 +200,7 @@ class EnvMachSpecific(EnvBase):
                     if env_name:
                         lines.append("setenv {} {}".format(env_name, env_value))
                     else:
-                        lines.append("echo \"This case includes a shell source file {} which cannot be used from csh type shells\"".format(env_value)
+                        lines.append("echo \"This case includes a shell source file {} which cannot be used from csh type shells\"".format(env_value))
                 else:
                     expect(False, "Unknown shell type: '{}'".format(shell))
 

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -191,9 +191,16 @@ class EnvMachSpecific(EnvBase):
         if envs_to_set is not None:
             for env_name, env_value in envs_to_set:
                 if shell == "sh":
-                    lines.append("export {}={}".format(env_name, env_value))
+                    if env_name:
+                        lines.append("export {}={}".format(env_name, env_value))
+                    else:
+                        lines.append("source {}".format(env_name, env_value))
+
                 elif shell == "csh":
-                    lines.append("setenv {} {}".format(env_name, env_value))
+                    if env_name:
+                        lines.append("setenv {} {}".format(env_name, env_value))
+                    else:
+                        lines.append("echo \"This case includes a shell source file {} which cannot be used from csh type shells\"".format(env_value)
                 else:
                     expect(False, "Unknown shell type: '{}'".format(shell))
 

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -15,400 +15,391 @@ logger = logging.getLogger(__name__)
 class EnvMachSpecific(EnvBase):
     # pylint: disable=unused-argument
     def __init__(self, caseroot=None, infile="env_mach_specific.xml",
-		 components=None, unit_testing=False, read_only=False,
-		 standalone_configure=False):
-	"""
-	initialize an object interface to file env_mach_specific.xml in the case directory
+                 components=None, unit_testing=False, read_only=False,
+                 standalone_configure=False):
+        """
+        initialize an object interface to file env_mach_specific.xml in the case directory
 
-	Notes on some arguments:
-	standalone_configure: logical - whether this is being called from the standalone
-	    configure utility, outside of a case
-	"""
-	schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_specific.xsd")
-	EnvBase.__init__(self, caseroot, infile, schema=schema, read_only=read_only)
-	self._allowed_mpi_attributes = ("compiler", "mpilib", "threaded", "unit_testing", "queue")
-	self._unit_testing = unit_testing
-	self._standalone_configure = standalone_configure
+        Notes on some arguments:
+        standalone_configure: logical - whether this is being called from the standalone
+            configure utility, outside of a case
+        """
+        schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_specific.xsd")
+        EnvBase.__init__(self, caseroot, infile, schema=schema, read_only=read_only)
+        self._allowed_mpi_attributes = ("compiler", "mpilib", "threaded", "unit_testing", "queue")
+        self._unit_testing = unit_testing
+        self._standalone_configure = standalone_configure
 
     def populate(self, machobj):
-	"""Add entries to the file using information from a Machines object."""
-	items = ("module_system", "environment_variables", "resource_limits", "mpirun", "run_exe","run_misc_suffix", "source_files")
-	default_run_suffix = machobj.get_child("default_run_suffix", root=machobj.root)
-	default_run_exe_node = machobj.get_child("default_run_exe", root=default_run_suffix)
-	default_run_misc_suffix_node = machobj.get_child("default_run_misc_suffix", root=default_run_suffix)
+        """Add entries to the file using information from a Machines object."""
+        items = ("module_system", "environment_variables", "resource_limits", "mpirun", "run_exe","run_misc_suffix")
+        default_run_suffix = machobj.get_child("default_run_suffix", root=machobj.root)
+        default_run_exe_node = machobj.get_child("default_run_exe", root=default_run_suffix)
+        default_run_misc_suffix_node = machobj.get_child("default_run_misc_suffix", root=default_run_suffix)
 
-	group_node = self.make_child("group", {"id":"compliant_values"})
+        group_node = self.make_child("group", {"id":"compliant_values"})
 
-	for item in items:
-	    nodes = machobj.get_first_child_nodes(item)
-	    print("HERE item is {} and nodes len {}".format(item,len(nodes)))
-	    if item == "environment_variables":
-		if len(nodes) == 0:
-		    example_text = """This section is for the user to specify any additional machine-specific env var, or to overwite existing ones.\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
-		    self.make_child_comment(text = example_text)
-	    if item == "run_exe" or item == "run_misc_suffix":
-		if len(nodes) == 0:
-		    value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)
-		else:
-		    value = self.text(nodes[0])
+        for item in items:
+            nodes = machobj.get_first_child_nodes(item)
+            if item == "environment_variables":
+                if len(nodes) == 0:
+                    example_text = """This section is for the user to specify any additional machine-specific env var, or to overwite existing ones.\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
+                    self.make_child_comment(text = example_text)
+            if item == "run_exe" or item == "run_misc_suffix":
+                if len(nodes) == 0:
+                    value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)
+                else:
+                    value = self.text(nodes[0])
 
-		entity_node = self.make_child("entry", {"id":item, "value":value}, root=group_node)
+                entity_node = self.make_child("entry", {"id":item, "value":value}, root=group_node)
 
-		self.make_child("type", root=entity_node, text="char")
-		self.make_child("desc", root=entity_node, text=("executable name" if item == "run_exe" else "redirect for job output"))
+                self.make_child("type", root=entity_node, text="char")
+                self.make_child("desc", root=entity_node, text=("executable name" if item == "run_exe" else "redirect for job output"))
 
-	    else:
-		for node in nodes:
-		    self.add_child(node)
+            else:
+                for node in nodes:
+                    self.add_child(node)
 
     def _get_modules_for_case(self, case, job=None):
-	module_nodes = self.get_children("modules", root=self.get_child("module_system"))
-	modules_to_load = None
-	if module_nodes is not None:
-	    modules_to_load = self._compute_module_actions(module_nodes, case, job=job)
+        module_nodes = self.get_children("modules", root=self.get_child("module_system"))
+        modules_to_load = None
+        if module_nodes is not None:
+            modules_to_load = self._compute_module_actions(module_nodes, case, job=job)
 
-	return modules_to_load
+        return modules_to_load
 
     def _get_envs_for_case(self, case, job=None):
-	env_nodes = self.get_children("environment_variables")
+        env_nodes = self.get_children("environment_variables")
 
-	envs_to_set = None
-	if env_nodes is not None:
-	    envs_to_set = self._compute_env_actions(env_nodes, case, job=job)
+        envs_to_set = None
+        if env_nodes is not None:
+            envs_to_set = self._compute_env_actions(env_nodes, case, job=job)
 
-	return envs_to_set
+        return envs_to_set
 
-    def _get_source_files_for_case(self, case, job=None):
-	sf_nodes = self.get_children("source_files")
-	if sf_nodes:
-	    files_to_source = self._compute_actions(sf_nodes, "filepath", case, job=job)
-	logger.debug("files_to_source = {}".format(files_to_source))
-	return files_to_source
+    def load_env(self, case, force_method=None, job=None, verbose=False):
+        """
+        Should only be called by case.load_env
+        """
+        # Do the modules so we can refer to env vars set by the modules
+        # in the environment_variables block
+        modules_to_load = self._get_modules_for_case(case)
+        if (modules_to_load is not None):
+            self._load_modules(modules_to_load, force_method=force_method, verbose=verbose)
 
-    def load_env(self, case, force_method=None, job=None, verbose=True):
-	"""
-	Should only be called by case.load_env
-	"""
-	# Do the modules so we can refer to env vars set by the modules
-	# in the environment_variables block
-	modules_to_load = self._get_modules_for_case(case)
-	if (modules_to_load is not None):
-	    self._load_modules(modules_to_load, force_method=force_method, verbose=verbose)
+        envs_to_set = self._get_envs_for_case(case, job=job)
+        if (envs_to_set is not None):
+            self._load_envs(envs_to_set, verbose=verbose)
 
-	envs_to_set = self._get_envs_for_case(case, job=job)
-	if (envs_to_set is not None):
-	    self._load_envs(envs_to_set, verbose=verbose)
-
-	files_to_source = self._get_source_files_for_case(case, job=job)
-	if files_to_source:
-	    self._source_files(files_to_source, verbose=verbose)
-
-	self._get_resources_for_case(case)
-
-    def _source_files(self, files_to_source, verbose=True):
-	for _,_file in files_to_source:
-	    logger.info("sourcing file {}".format(_file))
-	    run_cmd_no_fail("source {}".format(_file), combine_output=True, verbose=verbose)
-
+        self._get_resources_for_case(case)
 
     def _get_resources_for_case(self, case):
-	resource_nodes = self.get_children("resource_limits")
-	if resource_nodes is not None:
-	    nodes = self._compute_resource_actions(resource_nodes, case)
-	    for name, val in nodes:
-		attr = getattr(resource, name)
-		limits = resource.getrlimit(attr)
-		logger.info("Setting resource.{} to {} from {}".format(name, val, limits))
-		limits = (int(val), limits[1])
-		resource.setrlimit(attr, limits)
+        resource_nodes = self.get_children("resource_limits")
+        if resource_nodes is not None:
+            nodes = self._compute_resource_actions(resource_nodes, case)
+            for name, val in nodes:
+                attr = getattr(resource, name)
+                limits = resource.getrlimit(attr)
+                logger.info("Setting resource.{} to {} from {}".format(name, val, limits))
+                limits = (int(val), limits[1])
+                resource.setrlimit(attr, limits)
 
     def _load_modules(self, modules_to_load, force_method=None, verbose=False):
-	module_system = self.get_module_system_type() if force_method is None else force_method
-	if (module_system == "module"):
-	    self._load_module_modules(modules_to_load, verbose=verbose)
-	elif (module_system == "soft"):
-	    self._load_modules_generic(modules_to_load, verbose=verbose)
-	elif (module_system == "generic"):
-	    self._load_modules_generic(modules_to_load, verbose=verbose)
-	elif (module_system == "none"):
-	    self._load_none_modules(modules_to_load)
-	else:
-	    expect(False, "Unhandled module system '{}'".format(module_system))
+        module_system = self.get_module_system_type() if force_method is None else force_method
+        if (module_system == "module"):
+            self._load_module_modules(modules_to_load, verbose=verbose)
+        elif (module_system == "soft"):
+            self._load_modules_generic(modules_to_load, verbose=verbose)
+        elif (module_system == "generic"):
+            self._load_modules_generic(modules_to_load, verbose=verbose)
+        elif (module_system == "none"):
+            self._load_none_modules(modules_to_load)
+        else:
+            expect(False, "Unhandled module system '{}'".format(module_system))
 
     def list_modules(self):
-	module_system = self.get_module_system_type()
+        module_system = self.get_module_system_type()
 
-	# If the user's login shell is not sh, it's possible that modules
-	# won't be configured so we need to be sure to source the module
-	# setup script if it exists.
-	init_path = self.get_module_system_init_path("sh")
-	if init_path:
-	    source_cmd = "source {} && ".format(init_path)
-	else:
-	    source_cmd = ""
+        # If the user's login shell is not sh, it's possible that modules
+        # won't be configured so we need to be sure to source the module
+        # setup script if it exists.
+        init_path = self.get_module_system_init_path("sh")
+        if init_path:
+            source_cmd = "source {} && ".format(init_path)
+        else:
+            source_cmd = ""
 
-	if (module_system in ["module"]):
-	    return run_cmd_no_fail("{}module list".format(source_cmd), combine_output=True)
-	elif (module_system == "soft"):
-	    # Does soft really not provide this capability?
-	    return ""
-	elif (module_system == "generic"):
-	    return run_cmd_no_fail("{}use -lv".format(source_cmd))
-	elif (module_system == "none"):
-	    return ""
-	else:
-	    expect(False, "Unhandled module system '{}'".format(module_system))
+        if (module_system in ["module"]):
+            return run_cmd_no_fail("{}module list".format(source_cmd), combine_output=True)
+        elif (module_system == "soft"):
+            # Does soft really not provide this capability?
+            return ""
+        elif (module_system == "generic"):
+            return run_cmd_no_fail("{}use -lv".format(source_cmd))
+        elif (module_system == "none"):
+            return ""
+        else:
+            expect(False, "Unhandled module system '{}'".format(module_system))
 
     def save_all_env_info(self, filename):
-	"""
-	Get a string representation of all current environment info and
-	save it to file.
-	"""
-	with open(filename, "w") as f:
-	    f.write(self.list_modules())
-	run_cmd_no_fail("echo -e '\n' && env", arg_stdout=filename)
+        """
+        Get a string representation of all current environment info and
+        save it to file.
+        """
+        with open(filename, "w") as f:
+            f.write(self.list_modules())
+        run_cmd_no_fail("echo -e '\n' && env", arg_stdout=filename)
 
     def make_env_mach_specific_file(self, shell, case, output_dir=''):
-	"""Writes .env_mach_specific.sh or .env_mach_specific.csh
+        """Writes .env_mach_specific.sh or .env_mach_specific.csh
 
-	Args:
-	shell: string - 'sh' or 'csh'
-	case: case object
-	output_dir: string - path to output directory (if empty string, uses current directory)
-	"""
-	module_system = self.get_module_system_type()
-	sh_init_cmd = self.get_module_system_init_path(shell)
-	sh_mod_cmd = self.get_module_system_cmd_path(shell)
-	lines = ["# This file is for user convenience only and is not used by the model"]
+        Args:
+        shell: string - 'sh' or 'csh'
+        case: case object
+        output_dir: string - path to output directory (if empty string, uses current directory)
+        """
+        module_system = self.get_module_system_type()
+        sh_init_cmd = self.get_module_system_init_path(shell)
+        sh_mod_cmd = self.get_module_system_cmd_path(shell)
+        lines = ["# This file is for user convenience only and is not used by the model"]
 
-	lines.append("# Changes to this file will be ignored and overwritten")
-	lines.append("# Changes to the environment should be made in env_mach_specific.xml")
-	lines.append("# Run ./case.setup --reset to regenerate this file")
-	if sh_init_cmd:
-	    lines.append("source {}".format(sh_init_cmd))
+        lines.append("# Changes to this file will be ignored and overwritten")
+        lines.append("# Changes to the environment should be made in env_mach_specific.xml")
+        lines.append("# Run ./case.setup --reset to regenerate this file")
+        if sh_init_cmd:
+            lines.append("source {}".format(sh_init_cmd))
 
-	if "SOFTENV_ALIASES" in os.environ:
-	    lines.append("source $SOFTENV_ALIASES")
-	if "SOFTENV_LOAD" in os.environ:
-	    lines.append("source $SOFTENV_LOAD")
+        if "SOFTENV_ALIASES" in os.environ:
+            lines.append("source $SOFTENV_ALIASES")
+        if "SOFTENV_LOAD" in os.environ:
+            lines.append("source $SOFTENV_LOAD")
 
-	if self._unit_testing or self._standalone_configure:
-	    job = None
-	else:
-	    job = case.get_primary_job()
-	modules_to_load = self._get_modules_for_case(case, job=job)
-	envs_to_set = self._get_envs_for_case(case, job=job)
-	filename = ".env_mach_specific.{}".format(shell)
-	if modules_to_load is not None:
-	    if module_system == "module":
-		lines.extend(self._get_module_commands(modules_to_load, shell))
-	    else:
-		for action, argument in modules_to_load:
-		    lines.append("{} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument))
+        if self._unit_testing or self._standalone_configure:
+            job = None
+        else:
+            job = case.get_primary_job()
+        modules_to_load = self._get_modules_for_case(case, job=job)
+        envs_to_set = self._get_envs_for_case(case, job=job)
+        filename = ".env_mach_specific.{}".format(shell)
+        if modules_to_load is not None:
+            if module_system == "module":
+                lines.extend(self._get_module_commands(modules_to_load, shell))
+            else:
+                for action, argument in modules_to_load:
+                    lines.append("{} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument))
 
-	if envs_to_set is not None:
-	    for env_name, env_value in envs_to_set:
-		if shell == "sh":
-		    lines.append("export {}={}".format(env_name, env_value))
-		elif shell == "csh":
-		    lines.append("setenv {} {}".format(env_name, env_value))
-		else:
-		    expect(False, "Unknown shell type: '{}'".format(shell))
+        if envs_to_set is not None:
+            for env_name, env_value in envs_to_set:
+                if shell == "sh":
+                    lines.append("export {}={}".format(env_name, env_value))
+                elif shell == "csh":
+                    lines.append("setenv {} {}".format(env_name, env_value))
+                else:
+                    expect(False, "Unknown shell type: '{}'".format(shell))
 
-	with open(os.path.join(output_dir, filename), "w") as fd:
-	    fd.write("\n".join(lines))
+        with open(os.path.join(output_dir, filename), "w") as fd:
+            fd.write("\n".join(lines))
 
     # Private API
 
     def _load_envs(self, envs_to_set, verbose=False):
-	for env_name, env_value in envs_to_set:
-	    logger_func = logger.warning if verbose else logger.debug
-	    if env_value is None and env_name in os.environ:
-		del os.environ[env_name]
-		logger_func("Unsetting Environment {}".format(env_name))
-	    elif env_value is not None:
-		os.environ[env_name] = env_value
-		logger_func("Setting Environment {}={}".format(env_name, env_value))
+        for env_name, env_value in envs_to_set:
+            logger_func = logger.warning if verbose else logger.debug
+            if env_value is None and env_name in os.environ:
+                del os.environ[env_name]
+                logger_func("Unsetting Environment {}".format(env_name))
+            elif env_value is not None:
+                if env_name is None:
+                    cmd = "source "+ env_value
+                    self._source_sh_file(cmd, verbose=True)
+                else:
+                    print("Setting Environment {}={}".format(env_name, env_value))
+                    logger_func("Setting Environment {}={}".format(env_name, env_value))
+                    os.environ[env_name] = env_value
 
     def _compute_module_actions(self, module_nodes, case, job=None):
-	return self._compute_actions(module_nodes, "command", case, job=job)
+        return self._compute_actions(module_nodes, "command", case, job=job)
 
     def _compute_env_actions(self, env_nodes, case, job=None):
-	return self._compute_actions(env_nodes, "env", case, job=job)
+        return self._compute_actions(env_nodes, "env", case, job=job)
 
     def _compute_resource_actions(self, resource_nodes, case, job=None):
-	return self._compute_actions(resource_nodes, "resource", case, job=job)
+        return self._compute_actions(resource_nodes, "resource", case, job=job)
 
     def _compute_actions(self, nodes, child_tag, case, job=None):
-	result = [] # list of tuples ("name", "argument")
-	compiler, mpilib = case.get_value("COMPILER"), case.get_value("MPILIB")
+        result = [] # list of tuples ("name", "argument")
+        compiler, mpilib = case.get_value("COMPILER"), case.get_value("MPILIB")
 
-	for node in nodes:
-	    if (self._match_attribs(self.attrib(node), case, job=job)):
-		for child in self.get_children(root=node):
-		    expect(self.name(child) == child_tag, "Expected {} element".format(child_tag))
-		    if (self._match_attribs(self.attrib(child), case, job=job)):
-			val = self.text(child)
-			if val is not None:
-			    # We allow a couple special substitutions for these fields
-			    for repl_this, repl_with in [("$COMPILER", compiler), ("$MPILIB", mpilib)]:
-				val = val.replace(repl_this, repl_with)
+        for node in nodes:
+            if (self._match_attribs(self.attrib(node), case, job=job)):
+                for child in self.get_children(root=node):
+                    expect(self.name(child) == child_tag, "Expected {} element".format(child_tag))
+                    if (self._match_attribs(self.attrib(child), case, job=job)):
+                        val = self.text(child)
+                        if val is not None:
+                            # We allow a couple special substitutions for these fields
+                            for repl_this, repl_with in [("$COMPILER", compiler), ("$MPILIB", mpilib)]:
+                                val = val.replace(repl_this, repl_with)
 
-			    val = self.get_resolved_value(val)
-			    expect("$" not in val, "Not safe to leave unresolved items in env var value: '{}'".format(val))
+                            val = self.get_resolved_value(val)
+                            expect("$" not in val, "Not safe to leave unresolved items in env var value: '{}'".format(val))
 
-			# intentional unindent, result is appended even if val is None
-			result.append( (self.get(child, "name"), val) )
+                        # intentional unindent, result is appended even if val is None
+                        result.append( (self.get(child, "name"), val) )
 
-	return result
+        return result
 
     def _match_attribs(self, attribs, case, job=None):
-	# check for matches with case-vars
-	for attrib in attribs:
-	    if attrib == "unit_testing": # special case
-		if not self._match(self._unit_testing, attribs["unit_testing"].upper()):
-		    return False
-	    elif attrib == "queue":
-		if job is not None:
-		    val = case.get_value("JOB_QUEUE", subgroup=job)
-		    expect(val is not None, "Cannot match attrib '%s', case has no value for it" % attrib.upper())
-		    if not self._match(val, attribs[attrib]):
-			return False
-	    elif attrib == "name":
-		pass
-	    else:
-		val = case.get_value(attrib.upper())
-		expect(val is not None, "Cannot match attrib '%s', case has no value for it" % attrib.upper())
-		if not self._match(val, attribs[attrib]):
-		    return False
+        # check for matches with case-vars
+        for attrib in attribs:
+            if attrib == "unit_testing": # special case
+                if not self._match(self._unit_testing, attribs["unit_testing"].upper()):
+                    return False
+            elif attrib == "queue":
+                if job is not None:
+                    val = case.get_value("JOB_QUEUE", subgroup=job)
+                    expect(val is not None, "Cannot match attrib '%s', case has no value for it" % attrib.upper())
+                    if not self._match(val, attribs[attrib]):
+                        return False
+            elif attrib in ("name", "source"):
+                pass
+            else:
+                val = case.get_value(attrib.upper())
+                expect(val is not None, "Cannot match attrib '%s', case has no value for it" % attrib.upper())
+                if not self._match(val, attribs[attrib]):
+                    return False
 
-	return True
+        return True
 
     def _match(self, my_value, xml_value):
-	if xml_value.startswith("!"):
-	    result = re.match(xml_value[1:] + "$",str(my_value)) is None
-	elif isinstance(my_value, bool):
-	    if my_value: result = xml_value == "TRUE"
-	    else: result = xml_value == "FALSE"
-	else:
-	    result = re.match(xml_value + "$",str(my_value)) is not None
+        if xml_value.startswith("!"):
+            result = re.match(xml_value[1:] + "$",str(my_value)) is None
+        elif isinstance(my_value, bool):
+            if my_value: result = xml_value == "TRUE"
+            else: result = xml_value == "FALSE"
+        else:
+            result = re.match(xml_value + "$",str(my_value)) is not None
 
-	logger.debug("(env_mach_specific) _match {} {} {}".format(my_value, xml_value, result))
-	return result
+        logger.debug("(env_mach_specific) _match {} {} {}".format(my_value, xml_value, result))
+        return result
 
     def _get_module_commands(self, modules_to_load, shell):
-	# Note this is independent of module system type
-	mod_cmd = self.get_module_system_cmd_path(shell)
-	cmds = []
-	last_action = None
-	last_cmd    = None
+        # Note this is independent of module system type
+        mod_cmd = self.get_module_system_cmd_path(shell)
+        cmds = []
+        last_action = None
+        last_cmd    = None
 
-	# Normally, we will try to combine or batch module commands together...
-	#
-	# module load X
-	# module load Y
-	# module load Z
-	#
-	# is the same as ...
-	#
-	# module load X Y Z
-	#
-	# ... except the latter is significatly faster due to performing 1/3 as
-	# many forks.
-	#
-	# Not all module commands support batching though and we enurmerate those
-	# here.
-	actions_that_cannot_be_batched = ["swap", "switch"]
+        # Normally, we will try to combine or batch module commands together...
+        #
+        # module load X
+        # module load Y
+        # module load Z
+        #
+        # is the same as ...
+        #
+        # module load X Y Z
+        #
+        # ... except the latter is significatly faster due to performing 1/3 as
+        # many forks.
+        #
+        # Not all module commands support batching though and we enurmerate those
+        # here.
+        actions_that_cannot_be_batched = ["swap", "switch"]
 
-	for action, argument in modules_to_load:
-	    if argument is None:
-		argument = ""
+        for action, argument in modules_to_load:
+            if argument is None:
+                argument = ""
 
-	    if action == last_action and action not in actions_that_cannot_be_batched:
-		last_cmd = "{} {}".format(last_cmd, argument)
-	    else:
-		if last_cmd is not None:
-		    cmds.append(last_cmd)
+            if action == last_action and action not in actions_that_cannot_be_batched:
+                last_cmd = "{} {}".format(last_cmd, argument)
+            else:
+                if last_cmd is not None:
+                    cmds.append(last_cmd)
 
-		last_cmd = "{} {} {}".format(mod_cmd, action, "" if argument is None else argument)
-		last_action = action
+                last_cmd = "{} {} {}".format(mod_cmd, action, "" if argument is None else argument)
+                last_action = action
 
-	if last_cmd:
-	    cmds.append(last_cmd)
+        if last_cmd:
+            cmds.append(last_cmd)
 
-	return cmds
+        return cmds
 
     def _load_module_modules(self, modules_to_load, verbose=False):
-	logger_func = logger.warning if verbose else logger.debug
-	for cmd in self._get_module_commands(modules_to_load, "python"):
-	    logger_func("module command is {}".format(cmd))
-	    stat, py_module_code, errout = run_cmd(cmd)
-	    expect(stat==0 and (len(errout) == 0 or self.allow_error()),
-		   "module command {} failed with message:\n{}".format(cmd, errout))
-	    exec(py_module_code)
+        logger_func = logger.warning if verbose else logger.debug
+        for cmd in self._get_module_commands(modules_to_load, "python"):
+            logger_func("module command is {}".format(cmd))
+            stat, py_module_code, errout = run_cmd(cmd)
+            expect(stat==0 and (len(errout) == 0 or self.allow_error()),
+                   "module command {} failed with message:\n{}".format(cmd, errout))
+            exec(py_module_code)
 
     def _load_modules_generic(self, modules_to_load, verbose=False):
-	sh_init_cmd = self.get_module_system_init_path("sh")
-	sh_mod_cmd = self.get_module_system_cmd_path("sh")
-	logger_func = logger.warning if verbose else logger.debug
+        sh_init_cmd = self.get_module_system_init_path("sh")
+        sh_mod_cmd = self.get_module_system_cmd_path("sh")
+        logger_func = logger.warning if verbose else logger.debug
 
-	# Purpose is for environment management system that does not have
-	# a python interface and therefore can only determine what they
-	# do by running shell command and looking at the changes
-	# in the environment.
+        # Purpose is for environment management system that does not have
+        # a python interface and therefore can only determine what they
+        # do by running shell command and looking at the changes
+        # in the environment.
 
-	cmd = "source {}".format(sh_init_cmd)
+        cmd = "source {}".format(sh_init_cmd)
 
-	if "SOFTENV_ALIASES" in os.environ:
-	    cmd += " && source $SOFTENV_ALIASES"
-	if "SOFTENV_LOAD" in os.environ:
-	    cmd += " && source $SOFTENV_LOAD"
+        if "SOFTENV_ALIASES" in os.environ:
+            cmd += " && source $SOFTENV_ALIASES"
+        if "SOFTENV_LOAD" in os.environ:
+            cmd += " && source $SOFTENV_LOAD"
 
-	for action,argument in modules_to_load:
-	    cmd += " && {} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument)
+        for action,argument in modules_to_load:
+            cmd += " && {} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument)
 
-	# Use null terminated lines to give us something more definitive to split on.
-	# Env vars can contain newlines, so splitting on newlines can be ambiguous
-	cmd += " && env -0"
-	logger_func("cmd: {}".format(cmd))
-	output = run_cmd_no_fail(cmd)
+        self._source_sh_file(cmd, verbose=verbose)
 
-	###################################################
-	# Parse the output to set the os.environ dictionary
-	###################################################
-	newenv = OrderedDict()
-	for line in output.split('\0'):
-	    if "=" in line:
-		key, val = line.split("=", 1)
-		newenv[key] = val
+    def _source_sh_file(self, cmd, verbose=False):
+        # Use null terminated lines to give us something more definitive to split on.
+        # Env vars can contain newlines, so splitting on newlines can be ambiguous
+        logger_func = logger.warning if verbose else logger.debug
+        cmd += " && env -0"
+        logger_func("cmd: {}".format(cmd))
+        output = run_cmd_no_fail(cmd)
 
-	# resolve variables
-	for key, val in newenv.items():
-	    newenv[key] = string.Template(val).safe_substitute(newenv)
+        ###################################################
+        # Parse the output to set the os.environ dictionary
+        ###################################################
+        newenv = OrderedDict()
+        for line in output.split('\0'):
+            if "=" in line:
+                key, val = line.split("=", 1)
+                newenv[key] = val
 
-	# Set environment with new or updated values
-	for key in newenv:
-	    if key in os.environ and os.environ[key] == newenv[key]:
-		pass
-	    else:
-		os.environ[key] = newenv[key]
+        # resolve variables
+        for key, val in newenv.items():
+            newenv[key] = string.Template(val).safe_substitute(newenv)
 
-	for oldkey in list(os.environ.keys()):
-	    if oldkey not in newenv:
-		del os.environ[oldkey]
+        # Set environment with new or updated values
+        for key in newenv:
+            if key in os.environ and os.environ[key] == newenv[key]:
+                pass
+            else:
+                os.environ[key] = newenv[key]
+
+        for oldkey in list(os.environ.keys()):
+            if oldkey not in newenv:
+                del os.environ[oldkey]
 
     def _load_none_modules(self, modules_to_load):
-	"""
-	No Action required
-	"""
-	expect(not modules_to_load,
-	       "Module system was specified as 'none' yet there are modules that need to be loaded?")
+        """
+        No Action required
+        """
+        expect(not modules_to_load,
+               "Module system was specified as 'none' yet there are modules that need to be loaded?")
 
     def _mach_specific_header(self, shell):
-	'''
-	write a shell module file for this case.
-	'''
-	header = '''
+        '''
+        write a shell module file for this case.
+        '''
+        header = '''
 #!/usr/bin/env {}
 #===============================================================================
 # Automatically generated module settings for $self->{{machine}}
@@ -416,115 +407,115 @@ class EnvMachSpecific(EnvBase):
 # in your CASEROOT. This file is overwritten every time modules are loaded!
 #===============================================================================
 '''.format(shell)
-	header += "source {}".format(self.get_module_system_init_path(shell))
-	return header
+        header += "source {}".format(self.get_module_system_init_path(shell))
+        return header
 
     def get_module_system_type(self):
-	"""
-	Return the module system used on this machine
-	"""
-	module_system = self.get_child("module_system")
-	return self.get(module_system, "type")
+        """
+        Return the module system used on this machine
+        """
+        module_system = self.get_child("module_system")
+        return self.get(module_system, "type")
 
     def allow_error(self):
-	"""
-	Return True if stderr output from module commands should be assumed
-	to be an error. Default False. This is necessary since implementations
-	of environment modules are highlty variable and some systems produce
-	stderr output even when things are working fine.
-	"""
-	module_system = self.get_child("module_system")
-	value = self.get(module_system, "allow_error")
-	return value.upper() == "TRUE" if value is not None else False
+        """
+        Return True if stderr output from module commands should be assumed
+        to be an error. Default False. This is necessary since implementations
+        of environment modules are highlty variable and some systems produce
+        stderr output even when things are working fine.
+        """
+        module_system = self.get_child("module_system")
+        value = self.get(module_system, "allow_error")
+        return value.upper() == "TRUE" if value is not None else False
 
     def get_module_system_init_path(self, lang):
-	init_nodes = self.get_optional_child("init_path", attributes={"lang":lang}, root=self.get_child("module_system"))
-	return self.text(init_nodes) if init_nodes is not None else None
+        init_nodes = self.get_optional_child("init_path", attributes={"lang":lang}, root=self.get_child("module_system"))
+        return self.text(init_nodes) if init_nodes is not None else None
 
     def get_module_system_cmd_path(self, lang):
-	cmd_nodes = self.get_optional_child("cmd_path", attributes={"lang":lang}, root=self.get_child("module_system"))
-	return self.text(cmd_nodes) if cmd_nodes is not None else None
+        cmd_nodes = self.get_optional_child("cmd_path", attributes={"lang":lang}, root=self.get_child("module_system"))
+        return self.text(cmd_nodes) if cmd_nodes is not None else None
 
     def get_mpirun(self, case, attribs, job, exe_only=False, overrides=None):
-	"""
-	Find best match, return (executable, {arg_name : text})
-	"""
-	mpirun_nodes = self.get_children("mpirun")
-	best_match = None
-	best_num_matched = -1
-	default_match = None
-	best_num_matched_default = -1
-	args = []
-	for mpirun_node in mpirun_nodes:
-	    xml_attribs = self.attrib(mpirun_node)
-	    all_match = True
-	    matches = 0
-	    is_default = False
+        """
+        Find best match, return (executable, {arg_name : text})
+        """
+        mpirun_nodes = self.get_children("mpirun")
+        best_match = None
+        best_num_matched = -1
+        default_match = None
+        best_num_matched_default = -1
+        args = []
+        for mpirun_node in mpirun_nodes:
+            xml_attribs = self.attrib(mpirun_node)
+            all_match = True
+            matches = 0
+            is_default = False
 
-	    for key, value in attribs.items():
-		expect(key in self._allowed_mpi_attributes, "Unexpected key {} in mpirun attributes".format(key))
-		if key in xml_attribs:
-		    if xml_attribs[key].lower() == "false":
-			xml_attrib = False
-		    elif xml_attribs[key].lower() == "true":
-			xml_attrib = True
-		    else:
-			xml_attrib = xml_attribs[key]
+            for key, value in attribs.items():
+                expect(key in self._allowed_mpi_attributes, "Unexpected key {} in mpirun attributes".format(key))
+                if key in xml_attribs:
+                    if xml_attribs[key].lower() == "false":
+                        xml_attrib = False
+                    elif xml_attribs[key].lower() == "true":
+                        xml_attrib = True
+                    else:
+                        xml_attrib = xml_attribs[key]
 
-		    if xml_attrib == value:
-			matches += 1
-		    elif key == "mpilib" and value != "mpi-serial" and xml_attrib == "default":
-			is_default = True
-		    else:
-			all_match = False
-			break
+                    if xml_attrib == value:
+                        matches += 1
+                    elif key == "mpilib" and value != "mpi-serial" and xml_attrib == "default":
+                        is_default = True
+                    else:
+                        all_match = False
+                        break
 
-	    if all_match:
-		if is_default:
-		    if matches > best_num_matched_default:
-			default_match = mpirun_node
-			best_num_matched_default = matches
-		else:
-		    if matches > best_num_matched:
-			best_match = mpirun_node
-			best_num_matched = matches
+            if all_match:
+                if is_default:
+                    if matches > best_num_matched_default:
+                        default_match = mpirun_node
+                        best_num_matched_default = matches
+                else:
+                    if matches > best_num_matched:
+                        best_match = mpirun_node
+                        best_num_matched = matches
 
-	# if there are no special arguments required for mpi-serial it need not have an entry in config_machines.xml
-	if "mpilib" in attribs and attribs["mpilib"] == "mpi-serial" and best_match is None:
-	    return "",[],None,None
+        # if there are no special arguments required for mpi-serial it need not have an entry in config_machines.xml
+        if "mpilib" in attribs and attribs["mpilib"] == "mpi-serial" and best_match is None:
+            return "",[],None,None
 
-	expect(best_match is not None or default_match is not None,
-	       "Could not find a matching MPI for attributes: {}".format(attribs))
+        expect(best_match is not None or default_match is not None,
+               "Could not find a matching MPI for attributes: {}".format(attribs))
 
-	the_match = best_match if best_match is not None else default_match
+        the_match = best_match if best_match is not None else default_match
 
-	# Now that we know the best match, compute the arguments
-	if not exe_only:
-	    arg_node = self.get_optional_child("arguments", root=the_match)
-	    if arg_node:
-		arg_nodes = self.get_children("arg", root=arg_node)
-		for arg_node in arg_nodes:
-		    arg_value = transform_vars(self.text(arg_node),
-					       case=case,
-					       subgroup=job,overrides=overrides,
-					       default=self.get(arg_node, "default"))
-		    args.append(arg_value)
+        # Now that we know the best match, compute the arguments
+        if not exe_only:
+            arg_node = self.get_optional_child("arguments", root=the_match)
+            if arg_node:
+                arg_nodes = self.get_children("arg", root=arg_node)
+                for arg_node in arg_nodes:
+                    arg_value = transform_vars(self.text(arg_node),
+                                               case=case,
+                                               subgroup=job,overrides=overrides,
+                                               default=self.get(arg_node, "default"))
+                    args.append(arg_value)
 
-	exec_node = self.get_child("executable", root=the_match)
-	expect(exec_node is not None,"No executable found")
-	executable = self.text(exec_node)
-	run_exe = None
-	run_misc_suffix = None
+        exec_node = self.get_child("executable", root=the_match)
+        expect(exec_node is not None,"No executable found")
+        executable = self.text(exec_node)
+        run_exe = None
+        run_misc_suffix = None
 
-	run_exe_node = self.get_optional_child('run_exe', root=the_match)
-	if run_exe_node:
-	    run_exe = self.text(run_exe_node)
+        run_exe_node = self.get_optional_child('run_exe', root=the_match)
+        if run_exe_node:
+            run_exe = self.text(run_exe_node)
 
-	run_misc_suffix_node = self.get_optional_child('run_misc_suffix', root=the_match)
-	if run_misc_suffix_node:
-	    run_misc_suffix = self.text(run_misc_suffix_node)
+        run_misc_suffix_node = self.get_optional_child('run_misc_suffix', root=the_match)
+        if run_misc_suffix_node:
+            run_misc_suffix = self.text(run_misc_suffix_node)
 
-	return executable, args, run_exe, run_misc_suffix
+        return executable, args, run_exe, run_misc_suffix
 
     def get_type_info(self, vid):
-	return "char"
+        return "char"

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -337,7 +337,6 @@ class EnvMachSpecific(EnvBase):
     def _load_modules_generic(self, modules_to_load, verbose=False):
         sh_init_cmd = self.get_module_system_init_path("sh")
         sh_mod_cmd = self.get_module_system_cmd_path("sh")
-        logger_func = logger.warning if verbose else logger.debug
 
         # Purpose is for environment management system that does not have
         # a python interface and therefore can only determine what they

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -15,382 +15,400 @@ logger = logging.getLogger(__name__)
 class EnvMachSpecific(EnvBase):
     # pylint: disable=unused-argument
     def __init__(self, caseroot=None, infile="env_mach_specific.xml",
-                 components=None, unit_testing=False, read_only=False,
-                 standalone_configure=False):
-        """
-        initialize an object interface to file env_mach_specific.xml in the case directory
+		 components=None, unit_testing=False, read_only=False,
+		 standalone_configure=False):
+	"""
+	initialize an object interface to file env_mach_specific.xml in the case directory
 
-        Notes on some arguments:
-        standalone_configure: logical - whether this is being called from the standalone
-            configure utility, outside of a case
-        """
-        schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_specific.xsd")
-        EnvBase.__init__(self, caseroot, infile, schema=schema, read_only=read_only)
-        self._allowed_mpi_attributes = ("compiler", "mpilib", "threaded", "unit_testing", "queue")
-        self._unit_testing = unit_testing
-        self._standalone_configure = standalone_configure
+	Notes on some arguments:
+	standalone_configure: logical - whether this is being called from the standalone
+	    configure utility, outside of a case
+	"""
+	schema = os.path.join(get_cime_root(), "config", "xml_schemas", "env_mach_specific.xsd")
+	EnvBase.__init__(self, caseroot, infile, schema=schema, read_only=read_only)
+	self._allowed_mpi_attributes = ("compiler", "mpilib", "threaded", "unit_testing", "queue")
+	self._unit_testing = unit_testing
+	self._standalone_configure = standalone_configure
 
     def populate(self, machobj):
-        """Add entries to the file using information from a Machines object."""
-        items = ("module_system", "environment_variables", "resource_limits", "mpirun", "run_exe","run_misc_suffix")
-        default_run_suffix = machobj.get_child("default_run_suffix", root=machobj.root)
-        default_run_exe_node = machobj.get_child("default_run_exe", root=default_run_suffix)
-        default_run_misc_suffix_node = machobj.get_child("default_run_misc_suffix", root=default_run_suffix)
+	"""Add entries to the file using information from a Machines object."""
+	items = ("module_system", "environment_variables", "resource_limits", "mpirun", "run_exe","run_misc_suffix", "source_files")
+	default_run_suffix = machobj.get_child("default_run_suffix", root=machobj.root)
+	default_run_exe_node = machobj.get_child("default_run_exe", root=default_run_suffix)
+	default_run_misc_suffix_node = machobj.get_child("default_run_misc_suffix", root=default_run_suffix)
 
-        group_node = self.make_child("group", {"id":"compliant_values"})
+	group_node = self.make_child("group", {"id":"compliant_values"})
 
-        for item in items:
-            nodes = machobj.get_first_child_nodes(item)
-            if item == "environment_variables":
-                if len(nodes) == 0:
-                    example_text = """This section is for the user to specify any additional machine-specific env var, or to overwite existing ones.\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
-                    self.make_child_comment(text = example_text)
-            if item == "run_exe" or item == "run_misc_suffix":
-                if len(nodes) == 0:
-                    value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)
-                else:
-                    value = self.text(nodes[0])
+	for item in items:
+	    nodes = machobj.get_first_child_nodes(item)
+	    print("HERE item is {} and nodes len {}".format(item,len(nodes)))
+	    if item == "environment_variables":
+		if len(nodes) == 0:
+		    example_text = """This section is for the user to specify any additional machine-specific env var, or to overwite existing ones.\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
+		    self.make_child_comment(text = example_text)
+	    if item == "run_exe" or item == "run_misc_suffix":
+		if len(nodes) == 0:
+		    value = self.text(default_run_exe_node) if item == "run_exe" else self.text(default_run_misc_suffix_node)
+		else:
+		    value = self.text(nodes[0])
 
-                entity_node = self.make_child("entry", {"id":item, "value":value}, root=group_node)
+		entity_node = self.make_child("entry", {"id":item, "value":value}, root=group_node)
 
-                self.make_child("type", root=entity_node, text="char")
-                self.make_child("desc", root=entity_node, text=("executable name" if item == "run_exe" else "redirect for job output"))
+		self.make_child("type", root=entity_node, text="char")
+		self.make_child("desc", root=entity_node, text=("executable name" if item == "run_exe" else "redirect for job output"))
 
-            else:
-                for node in nodes:
-                    self.add_child(node)
+	    else:
+		for node in nodes:
+		    self.add_child(node)
 
     def _get_modules_for_case(self, case, job=None):
-        module_nodes = self.get_children("modules", root=self.get_child("module_system"))
-        modules_to_load = None
-        if module_nodes is not None:
-            modules_to_load = self._compute_module_actions(module_nodes, case, job=job)
+	module_nodes = self.get_children("modules", root=self.get_child("module_system"))
+	modules_to_load = None
+	if module_nodes is not None:
+	    modules_to_load = self._compute_module_actions(module_nodes, case, job=job)
 
-        return modules_to_load
+	return modules_to_load
 
     def _get_envs_for_case(self, case, job=None):
-        env_nodes = self.get_children("environment_variables")
+	env_nodes = self.get_children("environment_variables")
 
-        envs_to_set = None
-        if env_nodes is not None:
-            envs_to_set = self._compute_env_actions(env_nodes, case, job=job)
+	envs_to_set = None
+	if env_nodes is not None:
+	    envs_to_set = self._compute_env_actions(env_nodes, case, job=job)
 
-        return envs_to_set
+	return envs_to_set
 
-    def load_env(self, case, force_method=None, job=None, verbose=False):
-        """
-        Should only be called by case.load_env
-        """
-        # Do the modules so we can refer to env vars set by the modules
-        # in the environment_variables block
-        modules_to_load = self._get_modules_for_case(case)
-        if (modules_to_load is not None):
-            self._load_modules(modules_to_load, force_method=force_method, verbose=verbose)
+    def _get_source_files_for_case(self, case, job=None):
+	sf_nodes = self.get_children("source_files")
+	if sf_nodes:
+	    files_to_source = self._compute_actions(sf_nodes, "filepath", case, job=job)
+	logger.debug("files_to_source = {}".format(files_to_source))
+	return files_to_source
 
-        envs_to_set = self._get_envs_for_case(case, job=job)
-        if (envs_to_set is not None):
-            self._load_envs(envs_to_set, verbose=verbose)
+    def load_env(self, case, force_method=None, job=None, verbose=True):
+	"""
+	Should only be called by case.load_env
+	"""
+	# Do the modules so we can refer to env vars set by the modules
+	# in the environment_variables block
+	modules_to_load = self._get_modules_for_case(case)
+	if (modules_to_load is not None):
+	    self._load_modules(modules_to_load, force_method=force_method, verbose=verbose)
 
-        self._get_resources_for_case(case)
+	envs_to_set = self._get_envs_for_case(case, job=job)
+	if (envs_to_set is not None):
+	    self._load_envs(envs_to_set, verbose=verbose)
+
+	files_to_source = self._get_source_files_for_case(case, job=job)
+	if files_to_source:
+	    self._source_files(files_to_source, verbose=verbose)
+
+	self._get_resources_for_case(case)
+
+    def _source_files(self, files_to_source, verbose=True):
+	for _,_file in files_to_source:
+	    logger.info("sourcing file {}".format(_file))
+	    run_cmd_no_fail("source {}".format(_file), combine_output=True, verbose=verbose)
+
 
     def _get_resources_for_case(self, case):
-        resource_nodes = self.get_children("resource_limits")
-        if resource_nodes is not None:
-            nodes = self._compute_resource_actions(resource_nodes, case)
-            for name, val in nodes:
-                attr = getattr(resource, name)
-                limits = resource.getrlimit(attr)
-                logger.info("Setting resource.{} to {} from {}".format(name, val, limits))
-                limits = (int(val), limits[1])
-                resource.setrlimit(attr, limits)
+	resource_nodes = self.get_children("resource_limits")
+	if resource_nodes is not None:
+	    nodes = self._compute_resource_actions(resource_nodes, case)
+	    for name, val in nodes:
+		attr = getattr(resource, name)
+		limits = resource.getrlimit(attr)
+		logger.info("Setting resource.{} to {} from {}".format(name, val, limits))
+		limits = (int(val), limits[1])
+		resource.setrlimit(attr, limits)
 
     def _load_modules(self, modules_to_load, force_method=None, verbose=False):
-        module_system = self.get_module_system_type() if force_method is None else force_method
-        if (module_system == "module"):
-            self._load_module_modules(modules_to_load, verbose=verbose)
-        elif (module_system == "soft"):
-            self._load_modules_generic(modules_to_load, verbose=verbose)
-        elif (module_system == "generic"):
-            self._load_modules_generic(modules_to_load, verbose=verbose)
-        elif (module_system == "none"):
-            self._load_none_modules(modules_to_load)
-        else:
-            expect(False, "Unhandled module system '{}'".format(module_system))
+	module_system = self.get_module_system_type() if force_method is None else force_method
+	if (module_system == "module"):
+	    self._load_module_modules(modules_to_load, verbose=verbose)
+	elif (module_system == "soft"):
+	    self._load_modules_generic(modules_to_load, verbose=verbose)
+	elif (module_system == "generic"):
+	    self._load_modules_generic(modules_to_load, verbose=verbose)
+	elif (module_system == "none"):
+	    self._load_none_modules(modules_to_load)
+	else:
+	    expect(False, "Unhandled module system '{}'".format(module_system))
 
     def list_modules(self):
-        module_system = self.get_module_system_type()
+	module_system = self.get_module_system_type()
 
-        # If the user's login shell is not sh, it's possible that modules
-        # won't be configured so we need to be sure to source the module
-        # setup script if it exists.
-        init_path = self.get_module_system_init_path("sh")
-        if init_path:
-            source_cmd = "source {} && ".format(init_path)
-        else:
-            source_cmd = ""
+	# If the user's login shell is not sh, it's possible that modules
+	# won't be configured so we need to be sure to source the module
+	# setup script if it exists.
+	init_path = self.get_module_system_init_path("sh")
+	if init_path:
+	    source_cmd = "source {} && ".format(init_path)
+	else:
+	    source_cmd = ""
 
-        if (module_system in ["module"]):
-            return run_cmd_no_fail("{}module list".format(source_cmd), combine_output=True)
-        elif (module_system == "soft"):
-            # Does soft really not provide this capability?
-            return ""
-        elif (module_system == "generic"):
-            return run_cmd_no_fail("{}use -lv".format(source_cmd))
-        elif (module_system == "none"):
-            return ""
-        else:
-            expect(False, "Unhandled module system '{}'".format(module_system))
+	if (module_system in ["module"]):
+	    return run_cmd_no_fail("{}module list".format(source_cmd), combine_output=True)
+	elif (module_system == "soft"):
+	    # Does soft really not provide this capability?
+	    return ""
+	elif (module_system == "generic"):
+	    return run_cmd_no_fail("{}use -lv".format(source_cmd))
+	elif (module_system == "none"):
+	    return ""
+	else:
+	    expect(False, "Unhandled module system '{}'".format(module_system))
 
     def save_all_env_info(self, filename):
-        """
-        Get a string representation of all current environment info and
-        save it to file.
-        """
-        with open(filename, "w") as f:
-            f.write(self.list_modules())
-        run_cmd_no_fail("echo -e '\n' && env", arg_stdout=filename)
+	"""
+	Get a string representation of all current environment info and
+	save it to file.
+	"""
+	with open(filename, "w") as f:
+	    f.write(self.list_modules())
+	run_cmd_no_fail("echo -e '\n' && env", arg_stdout=filename)
 
     def make_env_mach_specific_file(self, shell, case, output_dir=''):
-        """Writes .env_mach_specific.sh or .env_mach_specific.csh
+	"""Writes .env_mach_specific.sh or .env_mach_specific.csh
 
-        Args:
-        shell: string - 'sh' or 'csh'
-        case: case object
-        output_dir: string - path to output directory (if empty string, uses current directory)
-        """
-        module_system = self.get_module_system_type()
-        sh_init_cmd = self.get_module_system_init_path(shell)
-        sh_mod_cmd = self.get_module_system_cmd_path(shell)
-        lines = ["# This file is for user convenience only and is not used by the model"]
+	Args:
+	shell: string - 'sh' or 'csh'
+	case: case object
+	output_dir: string - path to output directory (if empty string, uses current directory)
+	"""
+	module_system = self.get_module_system_type()
+	sh_init_cmd = self.get_module_system_init_path(shell)
+	sh_mod_cmd = self.get_module_system_cmd_path(shell)
+	lines = ["# This file is for user convenience only and is not used by the model"]
 
-        lines.append("# Changes to this file will be ignored and overwritten")
-        lines.append("# Changes to the environment should be made in env_mach_specific.xml")
-        lines.append("# Run ./case.setup --reset to regenerate this file")
-        if sh_init_cmd:
-            lines.append("source {}".format(sh_init_cmd))
+	lines.append("# Changes to this file will be ignored and overwritten")
+	lines.append("# Changes to the environment should be made in env_mach_specific.xml")
+	lines.append("# Run ./case.setup --reset to regenerate this file")
+	if sh_init_cmd:
+	    lines.append("source {}".format(sh_init_cmd))
 
-        if "SOFTENV_ALIASES" in os.environ:
-            lines.append("source $SOFTENV_ALIASES")
-        if "SOFTENV_LOAD" in os.environ:
-            lines.append("source $SOFTENV_LOAD")
+	if "SOFTENV_ALIASES" in os.environ:
+	    lines.append("source $SOFTENV_ALIASES")
+	if "SOFTENV_LOAD" in os.environ:
+	    lines.append("source $SOFTENV_LOAD")
 
-        if self._unit_testing or self._standalone_configure:
-            job = None
-        else:
-            job = case.get_primary_job()
-        modules_to_load = self._get_modules_for_case(case, job=job)
-        envs_to_set = self._get_envs_for_case(case, job=job)
-        filename = ".env_mach_specific.{}".format(shell)
-        if modules_to_load is not None:
-            if module_system == "module":
-                lines.extend(self._get_module_commands(modules_to_load, shell))
-            else:
-                for action, argument in modules_to_load:
-                    lines.append("{} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument))
+	if self._unit_testing or self._standalone_configure:
+	    job = None
+	else:
+	    job = case.get_primary_job()
+	modules_to_load = self._get_modules_for_case(case, job=job)
+	envs_to_set = self._get_envs_for_case(case, job=job)
+	filename = ".env_mach_specific.{}".format(shell)
+	if modules_to_load is not None:
+	    if module_system == "module":
+		lines.extend(self._get_module_commands(modules_to_load, shell))
+	    else:
+		for action, argument in modules_to_load:
+		    lines.append("{} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument))
 
-        if envs_to_set is not None:
-            for env_name, env_value in envs_to_set:
-                if shell == "sh":
-                    lines.append("export {}={}".format(env_name, env_value))
-                elif shell == "csh":
-                    lines.append("setenv {} {}".format(env_name, env_value))
-                else:
-                    expect(False, "Unknown shell type: '{}'".format(shell))
+	if envs_to_set is not None:
+	    for env_name, env_value in envs_to_set:
+		if shell == "sh":
+		    lines.append("export {}={}".format(env_name, env_value))
+		elif shell == "csh":
+		    lines.append("setenv {} {}".format(env_name, env_value))
+		else:
+		    expect(False, "Unknown shell type: '{}'".format(shell))
 
-        with open(os.path.join(output_dir, filename), "w") as fd:
-            fd.write("\n".join(lines))
+	with open(os.path.join(output_dir, filename), "w") as fd:
+	    fd.write("\n".join(lines))
 
     # Private API
 
     def _load_envs(self, envs_to_set, verbose=False):
-        for env_name, env_value in envs_to_set:
-            logger_func = logger.warning if verbose else logger.debug
-            if env_value is None and env_name in os.environ:
-                del os.environ[env_name]
-                logger_func("Unsetting Environment {}".format(env_name))
-            elif env_value is not None:
-                os.environ[env_name] = env_value
-                logger_func("Setting Environment {}={}".format(env_name, env_value))
+	for env_name, env_value in envs_to_set:
+	    logger_func = logger.warning if verbose else logger.debug
+	    if env_value is None and env_name in os.environ:
+		del os.environ[env_name]
+		logger_func("Unsetting Environment {}".format(env_name))
+	    elif env_value is not None:
+		os.environ[env_name] = env_value
+		logger_func("Setting Environment {}={}".format(env_name, env_value))
 
     def _compute_module_actions(self, module_nodes, case, job=None):
-        return self._compute_actions(module_nodes, "command", case, job=job)
+	return self._compute_actions(module_nodes, "command", case, job=job)
 
     def _compute_env_actions(self, env_nodes, case, job=None):
-        return self._compute_actions(env_nodes, "env", case, job=job)
+	return self._compute_actions(env_nodes, "env", case, job=job)
 
     def _compute_resource_actions(self, resource_nodes, case, job=None):
-        return self._compute_actions(resource_nodes, "resource", case, job=job)
+	return self._compute_actions(resource_nodes, "resource", case, job=job)
 
     def _compute_actions(self, nodes, child_tag, case, job=None):
-        result = [] # list of tuples ("name", "argument")
-        compiler, mpilib = case.get_value("COMPILER"), case.get_value("MPILIB")
+	result = [] # list of tuples ("name", "argument")
+	compiler, mpilib = case.get_value("COMPILER"), case.get_value("MPILIB")
 
-        for node in nodes:
-            if (self._match_attribs(self.attrib(node), case, job=job)):
-                for child in self.get_children(root=node):
-                    expect(self.name(child) == child_tag, "Expected {} element".format(child_tag))
-                    if (self._match_attribs(self.attrib(child), case, job=job)):
-                        val = self.text(child)
-                        if val is not None:
-                            # We allow a couple special substitutions for these fields
-                            for repl_this, repl_with in [("$COMPILER", compiler), ("$MPILIB", mpilib)]:
-                                val = val.replace(repl_this, repl_with)
+	for node in nodes:
+	    if (self._match_attribs(self.attrib(node), case, job=job)):
+		for child in self.get_children(root=node):
+		    expect(self.name(child) == child_tag, "Expected {} element".format(child_tag))
+		    if (self._match_attribs(self.attrib(child), case, job=job)):
+			val = self.text(child)
+			if val is not None:
+			    # We allow a couple special substitutions for these fields
+			    for repl_this, repl_with in [("$COMPILER", compiler), ("$MPILIB", mpilib)]:
+				val = val.replace(repl_this, repl_with)
 
-                            val = self.get_resolved_value(val)
-                            expect("$" not in val, "Not safe to leave unresolved items in env var value: '{}'".format(val))
+			    val = self.get_resolved_value(val)
+			    expect("$" not in val, "Not safe to leave unresolved items in env var value: '{}'".format(val))
 
-                        # intentional unindent, result is appended even if val is None
-                        result.append( (self.get(child, "name"), val) )
+			# intentional unindent, result is appended even if val is None
+			result.append( (self.get(child, "name"), val) )
 
-        return result
+	return result
 
     def _match_attribs(self, attribs, case, job=None):
-        # check for matches with case-vars
-        for attrib in attribs:
-            if attrib == "unit_testing": # special case
-                if not self._match(self._unit_testing, attribs["unit_testing"].upper()):
-                    return False
-            elif attrib == "queue":
-                if job is not None:
-                    val = case.get_value("JOB_QUEUE", subgroup=job)
-                    expect(val is not None, "Cannot match attrib '%s', case has no value for it" % attrib.upper())
-                    if not self._match(val, attribs[attrib]):
-                        return False
-            elif attrib == "name":
-                pass
-            else:
-                val = case.get_value(attrib.upper())
-                expect(val is not None, "Cannot match attrib '%s', case has no value for it" % attrib.upper())
-                if not self._match(val, attribs[attrib]):
-                    return False
+	# check for matches with case-vars
+	for attrib in attribs:
+	    if attrib == "unit_testing": # special case
+		if not self._match(self._unit_testing, attribs["unit_testing"].upper()):
+		    return False
+	    elif attrib == "queue":
+		if job is not None:
+		    val = case.get_value("JOB_QUEUE", subgroup=job)
+		    expect(val is not None, "Cannot match attrib '%s', case has no value for it" % attrib.upper())
+		    if not self._match(val, attribs[attrib]):
+			return False
+	    elif attrib == "name":
+		pass
+	    else:
+		val = case.get_value(attrib.upper())
+		expect(val is not None, "Cannot match attrib '%s', case has no value for it" % attrib.upper())
+		if not self._match(val, attribs[attrib]):
+		    return False
 
-        return True
+	return True
 
     def _match(self, my_value, xml_value):
-        if xml_value.startswith("!"):
-            result = re.match(xml_value[1:] + "$",str(my_value)) is None
-        elif isinstance(my_value, bool):
-            if my_value: result = xml_value == "TRUE"
-            else: result = xml_value == "FALSE"
-        else:
-            result = re.match(xml_value + "$",str(my_value)) is not None
+	if xml_value.startswith("!"):
+	    result = re.match(xml_value[1:] + "$",str(my_value)) is None
+	elif isinstance(my_value, bool):
+	    if my_value: result = xml_value == "TRUE"
+	    else: result = xml_value == "FALSE"
+	else:
+	    result = re.match(xml_value + "$",str(my_value)) is not None
 
-        logger.debug("(env_mach_specific) _match {} {} {}".format(my_value, xml_value, result))
-        return result
+	logger.debug("(env_mach_specific) _match {} {} {}".format(my_value, xml_value, result))
+	return result
 
     def _get_module_commands(self, modules_to_load, shell):
-        # Note this is independent of module system type
-        mod_cmd = self.get_module_system_cmd_path(shell)
-        cmds = []
-        last_action = None
-        last_cmd    = None
+	# Note this is independent of module system type
+	mod_cmd = self.get_module_system_cmd_path(shell)
+	cmds = []
+	last_action = None
+	last_cmd    = None
 
-        # Normally, we will try to combine or batch module commands together...
-        #
-        # module load X
-        # module load Y
-        # module load Z
-        #
-        # is the same as ...
-        #
-        # module load X Y Z
-        #
-        # ... except the latter is significatly faster due to performing 1/3 as
-        # many forks.
-        #
-        # Not all module commands support batching though and we enurmerate those
-        # here.
-        actions_that_cannot_be_batched = ["swap", "switch"]
+	# Normally, we will try to combine or batch module commands together...
+	#
+	# module load X
+	# module load Y
+	# module load Z
+	#
+	# is the same as ...
+	#
+	# module load X Y Z
+	#
+	# ... except the latter is significatly faster due to performing 1/3 as
+	# many forks.
+	#
+	# Not all module commands support batching though and we enurmerate those
+	# here.
+	actions_that_cannot_be_batched = ["swap", "switch"]
 
-        for action, argument in modules_to_load:
-            if argument is None:
-                argument = ""
+	for action, argument in modules_to_load:
+	    if argument is None:
+		argument = ""
 
-            if action == last_action and action not in actions_that_cannot_be_batched:
-                last_cmd = "{} {}".format(last_cmd, argument)
-            else:
-                if last_cmd is not None:
-                    cmds.append(last_cmd)
+	    if action == last_action and action not in actions_that_cannot_be_batched:
+		last_cmd = "{} {}".format(last_cmd, argument)
+	    else:
+		if last_cmd is not None:
+		    cmds.append(last_cmd)
 
-                last_cmd = "{} {} {}".format(mod_cmd, action, "" if argument is None else argument)
-                last_action = action
+		last_cmd = "{} {} {}".format(mod_cmd, action, "" if argument is None else argument)
+		last_action = action
 
-        if last_cmd:
-            cmds.append(last_cmd)
+	if last_cmd:
+	    cmds.append(last_cmd)
 
-        return cmds
+	return cmds
 
     def _load_module_modules(self, modules_to_load, verbose=False):
-        logger_func = logger.warning if verbose else logger.debug
-        for cmd in self._get_module_commands(modules_to_load, "python"):
-            logger_func("module command is {}".format(cmd))
-            stat, py_module_code, errout = run_cmd(cmd)
-            expect(stat==0 and (len(errout) == 0 or self.allow_error()),
-                   "module command {} failed with message:\n{}".format(cmd, errout))
-            exec(py_module_code)
+	logger_func = logger.warning if verbose else logger.debug
+	for cmd in self._get_module_commands(modules_to_load, "python"):
+	    logger_func("module command is {}".format(cmd))
+	    stat, py_module_code, errout = run_cmd(cmd)
+	    expect(stat==0 and (len(errout) == 0 or self.allow_error()),
+		   "module command {} failed with message:\n{}".format(cmd, errout))
+	    exec(py_module_code)
 
     def _load_modules_generic(self, modules_to_load, verbose=False):
-        sh_init_cmd = self.get_module_system_init_path("sh")
-        sh_mod_cmd = self.get_module_system_cmd_path("sh")
-        logger_func = logger.warning if verbose else logger.debug
+	sh_init_cmd = self.get_module_system_init_path("sh")
+	sh_mod_cmd = self.get_module_system_cmd_path("sh")
+	logger_func = logger.warning if verbose else logger.debug
 
-        # Purpose is for environment management system that does not have
-        # a python interface and therefore can only determine what they
-        # do by running shell command and looking at the changes
-        # in the environment.
+	# Purpose is for environment management system that does not have
+	# a python interface and therefore can only determine what they
+	# do by running shell command and looking at the changes
+	# in the environment.
 
-        cmd = "source {}".format(sh_init_cmd)
+	cmd = "source {}".format(sh_init_cmd)
 
-        if "SOFTENV_ALIASES" in os.environ:
-            cmd += " && source $SOFTENV_ALIASES"
-        if "SOFTENV_LOAD" in os.environ:
-            cmd += " && source $SOFTENV_LOAD"
+	if "SOFTENV_ALIASES" in os.environ:
+	    cmd += " && source $SOFTENV_ALIASES"
+	if "SOFTENV_LOAD" in os.environ:
+	    cmd += " && source $SOFTENV_LOAD"
 
-        for action,argument in modules_to_load:
-            cmd += " && {} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument)
+	for action,argument in modules_to_load:
+	    cmd += " && {} {} {}".format(sh_mod_cmd, action, "" if argument is None else argument)
 
-        # Use null terminated lines to give us something more definitive to split on.
-        # Env vars can contain newlines, so splitting on newlines can be ambiguous
-        cmd += " && env -0"
-        logger_func("cmd: {}".format(cmd))
-        output = run_cmd_no_fail(cmd)
+	# Use null terminated lines to give us something more definitive to split on.
+	# Env vars can contain newlines, so splitting on newlines can be ambiguous
+	cmd += " && env -0"
+	logger_func("cmd: {}".format(cmd))
+	output = run_cmd_no_fail(cmd)
 
-        ###################################################
-        # Parse the output to set the os.environ dictionary
-        ###################################################
-        newenv = OrderedDict()
-        for line in output.split('\0'):
-            if "=" in line:
-                key, val = line.split("=", 1)
-                newenv[key] = val
+	###################################################
+	# Parse the output to set the os.environ dictionary
+	###################################################
+	newenv = OrderedDict()
+	for line in output.split('\0'):
+	    if "=" in line:
+		key, val = line.split("=", 1)
+		newenv[key] = val
 
-        # resolve variables
-        for key, val in newenv.items():
-            newenv[key] = string.Template(val).safe_substitute(newenv)
+	# resolve variables
+	for key, val in newenv.items():
+	    newenv[key] = string.Template(val).safe_substitute(newenv)
 
-        # Set environment with new or updated values
-        for key in newenv:
-            if key in os.environ and os.environ[key] == newenv[key]:
-                pass
-            else:
-                os.environ[key] = newenv[key]
+	# Set environment with new or updated values
+	for key in newenv:
+	    if key in os.environ and os.environ[key] == newenv[key]:
+		pass
+	    else:
+		os.environ[key] = newenv[key]
 
-        for oldkey in list(os.environ.keys()):
-            if oldkey not in newenv:
-                del os.environ[oldkey]
+	for oldkey in list(os.environ.keys()):
+	    if oldkey not in newenv:
+		del os.environ[oldkey]
 
     def _load_none_modules(self, modules_to_load):
-        """
-        No Action required
-        """
-        expect(not modules_to_load,
-               "Module system was specified as 'none' yet there are modules that need to be loaded?")
+	"""
+	No Action required
+	"""
+	expect(not modules_to_load,
+	       "Module system was specified as 'none' yet there are modules that need to be loaded?")
 
     def _mach_specific_header(self, shell):
-        '''
-        write a shell module file for this case.
-        '''
-        header = '''
+	'''
+	write a shell module file for this case.
+	'''
+	header = '''
 #!/usr/bin/env {}
 #===============================================================================
 # Automatically generated module settings for $self->{{machine}}
@@ -398,115 +416,115 @@ class EnvMachSpecific(EnvBase):
 # in your CASEROOT. This file is overwritten every time modules are loaded!
 #===============================================================================
 '''.format(shell)
-        header += "source {}".format(self.get_module_system_init_path(shell))
-        return header
+	header += "source {}".format(self.get_module_system_init_path(shell))
+	return header
 
     def get_module_system_type(self):
-        """
-        Return the module system used on this machine
-        """
-        module_system = self.get_child("module_system")
-        return self.get(module_system, "type")
+	"""
+	Return the module system used on this machine
+	"""
+	module_system = self.get_child("module_system")
+	return self.get(module_system, "type")
 
     def allow_error(self):
-        """
-        Return True if stderr output from module commands should be assumed
-        to be an error. Default False. This is necessary since implementations
-        of environment modules are highlty variable and some systems produce
-        stderr output even when things are working fine.
-        """
-        module_system = self.get_child("module_system")
-        value = self.get(module_system, "allow_error")
-        return value.upper() == "TRUE" if value is not None else False
+	"""
+	Return True if stderr output from module commands should be assumed
+	to be an error. Default False. This is necessary since implementations
+	of environment modules are highlty variable and some systems produce
+	stderr output even when things are working fine.
+	"""
+	module_system = self.get_child("module_system")
+	value = self.get(module_system, "allow_error")
+	return value.upper() == "TRUE" if value is not None else False
 
     def get_module_system_init_path(self, lang):
-        init_nodes = self.get_optional_child("init_path", attributes={"lang":lang}, root=self.get_child("module_system"))
-        return self.text(init_nodes) if init_nodes is not None else None
+	init_nodes = self.get_optional_child("init_path", attributes={"lang":lang}, root=self.get_child("module_system"))
+	return self.text(init_nodes) if init_nodes is not None else None
 
     def get_module_system_cmd_path(self, lang):
-        cmd_nodes = self.get_optional_child("cmd_path", attributes={"lang":lang}, root=self.get_child("module_system"))
-        return self.text(cmd_nodes) if cmd_nodes is not None else None
+	cmd_nodes = self.get_optional_child("cmd_path", attributes={"lang":lang}, root=self.get_child("module_system"))
+	return self.text(cmd_nodes) if cmd_nodes is not None else None
 
     def get_mpirun(self, case, attribs, job, exe_only=False, overrides=None):
-        """
-        Find best match, return (executable, {arg_name : text})
-        """
-        mpirun_nodes = self.get_children("mpirun")
-        best_match = None
-        best_num_matched = -1
-        default_match = None
-        best_num_matched_default = -1
-        args = []
-        for mpirun_node in mpirun_nodes:
-            xml_attribs = self.attrib(mpirun_node)
-            all_match = True
-            matches = 0
-            is_default = False
+	"""
+	Find best match, return (executable, {arg_name : text})
+	"""
+	mpirun_nodes = self.get_children("mpirun")
+	best_match = None
+	best_num_matched = -1
+	default_match = None
+	best_num_matched_default = -1
+	args = []
+	for mpirun_node in mpirun_nodes:
+	    xml_attribs = self.attrib(mpirun_node)
+	    all_match = True
+	    matches = 0
+	    is_default = False
 
-            for key, value in attribs.items():
-                expect(key in self._allowed_mpi_attributes, "Unexpected key {} in mpirun attributes".format(key))
-                if key in xml_attribs:
-                    if xml_attribs[key].lower() == "false":
-                        xml_attrib = False
-                    elif xml_attribs[key].lower() == "true":
-                        xml_attrib = True
-                    else:
-                        xml_attrib = xml_attribs[key]
+	    for key, value in attribs.items():
+		expect(key in self._allowed_mpi_attributes, "Unexpected key {} in mpirun attributes".format(key))
+		if key in xml_attribs:
+		    if xml_attribs[key].lower() == "false":
+			xml_attrib = False
+		    elif xml_attribs[key].lower() == "true":
+			xml_attrib = True
+		    else:
+			xml_attrib = xml_attribs[key]
 
-                    if xml_attrib == value:
-                        matches += 1
-                    elif key == "mpilib" and value != "mpi-serial" and xml_attrib == "default":
-                        is_default = True
-                    else:
-                        all_match = False
-                        break
+		    if xml_attrib == value:
+			matches += 1
+		    elif key == "mpilib" and value != "mpi-serial" and xml_attrib == "default":
+			is_default = True
+		    else:
+			all_match = False
+			break
 
-            if all_match:
-                if is_default:
-                    if matches > best_num_matched_default:
-                        default_match = mpirun_node
-                        best_num_matched_default = matches
-                else:
-                    if matches > best_num_matched:
-                        best_match = mpirun_node
-                        best_num_matched = matches
+	    if all_match:
+		if is_default:
+		    if matches > best_num_matched_default:
+			default_match = mpirun_node
+			best_num_matched_default = matches
+		else:
+		    if matches > best_num_matched:
+			best_match = mpirun_node
+			best_num_matched = matches
 
-        # if there are no special arguments required for mpi-serial it need not have an entry in config_machines.xml
-        if "mpilib" in attribs and attribs["mpilib"] == "mpi-serial" and best_match is None:
-            return "",[],None,None
+	# if there are no special arguments required for mpi-serial it need not have an entry in config_machines.xml
+	if "mpilib" in attribs and attribs["mpilib"] == "mpi-serial" and best_match is None:
+	    return "",[],None,None
 
-        expect(best_match is not None or default_match is not None,
-               "Could not find a matching MPI for attributes: {}".format(attribs))
+	expect(best_match is not None or default_match is not None,
+	       "Could not find a matching MPI for attributes: {}".format(attribs))
 
-        the_match = best_match if best_match is not None else default_match
+	the_match = best_match if best_match is not None else default_match
 
-        # Now that we know the best match, compute the arguments
-        if not exe_only:
-            arg_node = self.get_optional_child("arguments", root=the_match)
-            if arg_node:
-                arg_nodes = self.get_children("arg", root=arg_node)
-                for arg_node in arg_nodes:
-                    arg_value = transform_vars(self.text(arg_node),
-                                               case=case,
-                                               subgroup=job,overrides=overrides,
-                                               default=self.get(arg_node, "default"))
-                    args.append(arg_value)
+	# Now that we know the best match, compute the arguments
+	if not exe_only:
+	    arg_node = self.get_optional_child("arguments", root=the_match)
+	    if arg_node:
+		arg_nodes = self.get_children("arg", root=arg_node)
+		for arg_node in arg_nodes:
+		    arg_value = transform_vars(self.text(arg_node),
+					       case=case,
+					       subgroup=job,overrides=overrides,
+					       default=self.get(arg_node, "default"))
+		    args.append(arg_value)
 
-        exec_node = self.get_child("executable", root=the_match)
-        expect(exec_node is not None,"No executable found")
-        executable = self.text(exec_node)
-        run_exe = None
-        run_misc_suffix = None
+	exec_node = self.get_child("executable", root=the_match)
+	expect(exec_node is not None,"No executable found")
+	executable = self.text(exec_node)
+	run_exe = None
+	run_misc_suffix = None
 
-        run_exe_node = self.get_optional_child('run_exe', root=the_match)
-        if run_exe_node:
-            run_exe = self.text(run_exe_node)
+	run_exe_node = self.get_optional_child('run_exe', root=the_match)
+	if run_exe_node:
+	    run_exe = self.text(run_exe_node)
 
-        run_misc_suffix_node = self.get_optional_child('run_misc_suffix', root=the_match)
-        if run_misc_suffix_node:
-            run_misc_suffix = self.text(run_misc_suffix_node)
+	run_misc_suffix_node = self.get_optional_child('run_misc_suffix', root=the_match)
+	if run_misc_suffix_node:
+	    run_misc_suffix = self.text(run_misc_suffix_node)
 
-        return executable, args, run_exe, run_misc_suffix
+	return executable, args, run_exe, run_misc_suffix
 
     def get_type_info(self, vid):
-        return "char"
+	return "char"

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -19,26 +19,26 @@ logger = logging.getLogger(__name__)
 def redirect_stdout(new_target):
     old_target, sys.stdout = sys.stdout, new_target # replace sys.stdout
     try:
-        yield new_target # run some code with the replaced stdout
+	yield new_target # run some code with the replaced stdout
     finally:
-        sys.stdout = old_target # restore to the previous value
+	sys.stdout = old_target # restore to the previous value
 
 @contextmanager
 def redirect_stderr(new_target):
     old_target, sys.stderr = sys.stderr, new_target # replace sys.stdout
     try:
-        yield new_target # run some code with the replaced stdout
+	yield new_target # run some code with the replaced stdout
     finally:
-        sys.stderr = old_target # restore to the previous value
+	sys.stderr = old_target # restore to the previous value
 
 @contextmanager
 def redirect_stdout_stderr(new_target):
     old_stdout, old_stderr = sys.stdout, sys.stderr
     sys.stdout, sys.stderr = new_target, new_target
     try:
-        yield new_target
+	yield new_target
     finally:
-        sys.stdout, sys.stderr = old_stdout, old_stderr
+	sys.stdout, sys.stderr = old_stdout, old_stderr
 
 @contextmanager
 def redirect_logger(new_target, logger_name):
@@ -50,22 +50,22 @@ def redirect_logger(new_target, logger_name):
     orig_root_loggers = root_log.handlers
 
     try:
-        root_log.handlers = []
-        log.handlers = [ch]
-        yield log
+	root_log.handlers = []
+	log.handlers = [ch]
+	yield log
     finally:
-        root_log.handlers = orig_root_loggers
-        log.handlers = orig_handlers
+	root_log.handlers = orig_root_loggers
+	log.handlers = orig_handlers
 
 class IndentFormatter(logging.Formatter):
     def __init__(self, indent, fmt=None, datefmt=None):
-        logging.Formatter.__init__(self, fmt, datefmt)
-        self._indent = indent
+	logging.Formatter.__init__(self, fmt, datefmt)
+	self._indent = indent
 
     def format(self, record):
-        record.msg = "{}{}".format(self._indent, record.msg)
-        out = logging.Formatter.format(self, record)
-        return out
+	record.msg = "{}{}".format(self._indent, record.msg)
+	out = logging.Formatter.format(self, record)
+	return out
 
 def set_logger_indent(indent):
     root_log = logging.getLogger()
@@ -80,32 +80,32 @@ class EnvironmentContext(object):
     """
     Context manager for environment variables
     Usage:
-        os.environ['MYVAR'] = 'oldvalue'
-        with EnvironmentContex(MYVAR='myvalue', MYVAR2='myvalue2'):
-            print os.getenv('MYVAR')    # Should print myvalue.
-            print os.getenv('MYVAR2')    # Should print myvalue2.
-        print os.getenv('MYVAR')        # Should print oldvalue.
-        print os.getenv('MYVAR2')        # Should print None.
+	os.environ['MYVAR'] = 'oldvalue'
+	with EnvironmentContex(MYVAR='myvalue', MYVAR2='myvalue2'):
+	    print os.getenv('MYVAR')    # Should print myvalue.
+	    print os.getenv('MYVAR2')    # Should print myvalue2.
+	print os.getenv('MYVAR')        # Should print oldvalue.
+	print os.getenv('MYVAR2')        # Should print None.
 
     CREDIT: https://github.com/sakurai-youhei/envcontext
     """
 
     def __init__(self, **kwargs):
-        self.envs = kwargs
-        self.old_envs = {}
+	self.envs = kwargs
+	self.old_envs = {}
 
     def __enter__(self):
-        self.old_envs = {}
-        for k, v in self.envs.items():
-            self.old_envs[k] = os.environ.get(k)
-            os.environ[k] = v
+	self.old_envs = {}
+	for k, v in self.envs.items():
+	    self.old_envs[k] = os.environ.get(k)
+	    os.environ[k] = v
 
     def __exit__(self, *args):
-        for k, v in self.old_envs.items():
-            if v:
-                os.environ[k] = v
-            else:
-                del os.environ[k]
+	for k, v in self.old_envs.items():
+	    if v:
+		os.environ[k] = v
+	    else:
+		del os.environ[k]
 
 # This should be the go-to exception for CIME use. It's a subclass
 # of SystemExit in order suppress tracebacks, which users generally
@@ -123,18 +123,18 @@ def expect(condition, error_msg, exc_type=CIMEError, error_prefix="ERROR:"):
     >>> expect(True, "error1")
     >>> expect(False, "error2") # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-        ...
+	...
     CIMEError: ERROR: error2
     """
     # Without this line we get a futurewarning on the use of condition below
     warnings.filterwarnings("ignore")
     if not condition:
-        if logger.isEnabledFor(logging.DEBUG):
-            import pdb
-            pdb.set_trace()
+	if logger.isEnabledFor(logging.DEBUG):
+	    import pdb
+	    pdb.set_trace()
 
-        msg = error_prefix + " " + error_msg
-        raise exc_type(msg)
+	msg = error_prefix + " " + error_msg
+	raise exc_type(msg)
 
 def id_generator(size=6, chars=string.ascii_lowercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
@@ -163,17 +163,17 @@ def check_name(fullname, additional_chars=None, fullpath=False):
 
     chars = '+*?<>/{}[\]~`@:' # pylint: disable=anomalous-backslash-in-string
     if additional_chars is not None:
-        chars += additional_chars
+	chars += additional_chars
     if fullname.endswith('/'):
-        return False
+	return False
     if fullpath:
-        _, name = os.path.split(fullname)
+	_, name = os.path.split(fullname)
     else:
-        name = fullname
+	name = fullname
     match = re.search(r"["+re.escape(chars)+"]", name)
     if match is not None:
-        logger.warning("Illegal character {} found in name {}".format(match.group(0), name))
-        return False
+	logger.warning("Illegal character {} found in name {}".format(match.group(0), name))
+	return False
     return True
 
 # Should only be called from get_cime_config()
@@ -187,30 +187,30 @@ def _read_cime_config_file():
     allowed_sections = ("main", "create_test")
 
     allowed_in_main = ("cime_model", "project", "charge_account", "srcroot", "mail_type",
-                       "mail_user", "machine", "mpilib", "compiler", "input_dir", "cime_driver")
+		       "mail_user", "machine", "mpilib", "compiler", "input_dir", "cime_driver")
     allowed_in_create_test = ("mail_type", "mail_user", "save_timing", "single_submit",
-                              "test_root", "output_root", "baseline_root", "clean",
-                              "machine", "mpilib", "compiler", "parallel_jobs", "proc_pool",
-                              "walltime", "job_queue", "allow_baseline_overwrite", "wait",
-                              "force_procs", "force_threads", "input_dir", "pesfile", "retry",
-                              "walltime")
+			      "test_root", "output_root", "baseline_root", "clean",
+			      "machine", "mpilib", "compiler", "parallel_jobs", "proc_pool",
+			      "walltime", "job_queue", "allow_baseline_overwrite", "wait",
+			      "force_procs", "force_threads", "input_dir", "pesfile", "retry",
+			      "walltime")
 
     cime_config_file = os.path.abspath(os.path.join(os.path.expanduser("~"),
-                                                  ".cime","config"))
+						  ".cime","config"))
     cime_config = configparser.SafeConfigParser()
     if(os.path.isfile(cime_config_file)):
-        cime_config.read(cime_config_file)
-        for section in cime_config.sections():
-            expect(section in allowed_sections,"Unknown section {} in .cime/config\nallowed sections are {}".format(section, allowed_sections))
-        if cime_config.has_section('main'):
-            for item,_ in cime_config.items('main'):
-                expect(item in allowed_in_main,"Unknown option in config section \"main\": \"{}\"\nallowed options are {}".format(item, allowed_in_main))
-        if cime_config.has_section('create_test'):
-            for item,_ in cime_config.items('create_test'):
-                expect(item in allowed_in_create_test,"Unknown option in config section \"test\": \"{}\"\nallowed options are {}".format(item, allowed_in_create_test))
+	cime_config.read(cime_config_file)
+	for section in cime_config.sections():
+	    expect(section in allowed_sections,"Unknown section {} in .cime/config\nallowed sections are {}".format(section, allowed_sections))
+	if cime_config.has_section('main'):
+	    for item,_ in cime_config.items('main'):
+		expect(item in allowed_in_main,"Unknown option in config section \"main\": \"{}\"\nallowed options are {}".format(item, allowed_in_main))
+	if cime_config.has_section('create_test'):
+	    for item,_ in cime_config.items('create_test'):
+		expect(item in allowed_in_create_test,"Unknown option in config section \"test\": \"{}\"\nallowed options are {}".format(item, allowed_in_create_test))
     else:
-        logger.debug("File {} not found".format(cime_config_file))
-        cime_config.add_section('main')
+	logger.debug("File {} not found".format(cime_config_file))
+	cime_config.add_section('main')
 
     return cime_config
 
@@ -218,7 +218,7 @@ _CIMECONFIG = None
 def get_cime_config():
     global _CIMECONFIG
     if (not _CIMECONFIG):
-        _CIMECONFIG = _read_cime_config_file()
+	_CIMECONFIG = _read_cime_config_file()
 
     return _CIMECONFIG
 
@@ -247,9 +247,9 @@ def get_cime_root(case=None):
     cimeroot = os.path.abspath(os.path.join(script_absdir,"..",".."))
 
     if case is not None:
-        case_cimeroot = os.path.abspath(case.get_value("CIMEROOT"))
-        cimeroot = os.path.abspath(cimeroot)
-        expect(cimeroot == case_cimeroot, "Inconsistent CIMEROOT variable: case -> '{}', file location -> '{}'".format(case_cimeroot, cimeroot))
+	case_cimeroot = os.path.abspath(case.get_value("CIMEROOT"))
+	cimeroot = os.path.abspath(cimeroot)
+	expect(cimeroot == case_cimeroot, "Inconsistent CIMEROOT variable: case -> '{}', file location -> '{}'".format(case_cimeroot, cimeroot))
 
     logger.debug( "CIMEROOT is " + cimeroot)
     return cimeroot
@@ -257,19 +257,19 @@ def get_cime_root(case=None):
 def get_cime_default_driver():
     driver = os.environ.get("CIME_DRIVER")
     if driver:
-        logger.debug("Setting CIME_DRIVER={} from environment".format(driver))
+	logger.debug("Setting CIME_DRIVER={} from environment".format(driver))
     else:
-        cime_config = get_cime_config()
-        if (cime_config.has_option('main','CIME_DRIVER')):
-            driver = cime_config.get('main','CIME_DRIVER')
-            if driver:
-                logger.debug("Setting CIME_driver={} from ~/.cime/config".format(driver))
+	cime_config = get_cime_config()
+	if (cime_config.has_option('main','CIME_DRIVER')):
+	    driver = cime_config.get('main','CIME_DRIVER')
+	    if driver:
+		logger.debug("Setting CIME_driver={} from ~/.cime/config".format(driver))
     if not driver:
-        model = get_model()
-        if model == "ufs":
-            driver = "nuopc"
-        else:
-            driver = "mct"
+	model = get_model()
+	if model == "ufs":
+	    driver = "nuopc"
+	else:
+	    driver = "mct"
     expect(driver in ("mct", "nuopc", "moab"),"Attempt to set invalid driver {}".format(driver))
     return driver
 
@@ -277,8 +277,8 @@ def get_all_cime_models():
     modelsroot = os.path.join(get_cime_root(), "config")
     models = []
     for entry in os.listdir(modelsroot):
-        if os.path.isdir(os.path.join(modelsroot,entry)):
-            models.append(entry)
+	if os.path.isdir(os.path.join(modelsroot,entry)):
+	    models.append(entry)
     models.remove('xml_schemas')
     return models
 
@@ -289,7 +289,7 @@ def set_model(model):
     cime_config = get_cime_config()
     cime_models = get_all_cime_models()
     if not cime_config.has_section('main'):
-        cime_config.add_section('main')
+	cime_config.add_section('main')
     expect(model in cime_models,"model {} not recognized. The acceptable values of CIME_MODEL currently are {}".format(model, cime_models))
     cime_config.set('main','CIME_MODEL',model)
 
@@ -301,12 +301,12 @@ def get_model():
     >>> os.environ["CIME_MODEL"] = "garbage"
     >>> get_model() # doctest:+ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-        ...
+	...
     CIMEError: ERROR: model garbage not recognized
     >>> del os.environ["CIME_MODEL"]
     >>> set_model('rocky') # doctest:+ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-        ...
+	...
     CIMEError: ERROR: model rocky not recognized
     >>> set_model('e3sm')
     >>> get_model()
@@ -316,48 +316,48 @@ def get_model():
     model = os.environ.get("CIME_MODEL")
     cime_models = get_all_cime_models()
     if model in cime_models:
-        logger.debug("Setting CIME_MODEL={} from environment".format(model))
+	logger.debug("Setting CIME_MODEL={} from environment".format(model))
     else:
-        expect(model is None,"model {} not recognized. The acceptable values of CIME_MODEL currently are {}".format(model, cime_models))
-        cime_config = get_cime_config()
-        if (cime_config.has_option('main','CIME_MODEL')):
-            model = cime_config.get('main','CIME_MODEL')
-            if model is not None:
-                logger.debug("Setting CIME_MODEL={} from ~/.cime/config".format(model))
+	expect(model is None,"model {} not recognized. The acceptable values of CIME_MODEL currently are {}".format(model, cime_models))
+	cime_config = get_cime_config()
+	if (cime_config.has_option('main','CIME_MODEL')):
+	    model = cime_config.get('main','CIME_MODEL')
+	    if model is not None:
+		logger.debug("Setting CIME_MODEL={} from ~/.cime/config".format(model))
 
     # One last try
     if (model is None):
-        srcroot = None
-        if cime_config.has_section('main') and cime_config.has_option('main', 'SRCROOT'):
-            srcroot = cime_config.get('main','SRCROOT')
-        if srcroot is None:
-            srcroot = os.path.dirname(os.path.abspath(get_cime_root()))
-        if os.path.isfile(os.path.join(srcroot, "Externals.cfg")):
-            model = 'cesm'
-            with open(os.path.join(srcroot, "Externals.cfg")) as fd:
-                for line in fd:
-                    if re.search('fv3gfs', line):
-                        model = 'ufs'
-        else:
-            model = 'e3sm'
-        # This message interfers with the correct operation of xmlquery
-        # logger.debug("Guessing CIME_MODEL={}, set environment variable if this is incorrect".format(model))
+	srcroot = None
+	if cime_config.has_section('main') and cime_config.has_option('main', 'SRCROOT'):
+	    srcroot = cime_config.get('main','SRCROOT')
+	if srcroot is None:
+	    srcroot = os.path.dirname(os.path.abspath(get_cime_root()))
+	if os.path.isfile(os.path.join(srcroot, "Externals.cfg")):
+	    model = 'cesm'
+	    with open(os.path.join(srcroot, "Externals.cfg")) as fd:
+		for line in fd:
+		    if re.search('fv3gfs', line):
+			model = 'ufs'
+	else:
+	    model = 'e3sm'
+	# This message interfers with the correct operation of xmlquery
+	# logger.debug("Guessing CIME_MODEL={}, set environment variable if this is incorrect".format(model))
 
     if model is not None:
-        set_model(model)
-        return model
+	set_model(model)
+	return model
 
     modelroot = os.path.join(get_cime_root(), "config")
     models = os.listdir(modelroot)
     msg = ".cime/config or environment variable CIME_MODEL must be set to one of: "
     msg += ", ".join([model for model in models
-                      if os.path.isdir(os.path.join(modelroot,model))
-                      and model != "xml_schemas"])
+		      if os.path.isdir(os.path.join(modelroot,model))
+		      and model != "xml_schemas"])
     expect(False, msg)
 
 def _get_path(filearg, from_dir):
     if not filearg.startswith("/") and from_dir is not None:
-        filearg = os.path.join(from_dir, filearg)
+	filearg = os.path.join(from_dir, filearg)
 
     return filearg
 
@@ -372,17 +372,17 @@ def check_for_python(filepath, funcname=None):
     is_python = is_python_executable(filepath)
     has_function = True
     if funcname is not None:
-        has_function = False
-        with open(filepath, 'r') as fd:
-            for line in fd.readlines():
-                if re.search(r"^def\s+{}\(".format(funcname), line) or re.search(r"^from.+import.+\s{}".format(funcname), line):
-                    has_function = True
-                    break
+	has_function = False
+	with open(filepath, 'r') as fd:
+	    for line in fd.readlines():
+		if re.search(r"^def\s+{}\(".format(funcname), line) or re.search(r"^from.+import.+\s{}".format(funcname), line):
+		    has_function = True
+		    break
 
     return is_python and has_function
 
 def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
-                   from_dir=None, timeout=None):
+		   from_dir=None, timeout=None):
     """
     This code will try to import and run each cmd as a subroutine
     if that fails it will run it as a program in a seperate shell
@@ -394,71 +394,71 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
     # Before attempting to load the script make sure it contains the subroutine
     # we are expecting
     with open(cmd, 'r') as fd:
-        for line in fd.readlines():
-            if re.search(r"^def {}\(".format(subname), line):
-                do_run_cmd = False
-                break
+	for line in fd.readlines():
+	    if re.search(r"^def {}\(".format(subname), line):
+		do_run_cmd = False
+		break
 
     if not do_run_cmd:
-        try:
-            mod = imp.load_source(subname, cmd)
-            logger.info("   Calling {}".format(cmd))
-            # Careful: logfile code is not thread safe!
-            if logfile:
-                with open(logfile,"w") as log_fd:
-                    with redirect_logger(log_fd, subname):
-                        with redirect_stdout_stderr(log_fd):
-                            getattr(mod, subname)(*subargs)
-            else:
-                getattr(mod, subname)(*subargs)
+	try:
+	    mod = imp.load_source(subname, cmd)
+	    logger.info("   Calling {}".format(cmd))
+	    # Careful: logfile code is not thread safe!
+	    if logfile:
+		with open(logfile,"w") as log_fd:
+		    with redirect_logger(log_fd, subname):
+			with redirect_stdout_stderr(log_fd):
+			    getattr(mod, subname)(*subargs)
+	    else:
+		getattr(mod, subname)(*subargs)
 
-        except (SyntaxError, AttributeError) as _:
-            pass # Need to try to run as shell command
+	except (SyntaxError, AttributeError) as _:
+	    pass # Need to try to run as shell command
 
-        except Exception:
-            if logfile:
-                with open(logfile, "a") as log_fd:
-                    log_fd.write(str(sys.exc_info()[1]))
+	except Exception:
+	    if logfile:
+		with open(logfile, "a") as log_fd:
+		    log_fd.write(str(sys.exc_info()[1]))
 
-                expect(False, "{} FAILED, cat {}".format(cmd, logfile))
-            else:
-                raise
+		expect(False, "{} FAILED, cat {}".format(cmd, logfile))
+	    else:
+		raise
 
-        else:
-            return # Running as python function worked, we're done
+	else:
+	    return # Running as python function worked, we're done
 
     logger.info("   Running {} ".format(cmd))
     if case is not None:
-        case.flush()
+	case.flush()
 
     fullcmd = cmd
     if isinstance(cmdargs, list):
-        for arg in cmdargs:
-            fullcmd += " " + str(arg)
+	for arg in cmdargs:
+	    fullcmd += " " + str(arg)
     else:
-        fullcmd += " " + cmdargs
+	fullcmd += " " + cmdargs
 
     if logfile:
-        fullcmd += " >& {} ".format(logfile)
+	fullcmd += " >& {} ".format(logfile)
 
     stat, output, _ = run_cmd("{}".format(fullcmd), combine_output=True,
-                              from_dir=from_dir, timeout=timeout)
+			      from_dir=from_dir, timeout=timeout)
     if output: # Will be empty if logfile
-        logger.info(output)
+	logger.info(output)
 
     if stat != 0:
-        if logfile:
-            expect(False, "{} FAILED, cat {}".format(fullcmd, logfile))
-        else:
-            expect(False, "{} FAILED, see above".format(fullcmd))
+	if logfile:
+	    expect(False, "{} FAILED, cat {}".format(fullcmd, logfile))
+	else:
+	    expect(False, "{} FAILED, see above".format(fullcmd))
 
     # refresh case xml object from file
     if case is not None:
-        case.read_xml()
+	case.read_xml()
 
 def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
-            arg_stdout=_hack, arg_stderr=_hack, env=None,
-            combine_output=False, timeout=None):
+	    arg_stdout=_hack, arg_stderr=_hack, env=None,
+	    combine_output=False, timeout=None):
     """
     Wrapper around subprocess to make it much more convenient to run shell commands
 
@@ -469,92 +469,92 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
 
     # Real defaults for these value should be subprocess.PIPE
     if arg_stdout is _hack:
-        arg_stdout = subprocess.PIPE
+	arg_stdout = subprocess.PIPE
     elif isinstance(arg_stdout, six.string_types):
-        arg_stdout = _convert_to_fd(arg_stdout, from_dir)
+	arg_stdout = _convert_to_fd(arg_stdout, from_dir)
 
     if arg_stderr is _hack:
-        arg_stderr = subprocess.STDOUT if combine_output else subprocess.PIPE
+	arg_stderr = subprocess.STDOUT if combine_output else subprocess.PIPE
     elif isinstance(arg_stderr, six.string_types):
-        arg_stderr = _convert_to_fd(arg_stdout, from_dir)
+	arg_stderr = _convert_to_fd(arg_stdout, from_dir)
 
     if (verbose != False and (verbose or logger.isEnabledFor(logging.DEBUG))):
-        logger.info("RUN: {}\nFROM: {}".format(cmd, os.getcwd() if from_dir is None else from_dir))
+	logger.info("RUN: {}\nFROM: {}".format(cmd, os.getcwd() if from_dir is None else from_dir))
 
     if (input_str is not None):
-        stdin = subprocess.PIPE
+	stdin = subprocess.PIPE
     else:
-        stdin = None
+	stdin = None
     if timeout:
-        with Timeout(timeout):
-            proc = subprocess.Popen(cmd,
-                                    shell=True,
-                                    stdout=arg_stdout,
-                                    stderr=arg_stderr,
-                                    stdin=stdin,
-                                    cwd=from_dir,
-                                    env=env)
+	with Timeout(timeout):
+	    proc = subprocess.Popen(cmd,
+				    shell=True,
+				    stdout=arg_stdout,
+				    stderr=arg_stderr,
+				    stdin=stdin,
+				    cwd=from_dir,
+				    env=env)
 
-            output, errput = proc.communicate(input_str)
+	    output, errput = proc.communicate(input_str)
     else:
-        proc = subprocess.Popen(cmd,
-                                shell=True,
-                                stdout=arg_stdout,
-                                stderr=arg_stderr,
-                                stdin=stdin,
-                                cwd=from_dir,
-                                env=env)
+	proc = subprocess.Popen(cmd,
+				shell=True,
+				stdout=arg_stdout,
+				stderr=arg_stderr,
+				stdin=stdin,
+				cwd=from_dir,
+				env=env)
 
-        output, errput = proc.communicate(input_str)
+	output, errput = proc.communicate(input_str)
 
     # In Python3, subprocess.communicate returns bytes. We want to work with strings
     # as much as possible, so we convert bytes to string (which is unicode in py3) via
     # decode. For python2, we do NOT want to do this since decode will yield unicode
     # strings which are not necessarily compatible with the system's default base str type.
     if not six.PY2:
-        if output is not None:
-            try:
-                output = output.decode('utf-8', errors='ignore')
-            except AttributeError:
-                pass
-        if errput is not None:
-            try:
-                errput = errput.decode('utf-8', errors='ignore')
-            except AttributeError:
-                pass
+	if output is not None:
+	    try:
+		output = output.decode('utf-8', errors='ignore')
+	    except AttributeError:
+		pass
+	if errput is not None:
+	    try:
+		errput = errput.decode('utf-8', errors='ignore')
+	    except AttributeError:
+		pass
 
     # Always strip outputs
     if output:
-        output = output.strip()
+	output = output.strip()
     if errput:
-        errput = errput.strip()
+	errput = errput.strip()
 
     stat = proc.wait()
     if six.PY2:
-        if isinstance(arg_stdout, file): # pylint: disable=undefined-variable
-            arg_stdout.close() # pylint: disable=no-member
-        if isinstance(arg_stderr, file) and arg_stderr is not arg_stdout: # pylint: disable=undefined-variable
-            arg_stderr.close() # pylint: disable=no-member
+	if isinstance(arg_stdout, file): # pylint: disable=undefined-variable
+	    arg_stdout.close() # pylint: disable=no-member
+	if isinstance(arg_stderr, file) and arg_stderr is not arg_stdout: # pylint: disable=undefined-variable
+	    arg_stderr.close() # pylint: disable=no-member
     else:
-        if isinstance(arg_stdout, io.IOBase):
-            arg_stdout.close() # pylint: disable=no-member
-        if isinstance(arg_stderr, io.IOBase) and arg_stderr is not arg_stdout:
-            arg_stderr.close() # pylint: disable=no-member
+	if isinstance(arg_stdout, io.IOBase):
+	    arg_stdout.close() # pylint: disable=no-member
+	if isinstance(arg_stderr, io.IOBase) and arg_stderr is not arg_stdout:
+	    arg_stderr.close() # pylint: disable=no-member
 
 
     if (verbose != False and (verbose or logger.isEnabledFor(logging.DEBUG))):
-        if stat != 0:
-            logger.info("  stat: {:d}\n".format(stat))
-        if output:
-            logger.info("  output: {}\n".format(output))
-        if errput:
-            logger.info("  errput: {}\n".format(errput))
+	if stat != 0:
+	    logger.info("  stat: {:d}\n".format(stat))
+	if output:
+	    logger.info("  output: {}\n".format(output))
+	if errput:
+	    logger.info("  errput: {}\n".format(errput))
 
     return stat, output, errput
 
 def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
-                    arg_stdout=_hack, arg_stderr=_hack, env=None,
-                    combine_output=False, timeout=None):
+		    arg_stdout=_hack, arg_stderr=_hack, env=None,
+		    combine_output=False, timeout=None):
     """
     Wrapper around subprocess to make it much more convenient to run shell commands.
     Expects command to work. Just returns output string.
@@ -563,7 +563,7 @@ def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
     True
     >>> run_cmd_no_fail('echo THE ERROR >&2; false') # doctest:+ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-        ...
+	...
     CIMEError: ERROR: Command: 'echo THE ERROR >&2; false' failed with error ...
 
     >>> run_cmd_no_fail('grep foo', input_str=b'foo') == 'foo'
@@ -572,23 +572,23 @@ def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
     True
     """
     stat, output, errput = run_cmd(cmd, input_str, from_dir, verbose, arg_stdout,
-                                   arg_stderr, env, combine_output, timeout=timeout)
+				   arg_stderr, env, combine_output, timeout=timeout)
     if stat != 0:
-        # If command produced no errput, put output in the exception since we
-        # have nothing else to go on.
-        errput = output if not errput else errput
-        if errput is None:
-            if combine_output:
-                if isinstance(arg_stdout, six.string_types):
-                    errput = "See {}".format(_get_path(arg_stdout, from_dir))
-                else:
-                    errput = ""
-            elif isinstance(arg_stderr, six.string_types):
-                errput = "See {}".format(_get_path(arg_stderr, from_dir))
-            else:
-                errput = ""
+	# If command produced no errput, put output in the exception since we
+	# have nothing else to go on.
+	errput = output if not errput else errput
+	if errput is None:
+	    if combine_output:
+		if isinstance(arg_stdout, six.string_types):
+		    errput = "See {}".format(_get_path(arg_stdout, from_dir))
+		else:
+		    errput = ""
+	    elif isinstance(arg_stderr, six.string_types):
+		errput = "See {}".format(_get_path(arg_stderr, from_dir))
+	    else:
+		errput = ""
 
-        expect(False, "Command: '{}' failed with error '{}' from dir '{}'".format(cmd, errput, os.getcwd() if from_dir is None else from_dir))
+	expect(False, "Command: '{}' failed with error '{}' from dir '{}'".format(cmd, errput, os.getcwd() if from_dir is None else from_dir))
 
     return output
 
@@ -601,7 +601,7 @@ def check_minimum_python_version(major, minor):
     """
     msg = "Python " + str(major) + ", minor version " + str(minor) + " is required, you have " + str(sys.version_info[0]) + "." + str(sys.version_info[1])
     expect(sys.version_info[0] > major or
-           (sys.version_info[0] == major and sys.version_info[1] >= minor), msg)
+	   (sys.version_info[0] == major and sys.version_info[1] >= minor), msg)
 
 def normalize_case_id(case_id):
     """
@@ -618,11 +618,11 @@ def normalize_case_id(case_id):
     """
     sep_count = case_id.count(".")
     expect(sep_count >= 3 and sep_count <= 6,
-           "Case '{}' needs to be in form: TESTCASE.GRID.COMPSET.PLATFORM[.TESTMOD]  or  TESTCASE.GRID.COMPSET.PLATFORM[.TESTMOD].GC.TESTID".format(case_id))
+	   "Case '{}' needs to be in form: TESTCASE.GRID.COMPSET.PLATFORM[.TESTMOD]  or  TESTCASE.GRID.COMPSET.PLATFORM[.TESTMOD].GC.TESTID".format(case_id))
     if (sep_count in [5, 6]):
-        return ".".join(case_id.split(".")[:-2])
+	return ".".join(case_id.split(".")[:-2])
     else:
-        return case_id
+	return case_id
 
 def parse_test_name(test_name):
     """
@@ -649,11 +649,11 @@ def parse_test_name(test_name):
     ['ERS', None, 'fe12_123', 'JGF', 'machine', 'compiler', 'test/mods']
     >>> parse_test_name('SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-        ...
+	...
     CIMEError: ERROR: Expected 4th item of 'SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods' ('A_XLND_SICE_SOCN_XROF_XGLC_SWAV') to be in form machine_compiler
     >>> parse_test_name('SMS.f19_g16.2000_DATM%QI/A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-        ...
+	...
     CIMEError: ERROR: Invalid compset name 2000_DATM%QI/A_XLND_SICE_SOCN_XROF_XGLC_SWAV
     """
     rv = [None] * 7
@@ -664,23 +664,23 @@ def parse_test_name(test_name):
     rv.insert(1, None) # Make room for caseopts
     rv.pop()
     if (testcase_field_underscores > 0):
-        full_str = rv[0]
-        rv[0]    = full_str.split("_")[0]
-        rv[1]    = full_str.split("_")[1:]
+	full_str = rv[0]
+	rv[0]    = full_str.split("_")[0]
+	rv[1]    = full_str.split("_")[1:]
 
     if (num_dots >= 3):
-        expect(check_name( rv[3] ), "Invalid compset name {}".format(rv[3]))
+	expect(check_name( rv[3] ), "Invalid compset name {}".format(rv[3]))
 
-        expect(rv[4].count("_") == 1,
-               "Expected 4th item of '{}' ('{}') to be in form machine_compiler".format(test_name, rv[4]))
-        rv[4:5] = rv[4].split("_")
-        rv.pop()
+	expect(rv[4].count("_") == 1,
+	       "Expected 4th item of '{}' ('{}') to be in form machine_compiler".format(test_name, rv[4]))
+	rv[4:5] = rv[4].split("_")
+	rv.pop()
 
     if (rv[-1] is not None):
-        rv[-1] = rv[-1].replace("-", "/")
+	rv[-1] = rv[-1].replace("-", "/")
 
     expect(num_dots <= 4,
-           "'{}' does not look like a CIME test name, expect TESTCASE.GRID.COMPSET[.MACHINE_COMPILER[.TESTMODS]]".format(test_name))
+	   "'{}' does not look like a CIME test name, expect TESTCASE.GRID.COMPSET[.MACHINE_COMPILER[.TESTMODS]]".format(test_name))
 
     return rv
 
@@ -705,43 +705,43 @@ def get_full_test_name(partial_test, caseopts=None, grid=None, compset=None, mac
     partial_testcase, partial_caseopts, partial_grid, partial_compset, partial_machine, partial_compiler, partial_testmod = parse_test_name(partial_test)
 
     required_fields = [
-        (partial_grid, grid, "grid"),
-        (partial_compset, compset, "compset"),
-        (partial_machine, machine, "machine"),
-        (partial_compiler, compiler, "compiler"),
-        ]
+	(partial_grid, grid, "grid"),
+	(partial_compset, compset, "compset"),
+	(partial_machine, machine, "machine"),
+	(partial_compiler, compiler, "compiler"),
+	]
 
     result = partial_test
 
     for partial_val, arg_val, name in required_fields:
-        if (partial_val is None):
-            # Add to result based on args
-            expect(arg_val is not None,
-                   "Could not fill-out test name, partial string '{}' had no {} information and you did not provide any".format(partial_test, name))
-            result = "{}{}{}".format(result, "_" if name == "compiler" else ".", arg_val)
-        elif (arg_val is not None and partial_val != partial_compiler):
-            expect(arg_val == partial_val,
-                   "Mismatch in field {}, partial string '{}' indicated it should be '{}' but you provided '{}'".format(name, partial_test, partial_val, arg_val))
+	if (partial_val is None):
+	    # Add to result based on args
+	    expect(arg_val is not None,
+		   "Could not fill-out test name, partial string '{}' had no {} information and you did not provide any".format(partial_test, name))
+	    result = "{}{}{}".format(result, "_" if name == "compiler" else ".", arg_val)
+	elif (arg_val is not None and partial_val != partial_compiler):
+	    expect(arg_val == partial_val,
+		   "Mismatch in field {}, partial string '{}' indicated it should be '{}' but you provided '{}'".format(name, partial_test, partial_val, arg_val))
 
     if (partial_testmod is None):
-        if (testmod is None):
-            # No testmod for this test and that's OK
-            pass
-        else:
-            result += ".{}".format(testmod.replace("/", "-"))
+	if (testmod is None):
+	    # No testmod for this test and that's OK
+	    pass
+	else:
+	    result += ".{}".format(testmod.replace("/", "-"))
     elif (testmod is not None):
-        expect(testmod == partial_testmod,
-               "Mismatch in field testmod, partial string '{}' indicated it should be '{}' but you provided '{}'".format(partial_test, partial_testmod, testmod))
+	expect(testmod == partial_testmod,
+	       "Mismatch in field testmod, partial string '{}' indicated it should be '{}' but you provided '{}'".format(partial_test, partial_testmod, testmod))
 
     if (partial_caseopts is None):
-        if caseopts is None:
-            # No casemods for this test and that's OK
-            pass
-        else:
-            result = result.replace(partial_testcase, "{}_{}".format(partial_testcase, "_".join(caseopts)), 1)
+	if caseopts is None:
+	    # No casemods for this test and that's OK
+	    pass
+	else:
+	    result = result.replace(partial_testcase, "{}_{}".format(partial_testcase, "_".join(caseopts)), 1)
     elif caseopts is not None:
-        expect(caseopts == partial_caseopts,
-               "Mismatch in field caseopts, partial string '{}' indicated it should be '{}' but you provided '{}'".format(partial_test, partial_caseopts, caseopts))
+	expect(caseopts == partial_caseopts,
+	       "Mismatch in field caseopts, partial string '{}' indicated it should be '{}' but you provided '{}'".format(partial_test, partial_caseopts, caseopts))
 
     return result
 
@@ -757,19 +757,19 @@ def get_current_branch(repo=None):
     True
     """
     if ("GIT_BRANCH" in os.environ):
-        # This approach works better for Jenkins jobs because the Jenkins
-        # git plugin does not use local tracking branches, it just checks out
-        # to a commit
-        branch = os.environ["GIT_BRANCH"]
-        if (branch.startswith("origin/")):
-            branch = branch.replace("origin/", "", 1)
-        return branch
+	# This approach works better for Jenkins jobs because the Jenkins
+	# git plugin does not use local tracking branches, it just checks out
+	# to a commit
+	branch = os.environ["GIT_BRANCH"]
+	if (branch.startswith("origin/")):
+	    branch = branch.replace("origin/", "", 1)
+	return branch
     else:
-        stat, output, _ = run_cmd("git symbolic-ref HEAD", from_dir=repo)
-        if (stat != 0):
-            return None
-        else:
-            return output.replace("refs/heads/", "")
+	stat, output, _ = run_cmd("git symbolic-ref HEAD", from_dir=repo)
+	if (stat != 0):
+	    return None
+	else:
+	    return output.replace("refs/heads/", "")
 
 def get_current_commit(short=False, repo=None, tag=False):
     """
@@ -779,9 +779,9 @@ def get_current_commit(short=False, repo=None, tag=False):
     True
     """
     if tag:
-        rc, output, _ = run_cmd("git describe --tags $(git log -n1 --pretty='%h')", from_dir=repo)
+	rc, output, _ = run_cmd("git describe --tags $(git log -n1 --pretty='%h')", from_dir=repo)
     else:
-        rc, output, _ = run_cmd("git rev-parse {} HEAD".format("--short" if short else ""), from_dir=repo)
+	rc, output, _ = run_cmd("git rev-parse {} HEAD".format("--short" if short else ""), from_dir=repo)
 
     return output if rc == 0 else "unknown"
 
@@ -856,9 +856,9 @@ def match_any(item, re_list):
     Return true if item matches any regex in re_list
     """
     for regex_str in re_list:
-        regex = re.compile(regex_str)
-        if (regex.match(item)):
-            return True
+	regex = re.compile(regex_str)
+	if (regex.match(item)):
+	    return True
 
     return False
 
@@ -883,34 +883,34 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
 
     # Handle pre-existing file
     if os.path.isfile(tgt_path):
-        st = os.stat(tgt_path)
-        owner_uid = st.st_uid
+	st = os.stat(tgt_path)
+	owner_uid = st.st_uid
 
-        # Handle read-only files if possible
-        if not os.access(tgt_path, os.W_OK):
-            if owner_uid == os.getuid():
-                # I am the owner, make writeable
-                os.chmod(tgt_path, st.st_mode | statlib.S_IWRITE)
-            else:
-                # I won't be able to copy this file
-                raise OSError("Cannot copy over file {}, it is readonly and you are not the owner".format(tgt_path))
+	# Handle read-only files if possible
+	if not os.access(tgt_path, os.W_OK):
+	    if owner_uid == os.getuid():
+		# I am the owner, make writeable
+		os.chmod(tgt_path, st.st_mode | statlib.S_IWRITE)
+	    else:
+		# I won't be able to copy this file
+		raise OSError("Cannot copy over file {}, it is readonly and you are not the owner".format(tgt_path))
 
-        if owner_uid == os.getuid():
-            # I am the owner, copy file contents, permissions, and metadata
-            file_util.copy_file(src_path, tgt_path, preserve_mode=preserve_meta, preserve_times=preserve_meta)
-        else:
-            # I am not the owner, just copy file contents
-            shutil.copyfile(src_path, tgt_path)
+	if owner_uid == os.getuid():
+	    # I am the owner, copy file contents, permissions, and metadata
+	    file_util.copy_file(src_path, tgt_path, preserve_mode=preserve_meta, preserve_times=preserve_meta)
+	else:
+	    # I am not the owner, just copy file contents
+	    shutil.copyfile(src_path, tgt_path)
 
     else:
-        # We are making a new file, copy file contents, permissions, and metadata.
-        # This can fail if the underlying directory is not writable by current user.
-        file_util.copy_file(src_path, tgt_path, preserve_mode=preserve_meta, preserve_times=preserve_meta)
+	# We are making a new file, copy file contents, permissions, and metadata.
+	# This can fail if the underlying directory is not writable by current user.
+	file_util.copy_file(src_path, tgt_path, preserve_mode=preserve_meta, preserve_times=preserve_meta)
 
     # If src file was executable, then the tgt file should be too
     st = os.stat(tgt_path)
     if os.access(src_path, os.X_OK) and st.st_uid == os.getuid():
-        os.chmod(tgt_path, st.st_mode | statlib.S_IXUSR | statlib.S_IXGRP | statlib.S_IXOTH)
+	os.chmod(tgt_path, st.st_mode | statlib.S_IXUSR | statlib.S_IXGRP | statlib.S_IXOTH)
 
 def safe_recursive_copy(src_dir, tgt_dir, file_map):
     """
@@ -919,10 +919,10 @@ def safe_recursive_copy(src_dir, tgt_dir, file_map):
     matched on the tgt side.
     """
     for src_file, tgt_file in file_map:
-        full_tgt = os.path.join(tgt_dir, tgt_file)
-        full_src = src_file if os.path.isabs(src_file) else os.path.join(src_dir, src_file)
-        expect(os.path.isfile(full_src), "Source dir '{}' missing file '{}'".format(src_dir, src_file))
-        safe_copy(full_src, full_tgt)
+	full_tgt = os.path.join(tgt_dir, tgt_file)
+	full_src = src_file if os.path.isabs(src_file) else os.path.join(src_dir, src_file)
+	expect(os.path.isfile(full_src), "Source dir '{}' missing file '{}'".format(src_dir, src_file))
+	safe_copy(full_src, full_tgt)
 
 def symlink_force(target, link_name):
     """
@@ -931,40 +931,40 @@ def symlink_force(target, link_name):
     which case link_name will be overwritten).
     """
     try:
-        os.symlink(target, link_name)
+	os.symlink(target, link_name)
     except OSError as e:
-        if e.errno == errno.EEXIST:
-            os.remove(link_name)
-            os.symlink(target, link_name)
-        else:
-            raise e
+	if e.errno == errno.EEXIST:
+	    os.remove(link_name)
+	    os.symlink(target, link_name)
+	else:
+	    raise e
 
 def find_proc_id(proc_name=None,
-                 children_only=False,
-                 of_parent=None):
+		 children_only=False,
+		 of_parent=None):
     """
     Children implies recursive.
     """
     expect(proc_name is not None or children_only,
-           "Must provide proc_name if not searching for children")
+	   "Must provide proc_name if not searching for children")
     expect(not (of_parent is not None and not children_only),
-           "of_parent only used with children_only")
+	   "of_parent only used with children_only")
 
     parent = of_parent if of_parent is not None else os.getpid()
 
     pgrep_cmd = "pgrep {} {}".format(proc_name if proc_name is not None else "",
-                                 "-P {:d}".format(parent if children_only else ""))
+				 "-P {:d}".format(parent if children_only else ""))
     stat, output, errput = run_cmd(pgrep_cmd)
     expect(stat in [0, 1], "pgrep failed with error: '{}'".format(errput))
 
     rv = set([int(item.strip()) for item in output.splitlines()])
     if (children_only):
-        pgrep_cmd = "pgrep -P {}".format(parent)
-        stat, output, errput = run_cmd(pgrep_cmd)
-        expect(stat in [0, 1], "pgrep failed with error: '{}'".format(errput))
+	pgrep_cmd = "pgrep -P {}".format(parent)
+	stat, output, errput = run_cmd(pgrep_cmd)
+	expect(stat in [0, 1], "pgrep failed with error: '{}'".format(errput))
 
-        for child in output.splitlines():
-            rv = rv.union(set(find_proc_id(proc_name, children_only, int(child.strip()))))
+	for child in output.splitlines():
+	    rv = rv.union(set(find_proc_id(proc_name, children_only, int(child.strip()))))
 
     return list(rv)
 
@@ -975,9 +975,9 @@ def get_timestamp(timestamp_format="%Y%m%d_%H%M%S", utc_time=False):
     The format can be changed if needed.
     """
     if utc_time:
-        time_tuple = time.gmtime()
+	time_tuple = time.gmtime()
     else:
-        time_tuple = time.localtime()
+	time_tuple = time.localtime()
     return time.strftime(timestamp_format, time_tuple)
 
 def get_project(machobj=None):
@@ -992,37 +992,37 @@ def get_project(machobj=None):
     """
     project = os.environ.get("PROJECT")
     if (project is not None):
-        logger.info("Using project from env PROJECT: " + project)
-        return project
+	logger.info("Using project from env PROJECT: " + project)
+	return project
     project = os.environ.get("ACCOUNT")
     if (project is not None):
-        logger.info("Using project from env ACCOUNT: " + project)
-        return project
+	logger.info("Using project from env ACCOUNT: " + project)
+	return project
 
     cime_config = get_cime_config()
     if (cime_config.has_option('main','PROJECT')):
-        project = cime_config.get('main','PROJECT')
-        if (project is not None):
-            logger.info("Using project from .cime/config: " + project)
-            return project
+	project = cime_config.get('main','PROJECT')
+	if (project is not None):
+	    logger.info("Using project from .cime/config: " + project)
+	    return project
 
     projectfile = os.path.abspath(os.path.join(os.path.expanduser("~"), ".cesm_proj"))
     if (os.path.isfile(projectfile)):
-        with open(projectfile,'r') as myfile:
-            for line in myfile:
-                project = line.rstrip()
-                if not project.startswith("#"):
-                    break
-        if (project is not None):
-            logger.info("Using project from .cesm_proj: " + project)
-            cime_config.set('main','PROJECT',project)
-            return project
+	with open(projectfile,'r') as myfile:
+	    for line in myfile:
+		project = line.rstrip()
+		if not project.startswith("#"):
+		    break
+	if (project is not None):
+	    logger.info("Using project from .cesm_proj: " + project)
+	    cime_config.set('main','PROJECT',project)
+	    return project
 
     if machobj is not None:
-        project = machobj.get_value("PROJECT")
-        if project is not None:
-            logger.info("Using project from config_machines.xml: " + project)
-            return project
+	project = machobj.get_value("PROJECT")
+	if project is not None:
+	    logger.info("Using project from config_machines.xml: " + project)
+	    return project
 
     logger.info("No project info available")
     return None
@@ -1049,21 +1049,21 @@ def get_charge_account(machobj=None, project=None):
     """
     charge_account = os.environ.get("CHARGE_ACCOUNT")
     if (charge_account is not None):
-        logger.info("Using charge_account from env CHARGE_ACCOUNT: " + charge_account)
-        return charge_account
+	logger.info("Using charge_account from env CHARGE_ACCOUNT: " + charge_account)
+	return charge_account
 
     cime_config = get_cime_config()
     if (cime_config.has_option('main','CHARGE_ACCOUNT')):
-        charge_account = cime_config.get('main','CHARGE_ACCOUNT')
-        if (charge_account is not None):
-            logger.info("Using charge_account from .cime/config: " + charge_account)
-            return charge_account
+	charge_account = cime_config.get('main','CHARGE_ACCOUNT')
+	if (charge_account is not None):
+	    logger.info("Using charge_account from .cime/config: " + charge_account)
+	    return charge_account
 
     if machobj is not None:
-        charge_account = machobj.get_value("CHARGE_ACCOUNT")
-        if charge_account is not None:
-            logger.info("Using charge_account from config_machines.xml: " + charge_account)
-            return charge_account
+	charge_account = machobj.get_value("CHARGE_ACCOUNT")
+	if charge_account is not None:
+	    logger.info("Using charge_account from config_machines.xml: " + charge_account)
+	    return charge_account
 
     logger.info("No charge_account info available, using value from PROJECT")
     return project
@@ -1074,9 +1074,9 @@ def find_files(rootdir, pattern):
     """
     result = []
     for root, _, files in os.walk(rootdir):
-        for filename in files:
-            if (fnmatch.fnmatch(filename, pattern)):
-                result.append(os.path.join(root, filename))
+	for filename in files:
+	    if (fnmatch.fnmatch(filename, pattern)):
+		result.append(os.path.join(root, filename))
 
     return result
 
@@ -1084,20 +1084,20 @@ def find_files(rootdir, pattern):
 def setup_standard_logging_options(parser):
     helpfile = os.path.join(os.getcwd(),os.path.basename("{}.log".format(sys.argv[0])))
     parser.add_argument("-d", "--debug", action="store_true",
-                        help="Print debug information (very verbose) to file {}".format(helpfile))
+			help="Print debug information (very verbose) to file {}".format(helpfile))
     parser.add_argument("-v", "--verbose", action="store_true",
-                        help="Add additional context (time and file) to log messages")
+			help="Add additional context (time and file) to log messages")
     parser.add_argument("-s", "--silent", action="store_true",
-                        help="Print only warnings and error messages")
+			help="Print only warnings and error messages")
 
 class _LessThanFilter(logging.Filter):
     def __init__(self, exclusive_maximum, name=""):
-        super(_LessThanFilter, self).__init__(name)
-        self.max_level = exclusive_maximum
+	super(_LessThanFilter, self).__init__(name)
+	self.max_level = exclusive_maximum
 
     def filter(self, record):
-        #non-zero return means we log this message
-        return 1 if record.levelno < self.max_level else 0
+	#non-zero return means we log this message
+	return 1 if record.levelno < self.max_level else 0
 
 def parse_args_and_handle_standard_logging_options(args, parser=None):
     """
@@ -1111,7 +1111,7 @@ def parse_args_and_handle_standard_logging_options(args, parser=None):
     root_logger = logging.getLogger()
 
     verbose_formatter   = logging.Formatter(fmt='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                                            datefmt='%m-%d %H:%M')
+					    datefmt='%m-%d %H:%M')
 
     # Change info to go to stdout. This handle applies to INFO exclusively
     stdout_stream_handler = logging.StreamHandler(stream=sys.stdout)
@@ -1124,32 +1124,32 @@ def parse_args_and_handle_standard_logging_options(args, parser=None):
 
     # scripts_regression_tests is the only thing that should pass a None argument in parser
     if parser is not None:
-        if "--help" not in args[1:]:
-            _check_for_invalid_args(args[1:])
-        args = parser.parse_args(args[1:])
+	if "--help" not in args[1:]:
+	    _check_for_invalid_args(args[1:])
+	args = parser.parse_args(args[1:])
 
     # --verbose adds to the message format but does not impact the log level
     if args.verbose:
-        stdout_stream_handler.setFormatter(verbose_formatter)
-        stderr_stream_handler.setFormatter(verbose_formatter)
+	stdout_stream_handler.setFormatter(verbose_formatter)
+	stderr_stream_handler.setFormatter(verbose_formatter)
 
     root_logger.addHandler(stdout_stream_handler)
     root_logger.addHandler(stderr_stream_handler)
 
     if args.debug:
-        # Set up log file to catch ALL logging records
-        log_file = "{}.log".format(os.path.basename(sys.argv[0]))
+	# Set up log file to catch ALL logging records
+	log_file = "{}.log".format(os.path.basename(sys.argv[0]))
 
-        debug_log_handler = logging.FileHandler(log_file, mode='w')
-        debug_log_handler.setFormatter(verbose_formatter)
-        debug_log_handler.setLevel(logging.DEBUG)
-        root_logger.addHandler(debug_log_handler)
+	debug_log_handler = logging.FileHandler(log_file, mode='w')
+	debug_log_handler.setFormatter(verbose_formatter)
+	debug_log_handler.setLevel(logging.DEBUG)
+	root_logger.addHandler(debug_log_handler)
 
-        root_logger.setLevel(logging.DEBUG)
+	root_logger.setLevel(logging.DEBUG)
     elif args.silent:
-        root_logger.setLevel(logging.WARN)
+	root_logger.setLevel(logging.WARN)
     else:
-        root_logger.setLevel(logging.INFO)
+	root_logger.setLevel(logging.INFO)
     return args
 
 def get_logging_options():
@@ -1160,11 +1160,11 @@ def get_logging_options():
     root_logger = logging.getLogger()
 
     if (root_logger.level == logging.DEBUG):
-        return "--debug"
+	return "--debug"
     elif (root_logger.level == logging.WARN):
-        return "--silent"
+	return "--silent"
     else:
-        return ""
+	return ""
 
 def convert_to_type(value, type_str, vid=""):
     """
@@ -1173,28 +1173,28 @@ def convert_to_type(value, type_str, vid=""):
     """
     if value is not None:
 
-        if type_str == "char":
-            pass
+	if type_str == "char":
+	    pass
 
-        elif type_str == "integer":
-            try:
-                value = int(eval(value))
-            except Exception:
-                expect(False, "Entry {} was listed as type int but value '{}' is not valid int".format(vid, value))
+	elif type_str == "integer":
+	    try:
+		value = int(eval(value))
+	    except Exception:
+		expect(False, "Entry {} was listed as type int but value '{}' is not valid int".format(vid, value))
 
-        elif type_str == "logical":
-            expect(value.upper() in ["TRUE", "FALSE"],
-                   "Entry {} was listed as type logical but had val '{}' instead of TRUE or FALSE".format(vid, value))
-            value = value.upper() == "TRUE"
+	elif type_str == "logical":
+	    expect(value.upper() in ["TRUE", "FALSE"],
+		   "Entry {} was listed as type logical but had val '{}' instead of TRUE or FALSE".format(vid, value))
+	    value = value.upper() == "TRUE"
 
-        elif type_str == "real":
-            try:
-                value = float(value)
-            except Exception:
-                expect(False, "Entry {} was listed as type real but value '{}' is not valid real".format(vid, value))
+	elif type_str == "real":
+	    try:
+		value = float(value)
+	    except Exception:
+		expect(False, "Entry {} was listed as type real but value '{}' is not valid real".format(vid, value))
 
-        else:
-            expect(False, "Unknown type '{}'".format(type_str))
+	else:
+	    expect(False, "Unknown type '{}'".format(type_str))
 
     return value
 
@@ -1204,27 +1204,27 @@ def convert_to_unknown_type(value):
     """
     if value is not None:
 
-        # Attempt to convert to logical
-        if value.upper() in ["TRUE", "FALSE"]:
-            return value.upper() == "TRUE"
+	# Attempt to convert to logical
+	if value.upper() in ["TRUE", "FALSE"]:
+	    return value.upper() == "TRUE"
 
-        # Attempt to convert to integer
-        try:
-            value = int(eval(value))
-        except Exception:
-            pass
-        else:
-            return value
+	# Attempt to convert to integer
+	try:
+	    value = int(eval(value))
+	except Exception:
+	    pass
+	else:
+	    return value
 
-        # Attempt to convert to float
-        try:
-            value = float(value)
-        except Exception:
-            pass
-        else:
-            return value
+	# Attempt to convert to float
+	try:
+	    value = float(value)
+	except Exception:
+	    pass
+	else:
+	    return value
 
-        # Just treat as string
+	# Just treat as string
 
     return value
 
@@ -1242,22 +1242,22 @@ def convert_to_string(value, type_str=None, vid=""):
     True
     """
     if value is not None and not isinstance(value, six.string_types):
-        if type_str == "char":
-            expect(isinstance(value, six.string_types), "Wrong type for entry id '{}'".format(vid))
-        elif type_str == "integer":
-            expect(isinstance(value, six.integer_types), "Wrong type for entry id '{}'".format(vid))
-            value = str(value)
-        elif type_str == "logical":
-            expect(type(value) is bool, "Wrong type for entry id '{}'".format(vid))
-            value = "TRUE" if value else "FALSE"
-        elif type_str == "real":
-            expect(type(value) is float, "Wrong type for entry id '{}'".format(vid))
-            value = str(value)
-        else:
-            expect(False, "Unknown type '{}'".format(type_str))
+	if type_str == "char":
+	    expect(isinstance(value, six.string_types), "Wrong type for entry id '{}'".format(vid))
+	elif type_str == "integer":
+	    expect(isinstance(value, six.integer_types), "Wrong type for entry id '{}'".format(vid))
+	    value = str(value)
+	elif type_str == "logical":
+	    expect(type(value) is bool, "Wrong type for entry id '{}'".format(vid))
+	    value = "TRUE" if value else "FALSE"
+	elif type_str == "real":
+	    expect(type(value) is float, "Wrong type for entry id '{}'".format(vid))
+	    value = str(value)
+	else:
+	    expect(False, "Unknown type '{}'".format(type_str))
     if value is None:
-        value = ""
-        logger.debug("Attempt to convert None value for vid {} {}".format(vid,value))
+	value = ""
+	logger.debug("Attempt to convert None value for vid {} {}".format(vid,value))
 
     return value
 
@@ -1281,7 +1281,7 @@ def convert_to_seconds(time_str):
     result = 0
     starting_exp = 1 if len(components) == 2 else 0
     for idx, component in enumerate(components):
-        result += int(component) * pow(60, idx + starting_exp)
+	result += int(component) * pow(60, idx + starting_exp)
 
     return result
 
@@ -1304,17 +1304,17 @@ def get_time_in_seconds(timeval, unit):
     Convert a time from 'unit' to seconds
     """
     if 'nyear' in unit:
-        dmult = 365 * 24 * 3600
+	dmult = 365 * 24 * 3600
     elif 'nmonth' in unit:
-        dmult = 30 * 24 * 3600
+	dmult = 30 * 24 * 3600
     elif 'nday' in unit:
-        dmult = 24 * 3600
+	dmult = 24 * 3600
     elif 'nhour' in unit:
-        dmult = 3600
+	dmult = 3600
     elif 'nminute' in unit:
-        dmult = 60
+	dmult = 60
     else:
-        dmult = 1
+	dmult = 1
 
     return dmult * timeval
 
@@ -1335,28 +1335,28 @@ def compute_total_time(job_cost_map, proc_pool):
     waiting_jobs = dict(job_cost_map)
     running_jobs = {} # name -> (procs, est-time, start-time)
     while len(waiting_jobs) > 0 or len(running_jobs) > 0:
-        launched_jobs = []
-        for jobname, data in waiting_jobs.items():
-            procs_for_job, time_for_job = data
-            if procs_for_job <= proc_pool:
-                proc_pool -= procs_for_job
-                launched_jobs.append(jobname)
-                running_jobs[jobname] = (procs_for_job, time_for_job, current_time)
+	launched_jobs = []
+	for jobname, data in waiting_jobs.items():
+	    procs_for_job, time_for_job = data
+	    if procs_for_job <= proc_pool:
+		proc_pool -= procs_for_job
+		launched_jobs.append(jobname)
+		running_jobs[jobname] = (procs_for_job, time_for_job, current_time)
 
-        for launched_job in launched_jobs:
-            del waiting_jobs[launched_job]
+	for launched_job in launched_jobs:
+	    del waiting_jobs[launched_job]
 
-        completed_jobs = []
-        for jobname, data in running_jobs.items():
-            procs_for_job, time_for_job, time_started = data
-            if (current_time - time_started) >= time_for_job:
-                proc_pool += procs_for_job
-                completed_jobs.append(jobname)
+	completed_jobs = []
+	for jobname, data in running_jobs.items():
+	    procs_for_job, time_for_job, time_started = data
+	    if (current_time - time_started) >= time_for_job:
+		proc_pool += procs_for_job
+		completed_jobs.append(jobname)
 
-        for completed_job in completed_jobs:
-            del running_jobs[completed_job]
+	for completed_job in completed_jobs:
+	    del running_jobs[completed_job]
 
-        current_time += 60 # minute time step
+	current_time += 60 # minute time step
 
     return current_time
 
@@ -1380,7 +1380,7 @@ def format_time(time_format, input_format, input_time):
     """
     input_fields = input_format.split("%")
     expect(input_fields[0] == input_time[:len(input_fields[0])],
-           "Failed to parse the input time '{}'; does not match the header string '{}'".format(input_time, input_format))
+	   "Failed to parse the input time '{}'; does not match the header string '{}'".format(input_time, input_format))
     input_time = input_time[len(input_fields[0]):]
     timespec = {"H": None, "M": None, "S": None}
     maxvals = {"M": 60, "S": 60}
@@ -1389,27 +1389,27 @@ def format_time(time_format, input_format, input_time):
     # field starts with H, M, or S
     # input_time starts with a number corresponding with the start of field
     for field in input_fields[1:]:
-        # Find all of the digits at the start of the string
-        spec = field[0]
-        value_re = re.match(r'\d*', input_time)
-        expect(value_re is not None,
-               "Failed to parse the input time for the '{}' specifier, expected an integer".format(spec))
-        value = value_re.group(0)
-        expect(spec in timespec, "Unknown time specifier '" + spec + "'")
-        # Don't do anything if the time field is already specified
-        if timespec[spec] is None:
-            # Verify we aren't exceeding the maximum value
-            if spec in maxvals:
-                expect(int(value) < maxvals[spec],
-                       "Failed to parse the '{}' specifier: A value less than {:d} is expected".format(spec, maxvals[spec]))
-            timespec[spec] = value
-        input_time = input_time[len(value):]
-        # Check for the separator string
-        expect(len(re.match(DIGIT_CHECK, field).group(0)) == len(field),
-               "Numbers are not permissible in separator strings")
-        expect(input_time[:len(field) - 1] == field[1:],
-               "The separator string ({}) doesn't match '{}'".format(field[1:], input_time))
-        input_time = input_time[len(field) - 1:]
+	# Find all of the digits at the start of the string
+	spec = field[0]
+	value_re = re.match(r'\d*', input_time)
+	expect(value_re is not None,
+	       "Failed to parse the input time for the '{}' specifier, expected an integer".format(spec))
+	value = value_re.group(0)
+	expect(spec in timespec, "Unknown time specifier '" + spec + "'")
+	# Don't do anything if the time field is already specified
+	if timespec[spec] is None:
+	    # Verify we aren't exceeding the maximum value
+	    if spec in maxvals:
+		expect(int(value) < maxvals[spec],
+		       "Failed to parse the '{}' specifier: A value less than {:d} is expected".format(spec, maxvals[spec]))
+	    timespec[spec] = value
+	input_time = input_time[len(value):]
+	# Check for the separator string
+	expect(len(re.match(DIGIT_CHECK, field).group(0)) == len(field),
+	       "Numbers are not permissible in separator strings")
+	expect(input_time[:len(field) - 1] == field[1:],
+	       "The separator string ({}) doesn't match '{}'".format(field[1:], input_time))
+	input_time = input_time[len(field) - 1:]
     output_fields = time_format.split("%")
     output_time = output_fields[0]
     # Used when a value isn't given
@@ -1418,16 +1418,16 @@ def format_time(time_format, input_format, input_time):
     # field starts with H, M, or S
     # output_time
     for field in output_fields[1:]:
-        expect(field == output_fields[-1] or len(field) > 1,
-               "Separator strings are required to properly parse times")
-        spec = field[0]
-        expect(spec in timespec, "Unknown time specifier '" + spec + "'")
-        if timespec[spec] is not None:
-            output_time += "0" * (min_len_spec[spec] - len(timespec[spec]))
-            output_time += timespec[spec]
-        else:
-            output_time += "0" * min_len_spec[spec]
-        output_time += field[1:]
+	expect(field == output_fields[-1] or len(field) > 1,
+	       "Separator strings are required to properly parse times")
+	spec = field[0]
+	expect(spec in timespec, "Unknown time specifier '" + spec + "'")
+	if timespec[spec] is not None:
+	    output_time += "0" * (min_len_spec[spec] - len(timespec[spec]))
+	    output_time += timespec[spec]
+	else:
+	    output_time += "0" * min_len_spec[spec]
+	output_time += field[1:]
     return output_time
 
 def append_status(msg, sfile, caseroot='.'):
@@ -1441,8 +1441,8 @@ def append_status(msg, sfile, caseroot='.'):
     line_ending = "\n"
 
     with open(os.path.join(caseroot, sfile), "a") as fd:
-        fd.write(ctime + msg + line_ending)
-        fd.write(" ---------------------------------------------------" + line_ending)
+	fd.write(ctime + msg + line_ending)
+	fd.write(" ---------------------------------------------------" + line_ending)
 
 def append_testlog(msg, caseroot='.'):
     """
@@ -1476,18 +1476,18 @@ def is_last_process_complete(filepath, expect_text, fail_text):
 
     findex = re.search(fail_text, rfb)
     if findex is None:
-        findex = 0
+	findex = 0
     else:
-        findex = findex.start()
+	findex = findex.start()
 
     eindex = re.search(expect_text, rfb)
     if eindex is None:
-        eindex = 0
+	eindex = 0
     else:
-        eindex = eindex.start()
+	eindex = eindex.start()
 
     if findex > eindex:
-        complete = True
+	complete = True
 
     return complete
 
@@ -1507,35 +1507,35 @@ def transform_vars(text, case=None, subgroup=None, overrides=None, default=None)
     # loop through directive text, replacing each string enclosed with
     # template characters with the necessary values.
     while directive_re.search(text):
-        m = directive_re.search(text)
-        variable = m.groups()[0]
-        whole_match = m.group()
-        if overrides is not None and variable.lower() in overrides and overrides[variable.lower()] is not None:
-            repl = overrides[variable.lower()]
-            logger.debug("from overrides: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
-            text = text.replace(whole_match, str(repl))
+	m = directive_re.search(text)
+	variable = m.groups()[0]
+	whole_match = m.group()
+	if overrides is not None and variable.lower() in overrides and overrides[variable.lower()] is not None:
+	    repl = overrides[variable.lower()]
+	    logger.debug("from overrides: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
+	    text = text.replace(whole_match, str(repl))
 
-        elif case is not None and hasattr(case, variable.lower()) and getattr(case, variable.lower()) is not None:
-            repl = getattr(case, variable.lower())
-            logger.debug("from case members: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
-            text = text.replace(whole_match, str(repl))
+	elif case is not None and hasattr(case, variable.lower()) and getattr(case, variable.lower()) is not None:
+	    repl = getattr(case, variable.lower())
+	    logger.debug("from case members: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
+	    text = text.replace(whole_match, str(repl))
 
-        elif case is not None and case.get_value(variable.upper(), subgroup=subgroup) is not None:
-            repl = case.get_value(variable.upper(), subgroup=subgroup)
-            logger.debug("from case: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
-            text = text.replace(whole_match, str(repl))
+	elif case is not None and case.get_value(variable.upper(), subgroup=subgroup) is not None:
+	    repl = case.get_value(variable.upper(), subgroup=subgroup)
+	    logger.debug("from case: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
+	    text = text.replace(whole_match, str(repl))
 
-        elif default is not None:
-            logger.debug("from default: in {}, replacing {} with {}".format(text, whole_match, str(default)))
-            text = text.replace(whole_match, default)
+	elif default is not None:
+	    logger.debug("from default: in {}, replacing {} with {}".format(text, whole_match, str(default)))
+	    text = text.replace(whole_match, default)
 
-        else:
-            # If no queue exists, then the directive '-q' by itself will cause an error
-            if "-q {{ queue }}" in text:
-                text = ""
-            else:
-                logger.warning("Could not replace variable '{}'".format(variable))
-                text = text.replace(whole_match, "")
+	else:
+	    # If no queue exists, then the directive '-q' by itself will cause an error
+	    if "-q {{ queue }}" in text:
+		text = ""
+	    else:
+		logger.warning("Could not replace variable '{}'".format(variable))
+		text = text.replace(whole_match, "")
 
     return text
 
@@ -1543,22 +1543,22 @@ def wait_for_unlocked(filepath):
     locked = True
     file_object = None
     while locked:
-        try:
-            buffer_size = 8
-            # Opening file in append mode and read the first 8 characters.
-            file_object = open(filepath, 'a', buffer_size)
-            if file_object:
-                locked = False
-        except IOError:
-            locked = True
-            time.sleep(1)
-        finally:
-            if file_object:
-                file_object.close()
+	try:
+	    buffer_size = 8
+	    # Opening file in append mode and read the first 8 characters.
+	    file_object = open(filepath, 'a', buffer_size)
+	    if file_object:
+		locked = False
+	except IOError:
+	    locked = True
+	    time.sleep(1)
+	finally:
+	    if file_object:
+		file_object.close()
 
 def gunzip_existing_file(filepath):
     with gzip.open(filepath, "rb") as fd:
-        return fd.read()
+	return fd.read()
 
 def gzip_existing_file(filepath):
     """
@@ -1582,8 +1582,8 @@ def gzip_existing_file(filepath):
 
     gzpath = '{}.gz'.format(filepath)
     with open(filepath, "rb") as f_in:
-        with gzip.open(gzpath, "wb") as f_out:
-            shutil.copyfileobj(f_in, f_out)
+	with gzip.open(gzpath, "wb") as f_out:
+	    shutil.copyfileobj(f_in, f_out)
 
     os.remove(filepath)
 
@@ -1593,9 +1593,9 @@ def gzip_existing_file(filepath):
 
 def touch(fname):
     if os.path.exists(fname):
-        os.utime(fname, None)
+	os.utime(fname, None)
     else:
-        open(fname, 'a').close()
+	open(fname, 'a').close()
 
 def find_system_test(testname, case):
     """
@@ -1608,29 +1608,29 @@ def find_system_test(testname, case):
     from importlib import import_module
     system_test_path = None
     if testname.startswith("TEST"):
-        system_test_path =  "CIME.SystemTests.system_tests_common.{}".format(testname)
+	system_test_path =  "CIME.SystemTests.system_tests_common.{}".format(testname)
     else:
-        components = ["any"]
-        components.extend( case.get_compset_components())
-        fdir = []
-        for component in components:
-            tdir = case.get_value("SYSTEM_TESTS_DIR",
-                                      attribute={"component":component})
-            if tdir is not None:
-                tdir = os.path.abspath(tdir)
-                system_test_file = os.path.join(tdir  ,"{}.py".format(testname.lower()))
-                if os.path.isfile(system_test_file):
-                    fdir.append(tdir)
-                    logger.debug( "found "+system_test_file)
-                    if component == "any":
-                        system_test_path = "CIME.SystemTests.{}.{}".format(testname.lower(), testname)
-                    else:
-                        system_test_dir = os.path.dirname(system_test_file)
-                        if system_test_dir not in sys.path:
-                            sys.path.append(system_test_dir)
-                        system_test_path = "{}.{}".format(testname.lower(), testname)
-        expect(len(fdir) > 0, "Test {} not found, aborting".format(testname))
-        expect(len(fdir) == 1, "Test {} found in multiple locations {}, aborting".format(testname, fdir))
+	components = ["any"]
+	components.extend( case.get_compset_components())
+	fdir = []
+	for component in components:
+	    tdir = case.get_value("SYSTEM_TESTS_DIR",
+				      attribute={"component":component})
+	    if tdir is not None:
+		tdir = os.path.abspath(tdir)
+		system_test_file = os.path.join(tdir  ,"{}.py".format(testname.lower()))
+		if os.path.isfile(system_test_file):
+		    fdir.append(tdir)
+		    logger.debug( "found "+system_test_file)
+		    if component == "any":
+			system_test_path = "CIME.SystemTests.{}.{}".format(testname.lower(), testname)
+		    else:
+			system_test_dir = os.path.dirname(system_test_file)
+			if system_test_dir not in sys.path:
+			    sys.path.append(system_test_dir)
+			system_test_path = "{}.{}".format(testname.lower(), testname)
+	expect(len(fdir) > 0, "Test {} not found, aborting".format(testname))
+	expect(len(fdir) == 1, "Test {} found in multiple locations {}, aborting".format(testname, fdir))
     expect(system_test_path is not None, "No test {} found".format(testname))
 
     path, m = system_test_path.rsplit('.',1)
@@ -1648,12 +1648,12 @@ def _get_most_recent_lid_impl(files):
     """
     results = []
     for item in files:
-        basename = os.path.basename(item)
-        components = basename.split(".")
-        if len(components) > 2:
-            results.append(components[2])
-        else:
-            logger.warning("Apparent model log file '{}' did not conform to expected name format".format(item))
+	basename = os.path.basename(item)
+	components = basename.split(".")
+	if len(components) > 2:
+	    results.append(components[2])
+	else:
+	    logger.warning("Apparent model log file '{}' did not conform to expected name format".format(item))
 
     return sorted(list(set(results)))
 
@@ -1671,18 +1671,18 @@ def new_lid():
     lid = time.strftime("%y%m%d-%H%M%S")
     jobid = batch_jobid()
     if jobid is not None:
-        lid = jobid+'.'+lid
+	lid = jobid+'.'+lid
     os.environ["LID"] = lid
     return lid
 
 def batch_jobid():
     jobid = os.environ.get("PBS_JOBID")
     if jobid is None:
-        jobid = os.environ.get("SLURM_JOB_ID")
+	jobid = os.environ.get("SLURM_JOB_ID")
     if jobid is None:
-        jobid = os.environ.get("LSB_JOBID")
+	jobid = os.environ.get("LSB_JOBID")
     if jobid is None:
-        jobid = os.environ.get("COBALT_JOBID")
+	jobid = os.environ.get("COBALT_JOBID")
     return jobid
 
 def analyze_build_log(comp, log, compiler):
@@ -1692,39 +1692,39 @@ def analyze_build_log(comp, log, compiler):
     """
     warncnt = 0
     if "intel" in compiler:
-        warn_re = re.compile(r" warning #")
-        error_re = re.compile(r" error #")
-        undefined_re = re.compile(r" undefined reference to ")
+	warn_re = re.compile(r" warning #")
+	error_re = re.compile(r" error #")
+	undefined_re = re.compile(r" undefined reference to ")
     elif "gnu" in compiler or "nag" in compiler:
-        warn_re = re.compile(r"^Warning: ")
-        error_re = re.compile(r"^Error: ")
-        undefined_re = re.compile(r" undefined reference to ")
+	warn_re = re.compile(r"^Warning: ")
+	error_re = re.compile(r"^Error: ")
+	undefined_re = re.compile(r" undefined reference to ")
     else:
-        # don't know enough about this compiler
-        return
+	# don't know enough about this compiler
+	return
 
     with open(log,"r") as fd:
-        for line in fd:
-            if re.search(warn_re, line):
-                warncnt += 1
-            if re.search(error_re, line):
-                logger.warning(line)
-            if re.search(undefined_re, line):
-                logger.warning(line)
+	for line in fd:
+	    if re.search(warn_re, line):
+		warncnt += 1
+	    if re.search(error_re, line):
+		logger.warning(line)
+	    if re.search(undefined_re, line):
+		logger.warning(line)
 
     if warncnt > 0:
-        logger.info("Component {} build complete with {} warnings".format(comp, warncnt))
+	logger.info("Component {} build complete with {} warnings".format(comp, warncnt))
 
 def is_python_executable(filepath):
     first_line = None
     if os.path.isfile(filepath):
-        with open(filepath, "rt") as f:
-            try:
-                first_line = f.readline()
-            except Exception:
-                pass
+	with open(filepath, "rt") as f:
+	    try:
+		first_line = f.readline()
+	    except Exception:
+		pass
 
-        return first_line is not None and first_line.startswith("#!") and "python" in first_line
+	return first_line is not None and first_line.startswith("#!") and "python" in first_line
     return False
 
 def get_umask():
@@ -1765,49 +1765,49 @@ def run_and_log_case_status(func, phase, caseroot='.', custom_success_msg_functo
     append_case_status(phase, "starting", caseroot=caseroot)
     rv = None
     try:
-        rv = func()
+	rv = func()
     except BaseException:
-        e = sys.exc_info()[1]
-        append_case_status(phase, CASE_FAILURE, msg=("\n{}".format(e)), caseroot=caseroot)
-        raise
+	e = sys.exc_info()[1]
+	append_case_status(phase, CASE_FAILURE, msg=("\n{}".format(e)), caseroot=caseroot)
+	raise
     else:
-        custom_success_msg = custom_success_msg_functor(rv) if custom_success_msg_functor else None
-        append_case_status(phase, CASE_SUCCESS, msg=custom_success_msg, caseroot=caseroot)
+	custom_success_msg = custom_success_msg_functor(rv) if custom_success_msg_functor else None
+	append_case_status(phase, CASE_SUCCESS, msg=custom_success_msg, caseroot=caseroot)
 
     return rv
 
 def _check_for_invalid_args(args):
     if get_model() != "e3sm":
-        for arg in args:
-            # if arg contains a space then it was originally quoted and we can ignore it here.
-            if " " in arg or arg.startswith("--"):
-                continue
-            if arg.startswith("-") and len(arg) > 2:
-                sys.stderr.write( "WARNING: The {} argument is deprecated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options\n".format(arg))
+	for arg in args:
+	    # if arg contains a space then it was originally quoted and we can ignore it here.
+	    if " " in arg or arg.startswith("--"):
+		continue
+	    if arg.startswith("-") and len(arg) > 2:
+		sys.stderr.write( "WARNING: The {} argument is deprecated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options\n".format(arg))
 
 def add_mail_type_args(parser):
     parser.add_argument("--mail-user", help="Email to be used for batch notification.")
 
     parser.add_argument("-M", "--mail-type", action="append",
-                        help="When to send user email. Options are: never, all, begin, end, fail.\n"
-                        "You can specify multiple types with either comma-separated args or multiple -M flags.")
+			help="When to send user email. Options are: never, all, begin, end, fail.\n"
+			"You can specify multiple types with either comma-separated args or multiple -M flags.")
 
 def resolve_mail_type_args(args):
     if args.mail_type is not None:
-        resolved_mail_types = []
-        for mail_type in args.mail_type:
-            resolved_mail_types.extend(mail_type.split(","))
+	resolved_mail_types = []
+	for mail_type in args.mail_type:
+	    resolved_mail_types.extend(mail_type.split(","))
 
-        for mail_type in resolved_mail_types:
-            expect(mail_type in ("never", "all", "begin", "end", "fail"),
-                   "Unsupported mail-type '{}'".format(mail_type))
+	for mail_type in resolved_mail_types:
+	    expect(mail_type in ("never", "all", "begin", "end", "fail"),
+		   "Unsupported mail-type '{}'".format(mail_type))
 
-        args.mail_type = resolved_mail_types
+	args.mail_type = resolved_mail_types
 
 def copyifnewer(src, dest):
     """ if dest does not exist or is older than src copy src to dest """
     if not os.path.isfile(dest) or not filecmp.cmp(src, dest):
-        safe_copy(src, dest)
+	safe_copy(src, dest)
 
 class SharedArea(object):
     """
@@ -1815,14 +1815,14 @@ class SharedArea(object):
     """
 
     def __init__(self, new_perms=0o002):
-        self._orig_umask = None
-        self._new_perms  = new_perms
+	self._orig_umask = None
+	self._new_perms  = new_perms
 
     def __enter__(self):
-        self._orig_umask = os.umask(self._new_perms)
+	self._orig_umask = os.umask(self._new_perms)
 
     def __exit__(self, *_):
-        os.umask(self._orig_umask)
+	os.umask(self._orig_umask)
 
 class Timeout(object):
     """
@@ -1831,20 +1831,20 @@ class Timeout(object):
     Provided None as seconds makes this class a no-op
     """
     def __init__(self, seconds, action=None):
-        self._seconds = seconds
-        self._action  = action if action is not None else self._handle_timeout
+	self._seconds = seconds
+	self._action  = action if action is not None else self._handle_timeout
 
     def _handle_timeout(self, *_):
-        raise RuntimeError("Timeout expired")
+	raise RuntimeError("Timeout expired")
 
     def __enter__(self):
-        if self._seconds is not None:
-            signal.signal(signal.SIGALRM, self._action)
-            signal.alarm(self._seconds)
+	if self._seconds is not None:
+	    signal.signal(signal.SIGALRM, self._action)
+	    signal.alarm(self._seconds)
 
     def __exit__(self, *_):
-        if self._seconds is not None:
-            signal.alarm(0)
+	if self._seconds is not None:
+	    signal.alarm(0)
 
 def filter_unicode(unistr):
     """
@@ -1872,15 +1872,15 @@ def string_in_list(_string, _list):
     >>> string_in_list("foo", ["FFO", "foo2", "foo3"])
     """
     for x in _list:
-        if _string.lower() == x.lower():
-            return x
+	if _string.lower() == x.lower():
+	    return x
     return None
 
 def model_log(model, arg_logger, msg, debug_others=True):
     if get_model() == model:
-        arg_logger.info(msg)
+	arg_logger.info(msg)
     elif debug_others:
-        arg_logger.debug(msg)
+	arg_logger.debug(msg)
 
 def get_htmlroot(machobj=None):
     """Get location for test HTML output
@@ -1892,21 +1892,21 @@ def get_htmlroot(machobj=None):
     """
     htmlroot = os.environ.get("CIME_HTML_ROOT")
     if htmlroot is not None:
-        logger.info("Using htmlroot from env CIME_HTML_ROOT: {}".format(htmlroot))
-        return htmlroot
+	logger.info("Using htmlroot from env CIME_HTML_ROOT: {}".format(htmlroot))
+	return htmlroot
 
     cime_config = get_cime_config()
     if cime_config.has_option("main", "CIME_HTML_ROOT"):
-        htmlroot = cime_config.get("main", "CIME_HTML_ROOT")
-        if htmlroot is not None:
-            logger.info("Using htmlroot from .cime/config: {}".format(htmlroot))
-            return htmlroot
+	htmlroot = cime_config.get("main", "CIME_HTML_ROOT")
+	if htmlroot is not None:
+	    logger.info("Using htmlroot from .cime/config: {}".format(htmlroot))
+	    return htmlroot
 
     if machobj is not None:
-        htmlroot = machobj.get_value("CIME_HTML_ROOT")
-        if htmlroot is not None:
-            logger.info("Using htmlroot from config_machines.xml: {}".format(htmlroot))
-            return htmlroot
+	htmlroot = machobj.get_value("CIME_HTML_ROOT")
+	if htmlroot is not None:
+	    logger.info("Using htmlroot from config_machines.xml: {}".format(htmlroot))
+	    return htmlroot
 
     logger.info("No htmlroot info available")
     return None
@@ -1921,21 +1921,21 @@ def get_urlroot(machobj=None):
     """
     urlroot = os.environ.get("CIME_URL_ROOT")
     if urlroot is not None:
-        logger.info("Using urlroot from env CIME_URL_ROOT: {}".format(urlroot))
-        return urlroot
+	logger.info("Using urlroot from env CIME_URL_ROOT: {}".format(urlroot))
+	return urlroot
 
     cime_config = get_cime_config()
     if cime_config.has_option("main", "CIME_URL_ROOT"):
-        urlroot = cime_config.get("main", "CIME_URL_ROOT")
-        if urlroot is not None:
-            logger.info("Using urlroot from .cime/config: {}".format(urlroot))
-            return urlroot
+	urlroot = cime_config.get("main", "CIME_URL_ROOT")
+	if urlroot is not None:
+	    logger.info("Using urlroot from .cime/config: {}".format(urlroot))
+	    return urlroot
 
     if machobj is not None:
-        urlroot = machobj.get_value("CIME_URL_ROOT")
-        if urlroot is not None:
-            logger.info("Using urlroot from config_machines.xml: {}".format(urlroot))
-            return urlroot
+	urlroot = machobj.get_value("CIME_URL_ROOT")
+	if urlroot is not None:
+	    logger.info("Using urlroot from config_machines.xml: {}".format(urlroot))
+	    return urlroot
 
     logger.info("No urlroot info available")
     return None

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -19,26 +19,26 @@ logger = logging.getLogger(__name__)
 def redirect_stdout(new_target):
     old_target, sys.stdout = sys.stdout, new_target # replace sys.stdout
     try:
-	yield new_target # run some code with the replaced stdout
+        yield new_target # run some code with the replaced stdout
     finally:
-	sys.stdout = old_target # restore to the previous value
+        sys.stdout = old_target # restore to the previous value
 
 @contextmanager
 def redirect_stderr(new_target):
     old_target, sys.stderr = sys.stderr, new_target # replace sys.stdout
     try:
-	yield new_target # run some code with the replaced stdout
+        yield new_target # run some code with the replaced stdout
     finally:
-	sys.stderr = old_target # restore to the previous value
+        sys.stderr = old_target # restore to the previous value
 
 @contextmanager
 def redirect_stdout_stderr(new_target):
     old_stdout, old_stderr = sys.stdout, sys.stderr
     sys.stdout, sys.stderr = new_target, new_target
     try:
-	yield new_target
+        yield new_target
     finally:
-	sys.stdout, sys.stderr = old_stdout, old_stderr
+        sys.stdout, sys.stderr = old_stdout, old_stderr
 
 @contextmanager
 def redirect_logger(new_target, logger_name):
@@ -50,22 +50,22 @@ def redirect_logger(new_target, logger_name):
     orig_root_loggers = root_log.handlers
 
     try:
-	root_log.handlers = []
-	log.handlers = [ch]
-	yield log
+        root_log.handlers = []
+        log.handlers = [ch]
+        yield log
     finally:
-	root_log.handlers = orig_root_loggers
-	log.handlers = orig_handlers
+        root_log.handlers = orig_root_loggers
+        log.handlers = orig_handlers
 
 class IndentFormatter(logging.Formatter):
     def __init__(self, indent, fmt=None, datefmt=None):
-	logging.Formatter.__init__(self, fmt, datefmt)
-	self._indent = indent
+        logging.Formatter.__init__(self, fmt, datefmt)
+        self._indent = indent
 
     def format(self, record):
-	record.msg = "{}{}".format(self._indent, record.msg)
-	out = logging.Formatter.format(self, record)
-	return out
+        record.msg = "{}{}".format(self._indent, record.msg)
+        out = logging.Formatter.format(self, record)
+        return out
 
 def set_logger_indent(indent):
     root_log = logging.getLogger()
@@ -80,32 +80,32 @@ class EnvironmentContext(object):
     """
     Context manager for environment variables
     Usage:
-	os.environ['MYVAR'] = 'oldvalue'
-	with EnvironmentContex(MYVAR='myvalue', MYVAR2='myvalue2'):
-	    print os.getenv('MYVAR')    # Should print myvalue.
-	    print os.getenv('MYVAR2')    # Should print myvalue2.
-	print os.getenv('MYVAR')        # Should print oldvalue.
-	print os.getenv('MYVAR2')        # Should print None.
+        os.environ['MYVAR'] = 'oldvalue'
+        with EnvironmentContex(MYVAR='myvalue', MYVAR2='myvalue2'):
+            print os.getenv('MYVAR')    # Should print myvalue.
+            print os.getenv('MYVAR2')    # Should print myvalue2.
+        print os.getenv('MYVAR')        # Should print oldvalue.
+        print os.getenv('MYVAR2')        # Should print None.
 
     CREDIT: https://github.com/sakurai-youhei/envcontext
     """
 
     def __init__(self, **kwargs):
-	self.envs = kwargs
-	self.old_envs = {}
+        self.envs = kwargs
+        self.old_envs = {}
 
     def __enter__(self):
-	self.old_envs = {}
-	for k, v in self.envs.items():
-	    self.old_envs[k] = os.environ.get(k)
-	    os.environ[k] = v
+        self.old_envs = {}
+        for k, v in self.envs.items():
+            self.old_envs[k] = os.environ.get(k)
+            os.environ[k] = v
 
     def __exit__(self, *args):
-	for k, v in self.old_envs.items():
-	    if v:
-		os.environ[k] = v
-	    else:
-		del os.environ[k]
+        for k, v in self.old_envs.items():
+            if v:
+                os.environ[k] = v
+            else:
+                del os.environ[k]
 
 # This should be the go-to exception for CIME use. It's a subclass
 # of SystemExit in order suppress tracebacks, which users generally
@@ -123,18 +123,18 @@ def expect(condition, error_msg, exc_type=CIMEError, error_prefix="ERROR:"):
     >>> expect(True, "error1")
     >>> expect(False, "error2") # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-	...
+        ...
     CIMEError: ERROR: error2
     """
     # Without this line we get a futurewarning on the use of condition below
     warnings.filterwarnings("ignore")
     if not condition:
-	if logger.isEnabledFor(logging.DEBUG):
-	    import pdb
-	    pdb.set_trace()
+        if logger.isEnabledFor(logging.DEBUG):
+            import pdb
+            pdb.set_trace()
 
-	msg = error_prefix + " " + error_msg
-	raise exc_type(msg)
+        msg = error_prefix + " " + error_msg
+        raise exc_type(msg)
 
 def id_generator(size=6, chars=string.ascii_lowercase + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
@@ -163,17 +163,17 @@ def check_name(fullname, additional_chars=None, fullpath=False):
 
     chars = '+*?<>/{}[\]~`@:' # pylint: disable=anomalous-backslash-in-string
     if additional_chars is not None:
-	chars += additional_chars
+        chars += additional_chars
     if fullname.endswith('/'):
-	return False
+        return False
     if fullpath:
-	_, name = os.path.split(fullname)
+        _, name = os.path.split(fullname)
     else:
-	name = fullname
+        name = fullname
     match = re.search(r"["+re.escape(chars)+"]", name)
     if match is not None:
-	logger.warning("Illegal character {} found in name {}".format(match.group(0), name))
-	return False
+        logger.warning("Illegal character {} found in name {}".format(match.group(0), name))
+        return False
     return True
 
 # Should only be called from get_cime_config()
@@ -187,30 +187,30 @@ def _read_cime_config_file():
     allowed_sections = ("main", "create_test")
 
     allowed_in_main = ("cime_model", "project", "charge_account", "srcroot", "mail_type",
-		       "mail_user", "machine", "mpilib", "compiler", "input_dir", "cime_driver")
+                       "mail_user", "machine", "mpilib", "compiler", "input_dir", "cime_driver")
     allowed_in_create_test = ("mail_type", "mail_user", "save_timing", "single_submit",
-			      "test_root", "output_root", "baseline_root", "clean",
-			      "machine", "mpilib", "compiler", "parallel_jobs", "proc_pool",
-			      "walltime", "job_queue", "allow_baseline_overwrite", "wait",
-			      "force_procs", "force_threads", "input_dir", "pesfile", "retry",
-			      "walltime")
+                              "test_root", "output_root", "baseline_root", "clean",
+                              "machine", "mpilib", "compiler", "parallel_jobs", "proc_pool",
+                              "walltime", "job_queue", "allow_baseline_overwrite", "wait",
+                              "force_procs", "force_threads", "input_dir", "pesfile", "retry",
+                              "walltime")
 
     cime_config_file = os.path.abspath(os.path.join(os.path.expanduser("~"),
-						  ".cime","config"))
+                                                  ".cime","config"))
     cime_config = configparser.SafeConfigParser()
     if(os.path.isfile(cime_config_file)):
-	cime_config.read(cime_config_file)
-	for section in cime_config.sections():
-	    expect(section in allowed_sections,"Unknown section {} in .cime/config\nallowed sections are {}".format(section, allowed_sections))
-	if cime_config.has_section('main'):
-	    for item,_ in cime_config.items('main'):
-		expect(item in allowed_in_main,"Unknown option in config section \"main\": \"{}\"\nallowed options are {}".format(item, allowed_in_main))
-	if cime_config.has_section('create_test'):
-	    for item,_ in cime_config.items('create_test'):
-		expect(item in allowed_in_create_test,"Unknown option in config section \"test\": \"{}\"\nallowed options are {}".format(item, allowed_in_create_test))
+        cime_config.read(cime_config_file)
+        for section in cime_config.sections():
+            expect(section in allowed_sections,"Unknown section {} in .cime/config\nallowed sections are {}".format(section, allowed_sections))
+        if cime_config.has_section('main'):
+            for item,_ in cime_config.items('main'):
+                expect(item in allowed_in_main,"Unknown option in config section \"main\": \"{}\"\nallowed options are {}".format(item, allowed_in_main))
+        if cime_config.has_section('create_test'):
+            for item,_ in cime_config.items('create_test'):
+                expect(item in allowed_in_create_test,"Unknown option in config section \"test\": \"{}\"\nallowed options are {}".format(item, allowed_in_create_test))
     else:
-	logger.debug("File {} not found".format(cime_config_file))
-	cime_config.add_section('main')
+        logger.debug("File {} not found".format(cime_config_file))
+        cime_config.add_section('main')
 
     return cime_config
 
@@ -218,7 +218,7 @@ _CIMECONFIG = None
 def get_cime_config():
     global _CIMECONFIG
     if (not _CIMECONFIG):
-	_CIMECONFIG = _read_cime_config_file()
+        _CIMECONFIG = _read_cime_config_file()
 
     return _CIMECONFIG
 
@@ -247,9 +247,9 @@ def get_cime_root(case=None):
     cimeroot = os.path.abspath(os.path.join(script_absdir,"..",".."))
 
     if case is not None:
-	case_cimeroot = os.path.abspath(case.get_value("CIMEROOT"))
-	cimeroot = os.path.abspath(cimeroot)
-	expect(cimeroot == case_cimeroot, "Inconsistent CIMEROOT variable: case -> '{}', file location -> '{}'".format(case_cimeroot, cimeroot))
+        case_cimeroot = os.path.abspath(case.get_value("CIMEROOT"))
+        cimeroot = os.path.abspath(cimeroot)
+        expect(cimeroot == case_cimeroot, "Inconsistent CIMEROOT variable: case -> '{}', file location -> '{}'".format(case_cimeroot, cimeroot))
 
     logger.debug( "CIMEROOT is " + cimeroot)
     return cimeroot
@@ -257,19 +257,19 @@ def get_cime_root(case=None):
 def get_cime_default_driver():
     driver = os.environ.get("CIME_DRIVER")
     if driver:
-	logger.debug("Setting CIME_DRIVER={} from environment".format(driver))
+        logger.debug("Setting CIME_DRIVER={} from environment".format(driver))
     else:
-	cime_config = get_cime_config()
-	if (cime_config.has_option('main','CIME_DRIVER')):
-	    driver = cime_config.get('main','CIME_DRIVER')
-	    if driver:
-		logger.debug("Setting CIME_driver={} from ~/.cime/config".format(driver))
+        cime_config = get_cime_config()
+        if (cime_config.has_option('main','CIME_DRIVER')):
+            driver = cime_config.get('main','CIME_DRIVER')
+            if driver:
+                logger.debug("Setting CIME_driver={} from ~/.cime/config".format(driver))
     if not driver:
-	model = get_model()
-	if model == "ufs":
-	    driver = "nuopc"
-	else:
-	    driver = "mct"
+        model = get_model()
+        if model == "ufs":
+            driver = "nuopc"
+        else:
+            driver = "mct"
     expect(driver in ("mct", "nuopc", "moab"),"Attempt to set invalid driver {}".format(driver))
     return driver
 
@@ -277,8 +277,8 @@ def get_all_cime_models():
     modelsroot = os.path.join(get_cime_root(), "config")
     models = []
     for entry in os.listdir(modelsroot):
-	if os.path.isdir(os.path.join(modelsroot,entry)):
-	    models.append(entry)
+        if os.path.isdir(os.path.join(modelsroot,entry)):
+            models.append(entry)
     models.remove('xml_schemas')
     return models
 
@@ -289,7 +289,7 @@ def set_model(model):
     cime_config = get_cime_config()
     cime_models = get_all_cime_models()
     if not cime_config.has_section('main'):
-	cime_config.add_section('main')
+        cime_config.add_section('main')
     expect(model in cime_models,"model {} not recognized. The acceptable values of CIME_MODEL currently are {}".format(model, cime_models))
     cime_config.set('main','CIME_MODEL',model)
 
@@ -301,12 +301,12 @@ def get_model():
     >>> os.environ["CIME_MODEL"] = "garbage"
     >>> get_model() # doctest:+ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-	...
+        ...
     CIMEError: ERROR: model garbage not recognized
     >>> del os.environ["CIME_MODEL"]
     >>> set_model('rocky') # doctest:+ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-	...
+        ...
     CIMEError: ERROR: model rocky not recognized
     >>> set_model('e3sm')
     >>> get_model()
@@ -316,48 +316,48 @@ def get_model():
     model = os.environ.get("CIME_MODEL")
     cime_models = get_all_cime_models()
     if model in cime_models:
-	logger.debug("Setting CIME_MODEL={} from environment".format(model))
+        logger.debug("Setting CIME_MODEL={} from environment".format(model))
     else:
-	expect(model is None,"model {} not recognized. The acceptable values of CIME_MODEL currently are {}".format(model, cime_models))
-	cime_config = get_cime_config()
-	if (cime_config.has_option('main','CIME_MODEL')):
-	    model = cime_config.get('main','CIME_MODEL')
-	    if model is not None:
-		logger.debug("Setting CIME_MODEL={} from ~/.cime/config".format(model))
+        expect(model is None,"model {} not recognized. The acceptable values of CIME_MODEL currently are {}".format(model, cime_models))
+        cime_config = get_cime_config()
+        if (cime_config.has_option('main','CIME_MODEL')):
+            model = cime_config.get('main','CIME_MODEL')
+            if model is not None:
+                logger.debug("Setting CIME_MODEL={} from ~/.cime/config".format(model))
 
     # One last try
     if (model is None):
-	srcroot = None
-	if cime_config.has_section('main') and cime_config.has_option('main', 'SRCROOT'):
-	    srcroot = cime_config.get('main','SRCROOT')
-	if srcroot is None:
-	    srcroot = os.path.dirname(os.path.abspath(get_cime_root()))
-	if os.path.isfile(os.path.join(srcroot, "Externals.cfg")):
-	    model = 'cesm'
-	    with open(os.path.join(srcroot, "Externals.cfg")) as fd:
-		for line in fd:
-		    if re.search('fv3gfs', line):
-			model = 'ufs'
-	else:
-	    model = 'e3sm'
-	# This message interfers with the correct operation of xmlquery
-	# logger.debug("Guessing CIME_MODEL={}, set environment variable if this is incorrect".format(model))
+        srcroot = None
+        if cime_config.has_section('main') and cime_config.has_option('main', 'SRCROOT'):
+            srcroot = cime_config.get('main','SRCROOT')
+        if srcroot is None:
+            srcroot = os.path.dirname(os.path.abspath(get_cime_root()))
+        if os.path.isfile(os.path.join(srcroot, "Externals.cfg")):
+            model = 'cesm'
+            with open(os.path.join(srcroot, "Externals.cfg")) as fd:
+                for line in fd:
+                    if re.search('fv3gfs', line):
+                        model = 'ufs'
+        else:
+            model = 'e3sm'
+        # This message interfers with the correct operation of xmlquery
+        # logger.debug("Guessing CIME_MODEL={}, set environment variable if this is incorrect".format(model))
 
     if model is not None:
-	set_model(model)
-	return model
+        set_model(model)
+        return model
 
     modelroot = os.path.join(get_cime_root(), "config")
     models = os.listdir(modelroot)
     msg = ".cime/config or environment variable CIME_MODEL must be set to one of: "
     msg += ", ".join([model for model in models
-		      if os.path.isdir(os.path.join(modelroot,model))
-		      and model != "xml_schemas"])
+                      if os.path.isdir(os.path.join(modelroot,model))
+                      and model != "xml_schemas"])
     expect(False, msg)
 
 def _get_path(filearg, from_dir):
     if not filearg.startswith("/") and from_dir is not None:
-	filearg = os.path.join(from_dir, filearg)
+        filearg = os.path.join(from_dir, filearg)
 
     return filearg
 
@@ -372,17 +372,17 @@ def check_for_python(filepath, funcname=None):
     is_python = is_python_executable(filepath)
     has_function = True
     if funcname is not None:
-	has_function = False
-	with open(filepath, 'r') as fd:
-	    for line in fd.readlines():
-		if re.search(r"^def\s+{}\(".format(funcname), line) or re.search(r"^from.+import.+\s{}".format(funcname), line):
-		    has_function = True
-		    break
+        has_function = False
+        with open(filepath, 'r') as fd:
+            for line in fd.readlines():
+                if re.search(r"^def\s+{}\(".format(funcname), line) or re.search(r"^from.+import.+\s{}".format(funcname), line):
+                    has_function = True
+                    break
 
     return is_python and has_function
 
 def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
-		   from_dir=None, timeout=None):
+                   from_dir=None, timeout=None):
     """
     This code will try to import and run each cmd as a subroutine
     if that fails it will run it as a program in a seperate shell
@@ -394,71 +394,71 @@ def run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile=None, case=None,
     # Before attempting to load the script make sure it contains the subroutine
     # we are expecting
     with open(cmd, 'r') as fd:
-	for line in fd.readlines():
-	    if re.search(r"^def {}\(".format(subname), line):
-		do_run_cmd = False
-		break
+        for line in fd.readlines():
+            if re.search(r"^def {}\(".format(subname), line):
+                do_run_cmd = False
+                break
 
     if not do_run_cmd:
-	try:
-	    mod = imp.load_source(subname, cmd)
-	    logger.info("   Calling {}".format(cmd))
-	    # Careful: logfile code is not thread safe!
-	    if logfile:
-		with open(logfile,"w") as log_fd:
-		    with redirect_logger(log_fd, subname):
-			with redirect_stdout_stderr(log_fd):
-			    getattr(mod, subname)(*subargs)
-	    else:
-		getattr(mod, subname)(*subargs)
+        try:
+            mod = imp.load_source(subname, cmd)
+            logger.info("   Calling {}".format(cmd))
+            # Careful: logfile code is not thread safe!
+            if logfile:
+                with open(logfile,"w") as log_fd:
+                    with redirect_logger(log_fd, subname):
+                        with redirect_stdout_stderr(log_fd):
+                            getattr(mod, subname)(*subargs)
+            else:
+                getattr(mod, subname)(*subargs)
 
-	except (SyntaxError, AttributeError) as _:
-	    pass # Need to try to run as shell command
+        except (SyntaxError, AttributeError) as _:
+            pass # Need to try to run as shell command
 
-	except Exception:
-	    if logfile:
-		with open(logfile, "a") as log_fd:
-		    log_fd.write(str(sys.exc_info()[1]))
+        except Exception:
+            if logfile:
+                with open(logfile, "a") as log_fd:
+                    log_fd.write(str(sys.exc_info()[1]))
 
-		expect(False, "{} FAILED, cat {}".format(cmd, logfile))
-	    else:
-		raise
+                expect(False, "{} FAILED, cat {}".format(cmd, logfile))
+            else:
+                raise
 
-	else:
-	    return # Running as python function worked, we're done
+        else:
+            return # Running as python function worked, we're done
 
     logger.info("   Running {} ".format(cmd))
     if case is not None:
-	case.flush()
+        case.flush()
 
     fullcmd = cmd
     if isinstance(cmdargs, list):
-	for arg in cmdargs:
-	    fullcmd += " " + str(arg)
+        for arg in cmdargs:
+            fullcmd += " " + str(arg)
     else:
-	fullcmd += " " + cmdargs
+        fullcmd += " " + cmdargs
 
     if logfile:
-	fullcmd += " >& {} ".format(logfile)
+        fullcmd += " >& {} ".format(logfile)
 
     stat, output, _ = run_cmd("{}".format(fullcmd), combine_output=True,
-			      from_dir=from_dir, timeout=timeout)
+                              from_dir=from_dir, timeout=timeout)
     if output: # Will be empty if logfile
-	logger.info(output)
+        logger.info(output)
 
     if stat != 0:
-	if logfile:
-	    expect(False, "{} FAILED, cat {}".format(fullcmd, logfile))
-	else:
-	    expect(False, "{} FAILED, see above".format(fullcmd))
+        if logfile:
+            expect(False, "{} FAILED, cat {}".format(fullcmd, logfile))
+        else:
+            expect(False, "{} FAILED, see above".format(fullcmd))
 
     # refresh case xml object from file
     if case is not None:
-	case.read_xml()
+        case.read_xml()
 
 def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
-	    arg_stdout=_hack, arg_stderr=_hack, env=None,
-	    combine_output=False, timeout=None):
+            arg_stdout=_hack, arg_stderr=_hack, env=None,
+            combine_output=False, timeout=None):
     """
     Wrapper around subprocess to make it much more convenient to run shell commands
 
@@ -469,92 +469,92 @@ def run_cmd(cmd, input_str=None, from_dir=None, verbose=None,
 
     # Real defaults for these value should be subprocess.PIPE
     if arg_stdout is _hack:
-	arg_stdout = subprocess.PIPE
+        arg_stdout = subprocess.PIPE
     elif isinstance(arg_stdout, six.string_types):
-	arg_stdout = _convert_to_fd(arg_stdout, from_dir)
+        arg_stdout = _convert_to_fd(arg_stdout, from_dir)
 
     if arg_stderr is _hack:
-	arg_stderr = subprocess.STDOUT if combine_output else subprocess.PIPE
+        arg_stderr = subprocess.STDOUT if combine_output else subprocess.PIPE
     elif isinstance(arg_stderr, six.string_types):
-	arg_stderr = _convert_to_fd(arg_stdout, from_dir)
+        arg_stderr = _convert_to_fd(arg_stdout, from_dir)
 
     if (verbose != False and (verbose or logger.isEnabledFor(logging.DEBUG))):
-	logger.info("RUN: {}\nFROM: {}".format(cmd, os.getcwd() if from_dir is None else from_dir))
+        logger.info("RUN: {}\nFROM: {}".format(cmd, os.getcwd() if from_dir is None else from_dir))
 
     if (input_str is not None):
-	stdin = subprocess.PIPE
+        stdin = subprocess.PIPE
     else:
-	stdin = None
+        stdin = None
     if timeout:
-	with Timeout(timeout):
-	    proc = subprocess.Popen(cmd,
-				    shell=True,
-				    stdout=arg_stdout,
-				    stderr=arg_stderr,
-				    stdin=stdin,
-				    cwd=from_dir,
-				    env=env)
+        with Timeout(timeout):
+            proc = subprocess.Popen(cmd,
+                                    shell=True,
+                                    stdout=arg_stdout,
+                                    stderr=arg_stderr,
+                                    stdin=stdin,
+                                    cwd=from_dir,
+                                    env=env)
 
-	    output, errput = proc.communicate(input_str)
+            output, errput = proc.communicate(input_str)
     else:
-	proc = subprocess.Popen(cmd,
-				shell=True,
-				stdout=arg_stdout,
-				stderr=arg_stderr,
-				stdin=stdin,
-				cwd=from_dir,
-				env=env)
+        proc = subprocess.Popen(cmd,
+                                shell=True,
+                                stdout=arg_stdout,
+                                stderr=arg_stderr,
+                                stdin=stdin,
+                                cwd=from_dir,
+                                env=env)
 
-	output, errput = proc.communicate(input_str)
+        output, errput = proc.communicate(input_str)
 
     # In Python3, subprocess.communicate returns bytes. We want to work with strings
     # as much as possible, so we convert bytes to string (which is unicode in py3) via
     # decode. For python2, we do NOT want to do this since decode will yield unicode
     # strings which are not necessarily compatible with the system's default base str type.
     if not six.PY2:
-	if output is not None:
-	    try:
-		output = output.decode('utf-8', errors='ignore')
-	    except AttributeError:
-		pass
-	if errput is not None:
-	    try:
-		errput = errput.decode('utf-8', errors='ignore')
-	    except AttributeError:
-		pass
+        if output is not None:
+            try:
+                output = output.decode('utf-8', errors='ignore')
+            except AttributeError:
+                pass
+        if errput is not None:
+            try:
+                errput = errput.decode('utf-8', errors='ignore')
+            except AttributeError:
+                pass
 
     # Always strip outputs
     if output:
-	output = output.strip()
+        output = output.strip()
     if errput:
-	errput = errput.strip()
+        errput = errput.strip()
 
     stat = proc.wait()
     if six.PY2:
-	if isinstance(arg_stdout, file): # pylint: disable=undefined-variable
-	    arg_stdout.close() # pylint: disable=no-member
-	if isinstance(arg_stderr, file) and arg_stderr is not arg_stdout: # pylint: disable=undefined-variable
-	    arg_stderr.close() # pylint: disable=no-member
+        if isinstance(arg_stdout, file): # pylint: disable=undefined-variable
+            arg_stdout.close() # pylint: disable=no-member
+        if isinstance(arg_stderr, file) and arg_stderr is not arg_stdout: # pylint: disable=undefined-variable
+            arg_stderr.close() # pylint: disable=no-member
     else:
-	if isinstance(arg_stdout, io.IOBase):
-	    arg_stdout.close() # pylint: disable=no-member
-	if isinstance(arg_stderr, io.IOBase) and arg_stderr is not arg_stdout:
-	    arg_stderr.close() # pylint: disable=no-member
+        if isinstance(arg_stdout, io.IOBase):
+            arg_stdout.close() # pylint: disable=no-member
+        if isinstance(arg_stderr, io.IOBase) and arg_stderr is not arg_stdout:
+            arg_stderr.close() # pylint: disable=no-member
 
 
     if (verbose != False and (verbose or logger.isEnabledFor(logging.DEBUG))):
-	if stat != 0:
-	    logger.info("  stat: {:d}\n".format(stat))
-	if output:
-	    logger.info("  output: {}\n".format(output))
-	if errput:
-	    logger.info("  errput: {}\n".format(errput))
+        if stat != 0:
+            logger.info("  stat: {:d}\n".format(stat))
+        if output:
+            logger.info("  output: {}\n".format(output))
+        if errput:
+            logger.info("  errput: {}\n".format(errput))
 
     return stat, output, errput
 
 def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
-		    arg_stdout=_hack, arg_stderr=_hack, env=None,
-		    combine_output=False, timeout=None):
+                    arg_stdout=_hack, arg_stderr=_hack, env=None,
+                    combine_output=False, timeout=None):
     """
     Wrapper around subprocess to make it much more convenient to run shell commands.
     Expects command to work. Just returns output string.
@@ -563,7 +563,7 @@ def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
     True
     >>> run_cmd_no_fail('echo THE ERROR >&2; false') # doctest:+ELLIPSIS +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-	...
+        ...
     CIMEError: ERROR: Command: 'echo THE ERROR >&2; false' failed with error ...
 
     >>> run_cmd_no_fail('grep foo', input_str=b'foo') == 'foo'
@@ -572,23 +572,23 @@ def run_cmd_no_fail(cmd, input_str=None, from_dir=None, verbose=None,
     True
     """
     stat, output, errput = run_cmd(cmd, input_str, from_dir, verbose, arg_stdout,
-				   arg_stderr, env, combine_output, timeout=timeout)
+                                   arg_stderr, env, combine_output, timeout=timeout)
     if stat != 0:
-	# If command produced no errput, put output in the exception since we
-	# have nothing else to go on.
-	errput = output if not errput else errput
-	if errput is None:
-	    if combine_output:
-		if isinstance(arg_stdout, six.string_types):
-		    errput = "See {}".format(_get_path(arg_stdout, from_dir))
-		else:
-		    errput = ""
-	    elif isinstance(arg_stderr, six.string_types):
-		errput = "See {}".format(_get_path(arg_stderr, from_dir))
-	    else:
-		errput = ""
+        # If command produced no errput, put output in the exception since we
+        # have nothing else to go on.
+        errput = output if not errput else errput
+        if errput is None:
+            if combine_output:
+                if isinstance(arg_stdout, six.string_types):
+                    errput = "See {}".format(_get_path(arg_stdout, from_dir))
+                else:
+                    errput = ""
+            elif isinstance(arg_stderr, six.string_types):
+                errput = "See {}".format(_get_path(arg_stderr, from_dir))
+            else:
+                errput = ""
 
-	expect(False, "Command: '{}' failed with error '{}' from dir '{}'".format(cmd, errput, os.getcwd() if from_dir is None else from_dir))
+        expect(False, "Command: '{}' failed with error '{}' from dir '{}'".format(cmd, errput, os.getcwd() if from_dir is None else from_dir))
 
     return output
 
@@ -601,7 +601,7 @@ def check_minimum_python_version(major, minor):
     """
     msg = "Python " + str(major) + ", minor version " + str(minor) + " is required, you have " + str(sys.version_info[0]) + "." + str(sys.version_info[1])
     expect(sys.version_info[0] > major or
-	   (sys.version_info[0] == major and sys.version_info[1] >= minor), msg)
+           (sys.version_info[0] == major and sys.version_info[1] >= minor), msg)
 
 def normalize_case_id(case_id):
     """
@@ -618,11 +618,11 @@ def normalize_case_id(case_id):
     """
     sep_count = case_id.count(".")
     expect(sep_count >= 3 and sep_count <= 6,
-	   "Case '{}' needs to be in form: TESTCASE.GRID.COMPSET.PLATFORM[.TESTMOD]  or  TESTCASE.GRID.COMPSET.PLATFORM[.TESTMOD].GC.TESTID".format(case_id))
+           "Case '{}' needs to be in form: TESTCASE.GRID.COMPSET.PLATFORM[.TESTMOD]  or  TESTCASE.GRID.COMPSET.PLATFORM[.TESTMOD].GC.TESTID".format(case_id))
     if (sep_count in [5, 6]):
-	return ".".join(case_id.split(".")[:-2])
+        return ".".join(case_id.split(".")[:-2])
     else:
-	return case_id
+        return case_id
 
 def parse_test_name(test_name):
     """
@@ -649,11 +649,11 @@ def parse_test_name(test_name):
     ['ERS', None, 'fe12_123', 'JGF', 'machine', 'compiler', 'test/mods']
     >>> parse_test_name('SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-	...
+        ...
     CIMEError: ERROR: Expected 4th item of 'SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods' ('A_XLND_SICE_SOCN_XROF_XGLC_SWAV') to be in form machine_compiler
     >>> parse_test_name('SMS.f19_g16.2000_DATM%QI/A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
-	...
+        ...
     CIMEError: ERROR: Invalid compset name 2000_DATM%QI/A_XLND_SICE_SOCN_XROF_XGLC_SWAV
     """
     rv = [None] * 7
@@ -664,23 +664,23 @@ def parse_test_name(test_name):
     rv.insert(1, None) # Make room for caseopts
     rv.pop()
     if (testcase_field_underscores > 0):
-	full_str = rv[0]
-	rv[0]    = full_str.split("_")[0]
-	rv[1]    = full_str.split("_")[1:]
+        full_str = rv[0]
+        rv[0]    = full_str.split("_")[0]
+        rv[1]    = full_str.split("_")[1:]
 
     if (num_dots >= 3):
-	expect(check_name( rv[3] ), "Invalid compset name {}".format(rv[3]))
+        expect(check_name( rv[3] ), "Invalid compset name {}".format(rv[3]))
 
-	expect(rv[4].count("_") == 1,
-	       "Expected 4th item of '{}' ('{}') to be in form machine_compiler".format(test_name, rv[4]))
-	rv[4:5] = rv[4].split("_")
-	rv.pop()
+        expect(rv[4].count("_") == 1,
+               "Expected 4th item of '{}' ('{}') to be in form machine_compiler".format(test_name, rv[4]))
+        rv[4:5] = rv[4].split("_")
+        rv.pop()
 
     if (rv[-1] is not None):
-	rv[-1] = rv[-1].replace("-", "/")
+        rv[-1] = rv[-1].replace("-", "/")
 
     expect(num_dots <= 4,
-	   "'{}' does not look like a CIME test name, expect TESTCASE.GRID.COMPSET[.MACHINE_COMPILER[.TESTMODS]]".format(test_name))
+           "'{}' does not look like a CIME test name, expect TESTCASE.GRID.COMPSET[.MACHINE_COMPILER[.TESTMODS]]".format(test_name))
 
     return rv
 
@@ -705,43 +705,43 @@ def get_full_test_name(partial_test, caseopts=None, grid=None, compset=None, mac
     partial_testcase, partial_caseopts, partial_grid, partial_compset, partial_machine, partial_compiler, partial_testmod = parse_test_name(partial_test)
 
     required_fields = [
-	(partial_grid, grid, "grid"),
-	(partial_compset, compset, "compset"),
-	(partial_machine, machine, "machine"),
-	(partial_compiler, compiler, "compiler"),
-	]
+        (partial_grid, grid, "grid"),
+        (partial_compset, compset, "compset"),
+        (partial_machine, machine, "machine"),
+        (partial_compiler, compiler, "compiler"),
+        ]
 
     result = partial_test
 
     for partial_val, arg_val, name in required_fields:
-	if (partial_val is None):
-	    # Add to result based on args
-	    expect(arg_val is not None,
-		   "Could not fill-out test name, partial string '{}' had no {} information and you did not provide any".format(partial_test, name))
-	    result = "{}{}{}".format(result, "_" if name == "compiler" else ".", arg_val)
-	elif (arg_val is not None and partial_val != partial_compiler):
-	    expect(arg_val == partial_val,
-		   "Mismatch in field {}, partial string '{}' indicated it should be '{}' but you provided '{}'".format(name, partial_test, partial_val, arg_val))
+        if (partial_val is None):
+            # Add to result based on args
+            expect(arg_val is not None,
+                   "Could not fill-out test name, partial string '{}' had no {} information and you did not provide any".format(partial_test, name))
+            result = "{}{}{}".format(result, "_" if name == "compiler" else ".", arg_val)
+        elif (arg_val is not None and partial_val != partial_compiler):
+            expect(arg_val == partial_val,
+                   "Mismatch in field {}, partial string '{}' indicated it should be '{}' but you provided '{}'".format(name, partial_test, partial_val, arg_val))
 
     if (partial_testmod is None):
-	if (testmod is None):
-	    # No testmod for this test and that's OK
-	    pass
-	else:
-	    result += ".{}".format(testmod.replace("/", "-"))
+        if (testmod is None):
+            # No testmod for this test and that's OK
+            pass
+        else:
+            result += ".{}".format(testmod.replace("/", "-"))
     elif (testmod is not None):
-	expect(testmod == partial_testmod,
-	       "Mismatch in field testmod, partial string '{}' indicated it should be '{}' but you provided '{}'".format(partial_test, partial_testmod, testmod))
+        expect(testmod == partial_testmod,
+               "Mismatch in field testmod, partial string '{}' indicated it should be '{}' but you provided '{}'".format(partial_test, partial_testmod, testmod))
 
     if (partial_caseopts is None):
-	if caseopts is None:
-	    # No casemods for this test and that's OK
-	    pass
-	else:
-	    result = result.replace(partial_testcase, "{}_{}".format(partial_testcase, "_".join(caseopts)), 1)
+        if caseopts is None:
+            # No casemods for this test and that's OK
+            pass
+        else:
+            result = result.replace(partial_testcase, "{}_{}".format(partial_testcase, "_".join(caseopts)), 1)
     elif caseopts is not None:
-	expect(caseopts == partial_caseopts,
-	       "Mismatch in field caseopts, partial string '{}' indicated it should be '{}' but you provided '{}'".format(partial_test, partial_caseopts, caseopts))
+        expect(caseopts == partial_caseopts,
+               "Mismatch in field caseopts, partial string '{}' indicated it should be '{}' but you provided '{}'".format(partial_test, partial_caseopts, caseopts))
 
     return result
 
@@ -757,19 +757,19 @@ def get_current_branch(repo=None):
     True
     """
     if ("GIT_BRANCH" in os.environ):
-	# This approach works better for Jenkins jobs because the Jenkins
-	# git plugin does not use local tracking branches, it just checks out
-	# to a commit
-	branch = os.environ["GIT_BRANCH"]
-	if (branch.startswith("origin/")):
-	    branch = branch.replace("origin/", "", 1)
-	return branch
+        # This approach works better for Jenkins jobs because the Jenkins
+        # git plugin does not use local tracking branches, it just checks out
+        # to a commit
+        branch = os.environ["GIT_BRANCH"]
+        if (branch.startswith("origin/")):
+            branch = branch.replace("origin/", "", 1)
+        return branch
     else:
-	stat, output, _ = run_cmd("git symbolic-ref HEAD", from_dir=repo)
-	if (stat != 0):
-	    return None
-	else:
-	    return output.replace("refs/heads/", "")
+        stat, output, _ = run_cmd("git symbolic-ref HEAD", from_dir=repo)
+        if (stat != 0):
+            return None
+        else:
+            return output.replace("refs/heads/", "")
 
 def get_current_commit(short=False, repo=None, tag=False):
     """
@@ -779,9 +779,9 @@ def get_current_commit(short=False, repo=None, tag=False):
     True
     """
     if tag:
-	rc, output, _ = run_cmd("git describe --tags $(git log -n1 --pretty='%h')", from_dir=repo)
+        rc, output, _ = run_cmd("git describe --tags $(git log -n1 --pretty='%h')", from_dir=repo)
     else:
-	rc, output, _ = run_cmd("git rev-parse {} HEAD".format("--short" if short else ""), from_dir=repo)
+        rc, output, _ = run_cmd("git rev-parse {} HEAD".format("--short" if short else ""), from_dir=repo)
 
     return output if rc == 0 else "unknown"
 
@@ -856,9 +856,9 @@ def match_any(item, re_list):
     Return true if item matches any regex in re_list
     """
     for regex_str in re_list:
-	regex = re.compile(regex_str)
-	if (regex.match(item)):
-	    return True
+        regex = re.compile(regex_str)
+        if (regex.match(item)):
+            return True
 
     return False
 
@@ -883,34 +883,34 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
 
     # Handle pre-existing file
     if os.path.isfile(tgt_path):
-	st = os.stat(tgt_path)
-	owner_uid = st.st_uid
+        st = os.stat(tgt_path)
+        owner_uid = st.st_uid
 
-	# Handle read-only files if possible
-	if not os.access(tgt_path, os.W_OK):
-	    if owner_uid == os.getuid():
-		# I am the owner, make writeable
-		os.chmod(tgt_path, st.st_mode | statlib.S_IWRITE)
-	    else:
-		# I won't be able to copy this file
-		raise OSError("Cannot copy over file {}, it is readonly and you are not the owner".format(tgt_path))
+        # Handle read-only files if possible
+        if not os.access(tgt_path, os.W_OK):
+            if owner_uid == os.getuid():
+                # I am the owner, make writeable
+                os.chmod(tgt_path, st.st_mode | statlib.S_IWRITE)
+            else:
+                # I won't be able to copy this file
+                raise OSError("Cannot copy over file {}, it is readonly and you are not the owner".format(tgt_path))
 
-	if owner_uid == os.getuid():
-	    # I am the owner, copy file contents, permissions, and metadata
-	    file_util.copy_file(src_path, tgt_path, preserve_mode=preserve_meta, preserve_times=preserve_meta)
-	else:
-	    # I am not the owner, just copy file contents
-	    shutil.copyfile(src_path, tgt_path)
+        if owner_uid == os.getuid():
+            # I am the owner, copy file contents, permissions, and metadata
+            file_util.copy_file(src_path, tgt_path, preserve_mode=preserve_meta, preserve_times=preserve_meta)
+        else:
+            # I am not the owner, just copy file contents
+            shutil.copyfile(src_path, tgt_path)
 
     else:
-	# We are making a new file, copy file contents, permissions, and metadata.
-	# This can fail if the underlying directory is not writable by current user.
-	file_util.copy_file(src_path, tgt_path, preserve_mode=preserve_meta, preserve_times=preserve_meta)
+        # We are making a new file, copy file contents, permissions, and metadata.
+        # This can fail if the underlying directory is not writable by current user.
+        file_util.copy_file(src_path, tgt_path, preserve_mode=preserve_meta, preserve_times=preserve_meta)
 
     # If src file was executable, then the tgt file should be too
     st = os.stat(tgt_path)
     if os.access(src_path, os.X_OK) and st.st_uid == os.getuid():
-	os.chmod(tgt_path, st.st_mode | statlib.S_IXUSR | statlib.S_IXGRP | statlib.S_IXOTH)
+        os.chmod(tgt_path, st.st_mode | statlib.S_IXUSR | statlib.S_IXGRP | statlib.S_IXOTH)
 
 def safe_recursive_copy(src_dir, tgt_dir, file_map):
     """
@@ -919,10 +919,10 @@ def safe_recursive_copy(src_dir, tgt_dir, file_map):
     matched on the tgt side.
     """
     for src_file, tgt_file in file_map:
-	full_tgt = os.path.join(tgt_dir, tgt_file)
-	full_src = src_file if os.path.isabs(src_file) else os.path.join(src_dir, src_file)
-	expect(os.path.isfile(full_src), "Source dir '{}' missing file '{}'".format(src_dir, src_file))
-	safe_copy(full_src, full_tgt)
+        full_tgt = os.path.join(tgt_dir, tgt_file)
+        full_src = src_file if os.path.isabs(src_file) else os.path.join(src_dir, src_file)
+        expect(os.path.isfile(full_src), "Source dir '{}' missing file '{}'".format(src_dir, src_file))
+        safe_copy(full_src, full_tgt)
 
 def symlink_force(target, link_name):
     """
@@ -931,40 +931,40 @@ def symlink_force(target, link_name):
     which case link_name will be overwritten).
     """
     try:
-	os.symlink(target, link_name)
+        os.symlink(target, link_name)
     except OSError as e:
-	if e.errno == errno.EEXIST:
-	    os.remove(link_name)
-	    os.symlink(target, link_name)
-	else:
-	    raise e
+        if e.errno == errno.EEXIST:
+            os.remove(link_name)
+            os.symlink(target, link_name)
+        else:
+            raise e
 
 def find_proc_id(proc_name=None,
-		 children_only=False,
-		 of_parent=None):
+                 children_only=False,
+                 of_parent=None):
     """
     Children implies recursive.
     """
     expect(proc_name is not None or children_only,
-	   "Must provide proc_name if not searching for children")
+           "Must provide proc_name if not searching for children")
     expect(not (of_parent is not None and not children_only),
-	   "of_parent only used with children_only")
+           "of_parent only used with children_only")
 
     parent = of_parent if of_parent is not None else os.getpid()
 
     pgrep_cmd = "pgrep {} {}".format(proc_name if proc_name is not None else "",
-				 "-P {:d}".format(parent if children_only else ""))
+                                 "-P {:d}".format(parent if children_only else ""))
     stat, output, errput = run_cmd(pgrep_cmd)
     expect(stat in [0, 1], "pgrep failed with error: '{}'".format(errput))
 
     rv = set([int(item.strip()) for item in output.splitlines()])
     if (children_only):
-	pgrep_cmd = "pgrep -P {}".format(parent)
-	stat, output, errput = run_cmd(pgrep_cmd)
-	expect(stat in [0, 1], "pgrep failed with error: '{}'".format(errput))
+        pgrep_cmd = "pgrep -P {}".format(parent)
+        stat, output, errput = run_cmd(pgrep_cmd)
+        expect(stat in [0, 1], "pgrep failed with error: '{}'".format(errput))
 
-	for child in output.splitlines():
-	    rv = rv.union(set(find_proc_id(proc_name, children_only, int(child.strip()))))
+        for child in output.splitlines():
+            rv = rv.union(set(find_proc_id(proc_name, children_only, int(child.strip()))))
 
     return list(rv)
 
@@ -975,9 +975,9 @@ def get_timestamp(timestamp_format="%Y%m%d_%H%M%S", utc_time=False):
     The format can be changed if needed.
     """
     if utc_time:
-	time_tuple = time.gmtime()
+        time_tuple = time.gmtime()
     else:
-	time_tuple = time.localtime()
+        time_tuple = time.localtime()
     return time.strftime(timestamp_format, time_tuple)
 
 def get_project(machobj=None):
@@ -992,37 +992,37 @@ def get_project(machobj=None):
     """
     project = os.environ.get("PROJECT")
     if (project is not None):
-	logger.info("Using project from env PROJECT: " + project)
-	return project
+        logger.info("Using project from env PROJECT: " + project)
+        return project
     project = os.environ.get("ACCOUNT")
     if (project is not None):
-	logger.info("Using project from env ACCOUNT: " + project)
-	return project
+        logger.info("Using project from env ACCOUNT: " + project)
+        return project
 
     cime_config = get_cime_config()
     if (cime_config.has_option('main','PROJECT')):
-	project = cime_config.get('main','PROJECT')
-	if (project is not None):
-	    logger.info("Using project from .cime/config: " + project)
-	    return project
+        project = cime_config.get('main','PROJECT')
+        if (project is not None):
+            logger.info("Using project from .cime/config: " + project)
+            return project
 
     projectfile = os.path.abspath(os.path.join(os.path.expanduser("~"), ".cesm_proj"))
     if (os.path.isfile(projectfile)):
-	with open(projectfile,'r') as myfile:
-	    for line in myfile:
-		project = line.rstrip()
-		if not project.startswith("#"):
-		    break
-	if (project is not None):
-	    logger.info("Using project from .cesm_proj: " + project)
-	    cime_config.set('main','PROJECT',project)
-	    return project
+        with open(projectfile,'r') as myfile:
+            for line in myfile:
+                project = line.rstrip()
+                if not project.startswith("#"):
+                    break
+        if (project is not None):
+            logger.info("Using project from .cesm_proj: " + project)
+            cime_config.set('main','PROJECT',project)
+            return project
 
     if machobj is not None:
-	project = machobj.get_value("PROJECT")
-	if project is not None:
-	    logger.info("Using project from config_machines.xml: " + project)
-	    return project
+        project = machobj.get_value("PROJECT")
+        if project is not None:
+            logger.info("Using project from config_machines.xml: " + project)
+            return project
 
     logger.info("No project info available")
     return None
@@ -1049,21 +1049,21 @@ def get_charge_account(machobj=None, project=None):
     """
     charge_account = os.environ.get("CHARGE_ACCOUNT")
     if (charge_account is not None):
-	logger.info("Using charge_account from env CHARGE_ACCOUNT: " + charge_account)
-	return charge_account
+        logger.info("Using charge_account from env CHARGE_ACCOUNT: " + charge_account)
+        return charge_account
 
     cime_config = get_cime_config()
     if (cime_config.has_option('main','CHARGE_ACCOUNT')):
-	charge_account = cime_config.get('main','CHARGE_ACCOUNT')
-	if (charge_account is not None):
-	    logger.info("Using charge_account from .cime/config: " + charge_account)
-	    return charge_account
+        charge_account = cime_config.get('main','CHARGE_ACCOUNT')
+        if (charge_account is not None):
+            logger.info("Using charge_account from .cime/config: " + charge_account)
+            return charge_account
 
     if machobj is not None:
-	charge_account = machobj.get_value("CHARGE_ACCOUNT")
-	if charge_account is not None:
-	    logger.info("Using charge_account from config_machines.xml: " + charge_account)
-	    return charge_account
+        charge_account = machobj.get_value("CHARGE_ACCOUNT")
+        if charge_account is not None:
+            logger.info("Using charge_account from config_machines.xml: " + charge_account)
+            return charge_account
 
     logger.info("No charge_account info available, using value from PROJECT")
     return project
@@ -1074,9 +1074,9 @@ def find_files(rootdir, pattern):
     """
     result = []
     for root, _, files in os.walk(rootdir):
-	for filename in files:
-	    if (fnmatch.fnmatch(filename, pattern)):
-		result.append(os.path.join(root, filename))
+        for filename in files:
+            if (fnmatch.fnmatch(filename, pattern)):
+                result.append(os.path.join(root, filename))
 
     return result
 
@@ -1084,20 +1084,20 @@ def find_files(rootdir, pattern):
 def setup_standard_logging_options(parser):
     helpfile = os.path.join(os.getcwd(),os.path.basename("{}.log".format(sys.argv[0])))
     parser.add_argument("-d", "--debug", action="store_true",
-			help="Print debug information (very verbose) to file {}".format(helpfile))
+                        help="Print debug information (very verbose) to file {}".format(helpfile))
     parser.add_argument("-v", "--verbose", action="store_true",
-			help="Add additional context (time and file) to log messages")
+                        help="Add additional context (time and file) to log messages")
     parser.add_argument("-s", "--silent", action="store_true",
-			help="Print only warnings and error messages")
+                        help="Print only warnings and error messages")
 
 class _LessThanFilter(logging.Filter):
     def __init__(self, exclusive_maximum, name=""):
-	super(_LessThanFilter, self).__init__(name)
-	self.max_level = exclusive_maximum
+        super(_LessThanFilter, self).__init__(name)
+        self.max_level = exclusive_maximum
 
     def filter(self, record):
-	#non-zero return means we log this message
-	return 1 if record.levelno < self.max_level else 0
+        #non-zero return means we log this message
+        return 1 if record.levelno < self.max_level else 0
 
 def parse_args_and_handle_standard_logging_options(args, parser=None):
     """
@@ -1111,7 +1111,7 @@ def parse_args_and_handle_standard_logging_options(args, parser=None):
     root_logger = logging.getLogger()
 
     verbose_formatter   = logging.Formatter(fmt='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-					    datefmt='%m-%d %H:%M')
+                                            datefmt='%m-%d %H:%M')
 
     # Change info to go to stdout. This handle applies to INFO exclusively
     stdout_stream_handler = logging.StreamHandler(stream=sys.stdout)
@@ -1124,32 +1124,32 @@ def parse_args_and_handle_standard_logging_options(args, parser=None):
 
     # scripts_regression_tests is the only thing that should pass a None argument in parser
     if parser is not None:
-	if "--help" not in args[1:]:
-	    _check_for_invalid_args(args[1:])
-	args = parser.parse_args(args[1:])
+        if "--help" not in args[1:]:
+            _check_for_invalid_args(args[1:])
+        args = parser.parse_args(args[1:])
 
     # --verbose adds to the message format but does not impact the log level
     if args.verbose:
-	stdout_stream_handler.setFormatter(verbose_formatter)
-	stderr_stream_handler.setFormatter(verbose_formatter)
+        stdout_stream_handler.setFormatter(verbose_formatter)
+        stderr_stream_handler.setFormatter(verbose_formatter)
 
     root_logger.addHandler(stdout_stream_handler)
     root_logger.addHandler(stderr_stream_handler)
 
     if args.debug:
-	# Set up log file to catch ALL logging records
-	log_file = "{}.log".format(os.path.basename(sys.argv[0]))
+        # Set up log file to catch ALL logging records
+        log_file = "{}.log".format(os.path.basename(sys.argv[0]))
 
-	debug_log_handler = logging.FileHandler(log_file, mode='w')
-	debug_log_handler.setFormatter(verbose_formatter)
-	debug_log_handler.setLevel(logging.DEBUG)
-	root_logger.addHandler(debug_log_handler)
+        debug_log_handler = logging.FileHandler(log_file, mode='w')
+        debug_log_handler.setFormatter(verbose_formatter)
+        debug_log_handler.setLevel(logging.DEBUG)
+        root_logger.addHandler(debug_log_handler)
 
-	root_logger.setLevel(logging.DEBUG)
+        root_logger.setLevel(logging.DEBUG)
     elif args.silent:
-	root_logger.setLevel(logging.WARN)
+        root_logger.setLevel(logging.WARN)
     else:
-	root_logger.setLevel(logging.INFO)
+        root_logger.setLevel(logging.INFO)
     return args
 
 def get_logging_options():
@@ -1160,11 +1160,11 @@ def get_logging_options():
     root_logger = logging.getLogger()
 
     if (root_logger.level == logging.DEBUG):
-	return "--debug"
+        return "--debug"
     elif (root_logger.level == logging.WARN):
-	return "--silent"
+        return "--silent"
     else:
-	return ""
+        return ""
 
 def convert_to_type(value, type_str, vid=""):
     """
@@ -1173,28 +1173,28 @@ def convert_to_type(value, type_str, vid=""):
     """
     if value is not None:
 
-	if type_str == "char":
-	    pass
+        if type_str == "char":
+            pass
 
-	elif type_str == "integer":
-	    try:
-		value = int(eval(value))
-	    except Exception:
-		expect(False, "Entry {} was listed as type int but value '{}' is not valid int".format(vid, value))
+        elif type_str == "integer":
+            try:
+                value = int(eval(value))
+            except Exception:
+                expect(False, "Entry {} was listed as type int but value '{}' is not valid int".format(vid, value))
 
-	elif type_str == "logical":
-	    expect(value.upper() in ["TRUE", "FALSE"],
-		   "Entry {} was listed as type logical but had val '{}' instead of TRUE or FALSE".format(vid, value))
-	    value = value.upper() == "TRUE"
+        elif type_str == "logical":
+            expect(value.upper() in ["TRUE", "FALSE"],
+                   "Entry {} was listed as type logical but had val '{}' instead of TRUE or FALSE".format(vid, value))
+            value = value.upper() == "TRUE"
 
-	elif type_str == "real":
-	    try:
-		value = float(value)
-	    except Exception:
-		expect(False, "Entry {} was listed as type real but value '{}' is not valid real".format(vid, value))
+        elif type_str == "real":
+            try:
+                value = float(value)
+            except Exception:
+                expect(False, "Entry {} was listed as type real but value '{}' is not valid real".format(vid, value))
 
-	else:
-	    expect(False, "Unknown type '{}'".format(type_str))
+        else:
+            expect(False, "Unknown type '{}'".format(type_str))
 
     return value
 
@@ -1204,27 +1204,27 @@ def convert_to_unknown_type(value):
     """
     if value is not None:
 
-	# Attempt to convert to logical
-	if value.upper() in ["TRUE", "FALSE"]:
-	    return value.upper() == "TRUE"
+        # Attempt to convert to logical
+        if value.upper() in ["TRUE", "FALSE"]:
+            return value.upper() == "TRUE"
 
-	# Attempt to convert to integer
-	try:
-	    value = int(eval(value))
-	except Exception:
-	    pass
-	else:
-	    return value
+        # Attempt to convert to integer
+        try:
+            value = int(eval(value))
+        except Exception:
+            pass
+        else:
+            return value
 
-	# Attempt to convert to float
-	try:
-	    value = float(value)
-	except Exception:
-	    pass
-	else:
-	    return value
+        # Attempt to convert to float
+        try:
+            value = float(value)
+        except Exception:
+            pass
+        else:
+            return value
 
-	# Just treat as string
+        # Just treat as string
 
     return value
 
@@ -1242,22 +1242,22 @@ def convert_to_string(value, type_str=None, vid=""):
     True
     """
     if value is not None and not isinstance(value, six.string_types):
-	if type_str == "char":
-	    expect(isinstance(value, six.string_types), "Wrong type for entry id '{}'".format(vid))
-	elif type_str == "integer":
-	    expect(isinstance(value, six.integer_types), "Wrong type for entry id '{}'".format(vid))
-	    value = str(value)
-	elif type_str == "logical":
-	    expect(type(value) is bool, "Wrong type for entry id '{}'".format(vid))
-	    value = "TRUE" if value else "FALSE"
-	elif type_str == "real":
-	    expect(type(value) is float, "Wrong type for entry id '{}'".format(vid))
-	    value = str(value)
-	else:
-	    expect(False, "Unknown type '{}'".format(type_str))
+        if type_str == "char":
+            expect(isinstance(value, six.string_types), "Wrong type for entry id '{}'".format(vid))
+        elif type_str == "integer":
+            expect(isinstance(value, six.integer_types), "Wrong type for entry id '{}'".format(vid))
+            value = str(value)
+        elif type_str == "logical":
+            expect(type(value) is bool, "Wrong type for entry id '{}'".format(vid))
+            value = "TRUE" if value else "FALSE"
+        elif type_str == "real":
+            expect(type(value) is float, "Wrong type for entry id '{}'".format(vid))
+            value = str(value)
+        else:
+            expect(False, "Unknown type '{}'".format(type_str))
     if value is None:
-	value = ""
-	logger.debug("Attempt to convert None value for vid {} {}".format(vid,value))
+        value = ""
+        logger.debug("Attempt to convert None value for vid {} {}".format(vid,value))
 
     return value
 
@@ -1281,7 +1281,7 @@ def convert_to_seconds(time_str):
     result = 0
     starting_exp = 1 if len(components) == 2 else 0
     for idx, component in enumerate(components):
-	result += int(component) * pow(60, idx + starting_exp)
+        result += int(component) * pow(60, idx + starting_exp)
 
     return result
 
@@ -1304,17 +1304,17 @@ def get_time_in_seconds(timeval, unit):
     Convert a time from 'unit' to seconds
     """
     if 'nyear' in unit:
-	dmult = 365 * 24 * 3600
+        dmult = 365 * 24 * 3600
     elif 'nmonth' in unit:
-	dmult = 30 * 24 * 3600
+        dmult = 30 * 24 * 3600
     elif 'nday' in unit:
-	dmult = 24 * 3600
+        dmult = 24 * 3600
     elif 'nhour' in unit:
-	dmult = 3600
+        dmult = 3600
     elif 'nminute' in unit:
-	dmult = 60
+        dmult = 60
     else:
-	dmult = 1
+        dmult = 1
 
     return dmult * timeval
 
@@ -1335,28 +1335,28 @@ def compute_total_time(job_cost_map, proc_pool):
     waiting_jobs = dict(job_cost_map)
     running_jobs = {} # name -> (procs, est-time, start-time)
     while len(waiting_jobs) > 0 or len(running_jobs) > 0:
-	launched_jobs = []
-	for jobname, data in waiting_jobs.items():
-	    procs_for_job, time_for_job = data
-	    if procs_for_job <= proc_pool:
-		proc_pool -= procs_for_job
-		launched_jobs.append(jobname)
-		running_jobs[jobname] = (procs_for_job, time_for_job, current_time)
+        launched_jobs = []
+        for jobname, data in waiting_jobs.items():
+            procs_for_job, time_for_job = data
+            if procs_for_job <= proc_pool:
+                proc_pool -= procs_for_job
+                launched_jobs.append(jobname)
+                running_jobs[jobname] = (procs_for_job, time_for_job, current_time)
 
-	for launched_job in launched_jobs:
-	    del waiting_jobs[launched_job]
+        for launched_job in launched_jobs:
+            del waiting_jobs[launched_job]
 
-	completed_jobs = []
-	for jobname, data in running_jobs.items():
-	    procs_for_job, time_for_job, time_started = data
-	    if (current_time - time_started) >= time_for_job:
-		proc_pool += procs_for_job
-		completed_jobs.append(jobname)
+        completed_jobs = []
+        for jobname, data in running_jobs.items():
+            procs_for_job, time_for_job, time_started = data
+            if (current_time - time_started) >= time_for_job:
+                proc_pool += procs_for_job
+                completed_jobs.append(jobname)
 
-	for completed_job in completed_jobs:
-	    del running_jobs[completed_job]
+        for completed_job in completed_jobs:
+            del running_jobs[completed_job]
 
-	current_time += 60 # minute time step
+        current_time += 60 # minute time step
 
     return current_time
 
@@ -1380,7 +1380,7 @@ def format_time(time_format, input_format, input_time):
     """
     input_fields = input_format.split("%")
     expect(input_fields[0] == input_time[:len(input_fields[0])],
-	   "Failed to parse the input time '{}'; does not match the header string '{}'".format(input_time, input_format))
+           "Failed to parse the input time '{}'; does not match the header string '{}'".format(input_time, input_format))
     input_time = input_time[len(input_fields[0]):]
     timespec = {"H": None, "M": None, "S": None}
     maxvals = {"M": 60, "S": 60}
@@ -1389,27 +1389,27 @@ def format_time(time_format, input_format, input_time):
     # field starts with H, M, or S
     # input_time starts with a number corresponding with the start of field
     for field in input_fields[1:]:
-	# Find all of the digits at the start of the string
-	spec = field[0]
-	value_re = re.match(r'\d*', input_time)
-	expect(value_re is not None,
-	       "Failed to parse the input time for the '{}' specifier, expected an integer".format(spec))
-	value = value_re.group(0)
-	expect(spec in timespec, "Unknown time specifier '" + spec + "'")
-	# Don't do anything if the time field is already specified
-	if timespec[spec] is None:
-	    # Verify we aren't exceeding the maximum value
-	    if spec in maxvals:
-		expect(int(value) < maxvals[spec],
-		       "Failed to parse the '{}' specifier: A value less than {:d} is expected".format(spec, maxvals[spec]))
-	    timespec[spec] = value
-	input_time = input_time[len(value):]
-	# Check for the separator string
-	expect(len(re.match(DIGIT_CHECK, field).group(0)) == len(field),
-	       "Numbers are not permissible in separator strings")
-	expect(input_time[:len(field) - 1] == field[1:],
-	       "The separator string ({}) doesn't match '{}'".format(field[1:], input_time))
-	input_time = input_time[len(field) - 1:]
+        # Find all of the digits at the start of the string
+        spec = field[0]
+        value_re = re.match(r'\d*', input_time)
+        expect(value_re is not None,
+               "Failed to parse the input time for the '{}' specifier, expected an integer".format(spec))
+        value = value_re.group(0)
+        expect(spec in timespec, "Unknown time specifier '" + spec + "'")
+        # Don't do anything if the time field is already specified
+        if timespec[spec] is None:
+            # Verify we aren't exceeding the maximum value
+            if spec in maxvals:
+                expect(int(value) < maxvals[spec],
+                       "Failed to parse the '{}' specifier: A value less than {:d} is expected".format(spec, maxvals[spec]))
+            timespec[spec] = value
+        input_time = input_time[len(value):]
+        # Check for the separator string
+        expect(len(re.match(DIGIT_CHECK, field).group(0)) == len(field),
+               "Numbers are not permissible in separator strings")
+        expect(input_time[:len(field) - 1] == field[1:],
+               "The separator string ({}) doesn't match '{}'".format(field[1:], input_time))
+        input_time = input_time[len(field) - 1:]
     output_fields = time_format.split("%")
     output_time = output_fields[0]
     # Used when a value isn't given
@@ -1418,16 +1418,16 @@ def format_time(time_format, input_format, input_time):
     # field starts with H, M, or S
     # output_time
     for field in output_fields[1:]:
-	expect(field == output_fields[-1] or len(field) > 1,
-	       "Separator strings are required to properly parse times")
-	spec = field[0]
-	expect(spec in timespec, "Unknown time specifier '" + spec + "'")
-	if timespec[spec] is not None:
-	    output_time += "0" * (min_len_spec[spec] - len(timespec[spec]))
-	    output_time += timespec[spec]
-	else:
-	    output_time += "0" * min_len_spec[spec]
-	output_time += field[1:]
+        expect(field == output_fields[-1] or len(field) > 1,
+               "Separator strings are required to properly parse times")
+        spec = field[0]
+        expect(spec in timespec, "Unknown time specifier '" + spec + "'")
+        if timespec[spec] is not None:
+            output_time += "0" * (min_len_spec[spec] - len(timespec[spec]))
+            output_time += timespec[spec]
+        else:
+            output_time += "0" * min_len_spec[spec]
+        output_time += field[1:]
     return output_time
 
 def append_status(msg, sfile, caseroot='.'):
@@ -1441,8 +1441,8 @@ def append_status(msg, sfile, caseroot='.'):
     line_ending = "\n"
 
     with open(os.path.join(caseroot, sfile), "a") as fd:
-	fd.write(ctime + msg + line_ending)
-	fd.write(" ---------------------------------------------------" + line_ending)
+        fd.write(ctime + msg + line_ending)
+        fd.write(" ---------------------------------------------------" + line_ending)
 
 def append_testlog(msg, caseroot='.'):
     """
@@ -1476,18 +1476,18 @@ def is_last_process_complete(filepath, expect_text, fail_text):
 
     findex = re.search(fail_text, rfb)
     if findex is None:
-	findex = 0
+        findex = 0
     else:
-	findex = findex.start()
+        findex = findex.start()
 
     eindex = re.search(expect_text, rfb)
     if eindex is None:
-	eindex = 0
+        eindex = 0
     else:
-	eindex = eindex.start()
+        eindex = eindex.start()
 
     if findex > eindex:
-	complete = True
+        complete = True
 
     return complete
 
@@ -1507,35 +1507,35 @@ def transform_vars(text, case=None, subgroup=None, overrides=None, default=None)
     # loop through directive text, replacing each string enclosed with
     # template characters with the necessary values.
     while directive_re.search(text):
-	m = directive_re.search(text)
-	variable = m.groups()[0]
-	whole_match = m.group()
-	if overrides is not None and variable.lower() in overrides and overrides[variable.lower()] is not None:
-	    repl = overrides[variable.lower()]
-	    logger.debug("from overrides: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
-	    text = text.replace(whole_match, str(repl))
+        m = directive_re.search(text)
+        variable = m.groups()[0]
+        whole_match = m.group()
+        if overrides is not None and variable.lower() in overrides and overrides[variable.lower()] is not None:
+            repl = overrides[variable.lower()]
+            logger.debug("from overrides: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
+            text = text.replace(whole_match, str(repl))
 
-	elif case is not None and hasattr(case, variable.lower()) and getattr(case, variable.lower()) is not None:
-	    repl = getattr(case, variable.lower())
-	    logger.debug("from case members: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
-	    text = text.replace(whole_match, str(repl))
+        elif case is not None and hasattr(case, variable.lower()) and getattr(case, variable.lower()) is not None:
+            repl = getattr(case, variable.lower())
+            logger.debug("from case members: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
+            text = text.replace(whole_match, str(repl))
 
-	elif case is not None and case.get_value(variable.upper(), subgroup=subgroup) is not None:
-	    repl = case.get_value(variable.upper(), subgroup=subgroup)
-	    logger.debug("from case: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
-	    text = text.replace(whole_match, str(repl))
+        elif case is not None and case.get_value(variable.upper(), subgroup=subgroup) is not None:
+            repl = case.get_value(variable.upper(), subgroup=subgroup)
+            logger.debug("from case: in {}, replacing {} with {}".format(text, whole_match, str(repl)))
+            text = text.replace(whole_match, str(repl))
 
-	elif default is not None:
-	    logger.debug("from default: in {}, replacing {} with {}".format(text, whole_match, str(default)))
-	    text = text.replace(whole_match, default)
+        elif default is not None:
+            logger.debug("from default: in {}, replacing {} with {}".format(text, whole_match, str(default)))
+            text = text.replace(whole_match, default)
 
-	else:
-	    # If no queue exists, then the directive '-q' by itself will cause an error
-	    if "-q {{ queue }}" in text:
-		text = ""
-	    else:
-		logger.warning("Could not replace variable '{}'".format(variable))
-		text = text.replace(whole_match, "")
+        else:
+            # If no queue exists, then the directive '-q' by itself will cause an error
+            if "-q {{ queue }}" in text:
+                text = ""
+            else:
+                logger.warning("Could not replace variable '{}'".format(variable))
+                text = text.replace(whole_match, "")
 
     return text
 
@@ -1543,22 +1543,22 @@ def wait_for_unlocked(filepath):
     locked = True
     file_object = None
     while locked:
-	try:
-	    buffer_size = 8
-	    # Opening file in append mode and read the first 8 characters.
-	    file_object = open(filepath, 'a', buffer_size)
-	    if file_object:
-		locked = False
-	except IOError:
-	    locked = True
-	    time.sleep(1)
-	finally:
-	    if file_object:
-		file_object.close()
+        try:
+            buffer_size = 8
+            # Opening file in append mode and read the first 8 characters.
+            file_object = open(filepath, 'a', buffer_size)
+            if file_object:
+                locked = False
+        except IOError:
+            locked = True
+            time.sleep(1)
+        finally:
+            if file_object:
+                file_object.close()
 
 def gunzip_existing_file(filepath):
     with gzip.open(filepath, "rb") as fd:
-	return fd.read()
+        return fd.read()
 
 def gzip_existing_file(filepath):
     """
@@ -1582,8 +1582,8 @@ def gzip_existing_file(filepath):
 
     gzpath = '{}.gz'.format(filepath)
     with open(filepath, "rb") as f_in:
-	with gzip.open(gzpath, "wb") as f_out:
-	    shutil.copyfileobj(f_in, f_out)
+        with gzip.open(gzpath, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
 
     os.remove(filepath)
 
@@ -1593,9 +1593,9 @@ def gzip_existing_file(filepath):
 
 def touch(fname):
     if os.path.exists(fname):
-	os.utime(fname, None)
+        os.utime(fname, None)
     else:
-	open(fname, 'a').close()
+        open(fname, 'a').close()
 
 def find_system_test(testname, case):
     """
@@ -1608,29 +1608,29 @@ def find_system_test(testname, case):
     from importlib import import_module
     system_test_path = None
     if testname.startswith("TEST"):
-	system_test_path =  "CIME.SystemTests.system_tests_common.{}".format(testname)
+        system_test_path =  "CIME.SystemTests.system_tests_common.{}".format(testname)
     else:
-	components = ["any"]
-	components.extend( case.get_compset_components())
-	fdir = []
-	for component in components:
-	    tdir = case.get_value("SYSTEM_TESTS_DIR",
-				      attribute={"component":component})
-	    if tdir is not None:
-		tdir = os.path.abspath(tdir)
-		system_test_file = os.path.join(tdir  ,"{}.py".format(testname.lower()))
-		if os.path.isfile(system_test_file):
-		    fdir.append(tdir)
-		    logger.debug( "found "+system_test_file)
-		    if component == "any":
-			system_test_path = "CIME.SystemTests.{}.{}".format(testname.lower(), testname)
-		    else:
-			system_test_dir = os.path.dirname(system_test_file)
-			if system_test_dir not in sys.path:
-			    sys.path.append(system_test_dir)
-			system_test_path = "{}.{}".format(testname.lower(), testname)
-	expect(len(fdir) > 0, "Test {} not found, aborting".format(testname))
-	expect(len(fdir) == 1, "Test {} found in multiple locations {}, aborting".format(testname, fdir))
+        components = ["any"]
+        components.extend( case.get_compset_components())
+        fdir = []
+        for component in components:
+            tdir = case.get_value("SYSTEM_TESTS_DIR",
+                                      attribute={"component":component})
+            if tdir is not None:
+                tdir = os.path.abspath(tdir)
+                system_test_file = os.path.join(tdir  ,"{}.py".format(testname.lower()))
+                if os.path.isfile(system_test_file):
+                    fdir.append(tdir)
+                    logger.debug( "found "+system_test_file)
+                    if component == "any":
+                        system_test_path = "CIME.SystemTests.{}.{}".format(testname.lower(), testname)
+                    else:
+                        system_test_dir = os.path.dirname(system_test_file)
+                        if system_test_dir not in sys.path:
+                            sys.path.append(system_test_dir)
+                        system_test_path = "{}.{}".format(testname.lower(), testname)
+        expect(len(fdir) > 0, "Test {} not found, aborting".format(testname))
+        expect(len(fdir) == 1, "Test {} found in multiple locations {}, aborting".format(testname, fdir))
     expect(system_test_path is not None, "No test {} found".format(testname))
 
     path, m = system_test_path.rsplit('.',1)
@@ -1648,12 +1648,12 @@ def _get_most_recent_lid_impl(files):
     """
     results = []
     for item in files:
-	basename = os.path.basename(item)
-	components = basename.split(".")
-	if len(components) > 2:
-	    results.append(components[2])
-	else:
-	    logger.warning("Apparent model log file '{}' did not conform to expected name format".format(item))
+        basename = os.path.basename(item)
+        components = basename.split(".")
+        if len(components) > 2:
+            results.append(components[2])
+        else:
+            logger.warning("Apparent model log file '{}' did not conform to expected name format".format(item))
 
     return sorted(list(set(results)))
 
@@ -1671,18 +1671,18 @@ def new_lid():
     lid = time.strftime("%y%m%d-%H%M%S")
     jobid = batch_jobid()
     if jobid is not None:
-	lid = jobid+'.'+lid
+        lid = jobid+'.'+lid
     os.environ["LID"] = lid
     return lid
 
 def batch_jobid():
     jobid = os.environ.get("PBS_JOBID")
     if jobid is None:
-	jobid = os.environ.get("SLURM_JOB_ID")
+        jobid = os.environ.get("SLURM_JOB_ID")
     if jobid is None:
-	jobid = os.environ.get("LSB_JOBID")
+        jobid = os.environ.get("LSB_JOBID")
     if jobid is None:
-	jobid = os.environ.get("COBALT_JOBID")
+        jobid = os.environ.get("COBALT_JOBID")
     return jobid
 
 def analyze_build_log(comp, log, compiler):
@@ -1692,39 +1692,39 @@ def analyze_build_log(comp, log, compiler):
     """
     warncnt = 0
     if "intel" in compiler:
-	warn_re = re.compile(r" warning #")
-	error_re = re.compile(r" error #")
-	undefined_re = re.compile(r" undefined reference to ")
+        warn_re = re.compile(r" warning #")
+        error_re = re.compile(r" error #")
+        undefined_re = re.compile(r" undefined reference to ")
     elif "gnu" in compiler or "nag" in compiler:
-	warn_re = re.compile(r"^Warning: ")
-	error_re = re.compile(r"^Error: ")
-	undefined_re = re.compile(r" undefined reference to ")
+        warn_re = re.compile(r"^Warning: ")
+        error_re = re.compile(r"^Error: ")
+        undefined_re = re.compile(r" undefined reference to ")
     else:
-	# don't know enough about this compiler
-	return
+        # don't know enough about this compiler
+        return
 
     with open(log,"r") as fd:
-	for line in fd:
-	    if re.search(warn_re, line):
-		warncnt += 1
-	    if re.search(error_re, line):
-		logger.warning(line)
-	    if re.search(undefined_re, line):
-		logger.warning(line)
+        for line in fd:
+            if re.search(warn_re, line):
+                warncnt += 1
+            if re.search(error_re, line):
+                logger.warning(line)
+            if re.search(undefined_re, line):
+                logger.warning(line)
 
     if warncnt > 0:
-	logger.info("Component {} build complete with {} warnings".format(comp, warncnt))
+        logger.info("Component {} build complete with {} warnings".format(comp, warncnt))
 
 def is_python_executable(filepath):
     first_line = None
     if os.path.isfile(filepath):
-	with open(filepath, "rt") as f:
-	    try:
-		first_line = f.readline()
-	    except Exception:
-		pass
+        with open(filepath, "rt") as f:
+            try:
+                first_line = f.readline()
+            except Exception:
+                pass
 
-	return first_line is not None and first_line.startswith("#!") and "python" in first_line
+        return first_line is not None and first_line.startswith("#!") and "python" in first_line
     return False
 
 def get_umask():
@@ -1765,49 +1765,49 @@ def run_and_log_case_status(func, phase, caseroot='.', custom_success_msg_functo
     append_case_status(phase, "starting", caseroot=caseroot)
     rv = None
     try:
-	rv = func()
+        rv = func()
     except BaseException:
-	e = sys.exc_info()[1]
-	append_case_status(phase, CASE_FAILURE, msg=("\n{}".format(e)), caseroot=caseroot)
-	raise
+        e = sys.exc_info()[1]
+        append_case_status(phase, CASE_FAILURE, msg=("\n{}".format(e)), caseroot=caseroot)
+        raise
     else:
-	custom_success_msg = custom_success_msg_functor(rv) if custom_success_msg_functor else None
-	append_case_status(phase, CASE_SUCCESS, msg=custom_success_msg, caseroot=caseroot)
+        custom_success_msg = custom_success_msg_functor(rv) if custom_success_msg_functor else None
+        append_case_status(phase, CASE_SUCCESS, msg=custom_success_msg, caseroot=caseroot)
 
     return rv
 
 def _check_for_invalid_args(args):
     if get_model() != "e3sm":
-	for arg in args:
-	    # if arg contains a space then it was originally quoted and we can ignore it here.
-	    if " " in arg or arg.startswith("--"):
-		continue
-	    if arg.startswith("-") and len(arg) > 2:
-		sys.stderr.write( "WARNING: The {} argument is deprecated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options\n".format(arg))
+        for arg in args:
+            # if arg contains a space then it was originally quoted and we can ignore it here.
+            if " " in arg or arg.startswith("--"):
+                continue
+            if arg.startswith("-") and len(arg) > 2:
+                sys.stderr.write( "WARNING: The {} argument is deprecated. Multi-character arguments should begin with \"--\" and single character with \"-\"\n  Use --help for a complete list of available options\n".format(arg))
 
 def add_mail_type_args(parser):
     parser.add_argument("--mail-user", help="Email to be used for batch notification.")
 
     parser.add_argument("-M", "--mail-type", action="append",
-			help="When to send user email. Options are: never, all, begin, end, fail.\n"
-			"You can specify multiple types with either comma-separated args or multiple -M flags.")
+                        help="When to send user email. Options are: never, all, begin, end, fail.\n"
+                        "You can specify multiple types with either comma-separated args or multiple -M flags.")
 
 def resolve_mail_type_args(args):
     if args.mail_type is not None:
-	resolved_mail_types = []
-	for mail_type in args.mail_type:
-	    resolved_mail_types.extend(mail_type.split(","))
+        resolved_mail_types = []
+        for mail_type in args.mail_type:
+            resolved_mail_types.extend(mail_type.split(","))
 
-	for mail_type in resolved_mail_types:
-	    expect(mail_type in ("never", "all", "begin", "end", "fail"),
-		   "Unsupported mail-type '{}'".format(mail_type))
+        for mail_type in resolved_mail_types:
+            expect(mail_type in ("never", "all", "begin", "end", "fail"),
+                   "Unsupported mail-type '{}'".format(mail_type))
 
-	args.mail_type = resolved_mail_types
+        args.mail_type = resolved_mail_types
 
 def copyifnewer(src, dest):
     """ if dest does not exist or is older than src copy src to dest """
     if not os.path.isfile(dest) or not filecmp.cmp(src, dest):
-	safe_copy(src, dest)
+        safe_copy(src, dest)
 
 class SharedArea(object):
     """
@@ -1815,14 +1815,14 @@ class SharedArea(object):
     """
 
     def __init__(self, new_perms=0o002):
-	self._orig_umask = None
-	self._new_perms  = new_perms
+        self._orig_umask = None
+        self._new_perms  = new_perms
 
     def __enter__(self):
-	self._orig_umask = os.umask(self._new_perms)
+        self._orig_umask = os.umask(self._new_perms)
 
     def __exit__(self, *_):
-	os.umask(self._orig_umask)
+        os.umask(self._orig_umask)
 
 class Timeout(object):
     """
@@ -1831,20 +1831,20 @@ class Timeout(object):
     Provided None as seconds makes this class a no-op
     """
     def __init__(self, seconds, action=None):
-	self._seconds = seconds
-	self._action  = action if action is not None else self._handle_timeout
+        self._seconds = seconds
+        self._action  = action if action is not None else self._handle_timeout
 
     def _handle_timeout(self, *_):
-	raise RuntimeError("Timeout expired")
+        raise RuntimeError("Timeout expired")
 
     def __enter__(self):
-	if self._seconds is not None:
-	    signal.signal(signal.SIGALRM, self._action)
-	    signal.alarm(self._seconds)
+        if self._seconds is not None:
+            signal.signal(signal.SIGALRM, self._action)
+            signal.alarm(self._seconds)
 
     def __exit__(self, *_):
-	if self._seconds is not None:
-	    signal.alarm(0)
+        if self._seconds is not None:
+            signal.alarm(0)
 
 def filter_unicode(unistr):
     """
@@ -1872,15 +1872,15 @@ def string_in_list(_string, _list):
     >>> string_in_list("foo", ["FFO", "foo2", "foo3"])
     """
     for x in _list:
-	if _string.lower() == x.lower():
-	    return x
+        if _string.lower() == x.lower():
+            return x
     return None
 
 def model_log(model, arg_logger, msg, debug_others=True):
     if get_model() == model:
-	arg_logger.info(msg)
+        arg_logger.info(msg)
     elif debug_others:
-	arg_logger.debug(msg)
+        arg_logger.debug(msg)
 
 def get_htmlroot(machobj=None):
     """Get location for test HTML output
@@ -1892,21 +1892,21 @@ def get_htmlroot(machobj=None):
     """
     htmlroot = os.environ.get("CIME_HTML_ROOT")
     if htmlroot is not None:
-	logger.info("Using htmlroot from env CIME_HTML_ROOT: {}".format(htmlroot))
-	return htmlroot
+        logger.info("Using htmlroot from env CIME_HTML_ROOT: {}".format(htmlroot))
+        return htmlroot
 
     cime_config = get_cime_config()
     if cime_config.has_option("main", "CIME_HTML_ROOT"):
-	htmlroot = cime_config.get("main", "CIME_HTML_ROOT")
-	if htmlroot is not None:
-	    logger.info("Using htmlroot from .cime/config: {}".format(htmlroot))
-	    return htmlroot
+        htmlroot = cime_config.get("main", "CIME_HTML_ROOT")
+        if htmlroot is not None:
+            logger.info("Using htmlroot from .cime/config: {}".format(htmlroot))
+            return htmlroot
 
     if machobj is not None:
-	htmlroot = machobj.get_value("CIME_HTML_ROOT")
-	if htmlroot is not None:
-	    logger.info("Using htmlroot from config_machines.xml: {}".format(htmlroot))
-	    return htmlroot
+        htmlroot = machobj.get_value("CIME_HTML_ROOT")
+        if htmlroot is not None:
+            logger.info("Using htmlroot from config_machines.xml: {}".format(htmlroot))
+            return htmlroot
 
     logger.info("No htmlroot info available")
     return None
@@ -1921,21 +1921,21 @@ def get_urlroot(machobj=None):
     """
     urlroot = os.environ.get("CIME_URL_ROOT")
     if urlroot is not None:
-	logger.info("Using urlroot from env CIME_URL_ROOT: {}".format(urlroot))
-	return urlroot
+        logger.info("Using urlroot from env CIME_URL_ROOT: {}".format(urlroot))
+        return urlroot
 
     cime_config = get_cime_config()
     if cime_config.has_option("main", "CIME_URL_ROOT"):
-	urlroot = cime_config.get("main", "CIME_URL_ROOT")
-	if urlroot is not None:
-	    logger.info("Using urlroot from .cime/config: {}".format(urlroot))
-	    return urlroot
+        urlroot = cime_config.get("main", "CIME_URL_ROOT")
+        if urlroot is not None:
+            logger.info("Using urlroot from .cime/config: {}".format(urlroot))
+            return urlroot
 
     if machobj is not None:
-	urlroot = machobj.get_value("CIME_URL_ROOT")
-	if urlroot is not None:
-	    logger.info("Using urlroot from config_machines.xml: {}".format(urlroot))
-	    return urlroot
+        urlroot = machobj.get_value("CIME_URL_ROOT")
+        if urlroot is not None:
+            logger.info("Using urlroot from config_machines.xml: {}".format(urlroot))
+            return urlroot
 
     logger.info("No urlroot info available")
     return None


### PR DESCRIPTION
Allows for a sh format file to be sourced and incorporated into the cime environment.  
To use it you would add an entry in the <environment_variables> section such as
```
<environment_variables>
  <env source="sh">/path/to/an/sh/shell/file</env>
</environment_variables>
```
Note that sh is the only supported format for this feature.  

Test suite: hand testing, scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes #3631 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
