### PR TITLE
Add JRA Repeat Year Forcing data modes

### DIFF
--- a/src/components/data_comps_mct/datm/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/datm/cime_config/config_component.xml
@@ -10,7 +10,7 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
@@ -24,6 +24,7 @@
     <desc option="IAF">COREv2 interannual forcing</desc>
     <desc option="JRA">interannual JRA55 forcing</desc>
     <desc option="JRA-1p4-2018">interannual JRA55 forcing, v1.4, through 2018</desc>
+    <desc option="JRA-RYF8485"> JRA55 Repeat Year Forcing v1.3 1984-1985</desc>
   </description>
 
   <entry id="COMP_ATM">
@@ -37,7 +38,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -53,6 +54,7 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value compset="%IAF">CORE2_IAF</value>
       <value compset="%JRA">CORE_IAF_JRA</value>
       <value compset="%JRA-1p4-2018">CORE_IAF_JRA_1p4_2018</value>
+      <value compset="%JRA-RYF8485">CORE_RYF8485_JRA</value>
       <value compset="%QIA">CLM_QIAN</value>
       <value compset="%WISOQIA">CLM_QIAN_WISO</value>
       <value compset="%CRU">CLMCRUNCEP</value>

--- a/src/components/data_comps_mct/datm/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/datm/cime_config/config_component.xml
@@ -10,7 +10,7 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
@@ -25,6 +25,7 @@
     <desc option="JRA">interannual JRA55 forcing</desc>
     <desc option="JRA-1p4-2018">interannual JRA55 forcing, v1.4, through 2018</desc>
     <desc option="JRA-RYF8485"> JRA55 Repeat Year Forcing v1.3 1984-1985</desc>
+    <desc option="JRA-RYF9091"> JRA55 Repeat Year Forcing v1.3 1990-1991</desc>
   </description>
 
   <entry id="COMP_ATM">
@@ -38,7 +39,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA,CORE_RYF9091_JRA</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -55,6 +56,7 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value compset="%JRA">CORE_IAF_JRA</value>
       <value compset="%JRA-1p4-2018">CORE_IAF_JRA_1p4_2018</value>
       <value compset="%JRA-RYF8485">CORE_RYF8485_JRA</value>
+      <value compset="%JRA-RYF9091">CORE_RYF9091_JRA</value>
       <value compset="%QIA">CLM_QIAN</value>
       <value compset="%WISOQIA">CLM_QIAN_WISO</value>
       <value compset="%CRU">CLMCRUNCEP</value>

--- a/src/components/data_comps_mct/datm/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/datm/cime_config/config_component.xml
@@ -10,7 +10,7 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%MOSARTTEST][%NLDAS2][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRA-1p4-2018][%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
@@ -26,6 +26,7 @@
     <desc option="JRA-1p4-2018">interannual JRA55 forcing, v1.4, through 2018</desc>
     <desc option="JRA-RYF8485"> JRA55 Repeat Year Forcing v1.3 1984-1985</desc>
     <desc option="JRA-RYF9091"> JRA55 Repeat Year Forcing v1.3 1990-1991</desc>
+    <desc option="JRA-RYF0304"> JRA55 Repeat Year Forcing v1.3 2003-2004</desc>
   </description>
 
   <entry id="COMP_ATM">
@@ -39,7 +40,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA,CORE_RYF9091_JRA</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CLMMOSARTTEST,CLMNLDAS2,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRA_1p4_2018,CORE_RYF8485_JRA,CORE_RYF9091_JRA,CORE_RYF0304_JRA</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -57,6 +58,7 @@ data (see cime issue #3653 -- https://github.com/ESMCI/cime/issues/3653).
       <value compset="%JRA-1p4-2018">CORE_IAF_JRA_1p4_2018</value>
       <value compset="%JRA-RYF8485">CORE_RYF8485_JRA</value>
       <value compset="%JRA-RYF9091">CORE_RYF9091_JRA</value>
+      <value compset="%JRA-RYF0304">CORE_RYF0304_JRA</value>
       <value compset="%QIA">CLM_QIAN</value>
       <value compset="%WISOQIA">CLM_QIAN_WISO</value>
       <value compset="%CRU">CLMCRUNCEP</value>

--- a/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
@@ -43,6 +43,7 @@
     CORE2_IAF		= CORE2 intra-annual year forcing (for forcing POP and CICE)
     CORE_IAF_JRA	= JRA55 intra-annual year forcing (for forcing POP and CICE)
     CORE_IAF_JRA_1p4_2018 = JRA55 intra-annual year forcing, v1.4, through 2018 (for forcing POP and CICE)
+    CORE_RYF8485_JRA = JRA55 repeat year forcing, v1.3, 1984-1985 (for forcing POP and CICE)
     CPLHIST     	= Streams for lnd or ocn/ice forcing used for spinup
     presaero		= Prescribed aerosol forcing
     topo		= Surface topography
@@ -203,6 +204,7 @@
       <value datm_mode="CORE2_IAF" >CORE2_IAF.GCGCS.PREC,CORE2_IAF.GISS.LWDN,CORE2_IAF.GISS.SWDN,CORE2_IAF.GISS.SWUP,CORE2_IAF.NCEP.DN10,CORE2_IAF.NCEP.Q_10,CORE2_IAF.NCEP.SLP_,CORE2_IAF.NCEP.T_10,CORE2_IAF.NCEP.U_10,CORE2_IAF.NCEP.V_10,CORE2_IAF.CORE2.ArcFactor</value>
       <value datm_mode="CORE_IAF_JRA_1p4_2018" >CORE_IAF_JRA_1p4_2018.GCGCS.PREC,CORE_IAF_JRA_1p4_2018.GISS.LWDN,CORE_IAF_JRA_1p4_2018.GISS.SWDN,CORE_IAF_JRA_1p4_2018.NCEP.Q_10,CORE_IAF_JRA_1p4_2018.NCEP.SLP_,CORE_IAF_JRA_1p4_2018.NCEP.T_10,CORE_IAF_JRA_1p4_2018.NCEP.U_10,CORE_IAF_JRA_1p4_2018.NCEP.V_10</value>
       <value datm_mode="CORE_IAF_JRA" >CORE_IAF_JRA.GCGCS.PREC,CORE_IAF_JRA.GISS.LWDN,CORE_IAF_JRA.GISS.SWDN,CORE_IAF_JRA.NCEP.Q_10,CORE_IAF_JRA.NCEP.SLP_,CORE_IAF_JRA.NCEP.T_10,CORE_IAF_JRA.NCEP.U_10,CORE_IAF_JRA.NCEP.V_10</value>
+      <value datm_mode="CORE_RYF8485_JRA" >CORE_RYF8485_JRA.GISS,CORE_RYF8485_JRA.GCGCS,CORE_RYF8485_JRA.NCEP</value>
       <value datm_mode="CORE2_IAF" atm_grid="01col" >CORE2_IAF.NCEP.DENS.SOFS,CORE2_IAF.NCEP.PSLV.SOFS,CORE2_IAF.PREC.SOFS.DAILY,CORE2_IAF.LWDN.SOFS.DAILY,CORE2_IAF.SWDN.SOFS.DAILY,CORE2_IAF.SWUP.SOFS.DAILY,CORE2_IAF.SHUM.SOFS.6HOUR,CORE2_IAF.TBOT.SOFS.6HOUR,CORE2_IAF.U.SOFS.6HOUR,CORE2_IAF.V.SOFS.6HOUR,CORE2_IAF.CORE2.ArcFactor</value>
       <value datm_mode="CPLHIST">CPLHISTForcing.Solar,CPLHISTForcing.nonSolarFlux,CPLHISTForcing.State3hr,CPLHISTForcing.State1hr</value>
     </values>
@@ -250,6 +252,7 @@
       <value stream="CORE2_IAF.NCEP.U_10">$DIN_LOC_ROOT/atm/datm7</value>
       <value stream="CORE2_IAF.NCEP.V_10">$DIN_LOC_ROOT/atm/datm7</value>
       <value stream="CORE_IAF_JRA.*">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
+      <value stream="CORE_RYF*">$DIN_LOC_ROOT/atm/datm7/JRA55</value>
       <value stream="co2tseries">$DIN_LOC_ROOT/atm/datm7/CO2 </value>
       <value stream="BC.QIAN.Precip">$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/gpcp/qian</value>
       <value stream="BC.CRUNCEP.GPCP.Precip">$DIN_LOC_ROOT/atm/datm7/clm_output/cruncep_precip_1deg/gpcp_1deg_bias_correction</value>
@@ -312,6 +315,7 @@
       <value stream="CORE2_IAF.NCEP.V_10">domain.T62.050609.nc</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">CORE2.t_10.ArcFactor.T62.1997-2004.nc</value>
       <value stream="CORE_IAF_JRA.*">domain.atm.TL319.151007.nc</value>
+      <value stream="CORE_RYF*">domain.atm.TL319.151007.nc</value>
       <value stream="co2tseries.20tr" cime_model="e3sm">fco2_datm_1765-2007_c100614.nc</value>
       <value stream="co2tseries.20tr" cime_model="cesm">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
@@ -455,6 +459,7 @@
       <value stream="CORE2_IAF.CORE2.ArcFactor">$DIN_LOC_ROOT/atm/datm7/CORE2</value>
       <value stream="CORE2_IAF">$DIN_LOC_ROOT/ocn/iaf</value>
       <value stream="CORE_IAF_JRA.*">$DIN_LOC_ROOT/ocn/jra55/v1.3_noleap</value>
+      <value stream="CORE_RYF*">$DIN_LOC_ROOT/ocn/jra55/v1.3_ryf</value>
       <value stream="co2tseries">$DIN_LOC_ROOT/atm/datm7/CO2</value>
       <value stream="BC.QIAN.Precip">$DIN_LOC_ROOT/atm/datm7/bias_correction/precip/gpcp/qian</value>
       <value stream="BC.CRUNCEP.GPCP.Precip">$DIN_LOC_ROOT/atm/datm7/clm_output/cruncep_precip_1deg/gpcp_1deg_bias_correction</value>
@@ -2169,6 +2174,9 @@
         JRA.v1.3.v_10.TL319.2017.190528.nc
         JRA.v1.3.v_10.TL319.2018.190528.nc
       </value> 
+      <value stream="CORE_RYF8485_JRA.GISS">RAF_8485.JRA.v1.3.radiation.TL319.180404.nc</value>
+      <value stream="CORE_RYF8485_JRA.GCGCS">RAF_8485.JRA.v1.3.prec.TL319.180404.nc</value>
+      <value stream="CORE_RYF8485_JRA.NCEP">RAF_8485.JRA.v1.3.states.TL319.180404.nc</value>
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr" cime_model="cesm">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr" cime_model="e3sm">fco2_datm_1765-2007_c100614.nc</value>
@@ -2499,6 +2507,20 @@
       <value  stream="CORE_IAF_JRA.*.NCEP.V_10">
         v_10  v
       </value>
+      <value stream="CORE_RYF8485_JRA.GISS">
+        lwdn  lwdn
+        swdn  swdn
+      </value>
+      <value stream="CORE_RYF8485_JRA.GCGCS">
+        prec  prec
+      </value>
+      <value stream="CORE_RYF8485_JRA.NCEP">
+        slp  pslv
+        q_10  shum
+        t_10  tbot
+        u_10  u
+        v_10  v
+      </value>
       <value  stream="co2tseries.20tr">
         CO2        co2diag
       </value>
@@ -2600,6 +2622,7 @@
       <value stream="CORE2_IAF.CORE2.ArcFactor">1</value>
       <value stream="CORE2_IAF">1</value>
       <value stream="CORE_IAF_JRA.*">1</value>
+      <value stream="CORE_RYF*">1</value>
       <value stream="co2tseries.20tr">1850</value>
       <!-- ncycles*(year_end-year_start+1)-(year_end-co2_year_start) -->
       <value stream="co2tseries.omip" datm_mode="CORE2_IAF">213</value>    <!-- 6*(2009-1948+1)-(2009-1850) -->
@@ -2664,6 +2687,7 @@
       <value stream="CORE2_IAF.NCEP.V_10">1948</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1948</value>
       <value stream="CORE_IAF_JRA.*">1958</value>
+      <value stream="CORE_RYF*">1984</value>
       <value stream="co2tseries.20tr">1850</value>
       <value stream="co2tseries.omip">1850</value>
       <value stream="co2tseries.SSP">2015</value>
@@ -2731,6 +2755,7 @@
       <value stream="co2tseries.20tr" cime_model="cesm">2014</value>
       <value stream="CORE_IAF_JRA.*2018">2018</value>
       <value stream="CORE_IAF_JRA.*">2016</value>
+      <value stream="CORE_RYF*">1984</value>
       <value stream="co2tseries.omip">2019</value>
       <value stream="co2tseries.SSP">2500</value>
       <value stream="BC.QIAN.Precip">2004</value>
@@ -2784,7 +2809,7 @@
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>CLMNCEP,COPYALL,CORE2_NYF,CORE2_IAF,CORE_IAF_JRA,NULL</valid_values>
+    <valid_values>CLMNCEP,COPYALL,CORE2_NYF,CORE2_IAF,CORE_IAF_JRA,CORE_RYF_JRA,NULL</valid_values>
     <desc>
       general method that operates on the data.  this is generally
       implemented in the data models but is set in the strdata method for
@@ -2836,6 +2861,7 @@
       <value datm_mode="CORE2_NYF">CORE2_NYF</value>
       <value datm_mode="CORE2_IAF">CORE2_IAF</value>
       <value datm_mode="CORE_IAF_JRA.*">CORE_IAF_JRA</value>
+      <value datm_mode="CORE_RYF*">CORE_RYF_JRA</value>
       <value datm_mode="CPLHIST">COPYALL</value>
     </values>
   </entry>
@@ -3133,6 +3159,7 @@
       <value datm_mode="CORE2_NYF">u:v</value>
       <value datm_mode="CORE2_IAF">u:v</value>
       <value datm_mode="CORE_IAF_JRA.*">u:v</value>
+      <value datm_mode="CORE_RYF*">u:v</value>
     </values>
   </entry>
 

--- a/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
@@ -44,6 +44,7 @@
     CORE_IAF_JRA	= JRA55 intra-annual year forcing (for forcing POP and CICE)
     CORE_IAF_JRA_1p4_2018 = JRA55 intra-annual year forcing, v1.4, through 2018 (for forcing POP and CICE)
     CORE_RYF8485_JRA = JRA55 repeat year forcing, v1.3, 1984-1985 (for forcing POP and CICE)
+    CORE_RYF9091_JRA = JRA55 repeat year forcing, v1.3, 1990-1991 (for forcing POP and CICE)
     CPLHIST     	= Streams for lnd or ocn/ice forcing used for spinup
     presaero		= Prescribed aerosol forcing
     topo		= Surface topography
@@ -205,6 +206,7 @@
       <value datm_mode="CORE_IAF_JRA_1p4_2018" >CORE_IAF_JRA_1p4_2018.GCGCS.PREC,CORE_IAF_JRA_1p4_2018.GISS.LWDN,CORE_IAF_JRA_1p4_2018.GISS.SWDN,CORE_IAF_JRA_1p4_2018.NCEP.Q_10,CORE_IAF_JRA_1p4_2018.NCEP.SLP_,CORE_IAF_JRA_1p4_2018.NCEP.T_10,CORE_IAF_JRA_1p4_2018.NCEP.U_10,CORE_IAF_JRA_1p4_2018.NCEP.V_10</value>
       <value datm_mode="CORE_IAF_JRA" >CORE_IAF_JRA.GCGCS.PREC,CORE_IAF_JRA.GISS.LWDN,CORE_IAF_JRA.GISS.SWDN,CORE_IAF_JRA.NCEP.Q_10,CORE_IAF_JRA.NCEP.SLP_,CORE_IAF_JRA.NCEP.T_10,CORE_IAF_JRA.NCEP.U_10,CORE_IAF_JRA.NCEP.V_10</value>
       <value datm_mode="CORE_RYF8485_JRA" >CORE_RYF8485_JRA.GISS,CORE_RYF8485_JRA.GCGCS,CORE_RYF8485_JRA.NCEP</value>
+      <value datm_mode="CORE_RYF9091_JRA" >CORE_RYF9091_JRA.GISS,CORE_RYF9091_JRA.GCGCS,CORE_RYF9091_JRA.NCEP</value>
       <value datm_mode="CORE2_IAF" atm_grid="01col" >CORE2_IAF.NCEP.DENS.SOFS,CORE2_IAF.NCEP.PSLV.SOFS,CORE2_IAF.PREC.SOFS.DAILY,CORE2_IAF.LWDN.SOFS.DAILY,CORE2_IAF.SWDN.SOFS.DAILY,CORE2_IAF.SWUP.SOFS.DAILY,CORE2_IAF.SHUM.SOFS.6HOUR,CORE2_IAF.TBOT.SOFS.6HOUR,CORE2_IAF.U.SOFS.6HOUR,CORE2_IAF.V.SOFS.6HOUR,CORE2_IAF.CORE2.ArcFactor</value>
       <value datm_mode="CPLHIST">CPLHISTForcing.Solar,CPLHISTForcing.nonSolarFlux,CPLHISTForcing.State3hr,CPLHISTForcing.State1hr</value>
     </values>
@@ -2177,6 +2179,9 @@
       <value stream="CORE_RYF8485_JRA.GISS">RAF_8485.JRA.v1.3.radiation.TL319.180404.nc</value>
       <value stream="CORE_RYF8485_JRA.GCGCS">RAF_8485.JRA.v1.3.prec.TL319.180404.nc</value>
       <value stream="CORE_RYF8485_JRA.NCEP">RAF_8485.JRA.v1.3.states.TL319.180404.nc</value>
+      <value stream="CORE_RYF9091_JRA.GISS">RAF_9091.JRA.v1.3.radiation.TL319.180404.nc</value>
+      <value stream="CORE_RYF9091_JRA.GCGCS">RAF_9091.JRA.v1.3.prec.TL319.180404.nc</value>
+      <value stream="CORE_RYF9091_JRA.NCEP">RAF_9091.JRA.v1.3.states.TL319.180404.nc</value>
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr" cime_model="cesm">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr" cime_model="e3sm">fco2_datm_1765-2007_c100614.nc</value>
@@ -2507,14 +2512,14 @@
       <value  stream="CORE_IAF_JRA.*.NCEP.V_10">
         v_10  v
       </value>
-      <value stream="CORE_RYF8485_JRA.GISS">
+      <value stream="CORE_RYF.*.GISS">
         lwdn  lwdn
         swdn  swdn
       </value>
-      <value stream="CORE_RYF8485_JRA.GCGCS">
+      <value stream="CORE_RYF.*.GCGCS">
         prec  prec
       </value>
-      <value stream="CORE_RYF8485_JRA.NCEP">
+      <value stream="CORE_RYF.*.NCEP">
         slp  pslv
         q_10  shum
         t_10  tbot
@@ -2687,7 +2692,8 @@
       <value stream="CORE2_IAF.NCEP.V_10">1948</value>
       <value stream="CORE2_IAF.CORE2.ArcFactor">1948</value>
       <value stream="CORE_IAF_JRA.*">1958</value>
-      <value stream="CORE_RYF*">1984</value>
+      <value stream="CORE_RYF8485_JRA">1984</value>
+      <value stream="CORE_RYF9091_JRA">1990</value>
       <value stream="co2tseries.20tr">1850</value>
       <value stream="co2tseries.omip">1850</value>
       <value stream="co2tseries.SSP">2015</value>
@@ -2755,7 +2761,8 @@
       <value stream="co2tseries.20tr" cime_model="cesm">2014</value>
       <value stream="CORE_IAF_JRA.*2018">2018</value>
       <value stream="CORE_IAF_JRA.*">2016</value>
-      <value stream="CORE_RYF*">1984</value>
+      <value stream="CORE_RYF8485_JRA">1984</value>
+      <value stream="CORE_RYF9091_JRA">1990</value>
       <value stream="co2tseries.omip">2019</value>
       <value stream="co2tseries.SSP">2500</value>
       <value stream="BC.QIAN.Precip">2004</value>

--- a/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
@@ -45,6 +45,7 @@
     CORE_IAF_JRA_1p4_2018 = JRA55 intra-annual year forcing, v1.4, through 2018 (for forcing POP and CICE)
     CORE_RYF8485_JRA = JRA55 repeat year forcing, v1.3, 1984-1985 (for forcing POP and CICE)
     CORE_RYF9091_JRA = JRA55 repeat year forcing, v1.3, 1990-1991 (for forcing POP and CICE)
+    CORE_RYF0304_JRA = JRA55 repeat year forcing, v1.3, 2003-2004 (for forcing POP and CICE)
     CPLHIST     	= Streams for lnd or ocn/ice forcing used for spinup
     presaero		= Prescribed aerosol forcing
     topo		= Surface topography
@@ -207,6 +208,7 @@
       <value datm_mode="CORE_IAF_JRA" >CORE_IAF_JRA.GCGCS.PREC,CORE_IAF_JRA.GISS.LWDN,CORE_IAF_JRA.GISS.SWDN,CORE_IAF_JRA.NCEP.Q_10,CORE_IAF_JRA.NCEP.SLP_,CORE_IAF_JRA.NCEP.T_10,CORE_IAF_JRA.NCEP.U_10,CORE_IAF_JRA.NCEP.V_10</value>
       <value datm_mode="CORE_RYF8485_JRA" >CORE_RYF8485_JRA.GISS,CORE_RYF8485_JRA.GCGCS,CORE_RYF8485_JRA.NCEP</value>
       <value datm_mode="CORE_RYF9091_JRA" >CORE_RYF9091_JRA.GISS,CORE_RYF9091_JRA.GCGCS,CORE_RYF9091_JRA.NCEP</value>
+      <value datm_mode="CORE_RYF0304_JRA" >CORE_RYF0304_JRA.GISS,CORE_RYF0304_JRA.GCGCS,CORE_RYF0304_JRA.NCEP</value>
       <value datm_mode="CORE2_IAF" atm_grid="01col" >CORE2_IAF.NCEP.DENS.SOFS,CORE2_IAF.NCEP.PSLV.SOFS,CORE2_IAF.PREC.SOFS.DAILY,CORE2_IAF.LWDN.SOFS.DAILY,CORE2_IAF.SWDN.SOFS.DAILY,CORE2_IAF.SWUP.SOFS.DAILY,CORE2_IAF.SHUM.SOFS.6HOUR,CORE2_IAF.TBOT.SOFS.6HOUR,CORE2_IAF.U.SOFS.6HOUR,CORE2_IAF.V.SOFS.6HOUR,CORE2_IAF.CORE2.ArcFactor</value>
       <value datm_mode="CPLHIST">CPLHISTForcing.Solar,CPLHISTForcing.nonSolarFlux,CPLHISTForcing.State3hr,CPLHISTForcing.State1hr</value>
     </values>
@@ -2182,6 +2184,9 @@
       <value stream="CORE_RYF9091_JRA.GISS">RAF_9091.JRA.v1.3.radiation.TL319.180404.nc</value>
       <value stream="CORE_RYF9091_JRA.GCGCS">RAF_9091.JRA.v1.3.prec.TL319.180404.nc</value>
       <value stream="CORE_RYF9091_JRA.NCEP">RAF_9091.JRA.v1.3.states.TL319.180404.nc</value>
+      <value stream="CORE_RYF0304_JRA.GISS">RAF_0304.JRA.v1.3.radiation.TL319.180404.nc</value>
+      <value stream="CORE_RYF0304_JRA.GCGCS">RAF_0304.JRA.v1.3.prec.TL319.180404.nc</value>
+      <value stream="CORE_RYF0304_JRA.NCEP">RAF_0304.JRA.v1.3.states.TL319.180404.nc</value>
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr" cime_model="cesm">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr" cime_model="e3sm">fco2_datm_1765-2007_c100614.nc</value>
@@ -2694,6 +2699,7 @@
       <value stream="CORE_IAF_JRA.*">1958</value>
       <value stream="CORE_RYF8485_JRA">1984</value>
       <value stream="CORE_RYF9091_JRA">1990</value>
+      <value stream="CORE_RYF0304_JRA">2003</value>
       <value stream="co2tseries.20tr">1850</value>
       <value stream="co2tseries.omip">1850</value>
       <value stream="co2tseries.SSP">2015</value>
@@ -2763,6 +2769,7 @@
       <value stream="CORE_IAF_JRA.*">2016</value>
       <value stream="CORE_RYF8485_JRA">1984</value>
       <value stream="CORE_RYF9091_JRA">1990</value>
+      <value stream="CORE_RYF0304_JRA">2003</value>
       <value stream="co2tseries.omip">2019</value>
       <value stream="co2tseries.SSP">2500</value>
       <value stream="BC.QIAN.Precip">2004</value>

--- a/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
@@ -206,9 +206,9 @@
       <value datm_mode="CORE2_IAF" >CORE2_IAF.GCGCS.PREC,CORE2_IAF.GISS.LWDN,CORE2_IAF.GISS.SWDN,CORE2_IAF.GISS.SWUP,CORE2_IAF.NCEP.DN10,CORE2_IAF.NCEP.Q_10,CORE2_IAF.NCEP.SLP_,CORE2_IAF.NCEP.T_10,CORE2_IAF.NCEP.U_10,CORE2_IAF.NCEP.V_10,CORE2_IAF.CORE2.ArcFactor</value>
       <value datm_mode="CORE_IAF_JRA_1p4_2018" >CORE_IAF_JRA_1p4_2018.GCGCS.PREC,CORE_IAF_JRA_1p4_2018.GISS.LWDN,CORE_IAF_JRA_1p4_2018.GISS.SWDN,CORE_IAF_JRA_1p4_2018.NCEP.Q_10,CORE_IAF_JRA_1p4_2018.NCEP.SLP_,CORE_IAF_JRA_1p4_2018.NCEP.T_10,CORE_IAF_JRA_1p4_2018.NCEP.U_10,CORE_IAF_JRA_1p4_2018.NCEP.V_10</value>
       <value datm_mode="CORE_IAF_JRA" >CORE_IAF_JRA.GCGCS.PREC,CORE_IAF_JRA.GISS.LWDN,CORE_IAF_JRA.GISS.SWDN,CORE_IAF_JRA.NCEP.Q_10,CORE_IAF_JRA.NCEP.SLP_,CORE_IAF_JRA.NCEP.T_10,CORE_IAF_JRA.NCEP.U_10,CORE_IAF_JRA.NCEP.V_10</value>
-      <value datm_mode="CORE_RYF8485_JRA" >CORE_RYF8485_JRA.GISS,CORE_RYF8485_JRA.GCGCS,CORE_RYF8485_JRA.NCEP</value>
-      <value datm_mode="CORE_RYF9091_JRA" >CORE_RYF9091_JRA.GISS,CORE_RYF9091_JRA.GCGCS,CORE_RYF9091_JRA.NCEP</value>
-      <value datm_mode="CORE_RYF0304_JRA" >CORE_RYF0304_JRA.GISS,CORE_RYF0304_JRA.GCGCS,CORE_RYF0304_JRA.NCEP</value>
+      <value datm_mode="CORE_RYF8485_JRA" >CORE_RYF8485_JRA.GISS.LWDN,CORE_RYF8485_JRA.GISS.SWDN,CORE_RYF8485_JRA.GCGCS,CORE_RYF8485_JRA.NCEP</value>
+      <value datm_mode="CORE_RYF9091_JRA" >CORE_RYF9091_JRA.GISS.LWDN,CORE_RYF9091_JRA.GISS.SWDN,CORE_RYF9091_JRA.GCGCS,CORE_RYF9091_JRA.NCEP</value>
+      <value datm_mode="CORE_RYF0304_JRA" >CORE_RYF0304_JRA.GISS.LWDN,CORE_RYF0304_JRA.GISS.SWDN,CORE_RYF0304_JRA.GCGCS,CORE_RYF0304_JRA.NCEP</value>
       <value datm_mode="CORE2_IAF" atm_grid="01col" >CORE2_IAF.NCEP.DENS.SOFS,CORE2_IAF.NCEP.PSLV.SOFS,CORE2_IAF.PREC.SOFS.DAILY,CORE2_IAF.LWDN.SOFS.DAILY,CORE2_IAF.SWDN.SOFS.DAILY,CORE2_IAF.SWUP.SOFS.DAILY,CORE2_IAF.SHUM.SOFS.6HOUR,CORE2_IAF.TBOT.SOFS.6HOUR,CORE2_IAF.U.SOFS.6HOUR,CORE2_IAF.V.SOFS.6HOUR,CORE2_IAF.CORE2.ArcFactor</value>
       <value datm_mode="CPLHIST">CPLHISTForcing.Solar,CPLHISTForcing.nonSolarFlux,CPLHISTForcing.State3hr,CPLHISTForcing.State1hr</value>
     </values>
@@ -2178,13 +2178,16 @@
         JRA.v1.3.v_10.TL319.2017.190528.nc
         JRA.v1.3.v_10.TL319.2018.190528.nc
       </value> 
-      <value stream="CORE_RYF8485_JRA.GISS">RAF_8485.JRA.v1.3.radiation.TL319.180404.nc</value>
+      <value stream="CORE_RYF8485_JRA.GISS.LWDN">RAF_8485.JRA.v1.3.radiation.lwdn.TL319.180404.nc</value>
+      <value stream="CORE_RYF8485_JRA.GISS.SWDN">RAF_8485.JRA.v1.3.radiation.swdn.TL319.180404.nc</value>
       <value stream="CORE_RYF8485_JRA.GCGCS">RAF_8485.JRA.v1.3.prec.TL319.180404.nc</value>
       <value stream="CORE_RYF8485_JRA.NCEP">RAF_8485.JRA.v1.3.states.TL319.180404.nc</value>
-      <value stream="CORE_RYF9091_JRA.GISS">RAF_9091.JRA.v1.3.radiation.TL319.180404.nc</value>
+      <value stream="CORE_RYF9091_JRA.GISS.LWDN">RAF_9091.JRA.v1.3.radiation.lwdn.TL319.180404.nc</value>
+      <value stream="CORE_RYF9091_JRA.GISS.SWDN">RAF_9091.JRA.v1.3.radiation.swdn.TL319.180404.nc</value>
       <value stream="CORE_RYF9091_JRA.GCGCS">RAF_9091.JRA.v1.3.prec.TL319.180404.nc</value>
       <value stream="CORE_RYF9091_JRA.NCEP">RAF_9091.JRA.v1.3.states.TL319.180404.nc</value>
-      <value stream="CORE_RYF0304_JRA.GISS">RAF_0304.JRA.v1.3.radiation.TL319.180404.nc</value>
+      <value stream="CORE_RYF0304_JRA.GISS.LWDN">RAF_0304.JRA.v1.3.radiation.lwdn.TL319.180404.nc</value>
+      <value stream="CORE_RYF0304_JRA.GISS.SWDN">RAF_0304.JRA.v1.3.radiation.swdn.TL319.180404.nc</value>
       <value stream="CORE_RYF0304_JRA.GCGCS">RAF_0304.JRA.v1.3.prec.TL319.180404.nc</value>
       <value stream="CORE_RYF0304_JRA.NCEP">RAF_0304.JRA.v1.3.states.TL319.180404.nc</value>
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
@@ -2517,8 +2520,10 @@
       <value  stream="CORE_IAF_JRA.*.NCEP.V_10">
         v_10  v
       </value>
-      <value stream="CORE_RYF.*.GISS">
+      <value stream="CORE_RYF.*.GISS.LWDN">
         lwdn  lwdn
+      </value>
+      <value stream="CORE_RYF.*.GISS.SWDN">
         swdn  swdn
       </value>
       <value stream="CORE_RYF.*.GCGCS">
@@ -2802,6 +2807,7 @@
     <values>
       <value>0</value>
       <value stream="CORE_IAF_JRA.*.GISS.SWDN">-5400</value>
+      <value stream="CORE_RYF.*.GISS.SWDN">-5400</value>
       <value stream="CPLHISTForcing.Solar">2700</value>
       <value stream="CPLHISTForcing.nonSolarFlux">900</value>
       <value stream="CPLHISTForcing.State3hr">900</value>
@@ -3081,6 +3087,7 @@
       <value stream="topo.observed">lower</value>
       <value stream="CORE2_IAF.GISS.SWDN">coszen</value>
       <value stream="CORE_IAF_JRA.*.GISS.SWDN">coszen</value>
+      <value stream="CORE_RYF.*.GISS.SWDN">coszen</value>
     </values>
   </entry>
 

--- a/src/components/data_comps_mct/datm/src/datm_comp_mod.F90
+++ b/src/components/data_comps_mct/datm/src/datm_comp_mod.F90
@@ -824,11 +824,11 @@ CONTAINS
 
        enddo   ! lsize
 
-    case('CORE_IAF_JRA')
+    case('CORE_IAF_JRA', 'CORE_RYF_JRA')
        if (firstcall) then
           if (sprec < 1 .or. sswdn < 1) then
-             write(logunit,F00) 'ERROR: prec and swdn must be in streams for CORE_IAF_JRA'
-             call shr_sys_abort(trim(subname)//'ERROR: prec and swdn must be in streams for CORE_IAF_JRA')
+             write(logunit,F00) 'ERROR: prec and swdn must be in streams for IAF/RYF JRA'
+             call shr_sys_abort(trim(subname)//'ERROR: prec and swdn must be in streams for IAF/RYF JRA')
           endif
           if (trim(factorFn) == 'null') then
              windFactor = 1.0_R8

--- a/src/components/data_comps_mct/datm/src/datm_shr_mod.F90
+++ b/src/components/data_comps_mct/datm/src/datm_shr_mod.F90
@@ -154,6 +154,7 @@ CONTAINS
          trim(datamode) == 'CORE2_NYF' .or. &
          trim(datamode) == 'CORE2_IAF' .or. &
          trim(datamode) == 'CORE_IAF_JRA' .or. &
+         trim(datamode) == 'CORE_RYF_JRA' .or. &
          trim(datamode) == 'CLMNCEP'   .or. &
          trim(datamode) == 'COPYALL'   ) then
        if (my_task == master_task) then

--- a/src/components/data_comps_mct/drof/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/drof/cime_config/config_component.xml
@@ -13,7 +13,7 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091]">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091][%JRA-RYF0304]">Data runoff model</desc>
     <desc option="NULL"     >NULL mode</desc>
     <desc option="NYF"      >COREv2 normal year forcing:</desc>
     <desc option="IAF"      >COREv2 interannual year forcing:</desc>
@@ -28,6 +28,7 @@
     <desc option="JRA"      >JRA55 interannual forcing</desc>
     <desc option="JRA-RYF8485">JRA55 Repeat Year Forcing v1.3 1984-1985</desc>
     <desc option="JRA-RYF9091">JRA55 Repeat Year Forcing v1.3 1990-1991</desc>
+    <desc option="JRA-RYF0304">JRA55 Repeat Year Forcing v1.3 2003-2004</desc>
   </description>
 
   <entry id="COMP_ROF">
@@ -41,7 +42,7 @@
 
   <entry id="DROF_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,RYF8485_JRA,RYF9091_JRA,NULL</valid_values>
+    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,RYF8485_JRA,RYF9091_JRA,RYF0304_JRA,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
     <values match="last">
       <value compset="_DROF%NULL">NULL</value>
@@ -61,6 +62,7 @@
       <value compset="_DROF%JRA-1p4-2018-AIS0ROF" >IAF_JRA_1p4_2018_AIS0ROF</value>
       <value compset="_DROF%JRA-RYF8485" >RYF8485_JRA</value>
       <value compset="_DROF%JRA-RYF9091" >RYF9091_JRA</value>
+      <value compset="_DROF%JRA-RYF0304" >RYF0304_JRA</value>
       <value compset=".+" grid="r%null">NULL</value> <!-- overwrites above if runoff grid is null -->
     </values>
     <group>run_component_drof</group>

--- a/src/components/data_comps_mct/drof/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/drof/cime_config/config_component.xml
@@ -13,7 +13,7 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485]">Data runoff model</desc>
     <desc option="NULL"     >NULL mode</desc>
     <desc option="NYF"      >COREv2 normal year forcing:</desc>
     <desc option="IAF"      >COREv2 interannual year forcing:</desc>
@@ -26,6 +26,7 @@
     <desc option="JRA-1p4-2018-AIS0LIQ">JRA55 interannual forcing, v1.4, through 2018, no rofl around AIS</desc>
     <desc option="JRA-1p4-2018-AIS0ROF">JRA55 interannual forcing, v1.4, through 2018, no rofi or rofl around AIS</desc>
     <desc option="JRA"      >JRA55 interannual forcing</desc>
+    <desc option="JRA-RYF8485">JRA55 Repeat Year Forcing v1.3 1984-1985</desc>
   </description>
 
   <entry id="COMP_ROF">
@@ -39,7 +40,7 @@
 
   <entry id="DROF_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,NULL</valid_values>
+    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,RYF8485_JRA,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
     <values match="last">
       <value compset="_DROF%NULL">NULL</value>
@@ -57,6 +58,7 @@
       <value compset="_DROF%JRA-1p4-2018-AIS0ICE" >IAF_JRA_1p4_2018_AIS0ICE</value>
       <value compset="_DROF%JRA-1p4-2018-AIS0LIQ" >IAF_JRA_1p4_2018_AIS0LIQ</value>
       <value compset="_DROF%JRA-1p4-2018-AIS0ROF" >IAF_JRA_1p4_2018_AIS0ROF</value>
+      <value compset="_DROF%JRA-RYF8485" >RYF8485_JRA</value>
       <value compset=".+" grid="r%null">NULL</value> <!-- overwrites above if runoff grid is null -->
     </values>
     <group>run_component_drof</group>

--- a/src/components/data_comps_mct/drof/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/drof/cime_config/config_component.xml
@@ -13,7 +13,7 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485]">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%IAFAIS00][%IAFAIS45][%IAFAIS55][%CPLHIST][%JRA][%JRA-1p4-2018][%JRA-1p4-2018-AIS0ICE][%JRA-1p4-2018-AIS0LIQ][%JRA-1p4-2018-AIS0ROF[%JRA-RYF8485][%JRA-RYF9091]">Data runoff model</desc>
     <desc option="NULL"     >NULL mode</desc>
     <desc option="NYF"      >COREv2 normal year forcing:</desc>
     <desc option="IAF"      >COREv2 interannual year forcing:</desc>
@@ -27,6 +27,7 @@
     <desc option="JRA-1p4-2018-AIS0ROF">JRA55 interannual forcing, v1.4, through 2018, no rofi or rofl around AIS</desc>
     <desc option="JRA"      >JRA55 interannual forcing</desc>
     <desc option="JRA-RYF8485">JRA55 Repeat Year Forcing v1.3 1984-1985</desc>
+    <desc option="JRA-RYF9091">JRA55 Repeat Year Forcing v1.3 1990-1991</desc>
   </description>
 
   <entry id="COMP_ROF">
@@ -40,7 +41,7 @@
 
   <entry id="DROF_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,RYF8485_JRA,NULL</valid_values>
+    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,DIATREN_IAF_AIS00_RX1,DIATREN_IAF_AIS45_RX1,DIATREN_IAF_AIS55_RX1,IAF_JRA,IAF_JRA_1p4_2018,IAF_JRA_1p4_2018_AIS0ICE,IAF_JRA_1p4_2018_AIS0LIQ,IAF_JRA_1p4_2018_AIS0ROF,RYF8485_JRA,RYF9091_JRA,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
     <values match="last">
       <value compset="_DROF%NULL">NULL</value>
@@ -59,6 +60,7 @@
       <value compset="_DROF%JRA-1p4-2018-AIS0LIQ" >IAF_JRA_1p4_2018_AIS0LIQ</value>
       <value compset="_DROF%JRA-1p4-2018-AIS0ROF" >IAF_JRA_1p4_2018_AIS0ROF</value>
       <value compset="_DROF%JRA-RYF8485" >RYF8485_JRA</value>
+      <value compset="_DROF%JRA-RYF9091" >RYF9091_JRA</value>
       <value compset=".+" grid="r%null">NULL</value> <!-- overwrites above if runoff grid is null -->
     </values>
     <group>run_component_drof</group>

--- a/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
@@ -66,6 +66,7 @@
       <value drof_mode="IAF_JRA"              >rof.iaf_jra</value>
       <value drof_mode="RYF8485_JRA"          >rof.ryf8485_jra</value>
       <value drof_mode="RYF9091_JRA"          >rof.ryf9091_jra</value>
+      <value drof_mode="RYF0304_JRA"          >rof.ryf0304_jra</value>
     </values>
   </entry>
 
@@ -198,6 +199,7 @@
       <value stream="rof.diatren_iaf_ais55_rx1">runoff.daitren.iaf-AISx55.20120419.nc</value>
       <value stream="rof.ryf8485_jra">RAF_8485.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.ryf9091_jra">RAF_9091.JRA.v1.3.runoff.180404.nc</value>
+      <value stream="rof.ryf0304_jra">RAF_0304.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.iaf_jra_1p4_2018_ais0ice">
            JRA.v1.4.runoff.1958.no_rofi.190214.nc
            JRA.v1.4.runoff.1959.no_rofi.190214.nc
@@ -592,6 +594,7 @@
       <value stream="rof.iaf_jra.*"            >1958</value>
       <value stream="rof.ryf8485_jra"          >1984</value>
       <value stream="rof.ryf9091_jra"          >1990</value>
+      <value stream="rof.ryf0304_jra"          >2003</value>
       <value stream="rof.cplhist"              >$DROF_CPLHIST_YR_START</value>
     </values>
   </entry>
@@ -617,6 +620,7 @@
       <value stream="rof.iaf_jra"              >2016</value>
       <value stream="rof.ryf8485_jra"          >1984</value>
       <value stream="rof.ryf9091_jra"          >1990</value>
+      <value stream="rof.ryf0304_jra"          >2003</value>
       <value stream="rof.cplhist"              >$DROF_CPLHIST_YR_END</value>
     </values>
   </entry>
@@ -811,8 +815,7 @@
       <value stream="rof.diatren_ann_rx1">upper</value>
       <value stream="rof.diatren_iaf_rx1">upper</value>
       <value stream="rof.iaf_jra.*">upper</value>
-      <value stream="rof.ryf8485_jra">upper</value>
-      <value stream="rof.ryf9091_jra">upper</value>
+      <value stream="rof.ryf*">upper</value>
       <value stream="rof.cplhist">nearest</value>
     </values>
   </entry>

--- a/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
@@ -65,6 +65,7 @@
       <value drof_mode="IAF_JRA_1p4_2018"     >rof.iaf_jra_1p4_2018</value>
       <value drof_mode="IAF_JRA"              >rof.iaf_jra</value>
       <value drof_mode="RYF8485_JRA"          >rof.ryf8485_jra</value>
+      <value drof_mode="RYF9091_JRA"          >rof.ryf9091_jra</value>
     </values>
   </entry>
 
@@ -196,6 +197,7 @@
       <value stream="rof.diatren_iaf_ais45_rx1">runoff.daitren.iaf-AISx45.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais55_rx1">runoff.daitren.iaf-AISx55.20120419.nc</value>
       <value stream="rof.ryf8485_jra">RAF_8485.JRA.v1.3.runoff.180404.nc</value>
+      <value stream="rof.ryf9091_jra">RAF_9091.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.iaf_jra_1p4_2018_ais0ice">
            JRA.v1.4.runoff.1958.no_rofi.190214.nc
            JRA.v1.4.runoff.1959.no_rofi.190214.nc
@@ -509,7 +511,6 @@
            JRA.v1.1.runoff.2015.170807.nc
            JRA.v1.1.runoff.2016.170807.nc
       </value>
-      <value stream="rof.ryf8485_jra">RAF_8485.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_CASE.cpl.hr2x.%ym.nc</value>
     </values>
   </entry>
@@ -590,6 +591,7 @@
       <value stream="rof.diatren_iaf_ais55_rx1">1948</value>
       <value stream="rof.iaf_jra.*"            >1958</value>
       <value stream="rof.ryf8485_jra"          >1984</value>
+      <value stream="rof.ryf9091_jra"          >1990</value>
       <value stream="rof.cplhist"              >$DROF_CPLHIST_YR_START</value>
     </values>
   </entry>
@@ -614,6 +616,7 @@
       <value stream="rof.iaf_jra_1p4_2018_ais0rof">2018</value>
       <value stream="rof.iaf_jra"              >2016</value>
       <value stream="rof.ryf8485_jra"          >1984</value>
+      <value stream="rof.ryf9091_jra"          >1990</value>
       <value stream="rof.cplhist"              >$DROF_CPLHIST_YR_END</value>
     </values>
   </entry>
@@ -809,6 +812,7 @@
       <value stream="rof.diatren_iaf_rx1">upper</value>
       <value stream="rof.iaf_jra.*">upper</value>
       <value stream="rof.ryf8485_jra">upper</value>
+      <value stream="rof.ryf9091_jra">upper</value>
       <value stream="rof.cplhist">nearest</value>
     </values>
   </entry>

--- a/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps_mct/drof/cime_config/namelist_definition_drof.xml
@@ -64,6 +64,7 @@
       <value drof_mode="IAF_JRA_1p4_2018_AIS0ROF">rof.iaf_jra_1p4_2018_ais0rof</value>
       <value drof_mode="IAF_JRA_1p4_2018"     >rof.iaf_jra_1p4_2018</value>
       <value drof_mode="IAF_JRA"              >rof.iaf_jra</value>
+      <value drof_mode="RYF8485_JRA"          >rof.ryf8485_jra</value>
     </values>
   </entry>
 
@@ -83,6 +84,7 @@
       <value stream="rof.diatren_iaf_ais45_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.diatren_iaf_ais55_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.iaf_jra.*"            >$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
+      <value stream="rof.ryf*"                 >$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
       <value stream="rof.cplhist"              >null</value>
     </values>
   </entry>
@@ -102,6 +104,7 @@
       <value stream="rof.diatren_iaf_ais45_rx1">runoff.daitren.iaf-AISx45.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais55_rx1">runoff.daitren.iaf-AISx55.20120419.nc</value>
       <value stream="rof.iaf_jra.*"            >domain.roff.JRA025.170111.nc</value>
+      <value stream="rof.ryf*"                 >domain.roff.JRA025.170111.nc</value>
       <value stream="rof.cplhist"              >null</value>
     </values>
   </entry>
@@ -173,6 +176,7 @@
       <value stream="rof.diatren_iaf_ais45_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.diatren_iaf_ais55_rx1">$DIN_LOC_ROOT/lnd/dlnd7/RX1</value>
       <value stream="rof.iaf_jra.*"            >$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
+      <value stream="rof.ryf*"                 >$DIN_LOC_ROOT/lnd/dlnd7/JRA55</value>
       <value stream="rof.cplhist"              >$DROF_CPLHIST_DIR</value>
     </values>
   </entry>
@@ -191,6 +195,7 @@
       <value stream="rof.diatren_iaf_ais00_rx1">runoff.daitren.iaf-AISx00.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais45_rx1">runoff.daitren.iaf-AISx45.20120419.nc</value>
       <value stream="rof.diatren_iaf_ais55_rx1">runoff.daitren.iaf-AISx55.20120419.nc</value>
+      <value stream="rof.ryf8485_jra">RAF_8485.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.iaf_jra_1p4_2018_ais0ice">
            JRA.v1.4.runoff.1958.no_rofi.190214.nc
            JRA.v1.4.runoff.1959.no_rofi.190214.nc
@@ -504,6 +509,7 @@
            JRA.v1.1.runoff.2015.170807.nc
            JRA.v1.1.runoff.2016.170807.nc
       </value>
+      <value stream="rof.ryf8485_jra">RAF_8485.JRA.v1.3.runoff.180404.nc</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_CASE.cpl.hr2x.%ym.nc</value>
     </values>
   </entry>
@@ -527,6 +533,10 @@
         runoff rofl
       </value>
       <value stream="rof.iaf_jra.*">
+        rofl  rofl
+        rofi  rofi
+      </value>
+      <value stream="rof.ryf*">
         rofl  rofl
         rofi  rofi
       </value>
@@ -559,6 +569,7 @@
       <value stream="rof.diatren_iaf_rx1">1</value>
       <value stream="rof.diatren_iaf_ais45_rx1">1</value>
       <value stream="rof.iaf_jra.*">1</value>
+      <value stream="rof.ryf*">1</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_YR_ALIGN</value>
     </values>
   </entry>
@@ -578,6 +589,7 @@
       <value stream="rof.diatren_iaf_ais45_rx1">1948</value>
       <value stream="rof.diatren_iaf_ais55_rx1">1948</value>
       <value stream="rof.iaf_jra.*"            >1958</value>
+      <value stream="rof.ryf8485_jra"          >1984</value>
       <value stream="rof.cplhist"              >$DROF_CPLHIST_YR_START</value>
     </values>
   </entry>
@@ -601,6 +613,7 @@
       <value stream="rof.iaf_jra_1p4_2018_ais0liq">2018</value>
       <value stream="rof.iaf_jra_1p4_2018_ais0rof">2018</value>
       <value stream="rof.iaf_jra"              >2016</value>
+      <value stream="rof.ryf8485_jra"          >1984</value>
       <value stream="rof.cplhist"              >$DROF_CPLHIST_YR_END</value>
     </values>
   </entry>
@@ -795,6 +808,7 @@
       <value stream="rof.diatren_ann_rx1">upper</value>
       <value stream="rof.diatren_iaf_rx1">upper</value>
       <value stream="rof.iaf_jra.*">upper</value>
+      <value stream="rof.ryf8485_jra">upper</value>
       <value stream="rof.cplhist">nearest</value>
     </values>
   </entry>


### PR DESCRIPTION
Brings in three JRA RYF (repeat year forcing) datm and drof data modes: RYF8485, RYF9091, RYF0304.
These new forcings are described in: https://doi.org/10.1016/j.ocemod.2019.101557

Test suite: G cases with all three RYF modes. scripts_regression_test
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

User interface changes?:  np

Update gh-pages html (Y/N)?:

Code review: 
