### PR TITLE
Support concurrent env XML changes during case.run

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -214,6 +214,8 @@ TESTTESTDIFF      Simulates internal test diff (non baseline). Used to check tha
 TESTRUNSLOWPASS   After 5 minutes of sleep, pass run step. Used to test timeouts
                   and kills.
 
+TESTRUNUSERXMLCHANGE Test concurrent user modifications via xmlchange while case is running
+
 NODEFAIL          Tests restart upon detected node failure. Generates fake failures,
                   the number of which is controlled by NODEFAIL_NUM_FAILS.
 
@@ -506,6 +508,18 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
+  </test>
+
+  <test NAME="TESTRUNUSERXMLCHANGE" INFRASTRUCTURE_TEST="TRUE">
+    <DESC>For testing infra only. Test simultaneous xmlchanges while first run is running.</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <STOP_OPTION>ndays</STOP_OPTION>
+    <STOP_N>11</STOP_N>
+    <CHECK_TIMING>FALSE</CHECK_TIMING>
+    <DOUT_S>FALSE</DOUT_S>
+    <REST_OPTION>none</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
   </test>
 
   <test NAME="NODEFAIL" INFRASTRUCTURE_TEST="TRUE">

--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -514,7 +514,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DESC>For testing infra only. Test simultaneous xmlchanges while first run is running.</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <STOP_OPTION>ndays</STOP_OPTION>
-    <STOP_N>11</STOP_N>
+    <STOP_N>3</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
     <REST_OPTION>none</REST_OPTION>

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -740,30 +740,21 @@ class TESTRUNUSERXMLCHANGE(FakeTest):
         script = \
 """
 cd {caseroot}
-echo JGF1
 ./xmlchange DOUT_S=TRUE
-echo JGF2
 ./xmlchange DOUT_S=TRUE --file env_test.xml
-echo JGF3
 ./xmlchange RESUBMIT=1
-echo JGF4
 ./xmlchange STOP_N={stopn}
-echo JGF5
 ./xmlchange CONTINUE_RUN=FALSE
-echo JGF6
+./xmlchange RESUBMIT_SETS_CONTINUE_RUN=FALSE
 cd -
 sleep 5
-echo JGF7
 {modelexe}.real "$@"
-echo JGF8
 sleep 5
 
 # Need to remove self in order to avoid infinite loop
-echo JGF9
 ls $(dirname {modelexe})
 mv {modelexe} {modelexe}.old
 mv {modelexe}.real {modelexe}
-echo JGF10
 ls $(dirname {modelexe})
 sleep 5
 """.format(caseroot=caseroot, modelexe=modelexe, stopn=str(new_stop_n))

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -343,8 +343,7 @@ class GenericXML(object):
     def validate_timestamp(self):
         timestamp_ok = self.check_timestamp()
         expect(timestamp_ok,
-               """File {} appears to have changed without a corresponding invalidation.
-It's possible an entry needs to be moved to env_volatile""".format(self.filename))
+               "File {} appears to have changed without a corresponding invalidation.".format(self.filename))
 
     def write(self, outfile=None, force_write=False):
         """

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -109,7 +109,8 @@ class GenericXML(object):
             self._FILEMAP[infile] = self.CacheEntry(self.tree, self.root, os.path.getmtime(infile))
 
     def read_fd(self, fd):
-        expect(self.read_only or not self.filename or not self.needsrewrite, "Reading into object marked for rewrite, file {}"               .format(self.filename))
+        expect(self.read_only or not self.filename or not self.needsrewrite,
+               "Reading into object marked for rewrite, file {}".format(self.filename))
         read_only = self.read_only
         if self.tree:
             addroot = _Element(ET.parse(fd).getroot())
@@ -329,20 +330,30 @@ class GenericXML(object):
         return version
 
     def check_timestamp(self):
+        """
+        Returns True if timestamp matches what is expected
+        """
         timestamp_cache = self._FILEMAP[self.filename].modtime
         if timestamp_cache != 0.0:
             timestamp_file  = os.path.getmtime(self.filename)
-            expect(timestamp_file == timestamp_cache,
-                   "File {} appears to have changed without a corresponding invalidation, modtimes {:0.2f} != {:0.2f}".format(self.filename, timestamp_cache, timestamp_file))
+            return timestamp_file == timestamp_cache
+        else:
+            return True
+
+    def validate_timestamp(self):
+        timestamp_ok = self.check_timestamp()
+        expect(timestamp_ok,
+               """File {} appears to have changed without a corresponding invalidation.
+It's possible an entry needs to be moved to env_volatile""".format(self.filename))
 
     def write(self, outfile=None, force_write=False):
         """
         Write an xml file from data in self
         """
-        #self.check_timestamp()
-
         if not (self.needsrewrite or force_write):
             return
+
+        self.validate_timestamp()
 
         if outfile is None:
             outfile = self.filename

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -266,6 +266,7 @@ class Case(object):
         if not os.path.isdir(self._caseroot):
             # do not flush if caseroot wasnt created
             return
+
         for env_file in self._files:
             env_file.write(force_write=flushall)
 

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -324,9 +324,16 @@ def case_run(self, skip_pnl=False, set_continue_run=False, submit_resubmits=Fals
             self.set_value("CONTINUE_RUN",
                            self.get_value("RESUBMIT_SETS_CONTINUE_RUN"))
 
+        # WARNING: All case variables are reloaded during run_model to get
+        # new values of any variables that may have been changed by
+        # the user during model execution. Thus, any local variables
+        # set from case variables before this point may be
+        # inconsistent with their latest values in the xml files, so
+        # should generally be reloaded (via case.get_value(XXX)) if they are still needed.
         model_log("e3sm", logger, "{} RUN_MODEL BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
         lid = _run_model(self, lid, skip_pnl, da_cycle=cycle)
         model_log("e3sm", logger, "{} RUN_MODEL HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
+
         if self.get_value("CHECK_TIMING") or self.get_value("SAVE_TIMING"):
             model_log("e3sm", logger, "{} GET_TIMING BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
             get_timing(self, lid)     # Run the getTiming script

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -118,8 +118,15 @@ def _run_model_impl(case, lid, skip_pnl=False, da_cycle=0):
         except CIMEError:
             cmd_success = False
 
-        # The run will potentially take a very long time. We need to allow the user to xmlchange things
-        # in their case
+        # The run will potentially take a very long time. We need to
+        # allow the user to xmlchange things in their case.
+        #
+        # WARNING: All case variables are reloaded after this call to get the
+        # new values of any variables that may have been changed by
+        # the user during model execution. Thus, any local variables
+        # set from case variables before this point may be
+        # inconsistent with their latest values in the xml files, so
+        # should generally be reloaded (via case.get_value(XXX)) if they are still needed.
         case.read_xml()
 
         model_log("e3sm", logger, "{} MODEL EXECUTION HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))

--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -736,10 +736,10 @@ def case_st_archive(self, last_date_str=None, archive_incomplete_logs=True, copy
     logger.info("st_archive completed")
 
     # resubmit case if appropriate
-    if not self.get_value("EXTERNAL_WORKFLOW"):
+    if not self.get_value("EXTERNAL_WORKFLOW") and resubmit:
         resubmit_cnt = self.get_value("RESUBMIT")
         logger.debug("resubmit_cnt {} resubmit {}".format(resubmit_cnt, resubmit))
-        if resubmit_cnt > 0 and resubmit:
+        if resubmit_cnt > 0:
             logger.info("resubmitting from st_archive, resubmit={:d}".format(resubmit_cnt))
             if self.get_value("MACH") == "mira":
                 expect(os.path.isfile(".original_host"), "ERROR alcf host file not found")

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1896,6 +1896,22 @@ class X_TestQueryConfig(unittest.TestCase):
         run_cmd_no_fail("{}/query_config --machines".format(SCRIPT_DIR))
 
 ###############################################################################
+class Y_TestUserConcurrentMods(TestCreateTestCommon):
+###############################################################################
+
+    ###########################################################################
+    def test_user_concurrent_mods(self):
+    ###########################################################################
+        # Put this inside any test that's slow
+        if (FAST_ONLY):
+            self.skipTest("Skipping slow test")
+
+        #case = \
+        self._create_test(["--walltime=0:15:00", "TESTRUNUSERXMLCHANGE_P1.f09_g16.X"], test_id=self._baseline_name)
+
+        # TODO: ensure resubmission happened and behaved according to user mods
+
+###############################################################################
 class Z_FullSystemTest(TestCreateTestCommon):
 ###############################################################################
 

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2449,19 +2449,21 @@ class K_TestCimeCase(TestCreateTestCommon):
             self.assertEqual(case.get_value("RUN_TYPE"), "startup")
             case.set_value("RUN_TYPE", "branch")
 
-        # behind the back detection. disable for now
-        # with self.assertRaises(CIMEError):
-        #     with Case(casedir, read_only=False) as case:
-        #         time.sleep(0.2)
-        #         safe_copy(backup, active)
+        # behind the back detection.
+        with self.assertRaises(CIMEError):
+            with Case(casedir, read_only=False) as case:
+                case.set_value("RUN_TYPE", "startup")
+                time.sleep(0.2)
+                safe_copy(backup, active)
 
-        # with Case(casedir, read_only=False) as case:
-        #     case.set_value("RUN_TYPE", "branch")
+        with Case(casedir, read_only=False) as case:
+            case.set_value("RUN_TYPE", "branch")
 
-        # with self.assertRaises(CIMEError):
-        #     with Case(casedir) as case:
-        #         time.sleep(0.2)
-        #         safe_copy(backup, active)
+        # If there's no modications within CIME, the files should not be written
+        # and therefore no timestamp check
+        with Case(casedir) as case:
+            time.sleep(0.2)
+            safe_copy(backup, active)
 
     ###########################################################################
     def test_configure(self):


### PR DESCRIPTION
This became mostly an exercise in coming up with a good test.

Adds a new type of FakeTest that uses both a custom shell script and a built model exe.

Adds a new system test to see that, if the user does this during case.run:
```
./xmlchange DOUT_S=TRUE
./xmlchange DOUT_S=TRUE --file env_test.xml
./xmlchange RESUBMIT=1
./xmlchange STOP_N={2*original_stopn}
./xmlchange CONTINUE_RUN=FALSE
./xmlchange RESUBMIT_SETS_CONTINUE_RUN=FALSE
```
... that CIME will successfully resubmit and run with more timesteps.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3338

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
