### PR TITLE
Sets coupling frequencies for new MPAS-Ocean grid in E3SM.

### DIFF
--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -310,6 +310,7 @@
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oEC60to30">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oEC60to30v3">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oEC60to30wLI">48</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%ECwISC30to60E1r2">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS30to10v3">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS30to10wLI">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS18to6v3">96</value>
@@ -425,6 +426,7 @@
       <value compset="_MPASO" grid="oi%oEC60to30">48</value>
       <value compset="_MPASO" grid="oi%oEC60to30v3">48</value>
       <value compset="_MPASO" grid="oi%oEC60to30wLI">48</value>
+      <value compset="_MPASO" grid="oi%ECwISC30to60E1r2">48</value>
       <value compset="_MPASO" grid="oi%oRRS30to10v3">48</value>
       <value compset="_MPASO" grid="oi%oRRS30to10wLI">48</value>
       <value compset="_MPASO" grid="oi%oRRS18to6v3">48</value>


### PR DESCRIPTION
Sets coupling frequency for new MPAS-Ocean/Sea ice grid ECwISC30to60E1r2 in E3SM.

[BFB]

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
