### PR TITLE
Cime changes required by the topounit inplementation in E3SM

### DIFF
--- a/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/src/drivers/mct/shr/seq_flds_mod.F90
@@ -702,6 +702,17 @@ contains
     units    = 'kg m-3'
     attname  = 'Sa_dens'
     call metadata_set(attname, longname, stdname, units)
+    
+    ! UoverN for use by topounits
+    if (trim(cime_model) == 'e3sm') then
+       call seq_flds_add(a2x_states,"Sa_uovern")
+       call seq_flds_add(x2l_states,"Sa_uovern")
+       longname = 'Froude Number'
+       stdname  = 'Froude Number'
+       units    = 'Unitless'
+       attname  = 'Sa_uovern'
+       call metadata_set(attname, longname, stdname, units)
+    end if
 
     ! convective precipitation rate
     ! large-scale (stable) snow rate (water equivalent)


### PR DESCRIPTION
The implementation of the topography-based subgrid structure in E3SM includes new methods of downscaling of atmospheric forcing from the atmosphere grid to the subgrid units of the land model. One of the downscaling methods of precipitation requires Froude Number calculated by the atmospheric model as input, which is used to calculate the subgrid level precipitation for the land model. For this purpose, changes have been applied to the cime code by adding the new field to pass  from the atmosphere through the coupler to the land model.

Test suite: testing in E3SM
Test baseline: 
Test namelist changes: none
Test status: bit for bit when not using topo-based subgrid.

Fixes ESMCI/cime#3656

User interface changes?:  N


Code review:  jacob
