### PR TITLE
Change NCPL's for G-case default and grids EC30to60E2r2 and WC14to60E2r3

### DIFF
--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -429,6 +429,8 @@
       <value compset="_MPASO" grid="oi%oEC60to30v3">48</value>
       <value compset="_MPASO" grid="oi%oEC60to30wLI">48</value>
       <value compset="_MPASO" grid="oi%ECwISC30to60E1r2">48</value>
+      <value compset="_MPASO" grid="oi%EC30to60E2r2">48</value>
+      <value compset="_MPASO" grid="oi%WC14to60E2r3">48</value>
       <value compset="_MPASO" grid="oi%oRRS30to10v3">48</value>
       <value compset="_MPASO" grid="oi%oRRS30to10wLI">48</value>
       <value compset="_MPASO" grid="oi%oRRS18to6v3">48</value>

--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -299,7 +299,7 @@
       <value compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
       <value compset="_DATM.*_CICE.*_DOCN">24</value>
       <value compset="_DATM.*_DOCN%US20">24</value>
-      <value compset="_MPASO">1</value>
+      <value compset="_MPASO">48</value>
       <value compset="_DLND.*_MALI">1</value>
       <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">24</value>
@@ -311,6 +311,8 @@
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oEC60to30v3">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oEC60to30wLI">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%ECwISC30to60E1r2">48</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%EC30to60E2r2">48</value>
+      <value compset="_DATM.*_SLND.*MPAS" grid="oi%WC14to60E2r3">48</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS30to10v3">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS30to10wLI">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS18to6v3">96</value>


### PR DESCRIPTION
Set the coupling frequency for new MPAS-Ocean/Seaice grids EC30to60E2r2 and WC14to60E2r3 in E3SM. Also update the default G-case coupling frequency in E3SM.

[BFB]

Test suite: N/A
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review:

