### PR TITLE
Add mpi_init timer and ouput memory usage before CIME Run loop

### DIFF
--- a/config/e3sm/config_files.xml
+++ b/config/e3sm/config_files.xml
@@ -109,7 +109,7 @@
       <value component="drv"      >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/config_compsets.xml</value>
       <value component="cam"      >$SRCROOT/components/cam/cime_config/config_compsets.xml</value>
       <value component="scream"   >$SRCROOT/components/scream/cime_config/config_compsets.xml</value>
-      <value component="clm"      >$SRCROOT/components/clm/cime_config/config_compsets.xml</value>
+      <value component="elm"      >$SRCROOT/components/elm/cime_config/config_compsets.xml</value>
       <value component="cice"     >$SRCROOT/components/cice/cime_config/config_compsets.xml</value>
       <value component="mpaso"    >$SRCROOT/components/mpas-ocean/cime_config/config_compsets.xml</value>
       <value component="mali"     >$SRCROOT/components/mpas-albany-landice/cime_config/config_compsets.xml</value>
@@ -129,7 +129,7 @@
       <value component="allactive">$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="drv"      >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/config_pes.xml</value>
       <value component="cam"      >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
-      <value component="clm"      >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
+      <value component="elm"      >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="cice"     >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="mpaso"    >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="mali"     >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
@@ -154,7 +154,7 @@
       <value component="dwav">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dwav/cime_config/config_archive.xml</value>
       <!-- external model components -->
       <value component="cam"      >$SRCROOT/components/cam/cime_config/config_archive.xml</value>
-      <value component="clm"      >$SRCROOT/components/clm/cime_config/config_archive.xml</value>
+      <value component="elm"      >$SRCROOT/components/elm/cime_config/config_archive.xml</value>
       <value component="cice"     >$SRCROOT/components/cice/cime_config/config_archive.xml</value>
     </values>
     <group>case_last</group>
@@ -167,7 +167,7 @@
     <type>char</type>
     <values>
       <value component="any">$CIMEROOT/scripts/lib/CIME/SystemTests</value>
-      <value component="clm">$SRCROOT/components/clm/cime_config/SystemTests</value>
+      <value component="elm">$SRCROOT/components/elm/cime_config/SystemTests</value>
       <value component="cam">$SRCROOT/components/cam/cime_config/SystemTests</value>
       <value component="cice">$SRCROOT/components/cice/cime_config/SystemTests</value>
     </values>
@@ -191,7 +191,7 @@
       <value component="allactive">$SRCROOT/cime_config/testmods_dirs</value>
       <value component="drv"      >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/testdefs/testmods_dirs</value>
       <value component="cam"      >$SRCROOT/components/cam/cime_config/testdefs/testmods_dirs</value>
-      <value component="clm"      >$SRCROOT/components/clm/cime_config/testdefs/testmods_dirs</value>
+      <value component="elm"      >$SRCROOT/components/elm/cime_config/testdefs/testmods_dirs</value>
       <value component="cice"     >$SRCROOT/components/cice/cime_config/testdefs/testmods_dirs</value>
       <value component="mosart"   >$SRCROOT/components/mosart/cime_config/testdefs/testmods_dirs</value>
     </values>
@@ -207,7 +207,7 @@
       <value component="allactive">$SRCROOT/cime_config/usermods_dirs</value>
       <value component="drv"      >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/usermods_dirs</value>
       <value component="cam"      >$SRCROOT/components/cam/cime_config/usermods_dirs</value>
-      <value component="clm"      >$SRCROOT/components/clm/cime_config/usermods_dirs</value>
+      <value component="elm"      >$SRCROOT/components/elm/cime_config/usermods_dirs</value>
       <value component="cice"     >$SRCROOT/components/cice/cime_config/usermods_dirs</value>
       <value component="mosart"   >$SRCROOT/components/mosart/cime_config/usermods_dirs</value>
     </values>
@@ -291,7 +291,7 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="clm" >$SRCROOT/components/clm/cime_config/config_component.xml</value>
+      <value component="elm" >$SRCROOT/components/elm/cime_config/config_component.xml</value>
       <value component="dlnd">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dlnd/cime_config/config_component.xml</value>
       <value component="slnd">$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/slnd/cime_config/config_component.xml</value>
       <value component="xlnd">$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xlnd/cime_config/config_component.xml</value>

--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -125,7 +125,7 @@
     <valid_values>none,never,nsteps,nstep,nseconds,nsecond,nminutes,nminute,nhours,nhour,ndays,nday,nmonths,nmonth,nyears,nyear,date,ifdays0,end</valid_values>
     <default_value>never</default_value>
     <values match="last">
-      <value compset="_DATM.+_CLM">ndays</value>
+      <value compset="_DATM.+_ELM">ndays</value>
     </values>
     <group>run_begin_stop_restart</group>
     <file>env_run.xml</file>
@@ -271,9 +271,9 @@
       <value compset="_SLND.*SOCN.*_MALI">day</value>
       <value compset="_MPASO"       >day</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">day</value>
-      <value compset="_CAM.*_CLM.*MPASO">day</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">day</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">day</value>
+      <value compset="_CAM.*_ELM.*MPASO">day</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne11np4">day</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne120np4">day</value>
     </values>
     <desc>Base period associated with NCPL coupling frequency.
     This xml variable is only used to set the driver namelist variables,
@@ -294,7 +294,7 @@
       <value compset="_CAM%ADIAB">48</value>
       <value compset="_CAM%IDEAL">48</value>
       <value compset="_DATM%COPYALL_NPS">72</value>
-      <value compset="_DATM.*_CLM">48</value>
+      <value compset="_DATM.*_ELM">48</value>
       <value compset="_DATM.*_DICE.*_POP2">4</value>
       <value compset="_DATM.*_SLND.*_CICE.*_POP2">24</value>
       <value compset="_DATM.*_CICE.*_DOCN">24</value>
@@ -319,10 +319,10 @@
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oRRS15to5">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to10">96</value>
       <value compset="_DATM.*_SLND.*MPAS" grid="oi%oARRM60to6">96</value>
-      <value compset="_CAM.*_CLM.*MPASO">48</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="oi%oARRM60to10">96</value>
+      <value compset="_CAM.*_ELM.*MPASO">48</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne11np4">12</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne120np4">96</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="oi%oARRM60to10">96</value>
       <value compset=".+" grid="a%0.23x0.31">96</value>
       <value compset=".+" grid="a%ne4np4">12</value>
       <value compset=".+" grid="a%ne4np4.pg2">24</value>
@@ -374,11 +374,11 @@
       <value compset="_DLND.*_MALI">1</value>
       <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">$ATM_NCPL</value>
-      <value compset="_CAM.*_CLM.*MPASO">48</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne4np4">$ATM_NCPL</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">12</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">96</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="oi%oARRM60to10">96</value>
+      <value compset="_CAM.*_ELM.*MPASO">48</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne4np4">$ATM_NCPL</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne11np4">12</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne120np4">96</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="oi%oARRM60to10">96</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -395,7 +395,7 @@
       <value compset="_DLND.*_MALI">1</value>
       <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">$ATM_NCPL</value>
-      <value compset="_CAM.*_CLM.*MPASO">$ATM_NCPL</value>
+      <value compset="_CAM.*_ELM.*MPASO">$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -410,12 +410,12 @@
     <values match="last">
       <value compset="_POP2">1</value>
       <value compset="_POP2" grid="oi%tx0.1v2">4</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
+      <value compset="_DATM.*_ELM.*_SICE.*_SOCN">1</value>
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN.*_SWAV">1</value>
       <value compset="_DATM.*_DLND.*_DICE.*_DOCN.*_DWAV">1</value>
       <value compset="_DATM%NYF.*_SLND.*_DICE.*_DOCN.*_SWAV">1</value>
       <value compset="_XATM.*_XLND.*_XICE.*_XOCN">1</value>
-      <value compset="_DATM.*_CLM4.*_SICE.*_SOCN">1</value>
+      <value compset="_DATM.*_ELM.*_SICE.*_SOCN">1</value>
       <value compset="_SATM.*_SLND.*_SICE.*_SOCN">1</value>
       <value compset="_DLND.*_CISM\d">1</value>
       <value compset="_DLND.*_MALI">1</value>
@@ -454,9 +454,9 @@
       <value compset="_DLND.*_MALI">1</value>
       <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">1</value>
-      <value compset="_CAM.*_CLM.*MPASO">1</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">1</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">1</value>
+      <value compset="_CAM.*_ELM.*MPASO">1</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne11np4">1</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne120np4">1</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -499,10 +499,10 @@
       <value compset="_DLND.*_MALI">1</value>
       <value compset="_SLND.*SOCN.*_MALI">1</value>
       <value compset="_DATM.*_SLND.*MPASO.*_MALI">24</value>
-      <value compset="_CAM.*_CLM.*MPASO">8</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne4np4">6</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne11np4">4</value>
-      <value compset="_CAM.*_CLM.*MPASO" grid="a%ne120np4">8</value>
+      <value compset="_CAM.*_ELM.*MPASO">8</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne4np4">6</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne11np4">4</value>
+      <value compset="_CAM.*_ELM.*MPASO" grid="a%ne120np4">8</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>
@@ -698,7 +698,7 @@
     </values>
     <group>run_co2</group>
     <file>env_run.xml</file>
-    <desc>This set the namelist values of CO2 ppmv for CAM and CLM. This variables is
+    <desc>This set the namelist values of CO2 ppmv for CAM and ELM. This variables is
       introduced to coordinate this value among multiple components.</desc>
   </entry>
 
@@ -730,7 +730,7 @@
     <group>run_glc</group>
     <file>env_run.xml</file>
     <desc>Glacier model number of elevation classes, 0 implies no glacier land unit in clm
-    Used by both CLM and CISM (even if CISM is not running, and only SGLC is used).</desc>
+    Used by both ELM and CISM (even if CISM is not running, and only SGLC is used).</desc>
   </entry>
 
   <entry id="GLC_TWO_WAY_COUPLING">
@@ -738,9 +738,8 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <values match="last">
-      <value compset="_CLM45.+CISM\d">TRUE</value>
-      <value compset="_CLM45.*_MALI">TRUE</value>
-      <value compset="_CLM50.+CISM\d">TRUE</value>
+      <value compset="_ELM.+CISM\d">TRUE</value>
+      <value compset="_ELM.*_MALI">TRUE</value>
       <!-- Turn on two-way coupling for TG compsets - even though there are no
 	   feedbacks for a TG compset, this will give us additional diagnostics -->
       <value compset="_DLND.+CISM\d">TRUE</value>
@@ -749,7 +748,7 @@
     <file>env_run.xml</file>
     <desc>Whether the glacier component feeds back to the rest of the system
       This affects:
-      (1) Whether CLM updates its areas based on glacier areas sent from GLC
+      (1) Whether ELM updates its areas based on glacier areas sent from GLC
       (2) Whether GLC sends fluxes (e.g., calving fluxes) to the coupler
       Note that this is set to TRUE by default for TG compsets - even though there are
       no feedbacks for TG compsets, this enables extra coupler diagnostics for these
@@ -806,8 +805,8 @@
     <desc compset="SDYN_CAM">prescribed meteorology: for stand-alone cam</desc>
     <desc compset="AR95_CAM">ARM95 IOP: for stand-alone cam</desc>
     <desc compset="AR97_CAM">ARM97 IOP: for stand-alone cam</desc>
-    <desc compset="HIST_CLM4[05]%CN">CLM transient land use:</desc>
-    <desc compset="20TR_CLM4[05]%CN">CLM transient land use:</desc>
+    <desc compset="HIST_ELM%CN">ELM transient land use:</desc>
+    <desc compset="20TR_ELM%CN">ELM transient land use:</desc>
     <desc compset="PIPD">
       pre-industrial (1850) to present day:
       -----------------------------WARNING ------------------------------------------------

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -21,9 +21,10 @@ module cime_comp_mod
   ! share code & libs
   !----------------------------------------------------------------------------
   use shr_kind_mod,      only: r8 => SHR_KIND_R8
+  use shr_kind_mod,      only: i8 => SHR_KIND_I8
   use shr_kind_mod,      only: cs => SHR_KIND_CS
   use shr_kind_mod,      only: cl => SHR_KIND_CL
-  use shr_sys_mod,       only: shr_sys_abort, shr_sys_flush
+  use shr_sys_mod,       only: shr_sys_abort, shr_sys_flush, shr_sys_irtc
   use shr_const_mod,     only: shr_const_cday
   use shr_file_mod,      only: shr_file_setLogLevel, shr_file_setLogUnit
   use shr_file_mod,      only: shr_file_setIO, shr_file_getUnit, shr_file_freeUnit
@@ -192,7 +193,9 @@ module cime_comp_mod
   private
 
   ! public data
-  public  :: timing_dir, mpicom_GLOID
+  public  :: timing_dir
+  public  :: mpicom_GLOID
+  public  :: mpi_init_time
 
   ! public routines
   public  :: cime_pre_init1
@@ -375,6 +378,7 @@ module cime_comp_mod
   real(r8)      :: cktime_acc(10)    ! cktime accumulator array 1 = all, 2 = atm, etc
   integer       :: cktime_cnt(10)    ! cktime counter array
   real(r8)      :: max_cplstep_time
+  real(r8)      :: mpi_init_time     ! time elapsed in mpi_init call
   character(CL) :: timing_file       ! Local path to tprof filename
   character(CL) :: timing_dir        ! timing directory
   character(CL) :: tchkpt_dir        ! timing checkpoint directory
@@ -675,8 +679,18 @@ contains
     character(len=8) :: c_cpl_inst    ! coupler instance number
     character(len=8) :: c_cpl_npes    ! number of pes in coupler
 
+    integer(i8) :: beg_count          ! start time
+    integer(i8) :: end_count          ! end time
+    integer(i8) :: irtc_rate          ! factor to convert time to seconds
+    
+    beg_count = shr_sys_irtc(irtc_rate)
+    
     call mpi_init(ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_init')
+
+    end_count = shr_sys_irtc(irtc_rate)
+    mpi_init_time = real( (end_count-beg_count), r8)/real(irtc_rate, r8)
+    
     call mpi_comm_dup(MPI_COMM_WORLD, global_comm, ierr)
     call shr_mpi_chkerr(ierr,subname//' mpi_comm_dup')
 
@@ -2353,6 +2367,7 @@ contains
 108 format( A, f10.2, A, i8.8)
 109 format( A, 2f10.3)
 
+    call t_startf ('CPL:cime_run_init')
     hashint = 0
 
     call seq_infodata_putData(infodata,atm_phase=1,lnd_phase=1,ocn_phase=1,ice_phase=1)
@@ -2377,8 +2392,29 @@ contains
 
     ! --- Write out performance data for initialization
     call seq_timemgr_EClockGetData( EClock_d, curr_ymd=ymd, curr_tod=tod)
+#ifndef CPL_BYPASS
+    ! Report on memory usage
+    ! (For now, just look at the first instance of each component)
+    if ( iamroot_CPLID .or. &
+         ocn(ens1)%iamroot_compid .or. &
+         atm(ens1)%iamroot_compid .or. &
+         lnd(ens1)%iamroot_compid .or. &
+         ice(ens1)%iamroot_compid .or. &
+         glc(ens1)%iamroot_compid .or. &
+         wav(ens1)%iamroot_compid .or. &
+         iac(ens1)%iamroot_compid) then
+       call shr_mem_getusage(msize,mrss,.true.)
+
+       write(logunit,105) ' memory_write: model date = ',ymd,tod, &
+            ' memory = ',msize,' MB (highwater)    ',mrss,' MB (usage)', &
+            '  (pe=',iam_GLOID,' comps=',trim(complist)//')'
+    endif
+#endif
+    ! Write out a timing file checkpoint
     write(timing_file,'(a,i8.8,a1,i5.5)') &
           trim(tchkpt_dir)//"/model_timing"//trim(cpl_inst_tag)//"_",ymd,"_",tod
+
+    call t_stopf ('CPL:cime_run_init')
 
     call t_set_prefixf("CPL:INIT_")
     call cime_write_performance_checkpoint(output_perf,timing_file,mpicom_GLOID)

--- a/src/drivers/mct/main/cime_driver.F90
+++ b/src/drivers/mct/main/cime_driver.F90
@@ -36,6 +36,7 @@ program cime_driver
   use cime_comp_mod, only : cime_init
   use cime_comp_mod, only : cime_run
   use cime_comp_mod, only : cime_final
+  use cime_comp_mod, only : mpi_init_time
   use seq_comm_mct,  only : logunit
 
   implicit none
@@ -45,7 +46,7 @@ program cime_driver
   !--------------------------------------------------------------------------
   integer(i8) :: beg_count, end_count, irtc_rate
   real(r8)    :: cime_pre_init1_time, ESMF_Initialize_time, &
-       cime_pre_init2_time, cime_init_time_adjustment
+                 cime_pre_init2_time, cime_init_time_adjustment
 
   !--------------------------------------------------------------------------
   ! For ESMF logging
@@ -115,7 +116,12 @@ program cime_driver
   call t_startf('CPL:INIT')
   call t_adj_detailf(+1)
 
-  call t_startstop_valsf('CPL:cime_pre_init1',  walltime=cime_pre_init1_time)
+  call t_startf('CPL:cime_pre_init1')
+  call t_startstop_valsf('CPL:mpi_init', walltime=mpi_init_time)
+  call t_stopf('CPL:cime_pre_init1')
+
+  call t_startstop_valsf('CPL:cime_pre_init1',  walltime=cime_pre_init1_time, &
+                         callcount = 0)
   call t_startstop_valsf('CPL:ESMF_Initialize', walltime=ESMF_Initialize_time)
   call t_startstop_valsf('CPL:cime_pre_init2',  walltime=cime_pre_init2_time)
 
@@ -125,10 +131,10 @@ program cime_driver
   call t_stopf('CPL:INIT')
 
   cime_init_time_adjustment = cime_pre_init1_time  &
-       + ESMF_Initialize_time &
-       + cime_pre_init2_time
+                            + ESMF_Initialize_time &
+                            + cime_pre_init2_time
   call t_startstop_valsf('CPL:INIT',  walltime=cime_init_time_adjustment, &
-       callcount=0)
+                         callcount=0)
 
   call cime_run()
   call cime_final()


### PR DESCRIPTION
Add mpi_init timer and ouput memory usage before CIME Run loop
- Add a timer around the call to MPI_Init in cime_pre_init1, to better
document MPI overhead.
- Also, right before the run loop, query memory usage with
shr_mem_getusage and write it out.
- Finally, add a timer around the initialization part of cime_run,
including the memory usage output.

[BFB]