### PR TITLE
Downgrade Intel Compiler for UFS applications

### DIFF
--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -110,7 +110,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">cmake/3.16.4</command>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel/19.1.1</command>
+	<command name="load">intel/19.0.5</command>
 	<command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">

--- a/config/ufs/machines/config_machines.xml
+++ b/config/ufs/machines/config_machines.xml
@@ -139,9 +139,9 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">NCEPlibs/1.1.0</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
-	<command name="use">/glade/p/ral/jntp/GMTB/tools/ufs-stack-20200825/intel-19.1.1/mpt-2.19/modules</command>
+	<command name="use">/glade/p/ral/jntp/GMTB/tools/ufs-stack-20200909/intel-19.0.5/mpt-2.19/modules</command>
 	<command name="load">libpng/1.6.35</command>
-	<command name="load">esmf/8.1.0bs21</command>
+	<command name="load">esmf/8.1.0bs27</command>
 	<command name="load">netcdf/4.7.4</command>
 	<command name="load">bacio/2.4.0</command>
 	<command name="load">crtm/2.3.0</command>
@@ -156,8 +156,6 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">gfsio/1.4.0</command>
 	<command name="load">sfcio/1.4.0</command>
 	<command name="load">sigio/2.3.0</command>
-	<command name="use">/glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.1.1/mpt-2.19/</command>
-	<command name="load">SIONlib/1.7.4</command>
       </modules>
       <modules compiler="intel" mpilib="impi" DEBUG="FALSE" comp_interface="nuopc">
 	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5</command>


### PR DESCRIPTION
This PR aims to downgrade the intel compiler version from 19.1.1, which was causing a problem in HYCOM+DATM application, to 19.0.5 for UFS applications.

Test suite: Two configuration of UFS HAFS (standalone UFSATM and HYCOM+DATM), S2S (just build) are working without any problem.
Test baseline: N/A
Test namelist changes: N/A
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
