### PR TITLE
allow for different atm names in chem_mech file generation

### DIFF
--- a/scripts/lib/CIME/case/preview_namelists.py
+++ b/scripts/lib/CIME/case/preview_namelists.py
@@ -107,6 +107,7 @@ def create_namelists(self, component=None):
             safe_copy(file_to_copy, docdir)
 
     # Copy over chemistry mechanism docs if they exist
-    if (os.path.isdir(os.path.join(casebuild, "camconf"))):
-        for file_to_copy in glob.glob(os.path.join(casebuild, "camconf", "*chem_mech*")):
+    atmconf = self.get_value("COMP_ATM") + "conf"
+    if (os.path.isdir(os.path.join(casebuild, atmconf))):
+        for file_to_copy in glob.glob(os.path.join(casebuild, atmconf, "*chem_mech*")):
             safe_copy(file_to_copy, docdir)


### PR DESCRIPTION
Allow for eam and cam in generation of chem files.

Test suite: hand tested B1850
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3724

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
