### PR TITLE
Add EAM case for 20TR CMIP6 docn component

### DIFF
--- a/src/components/data_comps_mct/docn/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/docn/cime_config/config_component.xml
@@ -187,6 +187,7 @@
       <value compset="2010S_" grid="a%ne30np4.*_oi%oEC60to30v3"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_2010_clim_c20190821.nc</value>
       <value compset="2010S_" grid="a%ne0np4_*.*"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_2010_clim_c20190821.nc</value>
       <value compset="20TR_CAM5%CMIP6" grid=".+"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_c20180213.nc</value>
+      <value compset="20TR_EAM%CMIP6" grid=".+"					>$DIN_LOC_ROOT/ocn/docn7/SSTDATA/sst_ice_CMIP6_DECK_E3SM_1x1_c20180213.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
       <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>
@@ -244,6 +245,7 @@
       <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
       <value compset="20TR_CAM5%AV">1850</value>
       <value compset="20TR_CAM5%CMIP6">1869</value>
+      <value compset="20TR_EAM%CMIP6">1869</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -268,6 +270,7 @@
       <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">1850</value>
       <value compset="20TR_CAM5%AV">1850</value>
       <value compset="20TR_CAM5%CMIP6">1869</value>
+      <value compset="20TR_EAM%CMIP6">1869</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -286,6 +289,7 @@
       <value compset="(AMIP_|HIST_|5505_|PIPD_|%TSCH)">2012</value>
       <value compset="20TR_CAM5%AV">2012</value>
       <value compset="20TR_CAM5%CMIP6">2016</value>
+      <value compset="20TR_EAM%CMIP6">2016</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Add EAM case for 20TR CMIP6 docn component


Test suite:  e3sm_prod

Test status: bit-for-bit except for E3SM F20TRC5-CMIP6 case

User interface changes?:  N