### PR TITLE
Fix check_input_data to fail over to svn when a wget download fails

### DIFF
--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -358,18 +358,21 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
 
                         if ("/" in rel_path and not os.path.exists(full_path) and not full_path.startswith('unknown')):
                             print("Model {} missing file {} = '{}'".format(model, description, full_path))
-                            no_files_missing = False
                             if (download):
                                 if use_ic_path:
-                                    no_files_missing = _download_if_in_repo(server,
+                                    success = _download_if_in_repo(server,
                                                                             input_ic_root, rel_path.strip(os.sep),
                                                                             isdirectory=isdirectory, ic_filepath=ic_filepath)
                                 else:
-                                    no_files_missing = _download_if_in_repo(server,
+                                    success = _download_if_in_repo(server,
                                                                             input_data_root, rel_path.strip(os.sep),
                                                                             isdirectory=isdirectory, ic_filepath=ic_filepath)
-                                if no_files_missing and chksum:
+                                if not success:
+                                    no_files_missing = False
+                                if success and chksum:
                                     verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)
+                            else:
+                                no_files_missing = False
                         else:
                             if chksum:
                                 verify_chksum(input_data_root, rundir, rel_path.strip(os.sep), isdirectory)


### PR DESCRIPTION
That commit, https://github.com/ESMCI/cime/commit/897f79b94b2706d3e2c41719ae5b3aee2f8f3264, causes that check_input_data(download=True) returns False when the last wget downloads fails, and returns True when the last wget download succeeds even if all other wget downloads have failed. This PR fixes this bug.