### PR TITLE
Some updates to E3SM test infrastructure

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -3,7 +3,7 @@ Base class for CIME system tests
 """
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_run import EnvRun
-from CIME.utils import append_testlog, get_model, safe_copy, get_timestamp, CIMEError, expect
+from CIME.utils import append_testlog, get_model, safe_copy, get_timestamp, CIMEError, expect, get_current_commit
 from CIME.test_status import *
 from CIME.hist_utils import copy_histfiles, compare_test, generate_teststatus, \
     compare_baseline, get_ts_synopsis, generate_baseline
@@ -202,7 +202,8 @@ class SystemTestsCommon(object):
                 # If run phase worked, remember the time it took in order to improve later walltime ests
                 baseline_root = self._case.get_value("BASELINE_ROOT")
                 if success:
-                    save_test_time(baseline_root, self._casebaseid, time_taken)
+                    srcroot = self._case.get_value("SRCROOT")
+                    save_test_time(baseline_root, self._casebaseid, time_taken, get_current_commit(repo=srcroot))
 
                 # If overall things did not pass, offer the user some insight into what might have broken things
                 overall_status = self._test_status.get_overall_test_status(ignore_namelists=True)

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -432,7 +432,7 @@ def get_recommended_test_time_based_on_past(baseline_root, test, raw=False):
         try:
             the_path = os.path.join(baseline_root, _WALLTIME_BASELINE_NAME, test, _WALLTIME_FILE_NAME)
             if os.path.exists(the_path):
-                last_line = int(open(the_path, "r").readlines()[-1])
+                last_line = int(open(the_path, "r").readlines()[-1].split()[0])
                 if raw:
                     best_walltime = last_line
                 else:
@@ -454,7 +454,7 @@ def get_recommended_test_time_based_on_past(baseline_root, test, raw=False):
 
     return None
 
-def save_test_time(baseline_root, test, time_seconds):
+def save_test_time(baseline_root, test, time_seconds, commit):
     if baseline_root is not None:
         try:
             with SharedArea():
@@ -464,7 +464,7 @@ def save_test_time(baseline_root, test, time_seconds):
 
                 the_path = os.path.join(the_dir, _WALLTIME_FILE_NAME)
                 with open(the_path, "a") as fd:
-                    fd.write("{}\n".format(int(time_seconds)))
+                    fd.write("{} {}\n".format(int(time_seconds), commit))
 
         except Exception:
             # We NEVER want a failure here to kill the run

--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -219,25 +219,21 @@ def create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_ti
         for test_name, test_data in results.items():
             test_path, test_status = test_data
 
-            if test_status not in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS] or force_log_upload:
+            if test_status != TEST_PASS_STATUS or force_log_upload:
                 test_case_dir = os.path.dirname(test_path)
-                ts = TestStatus(test_case_dir)
 
-                build_status    = ts.get_status(SHAREDLIB_BUILD_PHASE)
-                build_status    = TEST_FAIL_STATUS if build_status == TEST_FAIL_STATUS else ts.get_status(MODEL_BUILD_PHASE)
-                run_status      = ts.get_status(RUN_PHASE)
-                baseline_status = ts.get_status(BASELINE_PHASE)
+                case_dirs = [test_case_dir]
+                case_base = os.path.basename(test_case_dir)
+                test_case2_dir = os.path.join(test_case_dir, "case2", case_base)
+                if os.path.exists(test_case2_dir):
+                    case_dirs.append(test_case2_dir)
 
-                if build_status == TEST_FAIL_STATUS or run_status == TEST_FAIL_STATUS or baseline_status == TEST_FAIL_STATUS or force_log_upload:
-                    case_dirs = [test_case_dir]
-                    case_base = os.path.basename(test_case_dir)
-                    test_case2_dir = os.path.join(test_case_dir, "case2", case_base)
-                    if os.path.exists(test_case2_dir):
-                        case_dirs.append(test_case2_dir)
-
-                    for case_dir in case_dirs:
-                        param = "EXEROOT" if build_status == TEST_FAIL_STATUS else "RUNDIR"
-                        log_src_dir = run_cmd_no_fail("./xmlquery {} --value".format(param), from_dir=case_dir)
+                for case_dir in case_dirs:
+                    for param in ["EXEROOT", "RUNDIR", "CASEDIR"]:
+                        if param == "CASEDIR":
+                            log_src_dir = case_dir
+                        else:
+                            log_src_dir = run_cmd_no_fail("./xmlquery {} --value".format(param), from_dir=case_dir)
 
                         log_dst_dir = os.path.join(log_dir, "{}{}_{}_logs".format(test_name, "" if case_dir == test_case_dir else ".case2", param))
                         os.makedirs(log_dst_dir)
@@ -246,9 +242,9 @@ def create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_ti
                         for log_file in glob.glob(os.path.join(log_src_dir, "*.cprnc.out*")):
                             safe_copy(log_file, log_dst_dir)
 
-                        need_to_upload = True
+                need_to_upload = True
 
-        if (need_to_upload):
+        if need_to_upload:
 
             tarball = "{}.tar.gz".format(log_dir)
             if (os.path.exists(tarball)):

--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -233,12 +233,20 @@ def create_cdash_upload_xml(results, cdash_build_name, cdash_build_group, utc_ti
                         if param == "CASEDIR":
                             log_src_dir = case_dir
                         else:
-                            log_src_dir = run_cmd_no_fail("./xmlquery {} --value".format(param), from_dir=case_dir)
+                            # it's possible that tests that failed very badly/early, and fake cases for testing
+                            # will not be able to support xmlquery
+                            try:
+                                log_src_dir = run_cmd_no_fail("./xmlquery {} --value".format(param), from_dir=case_dir)
+                            except:
+                                continue
 
                         log_dst_dir = os.path.join(log_dir, "{}{}_{}_logs".format(test_name, "" if case_dir == test_case_dir else ".case2", param))
                         os.makedirs(log_dst_dir)
                         for log_file in glob.glob(os.path.join(log_src_dir, "*log*")):
-                            safe_copy(log_file, log_dst_dir)
+                            if os.path.isdir(log_file):
+                                shutil.copytree(log_file, os.path.join(log_dst_dir, os.path.basename(log_file)))
+                            else:
+                                safe_copy(log_file, log_dst_dir)
                         for log_file in glob.glob(os.path.join(log_src_dir, "*.cprnc.out*")):
                             safe_copy(log_file, log_dst_dir)
 


### PR DESCRIPTION
1) When recording walltimes, include commit for provenance. This data can now be more useful than simply creating more-accurate walltime estimates; for example, we could potentially create time plots of performance.
2) Be more aggressive about uploading logs: include logs from all potential sources, even when the only problem is NML diff.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @rljacob @amametjanov  
