### PR TITLE
In MEMLEAK checks, skip first day memory highwater while initializing.

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -421,9 +421,9 @@ class SystemTestsCommon(object):
                     self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS, comments="insuffiencient data for memleak test")
                 else:
                     finaldate = int(memlist[-1][0])
-                    originaldate = int(memlist[0][0])
+                    originaldate = int(memlist[1][0]) # skip first day mem record, it can be too low while initializing
                     finalmem = float(memlist[-1][1])
-                    originalmem = float(memlist[0][1])
+                    originalmem = float(memlist[1][1])
                     memdiff = -1
                     if originalmem > 0:
                         memdiff = (finalmem - originalmem)/originalmem


### PR DESCRIPTION
In MEMLEAK checks, skip first day memory highwater while initializing.

Test suite: SMS.f19_g16_rx1.A.anvil_intel
Test baseline: n/a
Test namelist changes: none
Test status: [bit for bit]

Fixes ESMCI/cime#3735

User interface changes?: none

Update gh-pages html (Y/N)?: n/a
