### PR TITLE
Wpcoomb change name ccsm cppdefs

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -493,7 +493,7 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
 def _create_build_metadata_for_component(config_dir, libroot, bldroot, case):
 ###############################################################################
     """
-    Ensure that crucial Filepath, CIME_CPPDEFS, and CCSM_CPPDEFS files exist for this component.
+    Ensure that crucial Filepath and CIME_CPPDEFS files exist for this component.
     In many cases, the bld/configure script will have already created these.
     """
     bc_path = os.path.join(config_dir, "buildlib_cmake")

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -493,13 +493,14 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
 def _create_build_metadata_for_component(config_dir, libroot, bldroot, case):
 ###############################################################################
     """
-    Ensure that crucial Filepath and CCSM_CPPDEFS files exist for this component.
+    Ensure that crucial Filepath, CIME_cppdefs, and CCSM_CPPDEFS files exist for this component.
     In many cases, the bld/configure script will have already created these.
     """
     bc_path = os.path.join(config_dir, "buildlib_cmake")
     expect(os.path.exists(bc_path), "Missing: {}".format(bc_path))
     buildlib = imp.load_source("buildlib_cmake", os.path.join(config_dir, "buildlib_cmake"))
     cmake_args = buildlib.buildlib(bldroot, libroot, case)
+    print("wpc2. in build.py bc_path is {} . cmake_args is {} .".format(bc_path, cmake_args))
     return "" if cmake_args is None else cmake_args
 
 ###############################################################################

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -493,7 +493,7 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
 def _create_build_metadata_for_component(config_dir, libroot, bldroot, case):
 ###############################################################################
     """
-    Ensure that crucial Filepath, CIME_cppdefs, and CCSM_CPPDEFS files exist for this component.
+    Ensure that crucial Filepath, CIME_CPPDEFS, and CCSM_CPPDEFS files exist for this component.
     In many cases, the bld/configure script will have already created these.
     """
     bc_path = os.path.join(config_dir, "buildlib_cmake")

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -500,7 +500,6 @@ def _create_build_metadata_for_component(config_dir, libroot, bldroot, case):
     expect(os.path.exists(bc_path), "Missing: {}".format(bc_path))
     buildlib = imp.load_source("buildlib_cmake", os.path.join(config_dir, "buildlib_cmake"))
     cmake_args = buildlib.buildlib(bldroot, libroot, case)
-    print("wpc2. in build.py bc_path is {} . cmake_args is {} .".format(bc_path, cmake_args))
     return "" if cmake_args is None else cmake_args
 
 ###############################################################################

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -71,7 +71,6 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
     with open(os.path.join(confdir, "CIME_cppdefs"), "w") as out:
         out.write("")
 
-    print("wpc1. in buildlib.py confdir is {} . bldroot is {} .".format(confdir, bldroot))
     # Build the component
     if get_model() != "e3sm" or use_old:
         safe_copy(os.path.join(confdir, "Filepath"), bldroot)

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -66,16 +66,17 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
         elif compname.startswith('s'):
             out.write(os.path.join(cimeroot, "src", "components", "stub_comps_"+comp_interface, compname, "src") + "\n")
 
-    with open(os.path.join(confdir, "CCSM_cppdefs"), "w") as out:
-        out.write("")
     with open(os.path.join(confdir, "CIME_cppdefs"), "w") as out:
         out.write("")
 
     # Build the component
     if get_model() != "e3sm" or use_old:
         safe_copy(os.path.join(confdir, "Filepath"), bldroot)
-        safe_copy(os.path.join(confdir, "CCSM_cppdefs"), bldroot)
-        safe_copy(os.path.join(confdir, "CIME_cppdefs"), bldroot)
+        if os.path.exists(os.path.join(confdir, "CIME_cppdefs")):
+            safe_copy(os.path.join(confdir, "CIME_cppdefs"), bldroot)
+        elif os.path.exists(os.path.join(confdir, "CCSM_cppdefs")):
+            safe_copy(os.path.join(confdir, "CCSM_cppdefs"), bldroot)
+
         run_gmake(case, compclass, compname, libroot, bldroot)
 
 ###############################################################################

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -76,7 +76,6 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
             safe_copy(os.path.join(confdir, "CIME_cppdefs"), bldroot)
         elif os.path.exists(os.path.join(confdir, "CCSM_cppdefs")):
             safe_copy(os.path.join(confdir, "CCSM_cppdefs"), bldroot)
-
         run_gmake(case, compclass, compname, libroot, bldroot)
 
 ###############################################################################

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -68,11 +68,15 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
 
     with open(os.path.join(confdir, "CCSM_cppdefs"), "w") as out:
         out.write("")
+    with open(os.path.join(confdir, "CIME_cppdefs"), "w") as out:
+        out.write("")
 
+    print("wpc1. in buildlib.py confdir is {} . bldroot is {} .".format(confdir, bldroot))
     # Build the component
     if get_model() != "e3sm" or use_old:
         safe_copy(os.path.join(confdir, "Filepath"), bldroot)
         safe_copy(os.path.join(confdir, "CCSM_cppdefs"), bldroot)
+        safe_copy(os.path.join(confdir, "CIME_cppdefs"), bldroot)
         run_gmake(case, compclass, compname, libroot, bldroot)
 
 ###############################################################################

--- a/src/drivers/mct/cime_config/buildlib_cmake
+++ b/src/drivers/mct/cime_config/buildlib_cmake
@@ -30,8 +30,6 @@ def buildlib(bldroot, installpath, case): # pylint: disable=unused-argument
         out.write(os.path.join(caseroot, "SourceMods", "src.drv") + "\n")
         out.write(os.path.join(cimeroot, "src", "drivers", "mct", "main") + "\n")
 
-    with open(os.path.join(casebuild, "cplconf", "CCSM_cppdefs"), "w") as out:
-        out.write("")
     with open(os.path.join(casebuild, "cplconf", "CIME_cppdefs"), "w") as out:
         out.write("")
 

--- a/src/drivers/mct/cime_config/buildlib_cmake
+++ b/src/drivers/mct/cime_config/buildlib_cmake
@@ -32,6 +32,8 @@ def buildlib(bldroot, installpath, case): # pylint: disable=unused-argument
 
     with open(os.path.join(casebuild, "cplconf", "CCSM_cppdefs"), "w") as out:
         out.write("")
+    with open(os.path.join(casebuild, "cplconf", "CIME_cppdefs"), "w") as out:
+        out.write("")
 
 ###############################################################################
 def _main_func():


### PR DESCRIPTION
I improved the cime commits to
1)Execute new writes to the new renamed CIME _cppdefs file,
2)Open and safe copy the new CIME_cppdefs file, if the file exists
3)Open and safe copy the old CCSM_cppdefs file, if the system
is unable to find the CIME_cppdefs file. 
This supports Rob Jacob's proposal to keep both, CIME_cppdefs and CCSM_cppdefs,
for a little while to give models time to adjust.

Test suite: scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: [bit for bit]

Fixes #3717

User interface changes?:

Update gh-pages html (Y/N)?:

Code review: @jgfouca 