### PR TITLE
Add a no-submit option to jenkins_generic_job

### DIFF
--- a/scripts/Tools/jenkins_generic_job
+++ b/scripts/Tools/jenkins_generic_job
@@ -54,6 +54,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("--submit-to-cdash", action="store_true",
                         help="Send results to CDash")
 
+    parser.add_argument("-n", "--no-submit", action="store_true",
+                        help="For us to not send results to CDash, overrides --submit-to-cdash")
+
     parser.add_argument("--update-success", action="store_true",
                         help="Record test success in baselines. Only the nightly process should use this in general.")
 
@@ -103,6 +106,9 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
                         help="Compiler to use to build cime.  Default will be the default defined for the machine.")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+
+    if args.no_submit:
+        args.submit_to_cdash = False
 
     expect(not (args.submit_to_cdash and args.generate_baselines),
            "Does not make sense to use --generate-baselines and --submit-to-cdash together")


### PR DESCRIPTION
Will allow users of jenkins_script to override the default behavior (submitting to cdash).

Test suite: P_TestJenkinsGenericJob, code-checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
