### PR TITLE
Fix hang in TESTRUNDIFFRESUBMIT

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -613,7 +613,7 @@ class FakeTest(SystemTestsCommon):
                 expect(os.path.exists(modelexe),"Could not find expected file {}".format(modelexe))
                 logger.info("FakeTest build_phase complete {} {}".format(modelexe, self._requires_exe))
 
-    def run_indv(self, suffix="base", st_archive=False, submit_resubmits=False):
+    def run_indv(self, suffix="base", st_archive=False, submit_resubmits=None):
         mpilib = self._case.get_value("MPILIB")
         # This flag is needed by mpt to run a script under mpiexec
         if mpilib == "mpt":


### PR DESCRIPTION
It was causing Q_TestBlessTestResults to hang

Test suite: by-hand
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3743 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b 
