### PR TITLE
Esmf and pgi cheyenne update

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -501,7 +501,7 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">openblas/0.3.6</command>
       </modules>
       <modules compiler="pgi">
-	<command name="load">pgi/19.3</command>
+	<command name="load">pgi/19.9</command>
       </modules>
 
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
@@ -520,14 +520,56 @@ This allows using a different mpirun command to launch unit tests
 	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
 	<command name="load">esmf-8.1.0b33-ncdfio-mpiuni-O</command>
       </modules>
-      <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="TRUE">
-	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+      <modules compiler="gnu" mpilib="mpt" DEBUG="TRUE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
 	<command name="load">esmf-8.1.0b33-ncdfio-mpt-g</command>
       </modules>
-      <modules compiler="gnu" mpilib="!mpi-serial" DEBUG="FALSE">
-	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
+      <modules compiler="gnu" mpilib="mpt" DEBUG="FALSE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
 	<command name="load">esmf-8.1.0b33-ncdfio-mpt-O</command>
       </modules>
+      <modules compiler="gnu" mpilib="openmpi" DEBUG="TRUE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
+	<command name="load">esmf-8.1.0b33-ncdfio-openmpi-g</command>
+      </modules>
+      <modules compiler="gnu" mpilib="openmpi" DEBUG="FALSE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
+	<command name="load">esmf-8.1.0b33-ncdfio-openmpi-O</command>
+      </modules>
+      <modules compiler="gnu" mpilib="mpi-serial" DEBUG="TRUE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
+	<command name="load">esmf-8.1.0b33-ncdfio-mpiuni-g</command>
+      </modules>
+      <modules compiler="gnu" mpilib="mpi-serial" DEBUG="FALSE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
+	<command name="load">esmf-8.1.0b33-ncdfio-mpiuni-O</command>
+      </modules>
+
+      <modules compiler="pgi" mpilib="mpt" DEBUG="TRUE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
+	<command name="load">esmf-8.1.0b29-ncdfio-mpt-g</command>
+      </modules>
+      <modules compiler="pgi" mpilib="mpt" DEBUG="FALSE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
+	<command name="load">esmf-8.1.0b29-ncdfio-mpt-O</command>
+      </modules>
+      <modules compiler="pgi" mpilib="openmpi" DEBUG="TRUE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
+	<command name="load">esmf-8.1.0b29-ncdfio-openmpi-g</command>
+      </modules>
+      <modules compiler="pgi" mpilib="openmpi" DEBUG="FALSE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
+	<command name="load">esmf-8.1.0b29-ncdfio-openmpi-O</command>
+      </modules>
+      <modules compiler="pgi" mpilib="mpi-serial" DEBUG="TRUE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
+	<command name="load">esmf-8.1.0b29-ncdfio-mpiuni-g</command>
+      </modules>
+      <modules compiler="pgi" mpilib="mpi-serial" DEBUG="FALSE">
+	<command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
+	<command name="load">esmf-8.1.0b29-ncdfio-mpiuni-O</command>
+      </modules>
+
 
       <modules mpilib="mpt" compiler="gnu">
 	<command name="load">mpt/2.21</command>

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -136,7 +136,7 @@ def buildlib(bldroot, installpath, case):
     #
     case_inc_dir = os.path.join(libroot, "include")
     if not os.path.isdir(case_inc_dir):
-        os.path.mkdir(case_inc_dir)
+        os.mkdir(case_inc_dir)
     for _file in glob.iglob(os.path.join(installdir,"include","*")):
         symlink_force(_file, os.path.join(case_inc_dir,os.path.basename(_file)))
 

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from standard_script_setup import *
-from CIME.utils import copyifnewer, run_bld_cmd_ensure_logging, expect
+from CIME.utils import copyifnewer, run_bld_cmd_ensure_logging, expect, symlink_force
 from CIME.case import Case
 from CIME.build import get_standard_makefile_args
 import glob
@@ -48,6 +48,7 @@ def buildlib(bldroot, installpath, case):
     comp_interface = case.get_value("COMP_INTERFACE")
     cimeroot = case.get_value("CIMEROOT")
     caseroot = case.get_value("CASEROOT")
+    libroot = case.get_value("LIBROOT")
 
     filepath = [os.path.join(caseroot,"SourceMods","src.share"),
                 os.path.join(cimeroot,"src","share","streams"),
@@ -129,6 +130,17 @@ def buildlib(bldroot, installpath, case):
 
     cmd = "{} {}".format(gmake_cmd, gmake_opts)
     run_bld_cmd_ensure_logging(cmd, logger)
+    #
+    # The pgi compiler sometimes has issues with long include paths
+    # on the command line, this is a workaround for that problem
+    #
+    case_inc_dir = os.path.join(libroot, "include")
+    if not os.path.isdir(case_inc_dir):
+        os.path.mkdir(case_inc_dir)
+    for _file in glob.iglob(os.path.join(installdir,"include","*")):
+        symlink_force(_file, os.path.join(case_inc_dir,os.path.basename(_file)))
+
+
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)


### PR DESCRIPTION
Updating the pgi compiler version and esmf for pgi and gnu on cheyenne, add a workaround for pgi include path length

Test suite: scripts_regression_tests.py on cheyenne with pgi and gnu and openmpi and mct
Test baseline: 
Test namelist changes: 
Test status: bit for bit,

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
