### PR TITLE
Use enhanced compiler flags for PUMAS/MG3 related F90 codes

### DIFF
--- a/config/cesm/machines/Depends.intel
+++ b/config/cesm/machines/Depends.intel
@@ -26,6 +26,13 @@ dSFMT.o \
 dSFMT_utils.o \
 kissvec.o
 
+PUMAS_MG_OBJS=\
+micro_mg1_0.o \
+micro_mg3_0.o \
+micro_pumas_data.o \
+micro_pumas_utils.o \
+wv_sat_methods.o
+
 ifeq ($(DEBUG),FALSE)
   $(PERFOBJS): %.o: %.F90
 	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -O3  -no-prec-div $<
@@ -37,4 +44,6 @@ ifeq ($(DEBUG),FALSE)
 	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -fp-model fast -no-prec-div -no-prec-sqrt -qoverride-limits $<
   $(SHR_RANDNUM_C_OBJS): %.o: %.c
 	  $(CC) -c $(INCLDIR) $(INCS) $(CFLAGS) -O3 -fp-model fast $<
+  $(PUMAS_MG_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -xCORE-AVX2 -no-fma -ftz -fast-transcendentals -no-prec-sqrt -no-prec-div -qoverride-limits -no-inline-max-total-size -inline-factor=200 -fp-model fast -qopt-report=5 $<
 endif


### PR DESCRIPTION
We have updated the `Depends.intel` file to apply enhanced Intel compiler flags to the PUMAS/MG3 related F90 codes.
These flags are necessary to make our future optimization of PUMAS/MG3 codes work properly.

- Test suite: UF-ECT in CESM (tag: release-cesm2.2.0)
- Test baseline: On Cheyenne, /glade/p/cesmdata/cseg/inputdata/validation/uf_ensembles/cesm2.2.0/uf_ens.f19_f19_mg17.F2000climo.cesm2.2.0.cheyenne_intel.summary_c200914
- Test status: non bit for bit, but ECT issues PASS flag

Code review: @johnmauff @jedwards4b 