### PR TITLE
Fix E3SM nightly TSC test failure

### DIFF
--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -108,7 +108,7 @@ def rename_all_hist_files(case, suffix):
             mname = 'drv'
         else:
             mname = model
-        test_hists = archive.get_all_hist_files(mname, rundir, ref_case=ref_case)
+        test_hists = archive.get_all_hist_files(case, mname, rundir, ref_case=ref_case)
         num_renamed += len(test_hists)
         for test_hist in test_hists:
             test_hist = os.path.join(rundir, test_hist)

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -108,7 +108,7 @@ def rename_all_hist_files(case, suffix):
             mname = 'drv'
         else:
             mname = model
-        test_hists = archive.get_all_hist_files(case, mname, rundir, ref_case=ref_case)
+        test_hists = archive.get_all_hist_files(case.get_value("CASE"), mname, rundir, ref_case=ref_case)
         num_renamed += len(test_hists)
         for test_hist in test_hists:
             test_hist = os.path.join(rundir, test_hist)


### PR DESCRIPTION
In c66e1c9, casename was added as an argument to
`ArchiveBase.get_all_histfiles()`. This function is called from
`TSC._run_with_specified_dtime()`, and causes the error here:
https://my.cdash.org/test/10724501

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
