### PR TITLE
Some build system updates for e3sm

### DIFF
--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -63,13 +63,13 @@ def parse_command_line(args, description):
                         "Default is current directory.")
 
     if get_model() == "e3sm":
-        parser.add_argument("--use-old", action="store_true",
-                            help="Use old Makefile build system (not cmake)")
-
         parser.add_argument("--ninja", action="store_true",
                             help="Use ninja backed for CMake (instead of gmake). "
                             "The ninja backend is better at scanning fortran dependencies but "
                             "seems to be less reliable across different platforms and compilers.")
+
+        parser.add_argument("--separate-builds", action="store_true",
+                            help="Build each component one at a time, separately, with output going to separate logs")
 
     parser.add_argument("--dry-run", action="store_true",
                         help="Just print the cmake and ninja commands.")
@@ -119,15 +119,15 @@ def parse_command_line(args, description):
     buildlist = None if args.build is None or len(args.build) == 0 else args.build
 
     if get_model() != "e3sm":
-        args.use_old = False
-        args.ninja   = False
+        args.separate_builds = False
+        args.ninja           = False
 
-    return args.caseroot, args.sharedlib_only, args.model_only, cleanlist, args.clean_all, buildlist, clean_depends, not args.skip_provenance_check, args.use_old, args.ninja, args.dry_run
+    return args.caseroot, args.sharedlib_only, args.model_only, cleanlist, args.clean_all, buildlist, clean_depends, not args.skip_provenance_check, args.separate_builds, args.ninja, args.dry_run
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    caseroot, sharedlib_only, model_only, cleanlist, clean_all, buildlist,clean_depends, save_build_provenance, use_old, ninja, dry_run = \
+    caseroot, sharedlib_only, model_only, cleanlist, clean_all, buildlist,clean_depends, save_build_provenance, separate_builds, ninja, dry_run = \
         parse_command_line(sys.argv, description)
 
     success = True
@@ -152,12 +152,12 @@ def _main_func(description):
                 raise
 
             expect(buildlist is None, "Build lists don't work with tests")
-            success = test.build(sharedlib_only=sharedlib_only, model_only=model_only, old_build=use_old, ninja=ninja, dry_run=dry_run)
+            success = test.build(sharedlib_only=sharedlib_only, model_only=model_only, ninja=ninja, dry_run=dry_run)
         else:
             success = build.case_build(caseroot, case=case, sharedlib_only=sharedlib_only,
                                        model_only=model_only, buildlist=buildlist,
                                        save_build_provenance=save_build_provenance,
-                                       use_old=use_old, ninja=ninja, dry_run=dry_run)
+                                       separate_builds=separate_builds, ninja=ninja, dry_run=dry_run)
 
     sys.exit(0 if success else 1)
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -128,7 +128,7 @@ class SystemTestsCommon(object):
         build.case_build(self._caseroot, case=self._case,
                          sharedlib_only=sharedlib_only, model_only=model_only,
                          save_build_provenance=not model=='cesm',
-                         use_old=self._old_build, ninja=self._ninja, dry_run=self._dry_run)
+                         ninja=self._ninja, dry_run=self._dry_run)
         logger.info("build_indv complete")
 
     def clean_build(self, comps=None):

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -40,7 +40,7 @@ def parse_input(argv):
     return args.caseroot, args.libroot, args.bldroot
 
 ###############################################################################
-def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
+def build_cime_component_lib(case, compname, libroot, bldroot):
 ###############################################################################
 
     cimeroot  = case.get_value("CIMEROOT")
@@ -70,7 +70,7 @@ def build_cime_component_lib(case, compname, libroot, bldroot, use_old=True):
         out.write("")
 
     # Build the component
-    if get_model() != "e3sm" or use_old:
+    if get_model() != "e3sm":
         safe_copy(os.path.join(confdir, "Filepath"), bldroot)
         if os.path.exists(os.path.join(confdir, "CIME_cppdefs")):
             safe_copy(os.path.join(confdir, "CIME_cppdefs"), bldroot)

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -23,7 +23,7 @@ def buildlib(bldroot, libroot, case, compname=None):
             compname = dir2
         else:
             compname = dir1.split('.')[1]
-    build_cime_component_lib(case, compname, libroot, bldroot, use_old=False)
+    build_cime_component_lib(case, compname, libroot, bldroot)
 
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)

--- a/src/build_scripts/buildlib_cmake.internal_components
+++ b/src/build_scripts/buildlib_cmake.internal_components
@@ -23,7 +23,7 @@ def buildlib(bldroot, libroot, case, compname=None):
             compname = dir2
         else:
             compname = dir1.split('.')[1]
-    build_cime_component_lib(case, compname, libroot, bldroot, use_old=False)
+    build_cime_component_lib(case, compname, libroot, bldroot)
 
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)


### PR DESCRIPTION
1) Add new --separate-builds flag for case.build. Component builds
   will be done one at a time and produce separate log files for each
   component.
2) Remove --use-old flag. The old system is not being maintained or tested
   and it's no longer safe to use.
3) Produce more logging output for case.build.
4) Re-establish support for building only specific components with case.build.
   This capability had been lost in the initial cmake conversion. Building components
   this way will cause them to get their own log file.

Test suite: by-hand, scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes E3SM 3769 and 3758

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
