### PR TITLE
Remove the flags that fail the ERP test

### DIFF
--- a/config/cesm/machines/Depends.intel
+++ b/config/cesm/machines/Depends.intel
@@ -45,5 +45,5 @@ ifeq ($(DEBUG),FALSE)
   $(SHR_RANDNUM_C_OBJS): %.o: %.c
 	  $(CC) -c $(INCLDIR) $(INCS) $(CFLAGS) -O3 -fp-model fast $<
   $(PUMAS_MG_OBJS): %.o: %.F90
-	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -xCORE-AVX2 -no-fma -ftz -fast-transcendentals -no-prec-sqrt -no-prec-div -qoverride-limits -no-inline-max-total-size -inline-factor=200 -fp-model fast -qopt-report=5 $<
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -xCORE-AVX2 -no-fma -ftz -no-prec-sqrt -qoverride-limits -no-inline-max-total-size -inline-factor=200 -qopt-report=5 $<
 endif


### PR DESCRIPTION
We have removed the problematic "**-fp-model fast -fast-transcendentals -no-prec-div**" flags in the previous PR #3752, which would fail the ERP test.

We apply the rest enhanced Intel compiler flags to the PUMAS/MG3 related F90 codes and they are still beneficial in terms of computation. In addition, the result of test run is identical with that of baseline, which makes it a BFB change. Therefore, we would like to merge those flags to the master branch.

Test suite: ERP_Ln9.f09_f09_mg17.F2000climo.cheyenne_intel.cam-outfrq9s_mg3 in CESM (tag: release-cesm2.2.0)

Test baseline: On Cheyenne, /glade/p/cesmdata/cseg/cesm_baselines/cesm2.2.0/ERP_Ln9.f09_f09_mg17.F2000climo.cheyenne_intel.cam-outfrq9s_mg3

Test status: BFB

Fixes #3752 

Code review: @jedwards4b @johnmauff 