### PR TITLE
These changes should have been included in prior cmake PR

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -34,7 +34,6 @@ class SystemTestsCommon(object):
         self._init_locked_files(caseroot, expected)
         self._skip_pnl = False
         self._cpllog = "med" if self._case.get_value("COMP_INTERFACE")=="nuopc" else "cpl"
-        self._old_build = False
         self._ninja     = False
         self._dry_run   = False
 
@@ -70,14 +69,13 @@ class SystemTestsCommon(object):
 
             self._case.case_setup(reset=True, test_mode=True)
 
-    def build(self, sharedlib_only=False, model_only=False, old_build=False, ninja=False, dry_run=False):
+    def build(self, sharedlib_only=False, model_only=False, ninja=False, dry_run=False):
         """
         Do NOT override this method, this method is the framework that
         controls the build phase. build_phase is the extension point
         that subclasses should use.
         """
         success = True
-        self._old_build = old_build
         self._ninja     = ninja
         self._dry_run   = dry_run
         for phase_name, phase_bool in [(SHAREDLIB_BUILD_PHASE, not model_only),


### PR DESCRIPTION
Forgot to remove a data member in SystemTestsCommon that is no longer needed now that use-old is not support for e3sm.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
