### PR TITLE
Add an error check for separate builds

### DIFF
--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -151,7 +151,10 @@ def _main_func(description):
                     ts.set_status(phase_to_fail, TEST_FAIL_STATUS, comments="failed to initialize")
                 raise
 
-            expect(buildlist is None, "Build lists don't work with tests")
+            expect(buildlist is None,
+                   "Build lists don't work with tests, use create_newcase (not create_test) to use this feature")
+            expect(not separate_builds,
+                   "Separate builds don't work for tests, use create_newcase (not create_test) to use this feature")
             success = test.build(sharedlib_only=sharedlib_only, model_only=model_only, ninja=ninja, dry_run=dry_run)
         else:
             success = build.case_build(caseroot, case=case, sharedlib_only=sharedlib_only,


### PR DESCRIPTION
It won't work for test cases.

Test suite: code-checker
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
