### PR TITLE
Rename _separate_builds to _user_separate_builds

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -36,7 +36,7 @@ class SystemTestsCommon(object):
         self._cpllog = "med" if self._case.get_value("COMP_INTERFACE")=="nuopc" else "cpl"
         self._ninja     = False
         self._dry_run   = False
-        self._separate_builds = False
+        self._user_separate_builds = False
 
     def _init_environment(self, caseroot):
         """
@@ -79,7 +79,7 @@ class SystemTestsCommon(object):
         success = True
         self._ninja           = ninja
         self._dry_run         = dry_run
-        self._separate_builds = separate_builds
+        self._user_separate_builds = separate_builds
         for phase_name, phase_bool in [(SHAREDLIB_BUILD_PHASE, not model_only),
                                        (MODEL_BUILD_PHASE, not sharedlib_only)]:
             if phase_bool:
@@ -128,7 +128,7 @@ class SystemTestsCommon(object):
         build.case_build(self._caseroot, case=self._case,
                          sharedlib_only=sharedlib_only, model_only=model_only,
                          save_build_provenance=not model=='cesm',
-                         ninja=self._ninja, dry_run=self._dry_run, separate_builds=self._separate_builds)
+                         ninja=self._ninja, dry_run=self._dry_run, separate_builds=self._user_separate_builds)
         logger.info("build_indv complete")
 
     def clean_build(self, comps=None):


### PR DESCRIPTION
So that it doesn't collide with the _separate_builds member in
system_tests_compare_two.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3762

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b 
