### PR TITLE
Fix python3 incompatibilities in case.py

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -865,7 +865,7 @@ class Case(object):
 
         if other is not None:
             logger.info("setting additional fields from config_pes: {}".format(other))
-            for key, value in other.items():
+            for key, value in list(other.items()):
                 self.set_value(key, value)
 
         totaltasks = []
@@ -935,7 +935,7 @@ class Case(object):
 
         gridinfo = grids.get_grid_info(name=grid_name, compset=self._compsetname, driver=driver)
         self._gridname = gridinfo["GRID"]
-        for key,value in gridinfo.items():
+        for key,value in list(gridinfo.items()):
             logger.debug("Set grid {} {}".format(key,value))
             self.set_lookup_value(key,value)
 
@@ -1015,7 +1015,7 @@ class Case(object):
 
         self._setup_mach_pes(pecount, multi_driver, ninst, machine_name, mpilib)
 
-        if multi_driver and ninst>1:
+        if multi_driver and int(ninst)>1:
             logger.info(" Driver/Coupler has %s instances" % ninst)
 
         #--------------------------------------------
@@ -1165,7 +1165,7 @@ class Case(object):
 
         defaults = pioobj.get_defaults(grid=grid, compset=compset, mach=mach, compiler=compiler, mpilib=mpilib)
 
-        for vid, value in defaults.items():
+        for vid, value in list(defaults.items()):
             self.set_value(vid,value)
 
     def _create_caseroot_tools(self):
@@ -1402,7 +1402,7 @@ directory, NOT in this subdirectory."""
         if not jobmap:
             logger.info("No job ids associated with this case. Either case.submit was not run or was run with no-batch")
         else:
-            for jobname, jobid in jobmap.items():
+            for jobname, jobid in list(jobmap.items()):
                 status = self.get_env("batch").get_status(jobid)
                 if status:
                     logger.info("{}: {}".format(jobname, status))


### PR DESCRIPTION
[ Explicit type conversion must be used when comparing ninst because in python3
'>' is not supported between instances of 'str' and 'int'.]

Test suite: scripts_regression_tests.py
Test baseline: NA
Test namelist changes: NA
Test status: [bit for bit, roundoff, climate changing] 

Fixes [CIME Github issue #] #3766 

User interface changes?: N

Update gh-pages html (Y/N)?: N
