### PR TITLE
Remove timing flags for e3sm build

### DIFF
--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -71,9 +71,6 @@ def parse_command_line(args, description):
         parser.add_argument("--separate-builds", action="store_true",
                             help="Build each component one at a time, separately, with output going to separate logs")
 
-        parser.add_argument("--timing", action="store_true",
-                            help="Enable timing of all compilations and links")
-
     parser.add_argument("--dry-run", action="store_true",
                         help="Just print the cmake and ninja commands.")
 
@@ -124,14 +121,13 @@ def parse_command_line(args, description):
     if get_model() != "e3sm":
         args.separate_builds = False
         args.ninja           = False
-        args.timing          = False
 
-    return args.caseroot, args.sharedlib_only, args.model_only, cleanlist, args.clean_all, buildlist, clean_depends, not args.skip_provenance_check, args.separate_builds, args.ninja, args.dry_run, args.timing
+    return args.caseroot, args.sharedlib_only, args.model_only, cleanlist, args.clean_all, buildlist, clean_depends, not args.skip_provenance_check, args.separate_builds, args.ninja, args.dry_run
 
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    caseroot, sharedlib_only, model_only, cleanlist, clean_all, buildlist,clean_depends, save_build_provenance, separate_builds, ninja, dry_run, timing = \
+    caseroot, sharedlib_only, model_only, cleanlist, clean_all, buildlist,clean_depends, save_build_provenance, separate_builds, ninja, dry_run = \
         parse_command_line(sys.argv, description)
 
     success = True
@@ -157,13 +153,13 @@ def _main_func(description):
 
             expect(buildlist is None,
                    "Build lists don't work with tests, use create_newcase (not create_test) to use this feature")
-            success = test.build(sharedlib_only=sharedlib_only, model_only=model_only, ninja=ninja, dry_run=dry_run, separate_builds=separate_builds, timing=timing)
+            success = test.build(sharedlib_only=sharedlib_only, model_only=model_only, ninja=ninja, dry_run=dry_run, separate_builds=separate_builds)
 
         else:
             success = build.case_build(caseroot, case=case, sharedlib_only=sharedlib_only,
                                        model_only=model_only, buildlist=buildlist,
                                        save_build_provenance=save_build_provenance,
-                                       separate_builds=separate_builds, ninja=ninja, dry_run=dry_run, timing=timing)
+                                       separate_builds=separate_builds, ninja=ninja, dry_run=dry_run)
 
     sys.exit(0 if success else 1)
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -37,7 +37,6 @@ class SystemTestsCommon(object):
         self._ninja     = False
         self._dry_run   = False
         self._user_separate_builds = False
-        self._timing = False
 
     def _init_environment(self, caseroot):
         """
@@ -71,7 +70,7 @@ class SystemTestsCommon(object):
 
             self._case.case_setup(reset=True, test_mode=True)
 
-    def build(self, sharedlib_only=False, model_only=False, ninja=False, dry_run=False, separate_builds=False, timing=False):
+    def build(self, sharedlib_only=False, model_only=False, ninja=False, dry_run=False, separate_builds=False):
         """
         Do NOT override this method, this method is the framework that
         controls the build phase. build_phase is the extension point
@@ -81,7 +80,6 @@ class SystemTestsCommon(object):
         self._ninja           = ninja
         self._dry_run         = dry_run
         self._user_separate_builds = separate_builds
-        self._timing = timing
         for phase_name, phase_bool in [(SHAREDLIB_BUILD_PHASE, not model_only),
                                        (MODEL_BUILD_PHASE, not sharedlib_only)]:
             if phase_bool:
@@ -130,7 +128,7 @@ class SystemTestsCommon(object):
         build.case_build(self._caseroot, case=self._case,
                          sharedlib_only=sharedlib_only, model_only=model_only,
                          save_build_provenance=not model=='cesm',
-                         ninja=self._ninja, dry_run=self._dry_run, separate_builds=self._user_separate_builds, timing=self._timing)
+                         ninja=self._ninja, dry_run=self._dry_run, separate_builds=self._user_separate_builds)
         logger.info("build_indv complete")
 
     def clean_build(self, comps=None):

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -170,7 +170,7 @@ def _build_model(build_threaded, exeroot, incroot, complist,
 
 ###############################################################################
 def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
-                       comp_interface, sharedpath, separate_builds, ninja, dry_run, timing, case):
+                       comp_interface, sharedpath, separate_builds, ninja, dry_run, case):
 ###############################################################################
     cime_model = get_model()
     bldroot    = os.path.join(exeroot, "cmake-bld")
@@ -204,9 +204,6 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     if ninja:
         cmake_args += " -GNinja "
         cmake_env += "PATH={}:$PATH ".format(ninja_path)
-
-    if timing:
-        cmake_args += " -DE3SM_ENABLE_TIMING=True "
 
     # Glue all pieces together:
     #  - cmake environment
@@ -604,7 +601,7 @@ def _clean_impl(case, cleanlist, clean_all, clean_depends):
 
 ###############################################################################
 def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
-                     save_build_provenance, separate_builds, ninja, dry_run, timing):
+                     save_build_provenance, separate_builds, ninja, dry_run):
 ###############################################################################
 
     t1 = time.time()
@@ -728,7 +725,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
     if not sharedlib_only:
         if get_model() == "e3sm":
             logs.extend(_build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
-                                           comp_interface, sharedpath, separate_builds, ninja, dry_run, timing, case))
+                                           comp_interface, sharedpath, separate_builds, ninja, dry_run, case))
         else:
             os.environ["INSTALL_SHAREDPATH"] = os.path.join(exeroot, sharedpath) # for MPAS makefile generators
             logs.extend(_build_model(build_threaded, exeroot, incroot, complist,
@@ -772,10 +769,10 @@ def post_build(case, logs, build_complete=False, save_build_provenance=True):
         lock_file("env_build.xml", caseroot=case.get_value("CASEROOT"))
 
 ###############################################################################
-def case_build(caseroot, case, sharedlib_only=False, model_only=False, buildlist=None, save_build_provenance=True, separate_builds=False, ninja=False, dry_run=False, timing=False):
+def case_build(caseroot, case, sharedlib_only=False, model_only=False, buildlist=None, save_build_provenance=True, separate_builds=False, ninja=False, dry_run=False):
 ###############################################################################
     functor = lambda: _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
-                                       save_build_provenance, separate_builds, ninja, dry_run, timing)
+                                       save_build_provenance, separate_builds, ninja, dry_run)
     cb = "case.build"
     if (sharedlib_only == True):
         cb = cb + " (SHAREDLIB_BUILD)"


### PR DESCRIPTION
We are going to have the new python wrapper always be on.

Test suite: by-hand, scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?:  N

Update gh-pages html (Y/N)?: N

Code review: None
