### PR TITLE
MPAS build fix for nag and pgi

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -577,7 +577,12 @@ ifeq ($(strip $(COMP_ATM)),cam)
 endif
 
 ifeq ($(CAM_DYCORE),mpas)
-MPAS_LIBDIR:=$(abspath $(EXEROOT)/atm/obj/mpas)
+  # For building CAM with the MPAS dycore
+  MPAS_LIBDIR:=$(abspath $(EXEROOT)/atm/obj/mpas)
+  ifeq ($(MODEL),driver)
+    # This is needed by some compilers when building the driver.
+    INCLDIR+=-I$(MPAS_LIBDIR)
+  endif
 endif
 
 ifeq ($(MODEL),cam)


### PR DESCRIPTION
Fix the CAM MPAS library build for nag and pgi.


Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
