### PR TITLE
build nuopc_cap with csm_share

### DIFF
--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -65,6 +65,7 @@ def buildlib(bldroot, installpath, case):
     elif comp_interface == "nuopc":
         filepath.append(os.path.join(cimeroot,"src","share","nuopc"))
         filepath.append(os.path.join(cimeroot,"src","share","streams_nuopc"))
+        filepath.append(os.path.join(cimeroot,"src","drivers","nuopc", "nuopc_cap_share"))
     else:
         expect(False, "driver value of {} not supported".format(comp_interface))
 


### PR DESCRIPTION
Build the nuopc_cap code with csm_share instead of in components (it's currently built anew for each component)
This means that the code source can be added to SourceMods/src.csm_share - currently it would need to be added
to each components SourceMods which creates a possibility of conflict

Test suite: scripts_regression_tests.py with CIME_DRIVER=nuopc and SMS_Vnuopc.f19_g17.B1850.cheyenne_intel
(with components build of that directory removed)

Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
