### PR TITLE
Update OS process id error-checking in GPTL's get_memusage

### DIFF
--- a/src/share/timing/GPTLget_memusage.c
+++ b/src/share/timing/GPTLget_memusage.c
@@ -118,8 +118,8 @@ int GPTLget_memusage (int *size, int *rss, int *share, int *text, int *datastack
   */
 
   pid = (int) getpid ();
-  if (pid > 999999) {
-    fprintf (stderr, "get_memusage: pid %d is too large\n", pid);
+  if (pid <= 0) {
+    fprintf (stderr, "get_memusage: pid %d is non-positive\n", pid);
     return -1;
   }
 


### PR DESCRIPTION
On newer machines with AMD Epyc + CentOS 8, processes on
compute nodes have pids larger than 6-digit numbers. This logs
many messages of the form:
```
  59: get_memusage: pid 1031078 is too large
```
This PR updates OS process id error-checking in GPTL's get_memusage

Test suite: by-hand
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit