### PR TITLE
More e3sm build upgrades

### DIFF
--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -210,7 +210,7 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     #  - common (i.e. project-wide) cmake args
     #  - component-specific cmake args
     #  - path to src folder
-    cmake_cmd = "{} time cmake {} {} {}/components".format(cmake_env, cmake_args, cmp_cmake_args, srcroot)
+    cmake_cmd = "{} /usr/bin/time cmake {} {} {}/components".format(cmake_env, cmake_args, cmp_cmake_args, srcroot)
     stat = 0
     if dry_run:
         logger.info("CMake cmd:\ncd {} && {}\n\n".format(bldroot, cmake_cmd))
@@ -241,7 +241,7 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     for model in buildlist:
         t1 = time.time()
 
-        make_cmd = "time {} -j {}".format(gmake if not ninja else "{} -v".format(os.path.join(ninja_path, "ninja")), gmake_j)
+        make_cmd = "/usr/bin/time {} -j {}".format(gmake if not ninja else "{} -v".format(os.path.join(ninja_path, "ninja")), gmake_j)
         if model != "cpl":
             make_cmd += " {}".format(model)
             curr_log = os.path.join(exeroot, "{}.bldlog.{}".format(model, lid))

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -210,7 +210,8 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     #  - common (i.e. project-wide) cmake args
     #  - component-specific cmake args
     #  - path to src folder
-    cmake_cmd = "{} /usr/bin/time cmake {} {} {}/components".format(cmake_env, cmake_args, cmp_cmake_args, srcroot)
+    do_timing = "/usr/bin/time " if os.path.exists("/usr/bin/time") else ""
+    cmake_cmd = "{} {}cmake {} {} {}/components".format(cmake_env, do_timing, cmake_args, cmp_cmake_args, srcroot)
     stat = 0
     if dry_run:
         logger.info("CMake cmd:\ncd {} && {}\n\n".format(bldroot, cmake_cmd))
@@ -241,7 +242,7 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     for model in buildlist:
         t1 = time.time()
 
-        make_cmd = "/usr/bin/time {} -j {}".format(gmake if not ninja else "{} -v".format(os.path.join(ninja_path, "ninja")), gmake_j)
+        make_cmd = "{}{} -j {}".format(gmake if not ninja else "{} -v".format(os.path.join(ninja_path, "ninja")), do_timing, gmake_j)
         if model != "cpl":
             make_cmd += " {}".format(model)
             curr_log = os.path.join(exeroot, "{}.bldlog.{}".format(model, lid))

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -210,7 +210,7 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     #  - common (i.e. project-wide) cmake args
     #  - component-specific cmake args
     #  - path to src folder
-    do_timing = "/usr/bin/time " if os.path.exists("/usr/bin/time") else ""
+    do_timing = "/usr/bin/time -p " if os.path.exists("/usr/bin/time") else ""
     cmake_cmd = "{} {}cmake {} {} {}/components".format(cmake_env, do_timing, cmake_args, cmp_cmake_args, srcroot)
     stat = 0
     if dry_run:
@@ -242,7 +242,7 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     for model in buildlist:
         t1 = time.time()
 
-        make_cmd = "{}{} -j {}".format(gmake if not ninja else "{} -v".format(os.path.join(ninja_path, "ninja")), do_timing, gmake_j)
+        make_cmd = "{}{} -j {}".format(do_timing, gmake if not ninja else "{} -v".format(os.path.join(ninja_path, "ninja")), gmake_j)
         if model != "cpl":
             make_cmd += " {}".format(model)
             curr_log = os.path.join(exeroot, "{}.bldlog.{}".format(model, lid))

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -34,13 +34,14 @@ def _extract_times(zipfiles, target_file):
 
     contents ="Target Build_time\n"
     for zipfile in zipfiles:
-        output = run_cmd_no_fail("zgrep 'built in' {}".format(zipfile))
-        for line in output.splitlines():
-            line = line.strip()
-            if line:
-                items = line.split()
-                target, the_time = items[1], items[-2]
-                contents += "{} {}\n".format(target, the_time)
+        stat, output, _ = run_cmd("zgrep 'built in' {}".format(zipfile))
+        if stat == 0:
+            for line in output.splitlines():
+                line = line.strip()
+                if line:
+                    items = line.split()
+                    target, the_time = items[1], items[-2]
+                    contents += "{} {}\n".format(target, the_time)
 
     with open(target_file, "w") as fd:
         fd.write(contents)

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -30,6 +30,21 @@ def _get_batch_job_id_for_syslog(case):
 
     return None
 
+def _extract_times(zipfiles, target_file):
+
+    contents ="Target Build_time\n"
+    for zipfile in zipfiles:
+        output = run_cmd_no_fail("zgrep 'built in' {}".format(zipfile))
+        for line in output.splitlines():
+            line = line.strip()
+            if line:
+                items = line.split()
+                target, the_time = items[1], items[-2]
+                contents += "{} {}\n".format(target, the_time)
+
+    with open(target_file, "w") as fd:
+        fd.write(contents)
+
 def _save_build_provenance_e3sm(case, lid):
     srcroot = case.get_value("SRCROOT")
     exeroot = case.get_value("EXEROOT")
@@ -71,9 +86,18 @@ def _save_build_provenance_e3sm(case, lid):
     env_module = case.get_env("mach_specific")
     env_module.save_all_env_info(env_prov)
 
+    # Save build times
+    build_times = os.path.join(exeroot, "build_times.{}.txt".format(lid))
+    if os.path.exists(build_times):
+        os.remove(build_times)
+    globstr = "{}/*bldlog*{}.gz".format(exeroot, lid)
+    matches = glob.glob(globstr)
+    if matches:
+        _extract_times(matches, build_times)
+
     # For all the just-created post-build provenance files, symlink a generic name
     # to them to indicate that these are the most recent or active.
-    for item in ["GIT_DESCRIBE", "GIT_LOGS_HEAD", "GIT_SUBMODULE_STATUS", "SourceMods", "build_environment"]:
+    for item in ["GIT_DESCRIBE", "GIT_LOGS_HEAD", "GIT_SUBMODULE_STATUS", "SourceMods", "build_environment", "build_times"]:
         globstr = "{}/{}.{}*".format(exeroot, item, lid)
         matches = glob.glob(globstr)
         expect(len(matches) < 2, "Multiple matches for glob {} should not have happened".format(globstr))
@@ -238,7 +262,8 @@ def _save_prerun_timing_e3sm(case, lid):
     # Copy some items from build provenance
     blddir_globs_to_copy = [
         "GIT_LOGS_HEAD",
-        "build_environment.txt"
+        "build_environment.txt",
+        "build_times.txt"
         ]
     for blddir_glob_to_copy in blddir_globs_to_copy:
         for item in glob.glob(os.path.join(blddir, blddir_glob_to_copy)):


### PR DESCRIPTION
Change list:
1) Make time gathering for cmake and make commands more robust.
2) When saving build provenance, collect and save the times needed to build targets to a "build_times.txt" file in similar approach to how build_environment.txt is saved.

Test suite: scripts_regression_tests, by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
