### PR TITLE
Print TPUTCOMP difference to TestStatus.log

### DIFF
--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -532,10 +532,12 @@ class SystemTestsCommon(object):
                         if tolerance is None:
                             tolerance = 0.1
                         expect(tolerance > 0.0, "Bad value for throughput tolerance in test")
+                        comment = "TPUTCOMP: Computation time changed by {:.2f}%".format(diff*100)
+                        append_testlog(comment, self._orig_caseroot)
                         if diff < tolerance and self._test_status.get_status(THROUGHPUT_PHASE) is None:
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)
                         elif self._test_status.get_status(THROUGHPUT_PHASE) != TEST_FAIL_STATUS:
-                            comment = "Error: Computation time increase > {:d} pct from baseline".format(int(tolerance*100))
+                            comment = "Error: Computation time increase > {:d}% from baseline".format(int(tolerance*100))
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
                             append_testlog(comment, self._orig_caseroot)
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -537,7 +537,7 @@ class SystemTestsCommon(object):
                         if diff < tolerance and self._test_status.get_status(THROUGHPUT_PHASE) is None:
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)
                         elif self._test_status.get_status(THROUGHPUT_PHASE) != TEST_FAIL_STATUS:
-                            comment = "Error: Computation time increase > {:d}% from baseline".format(int(tolerance*100))
+                            comment = "Error: TPUTCOMP: Computation time increase > {:d}% from baseline".format(int(tolerance*100))
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_FAIL_STATUS, comments=comment)
                             append_testlog(comment, self._orig_caseroot)
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -532,7 +532,7 @@ class SystemTestsCommon(object):
                         if tolerance is None:
                             tolerance = 0.1
                         expect(tolerance > 0.0, "Bad value for throughput tolerance in test")
-                        comment = "TPUTCOMP: Computation time changed by {:.2f}%".format(diff*100)
+                        comment = "TPUTCOMP: Computation time changed by {:.2f}% relative to baseline".format(diff*100)
                         append_testlog(comment, self._orig_caseroot)
                         if diff < tolerance and self._test_status.get_status(THROUGHPUT_PHASE) is None:
                             self._test_status.set_status(THROUGHPUT_PHASE, TEST_PASS_STATUS)


### PR DESCRIPTION
I sometimes want to know the actual change in throughput, whether or not TPUTCOMP failed - and not just whether or not it exceeded the given tolerance.

Test suite: I ran most testing on 618d443ca, but reran one test after making the change in 86da4a463; I ran:
- scripts_regression_tests on cheyenne
- create_test cime_developer with --compare: examined new TPUTCOMP lines in TestStatus.log files
Test baseline: cime master
Test namelist changes: none
Test status: bit for bit

Fixes: none

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b @jgfouca 
