### PR TITLE
fix issue with time variable in ha files

### DIFF
--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -131,7 +131,6 @@ contains
        atm, lnd, ice, ocn, rof, glc, wav, iac, &
        fractions_ax, fractions_lx, fractions_ix, fractions_ox, fractions_rx,  &
        fractions_gx, fractions_wx, fractions_zx, cpl_inst_tag)
-
     implicit none
     !
     ! Arguments
@@ -172,6 +171,7 @@ contains
     type(mct_gsMap), pointer :: gsmap
     type(mct_gGrid), pointer :: dom    ! comp domain on cpl pes
     character(CL) :: model_doi_url
+
     !-------------------------------------------------------------------------------
     !
     !-------------------------------------------------------------------------------
@@ -248,17 +248,9 @@ contains
           end if
 
           tbnds = curr_time
-          !------- tcx nov 2011 tbnds of same values causes problems in ferret
-          if (tbnds(1) >= tbnds(2)) then
-             call seq_io_write(hist_file,&
-                  time_units=time_units, time_cal=calendar, time_val=curr_time, &
-                  nt=1,whead=whead, wdata=wdata)
-          else
-             call seq_io_write(hist_file, &
-                  time_units=time_units, time_cal=calendar, time_val=curr_time, &
-                  nt=1,whead=whead, wdata=wdata, tbnds=tbnds)
-          endif
-
+          call seq_io_write(hist_file,&
+               time_units=time_units, time_cal=calendar, time_val=curr_time, &
+               nt=1,whead=whead, wdata=wdata)
           if (atm_present) then
              gsmap => component_get_gsmap_cx(atm(1))
              dom   => component_get_dom_cx(atm(1))
@@ -404,7 +396,6 @@ contains
                   nx=iac_nx, ny=iac_ny, nt=1, whead=whead, wdata=wdata, pre='x2w')
           endif
        enddo
-
        call seq_io_close(hist_file)
        if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
     endif
@@ -480,6 +471,7 @@ contains
     type(mct_avect),  pointer :: c2x    ! component->coupler avs on cpl pes
     type(mct_avect),  pointer :: x2c    ! coupler->component avs on cpl pes
     character(CL) :: model_doi_url
+
     !-------------------------------------------------------------------------------
     !
     !-------------------------------------------------------------------------------
@@ -862,16 +854,18 @@ contains
              end if
 
              avg_time = 0.5_r8 * (tbnds(1) + tbnds(2))
+
              !---------- tcx nov 2011 tbnds of same values causes problems in ferret
-             if (tbnds(1) >= tbnds(2)) then
+             if (tbnds(1) == tbnds(2)) then
                 call seq_io_write(hist_file, &
                      time_units=time_units, time_cal=calendar, time_val=avg_time, &
-                     whead=whead, wdata=wdata)
+                     whead=whead, wdata=wdata, nt=1)
              else
                 call seq_io_write(hist_file, &
                      time_units=time_units, time_cal=calendar, time_val=avg_time, &
                      whead=whead, wdata=wdata, nt=1, tbnds=tbnds)
              endif
+
              if (atm_present .and. histavg_atm) then
                 gsmap => component_get_gsmap_cx(atm(1))
                 dom   => component_get_dom_cx(atm(1))
@@ -985,6 +979,7 @@ contains
           enddo
 
           call seq_io_close(hist_file)
+
           if (drv_threading) call seq_comm_setnthreads(nthreads_GLOID)
 
           if (atm_present .and. histavg_atm) then


### PR DESCRIPTION
Fixes an issue in cpl hist avg files that caused the time variable not to be written correctly in pio2.

Test suite: scripts_regression_tests.py, ERS_Lm3.T62_g16.AIAF.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
