### PR TITLE
query_testlists: replace newlines in comments with spaces

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -38,7 +38,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - id: load-env
-        run: sudo apt-get -f install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - id: load-env
-        run: sudo apt-get install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
+        run: sudo apt-get -f install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/scripts/lib/CIME/test_utils.py
+++ b/scripts/lib/CIME/test_utils.py
@@ -87,6 +87,11 @@ def test_to_string(test, category_field_width=0, test_field_width=0, show_option
     >>> test_to_string(mytest, 10)
     'prealpha  : SMS.f19_g16.A.cheyenne_intel # my remarks'
 
+    Newlines in comments are converted to spaces
+    >>> mytest = {'name': 'SMS.f19_g16.A.cheyenne_intel', 'category': 'prealpha', 'options': {'comment': 'my\\nremarks'}}
+    >>> test_to_string(mytest, 10)
+    'prealpha  : SMS.f19_g16.A.cheyenne_intel # my remarks'
+
     Printing other options, too:
     >>> mytest = {'name': 'SMS.f19_g16.A.cheyenne_intel', 'category': 'prealpha', 'options': {'comment': 'my remarks', 'wallclock': '0:20', 'memleak_tolerance': 0.2}}
     >>> test_to_string(mytest, 10, show_options=True)
@@ -98,6 +103,7 @@ def test_to_string(test, category_field_width=0, test_field_width=0, show_option
         myopts = test['options'].copy()
         comment = myopts.pop('comment', None)
         if comment:
+            comment = comment.replace('\n', ' ')
             mystr += " # {}".format(comment)
         if show_options:
             for one_opt in sorted(myopts):


### PR DESCRIPTION
Without this, a newline in a comment breaks the rule that we should have one test per line in the output.

(A couple of tests defined by CTSM's testlist have newlines in the comments in the xml file.)

Test suite: scripts_regression_tests: ONLY A_RunUnitTests, B_CheckCode and S_TestManageAndQuery (nothing else is impacted by this change)
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: Slight change to output of query_testlists

Update gh-pages html (Y/N)?: N

Code review: @fischer-ncar 
