### PR TITLE
Check if TEST_ROOT exists earlier in cleanup from scripts_regression_tests 

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -3504,13 +3504,14 @@ def write_provenance_info():
 
 def cleanup():
     # if the TEST_ROOT directory exists and is empty, remove it
-    testreporter = os.path.join(TEST_ROOT,"testreporter")
-    files = os.listdir(TEST_ROOT)
-    if len(files)==1 and os.path.isfile(testreporter):
-        os.unlink(testreporter)
-    if os.path.exists(TEST_ROOT) and not os.listdir(TEST_ROOT):
-        print("All pass, removing directory:", TEST_ROOT)
-        os.rmdir(TEST_ROOT)
+    if os.path.exists(TEST_ROOT):
+        testreporter = os.path.join(TEST_ROOT,"testreporter")
+        files = os.listdir(TEST_ROOT)
+        if len(files)==1 and os.path.isfile(testreporter):
+            os.unlink(testreporter)
+        if not os.listdir(TEST_ROOT):
+            print("All pass, removing directory:", TEST_ROOT)
+            os.rmdir(TEST_ROOT)
 
 def _main_func(description):
     global MACHINE


### PR DESCRIPTION
I moved the if os.path.exists(TEST_ROOT)
    statement to be earlier in the
    cleanup() function. This makes the
    cleanup function more robust to
    the possibility that this directory
    may not have been created.

Test suite: scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: [bit for bit]

Fixes #3768

User interface changes?:

Update gh-pages html (Y/N)?:

Code review: @billsacks @jgfouca 