### PR TITLE
Add a mask

### DIFF
--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -352,9 +352,9 @@ contains
              call seq_io_write(hist_file, gsmap, fractions_ix, 'fractions_ix',  &
                   nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='fraci')
              call seq_io_write(hist_file, ice, 'c2x', 'i2x_ix', &
-                  nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='i2x')
+                  nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='i2x', mask=dom%data%rattr(1,:))
              call seq_io_write(hist_file, ice, 'x2c', 'x2i_ix', &
-                  nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='x2i')
+                  nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='x2i', mask=dom%data%rattr(1,:))
           endif
 
           if (glc_present) then


### PR DESCRIPTION
The test PET.T62_g16.G.cheyenne_intel.pop-cice fails with a difference in the cpl ha file.  This difference is due to 
a difference in fill values caused by the change in component block sizes between the two runs of the test.  
This PR adds a mask so that the correct fill value is used at all points outside the bounds of the case. 

Test suite: PET.T62_g16.G.cheyenne_intel.pop-cice, scripts_regression_tests.py 
Test baseline: 
Test namelist changes: 
Test status: bit for bit 

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
