### PR TITLE
update pgi and esmf on cheyenne

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -515,72 +515,72 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">openblas/0.3.6</command>
       </modules>
       <modules compiler="pgi">
-        <command name="load">pgi/19.9</command>
+        <command name="load">pgi/20.4</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpt-g</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpt-O</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpiuni-g</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpiuni-O</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpiuni-O</command>
       </modules>
       <modules compiler="gnu" mpilib="mpt" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpt-g</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="gnu" mpilib="mpt" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpt-O</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-openmpi-g</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-openmpi-g</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-openmpi-O</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-openmpi-O</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpiuni-g</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpiuni-O</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpiuni-O</command>
       </modules>
 
       <modules compiler="pgi" mpilib="mpt" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpt-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="pgi" mpilib="mpt" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpt-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="pgi" mpilib="openmpi" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-openmpi-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-openmpi-g</command>
       </modules>
       <modules compiler="pgi" mpilib="openmpi" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-openmpi-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-openmpi-O</command>
       </modules>
       <modules compiler="pgi" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpiuni-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="pgi" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/19.9/</command>
-        <command name="load">esmf-8.1.0b37-ncdfio-mpiuni-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.1.0b38-ncdfio-mpiuni-O</command>
       </modules>
 
 
@@ -1596,16 +1596,16 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="mvapich2">
       <executable>mpiexec</executable>
       <arguments>
-	       <arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
-	       <arg name="num_tasks"> -n {{ total_tasks }} </arg>
-	       <arg name="addrank"> --prepend-rank </arg>
+               <arg name="machine_file">--machinefile $ENV{PBS_NODEFILE}</arg>
+               <arg name="num_tasks"> -n {{ total_tasks }} </arg>
+               <arg name="addrank"> --prepend-rank </arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="openmpi">
       <executable>mpiexec</executable>
       <arguments>
-	      <arg name="num_tasks"> -n {{ total_tasks }} </arg>
-	      <arg name="addrank"> --tag-output </arg>
+              <arg name="num_tasks"> -n {{ total_tasks }} </arg>
+              <arg name="addrank"> --tag-output </arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">


### PR DESCRIPTION
Updates to the latest esmf for nuopc development on cheyenne, also updates pgi compiler level

Test suite: scripts_regression_tests.py with CIME_DRIVER=nuopc and pgi, intel, gnu compilers
Test baseline: 
Test namelist changes: 
Test status: bit for bit except pgi

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
