### PR TITLE
Seq io fix pio2

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -892,9 +892,6 @@ class Case(object):
             mach_pes_obj.set_value(rootpe_str, rootpe)
             mach_pes_obj.set_value(pstrid_str, pstrid)
 
-        if multi_driver:
-            mach_pes_obj.set_value("MULTI_DRIVER", True)
-
         # Make sure that every component has been accounted for
         # set, nthrds and ntasks to 1 otherwise. Also set the ninst values here.
         for compclass in self._component_classes:
@@ -909,6 +906,9 @@ class Case(object):
             key = "NTHRDS_{}".format(compclass)
             if compclass not in pes_nthrds:
                 mach_pes_obj.set_value(compclass,1)
+        if multi_driver:
+            mach_pes_obj.set_value("MULTI_DRIVER", True)
+
 
     def configure(self, compset_name, grid_name, machine_name=None,
                   project=None, pecount=None, compiler=None, mpilib=None,

--- a/src/drivers/mct/main/seq_hist_mod.F90
+++ b/src/drivers/mct/main/seq_hist_mod.F90
@@ -167,6 +167,7 @@ contains
     character(CL) :: hist_file    ! Local path to history filename
     real(r8)      :: tbnds(2)     ! CF1.0 time bounds
     logical       :: whead,wdata  ! for writing restart/history cdf files
+    integer       :: nmask        ! location of mask in dom structure
     character(len=18) :: date_str
     type(mct_gsMap), pointer :: gsmap
     type(mct_gGrid), pointer :: dom    ! comp domain on cpl pes
@@ -347,14 +348,15 @@ contains
           if (ice_present) then
              gsmap => component_get_gsmap_cx(ice(1))
              dom   => component_get_dom_cx(ice(1))
+             nmask = mct_aVect_indexRA(dom%data,'mask')
              call seq_io_write(hist_file, gsmap, dom%data, 'dom_ix',  &
                   nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='domi')
              call seq_io_write(hist_file, gsmap, fractions_ix, 'fractions_ix',  &
                   nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='fraci')
              call seq_io_write(hist_file, ice, 'c2x', 'i2x_ix', &
-                  nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='i2x', mask=dom%data%rattr(1,:))
+                  nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='i2x', mask=dom%data%rattr(nmask,:))
              call seq_io_write(hist_file, ice, 'x2c', 'x2i_ix', &
-                  nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='x2i', mask=dom%data%rattr(1,:))
+                  nx=ice_nx, ny=ice_ny, nt=1, whead=whead, wdata=wdata, pre='x2i', mask=dom%data%rattr(nmask,:))
           endif
 
           if (glc_present) then

--- a/src/drivers/mct/main/seq_io_mod.F90
+++ b/src/drivers/mct/main/seq_io_mod.F90
@@ -792,7 +792,7 @@ contains
           call mct_aVect_getRList(mstring,k,AVS(1))
           itemc = mct_string_toChar(mstring)
           call mct_string_clean(mstring)
-          !-------tcraig, this is a temporary mod to NOT write hgt
+          !------- this is a temporary mod to NOT write hgt
           if (trim(itemc) /= "hgt") then
              name1 = trim(lpre)//'_'//trim(itemc)
              rcode = pio_inq_varid(cpl_io_file(lfile_ind),trim(name1),varid)
@@ -803,8 +803,6 @@ contains
                 n = n + ns
              enddo
              call pio_write_darray(cpl_io_file(lfile_ind), varid, iodesc, data, rcode, fillval=lfillvalue)
-             call pio_setdebuglevel(0)
-             !-------tcraig
           endif
        enddo
 
@@ -1038,25 +1036,27 @@ contains
                 if (trim(flow) == 'x2c') avcomp => component_get_x2c_cx(comp(k1))
                 if (trim(flow) == 'c2x') avcomp => component_get_c2x_cx(comp(k1))
                 if (present(mask)) then
-                   where(mask /= 0)
-                      data = avcomp%rattr(k,:)
-                   elsewhere
-                      data = lfillvalue
-                   endwhere
+                   do k2=1,ns
+                      n = n + 1
+                      if(mask(k2) /= 0) then
+                         data(n) = avcomp%rattr(k,k2)
+                      else
+                         data(n) = lfillvalue
+                      end if
+                   end do
                 else
-                   do k2 = 1,ns
+                  do k2 = 1,ns
                       n = n + 1
                       data(n) = avcomp%rAttr(k,k2)
                    enddo
                 endif
              enddo
              call pio_write_darray(cpl_io_file(lfile_ind), varid, iodesc, data, rcode, fillval=lfillvalue)
-             !-------tcraig
           endif
        enddo
 
-       deallocate(data)
        call pio_freedecomp(cpl_io_file(lfile_ind), iodesc)
+       deallocate(data)
 
     end if
   end subroutine seq_io_write_avscomp

--- a/src/drivers/mct/main/seq_io_mod.F90
+++ b/src/drivers/mct/main/seq_io_mod.F90
@@ -805,9 +805,8 @@ contains
              call pio_write_darray(cpl_io_file(lfile_ind), varid, iodesc, data, rcode, fillval=lfillvalue)
           endif
        enddo
-
-       deallocate(data)
        call pio_freedecomp(cpl_io_file(lfile_ind), iodesc)
+       deallocate(data)
 
     end if
   end subroutine seq_io_write_avs

--- a/src/share/streams/shr_dmodel_mod.F90
+++ b/src/share/streams/shr_dmodel_mod.F90
@@ -4,6 +4,7 @@ module shr_dmodel_mod
 
   use shr_sys_mod
   use shr_kind_mod, only: IN=>SHR_KIND_IN, R8=>SHR_KIND_R8, &
+       R4=>SHR_KIND_R4, &
        CS=>SHR_KIND_CS, CL=>SHR_KIND_CL, &
        CX=>SHR_KIND_CX, CXX=>SHR_KIND_CXX
   use shr_log_mod, only: loglev  => shr_log_Level
@@ -575,7 +576,8 @@ CONTAINS
 
   !===============================================================================
 
-  subroutine shr_dmodel_readLBUB(stream,pio_subsystem,pio_iotype,pio_iodesc,mDate,mSec,mpicom,gsMap, &
+  subroutine shr_dmodel_readLBUB(stream,pio_subsystem,pio_iotype,pio_iodesc_r8, pio_iodesc_r4, pio_iodesc_int, &
+       mDate,mSec,mpicom,gsMap, &
        avLB,mDateLB,mSecLB,avUB,mDateUB,mSecUB,avFile,readMode, &
        newData,rmOldFile,istr)
 
@@ -587,7 +589,7 @@ CONTAINS
     type(shr_stream_streamType),intent(inout) :: stream
     type(iosystem_desc_t)      ,intent(inout), target :: pio_subsystem
     integer(IN)                ,intent(in)    :: pio_iotype
-    type(io_desc_t)            ,intent(inout) :: pio_iodesc
+    type(io_desc_t)            ,intent(inout) :: pio_iodesc_r8, pio_iodesc_r4, pio_iodesc_int
     integer(IN)                ,intent(in)    :: mDate  ,mSec
     integer(IN)                ,intent(in)    :: mpicom
     type(mct_gsMap)            ,intent(in)    :: gsMap
@@ -692,7 +694,8 @@ CONTAINS
 
           select case(readMode)
           case ('single')
-             call shr_dmodel_readstrm(stream, pio_subsystem, pio_iotype, pio_iodesc, gsMap, avLB, mpicom, &
+             call shr_dmodel_readstrm(stream, pio_subsystem, pio_iotype, pio_iodesc_r8, pio_iodesc_r4, &
+                  pio_iodesc_int, gsMap, avLB, mpicom, &
                   path, fn_lb, n_lb,istr=trim(lstr)//'_LB', boundstr = 'lb')
           case ('full_file')
              call shr_dmodel_readstrm_fullfile(stream, pio_subsystem, pio_iotype, &
@@ -710,7 +713,8 @@ CONTAINS
 
        select case(readMode)
        case ('single')
-          call shr_dmodel_readstrm(stream, pio_subsystem, pio_iotype, pio_iodesc, gsMap, avUB, mpicom, &
+          call shr_dmodel_readstrm(stream, pio_subsystem, pio_iotype, pio_iodesc_r8, pio_iodesc_r4, &
+               pio_iodesc_int, gsMap, avUB, mpicom, &
                path, fn_ub, n_ub,istr=trim(lstr)//'_UB', boundstr = 'ub')
        case ('full_file')
           call shr_dmodel_readstrm_fullfile(stream, pio_subsystem, pio_iotype, &
@@ -759,8 +763,8 @@ CONTAINS
 
   !===============================================================================
 
-  subroutine shr_dmodel_readstrm(stream, pio_subsystem, pio_iotype, pio_iodesc, gsMap, av, mpicom, &
-       path, fn, nt, istr, boundstr)
+  subroutine shr_dmodel_readstrm(stream, pio_subsystem, pio_iotype, pio_iodesc_r8, pio_iodesc_r4, pio_iodesc_int, &
+       gsMap, av, mpicom, path, fn, nt, istr, boundstr)
 
     use shr_file_mod, only : shr_file_noprefix, shr_file_queryprefix, shr_file_get
     use shr_stream_mod
@@ -770,7 +774,7 @@ CONTAINS
     type(shr_stream_streamType),intent(inout) :: stream
     type(iosystem_desc_t),intent(inout), target  :: pio_subsystem
     integer(IN)     ,intent(in)    :: pio_iotype
-    type(io_desc_t)      ,intent(inout)  :: pio_iodesc
+    type(io_desc_t)      ,intent(inout)  :: pio_iodesc_r8, pio_iodesc_r4, pio_iodesc_int
     type(mct_gsMap) ,intent(in)    :: gsMap
     type(mct_aVect) ,intent(inout) :: av
     integer(IN)     ,intent(in)    :: mpicom
@@ -792,6 +796,8 @@ CONTAINS
     integer(IN) :: rCode      ! return code
     real(R8),allocatable :: data2d(:,:)
     real(R8),allocatable :: data3d(:,:,:)
+    real(r4), allocatable :: rdata(:)
+    integer, allocatable :: idata(:)
     logical     :: d3dflag
     character(CL) :: fileName
     character(CL) :: sfldName
@@ -800,7 +806,7 @@ CONTAINS
     character(len=32) :: bstr
     logical :: fileopen
     character(CL) :: currfile
-
+    integer :: vtype
     integer(in) :: ndims
     integer(in),pointer :: dimid(:)
     type(file_desc_t) :: pioid
@@ -949,9 +955,22 @@ CONTAINS
           endif
           call shr_mpi_bcast(sfldName,mpicom,'sfldName')
           rcode = pio_inq_varid(pioid,trim(sfldName),varid)
+          rcode = pio_inq_vartype(pioid, varid, vtype)
           frame = nt
           call pio_setframe(pioid,varid,frame)
-          call pio_read_darray(pioid,varid,pio_iodesc,av%rattr(k,:),rcode)
+          if(vtype == PIO_DOUBLE) then
+             call pio_read_darray(pioid,varid,pio_iodesc_r8,av%rattr(k,:),rcode)
+          else if(vtype == PIO_REAL) then
+             allocate(rdata(size(av%rattr(k,:))))
+             call pio_read_darray(pioid,varid,pio_iodesc_r4,rdata,rcode)
+             av%rattr(k,:) = real(rdata, kind=r8)
+             deallocate(rdata)
+          else
+             allocate(idata(size(av%rattr(k,:))))
+             call pio_read_darray(pioid,varid,pio_iodesc_int,idata,rcode)
+             av%rattr(k,:) = real(idata, kind=r8)
+             deallocate(idata)
+          endif
        enddo
 
        call t_stopf(trim(lstr)//'_readpio')
@@ -1006,13 +1025,17 @@ CONTAINS
     type(file_desc_t)             :: pioid
     type(var_desc_t)              :: varid
     integer(kind=pio_offset_kind) :: frame
-    type(io_desc_t)               :: pio_iodesc_local
+    type(io_desc_t)               :: pio_iodesc_r8_local
+    type(io_desc_t)               :: pio_iodesc_r4_local
+    type(io_desc_t)               :: pio_iodesc_int_local
     integer(IN)                   :: avFile_beg, avFile_end
 
+    real(r4), allocatable         :: rdata(:)
+    integer, allocatable          :: idata(:)
     integer                       :: lsize, cnt,m,n
     integer, allocatable          :: count(:), compDOF(:)
     integer, pointer,dimension(:) :: gsmOP   ! gsmap ordered points
-
+    integer                       :: vtype ! variable type on stream file
     character(*), parameter :: subname = ' (shr_dmodel_readstrm_fullfile) '
     character(*), parameter :: F00   = "(' (shr_dmodel_readstrm_fullfile) ',8a)"
     character(*), parameter :: F01   = "(' (shr_dmodel_readstrm_fullfile) ',a,5i8)"
@@ -1145,7 +1168,9 @@ CONTAINS
           enddo
 
           ! Initialize the decomposition
-          call pio_initdecomp(pio_subsystem, pio_double, count, compDOF, pio_iodesc_local)
+          call pio_initdecomp(pio_subsystem, pio_double, count, compDOF, pio_iodesc_r8_local)
+          call pio_initdecomp(pio_subsystem, pio_real, count, compDOF, pio_iodesc_r4_local)
+          call pio_initdecomp(pio_subsystem, pio_int, count, compDOF, pio_iodesc_int_local)
 
           ! For each attribute, read all frames in one go
           frame = 1
@@ -1155,13 +1180,26 @@ CONTAINS
              endif
              call shr_mpi_bcast(sfldName,mpicom,'sfldName')
              rcode = pio_inq_varid(pioid,trim(sfldName),varid)
-
+             rcode = pio_inq_vartype(pioid, varid, vtype)
              call pio_setframe(pioid,varid,frame)
-
-             call pio_read_darray(pioid, varid, pio_iodesc_local, avFile%rattr(k,:), rcode)
+             if(vtype == PIO_DOUBLE) then
+                call pio_read_darray(pioid, varid, pio_iodesc_r8_local, avFile%rattr(k,:), rcode)
+             else if(vtype == PIO_REAL) then
+                allocate(rdata(size(avFile%rattr(k,:))))
+                call pio_read_darray(pioid, varid, pio_iodesc_r4_local, rdata, rcode)
+                avFile%rattr(k,:) = real(rdata, kind=r8)
+                deallocate(rdata)
+             else if(vtype == PIO_INT) then
+                allocate(idata(size(avFile%rattr(k,:))))
+                call pio_read_darray(pioid, varid, pio_iodesc_int_local, idata, rcode)
+                avFile%rattr(k,:) = real(idata, kind=r8)
+                deallocate(idata)
+             endif
           enddo
 
-          call pio_freedecomp(pio_subsystem, pio_iodesc_local)
+          call pio_freedecomp(pio_subsystem, pio_iodesc_r8_local)
+          call pio_freedecomp(pio_subsystem, pio_iodesc_r4_local)
+          call pio_freedecomp(pio_subsystem, pio_iodesc_int_local)
 
           deallocate(count)
           deallocate(compDOF)

--- a/src/share/streams/shr_strdata_mod.F90
+++ b/src/share/streams/shr_strdata_mod.F90
@@ -113,7 +113,9 @@ module shr_strdata_mod
      ! --- stream info, internal ---
      type(shr_stream_streamType)    :: stream(nStrMax)
      type(iosystem_desc_t), pointer :: pio_subsystem => null()
-     type(io_desc_t)                :: pio_iodesc(nStrMax)
+     type(io_desc_t)                :: pio_iodesc_r8(nStrMax)
+     type(io_desc_t)                :: pio_iodesc_r4(nStrMax)
+     type(io_desc_t)                :: pio_iodesc_int(nStrMax)
      integer(IN)                    :: nstreams          ! number of streams
      integer(IN)                    :: strnxg(nStrMax)
      integer(IN)                    :: strnyg(nStrMax)
@@ -495,10 +497,18 @@ contains
        call mct_gsmap_OrderedPoints(SDAT%gsmapR(n), my_task, dof)
        if (SDAT%strnzg(n) <= 0) then
           call pio_initdecomp(SDAT%pio_subsystem, pio_double, &
-               (/SDAT%strnxg(n),SDAT%strnyg(n)/), dof, SDAT%pio_iodesc(n))
+               (/SDAT%strnxg(n),SDAT%strnyg(n)/), dof, SDAT%pio_iodesc_r8(n))
+          call pio_initdecomp(SDAT%pio_subsystem, pio_real, &
+               (/SDAT%strnxg(n),SDAT%strnyg(n)/), dof, SDAT%pio_iodesc_r4(n))
+          call pio_initdecomp(SDAT%pio_subsystem, pio_int, &
+               (/SDAT%strnxg(n),SDAT%strnyg(n)/), dof, SDAT%pio_iodesc_int(n))
        else
           call pio_initdecomp(SDAT%pio_subsystem, pio_double, &
-               (/SDAT%strnxg(n),SDAT%strnyg(n),SDAT%strnzg(n)/), dof, SDAT%pio_iodesc(n))
+               (/SDAT%strnxg(n),SDAT%strnyg(n),SDAT%strnzg(n)/), dof, SDAT%pio_iodesc_r8(n))
+          call pio_initdecomp(SDAT%pio_subsystem, pio_real, &
+               (/SDAT%strnxg(n),SDAT%strnyg(n),SDAT%strnzg(n)/), dof, SDAT%pio_iodesc_r4(n))
+          call pio_initdecomp(SDAT%pio_subsystem, pio_int, &
+               (/SDAT%strnxg(n),SDAT%strnyg(n),SDAT%strnzg(n)/), dof, SDAT%pio_iodesc_int(n))
        endif
        deallocate(dof)
 
@@ -872,7 +882,8 @@ contains
           call t_barrierf(trim(lstr)//trim(timname)//'_readLBUB_BARRIER',mpicom)
           call t_startf(trim(lstr)//trim(timname)//'_readLBUB')
 
-          call shr_dmodel_readLBUB(SDAT%stream(n),SDAT%pio_subsystem,SDAT%io_type,SDAT%pio_iodesc(n), &
+          call shr_dmodel_readLBUB(SDAT%stream(n),SDAT%pio_subsystem,SDAT%io_type, &
+               SDAT%pio_iodesc_r8(n), SDAT%pio_iodesc_r4(n), SDAT%pio_iodesc_int(n), &
                ymdmod(n),todmod,mpicom,SDAT%gsmapR(n),&
                SDAT%avRLB(n),SDAT%ymdLB(n),SDAT%todLB(n), &
                SDAT%avRUB(n),SDAT%ymdUB(n),SDAT%todUB(n), &
@@ -1129,7 +1140,9 @@ contains
     call mct_gsmap_clean(SDAT%gsmap)
 
     do n = 1, SDAT%nstreams
-       call pio_freedecomp(SDAT%pio_subsystem, SDAT%pio_iodesc(n))
+       call pio_freedecomp(SDAT%pio_subsystem, SDAT%pio_iodesc_r8(n))
+       call pio_freedecomp(SDAT%pio_subsystem, SDAT%pio_iodesc_r4(n))
+       call pio_freedecomp(SDAT%pio_subsystem, SDAT%pio_iodesc_int(n))
        call mct_avect_clean(SDAT%avs(n))
        call mct_avect_clean(SDAT%avRLB(n))
        call mct_avect_clean(SDAT%avRUB(n))


### PR DESCRIPTION
Don't rely on pio to do data conversions.  Note that I used both pio2 and pio1 for these tests. 

Test suite: scripts_regression_tests.py, IRT_N2_Ln9.f19_g16_rx1.A.cheyenne_gnu, PET.T62_g16.G.cheyenne_pgi.pop-cice
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3810 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
