### PR TITLE
Pass integer and not floating point

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -183,7 +183,8 @@ class Case(object):
 
         os.environ["OMP_NUM_THREADS"] = str(self.thread_count)
 
-        self.srun_binding = smt_factor*max_mpitasks_per_node / self.tasks_per_node
+        self.srun_binding = math.floor(smt_factor*max_mpitasks_per_node / self.tasks_per_node)
+        self.srun_binding = max(1,self.srun_binding)
 
     # Define __enter__ and __exit__ so that we can use this as a context manager
     # and force a flush on exit.


### PR DESCRIPTION
Even though the calculation for cpus-per-task (in slurm) results in an integer, it passes it as a floating point i.e. 2.0 instead of 2. I was encountering issue on Cori (NERSC)

[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
