### PR TITLE
allow srt to skip some tests

### DIFF
--- a/scripts/lib/get_tests.py
+++ b/scripts/lib/get_tests.py
@@ -182,7 +182,7 @@ def get_test_suites():
     return list(_ALL_TESTS.keys())
 
 ###############################################################################
-def get_test_suite(suite, machine=None, compiler=None, skip_inherit=False):
+def get_test_suite(suite, machine=None, compiler=None, skip_inherit=False, skip_tests=None):
 ###############################################################################
     """
     Return a list of FULL test names for a suite.
@@ -209,8 +209,8 @@ def get_test_suite(suite, machine=None, compiler=None, skip_inherit=False):
             test_mod = test_components[-1]
         else:
             test_name = item
-
-        tests.append(CIME.utils.get_full_test_name(test_name, machine=machine, compiler=compiler, testmod=test_mod))
+        if not skip_tests or not test_name in skip_tests:
+            tests.append(CIME.utils.get_full_test_name(test_name, machine=machine, compiler=compiler, testmod=test_mod))
 
     if not skip_inherit:
         for inherits in inherits_from:

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -103,7 +103,7 @@ def verify_perms(test_obj, root_dir):
 def get_casedir(test_obj, case_fragment, all_cases):
 ###############################################################################
     potential_matches = [item for item in all_cases if case_fragment in item]
-    test_obj.assertTrue(len(potential_matches) <= 1, "Ambiguous casedir selection for {}, found  {}  among  {}".format(case_fragment, potential_matches, all_cases))
+    test_obj.assertTrue(len(potential_matches) == 1, "Ambiguous casedir selection for {}, found  {}  among  {}".format(case_fragment, potential_matches, all_cases))
     return potential_matches[0]
 
 ###############################################################################
@@ -1969,8 +1969,6 @@ class Z_FullSystemTest(TestCreateTestCommon):
         if CIME.utils.get_cime_default_driver() == 'nuopc':
             skip_tests=["SMS_Ln3.T42_T42.S","PRE.f19_f19.ADESP_TEST","PRE.f19_f19.ADESP","DAE.ww3a.ADWAV"]
         tests = get_tests.get_test_suite("cime_developer", machine=self._machine, compiler=self._compiler,skip_tests=skip_tests)
-
-
 
         for test in tests:
             casedir = get_casedir(self, test, cases)

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -103,7 +103,7 @@ def verify_perms(test_obj, root_dir):
 def get_casedir(test_obj, case_fragment, all_cases):
 ###############################################################################
     potential_matches = [item for item in all_cases if case_fragment in item]
-    test_obj.assertTrue(len(potential_matches) == 1, "Ambiguous casedir selection for {}, found  {}  among  {}".format(case_fragment, potential_matches, all_cases))
+    test_obj.assertTrue(len(potential_matches) <= 1, "Ambiguous casedir selection for {}, found  {}  among  {}".format(case_fragment, potential_matches, all_cases))
     return potential_matches[0]
 
 ###############################################################################
@@ -1965,7 +1965,13 @@ class Z_FullSystemTest(TestCreateTestCommon):
             self.assertTrue(test_time > 0, msg="test time was zero for %s" % test_status)
 
         # Test that re-running works
-        tests = get_tests.get_test_suite("cime_developer", machine=self._machine, compiler=self._compiler)
+        skip_tests = None
+        if CIME.utils.get_cime_default_driver() == 'nuopc':
+            skip_tests=["SMS_Ln3.T42_T42.S","PRE.f19_f19.ADESP_TEST","PRE.f19_f19.ADESP","DAE.ww3a.ADWAV"]
+        tests = get_tests.get_test_suite("cime_developer", machine=self._machine, compiler=self._compiler,skip_tests=skip_tests)
+
+
+
         for test in tests:
             casedir = get_casedir(self, test, cases)
 


### PR DESCRIPTION
In scripts_regression_tests.py with nuopc driver we skip some of the cime_developer tests but this wasn't being done consistently, this change makes it consistent. 

Test suite: scripts_regression_tests for mct and nuopc
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
