### PR TITLE
pnetcdf detection correction

### DIFF
--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -178,7 +178,7 @@ def buildlib(bldroot, installpath, case):
         valid_values += ",pnetcdf"
     if netcdf4_parallel_found:
         valid_values += ",netcdf4p,netcdf4c"
-    print("HERE valid_values {}".format(valid_values))
+
     _set_pio_valid_values(case, valid_values)
 
 

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -154,7 +154,7 @@ def buildlib(bldroot, installpath, case):
                 if item_time  > installed_file_time:
                     safe_copy(item, installed_file)
         expect_string = "NetCDF_C_LIBRARY-ADVANCED"
-        pnetcdf_string = "PnetCDF_C_LIBRARY-ADVANCED"
+        pnetcdf_string = "WITH_PNETCDF:STRING=TRUE"
         netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
 
 
@@ -178,6 +178,7 @@ def buildlib(bldroot, installpath, case):
         valid_values += ",pnetcdf"
     if netcdf4_parallel_found:
         valid_values += ",netcdf4p,netcdf4c"
+    print("HERE valid_values {}".format(valid_values))
     _set_pio_valid_values(case, valid_values)
 
 


### PR DESCRIPTION
With pio2 pnetcdf was always detected by the build script even when it wasn't there.  This corrects that issue. 

Test suite: scripts_regression_tests.py on centos7-linux
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
