### PR TITLE
Better create_test/wait_for_tests integration

### DIFF
--- a/scripts/Tools/cime_bisect
+++ b/scripts/Tools/cime_bisect
@@ -4,6 +4,9 @@
 A script to help track down the commit that caused tests to fail. This script
 can do bisections for both cime and the model that houses it, just be sure
 you run this script from the root of the repo you want to bisect.
+
+NOTE: this tool will only work for models that use git and, for bisecting CIME,
+bring in CIME via submodule or clone.
 """
 
 from standard_script_setup import *

--- a/scripts/Tools/cime_bisect
+++ b/scripts/Tools/cime_bisect
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 """
-A script to help track down the commit that caused tests to fail.
+A script to help track down the commit that caused tests to fail. This script
+can do bisections for both cime and the model that houses it, just be sure
+you run this script from the root of the repo you want to bisect.
 """
 
 from standard_script_setup import *
@@ -18,13 +20,17 @@ _MACHINE = Machines()
 def parse_command_line(args, description):
 ###############################################################################
     parser = argparse.ArgumentParser(
-        usage="""\n{0} <testargs> <last-known-good-commit> [--bad=<bad>] [--compare=<baseline-id>] [--no-batch]  [--verbose]
+        usage="""\n{0} <testargs> <last-known-good-commit> [--bad=<bad>] [--verbose]
 OR
 {0} --help
 
 \033[1mEXAMPLES:\033[0m
-    \033[1;32m# Bisect ERS.f45_g37.B1850C5 which got broken in the last 4 commits \033[0m
+    \033[1;32m# Bisect ERS.f45_g37.B1850C5 which got broken in the last 4 CIME commits \033[0m
     > cd <root-of-broken-cime-repo>
+    > {0} HEAD~4 ERS.f45_g37.B1850C5
+
+    \033[1;32m# Bisect ERS.f45_g37.B1850C5 which got broken in the last 4 MODEL commits \033[0m
+    > cd <root-of-broken-model>
     > {0} HEAD~4 ERS.f45_g37.B1850C5
 
     \033[1;32m# Bisect ERS.f45_g37.B1850C5 which started to DIFF in the last 4 commits \033[0m
@@ -38,6 +44,7 @@ OR
     \033[1;32m# Bisect two different failing tests which got broken in the last 4 commits \033[0m
     > cd <root-of-broken-cime-repo>
     > {0} HEAD~4 'ERS.f45_g37.B1850C5 --no-run' 'SMS.f45_g37.F'
+
 
 """.format(os.path.basename(args[0])),
 
@@ -56,56 +63,19 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
     parser.add_argument("-a", "--all-commits", action="store_true",
                         help="Test all commits, not just merges")
 
-    parser.add_argument("-C", "--cime-integration", action="store_true",
-                        help="Bisect CIME instead of the whole code. Useful for finding errors after CIME merges")
-
     parser.add_argument("-S", "--script",
                         help="Use your own custom script instead")
 
-    ct_modifiers = parser.add_argument_group("create_test", "flags for modifying create_test call to be bisected")
-
-    ct_modifiers.add_argument("testargs", nargs="*", help="String to pass to create_test. Combine with single quotes if it includes multiple args.")
-
-    ct_modifiers.add_argument("-r", "--test-root",
-                        help="Path to testroot to use for testcases for bisect. WARNING. This will be cleared by this script.")
-
-    ct_modifiers.add_argument("-n", "--check-namelists", action="store_true",
-                        help="Consider a commit to be broken if namelist check fails")
-
-    ct_modifiers.add_argument("-t", "--check-throughput", action="store_true",
-                        help="Consider a commit to be broken if throughput check fails (fail if tests slow down)")
-
-    ct_modifiers.add_argument("-m", "--check-memory", action="store_true",
-                        help="Consider a commit to be broken if memory check fails (fail if tests footprint grows)")
-
-    ct_modifiers.add_argument("-l", "--check-memleak", action="store_true",
-                        help="Consider a commit to be broken if a memleak is detected")
+    parser.add_argument("testargs", nargs="*", help="String to pass to create_test. Combine with single quotes if it includes multiple args.")
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    if args.test_root is None:
-        args.test_root = os.path.join(_MACHINE.get_value("CIME_OUTPUT_ROOT"), "cime_bisect")
+    expect(os.path.exists(".git"), "Please run the root of a repo. Either your CIME repo or model depending on which one you want to bisect on")
 
-    if args.cime_integration:
-        expect(os.path.basename(os.getcwd()) == "cime" and os.path.isdir(".git"), \
-"""
-In order for --cime-integration mode to work, it is expected that you have deleted
-your cime subtree and replaced it with a clone of ESMCI cime. It is also expected
-that you run this script from the cime direcory.
-""")
-
-    expect(os.path.isdir(".git"), "Please run the root of a repo")
-
-    expect( not (bool(args.script) and (bool(args.testargs) or args.check_namelists or args.check_throughput or args.check_memory or args.check_memleak) ),
-            "Makes no sense to use custom script but also ask for create_test modifiers")
-
-    return args.testargs, args.good, args.bad, args.test_root, \
-        args.check_namelists, args.check_throughput, args.check_memory, args.check_memleak, args.all_commits, args.script
+    return args.testargs, args.good, args.bad, args.all_commits, args.script
 
 ###############################################################################
-def cime_bisect(testargs, good, bad, testroot,
-                check_namelists, check_throughput, check_memory, check_memleak, commits_to_skip,
-                custom_script):
+def cime_bisect(testargs, good, bad, commits_to_skip, custom_script):
 ###############################################################################
     logger.info("####################################################")
     logger.info("TESTING WITH ARGS '{}'".format(testargs))
@@ -127,28 +97,16 @@ def cime_bisect(testargs, good, bad, testroot,
 
     # Formulate the create_test command, let create_test make the test-id, it will use
     # a timestamp that will allow us to avoid collisions
-    bisect_cmd = "git submodule update --recursive && {} {} --test-root {}".format(create_test, testargs, testroot)
+    thing_to_run = custom_script if custom_script else "{} {}".format(create_test, testargs)
+    bisect_cmd = "git submodule update --recursive && {}".format(thing_to_run)
 
     is_batch = _MACHINE.has_batch_system()
     if (is_batch and "--no-run" not in testargs and "--no-build" not in testargs and "--no-setup" not in testargs):
-        # Forumulate the wait_for_tests command.
-
-        bisect_cmd += " --wait"
-
-        if (check_throughput):
-            bisect_cmd += " --wait-check-throughput"
-        if (check_memory):
-            bisect_cmd += " --wait-check-memory"
-        if (not check_namelists):
-            bisect_cmd += " --wait-ignore-namelists"
-        if (not check_memleak):
-            bisect_cmd += " --wait-ignore-memleak"
+        expect("--wait" in testargs,
+               "Your create_test command likely needs --wait to work correctly with bisect")
 
     try:
-        if custom_script:
-            cmd = "git bisect run {}".format(custom_script)
-        else:
-            cmd = "git bisect run sh -c '{}'".format(bisect_cmd)
+        cmd = "git bisect run sh -c '{}'".format(bisect_cmd)
 
         output = run_cmd(cmd, verbose=True)[1]
 
@@ -172,7 +130,7 @@ def cime_bisect(testargs, good, bad, testroot,
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    testargs, good, bad, testroot, check_namelists, check_throughput, check_memory, check_memleak, all_commits, custom_script = \
+    testargs, good, bad, all_commits, custom_script = \
         parse_command_line(sys.argv, description)
 
     # Important: we only want to test merges
@@ -187,10 +145,10 @@ def _main_func(description):
         commits_to_skip = set()
 
     if custom_script:
-        cime_bisect(custom_script, good, bad, testroot, check_namelists, check_throughput, check_memory, check_memleak, commits_to_skip, custom_script)
+        cime_bisect(custom_script, good, bad, commits_to_skip, custom_script)
     else:
         for set_of_test_args in testargs:
-            cime_bisect(set_of_test_args, good, bad, testroot, check_namelists, check_throughput, check_memory, check_memleak, commits_to_skip, custom_script)
+            cime_bisect(set_of_test_args, good, bad, commits_to_skip, custom_script)
 
 ###############################################################################
 

--- a/scripts/Tools/wait_for_tests
+++ b/scripts/Tools/wait_for_tests
@@ -98,7 +98,8 @@ def _main_func(description):
                                                      timeout=timeout,
                                                      force_log_upload=force_log_upload,
                                                      no_run=no_run,
-                                                     update_success=update_success)
+                                                     update_success=update_success,
+                                                     expect_test_complete=not no_wait)
              else CIME.utils.TESTS_FAILED_ERR_CODE)
 
 ###############################################################################

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -254,17 +254,17 @@ def parse_command_line(args, description):
                         default=default,
                         help="Do not pass skip-pnl to case.submit")
 
-    parser.add_argument("--wait-check-throughput", action="store_true",
-                        help="If waiting, fail if throughput check fails")
+    parser.add_argument("--check-throughput", action="store_true",
+                        help="Fail if throughput check fails. Requires --wait on batch systems")
 
-    parser.add_argument("--wait-check-memory", action="store_true",
-                        help="If waiting, fail if memory check fails")
+    parser.add_argument("--check-memory", action="store_true",
+                        help="Fail if memory check fails. Requires --wait on batch systems")
 
-    parser.add_argument("--wait-ignore-namelists", action="store_true",
-                        help="If waiting, ignore if namelist diffs")
+    parser.add_argument("--ignore-namelists", action="store_true",
+                        help="Do not fail if there namelist diffs")
 
-    parser.add_argument("--wait-ignore-memleak", action="store_true",
-                        help="If waiting, ignore if there's a memleak")
+    parser.add_argument("--ignore-memleak", action="store_true",
+                        help="Do not fail if there's a memleak")
 
     default = get_default_setting(config, "FORCE_PROCS", None, check_main=False)
 
@@ -420,11 +420,9 @@ def parse_command_line(args, description):
     expect(mach_obj.is_valid_compiler(args.compiler),
            "Compiler %s not valid for machine %s" % (args.compiler, mach_obj.get_machine_name()))
 
-    if not args.wait:
-        expect(not args.wait_check_throughput, "Makes no sense to use --wait-check-throughput without --wait")
-        expect(not args.wait_check_memory, "Makes no sense to use --wait-check-memory without --wait")
-        expect(not args.wait_ignore_namelists, "Makes no sense to use --wait-ignore-namelists without --wait")
-        expect(not args.wait_ignore_memleak, "Makes no sense to use --wait-ignore-memleak without --wait")
+    if not args.wait and mach_obj.has_batch_system() and not args.no_batch:
+        expect(not args.check_throughput, "Makes no sense to use --check-throughput without --wait")
+        expect(not args.check_memory,     "Makes no sense to use --check-memory without --wait")
 
     # Normalize compare/generate between the models
     baseline_cmp_name = None
@@ -465,7 +463,7 @@ def parse_command_line(args, description):
         args.namelists_only, args.project, \
         args.test_id, args.parallel_jobs, args.walltime, \
         args.single_submit, args.proc_pool, args.use_existing, args.save_timing, args.queue, \
-        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib, args.input_dir, args.pesfile, args.retry, args.mail_user, args.mail_type, args.wait_check_throughput, args.wait_check_memory, args.wait_ignore_namelists, args.wait_ignore_memleak, args.allow_pnl, args.non_local, args.single_exe, args.workflow
+        args.allow_baseline_overwrite, args.output_root, args.wait, args.force_procs, args.force_threads, args.mpilib, args.input_dir, args.pesfile, args.retry, args.mail_user, args.mail_type, args.check_throughput, args.check_memory, args.ignore_namelists, args.ignore_memleak, args.allow_pnl, args.non_local, args.single_exe, args.workflow
 
 ###############################################################################
 def get_default_setting(config, varname, default_if_not_found, check_main=False):
@@ -573,7 +571,7 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
                 baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, project, test_id, parallel_jobs,
                 walltime, single_submit, proc_pool, use_existing, save_timing, queue, allow_baseline_overwrite, output_root, wait,
                 force_procs, force_threads, mpilib, input_dir, pesfile, mail_user, mail_type,
-                wait_check_throughput, wait_check_memory, wait_ignore_namelists, wait_ignore_memleak, 
+                check_throughput, check_memory, ignore_namelists, ignore_memleak,
                 allow_pnl, non_local, single_exe, workflow):
 ###############################################################################
     impl = TestScheduler(test_names, test_data=test_data,
@@ -591,10 +589,10 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
                          non_local=non_local, single_exe=single_exe, workflow=workflow)
 
     success = impl.run_tests(wait=wait,
-                             wait_check_throughput=wait_check_throughput,
-                             wait_check_memory=wait_check_memory,
-                             wait_ignore_namelists=wait_ignore_namelists,
-                             wait_ignore_memleak=wait_ignore_memleak)
+                             check_throughput=check_throughput,
+                             check_memory=check_memory,
+                             ignore_namelists=ignore_namelists,
+                             ignore_memleak=ignore_memleak)
 
     if success and single_submit:
         # Get real test root
@@ -627,7 +625,7 @@ def _main_func(description):
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \
     save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile, \
-    retry, mail_user, mail_type, wait_check_throughput, wait_check_memory, wait_ignore_namelists, wait_ignore_memleak, allow_pnl, \
+    retry, mail_user, mail_type, check_throughput, check_memory, ignore_namelists, ignore_memleak, allow_pnl, \
     non_local, single_exe, workflow = \
         parse_command_line(sys.argv, description)
 
@@ -639,7 +637,7 @@ def _main_func(description):
                               baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only,
                               project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, save_timing,
                               queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile,
-                              mail_user, mail_type, wait_check_throughput, wait_check_memory, wait_ignore_namelists, wait_ignore_memleak, 
+                              mail_user, mail_type, check_throughput, check_memory, ignore_namelists, ignore_memleak,
                               allow_pnl, non_local, single_exe, workflow)
         run_count += 1
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -206,7 +206,7 @@ class SystemTestsCommon(object):
                     save_test_time(baseline_root, self._casebaseid, time_taken, get_current_commit(repo=srcroot))
 
                 # If overall things did not pass, offer the user some insight into what might have broken things
-                overall_status = self._test_status.get_overall_test_status(ignore_namelists=True)
+                overall_status = self._test_status.get_overall_test_status(ignore_namelists=True)[0]
                 if overall_status != TEST_PASS_STATUS:
                     srcroot = self._case.get_value("SRCROOT")
                     worked_before, last_pass, last_fail_transition = \

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -3,7 +3,7 @@ Base class for CIME system tests
 """
 from CIME.XML.standard_module_setup import *
 from CIME.XML.env_run import EnvRun
-from CIME.utils import append_testlog, get_model, safe_copy, get_timestamp, CIMEError, expect, get_current_commit
+from CIME.utils import append_testlog, get_model, safe_copy, get_timestamp, CIMEError, expect, get_current_commit, SharedArea
 from CIME.test_status import *
 from CIME.hist_utils import copy_histfiles, compare_test, generate_teststatus, \
     compare_baseline, get_ts_synopsis, generate_baseline
@@ -569,12 +569,13 @@ class SystemTestsCommon(object):
             # copy latest cpl log to baseline
             # drop the date so that the name is generic
             newestcpllogfiles = self._get_latest_cpl_logs()
-            for cpllog in newestcpllogfiles:
-                m = re.search(r"/({}.*.log).*.gz".format(self._cpllog),cpllog)
-                if m is not None:
-                    baselog = os.path.join(basegen_dir, m.group(1))+".gz"
-                    safe_copy(cpllog,
-                              os.path.join(basegen_dir,baselog))
+            with SharedArea():
+                for cpllog in newestcpllogfiles:
+                    m = re.search(r"/({}.*.log).*.gz".format(self._cpllog),cpllog)
+                    if m is not None:
+                        baselog = os.path.join(basegen_dir, m.group(1))+".gz"
+                        safe_copy(cpllog,
+                                  os.path.join(basegen_dir,baselog), preserve_meta=False)
 
 class FakeTest(SystemTestsCommon):
     """

--- a/scripts/lib/CIME/bless_test_results.py
+++ b/scripts/lib/CIME/bless_test_results.py
@@ -97,7 +97,7 @@ def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_i
                 continue
 
         if (bless_tests in [[], None] or CIME.utils.match_any(test_name, bless_tests)):
-            overall_result = ts.get_overall_test_status()
+            overall_result = ts.get_overall_test_status()[0]
 
             # See if we need to bless namelist
             if (not hist_only):

--- a/scripts/lib/CIME/cs_status.py
+++ b/scripts/lib/CIME/cs_status.py
@@ -102,5 +102,5 @@ def _overall_output(ts, format_str):
         contain place-holders for status and test_name
     """
     test_name = ts.get_name()
-    status = ts.get_overall_test_status()
+    status = ts.get_overall_test_status()[0]
     return format_str.format(status=status, test_name=test_name)

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -1057,13 +1057,16 @@ class TestScheduler(object):
         if no_need_to_wait:
             wait = False
 
+        expect_test_complete = no_need_to_wait or wait
+
         logger.info("Waiting for tests to finish")
         rv = wait_for_tests(glob.glob(os.path.join(self._test_root, "*{}/TestStatus".format(self._test_id))),
                             no_wait=not wait,
                             check_throughput=check_throughput,
                             check_memory=check_memory,
                             ignore_namelists=ignore_namelists,
-                            ignore_memleak=ignore_memleak)
+                            ignore_memleak=ignore_memleak,
+                            expect_test_complete=expect_test_complete)
 
         if not no_need_to_wait and not wait:
             logger.info("Due to presence of batch system, create_test will exit before tests are complete.\n" \

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -1057,7 +1057,7 @@ class TestScheduler(object):
         if no_need_to_wait:
             wait = False
 
-        expect_test_complete = no_need_to_wait or wait
+        expect_test_complete = not self._no_run and (self._no_batch or wait)
 
         logger.info("Waiting for tests to finish")
         rv = wait_for_tests(glob.glob(os.path.join(self._test_root, "*{}/TestStatus".format(self._test_id))),

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -1066,6 +1066,7 @@ class TestScheduler(object):
                             check_memory=check_memory,
                             ignore_namelists=ignore_namelists,
                             ignore_memleak=ignore_memleak,
+                            no_run=self._no_run,
                             expect_test_complete=expect_test_complete)
 
         if not no_need_to_wait and not wait:

--- a/scripts/lib/CIME/test_status.py
+++ b/scripts/lib/CIME/test_status.py
@@ -349,7 +349,7 @@ class TestStatus(object):
             if phase in [SUBMIT_PHASE, RUN_PHASE] and no_run:
                 break
 
-            if (status == TEST_PEND_STATUS):
+            if status == TEST_PEND_STATUS and rv in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS]:
                 rv = TEST_PEND_STATUS
                 phase_responsible_for_status = phase
                 if not no_run:
@@ -383,7 +383,7 @@ class TestStatus(object):
 
         # The test did not fail but the RUN phase was not found, so if the user requested
         # that we wait for the RUN phase, then the test must still be considered pending.
-        if rv != TEST_FAIL_STATUS and not run_phase_found and wait_for_run:
+        if rv in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS] and not run_phase_found and wait_for_run:
             phase_responsible_for_status = RUN_PHASE
             rv = TEST_PEND_STATUS
 
@@ -427,6 +427,8 @@ class TestStatus(object):
         ('PEND', 'COMPARE_2')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD')
         ('PASS', 'MODEL_BUILD')
+        >>> _test_helper2('PEND ERS.foo.A MODEL_BUILD\nPEND ERS.foo.A RUN')
+        ('PEND', 'MODEL_BUILD')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD', wait_for_run=True)
         ('PEND', 'RUN')
         >>> _test_helper2('FAIL ERS.foo.A MODEL_BUILD', wait_for_run=True)

--- a/scripts/lib/CIME/test_status.py
+++ b/scripts/lib/CIME/test_status.py
@@ -332,11 +332,15 @@ class TestStatus(object):
 
         rv = TEST_PASS_STATUS
         run_phase_found = False
+        phase_responsible_for_status = None
         for phase in phases: # ensure correct order of processing phases
             if phase in self._phase_statuses:
                 data = self._phase_statuses[phase]
             else:
                 continue
+
+            if phase in CORE_PHASES and rv in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS]:
+                phase_responsible_for_status = phase
 
             status = data[0]
             if phase == RUN_PHASE:
@@ -347,6 +351,7 @@ class TestStatus(object):
 
             if (status == TEST_PEND_STATUS):
                 rv = TEST_PEND_STATUS
+                phase_responsible_for_status = phase
                 if not no_run:
                     break
 
@@ -357,25 +362,32 @@ class TestStatus(object):
                      (ignore_memleak and phase == MEMLEAK_PHASE) ):
                     continue
 
-                if (phase == NAMELIST_PHASE):
+                if phase == NAMELIST_PHASE:
                     if (rv == TEST_PASS_STATUS):
                         rv = NAMELIST_FAIL_STATUS
 
-                elif (rv in [NAMELIST_FAIL_STATUS, TEST_PASS_STATUS] and phase == BASELINE_PHASE):
-                    rv = TEST_DIFF_STATUS
+                elif phase == BASELINE_PHASE:
+                    if rv in [NAMELIST_FAIL_STATUS, TEST_PASS_STATUS]:
+                        phase_responsible_for_status = phase
+                        rv = TEST_DIFF_STATUS
+                    else:
+                        pass # a DIFF doesn't not trump a FAIL
 
                 elif phase in CORE_PHASES:
-                    return TEST_FAIL_STATUS
+                    phase_responsible_for_status = phase
+                    return TEST_FAIL_STATUS, phase_responsible_for_status
 
                 else:
+                    phase_responsible_for_status = phase
                     rv = TEST_FAIL_STATUS
 
         # The test did not fail but the RUN phase was not found, so if the user requested
         # that we wait for the RUN phase, then the test must still be considered pending.
         if rv != TEST_FAIL_STATUS and not run_phase_found and wait_for_run:
+            phase_responsible_for_status = RUN_PHASE
             rv = TEST_PEND_STATUS
 
-        return rv
+        return rv, phase_responsible_for_status
 
     def get_overall_test_status(self, wait_for_run=False, check_throughput=False, check_memory=False, ignore_namelists=False, ignore_memleak=False, no_run=False):
         r"""
@@ -384,51 +396,51 @@ class TestStatus(object):
         that hasn't finished. Namelist diffs are given the lowest precedence.
 
         >>> _test_helper2('PASS ERS.foo.A RUN')
-        'PASS'
+        ('PASS', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A SHAREDLIB_BUILD\nPEND ERS.foo.A RUN')
-        'PEND'
+        ('PEND', 'RUN')
         >>> _test_helper2('FAIL ERS.foo.A MODEL_BUILD\nPEND ERS.foo.A RUN')
-        'FAIL'
+        ('FAIL', 'MODEL_BUILD')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPASS ERS.foo.A RUN')
-        'PASS'
+        ('PASS', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A TPUTCOMP')
-        'PASS'
+        ('PASS', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A TPUTCOMP', check_throughput=True)
-        'FAIL'
+        ('FAIL', 'TPUTCOMP')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPASS ERS.foo.A RUN\nFAIL ERS.foo.A NLCOMP')
-        'NLFAIL'
+        ('NLFAIL', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPEND ERS.foo.A RUN\nFAIL ERS.foo.A NLCOMP')
-        'PEND'
+        ('PEND', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A MEMCOMP')
-        'PASS'
+        ('PASS', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A NLCOMP', ignore_namelists=True)
-        'PASS'
+        ('PASS', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A COMPARE_1\nFAIL ERS.foo.A NLCOMP\nFAIL ERS.foo.A COMPARE_2\nPASS ERS.foo.A RUN')
-        'FAIL'
+        ('FAIL', 'COMPARE_2')
         >>> _test_helper2('FAIL ERS.foo.A BASELINE\nFAIL ERS.foo.A NLCOMP\nPASS ERS.foo.A COMPARE_2\nPASS ERS.foo.A RUN')
-        'DIFF'
+        ('DIFF', 'BASELINE')
         >>> _test_helper2('FAIL ERS.foo.A BASELINE\nFAIL ERS.foo.A NLCOMP\nFAIL ERS.foo.A COMPARE_2\nPASS ERS.foo.A RUN')
-        'FAIL'
+        ('FAIL', 'COMPARE_2')
         >>> _test_helper2('PEND ERS.foo.A COMPARE_2\nFAIL ERS.foo.A RUN')
-        'FAIL'
+        ('FAIL', 'RUN')
         >>> _test_helper2('PEND ERS.foo.A COMPARE_2\nPASS ERS.foo.A RUN')
-        'PEND'
+        ('PEND', 'COMPARE_2')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD')
-        'PASS'
+        ('PASS', 'MODEL_BUILD')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD', wait_for_run=True)
-        'PEND'
+        ('PEND', 'RUN')
         >>> _test_helper2('FAIL ERS.foo.A MODEL_BUILD', wait_for_run=True)
-        'FAIL'
+        ('FAIL', 'MODEL_BUILD')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPEND ERS.foo.A RUN', wait_for_run=True)
-        'PEND'
+        ('PEND', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nFAIL ERS.foo.A RUN', wait_for_run=True)
-        'FAIL'
+        ('FAIL', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPASS ERS.foo.A RUN', wait_for_run=True)
-        'PASS'
+        ('PASS', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nFAIL ERS.foo.A RUN\nPEND ERS.foo.A COMPARE')
-        'FAIL'
+        ('FAIL', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPEND ERS.foo.A RUN', no_run=True)
-        'PASS'
+        ('PASS', 'RUN')
         >>> s = '''PASS ERS.foo.A CREATE_NEWCASE
         ... PASS ERS.foo.A XML
         ... PASS ERS.foo.A SETUP
@@ -444,18 +456,18 @@ class TestStatus(object):
         ... PASS ERS.foo.A SHORT_TERM_ARCHIVER
         ... '''
         >>> _test_helper2(s, no_perm=True)
-        'PEND'
+        ('PEND', 'COMPARE_base_single_thread')
         """
         # Core phases take priority
-        core_rv = self._get_overall_status_based_on_phases(CORE_PHASES,
-                                                           wait_for_run=wait_for_run,
-                                                           check_throughput=check_throughput,
-                                                           check_memory=check_memory,
-                                                           ignore_namelists=ignore_namelists,
-                                                           ignore_memleak=ignore_memleak,
-                                                           no_run=no_run)
+        core_rv, phase = self._get_overall_status_based_on_phases(CORE_PHASES,
+                                                                  wait_for_run=wait_for_run,
+                                                                  check_throughput=check_throughput,
+                                                                  check_memory=check_memory,
+                                                                  ignore_namelists=ignore_namelists,
+                                                                  ignore_memleak=ignore_memleak,
+                                                                  no_run=no_run)
         if core_rv != TEST_PASS_STATUS:
-            return core_rv
+            return core_rv, phase
         else:
             phase_order = list(CORE_PHASES)
             phase_order.extend([item for item in self._phase_statuses if item not in CORE_PHASES])

--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -458,7 +458,7 @@ def wait_for_tests(test_paths,
         test_path, test_status, phase = test_data
         case_dir = os.path.dirname(test_path)
 
-        if test_status[0] == TEST_FAIL_STATUS:
+        if test_status not in [TEST_PASS_STATUS, TEST_PEND_STATUS, NAMELIST_FAIL_STATUS]:
             # Report failed phases
             logging.info( "{} {} (phase {})".format(test_status, test_name, phase))
             all_pass = False
@@ -467,7 +467,7 @@ def wait_for_tests(test_paths,
             # not know that the test passed yet.
             if test_status == TEST_PEND_STATUS:
                 if expect_test_complete:
-                    logging.info( "{} {} (phase {} unexpectedly left in PEND)".format(TEST_FAIL_STATUS, test_name, phase))
+                    logging.info( "{} {} (phase {} unexpectedly left in PEND)".format(TEST_PEND_STATUS, test_name, phase))
                     all_pass = False
                 else:
                     logging.info( "{} {} (phase {} has not yet completed)".format(TEST_PEND_STATUS, test_name, phase))
@@ -476,13 +476,13 @@ def wait_for_tests(test_paths,
                 logging.info( "{} {} (but otherwise OK) {}".format(NAMELIST_FAIL_STATUS, test_name, phase))
                 all_pass = False
             else:
+                expect(test_status == TEST_PASS_STATUS, "Expected pass if we made it here, instead: {}".format(test_status))
                 logging.info("{} {} {}".format(test_status, test_name, phase))
 
         logging.info("    Case dir: {}".format(case_dir))
 
         if update_success:
-            caseroot = os.path.dirname(test_data[0])
-            with Case(caseroot, read_only=True) as case:
+            with Case(case_dir, read_only=True) as case:
                 srcroot = case.get_value("SRCROOT")
                 baseline_root = case.get_value("BASELINE_ROOT")
                 save_test_success(baseline_root, srcroot, test_name, test_status in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS])

--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -110,7 +110,7 @@ def create_cdash_config_xml(results, cdash_build_name, cdash_build_group, utc_ti
 
     config_results = []
     for test_name in sorted(results):
-        test_path, test_status, _ = results[test_name]
+        test_path = results[test_name][0]
         test_norm_path = test_path if os.path.isdir(test_path) else os.path.dirname(test_path)
         nml_phase_result = get_test_phase(test_norm_path, NAMELIST_PHASE)
         cdash_warning = "{} Config PASS".format(test_name)

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -217,9 +217,8 @@ def make_fake_teststatus(path, testname, status, phase):
 ###############################################################################
 def parse_test_status(line):
 ###############################################################################
-    regex = re.compile(r"Test '(\w+)' finished with status '(\w+)'")
-    m = regex.match(line)
-    return m.groups()
+    status, test, phase = line.split()
+    return test, status
 
 ###############################################################################
 def kill_subprocesses(name=None, sig=signal.SIGKILL, expected_num_killed=None, tester=None):
@@ -985,7 +984,7 @@ class M_TestWaitForTests(unittest.TestCase):
         output = run_cmd_assert_result(self, "%s/wait_for_tests -p ACME_test */TestStatus %s" % (TOOLS_DIR, extra_args),
                                        from_dir=testdir, expected_stat=expected_stat)
 
-        lines = [line for line in output.splitlines() if line.startswith("Test '")]
+        lines = [line for line in output.splitlines() if not line.startswith(" ")]
         self.assertEqual(len(lines), len(expected_results))
         for idx, line in enumerate(lines):
             testname, status = parse_test_status(line)


### PR DESCRIPTION
This started out of frustration that I could not bisect a DIFF for E3SM because my bisection kept tripping over NML diffs that I wasn't interested in. create_test did support a `--wait-ignore-namelists` option, but it only did anything on batch systems and I was on a desktop. The basic problem is that create_test (test_scheduler.py) was doing it's own reporting in one case and relying on wait_for_test in another. This PR changes that so it always goes through wait_for_tests. In order to have wait_for_tests has as-good-of reports as create_tests, test_status.get_overall_test_status had to be augmented to not only return the overall status for a case but to also return the phase responsible for that status.

This PR also brings cime_bisect into better working order and it can now bisect on both CIME and the host model.

This is the biggest change to the core of CIME I've done in a while, so I've asked for a couple reviewers.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b , @billsacks 
