### PR TITLE
wait_for_tests: tweak cdash nml compare column

### DIFF
--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -113,12 +113,10 @@ def create_cdash_config_xml(results, cdash_build_name, cdash_build_group, utc_ti
         test_path = results[test_name][0]
         test_norm_path = test_path if os.path.isdir(test_path) else os.path.dirname(test_path)
         nml_phase_result = get_test_phase(test_norm_path, NAMELIST_PHASE)
-        cdash_warning = "{} Config PASS".format(test_name)
         if nml_phase_result == TEST_FAIL_STATUS:
             nml_diff = get_nml_diff(test_norm_path)
             cdash_warning = "CMake Warning:\n\n{} NML DIFF:\n{}\n".format(test_name, nml_diff)
-
-        config_results.append(cdash_warning)
+            config_results.append(cdash_warning)
 
     xmlet.SubElement(config_elem, "Log").text = "\n".join(config_results)
 


### PR DESCRIPTION
Do not print all the passes, just the problems/diffs.

Test suite: code-checker
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
