### PR TITLE
Remove collapse directives for Cray compiler

### DIFF
--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -17,11 +17,9 @@ def _get_batch_job_id_for_syslog(case):
     """
     mach = case.get_value("MACH")
     try:
-        if mach in ['titan']:
-            return os.environ["PBS_JOBID"]
-        elif mach in ['anvil', 'compy', 'cori-haswell', 'cori-knl']:
+        if mach in ['anvil', 'chrysalis', 'compy', 'cori-haswell', 'cori-knl']:
             return os.environ["SLURM_JOB_ID"]
-        elif mach in ['mira', 'theta']:
+        elif mach in ['theta']:
             return os.environ["COBALT_JOBID"]
         elif mach in ['summit']:
             return os.environ["LSB_JOBID"]
@@ -187,12 +185,7 @@ def _save_prerun_timing_e3sm(case, lid):
     # For some batch machines save queue info
     job_id = _get_batch_job_id_for_syslog(case)
     if job_id is not None:
-        if mach == "mira":
-            for cmd, filename in [("qstat -f", "qstatf"), ("qstat -lf %s" % job_id, "qstatf_jobid")]:
-                filename = "%s.%s" % (filename, lid)
-                run_cmd_no_fail(cmd, arg_stdout=filename, from_dir=full_timing_dir)
-                gzip_existing_file(os.path.join(full_timing_dir, filename))
-        elif mach == "theta":
+        if mach == "theta":
             for cmd, filename in [("qstat -l --header JobID:JobName:User:Project:WallTime:QueuedTime:Score:RunTime:TimeRemaining:Nodes:State:Location:Mode:Command:Args:Procs:Queue:StartTime:attrs:Geometry", "qstatf"),
                                   ("qstat -lf %s" % job_id, "qstatf_jobid"),
                                   ("xtnodestat", "xtnodestat"),
@@ -208,16 +201,7 @@ def _save_prerun_timing_e3sm(case, lid):
                 filename = "%s.%s" % (filename, lid)
                 run_cmd_no_fail(cmd, arg_stdout=filename, from_dir=full_timing_dir)
                 gzip_existing_file(os.path.join(full_timing_dir, filename))
-        elif mach == "titan":
-            for cmd, filename in [("qstat -f %s >" % job_id, "qstatf_jobid"),
-                                  ("xtnodestat >", "xtnodestat"),
-                                  # ("qstat -f >", "qstatf"),
-                                  # ("xtdb2proc -f", "xtdb2proc"),
-                                  ("showq >", "showq")]:
-                full_cmd = cmd + " " + filename
-                run_cmd_no_fail(full_cmd + "." + lid, from_dir=full_timing_dir)
-                gzip_existing_file(os.path.join(full_timing_dir, filename + "." + lid))
-        elif mach in ["anvil", "compy"]:
+        elif mach in ["anvil", "chrysalis", "compy"]:
             for cmd, filename in [("sinfo -l", "sinfol"), 
                                   ("squeue -o '%all' --job {}".format(job_id), "squeueall_jobid"),
                                   ("squeue -o '%.10i %.10P %.15u %.20a %.2t %.6D %.8C %.12M %.12l %.20S %.20V %j'", "squeuef"),
@@ -394,19 +378,12 @@ def _save_postrun_timing_e3sm(case, lid):
     #
     globs_to_copy = []
     if job_id is not None:
-        if mach == "titan":
-            globs_to_copy.append("%s*OU" % job_id)
-        elif mach == "anvil":
-            globs_to_copy.append("%s*run*%s" % (case.get_value("CASE"), job_id))
-        elif mach == "compy":
-            globs_to_copy.append("slurm.err")
-            globs_to_copy.append("slurm.out")
-        elif mach in ["mira", "theta"]:
+        if mach in ["anvil", "chrysalis", "compy", "cori-haswell", "cori-knl"]:
+            globs_to_copy.append("run*%s*%s" % (case.get_value("CASE"), job_id))
+        elif mach == "theta":
             globs_to_copy.append("%s*error" % job_id)
             globs_to_copy.append("%s*output" % job_id)
             globs_to_copy.append("%s*cobaltlog" % job_id)
-        elif mach in ["cori-haswell", "cori-knl"]:
-            globs_to_copy.append("%s*run*%s" % (case.get_value("CASE"), job_id))
         elif mach == "summit":
             globs_to_copy.append("e3sm.stderr.%s" % job_id)
             globs_to_copy.append("e3sm.stdout.%s" % job_id)

--- a/src/externals/mct/mct/m_AttrVect.F90
+++ b/src/externals/mct/mct/m_AttrVect.F90
@@ -845,7 +845,6 @@
   if(myZeroInts) then ! zero out INTEGER attributes
      if(List_allocated(aV%iList)) then
         if(associated(aV%iAttr) .and. (nIAttr_(aV)>0)) then
-!DIR$ COLLAPSE
            aV%iAttr=0
         endif
      endif
@@ -854,7 +853,6 @@
   if(myZeroReals) then ! zero out REAL attributes
      if(List_allocated(aV%rList)) then
         if(associated(aV%rAttr) .and. (nRAttr_(aV)>0)) then
-!DIR$ COLLAPSE
            aV%rAttr=0._FP
         endif
      endif


### PR DESCRIPTION
Remove `!DIR$ COLLAPSE` directives for Cray compiler that
cause build errors with `cce/10.0.3` + `PrgEnv-cray/6.0.7` on Theta.
PR E3SM-Project/E3SM#3855 includes this update.

Test suite: SMS.f19_g16.X.theta_cray
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit