### PR TITLE
added deleted f10_f10_musgs grid back into config_grids.xml

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -730,6 +730,13 @@
       <mask>gx3v7</mask>
     </model_grid>
 
+    <model_grid alias="f10_f10_musgs" not_compset="_POP">
+      <grid name="atm">10x15</grid>
+      <grid name="lnd">10x15</grid>
+      <grid name="ocnice">10x15</grid>
+      <mask>usgs</mask>
+    </model_grid>
+
     <model_grid alias="f10_g37">
       <grid name="atm">10x15</grid>
       <grid name="lnd">10x15</grid>
@@ -1442,6 +1449,8 @@
 
     <domain name="10x15">
       <nx>24</nx>   <ny>19</ny>
+      <file grid="atm|lnd" mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.fv10x15_USGS.110713.nc</file>
+      <file grid="ocnice"  mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.ocn.fv10x15_USGS_070807.nc</file>      
       <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.fv10x15_gx3v7.180321.nc</file>
       <file grid="ocnice"  mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.fv10x15_gx3v7.180321.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/10x15_nomask_c110308_ESMFmesh.nc</mesh>


### PR DESCRIPTION
The f10_f10_musgs is needed currently for CTSM testing. This will be changed to f10_f10_mg37 - but until then this alias and associated domain files need to remain in config_grids.xml.

Test suite: None
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit
Fixes: #3828 
User interface changes?: No
Update gh-pages html (Y/N)?: No
Code review: None
