### PR TITLE
Pio bld fixes

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -240,7 +240,6 @@ ifeq ($(findstring -DLINUX,$(CPPDEFS)),-DLINUX)
 endif
 
 ifdef LIB_PNETCDF
-   CPPDEFS += -D_PNETCDF
    SLIBS += -L$(LIB_PNETCDF) -lpnetcdf
 endif
 
@@ -659,13 +658,12 @@ endif
 # FIXEDFLAGS, so that both free & fixed code can be built (cmake
 # doesn't seem to be able to differentiate between free & fixed
 # fortran flags)
-CMAKE_OPTS += -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(EXTRA_PIO_FPPDEFS) $(INCLDIR)" \
+CMAKE_OPTS += -Wno-dev -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(EXTRA_PIO_FPPDEFS) $(INCLDIR)" \
 	      -D CMAKE_C_FLAGS:STRING="$(CFLAGS) $(EXTRA_PIO_CPPDEFS) $(INCLDIR)" \
 	      -D CMAKE_CXX_FLAGS:STRING="$(CXXFLAGS) $(EXTRA_PIO_CPPDEFS) $(INCLDIR)" \
 	      -D CMAKE_VERBOSE_MAKEFILE:BOOL=ON \
 	      -D GPTL_PATH:STRING=$(INSTALL_SHAREDPATH) \
 	      -D PIO_ENABLE_TESTS:BOOL=OFF \
-	      -D PIO_USE_MALLOC:BOOL=ON \
 	      -D USER_CMAKE_MODULE_PATH:LIST="$(CIMEROOT)/src/CMake;$(CIMEROOT)/src/externals/pio2/cmake"
 
 ifeq ($(DEBUG), TRUE)

--- a/scripts/lib/CIME/compare_namelists.py
+++ b/scripts/lib/CIME/compare_namelists.py
@@ -303,13 +303,9 @@ def _normalize_string_value(name, value, case):
         case_re = re.compile(r'{}[.]([GC]+)[.]([^./\s]+)'.format(case))
         value = case_re.sub("{}.ACTION.TESTID".format(case), value)
 
-    if (name in ["runid", "model_version", "username"]):
+    if (name in ["runid", "model_version", "username", "logfile"]):
         # Don't even attempt to diff these, we don't care
         return name.upper()
-    elif (".log." in value):
-        # Remove the part that's prone to diff
-        components = value.split(".")
-        return os.path.basename(".".join(components[0:-1]))
     elif (":" in value):
         items = value.split(":")
         items = [_normalize_string_value(name, item, case) for item in items]

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -154,7 +154,7 @@ def buildlib(bldroot, installpath, case):
                 if item_time  > installed_file_time:
                     safe_copy(item, installed_file)
         expect_string = "NetCDF_C_LIBRARY-ADVANCED"
-        pnetcdf_string = "WITH_PNETCDF:STRING=TRUE"
+        pnetcdf_string = "WITH_PNETCDF:BOOL=ON"
         netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
 
 
@@ -188,14 +188,13 @@ def _set_pio_valid_values(case, valid_values):
     logger.warning("Updating valid_values for PIO_TYPENAME: {}".format(valid_values))
     env_run = case.get_env("run")
     env_run.set_valid_values("PIO_TYPENAME",valid_values)
-    
+
     for comp in case.get_values("COMP_CLASSES"):
         comp_pio_typename = "{}_PIO_TYPENAME".format(comp)
         current_value = case.get_value(comp_pio_typename)
         if current_value not in valid_values:
-            logger.warning("Resetting PIO_TYPENAME=netcdf and PIO_REARRANGER=1 for component {}".format(comp))
+            logger.warning("Resetting PIO_TYPENAME=netcdf for component {}".format(comp))
             env_run.set_value(comp_pio_typename,"netcdf")
-            env_run.set_value("PIO_REARRANGER", 1)
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)


### PR DESCRIPTION
Fixed an issue with recognizing pnetcdf is in the build and removed code that set rearranger type in the pio buildlib
Also added logfile to the list of namelist entries to ignore in namelist_compare - this fixed Q_TestBlessTestResults in scripts_regression_tests.py which was failing because log names differed as:
'''
Comparison failed between '/glade/scratch/jedwards/scripts_regression_test.20210127_084719/TESTRUNPASS_P1.f19_g16_rx1.A.cheyenne_intel.C.fake_testing_only_20210127_092516-20210127_092540/CaseDocs/glc_modelio.nml' with '/glade/scratch/jedwards/scripts_regression_test.20210127_084719/baselines/fake_testing_only_20210127_092516/TESTRUNPASS_P1.f19_g16_rx1.A.cheyenne_intel/CaseDocs/glc_modelio.nml'
  BASE: logfile = 'glc.log
  COMP: logfile = 'glc.log.6134351.chadmin1.ib0.cheyenne.ucar.edu
'''

Test suite: scripts_regression_tests.py on izumi and cheyenne
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
