### PR TITLE
FIx i4 in shr_reposum_mod and add comments

### DIFF
--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -17,11 +17,9 @@ def _get_batch_job_id_for_syslog(case):
     """
     mach = case.get_value("MACH")
     try:
-        if mach in ['titan']:
-            return os.environ["PBS_JOBID"]
-        elif mach in ['anvil', 'compy', 'cori-haswell', 'cori-knl']:
+        if mach in ['anvil', 'chrysalis', 'compy', 'cori-haswell', 'cori-knl']:
             return os.environ["SLURM_JOB_ID"]
-        elif mach in ['mira', 'theta']:
+        elif mach in ['theta']:
             return os.environ["COBALT_JOBID"]
         elif mach in ['summit']:
             return os.environ["LSB_JOBID"]
@@ -187,12 +185,7 @@ def _save_prerun_timing_e3sm(case, lid):
     # For some batch machines save queue info
     job_id = _get_batch_job_id_for_syslog(case)
     if job_id is not None:
-        if mach == "mira":
-            for cmd, filename in [("qstat -f", "qstatf"), ("qstat -lf %s" % job_id, "qstatf_jobid")]:
-                filename = "%s.%s" % (filename, lid)
-                run_cmd_no_fail(cmd, arg_stdout=filename, from_dir=full_timing_dir)
-                gzip_existing_file(os.path.join(full_timing_dir, filename))
-        elif mach == "theta":
+        if mach == "theta":
             for cmd, filename in [("qstat -l --header JobID:JobName:User:Project:WallTime:QueuedTime:Score:RunTime:TimeRemaining:Nodes:State:Location:Mode:Command:Args:Procs:Queue:StartTime:attrs:Geometry", "qstatf"),
                                   ("qstat -lf %s" % job_id, "qstatf_jobid"),
                                   ("xtnodestat", "xtnodestat"),
@@ -208,16 +201,7 @@ def _save_prerun_timing_e3sm(case, lid):
                 filename = "%s.%s" % (filename, lid)
                 run_cmd_no_fail(cmd, arg_stdout=filename, from_dir=full_timing_dir)
                 gzip_existing_file(os.path.join(full_timing_dir, filename))
-        elif mach == "titan":
-            for cmd, filename in [("qstat -f %s >" % job_id, "qstatf_jobid"),
-                                  ("xtnodestat >", "xtnodestat"),
-                                  # ("qstat -f >", "qstatf"),
-                                  # ("xtdb2proc -f", "xtdb2proc"),
-                                  ("showq >", "showq")]:
-                full_cmd = cmd + " " + filename
-                run_cmd_no_fail(full_cmd + "." + lid, from_dir=full_timing_dir)
-                gzip_existing_file(os.path.join(full_timing_dir, filename + "." + lid))
-        elif mach in ["anvil", "compy"]:
+        elif mach in ["anvil", "chrysalis", "compy"]:
             for cmd, filename in [("sinfo -l", "sinfol"), 
                                   ("squeue -o '%all' --job {}".format(job_id), "squeueall_jobid"),
                                   ("squeue -o '%.10i %.10P %.15u %.20a %.2t %.6D %.8C %.12M %.12l %.20S %.20V %j'", "squeuef"),
@@ -394,19 +378,12 @@ def _save_postrun_timing_e3sm(case, lid):
     #
     globs_to_copy = []
     if job_id is not None:
-        if mach == "titan":
-            globs_to_copy.append("%s*OU" % job_id)
-        elif mach == "anvil":
-            globs_to_copy.append("%s*run*%s" % (case.get_value("CASE"), job_id))
-        elif mach == "compy":
-            globs_to_copy.append("slurm.err")
-            globs_to_copy.append("slurm.out")
-        elif mach in ["mira", "theta"]:
+        if mach in ["anvil", "chrysalis", "compy", "cori-haswell", "cori-knl"]:
+            globs_to_copy.append("run*%s*%s" % (case.get_value("CASE"), job_id))
+        elif mach == "theta":
             globs_to_copy.append("%s*error" % job_id)
             globs_to_copy.append("%s*output" % job_id)
             globs_to_copy.append("%s*cobaltlog" % job_id)
-        elif mach in ["cori-haswell", "cori-knl"]:
-            globs_to_copy.append("%s*run*%s" % (case.get_value("CASE"), job_id))
         elif mach == "summit":
             globs_to_copy.append("e3sm.stderr.%s" % job_id)
             globs_to_copy.append("e3sm.stdout.%s" % job_id)


### PR DESCRIPTION
Modify shr_reprosum_mod.F90 to fixes an error when building with the CPP
token noI8 defined (not currently used in E3SM) and add comments to
clarify logic in the code, as follows.

i) Fix calculation for maximum number of levels when using noI8

When using 4-byte integers instead of 8-byte integers in
shr_reprosum_mod.F90 (by defining the CPP token 'noI8' when
compiling), certain 8-byte (real*8) reals are not being represented as
a vector of integers exactly. We determined that this is because not
enough integers are being used to represent the value, introducing an
error in the sum by truncating the least significant bits for these
values.

We traced the error to the calculation of the maximum number of
integers needed to represent each of the real*8 summands. The current
logic is

2 + ((digits(0_i8) + (arr_gmax_exp(ifld)-arr_gmin_exp(ifld))) / arr_max_shift)

for 8-byte integers, and

2 + ((digits(0_i4) + (arr_gmax_exp(ifld)-arr_gmin_exp(ifld))) / arr_max_shift)

for 4-byte integers.

The error is that in both we should be using the number of significant
digits in the 8-byte real value, digits(0.0_r8), instead of the number
of digits in the integer representation. The fix is to replace the
above by

2 + ((digits(0.0_r8) + (arr_gmax_exp(ifld)-arr_gmin_exp(ifld))) / arr_max_shift)

When using 8-byte integers, digits(0_i8) is greater than
digits(0.0_r8), so no error is incurred in the original
logic. However, digits(0_i4) is less than digits(0.0_r8), resulting in
occasional errors when using 4-byte integers.

As the modified logic correctly calculates the maximum number of
integers needed to represent each real*8 summand, changing from
digits(0_i8) to digits(0.0_r8) does not change the results of
shr_reprosum_mod.F90 calculations when using 8-byte integers. This
modification will, however, eliminate the potential loss of accuracy
when using 4-byte integers, and could change the resulting sums. Both
statements have been verified in empirical studies, both standalone
and in E3SM using a range of mesh resolutions and both F and fully
coupled cases.

ii) Add comment to explain logic in shr_reprosum_mod.F90

The logic for defining the maximum number of summands

max_nsummands = (max_nsummands/omp_nthreads) + 1
max_nsummands = max(max_nsummands, tasks*omp_nthreads)
is not obvious. max_nsummands is used to determine an upper bound on
how many more bits an integer sum can require compared to the
individual summands, and this is used to determine how to partition
the real*8 summands and the intermediate sums into vectors of
integers. The reason that the maximum is taken in the second step
instead of a sum is that the integer vector representing the local sum
(per thread) is postprocessed in shr_reprosum_int to reduce the number
of bits for each integer to be no more than the assumed maximum for
the original integer summands. The sum over the threads and processes
is then applied to this modified vector. Therefore, the two sets of
sums can be treated separately, and only the maximum used.

Comments to this effect are added to the source code.

iii) Clarify and correct comments in shr_reprosum.F90

Comments in the shr_reprosum_mod.F90 claim that

"The algorithm will calculate the number of levels that is required
for the sum to be essentially exact."

Here another comment is added to be more precise about what is being
claimed, as follows.

"(The sum as represented by the integer expansion will be exact,
but roundoff may perturb the least significant digit of the
returned real*8 representation of the sum.)"

Also, legacy references to "mean" are replaced by "sum" in two
locations.

Marking this BFB as we do not currently define the noI8 CPP token
on our target systems.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: @jedwards4b 
