### PR TITLE
add grace to maint-5.6

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -372,6 +372,20 @@
     </queues>
   </batch_system>
 
+  <batch_system MACH="grace" type="slurm" >
+    <batch_submit>sbatch</batch_submit>
+    <submit_args>
+      <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-p" name="$JOB_QUEUE"/>
+    </submit_args>
+    <queues>
+      <queue walltimemax="02:00:00" nodemin="1" nodemax="32" default="true">short</queue>
+      <queue walltimemax="24:00:00" nodemin="1" nodemax="128">medium</queue>
+      <queue walltimemax="168:00:00" nodemin="1" nodemax="64" >long</queue>
+      <queue walltimemax="504:00:00" nodemin="1" nodemax="32" >xlong</queue>
+    </queues>
+  </batch_system>
+
   <!-- hobart is PBS -->
   <batch_system type="pbs" MACH="hobart" >
     <directives>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -378,6 +378,9 @@
       <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
       <arg flag="-p" name="$JOB_QUEUE"/>
     </submit_args>
+    <directives>
+      <directive> --mem=360GB </directive>
+    </directives>
     <queues>
       <queue walltimemax="02:00:00" nodemin="1" nodemax="32" default="true">short</queue>
       <queue walltimemax="24:00:00" nodemin="1" nodemax="128">medium</queue>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -863,6 +863,35 @@ using a fortran linker.
   </FFLAGS>
 </compiler>
 
+<compiler MACH="grace" COMPILER="intel">
+  <CPPDEFS>
+    <append> -DHAVE_NANOTIME -DNO_R16 </append>
+  </CPPDEFS>
+  <CFLAGS>
+    <append></append>
+  </CFLAGS>
+  <FFLAGS>
+    <append></append>
+  </FFLAGS>
+  <MPIFC>mpiifort</MPIFC>
+  <MPICC>mpiicc</MPICC>
+  <MPICXX>mpiicpc</MPICXX>
+  <SFC>ifort</SFC>
+  <SCC>icc</SCC>
+  <SCXX>icpc</SCXX>
+  <NETCDF_PATH>/scratch/group/ihesp/software/share/netcdf-c-4.7.4/install2019b</NETCDF_PATH>
+  <NETCDF_C_PATH>/scratch/group/ihesp/software/share/netcdf-c-4.7.4/install2019b</NETCDF_C_PATH>
+  <NETCDF_FORTRAN_PATH>/scratch/group/ihesp/software/share/netcdf-fortran-4.5.3/install2019b</NETCDF_FORTRAN_PATH>
+  <PNETCDF_PATH>/scratch/group/ihesp/software/share/pnetcdf-1.12.1/install2019b</PNETCDF_PATH>
+  <SLIBS>
+    <append>-L$(NETCDF_C_PATH)/lib -Wl,-rpath,$(NETCDF_PATH)/lib -lnetcdf</append>
+    <append>-L$(NETCDF_FORTRAN_PATH)/lib -Wl,-rpath,$(NETCDF_FORTRAN_PATH)/lib -lnetcdff</append>
+    <append>-L$(PNETCDF_PATH)/lib -Wl,-rpath,$(PNETCDF_PATH)/lib -lpnetcdf</append>
+  </SLIBS>
+  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
+</compiler>
+
 <compiler MACH="hobart">
   <CPPDEFS>
     <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -865,14 +865,8 @@ using a fortran linker.
 
 <compiler MACH="grace" COMPILER="intel">
   <CPPDEFS>
-    <append> -DHAVE_NANOTIME -DNO_R16 </append>
+    <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
   </CPPDEFS>
-  <CFLAGS>
-    <append></append>
-  </CFLAGS>
-  <FFLAGS>
-    <append></append>
-  </FFLAGS>
   <MPIFC>mpiifort</MPIFC>
   <MPICC>mpiicc</MPICC>
   <MPICXX>mpiicpc</MPICXX>
@@ -889,7 +883,6 @@ using a fortran linker.
     <append>-L$(PNETCDF_PATH)/lib -Wl,-rpath,$(PNETCDF_PATH)/lib -lpnetcdf</append>
   </SLIBS>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
-  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
 </compiler>
 
 <compiler MACH="hobart">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1228,6 +1228,56 @@ This allows using a different mpirun command to launch unit tests
     </environment_variables>
   </machine>
 
+  <machine MACH="grace">
+    <DESC>Intel Xeon 6248R 3.0 GHz ("Cascade Lake"),48 cores on two sockets (24 cores/socket) , batch system is SLURM</DESC>
+    <NODENAME_REGEX>.*grace</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>impi</MPILIBS>
+    <CIME_OUTPUT_ROOT>$ENV{SCRATCH}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/scratch/group/ihesp/software/cesm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/scratch/group/ihesp/software/cesm/inputdata/lmwg</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/scratch/group/ihesp/software/cesm/cesm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>/scratch/group/ihesp/software/cesm/cime/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>4</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>agopal</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>96</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>48</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="impi">
+      <executable>mpirun</executable>
+      <arguments>
+        <arg name="num_tasks"> -n $TOTALPES</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="module">
+      <init_path lang="perl">/sw/lmod/lmod/init/perl</init_path>
+      <init_path lang="python">/sw/lmod/lmod/init/env_modules_python.py</init_path>
+      <init_path lang="sh">/sw/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/sw/lmod/lmod/init/csh</init_path>
+      <cmd_path lang="perl">/sw/lmod/lmod/libexec/lmod perl</cmd_path>
+      <cmd_path lang="python">/sw/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="purge"></command>
+        <command name="load">intel/2019b</command>
+        <command name="load">CMake/3.15.3</command>
+        <command name="load">cURL/7.66.0</command>
+        <command name="load">Python/2.7.16</command>
+        <command name="load">XML-LibXML/2.0201</command>
+      </modules>
+      <modules mpilib="impi">
+        <command name="load">impi/2018.5.288</command>
+        <command name="load">HDF5/1.10.5</command>
+      </modules>
+    </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">256M</env>
+    </environment_variables>
+  </machine>
+
   <machine MACH="hobart">
     <DESC>NCAR CGD Linux Cluster 48 pes/node, batch system is PBS</DESC>
     <NODENAME_REGEX>^h.*\.cgd\.ucar\.edu</NODENAME_REGEX>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1246,9 +1246,12 @@ This allows using a different mpirun command to launch unit tests
     <MAX_TASKS_PER_NODE>96</MAX_TASKS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>48</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="impi">
-      <executable>mpirun</executable>
+      <executable>srun</executable>
       <arguments>
         <arg name="num_tasks"> -n $TOTALPES</arg>
+	<arg name="hint"> --hint compute_bound </arg>
+	<arg name="bindinfo"> --cpu-bind=verbose </arg>
+	<!--	<arg name="bindinfo"> -print-rank-map </arg> -->
       </arguments>
     </mpirun>
     <module_system type="module">
@@ -1275,6 +1278,8 @@ This allows using a different mpirun command to launch unit tests
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">256M</env>
+      <env name="I_MPI_PMI_LIBRARY">/usr/lib64/libpmi.so</env>
+      <env name="I_MPI_DEBUG">+4</env>
     </environment_variables>
   </machine>
 
@@ -1693,6 +1698,7 @@ This allows using a different mpirun command to launch unit tests
       <executable>srun</executable>
       <arguments>
 	<arg name="num_tasks">--ntasks={{ total_tasks }}</arg>
+	<arg name="cpu-bind">--cpu-bind=v</arg>
       </arguments>
     </mpirun>
     <!-- allow ls5 modules to write to stderr without cime error -->


### PR DESCRIPTION
Add the Texas A&M machine grace to the maint-5.6 branch.
Note: this machine does not have a reliable output from hostname and you must always use the --machine argument.

Test suite: scripts_regression_tests.py on grace
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
