### PR TITLE
Adds support of DATM_MODE=CLM1PT for ELM

### DIFF
--- a/src/components/data_comps_mct/datm/cime_config/buildnml
+++ b/src/components/data_comps_mct/datm/cime_config/buildnml
@@ -44,18 +44,30 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     datm_co2_tseries = case.get_value("DATM_CO2_TSERIES")
     atm_grid = case.get_value("ATM_GRID")
     grid = case.get_value("GRID")
-    clm_usrdat_name = case.get_value("CLM_USRDAT_NAME")
+    if get_model() != "e3sm":
+        clm_usrdat_name = case.get_value("CLM_USRDAT_NAME")
+    else:
+        elm_usrdat_name = case.get_value("ELM_USRDAT_NAME")
 
     #----------------------------------------------------
     # Check for incompatible options.
     #----------------------------------------------------
-    if "CLM" in datm_mode and case.get_value("COMP_LND") == "clm":
-        expect(datm_presaero != "none",
-               "A DATM_MODE for CLM is incompatible with DATM_PRESAERO=none.")
-        expect(datm_topo != "none",
-               "A DATM_MODE for CLM is incompatible with DATM_TOPO=none.")
-    expect(grid != "CLM_USRDAT" or clm_usrdat_name in ("", "UNSET"),
-           "GRID=CLM_USRDAT and CLM_USRDAT_NAME is NOT set.")
+    if get_model() != "e3sm":
+        if "CLM" in datm_mode and case.get_value("COMP_LND") == "clm":
+             expect(datm_presaero != "none",
+                     "A DATM_MODE for CLM is incompatible with DATM_PRESAERO=none.")
+             expect(datm_topo != "none",
+                    "A DATM_MODE for CLM is incompatible with DATM_TOPO=none.")
+        expect(grid != "CLM_USRDAT" or clm_usrdat_name in ("", "UNSET"),
+                "GRID=CLM_USRDAT and CLM_USRDAT_NAME is NOT set.")
+    else:
+        if "ELM" in datm_mode and case.get_value("COMP_LND") == "elm":
+             expect(datm_presaero != "none",
+                     "A DATM_MODE for ELM is incompatible with DATM_PRESAERO=none.")
+             expect(datm_topo != "none",
+                     "A DATM_MODE for ELM is incompatible with DATM_TOPO=none.")
+        expect(grid != "ELM_USRDAT" or elm_usrdat_name in ("", "UNSET"),
+                "GRID=ELM_USRDAT and ELM_USRDAT_NAME is NOT set.")
 
     #----------------------------------------------------
     # Log some settings.

--- a/src/components/data_comps_mct/datm/cime_config/buildnml
+++ b/src/components/data_comps_mct/datm/cime_config/buildnml
@@ -45,29 +45,22 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     atm_grid = case.get_value("ATM_GRID")
     grid = case.get_value("GRID")
     if get_model() != "e3sm":
-        clm_usrdat_name = case.get_value("CLM_USRDAT_NAME")
+        lm_name = "CLM"
     else:
-        elm_usrdat_name = case.get_value("ELM_USRDAT_NAME")
+        lm_name = "ELM"
+    lm_usrdat_name = case.get_value(lm_name + "_USRDAT_NAME")
+    lm_grid_name = lm_name + "USRDAT"
 
     #----------------------------------------------------
     # Check for incompatible options.
     #----------------------------------------------------
-    if get_model() != "e3sm":
-        if "CLM" in datm_mode and case.get_value("COMP_LND") == "clm":
-             expect(datm_presaero != "none",
-                     "A DATM_MODE for CLM is incompatible with DATM_PRESAERO=none.")
-             expect(datm_topo != "none",
-                    "A DATM_MODE for CLM is incompatible with DATM_TOPO=none.")
-        expect(grid != "CLM_USRDAT" or clm_usrdat_name in ("", "UNSET"),
-                "GRID=CLM_USRDAT and CLM_USRDAT_NAME is NOT set.")
-    else:
-        if "ELM" in datm_mode and case.get_value("COMP_LND") == "elm":
-             expect(datm_presaero != "none",
-                     "A DATM_MODE for ELM is incompatible with DATM_PRESAERO=none.")
-             expect(datm_topo != "none",
-                     "A DATM_MODE for ELM is incompatible with DATM_TOPO=none.")
-        expect(grid != "ELM_USRDAT" or elm_usrdat_name in ("", "UNSET"),
-                "GRID=ELM_USRDAT and ELM_USRDAT_NAME is NOT set.")
+    if lm_name in datm_mode and case.get_value("COMP_LND") == lm_name.lower():
+        expect(datm_presaero != "none",
+                 "A DATM_MODE for the land model is incompatible with DATM_PRESAERO=none.")
+        expect(datm_topo != "none",
+                 "A DATM_MODE for the land model is incompatible with DATM_TOPO=none.")
+        expect(grid != lm_grid_name or lm_usrdat_name in ("", "UNSET"),
+                "GRID=" + lm_grid_name + " and " + lm_name + "_USRDAT_NAME is NOT set.")
 
     #----------------------------------------------------
     # Log some settings.

--- a/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps_mct/datm/cime_config/namelist_definition_datm.xml
@@ -76,6 +76,7 @@
     CLM1PT.5x5_amazon
     CLM1PT.1x1_urbanc_alpha
     CLM1PT.CLM_USRDAT
+    CLM1PT.ELM_USRDAT
 
     CPLHISTForcing.Solar
     CPLHISTForcing.nonSolarFlux
@@ -223,6 +224,7 @@
       <value>null</value>
       <value stream="CLM1PT.1x1">$DIN_LOC_ROOT/atm/datm7/domain.clm</value>
       <value stream="CLM1PT.CLM_USRDAT">$ATM_DOMAIN_PATH</value>
+      <value stream="CLM1PT.ELM_USRDAT">$ATM_DOMAIN_PATH</value>
       <value stream="CPLHISTForcing">null</value>
       <value stream="CLM_QIAN">$DIN_LOC_ROOT/atm/datm7</value>
       <value stream="CLMCRUNCEPv7">$DIN_LOC_ROOT_CLMFORC/atm_forcing.datm7.cruncep_qianFill.0.5d.v7.c160715</value>
@@ -285,6 +287,7 @@
       <value stream="CLM1PT.1x1_vancouverCAN">domain.lnd.1x1pt-vancouverCAN_navy.090715.nc </value>
       <value stream="CLM1PT.1x1_urbanc_alpha">domain.lnd.1x1pt-urbanc_alpha_navy.090715.nc </value>
       <value stream="CLM1PT.CLM_USRDAT">$ATM_DOMAIN_FILE</value>
+      <value stream="CLM1PT.ELM_USRDAT">$ATM_DOMAIN_FILE</value>
       <value stream="CPLHISTForcing">null</value>
       <value stream="CLM_QIAN\.">domain.T62.050609.nc</value>
       <value stream="CLM_QIAN_WISO">domain.T62.050609.nc</value>
@@ -354,6 +357,15 @@
       <value stream="presaero.SSP4-6.0" atm_grid="CLM_USRDAT">aerosoldep_SSP4-6.0_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
       <value stream="presaero.SSP5-3.4" atm_grid="CLM_USRDAT">aerosoldep_SSP5-3.4_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
       <value stream="presaero.SSP5-8.5" atm_grid="CLM_USRDAT">aerosoldep_SSP5-8.5_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
+      <value stream="presaero atm_grid=ELM_USRDAT">aerosoldep_monthly_1849-2006_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP1-1.9" atm_grid="ELM_USRDAT">aerosoldep_SSP1-1.9_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP1-2.6" atm_grid="ELM_USRDAT">aerosoldep_SSP1-2.6_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP2-4.5" atm_grid="ELM_USRDAT">aerosoldep_SSP2-4.5_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP3-7.0" atm_grid="ELM_USRDAT">aerosoldep_SSP3-7.0_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP4-3.4" atm_grid="ELM_USRDAT">aerosoldep_SSP4-3.4_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP4-6.0" atm_grid="ELM_USRDAT">aerosoldep_SSP4-6.0_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP5-3.4" atm_grid="ELM_USRDAT">aerosoldep_SSP5-3.4_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP5-8.5" atm_grid="ELM_USRDAT">aerosoldep_SSP5-8.5_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
       <value stream="presaero.clim_1850" cime_model="e3sm">aerosoldep_monthly_1850_mean_1.9x2.5_c090421.nc</value>
       <value stream="presaero.clim_2000" cime_model="e3sm">aerosoldep_monthly_2000_mean_1.9x2.5_c090421.nc</value>
       <value stream="presaero.trans_1850-2000" cime_model="e3sm">aerosoldep_monthly_1849-2006_1.9x2.5_c090803.nc</value>
@@ -433,6 +445,7 @@
       <value stream="CLM1PT.1x1_vancouverCAN">$DIN_LOC_ROOT/atm/datm7/CLM1PT_data/vancouverCAN.c080124 </value>
       <value stream="CLM1PT.1x1_urbanc_alpha">$DIN_LOC_ROOT/atm/datm7/CLM1PT_data/urbanc_alpha.c080416 </value>
       <value stream="CLM1PT.CLM_USRDAT">$DIN_LOC_ROOT_CLMFORC/$CLM_USRDAT_NAME/CLM1PT_data</value>
+      <value stream="CLM1PT.ELM_USRDAT">$DIN_LOC_ROOT_CLMFORC/$ELM_USRDAT_NAME/CLM1PT_data</value>
       <value stream="CPLHISTForcing">$DATM_CPLHIST_DIR</value>
       <value stream="CLM_QIAN.Solar">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.Qian.T62.c080727/Solar6Hrly</value>
       <value stream="CLM_QIAN.Precip">$DIN_LOC_ROOT/atm/datm7/atm_forcing.datm7.Qian.T62.c080727/Precip6Hrly</value>
@@ -505,6 +518,7 @@
         clm1pt-0002-11.nc
       </value>
       <value  stream="CLM1PT.CLM_USRDAT">%ym.nc</value>
+      <value  stream="CLM1PT.ELM_USRDAT">%ym.nc</value>
       <value  stream="CPLHISTForcing.Solar">$DATM_CPLHIST_CASE.cpl.ha2x1hi.%ym.nc</value>
       <value  stream="CPLHISTForcing.nonSolarFlux">$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</value>
       <value  stream="CPLHISTForcing.State3hr">$DATM_CPLHIST_CASE.cpl.ha2x3h.%ym.nc</value>
@@ -2244,6 +2258,15 @@
       <value stream="presaero.SSP5-3.4" atm_grid="CLM_USRDAT">aerosoldep_SSP5-3.4_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
       <value stream="presaero.SSP5-8.5" atm_grid="CLM_USRDAT">aerosoldep_SSP5-8.5_monthly_1849-2101_${CLM_USRDAT_NAME}.nc</value>
 
+      <value stream="presaero.SSP1-1.9" atm_grid="ELM_USRDAT">aerosoldep_SSP1-1.9_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP1-2.6" atm_grid="ELM_USRDAT">aerosoldep_SSP1-2.6_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP2-4.5" atm_grid="ELM_USRDAT">aerosoldep_SSP2-4.5_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP3-7.0" atm_grid="ELM_USRDAT">aerosoldep_SSP3-7.0_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP4-3.4" atm_grid="ELM_USRDAT">aerosoldep_SSP4-3.4_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP4-6.0" atm_grid="ELM_USRDAT">aerosoldep_SSP4-6.0_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP5-3.4" atm_grid="ELM_USRDAT">aerosoldep_SSP5-3.4_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+      <value stream="presaero.SSP5-8.5" atm_grid="ELM_USRDAT">aerosoldep_SSP5-8.5_monthly_1849-2101_${ELM_USRDAT_NAME}.nc</value>
+
       <value stream="presaero.SSP1-2.6">aerodep_clm_SSP126_b.e21.BSSP126cmip6.f09_g17.CMIP6-SSP1-2.6.001_2014-2101_monthly_0.9x1.25_c190523.nc</value>
       <value stream="presaero.SSP2-4.5">aerodep_clm_SSP245_b.e21.BWSSP245cmip6.f09_g17.CMIP6-SSP2-4.5-WACCM.001_2014-2101_monthly_0.9x1.25_c190401.nc</value>
       <value stream="presaero.SSP3-7.0">aerodep_clm_SSP370_b.e21.BWSSP370cmip6.f09_g17.CMIP6-SSP3-7.0-WACCM.001_2014-2101_monthly_0.9x1.25_c190402.nc</value>
@@ -2297,6 +2320,16 @@
         FLDS     lwdn
       </value>
       <value  stream="CLM1PT.CLM_USRDAT">
+        ZBOT     z
+        TBOT     tbot
+        RH       rh
+        WIND     wind
+        PRECTmms precn
+        FSDS     swdn
+        PSRF     pbot
+        FLDS     lwdn
+      </value>
+      <value  stream="CLM1PT.ELM_USRDAT">
         ZBOT     z
         TBOT     tbot
         RH       rh
@@ -2672,6 +2705,7 @@
       <value stream="CLM1PT.1x1_vancouverCAN">1992</value>
       <value stream="CLM1PT.1x1_urbanc_alpha">0001</value>
       <value stream="CLM1PT.CLM_USRDAT">$DATM_CLMNCEP_YR_START</value>
+      <value stream="CLM1PT.ELM_USRDAT">$DATM_CLMNCEP_YR_START</value>
       <value stream="CPLHISTForcing">$DATM_CPLHIST_YR_START</value>
       <value stream="CLM_QIAN_WISO">2000</value>
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_START</value>
@@ -2739,6 +2773,7 @@
       <value stream="CLM1PT.1x1_vancouverCAN">1992</value>
       <value stream="CLM1PT.1x1_urbanc_alpha">0002</value>
       <value stream="CLM1PT.CLM_USRDAT">$DATM_CLMNCEP_YR_END</value>
+      <value stream="CLM1PT.ELM_USRDAT">$DATM_CLMNCEP_YR_END</value>
       <value stream="CPLHISTForcing">$DATM_CPLHIST_YR_END</value>
       <value stream="CLM_QIAN_WISO">2004  </value>
       <value stream="CLM_QIAN">$DATM_CLMNCEP_YR_END  </value>
@@ -3052,6 +3087,7 @@
       <value stream="CLM1PT.1x1_vancouverCAN">nearest</value>
       <value stream="CLM1PT.1x1_urbanc_alpha">nearest</value>
       <value stream="CLM1PT.CLM_USRDAT">nearest</value>
+      <value stream="CLM1PT.ELM_USRDAT">nearest</value>
       <value stream="CPLHISTForcing.Solar">nearest</value>
       <value stream="CPLHISTForcing.nonSolarFlux">nearest</value>
       <value stream="CPLHISTForcing.State3hr">linear</value>


### PR DESCRIPTION
Modifications to support user-defined atmospheric forcing
with ELM.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
