### PR TITLE
Make update success more robust

### DIFF
--- a/scripts/lib/CIME/wait_for_tests.py
+++ b/scripts/lib/CIME/wait_for_tests.py
@@ -512,10 +512,14 @@ def wait_for_tests(test_paths,
         logging.info("    Case dir: {}".format(case_dir))
 
         if update_success:
-            with Case(case_dir, read_only=True) as case:
-                srcroot = case.get_value("SRCROOT")
-                baseline_root = case.get_value("BASELINE_ROOT")
-                save_test_success(baseline_root, srcroot, test_name, test_status in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS])
+            try:
+                # This can fail if the case crashed before setup completed
+                with Case(case_dir, read_only=True) as case:
+                    srcroot = case.get_value("SRCROOT")
+                    baseline_root = case.get_value("BASELINE_ROOT")
+                    save_test_success(baseline_root, srcroot, test_name, test_status in [TEST_PASS_STATUS, NAMELIST_FAIL_STATUS])
+            except CIMEError as e:
+                logging.warning("Failed to update success for Case {}: {}".format(case_dir, e))
 
     if cdash_build_name:
         create_cdash_xml(test_results, cdash_build_name, cdash_project, cdash_build_group, force_log_upload)


### PR DESCRIPTION
Tests that failed very early, before SETUP, were causing the entire
wait_for_tests process to crash when it tried to update success status.

Test suite: scripts_regression_tests --fast
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3834 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
