### PR TITLE
Update driver-mct support for trigrid configuration where lnd is not on the atm grid

### DIFF
--- a/src/drivers/mct/main/prep_rof_mod.F90
+++ b/src/drivers/mct/main/prep_rof_mod.F90
@@ -82,6 +82,8 @@ module prep_rof_mod
   character(CXX) :: lnd2rof_normal_fluxes
   ! whether the model is being run with a separate irrigation field
   logical :: have_irrig_field
+  ! samegrid atm and lnd
+  logical :: samegrid_al   ! samegrid atm and lnd
   !================================================================================================
 
 contains
@@ -175,6 +177,8 @@ contains
 
        samegrid_lr = .true.
        if (trim(lnd_gnam) /= trim(rof_gnam)) samegrid_lr = .false.
+       samegrid_al = .true.
+       if (trim(atm_gnam) /= trim(lnd_gnam)) samegrid_al = .false.
 
        if (lnd_c2_rof) then
           if (iamroot_CPLID) then
@@ -451,10 +455,11 @@ contains
     integer, save :: index_l2x_coszen_str
     integer, save :: index_x2r_coszen_str
 
-    integer, save :: index_lfrac
+    integer, save :: index_frac
+    real(r8)      :: frac
+    character(CL) :: fracstr
     logical, save :: first_time = .true.
     logical, save :: flds_wiso_rof = .false.
-    real(r8)      :: lfrac
     integer       :: nflds,lsize
     logical       :: iamroot
     character(CL) :: field        ! field string
@@ -519,27 +524,32 @@ contains
           index_x2r_Flrl_rofl_HDO = mct_aVect_indexRA(x2r_r,'Flrl_rofl_HDO' )
           index_x2r_Flrl_rofi_HDO = mct_aVect_indexRA(x2r_r,'Flrl_rofi_HDO' )
        end if
-       index_lfrac = mct_aVect_indexRA(fractions_r,"lfrac")
 
-       index_lfrac = mct_aVect_indexRA(fractions_r,"lfrac")
+       if (samegrid_al) then
+          index_frac = mct_aVect_indexRA(fractions_r,"lfrac")
+          fracstr = 'lfrac'
+       else
+          index_frac = mct_aVect_indexRA(fractions_r,"lfrin")
+          fracstr = 'lfrin'
+       endif
 
        mrgstr(index_x2r_Flrl_rofsur) = trim(mrgstr(index_x2r_Flrl_rofsur))//' = '// &
-            'lfrac*l2x%Flrl_rofsur'
+            trim(fracstr)//'*l2x%Flrl_rofsur'
        mrgstr(index_x2r_Flrl_rofgwl) = trim(mrgstr(index_x2r_Flrl_rofgwl))//' = '// &
-            'lfrac*l2x%Flrl_rofgwl'
+            trim(fracstr)//'*l2x%Flrl_rofgwl'
        mrgstr(index_x2r_Flrl_rofsub) = trim(mrgstr(index_x2r_Flrl_rofsub))//' = '// &
-            'lfrac*l2x%Flrl_rofsub'
+            trim(fracstr)//'*l2x%Flrl_rofsub'
        mrgstr(index_x2r_Flrl_rofdto) = trim(mrgstr(index_x2r_Flrl_rofdto))//' = '// &
-            'lfrac*l2x%Flrl_rofdto'
+            trim(fracstr)//'*l2x%Flrl_rofdto'
        mrgstr(index_x2r_Flrl_rofi) = trim(mrgstr(index_x2r_Flrl_rofi))//' = '// &
-            'lfrac*l2x%Flrl_rofi'
+            trim(fracstr)//'*l2x%Flrl_rofi'
        if (trim(cime_model).eq.'e3sm') then
           mrgstr(index_x2r_Flrl_demand) = trim(mrgstr(index_x2r_Flrl_demand))//' = '// &
-               'lfrac*l2x%Flrl_demand'
+               trim(fracstr)//'*l2x%Flrl_demand'
        endif
        if (have_irrig_field) then
           mrgstr(index_x2r_Flrl_irrig) = trim(mrgstr(index_x2r_Flrl_irrig))//' = '// &
-               'lfrac*l2x%Flrl_irrig'
+               trim(fracstr)//'*l2x%Flrl_irrig'
        end if
        if(trim(cime_model) .eq. 'e3sm') then
           mrgstr(index_x2r_Flrl_Tqsur) = trim(mrgstr(index_x2r_Flrl_Tqsur))//' = '//'l2x%Flrl_Tqsur'
@@ -547,17 +557,17 @@ contains
        endif
        if ( flds_wiso_rof ) then
           mrgstr(index_x2r_Flrl_rofl_16O) = trim(mrgstr(index_x2r_Flrl_rofl_16O))//' = '// &
-               'lfrac*l2x%Flrl_rofl_16O'
+               trim(fracstr)//'*l2x%Flrl_rofl_16O'
           mrgstr(index_x2r_Flrl_rofi_16O) = trim(mrgstr(index_x2r_Flrl_rofi_16O))//' = '// &
-               'lfrac*l2x%Flrl_rofi_16O'
+               trim(fracstr)//'*l2x%Flrl_rofi_16O'
           mrgstr(index_x2r_Flrl_rofl_18O) = trim(mrgstr(index_x2r_Flrl_rofl_18O))//' = '// &
-               'lfrac*l2x%Flrl_rofl_18O'
+               trim(fracstr)//'*l2x%Flrl_rofl_18O'
           mrgstr(index_x2r_Flrl_rofi_18O) = trim(mrgstr(index_x2r_Flrl_rofi_18O))//' = '// &
-               'lfrac*l2x%Flrl_rofi_18O'
+               trim(fracstr)//'*l2x%Flrl_rofi_18O'
           mrgstr(index_x2r_Flrl_rofl_HDO) = trim(mrgstr(index_x2r_Flrl_rofl_HDO))//' = '// &
-               'lfrac*l2x%Flrl_rofl_HDO'
+               trim(fracstr)//'*l2x%Flrl_rofl_HDO'
           mrgstr(index_x2r_Flrl_rofi_HDO) = trim(mrgstr(index_x2r_Flrl_rofi_HDO))//' = '// &
-               'lfrac*l2x%Flrl_rofi_HDO'
+               trim(fracstr)//'*l2x%Flrl_rofi_HDO'
        end if
 	   
        if ( rof_heat ) then
@@ -598,29 +608,29 @@ contains
     end if
 
     do i = 1,lsize
-       lfrac = fractions_r%rAttr(index_lfrac,i)
-       x2r_r%rAttr(index_x2r_Flrl_rofsur,i) = l2x_r%rAttr(index_l2x_Flrl_rofsur,i) * lfrac
-       x2r_r%rAttr(index_x2r_Flrl_rofgwl,i) = l2x_r%rAttr(index_l2x_Flrl_rofgwl,i) * lfrac
-       x2r_r%rAttr(index_x2r_Flrl_rofsub,i) = l2x_r%rAttr(index_l2x_Flrl_rofsub,i) * lfrac
-       x2r_r%rAttr(index_x2r_Flrl_rofdto,i) = l2x_r%rAttr(index_l2x_Flrl_rofdto,i) * lfrac
-       x2r_r%rAttr(index_x2r_Flrl_rofi,i) = l2x_r%rAttr(index_l2x_Flrl_rofi,i) * lfrac
+       frac = fractions_r%rAttr(index_frac,i)
+       x2r_r%rAttr(index_x2r_Flrl_rofsur,i) = l2x_r%rAttr(index_l2x_Flrl_rofsur,i) * frac
+       x2r_r%rAttr(index_x2r_Flrl_rofgwl,i) = l2x_r%rAttr(index_l2x_Flrl_rofgwl,i) * frac
+       x2r_r%rAttr(index_x2r_Flrl_rofsub,i) = l2x_r%rAttr(index_l2x_Flrl_rofsub,i) * frac
+       x2r_r%rAttr(index_x2r_Flrl_rofdto,i) = l2x_r%rAttr(index_l2x_Flrl_rofdto,i) * frac
+       x2r_r%rAttr(index_x2r_Flrl_rofi,i) = l2x_r%rAttr(index_l2x_Flrl_rofi,i) * frac
        if (trim(cime_model).eq.'e3sm') then
-          x2r_r%rAttr(index_x2r_Flrl_demand,i) = l2x_r%rAttr(index_l2x_Flrl_demand,i) * lfrac
+          x2r_r%rAttr(index_x2r_Flrl_demand,i) = l2x_r%rAttr(index_l2x_Flrl_demand,i) * frac
        endif
        if (have_irrig_field) then
-          x2r_r%rAttr(index_x2r_Flrl_irrig,i) = l2x_r%rAttr(index_l2x_Flrl_irrig,i) * lfrac
+          x2r_r%rAttr(index_x2r_Flrl_irrig,i) = l2x_r%rAttr(index_l2x_Flrl_irrig,i) * frac
        end if
        if(trim(cime_model) .eq. 'e3sm') then
          x2r_r%rAttr(index_x2r_Flrl_Tqsur,i) = l2x_r%rAttr(index_l2x_Flrl_Tqsur,i)
          x2r_r%rAttr(index_x2r_Flrl_Tqsub,i) = l2x_r%rAttr(index_l2x_Flrl_Tqsub,i)
        endif
        if ( flds_wiso_rof ) then
-          x2r_r%rAttr(index_x2r_Flrl_rofl_16O,i) = l2x_r%rAttr(index_l2x_Flrl_rofl_16O,i) * lfrac
-          x2r_r%rAttr(index_x2r_Flrl_rofi_16O,i) = l2x_r%rAttr(index_l2x_Flrl_rofi_16O,i) * lfrac
-          x2r_r%rAttr(index_x2r_Flrl_rofl_18O,i) = l2x_r%rAttr(index_l2x_Flrl_rofl_18O,i) * lfrac
-          x2r_r%rAttr(index_x2r_Flrl_rofi_18O,i) = l2x_r%rAttr(index_l2x_Flrl_rofi_18O,i) * lfrac
-          x2r_r%rAttr(index_x2r_Flrl_rofl_HDO,i) = l2x_r%rAttr(index_l2x_Flrl_rofl_HDO,i) * lfrac
-          x2r_r%rAttr(index_x2r_Flrl_rofi_HDO,i) = l2x_r%rAttr(index_l2x_Flrl_rofi_HDO,i) * lfrac
+          x2r_r%rAttr(index_x2r_Flrl_rofl_16O,i) = l2x_r%rAttr(index_l2x_Flrl_rofl_16O,i) * frac
+          x2r_r%rAttr(index_x2r_Flrl_rofi_16O,i) = l2x_r%rAttr(index_l2x_Flrl_rofi_16O,i) * frac
+          x2r_r%rAttr(index_x2r_Flrl_rofl_18O,i) = l2x_r%rAttr(index_l2x_Flrl_rofl_18O,i) * frac
+          x2r_r%rAttr(index_x2r_Flrl_rofi_18O,i) = l2x_r%rAttr(index_l2x_Flrl_rofi_18O,i) * frac
+          x2r_r%rAttr(index_x2r_Flrl_rofl_HDO,i) = l2x_r%rAttr(index_l2x_Flrl_rofl_HDO,i) * frac
+          x2r_r%rAttr(index_x2r_Flrl_rofi_HDO,i) = l2x_r%rAttr(index_l2x_Flrl_rofi_HDO,i) * frac
        end if
       
        if ( rof_heat ) then

--- a/src/drivers/mct/main/seq_diag_mct.F90
+++ b/src/drivers/mct/main/seq_diag_mct.F90
@@ -221,6 +221,7 @@ module seq_diag_mct
   character(len=*),parameter :: latname   = 'lat'
   character(len=*),parameter :: afracname = 'afrac'
   character(len=*),parameter :: lfracname = 'lfrac'
+  character(len=*),parameter :: lfrinname = 'lfrin'
   character(len=*),parameter :: ofracname = 'ofrac'
   character(len=*),parameter :: ifracname = 'ifrac'
 
@@ -853,7 +854,7 @@ contains
     ip = p_inst
 
     kArea = mct_aVect_indexRA(dom_l%data,afldname)
-    kl    = mct_aVect_indexRA(frac_l,lfracname)
+    kl    = mct_aVect_indexRA(frac_l,lfrinname)
 
     if (present(do_l2x)) then
        if (first_time) then


### PR DESCRIPTION
Brings in changes to the mct coupler to fix both the diagnostics
and lnd2rof coupling for trigrid configurations, where atm is on
one grid, lnd and rof on another, and ocn/ice on a third. Issues
with this configuration were discovered during E3SM testing,
and these changes fix all uncovered issues.

These updates fix the diagnostics and lnd2rof coupling for the
case when lnd and rof are on the same grid. The diagnostics issue 
is easily seen in a small test configuration of the trigrid in E3SM,
in this case a fully-active run of ne4pg2-r05-oQU480, where the
atm is on ne4pg2, lnd/rof are on r05 (half-degree grid), and
ocn/ice are on an oQU480 grid (quasi-uniform 480-km spacing 
MPAS grid). Coupler output shows an issue even in the area budget:
```
(seq_diag_print_mct) NET AREA BUDGET (m2/m2): period =  monthly: date =     10201     0
                           atm            lnd            ocn         ice nh         ice sh        *SUM*
            area    -1.00000000     0.24638554     0.63952167     0.02429621     0.03700782    -0.05278876
```
The modification to the diagnostics fixes this problem but exposes a
similar issue in the actual lnd2rof coupling. The area budget is drastically
improved:
```
(seq_diag_print_mct) ATM_to_CPL AREA BUDGET (m2/m2): period =  monthly: date =     10201     0
                       a2c_atm        a2c_lnd        a2c_inh        a2c_ish        a2c_ocn        *SUM*
            area    -1.00000000     0.29916044     0.02427324     0.03706142     0.63949937    -0.00000553
```
but now shows a water budget problem:
```
(seq_diag_print_mct) NET WATER BUDGET (kg/m2s*1e6): period = all_time: date =    110101     0
                           atm            lnd            rof            ocn         ice nh         ice sh            glc        *SUM*
         wfreeze     0.00000000     0.00000000     0.00000000    -0.13322464     0.06696238     0.06626226     0.00000000    -0.00000000
           wmelt     0.00000000     0.00000000     0.00000000     0.76839575    -0.28894893    -0.47944686     0.00000000    -0.00000003
           wrain   -38.03418055     9.00948767     0.00000000    28.98419372     0.01967490     0.02089916     0.00000000     0.00007490
           wsnow    -0.88243926     0.46788059     0.00000000     0.29608527     0.04496143     0.07348853     0.00000000    -0.00002345
           wevap    39.01586187    -7.04244184     0.00000000   -31.97266799    -0.00010192    -0.00144629     0.00000000    -0.00079617
         wrunoff     0.00000000    -1.67305761     0.01005664     1.21279836     0.00000000     0.00000000     0.00000000    -0.45020262
         wfrzrof     0.00000000    -0.14139458     0.00000000     0.12515946     0.00000000     0.00000000     0.00000000    -0.01623512
           *SUM*     0.09924206     0.62047423     0.01005664    -0.71926006    -0.15745215    -0.32024321     0.00000000    -0.46718249
```
The other changes to the coupling resolve this.

Test suite: scripts_regression_test, hand testing with E3SM tri-grid cases.
Test baseline: 
Test namelist changes: 
Test status: bit-for-bit for bi-grid, climate-changing for trigrid (due to current errors)

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html: N

Code review:  billsacks, jedwards4b, jgfouca, apcraig
