### PR TITLE
bless/compare_test_results should not process build-only tests

### DIFF
--- a/scripts/lib/CIME/bless_test_results.py
+++ b/scripts/lib/CIME/bless_test_results.py
@@ -1,6 +1,6 @@
 import CIME.compare_namelists, CIME.simple_compare
 from CIME.test_scheduler import NAMELIST_PHASE
-from CIME.utils import run_cmd, get_scripts_root, get_model, EnvironmentContext
+from CIME.utils import run_cmd, get_scripts_root, get_model, EnvironmentContext, parse_test_name
 from CIME.test_status import *
 from CIME.hist_utils import generate_baseline, compare_baseline
 from CIME.case import Case
@@ -87,6 +87,9 @@ def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_i
         test_dir = os.path.dirname(test_status_file)
         ts = TestStatus(test_dir=test_dir)
         test_name = ts.get_name()
+        testopts = parse_test_name(test_name)[1]
+        testopts = [] if testopts is None else testopts
+        build_only = "B" in testopts
         if test_name is None:
             case_dir = os.path.basename(test_dir)
             test_name = CIME.utils.normalize_case_id(case_dir)
@@ -109,7 +112,7 @@ def bless_test_results(baseline_name, baseline_root, test_root, compiler, test_i
                 nl_bless = False
 
             # See if we need to bless baselines
-            if (not namelists_only):
+            if (not namelists_only and not build_only):
                 run_result = ts.get_status(RUN_PHASE)
                 if (run_result is None):
                     broken_blesses.append((test_name, "no run phase"))

--- a/scripts/lib/CIME/compare_test_results.py
+++ b/scripts/lib/CIME/compare_test_results.py
@@ -1,5 +1,5 @@
 import CIME.compare_namelists, CIME.simple_compare
-from CIME.utils import append_status, EnvironmentContext
+from CIME.utils import append_status, EnvironmentContext, parse_test_name
 from CIME.test_status import *
 from CIME.hist_utils import compare_baseline, get_ts_synopsis
 from CIME.case import Case
@@ -71,6 +71,10 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
         test_dir = os.path.dirname(test_status_file)
         ts = TestStatus(test_dir=test_dir)
         test_name = ts.get_name()
+        testopts = parse_test_name(test_name)[1]
+        testopts = [] if testopts is None else testopts
+        build_only = "B" in testopts
+
         if (compare_tests in [[], None] or CIME.utils.match_any(test_name, compare_tests)):
 
             if (not hist_only):
@@ -87,7 +91,7 @@ def compare_test_results(baseline_name, baseline_root, test_root, compiler, test
                 nl_do_compare = False
 
             detailed_comments = ""
-            if (not namelists_only):
+            if (not namelists_only and not build_only):
                 compare_result = None
                 compare_comment = ""
                 run_result = ts.get_status(RUN_PHASE)


### PR DESCRIPTION
Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
