### PR TITLE
nuopc result is in drv.log not med.log

### DIFF
--- a/scripts/lib/CIME/SystemTests/nodefail.py
+++ b/scripts/lib/CIME/SystemTests/nodefail.py
@@ -24,7 +24,7 @@ class NODEFAIL(ERS):
         exeroot = self._case.get_value("EXEROOT")
         driver = self._case.get_value("COMP_INTERFACE")
         if driver == "nuopc":
-            logname = "med"
+            logname = "drv"
         else:
             logname = "cpl"
         fake_exe = \

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -33,7 +33,7 @@ class SystemTestsCommon(object):
         self._init_environment(caseroot)
         self._init_locked_files(caseroot, expected)
         self._skip_pnl = False
-        self._cpllog = "med" if self._case.get_value("COMP_INTERFACE")=="nuopc" else "cpl"
+        self._cpllog = "drv" if self._case.get_value("COMP_INTERFACE")=="nuopc" else "cpl"
         self._ninja     = False
         self._dry_run   = False
         self._user_separate_builds = False


### PR DESCRIPTION
Change location of the 'Successful Completion' message from med.log to drv.log in nuopc driver.  

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3862 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
