### PR TITLE
1pt grid update

### DIFF
--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -30,7 +30,7 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing specification of all supported model grids, domains and mapping files (for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/config/xml_schemas/config_grids_v2.1.xsd</schema>
+    <schema>$CIMEROOT/config/xml_schemas/config_grids_v2.2.xsd</schema>
   </entry>
 
   <entry id="MACHINES_SPEC_FILE">

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -31,19 +31,19 @@
       <grid name="ocnice"    compset="SOCN"        >null</grid>
       <grid name="rof"       compset="SROF"        >null</grid>
       <grid name="rof"       compset="DWAV"        >rx1</grid>
-      <grid name="rof"       compset="RTM"	   >r05</grid>
+      <grid name="rof"       compset="RTM"         >r05</grid>
       <grid name="rof"       compset="MOSART"      >r05</grid>
       <grid name="rof"       compset="MIZUROUTE"   >HDMA</grid>
       <grid name="rof"       compset="DROF"        >rx1</grid>
       <grid name="rof"       compset="DROF%CPLHIST">r05</grid>
       <grid name="rof"       compset="XROF"        >r05</grid>
-      <grid name="glc"	     compset="SGLC"        >null</grid>
-      <grid name="glc"	     compset="CISM1"       >gland5UM</grid>
-      <grid name="glc"	     compset="CISM2"       >gland4</grid>
+      <grid name="glc"       compset="SGLC"        >null</grid>
+      <grid name="glc"       compset="CISM1"       >gland5UM</grid>
+      <grid name="glc"       compset="CISM2"       >gland4</grid>
       <grid name="glc"       compset="XGLC"        >gland4</grid>
-      <grid name="wav"	     compset="SWAV"        >null</grid>
-      <grid name="wav"	     compset="DWAV"        >ww3a</grid>
-      <grid name="wav"	     compset="WW3"	   >ww3a</grid>
+      <grid name="wav"       compset="SWAV"        >null</grid>
+      <grid name="wav"       compset="DWAV"        >ww3a</grid>
+      <grid name="wav"       compset="WW3"         >ww3a</grid>
       <grid name="wav"       compset="XWAV"        >ww3a</grid>
       <grid name="iac"       compset="SIAC"        >null</grid>
     </model_grid_defaults>
@@ -1290,64 +1290,6 @@
       <desc>null is no grid: </desc>
     </domain>
 
-    <!-- ======================================================== -->
-    <!-- ATM/LND domains for single column -->
-    <!-- ======================================================== -->
-
-    <domain name="01col">
-      <nx>1</nx> <ny>1</ny>
-      <file>domain.ocn.01col.ArcticOcean.20150824.nc</file>
-      <file>domain.ocn.01col.ArcticOcean.20150824.nc</file>
-      <desc>01col is a single-column grid for datm and POP:</desc>
-    </domain>
-    <domain name="CLM_USRDAT">
-      <nx>1</nx> <ny>1</ny>
-      <file>$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.${CLM_USRDAT_NAME}_navy.nc</file>
-      <mesh driver="nuopc">create_mesh</mesh>
-      <desc>user specified domain - only valid for DATM/CLM compset</desc>
-    </domain>
-    <domain name="1x1_numaIA">
-      <nx>1</nx> <ny>1</ny>
-      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-numaIA_navy.110106.nc</file>
-      <mesh driver="nuopc">create_mesh</mesh>
-      <desc>1x1 Numa Iowa -- only valid for DATM/CLM compset</desc>
-    </domain>
-    <domain name="1x1_brazil">
-      <nx>1</nx> <ny>1</ny>
-      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-brazil_navy.090715.nc</file>
-      <mesh driver="nuopc">create_mesh</mesh>
-      <desc>1x1 Brazil -- only valid for DATM/CLM compset</desc>
-    </domain>
-    <domain name="1x1_smallvilleIA">
-      <nx>1</nx> <ny>1</ny>
-      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-smallvilleIA_test.110106.nc</file>
-      <mesh driver="nuopc">create_mesh</mesh>
-      <desc>1x1 Smallville Iowa Crop Test Case -- only valid for DATM/CLM compset</desc>
-    </domain>
-    <domain name="1x1_camdenNJ">
-      <nx>1</nx> <ny>1</ny>
-      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-camdenNJ_navy.111004.nc</file>
-      <mesh driver="nuopc">create_mesh</mesh>
-      <desc>1x1 Camden New Jersey -- only valid for DATM/CLM compset</desc>
-    </domain>
-    <domain name="1x1_mexicocityMEX">
-      <nx>1</nx> <ny>1</ny>
-      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc</file>
-      <mesh driver="nuopc">create_mesh</mesh>
-      <desc>1x1 Mexico City Mexico -- only valid for DATM/CLM compset</desc>
-    </domain>
-    <domain name="1x1_vancouverCAN">
-      <nx>1</nx> <ny>1</ny>
-      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>
-      <mesh driver="nuopc">create_mesh</mesh>
-      <desc>1x1 Vancouver Canada -- only valid for DATM/CLM compset</desc>
-    </domain>
-    <domain name="1x1_urbanc_alpha">
-      <nx>1</nx> <ny>1</ny>
-      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-urbanc_alpha_test.110201.nc</file>
-      <mesh driver="nuopc">create_mesh</mesh>
-      <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
-    </domain>
 
     <!-- ======================================================== -->
     <!-- ATM/LND meshes regional and global -->
@@ -1446,7 +1388,7 @@
     <domain name="10x15">
       <nx>24</nx>   <ny>19</ny>
       <file grid="atm|lnd" mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.fv10x15_USGS.110713.nc</file>
-      <file grid="ocnice"  mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.ocn.fv10x15_USGS_070807.nc</file>      
+      <file grid="ocnice"  mask="usgs">$DIN_LOC_ROOT/share/domains/domain.clm/domain.ocn.fv10x15_USGS_070807.nc</file>
       <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.fv10x15_gx3v7.180321.nc</file>
       <file grid="ocnice"  mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.fv10x15_gx3v7.180321.nc</file>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/10x15_nomask_c110308_ESMFmesh.nc</mesh>
@@ -2012,11 +1954,119 @@
     </domain>
 
   </domains>
+  <!-- ======================================================== -->
+  <!-- ATM/LND domains for single column -->
+  <!-- ======================================================== -->
+  <domains driver="mct">
+    <domain name="01col">
+      <nx>1</nx> <ny>1</ny>
+      <file>domain.ocn.01col.ArcticOcean.20150824.nc</file>
+      <file>domain.ocn.01col.ArcticOcean.20150824.nc</file>
+      <desc>01col is a single-column grid for datm and POP:</desc>
+    </domain>
+    <domain name="CLM_USRDAT">
+      <nx>1</nx> <ny>1</ny>
+      <file>$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.${CLM_USRDAT_NAME}_navy.nc</file>
+      <mesh driver="nuopc">create_mesh</mesh>
+      <desc>user specified domain - only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_numaIA">
+      <nx>1</nx> <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-numaIA_navy.110106.nc</file>
+      <mesh driver="nuopc">create_mesh</mesh>
+      <desc>1x1 Numa Iowa -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_brazil">
+      <nx>1</nx> <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-brazil_navy.090715.nc</file>
+      <mesh driver="nuopc">create_mesh</mesh>
+      <desc>1x1 Brazil -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_smallvilleIA">
+      <nx>1</nx> <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-smallvilleIA_test.110106.nc</file>
+      <mesh driver="nuopc">create_mesh</mesh>
+      <desc>1x1 Smallville Iowa Crop Test Case -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_camdenNJ">
+      <nx>1</nx> <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-camdenNJ_navy.111004.nc</file>
+      <mesh driver="nuopc">create_mesh</mesh>
+      <desc>1x1 Camden New Jersey -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_mexicocityMEX">
+      <nx>1</nx> <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-mexicocityMEX_navy.090715.nc</file>
+      <mesh driver="nuopc">create_mesh</mesh>
+      <desc>1x1 Mexico City Mexico -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_vancouverCAN">
+      <nx>1</nx> <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-vancouverCAN_navy.090715.nc</file>
+      <mesh driver="nuopc">create_mesh</mesh>
+      <desc>1x1 Vancouver Canada -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_urbanc_alpha">
+      <nx>1</nx> <ny>1</ny>
+      <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-urbanc_alpha_test.110201.nc</file>
+      <mesh driver="nuopc">create_mesh</mesh>
+      <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
+    </domain>
+  </domains>
+  <!-- ======================================================== -->
+  <!-- ATM/LND domains for single column -->
+  <!-- ======================================================== -->
+  <domains driver="nuopc">
+    <domain name="01col">
+      <lat>83.144928</lat>
+      <lon>359.150902</lon>
+      <desc>01col is a single-column grid for datm and POP:</desc>
+    </domain>
+    <domain name="CLM_USRDAT">
+      <!-- User must specify lat and lon prior to building case-->
+      <desc>user specified domain - only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_numaIA">
+      <lat>40.6878</lat>
+      <lon>267.0228</lon>
+      <desc>1x1 Numa Iowa -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_brazil">
+      <lat>-7.0</lat>
+      <lon>305.0</lon>
+      <desc>1x1 Brazil -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_smallvilleIA">
+      <lat>40.6878</lat>
+      <lon>267.0228</lon>
+      <desc>1x1 Smallville Iowa Crop Test Case -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_camdenNJ">
+      <lat>40.0</lat>
+      <lon>285.0</lon>
+      <desc>1x1 Camden New Jersey -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_mexicocityMEX">
+      <lat>19.5</lat>
+      <lon>260.5</lon>
+      <desc>1x1 Mexico City Mexico -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_vancouverCAN">
+      <lat>49.5</lat>
+      <lon>236.5</lon>
+      <desc>1x1 Vancouver Canada -- only valid for DATM/CLM compset</desc>
+    </domain>
+    <domain name="1x1_urbanc_alpha">
+      <lat>-37.7308</lat>
+      <lon>0.0</lon>
+      <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
+    </domain>
+  </domains>
+
 
   <!-- ======================================================== -->
   <!-- Mapping -->
   <!-- ======================================================== -->
-
   <!-- The following are the required grid maps that must not be idmap if the   -->
   <!-- attributes grid1 and grid2 are not equal -->
 

--- a/config/cesm/config_grids_mct.xml
+++ b/config/cesm/config_grids_mct.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 
-  <gridmaps driver="mct">
 
     <!-- ======================================================== -->
     <!--- atm to ocean and ocean to atm mapping files -->
     <!-- ======================================================== -->
+  <gridmaps driver="mct">
 
     <gridmap atm_grid="C24" ocn_grid="gx1v6">
       <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/C24/map_C24_TO_gx1v6_aave.181018.nc</map>

--- a/config/xml_schemas/config_grids_v2.2.xsd
+++ b/config/xml_schemas/config_grids_v2.2.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
   <!-- attributes -->
-  <xs:attribute name="version"	   type="xs:decimal"/>
-  <xs:attribute name="alias"	   type="xs:NMTOKEN"/>
-  <xs:attribute name="compset"	   type="xs:token"/>
+  <xs:attribute name="version"     type="xs:decimal"/>
+  <xs:attribute name="alias"       type="xs:NMTOKEN"/>
+  <xs:attribute name="compset"     type="xs:token"/>
   <xs:attribute name="not_compset" type="xs:token"/>
-  <xs:attribute name="name"	   type="xs:NMTOKEN"/>
-  <xs:attribute name="grid"	   type="xs:token"/>
-  <xs:attribute name="lnd_mask"	   type="xs:NMTOKEN"/>
-  <xs:attribute name="mask"	   type="xs:NMTOKEN"/>
-  <xs:attribute name="ocn_mask"	   type="xs:NMTOKEN"/>
-  <xs:attribute name="grid1"	   type="xs:NCName"/>
-  <xs:attribute name="grid2"	   type="xs:NCName"/>
-  <xs:attribute name="atm_grid"	   type="xs:NMTOKEN"/>
-  <xs:attribute name="glc_grid"	   type="xs:NCName"/>
-  <xs:attribute name="lnd_grid"	   type="xs:NMTOKEN"/>
-  <xs:attribute name="ocn_grid"	   type="xs:NCName"/>
-  <xs:attribute name="rof_grid"	   type="xs:NCName"/>
-  <xs:attribute name="wav_grid"	   type="xs:NCName"/>
-  <xs:attribute name="driver"	   type="xs:NCName"/>
+  <xs:attribute name="name"        type="xs:NMTOKEN"/>
+  <xs:attribute name="grid"        type="xs:token"/>
+  <xs:attribute name="lnd_mask"    type="xs:NMTOKEN"/>
+  <xs:attribute name="mask"        type="xs:NMTOKEN"/>
+  <xs:attribute name="ocn_mask"    type="xs:NMTOKEN"/>
+  <xs:attribute name="grid1"       type="xs:NCName"/>
+  <xs:attribute name="grid2"       type="xs:NCName"/>
+  <xs:attribute name="atm_grid"    type="xs:NMTOKEN"/>
+  <xs:attribute name="glc_grid"    type="xs:NCName"/>
+  <xs:attribute name="lnd_grid"    type="xs:NMTOKEN"/>
+  <xs:attribute name="ocn_grid"    type="xs:NCName"/>
+  <xs:attribute name="rof_grid"    type="xs:NCName"/>
+  <xs:attribute name="wav_grid"    type="xs:NCName"/>
+  <xs:attribute name="driver"      type="xs:NCName"/>
 
   <!-- simple elements -->
   <xs:element name="support" type="xs:string"/>
@@ -26,6 +26,8 @@
   <xs:element name="mask" type="xs:string"/>
   <xs:element name="nx" type="xs:integer"/>
   <xs:element name="ny" type="xs:integer"/>
+  <xs:element name="lat" type="xs:decimal"/>
+  <xs:element name="lon" type="xs:decimal"/>
   <xs:element name="desc" type="xs:string"/>
 
   <!-- complex elements -->
@@ -35,7 +37,7 @@
       <xs:sequence>
         <xs:element ref="help"/>
         <xs:element ref="grids"/>
-        <xs:element ref="domains"/>
+        <xs:element ref="domains" maxOccurs="3"/>
         <xs:element ref="required_gridmaps"/>
         <xs:element ref="gridmaps" maxOccurs="3"/>
       </xs:sequence>
@@ -78,14 +80,17 @@
       <xs:sequence>
         <xs:element ref="domain" maxOccurs="unbounded" />
       </xs:sequence>
+      <xs:attribute ref="driver"/>
     </xs:complexType>
   </xs:element>
 
   <xs:element name="domain">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="nx"/>
-        <xs:element ref="ny"/>
+        <xs:element ref="nx" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="ny" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="lat" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="lon" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="file" minOccurs="0" maxOccurs="unbounded"/>
         <xs:element ref="mesh" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="desc"/>

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -24,7 +24,6 @@ class Grids(GenericXML):
             expect(False, "Could not initialize Grids")
 
         self._version = self.get_version()
-        print("grid version is {}".format(self._version))
         self._comp_gridnames = self._get_grid_names()
 
     def _get_grid_names(self):

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -245,7 +245,8 @@ class Grids(GenericXML):
                         domains["PTS_LAT"] = self.get_element_text("lat", root=domain_node)
                         domains["PTS_LON"] = self.get_element_text("lon", root=domain_node)
                     else:
-                        expect(False,"In config_grids.xml either nx and ny or lat and lon must be set")
+                        domains[comp_name + "_NX"] = 1
+                        domains[comp_name + "_NY"] = 1
 
                     file_name = comp_name + "_DOMAIN_FILE"
                     path_name = comp_name + "_DOMAIN_PATH"

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -237,8 +237,17 @@ class Grids(GenericXML):
 
                 # determine xml variable name
                 if not comp_name == "MASK":
-                    domains[comp_name + "_NX"] = int(self.get_element_text("nx", root=domain_node))
-                    domains[comp_name + "_NY"] = int(self.get_element_text("ny", root=domain_node))
+                    if self.get_element_text("nx", root=domain_node):
+                        domains[comp_name + "_NX"] = int(self.get_element_text("nx", root=domain_node))
+                        domains[comp_name + "_NY"] = int(self.get_element_text("ny", root=domain_node))
+                    elif self.get_element_text("lon", root=domain_node):
+                        domains[comp_name + "_NX"] = 1
+                        domains[comp_name + "_NY"] = 1
+                        domains["PTS_LAT"] = self.get_element_text("lat", root=domain_node)
+                        domains["PTS_LON"] = self.get_element_text("lon", root=domain_node)
+                    else:
+                        expect(False,"In config_grids.xml either nx and ny or lat and lon must be set")
+
                     file_name = comp_name + "_DOMAIN_FILE"
                     path_name = comp_name + "_DOMAIN_PATH"
                     mesh_name = comp_name + "_DOMAIN_MESH"

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -24,7 +24,7 @@ class Grids(GenericXML):
             expect(False, "Could not initialize Grids")
 
         self._version = self.get_version()
-
+        print("grid version is {}".format(self._version))
         self._comp_gridnames = self._get_grid_names()
 
     def _get_grid_names(self):
@@ -229,7 +229,10 @@ class Grids(GenericXML):
             # Determine all domain information search for the grid name with no level suffix in config_grids.xml
             domain_node = self.get_optional_child("domain", attributes={"name":grid_name_nonlev},
                                                   root=self.get_child("domains"))
-            if domain_node is not None:
+            if not domain_node:
+                domain_node = self.get_optional_child("domain", attributes={"name":grid_name_nonlev},
+                                                      root=self.get_child("domains",{"driver":driver}))
+            if domain_node:
                 comp_name = grid[0].upper()
 
                 # determine xml variable name


### PR DESCRIPTION
Instead of requiring a netcdf domain file here we allow single point cases to just set the lat and lon values in PTS_LAT and PTS_LON.   This requires an update of the grids schema to v2.2.  This schema was tested with cpl7 which continues to use domain files and with cmeps which will use the new PTS_LAT and PTS_LON.   Depends on cmeps https://github.com/ESCOMP/CMEPS/pull/160
 
Test suite: scripts_regression_tests.py SMS_D_Ly6_Mmpi-serial.1x1_smallvilleIA.IHistClm45BgcCropQianRs.cheyenne_intel.clm-cropMonthOutput
Test baseline: ctsm5.1.dev019
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
