### PR TITLE
Generalize the file pattern match for cism.config files

### DIFF
--- a/scripts/lib/CIME/case/preview_namelists.py
+++ b/scripts/lib/CIME/case/preview_namelists.py
@@ -101,7 +101,7 @@ def create_namelists(self, component=None):
             expect(False, "Failed to write {}/README: {}".format(docdir, e))
 
     for cpglob in ["*_in_[0-9]*", "*modelio*", "*_in", "nuopc.runconfig",
-                   "*streams*txt*", "*streams.xml", "*stxt", "*maps.rc", "*cism.config*", "nuopc.runseq"]:
+                   "*streams*txt*", "*streams.xml", "*stxt", "*maps.rc", "*cism*.config*", "nuopc.runseq"]:
         for file_to_copy in glob.glob(os.path.join(rundir, cpglob)):
             logger.debug("Copy file from '{}' to '{}'".format(file_to_copy, docdir))
             safe_copy(file_to_copy, docdir)


### PR DESCRIPTION
This supports an upcoming CISM change where we are going to use config
file names like cism.gris.config and cism.ais.config; or for
multi-instance, cism_0001.gris.config, cism_0002.gris.config, etc.

This is backwards compatible with old versions of CISM.

Test suite:
- manual testing
- scripts_regression_tests: only A & B
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Note: On my mac (with python 3.9.1), I got this failure in B_CheckCode which is unrelated to this PR:

```
======================================================================
FAIL: test_pylint_scripts_tests_scripts_regression_tests_py (__main__.B_CheckCode)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sacks/cime/scripts/tests/./scripts_regression_tests.py", line 3481, in test
    self.assertTrue(result == "", msg=result)
AssertionError: False is not true : ************* Module scripts_regression_tests
scripts/tests/scripts_regression_tests.py:1039:24: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1046:25: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1059:24: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1066:25: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1080:24: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1086:25: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1102:25: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1120:24: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1126:25: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1157:24: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1166:32: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1169:33: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
scripts/tests/scripts_regression_tests.py:1633:25: E1101: Instance of 'Thread' has no 'isAlive' member (no-member)
```

Fixes none

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
