### PR TITLE
make 64bit data default format

### DIFF
--- a/src/share/unit_test_stubs/pio/pio.F90.in
+++ b/src/share/unit_test_stubs/pio/pio.F90.in
@@ -63,6 +63,7 @@ module pio
        r8        = selected_real_kind(13)
 
   integer, parameter, public :: PIO_64BIT_OFFSET = 0
+  integer, parameter, public :: PIO_64BIT_DATA = 0
   integer(i4), parameter, public :: PIO_BCAST_ERROR = 0
   integer, parameter, public :: PIO_CLOBBER = 0
   integer, parameter, public :: PIO_DOUBLE = 0

--- a/src/share/util/shr_pio_mod.F90
+++ b/src/share/util/shr_pio_mod.F90
@@ -572,7 +572,7 @@ contains
     pio_default_numiotasks = pio_numiotasks
     pio_default_iotype = pio_iotype
     pio_default_rearranger = pio_rearranger
-    pio_default_netcdf_ioformat = PIO_64BIT_OFFSET
+    pio_default_netcdf_ioformat = PIO_64BIT_DATA
 
     !--------------------------------------------------------------------------
     ! read io nml parameters
@@ -643,10 +643,8 @@ contains
        pio_netcdf_ioformat = 0
     elseif ( pio_netcdf_format .eq. '64BIT_OFFSET' ) then
        pio_netcdf_ioformat = PIO_64BIT_OFFSET
-#ifdef _PNETCDF
     elseif ( pio_netcdf_format .eq. '64BIT_DATA' ) then
        pio_netcdf_ioformat = PIO_64BIT_DATA
-#endif
     else
        pio_netcdf_ioformat = pio_default_netcdf_ioformat
     endif


### PR DESCRIPTION
Makes the 64bit_data format the default.  Removes a requirement that pnetcdf must be built to use this format.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
