### PR TITLE
Add run scripts to provenance capture

### DIFF
--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -228,6 +228,7 @@ def _save_prerun_timing_e3sm(case, lid):
     os.mkdir(case_docs)
     globs_to_copy = [
         "CaseDocs/*",
+        "run_script_provenance/*",
         "*.run",
         ".*.run",
         "*.xml",


### PR DESCRIPTION
When a run script is used to setup simulations, it is copied in
the case directory under 'run_script_provenance'. Adding that to
the list of files captured in the provenance/performance archive.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes : https://github.com/E3SM-Project/E3SM/issues/4118

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jgfouca 
