### PR TITLE
Capture memory profiles in provenance

### DIFF
--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -393,6 +393,7 @@ def _save_postrun_timing_e3sm(case, lid):
     globs_to_copy.append(os.path.join(rundir, "e3sm.log.{}.gz".format(lid)))
     globs_to_copy.append(os.path.join(rundir, "cpl.log.{}.gz".format(lid)))
     globs_to_copy.append(os.path.join(rundir, "atm_chunk_costs.{}.gz".format(lid)))
+    globs_to_copy.append(os.path.join(rundir, "memory.[0-4].*.log"))
     globs_to_copy.append("timing/*.{}*".format(lid))
     globs_to_copy.append("CaseStatus")
 


### PR DESCRIPTION
Recent support for memory profiling generates new files
in the run directory (memory.{0,1,2,3,4}.run_duration.log).

These need to be captured in provenance.

Test status: bit for bit

Fixes https://github.com/E3SM-Project/E3SM/issues/4119

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jgfouca 

In the future, it would be good to add $LID to the filenames to disambiguate multiple jobs launched from the same run directory. Not sure if they should be renamed here or during file creation. (cc @amametjanov)
