### PR TITLE
Add header row and perf-archiving to memory profiling logs

### DIFF
--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -336,6 +336,13 @@ def _save_postrun_timing_e3sm(case, lid):
         shutil.move(atm_chunk_costs_src_path, atm_chunk_costs_dst_path)
         gzip_existing_file(atm_chunk_costs_dst_path)
 
+    # gzip memory profile log
+    glob_to_copy = "memory.[0-4].*.log"
+    for item in glob.glob(os.path.join(rundir, glob_to_copy)):
+        mprof_dst_path = os.path.join(os.path.dirname(item), (os.path.basename(item) + ".{}").format(lid))
+        shutil.move(item, mprof_dst_path)
+        gzip_existing_file(mprof_dst_path)
+
     gzip_existing_file(os.path.join(caseroot, "timing", "e3sm_timing_stats.%s" % lid))
 
     # JGF: not sure why we do this
@@ -393,6 +400,7 @@ def _save_postrun_timing_e3sm(case, lid):
     globs_to_copy.append(os.path.join(rundir, "e3sm.log.{}.gz".format(lid)))
     globs_to_copy.append(os.path.join(rundir, "cpl.log.{}.gz".format(lid)))
     globs_to_copy.append(os.path.join(rundir, "atm_chunk_costs.{}.gz".format(lid)))
+    globs_to_copy.append(os.path.join(rundir, "memory.[0-4].*.log.{}.gz".format(lid)))
     globs_to_copy.append("timing/*.{}*".format(lid))
     globs_to_copy.append("CaseStatus")
 

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2512,16 +2512,55 @@ contains
              open(mlog, file=trim(c_mprof_file), status='old', position='append')
           else
              open(mlog, file=trim(c_mprof_file), status='new', position='append')
+             ! write header row
+             if (info_mprof == 2) then       ! log each task
+                write(mlog,'(a, *(a6,i0,a8,i0,:,", "))') "#TOD, ",&
+                   ("VSZ_T_",i,", RSS_T_",i,i=0,npes_GLOID-1)
+             else if (info_mprof == 1) then  ! log ROOTPE tasks only
+                write(mlog,'(a, 9(a12,i0,a12,i0))') "#TOD",&
+                   & ", VSZ_CPL_T_",iam_GLOID, ", RSS_CPL_T_",iam_GLOID,  &
+                   & ", VSZ_ATM_T_",atm_rootpe,", RSS_ATM_T_",atm_rootpe, &
+                   & ", VSZ_LND_T_",lnd_rootpe,", RSS_LND_T_",lnd_rootpe, &
+                   & ", VSZ_ICE_T_",ice_rootpe,", RSS_ICE_T_",ice_rootpe, &
+                   & ", VSZ_OCN_T_",ocn_rootpe,", RSS_OCN_T_",ocn_rootpe, &
+                   & ", VSZ_GLC_T_",glc_rootpe,", RSS_GLC_T_",glc_rootpe, &
+                   & ", VSZ_ROF_T_",rof_rootpe,", RSS_ROF_T_",rof_rootpe, &
+                   & ", VSZ_WAV_T_",wav_rootpe,", RSS_WAV_T_",wav_rootpe, &
+                   & ", VSZ_IAC_T_",iac_rootpe,", RSS_IAC_T_",iac_rootpe
+             else if (info_mprof == 4) then  ! log each node
+                write(mlog,'(a, *(a6,i0,a8,i0,:,", "))') "#TOD, ",&
+                   ("VSZ_N_",i,", RSS_N_",i,i=0,driver_nnodes-1)
+             else if (info_mprof == 3) then  ! log ROOTPE nodes
+                write(mlog,'(a, 9(a12,i0,a12,i0))') "#TOD",&
+                   & ", VSZ_CPL_N_",driver_task_node_map(iam_GLOID), &
+                   & ", RSS_CPL_N_",driver_task_node_map(iam_GLOID), &
+                   & ", VSZ_ATM_N_",driver_task_node_map(atm_rootpe),&
+                   & ", RSS_ATM_N_",driver_task_node_map(atm_rootpe),&
+                   & ", VSZ_LND_N_",driver_task_node_map(lnd_rootpe),&
+                   & ", RSS_LND_N_",driver_task_node_map(lnd_rootpe),&
+                   & ", VSZ_ICE_N_",driver_task_node_map(ice_rootpe),&
+                   & ", RSS_ICE_N_",driver_task_node_map(ice_rootpe),&
+                   & ", VSZ_OCN_N_",driver_task_node_map(ocn_rootpe),&
+                   & ", RSS_OCN_N_",driver_task_node_map(ocn_rootpe),&
+                   & ", VSZ_GLC_N_",driver_task_node_map(glc_rootpe),&
+                   & ", RSS_GLC_N_",driver_task_node_map(glc_rootpe),&
+                   & ", VSZ_ROF_N_",driver_task_node_map(rof_rootpe),&
+                   & ", RSS_ROF_N_",driver_task_node_map(rof_rootpe),&
+                   & ", VSZ_WAV_N_",driver_task_node_map(wav_rootpe),&
+                   & ", RSS_WAV_N_",driver_task_node_map(wav_rootpe),&
+                   & ", VSZ_IAC_N_",driver_task_node_map(iac_rootpe),&
+                   & ", RSS_IAC_N_",driver_task_node_map(iac_rootpe)
+             endif
           endif
 
           ! log memory highwater and usage
           write(c_ymdtod,'(f14.5)') ymd+tod/86400.
           if (info_mprof == 2) then        ! log each task
              !---YMMDD.HHMMSS,--1234.567,--1234.567, msize,mrss (in MB) for each task
-             write(mlog,'(a15, a, *(f10.3,:,","))') c_ymdtod, ",", &
+             write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
                 (msizeOnTask(i),mrssOnTask(i),i=0,npes_GLOID-1)
           else if (info_mprof == 1) then  ! log ROOTPE tasks only
-             write(mlog,'(a15, a, *(f10.3,:,","))') c_ymdtod,",", &
+             write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod,",", &
                 (/msizeOnTask(iam_GLOID), mrssOnTask(iam_GLOID),  &
                 & msizeOnTask(atm_rootpe),mrssOnTask(atm_rootpe), &
                 & msizeOnTask(lnd_rootpe),mrssOnTask(lnd_rootpe), &
@@ -2532,10 +2571,10 @@ contains
                 & msizeOnTask(wav_rootpe),mrssOnTask(wav_rootpe), &
                 & msizeOnTask(iac_rootpe),mrssOnTask(iac_rootpe)/)
           else if (info_mprof == 4) then  ! log each node
-             write(mlog,'(a15, a, *(f10.3,:,","))') c_ymdtod, ",", &
+             write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
                 (msizeOnNode(i),mrssOnNode(i),i=0,driver_nnodes-1)
           else if (info_mprof == 3) then  ! log ROOTPE nodes
-             write(mlog,'(a15, a, *(f10.3,:,","))') c_ymdtod, ",", &
+             write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
                 (/msizeOnNode(driver_task_node_map(iam_GLOID)),  &
                 &  mrssOnNode(driver_task_node_map(iam_GLOID)),  &
                 & msizeOnNode(driver_task_node_map(atm_rootpe)), &
@@ -3481,10 +3520,10 @@ contains
                 write(c_ymdtod,'(f14.5)') ymd+tod/86400.
                 if (info_mprof == 2) then      ! log each task
                    !---YMMDD.HHMMSS,--1234.567,--1234.567, msize,mrss (in MB) for each task
-                   write(mlog,'(a15, a, *(f10.3,:,","))') c_ymdtod, ",", &
+                   write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
                       (msizeOnTask(i),mrssOnTask(i),i=0,npes_GLOID-1)
                 else if (info_mprof == 1) then ! ROOTPEs only
-                   write(mlog,'(a15, a, *(f10.3,:,","))') c_ymdtod, ",", &
+                   write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
                       (/msizeOnTask(iam_GLOID), mrssOnTask(iam_GLOID),  &
                       & msizeOnTask(atm_rootpe),mrssOnTask(atm_rootpe), &
                       & msizeOnTask(lnd_rootpe),mrssOnTask(lnd_rootpe), &
@@ -3495,10 +3534,10 @@ contains
                       & msizeOnTask(wav_rootpe),mrssOnTask(wav_rootpe), &
                       & msizeOnTask(iac_rootpe),mrssOnTask(iac_rootpe)/)
                 else if (info_mprof == 4) then  ! log each node
-                   write(mlog,'(a15, a, *(f10.3,:,","))') c_ymdtod, ",", &
+                   write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
                       (msizeOnNode(i),mrssOnNode(i),i=0,driver_nnodes-1)
                 else if (info_mprof == 3) then  ! log ROOTPE nodes
-                   write(mlog,'(a15, a, *(f10.3,:,","))') c_ymdtod, ",", &
+                   write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
                       (/msizeOnNode(driver_task_node_map(iam_GLOID)),  &
                       &  mrssOnNode(driver_task_node_map(iam_GLOID)),  &
                       & msizeOnNode(driver_task_node_map(atm_rootpe)), &


### PR DESCRIPTION
Add header row and perf-archiving to memory profiling logs.

Test suite: SMS.f19_g16.X.chrysalis_intel
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes E3SM-Project/E3SM#4133

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: @jgfouca 