### PR TITLE
Fix format descriptor in mem-logging for IBM compiler

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -39,7 +39,7 @@ jobs:
 
       - id: load-env
         run: |
-          sudo apt-get update
+          #sudo apt-get update
           sudo apt-get install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/pnetcdf
-          key: ${{ runner.os }}-${{ env.PNETCDF_VERSION}}-pnetcdf
+          key: ${{ runner.os }}-${{ env.PNETCDF_VERSION}}-pnetcdf-redo
 
       - name: pnetcdf build
         if: steps.cache-pnetcdf.outputs.cache-hit != 'true'
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/netcdf-fortran
-          key: ${{ runner.os }}-${{ env.NETCDF_FORTRAN_VERSION }}-netcdf-fortran
+          key: ${{ runner.os }}-${{ env.NETCDF_FORTRAN_VERSION }}-netcdf-fortran-redo
 
       - name: netcdf fortran build
         if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
@@ -115,3 +115,9 @@ jobs:
           export PATH=$NETCDF/bin:$PATH
           export LD_LIBRARY_PATH=$NETCDF/lib:$HOME/pnetcdf/lib:$LD_LIBRARY_PATH
           ./scripts_regression_tests.py --no-fortran-run --compiler gnu --mpilib openmpi --machine ubuntu-latest
+
+#     the following can be used by developers to login to the github server in case of errors
+#     see https://github.com/marketplace/actions/debugging-with-tmate for further details
+#      - name: Setup tmate session
+#        if: ${{ failure() }}
+#        uses: mxschmitt/action-tmate@v3

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2430,10 +2430,10 @@ contains
 105 format( A, i10.8, i8, A, f10.2, A, f10.2, A, A, i5, A, A)
 108 format( A, f10.2, A, i8.8)
 109 format( A, 2f10.3)
-110 format( A, 999999999(A8, i0, A8, i0) )
-111 format( A, 9(A12, i0, A12, i0) )
-112 format( A14, A, 999999999(f13.3, :, ",") )
-113 format( A14, A, 9(f13.3, :, ",") )
+110 format( A,   999999999(:, A8,  i0, A8,  i0) )
+111 format( A,   999999999(:, A12, i0, A12, i0) )
+112 format( A14, 999999999(:, ',', f13.3) )
+113 format( A14, 999999999(:, ',', f13.3) )
 
     call t_startf ('CPL:cime_run_init')
     hashint = 0
@@ -2561,10 +2561,10 @@ contains
           write(c_ymdtod,'(f14.5)') ymd+tod/86400.
           if (info_mprof == 2) then        ! log each task
              !---YMMDD.HHMMSS,--1234.567,--1234.567, msize,mrss (in MB) for each task
-             write(mlog,112) c_ymdtod, ",", &
+             write(mlog,112) c_ymdtod, &
                 (msizeOnTask(i),mrssOnTask(i),i=0,npes_GLOID-1)
           else if (info_mprof == 1) then  ! log ROOTPE tasks only
-             write(mlog,113) c_ymdtod,",", &
+             write(mlog,113) c_ymdtod, &
                 (/msizeOnTask(iam_GLOID), mrssOnTask(iam_GLOID),  &
                 & msizeOnTask(atm_rootpe),mrssOnTask(atm_rootpe), &
                 & msizeOnTask(lnd_rootpe),mrssOnTask(lnd_rootpe), &
@@ -2575,10 +2575,10 @@ contains
                 & msizeOnTask(wav_rootpe),mrssOnTask(wav_rootpe), &
                 & msizeOnTask(iac_rootpe),mrssOnTask(iac_rootpe)/)
           else if (info_mprof == 4) then  ! log each node
-             write(mlog,112) c_ymdtod, ",", &
+             write(mlog,112) c_ymdtod, &
                 (msizeOnNode(i),mrssOnNode(i),i=0,driver_nnodes-1)
           else if (info_mprof == 3) then  ! log ROOTPE nodes
-             write(mlog,113) c_ymdtod, ",", &
+             write(mlog,113) c_ymdtod, &
                 (/msizeOnNode(driver_task_node_map(iam_GLOID)),  &
                 &  mrssOnNode(driver_task_node_map(iam_GLOID)),  &
                 & msizeOnNode(driver_task_node_map(atm_rootpe)), &
@@ -3524,10 +3524,10 @@ contains
                 write(c_ymdtod,'(f14.5)') ymd+tod/86400.
                 if (info_mprof == 2) then      ! log each task
                    !---YMMDD.HHMMSS,--1234.567,--1234.567, msize,mrss (in MB) for each task
-                   write(mlog,112) c_ymdtod, ",", &
+                   write(mlog,112) c_ymdtod, &
                       (msizeOnTask(i),mrssOnTask(i),i=0,npes_GLOID-1)
                 else if (info_mprof == 1) then ! ROOTPEs only
-                   write(mlog,113) c_ymdtod, ",", &
+                   write(mlog,113) c_ymdtod, &
                       (/msizeOnTask(iam_GLOID), mrssOnTask(iam_GLOID),  &
                       & msizeOnTask(atm_rootpe),mrssOnTask(atm_rootpe), &
                       & msizeOnTask(lnd_rootpe),mrssOnTask(lnd_rootpe), &
@@ -3538,10 +3538,10 @@ contains
                       & msizeOnTask(wav_rootpe),mrssOnTask(wav_rootpe), &
                       & msizeOnTask(iac_rootpe),mrssOnTask(iac_rootpe)/)
                 else if (info_mprof == 4) then  ! log each node
-                   write(mlog,112) c_ymdtod, ",", &
+                   write(mlog,112) c_ymdtod, &
                       (msizeOnNode(i),mrssOnNode(i),i=0,driver_nnodes-1)
                 else if (info_mprof == 3) then  ! log ROOTPE nodes
-                   write(mlog,113) c_ymdtod, ",", &
+                   write(mlog,113) c_ymdtod, &
                       (/msizeOnNode(driver_task_node_map(iam_GLOID)),  &
                       &  mrssOnNode(driver_task_node_map(iam_GLOID)),  &
                       & msizeOnNode(driver_task_node_map(atm_rootpe)), &

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -2430,6 +2430,10 @@ contains
 105 format( A, i10.8, i8, A, f10.2, A, f10.2, A, A, i5, A, A)
 108 format( A, f10.2, A, i8.8)
 109 format( A, 2f10.3)
+110 format( A, 999999999(A8, i0, A8, i0) )
+111 format( A, 9(A12, i0, A12, i0) )
+112 format( A14, A, 999999999(f13.3, :, ",") )
+113 format( A14, A, 9(f13.3, :, ",") )
 
     call t_startf ('CPL:cime_run_init')
     hashint = 0
@@ -2514,10 +2518,10 @@ contains
              open(mlog, file=trim(c_mprof_file), status='new', position='append')
              ! write header row
              if (info_mprof == 2) then       ! log each task
-                write(mlog,'(a, *(a6,i0,a8,i0,:,", "))') "#TOD, ",&
-                   ("VSZ_T_",i,", RSS_T_",i,i=0,npes_GLOID-1)
+                write(mlog,110) "#TOD", &
+                   (", VSZ_T_",i,", RSS_T_",i,i=0,npes_GLOID-1)
              else if (info_mprof == 1) then  ! log ROOTPE tasks only
-                write(mlog,'(a, 9(a12,i0,a12,i0))') "#TOD",&
+                write(mlog,111) "#TOD",&
                    & ", VSZ_CPL_T_",iam_GLOID, ", RSS_CPL_T_",iam_GLOID,  &
                    & ", VSZ_ATM_T_",atm_rootpe,", RSS_ATM_T_",atm_rootpe, &
                    & ", VSZ_LND_T_",lnd_rootpe,", RSS_LND_T_",lnd_rootpe, &
@@ -2528,10 +2532,10 @@ contains
                    & ", VSZ_WAV_T_",wav_rootpe,", RSS_WAV_T_",wav_rootpe, &
                    & ", VSZ_IAC_T_",iac_rootpe,", RSS_IAC_T_",iac_rootpe
              else if (info_mprof == 4) then  ! log each node
-                write(mlog,'(a, *(a6,i0,a8,i0,:,", "))') "#TOD, ",&
-                   ("VSZ_N_",i,", RSS_N_",i,i=0,driver_nnodes-1)
+                write(mlog,110) "#TOD", &
+                   (", VSZ_N_",i,", RSS_N_",i,i=0,driver_nnodes-1)
              else if (info_mprof == 3) then  ! log ROOTPE nodes
-                write(mlog,'(a, 9(a12,i0,a12,i0))') "#TOD",&
+                write(mlog,111) "#TOD",&
                    & ", VSZ_CPL_N_",driver_task_node_map(iam_GLOID), &
                    & ", RSS_CPL_N_",driver_task_node_map(iam_GLOID), &
                    & ", VSZ_ATM_N_",driver_task_node_map(atm_rootpe),&
@@ -2557,10 +2561,10 @@ contains
           write(c_ymdtod,'(f14.5)') ymd+tod/86400.
           if (info_mprof == 2) then        ! log each task
              !---YMMDD.HHMMSS,--1234.567,--1234.567, msize,mrss (in MB) for each task
-             write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
+             write(mlog,112) c_ymdtod, ",", &
                 (msizeOnTask(i),mrssOnTask(i),i=0,npes_GLOID-1)
           else if (info_mprof == 1) then  ! log ROOTPE tasks only
-             write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod,",", &
+             write(mlog,113) c_ymdtod,",", &
                 (/msizeOnTask(iam_GLOID), mrssOnTask(iam_GLOID),  &
                 & msizeOnTask(atm_rootpe),mrssOnTask(atm_rootpe), &
                 & msizeOnTask(lnd_rootpe),mrssOnTask(lnd_rootpe), &
@@ -2571,10 +2575,10 @@ contains
                 & msizeOnTask(wav_rootpe),mrssOnTask(wav_rootpe), &
                 & msizeOnTask(iac_rootpe),mrssOnTask(iac_rootpe)/)
           else if (info_mprof == 4) then  ! log each node
-             write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
+             write(mlog,112) c_ymdtod, ",", &
                 (msizeOnNode(i),mrssOnNode(i),i=0,driver_nnodes-1)
           else if (info_mprof == 3) then  ! log ROOTPE nodes
-             write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
+             write(mlog,113) c_ymdtod, ",", &
                 (/msizeOnNode(driver_task_node_map(iam_GLOID)),  &
                 &  mrssOnNode(driver_task_node_map(iam_GLOID)),  &
                 & msizeOnNode(driver_task_node_map(atm_rootpe)), &
@@ -3520,10 +3524,10 @@ contains
                 write(c_ymdtod,'(f14.5)') ymd+tod/86400.
                 if (info_mprof == 2) then      ! log each task
                    !---YMMDD.HHMMSS,--1234.567,--1234.567, msize,mrss (in MB) for each task
-                   write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
+                   write(mlog,112) c_ymdtod, ",", &
                       (msizeOnTask(i),mrssOnTask(i),i=0,npes_GLOID-1)
                 else if (info_mprof == 1) then ! ROOTPEs only
-                   write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
+                   write(mlog,113) c_ymdtod, ",", &
                       (/msizeOnTask(iam_GLOID), mrssOnTask(iam_GLOID),  &
                       & msizeOnTask(atm_rootpe),mrssOnTask(atm_rootpe), &
                       & msizeOnTask(lnd_rootpe),mrssOnTask(lnd_rootpe), &
@@ -3534,10 +3538,10 @@ contains
                       & msizeOnTask(wav_rootpe),mrssOnTask(wav_rootpe), &
                       & msizeOnTask(iac_rootpe),mrssOnTask(iac_rootpe)/)
                 else if (info_mprof == 4) then  ! log each node
-                   write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
+                   write(mlog,112) c_ymdtod, ",", &
                       (msizeOnNode(i),mrssOnNode(i),i=0,driver_nnodes-1)
                 else if (info_mprof == 3) then  ! log ROOTPE nodes
-                   write(mlog,'(a14, a, *(f13.3,:,","))') c_ymdtod, ",", &
+                   write(mlog,113) c_ymdtod, ",", &
                       (/msizeOnNode(driver_task_node_map(iam_GLOID)),  &
                       &  mrssOnNode(driver_task_node_map(iam_GLOID)),  &
                       & msizeOnNode(driver_task_node_map(atm_rootpe)), &


### PR DESCRIPTION
Replace indefinite repeat (star) with large numeric value.
Checked changes with several compilers:
* xl/16.1.1-7
* intel/19.1.0.166
* gcc/9.3.0 and gcc/8.1.1
* pgi/19.9
* cce/10.0.3

Test suite: SMS.f19_g16.X
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes E3SM-Project/E3SM#4138

User interface changes?: none

Update gh-pages html (Y/N)?: N

Code review: @dqwu 
