### PR TITLE
Disable kokkos tests when building for E3SM

### DIFF
--- a/src/build_scripts/buildlib.kokkos
+++ b/src/build_scripts/buildlib.kokkos
@@ -72,7 +72,7 @@ def buildlib(bldroot, installpath, case):
     gmake_cmd = case.get_value("GMAKE")
     gmake_j = case.get_value("GMAKE_J")
 
-    gen_makefile_cmd = "{kokkos_dir}/generate_makefile.bash {kokkos_options} --compiler={cxx} --prefix={installpath}"\
+    gen_makefile_cmd = "{kokkos_dir}/generate_makefile.bash {kokkos_options} --disable-tests --compiler={cxx} --prefix={installpath}"\
         .format(kokkos_dir=kokkos_dir, kokkos_options=kokkos_options, cxx=cxx, installpath=installpath)
 
     run_bld_cmd_ensure_logging(gen_makefile_cmd, logger, from_dir=bldroot)


### PR DESCRIPTION
Generate_makefile (which is how E3SM builds Kokkos) has Kokkos_ENABLE_TESTS ON by default and this is causing slower builds and increasing the chances of build problems. I cant imagine why E3SM would ever want kokkos tests, so I'm thinking we should turn this off.

Test suite: By hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
