### PR TITLE
Avoid adding CDEPS things to inc & lib paths with LILAC

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -117,11 +117,16 @@ endif
 
 ifeq ($(COMP_INTERFACE), nuopc)
    CPPDEFS += -DNUOPC_INTERFACE
-   INCLDIR += -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/include -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr
-   # FoX libraries are provided and built by CDEPS
-   FoX_LIBS := -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/lib -lFoX_wxml -lFoX_dom -lFoX_sax -lFoX_common -lFoX_utils -lFoX_fsys
-   ULIBS += -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr -ldshr -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/streams -lstreams
-   SLIBS += $(FoX_LIBS)
+   ifneq ($(LILAC_MODE), on)
+      # CDEPS isn't required yet when building CTSM with LILAC; once it is needed, we
+      # should remove this conditional and the similar one in build.py (along with the
+      # addition of LILAC_MODE to _CMD_ARGS_FOR_BUILD)
+      INCLDIR += -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/include -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr
+      # FoX libraries are provided and built by CDEPS
+      FoX_LIBS := -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/lib -lFoX_wxml -lFoX_dom -lFoX_sax -lFoX_common -lFoX_utils -lFoX_fsys
+      ULIBS += -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr -ldshr -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/streams -lstreams
+      SLIBS += $(FoX_LIBS)
+   endif
 else
    CPPDEFS += -DMCT_INTERFACE
 endif

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 _CMD_ARGS_FOR_BUILD = \
     ("CASEROOT", "CASETOOLS", "CIMEROOT", "COMP_INTERFACE",
-     "COMPILER", "DEBUG", "EXEROOT", "INCROOT", "LIBROOT",
+     "COMPILER", "DEBUG", "EXEROOT", "INCROOT", "LIBROOT", "LILAC_MODE",
      "MACH", "MPILIB", "NINST_VALUE", "OS", "PIO_VERSION",
      "SHAREDLIBROOT", "SMP_PRESENT", "USE_ESMF_LIB", "USE_MOAB",
      "CAM_CONFIG_OPTS", "COMP_LND", "COMPARE_TO_NUOPC", "HOMME_TARGET",
@@ -401,7 +401,8 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
         # this configuration and CDEPS relies on unreleased ESMF code. Eventually we will
         # require CDEPS (for its streams functionality), at which point CDEPS should only
         # require released ESMF code; then we should remove the 'lilac_mode' part of this
-        # conditional.
+        # conditional and the similar conditional in the Makefile (along with the addition
+        # of LILAC_MODE to _CMD_ARGS_FOR_BUILD).
         libs.append("CDEPS")
 
     ocn_model = case.get_value("COMP_OCN")


### PR DESCRIPTION
This is now needed with https://github.com/ESMCI/cime/pull/3770, given
some other changes to the build that have been made in the last few
months (I think the removal of the conditional in the Makefile in
https://github.com/ESMCI/cime/pull/3779, but I'm not sure).

This and the changes in #3770 will be backed out once we require pieces
of CDEPS in the LILAC build (specifically for the streams
functionality).

Test suite: scripts_regression_tests on cheyenne (still ongoing after 2+ hours, which is happening for me today on master as well as the branch; machine issue?); tested build in a LILAC case; `SMS_D_Ld5_Vnuopc.f10_f10_mg37.I2000Clm50BgcCrop.cheyenne_intel.clm-default` (to make sure I haven't broken the nuopc build)
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
