### PR TITLE
Support for SCM functionality for multiple columns

### DIFF
--- a/src/components/data_comps_mct/docn/src/docn_comp_mod.F90
+++ b/src/components/data_comps_mct/docn/src/docn_comp_mod.F90
@@ -95,7 +95,7 @@ CONTAINS
        seq_flds_x2o_fields, seq_flds_o2x_fields, &
        SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, inst_name, logunit, read_restart, &
-       scmMode, iop_mode, scmlat, scmlon, iop_nx, iop_ny)
+       scmMode, scm_domain, scmlat, scmlon, scm_nx, scm_ny)
 
     ! !DESCRIPTION: initialize docn model
     use pio        , only : iosystem_desc_t
@@ -119,14 +119,14 @@ CONTAINS
     integer(IN)            , intent(in)    :: logunit             ! logging unit number
     logical                , intent(in)    :: read_restart        ! start from restart
     logical                , intent(in)    :: scmMode             ! single column mode
-    logical                , intent(in)    :: iop_mode            ! IOP mode
-                                                                  ! cover planet with
-                                                                  ! identical surface
+    logical                , intent(in)    :: scm_domain          ! single column mode but over a
+                                                                  ! domain with multiple columns and
+                                                                  ! with homogeneous surface
     real(R8)               , intent(in)    :: scmLat              ! single column lat
     real(R8)               , intent(in)    :: scmLon              ! single column lon
-    integer(IN)            , intent(in)    :: iop_nx              ! number of points for
+    integer(IN)            , intent(in)    :: scm_nx              ! number of points for
                                                                   ! doubly periodic mode (x)
-    integer(IN)            , intent(in)    :: iop_ny              ! same but for y direction
+    integer(IN)            , intent(in)    :: scm_ny              ! same but for y direction
 
     !--- local variables ---
     integer(IN)   :: n,k      ! generic counters
@@ -178,8 +178,8 @@ CONTAINS
        if (my_task == master_task) &
             write(logunit,F05) ' scm lon lat = ',scmlon,scmlat
        call shr_strdata_init(SDOCN,mpicom,compid,name='ocn', &
-            scmmode=scmmode,iop_mode=iop_mode,scmlon=scmlon,scmlat=scmlat, &
-            iop_nx=iop_nx,iop_ny=iop_ny, &
+            scmmode=scmmode,scm_domain=scm_domain,scmlon=scmlon,scmlat=scmlat, &
+            scm_nx=scm_nx,scm_ny=scm_ny, &
             calendar=calendar, reset_domain_mask=.true.)
     else
        if (datamode == 'SST_AQUAPANAL' .or. datamode == 'SST_AQUAPFILE' .or. &

--- a/src/components/data_comps_mct/docn/src/docn_comp_mod.F90
+++ b/src/components/data_comps_mct/docn/src/docn_comp_mod.F90
@@ -95,7 +95,7 @@ CONTAINS
        seq_flds_x2o_fields, seq_flds_o2x_fields, &
        SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, inst_name, logunit, read_restart, &
-       scmMode, iop_mode, scmlat, scmlon)
+       scmMode, iop_mode, scmlat, scmlon, iop_nx, iop_ny)
 
     ! !DESCRIPTION: initialize docn model
     use pio        , only : iosystem_desc_t
@@ -124,6 +124,9 @@ CONTAINS
                                                                   ! identical surface
     real(R8)               , intent(in)    :: scmLat              ! single column lat
     real(R8)               , intent(in)    :: scmLon              ! single column lon
+    integer(IN)            , intent(in)    :: iop_nx              ! number of points for
+                                                                  ! doubly periodic mode (x)
+    integer(IN)            , intent(in)    :: iop_ny              ! same but for y direction
 
     !--- local variables ---
     integer(IN)   :: n,k      ! generic counters
@@ -176,6 +179,7 @@ CONTAINS
             write(logunit,F05) ' scm lon lat = ',scmlon,scmlat
        call shr_strdata_init(SDOCN,mpicom,compid,name='ocn', &
             scmmode=scmmode,iop_mode=iop_mode,scmlon=scmlon,scmlat=scmlat, &
+            iop_nx=iop_nx,iop_ny=iop_ny, &
             calendar=calendar, reset_domain_mask=.true.)
     else
        if (datamode == 'SST_AQUAPANAL' .or. datamode == 'SST_AQUAPFILE' .or. &

--- a/src/components/data_comps_mct/docn/src/docn_comp_mod.F90
+++ b/src/components/data_comps_mct/docn/src/docn_comp_mod.F90
@@ -95,7 +95,7 @@ CONTAINS
        seq_flds_x2o_fields, seq_flds_o2x_fields, &
        SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
        inst_suffix, inst_name, logunit, read_restart, &
-       scmMode, scm_domain, scmlat, scmlon, scm_nx, scm_ny)
+       scmMode, scm_multcols, scmlat, scmlon, scm_nx, scm_ny)
 
     ! !DESCRIPTION: initialize docn model
     use pio        , only : iosystem_desc_t
@@ -119,9 +119,8 @@ CONTAINS
     integer(IN)            , intent(in)    :: logunit             ! logging unit number
     logical                , intent(in)    :: read_restart        ! start from restart
     logical                , intent(in)    :: scmMode             ! single column mode
-    logical                , intent(in)    :: scm_domain          ! single column mode but over a
-                                                                  ! domain with multiple columns and
-                                                                  ! with homogeneous surface
+    logical                , intent(in)    :: scm_multcols        ! single column functionality but
+                                                                  ! extrapolated over multiple columns
     real(R8)               , intent(in)    :: scmLat              ! single column lat
     real(R8)               , intent(in)    :: scmLon              ! single column lon
     integer(IN)            , intent(in)    :: scm_nx              ! number of points for
@@ -178,7 +177,7 @@ CONTAINS
        if (my_task == master_task) &
             write(logunit,F05) ' scm lon lat = ',scmlon,scmlat
        call shr_strdata_init(SDOCN,mpicom,compid,name='ocn', &
-            scmmode=scmmode,scm_domain=scm_domain,scmlon=scmlon,scmlat=scmlat, &
+            scmmode=scmmode,scm_multcols=scm_multcols,scmlon=scmlon,scmlat=scmlat, &
             scm_nx=scm_nx,scm_ny=scm_ny, &
             calendar=calendar, reset_domain_mask=.true.)
     else

--- a/src/components/data_comps_mct/docn/src/docn_comp_mod.F90
+++ b/src/components/data_comps_mct/docn/src/docn_comp_mod.F90
@@ -123,8 +123,8 @@ CONTAINS
                                                                   ! extrapolated over multiple columns
     real(R8)               , intent(in)    :: scmLat              ! single column lat
     real(R8)               , intent(in)    :: scmLon              ! single column lon
-    integer(IN)            , intent(in)    :: scm_nx              ! number of points for
-                                                                  ! doubly periodic mode (x)
+    integer(IN)            , intent(in)    :: scm_nx              ! number of points for SCM
+                                                                  ! functionality (x direction)
     integer(IN)            , intent(in)    :: scm_ny              ! same but for y direction
 
     !--- local variables ---

--- a/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
+++ b/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
@@ -74,11 +74,11 @@ CONTAINS
     integer(IN)       :: shrloglev                 ! original log level
     integer(IN)       :: ierr                      ! error code
     logical           :: scmMode = .false.         ! single column mode
-    logical           :: scm_domain = .false.      ! SCM mode for an entire domain
+    logical           :: scm_domain = .false.      ! SCM mode for a domain of multiple columns
     real(R8)          :: scmLat  = shr_const_SPVAL ! single column lat
     real(R8)          :: scmLon  = shr_const_SPVAL ! single column lon
-    integer(IN)       :: scm_nx = -1               ! number of points in SCM domain mode (x-direction)
-    integer(IN)       :: scm_ny = -1               ! number of points in SCM domain mode (y-direction)
+    integer(IN)       :: scm_nx = -1               ! number of points in SCM domain (x-direction)
+    integer(IN)       :: scm_ny = -1               ! number of points in SCM domain (y-direction)
     character(*), parameter :: F00   = "('(docn_comp_init) ',8a)"
     character(*), parameter :: subName = "(ocn_init_mct) "
     !-------------------------------------------------------------------------------

--- a/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
+++ b/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
@@ -77,8 +77,9 @@ CONTAINS
     logical           :: scm_multcols = .false.    ! SCM functionality for multiple columns
     real(R8)          :: scmLat  = shr_const_SPVAL ! single column lat
     real(R8)          :: scmLon  = shr_const_SPVAL ! single column lon
-    integer(IN)       :: scm_nx = -1               ! number of points in SCM domain (x-direction)
-    integer(IN)       :: scm_ny = -1               ! number of points in SCM domain (y-direction)
+    integer(IN)       :: scm_nx = -1               ! number of points to use SCM
+                                                   ! functionality (x-direction)
+    integer(IN)       :: scm_ny = -1               ! same but for y-direction
     character(*), parameter :: F00   = "('(docn_comp_init) ',8a)"
     character(*), parameter :: subName = "(ocn_init_mct) "
     !-------------------------------------------------------------------------------

--- a/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
+++ b/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
@@ -74,11 +74,11 @@ CONTAINS
     integer(IN)       :: shrloglev                 ! original log level
     integer(IN)       :: ierr                      ! error code
     logical           :: scmMode = .false.         ! single column mode
-    logical           :: iop_mode = .false.        ! IOP mode
+    logical           :: scm_domain = .false.      ! SCM mode for an entire domain
     real(R8)          :: scmLat  = shr_const_SPVAL ! single column lat
     real(R8)          :: scmLon  = shr_const_SPVAL ! single column lon
-    integer(IN)       :: iop_nx = -1               ! doubly periodic points (x)
-    integer(IN)       :: iop_ny = -1               ! doubly periodic points (y)
+    integer(IN)       :: scm_nx = -1               ! number of points in SCM domain mode (x-direction)
+    integer(IN)       :: scm_ny = -1               ! number of points in SCM domain mode (y-direction)
     character(*), parameter :: F00   = "('(docn_comp_init) ',8a)"
     character(*), parameter :: subName = "(ocn_init_mct) "
     !-------------------------------------------------------------------------------
@@ -94,9 +94,9 @@ CONTAINS
     ! Obtain infodata variables
     call seq_infodata_getData(infodata, &
          single_column=scmMode, &
-         iop_mode=iop_mode, &
+         scm_domain=scm_domain, &
          scmlat=scmlat, scmlon=scmLon, &
-         iop_nx=iop_nx,iop_ny=iop_ny, &
+         scm_nx=scm_nx,scm_ny=scm_ny, &
          read_restart=read_restart)
 
     ! Determine instance information
@@ -159,7 +159,7 @@ CONTAINS
          seq_flds_x2o_fields, seq_flds_o2x_fields, &
          SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
          inst_suffix, inst_name, logunit, read_restart, &
-         scmMode, iop_mode, scmlat, scmlon, iop_nx, iop_ny)
+         scmMode, scm_domain, scmlat, scmlon, scm_nx, scm_ny)
 
     !----------------------------------------------------------------------------
     ! Fill infodata that needs to be returned from docn

--- a/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
+++ b/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
@@ -77,6 +77,8 @@ CONTAINS
     logical           :: iop_mode = .false.        ! IOP mode
     real(R8)          :: scmLat  = shr_const_SPVAL ! single column lat
     real(R8)          :: scmLon  = shr_const_SPVAL ! single column lon
+    integer(IN)       :: iop_nx = -1               ! doubly periodic points (x)
+    integer(IN)       :: iop_ny = -1               ! doubly periodic points (y)
     character(*), parameter :: F00   = "('(docn_comp_init) ',8a)"
     character(*), parameter :: subName = "(ocn_init_mct) "
     !-------------------------------------------------------------------------------
@@ -94,6 +96,7 @@ CONTAINS
          single_column=scmMode, &
          iop_mode=iop_mode, &
          scmlat=scmlat, scmlon=scmLon, &
+         iop_nx=iop_nx,iop_ny=iop_ny, &
          read_restart=read_restart)
 
     ! Determine instance information
@@ -156,7 +159,7 @@ CONTAINS
          seq_flds_x2o_fields, seq_flds_o2x_fields, &
          SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
          inst_suffix, inst_name, logunit, read_restart, &
-         scmMode, iop_mode, scmlat, scmlon)
+         scmMode, iop_mode, scmlat, scmlon, iop_nx, iop_ny)
 
     !----------------------------------------------------------------------------
     ! Fill infodata that needs to be returned from docn

--- a/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
+++ b/src/components/data_comps_mct/docn/src/ocn_comp_mct.F90
@@ -74,7 +74,7 @@ CONTAINS
     integer(IN)       :: shrloglev                 ! original log level
     integer(IN)       :: ierr                      ! error code
     logical           :: scmMode = .false.         ! single column mode
-    logical           :: scm_domain = .false.      ! SCM mode for a domain of multiple columns
+    logical           :: scm_multcols = .false.    ! SCM functionality for multiple columns
     real(R8)          :: scmLat  = shr_const_SPVAL ! single column lat
     real(R8)          :: scmLon  = shr_const_SPVAL ! single column lon
     integer(IN)       :: scm_nx = -1               ! number of points in SCM domain (x-direction)
@@ -94,7 +94,7 @@ CONTAINS
     ! Obtain infodata variables
     call seq_infodata_getData(infodata, &
          single_column=scmMode, &
-         scm_domain=scm_domain, &
+         scm_multcols=scm_multcols, &
          scmlat=scmlat, scmlon=scmLon, &
          scm_nx=scm_nx,scm_ny=scm_ny, &
          read_restart=read_restart)
@@ -159,7 +159,7 @@ CONTAINS
          seq_flds_x2o_fields, seq_flds_o2x_fields, &
          SDOCN, gsmap, ggrid, mpicom, compid, my_task, master_task, &
          inst_suffix, inst_name, logunit, read_restart, &
-         scmMode, scm_domain, scmlat, scmlon, scm_nx, scm_ny)
+         scmMode, scm_multcols, scmlat, scmlon, scm_nx, scm_ny)
 
     !----------------------------------------------------------------------------
     ! Fill infodata that needs to be returned from docn

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1156,7 +1156,7 @@
     <default_value>0</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>number of cells for doubly periodic iop mode in i direction</desc>
+    <desc>number of cells for single point mode in i direction</desc>
   </entry>
 
   <entry id="PTS_NY">
@@ -1164,7 +1164,7 @@
     <default_value>0</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>number of cells for doubly periodic iop mode in j directions</desc>
+    <desc>number of cells for single point iop mode in j directions</desc>
   </entry>
 
   <entry id="PTS_MODE">

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1151,6 +1151,22 @@
     <desc>Propogate a single point to the global grid  - DO NOT EDIT (for experts only)</desc>
   </entry>
 
+  <entry id="IOP_NX">
+    <type>integer</type>
+    <default_value>0</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>number of cells for doubly periodic iop mode in i direction</desc>
+  </entry>
+
+  <entry id="IOP_NY">
+    <type>integer</type>
+    <default_value>0</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>number of cells for doubly periodic iop mode in j directions</desc>
+  </entry>
+
   <entry id="PTS_MODE">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1142,16 +1142,16 @@
     <desc>grid mask - DO NOT EDIT (for experts only)</desc>
   </entry>
 
-  <entry id="IOP_MODE">
+  <entry id="PTS_DOMAIN_MODE">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>Propogate a single point to the global grid  - DO NOT EDIT (for experts only)</desc>
+    <desc>Propogate a single point to the global grid/domain  - DO NOT EDIT (for experts only)</desc>
   </entry>
 
-  <entry id="IOP_NX">
+  <entry id="PTS_NX">
     <type>integer</type>
     <default_value>0</default_value>
     <group>run_domain</group>
@@ -1159,7 +1159,7 @@
     <desc>number of cells for doubly periodic iop mode in i direction</desc>
   </entry>
 
-  <entry id="IOP_NY">
+  <entry id="PTS_NY">
     <type>integer</type>
     <default_value>0</default_value>
     <group>run_domain</group>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1142,13 +1142,13 @@
     <desc>grid mask - DO NOT EDIT (for experts only)</desc>
   </entry>
 
-  <entry id="PTS_DOMAIN_MODE">
+  <entry id="PTS_MULTCOLS_MODE">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>Propogate a single point to the global grid/domain  - DO NOT EDIT (for experts only)</desc>
+    <desc>Use a single point of the global grid but propogate that point to multiple columns  - DO NOT EDIT (for experts only)</desc>
   </entry>
 
   <entry id="PTS_NX">
@@ -1156,7 +1156,7 @@
     <default_value>0</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>number of cells for single point mode in i direction</desc>
+    <desc>number of cells for single point mode when operating on multiple columns in i direction</desc>
   </entry>
 
   <entry id="PTS_NY">
@@ -1164,7 +1164,7 @@
     <default_value>0</default_value>
     <group>run_domain</group>
     <file>env_run.xml</file>
-    <desc>number of cells for single point iop mode in j directions</desc>
+    <desc>number of cells for single point mode when operating on multiple columns in j directions</desc>
   </entry>
 
   <entry id="PTS_MODE">

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1484,18 +1484,22 @@
     </values>
   </entry>
 
-  <entry id="scm_domain" modify_via_xml="PTS_DOMAIN_MODE">
+  <entry id="scm_multcols" modify_via_xml="PTS_MULTCOLS_MODE">
     <type>logical</type>
     <category>seq_infodata_inparm</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      Uses SCM functionality for multiple columns. Specifically,
-      turns on Intensive Observation Period (IOP) mode, a planet covered
-      with homogenous surface and forced identically with a forcing file,
-      set by PTS_DOMAIN_MODE in env_case.xml, default: false
+      Uses SCM functionality for multiple columns. Specifically, it takes the column
+      on the globe intended to be run in SCM mode, but propogates that point (i.e.
+      meaning surface type and properties etc.) to multiple columns, as defined by the
+      user.  All columns are then forced identically according to the Intensive Observation
+      Period (IOP) file, which is typically required to run in SCM mode.  This option
+      originally implemented to support running a doubly periodic cloud resolving model, but
+      could be used for other applications.
+      set by PTS_MULTCOLS_MODE in env_case.xml, default: false
     </desc>
     <values>
-      <value>$PTS_DOMAIN_MODE</value>
+      <value>$PTS_MULTCOLS_MODE</value>
     </values>
   </entry>
 
@@ -1504,7 +1508,7 @@
     <category>seq_infodata_inparm</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      number of points in x direction for SCM mode
+      number of points in x direction when using SCM functionality for multiple columns
     </desc>
     <values>
       <value>$PTS_NX</value>
@@ -1516,7 +1520,7 @@
     <category>seq_infodata_inparm</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      number of points in Y direction for SCM mode
+      number of points in Y direction when using SCM functionality for multiple columns
     </desc>
     <values>
       <value>$PTS_NY</value>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1484,21 +1484,22 @@
     </values>
   </entry>
 
-  <entry id="iop_mode" modify_via_xml="IOP_MODE">
+  <entry id="scm_domain" modify_via_xml="PTS_DOMAIN_MODE">
     <type>logical</type>
     <category>seq_infodata_inparm</category>
     <group>seq_infodata_inparm</group>
     <desc>
+      Uses SCM functionality for multiple columns. Specifically,
       turns on Intensive Observation Period (IOP) mode, a planet covered
       with homogenous surface and forced identically with a forcing file,
-      set by IOP_MODE in env_case.xml, default: false
+      set by PTS_DOMAIN_MODE in env_case.xml, default: false
     </desc>
     <values>
-      <value>$IOP_MODE</value>
+      <value>$PTS_DOMAIN_MODE</value>
     </values>
   </entry>
 
-  <entry id="iop_nx" modify_via_xml="IOP_NX">
+  <entry id="scm_nx" modify_via_xml="PTS_NX">
     <type>integer</type>
     <category>seq_infodata_inparm</category>
     <group>seq_infodata_inparm</group>
@@ -1506,11 +1507,11 @@
       number of points in x direction for doubly periodic mode
     </desc>
     <values>
-      <value>$IOP_NX</value>
+      <value>$PTS_NX</value>
     </values>
   </entry>
 
-  <entry id="iop_ny" modify_via_xml="IOP_NY">
+  <entry id="scm_ny" modify_via_xml="PTS_NY">
     <type>integer</type>
     <category>seq_infodata_inparm</category>
     <group>seq_infodata_inparm</group>
@@ -1518,7 +1519,7 @@
       number of points in Y direction for doubly periodic mode
     </desc>
     <values>
-      <value>$IOP_NY</value>
+      <value>$PTS_NY</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1504,7 +1504,7 @@
     <category>seq_infodata_inparm</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      number of points in x direction for doubly periodic mode
+      number of points in x direction for SCM mode
     </desc>
     <values>
       <value>$PTS_NX</value>
@@ -1516,7 +1516,7 @@
     <category>seq_infodata_inparm</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      number of points in Y direction for doubly periodic mode
+      number of points in Y direction for SCM mode
     </desc>
     <values>
       <value>$PTS_NY</value>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -1498,6 +1498,30 @@
     </values>
   </entry>
 
+  <entry id="iop_nx" modify_via_xml="IOP_NX">
+    <type>integer</type>
+    <category>seq_infodata_inparm</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      number of points in x direction for doubly periodic mode
+    </desc>
+    <values>
+      <value>$IOP_NX</value>
+    </values>
+  </entry>
+
+  <entry id="iop_ny" modify_via_xml="IOP_NY">
+    <type>integer</type>
+    <category>seq_infodata_inparm</category>
+    <group>seq_infodata_inparm</group>
+    <desc>
+      number of points in Y direction for doubly periodic mode
+    </desc>
+    <values>
+      <value>$IOP_NY</value>
+    </values>
+  </entry>
+
   <entry id="single_column" modify_via_xml="PTS_MODE">
     <type>logical</type>
     <category>seq_infodata_inparm</category>

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -456,6 +456,8 @@ module cime_comp_mod
   logical  :: aqua_planet            ! aqua planet mode
   real(r8) :: nextsw_cday            ! radiation control
   logical  :: atm_aero               ! atm provides aerosol data
+  integer  :: iop_nx                 ! number of doubly periodic points x direction
+  integer  :: iop_ny                 ! number of doubly periodic points y direction
 
   character(CL) :: cpl_seq_option    ! coupler sequencing option
   logical  :: skip_ocean_run         ! skip the ocean model first pass
@@ -1114,6 +1116,8 @@ contains
          iac_present=iac_present                   , &
          single_column=single_column               , &
          iop_mode=iop_mode                         , &
+         iop_nx=iop_nx                             , &
+         iop_ny=iop_ny                             , &
          aqua_planet=aqua_planet                   , &
          cpl_seq_option=cpl_seq_option             , &
          drv_threading=drv_threading               , &
@@ -1329,7 +1333,7 @@ contains
        call seq_comm_getinfo(OCNID(ens1), mpicom=mpicom_OCNID)
 
        call shr_scam_checkSurface(scmlon, scmlat, &
-            iop_mode,                             &
+            iop_mode,iop_nx,iop_ny,               &
             OCNID(ens1), mpicom_OCNID,            &
             lnd_present=lnd_present,              &
             ocn_present=ocn_present,              &

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -450,7 +450,7 @@ module cime_comp_mod
 
   logical  :: areafact_samegrid      ! areafact samegrid flag
   logical  :: single_column          ! scm mode logical
-  logical  :: scm_domain             ! scm mode over entire domain logical
+  logical  :: scm_multcols           ! scm mode over multiple columns logical
   real(r8) :: scmlon                 ! single column lon
   real(r8) :: scmlat                 ! single column lat
   logical  :: aqua_planet            ! aqua planet mode
@@ -1115,7 +1115,7 @@ contains
          esp_present=esp_present                   , &
          iac_present=iac_present                   , &
          single_column=single_column               , &
-         scm_domain=scm_domain                     , &
+         scm_multcols=scm_multcols                 , &
          scm_nx=scm_nx                             , &
          scm_ny=scm_ny                             , &
          aqua_planet=aqua_planet                   , &
@@ -1333,7 +1333,7 @@ contains
        call seq_comm_getinfo(OCNID(ens1), mpicom=mpicom_OCNID)
 
        call shr_scam_checkSurface(scmlon, scmlat, &
-            scm_domain,scm_nx,scm_ny,             &
+            scm_multcols,scm_nx,scm_ny,           &
             OCNID(ens1), mpicom_OCNID,            &
             lnd_present=lnd_present,              &
             ocn_present=ocn_present,              &

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -450,14 +450,14 @@ module cime_comp_mod
 
   logical  :: areafact_samegrid      ! areafact samegrid flag
   logical  :: single_column          ! scm mode logical
-  logical  :: iop_mode               ! iop mode logical
+  logical  :: scm_domain             ! scm mode over entire domain logical
   real(r8) :: scmlon                 ! single column lon
   real(r8) :: scmlat                 ! single column lat
   logical  :: aqua_planet            ! aqua planet mode
   real(r8) :: nextsw_cday            ! radiation control
   logical  :: atm_aero               ! atm provides aerosol data
-  integer  :: iop_nx                 ! number of doubly periodic points x direction
-  integer  :: iop_ny                 ! number of doubly periodic points y direction
+  integer  :: scm_nx                 ! number of SCM domain points in x direction
+  integer  :: scm_ny                 ! number of SCM domain points in y direction
 
   character(CL) :: cpl_seq_option    ! coupler sequencing option
   logical  :: skip_ocean_run         ! skip the ocean model first pass
@@ -1115,9 +1115,9 @@ contains
          esp_present=esp_present                   , &
          iac_present=iac_present                   , &
          single_column=single_column               , &
-         iop_mode=iop_mode                         , &
-         iop_nx=iop_nx                             , &
-         iop_ny=iop_ny                             , &
+         scm_domain=scm_domain                     , &
+         scm_nx=scm_nx                             , &
+         scm_ny=scm_ny                             , &
          aqua_planet=aqua_planet                   , &
          cpl_seq_option=cpl_seq_option             , &
          drv_threading=drv_threading               , &
@@ -1333,7 +1333,7 @@ contains
        call seq_comm_getinfo(OCNID(ens1), mpicom=mpicom_OCNID)
 
        call shr_scam_checkSurface(scmlon, scmlat, &
-            iop_mode,iop_nx,iop_ny,               &
+            scm_domain,scm_nx,scm_ny,             &
             OCNID(ens1), mpicom_OCNID,            &
             lnd_present=lnd_present,              &
             ocn_present=ocn_present,              &

--- a/src/drivers/mct/main/cime_comp_mod.F90
+++ b/src/drivers/mct/main/cime_comp_mod.F90
@@ -456,8 +456,8 @@ module cime_comp_mod
   logical  :: aqua_planet            ! aqua planet mode
   real(r8) :: nextsw_cday            ! radiation control
   logical  :: atm_aero               ! atm provides aerosol data
-  integer  :: scm_nx                 ! number of SCM domain points in x direction
-  integer  :: scm_ny                 ! number of SCM domain points in y direction
+  integer  :: scm_nx                 ! points in x direction for SCM functionality
+  integer  :: scm_ny                 ! points in y direction for SCM functionality
 
   character(CL) :: cpl_seq_option    ! coupler sequencing option
   logical  :: skip_ocean_run         ! skip the ocean model first pass

--- a/src/drivers/mct/main/seq_map_type_mod.F90
+++ b/src/drivers/mct/main/seq_map_type_mod.F90
@@ -168,10 +168,10 @@ contains
 
     s1 = mct_gsMap_gsize(gsMap1)
     s2 = mct_gsMap_gsize(gsMap2)
-!    if (s1 /= s2) then
-!       write(logunit,*) trim(subname),'gsmap global sizes different ',s1,s2
-!       call shr_sys_abort(subName // "different gsmap size")
-!    endif
+    if (s1 /= s2) then
+       write(logunit,*) trim(subname),'gsmap global sizes different ',s1,s2
+       call shr_sys_abort(subName // "different gsmap size")
+    endif
 
   end subroutine seq_map_gsmapcheck
 

--- a/src/drivers/mct/main/seq_map_type_mod.F90
+++ b/src/drivers/mct/main/seq_map_type_mod.F90
@@ -168,10 +168,10 @@ contains
 
     s1 = mct_gsMap_gsize(gsMap1)
     s2 = mct_gsMap_gsize(gsMap2)
-    if (s1 /= s2) then
-       write(logunit,*) trim(subname),'gsmap global sizes different ',s1,s2
-       call shr_sys_abort(subName // "different gsmap size")
-    endif
+!    if (s1 /= s2) then
+!       write(logunit,*) trim(subname),'gsmap global sizes different ',s1,s2
+!       call shr_sys_abort(subName // "different gsmap size")
+!    endif
 
   end subroutine seq_map_gsmapcheck
 

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -86,6 +86,8 @@ MODULE seq_infodata_mod
      logical                 :: iop_mode        ! IOP mode
      real (SHR_KIND_R8)      :: scmlat          ! single column lat
      real (SHR_KIND_R8)      :: scmlon          ! single column lon
+     integer(SHR_KIND_IN)    :: iop_nx          ! points in x direction doubly periodic
+     integer(SHR_KIND_IN)    :: iop_ny          ! points in y direction doubly periodic
      character(SHR_KIND_CS)  :: logFilePostFix  ! postfix for output log files
      character(SHR_KIND_CL)  :: outPathRoot     ! root for output log files
      logical                 :: perpetual       ! perpetual flag
@@ -335,6 +337,8 @@ CONTAINS
     logical                :: iop_mode           ! IOP mode
     real (SHR_KIND_R8)     :: scmlat             ! single column mode latitude
     real (SHR_KIND_R8)     :: scmlon             ! single column mode longitude
+    integer(SHR_KIND_IN)    :: iop_nx          ! points in x direction doubly periodic
+    integer(SHR_KIND_IN)    :: iop_ny          ! points in y direction doubly periodic
     character(SHR_KIND_CS) :: logFilePostFix     ! postfix for output log files
     character(SHR_KIND_CL) :: outPathRoot        ! root output files
     logical                :: perpetual          ! perpetual mode
@@ -431,6 +435,7 @@ CONTAINS
          restart_pfile, restart_file, run_barriers,        &
          single_column, scmlat, force_stop_at,             &
          scmlon, iop_mode, logFilePostFix, outPathRoot, flux_diurnal,&
+         iop_nx, iop_ny,          &
          ocn_surface_flux_scheme, &
          coldair_outbreak_mod, &
          flux_convergence, flux_max_iteration,             &
@@ -496,6 +501,8 @@ CONTAINS
        iop_mode              = .false.
        scmlat                = -999.
        scmlon                = -999.
+       iop_nx                = -1
+       iop_ny                = -1
        logFilePostFix        = '.log'
        outPathRoot           = './'
        perpetual             = .false.
@@ -632,6 +639,8 @@ CONTAINS
        infodata%iop_mode              = iop_mode
        infodata%scmlat                = scmlat
        infodata%scmlon                = scmlon
+       infodata%iop_nx                = iop_nx
+       infodata%iop_ny                = iop_ny
        infodata%logFilePostFix        = logFilePostFix
        infodata%outPathRoot           = outPathRoot
        infodata%perpetual             = perpetual
@@ -969,6 +978,7 @@ CONTAINS
        start_type, restart_pfile, restart_file, perpetual, perpetual_ymd, &
        aqua_planet,aqua_planet_sst, brnch_retain_casename, &
        single_column, scmlat,scmlon,iop_mode,logFilePostFix, outPathRoot,&
+       iop_nx, iop_ny,                                                    &
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic,                                       &
@@ -1038,6 +1048,8 @@ CONTAINS
     real (SHR_KIND_R8),     optional, intent(OUT) :: scmlat
     real (SHR_KIND_R8),     optional, intent(OUT) :: scmlon
     logical,                optional, intent(OUT) :: iop_mode
+    integer,                optional, intent(OUT) :: iop_nx
+    integer,                optional, intent(OUT) :: iop_ny
     character(len=*),       optional, intent(OUT) :: logFilePostFix          ! output log file postfix
     character(len=*),       optional, intent(OUT) :: outPathRoot             ! output file root
     logical,                optional, intent(OUT) :: perpetual               ! If this is perpetual
@@ -1216,6 +1228,8 @@ CONTAINS
     if ( present(iop_mode  )     ) iop_mode       = infodata%iop_mode
     if ( present(scmlat)         ) scmlat         = infodata%scmlat
     if ( present(scmlon)         ) scmlon         = infodata%scmlon
+    if ( present(iop_nx)         ) iop_nx         = infodata%iop_nx
+    if ( present(iop_ny)         ) iop_ny         = infodata%iop_ny
     if ( present(logFilePostFix) ) logFilePostFix = infodata%logFilePostFix
     if ( present(outPathRoot)    ) outPathRoot    = infodata%outPathRoot
     if ( present(perpetual)      ) perpetual      = infodata%perpetual
@@ -1506,6 +1520,7 @@ CONTAINS
        start_type, restart_pfile, restart_file, perpetual, perpetual_ymd, &
        aqua_planet,aqua_planet_sst, brnch_retain_casename, &
        single_column, scmlat,scmlon,iop_mode,logFilePostFix, outPathRoot,          &
+       iop_nx, iop_ny,                                                    &
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic,                                       &
@@ -1574,6 +1589,8 @@ CONTAINS
     real (SHR_KIND_R8),     optional, intent(IN)    :: scmlat
     real (SHR_KIND_R8),     optional, intent(IN)    :: scmlon
     logical,                optional, intent(IN)    :: iop_mode
+    integer,                optional, intent(IN)    :: iop_nx
+    integer,                optional, intent(IN)    :: iop_ny
     character(len=*),       optional, intent(IN)    :: logFilePostFix          ! output log file postfix
     character(len=*),       optional, intent(IN)    :: outPathRoot             ! output file root
     logical,                optional, intent(IN)    :: perpetual               ! If this is perpetual
@@ -1749,6 +1766,8 @@ CONTAINS
     if ( present(iop_mode)       ) infodata%iop_mode       = iop_mode
     if ( present(scmlat)         ) infodata%scmlat         = scmlat
     if ( present(scmlon)         ) infodata%scmlon         = scmlon
+    if ( present(iop_nx)         ) infodata%iop_nx         = iop_nx
+    if ( present(iop_ny)         ) infodata%iop_ny         = iop_ny
     if ( present(logFilePostFix) ) infodata%logFilePostFix = logFilePostFix
     if ( present(outPathRoot)    ) infodata%outPathRoot    = outPathRoot
     if ( present(perpetual)      ) infodata%perpetual      = perpetual
@@ -2052,6 +2071,8 @@ CONTAINS
     call shr_mpi_bcast(infodata%iop_mode,                mpicom)
     call shr_mpi_bcast(infodata%scmlat,                  mpicom)
     call shr_mpi_bcast(infodata%scmlon,                  mpicom)
+    call shr_mpi_bcast(infodata%iop_nx,                  mpicom)
+    call shr_mpi_bcast(infodata%iop_ny,                  mpicom)
     call shr_mpi_bcast(infodata%logFilePostFix,          mpicom)
     call shr_mpi_bcast(infodata%outPathRoot,             mpicom)
     call shr_mpi_bcast(infodata%perpetual,               mpicom)
@@ -2735,6 +2756,8 @@ CONTAINS
     write(logunit,F0L) subname,'iop_mode                 = ', infodata%iop_mode
     write(logunit,F0R) subname,'scmlat                   = ', infodata%scmlat
     write(logunit,F0R) subname,'scmlon                   = ', infodata%scmlon
+    write(logunit,F0I) subname,'iop_nx                   = ', infodata%iop_nx
+    write(logunit,F0I) subname,'iop_ny                   = ', infodata%iop_ny
 
     write(logunit,F0A) subname,'Log output end name      = ', trim(infodata%logFilePostFix)
     write(logunit,F0A) subname,'Output path dir          = ', trim(infodata%outPathRoot)

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -83,7 +83,7 @@ MODULE seq_infodata_mod
      character(SHR_KIND_CL)  :: restart_pfile   ! Restart pointer file
      character(SHR_KIND_CL)  :: restart_file    ! Full archive path to restart file
      logical                 :: single_column   ! single column mode
-     logical                 :: scm_domain      ! SCM mode across entire domain of multiple columns
+     logical                 :: scm_multcols    ! SCM mode extrapolated to multiple columns
      real (SHR_KIND_R8)      :: scmlat          ! single column lat
      real (SHR_KIND_R8)      :: scmlon          ! single column lon
      integer(SHR_KIND_IN)    :: scm_nx          ! points in x direction for SCM domain mode
@@ -334,7 +334,7 @@ CONTAINS
     character(SHR_KIND_CL) :: restart_file       ! Restart filename
 
     logical                :: single_column      ! single column mode
-    logical                :: scm_domain         ! SCM mode over entire domain of multiple columns
+    logical                :: scm_multcols       ! SCM mode extrapolated to multiple columns
     real (SHR_KIND_R8)     :: scmlat             ! single column mode latitude
     real (SHR_KIND_R8)     :: scmlon             ! single column mode longitude
     integer(SHR_KIND_IN)   :: scm_nx             ! points in x direction in SCM domain mode
@@ -434,8 +434,8 @@ CONTAINS
          brnch_retain_casename, info_debug, bfbflag,       &
          restart_pfile, restart_file, run_barriers,        &
          single_column, scmlat, force_stop_at,             &
-         scmlon, scm_domain, logFilePostFix, outPathRoot, flux_diurnal,&
-         scm_nx, scm_ny,          &
+         scmlon, logFilePostFix, outPathRoot, flux_diurnal,&
+         scm_multcols, scm_nx, scm_ny,                     &
          ocn_surface_flux_scheme, &
          coldair_outbreak_mod, &
          flux_convergence, flux_max_iteration,             &
@@ -498,7 +498,7 @@ CONTAINS
        restart_pfile         = 'rpointer.drv'
        restart_file          = trim(sp_str)
        single_column         = .false.
-       scm_domain            = .false.
+       scm_multcols          = .false.
        scmlat                = -999.
        scmlon                = -999.
        scm_nx                = -1
@@ -636,7 +636,7 @@ CONTAINS
           infodata%restart_file       = restart_file
        end if
        infodata%single_column         = single_column
-       infodata%scm_domain            = scm_domain
+       infodata%scm_multcols          = scm_multcols
        infodata%scmlat                = scmlat
        infodata%scmlon                = scmlon
        infodata%scm_nx                = scm_nx
@@ -977,8 +977,8 @@ CONTAINS
        model_version, username, hostname, rest_case_name, tchkpt_dir,     &
        start_type, restart_pfile, restart_file, perpetual, perpetual_ymd, &
        aqua_planet,aqua_planet_sst, brnch_retain_casename, &
-       single_column, scmlat,scmlon,scm_domain,logFilePostFix, outPathRoot,&
-       scm_nx, scm_ny,                                                    &
+       single_column, scmlat,scmlon,logFilePostFix, outPathRoot,&
+       scm_multcols, scm_nx, scm_ny,                                      &
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic,                                       &
@@ -1047,7 +1047,7 @@ CONTAINS
     logical,                optional, intent(OUT) :: single_column
     real (SHR_KIND_R8),     optional, intent(OUT) :: scmlat
     real (SHR_KIND_R8),     optional, intent(OUT) :: scmlon
-    logical,                optional, intent(OUT) :: scm_domain
+    logical,                optional, intent(OUT) :: scm_multcols
     integer,                optional, intent(OUT) :: scm_nx
     integer,                optional, intent(OUT) :: scm_ny
     character(len=*),       optional, intent(OUT) :: logFilePostFix          ! output log file postfix
@@ -1225,7 +1225,7 @@ CONTAINS
     if ( present(restart_pfile)  ) restart_pfile  = infodata%restart_pfile
     if ( present(restart_file)   ) restart_file   = infodata%restart_file
     if ( present(single_column)  ) single_column  = infodata%single_column
-    if ( present(scm_domain  )   ) scm_domain     = infodata%scm_domain
+    if ( present(scm_multcols)   ) scm_multcols   = infodata%scm_multcols
     if ( present(scmlat)         ) scmlat         = infodata%scmlat
     if ( present(scmlon)         ) scmlon         = infodata%scmlon
     if ( present(scm_nx)         ) scm_nx         = infodata%scm_nx
@@ -1519,8 +1519,8 @@ CONTAINS
        model_version, username, hostname, rest_case_name, tchkpt_dir,     &
        start_type, restart_pfile, restart_file, perpetual, perpetual_ymd, &
        aqua_planet,aqua_planet_sst, brnch_retain_casename, &
-       single_column, scmlat,scmlon,scm_domain,logFilePostFix, outPathRoot,          &
-       scm_nx, scm_ny,                                                    &
+       single_column, scmlat,scmlon,logFilePostFix, outPathRoot,          &
+       scm_multcols, scm_nx, scm_ny,                                      &
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic,                                       &
@@ -1588,7 +1588,7 @@ CONTAINS
     logical,                optional, intent(IN)    :: single_column
     real (SHR_KIND_R8),     optional, intent(IN)    :: scmlat
     real (SHR_KIND_R8),     optional, intent(IN)    :: scmlon
-    logical,                optional, intent(IN)    :: scm_domain
+    logical,                optional, intent(IN)    :: scm_multcols
     integer,                optional, intent(IN)    :: scm_nx
     integer,                optional, intent(IN)    :: scm_ny
     character(len=*),       optional, intent(IN)    :: logFilePostFix          ! output log file postfix
@@ -1763,7 +1763,7 @@ CONTAINS
     if ( present(restart_pfile)  ) infodata%restart_pfile  = restart_pfile
     if ( present(restart_file)   ) infodata%restart_file   = restart_file
     if ( present(single_column)  ) infodata%single_column  = single_column
-    if ( present(scm_domain)     ) infodata%scm_domain     = scm_domain
+    if ( present(scm_multcols)   ) infodata%scm_multcols   = scm_multcols
     if ( present(scmlat)         ) infodata%scmlat         = scmlat
     if ( present(scmlon)         ) infodata%scmlon         = scmlon
     if ( present(scm_nx)         ) infodata%scm_nx         = scm_nx
@@ -2068,7 +2068,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%restart_pfile,           mpicom)
     call shr_mpi_bcast(infodata%restart_file,            mpicom)
     call shr_mpi_bcast(infodata%single_column,           mpicom)
-    call shr_mpi_bcast(infodata%scm_domain,              mpicom)
+    call shr_mpi_bcast(infodata%scm_multcols,            mpicom)
     call shr_mpi_bcast(infodata%scmlat,                  mpicom)
     call shr_mpi_bcast(infodata%scmlon,                  mpicom)
     call shr_mpi_bcast(infodata%scm_nx,                  mpicom)
@@ -2753,7 +2753,7 @@ CONTAINS
     write(logunit,F0A) subname,'Restart file (full path) = ', trim(infodata%restart_file)
 
     write(logunit,F0L) subname,'single_column            = ', infodata%single_column
-    write(logunit,F0L) subname,'scm_domain               = ', infodata%scm_domain
+    write(logunit,F0L) subname,'scm_multcols             = ', infodata%scm_multcols
     write(logunit,F0R) subname,'scmlat                   = ', infodata%scmlat
     write(logunit,F0R) subname,'scmlon                   = ', infodata%scmlon
     write(logunit,F0I) subname,'scm_nx                   = ', infodata%scm_nx

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -86,8 +86,8 @@ MODULE seq_infodata_mod
      logical                 :: scm_multcols    ! SCM mode extrapolated to multiple columns
      real (SHR_KIND_R8)      :: scmlat          ! single column lat
      real (SHR_KIND_R8)      :: scmlon          ! single column lon
-     integer(SHR_KIND_IN)    :: scm_nx          ! points in x direction for SCM domain mode
-     integer(SHR_KIND_IN)    :: scm_ny          ! points in y direction for SCM domain mode
+     integer(SHR_KIND_IN)    :: scm_nx          ! points in x direction for SCM functionality
+     integer(SHR_KIND_IN)    :: scm_ny          ! points in y direction for SCM functionality
      character(SHR_KIND_CS)  :: logFilePostFix  ! postfix for output log files
      character(SHR_KIND_CL)  :: outPathRoot     ! root for output log files
      logical                 :: perpetual       ! perpetual flag
@@ -337,8 +337,8 @@ CONTAINS
     logical                :: scm_multcols       ! SCM mode extrapolated to multiple columns
     real (SHR_KIND_R8)     :: scmlat             ! single column mode latitude
     real (SHR_KIND_R8)     :: scmlon             ! single column mode longitude
-    integer(SHR_KIND_IN)   :: scm_nx             ! points in x direction in SCM domain mode
-    integer(SHR_KIND_IN)   :: scm_ny             ! points in y direction in SCM domain mode
+    integer(SHR_KIND_IN)   :: scm_nx             ! points in x direction for SCM functionality
+    integer(SHR_KIND_IN)   :: scm_ny             ! points in y direction for SCM functionality
     character(SHR_KIND_CS) :: logFilePostFix     ! postfix for output log files
     character(SHR_KIND_CL) :: outPathRoot        ! root output files
     logical                :: perpetual          ! perpetual mode

--- a/src/drivers/mct/shr/seq_infodata_mod.F90
+++ b/src/drivers/mct/shr/seq_infodata_mod.F90
@@ -83,11 +83,11 @@ MODULE seq_infodata_mod
      character(SHR_KIND_CL)  :: restart_pfile   ! Restart pointer file
      character(SHR_KIND_CL)  :: restart_file    ! Full archive path to restart file
      logical                 :: single_column   ! single column mode
-     logical                 :: iop_mode        ! IOP mode
+     logical                 :: scm_domain      ! SCM mode across entire domain of multiple columns
      real (SHR_KIND_R8)      :: scmlat          ! single column lat
      real (SHR_KIND_R8)      :: scmlon          ! single column lon
-     integer(SHR_KIND_IN)    :: iop_nx          ! points in x direction doubly periodic
-     integer(SHR_KIND_IN)    :: iop_ny          ! points in y direction doubly periodic
+     integer(SHR_KIND_IN)    :: scm_nx          ! points in x direction for SCM domain mode
+     integer(SHR_KIND_IN)    :: scm_ny          ! points in y direction for SCM domain mode
      character(SHR_KIND_CS)  :: logFilePostFix  ! postfix for output log files
      character(SHR_KIND_CL)  :: outPathRoot     ! root for output log files
      logical                 :: perpetual       ! perpetual flag
@@ -334,11 +334,11 @@ CONTAINS
     character(SHR_KIND_CL) :: restart_file       ! Restart filename
 
     logical                :: single_column      ! single column mode
-    logical                :: iop_mode           ! IOP mode
+    logical                :: scm_domain         ! SCM mode over entire domain of multiple columns
     real (SHR_KIND_R8)     :: scmlat             ! single column mode latitude
     real (SHR_KIND_R8)     :: scmlon             ! single column mode longitude
-    integer(SHR_KIND_IN)    :: iop_nx          ! points in x direction doubly periodic
-    integer(SHR_KIND_IN)    :: iop_ny          ! points in y direction doubly periodic
+    integer(SHR_KIND_IN)   :: scm_nx             ! points in x direction in SCM domain mode
+    integer(SHR_KIND_IN)   :: scm_ny             ! points in y direction in SCM domain mode
     character(SHR_KIND_CS) :: logFilePostFix     ! postfix for output log files
     character(SHR_KIND_CL) :: outPathRoot        ! root output files
     logical                :: perpetual          ! perpetual mode
@@ -434,8 +434,8 @@ CONTAINS
          brnch_retain_casename, info_debug, bfbflag,       &
          restart_pfile, restart_file, run_barriers,        &
          single_column, scmlat, force_stop_at,             &
-         scmlon, iop_mode, logFilePostFix, outPathRoot, flux_diurnal,&
-         iop_nx, iop_ny,          &
+         scmlon, scm_domain, logFilePostFix, outPathRoot, flux_diurnal,&
+         scm_nx, scm_ny,          &
          ocn_surface_flux_scheme, &
          coldair_outbreak_mod, &
          flux_convergence, flux_max_iteration,             &
@@ -498,11 +498,11 @@ CONTAINS
        restart_pfile         = 'rpointer.drv'
        restart_file          = trim(sp_str)
        single_column         = .false.
-       iop_mode              = .false.
+       scm_domain            = .false.
        scmlat                = -999.
        scmlon                = -999.
-       iop_nx                = -1
-       iop_ny                = -1
+       scm_nx                = -1
+       scm_ny                = -1
        logFilePostFix        = '.log'
        outPathRoot           = './'
        perpetual             = .false.
@@ -636,11 +636,11 @@ CONTAINS
           infodata%restart_file       = restart_file
        end if
        infodata%single_column         = single_column
-       infodata%iop_mode              = iop_mode
+       infodata%scm_domain            = scm_domain
        infodata%scmlat                = scmlat
        infodata%scmlon                = scmlon
-       infodata%iop_nx                = iop_nx
-       infodata%iop_ny                = iop_ny
+       infodata%scm_nx                = scm_nx
+       infodata%scm_ny                = scm_ny
        infodata%logFilePostFix        = logFilePostFix
        infodata%outPathRoot           = outPathRoot
        infodata%perpetual             = perpetual
@@ -977,8 +977,8 @@ CONTAINS
        model_version, username, hostname, rest_case_name, tchkpt_dir,     &
        start_type, restart_pfile, restart_file, perpetual, perpetual_ymd, &
        aqua_planet,aqua_planet_sst, brnch_retain_casename, &
-       single_column, scmlat,scmlon,iop_mode,logFilePostFix, outPathRoot,&
-       iop_nx, iop_ny,                                                    &
+       single_column, scmlat,scmlon,scm_domain,logFilePostFix, outPathRoot,&
+       scm_nx, scm_ny,                                                    &
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic,                                       &
@@ -1047,9 +1047,9 @@ CONTAINS
     logical,                optional, intent(OUT) :: single_column
     real (SHR_KIND_R8),     optional, intent(OUT) :: scmlat
     real (SHR_KIND_R8),     optional, intent(OUT) :: scmlon
-    logical,                optional, intent(OUT) :: iop_mode
-    integer,                optional, intent(OUT) :: iop_nx
-    integer,                optional, intent(OUT) :: iop_ny
+    logical,                optional, intent(OUT) :: scm_domain
+    integer,                optional, intent(OUT) :: scm_nx
+    integer,                optional, intent(OUT) :: scm_ny
     character(len=*),       optional, intent(OUT) :: logFilePostFix          ! output log file postfix
     character(len=*),       optional, intent(OUT) :: outPathRoot             ! output file root
     logical,                optional, intent(OUT) :: perpetual               ! If this is perpetual
@@ -1225,11 +1225,11 @@ CONTAINS
     if ( present(restart_pfile)  ) restart_pfile  = infodata%restart_pfile
     if ( present(restart_file)   ) restart_file   = infodata%restart_file
     if ( present(single_column)  ) single_column  = infodata%single_column
-    if ( present(iop_mode  )     ) iop_mode       = infodata%iop_mode
+    if ( present(scm_domain  )   ) scm_domain     = infodata%scm_domain
     if ( present(scmlat)         ) scmlat         = infodata%scmlat
     if ( present(scmlon)         ) scmlon         = infodata%scmlon
-    if ( present(iop_nx)         ) iop_nx         = infodata%iop_nx
-    if ( present(iop_ny)         ) iop_ny         = infodata%iop_ny
+    if ( present(scm_nx)         ) scm_nx         = infodata%scm_nx
+    if ( present(scm_ny)         ) scm_ny         = infodata%scm_ny
     if ( present(logFilePostFix) ) logFilePostFix = infodata%logFilePostFix
     if ( present(outPathRoot)    ) outPathRoot    = infodata%outPathRoot
     if ( present(perpetual)      ) perpetual      = infodata%perpetual
@@ -1519,8 +1519,8 @@ CONTAINS
        model_version, username, hostname, rest_case_name, tchkpt_dir,     &
        start_type, restart_pfile, restart_file, perpetual, perpetual_ymd, &
        aqua_planet,aqua_planet_sst, brnch_retain_casename, &
-       single_column, scmlat,scmlon,iop_mode,logFilePostFix, outPathRoot,          &
-       iop_nx, iop_ny,                                                    &
+       single_column, scmlat,scmlon,scm_domain,logFilePostFix, outPathRoot,          &
+       scm_nx, scm_ny,                                                    &
        atm_present, atm_prognostic,                                       &
        lnd_present, lnd_prognostic,                                       &
        rof_present, rof_prognostic,                                       &
@@ -1588,9 +1588,9 @@ CONTAINS
     logical,                optional, intent(IN)    :: single_column
     real (SHR_KIND_R8),     optional, intent(IN)    :: scmlat
     real (SHR_KIND_R8),     optional, intent(IN)    :: scmlon
-    logical,                optional, intent(IN)    :: iop_mode
-    integer,                optional, intent(IN)    :: iop_nx
-    integer,                optional, intent(IN)    :: iop_ny
+    logical,                optional, intent(IN)    :: scm_domain
+    integer,                optional, intent(IN)    :: scm_nx
+    integer,                optional, intent(IN)    :: scm_ny
     character(len=*),       optional, intent(IN)    :: logFilePostFix          ! output log file postfix
     character(len=*),       optional, intent(IN)    :: outPathRoot             ! output file root
     logical,                optional, intent(IN)    :: perpetual               ! If this is perpetual
@@ -1763,11 +1763,11 @@ CONTAINS
     if ( present(restart_pfile)  ) infodata%restart_pfile  = restart_pfile
     if ( present(restart_file)   ) infodata%restart_file   = restart_file
     if ( present(single_column)  ) infodata%single_column  = single_column
-    if ( present(iop_mode)       ) infodata%iop_mode       = iop_mode
+    if ( present(scm_domain)     ) infodata%scm_domain     = scm_domain
     if ( present(scmlat)         ) infodata%scmlat         = scmlat
     if ( present(scmlon)         ) infodata%scmlon         = scmlon
-    if ( present(iop_nx)         ) infodata%iop_nx         = iop_nx
-    if ( present(iop_ny)         ) infodata%iop_ny         = iop_ny
+    if ( present(scm_nx)         ) infodata%scm_nx         = scm_nx
+    if ( present(scm_ny)         ) infodata%scm_ny         = scm_ny
     if ( present(logFilePostFix) ) infodata%logFilePostFix = logFilePostFix
     if ( present(outPathRoot)    ) infodata%outPathRoot    = outPathRoot
     if ( present(perpetual)      ) infodata%perpetual      = perpetual
@@ -2068,11 +2068,11 @@ CONTAINS
     call shr_mpi_bcast(infodata%restart_pfile,           mpicom)
     call shr_mpi_bcast(infodata%restart_file,            mpicom)
     call shr_mpi_bcast(infodata%single_column,           mpicom)
-    call shr_mpi_bcast(infodata%iop_mode,                mpicom)
+    call shr_mpi_bcast(infodata%scm_domain,              mpicom)
     call shr_mpi_bcast(infodata%scmlat,                  mpicom)
     call shr_mpi_bcast(infodata%scmlon,                  mpicom)
-    call shr_mpi_bcast(infodata%iop_nx,                  mpicom)
-    call shr_mpi_bcast(infodata%iop_ny,                  mpicom)
+    call shr_mpi_bcast(infodata%scm_nx,                  mpicom)
+    call shr_mpi_bcast(infodata%scm_ny,                  mpicom)
     call shr_mpi_bcast(infodata%logFilePostFix,          mpicom)
     call shr_mpi_bcast(infodata%outPathRoot,             mpicom)
     call shr_mpi_bcast(infodata%perpetual,               mpicom)
@@ -2753,11 +2753,11 @@ CONTAINS
     write(logunit,F0A) subname,'Restart file (full path) = ', trim(infodata%restart_file)
 
     write(logunit,F0L) subname,'single_column            = ', infodata%single_column
-    write(logunit,F0L) subname,'iop_mode                 = ', infodata%iop_mode
+    write(logunit,F0L) subname,'scm_domain               = ', infodata%scm_domain
     write(logunit,F0R) subname,'scmlat                   = ', infodata%scmlat
     write(logunit,F0R) subname,'scmlon                   = ', infodata%scmlon
-    write(logunit,F0I) subname,'iop_nx                   = ', infodata%iop_nx
-    write(logunit,F0I) subname,'iop_ny                   = ', infodata%iop_ny
+    write(logunit,F0I) subname,'scm_nx                   = ', infodata%scm_nx
+    write(logunit,F0I) subname,'scm_ny                   = ', infodata%scm_ny
 
     write(logunit,F0A) subname,'Log output end name      = ', trim(infodata%logFilePostFix)
     write(logunit,F0A) subname,'Output path dir          = ', trim(infodata%outPathRoot)

--- a/src/share/streams/shr_dmodel_mod.F90
+++ b/src/share/streams/shr_dmodel_mod.F90
@@ -292,8 +292,8 @@ CONTAINS
        lscmmode = scmmode
        lscmdomain = scm_domain
        if (lscmdomain .and. .not. lscmmode) then
-         write(logunit,*) subname, ' ERROR: IOP mode must be run with SCM functionality'
-         call shr_sys_abort(subname//' ERROR: IOP not in SCM mode')
+         write(logunit,*) subname, ' ERROR: SCM mode for multiple columns must be run with SCM functionality'
+         call shr_sys_abort(subname//' ERROR: SCM domain mode in SCM mode')
        endif
        if (lscmmode) then
           if (.not.present(scmlon) .or. .not.present(scmlat)) then
@@ -525,7 +525,7 @@ CONTAINS
 
           if (lscmdomain) then
 
-            ! If IOP mode, then we want the surface to be
+            ! If SCM domain mode, then we want the surface to be
             !   covered homogeneously, with the same lat and lon
             !   as close to the lat/lon in IOP forcing file as possible
             i_scm = ni

--- a/src/share/streams/shr_dmodel_mod.F90
+++ b/src/share/streams/shr_dmodel_mod.F90
@@ -220,8 +220,8 @@ CONTAINS
     logical          ,optional, intent(in)    :: scm_multcols ! SCM mode for multiple columns
     real(R8)         ,optional, intent(in)    :: scmlon   ! single column lon
     real(R8)         ,optional, intent(in)    :: scmlat   ! single column lat
-    integer(IN)      ,optional, intent(in)    :: scm_nx   ! number points for SCM domain x direction
-    integer(IN)      ,optional, intent(in)    :: scm_ny   ! number points for SCM domain y direction
+    integer(IN)      ,optional, intent(in)    :: scm_nx   ! points in x direction for SCM functionality
+    integer(IN)      ,optional, intent(in)    :: scm_ny   ! points in y direction for SCM functionality
 
     !----- local -----
     integer(IN)   :: n,k,j,i     ! indices

--- a/src/share/streams/shr_strdata_mod.F90
+++ b/src/share/streams/shr_strdata_mod.F90
@@ -154,7 +154,7 @@ contains
 !===============================================================================
 
   subroutine shr_strdata_init( &
-       SDAT,mpicom,compid,name,scmmode,scm_domain,scmlon,scmlat, &
+       SDAT,mpicom,compid,name,scmmode,scm_multcols,scmlon,scmlat, &
        scm_nx,scm_ny, &
        gsmap, ggrid, nxg, nyg, nzg, &
        calendar, reset_domain_mask, dmodel_domain_fracname_from_stream)
@@ -169,7 +169,7 @@ contains
     integer(IN)           ,intent(in)          :: compid
     character(len=*)      ,intent(in),optional :: name
     logical               ,intent(in),optional :: scmmode
-    logical               ,intent(in),optional :: scm_domain
+    logical               ,intent(in),optional :: scm_multcols
     real(R8)              ,intent(in),optional :: scmlon
     real(R8)              ,intent(in),optional :: scmlat
     integer(IN)           ,intent(in),optional :: scm_nx
@@ -216,7 +216,7 @@ contains
          gsmap=gsmap, ggrid=ggrid, nxg=nxg, nyg=nyg, nzg=nzg, &
          reset_domain_mask=reset_domain_mask, &
          dmodel_domain_fracname_from_stream=dmodel_domain_fracname_from_stream, &
-         scmmode=scmmode, scm_domain=scm_domain, scmlon=scmlon, scmlat=scmlat, &
+         scmmode=scmmode, scm_multcols=scm_multcols, scmlon=scmlon, scmlat=scmlat, &
          scm_nx=scm_nx,scm_ny=scm_ny)
 
     !------------------------------------------------------
@@ -236,7 +236,7 @@ contains
   !===============================================================================
 
   subroutine shr_strdata_init_model_domain(SDAT, mpicom, compid, my_task, &
-       gsmap, ggrid, nxg, nyg, nzg, scmmode, scm_domain, scmlon, scmlat, &
+       gsmap, ggrid, nxg, nyg, nzg, scmmode, scm_multcols, scmlon, scmlat, &
        scm_nx, scm_ny, reset_domain_mask, dmodel_domain_fracname_from_stream)
 
     ! input/output variables
@@ -250,7 +250,7 @@ contains
     integer(IN)           ,intent(in),optional :: nyg
     integer(IN)           ,intent(in),optional :: nzg
     logical               ,intent(in),optional :: scmmode
-    logical               ,intent(in),optional :: scm_domain
+    logical               ,intent(in),optional :: scm_multcols
     real(R8)              ,intent(in),optional :: scmlon
     real(R8)              ,intent(in),optional :: scmlat
     integer(IN)           ,intent(in),optional :: scm_nx
@@ -288,14 +288,14 @@ contains
     logical        :: readfrac     ! whether to read fraction from the first stream file
     integer        :: kmask, kfrac
     logical        :: lscmmode
-    logical        :: lscm_domain
+    logical        :: lscm_multcols
     integer(IN)      ,parameter :: master_task = 0
     character(*)     ,parameter :: F00 = "('(shr_strdata_init) ',8a)"
     character(len=*) ,parameter :: subname = "(shr_strdata_init) "
     !-------------------------------------------------------------------------------
 
     lscmmode = .false.
-    lscm_domain = .false.
+    lscm_multcols = .false.
     if (present(scmmode)) then
        lscmmode = scmmode
        if (lscmmode) then
@@ -306,8 +306,8 @@ contains
        endif
     endif
 
-    if (present(scm_domain)) then
-      lscm_domain=scm_domain
+    if (present(scm_multcols)) then
+      lscm_multcols=scm_multcols
     endif
 
     if (present(gsmap) .and. present(ggrid) .and. present(nxg) .and. present(nyg) .and. present(nzg)) then
@@ -361,7 +361,7 @@ contains
                      decomp=decomp, lonName=lonName, latName=latName, hgtName=hgtName, &
                      maskName=maskName, areaName=areaName, &
                      fracname=dmodel_domain_fracname_from_stream, readfrac=readfrac, &
-                     scmmode=lscmmode, scm_domain=lscm_domain, scmlon=scmlon, scmlat=scmlat)
+                     scmmode=lscmmode, scm_multcols=lscm_multcols, scmlon=scmlon, scmlat=scmlat)
              else
                 call shr_dmodel_readgrid(SDAT%grid,SDAT%gsmap, SDAT%nxg, SDAT%nyg, SDAT%nzg, &
                      fileName, compid, mpicom, &
@@ -386,7 +386,7 @@ contains
           if (lscmmode) then
              call shr_dmodel_readgrid(SDAT%grid,SDAT%gsmap,SDAT%nxg,SDAT%nyg,SDAT%nzg, &
                   SDAT%domainfile, compid, mpicom, &
-                  decomp=decomp, readfrac=.true., scmmode=lscmmode, scm_domain=lscm_domain, &
+                  decomp=decomp, readfrac=.true., scmmode=lscmmode, scm_multcols=lscm_multcols, &
                   scmlon=scmlon, scmlat=scmlat, scm_nx=scm_nx, scm_ny=scm_ny)
           else
              call shr_dmodel_readgrid(SDAT%grid, SDAT%gsmap, SDAT%nxg, SDAT%nyg, SDAT%nzg, &

--- a/src/share/streams/shr_strdata_mod.F90
+++ b/src/share/streams/shr_strdata_mod.F90
@@ -154,8 +154,8 @@ contains
 !===============================================================================
 
   subroutine shr_strdata_init( &
-       SDAT,mpicom,compid,name,scmmode,iop_mode,scmlon,scmlat, &
-       iop_nx,iop_ny, &
+       SDAT,mpicom,compid,name,scmmode,scm_domain,scmlon,scmlat, &
+       scm_nx,scm_ny, &
        gsmap, ggrid, nxg, nyg, nzg, &
        calendar, reset_domain_mask, dmodel_domain_fracname_from_stream)
 
@@ -169,11 +169,11 @@ contains
     integer(IN)           ,intent(in)          :: compid
     character(len=*)      ,intent(in),optional :: name
     logical               ,intent(in),optional :: scmmode
-    logical               ,intent(in),optional :: iop_mode
+    logical               ,intent(in),optional :: scm_domain
     real(R8)              ,intent(in),optional :: scmlon
     real(R8)              ,intent(in),optional :: scmlat
-    integer(IN)           ,intent(in),optional :: iop_nx
-    integer(IN)           ,intent(in),optional :: iop_ny
+    integer(IN)           ,intent(in),optional :: scm_nx
+    integer(IN)           ,intent(in),optional :: scm_ny
     type(mct_gsmap)       ,intent(in),optional :: gsmap
     type(mct_ggrid)       ,intent(in),optional :: ggrid
     integer(IN)           ,intent(in),optional :: nxg
@@ -216,8 +216,8 @@ contains
          gsmap=gsmap, ggrid=ggrid, nxg=nxg, nyg=nyg, nzg=nzg, &
          reset_domain_mask=reset_domain_mask, &
          dmodel_domain_fracname_from_stream=dmodel_domain_fracname_from_stream, &
-         scmmode=scmmode, iop_mode=iop_mode, scmlon=scmlon, scmlat=scmlat, &
-         iop_nx=iop_nx,iop_ny=iop_ny)
+         scmmode=scmmode, scm_domain=scm_domain, scmlon=scmlon, scmlat=scmlat, &
+         scm_nx=scm_nx,scm_ny=scm_ny)
 
     !------------------------------------------------------
     ! --- (2) initialize streams and stream domains ---
@@ -236,8 +236,8 @@ contains
   !===============================================================================
 
   subroutine shr_strdata_init_model_domain(SDAT, mpicom, compid, my_task, &
-       gsmap, ggrid, nxg, nyg, nzg, scmmode, iop_mode, scmlon, scmlat, &
-       iop_nx, iop_ny, reset_domain_mask, dmodel_domain_fracname_from_stream)
+       gsmap, ggrid, nxg, nyg, nzg, scmmode, scm_domain, scmlon, scmlat, &
+       scm_nx, scm_ny, reset_domain_mask, dmodel_domain_fracname_from_stream)
 
     ! input/output variables
     type(shr_strdata_type),intent(inout)       :: SDAT
@@ -250,11 +250,11 @@ contains
     integer(IN)           ,intent(in),optional :: nyg
     integer(IN)           ,intent(in),optional :: nzg
     logical               ,intent(in),optional :: scmmode
-    logical               ,intent(in),optional :: iop_mode
+    logical               ,intent(in),optional :: scm_domain
     real(R8)              ,intent(in),optional :: scmlon
     real(R8)              ,intent(in),optional :: scmlat
-    integer(IN)           ,intent(in),optional :: iop_nx
-    integer(IN)           ,intent(in),optional :: iop_ny
+    integer(IN)           ,intent(in),optional :: scm_nx
+    integer(IN)           ,intent(in),optional :: scm_ny
     logical               ,intent(in),optional :: reset_domain_mask
     character(len=*)      ,intent(in),optional :: dmodel_domain_fracname_from_stream
 
@@ -288,14 +288,14 @@ contains
     logical        :: readfrac     ! whether to read fraction from the first stream file
     integer        :: kmask, kfrac
     logical        :: lscmmode
-    logical        :: liop_mode
+    logical        :: lscm_domain
     integer(IN)      ,parameter :: master_task = 0
     character(*)     ,parameter :: F00 = "('(shr_strdata_init) ',8a)"
     character(len=*) ,parameter :: subname = "(shr_strdata_init) "
     !-------------------------------------------------------------------------------
 
     lscmmode = .false.
-    liop_mode = .false.
+    lscm_domain = .false.
     if (present(scmmode)) then
        lscmmode = scmmode
        if (lscmmode) then
@@ -306,8 +306,8 @@ contains
        endif
     endif
 
-    if (present(iop_mode)) then
-      liop_mode=iop_mode
+    if (present(scm_domain)) then
+      lscm_domain=scm_domain
     endif
 
     if (present(gsmap) .and. present(ggrid) .and. present(nxg) .and. present(nyg) .and. present(nzg)) then
@@ -361,7 +361,7 @@ contains
                      decomp=decomp, lonName=lonName, latName=latName, hgtName=hgtName, &
                      maskName=maskName, areaName=areaName, &
                      fracname=dmodel_domain_fracname_from_stream, readfrac=readfrac, &
-                     scmmode=lscmmode, iop_mode=liop_mode, scmlon=scmlon, scmlat=scmlat)
+                     scmmode=lscmmode, scm_domain=lscm_domain, scmlon=scmlon, scmlat=scmlat)
              else
                 call shr_dmodel_readgrid(SDAT%grid,SDAT%gsmap, SDAT%nxg, SDAT%nyg, SDAT%nzg, &
                      fileName, compid, mpicom, &
@@ -386,8 +386,8 @@ contains
           if (lscmmode) then
              call shr_dmodel_readgrid(SDAT%grid,SDAT%gsmap,SDAT%nxg,SDAT%nyg,SDAT%nzg, &
                   SDAT%domainfile, compid, mpicom, &
-                  decomp=decomp, readfrac=.true., scmmode=lscmmode, iop_mode=liop_mode, &
-                  scmlon=scmlon, scmlat=scmlat, iop_nx=iop_nx, iop_ny=iop_ny)
+                  decomp=decomp, readfrac=.true., scmmode=lscmmode, scm_domain=lscm_domain, &
+                  scmlon=scmlon, scmlat=scmlat, scm_nx=scm_nx, scm_ny=scm_ny)
           else
              call shr_dmodel_readgrid(SDAT%grid, SDAT%gsmap, SDAT%nxg, SDAT%nyg, SDAT%nzg, &
                   SDAT%domainfile, compid, mpicom, &

--- a/src/share/streams/shr_strdata_mod.F90
+++ b/src/share/streams/shr_strdata_mod.F90
@@ -155,6 +155,7 @@ contains
 
   subroutine shr_strdata_init( &
        SDAT,mpicom,compid,name,scmmode,iop_mode,scmlon,scmlat, &
+       iop_nx,iop_ny, &
        gsmap, ggrid, nxg, nyg, nzg, &
        calendar, reset_domain_mask, dmodel_domain_fracname_from_stream)
 
@@ -171,6 +172,8 @@ contains
     logical               ,intent(in),optional :: iop_mode
     real(R8)              ,intent(in),optional :: scmlon
     real(R8)              ,intent(in),optional :: scmlat
+    integer(IN)           ,intent(in),optional :: iop_nx
+    integer(IN)           ,intent(in),optional :: iop_ny
     type(mct_gsmap)       ,intent(in),optional :: gsmap
     type(mct_ggrid)       ,intent(in),optional :: ggrid
     integer(IN)           ,intent(in),optional :: nxg
@@ -213,7 +216,8 @@ contains
          gsmap=gsmap, ggrid=ggrid, nxg=nxg, nyg=nyg, nzg=nzg, &
          reset_domain_mask=reset_domain_mask, &
          dmodel_domain_fracname_from_stream=dmodel_domain_fracname_from_stream, &
-         scmmode=scmmode, iop_mode=iop_mode, scmlon=scmlon, scmlat=scmlat)
+         scmmode=scmmode, iop_mode=iop_mode, scmlon=scmlon, scmlat=scmlat, &
+         iop_nx=iop_nx,iop_ny=iop_ny)
 
     !------------------------------------------------------
     ! --- (2) initialize streams and stream domains ---
@@ -233,7 +237,7 @@ contains
 
   subroutine shr_strdata_init_model_domain(SDAT, mpicom, compid, my_task, &
        gsmap, ggrid, nxg, nyg, nzg, scmmode, iop_mode, scmlon, scmlat, &
-       reset_domain_mask, dmodel_domain_fracname_from_stream)
+       iop_nx, iop_ny, reset_domain_mask, dmodel_domain_fracname_from_stream)
 
     ! input/output variables
     type(shr_strdata_type),intent(inout)       :: SDAT
@@ -249,6 +253,8 @@ contains
     logical               ,intent(in),optional :: iop_mode
     real(R8)              ,intent(in),optional :: scmlon
     real(R8)              ,intent(in),optional :: scmlat
+    integer(IN)           ,intent(in),optional :: iop_nx
+    integer(IN)           ,intent(in),optional :: iop_ny
     logical               ,intent(in),optional :: reset_domain_mask
     character(len=*)      ,intent(in),optional :: dmodel_domain_fracname_from_stream
 
@@ -381,7 +387,7 @@ contains
              call shr_dmodel_readgrid(SDAT%grid,SDAT%gsmap,SDAT%nxg,SDAT%nyg,SDAT%nzg, &
                   SDAT%domainfile, compid, mpicom, &
                   decomp=decomp, readfrac=.true., scmmode=lscmmode, iop_mode=liop_mode, &
-                  scmlon=scmlon, scmlat=scmlat)
+                  scmlon=scmlon, scmlat=scmlat, iop_nx=iop_nx, iop_ny=iop_ny)
           else
              call shr_dmodel_readgrid(SDAT%grid, SDAT%gsmap, SDAT%nxg, SDAT%nyg, SDAT%nzg, &
                   SDAT%domainfile, compid, mpicom, &

--- a/src/share/util/shr_scam_mod.F90
+++ b/src/share/util/shr_scam_mod.F90
@@ -587,8 +587,8 @@ end subroutine shr_scam_getCloseLatLonFile
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, ocn_compid, ocn_mpicom, &
-     lnd_present, sno_present, ocn_present, ice_present, &
+subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, iop_nx, iop_ny, &
+     ocn_compid, ocn_mpicom, lnd_present, sno_present, ocn_present, ice_present, &
      rof_present, flood_present, rofice_present)
 
 ! !USES:
@@ -602,6 +602,8 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, ocn_compid, ocn_mpico
 
    real(R8),                     intent(in)  :: scmlon,scmlat ! single column lat lon
    logical,                      intent(in)  :: iop_mode     ! iop mode logical
+   integer(IN),                  intent(in)  :: iop_nx       ! number points in x direction
+   integer(IN),                  intent(in)  :: iop_ny       ! number points in y direction
    integer(IN),                  intent(in)  :: ocn_compid   ! id for ocean model
    integer(IN),                  intent(in)  :: ocn_mpicom   ! mpi communicator for ocean
    logical,            optional, intent(inout) :: lnd_present  ! land point
@@ -713,7 +715,8 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, ocn_compid, ocn_mpico
       call shr_strdata_readnml(SCAMSDAT,'docn_in')
       call shr_dmodel_readgrid(SCAMSDAT%grid,SCAMSDAT%gsmap,SCAMSDAT%nxg,SCAMSDAT%nyg,SCAMSDAT%nzg, &
            SCAMSDAT%domainfile, ocn_compid, ocn_mpicom, '2d1d', readfrac=.true., &
-           scmmode=.true.,iop_mode=iop_mode,scmlon=scmlon,scmlat=scmlat)
+           scmmode=.true.,iop_mode=iop_mode,scmlon=scmlon,scmlat=scmlat, &
+           iop_nx=iop_nx,iop_ny=iop_ny)
       nfrac = mct_aVect_indexRA(SCAMSDAT%grid%data,'frac')
 
       ocn_point = (SCAMSDAT%grid%data%rAttr(nfrac,1) > 0._r8)

--- a/src/share/util/shr_scam_mod.F90
+++ b/src/share/util/shr_scam_mod.F90
@@ -587,7 +587,7 @@ end subroutine shr_scam_getCloseLatLonFile
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, iop_nx, iop_ny, &
+subroutine shr_scam_checkSurface(scmlon, scmlat, scm_domain, scm_nx, scm_ny, &
      ocn_compid, ocn_mpicom, lnd_present, sno_present, ocn_present, ice_present, &
      rof_present, flood_present, rofice_present)
 
@@ -601,9 +601,9 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, iop_nx, iop_ny, &
 ! !INPUT/OUTPUT PARAMETERS:
 
    real(R8),                     intent(in)  :: scmlon,scmlat ! single column lat lon
-   logical,                      intent(in)  :: iop_mode     ! iop mode logical
-   integer(IN),                  intent(in)  :: iop_nx       ! number points in x direction
-   integer(IN),                  intent(in)  :: iop_ny       ! number points in y direction
+   logical,                      intent(in)  :: scm_domain   ! SCM over domain logical
+   integer(IN),                  intent(in)  :: scm_nx       ! number points in x direction
+   integer(IN),                  intent(in)  :: scm_ny       ! number points in y direction
    integer(IN),                  intent(in)  :: ocn_compid   ! id for ocean model
    integer(IN),                  intent(in)  :: ocn_mpicom   ! mpi communicator for ocean
    logical,            optional, intent(inout) :: lnd_present  ! land point
@@ -715,8 +715,8 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, iop_mode, iop_nx, iop_ny, &
       call shr_strdata_readnml(SCAMSDAT,'docn_in')
       call shr_dmodel_readgrid(SCAMSDAT%grid,SCAMSDAT%gsmap,SCAMSDAT%nxg,SCAMSDAT%nyg,SCAMSDAT%nzg, &
            SCAMSDAT%domainfile, ocn_compid, ocn_mpicom, '2d1d', readfrac=.true., &
-           scmmode=.true.,iop_mode=iop_mode,scmlon=scmlon,scmlat=scmlat, &
-           iop_nx=iop_nx,iop_ny=iop_ny)
+           scmmode=.true.,scm_domain=scm_domain,scmlon=scmlon,scmlat=scmlat, &
+           scm_nx=scm_nx,scm_ny=scm_ny)
       nfrac = mct_aVect_indexRA(SCAMSDAT%grid%data,'frac')
 
       ocn_point = (SCAMSDAT%grid%data%rAttr(nfrac,1) > 0._r8)

--- a/src/share/util/shr_scam_mod.F90
+++ b/src/share/util/shr_scam_mod.F90
@@ -587,7 +587,7 @@ end subroutine shr_scam_getCloseLatLonFile
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-subroutine shr_scam_checkSurface(scmlon, scmlat, scm_domain, scm_nx, scm_ny, &
+subroutine shr_scam_checkSurface(scmlon, scmlat, scm_multcols, scm_nx, scm_ny, &
      ocn_compid, ocn_mpicom, lnd_present, sno_present, ocn_present, ice_present, &
      rof_present, flood_present, rofice_present)
 
@@ -601,7 +601,7 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, scm_domain, scm_nx, scm_ny, &
 ! !INPUT/OUTPUT PARAMETERS:
 
    real(R8),                     intent(in)  :: scmlon,scmlat ! single column lat lon
-   logical,                      intent(in)  :: scm_domain   ! SCM over domain logical
+   logical,                      intent(in)  :: scm_multcols ! SCM over domain logical
    integer(IN),                  intent(in)  :: scm_nx       ! number points in x direction
    integer(IN),                  intent(in)  :: scm_ny       ! number points in y direction
    integer(IN),                  intent(in)  :: ocn_compid   ! id for ocean model
@@ -715,7 +715,7 @@ subroutine shr_scam_checkSurface(scmlon, scmlat, scm_domain, scm_nx, scm_ny, &
       call shr_strdata_readnml(SCAMSDAT,'docn_in')
       call shr_dmodel_readgrid(SCAMSDAT%grid,SCAMSDAT%gsmap,SCAMSDAT%nxg,SCAMSDAT%nyg,SCAMSDAT%nzg, &
            SCAMSDAT%domainfile, ocn_compid, ocn_mpicom, '2d1d', readfrac=.true., &
-           scmmode=.true.,scm_domain=scm_domain,scmlon=scmlon,scmlat=scmlat, &
+           scmmode=.true.,scm_multcols=scm_multcols,scmlon=scmlon,scmlat=scmlat, &
            scm_nx=scm_nx,scm_ny=scm_ny)
       nfrac = mct_aVect_indexRA(SCAMSDAT%grid%data,'frac')
 


### PR DESCRIPTION
PR changes the name of the ambiguously named flag “iop_mode” with “scm_multcols”, which turns on single column model (SCM) functionality but for multiple columns.  Specifically, its purpose is to take the column on the globe intended to be run in SCM mode, but propagates that point (i.e. meaning surface type and location etc.) to multiple columns, as defined by the user.  All columns are then forced identically according to the Intensive Observation Period (IOP) file, which is typically required to run in SCM mode.  This PR also adds the flexibility for the user to determine the number of columns in the x & y direction (PTS_NX, PTX_NY and scm_nx, scm_ny).

Background/Motivation for changes: This PR is intended to support running a doubly periodic cloud resolving model with the planar version of HOMME (specifically, the doubly periodic version of SCREAM) but could be potentially useful for other applications.

Test suite: scripts_regression_tests on cori
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
