### PR TITLE
bug fix for specifying mesh for  0.25 degree runoff grid 

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1820,13 +1820,13 @@
 
     <domain name="JRA025v2">
       <nx>1440</nx> <ny>720</ny>
-      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/JRA025m.170209_ESMFmesh.nc</mesh>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/lnd/dlnd7/JRA55/JRA.v1.4.runoff.1958_ESMFmesh_cdf5_20201020.nc</mesh>
       <desc>JRA 0.25 degree runoff grid for use with JRA-55 runoff data</desc>
     </domain>
 
     <domain name="JRA025">
       <nx>1440</nx> <ny>720</ny>
-      <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/JRA025m.170209_ESMFmesh.nc</mesh>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/lnd/dlnd7/JRA55/JRA.v1.4.runoff.1958_ESMFmesh_cdf5_20201020.nc</mesh>
       <desc>JRA is 0.25 degree runoff grid for use with JRA-55 runoff data</desc>
     </domain>
 


### PR DESCRIPTION
fixed specification of nuopc mesh for 0.25 degree runoff grid 

This mesh is used for JRA55 runoff data

Verified that now 
```
SMS_Vnuopc_Ld1.TL319_g17.GIAF_JRA.cheyenne_intel.pop-default
SMS_Vmct_Ld1.TL319_g17.GIAF_JRA.cheyenne_intel.pop-default
```
have roundoff level runoff input differences

Test suite: None
Test baseline: No
Test namelist changes: No
Test status: [bit for bit, roundoff, climate changing] NA
Fixes: None
User interface changes?: No
Update gh-pages html (Y/N)?:No
Code review: 
