### PR TITLE
Switch e3sm config to COMP_ROOT_DIR

### DIFF
--- a/config/e3sm/config_files.xml
+++ b/config/e3sm/config_files.xml
@@ -101,20 +101,165 @@
   <!-- Depends on component attribute value   -->
   <!-- ============================================================ -->
 
+  <entry id="COMP_ROOT_DIR_CPL">
+    <type>char</type>
+    <values>
+      <value>$CIMEROOT/src/drivers/$COMP_INTERFACE</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case driver/coupler component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+  <entry id="COMP_ROOT_DIR_ATM">
+    <type>char</type>
+    <values>
+      <value component="datm"                        >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/datm</value>
+      <value component="satm"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/satm</value>
+      <value component="xatm"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xatm</value>
+      <value component="eam"                         >$SRCROOT/components/eam/</value>
+      <value component="scream"                      >$SRCROOT/components/scream/</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case atmospheric component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+  <entry id="COMP_ROOT_DIR_LND">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value component="elm"                         >$SRCROOT/components/elm/</value>
+      <value component="dlnd"                        >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dlnd</value>
+      <value component="slnd"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/slnd</value>
+      <value component="xlnd"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xlnd</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case land model component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+
+  <entry id="COMP_ROOT_DIR_ROF">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value component="mosart"                      >$SRCROOT/components/mosart/</value>
+      <value component="drof"                        >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/drof</value>
+      <value component="srof"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/srof</value>
+      <value component="xrof"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xrof</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case river runoff model component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+  <entry id="COMP_ROOT_DIR_ICE">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value component="dice"                        >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dice</value>
+      <value component="sice"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sice</value>
+      <value component="xice"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xice</value>
+      <value component="mpassi"                      >$SRCROOT/components/mpas-seaice</value>
+      <value component="cice"                        >$SRCROOT/components/cice</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case sea ice component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+  <entry id="COMP_ROOT_DIR_OCN">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value component="docn"                         >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/docn</value>
+      <value component="socn"                         >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/socn</value>
+      <value component="xocn"                         >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xocn</value>
+      <value component="mpaso"                        >$SRCROOT/components/mpas-ocean</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case ocean component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+  <entry id="COMP_ROOT_DIR_WAV">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value component="ww3"                         >$SRCROOT/components/ww3/</value>
+      <value component="dwav" comp_interface="mct"   >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dwav</value>
+      <value component="swav"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/swav</value>
+      <value component="xwav"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xwav</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case wave model component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+  <entry id="COMP_ROOT_DIR_GLC">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value component="mali"  >$SRCROOT/components/mpas-albany-landice</value>
+      <value component="dglc" >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dglc</value>
+      <value component="sglc" >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sglc</value>
+      <value component="xglc" >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xglc</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case land ice component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+  <entry id="COMP_ROOT_DIR_IAC">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value component="siac"      >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/siac</value>
+      <value component="xiac"      >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xiac</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case integrated assessment component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+  <entry id="COMP_ROOT_DIR_ESP">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value component="desp"      >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/desp</value>
+      <value component="sesp"      >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sesp</value>
+    </values>
+    <group>case_comps</group>
+    <file>env_case.xml</file>
+    <desc>Root directory of the case external system processing (esp) component  </desc>
+    <schema>$CIMEROOT/config/xml_schemas/config_compsets.xsd</schema>
+  </entry>
+
+
   <entry id="COMPSETS_SPEC_FILE">
     <type>char</type>
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/allactive/config_compsets.xml</value>
-      <value component="drv"      >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/config_compsets.xml</value>
-      <value component="eam"      >$SRCROOT/components/eam/cime_config/config_compsets.xml</value>
-      <value component="scream"   >$SRCROOT/components/scream/cime_config/config_compsets.xml</value>
-      <value component="elm"      >$SRCROOT/components/elm/cime_config/config_compsets.xml</value>
-      <value component="cice"     >$SRCROOT/components/cice/cime_config/config_compsets.xml</value>
-      <value component="mpaso"    >$SRCROOT/components/mpas-ocean/cime_config/config_compsets.xml</value>
-      <value component="mali"     >$SRCROOT/components/mpas-albany-landice/cime_config/config_compsets.xml</value>
-      <value component="mpassi"   >$SRCROOT/components/mpas-seaice/cime_config/config_compsets.xml</value>
-      <value component="mosart"   >$SRCROOT/components/mosart/cime_config/config_compsets.xml</value>
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_compsets.xml</value>
+      <value component="eam"      >$COMP_ROOT_DIR_ATM/cime_config/config_compsets.xml</value>
+      <value component="scream"   >$COMP_ROOT_DIR_ATM/cime_config/config_compsets.xml</value>
+      <value component="elm"      >$COMP_ROOT_DIR_LND/cime_config/config_compsets.xml</value>
+      <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
+      <value component="mpaso"    >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
+      <value component="mali"     >$COMP_ROOT_DIR_GLC/cime_config/config_compsets.xml</value>
+      <value component="mpassi"   >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
+      <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/config_compsets.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -127,7 +272,7 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/allactive/config_pesall.xml</value>
-      <value component="drv"      >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/config_pes.xml</value>
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_pes.xml</value>
       <value component="eam"      >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="elm"      >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="cice"     >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
@@ -140,22 +285,20 @@
     <desc>file containing specification of all pe-layouts for primary component (for documentation only - DO NOT EDIT)</desc>
     <schema>$CIMEROOT/config/xml_schemas/config_pes.xsd</schema>
   </entry>
+
   <entry id="ARCHIVE_SPEC_FILE">
     <type>char</type>
     <values>
       <value>$SRCROOT/cime_config/config_archive.xml</value>
-      <value component="drv"      >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/config_archive.xml</value>
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_archive.xml</value>
       <!-- data model components -->
-      <value component="drof">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/drof/cime_config/config_archive.xml</value>
-      <value component="datm">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/datm/cime_config/config_archive.xml</value>
-      <value component="dice">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dice/cime_config/config_archive.xml</value>
-      <value component="dlnd">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dlnd/cime_config/config_archive.xml</value>
-      <value component="docn">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/docn/cime_config/config_archive.xml</value>
-      <value component="dwav">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dwav/cime_config/config_archive.xml</value>
+      <value component="drof">$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
+      <value component="datm">$COMP_ROOT_DIR_ATM/cime_config/config_archive.xml</value>
+      <value component="dice">$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
+      <value component="dlnd">$COMP_ROOT_DIR_LND/cime_config/config_archive.xml</value>
+      <value component="docn">$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
+      <value component="dwav">$COMP_ROOT_DIR_WAV/cime_config/config_archive.xml</value>
       <!-- external model components -->
-      <value component="eam"      >$SRCROOT/components/eam/cime_config/config_archive.xml</value>
-      <value component="elm"      >$SRCROOT/components/elm/cime_config/config_archive.xml</value>
-      <value component="cice"     >$SRCROOT/components/cice/cime_config/config_archive.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -167,9 +310,6 @@
     <type>char</type>
     <values>
       <value component="any">$CIMEROOT/scripts/lib/CIME/SystemTests</value>
-      <value component="elm">$SRCROOT/components/elm/cime_config/SystemTests</value>
-      <value component="eam">$SRCROOT/components/eam/cime_config/SystemTests</value>
-      <value component="cice">$SRCROOT/components/cice/cime_config/SystemTests</value>
     </values>
     <group>test</group>
     <file>env_test.xml</file>
@@ -189,12 +329,12 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/testmods_dirs</value>
-      <value component="drv"      >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/testdefs/testmods_dirs</value>
-      <value component="eam"      >$SRCROOT/components/eam/cime_config/testdefs/testmods_dirs</value>
-      <value component="elm"      >$SRCROOT/components/elm/cime_config/testdefs/testmods_dirs</value>
-      <value component="cice"     >$SRCROOT/components/cice/cime_config/testdefs/testmods_dirs</value>
-      <value component="mosart"   >$SRCROOT/components/mosart/cime_config/testdefs/testmods_dirs</value>
-      <value component="scream"   >$SRCROOT/components/scream/cime_config/testdefs/testmods_dirs</value>
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/testdefs/testmods_dirs</value>
+      <value component="eam"      >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
+      <value component="elm"      >$COMP_ROOT_DIR_LND/cime_config/testdefs/testmods_dirs</value>
+      <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testmods_dirs</value>
+      <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
+      <value component="scream"   >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -206,12 +346,12 @@
     <default_value>unset</default_value>
     <values>
       <value component="allactive">$SRCROOT/cime_config/usermods_dirs</value>
-      <value component="drv"      >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/usermods_dirs</value>
-      <value component="eam"      >$SRCROOT/components/eam/cime_config/usermods_dirs</value>
-      <value component="elm"      >$SRCROOT/components/elm/cime_config/usermods_dirs</value>
-      <value component="cice"     >$SRCROOT/components/cice/cime_config/usermods_dirs</value>
-      <value component="mosart"   >$SRCROOT/components/mosart/cime_config/usermods_dirs</value>
-      <value component="scream"   >$SRCROOT/components/scream/cime_config/usermods_dirs</value>
+      <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/usermods_dirs</value>
+      <value component="eam"      >$COMP_ROOT_DIR_ATM/cime_config/usermods_dirs</value>
+      <value component="elm"      >$COMP_ROOT_DIR_LND/cime_config/usermods_dirs</value>
+      <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/usermods_dirs</value>
+      <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/usermods_dirs</value>
+      <value component="scream"   >$COMP_ROOT_DIR_ATM/cime_config/usermods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -222,14 +362,14 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="drv"     >$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/namelist_definition_drv.xml</value>
+      <value component="drv"     >$COMP_ROOT_DIR_CPL/cime_config/namelist_definition_drv.xml</value>
       <!-- data model components -->
-      <value component="drof">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/drof/cime_config/namelist_definition_drof.xml</value>
-      <value component="datm">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/datm/cime_config/namelist_definition_datm.xml</value>
-      <value component="dice">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dice/cime_config/namelist_definition_dice.xml</value>
-      <value component="dlnd">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dlnd/cime_config/namelist_definition_dlnd.xml</value>
-      <value component="docn">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/docn/cime_config/namelist_definition_docn.xml</value>
-      <value component="dwav">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dwav/cime_config/namelist_definition_dwav.xml</value>
+      <value component="drof">$COMP_ROOT_DIR_ROF/cime_config/namelist_definition_drof.xml</value>
+      <value component="datm">$COMP_ROOT_DIR_ATM/cime_config/namelist_definition_datm.xml</value>
+      <value component="dice">$COMP_ROOT_DIR_ICE/cime_config/namelist_definition_dice.xml</value>
+      <value component="dlnd">$COMP_ROOT_DIR_LND/cime_config/namelist_definition_dlnd.xml</value>
+      <value component="docn">$COMP_ROOT_DIR_OCN/cime_config/namelist_definition_docn.xml</value>
+      <value component="dwav">$COMP_ROOT_DIR_WAV/cime_config/namelist_definition_dwav.xml</value>
       <!-- external model components -->
       <!--  TODO
       <value component="cam"      >$SRCROOT/components/cam/bld/namelist_files/namelist_definition.xml</value>
@@ -251,7 +391,7 @@
   <entry id="CONFIG_CPL_FILE">
     <type>char</type>
     <values>
-    <value>$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/config_component.xml</value>
+    <value>$COMP_ROOT_DIR_CPL/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -274,13 +414,8 @@
 
   <entry id="CONFIG_ATM_FILE">
     <type>char</type>
-    <default_value>unset</default_value>
     <values>
-      <value component="eam"   >$SRCROOT/components/eam/cime_config/config_component.xml</value>
-      <value component="scream">$SRCROOT/components/scream/cime_config/config_component.xml</value>
-      <value component="datm"  >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/datm/cime_config/config_component.xml</value>
-      <value component="satm"  >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/satm/cime_config/config_component.xml</value>
-      <value component="xatm"  >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xatm/cime_config/config_component.xml</value>
+      <value>$COMP_ROOT_DIR_ATM/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -291,12 +426,8 @@
 
   <entry id="CONFIG_LND_FILE">
     <type>char</type>
-    <default_value>unset</default_value>
     <values>
-      <value component="elm" >$SRCROOT/components/elm/cime_config/config_component.xml</value>
-      <value component="dlnd">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dlnd/cime_config/config_component.xml</value>
-      <value component="slnd">$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/slnd/cime_config/config_component.xml</value>
-      <value component="xlnd">$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xlnd/cime_config/config_component.xml</value>
+      <value>$COMP_ROOT_DIR_LND/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -307,12 +438,8 @@
 
   <entry id="CONFIG_ROF_FILE">
     <type>char</type>
-    <default_value>unset</default_value>
     <values>
-      <value component="mosart"	>$SRCROOT/components/mosart/cime_config/config_component.xml</value>
-      <value component="drof"	>$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/drof/cime_config/config_component.xml</value>
-      <value component="srof"	>$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/srof/cime_config/config_component.xml</value>
-      <value component="xrof"	>$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xrof/cime_config/config_component.xml</value>
+      <value>$COMP_ROOT_DIR_ROF/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -323,13 +450,8 @@
 
   <entry id="CONFIG_ICE_FILE">
     <type>char</type>
-    <default_value>unset</default_value>
     <values>
-      <value component="mpassi">$SRCROOT/components/mpas-seaice/cime_config/config_component.xml</value>
-      <value component="cice">$SRCROOT/components/cice/cime_config/config_component.xml</value>
-      <value component="dice">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dice/cime_config/config_component.xml</value>
-      <value component="sice">$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sice/cime_config/config_component.xml</value>
-      <value component="xice">$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xice/cime_config/config_component.xml</value>
+      <value>$COMP_ROOT_DIR_ICE/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -340,12 +462,8 @@
 
   <entry id="CONFIG_OCN_FILE">
     <type>char</type>
-    <default_value>unset</default_value>
     <values>
-      <value component="mpaso"  >$SRCROOT/components/mpas-ocean/cime_config/config_component.xml</value>
-      <value component="docn" >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/docn/cime_config/config_component.xml</value>
-      <value component="socn" >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/socn/cime_config/config_component.xml</value>
-      <value component="xocn" >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xocn/cime_config/config_component.xml</value>
+      <value>$COMP_ROOT_DIR_OCN/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -356,11 +474,8 @@
 
   <entry id="CONFIG_GLC_FILE">
     <type>char</type>
-    <default_value>unset</default_value>
     <values>
-      <value component="mali">$SRCROOT/components/mpas-albany-landice/cime_config/config_component.xml</value>
-      <value component="sglc">$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sglc/cime_config/config_component.xml</value>
-      <value component="xglc">$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xglc/cime_config/config_component.xml</value>
+      <value>$COMP_ROOT_DIR_GLC/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -371,9 +486,8 @@
 
   <entry id="CONFIG_IAC_FILE">
     <type>char</type>
-    <default_value>unset</default_value>
     <values>
-      <value component="siac">$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/siac/cime_config/config_component.xml</value>
+      <value>$COMP_ROOT_DIR_IAC/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -384,11 +498,8 @@
 
   <entry id="CONFIG_WAV_FILE">
     <type>char</type>
-    <default_value>unset</default_value>
     <values>
-      <value component="dwav">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dwav/cime_config/config_component.xml</value>
-      <value component="swav">$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/swav/cime_config/config_component.xml</value>
-      <value component="xwav">$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xwav/cime_config/config_component.xml</value>
+      <value>$COMP_ROOT_DIR_WAV/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -399,10 +510,8 @@
 
   <entry id="CONFIG_ESP_FILE">
     <type>char</type>
-    <default_value>$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sesp/cime_config/config_component.xml</default_value>
     <values>
-      <value component="sesp">$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sesp/cime_config/config_component.xml</value>
-      <value component="desp">$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/desp/cime_config/config_component.xml</value>
+      <value >$COMP_ROOT_DIR_ESP/cime_config/config_component.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>


### PR DESCRIPTION
Use COMP_ROOT_DIR_* for the paths of various
files in e3sm config_files.xml

Test suite:  passed create_test --no-build e3sm_integration and xmllint.
Test namelist changes:  none
Test status: bit for bit
