### PR TITLE
fixes to nuopc single column PTS_LAT and PTS_LON

### DIFF
--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -235,8 +235,10 @@ class Grids(GenericXML):
                 comp_name = grid[0].upper()
 
                 # determine xml variable name
-                domains["PTS_LAT"] = '-999.99'
-                domains["PTS_LON"] = '-999.99'
+                if not "PTS_LAT" in domains:
+                    domains["PTS_LAT"] = '-999.99'
+                if not "PTS_LON" in domains:
+                    domains["PTS_LON"] = '-999.99'
                 if not comp_name == "MASK":
                     if self.get_element_text("nx", root=domain_node):
                         domains[comp_name + "_NX"] = int(self.get_element_text("nx", root=domain_node))


### PR DESCRIPTION
fixes to nuopc single column PTS_LAT and PTS_LON

Tested that SMS_D_Ld6_Mmpi-serial_Vnuopc.1x1_smallvilleIA.IHistClm45BgcCropQianRs.cheyenne_intel.clm-cropMonthOutput had PTS_LAT and PTS_LON set correctly.  Before these were set to -999.99 for this test.

Test suite: (see above)
Test baseline: NA
Test namelist changes: No
Test status: bit for bit
Fixes: None
User interface changes?: No
Update gh-pages html (Y/N)?:N
Code review: jedwards4b
