### PR TITLE
Add ROF support in the primary component computation

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -563,6 +563,9 @@ class Case(object):
         elif "GLC" in progcomps and progcomps["GLC"]:
             # This is a "TG" compset
             primary_component = spec["GLC"]
+        elif progcomps["ROF"]:
+            # This is a "R" compset
+            primary_component = spec["ROF"]
         else:
             # This is "A", "X" or "S"
             primary_component = "drv"


### PR DESCRIPTION
Without this change, "drv" gets selected as the primary component for a compset that has mosart as the primary component: 2000_DATM%QIA_DLND%QIA_SICE_SOCN_MOSART_SGLC_SWAV_SIAC_SESP

Test suite: by-hand, scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
