### PR TITLE
archive pop.rh.ecosys.nyear1 files

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -38,7 +38,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - id: load-env
-        run: sudo apt-get install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
+        run: |
+          #sudo apt-get update
+          sudo apt-get install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -50,7 +52,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/pnetcdf
-          key: ${{ runner.os }}-${{ env.PNETCDF_VERSION}}-pnetcdf
+          key: ${{ runner.os }}-${{ env.PNETCDF_VERSION}}-pnetcdf-redo
 
       - name: pnetcdf build
         if: steps.cache-pnetcdf.outputs.cache-hit != 'true'
@@ -69,7 +71,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/netcdf-fortran
-          key: ${{ runner.os }}-${{ env.NETCDF_FORTRAN_VERSION }}-netcdf-fortran
+          key: ${{ runner.os }}-${{ env.NETCDF_FORTRAN_VERSION }}-netcdf-fortran-redo
 
       - name: netcdf fortran build
         if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
@@ -113,3 +115,9 @@ jobs:
           export PATH=$NETCDF/bin:$PATH
           export LD_LIBRARY_PATH=$NETCDF/lib:$HOME/pnetcdf/lib:$LD_LIBRARY_PATH
           ./scripts_regression_tests.py --no-fortran-run --compiler gnu --mpilib openmpi --machine ubuntu-latest
+
+#     the following can be used by developers to login to the github server in case of errors
+#     see https://github.com/marketplace/actions/debugging-with-tmate for further details
+#      - name: Setup tmate session
+#        if: ${{ failure() }}
+#        uses: mxschmitt/action-tmate@v3

--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -17,7 +17,8 @@
 
   <comp_archive_spec compname="pop" compclass="ocn">
     <rest_file_extension>r</rest_file_extension>
-    <rest_file_extension>r[ho]</rest_file_extension>
+    <rest_file_extension>ro.*</rest_file_extension>
+    <rest_file_extension>rh.*</rest_file_extension>
     <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
     <hist_file_extension>d[dovt]</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
@@ -37,6 +38,7 @@
       <tfile disposition="copy">rpointer.pop</tfile>
       <tfile disposition="copy">casename.pop_0001.r.1976-01-01-00000.nc</tfile>
       <tfile disposition="copy">casename.pop.r.1976-01-01-00000.nc</tfile>
+      <tfile disposition="copy">casename.pop.rh.ecosys.nyear1.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.pop.h.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.pop.h.1975-02-01-00000.nc</tfile>
       <tfile disposition="move">casename.pop.h0.1976-01-01-00000.nc</tfile>


### PR DESCRIPTION
Files of the form pop.rh.ecosys.nyear1. were not being archived.  A template of the file name was added to <test_file_names> and a change was made to rest_file_extension to solve the problem.

Test suite: added template to <test_file_names>, reproduced the problem with case.st_archive --test-all then fixed the issue with a change to rest_file_extension to solve the problem.
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes #3896 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
