### PR TITLE
bug fix for single column mode for nuopc/cmeps

### DIFF
--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -300,8 +300,8 @@ class Grids(GenericXML):
                 driver_attrib = self.get(mesh_node, "driver")
                 if driver == driver_attrib:
                     domains["MASK_MESH"] = self.text(mesh_node)
-                if (domains["PTS_LAT"] != '-999.99' and domains["PTS_LON"] != '-999.99'):
-                    domains["PTS_DOMAINFILE"] = os.path.join("$DIN_LOC_ROOT/share/domains",domains["ATM_DOMAIN_FILE"])
+                    if domains["LND_DOMAIN_FILE"] != 'UNSET':
+                        domains["PTS_DOMAINFILE"] = os.path.join("$DIN_LOC_ROOT/share/domains",domains["LND_DOMAIN_FILE"])
 
         return domains
 


### PR DESCRIPTION
This is another small bug fix get the new single column functionality working for nuopc/cmeps
This fixes the test  SMS_Ld1_Mmpi-serial_Vnuopc.f45_f45_mg37.I2000Clm50SpRs.cheyenne_intel.clm-ptsRLA

Test suite:  SMS_Ld1_Mmpi-serial_Vnuopc.f45_f45_mg37.I2000Clm50SpRs.cheyenne_intel.clm-ptsRLA
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit
Fixes: None
User interface changes?: No
Update gh-pages html (Y/N)?: N
Code review: 
