### PR TITLE
support for threading in two different ways for esmf

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -39,7 +39,7 @@ jobs:
 
       - id: load-env
         run: |
-          #sudo apt-get update
+          sudo apt-get update
           sudo apt-get install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -635,7 +635,6 @@ This allows using a different mpirun command to launch unit tests
       <env name="UGCSFIXEDFILEPATH">/glade/work/turuncu/FV3GFS/fix_am</env>
       <env name="UGCSADDONPATH">/glade/work/turuncu/FV3GFS/addon</env>
       <env name="OMP_WAIT_POLICY">PASSIVE</env>
-<!--      <env name="OMP_PROC_BIND">true</env> -->
       <env name="MPI_DSM_VERBOSE">true</env>
     </environment_variables>
     <environment_variables unit_testing="true">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -644,8 +644,6 @@ This allows using a different mpirun command to launch unit tests
       <env name="TMPDIR">/glade/scratch/$USER</env>
     </environment_variables>
     <resource_limits>
-      <!--      <resource name="RLIMIT_STACK"> 80000000</resource> -->
-      <!-- set to unlimited -->
       <resource name="RLIMIT_STACK">-1</resource>
     </resource_limits>
   </machine>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -644,7 +644,9 @@ This allows using a different mpirun command to launch unit tests
       <env name="TMPDIR">/glade/scratch/$USER</env>
     </environment_variables>
     <resource_limits>
-      <resource name="RLIMIT_STACK"> 80000000</resource>
+      <!--      <resource name="RLIMIT_STACK"> 80000000</resource> -->
+      <!-- set to unlimited -->
+      <resource name="RLIMIT_STACK">-1</resource>
     </resource_limits>
   </machine>
 

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -472,6 +472,7 @@ This allows using a different mpirun command to launch unit tests
       <arguments>
         <arg name="labelstdout">-p "%g:"</arg>
         <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        <arg name="zthreadplacement"> omplace -tm open64 -vv</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpt" queue="share" comp_interface="nuopc">
@@ -633,16 +634,18 @@ This allows using a different mpirun command to launch unit tests
       <env name="UGCSINPUTPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/2012010100/gfs/fcst</env>
       <env name="UGCSFIXEDFILEPATH">/glade/work/turuncu/FV3GFS/fix_am</env>
       <env name="UGCSADDONPATH">/glade/work/turuncu/FV3GFS/addon</env>
+      <env name="OMP_WAIT_POLICY">PASSIVE</env>
+<!--      <env name="OMP_PROC_BIND">true</env> -->
+      <env name="MPI_DSM_VERBOSE">true</env>
     </environment_variables>
     <environment_variables unit_testing="true">
       <env name="MPI_USE_ARRAY">false</env>
     </environment_variables>
     <environment_variables queue="share">
       <env name="TMPDIR">/glade/scratch/$USER</env>
-<!--      <env name="MPI_USE_ARRAY">false</env> -->
     </environment_variables>
     <resource_limits>
-      <resource name="RLIMIT_STACK"> -1</resource>
+      <resource name="RLIMIT_STACK"> 80000000</resource>
     </resource_limits>
   </machine>
 

--- a/scripts/Tools/pelayout
+++ b/scripts/Tools/pelayout
@@ -63,11 +63,11 @@ def parse_command_line(args, description):
                         help="Number of threads to set for all components")
 
     parser.add_argument("--format",
-                        default="%4C: %6T/%6H; %6R",
+                        default="%4C: %6T/%6H; %6R %6P",
                         help="Format the PE layout items for each component (see below)")
 
     parser.add_argument("--header",
-                        default="Comp  NTASKS  NTHRDS  ROOTPE",
+                        default="Comp  NTASKS  NTHRDS  ROOTPE PSTRIDE",
                         help="Custom header for PE layout display")
 
     parser.add_argument("--no-header", default=False , action="store_true" ,
@@ -96,23 +96,24 @@ def get_value_as_string(case, var, attribute=None, resolved=False, subgroup=None
     return value
 
 ###############################################################################
-def format_pelayout(comp, ntasks, nthreads, rootpe, arg_format):
+def format_pelayout(comp, ntasks, nthreads, rootpe, pstride, arg_format):
 ###############################################################################
     """
     Format the PE layout information for each component, using a default format,
     or using the arg_format input, if it exists.
     """
-    subs = { 'C': comp, 'T': ntasks, 'H': nthreads, 'R': rootpe }
+    subs = { 'C': comp, 'T': ntasks, 'H': nthreads, 'R': rootpe, 'P' : pstride}
     layout_str = re.sub(r"%([0-9]*)C", r"{C:\1}", arg_format)
     layout_str = re.sub(r"%([-+0-9]*)T", r"{T:\1}", layout_str)
     layout_str = re.sub(r"%([-+0-9]*)H", r"{H:\1}", layout_str)
     layout_str = re.sub(r"%([-+0-9]*)R", r"{R:\1}", layout_str)
+    layout_str = re.sub(r"%([-+0-9]*)P", r"{P:\1}", layout_str)
     layout_str = layout_str.format(**subs)
     return layout_str
 # End def format_pelayout
 
 ###############################################################################
-def print_pelayout(case, ntasks, nthreads, rootpes, arg_format, header):
+def print_pelayout(case, ntasks, nthreads, rootpes, pstrid, arg_format, header):
 ###############################################################################
     """
     Print the PE layout information for each component, using the format,
@@ -123,9 +124,22 @@ def print_pelayout(case, ntasks, nthreads, rootpes, arg_format, header):
     if (header is not None):
         print(header)
     # End if
+    maxthrds = -1
     for comp in comp_classes:
-        print(format_pelayout(comp, ntasks[comp], nthreads[comp], rootpes[comp], arg_format))
+        print(format_pelayout(comp, ntasks[comp], nthreads[comp], rootpes[comp], pstrid[comp], arg_format))
+        if nthreads[comp] > maxthrds:
+            maxthrds = nthreads[comp]
     # End for
+    if case.get_value("COMP_INTERFACE") == "nuopc":
+        eat = case.get_value("ESMF_AWARE_THREADING")
+        if not eat:
+            eat = False
+        print("ESMF_AWARE_THREADING is {}".format(eat))
+        tasks = case.get_value("MAX_MPITASKS_PER_NODE")
+        if not eat:
+            tasks = tasks/maxthrds
+
+        print("ROOTPE is with respect to {} tasks per node".format(tasks))
 
 # End def print_pelayout
 
@@ -138,14 +152,16 @@ def gather_pelayout(case):
     ntasks = {}
     nthreads = {}
     rootpes = {}
+    pstride = {}
     comp_classes = case.get_values("COMP_CLASSES")
 
     for comp in comp_classes:
         ntasks[comp]   = int(case.get_value("NTASKS_"+comp))
         nthreads[comp] = int(case.get_value("NTHRDS_"+comp))
         rootpes[comp]  = int(case.get_value("ROOTPE_"+comp))
+        pstride[comp]  = int(case.get_value("PSTRID_"+comp))
     # End for
-    return ntasks, nthreads, rootpes
+    return ntasks, nthreads, rootpes, pstride
 # End def gather_pelayout
 
 ###############################################################################
@@ -167,7 +183,7 @@ def modify_ntasks(case, new_tot_tasks):
     curr_tot_tasks = 0
 
     # First, gather current task and root pe info
-    curr_tasks, _, curr_roots = gather_pelayout(case)
+    curr_tasks, _, curr_roots, _ = gather_pelayout(case)
 
     # How many tasks are currently being used?
     for comp in comp_classes:
@@ -218,8 +234,8 @@ def _main_func(description):
         if (set_ntasks is not None):
             modify_ntasks(case, int(set_ntasks))
         # End if
-        ntasks, nthreads, rootpes = gather_pelayout(case)
-        print_pelayout(case, ntasks, nthreads, rootpes, arg_format, header)
+        ntasks, nthreads, rootpes, pstrid = gather_pelayout(case)
+        print_pelayout(case, ntasks, nthreads, rootpes, pstrid, arg_format, header)
     # End with
 
 # End def _main_func

--- a/scripts/lib/CIME/XML/env_mach_pes.py
+++ b/scripts/lib/CIME/XML/env_mach_pes.py
@@ -94,14 +94,15 @@ class EnvMachPes(EnvBase):
             ntasks = self.get_value("NTASKS", attribute={"compclass":comp})
             rootpe = self.get_value("ROOTPE", attribute={"compclass":comp})
             pstrid = self.get_value("PSTRID", attribute={"compclass":comp})
+            esmf_aware_threading = self.get_value("ESMF_AWARE_THREADING")
             # mct is unaware of threads and they should not be counted here
-            # esmf is thread aware and so they are included
-            if comp_interface == "nuopc":
+            # if esmf is thread aware they are included
+            if comp_interface == "nuopc" and esmf_aware_threading:
                 nthrds = self.get_value("NTHRDS", attribute={"compclass":comp})
             else:
                 nthrds = 1
 
-            if comp != "CPL" and comp_interface!="nuopc":
+            if comp != "CPL" and (comp_interface!="nuopc" or not esmf_aware_threading):
                 ninst = self.get_value("NINST", attribute={"compclass":comp})
                 maxinst = max(maxinst, ninst)
             tt = rootpe + nthrds*((ntasks - 1) * pstrid + 1)
@@ -112,7 +113,7 @@ class EnvMachPes(EnvBase):
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):
         expect(total_tasks > 0,"totaltasks > 0 expected, totaltasks = {}".format(total_tasks))
-        if self._comp_interface == 'nuopc':
+        if self._comp_interface == 'nuopc' and self.get_value("ESMF_AWARE_THREADING"):
             tasks_per_node = self.get_value("MAX_MPITASKS_PER_NODE")
         else:
             tasks_per_node = min(self.get_value("MAX_TASKS_PER_NODE")// max_thread_count,
@@ -124,7 +125,7 @@ class EnvMachPes(EnvBase):
         Return (num_active_nodes, num_spare_nodes)
         """
         # threads have already been included in nuopc interface
-        if self._comp_interface == 'nuopc':
+        if self._comp_interface == 'nuopc' and self.get_value("ESMF_AWARE_THREADING"):
             max_thread_count = 1
         tasks_per_node = self.get_tasks_per_node(total_tasks, max_thread_count)
         num_nodes = int(math.ceil(float(total_tasks) / tasks_per_node))

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -405,7 +405,7 @@ class _TimingParser:
                 comp_label = m.comp + inst_label
             else:
                 comp_label = m.comp
-            self.write("  {} = {:<8s}   {:<6d}      {:<6d}   {:<6d} x {:<6d}  {:<6d} ({:<6d}) \n".format(m.name.lower(), comp_label, (m.ntasks*m.nthrds *smt_factor), m.rootpe, m.ntasks, m.nthrds, m.ninst, m.pstrid))
+            self.write("  {} = {:<8s}   {:<6d}      {:<6d}   {:<6d} x {:<6d}  {:<6d} ({:<6d}) \n".format(m.name.lower(), comp_label, (m.ntasks*m.nthrds), m.rootpe, m.ntasks, m.nthrds, m.ninst, m.pstrid))
             if m.nthrds > maxthrds:
                 maxthrds = m.nthrds
         if self._driver == 'nuopc':

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -90,7 +90,8 @@ class _TimingParser:
     def _gettime2_nuopc(self):
         self.nprocs = 0
         self.ncount = 0
-        expression = re.compile(r'\s*\MED:\s*\(med_phases_profile\)\s+(\d+)\s+(\d+)')
+#        expression = re.compile(r'\s*\MED:\s*\(med_phases_profile\)\s+(\d+)\s+(\d+)')
+        expression = re.compile(r'\s*\[ATM]\s*RunPhase1\s+(\d+)\s+(\d+)')
 
         for line in self.finlines:
             match = expression.match(line)
@@ -353,7 +354,6 @@ class _TimingParser:
             nprocs, nsteps = self.gettime2('')
 
         adays = nsteps*tlen/ncpl
-        print("adays = {} nsteps {} tlen {} ncpl {} nprocs {}".format(adays, nsteps, tlen, ncpl, nprocs))
         odays = nsteps*tlen/ncpl
         if ocn_ncpl and inittype == "TRUE":
             odays = odays - (tlen/ocn_ncpl)
@@ -459,11 +459,10 @@ class _TimingParser:
             xmaxr = adays*86400.0/(xmax*365.0)
         tmaxr = 0
         if tmax > 0:
-            print ("HERE adays {} tmax {}".format(adays, tmax))
             tmaxr = adays*86400.0/(tmax*365.0)
 
         self.write("\n")
-        self.write("  total pes active           : {} \n".format(totalpes*maxthrds*smt_factor ))
+        self.write("  total pes active           : {} \n".format(totalpes*smt_factor ))
         self.write("  mpi tasks per node               : {} \n".format(max_mpitasks_per_node))
         self.write("  pe count for cost estimate : {} \n".format(pecost))
         self.write("\n")

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -463,7 +463,7 @@ class _TimingParser:
 
         self.write("\n")
         self.write("  total pes active           : {} \n".format(totalpes*smt_factor ))
-        self.write("  mpi tasks per node               : {} \n".format(max_mpitasks_per_node))
+        self.write("  mpi tasks per node         : {} \n".format(max_mpitasks_per_node))
         self.write("  pe count for cost estimate : {} \n".format(pecost))
         self.write("\n")
 


### PR DESCRIPTION
Adds threading support for nuopc in two ways with the introduction of a new xml variable in cmeps 
ESMF_AWARE_THREADING.   When this variable is False or None the threading implementation is the same as that in mct, this is the default.  When ESMF_AWARE_THREADING is True the driver uses all available mpi tasks on a given node and component threads are launched using pthreads.  This allows for each component to specify its thread count independent of the other components.  It also changes the definition of ROOTPE.  The pelayout was changed to add PSTRID and to document the value of ESMF_AWARE_THREADING and how that value affects the ROOTPE variable.  

Test suite: scripts_regression_tests.py + manual tests of pelayout script 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]
Depends on https://github.com/ESCOMP/CMEPS/pull/144
 
User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
