### PR TITLE
bug fix for generating C/G nuopc compsets

### DIFF
--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -300,8 +300,9 @@ class Grids(GenericXML):
                 driver_attrib = self.get(mesh_node, "driver")
                 if driver == driver_attrib:
                     domains["MASK_MESH"] = self.text(mesh_node)
-                    if domains["LND_DOMAIN_FILE"] != 'UNSET':
-                        domains["PTS_DOMAINFILE"] = os.path.join("$DIN_LOC_ROOT/share/domains",domains["LND_DOMAIN_FILE"])
+                    if "LND_DOMAIN_FILE" in domains:
+                        if domains["LND_DOMAIN_FILE"] != 'UNSET':
+                            domains["PTS_DOMAINFILE"] = os.path.join("$DIN_LOC_ROOT/share/domains",domains["LND_DOMAIN_FILE"])
 
         return domains
 


### PR DESCRIPTION
This is a minor bugfix that only effects nuopc compsets. Without this fix C/G compsets could not be created.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes: None

User interface changes?: No

Update gh-pages html (Y/N)?: N

Code review: @jedwards4b 
