### PR TITLE
Point to new dlnd scpl forcing data

### DIFF
--- a/src/components/data_comps_mct/dlnd/cime_config/config_component.xml
+++ b/src/components/data_comps_mct/dlnd/cime_config/config_component.xml
@@ -71,7 +71,7 @@
     <default_value>UNSET</default_value>
     <values match="last">
       <value compset="DLND%LCLMR" grid="l%NLDAS">$DIN_LOC_ROOT/lnd/dlnd7/NLDAS</value>
-      <value compset="DLND%SCPL" grid="l%0.9x1.25">$DIN_LOC_ROOT/lnd/dlnd7/CPLHIST_SNO/i.e20.I1850Clm50Sp.f09_g17.001_c180502</value>
+      <value compset="DLND%SCPL" grid="l%0.9x1.25">$DIN_LOC_ROOT/lnd/dlnd7/CPLHIST_SNO/b.e21.B1850.f09_g17.CMIP6-piControl.001_c210324</value>
       <value compset="DLND%QIA">$DIN_LOC_ROOT/lnd/dlnd7/hcru_hcru</value>
       <value compset="DLND%GPCC">$DIN_LOC_ROOT/lnd/dlnd7/hcru_hcru</value>
     </values>
@@ -85,7 +85,7 @@
     <default_value>UNSET</default_value>
     <values match="last">
       <value compset="DLND%LCLMR" grid="l%NLDAS">NLDAS</value>
-      <value compset="DLND%SCPL" grid="l%0.9x1.25">i.e20.I1850Clm50Sp.f09_g17.001</value>
+      <value compset="DLND%SCPL" grid="l%0.9x1.25">b.e21.B1850.f09_g17.CMIP6-piControl.001</value>
     </values>
     <group>run_component_dlnd</group>
     <file>env_run.xml</file>
@@ -123,7 +123,7 @@
     <default_value>-999</default_value>
     <values match="last">
       <value compset="DLND%LCLMR" grid="l%NLDAS">1975</value>
-      <value compset="DLND%SCPL" grid="l%0.9x1.25">1</value>
+      <value compset="DLND%SCPL" grid="l%0.9x1.25">1971</value>
       <value compset="DLND%QIA">1948</value>
       <value compset="DLND%GPCC">1979</value>
     </values>
@@ -137,7 +137,7 @@
     <default_value>-999</default_value>
     <values match="last">
       <value compset="DLND%LCLMR" grid="l%NLDAS">1975</value>
-      <value compset="DLND%SCPL" grid="l%0.9x1.25">30</value>
+      <value compset="DLND%SCPL" grid="l%0.9x1.25">2000</value>
       <value compset="DLND%QIA">2004</value>
       <value compset="DLND%GPCC">1979</value>
     </values>


### PR DESCRIPTION
Point to new dlnd scpl forcing data.

These data are used to force cases with GLC - i.e., T compsets.

Test suite: Just ran `SMS_Ly35.f09_g17_gl4.T1850G.cheyenne_intel` in the context of CESM's nuopc_dev branch
Test baseline: 
Test namelist changes: 
Test status: climate changing - just for T compsets

Fixes #3835 

User interface changes?: N

Update gh-pages html (Y/N)?: N

Code review: 
