### PR TITLE
fix order of timers

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -39,7 +39,7 @@ jobs:
 
       - id: load-env
         run: |
-          #sudo apt-get update
+          sudo apt-get update
           sudo apt-get install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/src/externals/pio1/pio/piodarray.F90.in
+++ b/src/externals/pio1/pio/piodarray.F90.in
@@ -7,8 +7,8 @@
 !<
 module piodarray
   use pio_types, only : file_desc_t, io_desc_t, var_desc_t, pio_noerr, iosystem_desc_t, &
-	pio_iotype_pbinary, pio_iotype_binary, pio_iotype_direct_pbinary, &
-	pio_iotype_netcdf, pio_iotype_pnetcdf, pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
+        pio_iotype_pbinary, pio_iotype_binary, pio_iotype_direct_pbinary, &
+        pio_iotype_netcdf, pio_iotype_pnetcdf, pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
         PIO_MAX_VAR_DIMS, pio_iotype_vdc2
   use pio_kinds
   use pio_support
@@ -318,16 +318,16 @@ contains
     ! !INPUT PARAMETERS:
 
     type (File_desc_t), intent(inout) :: &
-	 File                   ! file information
+         File                   ! file information
 
     type (var_desc_t), intent(inout) :: &
-	 varDesc                      ! variable descriptor
+         varDesc                      ! variable descriptor
 
     type (io_desc_t), intent(inout) :: &
-	 ioDesc                      ! iodecomp descriptor
+         ioDesc                      ! iodecomp descriptor
 
     {VTYPE}, dimension(:), intent(out) ::  &
-	 array                 ! array to be read
+         array                 ! array to be read
 
     integer(i4), intent(out) :: iostat
 
@@ -388,13 +388,13 @@ contains
     ! !INPUT PARAMETERS:
 
     type (File_desc_t), intent(inout) :: &
-	 File                   ! file information
+         File                   ! file information
 
     type (var_desc_t), intent(inout) :: &
-	 varDesc                      ! variable descriptor
+         varDesc                      ! variable descriptor
 
     type (io_desc_t), intent(inout) :: &
-	 ioDesc                      ! iodecomp descriptor
+         ioDesc                      ! iodecomp descriptor
 
     {VTYPE}, intent(out) ::  array{DIMSTR}                 ! array to be read
 
@@ -504,8 +504,8 @@ contains
     if(Debug) print *,__PIO_FILE__,__LINE__,' NAME : IAM: ', &
     File%iosystem%comp_rank,' UseRearranger: ',UseRearranger,iodesc%glen, iodesc%iomap%start, len
 #ifdef TIMING
-    call t_startf("PIO:pio_rearrange_write")
     call t_startf("PIO:pre_pio_write_nf")
+    call t_startf("PIO:pio_rearrange_write")
 #endif
     if(UseRearranger) then
        if (IOproc) then
@@ -842,7 +842,7 @@ contains
     call t_startf("PIO:pio_write_bin")
 #endif
        !----------------------------------------------
-       !	 write the global 2-d slice from IO processors
+       !         write the global 2-d slice from IO processors
        !----------------------------------------------
        ierr = write_mpiio(File,IOBUF,varDesc,iodesc)
 #ifdef TIMING
@@ -896,9 +896,9 @@ contains
          File                   ! info about data file
 
     type (var_desc_t), intent(inout) :: &
-         varDesc			  ! variable descriptor
+         varDesc                          ! variable descriptor
     type (io_desc_t), intent(inout) :: &
-         ioDesc			  ! io decomp descriptor
+         ioDesc                   ! io decomp descriptor
 
     ! !INPUT/OUTPUT PARAMETERS:
 
@@ -985,13 +985,13 @@ contains
           count(1:ndims-1)=iodesc%count
           start(ndims:ndims)=vardesc%rec
           count(ndims:ndims)=1
-	  ! this is a timedependent single value
+          ! this is a timedependent single value
        else if(vardesc%rec>=0) then
           ndims=1
           start(1) = int(vardesc%rec,kind=PIO_Offset)
           count(1) = 1_PIO_Offset
 
-	  ! this is a non-timedependent array
+          ! this is a non-timedependent array
        else
           ndims = size(iodesc%start)
           start(1:ndims)=iodesc%start
@@ -1014,7 +1014,7 @@ contains
 #endif
 
     if(DebugIO) print *, subName,': {comp,io}_rank: ',File%iosystem%comp_rank,File%iosystem%io_rank,  &
-	 'offset: ',iodesc%iomap%start,'len: ',len !,' IOBUF: ',IOBUF
+         'offset: ',iodesc%iomap%start,'len: ',len !,' IOBUF: ',IOBUF
 
 
 #ifdef TIMING
@@ -1094,10 +1094,10 @@ contains
          File                   ! info about data file
 
     type (var_desc_t), intent(inout) :: &
-         varDesc			  ! variable descriptor
+         varDesc                          ! variable descriptor
 
     type (io_desc_t), intent(inout) :: &
-         ioDesc			  ! io decomp descriptor
+         ioDesc                   ! io decomp descriptor
 
     ! !INPUT/OUTPUT PARAMETERS:
 
@@ -1528,7 +1528,7 @@ subroutine read_vdc2_real(File, Vardesc, iodesc, array, iostat)
           call alloc_check(IOBUF,len,' TYPE :IOBUF')
           IOBUF= -1.0_r8
           cptr = c_loc(iobuf(1))
-  	  call ReadVDC2Var(cptr, start, count,  File%iosystem%IO_comm, vardesc%rec, -1, -1, File%iosystem%num_iotasks, &
+          call ReadVDC2Var(cptr, start, count,  File%iosystem%IO_comm, vardesc%rec, -1, -1, File%iosystem%num_iotasks, &
           F_C_String_dup(varDesc%name))
        else
           call alloc_check(IOBUF,0)


### PR DESCRIPTION
Correct timer order in piodarray.F90.in, out of order timers causes a gptl error at end of run.

Test suite:hand testing with SMS.f19_g17.B1850cmip6.cheyenne_intel 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
