### PR TITLE
fix issue with build of nag mpiserial

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -39,7 +39,7 @@ jobs:
 
       - id: load-env
         run: |
-          #sudo apt-get update
+          sudo apt-get update
           sudo apt-get install libxml2-utils pylint wget gfortran openmpi-bin netcdf-bin libopenmpi-dev cmake libnetcdf-dev
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1733,6 +1733,9 @@ This allows using a different mpirun command to launch unit tests
       <modules compiler="nag" mpilib="mvapich2">
         <command name="load">mpi/2.3.3/nag/6.2</command>
       </modules>
+      <modules compiler="nag" mpilib="mpi-serial">
+        <command name="rm">mpi</command>
+      </modules>
       <modules compiler="gnu" mpilib="mvapich2" DEBUG="FALSE">
         <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/gfortran/9.3.0</command>
         <command name="load">esmf-8.1.0b47-ncdfio-mvapich2-O</command>


### PR DESCRIPTION
Izumi module system requires that you explicitly unload mpi to build mpi-serial.

Test suite: Hand tested SMS_Vnuopc_D_P1x1.f10_f10_mg37.I2000Clm50Sp.izumi_nag.clm-default 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3907 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
