### PR TITLE
Generalize build directory paths, and prep for CESM share repository

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -612,17 +612,25 @@ endif
 # Drive configure scripts for support libraries (mct)
 #------------------------------------------------------------------------------
 
+ifeq ($(CIME_MODEL),cesm)
+    #This will be changed to EXTERN_PATH = $(SRCROOT)/libraries when the new
+    #share repos are used for cesm2.
+    EXTERN_PATH = $(CIMEROOT)/src/externals
+else
+    EXTERN_PATH = $(CIMEROOT)/src/externals
+endif
+
 $(SHAREDLIBROOT)/$(SHAREDPATH)/mct/Makefile.conf:
 	@echo "SHAREDLIBROOT |$(SHAREDLIBROOT)| SHAREDPATH |$(SHAREDPATH)|"; \
-	$(CONFIG_SHELL) $(CIMEROOT)/src/externals/mct/configure $(CONFIG_ARGS) --srcdir $(CIMEROOT)/src/externals/mct
+	$(CONFIG_SHELL) $(EXTERN_PATH)/mct/configure $(CONFIG_ARGS) --srcdir $(EXTERN_PATH)/mct
 
 $(SHAREDLIBROOT)/$(SHAREDPATH)/mct/mpi-serial/Makefile.conf:
 	@echo "SHAREDLIBROOT |$(SHAREDLIBROOT)| SHAREDPATH |$(SHAREDPATH)|"; \
-	$(CONFIG_SHELL) $(CIMEROOT)/src/externals/mct/mpi-serial/configure $(CONFIG_ARGS) --srcdir $(CIMEROOT)/src/externals/mct/mpi-serial
+	$(CONFIG_SHELL) $(EXTERN_PATH)/mct/mpi-serial/configure $(CONFIG_ARGS) --srcdir $(EXTERN_PATH)/mct/mpi-serial
 
 ifndef IO_LIB_SRCROOT
   ifndef PIO_SRCROOT
-    PIO_SRCROOT = $(CIMEROOT)/src/externals
+    PIO_SRCROOT = $(EXTERN_PATH)
   endif
 
   ifeq ($(PIO_VERSION),2)
@@ -673,7 +681,7 @@ CMAKE_OPTS += -Wno-dev -D CMAKE_Fortran_FLAGS:STRING="$(FFLAGS) $(EXTRA_PIO_FPPD
 	      -D GPTL_PATH:STRING=$(INSTALL_SHAREDPATH) \
 	      -D PIO_ENABLE_TESTS:BOOL=OFF \
 	      -D PIO_USE_MALLOC:BOOL=ON \
-	      -D USER_CMAKE_MODULE_PATH:LIST="$(CIMEROOT)/src/CMake;$(CIMEROOT)/src/externals/pio2/cmake"
+	      -D USER_CMAKE_MODULE_PATH:LIST="$(CIMEROOT)/src/CMake;$(EXTERN_PATH)/pio2/cmake"
 
 ifeq ($(DEBUG), TRUE)
   CMAKE_OPTS += -D PIO_ENABLE_LOGGING=ON

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -41,7 +41,7 @@ import argparse, math, glob
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def parse_command_line(args, cimeroot, description):
+def parse_command_line(args, description):
 ###############################################################################
 
     parser = argparse.ArgumentParser(description=description,
@@ -89,11 +89,6 @@ def parse_command_line(args, cimeroot, description):
                         default=default,
                         help="Use a single interactive allocation to run all the tests. This can "
                         "\ndrastically reduce queue waiting but only makes sense on batch machines.")
-
-    if config and config.has_option('main','SRCROOT'):
-        srcroot_default = cime_config.get('main', 'srcroot')
-    else:
-        srcroot_default = os.path.dirname(cimeroot)
 
     default = get_default_setting(config, "TEST_ROOT", None, check_main=False)
 
@@ -626,15 +621,13 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
 ###############################################################################
 def _main_func(description):
 ###############################################################################
-    cimeroot = os.path.abspath(CIME.utils.get_cime_root())
-
     test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, \
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \
     save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile, \
     retry, mail_user, mail_type, check_throughput, check_memory, ignore_namelists, ignore_memleak, allow_pnl, \
     non_local, single_exe, workflow = \
-        parse_command_line(sys.argv, cimeroot, description)
+        parse_command_line(sys.argv, description)
 
     success = False
     run_count = 0

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -41,7 +41,7 @@ import argparse, math, glob
 logger = logging.getLogger(__name__)
 
 ###############################################################################
-def parse_command_line(args, description):
+def parse_command_line(args, cimeroot, description):
 ###############################################################################
 
     parser = argparse.ArgumentParser(description=description,
@@ -89,6 +89,11 @@ def parse_command_line(args, description):
                         default=default,
                         help="Use a single interactive allocation to run all the tests. This can "
                         "\ndrastically reduce queue waiting but only makes sense on batch machines.")
+
+    if config and config.has_option('main','SRCROOT'):
+        srcroot_default = cime_config.get('main', 'srcroot')
+    else:
+        srcroot_default = os.path.dirname(cimeroot)
 
     default = get_default_setting(config, "TEST_ROOT", None, check_main=False)
 
@@ -621,13 +626,15 @@ def create_test(test_names, test_data, compiler, machine_name, no_run, no_build,
 ###############################################################################
 def _main_func(description):
 ###############################################################################
+    cimeroot = os.path.abspath(CIME.utils.get_cime_root())
+
     test_names, test_data, compiler, machine_name, no_run, no_build, no_setup, no_batch, \
     test_root, baseline_root, clean, baseline_cmp_name, baseline_gen_name, namelists_only, \
     project, test_id, parallel_jobs, walltime, single_submit, proc_pool, use_existing, \
     save_timing, queue, allow_baseline_overwrite, output_root, wait, force_procs, force_threads, mpilib, input_dir, pesfile, \
     retry, mail_user, mail_type, check_throughput, check_memory, ignore_namelists, ignore_memleak, allow_pnl, \
     non_local, single_exe, workflow = \
-        parse_command_line(sys.argv, description)
+        parse_command_line(sys.argv, cimeroot, description)
 
     success = False
     run_count = 0

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -3,7 +3,7 @@ Common interface to XML files, this is an abstract class and is expected to
 be used by other XML interface modules and not directly.
 """
 from CIME.XML.standard_module_setup import *
-from CIME.utils import safe_copy
+from CIME.utils import safe_copy, get_src_root
 
 import xml.etree.ElementTree as ET
 #pylint: disable=import-error
@@ -528,7 +528,7 @@ class GenericXML(object):
                 cimeroot = get_cime_root()
                 item_data = item_data.replace(m.group(), cimeroot)
             elif var == "SRCROOT":
-                srcroot = os.path.normpath(os.path.join(get_cime_root(),".."))
+                srcroot = get_src_root()
                 item_data = item_data.replace(m.group(), srcroot)
             elif var == "USER":
                 item_data = item_data.replace(m.group(), getpass.getuser())

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -189,6 +189,7 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     # regardless of requested build list
     cmp_cmake_args = ""
     all_models = []
+    files = Files(comp_interface=comp_interface)
     for model, _, _, _, config_dir in complist:
         # Create the Filepath and CIME_cppdefs files
         if model == "cpl":

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -11,7 +11,7 @@ from CIME.XML.files             import Files
 logger = logging.getLogger(__name__)
 
 _CMD_ARGS_FOR_BUILD = \
-    ("CASEROOT", "CASETOOLS", "CIMEROOT", "COMP_INTERFACE",
+    ("CASEROOT", "CASETOOLS", "CIMEROOT", "SRCROOT", "COMP_INTERFACE",
      "COMPILER", "DEBUG", "EXEROOT", "INCROOT", "LIBROOT", "LILAC_MODE",
      "MACH", "MPILIB", "NINST_VALUE", "OS", "PIO_VERSION",
      "SHAREDLIBROOT", "SMP_PRESENT", "USE_ESMF_LIB", "USE_MOAB",
@@ -143,7 +143,7 @@ def _build_model(build_threaded, exeroot, incroot, complist,
             if comp_interface == "nuopc":
                 config_dir = os.path.join(os.path.dirname(files.get_value("BUILD_LIB_FILE",{"lib":"CMEPS"})))
             else:
-                config_dir = os.path.join(cimeroot,"src","drivers","mct","cime_config")
+                config_dir = os.path.join(files.get_value("COMP_ROOT_DIR_CPL"),"cime_config")
 
         expect(os.path.exists(config_dir), "Config directory not found {}".format(config_dir))
         if "cpl" in complist:
@@ -192,7 +192,7 @@ def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
     for model, _, _, _, config_dir in complist:
         # Create the Filepath and CIME_cppdefs files
         if model == "cpl":
-            config_dir = os.path.join(cimeroot, "src", "drivers", comp_interface, "cime_config")
+            config_dir = os.path.join(files.get_value("COMP_ROOT_DIR_CPL"),"cime_config")
 
         cmp_cmake_args += _create_build_metadata_for_component(config_dir, libroot, bldroot, case)
         all_models.append(model)

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -169,7 +169,7 @@ def _build_model(build_threaded, exeroot, incroot, complist,
     return logs
 
 ###############################################################################
-def _build_model_cmake(exeroot, complist, lid, buildlist,
+def _build_model_cmake(exeroot, complist, lid, buildlist, comp_interface,
                        sharedpath, separate_builds, ninja, dry_run, case):
 ###############################################################################
     cime_model = get_model()
@@ -727,7 +727,7 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
 
     if not sharedlib_only:
         if get_model() == "e3sm":
-            logs.extend(_build_model_cmake(exeroot, complist, lid, buildlist,
+            logs.extend(_build_model_cmake(exeroot, complist, lid, buildlist, comp_interface,
                                            sharedpath, separate_builds, ninja, dry_run, case))
         else:
             os.environ["INSTALL_SHAREDPATH"] = os.path.join(exeroot, sharedpath) # for MPAS makefile generators

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -169,8 +169,8 @@ def _build_model(build_threaded, exeroot, incroot, complist,
     return logs
 
 ###############################################################################
-def _build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
-                       comp_interface, sharedpath, separate_builds, ninja, dry_run, case):
+def _build_model_cmake(exeroot, complist, lid, buildlist,
+                       sharedpath, separate_builds, ninja, dry_run, case):
 ###############################################################################
     cime_model = get_model()
     bldroot    = os.path.join(exeroot, "cmake-bld")
@@ -727,8 +727,8 @@ def _case_build_impl(caseroot, case, sharedlib_only, model_only, buildlist,
 
     if not sharedlib_only:
         if get_model() == "e3sm":
-            logs.extend(_build_model_cmake(exeroot, complist, lid, cimeroot, buildlist,
-                                           comp_interface, sharedpath, separate_builds, ninja, dry_run, case))
+            logs.extend(_build_model_cmake(exeroot, complist, lid, buildlist,
+                                           sharedpath, separate_builds, ninja, dry_run, case))
         else:
             os.environ["INSTALL_SHAREDPATH"] = os.path.join(exeroot, sharedpath) # for MPAS makefile generators
             logs.extend(_build_model(build_threaded, exeroot, incroot, complist,

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -6,6 +6,7 @@ from CIME.XML.standard_module_setup import *
 from CIME.case import Case
 from CIME.utils import parse_args_and_handle_standard_logging_options, setup_standard_logging_options, get_model, safe_copy
 from CIME.build import get_standard_makefile_args
+from CIME.XML.files             import Files
 
 import sys, os, argparse
 logger = logging.getLogger(__name__)
@@ -55,16 +56,16 @@ def build_cime_component_lib(case, compname, libroot, bldroot):
     with open(os.path.join(confdir, 'Filepath'), 'w') as out:
         out.write(os.path.join(case.get_value('CASEROOT'), "SourceMods",
                                "src.{}\n".format(compname)) + "\n")
+        files = Files(comp_interface=comp_interface)
+        compdir = files.get_value("COMP_ROOT_DIR_"+compclass.upper(),{"component":compname})
         if compname.startswith('d'):
-            if (comp_interface == 'nuopc'):
-                out.write(os.path.join(cimeroot, "src", "components", "data_comps_"+comp_interface, "dshr_nuopc") + "\n")
-            out.write(os.path.join(cimeroot, "src", "components", "data_comps_"+comp_interface, compname, "src") + "\n")
-            out.write(os.path.join(cimeroot, "src", "components", "data_comps_"+comp_interface, compname) + "\n")
+            out.write(os.path.join(compdir,"src") + "\n")
+            out.write(os.path.join(compdir) + "\n")
         elif compname.startswith('x'):
-            out.write(os.path.join(cimeroot, "src", "components", "xcpl_comps_"+comp_interface, "xshare") + "\n")
-            out.write(os.path.join(cimeroot, "src", "components", "xcpl_comps_"+comp_interface, compname, "src") + "\n")
+            out.write(os.path.join(compdir,"..","xshare") + "\n")
+            out.write(os.path.join(compdir,"src") + "\n")
         elif compname.startswith('s'):
-            out.write(os.path.join(cimeroot, "src", "components", "stub_comps_"+comp_interface, compname, "src") + "\n")
+            out.write(os.path.join(compdir,"src") + "\n")
 
     with open(os.path.join(confdir, "CIME_cppdefs"), "w") as out:
         out.write("")

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -44,7 +44,6 @@ def parse_input(argv):
 def build_cime_component_lib(case, compname, libroot, bldroot):
 ###############################################################################
 
-    cimeroot  = case.get_value("CIMEROOT")
     casebuild = case.get_value("CASEBUILD")
     compclass = compname[1:] # This very hacky
     comp_interface = case.get_value("COMP_INTERFACE")

--- a/scripts/lib/CIME/case/case_clone.py
+++ b/scripts/lib/CIME/case/case_clone.py
@@ -3,7 +3,7 @@ create_clone is a member of the Case class from file case.py
 """
 import os, glob, shutil
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect, check_name, safe_copy
+from CIME.utils import expect, check_name, safe_copy, get_model
 from CIME.simple_compare            import compare_files
 from CIME.locked_files         import lock_file
 from CIME.user_mod_support import apply_user_mods
@@ -39,7 +39,10 @@ def create_clone(self, newcaseroot, keepexe=False, mach_dir=None, project=None,
         logger.warning(" It is NOT recommended to clone cases from different versions of CIME.")
 
     # *** create case object as deepcopy of clone object ***
-    srcroot = os.path.join(newcase_cimeroot,"..")
+    if os.path.isdir(os.path.join(newcase_cimeroot,'share')) and get_model() == "cesm":
+        srcroot = newcase_cimeroot         
+    else:
+        srcroot = os.path.join(newcase_cimeroot,"..")
     newcase = self.copy(newcasename, newcaseroot, newsrcroot=srcroot)
     with newcase:
         newcase.set_value("CIMEROOT", newcase_cimeroot)

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -254,7 +254,7 @@ def get_cime_root(case=None):
     logger.debug( "CIMEROOT is " + cimeroot)
     return cimeroot
 
-def get_src_root(case=None):
+def get_src_root():
     """
     Return the absolute path to the root of SRCROOT.
 

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -259,18 +259,11 @@ def get_src_root(case=None):
     Return the absolute path to the root of SRCROOT.
 
     """
-    script_absdir = os.path.abspath(os.path.join(os.path.dirname(__file__),".."))
-    assert script_absdir.endswith(get_python_libs_location_within_cime()), script_absdir
     # This if statement will need to be updated when cesm brings in the new share repos.
     if get_model() == "cesm":
         srcroot = os.path.abspath(os.path.join(get_cime_root(),".."))
     else:
         srcroot = os.path.abspath(os.path.join(get_cime_root(),".."))
-
-    if case is not None:
-        case_srcroot = os.path.abspath(case.get_value("SRCROOT"))
-        srcroot = os.path.abspath(srcroot)
-        expect(srcroot == case_srcroot, "Inconsistent SRCROOT variable: case -> '{}', file location -> '{}'".format(case_srcroot, srcroot))
 
     logger.debug( "SRCROOT is " + srcroot)
     return srcroot

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -254,6 +254,27 @@ def get_cime_root(case=None):
     logger.debug( "CIMEROOT is " + cimeroot)
     return cimeroot
 
+def get_src_root(case=None):
+    """
+    Return the absolute path to the root of SRCROOT.
+
+    """
+    script_absdir = os.path.abspath(os.path.join(os.path.dirname(__file__),".."))
+    assert script_absdir.endswith(get_python_libs_location_within_cime()), script_absdir
+    # This if statement will need to be updated when cesm brings in the new share repos.
+    if get_model() == "cesm":
+        srcroot = os.path.abspath(os.path.join(get_cime_root(),".."))
+    else:
+        srcroot = os.path.abspath(os.path.join(get_cime_root(),".."))
+
+    if case is not None:
+        case_srcroot = os.path.abspath(case.get_value("SRCROOT"))
+        srcroot = os.path.abspath(srcroot)
+        expect(srcroot == case_srcroot, "Inconsistent CIMEROOT variable: case -> '{}', file location -> '{}'".format(case_cimeroot, cimeroot))
+
+    logger.debug( "SRCROOT is " + srcroot)
+    return srcroot
+
 def get_cime_default_driver():
     driver = os.environ.get("CIME_DRIVER")
     if driver:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -270,7 +270,7 @@ def get_src_root(case=None):
     if case is not None:
         case_srcroot = os.path.abspath(case.get_value("SRCROOT"))
         srcroot = os.path.abspath(srcroot)
-        expect(srcroot == case_srcroot, "Inconsistent CIMEROOT variable: case -> '{}', file location -> '{}'".format(case_cimeroot, cimeroot))
+        expect(srcroot == case_srcroot, "Inconsistent SRCROOT variable: case -> '{}', file location -> '{}'".format(case_srcroot, srcroot))
 
     logger.debug( "SRCROOT is " + srcroot)
     return srcroot

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -22,7 +22,7 @@ import stat as osstat
 
 import collections
 
-from CIME.utils import run_cmd, run_cmd_no_fail, get_lids, get_current_commit, safe_copy, CIMEError, get_cime_root, Timeout
+from CIME.utils import run_cmd, run_cmd_no_fail, get_lids, get_current_commit, safe_copy, CIMEError, get_cime_root, get_src_root, Timeout
 import get_tests
 import CIME.test_scheduler, CIME.wait_for_tests
 from  CIME.test_scheduler import TestScheduler
@@ -585,7 +585,12 @@ class J_TestCreateNewcase(unittest.TestCase):
 
         cls._testdirs.append(testdir)
 
-        pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
+        if CIME.utils.get_model() == "cesm":
+            # Will need to be updated when cesm brings in new share repo new line will be. 
+            # pesfile = os.path.join(get_src_root(),"cpl7","driver","cime_config","config_pes.xml")
+            pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
+        else:
+            pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
         args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV  --pesfile %s --res f19_g16 --output-root %s --handle-preexisting-dirs=r" % (testdir, pesfile, cls._testroot)
         if CIME.utils.get_model() == "cesm":
             args += " --run-unsupported"

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -22,7 +22,7 @@ import stat as osstat
 
 import collections
 
-from CIME.utils import run_cmd, run_cmd_no_fail, get_lids, get_current_commit, safe_copy, CIMEError, get_cime_root, get_src_root, Timeout
+from CIME.utils import run_cmd, run_cmd_no_fail, get_lids, get_current_commit, safe_copy, CIMEError, get_cime_root, Timeout
 import get_tests
 import CIME.test_scheduler, CIME.wait_for_tests
 from  CIME.test_scheduler import TestScheduler

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -588,9 +588,11 @@ class J_TestCreateNewcase(unittest.TestCase):
         if CIME.utils.get_model() == "cesm":
             # Will need to be updated when cesm brings in new share repo new line will be. 
             # pesfile = os.path.join(get_src_root(),"cpl7","driver","cime_config","config_pes.xml")
-            pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
+            # or
+            # pesfile = os.path.join(get_src_root(),"components","cmeps","cime_config","config_pes.xml")
+            pesfile = os.path.join("..","src","drivers",CIME.utils.get_model(),"cime_config","config_pes.xml")
         else:
-            pesfile = os.path.join("..","src","drivers","mct","cime_config","config_pes.xml")
+            pesfile = os.path.join("..","src","drivers",CIME.utils.get_model(),"cime_config","config_pes.xml")
         args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV  --pesfile %s --res f19_g16 --output-root %s --handle-preexisting-dirs=r" % (testdir, pesfile, cls._testroot)
         if CIME.utils.get_model() == "cesm":
             args += " --run-unsupported"

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -590,9 +590,9 @@ class J_TestCreateNewcase(unittest.TestCase):
             # pesfile = os.path.join(get_src_root(),"cpl7","driver","cime_config","config_pes.xml")
             # or
             # pesfile = os.path.join(get_src_root(),"components","cmeps","cime_config","config_pes.xml")
-            pesfile = os.path.join("..","src","drivers",CIME.utils.get_model(),"cime_config","config_pes.xml")
+            pesfile = os.path.join("..","src","drivers",CIME.utils.get_cime_default_driver(),"cime_config","config_pes.xml")
         else:
-            pesfile = os.path.join("..","src","drivers",CIME.utils.get_model(),"cime_config","config_pes.xml")
+            pesfile = os.path.join("..","src","drivers",CIME.utils.get_cime_default_driver(),"cime_config","config_pes.xml")
         args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV  --pesfile %s --res f19_g16 --output-root %s --handle-preexisting-dirs=r" % (testdir, pesfile, cls._testroot)
         if CIME.utils.get_model() == "cesm":
             args += " --run-unsupported"

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -7,7 +7,7 @@ components.
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+_CIMEROOT = os.environ.get("CIMEROOT")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -7,7 +7,9 @@ components.
 
 import sys, os
 
-_CIMEROOT = os.environ.get("CIMEROOT")
+_CIMEROOT = os.environ.get("CIMEROT")
+if _CIMEROOT == None:
+    raise ValueError("ERROR: CIMEROOT not defined in buildlib.internal_components.")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -7,7 +7,7 @@ components.
 
 import sys, os
 
-_CIMEROOT = os.environ.get("CIMEROT")
+_CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT == None:
     raise ValueError("ERROR: CIMEROOT not defined in buildlib.internal_components.")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))

--- a/src/build_scripts/buildlib_cmake.internal_components
+++ b/src/build_scripts/buildlib_cmake.internal_components
@@ -7,7 +7,7 @@ components.
 
 import sys, os
 
-_CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..","..","..","..", "..")
+_CIMEROOT = os.environ.get("CIMEROOT")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *

--- a/src/build_scripts/buildlib_cmake.internal_components
+++ b/src/build_scripts/buildlib_cmake.internal_components
@@ -8,6 +8,8 @@ components.
 import sys, os
 
 _CIMEROOT = os.environ.get("CIMEROOT")
+if _CIMEROOT == None:
+    raise ValueError("ERROR: CIMEROOT not defined in buildlib_cmake.internal_components.")
 sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *


### PR DESCRIPTION
- Generalize paths to source code in build.py and buildlib.py, to use 
   config_files.xml.
- Update Makefile to be able to handle different locations of of mct 
   and pio.  Also add an if statement place holder for furture CESM 
   share repository.
- Update case_clone.py to be able to handle the future CESM share 
   repository.
- Add get_src_root to utils.py, similar to get_cime_root.  Needed this 
   to correct an assumption in utilities.py that srcroot=cimeroot/...
- Added place holder if statement in scripts_regression_tests for the 
  new CESM share repository.
- Did some minor cleanup of build_scripts.

There's a couple of place holder if statements that I added that will be 
updated when we bring in the new CESM share repository.
 
Build_scripts and CMake files will still need to be updated when the 
CESM share repository is ready.  I didn't include any changes since
the structure of the CESM share repository will be changing.


Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
