### PR TITLE
fix query_config for py3 output format

### DIFF
--- a/scripts/query_config
+++ b/scripts/query_config
@@ -30,7 +30,7 @@ def query_grids(files, long_output, xml=False):
 
     grids = Grids(config_file)
     if xml:
-        print("{}".format(grids.get_raw_record()))
+        print("{}".format(grids.get_raw_record().decode("UTF-8")))
     elif long_output:
         grids.print_values(long_output=long_output)
     else:
@@ -47,10 +47,10 @@ def query_machines(files, machine_name='all', xml=False):
     machines = Machines(config_file, machine="Query")
     if xml:
         if machine_name == 'all':
-            print("{}".format(machines.get_raw_record()))
+            print("{}".format(machines.get_raw_record().decode("UTF-8")))
         else:
             machines.set_machine(machine_name)
-            print("{}".format(machines.get_raw_record(root=machines.machine_node)))
+            print("{}".format(machines.get_raw_record(root=machines.machine_node).decode("UTF-8")))
     else:
         machines.print_values(machine_name=machine_name)
 
@@ -110,7 +110,7 @@ def print_compset(name, files, all_components=False, xml=False):
     compsets = Compsets(config_file)
     # print compsets associated with component without help text
     if xml:
-        print("{}".format(compsets.get_raw_record()))
+        print("{}".format(compsets.get_raw_record().decode("UTF-8")))
     else:
         compsets.print_values(arg_help=False)
 
@@ -180,7 +180,7 @@ def query_component(name, files, all_components=False, xml=False):
     # determine component xml content
     component = Component(config_file, "CPL")
     if xml:
-        print("{}".format(component.get_raw_record()))
+        print("{}".format(component.get_raw_record().decode("UTF-8")))
     else:
         component.print_values()
 


### PR DESCRIPTION
add UTF-8 decoding for xml option in query_config

Test suite: hand testing query_config with py2 and py3
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3910 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
