### PR TITLE
Fixes phase 1 of multisubmit not executing during rerun

### DIFF
--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -11,6 +11,7 @@ This module contains unit tests of the core logic in SystemTestsCompareTwo.
 
 import unittest
 from collections import namedtuple
+import functools
 import os
 import shutil
 import tempfile
@@ -485,6 +486,56 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
         compare_phase_name = self.get_compare_phase_name(mytest)
         self.assertEqual(test_status.TEST_PASS_STATUS,
                          mytest._test_status.get_status(compare_phase_name))
+
+    def test_internal_calls_multisubmit_failed_state(self):
+        run_one_suffix = 'base'
+        run_two_suffix = 'run2'
+        case1root, case2root = self.get_caseroots()
+        case1 = CaseFake(case1root)
+
+        def _set_initial_test_values(x):
+            x.set_value('RESUBMIT', 1)
+
+        case1.set_initial_test_values = functools.partial(
+            _set_initial_test_values,
+            case1)
+
+        # Standard first phase
+        case1.set_value('IS_FIRST_RUN', True)
+        case1.set_value('RESUBMIT', 1)
+
+        mytest = SystemTestsCompareTwoFake(
+            case1 = case1,
+            run_one_suffix = run_one_suffix,
+            run_two_suffix = run_two_suffix,
+            multisubmit = True)
+
+        mytest.run()
+
+        expected_calls = [
+            Call(METHOD_case_one_custom_prerun_action, {}),
+            Call(METHOD_run_indv, {'CASEROOT': case1root, 'suffix': 'base'}),
+            Call(METHOD_case_one_custom_postrun_action, {})
+        ]
+
+        self.assertEqual(expected_calls, mytest.log)
+
+        # Emulate a rerun ensure phase 1 still runs
+        case1.set_value('IS_FIRST_RUN', True)
+        case1.set_value('RESUBMIT', 0)
+
+        # Reset the log
+        mytest.log = []
+
+        mytest.run()
+
+        expected_calls = [
+            Call(METHOD_case_one_custom_prerun_action, {}),
+            Call(METHOD_run_indv, {'CASEROOT': case1root, 'suffix': 'base'}),
+            Call(METHOD_case_one_custom_postrun_action, {})
+        ]
+
+        self.assertEqual(expected_calls, mytest.log)
 
     def test_run1_fails(self):
         # Make sure that a failure in run1 is reported correctly

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -490,7 +490,7 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
     def test_internal_calls_multisubmit_failed_state(self):
         run_one_suffix = 'base'
         run_two_suffix = 'run2'
-        case1root, case2root = self.get_caseroots()
+        case1root, _ = self.get_caseroots()
         case1 = CaseFake(case1root)
 
         def _set_initial_test_values(x):

--- a/scripts/lib/CIME/tests/case_fake.py
+++ b/scripts/lib/CIME/tests/case_fake.py
@@ -32,6 +32,9 @@ class CaseFake(object):
         self.set_exeroot()
         self.set_rundir()
 
+    def set_initial_test_values(self):
+        pass
+
     def get_value(self, item):
         """
         Get the value of the given item


### PR DESCRIPTION
On a batch system with multisubmit, the first phase would be skipped
if rerunning after a failed phase. This was due to case 1's "RESUBMIT"
variable being decremented before phase 2. During a rerun if the specific 
condition is met, the test will call `_setup_case` which triggers the default
test settings to be loaded.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: 

Fixes #3805 

User interface changes?: n/a
Update gh-pages html (Y/N)?: N
Code review: 
