### PR TITLE
Change behavior of check on DIN_LOC_ROOT in case_setup.py

### DIFF
--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -94,7 +94,7 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
                 os.makedirs(din_loc_root, exist_ok=True)
             except OSError as e:
                 if e.errno == errno.EACCES:
-                    logger.info("Invalid permissions to create {}".format(din_loc_root)
+                    logger.info("Invalid permissions to create {}".format(din_loc_root))
             
         expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
                "inputdata root is not a directory or is not readable: {}".format(din_loc_root))

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -83,10 +83,15 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
     extra_machines_dir = case.get_value("EXTRA_MACHDIR")
     expect(mach is not None, "xml variable MACH is not set")
 
-    # Check that $DIN_LOC_ROOT exists - and abort if not a namelist compare tests
+    # Check that $DIN_LOC_ROOT exists or can be created:
     if not non_local:
         din_loc_root = case.get_value("DIN_LOC_ROOT")
         testcase     = case.get_value("TESTCASE")
+
+        if not os.path.isdir(din_loc_root):
+          logger.info("Making inputdata directory: {}".format(din_loc_root))
+          os.mkdir(din_loc_root)
+            
         expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
                "inputdata root is not a directory or is not readable: {}".format(din_loc_root))
 

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -89,9 +89,9 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
         din_loc_root = case.get_value("DIN_LOC_ROOT")
         testcase     = case.get_value("TESTCASE")
 
-        if not os.path.isfile(din_loc_root):
+        if not os.path.isdir(din_loc_root):
             try:
-                os.makedirs(din_loc_root, exist_ok=True)
+                os.makedirs(din_loc_root)
             except OSError as e:
                 if e.errno == errno.EACCES:
                     logger.info("Invalid permissions to create {}".format(din_loc_root))

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -89,8 +89,8 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
         testcase     = case.get_value("TESTCASE")
 
         if not os.path.isdir(din_loc_root):
-          logger.info("Making inputdata directory: {}".format(din_loc_root))
-          os.mkdir(din_loc_root)
+            logger.info("Making inputdata directory: {}".format(din_loc_root))
+            os.mkdir(din_loc_root)
             
         expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
                "inputdata root is not a directory or is not readable: {}".format(din_loc_root))

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -10,6 +10,7 @@ from CIME.BuildTools.configure import configure
 from CIME.utils             import get_cime_root, run_and_log_case_status, get_model, get_batch_script_for_job, safe_copy
 from CIME.test_status       import *
 from CIME.locked_files      import unlock_file, lock_file
+import errno
 
 logger = logging.getLogger(__name__)
 
@@ -88,9 +89,12 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
         din_loc_root = case.get_value("DIN_LOC_ROOT")
         testcase     = case.get_value("TESTCASE")
 
-        if not os.path.isdir(din_loc_root):
-            logger.info("Making inputdata directory: {}".format(din_loc_root))
-            os.mkdir(din_loc_root)
+        if not os.path.isfile(din_loc_root):
+            try:
+                os.makedirs(din_loc_root, exist_ok=True)
+            except OSError as e:
+                if e.errno == errno.EACCES:
+                    logger.info("Invalid permissions to create {}".format(din_loc_root)
             
         expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
                "inputdata root is not a directory or is not readable: {}".format(din_loc_root))


### PR DESCRIPTION
This PR seeks to change the behavior of the check in case_setup  
on the DIN_LOC_ROOT directory so that when it doesn't exist an 
attempt is made to create it.  This is primarily useful for containers 
on laptops/desktops, since the non-shared environment means 
there isn't usually a pre-existing directory.  Any supported machines 
will already have a valid entry for inputdata, so it shouldn't effect 
them.

Test suite:  None yet; would like input on which to run, if needed.
Test baseline: None; not answer changing
Test namelist changes: No; doesn't affect namelists
Test status: Doesn't impact model

Fixes #3892 

User interface changes?:  In a very minor way; previous fails where 
a DIN_LOC_ROOT directory didn't exist will now succeed if it 
can be created.

Update gh-pages html (Y/N)?: N

Code review: 
