### PR TITLE
add neon server to inputdata

### DIFF
--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -36,4 +36,10 @@
     <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
   </server>
 
+  <server CLM_USRDAT_NAME="NEON">
+    <comment> NEON Tower data for datm </comment>
+    <protocol>wget</protocol>
+    <address>https://s3.data.neonscience.org/neon-ncar/NEON/</address>
+  </server>
+
 </inputdata>

--- a/scripts/lib/CIME/XML/inputdata.py
+++ b/scripts/lib/CIME/XML/inputdata.py
@@ -24,14 +24,17 @@ class Inputdata(GenericXML):
 
         self._servernode = None
 
-    def get_next_server(self):
+    def get_next_server(self, attributes=None):
         protocol = None
         address = None
         user = ''
         passwd = ''
         chksum_file = None
         ic_filepath = None
-        servernodes = self.get_children("server")
+        servernodes = self.get_children("server", attributes=attributes)
+        if not attributes:
+            servernodes = [x for x in servernodes if not self.attrib(x)]
+
         if self._servernode is None:
             self._servernode = servernodes[0]
         else:

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -170,12 +170,16 @@ def check_all_input_data(self, protocol=None, address=None, input_data_root=None
             if not chksum:
                 chksum_found = _download_checksum_file(self.get_value("RUNDIR"))
             success = _downloadfromserver(self, input_data_root, data_list_dir)
+            clm_usrdat_name = self.get_value("CLM_USRDAT_NAME")
+            if not success and clm_usrdat_name:
+                success = _downloadfromserver(self, input_data_root, data_list_dir,
+                                              attributes={"CLM_USRDAT_NAME":clm_usrdat_name})
 
     expect(not download or (download and success), "Could not find all inputdata on any server")
     self.stage_refcase(input_data_root=input_data_root, data_list_dir=data_list_dir)
     return success
 
-def _downloadfromserver(case, input_data_root, data_list_dir):
+def _downloadfromserver(case, input_data_root, data_list_dir, attributes=None):
     """
     Download files
     """
@@ -186,7 +190,7 @@ def _downloadfromserver(case, input_data_root, data_list_dir):
         input_data_root = case.get_value('DIN_LOC_ROOT')
 
     while not success and protocol is not None:
-        protocol, address, user, passwd, _, ic_filepath = inputdata.get_next_server()
+        protocol, address, user, passwd, _, ic_filepath = inputdata.get_next_server(attributes=attributes)
         logger.info("Checking server {} with protocol {}".format(address, protocol))
         success = case.check_input_data(protocol=protocol, address=address, download=True,
                                         input_data_root=input_data_root,
@@ -323,7 +327,7 @@ def check_input_data(case, protocol="svn", address=None, input_data_root=None, d
                     # that specify in their names whether they are files or filenames
                     # rather than 'datapath's or 'data_path's so we check to make sure
                     # the input data list has correct non-path values for input files.
-                    # This check happens whether or not a file already exists locally. 
+                    # This check happens whether or not a file already exists locally.
                     expect((not full_path.endswith(os.sep)), "Unsupported directory path in input_data_list named {}. Line entry is '{} = {}'.".format(data_list_file, description, full_path))
                 if(full_path):
                     # expand xml variables


### PR DESCRIPTION
Adds the NEON data server to inputdata, but only check that server if CLM_USRDAT_NAME==NEON

Test suite:hand testing, scripts_regression_tests.py  
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
