### PR TITLE
Add optional fields from atmosphere for calculation of surface stress

### DIFF
--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -199,6 +199,17 @@
     </desc>
   </entry>
 
+  <entry id="ATM_SUPPLIES_GUSTINESS">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>
+      Whether or not the atmosphere should supply an extra gustiness field.
+    </desc>
+  </entry>
+
   <!-- ===================================================================== -->
   <!-- component coupling options and frequencies -->
   <!-- ===================================================================== -->

--- a/src/drivers/mct/cime_config/config_component_e3sm.xml
+++ b/src/drivers/mct/cime_config/config_component_e3sm.xml
@@ -180,6 +180,25 @@
     <desc>Freezing point calculation for salt water.</desc>
   </entry>
 
+  <entry id="ATM_FLUX_INTEGRATION_METHOD">
+    <type>char</type>
+    <valid_values>explicit,implicit_stress</valid_values>
+    <default_value>explicit</default_value>
+    <group>run_flags</group>
+    <file>env_run.xml</file>
+    <desc>
+      Time integration method for calculation of fluxes to the atmosphere.
+
+      explicit: Fluxes are calculated using the atmosphere's lowest-level state
+          at the current time step.
+
+      implicit_stress: The atmosphere model exports a linearization of the
+          response of the boundary layer scheme to surface stress, and other
+          components use this linearization to solve for surface stress at the
+          next time step implicitly.
+    </desc>
+  </entry>
+
   <!-- ===================================================================== -->
   <!-- component coupling options and frequencies -->
   <!-- ===================================================================== -->

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -159,6 +159,16 @@
     </values>
   </entry>
 
+  <entry id="atm_gustiness" modify_via_xml="ATM_SUPPLIES_GUSTINESS">
+    <type>logical</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>Set to .true. if the atmosphere produces a gustiness velocity. Set by the xml variable ATM_SUPPLIES_GUSTINESS in env_run.xml</desc>
+    <values>
+      <value>$ATM_SUPPLIES_GUSTINESS</value>
+    </values>
+  </entry>
+
   <entry  id="glc_nec" modify_via_xml="GLC_NEC">
     <type>integer</type>
     <category>seq_flds</category>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -149,6 +149,16 @@
     </values>
   </entry>
 
+  <entry id="atm_flux_method" modify_via_xml="ATM_FLUX_INTEGRATION_METHOD">
+    <type>char</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>Time integration method for atmospheric fluxes. Set by the xml variable ATM_FLUX_INTEGRATION_METHOD in env_run.xml</desc>
+    <values>
+      <value>$ATM_FLUX_INTEGRATION_METHOD</value>
+    </values>
+  </entry>
+
   <entry  id="glc_nec" modify_via_xml="GLC_NEC">
     <type>integer</type>
     <category>seq_flds</category>
@@ -763,11 +773,13 @@
     <category>control</category>
     <group>seq_infodata_inparm</group>
     <desc>
-      Iterate atmocn flux calculation a max of this value
+      Maximum number of iterations in atmosphere-ocean flux calculation.
+      Setting this value to -1 will cause the model to use a default that
+      depends on the setting of atm_flux_method.
     </desc>
     <values>
       <value cime_model='cesm'>5</value>
-      <value cime_model='e3sm'>2</value>
+      <value cime_model='e3sm'>-1</value>
     </values>
   </entry>
 

--- a/src/drivers/mct/main/seq_flux_mct.F90
+++ b/src/drivers/mct/main/seq_flux_mct.F90
@@ -1114,14 +1114,15 @@ contains
             tbulk, tskin, tskin_day, tskin_night, &
             cskin, cskin_night, tod, dt,          &
             duu10n,ustar, re  , ssq , missval = 0.0_r8, &
-            cold_start=cold_start)
+            cold_start=cold_start, wsresp=wsresp, tau_est=tau_est)
     else if (ocn_surface_flux_scheme.eq.2) then
        call shr_flux_atmOcn_UA(nloc_a2o , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, pslv, &
             uocn, vocn , tocn , emask, sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
-            duu10n,ustar, re  , ssq , missval = 0.0_r8 )
+            duu10n,ustar, re  , ssq , missval = 0.0_r8, &
+            wsresp=wsresp, tau_est=tau_est)
     else
 
        call shr_flux_atmocn (nloc_a2o , zbot , ubot, vbot, thbot, &
@@ -1131,7 +1132,8 @@ contains
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
             ocn_surface_flux_scheme, &
-            duu10n,ustar, re  , ssq , missval = 0.0_r8 )
+            duu10n,ustar, re  , ssq , missval = 0.0_r8, &
+            wsresp=wsresp, tau_est=tau_est)
     endif
 
     !--- create temporary aVects on exchange, atm, or ocn decomp as needed
@@ -1548,14 +1550,14 @@ contains
                                 !missval should not be needed if flux calc
                                 !consistent with mrgx2a fraction
                                 !duu10n,ustar, re  , ssq, missval = 0.0_r8 )
-            cold_start=cold_start)
+            cold_start=cold_start, wsresp=wsresp, tau_est=tau_est)
     else if (ocn_surface_flux_scheme.eq.2) then
        call shr_flux_atmOcn_UA(nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, pslv, &
             uocn, vocn , tocn , emask, sen , lat , lwup , &
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
-            duu10n,ustar, re  , ssq)
+            duu10n,ustar, re  , ssq, wsresp=wsresp, tau_est=tau_est)
     else
        call shr_flux_atmocn (nloc , zbot , ubot, vbot, thbot, &
             shum , shum_16O , shum_HDO, shum_18O, dens , tbot, uocn, vocn , &
@@ -1564,7 +1566,8 @@ contains
             roce_16O, roce_HDO, roce_18O,    &
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             ocn_surface_flux_scheme, &
-            duu10n,ustar, re  , ssq)
+            duu10n,ustar, re  , ssq, &
+            wsresp=wsresp, tau_est=tau_est)
        !missval should not be needed if flux calc
        !consistent with mrgx2a fraction
        !duu10n,ustar, re  , ssq, missval = 0.0_r8 )

--- a/src/drivers/mct/main/seq_flux_mct.F90
+++ b/src/drivers/mct/main/seq_flux_mct.F90
@@ -45,6 +45,9 @@ module seq_flux_mct
   real(r8), allocatable ::  zbot (:)  ! atm level height
   real(r8), allocatable ::  ubot (:)  ! atm velocity, zonal
   real(r8), allocatable ::  vbot (:)  ! atm velocity, meridional
+  real(r8), allocatable ::  wsresp(:) ! atm response to surface stress
+  real(r8), allocatable ::  u_diff(:) ! approximate atmosphere change to ubot
+  real(r8), allocatable ::  v_diff(:) ! approximate atmosphere change to ubot
   real(r8), allocatable ::  thbot(:)  ! atm potential T
   real(r8), allocatable ::  shum (:)  ! atm specific humidity
   real(r8), allocatable ::  shum_16O (:)  ! atm H2O tracer
@@ -118,6 +121,9 @@ module seq_flux_mct
   integer :: index_a2x_Sa_z
   integer :: index_a2x_Sa_u
   integer :: index_a2x_Sa_v
+  integer :: index_a2x_Sa_wsresp
+  integer :: index_a2x_Sa_u_diff
+  integer :: index_a2x_Sa_v_diff
   integer :: index_a2x_Sa_tbot
   integer :: index_a2x_Sa_ptem
   integer :: index_a2x_Sa_shum
@@ -235,6 +241,15 @@ contains
     allocate( vbot(nloc))
     if(ier/=0) call mct_die(subName,'allocate vbot',ier)
     vbot = 0.0_r8
+    allocate( wsresp(nloc))
+    if(ier/=0) call mct_die(subName,'allocate wsresp',ier)
+    wsresp = 0.0_r8
+    allocate( u_diff(nloc))
+    if(ier/=0) call mct_die(subName,'allocate u_diff',ier)
+    u_diff = 0.0_r8
+    allocate( v_diff(nloc))
+    if(ier/=0) call mct_die(subName,'allocate v_diff',ier)
+    v_diff = 0.0_r8
     allocate(thbot(nloc),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate thbot',ier)
     thbot = 0.0_r8
@@ -661,6 +676,12 @@ contains
     if(ier/=0) call mct_die(subName,'allocate ubot',ier)
     allocate( vbot(nloc_a2o))
     if(ier/=0) call mct_die(subName,'allocate vbot',ier)
+    allocate( wsresp(nloc_a2o))
+    if(ier/=0) call mct_die(subName,'allocate wsresp',ier)
+    allocate( u_diff(nloc_a2o))
+    if(ier/=0) call mct_die(subName,'allocate u_diff',ier)
+    allocate( v_diff(nloc_a2o))
+    if(ier/=0) call mct_die(subName,'allocate v_diff',ier)
     allocate(thbot(nloc_a2o),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate thbot',ier)
     allocate(shum(nloc_a2o),stat=ier)
@@ -1022,6 +1043,9 @@ contains
           zbot(n) =  55.0_r8 ! atm height of bottom layer ~ m
           ubot(n) =   0.0_r8 ! atm velocity, zonal        ~ m/s
           vbot(n) =   2.0_r8 ! atm velocity, meridional   ~ m/s
+          wsresp(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
+          u_diff(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
+          v_diff(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
           thbot(n)= 301.0_r8 ! atm potential temperature  ~ Kelvin
           shum(n) = 1.e-2_r8 ! atm specific humidity      ~ kg/kg
           shum_16O(n) = 1.e-2_r8 ! H216O specific humidity    ~ kg/kg
@@ -1058,6 +1082,9 @@ contains
           zbot(n) = a2x_e%rAttr(index_a2x_Sa_z   ,ia)
           ubot(n) = a2x_e%rAttr(index_a2x_Sa_u   ,ia)
           vbot(n) = a2x_e%rAttr(index_a2x_Sa_v   ,ia)
+          wsresp(n) = a2x_e%rAttr(index_a2x_Sa_wsresp,ia)
+          u_diff(n) = a2x_e%rAttr(index_a2x_Sa_u_diff,ia)
+          v_diff(n) = a2x_e%rAttr(index_a2x_Sa_v_diff,ia)
           thbot(n)= a2x_e%rAttr(index_a2x_Sa_ptem,ia)
           shum(n) = a2x_e%rAttr(index_a2x_Sa_shum,ia)
           shum_16O(n) = a2x_e%rAttr(index_a2x_Sa_shum_16O,ia)
@@ -1346,6 +1373,9 @@ contains
        index_a2x_Sa_z      = mct_aVect_indexRA(a2x,'Sa_z')
        index_a2x_Sa_u      = mct_aVect_indexRA(a2x,'Sa_u')
        index_a2x_Sa_v      = mct_aVect_indexRA(a2x,'Sa_v')
+       index_a2x_Sa_wsresp = mct_aVect_indexRA(a2x,'Sa_wsresp')
+       index_a2x_Sa_u_diff = mct_aVect_indexRA(a2x,'Sa_u_diff')
+       index_a2x_Sa_v_diff = mct_aVect_indexRA(a2x,'Sa_v_diff')
        index_a2x_Sa_tbot   = mct_aVect_indexRA(a2x,'Sa_tbot')
        index_a2x_Sa_pslv   = mct_aVect_indexRA(a2x,'Sa_pslv')
        index_a2x_Sa_ptem   = mct_aVect_indexRA(a2x,'Sa_ptem')
@@ -1399,6 +1429,9 @@ contains
           zbot(n) =  55.0_r8 ! atm height of bottom layer ~ m
           ubot(n) =   0.0_r8 ! atm velocity, zonal        ~ m/s
           vbot(n) =   2.0_r8 ! atm velocity, meridional   ~ m/s
+          wsresp(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
+          u_diff(n) = 0.0_r8 ! atm velocity change, zonal ~ m/s
+          v_diff(n) = 0.0_r8 ! atm velocity change, meridional ~ m/s
           thbot(n)= 301.0_r8 ! atm potential temperature  ~ Kelvin
           shum(n) = 1.e-2_r8 ! atm specific humidity      ~ kg/kg
           !wiso note: shum_* should be multiplied by Rstd_* here?
@@ -1446,6 +1479,9 @@ contains
              zbot(n) = a2x%rAttr(index_a2x_Sa_z   ,n)
              ubot(n) = a2x%rAttr(index_a2x_Sa_u   ,n)
              vbot(n) = a2x%rAttr(index_a2x_Sa_v   ,n)
+             wsresp(n) = a2x%rAttr(index_a2x_Sa_wsresp,n)
+             u_diff(n) = a2x%rAttr(index_a2x_Sa_u_diff,n)
+             v_diff(n) = a2x%rAttr(index_a2x_Sa_v_diff,n)
              thbot(n)= a2x%rAttr(index_a2x_Sa_ptem,n)
              shum(n) = a2x%rAttr(index_a2x_Sa_shum,n)
              if ( index_a2x_Sa_shum_16O /= 0 ) shum_16O(n) = a2x%rAttr(index_a2x_Sa_shum_16O,n)

--- a/src/drivers/mct/main/seq_flux_mct.F90
+++ b/src/drivers/mct/main/seq_flux_mct.F90
@@ -47,6 +47,7 @@ module seq_flux_mct
   real(r8), allocatable ::  vbot (:)  ! atm velocity, meridional
   real(r8), allocatable ::  wsresp(:) ! atm response to surface stress
   real(r8), allocatable ::  tau_est(:)! estimation of tau in equilibrium with wind
+  real(r8), allocatable ::  ugust_atm(:)  ! atm gustiness
   real(r8), allocatable ::  thbot(:)  ! atm potential T
   real(r8), allocatable ::  shum (:)  ! atm specific humidity
   real(r8), allocatable ::  shum_16O (:)  ! atm H2O tracer
@@ -122,6 +123,7 @@ module seq_flux_mct
   integer :: index_a2x_Sa_v
   integer :: index_a2x_Sa_wsresp
   integer :: index_a2x_Sa_tau_est
+  integer :: index_a2x_Sa_ugust
   integer :: index_a2x_Sa_tbot
   integer :: index_a2x_Sa_ptem
   integer :: index_a2x_Sa_shum
@@ -240,12 +242,17 @@ contains
     if(ier/=0) call mct_die(subName,'allocate vbot',ier)
     vbot = 0.0_r8
     if (atm_flux_method == 'implicit_stress') then
-       allocate( wsresp(nloc))
+       allocate(wsresp(nloc))
        if(ier/=0) call mct_die(subName,'allocate wsresp',ier)
        wsresp = 0.0_r8
-       allocate( tau_est(nloc))
+       allocate(tau_est(nloc))
        if(ier/=0) call mct_die(subName,'allocate tau_est',ier)
        tau_est = 0.0_r8
+    end if
+    if (atm_gustiness) then
+       allocate(ugust_atm(nloc))
+       if(ier/=0) call mct_die(subName,'allocate ugust_atm',ier)
+       ugust_atm = 0.0_r8
     end if
     allocate(thbot(nloc),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate thbot',ier)
@@ -679,6 +686,10 @@ contains
        allocate( tau_est(nloc_a2o),stat=ier)
        if(ier/=0) call mct_die(subName,'allocate tau_est',ier)
     end if
+    if (atm_gustiness) then
+       allocate( ugust_atm(nloc_a2o),stat=ier)
+       if(ier/=0) call mct_die(subName,'allocate ugust_atm',ier)
+    end if
     allocate(thbot(nloc_a2o),stat=ier)
     if(ier/=0) call mct_die(subName,'allocate thbot',ier)
     allocate(shum(nloc_a2o),stat=ier)
@@ -1044,6 +1055,9 @@ contains
              wsresp(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
              tau_est(n) = 0.0_r8 ! estimation of stress in equilibrium with ubot/vbot ~ Pa
           end if
+          if (atm_gustiness) then
+             ugust_atm(n) = 0.0_r8 ! gustiness                ~ m/s
+          end if
           thbot(n)= 301.0_r8 ! atm potential temperature  ~ Kelvin
           shum(n) = 1.e-2_r8 ! atm specific humidity      ~ kg/kg
           shum_16O(n) = 1.e-2_r8 ! H216O specific humidity    ~ kg/kg
@@ -1083,6 +1097,9 @@ contains
           if (atm_flux_method == 'implicit_stress') then
              wsresp(n) = a2x_e%rAttr(index_a2x_Sa_wsresp,ia)
              tau_est(n) = a2x_e%rAttr(index_a2x_Sa_tau_est,ia)
+          end if
+          if (atm_gustiness) then
+             ugust_atm(n) = a2x_e%rAttr(index_a2x_Sa_ugust,ia)
           end if
           thbot(n)= a2x_e%rAttr(index_a2x_Sa_ptem,ia)
           shum(n) = a2x_e%rAttr(index_a2x_Sa_shum,ia)
@@ -1141,7 +1158,7 @@ contains
             evap , evap_16O, evap_HDO, evap_18O, taux, tauy, tref, qref , &
             ocn_surface_flux_scheme, &
             duu10n,ustar, re  , ssq , missval = 0.0_r8, &
-            wsresp=wsresp, tau_est=tau_est)
+            wsresp=wsresp, tau_est=tau_est, ugust=ugust)
     endif
 
     !--- create temporary aVects on exchange, atm, or ocn decomp as needed
@@ -1389,6 +1406,9 @@ contains
           index_a2x_Sa_wsresp = mct_aVect_indexRA(a2x,'Sa_wsresp')
           index_a2x_Sa_tau_est = mct_aVect_indexRA(a2x,'Sa_tau_est')
        end if
+       if (atm_gustiness) then
+          index_a2x_Sa_ugust = mct_aVect_indexRA(a2x,'Sa_ugust')
+       end if
        index_a2x_Sa_tbot   = mct_aVect_indexRA(a2x,'Sa_tbot')
        index_a2x_Sa_pslv   = mct_aVect_indexRA(a2x,'Sa_pslv')
        index_a2x_Sa_ptem   = mct_aVect_indexRA(a2x,'Sa_ptem')
@@ -1446,6 +1466,9 @@ contains
              wsresp(n) = 0.0_r8 ! response of wind to surface stress ~ m/s/Pa
              tau_est(n) = 0.0_r8 ! stress consistent w/ u/v  ~ Pa
           end if
+          if (atm_gustiness) then
+             ugust_atm(n) = 0.0_r8 ! gustiness                ~ m/s
+          end if
           thbot(n)= 301.0_r8 ! atm potential temperature  ~ Kelvin
           shum(n) = 1.e-2_r8 ! atm specific humidity      ~ kg/kg
           !wiso note: shum_* should be multiplied by Rstd_* here?
@@ -1496,6 +1519,9 @@ contains
              if (atm_flux_method == 'implicit_stress') then
                 wsresp(n) = a2x%rAttr(index_a2x_Sa_wsresp,n)
                 tau_est(n) = a2x%rAttr(index_a2x_Sa_tau_est,n)
+             end if
+             if (atm_gustiness) then
+                ugust_atm(n) = a2x%rAttr(index_a2x_Sa_ugust,n)
              end if
              thbot(n)= a2x%rAttr(index_a2x_Sa_ptem,n)
              shum(n) = a2x%rAttr(index_a2x_Sa_shum,n)
@@ -1592,7 +1618,7 @@ contains
             evap , evap_16O, evap_HDO, evap_18O, taux , tauy, tref, qref , &
             ocn_surface_flux_scheme, &
             duu10n,ustar, re  , ssq, &
-            wsresp=wsresp, tau_est=tau_est)
+            wsresp=wsresp, tau_est=tau_est, ugust=ugust_atm)
        !missval should not be needed if flux calc
        !consistent with mrgx2a fraction
        !duu10n,ustar, re  , ssq, missval = 0.0_r8 )

--- a/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/src/drivers/mct/shr/seq_flds_mod.F90
@@ -638,6 +638,51 @@ contains
     attname  = 'Sa_v'
     call metadata_set(attname, longname, stdname, units)
 
+    ! first-order response of wind to surface stresses (m/s/Pa)
+    call seq_flds_add(a2x_states,"Sa_wsresp")
+    call seq_flds_add(x2l_states,"Sa_wsresp")
+    call seq_flds_add(x2i_states,"Sa_wsresp")
+    if (rof_heat) then
+       call seq_flds_add(x2r_states,"Sa_wsresp")
+       call seq_flds_add(a2x_states_to_rof,"Sa_wsresp")
+    endif
+    call seq_flds_add(x2w_states,"Sa_wsresp")
+    longname = 'Response of wind to surface stress'
+    stdname  = 'wsresp'
+    units    = 'm s-1 Pa-1'
+    attname  = 'Sa_wsresp'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! approximate atmosphere change to lowest zonal wind (m/s)
+    call seq_flds_add(a2x_states,"Sa_u_diff")
+    call seq_flds_add(x2l_states,"Sa_u_diff")
+    call seq_flds_add(x2i_states,"Sa_u_diff")
+    if (rof_heat) then
+       call seq_flds_add(x2r_states,"Sa_u_diff")
+       call seq_flds_add(a2x_states_to_rof,"Sa_u_diff")
+    endif
+    call seq_flds_add(x2w_states,"Sa_u_diff")
+    longname = 'Approximate atmosphere change to lowest level zonal wind'
+    stdname  = 'u_diff'
+    units    = 'm s-1'
+    attname  = 'Sa_u_diff'
+    call metadata_set(attname, longname, stdname, units)
+
+    ! approximate atmosphere change to lowest meridional wind (m/s)
+    call seq_flds_add(a2x_states,"Sa_v_diff")
+    call seq_flds_add(x2l_states,"Sa_v_diff")
+    call seq_flds_add(x2i_states,"Sa_v_diff")
+    if (rof_heat) then
+       call seq_flds_add(x2r_states,"Sa_v_diff")
+       call seq_flds_add(a2x_states_to_rof,"Sa_v_diff")
+    endif
+    call seq_flds_add(x2w_states,"Sa_v_diff")
+    longname = 'Approximate atmosphere change to lowest level meridional wind'
+    stdname  = 'v_diff'
+    units    = 'm s-1'
+    attname  = 'Sa_v_diff'
+    call metadata_set(attname, longname, stdname, units)
+
     ! temperature at the lowest model level (K)
     call seq_flds_add(a2x_states,"Sa_tbot")
     call seq_flds_add(x2l_states,"Sa_tbot")

--- a/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/src/drivers/mct/shr/seq_flds_mod.F90
@@ -642,45 +642,20 @@ contains
     call seq_flds_add(a2x_states,"Sa_wsresp")
     call seq_flds_add(x2l_states,"Sa_wsresp")
     call seq_flds_add(x2i_states,"Sa_wsresp")
-    if (rof_heat) then
-       call seq_flds_add(x2r_states,"Sa_wsresp")
-       call seq_flds_add(a2x_states_to_rof,"Sa_wsresp")
-    endif
-    call seq_flds_add(x2w_states,"Sa_wsresp")
     longname = 'Response of wind to surface stress'
     stdname  = 'wsresp'
     units    = 'm s-1 Pa-1'
     attname  = 'Sa_wsresp'
     call metadata_set(attname, longname, stdname, units)
 
-    ! approximate atmosphere change to lowest zonal wind (m/s)
-    call seq_flds_add(a2x_states,"Sa_u_diff")
-    call seq_flds_add(x2l_states,"Sa_u_diff")
-    call seq_flds_add(x2i_states,"Sa_u_diff")
-    if (rof_heat) then
-       call seq_flds_add(x2r_states,"Sa_u_diff")
-       call seq_flds_add(a2x_states_to_rof,"Sa_u_diff")
-    endif
-    call seq_flds_add(x2w_states,"Sa_u_diff")
-    longname = 'Approximate atmosphere change to lowest level zonal wind'
-    stdname  = 'u_diff'
-    units    = 'm s-1'
-    attname  = 'Sa_u_diff'
-    call metadata_set(attname, longname, stdname, units)
-
-    ! approximate atmosphere change to lowest meridional wind (m/s)
-    call seq_flds_add(a2x_states,"Sa_v_diff")
-    call seq_flds_add(x2l_states,"Sa_v_diff")
-    call seq_flds_add(x2i_states,"Sa_v_diff")
-    if (rof_heat) then
-       call seq_flds_add(x2r_states,"Sa_v_diff")
-       call seq_flds_add(a2x_states_to_rof,"Sa_v_diff")
-    endif
-    call seq_flds_add(x2w_states,"Sa_v_diff")
-    longname = 'Approximate atmosphere change to lowest level meridional wind'
-    stdname  = 'v_diff'
-    units    = 'm s-1'
-    attname  = 'Sa_v_diff'
+    ! surface stress compatible with low level wind (Pa)
+    call seq_flds_add(a2x_states,"Sa_tau_est")
+    call seq_flds_add(x2l_states,"Sa_tau_est")
+    call seq_flds_add(x2i_states,"Sa_tau_est")
+    longname = 'estimate of surface stress in equilibrium with boundary layer'
+    stdname  = 'tau_est'
+    units    = 'Pa'
+    attname  = 'Sa_tau_est'
     call metadata_set(attname, longname, stdname, units)
 
     ! temperature at the lowest model level (K)

--- a/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/src/drivers/mct/shr/seq_flds_mod.F90
@@ -121,7 +121,7 @@ module seq_flds_mod
   ! variables CCSM_VOC, CCSM_BGC and GLC_NEC.
   !====================================================================
 
-  use shr_kind_mod      , only : CX => shr_kind_CX, CXX => shr_kind_CXX
+  use shr_kind_mod      , only : CS => shr_kind_CS, CX => shr_kind_CX, CXX => shr_kind_CXX
   use shr_sys_mod       , only : shr_sys_abort
   use seq_comm_mct      , only : seq_comm_iamroot, seq_comm_setptrs, logunit
   use seq_drydep_mod    , only : seq_drydep_init, seq_drydep_readnl, lnd_drydep
@@ -150,6 +150,9 @@ module seq_flds_mod
 
   logical            :: rof_heat            ! .true. if river model includes temperature
   logical            :: add_ndep_fields     ! .true. => add ndep fields
+
+  character(len=CS)  :: atm_flux_method     ! explicit => no extra fields needed
+                                            ! implicit_stress => atm provides wsresp and tau_est
 
   !----------------------------------------------------------------------------
   ! metadata
@@ -368,7 +371,7 @@ contains
     namelist /seq_cplflds_inparm/  &
          flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, glc_nec, &
          ice_ncat, seq_flds_i2o_per_cat, flds_bgc_oi, &
-         nan_check_component_fields, rof_heat
+         nan_check_component_fields, rof_heat, atm_flux_method
 
     ! user specified new fields
     integer,  parameter :: nfldmax = 200
@@ -404,6 +407,7 @@ contains
        seq_flds_i2o_per_cat = .false.
        nan_check_component_fields = .false.
        rof_heat = .false.
+       atm_flux_method = 'explicit'
 
        unitn = shr_file_getUnit()
        write(logunit,"(A)") subname//': read seq_cplflds_inparm namelist from: '&
@@ -431,6 +435,7 @@ contains
     call shr_mpi_bcast(seq_flds_i2o_per_cat, mpicom)
     call shr_mpi_bcast(nan_check_component_fields, mpicom)
     call shr_mpi_bcast(rof_heat    , mpicom)
+    call shr_mpi_bcast(atm_flux_method, mpicom)
 
     call glc_elevclass_init(glc_nec)
 
@@ -638,25 +643,27 @@ contains
     attname  = 'Sa_v'
     call metadata_set(attname, longname, stdname, units)
 
-    ! first-order response of wind to surface stresses (m/s/Pa)
-    call seq_flds_add(a2x_states,"Sa_wsresp")
-    call seq_flds_add(x2l_states,"Sa_wsresp")
-    call seq_flds_add(x2i_states,"Sa_wsresp")
-    longname = 'Response of wind to surface stress'
-    stdname  = 'wsresp'
-    units    = 'm s-1 Pa-1'
-    attname  = 'Sa_wsresp'
-    call metadata_set(attname, longname, stdname, units)
+    if (atm_flux_method == 'implicit_stress') then
+       ! first-order response of wind to surface stresses (m/s/Pa)
+       call seq_flds_add(a2x_states,"Sa_wsresp")
+       call seq_flds_add(x2l_states,"Sa_wsresp")
+       call seq_flds_add(x2i_states,"Sa_wsresp")
+       longname = 'Response of wind to surface stress'
+       stdname  = 'wsresp'
+       units    = 'm s-1 Pa-1'
+       attname  = 'Sa_wsresp'
+       call metadata_set(attname, longname, stdname, units)
 
-    ! surface stress compatible with low level wind (Pa)
-    call seq_flds_add(a2x_states,"Sa_tau_est")
-    call seq_flds_add(x2l_states,"Sa_tau_est")
-    call seq_flds_add(x2i_states,"Sa_tau_est")
-    longname = 'estimate of surface stress in equilibrium with boundary layer'
-    stdname  = 'tau_est'
-    units    = 'Pa'
-    attname  = 'Sa_tau_est'
-    call metadata_set(attname, longname, stdname, units)
+       ! surface stress compatible with low level wind (Pa)
+       call seq_flds_add(a2x_states,"Sa_tau_est")
+       call seq_flds_add(x2l_states,"Sa_tau_est")
+       call seq_flds_add(x2i_states,"Sa_tau_est")
+       longname = 'estimate of surface stress in equilibrium with boundary layer'
+       stdname  = 'tau_est'
+       units    = 'Pa'
+       attname  = 'Sa_tau_est'
+       call metadata_set(attname, longname, stdname, units)
+    end if
 
     ! temperature at the lowest model level (K)
     call seq_flds_add(a2x_states,"Sa_tbot")

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -150,7 +150,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
            &               taux  ,tauy  ,tref  ,qref  ,   &
            &               ocn_surface_flux_scheme, &
            &               duu10n,  ustar_sv   ,re_sv ,ssq_sv,   &
-           &               missval, wsresp, tau_est )
+           &               missval, wsresp, tau_est, ugust)
 
 ! !USES:
 
@@ -204,6 +204,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
 
    real(R8),intent(in) ,optional :: wsresp(nMax)   ! boundary layer wind response to stress (m/s/Pa)
    real(R8),intent(in) ,optional :: tau_est(nMax)  ! stress in equilibrium with boundary layer (Pa)
+   real(R8),intent(in) ,optional :: ugust(nMax)    ! extra wind speed from gustiness (m/s)
 
 ! !EOP
 
@@ -335,7 +336,11 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
 
         !--- compute some needed quantities ---
         wind0 = max(sqrt((ubot(n) - us(n))**2 + (vbot(n) - vs(n))**2), 0.01_r8)
-        vmag = max(seq_flux_atmocn_minwind, wind0)
+        vmag = wind0
+        if (present(ugust)) then
+           vmag = vmag + ugust(n)
+        end if
+        vmag = max(seq_flux_atmocn_minwind, vmag)
         if (use_coldair_outbreak_mod) then
             ! Cold Air Outbreak Modification:
             ! Increase windspeed for negative tbot-ts
@@ -376,7 +381,11 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
            tau = rbot(n) * ustar * rdn * wind_adj
            call shr_flux_update_stress(wind0, wsresp(n), tau_est(n), &
                 tau, prev_tau, tau_diff, prev_tau_diff, wind_adj)
-           vmag = max(seq_flux_atmocn_minwind, wind_adj)
+           vmag = wind_adj
+           if (present(ugust)) then
+              vmag = vmag + ugust(n)
+           end if
+           vmag = max(seq_flux_atmocn_minwind, vmag)
         else
            tau_diff = 0._R8
         end if
@@ -421,7 +430,11 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
               tau = rbot(n) * ustar * rd * wind_adj
               call shr_flux_update_stress(wind0, wsresp(n), tau_est(n), &
                    tau, prev_tau, tau_diff, prev_tau_diff, wind_adj)
-              vmag = max(seq_flux_atmocn_minwind, wind_adj)
+              vmag = wind_adj
+              if (present(ugust)) then
+                 vmag = vmag + ugust(n)
+              end if
+              vmag = max(seq_flux_atmocn_minwind, vmag)
            end if
         enddo
         if (iter < 1) then
@@ -511,7 +524,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
 
         !--- compute some needed quantities ---
         wind0 = max(sqrt((ubot(n) - us(n))**2 + (vbot(n) - vs(n))**2), 0.01_r8)
-        vmag = max(seq_flux_atmocn_minwind, wind0 )
+        vmag = max(seq_flux_atmocn_minwind, wind0)
 
          if (use_coldair_outbreak_mod) then
             ! Cold Air Outbreak Modification:

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -38,6 +38,8 @@ module shr_flux_mod
    public :: shr_flux_MOstability ! boundary layer stability scales/functions
    public :: shr_flux_adjust_constants ! adjust constant values used in flux calculations.
 
+   public :: shr_flux_update_stress ! Update of stress for iterations in implicit code.
+
 ! !PUBLIC DATA MEMBERS:
 
   integer(IN),parameter,public :: shr_flux_MOwScales   = 1 ! w scales  option
@@ -70,6 +72,7 @@ module shr_flux_mod
    ! (For Large and Pond scheme only; not UA or COARE).
    real(r8) :: flux_con_tol = 0.0_R8
    integer(IN) :: flux_con_max_iter = 2
+   real(r8), parameter :: dtaumin = 0.01_r8 ! limit for stress convergence [Pa]
 
    character(len=*), parameter :: sourcefile = &
      __FILE__
@@ -147,7 +150,7 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
            &               taux  ,tauy  ,tref  ,qref  ,   &
            &               ocn_surface_flux_scheme, &
            &               duu10n,  ustar_sv   ,re_sv ,ssq_sv,   &
-           &               missval    )
+           &               missval, wsresp, tau_est )
 
 ! !USES:
 
@@ -199,6 +202,9 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
 
    real(R8),intent(in) ,optional :: missval        ! masked value
 
+   real(R8),intent(in) ,optional :: wsresp(nMax)   ! boundary layer wind response to stress (m/s/Pa)
+   real(R8),intent(in) ,optional :: tau_est(nMax)  ! stress in equilibrium with boundary layer (Pa)
+
 ! !EOP
 
    !--- local constants --------------------------------
@@ -243,6 +249,11 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
    real(R8)    :: cp     ! specific heat of moist air
    real(R8)    :: fac    ! vertical interpolation factor
    real(R8)    :: spval  ! local missing value
+   real(R8)    :: wind0    ! wind speed from atmosphere (m/s)
+   real(R8)    :: prev_tau ! tau from previous iteration (Pa)
+   real(R8)    :: tau_diff ! difference in tau across iterations (Pa)
+   real(R8)    :: prev_tau_diff ! previous value of tau_diff (Pa)
+   real(R8)    :: wind_adj ! iteration-adjusted wind speed (m/s)
 !!++ COARE only
    real(R8)    :: zo,zot,zoq      ! roughness lengths
    real(R8)    :: hsb,hlb         ! sens & lat heat flxs at zbot
@@ -323,7 +334,8 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
      if (mask(n) /= 0) then
 
         !--- compute some needed quantities ---
-        vmag   = max(seq_flux_atmocn_minwind, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
+        wind0 = max(sqrt((ubot(n) - us(n))**2 + (vbot(n) - vs(n))**2), 0.01_r8)
+        vmag = max(seq_flux_atmocn_minwind, wind0)
         if (use_coldair_outbreak_mod) then
             ! Cold Air Outbreak Modification:
             ! Increase windspeed for negative tbot-ts
@@ -355,8 +367,23 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
         tstar = rhn * delt
         qstar = ren * delq
         ustar_prev = ustar*2.0_R8
+        if (present(wsresp) .and. present(tau_est)) prev_tau = tau_est(n)
+        tau_diff = 1.e100_R8
+        wind_adj = wind0
+        ! Since we already have an estimated u*, do one update before iteration loop.
+        if (present(wsresp) .and. present(tau_est)) then
+           ! Update stress and magnitude of mean wind.
+           tau = rbot(n) * ustar * rdn * wind_adj
+           call shr_flux_update_stress(wind0, wsresp(n), tau_est(n), &
+                tau, prev_tau, tau_diff, prev_tau_diff, wind_adj)
+           vmag = max(seq_flux_atmocn_minwind, wind_adj)
+        else
+           tau_diff = 0._R8
+        end if
         iter = 0
-        do while( abs((ustar - ustar_prev)/ustar) > flux_con_tol .and. iter < flux_con_max_iter)
+        do while( (abs((ustar - ustar_prev)/ustar) > flux_con_tol .or. &
+             abs(tau_diff) > dtaumin) .and. &
+             iter < flux_con_max_iter)
            iter = iter + 1
            ustar_prev = ustar
            !--- compute stability & evaluate all stability functions ---
@@ -388,6 +415,14 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
            ustar = rd * vmag
            tstar = rh * delt
            qstar = re * delq
+
+           if (present(wsresp) .and. present(tau_est)) then
+              ! Update stress and magnitude of mean wind.
+              tau = rbot(n) * ustar * rd * wind_adj
+              call shr_flux_update_stress(wind0, wsresp(n), tau_est(n), &
+                   tau, prev_tau, tau_diff, prev_tau_diff, wind_adj)
+              vmag = max(seq_flux_atmocn_minwind, wind_adj)
+           end if
         enddo
         if (iter < 1) then
            write(s_logunit,*) ustar,ustar_prev,flux_con_tol,flux_con_max_iter
@@ -400,8 +435,8 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
         tau = rbot(n) * ustar * ustar
 
         !--- momentum flux ---
-        taux(n) = tau * (ubot(n)-us(n)) / vmag
-        tauy(n) = tau * (vbot(n)-vs(n)) / vmag
+        taux(n) = tau * (ubot(n)-us(n)) / vmag * (wind_adj / wind0)
+        tauy(n) = tau * (vbot(n)-vs(n)) / vmag * (wind_adj / wind0)
 
         !--- heat flux ---
         sen (n) =          cp * tau * tstar / ustar
@@ -475,7 +510,8 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
      if (mask(n) /= 0) then
 
         !--- compute some needed quantities ---
-        vmag    = max(seq_flux_atmocn_minwind, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
+        wind0 = max(sqrt((ubot(n) - us(n))**2 + (vbot(n) - vs(n))**2), 0.01_r8)
+        vmag    = max(seq_flux_atmocn_minwind, wind0 )
 
          if (use_coldair_outbreak_mod) then
             ! Cold Air Outbreak Modification:
@@ -495,7 +531,8 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
                  & ,tau,hsb,hlb                             &  ! out: fluxes
                  & ,zo,zot,zoq,hol,ustar,tstar,qstar        &  ! out: ss scales
                  & ,rd,rh,re                                &  ! out: exch. coeffs
-                 & ,trf,qrf,urf,vrf) ! out: reference-height params
+                 & ,trf,qrf,urf,vrf                         &  ! out: reference-height params
+                 & ,wsresp(n),tau_est(n))                      ! in: optional stress params
 
 ! for the sake of maintaining same defs
         hol=zbot(n)/hol
@@ -504,8 +541,8 @@ SUBROUTINE shr_flux_atmOcn(nMax  ,zbot  ,ubot  ,vbot  ,thbot ,   &
         re=sqrt(re)
 
         !--- momentum flux ---
-        taux(n) = tau * (ubot(n)-us(n)) / vmag
-        tauy(n) = tau * (vbot(n)-vs(n)) / vmag
+        taux(n) = tau * (ubot(n)-us(n)) / wind0
+        tauy(n) = tau * (vbot(n)-vs(n)) / wind0
 
         !--- heat flux ---
         sen (n) =  hsb
@@ -606,7 +643,7 @@ SUBROUTINE shr_flux_atmOcn_UA(   &
            &               evap  ,evap_16O, evap_HDO, evap_18O, &
            &               taux  ,tauy  ,tref  ,qref  ,   &
            &               duu10n,  ustar_sv   ,re_sv ,ssq_sv,   &
-           &               missval    )
+           &               missval, wsresp, tau_est)
 
 
 ! !USES:
@@ -657,6 +694,9 @@ SUBROUTINE shr_flux_atmOcn_UA(   &
 
    real(R8),intent(in) ,optional :: missval        ! masked value
 
+   real(R8),intent(in) ,optional :: wsresp(nMax)   ! boundary layer wind response to stress (m/s/Pa)
+   real(R8),intent(in) ,optional :: tau_est(nMax)  ! stress in equilibrium with boundary layer (Pa)
+
 ! !EOP
 
    !--- local constants --------------------------------
@@ -705,6 +745,11 @@ SUBROUTINE shr_flux_atmOcn_UA(   &
                              ! with default algorithm.
    real(R8)    :: spval      ! local missing value
    real(R8)    :: loc_epsilon  ! Ratio of gas constants (-)
+   real(R8)    :: wind0    ! wind speed from atmosphere (m/s)
+   real(R8)    :: prev_tau ! tau from previous iteration (Pa)
+   real(R8)    :: tau_diff ! difference in tau across iterations (Pa)
+   real(R8)    :: prev_tau_diff ! previous value of tau_diff (Pa)
+   real(R8)    :: wind_adj ! iteration-adjusted wind speed (m/s)
 
    !--- for cold air outbreak calc --------------------------------
    real(R8)    :: tdiff(nMax)  ! tbot - ts
@@ -738,6 +783,7 @@ SUBROUTINE shr_flux_atmOcn_UA(   &
      !-----Calculate some required near surface variables.---------
         vmag_abs = sqrt( ubot(n)**2 + vbot(n)**2 )
         vmag_rel = sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2 )
+        wind0 = max(vmag_rel, 0.01_R8)
 
         ! For Cold Air Outbreak Modification (based on Mahrt & Sun 1995,MWR):
         if (use_coldair_outbreak_mod) then
@@ -806,6 +852,10 @@ SUBROUTINE shr_flux_atmOcn_UA(   &
         obu = sign(max(zbot(n)/10.0_R8, abs(obu)), obu)
 
      !-----Main iterations (2-10 iterations would be fine).-------
+        if (present(wsresp) .and. present(tau_est)) prev_tau = tau_est(n)
+        tau_diff = 1.e100_R8
+        wind_adj = wind0
+
         do i=1,10
 
             ! Update roughness lengths.
@@ -898,6 +948,14 @@ SUBROUTINE shr_flux_atmOcn_UA(   &
             obu = ustar*ustar * thv / (loc_karman*loc_g*thvstar)
             obu = sign( max(zbot(n)/10.0_R8, abs(obu)) ,obu)
 
+            if (present(wsresp) .and. present(tau_est)) then
+               ! Update stress and magnitude of mean wind.
+               tau = rbot(n) * ustar * ustar * wind_adj / vmag
+               call shr_flux_update_stress(wind0, wsresp(n), tau_est(n), &
+                    tau, prev_tau, tau_diff, prev_tau_diff, wind_adj)
+               vmag_rel = wind_adj * vscl
+            end if
+
             ! Update wind speed if in unstable regime.
             if (delthv.lt.0.0_R8) then
                 ! EQN (20)
@@ -918,9 +976,14 @@ SUBROUTINE shr_flux_atmOcn_UA(   &
         ! This should ensure zero wind stress when (relative) wind speed is zero,
         ! components are consistent with total, and we don't ever divide by zero.
         ! EQN (21)
-        tau = rbot(n) * ustar * ustar
-        taux(n) = tau * (ubot(n)-us(n)) / max(umin, vmag_rel)
-        tauy(n) = tau * (vbot(n)-vs(n)) / max(umin, vmag_rel)
+        if (present(wsresp) .and. present(tau_est)) then
+           taux(n) = tau * (ubot(n)-us(n)) / wind0
+           tauy(n) = tau * (vbot(n)-vs(n)) / wind0
+        else
+           tau = rbot(n) * ustar * ustar
+           taux(n) = tau * (ubot(n)-us(n)) / max(umin, vmag_rel)
+           tauy(n) = tau * (vbot(n)-vs(n)) / max(umin, vmag_rel)
+        end if
 
         !--- heat flux ---
         ! EQNs (22) and (23)
@@ -1166,7 +1229,7 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                            tBulk, tSkin, tSkin_day, tSkin_night,           &
                            cSkin, cSkin_night, secs ,dt,                   &
                            duu10n,  ustar_sv   ,re_sv ,ssq_sv,             &
-                           missval, cold_start    )
+                           missval, cold_start, wsresp, tau_est )
 ! !USES:
 
    use water_isotopes, only: wiso_flxoce !subroutine used to calculate water isotope fluxes.
@@ -1235,6 +1298,9 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8),intent(in)    :: seq_flux_atmocn_minwind   ! minimum wind speed for atmocn      (m/s)
 
    real(R8),intent(in) ,optional :: missval     ! masked value
+
+   real(R8),intent(in) ,optional :: wsresp(nMax)   ! boundary layer wind response to stress (m/s/Pa)
+   real(R8),intent(in) ,optional :: tau_est(nMax)  ! stress in equilibrium with boundary layer (Pa)
 
    !--- output arguments -------------------------------
    real(R8),intent(out)  ::  sen  (nMax) ! heat flux: sensible    (W/m^2)
@@ -1355,6 +1421,12 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
    real(R8)    :: phid
    real(R8)    :: spval
 
+   real(R8)    :: wind0    ! wind speed from atmosphere (m/s)
+   real(R8)    :: prev_tau ! tau from previous iteration (Pa)
+   real(R8)    :: tau_diff ! difference in tau across iterations (Pa)
+   real(R8)    :: prev_tau_diff ! previous value of tau_diff (Pa)
+   real(R8)    :: wind_adj ! iteration-adjusted wind speed (m/s)
+
 !!++ COARE only
    real(R8)    :: zo,zot,zoq      ! roughness lengths
    real(R8)    :: hsb,hlb         ! sens & lat heat flxs at zbot
@@ -1460,8 +1532,8 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
       if (mask(n) /= 0) then
 
          !--- compute some initial and useful flux quantities ---
-
-         vmag     = max(seq_flux_atmocn_minwind, sqrt( (ubot(n)-us(n))**2 + (vbot(n)-vs(n))**2) )
+         wind0 = max(sqrt((ubot(n) - us(n))**2 + (vbot(n) - vs(n))**2), 0.01_r8)
+         vmag = max(seq_flux_atmocn_minwind, wind0)
          if (use_coldair_outbreak_mod) then
             ! Cold Air Outbreak Modification:
             ! Increase windspeed for negative tbot-ts
@@ -1544,6 +1616,22 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             tstar = rhn * delt
             qstar = ren * delq
 
+            !--- Stress iteration variables
+            if (present(wsresp) .and. present(tau_est)) prev_tau = tau_est(n)
+            tau_diff = 1.e100_R8
+            wind_adj = wind0
+
+            ! Since we already have an estimated u*, do one update before iteration loop.
+            if (present(wsresp) .and. present(tau_est)) then
+               ! Update stress and magnitude of mean wind.
+               tau = rbot(n) * ustar * rdn * wind_adj
+               call shr_flux_update_stress(wind0, wsresp(n), tau_est(n), &
+                    tau, prev_tau, tau_diff, prev_tau_diff, wind_adj)
+               vmag = max(seq_flux_atmocn_minwind, wind_adj) * vscl
+            else
+               tau_diff = 0._R8
+            end if
+
          else if (ocn_surface_flux_scheme .eq. 1) then! use COARE algorithm
 
               call cor30a(ubot(n),vbot(n),tbot(n),qbot(n),rbot(n) &  ! in atm params
@@ -1552,12 +1640,15 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                        & ,tau,hsb,hlb                             &  ! out: fluxes
                        & ,zo,zot,zoq,hol,ustar,tstar,qstar        &  ! out: ss scales
                        & ,rd,rh,re                                &  ! out: exch. coeffs
-                       & ,trf,qrf,urf,vrf)			       ! out: reference-height params
+                       & ,trf,qrf,urf,vrf                         &  ! out: reference-height params
+                       & ,wsresp(n),tau_est(n))                      ! in: optional stress params
              ! for the sake of maintaining same defs
               hol=zbot(n)/hol
               rd=sqrt(rd)
               rh=sqrt(rh)
               re=sqrt(re)
+
+              tau_diff = 0._r8
 
          ELSE  ! N.B.: *no* valid ocn_surface_flux_scheme=2 option if diurnal=.true.
 
@@ -1571,7 +1662,9 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
         ! Originally this code did three iterations while the non-diurnal version did two
         ! So in the new loop this is <= flux_con_max_iter instead of < so that the same defaults
         ! will give the same answers in both cases.
-        do while( abs((ustar - ustar_prev)/ustar) > flux_con_tol .and. iter <= flux_con_max_iter)
+        do while( (abs((ustar - ustar_prev)/ustar) > flux_con_tol .or. &
+             abs(tau_diff) > dtaumin) .and. &
+             iter <= flux_con_max_iter)
             iter = iter + 1
             ustar_prev = ustar
             !------------------------------------------------------------
@@ -1700,9 +1793,18 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
             tstar = rh * delt
             qstar = re * delq
 
+            if (present(wsresp) .and. present(tau_est)) then
+               ! Update stress and magnitude of mean wind.
+               tau = rbot(n) * ustar * rd * wind_adj
+               call shr_flux_update_stress(wind0, wsresp(n), tau_est(n), &
+                    tau, prev_tau, tau_diff, prev_tau_diff, wind_adj)
+               vmag = max(seq_flux_atmocn_minwind, wind_adj) * vscl
+            else
+               tau = rbot(n) * ustar * ustar
+            end if
+
             !--- heat flux ---
 
-            tau     = rbot(n) * ustar * ustar
             sen (n) =                cp * tau * tstar / ustar
             lat (n) = shr_const_latvap * tau * qstar / ustar
 
@@ -1714,7 +1816,8 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
                      & ,tau,hsb,hlb                             &  ! out: fluxes
                      & ,zo,zot,zoq,hol,ustar,tstar,qstar        &  ! out: ss scales
                      & ,rd,rh,re                                &  ! out: exch. coeffs
-                     & ,trf,qrf,urf,vrf)			       ! out: reference-height params
+                     & ,trf,qrf,urf,vrf                         &  ! out: reference-height params
+                     & ,wsresp(n),tau_est(n))                      ! in: optional stress params
             ! for the sake of maintaining same defs
             hol=zbot(n)/hol
             rd=sqrt(rd)
@@ -1736,14 +1839,16 @@ SUBROUTINE shr_flux_atmOcn_diurnal &
          end if
          !--- COMPUTE FLUXES TO ATMOSPHERE AND OCEAN ---
 
-         ! Now calculated further up in subroutine.
-         !tau = rbot(n) * ustar * ustar
-         !sen (n) =                cp * tau * tstar / ustar
-         !lat (n) =  shr_const_latvap * tau * qstar / ustar
-
          !--- momentum flux ---
-         taux(n) = tau * (ubot(n)-us(n)) / vmag
-         tauy(n) = tau * (vbot(n)-vs(n)) / vmag
+         ! Conditional must be repeated here to preserve bfb when adding
+         ! implicit stress code.
+         if (present(wsresp) .and. present(tau_est)) then
+            taux(n) = tau * (ubot(n)-us(n)) / wind0
+            tauy(n) = tau * (vbot(n)-vs(n)) / wind0
+         else
+            taux(n) = tau * (ubot(n)-us(n)) / vmag
+            tauy(n) = tau * (vbot(n)-vs(n)) / vmag
+         end if
 
          !--- LW radiation ---
          lwup(n) = -shr_const_stebol * Tskin(n)**4
@@ -2293,6 +2398,66 @@ end subroutine shr_flux_MOstability
 !===============================================================================
 !===============================================================================
 
+! After the stress has been recalculated in iteration loops, call this routine
+! to adjust the value used in the next iteration for improved convergence.
+!
+! We use the sign convention where all arguments are assumed to be positive,
+! except for tau_diff and prev_tau_diff, which can be of either sign.
+subroutine shr_flux_update_stress(wind0, wsresp, tau_est, tau, prev_tau, &
+     tau_diff, prev_tau_diff, wind_adj)
+  ! Wind speed from atmosphere (not updated by iteration) [m/s]
+  real(r8), intent(in) :: wind0
+  ! Response of boundary layer wind to stress changes in a time step [m/s/Pa]
+  real(r8), intent(in) :: wsresp
+  ! Estimated tau that would be in equilibrium with boundary layer wind [Pa]
+  real(r8), intent(in) :: tau_est
+  ! Stress that has just been calculated in this loop [Pa]
+  real(r8), intent(inout) :: tau
+  ! Stress assumed when calculating this tau (use tau_est for first iter.) [Pa]
+  real(r8), intent(inout) :: prev_tau
+  ! Difference between last two values of tau used for iterations [Pa]
+  ! (Use a very large value for first iteration)
+  real(r8), intent(inout) :: tau_diff
+  ! Copy of the input tau_diff (for diagnostic purposes) [Pa]
+  real(r8), intent(out) :: prev_tau_diff
+  ! Wind updated by iteration [m/s]
+  real(r8), intent(out) :: wind_adj
+
+  ! maximum ratio between abs(tau_diff) and abs(prev_tau_diff)
+  real(r8) :: tau_diff_fac
+
+  ! Forbid removing more than 99% of wind speed.
+  ! This is applied before anything else to ensure that the applied stress is
+  ! not so strong that it reverses the direction of the winds.
+  if ( (tau - tau_est) * wsresp > 0.99_r8 * wind0 ) then
+     tau = tau_est + 0.99_r8 * wind0 / wsresp
+  end if
+
+  prev_tau_diff = tau_diff
+  tau_diff = tau - prev_tau
+
+  ! damp large changes each iteration for convergence
+  if (tau_diff * prev_tau_diff < 0._r8) then
+     ! if oscillating about the solution, use stronger damping
+     ! this should not be set below 0.5
+     tau_diff_fac = 0.6_r8
+  else
+     tau_diff_fac = 0.95_r8
+  end if
+
+  if (abs(tau_diff) > abs(tau_diff_fac*prev_tau_diff)) then
+     tau_diff = sign(tau_diff_fac*prev_tau_diff, tau_diff)
+     tau = prev_tau + tau_diff
+  end if
+  prev_tau = tau
+
+  wind_adj = wind0 - (tau - tau_est) * wsresp
+
+end subroutine shr_flux_update_stress
+
+!===============================================================================
+!===============================================================================
+
 !===============================================================================
 ! !DESCRIPTION:
 !
@@ -2316,7 +2481,8 @@ subroutine cor30a(ubt,vbt,tbt,qbt,rbt        &    ! in atm params
                & ,tau,hsb,hlb                &    ! out: fluxes
                & ,zo,zot,zoq,L,usr,tsr,qsr   &    ! out: ss scales
                & ,Cd,Ch,Ce                   &    ! out: exch. coeffs
-               & ,trf,qrf,urf,vrf)                ! out: reference-height params
+               & ,trf,qrf,urf,vrf            &    ! out: reference-height params
+               & ,wsresp,tau_est)                 ! in: optional stress params
 
 ! !USES:
 
@@ -2328,6 +2494,7 @@ real(R8),intent(in) :: ubt,vbt,tbt,qbt,rbt,uss,vss,tss,qss
 real(R8),intent(in) :: zbl,zbu,zbt,zrfu,zrfq,zrft
 real(R8),intent(out):: tau,hsb,hlb,zo,zot,zoq,L,usr,tsr,qsr,Cd,Ch,Ce &
                     & ,trf,qrf,urf,vrf
+real(R8),intent(in),optional:: wsresp,tau_est
 ! !EOP
 
 real(R8) ua,va,ta,q,rb,us,vs,ts,qs,zi,zu,zt,zq,zru,zrq,zrt ! internal vars
@@ -2344,6 +2511,9 @@ integer(IN):: i,nits ! iter loop counters
 
 integer(IN):: jcool                  ! aux. cool-skin vars
 real(R8):: dter,wetc,dqer
+
+! Stress iteration variables
+real(R8):: wind0, prev_tau, tau_diff, prev_tau_diff
 
 ua=ubt  !wind components (m/s) at height zu (m)
 va=vbt
@@ -2397,6 +2567,7 @@ zrt=zrft ! reference height for st.diagn.T,q
     ug=0.5_R8
 
     ut   = sqrt(du*du+ug*ug)
+    wind0 = du
     u10  = ut*log(10.0_R8/1.0e-4_R8)/log(zu/1.0e-4_R8)
     usr  = .035_R8*u10
     zo10 = 0.011_R8*usr*usr/grav+0.11_R8*visa/usr
@@ -2439,6 +2610,17 @@ zrt=zrft ! reference height for st.diagn.T,q
       charn=0.018_R8
     endif
 
+    if (present(wsresp) .and. present(tau_est)) prev_tau = tau_est
+    tau_diff = 1.e100_R8
+
+    ! Since we already have an estimated u*, do one update before iteration loop.
+    if (present(wsresp) .and. present(tau_est)) then
+       ! Update stress and magnitude of mean wind.
+       tau = rhoa * usr * usr * (du/ut)
+       call shr_flux_update_stress(wind0, wsresp, tau_est, &
+            tau, prev_tau, tau_diff, prev_tau_diff, du)
+    end if
+
 !***************  iteration loop ************
     do i=1, nits
 
@@ -2459,6 +2641,13 @@ zrt=zrft ! reference height for st.diagn.T,q
      usr =  ut            *von/(log(zu/zo )-psiuo(zu/L))
      tsr = (dt-dter*jcool)*von/(log(zt/zot)-psit_30(zt/L))
      qsr = (dq-dqer*jcool)*von/(log(zq/zoq)-psit_30(zq/L))
+
+     if (present(wsresp) .and. present(tau_est)) then
+        ! Update stress and magnitude of mean wind.
+        tau = rhoa * usr * usr * (du/ut)
+        call shr_flux_update_stress(wind0, wsresp, tau_est, &
+             tau, prev_tau, tau_diff, prev_tau_diff, du)
+     end if
 
      ! gustiness parametrisation
      Bf=-grav/ta*usr*(tsr+.61_R8*ta*qsr)

--- a/src/share/util/shr_flux_mod.F90
+++ b/src/share/util/shr_flux_mod.F90
@@ -2431,14 +2431,20 @@ subroutine shr_flux_update_stress(wind0, wsresp, tau_est, tau, prev_tau, &
   ! Wind updated by iteration [m/s]
   real(r8), intent(out) :: wind_adj
 
+  real(r8) :: wsresp_applied
+
   ! maximum ratio between abs(tau_diff) and abs(prev_tau_diff)
   real(r8) :: tau_diff_fac
+
+  ! Using wsresp_applied = 0.5 * wsresp improves accuracy somewhat, similar to
+  ! using the trapezoidal method rather than backward Euler.
+  wsresp_applied = 0.5 * wsresp
 
   ! Forbid removing more than 99% of wind speed.
   ! This is applied before anything else to ensure that the applied stress is
   ! not so strong that it reverses the direction of the winds.
-  if ( (tau - tau_est) * wsresp > 0.99_r8 * wind0 ) then
-     tau = tau_est + 0.99_r8 * wind0 / wsresp
+  if ( (tau - tau_est) * wsresp_applied > 0.99_r8 * wind0 ) then
+     tau = tau_est + 0.99_r8 * wind0 / wsresp_applied
   end if
 
   prev_tau_diff = tau_diff
@@ -2459,7 +2465,7 @@ subroutine shr_flux_update_stress(wind0, wsresp, tau_est, tau, prev_tau, &
   end if
   prev_tau = tau
 
-  wind_adj = wind0 - (tau - tau_est) * wsresp
+  wind_adj = wind0 - (tau - tau_est) * wsresp_applied
 
 end subroutine shr_flux_update_stress
 


### PR DESCRIPTION
This PR adds two new options to env_run.xml:

 1. `ATM_FLUX_INTEGRATION_METHOD`
 2. `ATM_SUPPLIES_GUSTINESS`

If the first option is set to `"explicit"` (the default), there is
no change in the behavior of the model. If this option is set
to `"implicit_stress"`, the atmosphere model is required to
export two new fields, `wsresp` and `tau_est`. These fields
represent an approximate linearization of the response of
the atmosphere's boundary layer scheme to stress, and can
be used to perform an explicit solution to the stress in
surface flux calculations. The implementation of this method
in the E3SM atmosphere/land/ice models is currently on a
branch here:

https://github.com/E3SM-Project/E3SM/tree/quantheory/equilibrium-surface-fluxes

This change is motivated by oscillations in the surface winds
that can occur in both E3SM and CESM, which are discussed
in these two issues:

 - E3SM-Project/E3SM#4073
 - ESCOMP/CAM#342

These oscillations are largely due to instabilities arising from
the surface stresses over land at a coarse time step, and are
therefore reduced by the use of an implicit method.

The second option is a logical flag, which keeps the current
behavior if set to `FALSE`, and if `TRUE` adds an
additional "ugust" field to be exported by the atmosphere. This
change is currently only useful for E3SM, which uses the
variance in horizontal winds produced by CLUBB as part of
its gustiness parameterization.

Test suite: Have not run a real test suite, but E3SM F2010 cases
        with default settings run BFB with the version of the code I
        branched from.
Test baseline: 
Test namelist changes: 
Test status: bit for bit

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: None yet!
