### PR TITLE
Allow E3SM to use its versions of coupler and data,stub,x models.

### DIFF
--- a/config/e3sm/config_files.xml
+++ b/config/e3sm/config_files.xml
@@ -104,7 +104,7 @@
   <entry id="COMP_ROOT_DIR_CPL">
     <type>char</type>
     <values>
-      <value>$CIMEROOT/src/drivers/$COMP_INTERFACE</value>
+      <value>$SRCROOT/driver-$COMP_INTERFACE</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -403,7 +403,7 @@
   <entry id="CONFIG_CPL_FILE_MODEL_SPECIFIC">
     <type>char</type>
     <values>
-      <value>$CIMEROOT/src/drivers/$COMP_INTERFACE/cime_config/config_component_$MODEL.xml</value>
+      <value>$SRCROOT/driver-$COMP_INTERFACE/cime_config/config_component_$MODEL.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>

--- a/config/e3sm/config_files.xml
+++ b/config/e3sm/config_files.xml
@@ -115,9 +115,9 @@
   <entry id="COMP_ROOT_DIR_ATM">
     <type>char</type>
     <values>
-      <value component="datm"                        >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/datm</value>
-      <value component="satm"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/satm</value>
-      <value component="xatm"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xatm</value>
+      <value component="datm"                        >$SRCROOT/components/data_comps/datm</value>
+      <value component="satm"                        >$SRCROOT/components/stub_comps/satm</value>
+      <value component="xatm"                        >$SRCROOT/components/xcpl_comps/xatm</value>
       <value component="eam"                         >$SRCROOT/components/eam/</value>
       <value component="scream"                      >$SRCROOT/components/scream/</value>
     </values>
@@ -132,9 +132,9 @@
     <default_value>unset</default_value>
     <values>
       <value component="elm"                         >$SRCROOT/components/elm/</value>
-      <value component="dlnd"                        >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dlnd</value>
-      <value component="slnd"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/slnd</value>
-      <value component="xlnd"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xlnd</value>
+      <value component="dlnd"                        >$SRCROOT/components/data_comps/dlnd</value>
+      <value component="slnd"                        >$SRCROOT/components/stub_comps/slnd</value>
+      <value component="xlnd"                        >$SRCROOT/components/xcpl_comps/xlnd</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -148,9 +148,9 @@
     <default_value>unset</default_value>
     <values>
       <value component="mosart"                      >$SRCROOT/components/mosart/</value>
-      <value component="drof"                        >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/drof</value>
-      <value component="srof"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/srof</value>
-      <value component="xrof"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xrof</value>
+      <value component="drof"                        >$SRCROOT/components/data_comps/drof</value>
+      <value component="srof"                        >$SRCROOT/components/stub_comps/srof</value>
+      <value component="xrof"                        >$SRCROOT/components/xcpl_comps/xrof</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -162,9 +162,9 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="dice"                        >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dice</value>
-      <value component="sice"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sice</value>
-      <value component="xice"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xice</value>
+      <value component="dice"                        >$SRCROOT/components/data_comps/dice</value>
+      <value component="sice"                        >$SRCROOT/components/stub_comps/sice</value>
+      <value component="xice"                        >$SRCROOT/components/xcpl_comps/xice</value>
       <value component="mpassi"                      >$SRCROOT/components/mpas-seaice</value>
       <value component="cice"                        >$SRCROOT/components/cice</value>
     </values>
@@ -178,9 +178,9 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="docn"                         >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/docn</value>
-      <value component="socn"                         >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/socn</value>
-      <value component="xocn"                         >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xocn</value>
+      <value component="docn"                         >$SRCROOT/components/data_comps/docn</value>
+      <value component="socn"                         >$SRCROOT/components/stub_comps/socn</value>
+      <value component="xocn"                         >$SRCROOT/components/xcpl_comps/xocn</value>
       <value component="mpaso"                        >$SRCROOT/components/mpas-ocean</value>
     </values>
     <group>case_comps</group>
@@ -194,9 +194,9 @@
     <default_value>unset</default_value>
     <values>
       <value component="ww3"                         >$SRCROOT/components/ww3/</value>
-      <value component="dwav" comp_interface="mct"   >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dwav</value>
-      <value component="swav"                        >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/swav</value>
-      <value component="xwav"                        >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xwav</value>
+      <value component="dwav" comp_interface="mct"   >$SRCROOT/components/data_comps/dwav</value>
+      <value component="swav"                        >$SRCROOT/components/stub_comps/swav</value>
+      <value component="xwav"                        >$SRCROOT/components/xcpl_comps/xwav</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -209,9 +209,9 @@
     <default_value>unset</default_value>
     <values>
       <value component="mali"  >$SRCROOT/components/mpas-albany-landice</value>
-      <value component="dglc" >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/dglc</value>
-      <value component="sglc" >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sglc</value>
-      <value component="xglc" >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xglc</value>
+      <value component="dglc" >$SRCROOT/components/data_comps/dglc</value>
+      <value component="sglc" >$SRCROOT/components/stub_comps/sglc</value>
+      <value component="xglc" >$SRCROOT/components/xcpl_comps/xglc</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -223,8 +223,8 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="siac"      >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/siac</value>
-      <value component="xiac"      >$CIMEROOT/src/components/xcpl_comps_$COMP_INTERFACE/xiac</value>
+      <value component="siac"      >$SRCROOT/components/stub_comps/siac</value>
+      <value component="xiac"      >$SRCROOT/components/xcpl_comps/xiac</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>
@@ -236,8 +236,8 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="desp"      >$CIMEROOT/src/components/data_comps_$COMP_INTERFACE/desp</value>
-      <value component="sesp"      >$CIMEROOT/src/components/stub_comps_$COMP_INTERFACE/sesp</value>
+      <value component="desp"      >$SRCROOT/components/data_comps/desp</value>
+      <value component="sesp"      >$SRCROOT/components/stub_comps/sesp</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -3,6 +3,7 @@ from standard_script_setup import *
 from CIME.utils import copyifnewer, run_bld_cmd_ensure_logging, expect, symlink_force
 from CIME.case import Case
 from CIME.build import get_standard_makefile_args
+from CIME.XML.files import Files
 import glob
 
 logger = logging.getLogger(__name__)
@@ -60,8 +61,10 @@ def buildlib(bldroot, installpath, case):
 
     # Append path for driver - currently only values of 'mct' and 'nuopc' are accepted
 
+    files = Files(comp_interface=comp_interface)
+
     if comp_interface == "mct":
-        filepath.append(os.path.join(cimeroot,"src","drivers","mct","shr"))
+        filepath.append(os.path.join(files.get_value("COMP_ROOT_DIR_CPL"), "shr"))
     elif comp_interface == "nuopc":
         filepath.append(os.path.join(cimeroot,"src","share","nuopc"))
         filepath.append(os.path.join(cimeroot,"src","share","streams_nuopc"))


### PR DESCRIPTION
Modify config_files.xml in config/e3sm to point to new locations
of the driver (MCT and MOAB) and MCT data,stub,x models within E3SM

Slightly modify buildlib.csm_share to use COMP_ROOT_DIR_CPL to find shr dir.

Still using cime/src/externals and cime/src/share

Test with e3sm_integration (build only) and an E3SM F-case (to test BFB)

[BFB]