### PR TITLE
Add support for WAV as primary component

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -566,6 +566,9 @@ class Case(object):
         elif progcomps["ROF"]:
             # This is a "R" compset
             primary_component = spec["ROF"]
+        elif progcomps["WAV"]:
+            # This is a "V" compset
+            primary_component = spec["WAV"]
         else:
             # This is "A", "X" or "S"
             primary_component = "drv"


### PR DESCRIPTION
This PR allows WAV to be identified as the primary component for compsets with WAVEWATCH III, such as:
`2000_DATM%IAF_SLND_SICE_SOCN_SROF_SGLC_WW3_SIAC_SESP`

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3934 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
