### PR TITLE
Remove "Code review" line from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -14,5 +14,3 @@ Fixes [CIME Github issue #]
 User interface changes?: 
 
 Update gh-pages html (Y/N)?:
-
-Code review: 


### PR DESCRIPTION
This is redundant with GitHub's PR reviewers list

Test suite: none
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: no

Update gh-pages html (Y/N)?: N

Code review: How very meta
