### PR TITLE
Reset a test that is rerun after a run failure

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -427,6 +427,15 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
   </test>
 
+  <test NAME="TESTRUNFAILRESET" INFRASTRUCTURE_TEST="TRUE">
+    <DESC>For testing infra only. Insta-fail run step, also testing that settings get reset upon rerun.</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <STOP_OPTION>ndays</STOP_OPTION>
+    <STOP_N>11</STOP_N>
+    <CHECK_TIMING>FALSE</CHECK_TIMING>
+    <DOUT_S>FALSE</DOUT_S>
+  </test>
+
   <test NAME="TESTRUNSTARCFAIL" INFRASTRUCTURE_TEST="TRUE">
     <DESC>For testing infra only. Insta-fail st archive test with exception.</DESC>
     <INFO_DBUG>1</INFO_DBUG>

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -772,7 +772,9 @@ class TESTRUNFAILRESET(TESTRUNFAIL):
         # upon a rerun
         self._case.set_value("STOP_N", stop_n + 1)
 
-        super().run_indv(suffix=suffix, st_archive=st_archive, submit_resubmits=submit_resubmits)
+        super(TESTRUNFAILRESET, self).run_indv(suffix=suffix,
+                                               st_archive=st_archive,
+                                               submit_resubmits=submit_resubmits)
 
 class TESTRUNFAILEXC(TESTRUNPASS):
 

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -63,7 +63,10 @@ class SystemTestsCommon(object):
         """
         # We never want to re-setup if we're doing the resubmitted run
         phase_status = self._test_status.get_status(phase)
-        if reset or (self._case.get_value("IS_FIRST_RUN") and phase_status != TEST_PEND_STATUS):
+        phase_comment = self._test_status.get_comment(phase)
+        rerunning = (phase_status != TEST_PEND_STATUS or
+                     phase_comment == TEST_RERUN_COMMENT)
+        if reset or (self._case.get_value("IS_FIRST_RUN") and rerunning):
 
             logging.warning("Resetting case due to detected re-run of phase {}".format(phase))
             self._case.set_initial_test_values()

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -274,7 +274,7 @@ class TestScheduler(object):
                             if status in [TEST_PEND_STATUS, TEST_FAIL_STATUS]:
                                 if status == TEST_FAIL_STATUS:
                                     # Import for potential subsequent waits
-                                    ts.set_status(phase, TEST_PEND_STATUS)
+                                    ts.set_status(phase, TEST_PEND_STATUS, TEST_RERUN_COMMENT)
 
                                 # We need to pick up here
                                 break

--- a/scripts/lib/CIME/test_status.py
+++ b/scripts/lib/CIME/test_status.py
@@ -44,7 +44,11 @@ TEST_DIFF_STATUS     = "DIFF"   # Implies a failure in the BASELINE phase
 NAMELIST_FAIL_STATUS = "NLFAIL" # Implies a failure in the NLCOMP phase
 
 # Special strings that can appear in comments, indicating particular types of failures
-TEST_NO_BASELINES_COMMENT = "BFAIL" # Implies baseline directory is missing in the baseline comparison phase
+TEST_NO_BASELINES_COMMENT = "BFAIL" # Implies baseline directory is missing in the
+                                    # baseline comparison phase
+TEST_RERUN_COMMENT        = "RERUN" # Added to a PEND status to indicate that the test
+                                    # system has changed this phase to PEND in order to
+                                    # rerun it (e.g., to retry a failed test).
 # The expected and unexpected failure comments aren't used directly in this module, but
 # are included here for symmetry, so other modules can access them from here.
 TEST_EXPECTED_FAILURE_COMMENT = expected_fails.EXPECTED_FAILURE_COMMENT

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -1541,7 +1541,7 @@ class O_TestTestScheduler(TestCreateTestCommon):
     ###########################################################################
     def test_d_retry(self):
     ###########################################################################
-        args = ["TESTBUILDFAIL_P1.f19_g16_rx1.A", "TESTRUNFAIL_P1.f19_g16_rx1.A", "TESTRUNPASS_P1.f19_g16_rx1.A", "--retry=1"]
+        args = ["TESTBUILDFAIL_P1.f19_g16_rx1.A", "TESTRUNFAILRESET_P1.f19_g16_rx1.A", "TESTRUNPASS_P1.f19_g16_rx1.A", "--retry=1"]
 
         self._create_test(args)
 


### PR DESCRIPTION
When running create_test with the --retry option set to 1 or more: If a
test (ERS, ERI and possibly others) failed in the last run, some xml
values would be set incorrectly in the retried run. This is because
--retry sets use_existing, which in turn changes a FAILed RUN phase into
a PEND. Then, in the call to _resetup_case(RUN_PHASE) from
system_tests_common:run, the test reset wasn't done, since PENDing
phases are not reset.

This commit solves this problem by adding a comment that the now-PENDing
phase is actually being RERUN, and checking for that in _resetup_case.

There may be other situations where we should add this RERUN comment,
but this change fixes my original issue, and it wasn't obvious to me
what, if anything, else should be changed from looking through the
code (especially test_scheduler.py).

Test suite:
- scripts_regression_tests on cheyenne
- Tested with ERS_Ln3 with the diff in https://github.com/ESMCI/cime/issues/3933#issuecomment-824387449, on both my Mac (no batch system) and cheyenne (batch system): in both cases, the retried run failed with `stop_n value 1 too short` before this fix, but with this fix got all the way to the end 

Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #3933 

User interface changes?: N

Update gh-pages html (Y/N)?: N
