### PR TITLE
Update intel compiler and esmf on cheyenne.

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -636,8 +636,7 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules mpilib="mpt" compiler="intel">
         <command name="load">mpt/2.23</command>
-        <!-- known failure in parallel netcdf with mpt, use serial -->
-        <command name="load">netcdf/4.7.3</command>
+        <command name="load">netcdf-mpi/4.7.4</command>
         <command name="load">pnetcdf/1.12.2</command>
       </modules>
       <modules mpilib="mpt" compiler="pgi">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -553,7 +553,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">cmake</command>
       </modules>
       <modules compiler="intel">
-        <command name="load">intel/19.0.5</command>
+        <command name="load">intel/19.1.1</command>
         <command name="load">esmf_libs</command>
         <command name="load">mkl</command>
       </modules>
@@ -565,20 +565,20 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">pgi/20.4</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpt-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.1.1/</command>
+        <command name="load">esmf-8.1.1-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpt-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.1.1/</command>
+        <command name="load">esmf-8.1.1-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpiuni-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.1.1/</command>
+        <command name="load">esmf-8.1.1-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.0.5/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpiuni-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.1.1/</command>
+        <command name="load">esmf-8.1.1-ncdfio-mpiuni-O</command>
       </modules>
       <modules compiler="gnu" mpilib="mpt" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
@@ -635,10 +635,10 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
-        <command name="load">mpt/2.21</command>
+        <command name="load">mpt/2.23</command>
         <!-- known failure in parallel netcdf with mpt, use serial -->
         <command name="load">netcdf/4.7.3</command>
-        <command name="load">pnetcdf/1.12.1</command>
+        <command name="load">pnetcdf/1.12.2</command>
       </modules>
       <modules mpilib="mpt" compiler="pgi">
         <command name="load">mpt/2.19</command>


### PR DESCRIPTION
Update Cheyenne intel compiler to 19.1.1, also update mpt to 2.23 and pnetcdf to 1.12.2.
Update ESMF libraries for intel to 8.1.1.

Test suite: aux_cime_baselines
Test baseline:  
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
