### PR TITLE
Rename GLC Greenland grid from "gland" to "gris"

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -37,8 +37,8 @@
       <grid name="rof"       compset="DROF"        >rx1</grid>
       <grid name="rof"       compset="DROF%CPLHIST">r05</grid>
       <grid name="rof"       compset="XROF"        >r05</grid>
-      <grid name="glc"	     compset="SGLC"        >null</grid>
-      <grid name="glc"	     compset="CISM2"       >gris4</grid>
+      <grid name="glc"       compset="SGLC"        >null</grid>
+      <grid name="glc"       compset="CISM2"       >gris4</grid>
       <grid name="glc"       compset="XGLC"        >gris4</grid>
       <grid name="wav"       compset="SWAV"        >null</grid>
       <grid name="wav"       compset="DWAV"        >ww3a</grid>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -466,22 +466,6 @@
       <mask>tn0.25v3</mask>
     </model_grid>
 
-    <model_grid alias="f09_g16_gris4" compset="_CISM">
-      <grid name="atm">0.9x1.25</grid>
-      <grid name="lnd">0.9x1.25</grid>
-      <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gris4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
-    <model_grid alias="f09_g16_gl4" compset="_CISM">
-      <grid name="atm">0.9x1.25</grid>
-      <grid name="lnd">0.9x1.25</grid>
-      <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gris4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
     <model_grid alias="f09_g17_gris4" compset="_CISM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
@@ -496,22 +480,6 @@
       <grid name="ocnice">gx1v7</grid>
       <grid name="glc">gris4</grid>
       <mask>gx1v7</mask>
-    </model_grid>
-
-    <model_grid alias="f09_g16_gris20" compset="_CISM">
-      <grid name="atm">0.9x1.25</grid>
-      <grid name="lnd">0.9x1.25</grid>
-      <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gris20</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
-    <model_grid alias="f09_g16_gl20" compset="_CISM">
-      <grid name="atm">0.9x1.25</grid>
-      <grid name="lnd">0.9x1.25</grid>
-      <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gris20</grid>
-      <mask>gx1v6</mask>
     </model_grid>
 
     <model_grid alias="f09_g17_gris20" compset="_CISM">
@@ -594,22 +562,6 @@
       <grid name="ocnice">gx1v7</grid>
       <grid name="rof">r05</grid>
       <mask>gx1v7</mask>
-    </model_grid>
-
-    <model_grid alias="f19_g16_gris4" compset="_CISM">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gris4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
-    <model_grid alias="f19_g16_gl4" compset="_CISM">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gris4</grid>
-      <mask>gx1v6</mask>
     </model_grid>
 
     <model_grid alias="f19_g17_gris4" compset="_CISM">

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -38,8 +38,8 @@
       <grid name="rof"       compset="DROF%CPLHIST">r05</grid>
       <grid name="rof"       compset="XROF"        >r05</grid>
       <grid name="glc"	     compset="SGLC"        >null</grid>
-      <grid name="glc"	     compset="CISM2"       >gland4</grid>
-      <grid name="glc"       compset="XGLC"        >gland4</grid>
+      <grid name="glc"	     compset="CISM2"       >gris4</grid>
+      <grid name="glc"       compset="XGLC"        >gris4</grid>
       <grid name="wav"       compset="SWAV"        >null</grid>
       <grid name="wav"       compset="DWAV"        >ww3a</grid>
       <grid name="wav"       compset="WW3"         >ww3a</grid>
@@ -153,19 +153,35 @@
       <mask>gx3v7</mask>
     </model_grid>
 
+    <model_grid alias="T31_g37_gris4" compset="_CISM">
+      <grid name="atm">T31</grid>
+      <grid name="lnd">T31</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="glc">gris4</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
     <model_grid alias="T31_g37_gl4" compset="_CISM">
       <grid name="atm">T31</grid>
       <grid name="lnd">T31</grid>
       <grid name="ocnice">gx3v7</grid>
-      <grid name="glc">gland4</grid>
+      <grid name="glc">gris4</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
+    <model_grid alias="T31_g37_gris20" compset="_CISM">
+      <grid name="atm">T31</grid>
+      <grid name="lnd">T31</grid>
+      <grid name="ocnice">gx3v7</grid>
+      <grid name="glc">gris20</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
     <model_grid alias="T31_g37_gl20" compset="_CISM">
       <grid name="atm">T31</grid>
       <grid name="lnd">T31</grid>
       <grid name="ocnice">gx3v7</grid>
-      <grid name="glc">gland20</grid>
+      <grid name="glc">gris20</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
@@ -450,35 +466,67 @@
       <mask>tn0.25v3</mask>
     </model_grid>
 
+    <model_grid alias="f09_g16_gris4" compset="_CISM">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="glc">gris4</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
     <model_grid alias="f09_g16_gl4" compset="_CISM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gland4</grid>
+      <grid name="glc">gris4</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="f09_g17_gris4" compset="_CISM">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">gx1v7</grid>
+      <grid name="glc">gris4</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
     <model_grid alias="f09_g17_gl4" compset="_CISM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v7</grid>
-      <grid name="glc">gland4</grid>
+      <grid name="glc">gris4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
+    <model_grid alias="f09_g16_gris20" compset="_CISM">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="glc">gris20</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
     <model_grid alias="f09_g16_gl20" compset="_CISM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gland20</grid>
+      <grid name="glc">gris20</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="f09_g17_gris20" compset="_CISM">
+      <grid name="atm">0.9x1.25</grid>
+      <grid name="lnd">0.9x1.25</grid>
+      <grid name="ocnice">gx1v7</grid>
+      <grid name="glc">gris20</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
     <model_grid alias="f09_g17_gl20" compset="_CISM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v7</grid>
-      <grid name="glc">gland20</grid>
+      <grid name="glc">gris20</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
@@ -548,19 +596,35 @@
       <mask>gx1v7</mask>
     </model_grid>
 
+    <model_grid alias="f19_g16_gris4" compset="_CISM">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v6</grid>
+      <grid name="glc">gris4</grid>
+      <mask>gx1v6</mask>
+    </model_grid>
+    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
     <model_grid alias="f19_g16_gl4" compset="_CISM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gland4</grid>
+      <grid name="glc">gris4</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
+    <model_grid alias="f19_g17_gris4" compset="_CISM">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">gx1v7</grid>
+      <grid name="glc">gris4</grid>
+      <mask>gx1v7</mask>
+    </model_grid>
+    <!-- Backwards compatibility with old use of _gl for Greenland grid -->
     <model_grid alias="f19_g17_gl4" compset="_CISM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v7</grid>
-      <grid name="glc">gland4</grid>
+      <grid name="glc">gris4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
@@ -1134,7 +1198,7 @@
       <grid name="atm">C96</grid>
       <grid name="lnd">C96</grid>
       <grid name="ocnice">C96</grid>
-      <grid name="glc">gland4</grid>
+      <grid name="glc">gris4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
@@ -1834,13 +1898,13 @@
     <!-- GLC domains -->
     <!-- ======================================================== -->
 
-    <domain name="gland20">
+    <domain name="gris20">
       <nx>76</nx> <ny>141</ny>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/gland_20km_c150511_ESMFmesh.nc</mesh>
       <desc>20-km Greenland grid</desc>
     </domain>
 
-    <domain name="gland4">
+    <domain name="gris4">
       <nx>416</nx> <ny>704</ny>
       <mesh driver="nuopc">$DIN_LOC_ROOT/share/meshes/greenland_4km_epsg3413_c170414_ESMFmesh_c20190729.nc</mesh>
       <desc>4-km Greenland grid, for use with the glissade dycore</desc>

--- a/config/cesm/config_grids_common.xml
+++ b/config/cesm/config_grids_common.xml
@@ -105,32 +105,32 @@
     <!-- mapping is turned off in the system.)                    -->
     <!-- ======================================================== -->
 
-    <gridmap ocn_grid="gx1v6" glc_grid="gland4" >
+    <gridmap ocn_grid="gx1v6" glc_grid="gris4" >
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx1v6_nn_open_ocean_nnsm_e1000r300_marginal_sea_171105.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx1v6_nnsm_e1000r300_171105.nc</map>
     </gridmap>
-    <gridmap ocn_grid="gx1v7" glc_grid="gland4" >
+    <gridmap ocn_grid="gx1v7" glc_grid="gris4" >
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx1v7_nn_open_ocean_nnsm_e1000r300_marginal_sea_171105.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx1v7_nnsm_e1000r300_171105.nc</map>
     </gridmap>
     <!-- POP's estuary box model is currently not active for gx3v7, so
          we need nnsm maps for liquid as well as ice. -->
-    <gridmap ocn_grid="gx3v7" glc_grid="gland4" >
+    <gridmap ocn_grid="gx3v7" glc_grid="gris4" >
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx3v7_nnsm_e1000r500_180502.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_gx3v7_nnsm_e1000r500_180502.nc</map>
     </gridmap>
 
-    <gridmap ocn_grid="gx1v6" glc_grid="gland20" >
+    <gridmap ocn_grid="gx1v6" glc_grid="gris20" >
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx1v6_nn_open_ocean_nnsm_e1000r300_marginal_sea_171105.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx1v6_nnsm_e1000r300_171105.nc</map>
     </gridmap>
-    <gridmap ocn_grid="gx1v7" glc_grid="gland20" >
+    <gridmap ocn_grid="gx1v7" glc_grid="gris20" >
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx1v7_nn_open_ocean_nnsm_e1000r300_marginal_sea_171105.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx1v7_nnsm_e1000r300_171105.nc</map>
     </gridmap>
     <!-- POP's estuary box model is currently not active for gx3v7, so
          we need nnsm maps for liquid as well as ice. -->
-    <gridmap ocn_grid="gx3v7" glc_grid="gland20" >
+    <gridmap ocn_grid="gx3v7" glc_grid="gris20" >
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx3v7_nnsm_e1000r500_180502.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/gland20km/map_gland20km_to_gx3v7_nnsm_e1000r500_180502.nc</map>
     </gridmap>
@@ -154,7 +154,7 @@
       <map name="OCN2WAV_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ww3a_splice_170214.nc</map>
       <map name="ICE2WAV_SMAPNAME">cpl/gridmaps/gx1v7/map_gx1v7_TO_ww3a_splice_170214.nc</map>
     </gridmap>
-    <gridmap ocn_grid="tx0.66v1" glc_grid="gland4" >
+    <gridmap ocn_grid="tx0.66v1" glc_grid="gris4" >
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_tx0.66v1_nnsm_e1000r300_190314.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_tx0.66v1_nnsm_e1000r300_190314.nc</map>
     </gridmap>

--- a/config/cesm/config_grids_mct.xml
+++ b/config/cesm/config_grids_mct.xml
@@ -737,157 +737,157 @@
     <!-- ======================================================== -->
 
     <!-- ====================  -->
-    <!-- GLC: gland4           -->
+    <!-- GLC: gris4           -->
     <!-- ====================  -->
 
-    <gridmap lnd_grid="0.47x0.63" glc_grid="gland4" >
+    <gridmap lnd_grid="0.47x0.63" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.47x0.63/map_fv0.47x0.63_TO_gland4km_aave.171105.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.47x0.63/map_fv0.47x0.63_TO_gland4km_blin.171105.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.47x0.63_aave.171105.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.47x0.63_aave.171105.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="0.9x1.25" glc_grid="gland4" >
+    <gridmap lnd_grid="0.9x1.25" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland4km_aave.170429.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.9x1.25_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv0.9x1.25_aave.170429.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="1.9x2.5" glc_grid="gland4" >
+    <gridmap lnd_grid="1.9x2.5" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland4km_aave.170429.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv1.9x2.5_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv1.9x2.5_aave.170429.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="C24" glc_grid="gland4" >
+    <gridmap lnd_grid="C24" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C24/map_C24_TO_gland4km_aave.181018.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C24/map_C24_TO_gland4km_blin.181018.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C24_aave.181018.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C24_aave.181018.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="C48" glc_grid="gland4" >
+    <gridmap lnd_grid="C48" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C48/map_C48_TO_gland4km_aave.181018.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C48/map_C48_TO_gland4km_blin.181018.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C48_aave.181018.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C48_aave.181018.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="C96" glc_grid="gland4" >
+    <gridmap lnd_grid="C96" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C96/map_C96_TO_gland4km_aave.181018.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C96/map_C96_TO_gland4km_blin.181018.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C96_aave.181018.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C96_aave.181018.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="C192" glc_grid="gland4" >
+    <gridmap lnd_grid="C192" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C192/map_C192_TO_gland4km_aave.181018.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C192/map_C192_TO_gland4km_blin.181018.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C192_aave.181018.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C192_aave.181018.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="C384" glc_grid="gland4" >
+    <gridmap lnd_grid="C384" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/C384/map_C384_TO_gland4km_aave.181018.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/C384/map_C384_TO_gland4km_blin.181018.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C384_aave.181018.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_C384_aave.181018.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="T31" glc_grid="gland4" >
+    <gridmap lnd_grid="T31" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland4km_aave.170429.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_T31_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_T31_aave.170429.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="360x720cru" glc_grid="gland4" >
+    <gridmap lnd_grid="360x720cru" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland4km_aave.170429.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_360x720_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_360x720_aave.170429.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="10x15" glc_grid="gland4" >
+    <gridmap lnd_grid="10x15" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland4km_aave.170429.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv10x15_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv10x15_aave.170429.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="4x5" glc_grid="gland4" >
+    <gridmap lnd_grid="4x5" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland4km_aave.170429.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv4x5_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_fv4x5_aave.170429.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne16np4" glc_grid="gland4" >
+    <gridmap lnd_grid="ne16np4" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland4km_aave.170429.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne16np4_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne16np4_aave.170429.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne30np4" glc_grid="gland4" >
+    <gridmap lnd_grid="ne30np4" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland4km_aave.170429.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland4km_blin.170429.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30np4_aave.170429.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30np4_aave.170429.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne30np4.pg2" glc_grid="gland4" >
+    <gridmap lnd_grid="ne30np4.pg2" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gland4km_aave.200626.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_ne30np4.pg2_TO_gland4km_blin.200626.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gland4km_TO_ne30np4.pg2_aave.200626.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne30np4.pg2/map_gland4km_TO_ne30np4.pg2_aave.200626.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne30np4.pg3" glc_grid="gland4" >
+    <gridmap lnd_grid="ne30np4.pg3" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_gland4km_aave.180515.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30pg3/map_ne30pg3_TO_gland4km_blin.180515.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30pg3_aave.180510.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne30pg3_aave.180510.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne0np4CONUS.ne30x8" glc_grid="gland4" >
+    <gridmap lnd_grid="ne0np4CONUS.ne30x8" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gland4km_aave.190322.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4CONUS.ne30x8/map_ne0CONUSne30x8_TO_gland4km_blin.190322.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne0CONUSne30x8_aave.190322.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne0CONUSne30x8_aave.190322.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne0np4.ARCTIC.ne30x4" glc_grid="gland4" >
+    <gridmap lnd_grid="ne0np4.ARCTIC.ne30x4" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_ne0np4.ARCTIC.ne30x4_TO_gland4km_aave.200626.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_ne0np4.ARCTIC.ne30x4_TO_gland4km_blin.200626.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_gland4km_TO_ne0np4.ARCTIC.ne30x4_aave.200626.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne0np4.ARCTIC.ne30x4/map_gland4km_TO_ne0np4.ARCTIC.ne30x4_aave.200626.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne0np4.ARCTICGRIS.ne30x8" glc_grid="gland4" >
+    <gridmap lnd_grid="ne0np4.ARCTICGRIS.ne30x8" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_ne0np4.ARCTICGRIS.ne30x8_TO_gland4km_aave.200626.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_ne0np4.ARCTICGRIS.ne30x8_TO_gland4km_blin.200626.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_gland4km_TO_ne0np4.ARCTICGRIS.ne30x8_aave.200626.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne0np4.ARCTICGRIS.ne30x8/map_gland4km_TO_ne0np4.ARCTICGRIS.ne30x8_aave.200626.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne120np4" glc_grid="gland4" >
+    <gridmap lnd_grid="ne120np4" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland4km_aave.190502.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland4km_blin.190502.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne120np4_aave.190502.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne120np4_aave.190502.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne120np4.pg2" glc_grid="gland4" >
+    <gridmap lnd_grid="ne120np4.pg2" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_gland4km_aave.200626.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_ne120np4.pg2_TO_gland4km_blin.200626.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/ne120np4.pg2/map_gland4km_TO_ne120np4.pg2_aave.200626.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/ne120np4.pg2/map_gland4km_TO_ne120np4.pg2_aave.200626.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne120np4.pg3" glc_grid="gland4" >
+    <gridmap lnd_grid="ne120np4.pg3" glc_grid="gris4" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_gland4km_aave.190503.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4.pg3/map_ne120np4.pg3_TO_gland4km_blin.190503.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland4km/map_gland4km_TO_ne120np4.pg3_aave.190503.nc</map>
@@ -895,66 +895,66 @@
     </gridmap>
 
     <!-- ====================  -->
-    <!-- GLC: gland20          -->
+    <!-- GLC: gris20          -->
     <!-- ====================  -->
 
-    <gridmap lnd_grid="0.9x1.25" glc_grid="gland20" >
+    <gridmap lnd_grid="0.9x1.25" glc_grid="gris20" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland20km_aave.150514.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv0.9x1.25/map_fv0.9x1.25_TO_gland20km_blin.150514.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_fv0.9x1.25_aave.150514.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_fv0.9x1.25_aave.150514.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="1.9x2.5" glc_grid="gland20" >
+    <gridmap lnd_grid="1.9x2.5" glc_grid="gris20" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland20km_aave.150514.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv1.9x2.5/map_fv1.9x2.5_TO_gland20km_blin.150514.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_fv1.9x2.5_aave.150514.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_fv1.9x2.5_aave.150514.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="T31" glc_grid="gland20" >
+    <gridmap lnd_grid="T31" glc_grid="gris20" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland20km_aave.150514.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/T31/map_T31_TO_gland20km_blin.150514.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_T31_aave.150514.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_T31_aave.150514.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="360x720cru" glc_grid="gland20" >
+    <gridmap lnd_grid="360x720cru" glc_grid="gris20" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland20km_aave.160329.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/360x720/map_360x720_TO_gland20km_blin.160329.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_360x720_aave.160329.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_360x720_aave.160329.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="10x15" glc_grid="gland20" >
+    <gridmap lnd_grid="10x15" glc_grid="gris20" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland20km_aave.160329.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv10x15/map_fv10x15_TO_gland20km_blin.160329.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_fv10x15_aave.160329.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_fv10x15_aave.160329.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="4x5" glc_grid="gland20" >
+    <gridmap lnd_grid="4x5" glc_grid="gris20" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland20km_aave.160329.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/fv4x5/map_fv4x5_TO_gland20km_blin.160329.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_fv4x5_aave.160329.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_fv4x5_aave.160329.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne16np4" glc_grid="gland20" >
+    <gridmap lnd_grid="ne16np4" glc_grid="gris20" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland20km_aave.160329.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne16np4/map_ne16np4_TO_gland20km_blin.160329.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_ne16np4_aave.160329.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_ne16np4_aave.160329.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne30np4" glc_grid="gland20" >
+    <gridmap lnd_grid="ne30np4" glc_grid="gris20" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland20km_aave.160329.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne30np4/map_ne30np4_TO_gland20km_blin.160329.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_ne30np4_aave.160329.nc</map>
       <map name="GLC2LND_SMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_ne30np4_aave.160329.nc</map>
     </gridmap>
 
-    <gridmap lnd_grid="ne120np4" glc_grid="gland20" >
+    <gridmap lnd_grid="ne120np4" glc_grid="gris20" >
       <map name="LND2GLC_FMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland20km_aave.160329.nc</map>
       <map name="LND2GLC_SMAPNAME">cpl/gridmaps/ne120np4/map_ne120np4_TO_gland20km_blin.160329.nc</map>
       <map name="GLC2LND_FMAPNAME">cpl/gridmaps/gland20km/map_gland20km_TO_ne120np4_aave.160329.nc</map>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -1071,7 +1071,7 @@
 
   <entry id="GLC_GRID">
     <type>char</type>
-    <valid_values>gland20,gland10,gland5,gland5UM,gland4,mpas.aisgis20km,mpas.gis20km,mpas.ais20km,mpas.gis1to10km,null</valid_values>
+    <valid_values>gland20,gris20,gland10,gland5,gland5UM,gland4,gris4,mpas.aisgis20km,mpas.gis20km,mpas.ais20km,mpas.gis1to10km,null</valid_values>
     <default_value>gland5UM</default_value>
     <group>build_grid</group>
     <file>env_build.xml</file>


### PR DESCRIPTION
We are renaming both the grid long name and alias to "gris". For now we
are maintaining backwards compatibility with old
aliases ("_gl4"/"_gl20").

Test suite: Ran a subset of tests from the aux_glc test list:
```
ERS_Ly11.f09_g17_gris20.T1850Gg.cheyenne_gnu
ERS_Vnuopc_Ly11.f09_g17_gris20.T1850Gg.cheyenne_gnu
ERS_Ly7.f09_g17_gris4.T1850Gg.cheyenne_intel
ERS_Vnuopc_Ly7.f09_g17_gris4.T1850Gg.cheyenne_intel
ERI.f10_f10_mg37.I1850Clm50SpG.cheyenne_gnu.cism-test_coupling
ERI_Vnuopc.f10_f10_mg37.I1850Clm50SpG.cheyenne_gnu.cism-test_coupling
SMS_D.T31_g37_gris20.I1850Clm50SpG.cheyenne_gnu.cism-test_coupling
SMS_Vnuopc_D.T31_g37_gris20.I1850Clm50SpG.cheyenne_gnu.cism-test_coupling
```

Test baseline: cism2_1_78
Test namelist changes: Yes, due to new grid name
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N

**Depends on cism changes in https://github.com/ESCOMP/CISM-wrapper/pull/58**