### PR TITLE
fix res for nuopc

### DIFF
--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -586,7 +586,7 @@ class J_TestCreateNewcase(unittest.TestCase):
         cls._testdirs.append(testdir)
 
         if CIME.utils.get_model() == "cesm":
-            # Will need to be updated when cesm brings in new share repo new line will be. 
+            # Will need to be updated when cesm brings in new share repo new line will be.
             # pesfile = os.path.join(get_src_root(),"cpl7","driver","cime_config","config_pes.xml")
             # or
             # pesfile = os.path.join(get_src_root(),"components","cmeps","cime_config","config_pes.xml")
@@ -713,7 +713,12 @@ class J_TestCreateNewcase(unittest.TestCase):
         if os.path.exists(testdir1):
             shutil.rmtree(testdir1)
         cls._testdirs.append(testdir1)
-        args = ' --case CreateNewcaseTest --script-root {} --compset 2000_DATM%NYF_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV --res f19_g16 --output-root {} --handle-preexisting-dirs u' .format(testdir1, cls._testroot)
+
+        args = ' --case CreateNewcaseTest --script-root {} --compset 2000_DATM%NYF_SLND_SICE_DOCN%SOMAQP_SROF_SGLC_SWAV --output-root {} --handle-preexisting-dirs u' .format(testdir1, cls._testroot)
+        if CIME.utils.get_cime_default_driver() == "nuopc":
+            args += " --res f19_g17 "
+        else:
+            args += " --res f19_g16 "
         if CIME.utils.get_model() == "cesm":
             args += " --run-unsupported"
         if TEST_COMPILER is not None:
@@ -743,7 +748,11 @@ class J_TestCreateNewcase(unittest.TestCase):
         if os.path.exists(testdir2):
             shutil.rmtree(testdir2)
         cls._testdirs.append(testdir2)
-        args = ' --case CreateNewcaseTest --script-root {} --compset ADSOMAQP --res f19_g16 --output-root {} --handle-preexisting-dirs u'.format(testdir2, cls._testroot)
+        args = ' --case CreateNewcaseTest --script-root {} --compset ADSOMAQP --output-root {} --handle-preexisting-dirs u'.format(testdir2, cls._testroot)
+        if CIME.utils.get_cime_default_driver() == "nuopc":
+            args += " --res f19_g17 "
+        else:
+            args += " --res f19_g16 "
         if CIME.utils.get_model() == "cesm":
             args += " --run-unsupported"
         if TEST_COMPILER is not None:


### PR DESCRIPTION
This test was not working with nuopc because the res was wrong and because of cdeps issue https://github.com/ESCOMP/CDEPS/issues/70

Test suite: scripts_regression_tests.py with CIME_DRIVER=nuopc
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
