### PR TITLE
Updates for pleiades systems

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -556,7 +556,8 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemin="" walltimemax="08:00:00" nodemin="0" nodemax="357" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="08:00:00" nodemin="1" nodemax="5256" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="02:00:00" nodemin="1" nodemax="1800" default="false">devel</queue>
     </queues>
   </batch_system>
 
@@ -570,7 +571,8 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemin="" walltimemax="08:00:00" nodemin="0" nodemax="357" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="08:00:00" nodemin="1" nodemax="5256" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="02:00:00" nodemin="1" nodemax="1800" default="false">devel</queue>
     </queues>
   </batch_system>
 
@@ -584,7 +586,8 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemin="" walltimemax="08:00:00" nodemin="0" nodemax="500" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="08:00:00" nodemin="1" nodemax="5256" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="02:00:00" nodemin="1" nodemax="1800" default="false">devel</queue>
     </queues>
   </batch_system>
 
@@ -598,7 +601,8 @@
       <directive default="/bin/bash" > -S {{ shell }}  </directive>
     </directives>
     <queues>
-      <queue walltimemin="" walltimemax="08:00:00" nodemin="0" nodemax="624" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="08:00:00" nodemin="1" nodemax="5256" default="true">normal</queue>
+      <queue walltimemin="" walltimemax="02:00:00" nodemin="1" nodemax="1800" default="false">devel</queue>
     </queues>
   </batch_system>
 

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1409,8 +1409,14 @@ using a fortran linker.
 </compiler>
 
 <compiler MACH="pleiades-bro">
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CFLAGS>
+    <append> -axCORE-AVX2 -xSSE4.2 </append>
+  </CFLAGS>
   <FFLAGS>
-    <append DEBUG="FALSE"> -O2 -xCORE-AVX2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 </append>
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
@@ -1419,12 +1425,19 @@ using a fortran linker.
   <SLIBS>
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
-  <ESMF_LIBDIR>/home6/fvitt/esmf_7_1_0r/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
+  <PNETCDF_PATH>/home6/fvitt/pnetcdf-1.12.2</PNETCDF_PATH>
+  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_0/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="pleiades-has">
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CFLAGS>
+    <append> -axCORE-AVX2 -xSSE4.2 </append>
+  </CFLAGS>
   <FFLAGS>
-    <append DEBUG="FALSE"> -O2 -xCORE-AVX2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 </append>
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
@@ -1433,12 +1446,19 @@ using a fortran linker.
   <SLIBS>
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
-  <ESMF_LIBDIR>/home6/fvitt/esmf_7_1_0r/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
+  <PNETCDF_PATH>/home6/fvitt/pnetcdf-1.12.2</PNETCDF_PATH>
+  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_0/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="pleiades-ivy">
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CFLAGS>
+    <append> -axCORE-AVX2 -xSSE4.2 </append>
+  </CFLAGS>
   <FFLAGS>
-    <append DEBUG="FALSE"> -O2 -xAVX </append>
+    <append> -axCORE-AVX2 -xSSE4.2 </append>
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
@@ -1447,12 +1467,19 @@ using a fortran linker.
   <SLIBS>
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
-  <ESMF_LIBDIR>/home6/fvitt/esmf_7_1_0r/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
+  <PNETCDF_PATH>/home6/fvitt/pnetcdf-1.12.2</PNETCDF_PATH>
+  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_0/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="pleiades-san">
+  <CONFIG_ARGS>
+    <base> --host=Linux </base>
+  </CONFIG_ARGS>
+  <CFLAGS>
+    <append> -axCORE-AVX2 -xSSE4.2 </append>
+  </CFLAGS>
   <FFLAGS>
-    <append DEBUG="FALSE"> -O2 -xAVX </append>
+    <append> -axCORE-AVX2 -xSSE4.2 </append>
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
@@ -1461,7 +1488,8 @@ using a fortran linker.
   <SLIBS>
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
-  <ESMF_LIBDIR>/home6/fvitt/esmf_7_1_0r/esmf/lib/libO/Linux.intel.64.mpi.default</ESMF_LIBDIR>
+  <PNETCDF_PATH>/home6/fvitt/pnetcdf-1.12.2</PNETCDF_PATH>
+  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_0/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="sandiatoss3" COMPILER="intel">

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1426,7 +1426,7 @@ using a fortran linker.
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
   <PNETCDF_PATH>/home6/fvitt/pnetcdf-1.12.2</PNETCDF_PATH>
-  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_0/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
+  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_1/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="pleiades-has">
@@ -1447,7 +1447,7 @@ using a fortran linker.
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
   <PNETCDF_PATH>/home6/fvitt/pnetcdf-1.12.2</PNETCDF_PATH>
-  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_0/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
+  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_1/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="pleiades-ivy">
@@ -1468,7 +1468,7 @@ using a fortran linker.
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
   <PNETCDF_PATH>/home6/fvitt/pnetcdf-1.12.2</PNETCDF_PATH>
-  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_0/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
+  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_1/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="pleiades-san">
@@ -1489,7 +1489,7 @@ using a fortran linker.
     <append>-L$ENV{NETCDF}/lib -lnetcdff -lnetcdf</append>
   </SLIBS>
   <PNETCDF_PATH>/home6/fvitt/pnetcdf-1.12.2</PNETCDF_PATH>
-  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_0/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
+  <ESMF_LIBDIR>/home6/fvitt/esmf-8_1_1/lib/libO/Linux.intel.64.mpt.default</ESMF_LIBDIR>
 </compiler>
 
 <compiler MACH="sandiatoss3" COMPILER="intel">

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1413,10 +1413,10 @@ using a fortran linker.
     <base> --host=Linux </base>
   </CONFIG_ARGS>
   <CFLAGS>
-    <append> -axCORE-AVX2 -xSSE4.2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
   </CFLAGS>
   <FFLAGS>
-    <append> -axCORE-AVX2 -xSSE4.2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
@@ -1434,10 +1434,10 @@ using a fortran linker.
     <base> --host=Linux </base>
   </CONFIG_ARGS>
   <CFLAGS>
-    <append> -axCORE-AVX2 -xSSE4.2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
   </CFLAGS>
   <FFLAGS>
-    <append> -axCORE-AVX2 -xSSE4.2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
@@ -1455,10 +1455,10 @@ using a fortran linker.
     <base> --host=Linux </base>
   </CONFIG_ARGS>
   <CFLAGS>
-    <append> -axCORE-AVX2 -xSSE4.2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
   </CFLAGS>
   <FFLAGS>
-    <append> -axCORE-AVX2 -xSSE4.2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>
@@ -1476,10 +1476,10 @@ using a fortran linker.
     <base> --host=Linux </base>
   </CONFIG_ARGS>
   <CFLAGS>
-    <append> -axCORE-AVX2 -xSSE4.2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
   </CFLAGS>
   <FFLAGS>
-    <append> -axCORE-AVX2 -xSSE4.2 </append>
+    <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
   </FFLAGS>
   <MPICC>icc</MPICC>
   <MPI_LIB_NAME>mpi</MPI_LIB_NAME>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2338,8 +2338,8 @@ This allows using a different mpirun command to launch unit tests
         <command name="purge"/>
         <command name="load">nas</command>
         <command name="load">pkgsrc</command>
-        <command name="load">comp-intel/2018.3.222</command>
-        <command name="load">mpi-sgi/mpt.2.15r20</command>
+        <command name="load">comp-intel/2020.4.304</command>
+        <command name="load">mpi-hpe/mpt.2.23</command>
         <command name="load">szip/2.1.1</command>
         <command name="load">hdf4/4.2.12</command>
         <command name="load">hdf5/1.8.18_mpt</command>
@@ -2390,8 +2390,8 @@ This allows using a different mpirun command to launch unit tests
         <command name="purge"/>
         <command name="load">nas</command>
         <command name="load">pkgsrc</command>
-        <command name="load">comp-intel/2018.3.222</command>
-        <command name="load">mpi-sgi/mpt.2.15r20</command>
+        <command name="load">comp-intel/2020.4.304</command>
+        <command name="load">mpi-hpe/mpt.2.23</command>
         <command name="load">szip/2.1.1</command>
         <command name="load">hdf4/4.2.12</command>
         <command name="load">hdf5/1.8.18_mpt</command>
@@ -2442,8 +2442,8 @@ This allows using a different mpirun command to launch unit tests
         <command name="purge"/>
         <command name="load">nas</command>
         <command name="load">pkgsrc</command>
-        <command name="load">comp-intel/2018.3.222</command>
-        <command name="load">mpi-sgi/mpt.2.15r20</command>
+        <command name="load">comp-intel/2020.4.304</command>
+        <command name="load">mpi-hpe/mpt.2.23</command>
         <command name="load">szip/2.1.1</command>
         <command name="load">hdf4/4.2.12</command>
         <command name="load">hdf5/1.8.18_mpt</command>
@@ -2494,8 +2494,8 @@ This allows using a different mpirun command to launch unit tests
         <command name="purge"/>
         <command name="load">nas</command>
         <command name="load">pkgsrc</command>
-        <command name="load">comp-intel/2018.3.222</command>
-        <command name="load">mpi-sgi/mpt.2.15r20</command>
+        <command name="load">comp-intel/2020.4.304</command>
+        <command name="load">mpi-hpe/mpt.2.23</command>
         <command name="load">szip/2.1.1</command>
         <command name="load">hdf4/4.2.12</command>
         <command name="load">hdf5/1.8.18_mpt</command>

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -198,9 +198,6 @@ class EnvBatch(EnvBase):
         if ext.startswith('.'):
             ext = ext[1:]
         overrides["job_id"] = ext + '.' + case.get_value("CASE")
-        if "pleiades" in case.get_value("MACH"):
-            # pleiades jobname needs to be limited to 15 chars
-            overrides["job_id"] = overrides["job_id"][:15]
         overrides["batchdirectives"] = self.get_batch_directives(case, job, overrides=overrides)
         output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)
         output_name = get_batch_script_for_job(job) if outfile is None else outfile


### PR DESCRIPTION
Updates for plieades machines:
 - use ESMF v8.1.1
 - use pnetcdf
 - update compiler version and options
 - update mpt mpi lib version
 
Test suite: 

  ERS_Ln9.f19_f19_mg17.QPX2000.pleiades-has_intel.cam-outfrq3s (Overall: PASS) details:
  ERS_Ln9.f19_f19_mg17.QPX2000.pleiades-ivy_intel.cam-outfrq9s (Overall: PASS) details:
  ERS_Ln9.f19_f19_mg17.QPX2000.pleiades-san_intel.cam-outfrq9s (Overall: PASS) details:
  SMS_D_Ln9.f19_f19_mg17.QPX2000.pleiades-ivy_intel (Overall: PASS) details:
  SMS_D_Ln9.f19_f19_mg17.QPX2000.pleiades-san_intel (Overall: PASS) details:
  SMS_D_Ln9_P560x1.ne16_ne16_mg17.FX2000.pleiades-bro_intel (Overall: PASS) details:
  SMS_Ld1_P840x1.ne30pg3_ne30pg3_mg17.FX2000.pleiades-bro_intel (Overall: PASS) details:


