### PR TITLE
Adds git submodule info to provenance

### DIFF
--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -44,6 +44,40 @@ def _extract_times(zipfiles, target_file):
     with open(target_file, "w") as fd:
         fd.write(contents)
 
+def _run_git_cmd_recursively(cmd, srcroot, output):
+    """ Runs a git command recursively
+
+    Runs the git command in srcroot then runs it on each submodule.
+    Then output from both commands is written to the output file.
+    """
+    rc1, output1, err1 = run_cmd("git {}".format(cmd), from_dir=srcroot)
+
+    rc2, output2, err2 = run_cmd(
+        "git submodule foreach --recursive \"git {}; echo\"".format(cmd),
+        from_dir=srcroot)
+
+    with open(output, "w") as fd:
+        fd.write((output1 if rc1 == 0 else err1) + "\n\n")
+        fd.write((output2 if rc2 == 0 else err2) + "\n")
+
+def _record_git_provenance(srcroot, exeroot, lid):
+    """ Records git provenance
+
+    Records git status, diff and logs for main repo and all submodules.
+    """
+    # Git Status
+    status_prov = os.path.join(exeroot, "GIT_STATUS.{}".format(lid))
+    _run_git_cmd_recursively("status", srcroot, status_prov)
+
+    # Git Diff
+    diff_prov = os.path.join(exeroot, "GIT_DIFF.{}".format(lid))
+    _run_git_cmd_recursively("diff", srcroot, diff_prov)
+
+    # Git Log
+    log_prov = os.path.join(exeroot, "GIT_LOG.{}".format(lid))
+    cmd = "log --first-parent --pretty=oneline -n 5"
+    _run_git_cmd_recursively(cmd, srcroot, log_prov)
+
 def _save_build_provenance_e3sm(case, lid):
     srcroot = case.get_value("SRCROOT")
     exeroot = case.get_value("EXEROOT")
@@ -68,6 +102,8 @@ def _save_build_provenance_e3sm(case, lid):
     subm_status = get_current_submodule_status(recursive=True, repo=srcroot)
     with open(submodule_prov, "w") as fd:
         fd.write(subm_status)
+
+    _record_git_provenance(srcroot, exeroot, lid)
 
     # Save SourceMods
     sourcemods = os.path.join(caseroot, "SourceMods")
@@ -96,7 +132,9 @@ def _save_build_provenance_e3sm(case, lid):
 
     # For all the just-created post-build provenance files, symlink a generic name
     # to them to indicate that these are the most recent or active.
-    for item in ["GIT_DESCRIBE", "GIT_LOGS_HEAD", "GIT_SUBMODULE_STATUS", "SourceMods", "build_environment", "build_times"]:
+    for item in ["GIT_DESCRIBE", "GIT_LOGS_HEAD", "GIT_SUBMODULE_STATUS",
+            "GIT_STATUS", "GIT_DIFF", "GIT_LOG", "SourceMods", "build_environment",
+            "build_times"]:
         globstr = "{}/{}.{}*".format(exeroot, item, lid)
         matches = glob.glob(globstr)
         expect(len(matches) < 2, "Multiple matches for glob {} should not have happened".format(globstr))

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -78,6 +78,15 @@ def _record_git_provenance(srcroot, exeroot, lid):
     cmd = "log --first-parent --pretty=oneline -n 5"
     _run_git_cmd_recursively(cmd, srcroot, log_prov)
 
+    # Git remote
+    remote_prov = os.path.join(exeroot, "GIT_REMOTE.{}".format(lid))
+    _run_git_cmd_recursively("remote -v", srcroot, remote_prov)
+
+    # Git config
+    config_src = os.path.join(srcroot, ".git", "config")
+    config_prov = os.path.join(exeroot, "GIT_CONFIG.{}".format(lid))
+    safe_copy(config_src, config_prov, preserve_meta=False)
+
 def _save_build_provenance_e3sm(case, lid):
     srcroot = case.get_value("SRCROOT")
     exeroot = case.get_value("EXEROOT")
@@ -133,8 +142,9 @@ def _save_build_provenance_e3sm(case, lid):
     # For all the just-created post-build provenance files, symlink a generic name
     # to them to indicate that these are the most recent or active.
     for item in ["GIT_DESCRIBE", "GIT_LOGS_HEAD", "GIT_SUBMODULE_STATUS",
-            "GIT_STATUS", "GIT_DIFF", "GIT_LOG", "SourceMods", "build_environment",
-            "build_times"]:
+                 "GIT_STATUS", "GIT_DIFF", "GIT_LOG", "GIT_CONFIG",
+                 "GIT_REMOTE", "SourceMods", "build_environment",
+                 "build_times"]:
         globstr = "{}/{}.{}*".format(exeroot, item, lid)
         matches = glob.glob(globstr)
         expect(len(matches) < 2, "Multiple matches for glob {} should not have happened".format(globstr))

--- a/scripts/lib/CIME/tests/test_provenance.py
+++ b/scripts/lib/CIME/tests/test_provenance.py
@@ -2,6 +2,8 @@ import os
 import sys
 import unittest
 
+from CIME import provenance
+
 # TODO replace with actual mock once 2.7 is dropped
 class Mocker:
     calls = []
@@ -40,8 +42,6 @@ class Mocker:
 
 class TestProvenance(unittest.TestCase):
     def test_run_git_cmd_recursively(self):
-        from CIME import provenance
-
         with Mocker() as mock:
             Mocker.calls =[]
             mock.patch("CIME.provenance.run_cmd", (0, "data", None))
@@ -66,12 +66,13 @@ class TestProvenance(unittest.TestCase):
             self.assertTrue(x == y, "{} != {}".format(x, y))
 
     def test_run_git_cmd_recursively_error(self):
-        from CIME import provenance
-
         with Mocker() as mock:
             Mocker.calls =[]
             mock.patch("CIME.provenance.run_cmd", (1, "data", "error"))
-            mock.patch("builtins.open")
+            if sys.version_info.major > 2:
+                mock.patch("builtins.open")
+            else:
+                mock.patch("__builtin__.open")
 
             provenance._run_git_cmd_recursively('status', '/srcroot', '/output.txt') # pylint: disable=protected-access
         expected = [
@@ -89,12 +90,13 @@ class TestProvenance(unittest.TestCase):
             self.assertTrue(x == y, "{} != {}".format(x, y))
 
     def test_record_git_provenance(self):
-        from CIME import provenance
-
         with Mocker() as mock:
             Mocker.calls =[]
             mock.patch("CIME.provenance.run_cmd", (0, "data", None))
-            mock.patch("builtins.open")
+            if sys.version_info.major > 2:
+                mock.patch("builtins.open")
+            else:
+                mock.patch("__builtin__.open")
 
             provenance._record_git_provenance("/srcroot", "/output", "5") # pylint: disable=protected-access
 

--- a/scripts/lib/CIME/tests/test_provenance.py
+++ b/scripts/lib/CIME/tests/test_provenance.py
@@ -92,6 +92,7 @@ class TestProvenance(unittest.TestCase):
     def test_record_git_provenance(self):
         with Mocker() as mock:
             Mocker.calls =[]
+            mock.patch("CIME.provenance.safe_copy")
             mock.patch("CIME.provenance.run_cmd", (0, "data", None))
             if sys.version_info.major > 2:
                 mock.patch("builtins.open")
@@ -119,9 +120,18 @@ class TestProvenance(unittest.TestCase):
             "open /output/GIT_LOG.5 w",
             "write data\n\n",
             "write data\n",
+            "run_cmd git remote -v from_dir=/srcroot",
+            ("run_cmd git submodule foreach --recursive \"git remote"
+             " -v; echo\" from_dir=/srcroot"),
+            "open /output/GIT_REMOTE.5 w",
+            "write data\n\n",
+            "write data\n",
+            ("safe_copy /srcroot/.git/config /output/GIT_CONFIG.5"
+             " preserve_meta=False")
         ]
 
-        self.assertTrue(len(expected) == len(mock.calls))
+        self.assertTrue(len(expected) == len(mock.calls),
+                        mock.calls)
 
         for x, y in zip(expected, mock.calls):
             self.assertTrue(x == y, "{} != {}".format(x, y))

--- a/scripts/lib/CIME/tests/test_provenance.py
+++ b/scripts/lib/CIME/tests/test_provenance.py
@@ -45,7 +45,10 @@ class TestProvenance(unittest.TestCase):
         with Mocker() as mock:
             Mocker.calls =[]
             mock.patch("CIME.provenance.run_cmd", (0, "data", None))
-            mock.patch("builtins.open")
+            if sys.version_info.major > 2:
+                mock.patch("builtins.open")
+            else:
+                mock.patch("__builtin__.open")
 
             provenance._run_git_cmd_recursively('status', '/srcroot', '/output.txt') # pylint: disable=protected-access
         expected = [

--- a/scripts/lib/CIME/tests/test_provenance.py
+++ b/scripts/lib/CIME/tests/test_provenance.py
@@ -1,0 +1,126 @@
+import os
+import sys
+import unittest
+
+# TODO replace with actual mock once 2.7 is dropped
+class Mocker:
+    calls = []
+
+    def __init__(self, ret=None, cmd=None):
+        self._orig = []
+        self._ret = ret
+        self._cmd = cmd
+
+    def __getattr__(self, name):
+        return Mocker(self._ret, name)
+
+    def __call__(self, *args, **kwargs):
+        args = list(args)
+        if self._cmd is not None:
+            args.insert(0, self._cmd)
+
+        call_sig = " ".join([
+            x for x in args + [
+                "{}={}".format(y, z) for y, z in kwargs.items()]])
+        self.calls.append(call_sig)
+        return self._ret if self._ret is not None else self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        for m, module, method in self._orig:
+            setattr(sys.modules[module], method, m)
+
+    def patch(self, method, ret=None):
+        x = method.split('.')
+        main = '.'.join(x[:-1])
+        self._orig.append((getattr(sys.modules[main], x[-1]), main, x[-1]))
+        setattr(sys.modules[main], x[-1], Mocker(ret, x[-1]))
+
+class TestProvenance(unittest.TestCase):
+    def test_run_git_cmd_recursively(self):
+        from CIME import provenance
+
+        with Mocker() as mock:
+            Mocker.calls =[]
+            mock.patch("CIME.provenance.run_cmd", (0, "data", None))
+            mock.patch("builtins.open")
+
+            provenance._run_git_cmd_recursively('status', '/srcroot', '/output.txt') # pylint: disable=protected-access
+        expected = [
+            "run_cmd git status from_dir=/srcroot",
+            ("run_cmd git submodule foreach --recursive \"git status; echo\""
+             " from_dir=/srcroot"),
+            "open /output.txt w",
+            "write data\n\n",
+            "write data\n",
+        ]
+
+        self.assertTrue(len(expected) == len(mock.calls))
+
+        for x, y in zip(expected, mock.calls):
+            self.assertTrue(x == y, "{} != {}".format(x, y))
+
+    def test_run_git_cmd_recursively_error(self):
+        from CIME import provenance
+
+        with Mocker() as mock:
+            Mocker.calls =[]
+            mock.patch("CIME.provenance.run_cmd", (1, "data", "error"))
+            mock.patch("builtins.open")
+
+            provenance._run_git_cmd_recursively('status', '/srcroot', '/output.txt') # pylint: disable=protected-access
+        expected = [
+            "run_cmd git status from_dir=/srcroot",
+            ("run_cmd git submodule foreach --recursive \"git status; echo\""
+             " from_dir=/srcroot"),
+            "open /output.txt w",
+            "write error\n\n",
+            "write error\n",
+        ]
+
+        self.assertTrue(len(expected) == len(mock.calls))
+
+        for x, y in zip(expected, mock.calls):
+            self.assertTrue(x == y, "{} != {}".format(x, y))
+
+    def test_record_git_provenance(self):
+        from CIME import provenance
+
+        with Mocker() as mock:
+            Mocker.calls =[]
+            mock.patch("CIME.provenance.run_cmd", (0, "data", None))
+            mock.patch("builtins.open")
+
+            provenance._record_git_provenance("/srcroot", "/output", "5") # pylint: disable=protected-access
+
+        expected = [
+            "run_cmd git status from_dir=/srcroot",
+            ("run_cmd git submodule foreach --recursive \"git status; echo\""
+             " from_dir=/srcroot"),
+            "open /output/GIT_STATUS.5 w",
+            "write data\n\n",
+            "write data\n",
+            "run_cmd git diff from_dir=/srcroot",
+            ("run_cmd git submodule foreach --recursive \"git diff; echo\""
+             " from_dir=/srcroot"),
+            "open /output/GIT_DIFF.5 w",
+            "write data\n\n",
+            "write data\n",
+            "run_cmd git log --first-parent --pretty=oneline -n 5 from_dir=/srcroot",
+            ("run_cmd git submodule foreach --recursive \"git log"
+             " --first-parent --pretty=oneline -n 5; echo\" from_dir=/srcroot"),
+            "open /output/GIT_LOG.5 w",
+            "write data\n\n",
+            "write data\n",
+        ]
+
+        self.assertTrue(len(expected) == len(mock.calls))
+
+        for x, y in zip(expected, mock.calls):
+            self.assertTrue(x == y, "{} != {}".format(x, y))
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.abspath(os.path.join('.', '..', '..', 'lib')))
+    unittest.main()


### PR DESCRIPTION
Provenance now captures git status, diff and log for the repo at 
srcroot as well as all submodules recursively. The output of the three
commands are stored in their respective output files; GIT_STATUS,
GIT_DIFF and GIT_LOG.

Test suite: scripts_regression_tests.py
Test baseline: n/a
Test namelist changes: n/a
Test status: bfb

Fixes #3290 

User interface changes?: n/a
Update gh-pages html (Y/N)?: n/a
