### PR TITLE
Revert cheyenne intel mpt to 2.22.

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -636,7 +636,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">pnetcdf/1.12.1</command>
       </modules>
       <modules mpilib="mpt" compiler="intel">
-        <command name="load">mpt/2.23</command>
+        <command name="load">mpt/2.22</command>
         <command name="load">netcdf-mpi/4.7.4</command>
         <command name="load">pnetcdf/1.12.2</command>
       </modules>


### PR DESCRIPTION
Having issues with mpt/2.23 for the intel compiler on cheyenne.  
Some WACCM and WACCM-X tests were failing.

Test suite: ERS_Ld3.f19_f19_mg17.FXHIST.cheyenne_intel.cam-waccmx_weimer
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
