### PR TITLE
add this back for mct CLM_USRDAT

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -37,8 +37,8 @@
       <grid name="rof"       compset="DROF"        >rx1</grid>
       <grid name="rof"       compset="DROF%CPLHIST">r05</grid>
       <grid name="rof"       compset="XROF"        >r05</grid>
-      <grid name="glc"	     compset="SGLC"        >null</grid>
-      <grid name="glc"	     compset="CISM2"       >gland4</grid>
+      <grid name="glc"       compset="SGLC"        >null</grid>
+      <grid name="glc"       compset="CISM2"       >gland4</grid>
       <grid name="glc"       compset="XGLC"        >gland4</grid>
       <grid name="wav"       compset="SWAV"        >null</grid>
       <grid name="wav"       compset="DWAV"        >ww3a</grid>
@@ -1872,6 +1872,13 @@
       <file>domain.ocn.01col.ArcticOcean.20150824.nc</file>
       <desc>01col is a single-column grid for datm and POP:</desc>
     </domain>
+
+    <domain name="CLM_USRDAT">
+      <nx>1</nx> <ny>1</ny>
+      <file>$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.${CLM_USRDAT_NAME}_navy.nc</file>
+      <desc>user specified domain - only valid for DATM/CLM compset</desc>
+    </domain>
+
     <domain name="1x1_numaIA">
       <nx>1</nx> <ny>1</ny>
       <file grid="atm|lnd">$DIN_LOC_ROOT/share/domains/domain.clm/domain.lnd.1x1pt-numaIA_navy.110106.nc</file>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -37,8 +37,8 @@
       <grid name="rof"       compset="DROF"        >rx1</grid>
       <grid name="rof"       compset="DROF%CPLHIST">r05</grid>
       <grid name="rof"       compset="XROF"        >r05</grid>
-      <grid name="glc"       compset="SGLC"        >null</grid>
-      <grid name="glc"       compset="CISM2"       >gland4</grid>
+      <grid name="glc"	     compset="SGLC"        >null</grid>
+      <grid name="glc"	     compset="CISM2"       >gland4</grid>
       <grid name="glc"       compset="XGLC"        >gland4</grid>
       <grid name="wav"       compset="SWAV"        >null</grid>
       <grid name="wav"       compset="DWAV"        >ww3a</grid>


### PR DESCRIPTION
Add back domain for CLM_USRDAT for mct driver. 

Test suite: SMS_D_Lm1_Mmpi-serial.CLM_USRDAT.I1PtClm50SpRs.cheyenne_intel.clm-USUMB (All pass)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3905 

User interface changes?: 

Update gh-pages html (Y/N)?:
