### PR TITLE
[WIP] Allow building csm_share and gptl in different locations

### DIFF
--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -47,11 +47,22 @@ def buildlib(bldroot, installpath, case):
 ###############################################################################
     gmake_args = get_standard_makefile_args(case, shared_lib=True)
     comp_interface = case.get_value("COMP_INTERFACE")
+    cime_model = case.get_value("MODEL")
     cimeroot = case.get_value("CIMEROOT")
+    srcroot = case.get_value("SRCROOT")
     caseroot = case.get_value("CASEROOT")
     libroot = case.get_value("LIBROOT")
 
-    filepath = [os.path.join(caseroot,"SourceMods","src.share"),
+    if cime_model == "e3sm":
+      filepath = [os.path.join(caseroot,"SourceMods","src.share"),
+                os.path.join(srcroot,"share","streams"),
+                os.path.join(srcroot,"share","util"),
+                os.path.join(srcroot,"share","RandNum","src"),
+                os.path.join(srcroot,"share","RandNum","src","dsfmt_f03"),
+                os.path.join(srcroot,"share","RandNum","src","kissvec"),
+                os.path.join(srcroot,"share","RandNum","src","mt19937")]
+    else:
+      filepath = [os.path.join(caseroot,"SourceMods","src.share"),
                 os.path.join(cimeroot,"src","share","streams"),
                 os.path.join(cimeroot,"src","share","util"),
                 os.path.join(cimeroot,"src","share","RandNum","src"),
@@ -76,7 +87,11 @@ def buildlib(bldroot, installpath, case):
         use_esmf = "esmf"
     else:
         use_esmf = "noesmf"
-        filepath.append(os.path.join(cimeroot, "src", "share", "esmf_wrf_timemgr"))
+        if cime_model == "e3sm":
+          filepath.append(os.path.join(srcroot, "share", "esmf_wrf_timemgr"))
+        else:
+          filepath.append(os.path.join(cimeroot, "src", "share", "esmf_wrf_timemgr"))
+
 
     comp_interface = case.get_value("COMP_INTERFACE")
     ninst_value = case.get_value("NINST_VALUE")
@@ -116,9 +131,15 @@ def buildlib(bldroot, installpath, case):
         if not os.path.isdir(os.path.join(installdir,ndir)):
             os.makedirs(os.path.join(installdir,ndir))
     # copy some header files
-    for _file in glob.iglob(os.path.join(cimeroot,"src","share","include","*")):
+    if cime_model == "e3sm":
+      for _file in glob.iglob(os.path.join(srcroot,"share","include","*")):
         copyifnewer(_file, os.path.join(installdir, "include", os.path.basename(_file)))
-    for _file in glob.iglob(os.path.join(cimeroot,"src","share","RandNum","include","*")):
+      for _file in glob.iglob(os.path.join(srcroot,"share","RandNum","include","*")):
+        copyifnewer(_file, os.path.join(installdir, "include", os.path.basename(_file)))
+    else:
+      for _file in glob.iglob(os.path.join(cimeroot,"src","share","include","*")):
+        copyifnewer(_file, os.path.join(installdir, "include", os.path.basename(_file)))
+      for _file in glob.iglob(os.path.join(cimeroot,"src","share","RandNum","include","*")):
         copyifnewer(_file, os.path.join(installdir, "include", os.path.basename(_file)))
 
     # This runs the make command

--- a/src/build_scripts/buildlib.gptl
+++ b/src/build_scripts/buildlib.gptl
@@ -43,9 +43,14 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 def buildlib(bldroot, installpath, case):
 ###############################################################################
     caseroot = case.get_value("CASEROOT")
+    cime_model = case.get_value("MODEL")
     comp_interface = case.get_value("COMP_INTERFACE")
     
-    gptl_dir = os.path.join(case.get_value("CIMEROOT"), "src", "share", "timing")
+    if cime_model == "e3sm":
+      gptl_dir = os.path.join(case.get_value("SRCROOT"), "share", "timing")
+    else:
+      gptl_dir = os.path.join(case.get_value("CIMEROOT"), "src", "share", "timing")
+
     gmake_opts = "-f {gptl}/Makefile install -C {bldroot} MACFILE={macfile} MODEL=gptl COMP_NAME=gptl GPTL_DIR={gptl} GPTL_LIBDIR={bldroot}"\
         " SHAREDPATH={install} COMP_INTERFACE={comp_interface} {stdargs} "\
         .format(gptl=gptl_dir, bldroot=bldroot, macfile=os.path.join(caseroot,"Macros.make"),


### PR DESCRIPTION
Add some "if model=" logic to allow building of csm_share and gptl when they are in a different location
in E3SM source.


Test suite:  Built an E3SM F-case with cime/src/share moved.
Test baseline: 
Test namelist changes:  NONE
Test status: BFB
