### PR TITLE
update this so that paths with % in them do not break cism build

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -736,11 +736,11 @@ CMAKE_ENV_VARS += CC=$(CC) \
 		  LDFLAGS="$(LDFLAGS)"
 
 
-# We declare $(GLC_DIR)/Makefile to be a phony target so that cmake is
-# always rerun whenever invoking 'make $(GLC_DIR)/Makefile'; this is
+# We declare GLCMakefile to be a phony target so that cmake is
+# always rerun whenever invoking 'make GLCMakefile'; this is
 # desirable to pick up any new source files that may have been added
-.PHONY: $(GLC_DIR)/Makefile
-$(GLC_DIR)/Makefile:
+.PHONY: GLCMakefile
+GLCMakefile:
 	cd $(GLC_DIR); \
 	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(GLCROOT)/source_cism
 


### PR DESCRIPTION
The % symbol has a special meaning in Makefile and when we create tests with long compset names this
was causing a problem with the cism build not being triggered.  But Phony targets are phony so you can call them whatever you want.  This fixes the issue when called from cism buildlib with cmake GLCMakefile 

Test suite: hand testing, scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
