### PR TITLE
Add script capture

### DIFF
--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -132,6 +132,8 @@ def _main_func(description):
 
     success = True
     with Case(caseroot, read_only=False) as case:
+        case.record_cmd()
+
         testname = case.get_value('TESTCASE')
 
         if cleanlist is not None or clean_all or clean_depends is not None:

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -61,6 +61,8 @@ def _main_func(description):
 ###############################################################################
     caseroot, clean, test_mode, reset, keep = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False) as case:
+        case.record_cmd()
+
         case.case_setup(clean=clean, test_mode=test_mode, reset=reset, keep=keep)
 
 if __name__ == "__main__":

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -118,6 +118,8 @@ def _main_func(description, test_args=False):
 
     if not test_args:
         with Case(caseroot, read_only=False) as case:
+            case.record_cmd()
+
             case.submit(job=job, no_batch=no_batch, prereq=prereq, allow_fail=allow_fail,
                         resubmit=resubmit, resubmit_immediate=resubmit_immediate, skip_pnl=skip_pnl,
                         mail_user=mail_user, mail_type=mail_type, batch_args=batch_args, workflow=workflow)

--- a/scripts/Tools/check_case
+++ b/scripts/Tools/check_case
@@ -44,6 +44,7 @@ def _main_func(description):
     parse_command_line(sys.argv, description)
 
     with Case(read_only=False) as case:
+        case.record_cmd()
         case.check_lockedfiles()
         case.create_namelists()
         build_complete = case.get_value("BUILD_COMPLETE")

--- a/scripts/Tools/pelayout
+++ b/scripts/Tools/pelayout
@@ -228,6 +228,8 @@ def _main_func(description):
 
     # Initialize case ; read in all xml files from caseroot
     with Case(caseroot) as case:
+        case.record_cmd()
+
         if (set_nthrds is not None):
             set_nthreads(case, set_nthrds)
         # End if

--- a/scripts/Tools/preview_namelists
+++ b/scripts/Tools/preview_namelists
@@ -51,6 +51,8 @@ def _main_func(description):
     expect(os.path.isfile(os.path.join(args.caseroot, "CaseStatus")),
            "case.setup must be run prior to running preview_namelists")
     with Case(args.caseroot, read_only=False) as case:
+        case.record_cmd()
+
         case.create_namelists(component=args.component)
 
 if (__name__ == "__main__"):

--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -184,6 +184,8 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
               append, noecho, force, dryrun):
 
     with Case(caseroot, read_only=False) as case:
+        case.record_cmd()
+
         comp_classes = case.get_values("COMP_CLASSES")
         env_test = None
         if (case.get_value("TEST") and os.path.exists(os.path.join(caseroot,"env_test.xml"))) and not (xmlfile or xmlfile == "env_test.xml"):

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -238,6 +238,9 @@ def _main_func(description):
                     input_dir=input_dir, driver=driver, workflowid=workflow, non_local=non_local,
                     extra_machines_dir=extra_machines_dir, case_group=case_group)
 
+        # Called after create since casedir does not exist yet
+        case.record_cmd(init=True)
+
 ###############################################################################
 
 if __name__ == "__main__":

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -5,7 +5,7 @@ All interaction with and between the module files in XML/ takes place
 through the Case module.
 """
 from copy import deepcopy
-import glob, os, shutil, math, six
+import glob, os, shutil, math, six, time
 from CIME.XML.standard_module_setup import *
 #pylint: disable=import-error,redefined-builtin
 from six.moves import input
@@ -1635,6 +1635,39 @@ directory, NOT in this subdirectory."""
             return cpllog
         else:
             return None
+
+    def record_cmd(self, cmd=None, init=False):
+        lines = []
+        caseroot = self.get_value("CASEROOT")
+        cimeroot = self.get_value("CIMEROOT")
+
+        if cmd is None:
+            cmd = list(sys.argv)
+
+        if init:
+            ctime = time.strftime("%Y-%m-%d %H:%M:%S")
+
+            lines.append("#!/bin/bash\n\n")
+            # stop script on error, prevents `create_newcase` from failing
+            # and continuing to execute commands
+            lines.append("set -e\n\n")
+            lines.append("# Created {}\n\n".format(ctime))
+            lines.append("CASEDIR=\"{}\"\n\n".format(caseroot))
+            lines.append("cd \"${CASEDIR}\"\n\n")
+
+            # Ensure program path is absolute
+            cmd[0] = re.sub("^./", "{}/scripts/".format(cimeroot), cmd[0])
+
+        cmd = " ".join(cmd)
+
+        # Replace instances of caseroot with variable
+        cmd = re.sub(caseroot, "\"${CASEDIR}\"", cmd)
+
+        lines_len = len(lines)
+        lines.insert(lines_len-1 if init else lines_len, "{}\n\n".format(cmd))
+
+        with open(os.path.join(caseroot, "replay.sh"), "a") as fd:
+            fd.writelines(lines)
 
     def create(self, casename, srcroot, compset_name, grid_name,
                user_mods_dir=None, machine_name=None,

--- a/scripts/lib/CIME/tests/test_case.py
+++ b/scripts/lib/CIME/tests/test_case.py
@@ -15,7 +15,7 @@ class TestCase_RecordCmd(unittest.TestCase):
 
         Case.__init__ = utils.Mocker()
         Case.flush = utils.Mocker()
-        Case._force_read_only = False
+        Case._force_read_only = False # pylint: disable=protected-access
 
     def assert_calls_match(self, calls, expected):
         self.assertTrue(len(calls) == len(expected), calls)
@@ -32,7 +32,7 @@ class TestCase_RecordCmd(unittest.TestCase):
                 ret=utils.Mocker()
             )
             mock.patch("time.strftime", ret="00:00:00")
-            mock.patch("sys.argv", ret=["/src/create_newcase"], property=True)
+            mock.patch("sys.argv", ret=["/src/create_newcase"], is_property=True)
 
             with Case(tempdir) as case:
                 case.get_value = utils.Mocker(
@@ -53,7 +53,7 @@ class TestCase_RecordCmd(unittest.TestCase):
             "cd \"${CASEDIR}\"\n\n",
         ]
 
-        calls = open_mock._ret.method_calls["writelines"][0]["args"][0]
+        calls = open_mock.ret.method_calls["writelines"][0]["args"][0]
 
         self.assert_calls_match(calls, expected)
 
@@ -66,7 +66,7 @@ class TestCase_RecordCmd(unittest.TestCase):
                 ret=utils.Mocker()
             )
             mock.patch("time.strftime", ret="00:00:00")
-            mock.patch("sys.argv", ret=["./create_newcase"], property=True)
+            mock.patch("sys.argv", ret=["./create_newcase"], is_property=True)
 
             with Case(tempdir) as case:
                 case.get_value = utils.Mocker(
@@ -84,7 +84,7 @@ class TestCase_RecordCmd(unittest.TestCase):
             "cd \"${CASEDIR}\"\n\n",
         ]
 
-        calls = open_mock._ret.method_calls["writelines"][0]["args"][0]
+        calls = open_mock.ret.method_calls["writelines"][0]["args"][0]
 
         self.assert_calls_match(calls, expected)
 
@@ -108,7 +108,7 @@ class TestCase_RecordCmd(unittest.TestCase):
             "/some/custom/command arg1\n\n",
         ]
 
-        calls = open_mock._ret.method_calls["writelines"][0]["args"][0]
+        calls = open_mock.ret.method_calls["writelines"][0]["args"][0]
 
         self.assert_calls_match(calls, expected)
 

--- a/scripts/lib/CIME/tests/test_case.py
+++ b/scripts/lib/CIME/tests/test_case.py
@@ -1,0 +1,113 @@
+import os
+import sys
+import unittest
+
+from CIME.case import Case
+from CIME import utils as cime_utils
+
+from . import utils
+
+class TestCase_RecordCmd(unittest.TestCase):
+
+    def setUp(self):
+        self.srcroot = os.path.abspath(cime_utils.get_cime_root())
+        self.tempdir = utils.TemporaryDirectory()
+
+        Case.__init__ = utils.Mocker()
+        Case.flush = utils.Mocker()
+        Case._force_read_only = False
+
+    def assert_calls_match(self, calls, expected):
+        self.assertTrue(len(calls) == len(expected), calls)
+
+        for x, y in zip(calls, expected):
+            self.assertTrue(x == y, calls)
+
+    def test_init(self):
+        with self.tempdir as tempdir:
+            mock = utils.Mocker()
+            open_mock = mock.patch(
+                "builtins.open" if sys.version_info.major > 2 else
+                    "__builtin__.open",
+                ret=utils.Mocker()
+            )
+            mock.patch("time.strftime", ret="00:00:00")
+            mock.patch("sys.argv", ret=["/src/create_newcase"], property=True)
+
+            with Case(tempdir) as case:
+                case.get_value = utils.Mocker(
+                    side_effect=[tempdir, "/src"]
+                )
+
+                case.record_cmd(init=True)
+
+        expected = [
+            "#!/bin/bash\n\n",
+            "set -e\n\n",
+            "# Created 00:00:00\n\n",
+            "CASEDIR=\"{}\"\n\n".format(tempdir),
+            "/src/create_newcase\n\n",
+            "cd \"${CASEDIR}\"\n\n",
+        ]
+
+        calls = open_mock.method_calls["writelines"][0]["args"][0]
+
+        self.assert_calls_match(calls, expected)
+
+    def test_sub_relative(self):
+        with self.tempdir as tempdir:
+            mock = utils.Mocker()
+            open_mock = mock.patch(
+                "builtins.open" if sys.version_info.major > 2 else
+                    "__builtin__.open",
+                ret=utils.Mocker()
+            )
+            mock.patch("time.strftime", ret="00:00:00")
+            mock.patch("sys.argv", ret=["./create_newcase"], property=True)
+
+            with Case(tempdir) as case:
+                case.get_value = utils.Mocker(
+                    side_effect=[tempdir, "/src"]
+                )
+
+                case.record_cmd(init=True)
+
+        expected = [
+            "#!/bin/bash\n\n",
+            "set -e\n\n",
+            "# Created 00:00:00\n\n",
+            "CASEDIR=\"{}\"\n\n".format(tempdir),
+            "/src/scripts/create_newcase\n\n",
+            "cd \"${CASEDIR}\"\n\n",
+        ]
+
+        calls = open_mock.method_calls["writelines"][0]["args"][0]
+
+        self.assert_calls_match(calls, expected)
+
+    def test_cmd_arg(self):
+        with self.tempdir as tempdir:
+            mock = utils.Mocker()
+            open_mock = mock.patch(
+                "builtins.open" if sys.version_info.major > 2 else
+                    "__builtin__.open",
+                ret=utils.Mocker()
+            )
+
+            with Case(tempdir) as case:
+                case.get_value = utils.Mocker(
+                    side_effect=[tempdir, "/src"]
+                )
+
+                case.record_cmd(["/some/custom/command", "arg1"])
+
+        expected = [
+            "/some/custom/command arg1\n\n",
+        ]
+
+        calls = open_mock.method_calls["writelines"][0]["args"][0]
+
+        self.assert_calls_match(calls, expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/lib/CIME/tests/test_case.py
+++ b/scripts/lib/CIME/tests/test_case.py
@@ -41,6 +41,9 @@ class TestCase_RecordCmd(unittest.TestCase):
 
                 case.record_cmd(init=True)
 
+        self.assertTrue(open_mock.calls[0]["args"] ==
+                        ("{}/replay.sh".format(tempdir), "a"))
+
         expected = [
             "#!/bin/bash\n\n",
             "set -e\n\n",
@@ -50,7 +53,7 @@ class TestCase_RecordCmd(unittest.TestCase):
             "cd \"${CASEDIR}\"\n\n",
         ]
 
-        calls = open_mock.method_calls["writelines"][0]["args"][0]
+        calls = open_mock._ret.method_calls["writelines"][0]["args"][0]
 
         self.assert_calls_match(calls, expected)
 
@@ -81,7 +84,7 @@ class TestCase_RecordCmd(unittest.TestCase):
             "cd \"${CASEDIR}\"\n\n",
         ]
 
-        calls = open_mock.method_calls["writelines"][0]["args"][0]
+        calls = open_mock._ret.method_calls["writelines"][0]["args"][0]
 
         self.assert_calls_match(calls, expected)
 
@@ -105,7 +108,7 @@ class TestCase_RecordCmd(unittest.TestCase):
             "/some/custom/command arg1\n\n",
         ]
 
-        calls = open_mock.method_calls["writelines"][0]["args"][0]
+        calls = open_mock._ret.method_calls["writelines"][0]["args"][0]
 
         self.assert_calls_match(calls, expected)
 

--- a/scripts/lib/CIME/tests/test_provenance.py
+++ b/scripts/lib/CIME/tests/test_provenance.py
@@ -4,137 +4,120 @@ import unittest
 
 from CIME import provenance
 
-# TODO replace with actual mock once 2.7 is dropped
-class Mocker:
-    calls = []
-
-    def __init__(self, ret=None, cmd=None):
-        self._orig = []
-        self._ret = ret
-        self._cmd = cmd
-
-    def __getattr__(self, name):
-        return Mocker(self._ret, name)
-
-    def __call__(self, *args, **kwargs):
-        args = list(args)
-        if self._cmd is not None:
-            args.insert(0, self._cmd)
-
-        call_sig = " ".join([
-            x for x in args + [
-                "{}={}".format(y, z) for y, z in kwargs.items()]])
-        self.calls.append(call_sig)
-        return self._ret if self._ret is not None else self
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        for m, module, method in self._orig:
-            setattr(sys.modules[module], method, m)
-
-    def patch(self, method, ret=None):
-        x = method.split('.')
-        main = '.'.join(x[:-1])
-        self._orig.append((getattr(sys.modules[main], x[-1]), main, x[-1]))
-        setattr(sys.modules[main], x[-1], Mocker(ret, x[-1]))
+from . import utils
 
 class TestProvenance(unittest.TestCase):
     def test_run_git_cmd_recursively(self):
-        with Mocker() as mock:
-            Mocker.calls =[]
-            mock.patch("CIME.provenance.run_cmd", (0, "data", None))
-            if sys.version_info.major > 2:
-                mock.patch("builtins.open")
-            else:
-                mock.patch("__builtin__.open")
-
+        with utils.Mocker() as mock:
+            open_mock = mock.patch(
+                "builtins.open" if sys.version_info.major > 2 else
+                    "__builtin__.open",
+                ret=utils.Mocker()
+            )
+            provenance.run_cmd = utils.Mocker(return_value=(0, "data", None))
             provenance._run_git_cmd_recursively('status', '/srcroot', '/output.txt') # pylint: disable=protected-access
-        expected = [
-            "run_cmd git status from_dir=/srcroot",
-            ("run_cmd git submodule foreach --recursive \"git status; echo\""
-             " from_dir=/srcroot"),
-            "open /output.txt w",
-            "write data\n\n",
-            "write data\n",
-        ]
 
-        self.assertTrue(len(expected) == len(mock.calls))
+        self.assertTrue(
+            open_mock.calls[0]["args"] == ("/output.txt", "w"),
+            open_mock.calls
+        )
 
-        for x, y in zip(expected, mock.calls):
-            self.assertTrue(x == y, "{} != {}".format(x, y))
+        write = open_mock._ret.method_calls["write"]
+
+        self.assertTrue(write[0]["args"][0] == "data\n\n", write)
+        self.assertTrue(write[1]["args"][0] == "data\n", write)
+
+        run_cmd = provenance.run_cmd.calls
+
+        self.assertTrue(run_cmd[0]["args"][0] == "git status")
+        self.assertTrue(run_cmd[0]["kwargs"]["from_dir"] == "/srcroot")
+
+        self.assertTrue(run_cmd[1]["args"][0] == "git submodule foreach"
+                        " --recursive \"git status; echo\"", run_cmd)
+        self.assertTrue(run_cmd[1]["kwargs"]["from_dir"] == "/srcroot")
 
     def test_run_git_cmd_recursively_error(self):
-        with Mocker() as mock:
-            Mocker.calls =[]
-            mock.patch("CIME.provenance.run_cmd", (1, "data", "error"))
-            if sys.version_info.major > 2:
-                mock.patch("builtins.open")
-            else:
-                mock.patch("__builtin__.open")
-
+        with utils.Mocker() as mock:
+            open_mock = mock.patch(
+                "builtins.open" if sys.version_info.major > 2 else
+                    "__builtin__.open",
+                ret=utils.Mocker()
+            )
+            provenance.run_cmd = utils.Mocker(return_value=(1, "data", "error"))
             provenance._run_git_cmd_recursively('status', '/srcroot', '/output.txt') # pylint: disable=protected-access
-        expected = [
-            "run_cmd git status from_dir=/srcroot",
-            ("run_cmd git submodule foreach --recursive \"git status; echo\""
-             " from_dir=/srcroot"),
-            "open /output.txt w",
-            "write error\n\n",
-            "write error\n",
-        ]
 
-        self.assertTrue(len(expected) == len(mock.calls))
+        write = open_mock._ret.method_calls["write"]
 
-        for x, y in zip(expected, mock.calls):
-            self.assertTrue(x == y, "{} != {}".format(x, y))
+        self.assertTrue(write[0]["args"][0] == "error\n\n", write)
+        self.assertTrue(write[1]["args"][0] == "error\n", write)
+
+        run_cmd = provenance.run_cmd.calls
+
+        self.assertTrue(run_cmd[0]["args"][0] == "git status")
+        self.assertTrue(run_cmd[0]["kwargs"]["from_dir"] == "/srcroot")
+
+        self.assertTrue(run_cmd[1]["args"][0] == "git submodule foreach"
+                        " --recursive \"git status; echo\"", run_cmd)
+        self.assertTrue(run_cmd[1]["kwargs"]["from_dir"] == "/srcroot")
 
     def test_record_git_provenance(self):
-        with Mocker() as mock:
-            Mocker.calls =[]
-            mock.patch("CIME.provenance.safe_copy")
-            mock.patch("CIME.provenance.run_cmd", (0, "data", None))
-            if sys.version_info.major > 2:
-                mock.patch("builtins.open")
-            else:
-                mock.patch("__builtin__.open")
+        with utils.Mocker() as mock:
+            open_mock = mock.patch(
+                "builtins.open" if sys.version_info.major > 2 else
+                    "__builtin__.open",
+                ret=utils.Mocker()
+            )
 
+            provenance.safe_copy = utils.Mocker()
+            provenance.run_cmd = utils.Mocker(return_value=(0, "data", None))
             provenance._record_git_provenance("/srcroot", "/output", "5") # pylint: disable=protected-access
 
         expected = [
-            "run_cmd git status from_dir=/srcroot",
-            ("run_cmd git submodule foreach --recursive \"git status; echo\""
-             " from_dir=/srcroot"),
-            "open /output/GIT_STATUS.5 w",
-            "write data\n\n",
-            "write data\n",
-            "run_cmd git diff from_dir=/srcroot",
-            ("run_cmd git submodule foreach --recursive \"git diff; echo\""
-             " from_dir=/srcroot"),
-            "open /output/GIT_DIFF.5 w",
-            "write data\n\n",
-            "write data\n",
-            "run_cmd git log --first-parent --pretty=oneline -n 5 from_dir=/srcroot",
-            ("run_cmd git submodule foreach --recursive \"git log"
-             " --first-parent --pretty=oneline -n 5; echo\" from_dir=/srcroot"),
-            "open /output/GIT_LOG.5 w",
-            "write data\n\n",
-            "write data\n",
-            "run_cmd git remote -v from_dir=/srcroot",
-            ("run_cmd git submodule foreach --recursive \"git remote"
-             " -v; echo\" from_dir=/srcroot"),
-            "open /output/GIT_REMOTE.5 w",
-            "write data\n\n",
-            "write data\n",
-            ("safe_copy /srcroot/.git/config /output/GIT_CONFIG.5"
-             " preserve_meta=False")
+            ("/output/GIT_STATUS.5", "w"),
+            ("/output/GIT_DIFF.5", "w"),
+            ("/output/GIT_LOG.5", "w"),
+            ("/output/GIT_REMOTE.5", "w")
         ]
 
-        self.assertTrue(len(expected) == len(mock.calls),
-                        mock.calls)
+        for i in range(4):
+             self.assertTrue(
+                 open_mock.calls[i]["args"] == expected[i], open_mock.calls)
 
-        for x, y in zip(expected, mock.calls):
-            self.assertTrue(x == y, "{} != {}".format(x, y))
+        write = open_mock._ret.method_calls["write"]
+
+        expected = [
+            "data\n\n",
+            "data\n",
+        ]
+
+        for x in range(8):
+            self.assertTrue(write[x]["args"][0] == expected[x%2], write)
+
+        run_cmd = provenance.run_cmd.calls
+
+        expected = [
+            "git status",
+            "git submodule foreach --recursive \"git status; echo\"",
+            "git diff",
+            "git submodule foreach --recursive \"git diff; echo\"",
+            "git log --first-parent --pretty=oneline -n 5",
+            "git submodule foreach --recursive \"git log --first-parent"
+                " --pretty=oneline -n 5; echo\"",
+            "git remote -v",
+            "git submodule foreach --recursive \"git remote -v; echo\"",
+        ]
+
+        for x in range(len(run_cmd)):
+            self.assertTrue(run_cmd[x]["args"][0] == expected[x], run_cmd[x])
+
+        self.assertTrue(
+            provenance.safe_copy.calls[0]["args"][0] == "/srcroot/.git/config",
+            provenance.safe_copy.calls
+        )
+        self.assertTrue(
+            provenance.safe_copy.calls[0]["args"][1] == "/output/GIT_CONFIG.5",
+            provenance.safe_copy.calls
+        )
 
 if __name__ == '__main__':
     sys.path.insert(0, os.path.abspath(os.path.join('.', '..', '..', 'lib')))

--- a/scripts/lib/CIME/tests/test_provenance.py
+++ b/scripts/lib/CIME/tests/test_provenance.py
@@ -22,7 +22,7 @@ class TestProvenance(unittest.TestCase):
             open_mock.calls
         )
 
-        write = open_mock._ret.method_calls["write"]
+        write = open_mock.ret.method_calls["write"]
 
         self.assertTrue(write[0]["args"][0] == "data\n\n", write)
         self.assertTrue(write[1]["args"][0] == "data\n", write)
@@ -46,7 +46,7 @@ class TestProvenance(unittest.TestCase):
             provenance.run_cmd = utils.Mocker(return_value=(1, "data", "error"))
             provenance._run_git_cmd_recursively('status', '/srcroot', '/output.txt') # pylint: disable=protected-access
 
-        write = open_mock._ret.method_calls["write"]
+        write = open_mock.ret.method_calls["write"]
 
         self.assertTrue(write[0]["args"][0] == "error\n\n", write)
         self.assertTrue(write[1]["args"][0] == "error\n", write)
@@ -80,10 +80,12 @@ class TestProvenance(unittest.TestCase):
         ]
 
         for i in range(4):
-             self.assertTrue(
-                 open_mock.calls[i]["args"] == expected[i], open_mock.calls)
+            self.assertTrue(
+                open_mock.calls[i]["args"] == expected[i],
+                open_mock.calls
+            )
 
-        write = open_mock._ret.method_calls["write"]
+        write = open_mock.ret.method_calls["write"]
 
         expected = [
             "data\n\n",

--- a/scripts/lib/CIME/tests/test_utils.py
+++ b/scripts/lib/CIME/tests/test_utils.py
@@ -7,6 +7,8 @@ import unittest
 import tempfile
 from CIME.utils import indent_string, run_and_log_case_status
 
+from . import utils
+
 class TestIndentStr(unittest.TestCase):
     """Test the indent_string function.
 
@@ -35,19 +37,6 @@ goodbye
   goodbye
 """
         self.assertEqual(expected, result)
-
-# TODO after dropping python 2.7 replace with tempfile.TemporaryDirectory
-class TemporaryDirectory(object):
-    def __init__(self):
-        self._tempdir = None
-
-    def __enter__(self):
-        self._tempdir = tempfile.mkdtemp()
-        return self._tempdir
-
-    def __exit__(self, *args, **kwargs):
-        if os.path.exists(self._tempdir):
-            shutil.rmtree(self._tempdir)
 
 class MockTime(object):
     def __init__(self):
@@ -104,7 +93,7 @@ class TestUtils(unittest.TestCase):
             "00:00:00 default success \n",
         ]
 
-        with TemporaryDirectory() as tempdir, MockTime():
+        with utils.TemporaryDirectory() as tempdir, MockTime():
             run_and_log_case_status(self.base_func, "default",
                                     caseroot=tempdir)
 
@@ -116,7 +105,7 @@ class TestUtils(unittest.TestCase):
             "00:00:00 case.submit success \n",
         ]
 
-        with TemporaryDirectory() as tempdir, MockTime():
+        with utils.TemporaryDirectory() as tempdir, MockTime():
             run_and_log_case_status(self.base_func, "case.submit",
                                     caseroot=tempdir, is_batch=True)
 
@@ -128,7 +117,7 @@ class TestUtils(unittest.TestCase):
             "00:00:00 case.submit success \n",
         ]
 
-        with TemporaryDirectory() as tempdir, MockTime():
+        with utils.TemporaryDirectory() as tempdir, MockTime():
             run_and_log_case_status(self.base_func, "case.submit",
                                     caseroot=tempdir, is_batch=False)
 
@@ -141,7 +130,7 @@ class TestUtils(unittest.TestCase):
             "Something went wrong\n",
         ]
 
-        with TemporaryDirectory() as tempdir, MockTime():
+        with utils.TemporaryDirectory() as tempdir, MockTime():
             with self.assertRaises(Exception):
                 run_and_log_case_status(self.error_func, "case.submit",
                                         caseroot=tempdir, is_batch=True)
@@ -157,7 +146,7 @@ class TestUtils(unittest.TestCase):
         starting_func = lambda *args: "starting extra"
         success_func = lambda *args: "success extra"
 
-        with TemporaryDirectory() as tempdir, MockTime():
+        with utils.TemporaryDirectory() as tempdir, MockTime():
             run_and_log_case_status(self.base_func, "default", 
                                     custom_starting_msg_functor=starting_func,
                                     custom_success_msg_functor=success_func,
@@ -172,7 +161,7 @@ class TestUtils(unittest.TestCase):
             "Something went wrong\n",
         ]
 
-        with TemporaryDirectory() as tempdir, MockTime():
+        with utils.TemporaryDirectory() as tempdir, MockTime():
             with self.assertRaises(Exception):
                 run_and_log_case_status(self.error_func, "default",
                                         caseroot=tempdir)

--- a/scripts/lib/CIME/tests/test_utils.py
+++ b/scripts/lib/CIME/tests/test_utils.py
@@ -2,9 +2,7 @@
 
 import sys
 import os
-import shutil
 import unittest
-import tempfile
 from CIME.utils import indent_string, run_and_log_case_status
 
 from . import utils
@@ -45,7 +43,7 @@ class MockTime(object):
     def __enter__(self):
         self._old = getattr(sys.modules["time"], "strftime")
         setattr(sys.modules["time"], "strftime", lambda *args: "00:00:00 ")
-        
+
     def __exit__(self, *args, **kwargs):
         setattr(sys.modules["time"], "strftime", self._old)
 

--- a/scripts/lib/CIME/tests/utils.py
+++ b/scripts/lib/CIME/tests/utils.py
@@ -1,0 +1,90 @@
+import os
+import tempfile
+import shutil
+import sys
+from collections.abc import Iterable
+
+# TODO after dropping python 2.7 replace with tempfile.TemporaryDirectory
+class TemporaryDirectory(object):
+    def __init__(self):
+        self._tempdir = None
+
+    def __enter__(self):
+        self._tempdir = tempfile.mkdtemp()
+        return self._tempdir
+
+    def __exit__(self, *args, **kwargs):
+        if os.path.exists(self._tempdir):
+            shutil.rmtree(self._tempdir)
+
+# TODO replace with actual mock once 2.7 is dropped
+class Mocker:
+
+    def __init__(self, ret=None, cmd=None, return_value=None, side_effect=None):
+        self._orig = []
+        self._ret = ret or return_value
+        self._cmd = cmd
+        self._calls = []
+
+        if isinstance(side_effect, (list, tuple)):
+            self._side_effect = iter(side_effect)
+        else:
+            self._side_effect = side_effect
+
+        self._method_calls = {}
+
+    @property
+    def calls(self):
+        return self._calls
+
+    @property
+    def method_calls(self):
+        return dict((x, y.calls) for x, y in self._method_calls.items())
+
+    def __getattr__(self, name):
+        new_method = Mocker(self, cmd=name)
+        self._method_calls[name] = new_method
+
+        return new_method
+
+    def __call__(self, *args, **kwargs):
+        self._calls.append({"args": args, "kwargs": kwargs})
+
+        if (self._side_effect is not None and
+                isinstance(self._side_effect, Iterable)):
+            rv = next(self._side_effect)
+        else:
+            rv = self._ret
+
+        return rv
+
+    def __del__(self):
+        self.revert_mocks()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.revert_mocks()
+
+    def revert_mocks(self):
+        for m, module, method in self._orig:
+            if isinstance(module, str):
+                setattr(sys.modules[module], method, m)
+            else:
+                setattr(module, method, m)
+
+    def patch(self, module, method=None, ret=None, property=False):
+        if isinstance(module, str):
+            x = module.split('.')
+            main = '.'.join(x[:-1])
+            self._orig.append((getattr(sys.modules[main], x[-1]), main, x[-1]))
+            if property:
+                setattr(sys.modules[main], x[-1], ret)
+            else:
+                setattr(sys.modules[main], x[-1], Mocker(ret, cmd=x[-1]))
+        else:
+            setattr(module, method, Mocker(ret))
+
+        return ret
+

--- a/scripts/lib/CIME/tests/utils.py
+++ b/scripts/lib/CIME/tests/utils.py
@@ -41,6 +41,10 @@ class Mocker:
     def method_calls(self):
         return dict((x, y.calls) for x, y in self._method_calls.items())
 
+    @property
+    def ret(self):
+        return self._ret
+
     def __getattr__(self, name):
         if name in self._method_calls:
             new_method = self._method_calls[name]
@@ -77,13 +81,13 @@ class Mocker:
             else:
                 setattr(module, method, m)
 
-    def patch(self, module, method=None, ret=None, property=False):
+    def patch(self, module, method=None, ret=None, is_property=False):
         rv = None
         if isinstance(module, str):
             x = module.split('.')
             main = '.'.join(x[:-1])
             self._orig.append((getattr(sys.modules[main], x[-1]), main, x[-1]))
-            if property:
+            if is_property:
                 setattr(sys.modules[main], x[-1], ret)
             else:
                 rv = Mocker(ret, cmd=x[-1])


### PR DESCRIPTION
Adds feature to capture CIME commands in a script. Captured 
commands are recorded in a `replay.sh` file in `CASEROOT`.

Test suite: scripts_regression_tests.py
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes #3911 

User interface changes?: n/a

Update gh-pages html (Y/N)?: n
