### PR TITLE
Update climate reproducibility tests

### DIFF
--- a/scripts/lib/CIME/SystemTests/mvk.py
+++ b/scripts/lib/CIME/SystemTests/mvk.py
@@ -24,8 +24,7 @@ from evv4esm.__main__ import main as evv  # pylint: disable=import-error
 
 evv_lib_dir = os.path.abspath(os.path.dirname(evv4esm.__file__))
 logger = logging.getLogger(__name__)
-
-NINST = 20
+NINST = 30
 
 
 class MVK(SystemTestsCommon):
@@ -60,13 +59,14 @@ class MVK(SystemTestsCommon):
 
             case_setup(self._case, test_mode=False, reset=True)
 
-        self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-
         for iinst in range(1, NINST + 1):
-            with open('user_nl_cam_{:04d}'.format(iinst), 'w') as nl_atm_file:
+            with open('user_nl_eam_{:04d}'.format(iinst), 'w') as nl_atm_file:
                 nl_atm_file.write('new_random = .true.\n')
                 nl_atm_file.write('pertlim = 1.0e-10\n')
                 nl_atm_file.write('seed_custom = {}\n'.format(iinst))
+                nl_atm_file.write('seed_clock = .true.\n')
+
+        self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
     def _generate_baseline(self):
         """
@@ -81,9 +81,9 @@ class MVK(SystemTestsCommon):
             rundir = self._case.get_value("RUNDIR")
             ref_case = self._case.get_value("RUN_REFCASE")
 
-            model = 'cam'
+            model = 'eam'
             env_archive = self._case.get_env("archive")
-            hists = env_archive.get_all_hist_files(self._case.get_value("CASE"), model, rundir, [r'h\d*.*\.nc'], ref_case=ref_case)
+            hists = env_archive.get_all_hist_files(self._case.get_value("CASE"), model, rundir, ref_case=ref_case)
             logger.debug("MVK additional baseline files: {}".format(hists))
             hists = [os.path.join(rundir,hist) for hist in hists]
             for hist in hists:

--- a/scripts/lib/CIME/SystemTests/mvk.py
+++ b/scripts/lib/CIME/SystemTests/mvk.py
@@ -35,6 +35,11 @@ class MVK(SystemTestsCommon):
         """
         SystemTestsCommon.__init__(self, case)
 
+        if self._case.get_value("MODEL") == "e3sm":
+            self.component = "eam"
+        else:
+            self.component = "cam"
+
         if self._case.get_value("RESUBMIT") == 0 \
                 and self._case.get_value("GENERATE_BASELINE") is False:
             self._case.set_value("COMPARE_BASELINE", True)
@@ -60,7 +65,7 @@ class MVK(SystemTestsCommon):
             case_setup(self._case, test_mode=False, reset=True)
 
         for iinst in range(1, NINST + 1):
-            with open('user_nl_eam_{:04d}'.format(iinst), 'w') as nl_atm_file:
+            with open('user_nl_{}_{:04d}'.format(self.component, iinst), 'w') as nl_atm_file:
                 nl_atm_file.write('new_random = .true.\n')
                 nl_atm_file.write('pertlim = 1.0e-10\n')
                 nl_atm_file.write('seed_custom = {}\n'.format(iinst))
@@ -81,13 +86,12 @@ class MVK(SystemTestsCommon):
             rundir = self._case.get_value("RUNDIR")
             ref_case = self._case.get_value("RUN_REFCASE")
 
-            model = 'eam'
             env_archive = self._case.get_env("archive")
-            hists = env_archive.get_all_hist_files(self._case.get_value("CASE"), model, rundir, ref_case=ref_case)
+            hists = env_archive.get_all_hist_files(self._case.get_value("CASE"), self.component, rundir, ref_case=ref_case)
             logger.debug("MVK additional baseline files: {}".format(hists))
             hists = [os.path.join(rundir,hist) for hist in hists]
             for hist in hists:
-                basename = hist[hist.rfind(model):]
+                basename = hist[hist.rfind(self.component):]
                 baseline = os.path.join(basegen_dir, basename)
                 if os.path.exists(baseline):
                     os.remove(baseline)
@@ -122,7 +126,8 @@ class MVK(SystemTestsCommon):
                     "ref-dir": base_dir,
                     "var-set": "default",
                     "ninst": NINST,
-                    "critical": 13
+                    "critical": 13,
+                    "component": self.component,
                 }
             }
 

--- a/scripts/lib/CIME/SystemTests/mvk.py
+++ b/scripts/lib/CIME/SystemTests/mvk.py
@@ -56,8 +56,6 @@ class MVK(SystemTestsCommon):
                 if comp != 'CPL':
                     self._case.set_value('NINST_{}'.format(comp), NINST)
 
-            self._case.set_value('ATM_NCPL', 18)
-
             self._case.flush()
 
             case_setup(self._case, test_mode=False, reset=True)

--- a/scripts/lib/CIME/SystemTests/pgn.py
+++ b/scripts/lib/CIME/SystemTests/pgn.py
@@ -44,8 +44,7 @@ PERTURBATIONS = OrderedDict([('woprt', 0.0),
 FCLD_NC = 'cam.h0.cloud.nc'
 INIT_COND_FILE_TEMPLATE = \
     "SMS_Ly5.ne4_ne4.FC5AV1C-04P2.eos_intel.ne45y.{}.{}.0002-{:02d}-01-00000.nc"
-# FIXME: should 'cam' be 'atm' now?
-INSTANCE_FILE_TEMPLATE = '{}cam_{:04d}.h0.0001-01-01-00000{}.nc'
+INSTANCE_FILE_TEMPLATE = '{}eam_{:04d}.h0.0001-01-01-00000{}.nc'
 
 
 class PGN(SystemTestsCommon):
@@ -94,8 +93,8 @@ class PGN(SystemTestsCommon):
             fatm_in = os.path.join(csmdata_atm, INIT_COND_FILE_TEMPLATE.format('cam', 'i', icond))
             flnd_in = os.path.join(csmdata_lnd, INIT_COND_FILE_TEMPLATE.format('clm2', 'r', icond))
             for iprt in PERTURBATIONS.values():
-                with open('user_nl_cam_{:04d}'.format(iinst), 'w') as atmnlfile, \
-                        open('user_nl_clm_{:04d}'.format(iinst), 'w') as lndnlfile:
+                with open('user_nl_eam_{:04d}'.format(iinst), 'w') as atmnlfile, \
+                        open('user_nl_elm_{:04d}'.format(iinst), 'w') as lndnlfile:
 
                     atmnlfile.write("ncdata  = '{}' \n".format(fatm_in))
                     lndnlfile.write("finidat = '{}' \n".format(flnd_in))
@@ -133,7 +132,7 @@ class PGN(SystemTestsCommon):
     def _compare_baseline(self):
         """
         Compare baselines in the pergro test sense. That is,
-        compare PGE from the test simulation with the baseline 
+        compare PGE from the test simulation with the baseline
         cloud
         """
         with self._test_status:

--- a/scripts/lib/CIME/SystemTests/pgn.py
+++ b/scripts/lib/CIME/SystemTests/pgn.py
@@ -281,7 +281,7 @@ class PGN(SystemTestsCommon):
         cld_rmse = np.reshape(rmse.RMSE.values, (NUMBER_INITIAL_CONDITIONS, nprt - 1, nvar))
 
         pg.rmse_writer(os.path.join(rundir, FCLD_NC),
-                       cld_rmse, list(PERTURBATIONS.keys()), var_list, INIT_COND_FILE_TEMPLATE)
+                       cld_rmse, list(PERTURBATIONS.keys()), var_list, INIT_COND_FILE_TEMPLATE, "cam")
 
         logger.debug("PGN_INFO:copy:{} to {}".format(FCLD_NC, basegen_dir))
         shutil.copy(os.path.join(rundir, FCLD_NC), basegen_dir)

--- a/scripts/lib/CIME/SystemTests/tsc.py
+++ b/scripts/lib/CIME/SystemTests/tsc.py
@@ -85,8 +85,8 @@ class TSC(SystemTestsCommon):
 
         nstep_output = OUT_FREQ // dtime
         for iinst in range(1, NINST+1):
-            with open('user_nl_cam_'+str(iinst).zfill(4), 'w') as atmnlfile, \
-                 open('user_nl_clm_'+str(iinst).zfill(4), 'w') as lndnlfile:
+            with open('user_nl_eam_'+str(iinst).zfill(4), 'w') as atmnlfile, \
+                 open('user_nl_elm_'+str(iinst).zfill(4), 'w') as lndnlfile:
 
                 fatm_in = os.path.join(csmdata_atm, INIT_COND_FILE_TEMPLATE.format('cam', 'i', iinst))
                 flnd_in = os.path.join(csmdata_lnd, INIT_COND_FILE_TEMPLATE.format('clm2', 'r', iinst))
@@ -203,9 +203,9 @@ class TSC(SystemTestsCommon):
             rundir = self._case.get_value("RUNDIR")
             ref_case = self._case.get_value("RUN_REFCASE")
 
-            model = 'cam'
+            model = 'eam'
             env_archive = self._case.get_env("archive")
-            hists = env_archive.get_all_hist_files(self._case.get_value("CASE"), model, rundir, [r'h\d*.*\.nc\.DT\d*'], ref_case=ref_case)
+            hists = env_archive.get_all_hist_files(self._case.get_value("CASE"), model, rundir, r'DT\d*', ref_case=ref_case)
             hists = [os.path.join(rundir,hist) for hist in hists]
             logger.debug("TSC additional baseline files: {}".format(hists))
             for hist in hists:

--- a/scripts/lib/CIME/SystemTests/tsc.py
+++ b/scripts/lib/CIME/SystemTests/tsc.py
@@ -71,7 +71,9 @@ class TSC(SystemTestsCommon):
         :param dtime (int): Specified time step size in seconds
         """
         coupling_frequency = 86400 // dtime
+
         self._case.set_value("ATM_NCPL", str(coupling_frequency))
+        se_tstep = dtime / 12
 
         nsteps = SIM_LENGTH // dtime
         self._case.set_value("STOP_N", str(nsteps))
@@ -94,6 +96,7 @@ class TSC(SystemTestsCommon):
                 lndnlfile.write("dtime = {} \n".format(dtime))
 
                 atmnlfile.write("dtime = {} \n".format(dtime))
+                atmnlfile.write("se_tstep = {} \n".format(se_tstep))
                 atmnlfile.write("iradsw = 2 \n")
                 atmnlfile.write("iradlw = 2 \n")
 

--- a/scripts/lib/CIME/SystemTests/tsc.py
+++ b/scripts/lib/CIME/SystemTests/tsc.py
@@ -44,6 +44,12 @@ class TSC(SystemTestsCommon):
         initialize an object interface to the TSC test
         """
         super(TSC, self).__init__(case)
+        if self._case.get_value("MODEL") == "e3sm":
+            self.atmmod = "eam"
+            self.lndmod = "elm"
+        else:
+            self.atmmod = "cam"
+            self.lndmod = "clm"
 
     def build_phase(self, sharedlib_only=False, model_only=False):
         # Only want this to happen once. It will impact the sharedlib build
@@ -85,8 +91,8 @@ class TSC(SystemTestsCommon):
 
         nstep_output = OUT_FREQ // dtime
         for iinst in range(1, NINST+1):
-            with open('user_nl_eam_'+str(iinst).zfill(4), 'w') as atmnlfile, \
-                 open('user_nl_elm_'+str(iinst).zfill(4), 'w') as lndnlfile:
+            with open(f'user_nl_{self.atmmod}_'+str(iinst).zfill(4), 'w') as atmnlfile, \
+                 open(f'user_nl_{self.lndmod}_'+str(iinst).zfill(4), 'w') as lndnlfile:
 
                 fatm_in = os.path.join(csmdata_atm, INIT_COND_FILE_TEMPLATE.format('cam', 'i', iinst))
                 flnd_in = os.path.join(csmdata_lnd, INIT_COND_FILE_TEMPLATE.format('clm2', 'r', iinst))
@@ -144,6 +150,7 @@ class TSC(SystemTestsCommon):
                     "inspect-times": INSPECT_AT,
                     "variables": VAR_LIST,
                     "p-threshold": P_THRESHOLD,
+                    "component": self.atmmod,
                 }
             }
 
@@ -203,13 +210,12 @@ class TSC(SystemTestsCommon):
             rundir = self._case.get_value("RUNDIR")
             ref_case = self._case.get_value("RUN_REFCASE")
 
-            model = 'eam'
             env_archive = self._case.get_env("archive")
-            hists = env_archive.get_all_hist_files(self._case.get_value("CASE"), model, rundir, r'DT\d*', ref_case=ref_case)
+            hists = env_archive.get_all_hist_files(self._case.get_value("CASE"), self.atmmod, rundir, r'DT\d*', ref_case=ref_case)
             hists = [os.path.join(rundir,hist) for hist in hists]
             logger.debug("TSC additional baseline files: {}".format(hists))
             for hist in hists:
-                basename = hist[hist.rfind(model):]
+                basename = hist[hist.rfind(self.atmmod):]
                 baseline = os.path.join(basegen_dir, basename)
                 if os.path.exists(baseline):
                     os.remove(baseline)


### PR DESCRIPTION
This updates the three E3SM climate reproducibility tests (MVK, PGN, 
and TSC) to work with updated component names (eam and elm) and
time step namelist variables. Additionally, the MVK test uses
`seed_clock=True` so unique ensembles are generated.

Test suite: e3sm_atm_nbfb
Test baseline: 
Test namelist changes: 

User interface changes?: N

Update gh-pages html (Y/N)?: N
