### PR TITLE
Adds CASE_HASH to env_case

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -5,7 +5,7 @@ All interaction with and between the module files in XML/ takes place
 through the Case module.
 """
 from copy import deepcopy
-import glob, os, shutil, math, six, time
+import glob, os, shutil, math, six, time, hashlib
 from CIME.XML.standard_module_setup import *
 #pylint: disable=import-error,redefined-builtin
 from six.moves import input
@@ -1686,6 +1686,7 @@ directory, NOT in this subdirectory."""
             self.set_lookup_value("CASE", os.path.basename(casename))
             self.set_lookup_value("CASEROOT", self._caseroot)
             self.set_lookup_value("SRCROOT", srcroot)
+            self.set_lookup_value("CASE_HASH", self.new_hash())
             # if the top level user_mods_dir contains a config_grids.xml file and
             # gridfile was not set on the command line, use it.
             if user_mods_dir:
@@ -1727,6 +1728,18 @@ directory, NOT in this subdirectory."""
                     logger.warning("Leaving broken case dir {}".format(self._caseroot))
 
             raise
+
+    def new_hash(self):
+        """ Creates a hash
+        """
+        args = "".join(sys.argv)
+        ctime = time.strftime("%Y-%m-%d %H:%M:%S")
+        hostname = os.environ["HOSTNAME"]
+        user = os.environ["USER"]
+
+        data = "{}{}{}{}".format(args, ctime, hostname, user)
+
+        return hashlib.sha256(data.encode()).hexdigest()
 
     def is_save_timing_dir_project(self,project):
         """

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -268,6 +268,7 @@ class Case(object):
         newcase.set_value("CASEROOT",newcaseroot)
         newcase.set_value("CONTINUE_RUN","FALSE")
         newcase.set_value("RESUBMIT",0)
+        newcase.set_value("CASE_HASH", newcase.new_hash())
 
         # Important, and subtle: Writability should NOT be copied because
         # this allows the copy to be modified without needing a "with" statement

--- a/scripts/lib/CIME/tests/test_case.py
+++ b/scripts/lib/CIME/tests/test_case.py
@@ -7,6 +7,77 @@ from CIME import utils as cime_utils
 
 from . import utils
 
+class TestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.srcroot = os.path.abspath(cime_utils.get_cime_root())
+        self.tempdir = utils.TemporaryDirectory()
+
+        self.mock = utils.Mocker()
+        self.mock.patch(Case, "read_xml")
+        Case._force_read_only = False # pylint: disable=protected-access
+        self.mock.patch('time.strftime', ret='00:00:00')
+        self.mock.patch("sys.argv", ret=["/src/create_newcase",
+                                            "--machine",
+                                            "docker"], is_property=True)
+
+    def test_new_hash(self):
+        with self.tempdir as tempdir:
+            with Case(tempdir) as case:
+                os.environ["USER"] = "root"
+                os.environ["HOSTNAME"] = "host1"
+
+                expected = "134a939f62115fb44bf08a46bfb2bd13426833b5c8848cf7c4884af7af05b91a"
+
+                # Check idempotency
+                for _ in range(2):
+                    value = case.new_hash()
+
+                    self.assertTrue(value == expected,
+                                    "{} != {}".format(value, expected))
+
+                os.environ["USER"] = "johndoe"
+
+                expected = "bb59f1c473ac07e9dd30bfab153c0530a777f89280b716cf42e6fe2f49811a6e"
+
+                value = case.new_hash()
+
+                self.assertTrue(value == expected,
+                                "{} != {}".format(value, expected))
+
+    def test_create(self):
+        with self.tempdir as tempdir:
+            caseroot = os.path.join(tempdir, "test1")
+            with Case(caseroot, read_only=False) as case:
+                os.environ["USER"] = "root"
+                os.environ["HOSTNAME"] = "host1"
+                os.environ["CIME_MODEL"] = "cesm"
+
+                # Need to mock all of these to prevent errors with xml files
+                # just want to ensure `create` calls `set_lookup_value`
+                # correctly.
+                _configure = self.mock.patch(case, 'configure')
+                _create_caseroot = self.mock.patch(case, 'create_caseroot')
+                _apply_user_mods = self.mock.patch(case, 'apply_user_mods')
+                _lock_file = self.mock.patch('CIME.case.case.lock_file')
+                _set_lookup_value = self.mock.patch(case, "set_lookup_value")
+
+                srcroot = os.path.abspath(os.path.join(
+                    os.path.dirname(__file__), "../../../../../"))
+                case.create("test1", srcroot, "A", "f19_g16_rx1",
+                            machine_name="ubuntu-latest")
+
+                # Check that they're all called
+                _configure.assert_called_with(args=["A", "f19_g16_rx1"])
+                _create_caseroot.assert_called()
+                _apply_user_mods.assert_called()
+                _lock_file.assert_called()
+
+                self.assertTrue(_set_lookup_value.calls[-1]['args'][0] ==
+                                "CASE_HASH")
+                self.assertTrue(_set_lookup_value.calls[-1]['args'][1] ==
+                                "134a939f62115fb44bf08a46bfb2bd13426833b5c8848cf7c4884af7af05b91a")
+
 class TestCase_RecordCmd(unittest.TestCase):
 
     def setUp(self):

--- a/scripts/lib/CIME/tests/test_case.py
+++ b/scripts/lib/CIME/tests/test_case.py
@@ -16,10 +16,13 @@ class TestCase(unittest.TestCase):
         self.mock = utils.Mocker()
         self.mock.patch(Case, "read_xml")
         Case._force_read_only = False # pylint: disable=protected-access
-        self.mock.patch('time.strftime', ret='00:00:00')
-        self.mock.patch("sys.argv", ret=["/src/create_newcase",
-                                            "--machine",
-                                            "docker"], is_property=True)
+        self._time_strftime = self.mock.patch('time.strftime', ret='00:00:00')
+        self.mock.patch("sys.argv",
+                        ret=[
+                            "/src/create_newcase",
+                            "--machine",
+                            "docker"
+                        ], is_property=True)
 
     def test_new_hash(self):
         with self.tempdir as tempdir:
@@ -85,13 +88,14 @@ class TestCase(unittest.TestCase):
                                              ret=utils.Mocker())
 
                 # simulate change
-                self.mock.patch('time.strftime', ret='10:00:00')
+                self._time_strftime.ret = "10:00:00"
                 self.mock.patch("sys.argv",
-                                ret=["/src/create_clone"], is_property=True)
+                                ret=[
+                                    "/src/create_clone"
+                                ], is_property=True, update_value_only=True)
 
                 case.copy("test2", "{}_2".format(tempdir))
 
-                print(_set_value.calls)
                 self.assertTrue(_set_value.calls[-1]['args'][0] ==
                                 "CASE_HASH")
                 self.assertTrue(_set_value.calls[-1]['args'][1] ==
@@ -179,7 +183,7 @@ class TestCase_RecordCmd(unittest.TestCase):
             "cd \"${CASEDIR}\"\n\n",
         ]
 
-        calls = open_mock.ret.method_calls["writelines"][0]["args"][0]
+        calls = open_mock.ret.method_calls["writelines"][0]["args"][0] # pylint: disable=no-member
 
         self.assert_calls_match(calls, expected)
 
@@ -210,7 +214,7 @@ class TestCase_RecordCmd(unittest.TestCase):
             "cd \"${CASEDIR}\"\n\n",
         ]
 
-        calls = open_mock.ret.method_calls["writelines"][0]["args"][0]
+        calls = open_mock.ret.method_calls["writelines"][0]["args"][0] # pylint: disable=no-member
 
         self.assert_calls_match(calls, expected)
 
@@ -234,7 +238,7 @@ class TestCase_RecordCmd(unittest.TestCase):
             "/some/custom/command arg1\n\n",
         ]
 
-        calls = open_mock.ret.method_calls["writelines"][0]["args"][0]
+        calls = open_mock.ret.method_calls["writelines"][0]["args"][0] # pylint: disable=no-member
 
         self.assert_calls_match(calls, expected)
 

--- a/scripts/lib/CIME/tests/utils.py
+++ b/scripts/lib/CIME/tests/utils.py
@@ -45,6 +45,27 @@ class Mocker:
     def ret(self):
         return self._ret
 
+    def assert_called(self):
+        assert len(self.calls) > 0
+
+    def assert_called_with(self, i=None, args=None, kwargs=None):
+        if i is None:
+            i = 0
+
+        call = self.calls[i]
+
+        if args is not None:
+            _call_args = set(call['args'])
+            _exp_args = set(args)
+            assert _exp_args <= _call_args, "Got {} missing {}".format(
+                _call_args, _exp_args-_call_args)
+
+        if kwargs is not None:
+            call_kwargs = call['kwargs']
+
+            for x, y in kwargs.items():
+                assert call_kwargs[x] == y, "Missing {}".format(x)
+
     def __getattr__(self, name):
         if name in self._method_calls:
             new_method = self._method_calls[name]

--- a/scripts/lib/CIME/tests/utils.py
+++ b/scripts/lib/CIME/tests/utils.py
@@ -45,6 +45,10 @@ class Mocker:
     def ret(self):
         return self._ret
 
+    @ret.setter
+    def ret(self, value):
+        self._ret = value
+
     def assert_called(self):
         assert len(self.calls) > 0
 
@@ -102,19 +106,22 @@ class Mocker:
             else:
                 setattr(module, method, m)
 
-    def patch(self, module, method=None, ret=None, is_property=False):
+    def patch(self, module, method=None, ret=None, is_property=False,
+              update_value_only=False):
         rv = None
         if isinstance(module, str):
             x = module.split('.')
             main = '.'.join(x[:-1])
-            self._orig.append((getattr(sys.modules[main], x[-1]), main, x[-1]))
+            if not update_value_only:
+                self._orig.append((getattr(sys.modules[main], x[-1]), main, x[-1]))
             if is_property:
                 setattr(sys.modules[main], x[-1], ret)
             else:
                 rv = Mocker(ret, cmd=x[-1])
                 setattr(sys.modules[main], x[-1], rv)
         elif method != None:
-            self._orig.append((getattr(module, method), module, method))
+            if not update_value_only:
+                self._orig.append((getattr(module, method), module, method))
             rv = Mocker(ret)
             setattr(module, method, rv)
         else:

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -178,6 +178,13 @@
     </desc>
   </entry>
 
+  <entry id="CASE_HASH">
+    <type>char</type>
+    <group>case_desc</group>
+    <file>env_case.xml</file>
+    <desc>Unique identifier for case</desc>
+  </entry>
+
   <!-- ===================================================================== -->
   <!-- definitions runtimes -->
   <!-- ===================================================================== -->


### PR DESCRIPTION
Adds CASE_HASH to env_case.xml. The hash is made up of 
create_newcase arguments, date/time, user, and hostname. This
is meant to be finer grain than case-group for case databases.

Test suite: scripts_regression_tests.py
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes #3944 

User interface changes?: n/a
Update gh-pages html (Y/N)?: n/a
