### PR TITLE
logical args to Make should not be quoted, and update esmf library and cheyenne_gnu compiler versions

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -896,6 +896,9 @@ using a fortran linker.
     <append MODEL="pio1"> -DNO_MPIMOD </append>
   </CPPDEFS>
   <FFLAGS>
+    <!-- -fallow-argument-mismatch is needed for building with the mpich library with gfortran10;
+         -fallow-invalid-boz is needed for some components that have non-standard uses of BOZ literal constants with gfortran10.
+         See https://github.com/ESMCI/cime/issues/3846 for details. -->
     <append> -fallow-argument-mismatch -fallow-invalid-boz </append>
   </FFLAGS>
   <SLIBS>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -200,7 +200,7 @@ using a fortran linker.
   <FFLAGS>
     <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS
        so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
-    <base>  -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </base>
+    <base>  -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none -fallow-argument-mismatch -fallow-invalid-boz </base>
     <append compile_threaded="TRUE"> -fopenmp </append>
     <!-- Ideally, we would also have 'invalid' in the ffpe-trap list. But at
          least with some versions of gfortran (confirmed with 5.4.0, 6.3.0 and

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -200,7 +200,7 @@ using a fortran linker.
   <FFLAGS>
     <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS
        so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
-    <base>  -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none -fallow-argument-mismatch -fallow-invalid-boz </base>
+    <base>  -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </base>
     <append compile_threaded="TRUE"> -fopenmp </append>
     <!-- Ideally, we would also have 'invalid' in the ffpe-trap list. But at
          least with some versions of gfortran (confirmed with 5.4.0, 6.3.0 and
@@ -895,6 +895,9 @@ using a fortran linker.
   <CPPDEFS>
     <append MODEL="pio1"> -DNO_MPIMOD </append>
   </CPPDEFS>
+  <FFLAGS>
+    <append> -fallow-argument-mismatch -fallow-invalid-boz </append>
+  </FFLAGS>
   <SLIBS>
     <append> -ldl </append>
   </SLIBS>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -559,76 +559,76 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">mkl</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gnu/9.1.0</command>
-        <command name="load">openblas/0.3.6</command>
+        <command name="load">gnu/10.1.0</command>
+        <command name="load">openblas/0.3.9</command>
       </modules>
       <modules compiler="pgi">
         <command name="load">pgi/20.4</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.1.1/</command>
-        <command name="load">esmf-8.1.1-ncdfio-mpt-g</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.1.1/</command>
-        <command name="load">esmf-8.1.1-ncdfio-mpt-O</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.1.1/</command>
-        <command name="load">esmf-8.1.1-ncdfio-mpiuni-g</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.1.1/</command>
-        <command name="load">esmf-8.1.1-ncdfio-mpiuni-O</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpiuni-O</command>
       </modules>
       <modules compiler="gnu" mpilib="mpt" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpt-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/10.1.0/</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="gnu" mpilib="mpt" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpt-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/10.1.0/</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-openmpi-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/10.1.0/</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-openmpi-g</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-openmpi-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/10.1.0/</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-openmpi-O</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpiuni-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/10.1.0/</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/9.1.0/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpiuni-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/gnu/10.1.0/</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpiuni-O</command>
       </modules>
 
       <modules compiler="pgi" mpilib="mpt" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpt-g</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpt-g</command>
       </modules>
       <modules compiler="pgi" mpilib="mpt" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpt-O</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpt-O</command>
       </modules>
       <modules compiler="pgi" mpilib="openmpi" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-openmpi-g</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-openmpi-g</command>
       </modules>
       <modules compiler="pgi" mpilib="openmpi" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-openmpi-O</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-openmpi-O</command>
       </modules>
       <modules compiler="pgi" mpilib="mpi-serial" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpiuni-g</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpiuni-g</command>
       </modules>
       <modules compiler="pgi" mpilib="mpi-serial" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
-        <command name="load">esmf-8.1.0b41-ncdfio-mpiuni-O</command>
+        <command name="load">esmf-8.2.0b10-ncdfio-mpiuni-O</command>
       </modules>
       <modules mpilib="mpt" compiler="gnu">
         <command name="load">mpt/2.21</command>
@@ -637,7 +637,7 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules mpilib="mpt" compiler="intel">
         <command name="load">mpt/2.22</command>
-        <command name="load">netcdf-mpi/4.7.4</command>
+        <command name="load">netcdf-mpi/4.8.0</command>
         <command name="load">pnetcdf/1.12.2</command>
       </modules>
       <modules mpilib="mpt" compiler="pgi">
@@ -3052,35 +3052,35 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-	<command name="purge"/>
+        <command name="purge"/>
       </modules>
       <modules compiler="intel">
-	<command name="load">intel20.1/20.1.217</command>
-	<command name="load">intel20.1/szip/2.1.1</command>
-	<command name="load">cmake/3.17.3</command>
-	<command name="load">curl/7.70.0</command>
+        <command name="load">intel20.1/20.1.217</command>
+        <command name="load">intel20.1/szip/2.1.1</command>
+        <command name="load">cmake/3.17.3</command>
+        <command name="load">curl/7.70.0</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">intel20.1/hdf5/1.12.0</command>
-	<command name="load">intel20.1/netcdf/C_4.7.4-F_4.5.3_CXX_4.3.1</command>
+        <command name="load">intel20.1/hdf5/1.12.0</command>
+        <command name="load">intel20.1/netcdf/C_4.7.4-F_4.5.3_CXX_4.3.1</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">impi20.1/19.7.217</command>
-	<command name="load">impi20.1/hdf5/1.12.0</command>
-	<command name="load">impi20.1/netcdf/C_4.7.4-F_4.5.3_CXX_4.3.1</command>
-	<command name="load">impi20.1/parallel-netcdf/1.12.1</command>
+        <command name="load">impi20.1/19.7.217</command>
+        <command name="load">impi20.1/hdf5/1.12.0</command>
+        <command name="load">impi20.1/netcdf/C_4.7.4-F_4.5.3_CXX_4.3.1</command>
+        <command name="load">impi20.1/parallel-netcdf/1.12.1</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
-	<command name="load">impi20.1/esmf/8.0.1-intelmpi-64-g</command>
+        <command name="load">impi20.1/esmf/8.0.1-intelmpi-64-g</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="FALSE">
-	<command name="load">impi20.1/esmf/8.0.1-intelmpi-64-O</command>
+        <command name="load">impi20.1/esmf/8.0.1-intelmpi-64-O</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-	<command name="load">intel20.1/esmf/8.0.1-mpiuni-64-g</command>
+        <command name="load">intel20.1/esmf/8.0.1-mpiuni-64-g</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-	<command name="load">intel20.1/esmf/8.0.1-mpiuni-64-O</command>
+        <command name="load">intel20.1/esmf/8.0.1-mpiuni-64-O</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -60,7 +60,11 @@ def xml_to_make_variable(case, varname, cmake=False):
         return ""
     if type(varvalue) == type(True):
         varvalue = stringify_bool(varvalue)
-    return "{}{}=\"{}\" ".format("-D" if cmake else "", varname, varvalue)
+
+    if cmake or type(varvalue) == type(str):
+        return "{}{}=\"{}\" ".format("-D" if cmake else "", varname, varvalue)
+    else:
+        return "{}={} ".format(varname, varvalue)
 
 ###############################################################################
 def uses_kokkos(case):

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -58,10 +58,10 @@ def xml_to_make_variable(case, varname, cmake=False):
     varvalue = case.get_value(varname)
     if varvalue is None:
         return ""
-    if type(varvalue) == type(True):
+    if isinstance(varvalue, bool):
         varvalue = stringify_bool(varvalue)
 
-    if cmake or type(varvalue) == type(str):
+    if cmake or isinstance(varvalue, str):
         return "{}{}=\"{}\" ".format("-D" if cmake else "", varname, varvalue)
     else:
         return "{}={} ".format(varname, varvalue)


### PR DESCRIPTION
Update the esmf library module on cheyenne for all compilers, update gnu compiler to 10.1.0 on cheyenne.  Fix an issue in build.py that was causing the ESMF_VERSION flags not to be available to 
the compile line (USE_ESMF_LIB=TRUE not USE_ESMF_LIB="TRUE")

Test suite: scripts regression tests with intel, gnu and pgi compilers on cheyenne with cime_driver=nuopc 
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
