### PR TITLE
Fixes unittest with py37

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     env:
       CC: mpicc
       FC: mpifort

--- a/scripts/lib/CIME/tests/test_case.py
+++ b/scripts/lib/CIME/tests/test_case.py
@@ -17,7 +17,9 @@ class TestCaseSubmit(unittest.TestCase):
         case.check_all_input_data.assert_called_with(chksum=True)
 
     @mock.patch("CIME.case.case_submit.lock_file")
-    def test__submit(self, lock_file): # pylint: disable=unused-argument
+    @mock.patch("CIME.case.case_submit.unlock_file")
+    @mock.patch("os.path.basename")
+    def test__submit(self, lock_file, unlock_file, basename): # pylint: disable=unused-argument
         case = mock.MagicMock()
 
         case_submit._submit(case, chksum=True) # pylint: disable=protected-access


### PR DESCRIPTION
Fixes unittest raising error on py37, `os.path.basename` needed to be
mocked.

Test suite: test_case.py with py36,py37,py38,py39
Test baseline: n/a
Test namelist changes: n/a
Test status: bfb

Fixes #3983 
User interface changes?: n/a
Update gh-pages html (Y/N)?: N
