### PR TITLE
Raise an error if no value can be found for a namelist variable

### DIFF
--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -174,6 +174,9 @@ class NamelistDefinition(EntryID):
         """This function is not implemented."""
         raise TypeError("NamelistDefinition does not support `set_value`.")
 
+    # In contrast to the entry_id version of this method, this version doesn't support the
+    # replacement_for_none argument, because it is hard-coded to ''.
+    # pylint: disable=arguments-differ
     def get_value_match(self, vid, attributes=None, exact_match=True, entry_node=None):
         """Return the default value for the variable named `vid`.
 
@@ -190,6 +193,8 @@ class NamelistDefinition(EntryID):
 
         if entry_node is None:
             entry_node = self._nodes[vid]
+        # NOTE(wjs, 2021-06-04) In the following call, replacement_for_none='' may not
+        # actually be needed, but I'm setting it to maintain some old logic, to be safe.
         value = super(NamelistDefinition, self).get_value_match(vid.lower(),attributes=all_attributes, exact_match=exact_match,
                                                                 entry_node=entry_node,
                                                                 replacement_for_none='')

--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -156,6 +156,10 @@ class NamelistDefinition(EntryID):
     def add_attributes(self, attributes):
         self._attributes = attributes
 
+    def get_attributes(self):
+        """Return this object's attributes dictionary"""
+        return self._attributes
+
     def get_entry_nodes(self):
         return self._entry_nodes
 

--- a/scripts/lib/CIME/XML/namelist_definition.py
+++ b/scripts/lib/CIME/XML/namelist_definition.py
@@ -191,10 +191,9 @@ class NamelistDefinition(EntryID):
         if entry_node is None:
             entry_node = self._nodes[vid]
         value = super(NamelistDefinition, self).get_value_match(vid.lower(),attributes=all_attributes, exact_match=exact_match,
-                                                                entry_node=entry_node)
-        if value is None:
-            value = ''
-        else:
+                                                                entry_node=entry_node,
+                                                                replacement_for_none='')
+        if value is not None:
             value =  self._split_defaults_text(value)
 
         return value
@@ -445,4 +444,4 @@ class NamelistDefinition(EntryID):
             all_attributes.update(attribute)
 
         value = self.get_value_match(item.lower(), all_attributes, True)
-        return self._split_defaults_text(value)
+        return value

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -953,7 +953,9 @@ class Namelist(object):
         if gn:
             vn = string_in_list(variable_name,self._groups[gn])
             if vn:
-                return self._groups[gn][vn]
+                # Make a copy of the list so that any modifications done by the caller
+                # don't modify the internal values.
+                return self._groups[gn][vn].copy()
         return ['']
 
     def get_value(self, variable_name):

--- a/scripts/lib/CIME/namelist.py
+++ b/scripts/lib/CIME/namelist.py
@@ -955,7 +955,7 @@ class Namelist(object):
             if vn:
                 # Make a copy of the list so that any modifications done by the caller
                 # don't modify the internal values.
-                return self._groups[gn][vn].copy()
+                return self._groups[gn][vn][:]
         return ['']
 
     def get_value(self, variable_name):

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -629,6 +629,8 @@ class NamelistGenerator(object):
         have_value = False
         # Check for existing value.
         current_literals = self._namelist.get_variable_value(group, name)
+        if current_literals != [""]:
+            have_value = True
 
         # Check for input argument.
         if value is not None:

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -645,7 +645,8 @@ class NamelistGenerator(object):
             have_value = True
             default_literals = self._to_namelist_literals(name, default)
             current_literals = merge_literal_lists(default_literals, current_literals)
-        expect(have_value, "No default value found for {}.".format(name))
+        expect(have_value, "No default value found for {} with attributes {}.".format(
+            name, self._definition.get_attributes()))
 
         # Go through file names and prepend input data root directory for
         # absolute pathnames.

--- a/src/drivers/mct/cime_config/namelist_definition_modelio.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_modelio.xml
@@ -172,6 +172,7 @@
     <value component="glc">$GLC_PIO_NETCDF_FORMAT</value>
     <value component="wav">$WAV_PIO_NETCDF_FORMAT</value>
     <value component="iac">$IAC_PIO_NETCDF_FORMAT</value>
+    <value component="esp">$ESP_PIO_NETCDF_FORMAT</value>
     </values>
   </entry>
 


### PR DESCRIPTION
Previously, if no value was found for a namelist variable, the code simply put an empty string in as the value, without raising any errors. This PR adds error checking.

Fixing this issue revealed some other latent issues, which were being masked by this one. So this PR also fixes those other latent issues. See https://github.com/ESMCI/cime/issues/3984 for extensive details.

Test suite:
- Manual testing of the situation described in https://github.com/ESMCI/cime/issues/3984
- scripts_regression_tests on cheyenne
- cime_developer tests on cheyenne, with baseline comparisons
- CESM's aux_cime_baseline tests on cheyenne (mct & nuopc), with baseline comparisons
- CESM's prealpha tests on cheyenne and izumi (mct & nuopc), with baseline comparisons

Test baseline: cesm2_3_alpha03a
Test namelist changes: Adds pio_netcdf_format for ESP, which was previously undefined; other than that, namelists are identical to baseline
Test status: bit for bit

Fixes #3984

User interface changes?: N

Update gh-pages html (Y/N)?: N
