### PR TITLE
fix issue reading streams from user_nl_datm

### DIFF
--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -290,6 +290,7 @@ class NamelistGenerator(object):
         streams = self.get_value("streams")
         if streams[0]:
             streams[:] = [text.split(" ",1)[0] for text in streams]
+            streams[:] = [text.split("txt.",1)[1] for text in streams]
         else:
             streams = self.get_default("streamslist")
 

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -286,8 +286,12 @@ class NamelistGenerator(object):
         return default
 
     def get_streams(self):
-        """Get a list of all streams used for the current data model  mode."""
-        return self.get_value("streams")
+        """Get a list of all streams used for the current data model mode, possibly modified in user_nl_dxxx."""
+        streams = self.get_value("streams")
+        if not streams[0]:
+            streams = self.get_default("streamslist")
+
+        return streams
 
     def clean_streams(self):
         for variable in self._streams_variables:

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -287,7 +287,7 @@ class NamelistGenerator(object):
 
     def get_streams(self):
         """Get a list of all streams used for the current data model  mode."""
-        return self.get_default("streamslist")
+        return self.get_value("streams")
 
     def clean_streams(self):
         for variable in self._streams_variables:

--- a/scripts/lib/CIME/nmlgen.py
+++ b/scripts/lib/CIME/nmlgen.py
@@ -288,7 +288,9 @@ class NamelistGenerator(object):
     def get_streams(self):
         """Get a list of all streams used for the current data model mode, possibly modified in user_nl_dxxx."""
         streams = self.get_value("streams")
-        if not streams[0]:
+        if streams[0]:
+            streams[:] = [text.split(" ",1)[0] for text in streams]
+        else:
             streams = self.get_default("streamslist")
 
         return streams

--- a/src/components/data_comps/datm/cime_config/buildnml
+++ b/src/components/data_comps/datm/cime_config/buildnml
@@ -90,13 +90,13 @@ def _create_namelists(case, confdir, inst_string, infile, nmlgen, data_list_path
     # may return a string or a list.  See issue #877 in ESMCI/cime
     #
     #pylint: disable=no-member
-    if datm_presaero != "none":
+    if datm_presaero != "none" and not any(x.startswith('presaero') for x in streams):
         streams.append("presaero.{}".format(datm_presaero))
 
-    if datm_topo != "none":
+    if datm_topo != "none" and not any(x.startswith('topo') for x in streams):
         streams.append("topo.{}".format(datm_topo))
 
-    if datm_co2_tseries != "none":
+    if datm_co2_tseries != "none" and not any(x.startswith('co2tseries') for x in streams):
         streams.append("co2tseries.{}".format(datm_co2_tseries))
 
     # Add bias correction stream if given in namelist.


### PR DESCRIPTION
In creation of the streamslist the user_nl_* file list of streams was being ignored and only the default was used.  

Test suite: scripts_regression_tests on cheyenne and tamu grace systems
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 
User interface changes?: 

Update gh-pages html (Y/N)?:
