### PR TITLE
remove thread placement for ESMF

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -518,7 +518,6 @@ This allows using a different mpirun command to launch unit tests
       <arguments>
         <arg name="labelstdout">-p "%g:"</arg>
         <arg name="num_tasks"> -np {{ total_tasks }}</arg>
-        <arg name="zthreadplacement"> omplace -tm open64 -vv</arg>
       </arguments>
     </mpirun>
     <mpirun mpilib="mpt" queue="share" comp_interface="nuopc">


### PR DESCRIPTION
Remove the thread placement script for nuopc on cheyenne, this is needed for ESMF_AWARE_THREADING
to work properly (ESMF handles thread placement internally)

Test suite: CIME_DRIVER=nuopc scripts_regression_tests.py (cheyenne intel)
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:
