### PR TITLE
add a check for case_dir (should contain env_case.xml if it exists

### DIFF
--- a/scripts/Tools/xmlchange
+++ b/scripts/Tools/xmlchange
@@ -161,6 +161,7 @@ def xmlchange(caseroot, listofsettings, xmlfile, xmlid, xmlval, subgroup,
               append, noecho, force, dryrun):
 
     with Case(caseroot, read_only=False) as case:
+        expect(os.path.isdir(caseroot), "Directory {} does not appear to be a valid case directory".format(caseroot))
         comp_classes = case.get_values("COMP_CLASSES")
         if xmlfile:
             case.set_file(xmlfile)

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -84,6 +84,9 @@ class Case(object):
 
         if case_root is None:
             case_root = os.getcwd()
+
+        expect(not os.path.isdir(case_root) or os.path.isfile(os.path.join(case_root,"env_case.xml")), "Directory {} does not appear to be a valid case directory".format(case_root))
+
         self._caseroot = case_root
         logger.debug("Initializing Case.")
         self._read_only_mode = True


### PR DESCRIPTION
For the case object, either the env_case.xml file must be present in case_root or case_root should not exist.

Test suite: scripts_regression_tests.py (maint-5.6) 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #4003

User interface changes?: 

Update gh-pages html (Y/N)?:
