### PR TITLE
Fix walltime check

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -85,7 +85,6 @@ class Case(object):
         if case_root is None:
             case_root = os.getcwd()
         if not (in_doctest() or in_unit_test()):
-            print("i am {}".format(isinstance(case,'Mock')))
             expect(not os.path.isdir(case_root) or os.path.isfile(os.path.join(case_root,"env_case.xml")), "Directory {} does not appear to be a valid case directory".format(case_root))
 
         self._caseroot = case_root
@@ -1830,9 +1829,9 @@ def in_doctest():
 import inspect
 
 def in_unit_test():
-  current_stack = inspect.stack()
-  for stack_frame in current_stack:
-    for program_line in stack_frame[4]:    # This element of the stack frame contains
-      if "unittest" in program_line:       # some contextual program lines
-        return True
-  return False
+    current_stack = inspect.stack()
+    for stack_frame in current_stack:
+        for program_line in stack_frame[4]:    # This element of the stack frame contains
+            if "unittest" in program_line:       # some contextual program lines
+                return True
+    return False

--- a/scripts/lib/CIME/tests/test_utils.py
+++ b/scripts/lib/CIME/tests/test_utils.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
-import sys
-import os
 
-sys.path.insert(0, "/data/E3SM/cime/scripts/lib")
+import os
+import sys
 
 import unittest
 from unittest import mock

--- a/scripts/lib/CIME/tests/test_xml_env_batch.py
+++ b/scripts/lib/CIME/tests/test_xml_env_batch.py
@@ -1,0 +1,235 @@
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath("../"))
+
+from CIME.XML.env_batch import EnvBatch
+
+# pylint: disable=unused-argument
+
+class TestXMLEnvBatch(unittest.TestCase):
+
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get")
+    def test_get_queue_specs(self, get):
+        node = mock.MagicMock()
+
+        batch = EnvBatch()
+
+        get.side_effect = [
+            "1", "1", None, None, "case.run", "05:00:00", "12:00:00", "false",
+        ]
+
+        nodemin, nodemax, jobname, walltimemin, walltimemax, jobmin, jobmax, \
+            strict = batch.get_queue_specs(node)
+
+        self.assertTrue(nodemin == 1)
+        self.assertTrue(nodemax == 1)
+        self.assertTrue(jobname == "case.run")
+        self.assertTrue(walltimemin == "05:00:00")
+        self.assertTrue(walltimemax == "12:00:00")
+        self.assertTrue(jobmin == None)
+        self.assertTrue(jobmax == None)
+        self.assertFalse(strict)
+
+    @mock.patch("CIME.XML.env_batch.EnvBatch.text", return_value="default")
+    # nodemin, nodemax, jobname, walltimemin, walltimemax, jobmin, jobmax, strict
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_queue_specs", return_value=[
+        1, 1, "case.run", "08:00:00", "12:00:00", 1, 1, False,
+    ])
+    @mock.patch("CIME.XML.env_batch.EnvBatch.select_best_queue")
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_default_queue")
+    def test_set_job_defaults_honor_walltimemax(self, get_default_queue, select_best_queue,
+                              get_queue_specs, text):
+        case = mock.MagicMock()
+
+        batch_jobs = [
+            ("case.run", {
+                "template": "template.case.run",
+                "prereq": "$BUILD_COMPLETE and not $TEST"
+            })
+        ]
+
+        def get_value(*args, **kwargs):
+            if args[0] == "USER_REQUESTED_WALLTIME":
+                return "20:00:00"
+
+            return mock.MagicMock()
+
+        case.get_value = get_value
+
+        case.get_env.return_value.get_jobs.return_value = ["case.run"]
+
+        batch = EnvBatch()
+
+        batch.set_job_defaults(batch_jobs, case)
+
+        env_workflow = case.get_env.return_value
+
+        env_workflow.set_value.assert_any_call("JOB_QUEUE", "default",
+                                               subgroup="case.run",
+                                               ignore_type=False)
+        env_workflow.set_value.assert_any_call("JOB_WALLCLOCK_TIME", "20:00:00",
+                                               subgroup="case.run")
+
+    @mock.patch("CIME.XML.env_batch.EnvBatch.text", return_value="default")
+    # nodemin, nodemax, jobname, walltimemin, walltimemax, jobmin, jobmax, strict
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_queue_specs", return_value=[
+        1, 1, "case.run", "08:00:00", "12:00:00", 1, 1, False,
+    ])
+    @mock.patch("CIME.XML.env_batch.EnvBatch.select_best_queue")
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_default_queue")
+    def test_set_job_defaults_honor_walltimemin(self, get_default_queue, select_best_queue,
+                              get_queue_specs, text):
+        case = mock.MagicMock()
+
+        batch_jobs = [
+            ("case.run", {
+                "template": "template.case.run",
+                "prereq": "$BUILD_COMPLETE and not $TEST"
+            })
+        ]
+
+        def get_value(*args, **kwargs):
+            if args[0] == "USER_REQUESTED_WALLTIME":
+                return "05:00:00"
+
+            return mock.MagicMock()
+
+        case.get_value = get_value
+
+        case.get_env.return_value.get_jobs.return_value = ["case.run"]
+
+        batch = EnvBatch()
+
+        batch.set_job_defaults(batch_jobs, case)
+
+        env_workflow = case.get_env.return_value
+
+        env_workflow.set_value.assert_any_call("JOB_QUEUE", "default",
+                                               subgroup="case.run",
+                                               ignore_type=False)
+        env_workflow.set_value.assert_any_call("JOB_WALLCLOCK_TIME", "05:00:00",
+                                               subgroup="case.run")
+
+    @mock.patch("CIME.XML.env_batch.EnvBatch.text", return_value="default")
+    # nodemin, nodemax, jobname, walltimemax, jobmin, jobmax, strict
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_queue_specs", return_value=[
+        1, 1, "case.run", "08:00:00", "12:00:00", 1, 1, False,
+    ])
+    @mock.patch("CIME.XML.env_batch.EnvBatch.select_best_queue")
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_default_queue")
+    def test_set_job_defaults_user_walltime(self, get_default_queue,
+                                            select_best_queue,
+                                            get_queue_specs, text):
+        case = mock.MagicMock()
+
+        batch_jobs = [
+            ("case.run", {
+                "template": "template.case.run",
+                "prereq": "$BUILD_COMPLETE and not $TEST"
+            })
+        ]
+
+        def get_value(*args, **kwargs):
+            if args[0] == "USER_REQUESTED_WALLTIME":
+                return "10:00:00"
+
+            return mock.MagicMock()
+
+        case.get_value = get_value
+
+        case.get_env.return_value.get_jobs.return_value = ["case.run"]
+
+        batch = EnvBatch()
+
+        batch.set_job_defaults(batch_jobs, case)
+
+        env_workflow = case.get_env.return_value
+
+        env_workflow.set_value.assert_any_call("JOB_QUEUE", "default",
+                                               subgroup="case.run",
+                                               ignore_type=False)
+        env_workflow.set_value.assert_any_call("JOB_WALLCLOCK_TIME", "10:00:00",
+                                               subgroup="case.run")
+
+    @mock.patch("CIME.XML.env_batch.EnvBatch.text", return_value="default")
+    # nodemin, nodemax, jobname, walltimemax, jobmin, jobmax, strict
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_queue_specs", return_value=[
+        1, 1, "case.run", None, "12:00:00", 1, 1, False,
+    ])
+    @mock.patch("CIME.XML.env_batch.EnvBatch.select_best_queue")
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_default_queue")
+    def test_set_job_defaults_walltimemin_none(self, get_default_queue, select_best_queue,
+                              get_queue_specs, text):
+        case = mock.MagicMock()
+
+        batch_jobs = [
+            ("case.run", {
+                "template": "template.case.run",
+                "prereq": "$BUILD_COMPLETE and not $TEST"
+            })
+        ]
+
+        def get_value(*args, **kwargs):
+            if args[0] == "USER_REQUESTED_WALLTIME":
+                return "08:00:00"
+
+            return mock.MagicMock()
+
+        case.get_value = get_value
+
+        case.get_env.return_value.get_jobs.return_value = ["case.run"]
+
+        batch = EnvBatch()
+
+        batch.set_job_defaults(batch_jobs, case)
+
+        env_workflow = case.get_env.return_value
+
+        env_workflow.set_value.assert_any_call("JOB_QUEUE", "default",
+                                               subgroup="case.run",
+                                               ignore_type=False)
+        env_workflow.set_value.assert_any_call("JOB_WALLCLOCK_TIME", "08:00:00",
+                                               subgroup="case.run")
+
+    @mock.patch("CIME.XML.env_batch.EnvBatch.text", return_value="default")
+    # nodemin, nodemax, jobname, walltimemax, jobmin, jobmax, strict
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_queue_specs", return_value=[
+        1, 1, "case.run", "08:00:00", "12:00:00", 1, 1, False,
+    ])
+    @mock.patch("CIME.XML.env_batch.EnvBatch.select_best_queue")
+    @mock.patch("CIME.XML.env_batch.EnvBatch.get_default_queue")
+    def test_set_job_defaults(self, get_default_queue, select_best_queue,
+                              get_queue_specs, text):
+        case = mock.MagicMock()
+
+        batch_jobs = [
+            ("case.run", {
+                "template": "template.case.run",
+                "prereq": "$BUILD_COMPLETE and not $TEST"
+            })
+        ]
+
+        def get_value(*args, **kwargs):
+            if args[0] == "USER_REQUESTED_WALLTIME":
+                return None
+
+            return mock.MagicMock()
+
+        case.get_value = get_value
+
+        case.get_env.return_value.get_jobs.return_value = ["case.run"]
+
+        batch = EnvBatch()
+
+        batch.set_job_defaults(batch_jobs, case)
+
+        env_workflow = case.get_env.return_value
+
+        env_workflow.set_value.assert_any_call("JOB_QUEUE", "default",
+                                               subgroup="case.run",
+                                               ignore_type=False)
+        env_workflow.set_value.assert_any_call("JOB_WALLCLOCK_TIME", "12:00:00",
+                                               subgroup="case.run")

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1321,6 +1321,8 @@ def convert_to_babylonian_time(seconds):
 
     >>> convert_to_babylonian_time(3661)
     '01:01:01'
+    >>> convert_to_babylonian_time(360000)
+    '100:00:00'
     """
     hours = int(seconds / 3600)
     seconds %= 3600

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -1793,7 +1793,7 @@ CASE_SUCCESS = "success"
 CASE_FAILURE = "error"
 def run_and_log_case_status(func, phase, caseroot='.',
                             custom_starting_msg_functor=None,
-                            custom_success_msg_functor=None, 
+                            custom_success_msg_functor=None,
                             is_batch=False):
     starting_msg = None
 
@@ -1808,7 +1808,8 @@ def run_and_log_case_status(func, phase, caseroot='.',
     try:
         rv = func()
     except BaseException:
-        custom_success_msg = custom_success_msg_functor(rv) if custom_success_msg_functor else None
+        custom_success_msg = custom_success_msg_functor(rv) \
+            if custom_success_msg_functor and rv is not None else None
         if phase == "case.submit" and is_batch:
             append_case_status(phase, "starting", msg=custom_success_msg,
                             caseroot=caseroot)
@@ -1817,11 +1818,12 @@ def run_and_log_case_status(func, phase, caseroot='.',
                            caseroot=caseroot)
         raise
     else:
-        custom_success_msg = custom_success_msg_functor(rv) if custom_success_msg_functor else None
+        custom_success_msg = custom_success_msg_functor(rv) \
+            if custom_success_msg_functor else None
         if phase == "case.submit" and is_batch:
             append_case_status(phase, "starting", msg=custom_success_msg,
                             caseroot=caseroot)
-        append_case_status(phase, CASE_SUCCESS, msg=custom_success_msg, 
+        append_case_status(phase, CASE_SUCCESS, msg=custom_success_msg,
                            caseroot=caseroot)
 
     return rv


### PR DESCRIPTION
Fixes only calling `custom_success_msg` function when there is a 
return value from `run_and_log_case_status`. Adds warnings when
walltime is outside of min/max for the selected queue.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bfb

Fixes #3993 

User interface changes?: n/a
Update gh-pages html (Y/N)?: n/a
