### PR TITLE
More python churn

### DIFF
--- a/config/cesm/machines/template.case.run
+++ b/config/cesm/machines/template.case.run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Batch system directives
 {{ batchdirectives }}
 

--- a/config/cesm/machines/template.case.test
+++ b/config/cesm/machines/template.case.test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 {{ batchdirectives }}
 """
 This is the system test submit script for CIME. This should only ever be called

--- a/config/cesm/machines/template.st_archive
+++ b/config/cesm/machines/template.st_archive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Batch system directives
 {{ batchdirectives }}
 

--- a/config/ufs/machines/template.case.run
+++ b/config/ufs/machines/template.case.run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Batch system directives
 {{ batchdirectives }}
 

--- a/config/ufs/machines/template.case.test
+++ b/config/ufs/machines/template.case.test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 {{ batchdirectives }}
 """
 This is the system test submit script for CIME. This should only ever be called

--- a/config/ufs/machines/template.st_archive
+++ b/config/ufs/machines/template.st_archive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Batch system directives
 {{ batchdirectives }}
 

--- a/doc/source/users_guide/running-a-case.rst
+++ b/doc/source/users_guide/running-a-case.rst
@@ -604,7 +604,7 @@ as an external shell script.
 
 ::
 
-   #!/usr/bin/env python
+   #!/usr/bin/env python3
    import sys
    from CIME.case import Case
 

--- a/doc/tools_autodoc.py
+++ b/doc/tools_autodoc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """script to auto generate rst documentation for cime/scripts/Tools 
    user facing utilities.
 

--- a/scripts/Tools/bld_diff
+++ b/scripts/Tools/bld_diff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """
 Try to calculate and succinctly present the differences between two bld logs

--- a/scripts/Tools/case_diff
+++ b/scripts/Tools/case_diff
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """
 Try to calculate and succinctly present the differences between two large

--- a/scripts/Tools/xmlconvertors/config_pes_converter.py
+++ b/scripts/Tools/xmlconvertors/config_pes_converter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 config_pes_converter.py -- convert (or verify) config_pes elements from CIME2
 format to CIME5. This tool will compare the two versions and suggest updates to

--- a/scripts/Tools/xmlconvertors/convert-grid-v1-to-v2
+++ b/scripts/Tools/xmlconvertors/convert-grid-v1-to-v2
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 """
 Convert a grid file from v1 to v2.

--- a/scripts/Tools/xmlconvertors/grid_xml_converter.py
+++ b/scripts/Tools/xmlconvertors/grid_xml_converter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 grid_xml_converter.py -- convert (or verify) grid elements from CIME2 format
 to CIME5. This tool will compare the two versions and suggest updates

--- a/scripts/fortran_unit_testing/python/test_xml_test_list.py
+++ b/scripts/fortran_unit_testing/python/test_xml_test_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Unit tests for the xml_test_list module.
 
 Public classes:

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import os, sys
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..")

--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """This script writes CIME build information to a directory.
 

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 case.submit - Submit a cesm workflow to the queueing system or run it

--- a/scripts/lib/CIME/get_timing.py
+++ b/scripts/lib/CIME/get_timing.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Library for implementing getTiming tool which gets timing

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Library for saving build/run provenance.

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 This module contains unit tests of the core logic in SystemTestsCompareTwo.

--- a/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two_link_to_case2_output.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_system_tests_compare_two_link_to_case2_output.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 This module contains unit tests of the method

--- a/scripts/lib/CIME/tests/SystemTests/test_utils/test_user_nl_utils.py
+++ b/scripts/lib/CIME/tests/SystemTests/test_utils/test_user_nl_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import unittest
 import os

--- a/scripts/lib/CIME/tests/XML/test_expected_fails_file.py
+++ b/scripts/lib/CIME/tests/XML/test_expected_fails_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import unittest
 import os

--- a/scripts/lib/CIME/tests/test_case_fake.py
+++ b/scripts/lib/CIME/tests/test_case_fake.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#/usr/bin/env python3
 
 """
 This module contains unit tests of CaseFake

--- a/scripts/lib/CIME/tests/test_compare_test_results.py
+++ b/scripts/lib/CIME/tests/test_compare_test_results.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#/usr/bin/env python3
 
 """
 This module contains unit tests for compare_test_results

--- a/scripts/lib/CIME/tests/test_cs_status.py
+++ b/scripts/lib/CIME/tests/test_cs_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import unittest
 import shutil

--- a/scripts/lib/CIME/tests/test_custom_assertions_test_status.py
+++ b/scripts/lib/CIME/tests/test_custom_assertions_test_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 This module contains unit tests of CustomAssertionsTestStatus

--- a/scripts/lib/CIME/tests/test_test_status.py
+++ b/scripts/lib/CIME/tests/test_test_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import unittest
 import os

--- a/scripts/lib/CIME/tests/test_user_mod_support.py
+++ b/scripts/lib/CIME/tests/test_user_mod_support.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import unittest
 import shutil

--- a/scripts/lib/CIME/tests/test_utils.py
+++ b/scripts/lib/CIME/tests/test_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -123,7 +123,7 @@ class A_RunUnitTests(unittest.TestCase):
         # (i.e., tests defined using python's unittest module).
         #
         # This is analogous to running:
-        #     python -m unittest discover -s CIME/tests -t .
+        #     python3 -m unittest discover -s CIME/tests -t .
         # from cime/scripts/lib
         #
         # Yes, that means we have a bunch of unit tests run from this one unit
@@ -158,7 +158,7 @@ class A_RunUnitTests(unittest.TestCase):
                         content = fd.read()
                     if '>>>' in content:
                         print("Running doctests for {}".format(filepath))
-                        run_cmd_assert_result(self, 'PYTHONPATH={}:$PYTHONPATH python -m doctest {} 2>&1'.format(LIB_DIR, filepath), from_dir=LIB_DIR)
+                        run_cmd_assert_result(self, 'PYTHONPATH={}:$PYTHONPATH python3 -m doctest {} 2>&1'.format(LIB_DIR, filepath), from_dir=LIB_DIR)
                     else:
                         print("{} has no doctests".format(filepath))
 

--- a/src/build_scripts/buildlib.cprnc
+++ b/src/build_scripts/buildlib.cprnc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from standard_script_setup import *
 from CIME.utils import run_bld_cmd_ensure_logging

--- a/src/build_scripts/buildlib.csm_share
+++ b/src/build_scripts/buildlib.csm_share
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from standard_script_setup import *
 from CIME.utils import copyifnewer, run_bld_cmd_ensure_logging, expect, symlink_force
 from CIME.case import Case

--- a/src/build_scripts/buildlib.gptl
+++ b/src/build_scripts/buildlib.gptl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from standard_script_setup import *
 from CIME.utils import run_bld_cmd_ensure_logging
 from CIME.case import Case

--- a/src/build_scripts/buildlib.internal_components
+++ b/src/build_scripts/buildlib.internal_components
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build cime component model library.   This buildlib script is used by all cime internal

--- a/src/build_scripts/buildlib.kokkos
+++ b/src/build_scripts/buildlib.kokkos
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from standard_script_setup import *
 from CIME.utils import expect, run_bld_cmd_ensure_logging, run_cmd_no_fail, run_cmd

--- a/src/build_scripts/buildlib.mct
+++ b/src/build_scripts/buildlib.mct
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from standard_script_setup import *
 from CIME.utils import copyifnewer, run_bld_cmd_ensure_logging
 from CIME.case import Case

--- a/src/build_scripts/buildlib.mpi-serial
+++ b/src/build_scripts/buildlib.mpi-serial
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from standard_script_setup import *
 from CIME.utils import copyifnewer, run_bld_cmd_ensure_logging
 from CIME.case import Case

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob, re
 from standard_script_setup import *

--- a/src/build_scripts/buildlib_cmake.internal_components
+++ b/src/build_scripts/buildlib_cmake.internal_components
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build cime component model library.   This buildlib script is used by all cime internal

--- a/src/components/data_comps_mct/datm/cime_config/buildnml
+++ b/src/components/data_comps_mct/datm/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Namelist creator for CIME's data atmosphere model.
 """

--- a/src/components/data_comps_mct/desp/cime_config/buildnml
+++ b/src/components/data_comps_mct/desp/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Namelist creator for CIME's data external system processing (ESP) model.
 """

--- a/src/components/data_comps_mct/dice/cime_config/buildnml
+++ b/src/components/data_comps_mct/dice/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Namelist creator for CIME's data ice model.
 """

--- a/src/components/data_comps_mct/dlnd/cime_config/buildnml
+++ b/src/components/data_comps_mct/dlnd/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Namelist creator for CIME's data land model.
 """

--- a/src/components/data_comps_mct/docn/cime_config/buildnml
+++ b/src/components/data_comps_mct/docn/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Namelist creator for CIME's data ocn model.
 """

--- a/src/components/data_comps_mct/drof/cime_config/buildnml
+++ b/src/components/data_comps_mct/drof/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Namelist creator for CIME's data river model.
 """

--- a/src/components/data_comps_mct/dwav/cime_config/buildnml
+++ b/src/components/data_comps_mct/dwav/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Namelist creator for CIME's data wave model.
 """

--- a/src/components/stub_comps_mct/satm/cime_config/buildnml
+++ b/src/components/stub_comps_mct/satm/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_mct/sesp/cime_config/buildnml
+++ b/src/components/stub_comps_mct/sesp/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_mct/sglc/cime_config/buildnml
+++ b/src/components/stub_comps_mct/sglc/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_mct/siac/cime_config/buildnml
+++ b/src/components/stub_comps_mct/siac/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_mct/sice/cime_config/buildnml
+++ b/src/components/stub_comps_mct/sice/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_mct/slnd/cime_config/buildnml
+++ b/src/components/stub_comps_mct/slnd/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_mct/socn/cime_config/buildnml
+++ b/src/components/stub_comps_mct/socn/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_mct/srof/cime_config/buildnml
+++ b/src/components/stub_comps_mct/srof/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_mct/swav/cime_config/buildnml
+++ b/src/components/stub_comps_mct/swav/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_nuopc/satm/cime_config/buildnml
+++ b/src/components/stub_comps_nuopc/satm/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_nuopc/sesp/cime_config/buildnml
+++ b/src/components/stub_comps_nuopc/sesp/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_nuopc/sglc/cime_config/buildnml
+++ b/src/components/stub_comps_nuopc/sglc/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_nuopc/siac/cime_config/buildnml
+++ b/src/components/stub_comps_nuopc/siac/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_nuopc/sice/cime_config/buildnml
+++ b/src/components/stub_comps_nuopc/sice/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_nuopc/slnd/cime_config/buildnml
+++ b/src/components/stub_comps_nuopc/slnd/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_nuopc/socn/cime_config/buildnml
+++ b/src/components/stub_comps_nuopc/socn/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_nuopc/srof/cime_config/buildnml
+++ b/src/components/stub_comps_nuopc/srof/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/stub_comps_nuopc/swav/cime_config/buildnml
+++ b/src/components/stub_comps_nuopc/swav/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build stub model namelist

--- a/src/components/xcpl_comps_mct/xatm/cime_config/buildnml
+++ b/src/components/xcpl_comps_mct/xatm/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_mct/xglc/cime_config/buildnml
+++ b/src/components/xcpl_comps_mct/xglc/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_mct/xice/cime_config/buildnml
+++ b/src/components/xcpl_comps_mct/xice/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_mct/xlnd/cime_config/buildnml
+++ b/src/components/xcpl_comps_mct/xlnd/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_mct/xocn/cime_config/buildnml
+++ b/src/components/xcpl_comps_mct/xocn/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_mct/xrof/cime_config/buildnml
+++ b/src/components/xcpl_comps_mct/xrof/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_mct/xwav/cime_config/buildnml
+++ b/src/components/xcpl_comps_mct/xwav/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_nuopc/xatm/cime_config/buildnml
+++ b/src/components/xcpl_comps_nuopc/xatm/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_nuopc/xglc/cime_config/buildnml
+++ b/src/components/xcpl_comps_nuopc/xglc/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_nuopc/xice/cime_config/buildnml
+++ b/src/components/xcpl_comps_nuopc/xice/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_nuopc/xlnd/cime_config/buildnml
+++ b/src/components/xcpl_comps_nuopc/xlnd/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_nuopc/xocn/cime_config/buildnml
+++ b/src/components/xcpl_comps_nuopc/xocn/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_nuopc/xrof/cime_config/buildnml
+++ b/src/components/xcpl_comps_nuopc/xrof/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/components/xcpl_comps_nuopc/xwav/cime_config/buildnml
+++ b/src/components/xcpl_comps_nuopc/xwav/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build data model library

--- a/src/drivers/mct/cime_config/buildexe
+++ b/src/drivers/mct/cime_config/buildexe
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build model executable

--- a/src/drivers/mct/cime_config/buildlib_cmake
+++ b/src/drivers/mct/cime_config/buildlib_cmake
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build model executable

--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Namelist creator for CIME's driver.
 """
 # Typically ignore this.

--- a/src/drivers/moab/cime_config/buildexe
+++ b/src/drivers/moab/cime_config/buildexe
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 build model executable

--- a/tools/configure
+++ b/tools/configure
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """This script writes CIME build information to a directory.
 


### PR DESCRIPTION
The python situation in CIME has become untenable on some of our Sandia machines. We have some E3SM ecosystem projects that are using python3 for their scripting and also trying to run CIME test suites and the py2/py3 situation is causing problems. This PR aims to remove all potential python2 invocations from CIME with the exception of some stuff from `tools` which is not part of the CIME CCS.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3987 

User interface changes?: 

Update gh-pages html (Y/N)?:
