### PR TITLE
refactor lilac build - only relevant to CESM

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -117,16 +117,11 @@ endif
 
 ifeq ($(COMP_INTERFACE), nuopc)
    CPPDEFS += -DNUOPC_INTERFACE
-   ifneq ($(LILAC_MODE), on)
-      # CDEPS isn't required yet when building CTSM with LILAC; once it is needed, we
-      # should remove this conditional and the similar one in build.py (along with the
-      # addition of LILAC_MODE to _CMD_ARGS_FOR_BUILD)
-      INCLDIR += -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/include -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr
-      # FoX libraries are provided and built by CDEPS
-      FoX_LIBS := -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/lib -lFoX_wxml -lFoX_dom -lFoX_sax -lFoX_common -lFoX_utils -lFoX_fsys
-      ULIBS += -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr -ldshr -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/streams -lstreams
-      SLIBS += $(FoX_LIBS)
-   endif
+   INCLDIR += -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/include -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr
+   # FoX libraries are provided and built by CDEPS
+   FoX_LIBS := -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/lib -lFoX_wxml -lFoX_dom -lFoX_sax -lFoX_common -lFoX_utils -lFoX_fsys
+   ULIBS += -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr -ldshr -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/streams -lstreams
+   SLIBS += $(FoX_LIBS)
 else
    CPPDEFS += -DMCT_INTERFACE
 endif

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -396,14 +396,7 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
 
     # Build shared code of CDEPS nuopc data models
     build_script = {}
-    if (comp_interface == "nuopc" and (not ufs_driver or ufs_driver != 'nems')
-        and lilac_mode != 'on'):
-        # For now, we avoid building CDEPS with CTSM's LILAC because it's not needed in
-        # this configuration and CDEPS relies on unreleased ESMF code. Eventually we will
-        # require CDEPS (for its streams functionality), at which point CDEPS should only
-        # require released ESMF code; then we should remove the 'lilac_mode' part of this
-        # conditional and the similar conditional in the Makefile (along with the addition
-        # of LILAC_MODE to _CMD_ARGS_FOR_BUILD).
+    if (comp_interface == "nuopc" and (not ufs_driver or ufs_driver != 'nems')):
         libs.append("CDEPS")
 
     ocn_model = case.get_value("COMP_OCN")

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 _CMD_ARGS_FOR_BUILD = \
     ("CASEROOT", "CASETOOLS", "CIMEROOT", "SRCROOT", "COMP_INTERFACE",
-     "COMPILER", "DEBUG", "EXEROOT", "INCROOT", "LIBROOT", "LILAC_MODE",
+     "COMPILER", "DEBUG", "EXEROOT", "INCROOT", "LIBROOT",
      "MACH", "MPILIB", "NINST_VALUE", "OS", "PIO_VERSION",
      "SHAREDLIBROOT", "SMP_PRESENT", "USE_ESMF_LIB", "USE_MOAB",
      "CAM_CONFIG_OPTS", "COMP_LND", "COMPARE_TO_NUOPC", "HOMME_TARGET",
@@ -375,7 +375,6 @@ def _build_libraries(case, exeroot, sharedpath, caseroot, cimeroot, libroot, lid
             os.makedirs(shared_item)
 
     mpilib = case.get_value("MPILIB")
-    lilac_mode = case.get_value("LILAC_MODE")
     ufs_driver = os.environ.get("UFS_DRIVER")
     cpl_in_complist = False
     for l in complist:


### PR DESCRIPTION
These are simple changes that are needed in ctsm5.1.dev044 and post ctsm5.1.dev044 tags. 

Test suite: aux_clm test suite
Test baseline: ctsm5.1.dev043
Test namelist changes: no
Test status: bit for bit

Fixes: None

User interface changes?: No

Update gh-pages html (Y/N)?:N
