### PR TITLE
Set default python to 'python3' for scripts tests CMake file

### DIFF
--- a/scripts/tests/CMakeLists.txt
+++ b/scripts/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ include(CTest)
 if (DEFINED ENV{PYTHON})
   set(PYTHON $ENV{PYTHON})
 else()
-  set(PYTHON "python")
+  set(PYTHON "python3")
 endif()
 
 execute_process(COMMAND ${PYTHON} "--version" OUTPUT_VARIABLE PY_VER


### PR DESCRIPTION
Test suite: by-hand
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
