### PR TITLE
Update for casper and Externals.cfg

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,12 +1,12 @@
 [cmeps]
-tag = cmeps0.13.10
+tag = cmeps0.13.13
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps0.12.9
+tag = cdeps0.12.11
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -14,14 +14,14 @@ externals = Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl7.0.1
+tag = cpl7.0.3
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
 required = True
 
 [share]
-tag = share1.0.0
+tag = share1.0.2
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_share
 local_path = share

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -413,13 +413,21 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">intel/19.1.1</command>
         <command name="load">mkl/2020.0.1</command>
       </modules>
+      <modules compiler="pgi" mpilib="openmpi" DEBUG="TRUE">
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.2.0b11_casper-ncdfio-openmpi-g</command>
+      </modules>
+      <modules compiler="pgi" mpilib="openmpi" DEBUG="FALSE">
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.2.0b11_casper-ncdfio-openmpi-O</command>
+      </modules>
       <modules mpilib="openmpi" compiler="pgi">
         <command name="load">openmpi/4.1.0</command>
-        <command name="load">netcdf-mpi/4.7.4</command>
+        <command name="load">netcdf-mpi/4.8.0</command>
         <command name="load">pnetcdf/1.12.2</command>
       </modules>
       <modules mpilib="mpi-serial" compiler="pgi">
-        <command name="load">netcdf/4.7.4</command>
+        <command name="load">netcdf/4.8.0</command>
       </modules>
       <modules mpilib="openmpi" compiler="pgi-gpu">
         <command name="load">openmpi/4.1.0</command>


### PR DESCRIPTION
Add ESMF libraries for PGI/openmpi on casper.  
Update Externals.cfg to fix missing MAX_GPUS_PER_NODE.

Test suite:  SMS.f09_g17.A.casper_pgi
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
