### PR TITLE
Additional support for ww3 as a component in the e3sm config file

### DIFF
--- a/config/e3sm/config_files.xml
+++ b/config/e3sm/config_files.xml
@@ -260,6 +260,7 @@
       <value component="mali"     >$COMP_ROOT_DIR_GLC/cime_config/config_compsets.xml</value>
       <value component="mpassi"   >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/config_compsets.xml</value>
+      <value component="ww3"      >$COMP_ROOT_DIR_WAV/cime_config/config_compsets.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -279,6 +280,7 @@
       <value component="mpaso"    >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="mali"     >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="mpassi"   >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
+      <value component="ww3"      >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>


### PR DESCRIPTION
Add more support for ww3 as a component by including it in the 
COMPSETS_SPEC_FILE and PES_SPEC_FILE entries in the e3sm version of
config_files.xml, needed by the Ocean NGD project. Limited testing showed
no impact in typical E3SM use.


Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:  N

Update gh-pages html (Y/N)?:
