### PR TITLE
Adds missing value for desp component

### DIFF
--- a/config/e3sm/config_files.xml
+++ b/config/e3sm/config_files.xml
@@ -372,6 +372,7 @@
       <value component="dlnd">$COMP_ROOT_DIR_LND/cime_config/namelist_definition_dlnd.xml</value>
       <value component="docn">$COMP_ROOT_DIR_OCN/cime_config/namelist_definition_docn.xml</value>
       <value component="dwav">$COMP_ROOT_DIR_WAV/cime_config/namelist_definition_dwav.xml</value>
+      <value component="desp">$COMP_ROOT_DIR_ESP/cime_config/namelist_definition_desp.xml</value>
       <!-- external model components -->
       <!--  TODO
       <value component="cam"      >$SRCROOT/components/cam/bld/namelist_files/namelist_definition.xml</value>


### PR DESCRIPTION
Adds missing value to `NAMELIST_DEFINITION_FILE` for `desp`
component. 

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes

User interface changes?: 

Update gh-pages html (Y/N)?:
