### PR TITLE
Fix auto r8 flag for CESM GNU builds

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -196,7 +196,7 @@ using a fortran linker.
   </CPPDEFS>
   <CXX_LINKER>FORTRAN</CXX_LINKER>
   <FC_AUTO_R8>
-    <base> -fdefault-real-8 </base>
+    <base> -fdefault-real-8 -fdefault-double-8</base>
   </FC_AUTO_R8>
   <FFLAGS>
     <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS


### PR DESCRIPTION
Fixes the auto -r8 GNU compiler flag specification for MOM6+CESM by adding `-fdefault-double-8` flag in addition to `-fdefault-real-8`. The issue was encountered while evaluating a MOM6 PR: 
https://github.com/NOAA-GFDL/MOM6/pull/1440#discussion_r666959886

Test suite: aux_mom
Test baseline: 210706
Test namelist changes: n/a 
Test status: b4b

Fixes https://github.com/NOAA-GFDL/MOM6/pull/1440#discussion_r666959886

User interface changes?: n/a

Update gh-pages html (Y/N)?: N
