### PR TITLE
Update python version check, and load python module on cheyenne

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -561,6 +561,7 @@ This allows using a different mpirun command to launch unit tests
       <modules>
         <command name="purge"/>
         <command name="load">ncarenv/1.3</command>
+        <command name="load">python/3.7.9</command>
         <command name="load">cmake</command>
       </modules>
       <modules compiler="intel">

--- a/scripts/Tools/standard_script_setup.py
+++ b/scripts/Tools/standard_script_setup.py
@@ -14,6 +14,6 @@ sys.path.append(_LIB_DIR)
 os.environ["CIMEROOT"] = _CIMEROOT
 
 import CIME.utils
-CIME.utils.check_minimum_python_version(2, 7)
+CIME.utils.check_minimum_python_version(3, 5)
 CIME.utils.stop_buffering_output()
 import logging, argparse

--- a/scripts/Tools/standard_script_setup.py
+++ b/scripts/Tools/standard_script_setup.py
@@ -14,6 +14,6 @@ sys.path.append(_LIB_DIR)
 os.environ["CIMEROOT"] = _CIMEROOT
 
 import CIME.utils
-CIME.utils.check_minimum_python_version(3, 5)
+CIME.utils.check_minimum_python_version(3, 6)
 CIME.utils.stop_buffering_output()
 import logging, argparse


### PR DESCRIPTION
(1) Update python version check to 3.5 or later (#4032 )

(2) Load python module on cheyenne (#4033 )

Test suite: scripts_regression_tests on cheyenne - mct and nuopc
- nuopc: all tests passed
- mct: all passed except `MCC_P1.f19_g16_rx1.A.cheyenne_intel`; I ran that separately via `create_test` and it passed
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes #4032 
Fixes #4033 

User interface changes?: N

Update gh-pages html (Y/N)?: N
