### PR TITLE
Fix bugs in climate reproducibility tests

### DIFF
--- a/scripts/lib/CIME/SystemTests/mvk.py
+++ b/scripts/lib/CIME/SystemTests/mvk.py
@@ -152,27 +152,27 @@ class MVK(SystemTestsCommon):
                                                      CIME.test_status.TEST_PASS_STATUS)
                     break
 
-                status = self._test_status.get_status(CIME.test_status.BASELINE_PHASE)
-                mach_name = self._case.get_value("MACH")
-                mach_obj = Machines(machine=mach_name)
-                htmlroot = CIME.utils.get_htmlroot(mach_obj)
-                urlroot = CIME.utils.get_urlroot(mach_obj)
-                if htmlroot is not None:
-                    with CIME.utils.SharedArea():
-                        dir_util.copy_tree(evv_out_dir, os.path.join(htmlroot, 'evv', case_name), preserve_mode=False)
-                    if urlroot is None:
-                        urlroot = "[{}_URL]".format(mach_name.capitalize())
-                    viewing = "{}/evv/{}/index.html".format(urlroot, case_name)
-                else:
-                    viewing = "{}\n" \
-                              "    EVV viewing instructions can be found at: " \
-                              "        https://github.com/E3SM-Project/E3SM/blob/master/cime/scripts/" \
-                              "climate_reproducibility/README.md#test-passfail-and-extended-output" \
-                              "".format(evv_out_dir)
+            status = self._test_status.get_status(CIME.test_status.BASELINE_PHASE)
+            mach_name = self._case.get_value("MACH")
+            mach_obj = Machines(machine=mach_name)
+            htmlroot = CIME.utils.get_htmlroot(mach_obj)
+            urlroot = CIME.utils.get_urlroot(mach_obj)
+            if htmlroot is not None:
+                with CIME.utils.SharedArea():
+                    dir_util.copy_tree(evv_out_dir, os.path.join(htmlroot, 'evv', case_name), preserve_mode=False)
+                if urlroot is None:
+                    urlroot = "[{}_URL]".format(mach_name.capitalize())
+                viewing = "{}/evv/{}/index.html".format(urlroot, case_name)
+            else:
+                viewing = "{}\n" \
+                            "    EVV viewing instructions can be found at: " \
+                            "        https://github.com/E3SM-Project/E3SM/blob/master/cime/scripts/" \
+                            "climate_reproducibility/README.md#test-passfail-and-extended-output" \
+                            "".format(evv_out_dir)
 
-                comments = "{} {} for test '{}'.\n" \
-                           "    {}\n" \
-                           "    EVV results can be viewed at:\n" \
-                           "        {}".format(CIME.test_status.BASELINE_PHASE, status, test_name, comments, viewing)
+            comments = "{} {} for test '{}'.\n" \
+                        "    {}\n" \
+                        "    EVV results can be viewed at:\n" \
+                        "        {}".format(CIME.test_status.BASELINE_PHASE, status, test_name, comments, viewing)
 
-                CIME.utils.append_testlog(comments, self._orig_caseroot)
+            CIME.utils.append_testlog(comments, self._orig_caseroot)

--- a/scripts/lib/CIME/SystemTests/pgn.py
+++ b/scripts/lib/CIME/SystemTests/pgn.py
@@ -86,8 +86,6 @@ class PGN(SystemTestsCommon):
 
                 case_setup(self._case, test_mode=False, reset=True)
 
-        self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
-
         logger.debug("PGN_INFO: Updating user_nl_* files")
 
         csmdata_root = self._case.get_value("DIN_LOC_ROOT")
@@ -119,6 +117,7 @@ class PGN(SystemTestsCommon):
 
         self._case.set_value("STOP_N", "1")
         self._case.set_value("STOP_OPTION", "nsteps")
+        self.build_indv(sharedlib_only=sharedlib_only, model_only=model_only)
 
     def get_var_list(self):
         """


### PR DESCRIPTION
Updates MVK and PGN non-bfb tests. The MVK test did not
publish results correctly, and PGN input namelists were not
created from user namelists. This update fixes these issues.

Test suite: e3sm_atm_nbfb

User interface changes?: N
Update gh-pages html (Y/N)?: N
