### PR TITLE
fix testmods path and fail if xmllint not found

### DIFF
--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -363,6 +363,7 @@ class GenericXML(object):
 
         # xmllint provides a better format option for the output file
         xmllint = find_executable("xmllint")
+
         if xmllint is not None:
             if isinstance(outfile, six.string_types):
                 run_cmd_no_fail("{} --format --output {} -".format(xmllint, outfile), input_str=xmlstr)
@@ -549,11 +550,10 @@ class GenericXML(object):
         expect(os.path.isfile(filename),"xml file not found {}".format(filename))
         expect(os.path.isfile(schema),"schema file not found {}".format(schema))
         xmllint = find_executable("xmllint")
-        if xmllint is not None:
-            logger.debug("Checking file {} against schema {}".format(filename, schema))
-            run_cmd_no_fail("{} --xinclude --noout --schema {} {}".format(xmllint, schema, filename))
-        else:
-            logger.warning("xmllint not found, could not validate file {}".format(filename))
+        expect(os.path.isfile(xmllint), " xmllint not found, xmllint is required for cime")
+
+        logger.debug("Checking file {} against schema {}".format(filename, schema))
+        run_cmd_no_fail("{} --xinclude --noout --schema {} {}".format(xmllint, schema, filename))
 
     def get_raw_record(self, root=None):
         logger.debug("writing file {}".format(self.filename))

--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -550,7 +550,7 @@ class GenericXML(object):
         expect(os.path.isfile(filename),"xml file not found {}".format(filename))
         expect(os.path.isfile(schema),"schema file not found {}".format(schema))
         xmllint = find_executable("xmllint")
-        expect(os.path.isfile(xmllint), " xmllint not found, xmllint is required for cime")
+        expect(os.path.isfile(xmllint), " xmllint not found in PATH, xmllint is required for cime.  PATH={}".format(os.environ["PATH"]))
 
         logger.debug("Checking file {} against schema {}".format(filename, schema))
         run_cmd_no_fail("{} --xinclude --noout --schema {} {}".format(xmllint, schema, filename))

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -472,32 +472,6 @@ class TestScheduler(object):
         if self._pesfile is not None:
             create_newcase_cmd += " --pesfile {} ".format(self._pesfile)
 
-        if test_mods is not None:
-            create_newcase_cmd += " --user-mods-dir "
-
-            for one_test_mod in test_mods: # pylint: disable=not-an-iterable
-                if one_test_mod.find('/') != -1:
-                    (component, modspath) = one_test_mod.split('/', 1)
-                else:
-                    error = "Missing testmod component. Testmods are specified as '${component}-${testmod}'"
-                    self._log_output(test, error)
-                    return False, error
-
-                files = Files(comp_interface=self._cime_driver)
-                testmods_dir = files.get_value("TESTS_MODS_DIR", {"component": component})
-                test_mod_file = os.path.join(testmods_dir, component, modspath)
-                # if no testmod is found check if a usermod of the same name exists and
-                # use it if it does.
-                if not os.path.exists(test_mod_file):
-                    usermods_dir = files.get_value("USER_MODS_DIR", {"component": component})
-                    test_mod_file = os.path.join(usermods_dir, modspath)
-                    if not os.path.exists(test_mod_file):
-                        error = "Missing testmod file '{}', checked {} and {}".format(modspath, testmods_dir, usermods_dir)
-                        self._log_output(test, error)
-                        return False, error
-
-                create_newcase_cmd += "{} ".format(test_mod_file)
-
         mpilib = None
         ninst = 1
         ncpl = 1
@@ -526,6 +500,32 @@ class TestScheduler(object):
                 elif case_opt.startswith('V'):
                     self._cime_driver = case_opt[1:]
                     create_newcase_cmd += " --driver {}".format(self._cime_driver)
+
+        if test_mods is not None:
+            create_newcase_cmd += " --user-mods-dir "
+
+            for one_test_mod in test_mods: # pylint: disable=not-an-iterable
+                if one_test_mod.find('/') != -1:
+                    (component, modspath) = one_test_mod.split('/', 1)
+                else:
+                    error = "Missing testmod component. Testmods are specified as '${component}-${testmod}'"
+                    self._log_output(test, error)
+                    return False, error
+
+                files = Files(comp_interface=self._cime_driver)
+                testmods_dir = files.get_value("TESTS_MODS_DIR", {"component": component})
+                test_mod_file = os.path.join(testmods_dir, component, modspath)
+                # if no testmod is found check if a usermod of the same name exists and
+                # use it if it does.
+                if not os.path.exists(test_mod_file):
+                    usermods_dir = files.get_value("USER_MODS_DIR", {"component": component})
+                    test_mod_file = os.path.join(usermods_dir, modspath)
+                    if not os.path.exists(test_mod_file):
+                        error = "Missing testmod file '{}', checked {} and {}".format(modspath, testmods_dir, usermods_dir)
+                        self._log_output(test, error)
+                        return False, error
+
+                create_newcase_cmd += "{} ".format(test_mod_file)
 
         # create_test mpilib option overrides default but not explicitly set case_opt mpilib
         if mpilib is None and self._mpilib is not None:


### PR DESCRIPTION
Fails if xmllint not found in path.  Fix testmods dir for cmeps cases by setting _cime_driver prior to looking for testmods

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #4041 
Fixes #4039 

User interface changes?: 

Update gh-pages html (Y/N)?:
