### PR TITLE
update modules and build flags on cori

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -676,7 +676,7 @@ using a fortran linker.
 
 <compiler MACH="aleph" COMPILER="intel">
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CFLAGS>
     <append> -xCORE-AVX2 </append>
@@ -958,7 +958,7 @@ using a fortran linker.
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
@@ -978,7 +978,7 @@ using a fortran linker.
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
@@ -995,7 +995,7 @@ using a fortran linker.
 
 <compiler MACH="cori-haswell" COMPILER="intel">
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CFLAGS>
     <append> -xCORE-AVX2 </append>
@@ -1018,7 +1018,7 @@ using a fortran linker.
 
 <compiler MACH="cori-knl" COMPILER="intel">
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CFLAGS>
     <append> -xMIC-AVX512 </append>
@@ -1044,7 +1044,7 @@ using a fortran linker.
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
@@ -1065,7 +1065,7 @@ using a fortran linker.
     <append compile_threaded="FALSE"> -nomp </append>
   </CFLAGS>
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
@@ -1089,7 +1089,7 @@ using a fortran linker.
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CPPDEFS>
     <append MODEL="gptl"> -DHAVE_PAPI </append>
@@ -1363,7 +1363,7 @@ using a fortran linker.
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CXX_LIBS>
     <base>-lstdc++ -lmpi_cxx</base>
@@ -1416,7 +1416,7 @@ using a fortran linker.
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CPPDEFS>
     <append> -DLINUX </append>
@@ -1433,7 +1433,7 @@ using a fortran linker.
 
 <compiler MACH="pleiades-bro">
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CFLAGS>
     <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
@@ -1454,7 +1454,7 @@ using a fortran linker.
 
 <compiler MACH="pleiades-has">
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CFLAGS>
     <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
@@ -1475,7 +1475,7 @@ using a fortran linker.
 
 <compiler MACH="pleiades-ivy">
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CFLAGS>
     <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
@@ -1496,7 +1496,7 @@ using a fortran linker.
 
 <compiler MACH="pleiades-san">
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <CFLAGS>
     <append> -axCORE-AVX2 -xSSE4.2 -no-fma </append>
@@ -1520,7 +1520,7 @@ using a fortran linker.
     <append DEBUG="FALSE"> -O2  </append>
   </CFLAGS>
   <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <ESMF_LIBDIR>/projects/ccsm/esmf-6.3.0rp1/lib/libO/Linux.intel.64.openmpi.default</ESMF_LIBDIR>
   <FFLAGS>
@@ -1618,7 +1618,7 @@ using a fortran linker.
     <append> -xMIC-AVX512 </append>
   </FFLAGS>
     <CONFIG_ARGS>
-    <base> --host=Linux </base>
+    <base> --host=cray </base>
   </CONFIG_ARGS>
   <SLIBS>
     <append>-L$(NETCDF_DIR)/lib -lnetcdff -L$(NETCDF_DIR)/lib -lnetcdf -Wl,-rpath -Wl,$(NETCDF_DIR)/lib </append>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -913,7 +913,7 @@ This allows using a different mpirun command to launch unit tests
 
       <modules compiler="intel">
         <command name="load">PrgEnv-intel</command>
-        <command name="switch">intel intel/19.0.3.199</command>
+        <command name="switch">intel intel/19.1.3.304</command>
         <command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
@@ -925,33 +925,33 @@ This allows using a different mpirun command to launch unit tests
 
       <modules compiler="cray">
         <command name="load">PrgEnv-cray</command>
-        <command name="switch">cce cce/8.7.9</command>
+        <command name="switch">cce cce/10.0.3</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">PrgEnv-gnu</command>
-        <command name="switch">gcc gcc/8.3.0</command>
+        <command name="switch">gcc gcc/10.1.0</command>
       </modules>
       <modules>
         <command name="load">cray-memkind</command>
-        <command name="swap">craype craype/2.6.2</command>
+        <command name="swap">craype craype/2.7.2</command>
       </modules>
       <modules>
-        <command name="switch">cray-libsci/19.06.1</command>
+        <command name="switch">cray-libsci/20.09.1</command>
       </modules>
       <modules>
-        <command name="load">cray-mpich/7.7.10</command>
+        <command name="load">cray-mpich/7.7.16</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">cray-hdf5/1.10.5.2</command>
-        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.12.0.0</command>
+        <command name="load">cray-netcdf/4.7.4.0</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
-        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
-        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.7.4.0</command>
+        <command name="load">cray-hdf5-parallel/1.12.0.0</command>
+        <command name="load">cray-parallel-netcdf/1.12.1.0</command>
       </modules>
       <modules>
-        <command name="load">cmake/3.14.4</command>
+        <command name="load">cmake/3.20.5</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -1018,7 +1018,7 @@ This allows using a different mpirun command to launch unit tests
 
       <modules compiler="intel">
         <command name="load">PrgEnv-intel</command>
-        <command name="switch">intel intel/19.0.3.199</command>
+        <command name="switch">intel intel/19.1.3.304</command>
         <command name="use">/global/project/projectdirs/ccsm1/modulefiles/cori</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" >
@@ -1030,31 +1030,31 @@ This allows using a different mpirun command to launch unit tests
 
       <modules compiler="cray">
         <command name="load">PrgEnv-cray</command>
-        <command name="switch">cce cce/9.1.0</command>
+        <command name="switch">cce cce/10.0.3</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">PrgEnv-gnu</command>
-        <command name="switch">gcc gcc/8.3.0</command>
+        <command name="switch">gcc gcc/10.1.0</command>
       </modules>
       <modules>
         <command name="load">cray-memkind</command>
-        <command name="swap">craype craype/2.6.2</command>
+        <command name="swap">craype craype/2.7.2</command>
         <command name="load">craype-mic-knl</command>
       </modules>
       <modules>
-        <command name="switch">cray-libsci/19.06.1</command>
+        <command name="switch">cray-libsci/20.09.1</command>
       </modules>
       <modules>
-        <command name="load">cray-mpich/7.7.10</command>
+        <command name="load">cray-mpich/7.7.16</command>
       </modules>
       <modules mpilib="mpi-serial">
-        <command name="load">cray-hdf5/1.10.5.2</command>
-        <command name="load">cray-netcdf/4.6.3.2</command>
+        <command name="load">cray-hdf5/1.12.0.0</command>
+        <command name="load">cray-netcdf/4.7.4.0</command>
       </modules>
       <modules mpilib="!mpi-serial">
-        <command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
-        <command name="load">cray-hdf5-parallel/1.10.5.2</command>
-        <command name="load">cray-parallel-netcdf/1.11.1.1</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.7.4.0</command>
+        <command name="load">cray-hdf5-parallel/1.12.0.0</command>
+        <command name="load">cray-parallel-netcdf/1.12.1.0</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
Updates modules and compiler flags for cori-haswell and cori-knl

Test suite:scripts_regression_tests.py on cori 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:
