### PR TITLE
Fix the failure of ensemble consistency tests for PGI/NVHPC compiler on Casper

### DIFF
--- a/config/cesm/machines/Depends.nvhpc-gpu
+++ b/config/cesm/machines/Depends.nvhpc-gpu
@@ -12,5 +12,5 @@ shr_spfn_mod.o
 
 ifeq ($(DEBUG),FALSE)
   $(PUMAS_MG_OBJS): %.o: %.F90
-	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -acc -ta=tesla:cc70,lineinfo -Minfo=accel $<
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -acc -ta=tesla:cc70,lineinfo,nofma -Minfo=accel $<
 endif

--- a/config/cesm/machines/Depends.pgi-gpu
+++ b/config/cesm/machines/Depends.pgi-gpu
@@ -12,5 +12,5 @@ shr_spfn_mod.o
 
 ifeq ($(DEBUG),FALSE)
   $(PUMAS_MG_OBJS): %.o: %.F90
-	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -acc -ta=tesla:cc70,lineinfo -Minfo=accel $<
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -acc -ta=tesla:cc70,lineinfo,nofma -Minfo=accel $<
 endif

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -874,7 +874,7 @@ using a fortran linker.
     <append> -I$(EXEROOT)/ocn/obj/FMS </append>
   </FFLAGS>
   <LDFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake -acc -ta=tesla:cc70,lineinfo,nofma -Minfo=accel </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma -acc -ta=tesla:cc70,lineinfo,nofma -Minfo=accel </append>
   </LDFLAGS>
   <SLIBS>
     <append> -llapack -lblas </append>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -813,14 +813,14 @@ using a fortran linker.
 
 <compiler MACH="casper" COMPILER="pgi">
   <CFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
   </CFLAGS>
   <FFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
     <append> -I$(EXEROOT)/ocn/obj/FMS </append>
   </FFLAGS>
   <LDFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
   </LDFLAGS>
   <SLIBS>
     <append> -llapack -lblas </append>
@@ -831,14 +831,14 @@ using a fortran linker.
 
 <compiler MACH="casper" COMPILER="pgi-gpu">
   <CFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
   </CFLAGS>
   <FFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
     <append> -I$(EXEROOT)/ocn/obj/FMS </append>
   </FFLAGS>
   <LDFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake -acc -ta=tesla:cc70,lineinfo -Minfo=accel </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma -acc -ta=tesla:cc70,lineinfo,nofma -Minfo=accel </append>
   </LDFLAGS>
   <SLIBS>
     <append> -llapack -lblas </append>
@@ -849,14 +849,14 @@ using a fortran linker.
 
 <compiler MACH="casper" COMPILER="nvhpc">
   <CFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
   </CFLAGS>
   <FFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
     <append> -I$(EXEROOT)/ocn/obj/FMS </append>
   </FFLAGS>
   <LDFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
   </LDFLAGS>
   <SLIBS>
     <append> -llapack -lblas </append>
@@ -867,14 +867,14 @@ using a fortran linker.
 
 <compiler MACH="casper" COMPILER="nvhpc-gpu">
   <CFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
   </CFLAGS>
   <FFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -Mnofma </append>
     <append> -I$(EXEROOT)/ocn/obj/FMS </append>
   </FFLAGS>
   <LDFLAGS>
-    <append DEBUG="FALSE"> -O -tp=skylake -acc -ta=tesla:cc70,lineinfo -Minfo=accel </append>
+    <append DEBUG="FALSE"> -O -tp=skylake -acc -ta=tesla:cc70,lineinfo,nofma -Minfo=accel </append>
   </LDFLAGS>
   <SLIBS>
     <append> -llapack -lblas </append>


### PR DESCRIPTION
In our previous PR (https://github.com/ESMCI/cime/pull/3922), we found that using the PGI and NVHPC compilers on Casper would fail the ensemble consistency test (ECT) if the baseline generated by the Intel compiler on Cheyenne was used.

Thanks to Allison Baker's suggestion, it turned out that we accidentally enabled the fused multiply-add (FMA) option for the PGI and NVHPC compilers on Casper, which was however explicitly disabled for the Intel compiler on Cheyenne.

After we turn off the FMA option for the PGI and NVHPC compilers on Casper, we are able to pass the ECT (both CPU and GPU simulations on Casper) by using the baseline generated by the Intel compiler on Cheyenne.

@allibco @jedwards4b @johnmauff 