### PR TITLE
Fix replay archive

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1729,8 +1729,11 @@ directory, NOT in this subdirectory."""
         lines_len = len(lines)
         lines.insert(lines_len-1 if init else lines_len, "{}\n\n".format(cmd))
 
-        with open(os.path.join(caseroot, "replay.sh"), "a") as fd:
-            fd.writelines(lines)
+        try:
+            with open(os.path.join(caseroot, "replay.sh"), "a") as fd:
+                fd.writelines(lines)
+        except PermissionError:
+            logger.warning("Could not write to 'replay.sh' script")
 
     def create(self, casename, srcroot, compset_name, grid_name,
                user_mods_dirs=None, machine_name=None,

--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -474,6 +474,7 @@ def _save_postrun_timing_e3sm(case, lid):
     globs_to_copy.append("timing/*.{}*".format(lid))
     globs_to_copy.append("CaseStatus")
     globs_to_copy.append(os.path.join(rundir, "spio_stats.{}.tar.gz".format(lid)))
+    globs_to_copy.append(os.path.join(caseroot, "replay.sh"))
 
     for glob_to_copy in globs_to_copy:
         for item in glob.glob(os.path.join(caseroot, glob_to_copy)):

--- a/scripts/lib/CIME/tests/test_case.py
+++ b/scripts/lib/CIME/tests/test_case.py
@@ -216,6 +216,25 @@ class TestCase_RecordCmd(unittest.TestCase):
 
         for x, y in zip(calls, expected):
             self.assertTrue(x == y, calls)
+    @mock.patch("CIME.case.case.Case.__init__", return_value=None)
+    @mock.patch("CIME.case.case.Case.flush")
+    @mock.patch("CIME.case.case.Case.get_value")
+    @mock.patch("CIME.case.case.open", mock.mock_open())
+    @mock.patch("time.strftime", return_value="00:00:00")
+    @mock.patch("sys.argv", ["/src/create_newcase"])
+    def test_error(self, strftime, get_value, flush, init): # pylint: disable=unused-argument
+        Case._force_read_only = False # pylint: disable=protected-access
+
+        with self.tempdir as tempdir, mock.patch("CIME.case.case.open", mock.mock_open()) as m:
+            m.side_effect = PermissionError()
+
+            with Case(tempdir) as case:
+                get_value.side_effect = [
+                    tempdir,
+                    "/src"
+                ]
+
+                case.record_cmd()
 
     @mock.patch("CIME.case.case.Case.__init__", return_value=None)
     @mock.patch("CIME.case.case.Case.flush")

--- a/scripts/lib/CIME/tests/test_provenance.py
+++ b/scripts/lib/CIME/tests/test_provenance.py
@@ -5,8 +5,6 @@ from unittest import mock
 
 from CIME import provenance
 
-from . import utils
-
 class TestProvenance(unittest.TestCase):
     @mock.patch("CIME.provenance.run_cmd")
     def test_run_git_cmd_recursively(self, run_cmd):

--- a/scripts/lib/CIME/tests/test_provenance.py
+++ b/scripts/lib/CIME/tests/test_provenance.py
@@ -39,7 +39,6 @@ class TestProvenance(unittest.TestCase):
         write.assert_any_call("error\n\n")
         write.assert_any_call("error\n")
 
-        print(run_cmd.mock_calls)
         run_cmd.assert_any_call("git status", from_dir="/srcroot")
         run_cmd.assert_any_call(
             "git submodule foreach --recursive \"git status; echo\"",

--- a/scripts/lib/CIME/tests/test_provenance.py
+++ b/scripts/lib/CIME/tests/test_provenance.py
@@ -20,7 +20,6 @@ class TestProvenance(unittest.TestCase):
         write.assert_any_call("data\n\n")
         write.assert_any_call("data\n")
 
-        print(run_cmd.mock_calls)
         run_cmd.assert_any_call("git status", from_dir="/srcroot")
         run_cmd.assert_any_call(
             "git submodule foreach --recursive \"git status; echo\"",
@@ -53,13 +52,6 @@ class TestProvenance(unittest.TestCase):
 
         with mock.patch("CIME.provenance.open", mock.mock_open()) as m:
             provenance._record_git_provenance("/srcroot", "/output", "5") # pylint: disable=protected-access
-
-        expected = [
-            ("/output/GIT_STATUS.5", "w"),
-            ("/output/GIT_DIFF.5", "w"),
-            ("/output/GIT_LOG.5", "w"),
-            ("/output/GIT_REMOTE.5", "w")
-        ]
 
         m.assert_any_call("/output/GIT_STATUS.5", "w")
         m.assert_any_call("/output/GIT_DIFF.5", "w")


### PR DESCRIPTION
- Fixes capturing `replay.sh` in performance archive.
- Fixes handling error when `replay.sh` is not writable.

Test suite: scripts_regression_tests.py
Test baseline: n/a
Test namelist changes: n/a 
Test status: bfb

Fixes #4049 #4050 

User interface changes?: n/a

Update gh-pages html (Y/N)?: n/a
