### PR TITLE
Fix e3sm archiving

### DIFF
--- a/scripts/lib/CIME/provenance.py
+++ b/scripts/lib/CIME/provenance.py
@@ -474,6 +474,11 @@ def _save_postrun_timing_e3sm(case, lid):
     globs_to_copy.append("timing/*.{}*".format(lid))
     globs_to_copy.append("CaseStatus")
     globs_to_copy.append(os.path.join(rundir, "spio_stats.{}.tar.gz".format(lid)))
+    # Can't use a single glob, similar files e.g. {filename}.{lid} get picked up.
+    bld_filenames = ["GIT_STATUS", "GIT_DIFF", "GIT_LOG", "GIT_REMOTE",
+                     "GIT_CONFIG", "GIT_SUBMODULE_STATUS"]
+    bld_globs = map(lambda x: f"bld/{x}", bld_filenames)
+    globs_to_copy.extend(bld_globs)
 
     for glob_to_copy in globs_to_copy:
         for item in glob.glob(os.path.join(caseroot, glob_to_copy)):


### PR DESCRIPTION
- Fixes archiving all GIT_* files generated during build
- Fixes writing preview_run.log and make a run specific copy
- Fixes archiving preview_run.log

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bfb

Fixes #3966

User interface changes?: n/a

Update gh-pages html (Y/N)?: n/a
