### PR TITLE
check the size of read only xml files

### DIFF
--- a/scripts/lib/CIME/XML/generic_xml.py
+++ b/scripts/lib/CIME/XML/generic_xml.py
@@ -59,7 +59,7 @@ class GenericXML(object):
         if infile is None:
             return
 
-        if os.path.isfile(infile) and os.access(infile, os.R_OK):
+        if os.path.isfile(infile) and os.access(infile, os.R_OK) and os.stat(infile).st_size > 0:
             # If file is defined and exists, read it
             self.read(infile, schema)
         else:


### PR DESCRIPTION
Add a test that the file size is none-zero before reading an xml file expected to exist.

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #4054 

User interface changes?: 

Update gh-pages html (Y/N)?:
