### PR TITLE
Prepend the casename to mpas component restart file search in st_archive

### DIFF
--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -413,7 +413,7 @@ def _archive_restarts_date_comp(case, casename, rundir, archive, archive_entry,
 #        logger.debug("suffix is {} ninst {}".format(suffix, ninst))
         restfiles = ""
         if compname.find('mpas') == 0 or compname == 'mali':
-            pattern = compname + r'\.' + suffix + r'\.' + '_'.join(datename_str.rsplit('-', 1))
+            pattern = casename + r'\.' + compname + r'\.' + suffix + r'\.' + '_'.join(datename_str.rsplit('-', 1))
             pfile = re.compile(pattern)
             restfiles = [f for f in os.listdir(rundir) if pfile.search(f)]
         elif compname == 'nemo':


### PR DESCRIPTION
Changes the pattern used to search for mpas/mali restart files to 
include the casename prepended to the current specification. All the
MPAS components modified their output filenames to include the
casename some time ago as other components do. While the st_archive
script continues to function correctly for the most part, the has been an
issue reported for hybrid configurations and this fixes it.

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
