### PR TITLE
pbs doesnt allow some compset characters in job name

### DIFF
--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -198,7 +198,14 @@ class EnvBatch(EnvBase):
             ext = job
         if ext.startswith('.'):
             ext = ext[1:]
-        overrides["job_id"] = ext + '.' + case.get_value("CASE")
+        job_id = ext + '.' + case.get_value("CASE")
+        # pbs limits characters that can be used in this field
+        chars = '+*?<>/{}[\]~`@:_%' 
+        overrides["job_id"] = ""
+        for i in range(0, len(job_id)):
+            if job_id[i] not in chars:
+                overrides["job_id"] = overrides["job_id"] + job_id[i]
+
         overrides["batchdirectives"] = self.get_batch_directives(case, job, overrides=overrides)
         output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)
         output_name = get_batch_script_for_job(job) if outfile is None else outfile

--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -198,13 +198,12 @@ class EnvBatch(EnvBase):
             ext = job
         if ext.startswith('.'):
             ext = ext[1:]
-        job_id = ext + '.' + case.get_value("CASE")
-        # pbs limits characters that can be used in this field
-        chars = '+*?<>/{}[\]~`@:_%' 
-        overrides["job_id"] = ""
-        for i in range(0, len(job_id)):
-            if job_id[i] not in chars:
-                overrides["job_id"] = overrides["job_id"] + job_id[i]
+
+        # A job name or job array name can be at most 230 characters.  It must consist only of alphabetic, numeric, plus 
+        # sign ("+"), dash or minus or hyphen ("-"), underscore ("_"), and dot or period (".") characters
+        # most of these are checked in utils:check_name, but % is not one of them.
+
+        overrides["job_id"] = ext + '.' + case.get_value("CASE").replace('%','')
 
         overrides["batchdirectives"] = self.get_batch_directives(case, job, overrides=overrides)
         output_text = transform_vars(open(input_template,"r").read(), case=case, subgroup=job, overrides=overrides)


### PR DESCRIPTION
Strip special character '%' from job name, PBS doesn't allow all characters. 

Test suite: 
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #4063 

User interface changes?: 

Update gh-pages html (Y/N)?:
