### PR TITLE
fix an issue with file locks when not run from caseroot

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1895,7 +1895,8 @@ import inspect
 def in_unit_test():
     current_stack = inspect.stack()
     for stack_frame in current_stack:
-        for program_line in stack_frame[4]:    # This element of the stack frame contains
-            if "unittest" in program_line:       # some contextual program lines
-                return True
+        if stack_frame[4]:
+            for program_line in stack_frame[4]:    # This element of the stack frame contains
+                if "unittest" in program_line:       # some contextual program lines
+                    return True
     return False

--- a/scripts/lib/CIME/case/case_submit.py
+++ b/scripts/lib/CIME/case/case_submit.py
@@ -28,7 +28,7 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
             batch_args=None, workflow=True, chksum=False):
     if job is None:
         job = case.get_first_job()
-
+    caseroot = case.get_value("CASEROOT")
     # Check mediator
     hasMediator = True
     comp_classes = case.get_values("COMP_CLASSES")
@@ -69,13 +69,13 @@ def _submit(case, job=None, no_batch=False, prereq=None, allow_fail=False, resub
         batch_system = "none"
     else:
         batch_system = env_batch.get_batch_system_type()
-    unlock_file(os.path.basename(env_batch.filename))
+    unlock_file(os.path.basename(env_batch.filename), caseroot=caseroot)
     case.set_value("BATCH_SYSTEM", batch_system)
 
     env_batch_has_changed = False
     if not external_workflow:
         try:
-            case.check_lockedfile(os.path.basename(env_batch.filename))
+            case.check_lockedfile(os.path.basename(env_batch.filename), caseroot=caseroot)
         except:
             env_batch_has_changed = True
 
@@ -88,7 +88,7 @@ manual edits to these file will be lost!
 """)
         env_batch.make_all_batch_files(case)
     case.flush()
-    lock_file(os.path.basename(env_batch.filename))
+    lock_file(os.path.basename(env_batch.filename), caseroot=caseroot)
 
     if resubmit:
         # This is a resubmission, do not reinitialize test values
@@ -127,8 +127,8 @@ manual edits to these file will be lost!
 """)
             env_batch.make_all_batch_files(case)
 
-        unlock_file(os.path.basename(env_batch.filename))
-        lock_file(os.path.basename(env_batch.filename))
+        unlock_file(os.path.basename(env_batch.filename), caseroot=caseroot)
+        lock_file(os.path.basename(env_batch.filename), caseroot=caseroot)
 
         case.check_case(skip_pnl=skip_pnl, chksum=chksum)
         if job == case.get_primary_job():

--- a/scripts/lib/CIME/code_checker.py
+++ b/scripts/lib/CIME/code_checker.py
@@ -83,7 +83,7 @@ def get_all_checkable_files():
             nuopc_git_files = run_cmd_no_fail("git ls-files", from_dir=os.path.join(srcroot,"components","cmeps"), verbose=False).splitlines()
         except:
             logger.warning("No nuopc driver found in source")
-        all_git_files.extend([os.path.join("components","cmeps",_file) for _file in nuopc_git_files])
+        all_git_files.extend([os.path.join(srcroot,"components","cmeps",_file) for _file in nuopc_git_files])
     files_to_test = [item for item in all_git_files
                      if ((item.endswith(".py") or is_python_executable(os.path.join(cimeroot, item))) and not _should_pylint_skip(item))]
 


### PR DESCRIPTION
If the case was not run from caseroot these locks didn't work.

Test suite: scripts_regression_tests.py cheyenne/intel nuopc driver all pass
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 

User interface changes?: 

Update gh-pages html (Y/N)?:
