### PR TITLE
Fix documentation of seq_flux_mct_alb* variables

### DIFF
--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -4246,7 +4246,7 @@
     <category>seq_flux_mct</category>
     <group>seq_flux_mct_inparm</group>
     <desc>
-       Surface albedo for direct radiation
+       Surface albedo for diffuse radiation
     </desc>
     <values>
       <value>0.06</value>
@@ -4259,7 +4259,7 @@
     <category>seq_flux_mct</category>
     <group>seq_flux_mct_inparm</group>
     <desc>
-       Surface albedo for diffuse radiation
+       Surface albedo for direct radiation
     </desc>
     <values>
       <value>0.07</value>


### PR DESCRIPTION
Thanks to @brianpm for pointing out this issue.

Note that this is into the maint-5.6 branch so that it can potentially appear in a release update.

Test suite: none
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N
