### PR TITLE
changes to have new user_nl_stream_xxx for cdeps

### DIFF
--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -55,10 +55,11 @@ def _build_usernl_files(case, model, comp):
         default_nlfile = "user_nl_{}".format(comp)
         model_nl = os.path.join(model_dir, default_nlfile)
         user_nl_list = _get_user_nl_list(case, default_nlfile, model_dir)
+
         # Note that, even if there are multiple elements of user_nl_list (i.e., we are
         # creating multiple user_nl files for this component with different names), all of
         # them will start out as copies of the single user_nl_comp file in the model's
-        # source tree.
+        # source tree - unless the file has _stream in its name 
         for nlfile in user_nl_list:
             if ninst > 1:
                 for inst_counter in range(1, ninst+1):
@@ -69,12 +70,16 @@ def _build_usernl_files(case, model, comp):
                         # user_nl_foo from model_dir
                         if os.path.exists(nlfile):
                             safe_copy(nlfile, inst_nlfile)
+                        elif "_stream" in nlfile:
+                            safe_copy(os.path.join(model_dir, nlfile), inst_nlfile)
                         elif os.path.exists(model_nl):
                             safe_copy(model_nl, inst_nlfile)
             else:
                 # ninst = 1
                 if not os.path.exists(nlfile):
-                    if os.path.exists(model_nl):
+                    if "_stream" in nlfile:
+                        safe_copy(os.path.join(model_dir, nlfile), nlfile)
+                    elif os.path.exists(model_nl):
                         safe_copy(model_nl, nlfile)
 
 ###############################################################################


### PR DESCRIPTION
Changes to have new user_nl_stream_xxx for cdeps 
This PR will should only effect CESM cases
When CIME is used with CDEPS, new user_nl_xxx_streams files now accompany user_nl_xxx files. This PR puts in the functionality to bring those changes into the user's CASEROOT.

Test suite: ran the test testlist_cdeps.xml (with accompanying changes in cdeps)
Test baseline: cdeps0.12.18
Test namelist changes: 
Test status: bit for bit
Fixes: None
User interface changes?: new user_nl_xxx_streams file to change CDEPS stream files
Update gh-pages html (Y/N)?: N
