### PR TITLE
change default cesm driver to nuopc

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -33,6 +33,7 @@ jobs:
       NETCDF_FORTRAN_PATH: ${HOME}/netcdf-fortran
       PNETCDF_PATH: ${HOME}/pnetcdf
       CIME_MODEL: cesm
+      CIME_DRIVER: mct
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/srt_nuopc.yml
+++ b/.github/workflows/srt_nuopc.yml
@@ -34,7 +34,6 @@ jobs:
       PNETCDF_PATH: ${HOME}/pnetcdf
       ESMF_VERSION: ESMF_8_2_0_beta_snapshot_14
       CIME_MODEL: cesm
-      CIME_DRIVER: nuopc
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -294,7 +294,7 @@ def get_cime_default_driver():
                 logger.debug("Setting CIME_driver={} from ~/.cime/config".format(driver))
     if not driver:
         model = get_model()
-        if model == "ufs":
+        if model == "ufs" or model == "cesm":
             driver = "nuopc"
         else:
             driver = "mct"


### PR DESCRIPTION
Changes the default driver for cesm to nuopc.   

Test suite: scripts_regression_tests.py
Test baseline: 
Test namelist changes: 
Test status: bit for bit
Fixes 

User interface changes?: Changes default for --driver from mct to nuopc for cesm

Update gh-pages html (Y/N)?:
