### PR TITLE
if nuopc and any datamodel add a cdeps directory

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1303,7 +1303,11 @@ class Case(object):
 
     def _create_caseroot_sourcemods(self):
         components = self.get_compset_components()
+        datamodels = [x for x in components if x.startswith('d')]
         components.extend(['share', 'drv'])
+        if self._comp_interface == 'nuopc' and datamodels:
+            components.extend(['cdeps'])
+
         readme_message = """Put source mods for the {component} library in this directory.
 
 WARNING: SourceMods are not kept under version control, and can easily

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1303,9 +1303,8 @@ class Case(object):
 
     def _create_caseroot_sourcemods(self):
         components = self.get_compset_components()
-        datamodels = [x for x in components if x.startswith('d')]
         components.extend(['share', 'drv'])
-        if self._comp_interface == 'nuopc' and datamodels:
+        if self._comp_interface == 'nuopc':
             components.extend(['cdeps'])
 
         readme_message = """Put source mods for the {component} library in this directory.


### PR DESCRIPTION
Add a SourceMods/src.cdeps directory for shared cdeps sourcemods

Test suite: scripts_regression_tests.py and hand testing of SMS.f19_g17.A.cheyenne_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes  https://github.com/ESCOMP/CDEPS/issues/98

User interface changes?: 

Update gh-pages html (Y/N)?:
