### PR TITLE
Fix scripts_regression_tests on mappy for e3sm

### DIFF
--- a/scripts/lib/CIME/code_checker.py
+++ b/scripts/lib/CIME/code_checker.py
@@ -19,7 +19,7 @@ def _run_pylint(on_file, interactive):
 
     cmd_options = " --disable=I,C,R,logging-not-lazy,wildcard-import,unused-wildcard-import"
     cmd_options += ",fixme,broad-except,bare-except,eval-used,exec-used,global-statement"
-    cmd_options += ",logging-format-interpolation,no-name-in-module"
+    cmd_options += ",logging-format-interpolation,no-name-in-module,arguments-renamed"
     cimeroot = get_cime_root()
     srcroot = get_src_root()
 

--- a/scripts/lib/CIME/tests/test_case.py
+++ b/scripts/lib/CIME/tests/test_case.py
@@ -108,6 +108,7 @@ class TestCase(unittest.TestCase):
     @mock.patch("CIME.case.case.Case.configure")
     @mock.patch("socket.getfqdn", return_value="host1")
     @mock.patch("getpass.getuser", return_value="root")
+    @mock.patch.dict(os.environ, {"CIME_MODEL": "cesm"})
     def test_copy(self, getuser, getfqdn, configure, create_caseroot, # pylint: disable=unused-argument
                   apply_user_mods, set_lookup_value, lock_file, strftime, # pylint: disable=unused-argument
                   read_xml): # pylint: disable=unused-argument
@@ -117,8 +118,6 @@ class TestCase(unittest.TestCase):
         with self.tempdir as tempdir:
             caseroot = os.path.join(tempdir, "test1")
             with Case(caseroot, read_only=False) as case:
-                os.environ["CIME_MODEL"] = "cesm"
-
                 srcroot = os.path.abspath(os.path.join(
                     os.path.dirname(__file__), "../../../../../"))
                 case.create("test1", srcroot, "A", "f19_g16_rx1",
@@ -169,14 +168,13 @@ class TestCase(unittest.TestCase):
     @mock.patch("CIME.case.case.Case.configure")
     @mock.patch("socket.getfqdn", return_value="host1")
     @mock.patch("getpass.getuser", return_value="root")
+    @mock.patch.dict(os.environ, {"CIME_MODEL": "cesm"})
     def test_create(self, get_user, getfqdn, configure, create_caseroot, # pylint: disable=unused-argument
                     apply_user_mods, set_lookup_value, lock_file, strftime, # pylint: disable=unused-argument
                     read_xml): # pylint: disable=unused-argument
         with self.tempdir as tempdir:
             caseroot = os.path.join(tempdir, "test1")
             with Case(caseroot, read_only=False) as case:
-                os.environ["CIME_MODEL"] = "cesm"
-
                 srcroot = os.path.abspath(os.path.join(
                     os.path.dirname(__file__), "../../../../../"))
                 case.create("test1", srcroot, "A", "f19_g16_rx1",

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -166,8 +166,6 @@ class A_RunUnitTests(unittest.TestCase):
                     else:
                         print("{} has no doctests".format(filepath))
 
-        self.assertTrue(get_model() == "e3sm")
-
 ###############################################################################
 class C_TestGridGeneration(unittest.TestCase):
 ###############################################################################

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -24,7 +24,7 @@ import collections
 
 from CIME.utils import run_cmd, run_cmd_no_fail, get_lids, get_current_commit, \
     safe_copy, CIMEError, get_cime_root, get_src_root, Timeout, \
-    import_from_file
+    import_from_file, get_model
 import get_tests
 import CIME.test_scheduler, CIME.wait_for_tests
 from  CIME.test_scheduler import TestScheduler
@@ -131,6 +131,7 @@ class A_RunUnitTests(unittest.TestCase):
         # Yes, that means we have a bunch of unit tests run from this one unit
         # test.
 
+        before_model = get_model()
         testsuite = unittest.defaultTestLoader.discover(
             start_dir = os.path.join(LIB_DIR,"CIME","tests"),
             pattern = 'test*.py',
@@ -148,6 +149,7 @@ class A_RunUnitTests(unittest.TestCase):
             logging.getLogger().setLevel(log_lvl)
 
         self.assertTrue(results.wasSuccessful())
+        self.assertEqual(get_model(), before_model)
 
     def test_lib_doctests(self):
         # Find and run all the doctests in the lib directory tree
@@ -164,6 +166,8 @@ class A_RunUnitTests(unittest.TestCase):
                     else:
                         print("{} has no doctests".format(filepath))
 
+        self.assertTrue(get_model() == "e3sm")
+
 ###############################################################################
 class C_TestGridGeneration(unittest.TestCase):
 ###############################################################################
@@ -174,7 +178,7 @@ class C_TestGridGeneration(unittest.TestCase):
         cls._testdirs = []
 
     def test_gen_domain(self):
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping gen_domain test. Depends on E3SM tools")
         cime_root = get_cime_root()
         inputdata = MACHINE.get_value("DIN_LOC_ROOT")
@@ -246,7 +250,7 @@ def kill_python_subprocesses(sig=signal.SIGKILL, expected_num_killed=None, teste
 def assert_dashboard_has_build(tester, build_name, expected_count=1):
 ###########################################################################
     # Do not test E3SM dashboard if model is CESM
-    if CIME.utils.get_model() == "e3sm":
+    if get_model() == "e3sm":
         time.sleep(10) # Give chance for cdash to update
 
         wget_file = tempfile.mktemp()
@@ -587,16 +591,16 @@ class J_TestCreateNewcase(unittest.TestCase):
 
         cls._testdirs.append(testdir)
 
-        if CIME.utils.get_model() == "cesm":
+        if get_model() == "cesm":
             if CIME.utils.get_cime_default_driver() == "nuopc":
                 pesfile = os.path.join(get_src_root(),"components","cmeps","cime_config","config_pes.xml")
             else:
                 pesfile = os.path.join(get_src_root(),"components","cpl7","driver","cime_config","config_pes.xml")
         else:
-            pesfile = os.path.join("..","src","drivers",CIME.utils.get_cime_default_driver(),"cime_config","config_pes.xml")
+            pesfile = os.path.join(get_src_root(),"driver-mct","cime_config","config_pes.xml")
 
         args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV  --pesfile %s --res f19_g16 --output-root %s --handle-preexisting-dirs=r" % (testdir, pesfile, cls._testroot)
-        if CIME.utils.get_model() == "cesm":
+        if get_model() == "cesm":
             args += " --run-unsupported"
         if TEST_COMPILER is not None:
             args += " --compiler %s"%TEST_COMPILER
@@ -620,7 +624,7 @@ class J_TestCreateNewcase(unittest.TestCase):
 
         pesfile = os.path.join(previous_testdir,"env_mach_pes.xml")
         args =  "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --pesfile %s --res f19_g16 --output-root %s --handle-preexisting-dirs=r" % (testdir, pesfile, cls._testroot)
-        if CIME.utils.get_model() == "cesm":
+        if get_model() == "cesm":
             args += " --run-unsupported"
         if TEST_COMPILER is not None:
             args += " --compiler %s"%TEST_COMPILER
@@ -721,7 +725,7 @@ class J_TestCreateNewcase(unittest.TestCase):
             args += " --res f19_g17 "
         else:
             args += " --res f19_g16 "
-        if CIME.utils.get_model() == "cesm":
+        if get_model() == "cesm":
             args += " --run-unsupported"
         if TEST_COMPILER is not None:
             args += " --compiler %s"%TEST_COMPILER
@@ -755,7 +759,7 @@ class J_TestCreateNewcase(unittest.TestCase):
             args += " --res f19_g17 "
         else:
             args += " --res f19_g16 "
-        if CIME.utils.get_model() == "cesm":
+        if get_model() == "cesm":
             args += " --run-unsupported"
         if TEST_COMPILER is not None:
             args += " --compiler %s"%TEST_COMPILER
@@ -858,7 +862,7 @@ class J_TestCreateNewcase(unittest.TestCase):
     def test_m_createnewcase_alternate_drivers(self):
         # Test that case.setup runs for nuopc and moab drivers
         cls = self.__class__
-        model = CIME.utils.get_model()
+        model = get_model()
         for driver in ("nuopc", "moab"):
             if not os.path.exists(os.path.join(get_cime_root(),"src","drivers",driver)):
                 self.skipTest("Skipping driver test for {}, driver not found".format(driver))
@@ -891,7 +895,7 @@ class J_TestCreateNewcase(unittest.TestCase):
 
     def test_n_createnewcase_bad_compset(self):
         cls = self.__class__
-        model = CIME.utils.get_model()
+        model = get_model()
 
         testdir = os.path.join(cls._testroot, 'testcreatenewcase_bad_compset')
         if os.path.exists(testdir):
@@ -996,7 +1000,7 @@ class M_TestWaitForTests(unittest.TestCase):
     def simple_test(self, testdir, expected_results, extra_args="", build_name=None):
     ###########################################################################
         # Need these flags to test dashboard if e3sm
-        if CIME.utils.get_model() == "e3sm" and build_name is not None:
+        if get_model() == "e3sm" and build_name is not None:
             extra_args += " -b %s" % build_name
 
         expected_stat = 0
@@ -1146,7 +1150,7 @@ class M_TestWaitForTests(unittest.TestCase):
 
         assert_dashboard_has_build(self, build_name)
 
-        if CIME.utils.get_model() == "e3sm":
+        if get_model() == "e3sm":
             cdash_result_dir = os.path.join(self._testdir_unfinished, "Testing")
             tag_file         = os.path.join(cdash_result_dir, "TAG")
             self.assertTrue(os.path.isdir(cdash_result_dir))
@@ -1563,7 +1567,7 @@ class P_TestJenkinsGenericJob(TestCreateTestCommon):
     ###########################################################################
     def setUp(self):
     ###########################################################################
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping Jenkins tests. E3SM feature")
         TestCreateTestCommon.setUp(self)
 
@@ -1590,7 +1594,7 @@ class P_TestJenkinsGenericJob(TestCreateTestCommon):
             extra_args += " --no-batch"
 
         # Need these flags to test dashboard if e3sm
-        if CIME.utils.get_model() == "e3sm" and build_name is not None:
+        if get_model() == "e3sm" and build_name is not None:
             extra_args += " -p ACME_test --submit-to-cdash --cdash-build-group=Nightly -c %s" % build_name
 
         run_cmd_assert_result(self, "%s/jenkins_generic_job -r %s %s -B %s" % (TOOLS_DIR, self._testdir, extra_args, self._baseline_area),
@@ -1784,7 +1788,7 @@ class Q_TestBlessTestResults(TestCreateTestCommon):
 
         # Generate some baselines
         for test_name in test_names:
-            if CIME.utils.get_model() == "e3sm":
+            if get_model() == "e3sm":
                 genargs = ["-g", "-o", "-b", self._baseline_name, test_name]
                 compargs = ["-c", "-b", self._baseline_name, test_name]
             else:
@@ -1829,7 +1833,7 @@ class Q_TestBlessTestResults(TestCreateTestCommon):
         if (NO_FORTRAN_RUN):
             self.skipTest("Skipping fortran test")
         test_to_change = "TESTRUNPASS_P1.f19_g16_rx1.A"
-        if CIME.utils.get_model() == "e3sm":
+        if get_model() == "e3sm":
             genargs = ["-g", "-o", "-b", self._baseline_name, "cime_test_only_pass"]
             compargs = ["-c", "-b", self._baseline_name, "cime_test_only_pass"]
         else:
@@ -2228,7 +2232,7 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_test_walltime_mgmt_1(self):
     ###########################################################################
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS.f19_g16_rx1.A"
@@ -2244,7 +2248,7 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_test_walltime_mgmt_2(self):
     ###########################################################################
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS_P64.f19_g16_rx1.A"
@@ -2260,7 +2264,7 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_test_walltime_mgmt_3(self):
     ###########################################################################
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS_P64.f19_g16_rx1.A"
@@ -2276,7 +2280,7 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_test_walltime_mgmt_4(self):
     ###########################################################################
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS_P1.f19_g16_rx1.A"
@@ -2292,7 +2296,7 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_test_walltime_mgmt_5(self):
     ###########################################################################
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS_P1.f19_g16_rx1.A"
@@ -2356,7 +2360,7 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
     def test_cime_case_test_walltime_mgmt_8(self):
     ###########################################################################
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "SMS_P25600.f19_g16_rx1.A"
@@ -2375,7 +2379,7 @@ class K_TestCimeCase(TestCreateTestCommon):
     ###########################################################################
         test_name = "ERS_P1.f19_g16_rx1.A"
         # have to use a machine both models know and one that doesn't put PROJECT in any key paths
-        if CIME.utils.get_model() == "e3sm":
+        if get_model() == "e3sm":
             machine = "mappy"
         else:
             machine = "melvin"
@@ -2564,7 +2568,7 @@ class X_TestSingleSubmit(TestCreateTestCommon):
         # Skip unless on a batch system and users did not select no-batch
         if (not self._hasbatch):
             self.skipTest("Skipping single submit. Not valid without batch")
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping single submit. E3SM experimental feature")
         if self._machine not in ["sandiatoss3"]:
             self.skipTest("Skipping single submit. Only works on sandiatoss3")
@@ -2580,7 +2584,7 @@ class G_TestBuildSystem(TestCreateTestCommon):
     ###########################################################################
     def test_clean_rebuild(self):
     ###########################################################################
-        casedir = self._create_test(["--no-run", "SMS.f19_g17_rx1.A"], test_id=self._baseline_name)
+        casedir = self._create_test(["--no-run", "SMS.f19_g16_rx1.A"], test_id=self._baseline_name)
 
         # Clean a component and a sharedlib
         run_cmd_assert_result(self, "./case.build --clean atm", from_dir=casedir)
@@ -2622,7 +2626,7 @@ class L_TestSaveTimings(TestCreateTestCommon):
 
         if manual_timing:
             run_cmd_assert_result(self, "cd %s && %s/save_provenance postrun" % (casedir, TOOLS_DIR))
-        if CIME.utils.get_model() == "e3sm":
+        if get_model() == "e3sm":
             provenance_glob = os.path.join(timing_dir, "performance_archive", getpass.getuser(), casename, lids[0] + "*")
             provenance_dirs = glob.glob(provenance_glob)
             self.assertEqual(len(provenance_dirs), 1, msg="wrong number of provenance dirs, expected 1, got {}, looked for {}".format(provenance_dirs, provenance_glob))
@@ -2652,7 +2656,7 @@ class L_TestSaveTimings(TestCreateTestCommon):
     ###########################################################################
     def test_success_recording(self):
     ###########################################################################
-        if CIME.utils.get_model() != "e3sm":
+        if get_model() != "e3sm":
             self.skipTest("Skipping success recording tests. E3SM feature")
 
         fake_test1 = "faketest1"
@@ -3449,7 +3453,7 @@ class S_TestManageAndQuery(unittest.TestCase):
     """Tests various scripts to manage and query xml files"""
 
     def setUp(self):
-        if CIME.utils.get_model() == "e3sm":
+        if get_model() == "e3sm":
             self.skipTest("Skipping XML test management tests. E3SM does not use this.")
 
     def _run_and_assert_query_testlist(self, extra_args=""):
@@ -3516,7 +3520,7 @@ def check_for_pylint():
 def write_provenance_info():
     curr_commit = get_current_commit(repo=LIB_DIR)
     logging.info("\nTesting commit %s" % curr_commit)
-    cime_model = CIME.utils.get_model()
+    cime_model = get_model()
     logging.info("Using cime_model = %s" % cime_model)
     logging.info("Testing machine = %s" % MACHINE.get_machine_name())
     if TEST_COMPILER is not None:


### PR DESCRIPTION
1) We have a newer version of pylint that's picking up a lot of
   new warnings that aren't useful, so disable arguments-renamed.
2) The test_case.py test was changing CIME_MODEL, which caused all
   subsequent tests to fail for e3sm since the model was set to cesm.
   Use mock instead to set this env var.
3) pesfile was wrong for some tests for e3sm
4) test_clean_build was using a grid alias that is unknown to e3sm. Use
   a more common one instead.
5) Many additional changes are needed on the E3SM side which will be pushed
   to that repo soon.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #4083 

User interface changes?: 

Update gh-pages html (Y/N)?:
