### PR TITLE
Fix limited github workflow nuopc scripts regression testing.

### DIFF
--- a/.github/workflows/srt_nuopc.yml
+++ b/.github/workflows/srt_nuopc.yml
@@ -185,7 +185,7 @@ jobs:
           export PATH=$NETCDF/bin:$PATH
           export LD_LIBRARY_PATH=$NETCDF/lib:$HOME/pnetcdf/lib:$LD_LIBRARY_PATH
           export ESMFMKFILE=$HOME/ESMF/lib/libg/Linux.gfortran.64.openmpi.default/esmf.mk
-          ./scripts_regression_tests.py J_TestCreateNewcase --no-fortran-run --compiler gnu --mpilib openmpi --machine ubuntu-latest
+          ./scripts_regression_tests.py --no-fortran-run --compiler gnu --mpilib openmpi --machine ubuntu-latest
 
 
 #     the following can be used by developers to login to the github server in case of errors


### PR DESCRIPTION
Remove some debugging in the workflow testing that was limiting
the amount of nuopc scripts regression tests.

Test suite: scripts_regression_tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
