### PR TITLE
Remove dependency of cprnc on non-existent COMPARE_VARS target

### DIFF
--- a/tools/cprnc/CMakeLists.txt
+++ b/tools/cprnc/CMakeLists.txt
@@ -84,6 +84,5 @@ set (CPRNC_SRCS
 )
 
 add_executable(cprnc ${CPRNC_SRCS})
-add_dependencies(cprnc COMPARE_VARS)
 
 target_link_libraries(cprnc ${NF_LIB_LIST})


### PR DESCRIPTION
In `tools/cprnc/CMakeLists.txt`, the target `cprnc` was set to be dependent
on non-existent target `COMPARE_VARS`. The latter was removed by
commit c2f7b31af, but the `add_dependency` clause was not removed.

This PR simply removes a cmake warning.

- User interface changes?: No
- Update gh-pages html (Y/N)?: No
- Testing: I ran `scripts_regression_test.py --fast --machine mappy` on mappy, and got `FAILED (failures=12, errors=2, skipped=17)`. But also running on master gives `FAILED (failures=12, errors=2, skipped=17)`, so I'm not sure what the deal is.