### PR TITLE
config_archive changes for running CISM with multiple ice sheets

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -48,32 +48,6 @@
     </test_file_names>
   </comp_archive_spec>
 
-  <comp_archive_spec compname="cism" compclass="glc">
-    <rest_file_extension>[ri]</rest_file_extension>
-    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
-    <hist_file_extension>initial_hist</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
-    <rpointer>
-      <rpointer_file>rpointer.glc$NINST_STRING</rpointer_file>
-      <rpointer_content>./$CASE.cism$NINST_STRING.r.$DATENAME.nc</rpointer_content>
-    </rpointer>
-    <test_file_names>
-      <!-- Should copy rpointer file(s) -->
-      <tfile disposition="copy">rpointer.glc</tfile>
-      <tfile disposition="copy">rpointer.glc_9999</tfile>
-      <!-- Should only copy last restart file -->
-      <tfile disposition="ignore">casename.cism.r.1975-01-01-00000.nc</tfile>
-      <tfile disposition="copy">casename.cism.r.1976-01-01-00000.nc</tfile>
-      <!-- Should copy all history files -->
-      <tfile disposition="move">casename.cism.initial_hist.0001-01-01-00000.nc</tfile>
-      <tfile disposition="move">casename.cism.h.1975-01-01-00000.nc</tfile>
-      <tfile disposition="move">casename.cism.h.1976-01-01-00000.nc</tfile>
-      <!-- Should ignore files created by test suite, files from other cases, etc. -->
-      <tfile disposition="ignore">casename.cism.h.1976-01-01-00000.nc.base</tfile>
-      <tfile disposition="ignore">anothercasename.cism.r.1976-01-01-00000.nc</tfile>
-    </test_file_names>
-  </comp_archive_spec>
-
   <comp_archive_spec compname="ww3" compclass="wav">
     <rest_file_extension>r</rest_file_extension>
     <hist_file_extension>hi.*\.nc$</hist_file_extension>

--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -93,6 +93,7 @@
       <!-- component specific config_tests files -->
       <value component="clm">$COMP_ROOT_DIR_LND/cime_config/config_tests.xml</value>
       <value component="cam">$COMP_ROOT_DIR_ATM/cime_config/config_tests.xml</value>
+      <value component="cism">$COMP_ROOT_DIR_GLC/cime_config/config_tests.xml</value>
     </values>
     <group>test</group>
     <file>env_test.xml</file>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -713,6 +713,14 @@
       <mask>gx3v7</mask>
     </model_grid>
 
+    <model_grid alias="f10_f10_ais8gris4_mg37" compset="_CISM" not_compset="_POP">
+      <grid name="atm">10x15</grid>
+      <grid name="lnd">10x15</grid>
+      <grid name="ocnice">10x15</grid>
+      <grid name="glc">ais8:gris4</grid>
+      <mask>gx3v7</mask>
+    </model_grid>
+
     <model_grid alias="f10_f10_musgs" not_compset="_POP">
       <grid name="atm">10x15</grid>
       <grid name="lnd">10x15</grid>

--- a/config/xml_schemas/config_archive.xsd
+++ b/config/xml_schemas/config_archive.xsd
@@ -14,6 +14,7 @@
  <xs:element name="rpointer_file" type="xs:string"/>
  <xs:element name="rpointer_content" type="xs:string"/>
  <xs:element name="hist_file_extension" type="xs:string"/>
+ <xs:element name="hist_file_ext_regex" type="xs:string"/>
 
  <!-- definition of complex elements -->
  <xs:element name="rpointer">
@@ -30,6 +31,19 @@
      <xs:sequence>
        <xs:element ref="rest_file_extension" minOccurs="0" maxOccurs="unbounded"/>
        <xs:element ref="hist_file_extension" minOccurs="0" maxOccurs="unbounded"/>
+       <!-- hist_file_ext_regex is used in a specific context: This
+            specifies the regex capture group following the component
+            name that is used to differentiate between different history
+            file streams for a given component. In most cases, this can
+            be excluded, falling back on the general-purpose extension
+            regex, "\w+". However, this is needed in situations where
+            the extension is more complex, such as when there is a
+            multi-part extension with embedded '.' characters. For
+            example, the CISM ice sheet model uses a hist_file_ext_regex
+            of "\w+\.\w+" because its history file names have a two-part
+            extension, with the first part giving the ice sheet name
+            (e.g., gris.h, ais.h). -->
+       <xs:element ref="hist_file_ext_regex" minOccurs="0" maxOccurs="unbounded"/>
        <xs:element ref="rest_history_varname" minOccurs="0" maxOccurs="unbounded"/>
        <xs:element ref="rpointer" minOccurs="0" maxOccurs="unbounded"/>
        <xs:element ref="test_file_names" minOccurs="0" maxOccurs="1"/>


### PR DESCRIPTION
This PR contains two (so far) changes needed for running CISM with multiple ice sheets, both related to config_archive.xml:

(1) CISM's config_archive.xml section is removed from CIME and will now appear in CISM's cime_config: see https://github.com/ESCOMP/CISM-wrapper/pull/63/files#diff-3f4e5c21f4a15e1fc7c5387bb63d2838f5a9654bfc2bbb49c6014c35d705be3c

(2) I have added a new, optional element to config_archive.xml, `hist_file_ext_regex`. If provided, this regex will be used in the `_get_extension` function defined in `archive_base.py` before falling back on the general-purpose regex. This is needed for CISM with its new file names that look like `CASENAME.cism.gris.h.DATE.nc`: we want the combined `gris.h` to be considered the extension, not just `gris` or `h`. For CISM, this new variable will be specified as `<hist_file_ext_regex>\w+\.\w+</hist_file_ext_regex>` (as in the above-referenced CISM PR). The code needed for this wasn't very extensive, though I am a little concerned about the potential for confusion between this new `hist_file_ext_regex` vs. the existing `hist_file_extension`; I have tried to explain the purpose of the new variable in the comment in `config_archive.xsd`, but I'm open to suggestions for making this more clear.

Note that the `_get_extension` function currently has hard-coded logic for MOM6 that could be replaced by use of this new component-defined variable after this PR is accepted. (@alperaltuntas ).

**I am marking this as a draft for now because I'm still doing some more testing of it together with the CISM branch for running multiple ice sheets, and I may end up adding more changes to it. But I'm opening this PR to get some initial feedback on whether this seems like a reasonable change.**

Test suite: So far, just A_RunUnitTests and B_CheckCode, along with a test exercising CISM multiple ice sheets (`ERS_Ly3.f09_g17_ais8gris4.T1850Gag.cheyenne_gnu`) that included baseline generation along with the in-test comparison, to ensure that all history files are being picked up now.
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#4100

User interface changes?: N

Update gh-pages html (Y/N)?: N
