### PR TITLE
Run all 14 mo. of MVK test in 1 submission

### DIFF
--- a/config/config_tests.xml
+++ b/config/config_tests.xml
@@ -620,12 +620,12 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <STOP_OPTION>nmonths</STOP_OPTION>
-    <STOP_N>2</STOP_N>
+    <STOP_N>14</STOP_N>
     <REST_OPTION>$STOP_OPTION</REST_OPTION>
     <REST_N>$STOP_N</REST_N>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <RESUBMIT>6</RESUBMIT>
+    <RESUBMIT>0</RESUBMIT>
   </test>
 
   <test NAME="NCK">


### PR DESCRIPTION
The MVK test has been passing in name only on chrysalis recently.
It will run the first two months, and then subsequent re-submissions
won't make it through the queue in time.
With this PR the 14 month MVK test is run with 1 queue submission,
which takes ~30 minutes on chrysalis using the "PS" pelayout.

Test suite: e3sm_atm_nbfb
Test baseline: master
Test namelist changes: none
Test status: bit for bit

Fixes N/A

User interface changes?: N

Update gh-pages html (Y/N)?: N
