### PR TITLE
Remove MODEL as a setting for the build system

### DIFF
--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -4,6 +4,17 @@
 #
 #===============================================================================
 
+ifdef MODEL
+  ifndef COMP_NAME
+    $(warning "Variable MODEL is deprecated, please use COMP_NAME instead")
+    COMP_NAME:=MODEL
+  else
+    ifneq ($(MODEL), $(COMP_NAME))
+      $(error "MODEL is inconsistent with COMP_NAME")
+    endif
+  endif
+endif
+
 # Set up special characters
 null  :=
 comma := ,

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -348,7 +348,7 @@ endif
 ifndef CONFIG_ARGS
   CONFIG_ARGS :=
 endif
-ifeq  ($(findstring pio,$(MODEL)),pio)
+ifeq  ($(findstring pio,$(COMP_NAME)),pio)
   CONFIG_ARGS+= --enable-timing
   ifeq ($DEBUG,TRUE)
      CONFIG_ARGS+= --enable-debug
@@ -408,7 +408,7 @@ ifdef INC_MOAB
   INCLDIR += -I$(INC_MOAB)
 endif
 
-ifeq ($(MODEL),driver)
+ifeq ($(COMP_NAME),driver)
   INCLDIR += -I$(EXEROOT)/atm/obj -I$(EXEROOT)/ice/obj -I$(EXEROOT)/ocn/obj -I$(EXEROOT)/glc/obj -I$(EXEROOT)/rof/obj -I$(EXEROOT)/wav/obj -I$(EXEROOT)/esp/obj -I$(EXEROOT)/iac/obj
 # nagfor and gcc have incompatible LDFLAGS.
 # nagfor requires the weird "-Wl,-Wl,," syntax.
@@ -490,7 +490,7 @@ FFLAGS_NOOPT += $(FPPDEFS)
 ifeq ($(findstring -cosp,$(CAM_CONFIG_OPTS)),-cosp)
   # The following is for the COSP simulator code:
   COSP_LIBDIR:=$(abspath $(EXEROOT)/atm/obj/cosp)
-  ifeq ($(MODEL),driver)
+  ifeq ($(COMP_NAME),driver)
     INCLDIR+=-I$(COSP_LIBDIR)
   endif
 endif
@@ -506,14 +506,14 @@ ifeq ($(strip $(COMP_ATM)),cam)
   ifeq ($(CAM_DYCORE),mpas)
     # For building CAM with the MPAS dycore
     MPAS_LIBDIR:=$(abspath $(EXEROOT)/atm/obj/mpas)
-    ifeq ($(MODEL),driver)
+    ifeq ($(COMP_NAME),driver)
       # This is needed by some compilers when building the driver.
       INCLDIR+=-I$(MPAS_LIBDIR)
     endif
   endif
 endif
 
-ifeq ($(MODEL),cam)
+ifeq ($(COMP_NAME),cam)
   # These RRTMG files take an extraordinarily long time to compile with optimization.
   # Until mods are made to read the data from files, just remove optimization from
   # their compilation.
@@ -834,7 +834,7 @@ else
   LNDOBJDIR = $(SHAREDLIBROOT)/$(SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/clm/obj
   LNDLIBDIR = $(EXEROOT)/$(SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/lib
   INCLDIR += -I$(INSTALL_SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/include
-  ifeq ($(MODEL),clm)
+  ifeq ($(COMP_NAME),clm)
     INCLUDE_DIR = $(INSTALL_SHAREDPATH)/$(COMP_INTERFACE)/$(ESMFDIR)/include
   endif
 endif
@@ -903,9 +903,9 @@ $(PIOLIB) : $(MPISERIAL) $(GPTLLIB)
 
 $(CSMSHARELIB):  $(MCTLIBS) $(PIOLIB) $(GPTLLIB)
 
-ifneq ($(findstring csm_share,$(MODEL)),csm_share)
+ifneq ($(findstring csm_share,$(COMP_NAME)),csm_share)
   $(OBJS):  $(CSMSHARELIB) $(CSMSHARELIB_CPL7)
-else ifeq ($(MODEL),csm_share_cpl7)
+else ifeq ($(COMP_NAME),csm_share_cpl7)
   complib: install_lib_cpl7
 else
   complib: install_lib
@@ -921,7 +921,7 @@ install_lib_cpl7: $(COMPLIB)
 
 # This rule writes the include flags and the link flags used in the $(EXEC_SE) rule below
 # It expects the variable OUTPUT_FILE to be defined
-# Set MODEL=driver to get the same flags as are used when building the driver
+# Set COMP_NAME=driver to get the same flags as are used when building the driver
 .PHONY: write_include_and_link_flags
 write_include_and_link_flags:
 	@$(RM) -f $(OUTPUT_FILE)
@@ -1063,6 +1063,6 @@ ifeq (,$(findstring clean,$(MAKECMDGOALS)))
 endif
 endif
 endif
-ifeq ($(MODEL),csm_share)
+ifeq ($(COMP_NAME),csm_share)
   shr_assert_mod.mod: shr_assert_mod.o
 endif

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -50,14 +50,14 @@ def generate_makefile_macro(case, caseroot):
                   replace("SLIBS := ", "SLIBS := $(SLIBS) ") + "\n"
     base_output = real_output.splitlines()
     for comp in comps:
-        output = run_cmd_no_fail("cmake -DMODEL={comp} -DCOMP_NAME={comp} -DCONVERT_TO_MAKE=ON {cmake_args} . 2>&1 | grep CIME_SET_MAKEFILE_VAR | grep -v BUILD_INTERNAL_IGNORE".format(comp=comp, cmake_args=cmake_args), from_dir=os.path.join(caseroot,"cmaketmp"))
+        output = run_cmd_no_fail("cmake -DCOMP_NAME={comp} -DCONVERT_TO_MAKE=ON {cmake_args} . 2>&1 | grep CIME_SET_MAKEFILE_VAR | grep -v BUILD_INTERNAL_IGNORE".format(comp=comp, cmake_args=cmake_args), from_dir=os.path.join(caseroot,"cmaketmp"))
         # The Tools/Makefile may have already adding things to CPPDEFS and SLIBS
         comp_output = (output.replace("CIME_SET_MAKEFILE_VAR ", "").\
                        replace("CPPDEFS := ", "CPPDEFS := $(CPPDEFS) ").\
                        replace("SLIBS := ", "SLIBS := $(SLIBS) ")).splitlines()
         for line in comp_output:
             if line not in base_output:
-                real_output += "ifeq \"$(MODEL)\" \"{}\"\n".format(comp)
+                real_output += "ifeq \"$(COMP_NAME)\" \"{}\"\n".format(comp)
                 real_output += "  "+line+"\n"
                 real_output += "\nendif\n"
 
@@ -579,7 +579,7 @@ def _build_model_thread(config_dir, compclass, compname, caseroot, libroot, bldr
         cmd = os.path.join(config_dir, "buildlib")
         expect(os.path.isfile(cmd), "Could not find buildlib for {}".format(compname))
 
-    compile_cmd = "MODEL={compclass} COMP_CLASS={compclass} COMP_NAME={compname} {cmd} {caseroot} {libroot} {bldroot} ".\
+    compile_cmd = "COMP_CLASS={compclass} COMP_NAME={compname} {cmd} {caseroot} {libroot} {bldroot} ".\
         format(compclass=compclass, compname=compname, cmd=cmd, caseroot=caseroot, libroot=libroot, bldroot=bldroot)
     if get_model() != "ufs":
         compile_cmd = "SMP={} {}".format(stringify_bool(smp), compile_cmd)

--- a/scripts/lib/CIME/buildlib.py
+++ b/scripts/lib/CIME/buildlib.py
@@ -94,7 +94,7 @@ def run_gmake(case, compclass, compname, libroot, bldroot, libname="", user_cppd
 
     makefile = os.path.join(case.get_value("CASETOOLS"), "Makefile")
 
-    cmd = "{gmake} complib -j {gmake_j:d} MODEL={compclass} COMP_CLASS={compclass} COMP_NAME={compname} COMPLIB={complib} {gmake_args} -f {makefile} -C {bldroot} " \
+    cmd = "{gmake} complib -j {gmake_j:d} COMP_CLASS={compclass} COMP_NAME={compname} COMPLIB={complib} {gmake_args} -f {makefile} -C {bldroot} " \
         .format(gmake=gmake, gmake_j=gmake_j, compclass=compclass, compname=compname, complib=complib, gmake_args=gmake_args, makefile=makefile, bldroot=bldroot)
     if user_cppdefs:
         cmd = cmd + "USER_CPPDEFS='{}'".format(user_cppdefs )

--- a/src/build_scripts/buildlib.gptl
+++ b/src/build_scripts/buildlib.gptl
@@ -50,7 +50,7 @@ def buildlib(bldroot, installpath, case):
     comp_interface = case.get_value("COMP_INTERFACE")
 
     gptl_dir = os.path.join(case.get_value("CIMEROOT"), "src", "share", "timing")
-    gmake_opts = "-f {gptl}/Makefile install -C {bldroot} MACFILE={macfile} MODEL=gptl COMP_NAME=gptl GPTL_DIR={gptl} GPTL_LIBDIR={bldroot}"\
+    gmake_opts = "-f {gptl}/Makefile install -C {bldroot} MACFILE={macfile} COMP_NAME=gptl GPTL_DIR={gptl} GPTL_LIBDIR={bldroot}"\
         " SHAREDPATH={install} COMP_INTERFACE={comp_interface} {stdargs} "\
         .format(gptl=gptl_dir, bldroot=bldroot, macfile=os.path.join(caseroot,"Macros.make"),
                 install=installpath, comp_interface=comp_interface, stdargs=get_standard_makefile_args(case, shared_lib=True))

--- a/src/build_scripts/buildlib.mct
+++ b/src/build_scripts/buildlib.mct
@@ -66,7 +66,7 @@ def buildlib(bldroot, installpath, case):
     gmake_opts = "-f {} ".format(os.path.join(caseroot,"Tools","Makefile"))
     gmake_opts += " -C {} ".format(bldroot)
     gmake_opts += get_standard_makefile_args(case, shared_lib=True)
-    gmake_opts += "MODEL=mct COMP_NAME=mct {}".format(os.path.join(bldroot,"Makefile.conf"))
+    gmake_opts += "COMP_NAME=mct {}".format(os.path.join(bldroot,"Makefile.conf"))
 
     gmake_cmd = case.get_value("GMAKE")
 

--- a/src/build_scripts/buildlib.mpi-serial
+++ b/src/build_scripts/buildlib.mpi-serial
@@ -57,7 +57,7 @@ def buildlib(bldroot, installpath, case):
     gmake_opts = "-f {} ".format(os.path.join(caseroot,"Tools","Makefile"))
     gmake_opts += " -C {} ".format(bldroot)
     gmake_opts += " {} ".format(get_standard_makefile_args(case, shared_lib=True))
-    gmake_opts += "MODEL=mpi-serial COMP_NAME=mpi-serial {}".format(os.path.join(bldroot,"Makefile.conf"))
+    gmake_opts += "COMP_NAME=mpi-serial {}".format(os.path.join(bldroot,"Makefile.conf"))
 
     gmake_cmd = case.get_value("GMAKE")
 

--- a/src/build_scripts/buildlib.pio
+++ b/src/build_scripts/buildlib.pio
@@ -93,7 +93,7 @@ def buildlib(bldroot, installpath, case):
 
     stdargs = get_standard_makefile_args(case, shared_lib=True)
 
-    gmake_vars =  "CASEROOT={caseroot} MODEL={pio_model} COMP_NAME={pio_model} "\
+    gmake_vars =  "CASEROOT={caseroot} COMP_NAME={pio_model} "\
                   "USER_CMAKE_OPTS={cmake_opts} "\
                   "PIO_LIBDIR={pio_dir} CASETOOLS={casetools} "\
                   "USER_CPPDEFS=-DTIMING"\


### PR DESCRIPTION
Use COMP_NAME instead.

If CESM has any build-scripts that are maintained outside of CIME, they may need to be updated. E3SM still had some that were using both MODEL= and COMP_NAME= and even a couple that were only using MODEL=.

This should hopefully remove some ambiguity from the system as it was never clear whether MODEL was supposed to be the component name or component class. COMP_NAME and COMP_CLASS make it very clear.

Test suite: scripts-regression-tests
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
