### PR TITLE
add IRT test to exceptions for generate history

### DIFF
--- a/scripts/lib/CIME/SystemTests/irt.py
+++ b/scripts/lib/CIME/SystemTests/irt.py
@@ -7,6 +7,7 @@ This test the model's restart capability as well as the short term archiver's in
 (3) Recover first interim restart to the case2 run directory
 (4) Start case2 from restart and run to the end of case1
 (5) compare results.
+(6) this test does not save or compare history files in baselines.
 
 """
 

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -494,7 +494,7 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
     testname = case.get_value("TESTCASE")
     testopts = parse_test_name(case.get_value("CASEBASEID"))[1]
     testopts = [] if testopts is None else testopts
-    expect(num_gen > 0 or (testname in ["PFS", "TSC"] or "B" in testopts),
+    expect(num_gen > 0 or (testname in ["PFS", "TSC", "IRT"] or "B" in testopts),
            "Could not generate any hist files for case '{}', something is seriously wrong".format(os.path.join(rundir, testcase)))
 
     if get_model() == "e3sm":

--- a/scripts/lib/CIME/hist_utils.py
+++ b/scripts/lib/CIME/hist_utils.py
@@ -34,6 +34,8 @@ COMPARISON_COMMENT_OPTIONS = set([NO_COMPARE,
 COMPARISON_FAILURE_COMMENT_OPTIONS = (COMPARISON_COMMENT_OPTIONS
                                       - set([NO_COMPARE, FIELDLISTS_DIFFER]))
 
+NO_HIST_TESTS = ["IRT", "PFS", "TSC"]
+
 def _iter_model_file_substrs(case):
     models = case.get_compset_components()
     models.append('cpl')
@@ -273,8 +275,8 @@ def _compare_hists(case, from_dir1, from_dir2, suffix1="", suffix2="", outfile_s
                         logger.warning("Could not copy {} to {}".format(cprnc_log_file, casedir))
 
                 all_success = False
-    # PFS test may not have any history files to compare.
-    if num_compared == 0 and testcase != "PFS":
+    # Some tests don't save history files. 
+    if num_compared == 0 and testcase not in NO_HIST_TESTS:
         all_success = False
         comments += "Did not compare any hist files! Missing baselines?\n"
 
@@ -494,7 +496,7 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
     testname = case.get_value("TESTCASE")
     testopts = parse_test_name(case.get_value("CASEBASEID"))[1]
     testopts = [] if testopts is None else testopts
-    expect(num_gen > 0 or (testname in ["PFS", "TSC", "IRT"] or "B" in testopts),
+    expect(num_gen > 0 or (testname in NO_HIST_TESTS or "B" in testopts),
            "Could not generate any hist files for case '{}', something is seriously wrong".format(os.path.join(rundir, testcase)))
 
     if get_model() == "e3sm":

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -382,7 +382,7 @@ class J_TestCreateNewcase(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(testdir, "case.setup")))
 
         run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
-        run_cmd_assert_result(self, "./case.build", from_dir=testdir)
+        run_cmd_assert_result(self, "./case.build --skip-provenance-check", from_dir=testdir)
 
         with Case(testdir, read_only=False) as case:
             ntasks = case.get_value("NTASKS_ATM")
@@ -393,12 +393,12 @@ class J_TestCreateNewcase(unittest.TestCase):
                               from_dir=testdir, expected_stat=1)
 
         run_cmd_assert_result(self, "./case.setup --reset", from_dir=testdir)
-        run_cmd_assert_result(self, "./case.build", from_dir=testdir)
+        run_cmd_assert_result(self, "./case.build --skip-provenance-check", from_dir=testdir)
         with Case(testdir, read_only=False) as case:
             case.set_value("CHARGE_ACCOUNT", "fred")
 
         # this should not fail with a locked file issue
-        run_cmd_assert_result(self, "./case.build", from_dir=testdir)
+        run_cmd_assert_result(self, "./case.build --skip-provenance-check", from_dir=testdir)
 
         run_cmd_assert_result(self, "./case.st_archive --test-all", from_dir=testdir)
 
@@ -611,7 +611,7 @@ class J_TestCreateNewcase(unittest.TestCase):
 
         run_cmd_assert_result(self, "%s/create_newcase %s"%(SCRIPT_DIR, args), from_dir=SCRIPT_DIR)
         run_cmd_assert_result(self, "./case.setup", from_dir=testdir)
-        run_cmd_assert_result(self, "./case.build", from_dir=testdir)
+        run_cmd_assert_result(self, "./case.build --skip-provenance-check", from_dir=testdir)
 
         cls._do_teardown.append(testdir)
 
@@ -2553,7 +2553,7 @@ class K_TestCimeCase(TestCreateTestCommon):
 
         run_cmd_assert_result(self, "./xmlchange CCSM_CPRNC=this_is_a_broken_cprnc",
                               from_dir=casedir)
-        run_cmd_assert_result(self, "./case.build", from_dir=casedir)
+        run_cmd_assert_result(self, "./case.build --skip-provenance-check", from_dir=casedir)
         run_cmd_assert_result(self, "./case.submit", from_dir=casedir)
 
         self._wait_for_tests(self._baseline_name, always_wait=True)
@@ -2604,7 +2604,7 @@ class G_TestBuildSystem(TestCreateTestCommon):
         run_cmd_assert_result(self, "./case.build --clean atm", from_dir=casedir)
         run_cmd_assert_result(self, "./case.build --clean gptl", from_dir=casedir)
 
-        run_cmd_assert_result(self, "./case.build", from_dir=casedir)
+        run_cmd_assert_result(self, "./case.build --skip-provanence-check", from_dir=casedir)
 
 ###############################################################################
 class L_TestSaveTimings(TestCreateTestCommon):

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2604,7 +2604,7 @@ class G_TestBuildSystem(TestCreateTestCommon):
         run_cmd_assert_result(self, "./case.build --clean atm", from_dir=casedir)
         run_cmd_assert_result(self, "./case.build --clean gptl", from_dir=casedir)
 
-        run_cmd_assert_result(self, "./case.build --skip-provenence-check", from_dir=casedir)
+        run_cmd_assert_result(self, "./case.build --skip-provenance-check", from_dir=casedir)
 
 ###############################################################################
 class L_TestSaveTimings(TestCreateTestCommon):

--- a/scripts/tests/scripts_regression_tests.py
+++ b/scripts/tests/scripts_regression_tests.py
@@ -2604,7 +2604,7 @@ class G_TestBuildSystem(TestCreateTestCommon):
         run_cmd_assert_result(self, "./case.build --clean atm", from_dir=casedir)
         run_cmd_assert_result(self, "./case.build --clean gptl", from_dir=casedir)
 
-        run_cmd_assert_result(self, "./case.build --skip-provanence-check", from_dir=casedir)
+        run_cmd_assert_result(self, "./case.build --skip-provenence-check", from_dir=casedir)
 
 ###############################################################################
 class L_TestSaveTimings(TestCreateTestCommon):


### PR DESCRIPTION
ADD IRT Test to list of exceptions for history file generate.

Test suite: scripts_regression_tests.py, IRT_C2_Ln9.f19_g16_rx1.A.cheyenne_intel.G
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #3978 

User interface changes?: 

Update gh-pages html (Y/N)?:
