### PR TITLE
add python 3.7.0 module load for izumi (CESM only)

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2064,6 +2064,7 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <modules>
         <command name="purge"></command>
+        <command name="load">lang/python/3.7.0</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">compiler/gnu/9.3.0</command>


### PR DESCRIPTION
Add module load for python 3.7 on izumi for CESM in config_machines.xml. 
Without this update, the python version is set in cime regardless of 
whether a user does a module load before building. This addition ensures 
that CAM specifically is being built & run using python 3.7.

Test suite: scripts_regression_tests.py, clean builds of CAM, CESM
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes #4116 

User interface changes?: N

Update gh-pages html (Y/N)?: N
