### PR TITLE
port to lonestar6

### DIFF
--- a/config/cesm/machines/cmake_macros/lonestar6.cmake
+++ b/config/cesm/machines/cmake_macros/lonestar6.cmake
@@ -1,0 +1,6 @@
+string(APPEND CPPDEFS " -DHAVE_NANOTIME")
+set(NETCDF_PATH "$ENV{TACC_NETCDF_DIR}")
+set(PIO_FILESYSTEM_HINTS "lustre")
+set(PNETCDF_PATH "$ENV{TACC_PNETCDF_DIR}")
+string(APPEND LDFLAGS " -Wl,-rpath,${NETCDF_PATH}/lib")
+string(APPEND SLIBS " -L${NETCDF_PATH}/lib -lnetcdff -lnetcdf")

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -593,8 +593,8 @@
     </submit_args>
     <queues>
       <!-- not yet available     <queue walltimemax="48:00:00" nodemin="1" nodemax="64" >flex</queue> -->
-      <queue walltimemax="48:00:00" nodemin="1" nodemax="64">normal</queue>
-      <queue walltimemax="02:00:00" nodemin="1" nodemax="4" default="true">development</queue>
+      <queue walltimemax="48:00:00" nodemin="1" nodemax="64" default="true">normal</queue>
+      <queue walltimemax="02:00:00" nodemin="1" nodemax="4" >development</queue>
       <queue walltimemax="48:00:00" nodemin="1" nodemax="256" >large</queue>
     </queues>
   </batch_system>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -592,9 +592,9 @@
       <arg flag="--account" name="$PROJECT"/>
     </submit_args>
     <queues>
-      <queue walltimemax="48:00:00" nodemin="1" nodemax="64" default="true">flex</queue>
+      <!-- not yet available     <queue walltimemax="48:00:00" nodemin="1" nodemax="64" >flex</queue> -->
       <queue walltimemax="48:00:00" nodemin="1" nodemax="64">normal</queue>
-      <queue walltimemax="02:00:00" nodemin="1" nodemax="4" >development</queue>
+      <queue walltimemax="02:00:00" nodemin="1" nodemax="4" default="true">development</queue>
       <queue walltimemax="48:00:00" nodemin="1" nodemax="256" >large</queue>
     </queues>
   </batch_system>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -583,6 +583,21 @@
     </queues>
   </batch_system>
 
+  <batch_system MACH="lonestar6" type="slurm" >
+    <batch_submit>ssh login1.ls6.tacc.utexas.edu cd $CASEROOT ; sbatch</batch_submit>
+    <submit_args>
+      <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-p" name="$JOB_QUEUE"/>
+      <arg flag="--account" name="$PROJECT"/>
+    </submit_args>
+    <queues>
+      <queue walltimemax="48:00:00" nodemin="1" nodemax="64" default="true">flex</queue>
+      <queue walltimemax="48:00:00" nodemin="1" nodemax="64">normal</queue>
+      <queue walltimemax="02:00:00" nodemin="1" nodemax="4" >development</queue>
+      <queue walltimemax="48:00:00" nodemin="1" nodemax="256" >large</queue>
+    </queues>
+  </batch_system>
+
   <batch_system MACH="mira" type="cobalt">
     <queues>
       <queue walltimemax="06:00:00" nodemin="1" nodemax="12288" default="true">default</queue>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -448,7 +448,8 @@
 
     <queues>
       <queue walltimemax="02:00:00" nodemin="1" nodemax="40">development</queue>
-      <queue walltimemax="24:00:00" nodemin="1" nodemax="512" default="true">normal</queue>
+      <queue walltimemax="24:00:00" nodemin="1" nodemax="2" default="true">small</queue>
+      <queue walltimemax="24:00:00" nodemin="3" nodemax="512" default="true">normal</queue>
       <queue walltimemax="24:00:00" nodemin="513" nodemax="2048" >large</queue>
     </queues>
   </batch_system>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2255,7 +2255,7 @@ This allows using a different mpirun command to launch unit tests
     <DIN_LOC_ROOT_CLMFORC>/global/scratch/$ENV{USER}/cesm_input_datasets/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines</BASELINE_ROOT>
-    <CCSM_CPRNC>/$CIME_OUTPUT_ROOT/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>$CIME_OUTPUT_ROOT/cesm_tools/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>4</GMAKE_J>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>rgknox at lbl dot gov</SUPPORTED_BY>
@@ -2414,10 +2414,11 @@ This allows using a different mpirun command to launch unit tests
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/work/02503/edwardsj/CESM/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/work/02503/edwardsj/CESM/inputdata/lmwg</DIN_LOC_ROOT_CLMFORC>
-    <DIN_STAGING_ROOT>$CIME_OUTPUT_ROOT/cesm/inputdata</DIN_STAGING_ROOT>
+    <!-- do not use CIME_OUTPUT_ROOT for this variable (it's subject to changing) -->
+    <DIN_STAGING_ROOT>$ENV{SCRATCH}/cesm/inputdata</DIN_STAGING_ROOT>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/work/02503/edwardsj/CESM/cesm_baselines</BASELINE_ROOT>
-    <CCSM_CPRNC>/work/02503/edwardsj/CESM/cime/tools/cprnc/cprnc</CCSM_CPRNC>
+    <BASELINE_ROOT>/work/02503/edwardsj/CESM/cesm_baselines/</BASELINE_ROOT>
+    <CCSM_CPRNC>/work/02503/edwardsj/CESM/cime/tools/cprnc/cprnc.ls6</CCSM_CPRNC>
     <GMAKE_J>16</GMAKE_J>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
@@ -2425,12 +2426,13 @@ This allows using a different mpirun command to launch unit tests
     <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
-      <executable>ibrun</executable>
+      <executable>sbcast ${EXEROOT}/cesm.exe /tmp/cesm.exe; ibrun</executable>
       <arguments>
-        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="ntasks"> -n {{ total_tasks }} </arg>
       </arguments>
+      <run_exe>/tmp/cesm.exe</run_exe>
     </mpirun>
-    <!-- allow ls5 modules to write to stderr without cime error -->
+    <!-- allow ls6 modules to write to stderr without cime error -->
     <module_system type="module" allow_error="true">
       <init_path lang="perl">/opt/apps/lmod/lmod/init/perl</init_path>
       <init_path lang="python">/opt/apps/lmod/lmod/init/env_modules_python.py</init_path>
@@ -2461,11 +2463,17 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
     </module_system>
-    <environment_variables compiler="intel" DEBUG="TRUE">
-      <env name="ESMFMKFILE">/work/02503/edwardsj/ESMF/lib/libg/Linux.intel.64.intelmpi.default/esmf.mk</env>
+    <environment_variables compiler="intel" DEBUG="TRUE" mpilib="impi">
+      <env name="ESMFMKFILE">/work/02503/edwardsj/ESMF8.2.0/lib/libg/Linux.intel.64.intelmpi.default/esmf.mk</env>
     </environment_variables>
-    <environment_variables compiler="intel" DEBUG="FALSE">
-      <env name="ESMFMKFILE">/work/02503/edwardsj/ESMF/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk</env>
+    <environment_variables compiler="intel" DEBUG="FALSE" mpilib="impi">
+      <env name="ESMFMKFILE">/work/02503/edwardsj/ESMF8.2.0/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk</env>
+    </environment_variables>
+    <environment_variables compiler="intel" DEBUG="TRUE" mpilib="mpi-serial">
+      <env name="ESMFMKFILE">/work/02503/edwardsj/ESMF8.2.0/lib/libg/Linux.intel.64.mpiuni.default/esmf.mk</env>
+    </environment_variables>
+    <environment_variables compiler="intel" DEBUG="FALSE" mpilib="mpi-serial">
+      <env name="ESMFMKFILE">/work/02503/edwardsj/ESMF8.2.0/lib/libO/Linux.intel.64.mpiuni.default/esmf.mk</env>
     </environment_variables>
   </machine>
 

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2457,6 +2457,21 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
     </module_system>
+    <environment_variables mpilib="impi">
+      <env name="OMP_STACKSIZE">256M</env>
+      <env name="UCX_UD_MLX5_TIMEOUT">600000000.00us</env>
+      <env name="UCX_RC_MLX5_TIMEOUT"  >1200000.00us</env>
+      <env name="UCX_DC_MLX5_TIMEOUT"  >1200000.00us</env>
+      <env name="UCX_RC_MLX5_RETRY_COUNT">80</env>
+      <env name="UCX_DC_MLX5_RETRY_COUNT">80</env>
+      <env name="MY_MPIRUN_OPTIONS">-prepend-rank </env>
+      <env name="I_MPI_ADJUST_ALLREDUCE">4</env>
+      <env name="I_MPI_ADJUST_GATHER">3</env>
+      <env name="I_MPI_ADJUST_GATHERV">3</env>
+      <env name="I_MPI_ADJUST_SCATTER">3</env>
+      <env name="I_MPI_ADJUST_SCATTERV">2</env>
+      <env name="I_MPI_EXTRA_FILESYSTEM">enable</env>
+     </environment_variables>
     <environment_variables compiler="intel" DEBUG="TRUE" mpilib="impi">
       <env name="ESMFMKFILE">/work/02503/edwardsj/ESMF8.2.0/lib/libg/Linux.intel.64.intelmpi.default/esmf.mk</env>
     </environment_variables>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2404,6 +2404,64 @@ This allows using a different mpirun command to launch unit tests
     </module_system>
   </machine>
 
+  <machine MACH="lonestar6">
+    <DESC>Lonestar6 cluster at TACC, OS is Linux (intel), batch system is SLURM
+           https://portal.tacc.utexas.edu/user-guides/lonestar6</DESC>
+    <NODENAME_REGEX>.*ls6\.tacc\.utexas\.edu</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel,gnu</COMPILERS>
+    <MPILIBS>impi</MPILIBS>
+    <CIME_OUTPUT_ROOT>$ENV{SCRATCH}</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/work/02503/edwardsj/CESM/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/work/02503/edwardsj/CESM/inputdata/lmwg</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/work/02503/edwardsj/CESM/cesm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>/work/02503/edwardsj/CESM/cime/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>16</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>cseg</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>ibrun</executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <!-- allow ls5 modules to write to stderr without cime error -->
+    <module_system type="module" allow_error="true">
+      <init_path lang="perl">/opt/apps/lmod/lmod/init/perl</init_path>
+      <init_path lang="python">/opt/apps/lmod/lmod/init/env_modules_python.py</init_path>
+      <init_path lang="sh">/opt/apps/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/opt/apps/lmod/lmod/init/csh</init_path>
+      <cmd_path lang="perl">/opt/apps/lmod/lmod/libexec/lmod perl</cmd_path>
+      <cmd_path lang="python">/opt/apps/lmod/lmod/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+
+      <modules>
+        <command name="reset"/>
+        <command name="load">cmake</command>
+	<command name="load">python3</command>
+      </modules>
+      <modules compiler="intel">
+        <command name="load">intel/19.1.1</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">gcc/9.4.0</command>
+	<!--	<command name="mkl">mkl </command> -->
+      </modules>
+      <modules mpilib="mpi-serial">
+        <command name="load">netcdf/4.6.2</command>
+      </modules>
+      <modules mpilib="!mpi-serial">
+        <command name="load">pnetcdf/1.12.2</command>
+        <command name="load">parallel-netcdf/4.6.2</command>
+      </modules>
+    </module_system>
+  </machine>
+
 
   <machine MACH="melvin">
     <DESC>Linux workstation for Jenkins testing</DESC>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2414,6 +2414,7 @@ This allows using a different mpirun command to launch unit tests
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/work/02503/edwardsj/CESM/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/work/02503/edwardsj/CESM/inputdata/lmwg</DIN_LOC_ROOT_CLMFORC>
+    <DIN_STAGING_ROOT>$CIME_OUTPUT_ROOT/cesm/inputdata</DIN_STAGING_ROOT>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/cesm_archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>/work/02503/edwardsj/CESM/cesm_baselines</BASELINE_ROOT>
     <CCSM_CPRNC>/work/02503/edwardsj/CESM/cime/tools/cprnc/cprnc</CCSM_CPRNC>
@@ -2460,6 +2461,12 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">parallel-netcdf/4.6.2</command>
       </modules>
     </module_system>
+    <environment_variables compiler="intel" DEBUG="TRUE">
+      <env name="ESMFMKFILE">/work/02503/edwardsj/ESMF/lib/libg/Linux.intel.64.intelmpi.default/esmf.mk</env>
+    </environment_variables>
+    <environment_variables compiler="intel" DEBUG="FALSE">
+      <env name="ESMFMKFILE">/work/02503/edwardsj/ESMF/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk</env>
+    </environment_variables>
   </machine>
 
 

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -561,10 +561,6 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">cray-netcdf</command>
       </modules>
     </module_system>
-    <environment_variables comp_interface="nuopc">
-      <env name="ESMF_RUNTIME_PROFILE">ON</env>
-      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
-    </environment_variables>
     <environment_variables comp_interface="nuopc" compiler="cray">
       <env name="ESMFMKFILE">/glade/work/jedwards/CPE/lib/libg/Unicos.cce.64.mpi.default/esmf.mk</env>
     </environment_variables>
@@ -784,8 +780,6 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_USE_ARRAY"/>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
-      <env name="ESMF_RUNTIME_PROFILE">ON</env>
-      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
       <env name="UGCSINPUTPATH">/glade/work/turuncu/FV3GFS/benchmark-inputs/2012010100/gfs/fcst</env>
       <env name="UGCSFIXEDFILEPATH">/glade/work/turuncu/FV3GFS/fix_am</env>
       <env name="UGCSADDONPATH">/glade/work/turuncu/FV3GFS/addon</env>
@@ -3193,8 +3187,6 @@ This allows using a different mpirun command to launch unit tests
       <env name="ESMFMKFILE">/work/01118/tg803972/stampede2/ESMF-INSTALL/8.0.0bs38/lib/libO/Linux.intel.64.intelmpi.default/esmf.mk</env>
     </environment_variables>
     <environment_variables comp_interface="nuopc">
-      <env name="ESMF_RUNTIME_PROFILE">ON</env>
-      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
       <env name="UGCSINPUTPATH">/work/06242/tg855414/stampede2/FV3GFS/benchmark-inputs/2012010100/gfs/fcst</env>
       <env name="UGCSFIXEDFILEPATH">/work/06242/tg855414/stampede2/FV3GFS/fix_am</env>
       <env name="UGCSADDONPATH">/work/06242/tg855414/stampede2/FV3GFS/addon</env>
@@ -3319,8 +3311,6 @@ This allows using a different mpirun command to launch unit tests
       </modules>
     </module_system>
     <environment_variables comp_interface="nuopc">
-      <env name="ESMF_RUNTIME_PROFILE">ON</env>
-      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
       <env name="ESMFMKFILE">/home/users/p62939/esmf/lib/libg/Unicos.cce.64.mpi.default/esmf.mk</env>
     </environment_variables>
   </machine>
@@ -3373,8 +3363,6 @@ This allows using a different mpirun command to launch unit tests
       </modules>
     </module_system>
     <environment_variables comp_interface="nuopc">
-      <env name="ESMF_RUNTIME_PROFILE">ON</env>
-      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
       <env name="UGCSINPUTPATH">/scratch4/NCEPDEV/nems/noscrub/Rocky.Dunlap/INPUTDATA/benchmark-inputs/2012010100/gfs/fcst</env>
       <env name="UGCSFIXEDFILEPATH">/scratch4/NCEPDEV/nems/noscrub/Rocky.Dunlap/INPUTDATA/fix_am</env>
       <env name="UGCSADDONPATH">/scratch4/NCEPDEV/nems/noscrub/Rocky.Dunlap/INPUTDATA/addon</env>
@@ -3543,10 +3531,6 @@ This allows using a different mpirun command to launch unit tests
       <env name="OMP_STACKSIZE">256M</env>
       <env name="NETCDF_PATH">$ENV{NETCDF}</env>
     </environment_variables>
-    <environment_variables comp_interface="nuopc">
-      <env name="ESMF_RUNTIME_PROFILE">ON</env>
-      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
-    </environment_variables>
   </machine>
 
   <machine MACH="ubuntu-latest">
@@ -3667,5 +3651,10 @@ This allows using a different mpirun command to launch unit tests
     <default_run_exe>${EXEROOT}/cesm.exe </default_run_exe>
     <default_run_misc_suffix> >> cesm.log.$LID 2>&amp;1 </default_run_misc_suffix>
   </default_run_suffix>
+  <!-- default env variables set on all systems -->
+  <environment_variables comp_interface="nuopc">
+    <env name="ESMF_RUNTIME_PROFILE">ON</env>
+    <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
+  </environment_variables>
 
 </config_machines>

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -42,6 +42,7 @@
   <xs:element name="CIME_URL_ROOT" type="xs:string"/>
   <xs:element name="DIN_LOC_ROOT" type="xs:string"/>
   <xs:element name="DIN_LOC_ROOT_CLMFORC" type="xs:string"/>
+  <xs:element name="DIN_STAGING_ROOT" type="xs:string"/>
   <xs:element name="DOUT_S_ROOT" type="xs:string"/>
   <xs:element name="BASELINE_ROOT" type="xs:string"/>
   <xs:element name="CCSM_CPRNC" type="xs:string"/>
@@ -135,6 +136,9 @@
         <xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
         <!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
         <xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
+        <!-- DIN_STAGING_ROOT: on some systems (eg TACC) the DIN_LOC_ROOT location is not available from 
+	     compute nodes and the data must be staged to the SCRATCH file system -->
+        <xs:element ref="DIN_STAGING_ROOT" minOccurs="0" maxOccurs="1"/>
         <!-- DOUT_S_ROOT: root directory of short term archive files -->
         <xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
         <!-- BASELINE_ROOT:  Root directory for system test baseline files -->

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -87,6 +87,7 @@
       <xs:sequence>
         <xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
         <xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="environment_variables" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute ref="version"/>
     </xs:complexType>
@@ -180,12 +181,12 @@
         <!-- module_system: how and what modules to load on this system ,
              see detail below -->
         <xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
-        <!-- environment_variables: environment_variables to set on this system,
-          see detail below-->
         <xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
+        <!-- environment_variables: environment_variables to set on this system,
+          see detail below-->
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
       </xs:sequence>

--- a/scripts/lib/CIME/XML/env_mach_specific.py
+++ b/scripts/lib/CIME/XML/env_mach_specific.py
@@ -37,7 +37,8 @@ class EnvMachSpecific(EnvBase):
         """
         items = ("module_system", "environment_variables", "resource_limits", "mpirun")
         default_run_suffix = machobj.get_child("default_run_suffix", root=machobj.root)
-
+        default_env_vars = machobj.get_child("environment_variables", root=machobj.root)
+        
         group_node = self.make_child("group", {"id":"compliant_values"})
         settings = {"run_exe":None,"run_misc_suffix":None}
 
@@ -47,6 +48,7 @@ class EnvMachSpecific(EnvBase):
                 if len(nodes) == 0:
                     example_text = """This section is for the user to specify any additional machine-specific env var, or to overwite existing ones.\n  <environment_variables>\n    <env name="NAME">ARGUMENT</env>\n  </environment_variables>\n  """
                     self.make_child_comment(text = example_text)
+                nodes.append(default_env_vars)
 
             if item == "mpirun":
                 for node in nodes:

--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -219,7 +219,7 @@ class Machines(GenericXML):
         Get Value of fields in the config_machines.xml file
         """
         if self.machine_node is None:
-            logger.warning("Machine object has no machine defined")
+            logger.debug("Machine object has no machine defined")
             return None
 
         expect(subgroup is None, "This class does not support subgroups")

--- a/scripts/lib/CIME/case/case_run.py
+++ b/scripts/lib/CIME/case/case_run.py
@@ -51,6 +51,9 @@ def _pre_run_check(case, lid, skip_pnl=False, da_cycle=0):
 
     os.makedirs(os.path.join(rundir, "timing", "checkpoints"))
 
+    if os.path.exists(os.path.join(rundir,"ESMF_Profile.summary")):
+        os.rename(os.path.join(rundir,"ESMF_Profile.summary"),os.path.join(rundir,"ESMF_Profile.summary.")+time.strftime("%Y-%m-%d_%H:%M:%S"))
+    
     # This needs to be done everytime the LID changes in order for log files to be set up correctly
     # The following also needs to be called in case a user changes a user_nl_xxx file OR an env_run.xml
     # variable while the job is in the queue
@@ -363,6 +366,8 @@ def case_run(self, skip_pnl=False, set_continue_run=False, submit_resubmits=Fals
             model_log("e3sm", logger, "{} GET_TIMING BEGINS HERE".format(time.strftime("%Y-%m-%d %H:%M:%S")))
             get_timing(self, lid)     # Run the getTiming script
             model_log("e3sm", logger, "{} GET_TIMING HAS FINISHED".format(time.strftime("%Y-%m-%d %H:%M:%S")))
+            if os.path.exists(os.path.join(rundir,"ESMF_Profile.summary")):
+                os.rename(os.path.join(rundir,"ESMF_Profile.summary"),os.path.join(rundir,"ESMF_Profile.summary")+lid)
 
 
         if data_assimilation:

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -204,17 +204,18 @@ def _case_setup_impl(case, caseroot, clean=False, test_mode=False, reset=False, 
     # Check that $DIN_LOC_ROOT exists or can be created:
     if not non_local:
         din_loc_root = case.get_value("DIN_LOC_ROOT")
+        din_staging_root = case.get_value("DIN_STAGING_ROOT")
         testcase     = case.get_value("TESTCASE")
-
-        if not os.path.isdir(din_loc_root):
-            try:
-                os.makedirs(din_loc_root)
-            except OSError as e:
-                if e.errno == errno.EACCES:
-                    logger.info("Invalid permissions to create {}".format(din_loc_root))
-
-        expect(not (not os.path.isdir(din_loc_root) and testcase != "SBN"),
-               "inputdata root is not a directory or is not readable: {}".format(din_loc_root))
+        for inputdir in (din_loc_root, din_staging_root):
+            if inputdir and not os.path.isdir(inputdir):
+                try:
+                    os.makedirs(inputdir)
+                except OSError as e:
+                    if e.errno == errno.EACCES:
+                        logger.info("Invalid permissions to create {}".format(inputdir))
+            if inputdir:
+                expect(not (not os.path.isdir(inputdir) and testcase != "SBN"),
+                       "inputdata root is not a directory or is not readable: {}".format(inputdir))
 
     # Remove batch scripts
     if reset or clean:

--- a/scripts/lib/CIME/case/check_input_data.py
+++ b/scripts/lib/CIME/case/check_input_data.py
@@ -478,15 +478,26 @@ def _stage_inputdata(src_root, dest_root, filelist):
         md5_output = 5
         if not os.path.exists(outdir):
             os.makedirs(outdir)
-        if os.path.isfile(outfile):
-            md5_input = md5(_file)
-            md5_output = md5(outfile)
+        elif os.path.isfile(outfile):
+            md5_input = md5inputdata(_file)
+            md5_output = md5inputdata(outfile)
 
         if md5_input != md5_output:
             logger.info("Staging inputdata file {} to {}".format(_file, outfile))
             t = threading.Thread(target=safe_copy, args=(_file, outfile))
             t.start()
             
-            #safe_copy(_file, outfile)
     while(threading.active_count() > 1):
         time.sleep(1)
+
+def md5inputdata(fname):
+    md5file = fname+".md5"
+    if os.path.isfile(md5file):
+        with open(md5file, "r") as fi:
+            md5sum = fi.read()
+    else:
+        md5sum = md5(fname)
+        with open(md5file, "w") as fo:
+            fo.write(md5sum)
+    return md5sum
+    

--- a/scripts/lib/CIME/case/preview_namelists.py
+++ b/scripts/lib/CIME/case/preview_namelists.py
@@ -8,6 +8,8 @@ from CIME.utils import run_sub_or_cmd, safe_copy
 import time, glob
 logger = logging.getLogger(__name__)
 
+NAMELIST_FILEPATTERNS = ["*_in_[0-9]*", "*modelio*", "*_in", "nuopc.runconfig",
+                       "*streams*txt*", "*streams.xml", "*stxt", "*maps.rc", "*cism*.config*", "nuopc.runseq"]
 def create_dirs(self):
     """
     Make necessary directories for case
@@ -95,8 +97,7 @@ def create_namelists(self, component=None):
     din_staging_root = self.get_value("DIN_STAGING_ROOT")
     if din_staging_root and din_staging_root != "UNSET":
         din_loc_root = self.get_value("DIN_LOC_ROOT")
-        for cpglob in ["*_in_[0-9]*", "*modelio*", "*_in", "nuopc.runconfig",
-                       "*streams*txt*", "*streams.xml", "*stxt", "*maps.rc", "*cism*.config*", "nuopc.runseq"]:
+        for cpglob in NAMELIST_FILEPATTERNS:
             for file_to_edit in glob.iglob(os.path.join(rundir, cpglob)):
                 with open(file_to_edit, "r") as file:
                     filedata = file.read()
@@ -113,8 +114,7 @@ def create_namelists(self, component=None):
         except (OSError, IOError) as e:
             expect(False, "Failed to write {}/README: {}".format(docdir, e))
 
-    for cpglob in ["*_in_[0-9]*", "*modelio*", "*_in", "nuopc.runconfig",
-                   "*streams*txt*", "*streams.xml", "*stxt", "*maps.rc", "*cism*.config*", "nuopc.runseq"]:
+    for cpglob in NAMELIST_FILEPATTERNS:
         for file_to_copy in glob.iglob(os.path.join(rundir, cpglob)):
             logger.debug("Copy file from '{}' to '{}'".format(file_to_copy, docdir))
             safe_copy(file_to_copy, docdir)

--- a/scripts/lib/CIME/case/preview_namelists.py
+++ b/scripts/lib/CIME/case/preview_namelists.py
@@ -91,6 +91,19 @@ def create_namelists(self, component=None):
 
         logger.debug("Finished creating component namelists, component {} models = {}".format(component, models))
 
+    # Some systems (eg TACC) require that we copy inputdata to a temporary staging directory
+    din_staging_root = self.get_value("DIN_STAGING_ROOT")
+    if din_staging_root and din_staging_root != "UNSET":
+        din_loc_root = self.get_value("DIN_LOC_ROOT")
+        for cpglob in ["*_in_[0-9]*", "*modelio*", "*_in", "nuopc.runconfig",
+                       "*streams*txt*", "*streams.xml", "*stxt", "*maps.rc", "*cism*.config*", "nuopc.runseq"]:
+            for file_to_edit in glob.iglob(os.path.join(rundir, cpglob)):
+                with open(file_to_edit, "r") as file:
+                    filedata = file.read()
+                filedata = filedata.replace(din_loc_root, din_staging_root)
+                with open(file_to_edit, "w") as file:
+                    file.write(filedata)
+
     # Save namelists to docdir
     if (not os.path.isdir(docdir)):
         os.makedirs(docdir)
@@ -102,7 +115,7 @@ def create_namelists(self, component=None):
 
     for cpglob in ["*_in_[0-9]*", "*modelio*", "*_in", "nuopc.runconfig",
                    "*streams*txt*", "*streams.xml", "*stxt", "*maps.rc", "*cism*.config*", "nuopc.runseq"]:
-        for file_to_copy in glob.glob(os.path.join(rundir, cpglob)):
+        for file_to_copy in glob.iglob(os.path.join(rundir, cpglob)):
             logger.debug("Copy file from '{}' to '{}'".format(file_to_copy, docdir))
             safe_copy(file_to_copy, docdir)
 


### PR DESCRIPTION
Port to the new TACC system [lonestar6](https://portal.tacc.utexas.edu/user-guides/lonestar6#introduction-to-lonestar6) 

This also implements a new variable in config_machines.xml DIN_STAGING_ROOT which will copy inputdata from DIN_LOC_ROOT needed for the case to the SCRATCH filesystem.  This is intended to reduce stress on the TACC $STOCKYARD ($WORK) filesystem.


Test suite: scripts_regression_tests.py with both mct and nuopc
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes 
User interface changes?: 

Update gh-pages html (Y/N)?:
