### PR TITLE
tools/configure was using deprecated config_compilers.xml system

### DIFF
--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -19,6 +19,9 @@ from CIME.XML.standard_module_setup import *
 from CIME.utils import expect, safe_copy
 from CIME.XML.compilers import Compilers
 from CIME.XML.env_mach_specific import EnvMachSpecific
+from CIME.XML.files import Files
+
+import shutil
 
 logger = logging.getLogger(__name__)
 
@@ -42,11 +45,25 @@ def configure(machobj, output_dir, macros_format, compiler, mpilib, debug,
     """
     # Macros generation.
     suffixes = {'Makefile': 'make', 'CMake': 'cmake'}
-    macro_maker = Compilers(machobj, compiler=compiler, mpilib=mpilib,
-                            extra_machines_dir=extra_machines_dir)
+
+    new_cmake_macros_dir = Files(comp_interface=comp_interface).get_value("CMAKE_MACROS_DIR")
+    macro_maker=None
     for form in macros_format:
-        out_file_name = os.path.join(output_dir,"Macros."+suffixes[form])
-        macro_maker.write_macros_file(macros_file=out_file_name, output_format=suffixes[form])
+
+        if form=="CMake" and new_cmake_macros_dir is not None and os.path.exists(new_cmake_macros_dir) and not "CIME_NO_CMAKE_MACRO" in os.environ:
+            if not os.path.isfile(os.path.join(output_dir, "Macros.cmake")):
+                safe_copy(os.path.join(new_cmake_macros_dir, "Macros.cmake"), output_dir)
+            if not os.path.exists(os.path.join(output_dir, "cmake_macros")):
+                shutil.copytree(new_cmake_macros_dir, os.path.join(output_dir, "cmake_macros"))
+
+        else:
+            logger.warning("Using deprecated CIME makefile generators")
+            if macro_maker is None:
+                macro_maker = Compilers(machobj, compiler=compiler, mpilib=mpilib,
+                                        extra_machines_dir=extra_machines_dir)
+
+            out_file_name = os.path.join(output_dir,"Macros."+suffixes[form])
+            macro_maker.write_macros_file(macros_file=out_file_name, output_format=suffixes[form])
 
     copy_depends_files(machobj.get_machine_name(), machobj.machines_dir, output_dir, compiler)
     generate_env_mach_specific(output_dir, machobj, compiler, mpilib,

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -61,7 +61,7 @@ def _build_usernl_files(case, model, comp):
         # Note that, even if there are multiple elements of user_nl_list (i.e., we are
         # creating multiple user_nl files for this component with different names), all of
         # them will start out as copies of the single user_nl_comp file in the model's
-        # source tree - unless the file has _stream in its name 
+        # source tree - unless the file has _stream in its name
         for nlfile in user_nl_list:
             if ninst > 1:
                 for inst_counter in range(1, ninst+1):
@@ -117,9 +117,9 @@ def _get_user_nl_list(case, default_nlfile, model_dir):
 ###############################################################################
 def _create_macros_cmake(caseroot, cmake_macros_dir, mach_obj, compiler, case_cmake_path):
 ###############################################################################
-    if not os.path.isfile("Macros.cmake"):
+    if not os.path.isfile(os.path.join(caseroot, "Macros.cmake")):
         safe_copy(os.path.join(cmake_macros_dir, "Macros.cmake"), caseroot)
-    if not os.path.exists("cmake_macros"):
+    if not os.path.exists(os.path.join(caseroot, "cmake_macros")):
         shutil.copytree(cmake_macros_dir, case_cmake_path)
 
     copy_depends_files(mach_obj.get_machine_name(), mach_obj.machines_dir, caseroot, compiler)
@@ -134,8 +134,6 @@ def _create_macros(case, mach_obj, caseroot, compiler, mpilib, debug, comp_inter
     reread = not os.path.isfile("env_mach_specific.xml")
     new_cmake_macros_dir = case.get_value("CMAKE_MACROS_DIR")
 
-    if new_cmake_macros_dir:
-        new_cmake_macro = os.path.join(new_cmake_macros_dir,"Macros.cmake")
     if reread:
         case.flush()
         generate_env_mach_specific(
@@ -144,14 +142,14 @@ def _create_macros(case, mach_obj, caseroot, compiler, mpilib, debug, comp_inter
         case.read_xml()
 
     # export CIME_NO_CMAKE_MACRO=1 to disable new macros
-    if os.path.exists(new_cmake_macro) and not "CIME_NO_CMAKE_MACRO" in os.environ:
+    if new_cmake_macros_dir is not None and os.path.exists(new_cmake_macros_dir) and not "CIME_NO_CMAKE_MACRO" in os.environ:
         case_cmake_path = os.path.join(caseroot, "cmake_macros")
 
         _create_macros_cmake(caseroot, new_cmake_macros_dir, mach_obj, compiler, case_cmake_path)
         # check for macros in extra_machines_dir and in .cime
         local_macros = []
         extra_machdir = case.get_value("EXTRA_MACHDIR")
-        if extra_machdir: 
+        if extra_machdir:
             if os.path.isdir(os.path.join(extra_machdir,"cmake_macros")):
                 local_macros.extend(glob.glob(os.path.join(extra_machdir,"cmake_macros/*.cmake")))
             elif os.path.isfile(os.path.join(extra_machdir,"config_compilers.xml")):


### PR DESCRIPTION
... as was scripts/fortran_unit_testing/run_tests.py. This PR changes
the implementation of BuildTools.configure to use the new CMake macros
if possible. We should note, without a full (non-fake) case object, it is
not possible to generate Makefile macros from the new Cmake macro system.
It doesn't appear that anyone is using configure for that purpose.

Test suite: pylint, K_TestCimeCase, check cprnc self-build by hand
Test baseline: 
Test namelist changes: 
Test status: bfb

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
