### PR TITLE
Update the documentation of --extra-machines-dir

### DIFF
--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -163,7 +163,8 @@ def parse_command_line(args, cimeroot, description):
 
     parser.add_argument("--extra-machines-dir",
                         help="Optional path to a directory containing one or more of:"
-                        "\nconfig_machines.xml, config_compilers.xml, config_batch.xml."
+                        "\nconfig_machines.xml, config_compilers.xml, config_batch.xml,"
+                        "\nand a cmake_macros subdirectory containing CMake macros files."
                         "\nIf provided, the contents of these files will be appended to"
                         "\nthe standard machine files (and any files in ~/.cime).")
 


### PR DESCRIPTION
The ability to put a cmake_macros subdirectory in here needed to be documented.

I was tripped up for a while by assuming that the cmake macros would go at the top level here like they do in the `.cime` directory. Digging through the code, I see that they are supposed to go in a `cmake_macros` subdirectory. In retrospect, I think this makes sense. Hopefully documenting it will save others (and my future self) from similar issues.

Test suite: None
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N
