### PR TITLE
Update modules for cori on maint-5.6 branch.

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -762,19 +762,19 @@ This allows using a different mpirun command to launch unit tests
 	<command name="switch">cray-libsci/19.02.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.8</command>
+	<command name="load">cray-mpich/7.7.10</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.5.0</command>
-	<command name="load">cray-netcdf/4.6.3.0</command>
+	<command name="load">cray-hdf5/1.10.5.2</command>
+	<command name="load">cray-netcdf/4.6.3.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.3.0</command>
-	<command name="load">cray-hdf5-parallel/1.10.5.0</command>
-	<command name="load">cray-parallel-netcdf/1.11.1.0</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.2</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
       <modules>
-	<command name="load">cmake/3.14.4</command>
+	<command name="load">cmake/3.21.3</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -868,16 +868,16 @@ This allows using a different mpirun command to launch unit tests
 	<command name="switch">cray-libsci/19.02.1</command>
       </modules>
       <modules>
-	<command name="load">cray-mpich/7.7.8</command>
+	<command name="load">cray-mpich/7.7.10</command>
       </modules>
       <modules mpilib="mpi-serial">
-	<command name="load">cray-hdf5/1.10.5.0</command>
-	<command name="load">cray-netcdf/4.6.3.0</command>
+	<command name="load">cray-hdf5/1.10.5.2</command>
+	<command name="load">cray-netcdf/4.6.3.2</command>
       </modules>
       <modules mpilib="!mpi-serial">
-	<command name="load">cray-netcdf-hdf5parallel/4.6.3.0</command>
-	<command name="load">cray-hdf5-parallel/1.10.5.0</command>
-	<command name="load">cray-parallel-netcdf/1.11.1.0</command>
+	<command name="load">cray-netcdf-hdf5parallel/4.6.3.2</command>
+	<command name="load">cray-hdf5-parallel/1.10.5.2</command>
+	<command name="load">cray-parallel-netcdf/1.11.1.1</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
Update modules for cori.

Test suite: Build SMS.f19_g17.B1850.cori-haswell_intel and SMS.f19_g17.B1850.cori-knl_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
