### PR TITLE
Rename izumi.unified.ucar.edu to izumi.cgd.ucar.edu

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -518,7 +518,7 @@
 
   <batch_system type="pbs" MACH="izumi" >
     <batch_submit>qsub</batch_submit>
-    <jobid_pattern>(\d+.izumi.unified.ucar.edu)$</jobid_pattern>
+    <jobid_pattern>(\d+.izumi.cgd.ucar.edu)$</jobid_pattern>
     <directives>
       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
       <directive default="/bin/bash" > -S {{ shell }}  </directive>


### PR DESCRIPTION
Izumi was renamed from izumi.unified.ucar.edu to izumi.cgd.ucar.edu.

Test suite: ERS.f45_g37.X.izumi_intel
Test baseline: 
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:
