### PR TITLE
Fixes returning correct test results

### DIFF
--- a/scripts/lib/CIME/tests/scripts_regression_tests.py
+++ b/scripts/lib/CIME/tests/scripts_regression_tests.py
@@ -222,9 +222,8 @@ OR
 
     test_runner = unittest.TextTestRunner(verbosity=2)
 
-    test_runner.run(test_suite)
+    TEST_RESULT = test_runner.run(test_suite)
 
-    TEST_RESULT = test_runner._makeResult()
     # Implements same behavior as unittesst.main
     # https://github.com/python/cpython/blob/b6d68aa08baebb753534a26d537ac3c0d2c21c79/Lib/unittest/main.py#L272-L273
     sys.exit(not TEST_RESULT.wasSuccessful())


### PR DESCRIPTION
Fixes returning correct test results. `wasSuccessful()` would
always return true, now reports correct results.

Test suite: scripts_regression_tests.py & pytest
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?: n/a
Update gh-pages html (Y/N)?: N
