### PR TITLE
new compset naming convention

### DIFF
--- a/.github/workflows/srt_nuopc.yml
+++ b/.github/workflows/srt_nuopc.yml
@@ -32,7 +32,7 @@ jobs:
       NETCDF_C_PATH: /usr
       NETCDF_FORTRAN_PATH: ${HOME}/netcdf-fortran
       PNETCDF_PATH: ${HOME}/pnetcdf
-      ESMF_VERSION: ESMF_8_2_0_beta_snapshot_14
+      ESMF_VERSION: ESMF_8_3_0_beta_snapshot_05
       CIME_MODEL: cesm
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -259,7 +259,7 @@ class Component(EntryID):
         (False, None)
         >>> obj._get_description_match("1850_CAM50%WCCM_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "+")
         (True, ['CAM50', 'WCCM'])
-        >>> obj._get_description_match("tim:1850_atm:CAM50%WCCM_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "+")
+        >>> obj._get_description_match("scn:1850_atm:CAM50%WCCM_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "+")
         (True, ['CAM50', 'WCCM'])
         """
         match = False

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -207,7 +207,7 @@ class Component(EntryID):
                 parts = opt_parts.pop(0).split("%")
                 reqset = set(parts)
                 fullset = set(parts + opt_parts)
-                
+
                 match, complist = self._get_description_match(
                     compsetname, reqset, fullset, modifier_mode
                 )
@@ -266,7 +266,7 @@ class Component(EntryID):
         comparts = compsetname.split("_")
         matchcomplist = None
         for comp in comparts:
-            if ':' in comp:
+            if ":" in comp:
                 comp = comp.split(":")[1]
             complist = comp.split("%")
             cset = set(complist)

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -259,6 +259,8 @@ class Component(EntryID):
         (False, None)
         >>> obj._get_description_match("1850_CAM50%WCCM_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "+")
         (True, ['CAM50', 'WCCM'])
+        >>> obj._get_description_match("tim:1850_atm:CAM50%WCCM_Barn",set(["CAM50", "WCCM"]), set(["CAM50","WCCM","RCO2"]), "+")
+        (True, ['CAM50', 'WCCM'])
         """
         match = False
         comparts = compsetname.split("_")
@@ -268,7 +270,7 @@ class Component(EntryID):
                 comp = comp.split(":")[1]
             complist = comp.split("%")
             cset = set(complist)
-            print("filename is {} reqset {} ".format(self.filename, reqset))
+
             if cset == reqset or (cset > reqset and cset <= fullset):
                 if modifier_mode == "1":
                     expect(

--- a/scripts/lib/CIME/XML/component.py
+++ b/scripts/lib/CIME/XML/component.py
@@ -207,6 +207,7 @@ class Component(EntryID):
                 parts = opt_parts.pop(0).split("%")
                 reqset = set(parts)
                 fullset = set(parts + opt_parts)
+                
                 match, complist = self._get_description_match(
                     compsetname, reqset, fullset, modifier_mode
                 )
@@ -262,10 +263,12 @@ class Component(EntryID):
         match = False
         comparts = compsetname.split("_")
         matchcomplist = None
-
         for comp in comparts:
+            if ':' in comp:
+                comp = comp.split(":")[1]
             complist = comp.split("%")
             cset = set(complist)
+            print("filename is {} reqset {} ".format(self.filename, reqset))
             if cset == reqset or (cset > reqset and cset <= fullset):
                 if modifier_mode == "1":
                     expect(

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -57,8 +57,6 @@ class Grids(GenericXML):
         atmnlev = None
         lndnlev = None
 
-        print("compset is now {} ".format(compset))
-
         # mechanism to specify atm levels
         atmlevregex = re.compile(r"([^_]+)z(\d+)(.*)$")
         levmatch = re.match(atmlevregex, name)

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -57,10 +57,7 @@ class Grids(GenericXML):
         atmnlev = None
         lndnlev = None
 
-        if ":" in compset:
-            components = compset.split("_")
-            compset = "_".join([comp[4:] for comp in components])
-            print("compset is now {} ".format(compset))
+        print("compset is now {} ".format(compset))
 
         # mechanism to specify atm levels
         atmlevregex = re.compile(r"([^_]+)z(\d+)(.*)$")

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -57,6 +57,11 @@ class Grids(GenericXML):
         atmnlev = None
         lndnlev = None
 
+        if ':' in compset:
+            components = compset.split('_')
+            compset = '_'.join([comp[4:] for comp in components])
+            print("compset is now {} ".format(compset))
+
         # mechanism to specify atm levels
         atmlevregex = re.compile(r"([^_]+)z(\d+)(.*)$")
         levmatch = re.match(atmlevregex, name)

--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -57,9 +57,9 @@ class Grids(GenericXML):
         atmnlev = None
         lndnlev = None
 
-        if ':' in compset:
-            components = compset.split('_')
-            compset = '_'.join([comp[4:] for comp in components])
+        if ":" in compset:
+            components = compset.split("_")
+            compset = "_".join([comp[4:] for comp in components])
             print("compset is now {} ".format(compset))
 
         # mechanism to specify atm levels

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -740,8 +740,8 @@ class Case(object):
         ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
         >>> Case(caseroot, read_only=False)._valid_compset_impl('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
         ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
-        >>> Case(caseroot, read_only=False)._valid_compset_impl('atm:DATM%NYF_rof:DROF%NYF_tim:2000_ice:DICE%SSMI_ocn:DOCN%DOM', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
-        ('tim:2000_atm:DATM%NYF_lnd:SLND_ice:DICE%SSMI_ocn:DOCN%DOM_rof:DROF%NYF_glc:SGLC_wav:SWAV_esp:SESP', ['tim:2000', 'atm:DATM%NYF', 'lnd:SLND', 'ice:DICE%SSMI', 'ocn:DOCN%DOM', 'rof:DROF%NYF', 'glc:SGLC', 'wav:SWAV', 'esp:SESP'])
+        >>> Case(caseroot, read_only=False)._valid_compset_impl('atm:DATM%NYF_rof:DROF%NYF_scn:2000_ice:DICE%SSMI_ocn:DOCN%DOM', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
+        ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
         >>> Case(caseroot, read_only=False)._valid_compset_impl('2000_DATM%NYF_DICE%SSMI_DOCN%DOM_DROF%NYF', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
         ('2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV_SESP', ['2000', 'DATM%NYF', 'SLND', 'DICE%SSMI', 'DOCN%DOM', 'DROF%NYF', 'SGLC', 'SWAV', 'SESP'])
         >>> Case(caseroot, read_only=False)._valid_compset_impl('2000_DICE%SSMI_DOCN%DOM_DATM%NYF_DROF%NYF', None, ['CPL', 'ATM', 'LND', 'ICE', 'OCN', 'ROF', 'GLC', 'WAV', 'ESP'], {'datm':1,'satm':1,'dlnd':2,'slnd':2,'dice':3,'sice':3,'docn':4,'socn':4,'drof':5,'srof':5,'sglc':6,'swav':7,'ww3':7,'sesp':8})
@@ -767,11 +767,11 @@ class Case(object):
         allstubs = True
         colonformat = ':' in compset_name
         if colonformat:
-            # make sure that tim: is component[0] as expected
+            # make sure that scn: is component[0] as expected
             for i in range(1,len(components)):
-                if components[i].startswith('tim:'):
+                if components[i].startswith('scn:'):
                     tmp = components[0]
-                    components[0] = components[i]
+                    components[0] = components[i][4:]
                     components[i] = tmp
                     break
 
@@ -799,11 +799,11 @@ class Case(object):
                 comp_class = comp_classes[comp_ind]
                 stub = "S" + comp_class
                 logger.info("Automatically adding {} to compset".format(stub))
-                if colonformat:
-                    model_set[comp_ind] = comp_class.lower()+":"+stub
-                else:
-                    model_set[comp_ind] = stub
-            elif model_set[comp_ind][0] != "S":
+                model_set[comp_ind] = stub
+            elif ':' in model_set[comp_ind]:
+                model_set[comp_ind] = model_set[comp_ind][4:]
+
+            if model_set[comp_ind][0] != "S":
                 allstubs = False
 
         expect(

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -774,7 +774,7 @@ class Case(object):
                     components[0] = components[i]
                     components[i] = tmp
                     break
-                    
+
                 model_set[0] = components[0][4:]
         else:
             model_set[0] = components[0]

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -765,11 +765,11 @@ class Case(object):
         components = compset_name.split("_")
         noncomps = []
         allstubs = True
-        colonformat = ':' in compset_name
+        colonformat = ":" in compset_name
         if colonformat:
             # make sure that scn: is component[0] as expected
-            for i in range(1,len(components)):
-                if components[i].startswith('scn:'):
+            for i in range(1, len(components)):
+                if components[i].startswith("scn:"):
                     tmp = components[0]
                     components[0] = components[i][4:]
                     components[i] = tmp
@@ -784,8 +784,7 @@ class Case(object):
             # Check for noncomponent appends (BGC & TEST)
             if mod_match in ("bgc", "test"):
                 noncomps.append(model)
-            elif ':' in mod_match:
-                mclass = mod_match[0:3]
+            elif ":" in mod_match:
                 comp_ind = comp_hash[mod_match[4:]]
                 model_set[comp_ind] = model
             else:
@@ -800,7 +799,7 @@ class Case(object):
                 stub = "S" + comp_class
                 logger.info("Automatically adding {} to compset".format(stub))
                 model_set[comp_ind] = stub
-            elif ':' in model_set[comp_ind]:
+            elif ":" in model_set[comp_ind]:
                 model_set[comp_ind] = model_set[comp_ind][4:]
 
             if model_set[comp_ind][0] != "S":
@@ -915,7 +914,7 @@ class Case(object):
         # the first element is always the date operator - skip it
         elements = compset.split("_")[1:]  # pylint: disable=maybe-no-member
         for element in elements:
-            if ':' in element:
+            if ":" in element:
                 element = element[4:]
             # ignore the possible BGC or TEST modifier
             if element.startswith("BGC%") or element.startswith("TEST"):
@@ -1008,8 +1007,8 @@ class Case(object):
         for i in range(1, len(self._component_classes)):
             comp_class = self._component_classes[i]
             comp_name = self._components[i - 1]
-            if ':' in comp_name:
-                comp_name=comp_name[4:]
+            if ":" in comp_name:
+                comp_name = comp_name[4:]
             root_dir_node_name = "COMP_ROOT_DIR_" + comp_class
             node_name = "CONFIG_" + comp_class + "_FILE"
             compatt = {"component": comp_name}

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -771,11 +771,13 @@ class Case(object):
             for i in range(1, len(components)):
                 if components[i].startswith("scn:"):
                     tmp = components[0]
-                    components[0] = components[i][4:]
+                    components[0] = components[i]
                     components[i] = tmp
                     break
-
-        model_set[0] = components[0]
+                    
+                model_set[0] = components[0][4:]
+        else:
+            model_set[0] = components[0]
 
         for model in components[1:]:
             match = Case.__mod_match_re__.match(model.lower())


### PR DESCRIPTION
Introduce a new compset naming convention which maintains backward compatibility and allows position independence.
This convention uses a three character lower case prefix to indicate the component class (tim, atm, lnd, ice, ...) followed by a : .  Some examples are:  

- tim:2000_atm:DATM%NYF_ocn:DOCN%SOMAQP
- tim:1850_lnd:DLND%SCPL
- atm:DATM%NYF_ice:DICE%SSMI_ocn:DOCN%DOM_rof:DROF%NYF_tim%2000

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes #4125 

User interface changes?:

Update gh-pages html (Y/N)?:
