### PR TITLE
FUNIT needs CIME_NO_CMAKE_MACRO ON for now

### DIFF
--- a/scripts/lib/CIME/SystemTests/funit.py
+++ b/scripts/lib/CIME/SystemTests/funit.py
@@ -53,8 +53,16 @@ class FUNIT(SystemTestsCommon):
         args = "--build-dir {} --test-spec-dir {} --machine {}".format(
             exeroot, test_spec_dir, mach
         )
+
+        # BUG(wjs, 2022-01-07, ESMCI/CIME#4136) For now, these Fortran unit tests only
+        # work with the old config_compilers.xml-based configuration
+        my_env = os.environ.copy()
+        my_env["CIME_NO_CMAKE_MACRO"] = "ON"
+
         stat = run_cmd(
-            "{} {} >& funit.log".format(unit_test_tool, args), from_dir=rundir
+            "{} {} >& funit.log".format(unit_test_tool, args),
+            from_dir=rundir,
+            env=my_env,
         )[0]
 
         append_testlog(open(os.path.join(rundir, "funit.log"), "r").read())


### PR DESCRIPTION
Related to ESMCI/CIME#4136

Test suite: pre-commit and manual testing
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N
