### PR TITLE
Extend throughput and memory checking in baseline tests

### DIFF
--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -66,6 +66,7 @@
   <xs:element name="RUNDIR" type="xs:string"/>
   <xs:element name="EXEROOT" type="xs:string"/>
   <xs:element name="TEST_TPUT_TOLERANCE" type="xs:string"/>
+  <xs:element name="TEST_MEMLEAK_TOLERANCE" type="xs:string"/>
   <xs:element name="MAX_GB_OLD_TEST_DATA" type="xs:string"/>
 
 
@@ -181,6 +182,7 @@
         <xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="TEST_MEMLEAK_TOLERANCE" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>

--- a/scripts/Tools/cs.status
+++ b/scripts/Tools/cs.status
@@ -70,6 +70,18 @@ def parse_command_line(args, description):
     )
 
     parser.add_argument(
+        "--check-throughput",
+        action="store_true",
+        help="Fail if throughput check fails (fail if tests slow down)",
+    )
+
+    parser.add_argument(
+        "--check-memory",
+        action="store_true",
+        help="Fail if memory check fails (fail if tests footprint grows)",
+    )
+
+    parser.add_argument(
         "-x",
         "--expected-fails-file",
         help="Path to XML file listing expected failures for this test suite",
@@ -103,6 +115,8 @@ def parse_command_line(args, description):
         args.summary,
         args.fails_only,
         args.count_fails,
+        args.check_throughput,
+        args.check_memory,
         args.expected_fails_file,
         args.test_id,
         args.test_root,
@@ -139,6 +153,8 @@ def _main_func(description):
         summary,
         fails_only,
         count_fails,
+        check_throughput,
+        check_memory,
         expected_fails_file,
         test_ids,
         test_root,
@@ -153,6 +169,8 @@ def _main_func(description):
         summary=summary,
         fails_only=fails_only,
         count_fails_phase_list=count_fails,
+        check_throughput=check_throughput,
+        check_memory=check_memory,
         expected_fails_filepath=expected_fails_file,
     )
 

--- a/scripts/Tools/jenkins_generic_job
+++ b/scripts/Tools/jenkins_generic_job
@@ -158,6 +158,18 @@ OR
         help="Compiler to use to build cime.  Default will be the default defined for the machine.",
     )
 
+    parser.add_argument(
+        "--check-throughput",
+        action="store_true",
+        help="Fail if throughput check fails (fail if tests slow down)",
+    )
+
+    parser.add_argument(
+        "--check-memory",
+        action="store_true",
+        help="Fail if memory check fails (fail if tests footprint grows)",
+    )
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.no_submit:
@@ -223,6 +235,8 @@ OR
         args.override_baseline_name,
         args.baseline_root,
         args.update_success,
+        args.check_throughput,
+        args.check_memory,
     )
 
 
@@ -247,6 +261,8 @@ def _main_func(description):
         real_baseline_name,
         baseline_root,
         update_success,
+        check_throughput,
+        check_memory,
     ) = parse_command_line(sys.argv, description)
 
     sys.exit(
@@ -269,6 +285,8 @@ def _main_func(description):
             real_baseline_name,
             baseline_root,
             update_success,
+            check_throughput,
+            check_memory,
         )
         else CIME.utils.TESTS_FAILED_ERR_CODE
     )

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -571,7 +571,7 @@ class SystemTestsCommon(object):
                         self._test_status.set_status(
                             MEMLEAK_PHASE,
                             TEST_PASS_STATUS,
-                            comments="insuffiencient data for memleak test",
+                            comments="data for memleak test is insuffiencient",
                         )
                     elif memdiff < tolerance:
                         self._test_status.set_status(MEMLEAK_PHASE, TEST_PASS_STATUS)
@@ -653,15 +653,20 @@ class SystemTestsCommon(object):
                     blmem = 0 if blmem == [] else blmem[-1][1]
                     curmem = memlist[-1][1]
                     diff = 0.0 if blmem == 0 else (curmem - blmem) / blmem
+                    tolerance = self._case.get_value("TEST_MEMLEAK_TOLERANCE")
+                    if tolerance is None:
+                        tolerance = 0.1
                     if (
-                        diff < 0.1
+                        diff < tolerance
                         and self._test_status.get_status(MEMCOMP_PHASE) is None
                     ):
                         self._test_status.set_status(MEMCOMP_PHASE, TEST_PASS_STATUS)
                     elif (
                         self._test_status.get_status(MEMCOMP_PHASE) != TEST_FAIL_STATUS
                     ):
-                        comment = "Error: Memory usage increase > 10% from baseline"
+                        comment = "Error: Memory usage increase >{:d}% from baseline's {:f} to {:f}".format(
+                            int(tolerance * 100), blmem, curmem
+                        )
                         self._test_status.set_status(
                             MEMCOMP_PHASE, TEST_FAIL_STATUS, comments=comment
                         )

--- a/scripts/lib/CIME/cs_status.py
+++ b/scripts/lib/CIME/cs_status.py
@@ -58,14 +58,18 @@ def cs_status(
         ts = TestStatus(test_dir=test_dir)
         test_id = os.path.basename(test_dir).split(".")[-1]
         if summary:
-            output = _overall_output(ts, "  {status} {test_name}\n", check_throughput, check_memory)
+            output = _overall_output(
+                ts, "  {status} {test_name}\n", check_throughput, check_memory
+            )
         else:
             if fails_only:
                 output = ""
             else:
                 output = _overall_output(
-                    ts, "  {test_name} (Overall: {status}) details:\n",
-                    check_throughput, check_memory
+                    ts,
+                    "  {test_name} (Overall: {status}) details:\n",
+                    check_throughput,
+                    check_memory,
                 )
             output += ts.phase_statuses_dump(
                 prefix="    ",

--- a/scripts/lib/CIME/cs_status.py
+++ b/scripts/lib/CIME/cs_status.py
@@ -17,6 +17,8 @@ def cs_status(
     summary=False,
     fails_only=False,
     count_fails_phase_list=None,
+    check_throughput=False,
+    check_memory=False,
     expected_fails_filepath=None,
     out=sys.stdout,
 ):
@@ -56,13 +58,14 @@ def cs_status(
         ts = TestStatus(test_dir=test_dir)
         test_id = os.path.basename(test_dir).split(".")[-1]
         if summary:
-            output = _overall_output(ts, "  {status} {test_name}\n")
+            output = _overall_output(ts, "  {status} {test_name}\n", check_throughput, check_memory)
         else:
             if fails_only:
                 output = ""
             else:
                 output = _overall_output(
-                    ts, "  {test_name} (Overall: {status}) details:\n"
+                    ts, "  {test_name} (Overall: {status}) details:\n",
+                    check_throughput, check_memory
                 )
             output += ts.phase_statuses_dump(
                 prefix="    ",
@@ -107,7 +110,7 @@ def _get_xfails(expected_fails_filepath):
     return xfails
 
 
-def _overall_output(ts, format_str):
+def _overall_output(ts, format_str, check_throughput, check_memory):
     """Returns a string giving the overall test status
 
     Args:
@@ -116,5 +119,8 @@ def _overall_output(ts, format_str):
         contain place-holders for status and test_name
     """
     test_name = ts.get_name()
-    status = ts.get_overall_test_status()[0]
+    status = ts.get_overall_test_status(
+        check_throughput=check_throughput,
+        check_memory=check_memory,
+    )[0]
     return format_str.format(status=status, test_name=test_name)

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -777,15 +777,17 @@ class TestScheduler(object):
         envtest.set_value("TESTCASE", test_case)
         envtest.set_value("TEST_TESTID", self._test_id)
         envtest.set_value("CASEBASEID", test)
+        memleak_tolerance = self._machobj.get_value("TEST_MEMLEAK_TOLERANCE", resolved=False)
         if (
             test in self._test_data
             and "options" in self._test_data[test]
             and "memleak_tolerance" in self._test_data[test]["options"]
         ):
-            envtest.set_value(
-                "TEST_MEMLEAK_TOLERANCE",
-                self._test_data[test]["options"]["memleak_tolerance"],
-            )
+            memleak_tolerance = self._test_data[test]["options"]["memleak_tolerance"]
+
+        envtest.set_value(
+            "TEST_MEMLEAK_TOLERANCE", 0.10 if memleak_tolerance is None else memleak_tolerance
+        )
 
         test_argv = "-testname {} -testroot {}".format(test, self._test_root)
         if self._baseline_gen_name:

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -777,7 +777,9 @@ class TestScheduler(object):
         envtest.set_value("TESTCASE", test_case)
         envtest.set_value("TEST_TESTID", self._test_id)
         envtest.set_value("CASEBASEID", test)
-        memleak_tolerance = self._machobj.get_value("TEST_MEMLEAK_TOLERANCE", resolved=False)
+        memleak_tolerance = self._machobj.get_value(
+            "TEST_MEMLEAK_TOLERANCE", resolved=False
+        )
         if (
             test in self._test_data
             and "options" in self._test_data[test]
@@ -786,7 +788,8 @@ class TestScheduler(object):
             memleak_tolerance = self._test_data[test]["options"]["memleak_tolerance"]
 
         envtest.set_value(
-            "TEST_MEMLEAK_TOLERANCE", 0.10 if memleak_tolerance is None else memleak_tolerance
+            "TEST_MEMLEAK_TOLERANCE",
+            0.10 if memleak_tolerance is None else memleak_tolerance,
         )
 
         test_argv = "-testname {} -testroot {}".format(test, self._test_root)

--- a/scripts/lib/jenkins_generic_job.py
+++ b/scripts/lib/jenkins_generic_job.py
@@ -262,6 +262,8 @@ def jenkins_generic_job(
     real_baseline_name,
     baseline_root,
     update_success,
+    check_throughput,
+    check_memory,
 ):
     ###############################################################################
     """
@@ -385,8 +387,8 @@ def jenkins_generic_job(
     tests_passed = CIME.wait_for_tests.wait_for_tests(
         glob.glob("{}/*{}/TestStatus".format(test_root, test_id)),
         no_wait=not use_batch,  # wait if using queue
-        check_throughput=False,  # don't check throughput
-        check_memory=False,  # don't check memory
+        check_throughput=check_throughput,
+        check_memory=check_memory,
         ignore_namelists=False,  # don't ignore namelist diffs
         cdash_build_name=cdash_build_name,
         cdash_project=cdash_project,


### PR DESCRIPTION
Extend throughput and memory checking in baseline tests:
* add XML variable `TEST_MEMLEAK_TOLERANCE` to config_machines.xsd
* add `--check-throughput` and `--check-memory` options to test `cs.status` script
* add throughput and memory checking options to Jenkins job script

This helps detect throughput and memory regressions while integrating new features.

Test suite: by-hand
Test baseline: no changes
Test namelist changes: none
Test status: bit for bit

User interface changes?: new `--check-throughput` and `--check-memory` options in
  `cs.status` and `jenkins_generic_job` scripts

Update gh-pages html (Y/N)?: N
