### PR TITLE
This fixes a number of fails in scripts_regression for e3sm on mappy

### DIFF
--- a/scripts/lib/CIME/tests/base.py
+++ b/scripts/lib/CIME/tests/base.py
@@ -220,8 +220,9 @@ class BaseTestCase(unittest.TestCase):
             [extra_arg for extra_arg in extra_args if "--mpilib" in extra_arg] == []
         ):
             extra_args.append("--mpilib={}".format(self.TEST_MPILIB))
+        if [extra_arg for extra_arg in extra_args if "--machine" in extra_arg] == []:
+            extra_args.append(f"--machine {self.MACHINE.get_machine_name()}")
         extra_args.append("--test-root={0} --output-root={0}".format(self._testroot))
-        extra_args.append(f"--machine {self.MACHINE.get_machine_name()}")
 
         full_run = (
             set(extra_args)

--- a/scripts/lib/CIME/tests/test_sys_grid_generation.py
+++ b/scripts/lib/CIME/tests/test_sys_grid_generation.py
@@ -32,7 +32,7 @@ class TestGridGeneration(base.BaseTestCase):
         cls._testdirs.append(test_dir)
         os.makedirs(test_dir)
         self.run_cmd_assert_result(
-            self, "{} {}".format(tool_location, args), from_dir=test_dir
+            "{} {}".format(tool_location, args), from_dir=test_dir
         )
         cls._do_teardown.append(test_dir)
 

--- a/scripts/lib/CIME/tests/test_sys_jenkins_generic_job.py
+++ b/scripts/lib/CIME/tests/test_sys_jenkins_generic_job.py
@@ -46,7 +46,6 @@ class TestJenkinsGenericJob(base.BaseTestCase):
             )
 
         self.run_cmd_assert_result(
-            self,
             "%s/jenkins_generic_job -r %s %s -B %s"
             % (self.TOOLS_DIR, self._testdir, extra_args, self._baseline_area),
             from_dir=self._testdir,

--- a/scripts/lib/CIME/tests/test_sys_test_scheduler.py
+++ b/scripts/lib/CIME/tests/test_sys_test_scheduler.py
@@ -14,9 +14,11 @@ from CIME.tests import base
 
 
 class TestTestScheduler(base.BaseTestCase):
-    @mock.patch.dict(os.environ, {"CIME_MODEL": "cesm"})
     @mock.patch("time.strftime", return_value="00:00:00")
     def test_chksum(self, strftime):  # pylint: disable=unused-argument
+        if utils.get_model() != "cesm":
+            self.skipTest("Skipping chksum test. Depends on CESM settings")
+
         ts = test_scheduler.TestScheduler(
             ["SEQ_Ln9.f19_g16_rx1.A.cori-haswell_gnu"],
             machine_name="cori-haswell",


### PR DESCRIPTION
It looks like these problems were missed because we aren't running in e3sm mode in GitHub actions.

Test suite: scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
