### PR TITLE
Remove the remaining users of config_compilers.xml

### DIFF
--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -13,7 +13,7 @@ from CIME.utils import run_cmd_no_fail, stringify_bool, expect, get_src_root, sa
 from CIME.XML.machines import Machines
 from CIME.XML.compilers import Compilers
 from CIME.XML.env_mach_specific import EnvMachSpecific
-from CIME.build import get_makefile_vars
+from CIME.build import CmakeTmpBuildDir
 from xml_test_list import TestSuiteSpec, suites_from_xml
 import socket, shutil
 from pathlib import Path
@@ -298,13 +298,8 @@ def find_pfunit(caseroot, cmake_args):
     - case: A fake case
     - caseroot: The dir with the macros
     """
-    new_cmake_dir = os.path.join(caseroot, "cmake_macros")
-    cmake_lists = os.path.join(new_cmake_dir, "CMakeLists.txt")
-    Path(os.path.join(caseroot, "cmaketmp")).mkdir(parents=False, exist_ok=True)
-    safe_copy(cmake_lists, "cmaketmp")
-
-    all_vars = get_makefile_vars(None, caseroot, cmake_args=cmake_args)
-    shutil.rmtree(os.path.join(caseroot, "cmaketmp"))
+    with CmakeTmpBuildDir(macroloc=caseroot) as cmaketmp:
+        all_vars = cmaketmp.get_makefile_vars(cmake_args=cmake_args)
 
     all_vars_list = all_vars.splitlines()
     for all_var in all_vars_list:

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -295,8 +295,8 @@ def find_pfunit(caseroot, cmake_args):
     Aborts if necessary information cannot be found.
 
     Args:
-    - case: A fake case
-    - caseroot: The dir with the macros
+    - caseroot:   The dir with the macros
+    - cmake_args: The cmake args used to invoke cmake (so that we get the correct makefile vars)
     """
     with CmakeTmpBuildDir(macroloc=caseroot) as cmaketmp:
         all_vars = cmaketmp.get_makefile_vars(cmake_args=cmake_args)

--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -423,10 +423,9 @@ def _main():
 
     fake_case = FakeCase(compiler, mpilib, debug, comp_interface, threading=use_openmp)
     machspecific.load_env(fake_case)
-    # JGF bug? original contents of cmake_args is lost
     cmake_args = (
         "{}-DOS={} -DMACH={} -DCOMPILER={} -DDEBUG={} -DMPILIB={} -Dcompile_threaded={} -DCASEROOT={}".format(
-            "" if not cmake_args else " ",
+            "" if not cmake_args else "{} ".format(cmake_args),
             os_,
             machine,
             compiler,

--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -22,7 +22,7 @@ from CIME.XML.env_mach_specific import EnvMachSpecific
 from CIME.XML.files import Files
 from CIME.build import CmakeTmpBuildDir
 
-import shutil
+import shutil, glob
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +79,12 @@ def configure(
                 shutil.copytree(
                     new_cmake_macros_dir, os.path.join(output_dir, "cmake_macros")
                 )
+
+            # Grab macros from extra machine dir if it was provided
+            if extra_machines_dir:
+                extra_cmake_macros = glob.glob("{}/cmake_macros/*.cmake".format(extra_machines_dir))
+                for extra_cmake_macro in extra_cmake_macros:
+                    safe_copy(extra_cmake_macro, new_cmake_macros_dir)
 
             if form == "Makefile":
                 # Use the cmake macros to generate the make macros

--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -67,8 +67,11 @@ def configure(
     for form in macros_format:
 
         if not "CIME_NO_CMAKE_MACRO" in os.environ:
-            expect(new_cmake_macros_dir is not None and os.path.exists(new_cmake_macros_dir),
-                   "Cannot create CMake macros without CMAKE_MACROS_DIR")
+            expect(
+                new_cmake_macros_dir is not None
+                and os.path.exists(new_cmake_macros_dir),
+                "Cannot create CMake macros without CMAKE_MACROS_DIR",
+            )
 
             if not os.path.isfile(os.path.join(output_dir, "Macros.cmake")):
                 safe_copy(
@@ -81,21 +84,21 @@ def configure(
 
             if form == "Makefile":
                 # Use the cmake macros to generate the make macros
-                cmake_args = (
-                        " -DOS={} -DMACH={} -DCOMPILER={} -DDEBUG={} -DMPILIB={} -Dcompile_threaded={} -DCASEROOT={}".format(
-                            sysos,
-                            machobj.get_machine_name(),
-                            compiler,
-                            stringify_bool(debug),
-                            mpilib,
-                            stringify_bool(threaded),
-                            output_dir
-                        )
+                cmake_args = " -DOS={} -DMACH={} -DCOMPILER={} -DDEBUG={} -DMPILIB={} -Dcompile_threaded={} -DCASEROOT={}".format(
+                    sysos,
+                    machobj.get_machine_name(),
+                    compiler,
+                    stringify_bool(debug),
+                    mpilib,
+                    stringify_bool(threaded),
+                    output_dir,
                 )
 
                 new_cmake_dir = os.path.join(output_dir, "cmake_macros")
                 cmake_lists = os.path.join(new_cmake_dir, "CMakeLists.txt")
-                Path(os.path.join(output_dir, "cmaketmp")).mkdir(parents=False, exist_ok=True)
+                Path(os.path.join(output_dir, "cmaketmp")).mkdir(
+                    parents=False, exist_ok=True
+                )
                 safe_copy(cmake_lists, "cmaketmp")
 
                 output = get_makefile_vars(None, output_dir, cmake_args=cmake_args)
@@ -170,8 +173,8 @@ class FakeCase(object):
             "COMP_INTERFACE": comp_interface,
             "PIO_VERSION": 2,
             "SMP_PRESENT": threading,
-            "MODEL" : get_model(),
-            "SRCROOT" : get_src_root()
+            "MODEL": get_model(),
+            "SRCROOT": get_src_root(),
         }
 
     def get_build_threaded(self):

--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -23,7 +23,6 @@ from CIME.XML.files import Files
 from CIME.build import CmakeTmpBuildDir
 
 import shutil
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -67,10 +66,10 @@ def configure(
     for form in macros_format:
 
         if (
-             new_cmake_macros_dir is not None
-             and os.path.exists(new_cmake_macros_dir)
-             and not "CIME_NO_CMAKE_MACRO" in os.environ
-         ):
+            new_cmake_macros_dir is not None
+            and os.path.exists(new_cmake_macros_dir)
+            and not "CIME_NO_CMAKE_MACRO" in os.environ
+        ):
 
             if not os.path.isfile(os.path.join(output_dir, "Macros.cmake")):
                 safe_copy(

--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -82,7 +82,9 @@ def configure(
 
             # Grab macros from extra machine dir if it was provided
             if extra_machines_dir:
-                extra_cmake_macros = glob.glob("{}/cmake_macros/*.cmake".format(extra_machines_dir))
+                extra_cmake_macros = glob.glob(
+                    "{}/cmake_macros/*.cmake".format(extra_machines_dir)
+                )
                 for extra_cmake_macro in extra_cmake_macros:
                     safe_copy(extra_cmake_macro, new_cmake_macros_dir)
 

--- a/scripts/lib/CIME/SystemTests/funit.py
+++ b/scripts/lib/CIME/SystemTests/funit.py
@@ -54,15 +54,9 @@ class FUNIT(SystemTestsCommon):
             exeroot, test_spec_dir, mach
         )
 
-        # BUG(wjs, 2022-01-07, ESMCI/CIME#4136) For now, these Fortran unit tests only
-        # work with the old config_compilers.xml-based configuration
-        my_env = os.environ.copy()
-        my_env["CIME_NO_CMAKE_MACRO"] = "ON"
-
         stat = run_cmd(
             "{} {} >& funit.log".format(unit_test_tool, args),
-            from_dir=rundir,
-            env=my_env,
+            from_dir=rundir
         )[0]
 
         append_testlog(open(os.path.join(rundir, "funit.log"), "r").read())

--- a/scripts/lib/CIME/SystemTests/funit.py
+++ b/scripts/lib/CIME/SystemTests/funit.py
@@ -55,8 +55,7 @@ class FUNIT(SystemTestsCommon):
         )
 
         stat = run_cmd(
-            "{} {} >& funit.log".format(unit_test_tool, args),
-            from_dir=rundir
+            "{} {} >& funit.log".format(unit_test_tool, args), from_dir=rundir
         )[0]
 
         append_testlog(open(os.path.join(rundir, "funit.log"), "r").read())

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -34,7 +34,10 @@ class Compilers(GenericXML):
         config_compilers.xml. An empty string is treated the same as None.
         """
 
-        expect("CIME_NO_CMAKE_MACRO" in os.environ, "Should not be using config_compilers.xml without CIME_NO_CMAKE_MACRO")
+        expect(
+            "CIME_NO_CMAKE_MACRO" in os.environ,
+            "Should not be using config_compilers.xml without CIME_NO_CMAKE_MACRO",
+        )
 
         if infile is None:
             if files is None:

--- a/scripts/lib/CIME/XML/compilers.py
+++ b/scripts/lib/CIME/XML/compilers.py
@@ -34,6 +34,8 @@ class Compilers(GenericXML):
         config_compilers.xml. An empty string is treated the same as None.
         """
 
+        expect("CIME_NO_CMAKE_MACRO" in os.environ, "Should not be using config_compilers.xml without CIME_NO_CMAKE_MACRO")
+
         if infile is None:
             if files is None:
                 files = Files()
@@ -136,11 +138,6 @@ class Compilers(GenericXML):
     def set_compiler(self, compiler, machine=None, os_=None, mpilib=None):
         """
         Sets the compiler block in the Compilers object
-        >>> from CIME.XML.machines import Machines
-        >>> compobj = Compilers(Machines(machine="melvin"))
-        >>> compobj.set_compiler("gnu")
-        >>> compobj.get_compiler()
-        'gnu'
         """
         machine = machine if machine else self.machine
         os_ = os_ if os_ else self.os

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -57,11 +57,13 @@ _CMD_ARGS_FOR_BUILD = (
 )
 
 
-def get_makefile_vars(case, caseroot, comp=None):
+def get_makefile_vars(case, caseroot, comp=None, cmake_args=None):
     """
     Run cmake and process output to a list of variable settings
+
+    case can be None if caller is providing their own cmake args
     """
-    cmake_args = get_standard_cmake_args(case, "DO_NOT_USE", shared_lib=True)
+    cmake_args = get_standard_cmake_args(case, "DO_NOT_USE", shared_lib=True) if cmake_args is None else cmake_args
     dcomp = "-DCOMP_NAME={}".format(comp) if comp else ""
     output = run_cmd_no_fail(
         "cmake -DCONVERT_TO_MAKE=ON {dcomp} {cmake_args} .".format(

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -71,7 +71,7 @@ class CmakeTmpBuildDir(object):
         """
         self._macroloc = os.getcwd() if macroloc is None else macroloc
         self._rootdir = self._macroloc if rootdir is None else rootdir
-        self._tmpdir  = "cmaketmp" if tmpdir is None else tmpdir
+        self._tmpdir = "cmaketmp" if tmpdir is None else tmpdir
 
         self._entered = False
 
@@ -80,7 +80,12 @@ class CmakeTmpBuildDir(object):
 
     def __enter__(self):
         cmake_macros_dir = os.path.join(self._macroloc, "cmake_macros")
-        expect(os.path.isdir(cmake_macros_dir, "Cannot create cmake temp build dir, no {} macros found".format(cmake_macros_dir)))
+        expect(
+            os.path.isdir(cmake_macros_dir),
+            "Cannot create cmake temp build dir, no {} macros found".format(
+                cmake_macros_dir
+            ),
+        )
         cmake_lists = os.path.join(cmake_macros_dir, "CMakeLists.txt")
         full_tmp_dir = self.get_full_tmpdir()
         Path(full_tmp_dir).mkdir(parents=False, exist_ok=True)
@@ -88,7 +93,7 @@ class CmakeTmpBuildDir(object):
 
         self._entered = True
 
-    def __exit__(self):
+    def __exit__(self, *args):
         shutil.rmtree(self.get_full_tmpdir())
         self._entered = False
 
@@ -98,9 +103,14 @@ class CmakeTmpBuildDir(object):
 
         case can be None if caller is providing their own cmake args
         """
-        expect(self._entered, "Should only call get_makefile_vars within a with statement")
+        expect(
+            self._entered, "Should only call get_makefile_vars within a with statement"
+        )
         if case is None:
-            expect(cmake_args is not None, "Need either a case or hardcoded cmake_args to generate makefile vars")
+            expect(
+                cmake_args is not None,
+                "Need either a case or hardcoded cmake_args to generate makefile vars",
+            )
 
         cmake_args = (
             get_standard_cmake_args(case, "DO_NOT_USE", shared_lib=True)
@@ -113,7 +123,7 @@ class CmakeTmpBuildDir(object):
                 dcomp=dcomp, cmake_args=cmake_args
             ),
             combine_output=True,
-            from_dir=self.get_full_tmpdir()
+            from_dir=self.get_full_tmpdir(),
         )
 
         lines_to_keep = []

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -63,7 +63,11 @@ def get_makefile_vars(case, caseroot, comp=None, cmake_args=None):
 
     case can be None if caller is providing their own cmake args
     """
-    cmake_args = get_standard_cmake_args(case, "DO_NOT_USE", shared_lib=True) if cmake_args is None else cmake_args
+    cmake_args = (
+        get_standard_cmake_args(case, "DO_NOT_USE", shared_lib=True)
+        if cmake_args is None
+        else cmake_args
+    )
     dcomp = "-DCOMP_NAME={}".format(comp) if comp else ""
     output = run_cmd_no_fail(
         "cmake -DCONVERT_TO_MAKE=ON {dcomp} {cmake_args} .".format(

--- a/scripts/lib/CIME/build.py
+++ b/scripts/lib/CIME/build.py
@@ -93,6 +93,8 @@ class CmakeTmpBuildDir(object):
 
         self._entered = True
 
+        return self
+
     def __exit__(self, *args):
         shutil.rmtree(self.get_full_tmpdir())
         self._entered = False

--- a/scripts/lib/CIME/tests/test_sys_cmake_macros.py
+++ b/scripts/lib/CIME/tests/test_sys_cmake_macros.py
@@ -5,6 +5,7 @@ from CIME.tests import base
 from CIME.tests import utils as test_utils
 from CIME.XML.compilers import Compilers
 
+import os
 
 class TestCMakeMacros(base.BaseTestCase):
     """CMake macros tests.
@@ -27,6 +28,9 @@ class TestCMakeMacros(base.BaseTestCase):
 
     def setUp(self):
         super().setUp()
+
+        if "CIME_NO_CMAKE_MACRO" not in os.environ:
+            self.skipTest("Skipping test of old macro system")
 
         self.test_os = "SomeOS"
         self.test_machine = "mymachine"

--- a/scripts/lib/CIME/tests/test_sys_cmake_macros.py
+++ b/scripts/lib/CIME/tests/test_sys_cmake_macros.py
@@ -7,6 +7,7 @@ from CIME.XML.compilers import Compilers
 
 import os
 
+
 class TestCMakeMacros(base.BaseTestCase):
     """CMake macros tests.
 

--- a/scripts/lib/CIME/tests/test_sys_create_newcase.py
+++ b/scripts/lib/CIME/tests/test_sys_create_newcase.py
@@ -706,7 +706,7 @@ set(NETCDF_PATH /my/netcdf/path)
         else:
             args += " --res f19_g16 "
         self.run_cmd_assert_result(
-            "./create_newcase {}".format(args), from_dir=self.SCRIPT_DIR, verbose=True
+            "./create_newcase {}".format(args), from_dir=self.SCRIPT_DIR
         )
 
         args += f" --machine {self.MACHINE.get_machine_name()}"

--- a/scripts/lib/CIME/tests/test_sys_create_newcase.py
+++ b/scripts/lib/CIME/tests/test_sys_create_newcase.py
@@ -653,7 +653,7 @@ class TestCreateNewcase(base.BaseTestCase):
 
     def test_ka_createnewcase_extra_machines_dir(self):
         # Test that we pick up changes in both config_machines.xml and
-        # config_compilers.xml in a directory specified with the --extra-machines-dir
+        # cmake macros in a directory specified with the --extra-machines-dir
         # argument to create_newcase.
         cls = self.__class__
         casename = "testcreatenewcase_extra_machines_dir"
@@ -673,18 +673,12 @@ class TestCreateNewcase(base.BaseTestCase):
         utils.safe_copy(
             newmachfile, os.path.join(extra_machines_dir, "config_machines.xml")
         )
-        os.environ["CIME_NO_CMAKE_MACRO"] = "ON"
-        config_compilers_text = """\
-<?xml version="1.0" encoding="UTF-8"?>
-<config_compilers version="2.0">
-<compiler MACH="mymachine">
-  <NETCDF_PATH>/my/netcdf/path</NETCDF_PATH>
-</compiler>
-</config_compilers>
+        cmake_macro_text = """\
+set(NETCDF_PATH /my/netcdf/path)
 """
-        config_compilers_path = os.path.join(extra_machines_dir, "config_compilers.xml")
-        with open(config_compilers_path, "w") as config_compilers:
-            config_compilers.write(config_compilers_text)
+        cmake_macro_path = os.path.join(extra_machines_dir, "mymachine.cmake")
+        with open(cmake_macro_path, "w") as cmake_macro:
+            cmake_macro.write(cmake_macro_text)
 
         # Create the case
         testdir = os.path.join(cls._testroot, casename)
@@ -727,7 +721,6 @@ class TestCreateNewcase(base.BaseTestCase):
                 macros_contents = macros_file.read()
             expected_re = re.compile("NETCDF_PATH.*/my/netcdf/path")
             self.assertTrue(expected_re.search(macros_contents))
-        del os.environ["CIME_NO_CMAKE_MACRO"]
 
     def test_m_createnewcase_alternate_drivers(self):
         # Test that case.setup runs for nuopc and moab drivers

--- a/scripts/lib/CIME/tests/test_sys_create_newcase.py
+++ b/scripts/lib/CIME/tests/test_sys_create_newcase.py
@@ -663,7 +663,7 @@ class TestCreateNewcase(base.BaseTestCase):
         extra_machines_dir = os.path.join(
             cls._testroot, "{}_machine_config".format(casename)
         )
-        os.makedirs(extra_machines_dir)
+        os.makedirs(os.path.join(extra_machines_dir, "cmake_macros"))
         cls._do_teardown.append(extra_machines_dir)
         newmachfile = os.path.join(
             utils.get_cime_root(),
@@ -677,7 +677,7 @@ class TestCreateNewcase(base.BaseTestCase):
         cmake_macro_text = """\
 set(NETCDF_PATH /my/netcdf/path)
 """
-        cmake_macro_path = os.path.join(extra_machines_dir, "mymachine.cmake")
+        cmake_macro_path = os.path.join(extra_machines_dir, "cmake_macros", "mymachine.cmake")
         with open(cmake_macro_path, "w") as cmake_macro:
             cmake_macro.write(cmake_macro_text)
 
@@ -704,7 +704,7 @@ set(NETCDF_PATH /my/netcdf/path)
         else:
             args += " --res f19_g16 "
         self.run_cmd_assert_result(
-            "./create_newcase {}".format(args), from_dir=self.SCRIPT_DIR
+            "./create_newcase {}".format(args), from_dir=self.SCRIPT_DIR, verbose=True
         )
 
         args += f" --machine {self.MACHINE.get_machine_name()}"
@@ -721,7 +721,8 @@ set(NETCDF_PATH /my/netcdf/path)
                 macros_contents = cmaketmp.get_makefile_vars(case=case)
 
             expected_re = re.compile("NETCDF_PATH.*/my/netcdf/path")
-            self.assertTrue(expected_re.search(macros_contents))
+            self.assertTrue(expected_re.search(macros_contents),
+                            msg="{} not found in:\n{}".format(expected_re.pattern, macros_contents))
 
     def test_m_createnewcase_alternate_drivers(self):
         # Test that case.setup runs for nuopc and moab drivers

--- a/scripts/lib/CIME/tests/test_sys_create_newcase.py
+++ b/scripts/lib/CIME/tests/test_sys_create_newcase.py
@@ -677,7 +677,9 @@ class TestCreateNewcase(base.BaseTestCase):
         cmake_macro_text = """\
 set(NETCDF_PATH /my/netcdf/path)
 """
-        cmake_macro_path = os.path.join(extra_machines_dir, "cmake_macros", "mymachine.cmake")
+        cmake_macro_path = os.path.join(
+            extra_machines_dir, "cmake_macros", "mymachine.cmake"
+        )
         with open(cmake_macro_path, "w") as cmake_macro:
             cmake_macro.write(cmake_macro_text)
 
@@ -721,8 +723,10 @@ set(NETCDF_PATH /my/netcdf/path)
                 macros_contents = cmaketmp.get_makefile_vars(case=case)
 
             expected_re = re.compile("NETCDF_PATH.*/my/netcdf/path")
-            self.assertTrue(expected_re.search(macros_contents),
-                            msg="{} not found in:\n{}".format(expected_re.pattern, macros_contents))
+            self.assertTrue(
+                expected_re.search(macros_contents),
+                msg="{} not found in:\n{}".format(expected_re.pattern, macros_contents),
+            )
 
     def test_m_createnewcase_alternate_drivers(self):
         # Test that case.setup runs for nuopc and moab drivers

--- a/scripts/lib/CIME/tests/test_sys_create_newcase.py
+++ b/scripts/lib/CIME/tests/test_sys_create_newcase.py
@@ -11,6 +11,7 @@ from CIME.tests import base
 from CIME.case.case import Case
 from CIME.build import CmakeTmpBuildDir
 
+
 class TestCreateNewcase(base.BaseTestCase):
     @classmethod
     def setUpClass(cls):

--- a/scripts/lib/CIME/tests/test_sys_create_newcase.py
+++ b/scripts/lib/CIME/tests/test_sys_create_newcase.py
@@ -9,7 +9,7 @@ import sys
 from CIME import utils
 from CIME.tests import base
 from CIME.case.case import Case
-
+from CIME.build import CmakeTmpBuildDir
 
 class TestCreateNewcase(base.BaseTestCase):
     @classmethod
@@ -714,11 +714,11 @@ set(NETCDF_PATH /my/netcdf/path)
         self.run_cmd_assert_result("./case.setup", from_dir=testdir)
 
         # Make sure Macros file contains expected text
-        if utils.get_model() != "e3sm":
-            macros_file_name = os.path.join(testdir, "Macros.make")
-            self.assertTrue(os.path.isfile(macros_file_name))
-            with open(macros_file_name) as macros_file:
-                macros_contents = macros_file.read()
+
+        with Case(testdir) as case:
+            with CmakeTmpBuildDir(macroloc=testdir) as cmaketmp:
+                macros_contents = cmaketmp.get_makefile_vars(case=case)
+
             expected_re = re.compile("NETCDF_PATH.*/my/netcdf/path")
             self.assertTrue(expected_re.search(macros_contents))
 

--- a/scripts/lib/CIME/tests/test_sys_full_system.py
+++ b/scripts/lib/CIME/tests/test_sys_full_system.py
@@ -12,7 +12,8 @@ from CIME.tests import base
 class TestFullSystem(base.BaseTestCase):
     def test_full_system(self):
         # Put this inside any test that's slow
-        self.skipTest("Skipping slow test")
+        if self.FAST_ONLY:
+            self.skipTest("Skipping slow test")
 
         driver = utils.get_cime_default_driver()
         if driver == "mct":

--- a/scripts/lib/CIME/tests/test_sys_full_system.py
+++ b/scripts/lib/CIME/tests/test_sys_full_system.py
@@ -12,8 +12,7 @@ from CIME.tests import base
 class TestFullSystem(base.BaseTestCase):
     def test_full_system(self):
         # Put this inside any test that's slow
-        if self.FAST_ONLY:
-            self.skipTest("Skipping slow test")
+        self.skipTest("Skipping slow test")
 
         driver = utils.get_cime_default_driver()
         if driver == "mct":

--- a/scripts/lib/CIME/tests/test_sys_macro_basic.py
+++ b/scripts/lib/CIME/tests/test_sys_macro_basic.py
@@ -7,6 +7,7 @@ from CIME.tests import base
 from CIME.tests import utils as test_utils
 from CIME.XML.compilers import Compilers
 
+import os
 
 class TestMacrosBasic(base.BaseTestCase):
     """Basic infrastructure tests.
@@ -15,6 +16,12 @@ class TestMacrosBasic(base.BaseTestCase):
     macro file conversion. This includes basic smoke testing and tests of
     error-handling in the routine.
     """
+
+    def setUp(self):
+        super().setUp()
+
+        if "CIME_NO_CMAKE_MACRO" not in os.environ:
+            self.skipTest("Skipping test of old macro system")
 
     def test_script_is_callable(self):
         """The test script can be called on valid output without dying."""

--- a/scripts/lib/CIME/tests/test_sys_macro_basic.py
+++ b/scripts/lib/CIME/tests/test_sys_macro_basic.py
@@ -9,6 +9,7 @@ from CIME.XML.compilers import Compilers
 
 import os
 
+
 class TestMacrosBasic(base.BaseTestCase):
     """Basic infrastructure tests.
 

--- a/scripts/lib/CIME/tests/test_sys_make_macros.py
+++ b/scripts/lib/CIME/tests/test_sys_make_macros.py
@@ -6,6 +6,7 @@ from CIME.tests import utils as test_utils
 from CIME.tests import base
 from CIME.XML.compilers import Compilers
 
+import os
 
 class TestMakeMacros(base.BaseTestCase):
     """Makefile macros tests.
@@ -17,6 +18,9 @@ class TestMakeMacros(base.BaseTestCase):
     """
 
     def setUp(self):
+        if "CIME_NO_CMAKE_MACRO" not in os.environ:
+            self.skipTest("Skipping test of old macro system")
+
         self.test_os = "SomeOS"
         self.test_machine = "mymachine"
         self.test_compiler = (

--- a/scripts/lib/CIME/tests/test_sys_make_macros.py
+++ b/scripts/lib/CIME/tests/test_sys_make_macros.py
@@ -8,6 +8,7 @@ from CIME.XML.compilers import Compilers
 
 import os
 
+
 class TestMakeMacros(base.BaseTestCase):
     """Makefile macros tests.
 

--- a/scripts/lib/CIME/tests/test_sys_unittest.py
+++ b/scripts/lib/CIME/tests/test_sys_unittest.py
@@ -33,7 +33,7 @@ class TestUnitTest(base.BaseTestCase):
 
         for macro_to_check in macros_to_check:
             if os.path.exists(macro_to_check):
-                macro_text = open(machine_macro, "r").read()
+                macro_text = open(macro_to_check, "r").read()
 
                 return "PFUNIT_PATH" in macro_text
 

--- a/scripts/lib/CIME/tests/test_sys_unittest.py
+++ b/scripts/lib/CIME/tests/test_sys_unittest.py
@@ -7,7 +7,6 @@ import sys
 from CIME import utils
 from CIME.tests import base
 from CIME.XML.compilers import Compilers
-from CIME.build import get_makefile_vars
 from CIME.XML.files import Files
 
 
@@ -27,15 +26,22 @@ class TestUnitTest(base.BaseTestCase):
         mach = self.MACHINE.get_machine_name()
         cmake_macros_dir = Files().get_value("CMAKE_MACROS_DIR")
 
-        machine_macro = os.path.join(
-            cmake_macros_dir, "{}_{}.cmake".format(compiler, mach)
-        )
-        if os.path.exists(machine_macro):
-            macro_text = open(machine_macro, "r").read()
+        macros_to_check = [
+            os.path.join(
+                cmake_macros_dir, "{}_{}.cmake".format(compiler, mach)
+            ),
+            os.path.join(
+                cmake_macros_dir, "{}.cmake".format(mach)
+            ),
+        ]
 
-            return "PFUNIT_PATH" in macro_text
-        else:
-            return False
+        for macro_to_check in macros_to_check:
+            if os.path.exists(macro_to_check):
+                macro_text = open(machine_macro, "r").read()
+
+                return "PFUNIT_PATH" in macro_text
+
+        return False
 
     def test_a_unit_test(self):
         cls = self.__class__

--- a/scripts/lib/CIME/tests/test_sys_unittest.py
+++ b/scripts/lib/CIME/tests/test_sys_unittest.py
@@ -10,6 +10,7 @@ from CIME.XML.compilers import Compilers
 from CIME.build import get_makefile_vars
 from CIME.XML.files import Files
 
+
 class TestUnitTest(base.BaseTestCase):
     @classmethod
     def setUpClass(cls):
@@ -26,7 +27,9 @@ class TestUnitTest(base.BaseTestCase):
         mach = self.MACHINE.get_machine_name()
         cmake_macros_dir = Files().get_value("CMAKE_MACROS_DIR")
 
-        machine_macro = os.path.join(cmake_macros_dir, "{}_{}.cmake".format(compiler, mach))
+        machine_macro = os.path.join(
+            cmake_macros_dir, "{}_{}.cmake".format(compiler, mach)
+        )
         if os.path.exists(machine_macro):
             macro_text = open(machine_macro, "r").read()
 

--- a/scripts/lib/CIME/tests/test_sys_unittest.py
+++ b/scripts/lib/CIME/tests/test_sys_unittest.py
@@ -27,12 +27,8 @@ class TestUnitTest(base.BaseTestCase):
         cmake_macros_dir = Files().get_value("CMAKE_MACROS_DIR")
 
         macros_to_check = [
-            os.path.join(
-                cmake_macros_dir, "{}_{}.cmake".format(compiler, mach)
-            ),
-            os.path.join(
-                cmake_macros_dir, "{}.cmake".format(mach)
-            ),
+            os.path.join(cmake_macros_dir, "{}_{}.cmake".format(compiler, mach)),
+            os.path.join(cmake_macros_dir, "{}.cmake".format(mach)),
         ]
 
         for macro_to_check in macros_to_check:

--- a/scripts/lib/CIME/tests/utils.py
+++ b/scripts/lib/CIME/tests/utils.py
@@ -353,34 +353,6 @@ file(WRITE query.out "${{{}}}")
         self.parent.assertRegexpMatches(self.query_var(var_name, env, var), regex)
 
 
-def get_macros(macro_maker, build_xml, build_system):
-    """Generate build system ("Macros" file) output from config_compilers XML.
-
-    Arguments:
-    macro_maker - The underlying Build object.
-    build_xml - A string containing the XML to operate on.
-    build_system - Either "Makefile" or "CMake", depending on desired output.
-
-    The return value is a string containing the build system output.
-    """
-    # Build.write_macros expects file-like objects as input, so
-    # we need to wrap the strings in StringIO objects.
-    xml = six.StringIO(str(build_xml))
-    output = six.StringIO()
-    output_format = None
-    if build_system == "Makefile":
-        output_format = "make"
-    elif build_system == "CMake":
-        output_format = "cmake"
-    else:
-        output_format = build_system
-
-    macro_maker.write_macros_file(
-        macros_file=output, output_format=output_format, xml=xml
-    )
-    return str(output.getvalue())
-
-
 # TODO after dropping python 2.7 replace with tempfile.TemporaryDirectory
 class TemporaryDirectory(object):
     def __init__(self):

--- a/tools/cprnc/README
+++ b/tools/cprnc/README
@@ -12,29 +12,18 @@ your case directory.
 Quick Start Guide:
 ------------------
 
-On cime supported systems you can generate a Macros file using the following
+On cime supported systems you can generate a cmake Macros file using the following
 (assuming you are running the command from the directory cime/tools/cprnc):
 
-CIMEROOT=../.. ../configure --macros-format=Makefile --mpilib=mpi-serial
-
-To change the compiler or MPI library used, or to enable debugging options,
-set the COMPILER, MPILIB, or DEBUG environment variables prior to running
-configure.
-
-Next, run make to build cprnc. For instance, using sh/bash as a login shell:
-
-CIMEROOT=../.. source ./.env_mach_specific.sh && make
-
-Finally, put the resulting executable in CCSM_CPRNC as defined in
-config_machines.xml.
-
-You can also build cprnc using cmake:
 export CIMEROOT=../..
 MPILIB=mpi-serial source ./.env_mach_specific.sh
 ../configure --macros-format=CMake --mpilib=mpi-serial
 
 Next run cmake . to build the Makefile and then
 make to build cprnc.
+
+Finally, put the resulting executable in CCSM_CPRNC as defined in
+config_machines.xml.
 
 
  Usage: cprnc  [-v] [-d dimname:start[:count]] file1 [file2]

--- a/tools/mapping/gen_domain_files/test_gen_domain.sh
+++ b/tools/mapping/gen_domain_files/test_gen_domain.sh
@@ -52,17 +52,22 @@ echo "" >> ${test_log}
 echo "Building gen_domain in ${PWD}/builds ..." >> ${test_log}
 mkdir -p builds
 cd builds
-${cime_root}/tools/configure --macros-format Makefile --mpilib mpi-serial >> ${test_log} 2>&1
+
+# Gen env_mach_specific
+${cime_root}/tools/configure --mpilib mpi-serial >> ${test_log} 2>&1
 if [ ! -f .env_mach_specific.sh ]; then
     # try without mpi-serial flag
     echo "ERROR running ${cime_root}/tools/configure" >&2
     echo "It's possible mpi-serial doesn't work on this machine. Trying again with default" >&2
-    ${cime_root}/tools/configure --clean --macros-format Makefile >> ${test_log} 2>&1
+    ${cime_root}/tools/configure --clean >> ${test_log} 2>&1
+    (. .env_mach_specific.sh && ${cime_root}/tools/configure --macros-format Makefile) >> ${test_log} 2>&1
     if [ ! -f .env_mach_specific.sh ]; then
         echo "ERROR running ${cime_root}/tools/configure" >&2
         echo "cat ${test_log} for more info" >&2
         exit 1
     fi
+else
+    (. .env_mach_specific.sh && ${cime_root}/tools/configure --macros-format Makefile --mpilib mpi-serial) >> ${test_log} 2>&1
 fi
 
 cp ${cime_root}/tools/mapping/gen_domain_files/src/* .


### PR DESCRIPTION
The Compilers XML object should not even be constructed unless
the env var enabling the deprecated macro system is on.

Test suite: scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: bfb

Fixes #4136 

User interface changes?:

Update gh-pages html (Y/N)?:
