### PR TITLE
Update tests to get status from new EVV output

### DIFF
--- a/scripts/lib/CIME/SystemTests/mvk.py
+++ b/scripts/lib/CIME/SystemTests/mvk.py
@@ -153,16 +153,13 @@ class MVK(SystemTestsCommon):
                 evv_status = json.load(evv_f)
 
             comments = ""
-            for evv_elem in evv_status["Data"]["Elements"]:
-                if (
-                    evv_elem["Type"] == "ValSummary"
-                    and evv_elem["TableTitle"] == "Kolmogorov-Smirnov test"
-                ):
+            for evv_ele in evv_status["Page"]["elements"]:
+                if "Table" in evv_ele:
                     comments = "; ".join(
-                        "{}: {}".format(key, val)
-                        for key, val in evv_elem["Data"][test_name][""].items()
+                        "{}: {}".format(key, val[0])
+                        for key, val in evv_ele["Table"]["data"].items()
                     )
-                    if evv_elem["Data"][test_name][""]["Test status"].lower() == "pass":
+                    if evv_ele["Table"]["data"]["Test status"][0].lower() == "pass":
                         self._test_status.set_status(
                             CIME.test_status.BASELINE_PHASE,
                             CIME.test_status.TEST_PASS_STATUS,

--- a/scripts/lib/CIME/SystemTests/pgn.py
+++ b/scripts/lib/CIME/SystemTests/pgn.py
@@ -202,16 +202,13 @@ class PGN(SystemTestsCommon):
                 evv_status = json.load(evv_f)
 
             comments = ""
-            for evv_elem in evv_status["Data"]["Elements"]:
-                if (
-                    evv_elem["Type"] == "ValSummary"
-                    and evv_elem["TableTitle"] == "Perturbation growth test"
-                ):
+            for evv_ele in evv_status["Page"]["elements"]:
+                if "Table" in evv_ele:
                     comments = "; ".join(
-                        "{}: {}".format(key, val)
-                        for key, val in evv_elem["Data"][test_name][""].items()
+                        "{}: {}".format(key, val[0])
+                        for key, val in evv_ele["Table"]["data"].items()
                     )
-                    if evv_elem["Data"][test_name][""]["Test status"].lower() == "pass":
+                    if evv_ele["Table"]["data"]["Test status"][0].lower() == "pass":
                         self._test_status.set_status(
                             CIME.test_status.BASELINE_PHASE,
                             CIME.test_status.TEST_PASS_STATUS,

--- a/scripts/lib/CIME/SystemTests/tsc.py
+++ b/scripts/lib/CIME/SystemTests/tsc.py
@@ -193,16 +193,13 @@ class TSC(SystemTestsCommon):
                 evv_status = json.load(evv_f)
 
             comments = ""
-            for evv_elem in evv_status["Data"]["Elements"]:
-                if (
-                    evv_elem["Type"] == "ValSummary"
-                    and evv_elem["TableTitle"] == "Time step convergence test"
-                ):
+            for evv_ele in evv_status["Page"]["elements"]:
+                if "Table" in evv_ele:
                     comments = "; ".join(
-                        "{}: {}".format(key, val)
-                        for key, val in evv_elem["Data"][test_name][""].items()
+                        "{}: {}".format(key, val[0])
+                        for key, val in evv_ele["Table"]["data"].items()
                     )
-                    if evv_elem["Data"][test_name][""]["Test status"].lower() == "pass":
+                    if evv_ele["Table"]["data"]["Test status"][0].lower() == "pass":
                         self._test_status.set_status(
                             CIME.test_status.BASELINE_PHASE,
                             CIME.test_status.TEST_PASS_STATUS,


### PR DESCRIPTION
Changes to the interface of evv4esm (https://github.com/LIVVkit/evv4esm/pull/8) 
necessitate changes to the CIME tests which interpret their output.
This PR fixes the issues seen in https://my.cdash.org/test/49822209 and
https://my.cdash.org/test/49822210

Test suite: e3sm_atm_nbfb

