### PR TITLE
need to move version check out of utils.py

### DIFF
--- a/scripts/Tools/standard_script_setup.py
+++ b/scripts/Tools/standard_script_setup.py
@@ -7,6 +7,29 @@ that every script should do.
 import sys, os
 import __main__ as main
 
+def check_minimum_python_version(major, minor):
+    """
+    Check your python version.
+
+    >>> check_minimum_python_version(sys.version_info[0], sys.version_info[1])
+    >>>
+    """
+    msg = (
+        "Python "
+        + str(major)
+        + ", minor version "
+        + str(minor)
+        + " is required, you have "
+        + str(sys.version_info[0])
+        + "."
+        + str(sys.version_info[1])
+    )
+    assert sys.version_info[0] > major \
+        or (sys.version_info[0] == major and sys.version_info[1] >= minor), \
+        msg
+    
+check_minimum_python_version(3, 6)
+
 _CIMEROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
 _LIB_DIR = os.path.join(_CIMEROOT, "scripts", "lib")
 sys.path.append(_LIB_DIR)
@@ -16,6 +39,6 @@ os.environ["CIMEROOT"] = _CIMEROOT
 
 import CIME.utils
 
-CIME.utils.check_minimum_python_version(3, 6)
+
 CIME.utils.stop_buffering_output()
 import logging, argparse

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -820,31 +820,6 @@ def run_cmd_no_fail(
 
     return output
 
-
-def check_minimum_python_version(major, minor):
-    """
-    Check your python version.
-
-    >>> check_minimum_python_version(sys.version_info[0], sys.version_info[1])
-    >>>
-    """
-    msg = (
-        "Python "
-        + str(major)
-        + ", minor version "
-        + str(minor)
-        + " is required, you have "
-        + str(sys.version_info[0])
-        + "."
-        + str(sys.version_info[1])
-    )
-    expect(
-        sys.version_info[0] > major
-        or (sys.version_info[0] == major and sys.version_info[1] >= minor),
-        msg,
-    )
-
-
 def normalize_case_id(case_id):
     """
     Given a case_id, return it in form TESTCASE.GRID.COMPSET.PLATFORM


### PR DESCRIPTION
The check_minimum_python_version script needed to be moved from utils.py.  Otherwise you get an import error on utils.py before the version message is printed.  

Test suite: hand testing with python 2.7, 3.4, 3.6 and 3.9
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
