### PR TITLE
Changes to CIME to make CICE6 the default component.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,29 @@
 ======================================================================
 
+Originator: David Bailey
+Date: 1-27-22
+Tag: cime6.0.1?
+Answer Changes: Yes. CICE6 is not bfb with CICE5
+Tests: aux_cice and aux_cice5
+Dependencies:
+
+cice5_*
+cice6_*
+cam*
+
+Brief Summary:
+    - CICE6 becomes the default sea ice component
+    - CICE5 becomes an option component and can only be used in long
+      compset names
+
+
+	modified:   ChangeLog
+	modified:   config/cesm/config_files.xml
+	modified:   scripts/lib/CIME/XML/archive_base.py
+	modified:   scripts/lib/CIME/case/case_st_archive.py
+
+======================================================================
+
 Originator: Chris Fischer
 Date: 1-11-22
 Tag: cime6.0.13

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,29 +1,5 @@
 ======================================================================
 
-Originator: David Bailey
-Date: 1-27-22
-Tag: cime6.0.1?
-Answer Changes: Yes. CICE6 is not bfb with CICE5
-Tests: aux_cice and aux_cice5
-Dependencies:
-
-cice5_*
-cice6_*
-cam*
-
-Brief Summary:
-    - CICE6 becomes the default sea ice component
-    - CICE5 becomes an option component and can only be used in long
-      compset names
-
-
-	modified:   ChangeLog
-	modified:   config/cesm/config_files.xml
-	modified:   scripts/lib/CIME/XML/archive_base.py
-	modified:   scripts/lib/CIME/case/case_st_archive.py
-
-======================================================================
-
 Originator: Chris Fischer
 Date: 1-11-22
 Tag: cime6.0.13

--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -211,7 +211,7 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="cice6"                       >$SRCROOT/components/cice6/</value>
+      <value component="cice5"                       >$SRCROOT/components/cice5/</value>
       <value component="cice"                        >$SRCROOT/components/cice/</value>
       <value component="dice" comp_interface="mct"   >$SRCROOT/components/cpl7/components/data_comps_$COMP_INTERFACE/dice</value>
       <value component="dice" comp_interface="nuopc" >$SRCROOT/components/cdeps/dice</value>
@@ -304,7 +304,7 @@
       <value component="ufsatm"    >$COMP_ROOT_DIR_ATM/cime_config/config_compsets.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/config_compsets.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/config_compsets.xml</value>
-      <value component="cice6"     >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
+      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
@@ -326,7 +326,7 @@
       <value component="ufsatm"    >$COMP_ROOT_DIR_ATM/cime_config/config_pes.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/config_pes.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/config_pes.xml</value>
-      <value component="cice6"     >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
+      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
@@ -354,7 +354,7 @@
       <value component="cam"       >$COMP_ROOT_DIR_ATM/cime_config/config_archive.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/config_archive.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/config_archive.xml</value>
-      <value component="cice6"     >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
+      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
@@ -379,7 +379,7 @@
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
       <value component="nemo"      >$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
-      <value component="cice6"     >$COMP_ROOT_DIR_ICE/cime_config/SystemTests</value>
+      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/SystemTests</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/SystemTests</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/SystemTests</value>
       <value component="rtm"       >$COMP_ROOT_DIR_ROF/cime_config/SystemTests</value>
@@ -400,7 +400,7 @@
       <value component="cam"       >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testlist_cam.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/testdefs/testlist_cism.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/testdefs/testlist_clm.xml</value>
-      <value component="cice6"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testlist_cice.xml</value>
+      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testlist_cice.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testlist_cice.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_pop.xml</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_mom.xml</value>
@@ -430,7 +430,7 @@
       <value component="cam"       >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/testdefs/testmods_dirs</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/testdefs/testmods_dirs</value>
-      <value component="cice6"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testmods_dirs</value>
+      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testmods_dirs</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testmods_dirs</value>
       <value component="rtm"       >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
       <value component="mosart"    >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
@@ -459,7 +459,7 @@
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/usermods_dirs</value>
       <value component="cism"     >$COMP_ROOT_DIR_GLC/cime_config/usermods_dirs</value>
       <value component="clm"      >$COMP_ROOT_DIR_LND/cime_config/usermods_dirs</value>
-      <value component="cice6"    >$COMP_ROOT_DIR_ICE/cime_config/usermods_dirs</value>
+      <value component="cice5"    >$COMP_ROOT_DIR_ICE/cime_config/usermods_dirs</value>
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/usermods_dirs</value>
       <value component="rtm"      >$COMP_ROOT_DIR_ROF/cime_config/usermods_dirs</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/usermods_dirs</value>
@@ -490,7 +490,7 @@
       <!--  TODO
       <value component="cam"  >$COMP_ROOT_DIR_ATM/bld/namelist_files/namelist_definition.xml</value>
       <value component="cism" >$COMP_ROOT_DIR_GLC/bld/namelist_files/namelist_definition_cism.xml</value>
-      <value component="cice6">$COMP_ROOT_DIR_ICE/cime_config/namelist_definition_cice.xml</value>
+      <value component="cice5">$COMP_ROOT_DIR_ICE/cime_config/namelist_definition_cice.xml</value>
       <value component="cice" >$COMP_ROOT_DIR_ICE/cime_config/namelist_definition_cice.xml</value>
       <value component="clm"  >$COMP_ROOT_DIR_LND/bld/namelist_files/namelist_definition_ctsm.xml</value>
       <value component="pop"  >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_pop.xml</value>

--- a/scripts/lib/CIME/XML/archive_base.py
+++ b/scripts/lib/CIME/XML/archive_base.py
@@ -99,7 +99,7 @@ class ArchiveBase(GenericXML):
         # remove when component name is changed
         if model == "fv3gfs":
             model = "fv3"
-        if model == "cice6":
+        if model == "cice5":
             model = "cice"
         if model == "ww3dev":
             model = "ww3"
@@ -205,7 +205,7 @@ def _get_extension(model, filepath, ext_regexes):
     # Remove with component namechange
     if model == "fv3gfs":
         model = "fv3"
-    if model == "cice6":
+    if model == "cice5":
         model = "cice"
     if model == "ww3dev":
         model = "ww3"

--- a/scripts/lib/CIME/case/case_st_archive.py
+++ b/scripts/lib/CIME/case/case_st_archive.py
@@ -531,7 +531,7 @@ def _archive_restarts_date_comp(
     # the compname is drv but the files are named cpl
     if compname == "drv":
         compname = "cpl"
-    if compname == "cice6":
+    if compname == "cice5":
         compname = "cice"
     if compname == "ww3dev":
         compname = "ww3"


### PR DESCRIPTION
This changes the default sea ice component from CICE5 to CICE6. The only CIME changes are to replace "cice6" with "cice5" in three files.

Test suite: aux_cice (formerly aux_cice6)
Test baseline:
Test namelist changes:
Test status: Changing from CICE5 to CICE6 is answer changing for all active sea ice cases. They have been deemed to have the same climate.

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
