### PR TITLE
update izumi jobid_pattern

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -419,6 +419,7 @@
 
   <batch_system type="pbs" MACH="izumi" >
     <batch_submit>ssh izumi cd $CASEROOT ; qsub</batch_submit>
+    <jobid_pattern>(\d+.izumi.cgd.ucar.edu)$</jobid_pattern>
     <directives>
       <directive>-l nodes={{ num_nodes }}:ppn={{ tasks_per_node }}</directive>
       <directive default="/bin/bash" > -S {{ shell }}  </directive>


### PR DESCRIPTION
Fix izumi jobid matching pattern.  The default pattern is disrupted by a message from module system.

Test suite: hand testing on izumi
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4174 

User interface changes?:

Update gh-pages html (Y/N)?:
