### PR TITLE
check current machine and exit if not case machine

### DIFF
--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -72,16 +72,25 @@ def parse_command_line(args, description):
         "Use should use this if you have local modifications to these files that you want to keep.",
     )
 
+    parser.add_argument(
+        "-N",
+        "--non-local",
+        action="store_true",
+        help="Use when you've requested a machine that you aren't on. "
+        "Will reduce errors for missing directories etc.",
+    )
+
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.caseroot, args.clean, args.test_mode, args.reset, args.keep
+    return args.caseroot, args.clean, args.test_mode, args.reset, args.keep, args.non_local
 
 
 ###############################################################################
 def _main_func(description):
     ###############################################################################
-    caseroot, clean, test_mode, reset, keep = parse_command_line(sys.argv, description)
-    with Case(caseroot, read_only=False, record=True) as case:
+    caseroot, clean, test_mode, reset, keep, non_local = parse_command_line(sys.argv, description)
+    with Case(caseroot, read_only=False, record=True, non_local=non_local) as case:
         case.case_setup(clean=clean, test_mode=test_mode, reset=reset, keep=keep)
 
 

--- a/scripts/Tools/xmlquery
+++ b/scripts/Tools/xmlquery
@@ -162,6 +162,14 @@ def parse_command_line(args, description):
         help="Do not resolve variable values.",
     )
 
+    parser.add_argument(
+        "-N",
+        "--non-local",
+        action="store_true",
+        help="Use when you've requested a machine that you aren't on. "
+        "Will reduce errors for missing directories etc.",
+    )
+
     group = parser.add_mutually_exclusive_group()
 
     group.add_argument(
@@ -251,6 +259,7 @@ def parse_command_line(args, description):
         args.valid_values,
         args.partial_match,
         args.file,
+        args.non_local,
     )
 
 
@@ -411,6 +420,7 @@ def _main_func(description):
         valid_values,
         partial_match,
         xmlfile,
+        non_local,
     ) = parse_command_line(sys.argv, description)
 
     expect(
@@ -419,7 +429,7 @@ def _main_func(description):
     )
 
     # Initialize case ; read in all xml files from caseroot
-    with Case(caseroot) as case:
+    with Case(caseroot, non_local=non_local) as case:
         if listall or partial_match:
             if xmlfile:
                 case.set_file(xmlfile)

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -196,36 +196,60 @@ def parse_command_line(args, cimeroot, description):
     # Indicates that create_newcase was called from create_test - do not use otherwise.
     parser.add_argument("--test", "-test", action="store_true", help=argparse.SUPPRESS)
 
-    parser.add_argument("--walltime", default=os.getenv("CIME_GLOBAL_WALLTIME"),
-                        help="Set the wallclock limit for this case in the format (the usual format is HH:MM:SS). "
-                        "\nYou may use env var CIME_GLOBAL_WALLTIME to set this. "
-                        "\nIf CIME_GLOBAL_WALLTIME is not defined in the environment, then the walltime"
-                        "\nwill be the maximum allowed time defined for the queue in config_batch.xml.")
+    parser.add_argument(
+        "--walltime",
+        default=os.getenv("CIME_GLOBAL_WALLTIME"),
+        help="Set the wallclock limit for this case in the format (the usual format is HH:MM:SS). "
+        "\nYou may use env var CIME_GLOBAL_WALLTIME to set this. "
+        "\nIf CIME_GLOBAL_WALLTIME is not defined in the environment, then the walltime"
+        "\nwill be the maximum allowed time defined for the queue in config_batch.xml.",
+    )
 
-    parser.add_argument("-q", "--queue", default=None,
-                        help="Force batch system to use the specified queue. ")
+    parser.add_argument(
+        "-q",
+        "--queue",
+        default=None,
+        help="Force batch system to use the specified queue. ",
+    )
 
-    parser.add_argument("--handle-preexisting-dirs", dest="answer", choices=("a", "r", "u"), default=None,
-                        help="Do not query how to handle pre-existing bld/exe dirs. "
-                        "\nValid options are (a)bort (r)eplace or (u)se existing. "
-                        "\nThis can be useful if you need to run create_newcase non-iteractively.")
+    parser.add_argument(
+        "--handle-preexisting-dirs",
+        dest="answer",
+        choices=("a", "r", "u"),
+        default=None,
+        help="Do not query how to handle pre-existing bld/exe dirs. "
+        "\nValid options are (a)bort (r)eplace or (u)se existing. "
+        "\nThis can be useful if you need to run create_newcase non-iteractively.",
+    )
 
-    parser.add_argument("-i", "--input-dir",
-                        help="Use a non-default location for input files. This will change the xml value of DIN_LOC_ROOT.")
-    parser.add_argument("--driver", default=get_cime_default_driver(),
-                        choices=('mct','nuopc', 'moab'),
-                        help=argparse.SUPPRESS)
+    parser.add_argument(
+        "-i",
+        "--input-dir",
+        help="Use a non-default location for input files. This will change the xml value of DIN_LOC_ROOT.",
+    )
+    parser.add_argument(
+        "--driver",
+        default=get_cime_default_driver(),
+        choices=("mct", "nuopc", "moab"),
+        help=argparse.SUPPRESS,
+    )
 
-    parser.add_argument("-n", "--non-local", action="store_true",
-                        help="Use when you've requested a machine that you aren't on. "
-                        "Will reduce errors for missing directories etc.")
+    parser.add_argument(
+        "-n",
+        "--non-local",
+        action="store_true",
+        help="Use when you've requested a machine that you aren't on. "
+        "Will reduce errors for missing directories etc.",
+    )
 
-    parser.add_argument("--extra-machines-dir",
-                        help="Optional path to a directory containing one or more of:"
-                        "\nconfig_machines.xml, config_compilers.xml, config_batch.xml,"
-                        "\nand a cmake_macros subdirectory containing CMake macros files."
-                        "\nIf provided, the contents of these files will be appended to"
-                        "\nthe standard machine files (and any files in ~/.cime).")
+    parser.add_argument(
+        "--extra-machines-dir",
+        help="Optional path to a directory containing one or more of:"
+        "\nconfig_machines.xml, config_compilers.xml, config_batch.xml,"
+        "\nand a cmake_macros subdirectory containing CMake macros files."
+        "\nIf provided, the contents of these files will be appended to"
+        "\nthe standard machine files (and any files in ~/.cime).",
+    )
 
     parser.add_argument("--case-group", help="Add this case to a case group")
 

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -374,7 +374,7 @@ def _main_func(description):
         )
         del os.environ["FROM_CREATE_TEST"]
 
-    with Case(caseroot, read_only=False) as case:
+    with Case(caseroot, read_only=False, non_local=non_local) as case:
         # Configure the Case
         case.create(
             casename,

--- a/scripts/lib/CIME/SystemTests/system_tests_common.py
+++ b/scripts/lib/CIME/SystemTests/system_tests_common.py
@@ -783,7 +783,7 @@ class FakeTest(SystemTestsCommon):
     Inheriters of the FakeTest Class are intended to test the code.
 
     All members of the FakeTest Class must
-    have names beginnig with "TEST" this is so that the find_system_test
+    have names beginning with "TEST" this is so that the find_system_test
     in utils.py will work with these classes.
     """
 
@@ -791,6 +791,7 @@ class FakeTest(SystemTestsCommon):
         super(FakeTest, self).__init__(case, expected=expected)
         self._script = None
         self._requires_exe = False
+        self._case._non_local = True
         self._original_exe = self._case.get_value("run_exe")
 
     def _set_script(self, script, requires_exe=False):

--- a/scripts/lib/CIME/bless_test_results.py
+++ b/scripts/lib/CIME/bless_test_results.py
@@ -49,7 +49,7 @@ def bless_namelists(
             create_test_gen_args += " -t {}".format(new_test_id)
 
         stat, out, _ = run_cmd(
-            "{}/create_test {} -n {} --baseline-root {} -o".format(
+            "{}/create_test {} --namelists-only {} --baseline-root {} -o".format(
                 get_scripts_root(), test_name, create_test_gen_args, baseline_root
             ),
             combine_output=True,

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -165,10 +165,11 @@ class Case(object):
             mach = self.get_value("MACH")
             machobj = Machines()
             probed_machine = machobj.probe_machine_name()
-            expect(
-                mach == probed_machine,
-                f"Current machine {probed_machine} does not match case machine {mach}.",
-            )
+            if probed_machine:
+                expect(
+                    mach == probed_machine,
+                    f"Current machine {probed_machine} does not match case machine {mach}.",
+                )
             self.initialize_derived_attributes()
 
     def check_if_comp_var(self, vid):

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -162,6 +162,10 @@ class Case(object):
 
         # check if case has been configured and if so initialize derived
         if self.get_value("CASEROOT") is not None:
+            mach = self.get_value("MACH")
+            machobj = Machines()
+            probed_machine = machobj.probe_machine_name()
+            expect(mach == probed_machine, f"Current machine {probed_machine} does not match case machine {mach}.")
             self.initialize_derived_attributes()
 
     def check_if_comp_var(self, vid):

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -97,7 +97,7 @@ class Case(object):
         check_input_data,
     )
 
-    def __init__(self, case_root=None, read_only=True, record=False):
+    def __init__(self, case_root=None, read_only=True, record=False, non_local=False):
 
         if case_root is None:
             case_root = os.getcwd()
@@ -119,7 +119,7 @@ class Case(object):
         self._env_generic_files = []
         self._files = []
         self._comp_interface = None
-
+        self._non_local=non_local
         self.read_xml()
 
         if record:
@@ -162,14 +162,15 @@ class Case(object):
 
         # check if case has been configured and if so initialize derived
         if self.get_value("CASEROOT") is not None:
-            mach = self.get_value("MACH")
-            machobj = Machines()
-            probed_machine = machobj.probe_machine_name()
-            if probed_machine:
-                expect(
-                    mach == probed_machine,
-                    f"Current machine {probed_machine} does not match case machine {mach}.",
-                )
+            if not self.non_local:
+                mach = self.get_value("MACH")
+                machobj = Machines()
+                probed_machine = machobj.probe_machine_name()
+                if probed_machine:
+                    expect(
+                        mach == probed_machine,
+                        f"Current machine {probed_machine} does not match case machine {mach}.",
+                    )
             self.initialize_derived_attributes()
 
     def check_if_comp_var(self, vid):

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -119,7 +119,7 @@ class Case(object):
         self._env_generic_files = []
         self._files = []
         self._comp_interface = None
-        self._non_local=non_local
+        self._non_local = non_local
         self.read_xml()
 
         if record:

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -162,7 +162,7 @@ class Case(object):
 
         # check if case has been configured and if so initialize derived
         if self.get_value("CASEROOT") is not None:
-            if not self.non_local:
+            if not self._non_local:
                 mach = self.get_value("MACH")
                 machobj = Machines()
                 probed_machine = machobj.probe_machine_name()

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -165,7 +165,10 @@ class Case(object):
             mach = self.get_value("MACH")
             machobj = Machines()
             probed_machine = machobj.probe_machine_name()
-            expect(mach == probed_machine, f"Current machine {probed_machine} does not match case machine {mach}.")
+            expect(
+                mach == probed_machine,
+                f"Current machine {probed_machine} does not match case machine {mach}.",
+            )
             self.initialize_derived_attributes()
 
     def check_if_comp_var(self, vid):

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -926,7 +926,7 @@ class TestScheduler(object):
         envtest.write()
         lock_file("env_run.xml", caseroot=test_dir, newname="env_run.orig.xml")
 
-        with Case(test_dir, read_only=False) as case:
+        with Case(test_dir, read_only=False, non_local=self._non_local) as case:
             if self._output_root is None:
                 self._output_root = case.get_value("CIME_OUTPUT_ROOT")
             # if we are running a single test we don't need sharedlibroot

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -341,7 +341,10 @@ class TestScheduler(object):
                     if os.path.isdir(test_baseline):
                         existing_baselines.append(test_baseline)
                         if allow_baseline_overwrite:
-                            clear_folder(test_baseline)
+                            if self._namelists_only:
+                                clear_folder(os.path.join(test_baseline,"CaseDocs"))
+                            else:
+                                clear_folder(test_baseline)
                 expect(
                     allow_baseline_overwrite or len(existing_baselines) == 0,
                     "Baseline directories already exists {}\n"

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -342,7 +342,7 @@ class TestScheduler(object):
                         existing_baselines.append(test_baseline)
                         if allow_baseline_overwrite:
                             if self._namelists_only:
-                                clear_folder(os.path.join(test_baseline,"CaseDocs"))
+                                clear_folder(os.path.join(test_baseline, "CaseDocs"))
                             else:
                                 clear_folder(test_baseline)
                 expect(

--- a/scripts/lib/CIME/tests/test_sys_bless_tests_results.py
+++ b/scripts/lib/CIME/tests/test_sys_bless_tests_results.py
@@ -71,7 +71,7 @@ class TestBlessTestResults(base.BaseTestCase):
             self._create_test(compargs, test_id=test_id, run_errors=True)
 
             # compare_test_results should detect the fail
-            cpr_cmd = "{}/compare_test_results --test-root {} -t {} 2>&1".format(
+            cpr_cmd = "{}/compare_test_results --test-root {} -t {} ".format(
                 self.TOOLS_DIR, self._testroot, test_id
             )
             output = self.run_cmd_assert_result(
@@ -122,7 +122,7 @@ class TestBlessTestResults(base.BaseTestCase):
         self.run_cmd_assert_result("./case.cmpgen_namelists", from_dir=casedir)
 
         # compare_test_results should pass
-        cpr_cmd = "{}/compare_test_results --test-root {} -n -t {} 2>&1".format(
+        cpr_cmd = "{}/compare_test_results --test-root {} -n -t {} ".format(
             self.TOOLS_DIR, self._testroot, test_id
         )
         output = self.run_cmd_assert_result(cpr_cmd)
@@ -130,11 +130,11 @@ class TestBlessTestResults(base.BaseTestCase):
         # use regex
         expected_pattern = re.compile(r"PASS %s[^\s]* NLCOMP" % test_to_change)
         the_match = expected_pattern.search(output)
+        msg=f"Cmd {cpr_cmd} failed to display passed test in output:\n{output}"
         self.assertNotEqual(
             the_match,
             None,
-            msg="Cmd '%s' failed to display passed test in output:\n%s"
-            % (cpr_cmd, output),
+            msg=msg,
         )
 
         # Modify namelist
@@ -183,7 +183,7 @@ class TestBlessTestResults(base.BaseTestCase):
         )
 
         # compare_test_results should fail
-        cpr_cmd = "{}/compare_test_results --test-root {} -n -t {} 2>&1".format(
+        cpr_cmd = "{}/compare_test_results --test-root {} -n -t {} ".format(
             self.TOOLS_DIR, self._testroot, test_id
         )
         output = self.run_cmd_assert_result(

--- a/scripts/lib/CIME/tests/test_sys_bless_tests_results.py
+++ b/scripts/lib/CIME/tests/test_sys_bless_tests_results.py
@@ -130,7 +130,7 @@ class TestBlessTestResults(base.BaseTestCase):
         # use regex
         expected_pattern = re.compile(r"PASS %s[^\s]* NLCOMP" % test_to_change)
         the_match = expected_pattern.search(output)
-        msg=f"Cmd {cpr_cmd} failed to display passed test in output:\n{output}"
+        msg = f"Cmd {cpr_cmd} failed to display passed test in output:\n{output}"
         self.assertNotEqual(
             the_match,
             None,

--- a/scripts/lib/CIME/tests/test_sys_cime_case.py
+++ b/scripts/lib/CIME/tests/test_sys_cime_case.py
@@ -534,7 +534,7 @@ class TestCimeCase(base.BaseTestCase):
                 "--project=testproj",
                 test_name,
                 "--mpilib=mpi-serial",
-                "--non-local=True",
+                "--non-local",
             ],
             test_id=self._baseline_name,
             env_changes="unset CIME_GLOBAL_WALLTIME &&",

--- a/scripts/lib/CIME/tests/test_sys_cime_case.py
+++ b/scripts/lib/CIME/tests/test_sys_cime_case.py
@@ -534,6 +534,7 @@ class TestCimeCase(base.BaseTestCase):
                 "--project=testproj",
                 test_name,
                 "--mpilib=mpi-serial",
+                "--non_local=True",
             ],
             test_id=self._baseline_name,
             env_changes="unset CIME_GLOBAL_WALLTIME &&",

--- a/scripts/lib/CIME/tests/test_sys_cime_case.py
+++ b/scripts/lib/CIME/tests/test_sys_cime_case.py
@@ -541,7 +541,7 @@ class TestCimeCase(base.BaseTestCase):
         )
 
         result = self.run_cmd_assert_result(
-            "./xmlquery --value PROJECT --subgroup=case.test", from_dir=casedir
+            "./xmlquery --non-local --value PROJECT --subgroup=case.test", from_dir=casedir
         )
         self.assertEqual(result, "testproj")
 

--- a/scripts/lib/CIME/tests/test_sys_cime_case.py
+++ b/scripts/lib/CIME/tests/test_sys_cime_case.py
@@ -534,7 +534,7 @@ class TestCimeCase(base.BaseTestCase):
                 "--project=testproj",
                 test_name,
                 "--mpilib=mpi-serial",
-                "--non_local=True",
+                "--non-local=True",
             ],
             test_id=self._baseline_name,
             env_changes="unset CIME_GLOBAL_WALLTIME &&",

--- a/scripts/lib/CIME/tests/test_sys_cime_case.py
+++ b/scripts/lib/CIME/tests/test_sys_cime_case.py
@@ -541,7 +541,8 @@ class TestCimeCase(base.BaseTestCase):
         )
 
         result = self.run_cmd_assert_result(
-            "./xmlquery --non-local --value PROJECT --subgroup=case.test", from_dir=casedir
+            "./xmlquery --non-local --value PROJECT --subgroup=case.test",
+            from_dir=casedir,
         )
         self.assertEqual(result, "testproj")
 

--- a/scripts/lib/CIME/tests/test_sys_create_newcase.py
+++ b/scripts/lib/CIME/tests/test_sys_create_newcase.py
@@ -271,7 +271,7 @@ class TestCreateNewcase(base.BaseTestCase):
         self.assertTrue(os.path.isfile(os.path.join(casedir, xmlquery)))
 
         # Test command line options
-        with Case(casedir, read_only=True, non_local=True) as case:
+        with Case(casedir, read_only=True) as case:
             STOP_N = case.get_value("STOP_N")
             COMP_CLASSES = case.get_values("COMP_CLASSES")
             BUILD_COMPLETE = case.get_value("BUILD_COMPLETE")

--- a/scripts/lib/CIME/tests/test_sys_create_newcase.py
+++ b/scripts/lib/CIME/tests/test_sys_create_newcase.py
@@ -271,7 +271,7 @@ class TestCreateNewcase(base.BaseTestCase):
         self.assertTrue(os.path.isfile(os.path.join(casedir, xmlquery)))
 
         # Test command line options
-        with Case(casedir, read_only=True) as case:
+        with Case(casedir, read_only=True, non_local=True) as case:
             STOP_N = case.get_value("STOP_N")
             COMP_CLASSES = case.get_values("COMP_CLASSES")
             BUILD_COMPLETE = case.get_value("BUILD_COMPLETE")

--- a/scripts/lib/CIME/tests/test_sys_create_newcase.py
+++ b/scripts/lib/CIME/tests/test_sys_create_newcase.py
@@ -271,19 +271,19 @@ class TestCreateNewcase(base.BaseTestCase):
         self.assertTrue(os.path.isfile(os.path.join(casedir, xmlquery)))
 
         # Test command line options
-        with Case(casedir, read_only=True) as case:
+        with Case(casedir, read_only=True, non_local=True) as case:
             STOP_N = case.get_value("STOP_N")
             COMP_CLASSES = case.get_values("COMP_CLASSES")
             BUILD_COMPLETE = case.get_value("BUILD_COMPLETE")
-            cmd = xmlquery + " STOP_N --value"
+            cmd = xmlquery + " --non-local STOP_N --value"
             output = utils.run_cmd_no_fail(cmd, from_dir=casedir)
             self.assertTrue(output == str(STOP_N), msg="%s != %s" % (output, STOP_N))
-            cmd = xmlquery + " BUILD_COMPLETE --value"
+            cmd = xmlquery + " --non-local BUILD_COMPLETE --value"
             output = utils.run_cmd_no_fail(cmd, from_dir=casedir)
             self.assertTrue(output == "TRUE", msg="%s != %s" % (output, BUILD_COMPLETE))
             # we expect DOCN_MODE to be undefined in this X compset
             # this test assures that we do not try to resolve this as a compvar
-            cmd = xmlquery + " DOCN_MODE --value"
+            cmd = xmlquery + " --non-local DOCN_MODE --value"
             _, output, error = utils.run_cmd(cmd, from_dir=casedir)
             self.assertTrue(
                 error == "ERROR:  No results found for variable DOCN_MODE",
@@ -294,25 +294,25 @@ class TestCreateNewcase(base.BaseTestCase):
 
             for comp in COMP_CLASSES:
                 caseresult = case.get_value("NTASKS_%s" % comp)
-                cmd = xmlquery + " NTASKS_%s --value" % comp
+                cmd = xmlquery + " --non-local NTASKS_%s --value" % comp
                 output = utils.run_cmd_no_fail(cmd, from_dir=casedir)
                 self.assertTrue(
                     output == str(caseresult), msg="%s != %s" % (output, caseresult)
                 )
-                cmd = xmlquery + " NTASKS --subgroup %s --value" % comp
+                cmd = xmlquery + " --non-local NTASKS --subgroup %s --value" % comp
                 output = utils.run_cmd_no_fail(cmd, from_dir=casedir)
                 self.assertTrue(
                     output == str(caseresult), msg="%s != %s" % (output, caseresult)
                 )
             if self.MACHINE.has_batch_system():
                 JOB_QUEUE = case.get_value("JOB_QUEUE", subgroup="case.run")
-                cmd = xmlquery + " JOB_QUEUE --subgroup case.run --value"
+                cmd = xmlquery + " --non-local JOB_QUEUE --subgroup case.run --value"
                 output = utils.run_cmd_no_fail(cmd, from_dir=casedir)
                 self.assertTrue(
                     output == JOB_QUEUE, msg="%s != %s" % (output, JOB_QUEUE)
                 )
 
-            cmd = xmlquery + " --listall"
+            cmd = xmlquery + " --non-local --listall"
             utils.run_cmd_no_fail(cmd, from_dir=casedir)
 
         cls._do_teardown.append(cls._testroot)
@@ -714,11 +714,11 @@ set(NETCDF_PATH /my/netcdf/path)
         cls._do_teardown.append(testdir)
 
         # Run case.setup
-        self.run_cmd_assert_result("./case.setup", from_dir=testdir)
+        self.run_cmd_assert_result("./case.setup --non-local", from_dir=testdir)
 
         # Make sure Macros file contains expected text
 
-        with Case(testdir) as case:
+        with Case(testdir, non_local=True) as case:
             with CmakeTmpBuildDir(macroloc=testdir) as cmaketmp:
                 macros_contents = cmaketmp.get_makefile_vars(case=case)
 

--- a/scripts/lib/CIME/tests/test_unit_case.py
+++ b/scripts/lib/CIME/tests/test_unit_case.py
@@ -22,7 +22,6 @@ def make_valid_case(path):
 class TestCaseSubmit(unittest.TestCase):
     def test_check_case(self):
         case = mock.MagicMock()
-
         case_submit.check_case(case, chksum=True)
 
         case.check_all_input_data.assert_called_with(chksum=True)
@@ -57,7 +56,7 @@ class TestCaseSubmit(unittest.TestCase):
             ]
 
             make_valid_case(tempdir)
-            with Case(tempdir) as case:
+            with Case(tempdir, non_local=True) as case:
                 case.submit(chksum=True)
 
             _submit.assert_called_with(


### PR DESCRIPTION
When initializing the case object for an existing case make sure that it matches the machine you are on,
throw an error otherwise

Test suite:scripts_regression_tests.py  hand testing on casper and cheyenne
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4178

User interface changes?:

Update gh-pages html (Y/N)?:
