### PR TITLE
Use of optional .exclude files for selective exclusion during build

### DIFF
--- a/scripts/Tools/mkSrcfiles
+++ b/scripts/Tools/mkSrcfiles
@@ -20,9 +20,56 @@ if ( open(FILEPATH,"< Filepath") ) {
 }
 chomp @paths;
 unshift(@paths, '.');
+
+my $excludeDir = '';
+my $foundExclude = 0;
 foreach $dir (@paths) {  # (could check that directories exist here)
+
+    # TMMF 01-2018
+    # the following Sets up .excludes if exists
+    # Only search in 4 dir levels: ./ ../ ../../ & ../../../
+    # Blunt force. Didn't wanna require any "use" statements since there are none.
+    # At this point, GEOS-Chem is the only dir tree that has dependency subdirs in
+    # Filepath generated for CAM by CIME.
+    if ( (-e "$dir/.exclude") && (open(EXCLUDE,"$dir/.exclude") ) ) {
+        #@excludes = <EXCLUDE>;
+        push @excludes, <EXCLUDE>;
+        close( EXCLUDE );
+        $excludeDir = $dir;
+        $foundExclude = 1;
+        print "Found .exclude in: $excludeDir\n";
+    }
+#    if ( (-e "$dir/../.exclude") && (open(EXCLUDE,"$dir/../.exclude") ) ) {
+#        @excludes = <EXCLUDE>;
+#        close( EXCLUDE );
+#        $excludeDir = $dir;
+#        $foundExclude = 1;
+#        print "Dir: $dir\n";
+#        print "Exclude:\n @excludes\n\n";
+#    }
+#    if ( (-e "$dir/../../.exclude") && (open(EXCLUDE,"$dir/../../.exclude") ) ) {
+#        @excludes = <EXCLUDE>;
+#        close( EXCLUDE );
+#        $excludeDir = $dir;
+#        $foundExclude = 1;
+#        print "Dir: $dir\n";
+#        print "Exclude:\n @excludes\n\n";
+#    }
+#    if ( (-e "$dir/../../../.exclude") && (open(EXCLUDE,"$dir/../../../.exclude") ) ) {
+#        @excludes = <EXCLUDE>;
+#        close( EXCLUDE );
+#        $excludeDir = $dir;
+#        $foundExclude = 1;
+#        print "Dir: $dir\n";
+#        print "Exclude:\n @excludes\n\n";
+#    }
+
     $dir =~ s!/?\s*$!!;  # remove / and any whitespace at end of directory name
     ($dir) = glob $dir;  # Expand tildes in path names.
+}
+
+if ($foundExclude) {
+    print "List of files to be excluded:\n @excludes\n\n";
 }
 
 # Loop through the directories and add each filename as a hash key.  This
@@ -31,26 +78,45 @@ foreach $dir (@paths) {  # (could check that directories exist here)
 my $skip_prefix = $ENV{mkSrcfiles_skip_prefix};
 
 foreach $dir (@paths) {
+    my $useExclude = 0;
+    if ($foundExclude) {
+        if (index($dir, $excludeDir) != -1) {
+            $useExclude = 1;
+        }
+    }
     @filenames = (glob("$dir/*.[Ffc]"), glob("$dir/*.[Ff]90"), glob("$dir/*.cpp"));
     foreach $filename (@filenames) {
-	$filename =~ s!.*/!!;                   # remove part before last slash
-	if (defined $skip_prefix){
-	    if ($filename =~ /^${skip_prefix}/){
-		print "WARNING: Skipping file $dir/$filename Source files beginning in $skip_prefix are ignored\n";
-		next;
-	    }
-	}
-	$src{$filename} = 1;
+        $filename =~ s!.*/!!;                   # remove part before last slash
+        if (defined $skip_prefix){
+            if ($filename =~ /^${skip_prefix}/){
+            print "WARNING: Skipping file $dir/$filename Source files beginning in $skip_prefix are ignored\n";
+            next;
+            }
+        }
+        # If filename is in local exclude file, don't add to list. - TMMF
+        if ($useExclude) {
+            my $matches = grep { /$filename/ } @excludes;
+            if ($matches) {
+                print "Exclusion matched file, $filename in $dir\n\n";
+            }else{
+                $src{$filename} = 1;
+            }
+        }else{
+            $src{$filename} = 1;
+        }
     }
+
+    # No exclusion func for templates - TMMF
     @templates = glob("$dir/*.F90.in");
     foreach $filename (@templates) {
-	$filename =~ s!.*/!!;                   # remove part before last slash
-	my $dfile = $filename;
-	$dfile =~ s/\.in//;
-	delete $src{$dfile} if(defined $src{$dfile});
-	$src{$filename} = 1;
+        $filename =~ s!.*/!!;                   # remove part before last slash
+        my $dfile = $filename;
+        $dfile =~ s/\.in//;
+        delete $src{$dfile} if(defined $src{$dfile});
+        $src{$filename} = 1;
     }
 }
+@excludes = ();
 
 my @srcfiles;
 my $foundcnt=0;

--- a/scripts/Tools/mkSrcfiles
+++ b/scripts/Tools/mkSrcfiles
@@ -6,7 +6,8 @@
 # this script tries to open in the current directory.  The current
 # directory is prepended to the specified list of directories.  If Filepath
 # doesn't exist then only the source files in the current directory are
-# listed.
+# listed. If directories contain file .exclude then source files listed
+# in that file are omitted from the source list.
 # The list of source files is written to the file Srcfiles.
 
 # Check usage:
@@ -25,13 +26,8 @@ my $excludeDir = '';
 my $foundExclude = 0;
 foreach $dir (@paths) {  # (could check that directories exist here)
 
-    # TMMF 01-2018
-    # the following sets up .excludes if exists
-    # Blunt force. Didn't want to require any "use" statements since there are none.
-    # At this point, GEOS-Chem is the only dir tree that has dependency subdirs in
-    # Filepath generated for CAM by CIME.
+    # Set up .excludes if exists
     if ( (-e "$dir/.exclude") && (open(EXCLUDE,"$dir/.exclude") ) ) {
-        #@excludes = <EXCLUDE>;
         push @excludes, <EXCLUDE>;
         close( EXCLUDE );
         $excludeDir = $dir;
@@ -68,7 +64,7 @@ foreach $dir (@paths) {
             next;
             }
         }
-        # If filename is in local exclude file, don't add to list. - TMMF
+        # If filename is in local .exclude file, do not add to list
         if ($useExclude) {
             my $matches = grep { /$filename/ } @excludes;
             if ($matches) {
@@ -81,7 +77,7 @@ foreach $dir (@paths) {
         }
     }
 
-    # No exclusion func for templates - TMMF
+    # No exclusion func for templates
     @templates = glob("$dir/*.F90.in");
     foreach $filename (@templates) {
         $filename =~ s!.*/!!;                   # remove part before last slash

--- a/scripts/Tools/mkSrcfiles
+++ b/scripts/Tools/mkSrcfiles
@@ -26,9 +26,8 @@ my $foundExclude = 0;
 foreach $dir (@paths) {  # (could check that directories exist here)
 
     # TMMF 01-2018
-    # the following Sets up .excludes if exists
-    # Only search in 4 dir levels: ./ ../ ../../ & ../../../
-    # Blunt force. Didn't wanna require any "use" statements since there are none.
+    # the following sets up .excludes if exists
+    # Blunt force. Didn't want to require any "use" statements since there are none.
     # At this point, GEOS-Chem is the only dir tree that has dependency subdirs in
     # Filepath generated for CAM by CIME.
     if ( (-e "$dir/.exclude") && (open(EXCLUDE,"$dir/.exclude") ) ) {
@@ -39,30 +38,6 @@ foreach $dir (@paths) {  # (could check that directories exist here)
         $foundExclude = 1;
         print "Found .exclude in: $excludeDir\n";
     }
-#    if ( (-e "$dir/../.exclude") && (open(EXCLUDE,"$dir/../.exclude") ) ) {
-#        @excludes = <EXCLUDE>;
-#        close( EXCLUDE );
-#        $excludeDir = $dir;
-#        $foundExclude = 1;
-#        print "Dir: $dir\n";
-#        print "Exclude:\n @excludes\n\n";
-#    }
-#    if ( (-e "$dir/../../.exclude") && (open(EXCLUDE,"$dir/../../.exclude") ) ) {
-#        @excludes = <EXCLUDE>;
-#        close( EXCLUDE );
-#        $excludeDir = $dir;
-#        $foundExclude = 1;
-#        print "Dir: $dir\n";
-#        print "Exclude:\n @excludes\n\n";
-#    }
-#    if ( (-e "$dir/../../../.exclude") && (open(EXCLUDE,"$dir/../../../.exclude") ) ) {
-#        @excludes = <EXCLUDE>;
-#        close( EXCLUDE );
-#        $excludeDir = $dir;
-#        $foundExclude = 1;
-#        print "Dir: $dir\n";
-#        print "Exclude:\n @excludes\n\n";
-#    }
 
     $dir =~ s!/?\s*$!!;  # remove / and any whitespace at end of directory name
     ($dir) = glob $dir;  # Expand tildes in path names.


### PR DESCRIPTION
As part of the coupling between CESM and GEOS-Chem, Thibaud Fritz
(@fritzt) added functionality of optional `.exclude` files to list files in the
sub-tree that do not need to be compiled. This is useful for coupling the
GEOS-Chem chemistry within CESM since some files contained in the
GEOS-Chem repository, such as the advection modules, are not used in
CESM. Using `.exclude` enables the GEOS-Chem source folder to be
unmodified from its Github repository.

The `.exclude` files are read from `mkSrcfiles` during creation of
`Srcfiles`. Any directory in `Filepath` could have a local `.exclude`
file containing filenames to exclude across its subdirectories.

An example of using `.exclude` for coupling GEOS-Chem within CESM
is here at [CAM PR #484](https://github.com/ESCOMP/CAM/pull/484/files#diff-4d5f6caee0a1d0ecb5cb75fa4346fc1182a5696f74d0cad280d2239798bbd456).

This PR supersedes PR https://github.com/ESMCI/cime/pull/3974. It is currently draft until I I get
to running the tests and updating docs as needed. Feedback welcome!

I looked at CIME documentation in doc/source/ but did not see any docs that need updating for this feature.

Test suite: **in progress**
Test baseline: 
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing] 

Fixes https://github.com/ESMCI/cime/issues/3366

User interface changes?: No

Update gh-pages html (Y/N)?: No
