### PR TITLE
fix for correct path for PTS_DOMAINFILE

### DIFF
--- a/scripts/lib/CIME/XML/grids.py
+++ b/scripts/lib/CIME/XML/grids.py
@@ -359,10 +359,7 @@ class Grids(GenericXML):
                         # Note: ONLY want to define PTS_DOMAINFILE for land
                         file_node = self.get_optional_child("file", root=domain_node)
                         if file_node is not None:
-                            domain_file = self.text(file_node)
-                            domains["PTS_DOMAINFILE"] = os.path.join(
-                                "$DIN_LOC_ROOT/share/domains", domain_file
-                            )
+                            domains["PTS_DOMAINFILE"] = self.text(file_node)
 
     def _get_gridmaps(self, component_grids, driver, compset):
         """Set all mapping files for config_grids.xml v2 schema


### PR DESCRIPTION
This PR fixes the path for PTS_DOMAIN_FILE
Cheyenne did not have problems with the incorrect path - but izumi did:

Verified that the following SMS_D_Ln9_Vnuopc.T42_T42.FSCAM.izumi_nag.cam-outfrq9s worked
Test status: bit for bit

Fixes: #4182 
User interface changes?: No
Update gh-pages html (Y/N)?: N
