### PR TITLE
Fixes extraneous warnings and machine detection

### DIFF
--- a/scripts/lib/CIME/XML/machines.py
+++ b/scripts/lib/CIME/XML/machines.py
@@ -4,7 +4,7 @@ Interface to the config_machines.xml file.  This class inherits from GenericXML.
 from CIME.XML.standard_module_setup import *
 from CIME.XML.generic_xml import GenericXML
 from CIME.XML.files import Files
-from CIME.utils import convert_to_unknown_type, get_cime_config, get_all_cime_models
+from CIME.utils import convert_to_unknown_type, get_cime_config
 
 import socket
 
@@ -79,7 +79,7 @@ class Machines(GenericXML):
 
         expect(
             machine is not None,
-            f"Could not initialize machine object from {', '.join(checked_files)}. This machine is not available for the target CIME_MODEL."
+            f"Could not initialize machine object from {', '.join(checked_files)}. This machine is not available for the target CIME_MODEL.",
         )
         self.set_machine(machine)
 


### PR DESCRIPTION
Changes warning messages to debug, as they don't actually indicate
a problem.

Removes reading old config_machines.xml that were stored in this
repository, this would raise unuseful error.

Test suite: scripts_regression_tests
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4135 
User interface changes?: n/a
Update gh-pages html (Y/N)?: N
