### PR TITLE
changes to support container environments

### DIFF
--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -58,6 +58,7 @@
   <xs:element name="MAX_MPITASKS_PER_NODE" type="AttrElement"/>
   <xs:element name="COSTPES_PER_NODE" type="xs:integer"/>
   <xs:element name="PROJECT_REQUIRED" type="xs:NCName"/>
+  <xs:element name="CONTAINER_ENVIRONMENT" type="xs:string"/>
   <xs:element name="executable" type="xs:string"/>
   <xs:element name="default_run_exe" type="xs:string"/>
   <xs:element name="default_run_misc_suffix" type="xs:string"/>
@@ -75,8 +76,8 @@
   <xs:complexType name="AttrElement">
     <xs:simpleContent>
       <xs:extension base="xs:string">
-        <xs:attribute ref="compiler">
-        </xs:attribute>
+	<xs:attribute ref="compiler">
+	</xs:attribute>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -85,8 +86,8 @@
   <xs:element name="config_machines">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
-        <xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
+	<xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
+	<xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute ref="version"/>
     </xs:complexType>
@@ -94,98 +95,100 @@
   <xs:element name="machine">
     <xs:complexType>
       <xs:sequence>
-        <!-- DESC: a text description of the machine, this field is current not used-->
-        <xs:element ref="DESC" minOccurs="1" maxOccurs="1"/>
-        <!-- NODENAME_REGEX: a regular expression used to identify this machine
-          it must work on compute nodes as well as login nodes, use machine option
-          to create_test or create_newcase if this flag is not available -->
-        <xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
-        <!-- regex to look for in log files that will triger retry of mpirun
-             command on extra allocated nodes -->
-        <xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
-        <!-- regex to look for in log files that will triger retry of mpirun command -->
-        <xs:element ref="MPIRUN_RETRY_REGEX" minOccurs="0" maxOccurs="1"/>
-        <!-- Number of retry attempts to make if MPIRUN_RETRY_REGEX matches   -->
-        <xs:element ref="MPIRUN_RETRY_COUNT" minOccurs="0" maxOccurs="1"/>
-        <!-- OS: the operating system of this machine. -->
-        <xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
-        <!-- PROXY: optional http proxy for access to the internet-->
-        <xs:element ref="PROXY" minOccurs="0" maxOccurs="1"/>
-        <!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
-        <xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
-        <!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
-        <xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
-        <!-- PROJECT: A project or account number used for batch jobs
-          can be overridden in environment or $HOME/.cime/config -->
-        <xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>
-        <!-- CHARGE_ACCOUNT: The name of the account to charge for batch jobs
-          can be overridden in environment or $HOME/.cime/config -->
-        <xs:element ref="CHARGE_ACCOUNT" minOccurs="0" maxOccurs="1"/>
-        <!-- SAVE_TIMING_DIR: (Acme only) directory for archiving timing output -->
-        <xs:element ref="SAVE_TIMING_DIR" minOccurs="0" maxOccurs="1"/>
-        <!-- SAVE_TIMING_DIR_PROJECTS: (Acme only) projects whose jobs archive timing output -->
-        <xs:element ref="SAVE_TIMING_DIR_PROJECTS" minOccurs="0" maxOccurs="1"/>
-        <!-- CIME_OUTPUT_ROOT: Base directory for case output,
-             the bld and run directories are written below here -->
-        <xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
-        <!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
-        <xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
-        <!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
-        <xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
-        <!-- DIN_LOC_ROOT: location of the inputdata directory -->
-        <xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
-        <!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
-        <xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
-        <!-- DOUT_S_ROOT: root directory of short term archive files -->
-        <xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
-        <!-- BASELINE_ROOT:  Root directory for system test baseline files -->
-        <xs:element ref="BASELINE_ROOT" minOccurs="0" maxOccurs="1"/>
-        <!-- CCSM_CPRNC: location of the cprnc tool, compares model output in testing-->
-        <xs:element ref="CCSM_CPRNC" minOccurs="0" maxOccurs="1"/>
-        <!-- PERL5LIB: location of external PERL modules (this variable is deprecated) -->
-        <xs:element ref="PERL5LIB" minOccurs="0" maxOccurs="1"/>
-        <!-- GMAKE: gnu compatible make tool, default is 'gmake' -->
-        <xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
-        <!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
-        <xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
-        <!-- TESTS: (acme only) list of tests to run on this machine -->
-        <xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
-        <!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->
-        <xs:element ref="NTEST_PARALLEL_JOBS" minOccurs="0" maxOccurs="1"/>
-        <!-- BATCH_SYSTEM: batch system used on this machine (none is okay) -->
-        <xs:element ref="BATCH_SYSTEM" minOccurs="1" maxOccurs="1"/>
-        <!-- ALLOCATE_SPARE_NODES: allocate spare nodes when job is launched default False-->
-        <xs:element ref="ALLOCATE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
-        <!-- SUPPORTED_BY: contact information for support for this system -->
-        <xs:element ref="SUPPORTED_BY" minOccurs="1" maxOccurs="1"/>
-        <!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
-             shared memory node on this machine-->
-        <xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
-        <!-- MAX_GPUS_PER_NODE: maximum number of GPUs per node on this machine-->
-        <xs:element ref="MAX_GPUS_PER_NODE" minOccurs="0" maxOccurs="1"/>
-        <!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
-             this machine, in practice the MPI tasks per node will not exceed this value -->
-        <xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
-        <!-- Optional cost factor per node unit -->
-        <xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
-        <!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
-             the batch system?  See PROJECT above -->
-        <xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>
-        <!-- mpirun: The mpi exec to start a job on this machine
-             see detail below-->
-        <xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
-        <!-- module_system: how and what modules to load on this system ,
-             see detail below -->
-        <xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
-        <!-- environment_variables: environment_variables to set on this system,
-          see detail below-->
-        <xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
-        <xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
-        <xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
-        <xs:element ref="TEST_MEMLEAK_TOLERANCE" minOccurs="0" maxOccurs="1"/>
-        <xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
+	<!-- DESC: a text description of the machine, this field is current not used-->
+	<xs:element ref="DESC" minOccurs="1" maxOccurs="1"/>
+	<!-- NODENAME_REGEX: a regular expression used to identify this machine
+	  it must work on compute nodes as well as login nodes, use machine option
+	  to create_test or create_newcase if this flag is not available -->
+	<xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
+	<!-- regex to look for in log files that will triger retry of mpirun
+	     command on extra allocated nodes -->
+	<xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
+	<!-- regex to look for in log files that will triger retry of mpirun command -->
+	<xs:element ref="MPIRUN_RETRY_REGEX" minOccurs="0" maxOccurs="1"/>
+	<!-- Number of retry attempts to make if MPIRUN_RETRY_REGEX matches   -->
+	<xs:element ref="MPIRUN_RETRY_COUNT" minOccurs="0" maxOccurs="1"/>
+	<!-- OS: the operating system of this machine. -->
+	<xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
+	<!-- PROXY: optional http proxy for access to the internet-->
+	<xs:element ref="PROXY" minOccurs="0" maxOccurs="1"/>
+	<!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
+	<xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
+	<!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
+	<xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
+	<!-- PROJECT: A project or account number used for batch jobs
+	  can be overridden in environment or $HOME/.cime/config -->
+	<xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>
+	<!-- CHARGE_ACCOUNT: The name of the account to charge for batch jobs
+	  can be overridden in environment or $HOME/.cime/config -->
+	<xs:element ref="CHARGE_ACCOUNT" minOccurs="0" maxOccurs="1"/>
+	<!-- SAVE_TIMING_DIR: (Acme only) directory for archiving timing output -->
+	<xs:element ref="SAVE_TIMING_DIR" minOccurs="0" maxOccurs="1"/>
+	<!-- SAVE_TIMING_DIR_PROJECTS: (Acme only) projects whose jobs archive timing output -->
+	<xs:element ref="SAVE_TIMING_DIR_PROJECTS" minOccurs="0" maxOccurs="1"/>
+	<!-- CIME_OUTPUT_ROOT: Base directory for case output,
+	     the bld and run directories are written below here -->
+	<xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
+	<!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
+	<xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
+	<!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
+	<xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
+	<!-- DIN_LOC_ROOT: location of the inputdata directory -->
+	<xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
+	<!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
+	<xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
+	<!-- DOUT_S_ROOT: root directory of short term archive files -->
+	<xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
+	<!-- BASELINE_ROOT:  Root directory for system test baseline files -->
+	<xs:element ref="BASELINE_ROOT" minOccurs="0" maxOccurs="1"/>
+	<!-- CCSM_CPRNC: location of the cprnc tool, compares model output in testing-->
+	<xs:element ref="CCSM_CPRNC" minOccurs="0" maxOccurs="1"/>
+	<!-- PERL5LIB: location of external PERL modules (this variable is deprecated) -->
+	<xs:element ref="PERL5LIB" minOccurs="0" maxOccurs="1"/>
+	<!-- GMAKE: gnu compatible make tool, default is 'gmake' -->
+	<xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
+	<!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
+	<xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
+	<!-- TESTS: (acme only) list of tests to run on this machine -->
+	<xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
+	<!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->
+	<xs:element ref="NTEST_PARALLEL_JOBS" minOccurs="0" maxOccurs="1"/>
+	<!-- BATCH_SYSTEM: batch system used on this machine (none is okay) -->
+	<xs:element ref="BATCH_SYSTEM" minOccurs="1" maxOccurs="1"/>
+	<!-- ALLOCATE_SPARE_NODES: allocate spare nodes when job is launched default False-->
+	<xs:element ref="ALLOCATE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
+	<!-- SUPPORTED_BY: contact information for support for this system -->
+	<xs:element ref="SUPPORTED_BY" minOccurs="1" maxOccurs="1"/>
+	<!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
+	     shared memory node on this machine-->
+	<xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
+	<!-- MAX_GPUS_PER_NODE: maximum number of GPUs per node on this machine-->
+	<xs:element ref="MAX_GPUS_PER_NODE" minOccurs="0" maxOccurs="1"/>
+	<!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
+	     this machine, in practice the MPI tasks per node will not exceed this value -->
+	<xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
+	<!-- Optional cost factor per node unit -->
+	<xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
+	<!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
+	     the batch system?  See PROJECT above -->
+	<xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>
+	<!-- Optional container prefix, if provided will be prepended to all commands (case.setup, case.build, etc) -->
+	<xs:element ref="CONTAINER_ENVIRONMENT" minOccurs="0" maxOccurs="1"/>
+	<!-- mpirun: The mpi exec to start a job on this machine
+	     see detail below-->
+	<xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
+	<!-- module_system: how and what modules to load on this system ,
+	     see detail below -->
+	<xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
+	<!-- environment_variables: environment_variables to set on this system,
+	  see detail below-->
+	<xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
+	<xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
+	<xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
+	<xs:element ref="TEST_MEMLEAK_TOLERANCE" minOccurs="0" maxOccurs="1"/>
+	<xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
       </xs:sequence>
       <xs:attribute ref="MACH" use="required"/>
     </xs:complexType>
@@ -194,12 +197,12 @@
   <xs:element name="mpirun">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="executable"/>
-        <xs:element ref="arguments" minOccurs="0"/>
-        <!-- run_exe: The run executable to use; overrides default_run_exe -->
-        <xs:element ref="run_exe" minOccurs="0"/>
-        <!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
-        <xs:element ref="run_misc_suffix" minOccurs="0"/>
+	<xs:element ref="executable"/>
+	<xs:element ref="arguments" minOccurs="0"/>
+	<!-- run_exe: The run executable to use; overrides default_run_exe -->
+	<xs:element ref="run_exe" minOccurs="0"/>
+	<!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
+	<xs:element ref="run_misc_suffix" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="queue"/>
@@ -212,7 +215,7 @@
   <xs:element name="arguments">
     <xs:complexType>
       <xs:sequence>
-        <xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
+	<xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -220,9 +223,9 @@
   <xs:element name="module_system">
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
       </xs:sequence>
       <xs:attribute ref="type" use="required"/>
       <xs:attribute ref="allow_error"/>
@@ -241,7 +244,7 @@
   <xs:element name="modules">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="command"/>
+	<xs:element maxOccurs="unbounded" ref="command"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="DEBUG"/>
@@ -258,7 +261,7 @@
   <xs:element name="environment_variables">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="env"/>
+	<xs:element maxOccurs="unbounded" ref="env"/>
       </xs:sequence>
       <xs:anyAttribute processContents="skip"/>
     </xs:complexType>
@@ -266,7 +269,7 @@
   <xs:element name="resource_limits">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="resource"/>
+	<xs:element maxOccurs="unbounded" ref="resource"/>
       </xs:sequence>
       <xs:attribute ref="DEBUG"/>
       <xs:attribute ref="mpilib"/>
@@ -289,8 +292,8 @@
   <xs:element name="default_run_suffix">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="default_run_exe"/>
-        <xs:element ref="default_run_misc_suffix"/>
+	<xs:element ref="default_run_exe"/>
+	<xs:element ref="default_run_misc_suffix"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -76,8 +76,8 @@
   <xs:complexType name="AttrElement">
     <xs:simpleContent>
       <xs:extension base="xs:string">
-	<xs:attribute ref="compiler">
-	</xs:attribute>
+        <xs:attribute ref="compiler">
+        </xs:attribute>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -86,8 +86,8 @@
   <xs:element name="config_machines">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
-	<xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="machine" minOccurs="1" maxOccurs="unbounded"/>
+        <xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute ref="version"/>
     </xs:complexType>
@@ -95,100 +95,100 @@
   <xs:element name="machine">
     <xs:complexType>
       <xs:sequence>
-	<!-- DESC: a text description of the machine, this field is current not used-->
-	<xs:element ref="DESC" minOccurs="1" maxOccurs="1"/>
-	<!-- NODENAME_REGEX: a regular expression used to identify this machine
-	  it must work on compute nodes as well as login nodes, use machine option
-	  to create_test or create_newcase if this flag is not available -->
-	<xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
-	<!-- regex to look for in log files that will triger retry of mpirun
-	     command on extra allocated nodes -->
-	<xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
-	<!-- regex to look for in log files that will triger retry of mpirun command -->
-	<xs:element ref="MPIRUN_RETRY_REGEX" minOccurs="0" maxOccurs="1"/>
-	<!-- Number of retry attempts to make if MPIRUN_RETRY_REGEX matches   -->
-	<xs:element ref="MPIRUN_RETRY_COUNT" minOccurs="0" maxOccurs="1"/>
-	<!-- OS: the operating system of this machine. -->
-	<xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
-	<!-- PROXY: optional http proxy for access to the internet-->
-	<xs:element ref="PROXY" minOccurs="0" maxOccurs="1"/>
-	<!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
-	<xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
-	<!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
-	<xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
-	<!-- PROJECT: A project or account number used for batch jobs
-	  can be overridden in environment or $HOME/.cime/config -->
-	<xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>
-	<!-- CHARGE_ACCOUNT: The name of the account to charge for batch jobs
-	  can be overridden in environment or $HOME/.cime/config -->
-	<xs:element ref="CHARGE_ACCOUNT" minOccurs="0" maxOccurs="1"/>
-	<!-- SAVE_TIMING_DIR: (Acme only) directory for archiving timing output -->
-	<xs:element ref="SAVE_TIMING_DIR" minOccurs="0" maxOccurs="1"/>
-	<!-- SAVE_TIMING_DIR_PROJECTS: (Acme only) projects whose jobs archive timing output -->
-	<xs:element ref="SAVE_TIMING_DIR_PROJECTS" minOccurs="0" maxOccurs="1"/>
-	<!-- CIME_OUTPUT_ROOT: Base directory for case output,
-	     the bld and run directories are written below here -->
-	<xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
-	<!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
-	<xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
-	<!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
-	<xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
-	<!-- DIN_LOC_ROOT: location of the inputdata directory -->
-	<xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
-	<!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
-	<xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
-	<!-- DOUT_S_ROOT: root directory of short term archive files -->
-	<xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
-	<!-- BASELINE_ROOT:  Root directory for system test baseline files -->
-	<xs:element ref="BASELINE_ROOT" minOccurs="0" maxOccurs="1"/>
-	<!-- CCSM_CPRNC: location of the cprnc tool, compares model output in testing-->
-	<xs:element ref="CCSM_CPRNC" minOccurs="0" maxOccurs="1"/>
-	<!-- PERL5LIB: location of external PERL modules (this variable is deprecated) -->
-	<xs:element ref="PERL5LIB" minOccurs="0" maxOccurs="1"/>
-	<!-- GMAKE: gnu compatible make tool, default is 'gmake' -->
-	<xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
-	<!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
-	<xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
-	<!-- TESTS: (acme only) list of tests to run on this machine -->
-	<xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
-	<!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->
-	<xs:element ref="NTEST_PARALLEL_JOBS" minOccurs="0" maxOccurs="1"/>
-	<!-- BATCH_SYSTEM: batch system used on this machine (none is okay) -->
-	<xs:element ref="BATCH_SYSTEM" minOccurs="1" maxOccurs="1"/>
-	<!-- ALLOCATE_SPARE_NODES: allocate spare nodes when job is launched default False-->
-	<xs:element ref="ALLOCATE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
-	<!-- SUPPORTED_BY: contact information for support for this system -->
-	<xs:element ref="SUPPORTED_BY" minOccurs="1" maxOccurs="1"/>
-	<!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
-	     shared memory node on this machine-->
-	<xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
-	<!-- MAX_GPUS_PER_NODE: maximum number of GPUs per node on this machine-->
-	<xs:element ref="MAX_GPUS_PER_NODE" minOccurs="0" maxOccurs="1"/>
-	<!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
-	     this machine, in practice the MPI tasks per node will not exceed this value -->
-	<xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
-	<!-- Optional cost factor per node unit -->
-	<xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
-	<!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
-	     the batch system?  See PROJECT above -->
-	<xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>
-	<!-- Optional container prefix, if provided will be prepended to all commands (case.setup, case.build, etc) -->
-	<xs:element ref="CONTAINER_ENVIRONMENT" minOccurs="0" maxOccurs="1"/>
-	<!-- mpirun: The mpi exec to start a job on this machine
-	     see detail below-->
-	<xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
-	<!-- module_system: how and what modules to load on this system ,
-	     see detail below -->
-	<xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
-	<!-- environment_variables: environment_variables to set on this system,
-	  see detail below-->
-	<xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
-	<xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
-	<xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
-	<xs:element ref="TEST_MEMLEAK_TOLERANCE" minOccurs="0" maxOccurs="1"/>
-	<xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
+        <!-- DESC: a text description of the machine, this field is current not used-->
+        <xs:element ref="DESC" minOccurs="1" maxOccurs="1"/>
+        <!-- NODENAME_REGEX: a regular expression used to identify this machine
+          it must work on compute nodes as well as login nodes, use machine option
+          to create_test or create_newcase if this flag is not available -->
+        <xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
+        <!-- regex to look for in log files that will triger retry of mpirun
+             command on extra allocated nodes -->
+        <xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
+        <!-- regex to look for in log files that will triger retry of mpirun command -->
+        <xs:element ref="MPIRUN_RETRY_REGEX" minOccurs="0" maxOccurs="1"/>
+        <!-- Number of retry attempts to make if MPIRUN_RETRY_REGEX matches   -->
+        <xs:element ref="MPIRUN_RETRY_COUNT" minOccurs="0" maxOccurs="1"/>
+        <!-- OS: the operating system of this machine. -->
+        <xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
+        <!-- PROXY: optional http proxy for access to the internet-->
+        <xs:element ref="PROXY" minOccurs="0" maxOccurs="1"/>
+        <!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
+        <xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
+        <!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
+        <xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- PROJECT: A project or account number used for batch jobs
+          can be overridden in environment or $HOME/.cime/config -->
+        <xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>
+        <!-- CHARGE_ACCOUNT: The name of the account to charge for batch jobs
+          can be overridden in environment or $HOME/.cime/config -->
+        <xs:element ref="CHARGE_ACCOUNT" minOccurs="0" maxOccurs="1"/>
+        <!-- SAVE_TIMING_DIR: (Acme only) directory for archiving timing output -->
+        <xs:element ref="SAVE_TIMING_DIR" minOccurs="0" maxOccurs="1"/>
+        <!-- SAVE_TIMING_DIR_PROJECTS: (Acme only) projects whose jobs archive timing output -->
+        <xs:element ref="SAVE_TIMING_DIR_PROJECTS" minOccurs="0" maxOccurs="1"/>
+        <!-- CIME_OUTPUT_ROOT: Base directory for case output,
+             the bld and run directories are written below here -->
+        <xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
+        <xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
+        <xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- DIN_LOC_ROOT: location of the inputdata directory -->
+        <xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
+        <xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
+        <!-- DOUT_S_ROOT: root directory of short term archive files -->
+        <xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- BASELINE_ROOT:  Root directory for system test baseline files -->
+        <xs:element ref="BASELINE_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- CCSM_CPRNC: location of the cprnc tool, compares model output in testing-->
+        <xs:element ref="CCSM_CPRNC" minOccurs="0" maxOccurs="1"/>
+        <!-- PERL5LIB: location of external PERL modules (this variable is deprecated) -->
+        <xs:element ref="PERL5LIB" minOccurs="0" maxOccurs="1"/>
+        <!-- GMAKE: gnu compatible make tool, default is 'gmake' -->
+        <xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
+        <!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
+        <xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
+        <!-- TESTS: (acme only) list of tests to run on this machine -->
+        <xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
+        <!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->
+        <xs:element ref="NTEST_PARALLEL_JOBS" minOccurs="0" maxOccurs="1"/>
+        <!-- BATCH_SYSTEM: batch system used on this machine (none is okay) -->
+        <xs:element ref="BATCH_SYSTEM" minOccurs="1" maxOccurs="1"/>
+        <!-- ALLOCATE_SPARE_NODES: allocate spare nodes when job is launched default False-->
+        <xs:element ref="ALLOCATE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
+        <!-- SUPPORTED_BY: contact information for support for this system -->
+        <xs:element ref="SUPPORTED_BY" minOccurs="1" maxOccurs="1"/>
+        <!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
+             shared memory node on this machine-->
+        <xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- MAX_GPUS_PER_NODE: maximum number of GPUs per node on this machine-->
+        <xs:element ref="MAX_GPUS_PER_NODE" minOccurs="0" maxOccurs="1"/>
+        <!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
+             this machine, in practice the MPI tasks per node will not exceed this value -->
+        <xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- Optional cost factor per node unit -->
+        <xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
+        <!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
+             the batch system?  See PROJECT above -->
+        <xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>
+        <!-- Optional container prefix, if provided will be prepended to all commands (case.setup, case.build, etc) -->
+        <xs:element ref="CONTAINER_ENVIRONMENT" minOccurs="0" maxOccurs="1"/>
+        <!-- mpirun: The mpi exec to start a job on this machine
+             see detail below-->
+        <xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- module_system: how and what modules to load on this system ,
+             see detail below -->
+        <xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
+        <!-- environment_variables: environment_variables to set on this system,
+          see detail below-->
+        <xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="TEST_MEMLEAK_TOLERANCE" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
       </xs:sequence>
       <xs:attribute ref="MACH" use="required"/>
     </xs:complexType>
@@ -197,12 +197,12 @@
   <xs:element name="mpirun">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="executable"/>
-	<xs:element ref="arguments" minOccurs="0"/>
-	<!-- run_exe: The run executable to use; overrides default_run_exe -->
-	<xs:element ref="run_exe" minOccurs="0"/>
-	<!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
-	<xs:element ref="run_misc_suffix" minOccurs="0"/>
+        <xs:element ref="executable"/>
+        <xs:element ref="arguments" minOccurs="0"/>
+        <!-- run_exe: The run executable to use; overrides default_run_exe -->
+        <xs:element ref="run_exe" minOccurs="0"/>
+        <!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
+        <xs:element ref="run_misc_suffix" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="queue"/>
@@ -215,7 +215,7 @@
   <xs:element name="arguments">
     <xs:complexType>
       <xs:sequence>
-	<xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -223,9 +223,9 @@
   <xs:element name="module_system">
     <xs:complexType>
       <xs:sequence>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
-	<xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
       </xs:sequence>
       <xs:attribute ref="type" use="required"/>
       <xs:attribute ref="allow_error"/>
@@ -244,7 +244,7 @@
   <xs:element name="modules">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="command"/>
+        <xs:element maxOccurs="unbounded" ref="command"/>
       </xs:sequence>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="DEBUG"/>
@@ -261,7 +261,7 @@
   <xs:element name="environment_variables">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="env"/>
+        <xs:element maxOccurs="unbounded" ref="env"/>
       </xs:sequence>
       <xs:anyAttribute processContents="skip"/>
     </xs:complexType>
@@ -269,7 +269,7 @@
   <xs:element name="resource_limits">
     <xs:complexType>
       <xs:sequence>
-	<xs:element maxOccurs="unbounded" ref="resource"/>
+        <xs:element maxOccurs="unbounded" ref="resource"/>
       </xs:sequence>
       <xs:attribute ref="DEBUG"/>
       <xs:attribute ref="mpilib"/>
@@ -292,8 +292,8 @@
   <xs:element name="default_run_suffix">
     <xs:complexType>
       <xs:sequence>
-	<xs:element ref="default_run_exe"/>
-	<xs:element ref="default_run_misc_suffix"/>
+        <xs:element ref="default_run_exe"/>
+        <xs:element ref="default_run_misc_suffix"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/scripts/Tools/Makefile
+++ b/scripts/Tools/Makefile
@@ -130,7 +130,7 @@ ifeq ($(COMP_INTERFACE), nuopc)
    CPPDEFS += -DNUOPC_INTERFACE
    INCLDIR += -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/include -I$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr
    # FoX libraries are provided and built by CDEPS
-   FoX_LIBS := -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/lib -lFoX_dom -lFoX_sax -lFoX_utils -lFoX_fsys -lFoX_wxml -lFoX_common
+   FoX_LIBS := -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/fox/lib -lFoX_dom -lFoX_sax -lFoX_utils -lFoX_fsys -lFoX_wxml -lFoX_common -lFoX_fsys
    ULIBS += -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/dshr -ldshr -L$(SHAREDLIBROOT)/$(SHAREDPATH)/CDEPS/streams -lstreams
    SLIBS += $(FoX_LIBS)
 else

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -86,6 +86,9 @@ def parse_command_line(args, description):
         help="Just print the cmake and ninja commands.",
     )
 
+    # The container argument is hidden and not intended to be invoked by the user
+    parser.add_argument("--container", default=None, help=argparse.SUPPRESS)
+
     mutex_group = parser.add_mutually_exclusive_group()
 
     # TODO mvertens: the following is hard-wired - otherwise it does not work with nuopc
@@ -146,6 +149,8 @@ def parse_command_line(args, description):
         "files in the source tree or in SourceMods.",
     )
 
+
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     clean_depends = (
@@ -173,6 +178,7 @@ def parse_command_line(args, description):
         args.separate_builds,
         args.ninja,
         args.dry_run,
+        args.container,
     )
 
 
@@ -191,11 +197,17 @@ def _main_func(description):
         separate_builds,
         ninja,
         dry_run,
+        container,
     ) = parse_command_line(sys.argv, description)
 
     success = True
     with Case(caseroot, read_only=False, record=True) as case:
         testname = case.get_value("TESTCASE")
+        container_env = case.get_value("CONTAINER_ENVIRONMENT")
+        if container_env and not container:
+            args = " ".join(sys.argv)
+            CIME.utils.run_cmd(f"{container_env} {args} --container {container_env}", verbose=True)
+            sys.exit(0 if success else 1)
 
         if cleanlist is not None or clean_all or clean_depends is not None:
             build.clean(

--- a/scripts/Tools/case.build
+++ b/scripts/Tools/case.build
@@ -149,8 +149,6 @@ def parse_command_line(args, description):
         "files in the source tree or in SourceMods.",
     )
 
-
-
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     clean_depends = (

--- a/scripts/Tools/case.setup
+++ b/scripts/Tools/case.setup
@@ -79,19 +79,25 @@ def parse_command_line(args, description):
         help="Use when you've requested a machine that you aren't on. "
         "Will reduce errors for missing directories etc.",
     )
-
+    # The container argument is hidden and not intended to be invoked by the user
+    parser.add_argument("--container", default=None, help=argparse.SUPPRESS)
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.caseroot, args.clean, args.test_mode, args.reset, args.keep, args.non_local
+    return args.caseroot, args.clean, args.test_mode, args.reset, args.keep, args.non_local, args.container
 
 
 ###############################################################################
 def _main_func(description):
     ###############################################################################
-    caseroot, clean, test_mode, reset, keep, non_local = parse_command_line(sys.argv, description)
+    caseroot, clean, test_mode, reset, keep, non_local, container = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False, record=True, non_local=non_local) as case:
-        case.case_setup(clean=clean, test_mode=test_mode, reset=reset, keep=keep)
+        container_env = case.get_value("CONTAINER_ENVIRONMENT")
+        if container_env and not container:
+            args = " ".join(sys.argv)
+            CIME.utils.run_cmd(f"{container_env} {args} --container {container_env}", verbose=True)
+        else:
+            case.case_setup(clean=clean, test_mode=test_mode, reset=reset, keep=keep)
 
 
 if __name__ == "__main__":

--- a/scripts/Tools/case.submit
+++ b/scripts/Tools/case.submit
@@ -104,6 +104,9 @@ def parse_command_line(args, description):
         "--chksum", action="store_true", help="Verifies input data checksums."
     )
 
+    # The container argument is hidden and not intended to be invoked by the user
+    parser.add_argument("--container", default=None, help=argparse.SUPPRESS)
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     CIME.utils.resolve_mail_type_args(args)
@@ -134,6 +137,7 @@ def parse_command_line(args, description):
         args.batch_args,
         workflow,
         args.chksum,
+        args.container,
     )
 
 
@@ -154,6 +158,7 @@ def _main_func(description, test_args=False):
         batch_args,
         workflow,
         chksum,
+        container,
     ) = parse_command_line(sys.argv, description)
 
     # save these options to a hidden file for use during resubmit
@@ -176,20 +181,25 @@ def _main_func(description, test_args=False):
 
     if not test_args:
         with Case(caseroot, read_only=False, record=True) as case:
-            case.submit(
-                job=job,
-                no_batch=no_batch,
-                prereq=prereq,
-                allow_fail=allow_fail,
-                resubmit=resubmit,
-                resubmit_immediate=resubmit_immediate,
-                skip_pnl=skip_pnl,
-                mail_user=mail_user,
-                mail_type=mail_type,
-                batch_args=batch_args,
-                workflow=workflow,
-                chksum=chksum,
-            )
+            container_env = case.get_value("CONTAINER_ENVIRONMENT")
+            if container_env and not container:
+                args = " ".join(sys.argv)
+                CIME.utils.run_cmd(f"{container_env} {args} --container {container_env}", verbose=True)
+            else:
+                case.submit(
+                    job=job,
+                    no_batch=no_batch,
+                    prereq=prereq,
+                    allow_fail=allow_fail,
+                    resubmit=resubmit,
+                    resubmit_immediate=resubmit_immediate,
+                    skip_pnl=skip_pnl,
+                    mail_user=mail_user,
+                    mail_type=mail_type,
+                    batch_args=batch_args,
+                    workflow=workflow,
+                    chksum=chksum,
+                )
 
 
 if __name__ == "__main__":

--- a/scripts/create_newcase
+++ b/scripts/create_newcase
@@ -333,7 +333,6 @@ def parse_command_line(args, cimeroot, description):
 def _main_func(description):
     ###############################################################################
     cimeroot = os.path.abspath(CIME.utils.get_cime_root())
-
     (
         casename,
         compset,

--- a/scripts/create_test
+++ b/scripts/create_test
@@ -581,6 +581,8 @@ def parse_command_line(args, description):
                         )
 
         mach_obj = Machines(machine=machine_name)
+        # does this machine define a container environment
+        container_environment = mach_obj.get_value("CONTAINER_ENVIRONMENT")
         if args.testargs:
             args.compiler = (
                 mach_obj.get_default_compiler()
@@ -728,6 +730,7 @@ def parse_command_line(args, description):
         args.single_exe,
         args.workflow,
         args.chksum,
+        container_environment,
     )
 
 
@@ -887,6 +890,7 @@ def create_test(
     single_exe,
     workflow,
     chksum,
+    container_environment,
 ):
     ###############################################################################
     impl = TestScheduler(
@@ -927,6 +931,7 @@ def create_test(
         single_exe=single_exe,
         workflow=workflow,
         chksum=chksum,
+        container_environment=container_environment,
     )
 
     success = impl.run_tests(
@@ -1023,6 +1028,7 @@ def _main_func(description):
         single_exe,
         workflow,
         chksum,
+        container_environment,
     ) = parse_command_line(sys.argv, description)
 
     success = False
@@ -1074,6 +1080,7 @@ def _main_func(description):
             single_exe,
             workflow,
             chksum,
+            container_environment,
         )
         run_count += 1
 

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -163,7 +163,6 @@ class Case(object):
         # check if case has been configured and if so initialize derived
         if self.get_value("CASEROOT") is not None:
             if not self._non_local:
-                container = self.get_value("CONTAINER_ENVIRONMENT")
                 mach = self.get_value("MACH")
                 machobj = Machines()
                 probed_machine = machobj.probe_machine_name()

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -163,10 +163,13 @@ class Case(object):
         # check if case has been configured and if so initialize derived
         if self.get_value("CASEROOT") is not None:
             if not self._non_local:
+                container = self.get_value("CONTAINER_ENVIRONMENT")
                 mach = self.get_value("MACH")
                 machobj = Machines()
                 probed_machine = machobj.probe_machine_name()
                 if probed_machine:
+                    if mach != probed_machine:
+                        return
                     expect(
                         mach == probed_machine,
                         f"Current machine {probed_machine} does not match case machine {mach}.",

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -169,10 +169,6 @@ class Case(object):
                 if probed_machine:
                     if mach != probed_machine:
                         return
-                    expect(
-                        mach == probed_machine,
-                        f"Current machine {probed_machine} does not match case machine {mach}.",
-                    )
             self.initialize_derived_attributes()
 
     def check_if_comp_var(self, vid):

--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -206,6 +206,7 @@ class TestScheduler(object):
         single_exe=False,
         workflow=None,
         chksum=False,
+        container_environment=None,
     ):
         ###########################################################################
         self._cime_root = get_cime_root()
@@ -250,6 +251,7 @@ class TestScheduler(object):
         self._no_build = no_build or no_setup or namelists_only
         self._no_run = no_run or self._no_build
         self._output_root = output_root
+        self._container_environment = container_environment
         # Figure out what project to use
         if project is None:
             self._project = get_project()
@@ -568,6 +570,9 @@ class TestScheduler(object):
     ###########################################################################
     def _shell_cmd_for_phase(self, test, cmd, phase, from_dir=None):
         ###########################################################################
+
+        if "create_newcase" not in cmd and self._container_environment:
+            cmd += f" --container {self._container_environment}"
         while True:
             rc, output, errput = run_cmd(cmd, from_dir=from_dir)
             if rc != 0:

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -2384,9 +2384,9 @@ def add_mail_type_args(parser):
         "You can specify multiple types with either comma-separated args or multiple -M flags.",
     )
 
+
 def add_container_arg(parser):
     parser.add_argument("--container", default=None, help=argparse.SUPPRESS)
-
 
 
 def resolve_mail_type_args(args):

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -2,7 +2,7 @@
 Common functions used by cime python scripts
 Warning: you cannot use CIME Classes in this module as it causes circular dependencies
 """
-import io, logging, gzip, sys, os, time, re, shutil, glob, string, random, importlib, fnmatch
+import io, logging, gzip, sys, os, time, re, shutil, glob, string, random, importlib, fnmatch, argparse
 import importlib.util
 import errno, signal, warnings, filecmp
 import stat as statlib
@@ -2383,6 +2383,10 @@ def add_mail_type_args(parser):
         help="When to send user email. Options are: never, all, begin, end, fail.\n"
         "You can specify multiple types with either comma-separated args or multiple -M flags.",
     )
+
+def add_container_arg(parser):
+    parser.add_argument("--container", default=None, help=argparse.SUPPRESS)
+
 
 
 def resolve_mail_type_args(args):


### PR DESCRIPTION
Support for running cesm in a container environment.   I have provided an example which runs in 
a cray environment container on cheyenne.  Please see [ESCOMP/CESM/wiki/Using-CESM-in-the-Cray-environment-container-on-Cheyenne](https://github.com/ESCOMP/CESM/wiki/Using-CESM-in-the-Cray-environment-container-on-Cheyenne) for usage details.

Test suite: scripts_regression_tests.py on cheyenne - lots of hand testing in crayenv
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
