### PR TITLE
Fix run_tests.py when no machine is given

### DIFF
--- a/scripts/fortran_unit_testing/run_tests.py
+++ b/scripts/fortran_unit_testing/run_tests.py
@@ -427,7 +427,7 @@ def _main():
         "{}-DOS={} -DMACH={} -DCOMPILER={} -DDEBUG={} -DMPILIB={} -Dcompile_threaded={} -DCASEROOT={}".format(
             "" if not cmake_args else "{} ".format(cmake_args),
             os_,
-            machine,
+            machobj.get_machine_name(),
             compiler,
             stringify_bool(debug),
             mpilib,


### PR DESCRIPTION
Test suite: Currently running scripts_regression_tests on cheyenne; will amend if any tests fail
Test baseline: none
Test namelist changes: no
Test status: bit for bit

Fixes ESMCI/cime#4202

User interface changes?: N

Update gh-pages html (Y/N)?: N
