### PR TITLE
Extend configure to get cmake macros files from the .cime directory

### DIFF
--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -29,7 +29,7 @@ from CIME.XML.env_mach_specific import EnvMachSpecific
 from CIME.XML.files import Files
 from CIME.build import CmakeTmpBuildDir
 
-import shutil, glob
+import shutil
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/lib/CIME/BuildTools/configure.py
+++ b/scripts/lib/CIME/BuildTools/configure.py
@@ -16,7 +16,14 @@ COMPILER, MPILIB, and DEBUG, respectively.
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.utils import expect, safe_copy, get_model, get_src_root, stringify_bool
+from CIME.utils import (
+    expect,
+    safe_copy,
+    get_model,
+    get_src_root,
+    stringify_bool,
+    copy_local_macros_to_dir,
+)
 from CIME.XML.compilers import Compilers
 from CIME.XML.env_mach_specific import EnvMachSpecific
 from CIME.XML.files import Files
@@ -75,18 +82,13 @@ def configure(
                 safe_copy(
                     os.path.join(new_cmake_macros_dir, "Macros.cmake"), output_dir
                 )
-            if not os.path.exists(os.path.join(output_dir, "cmake_macros")):
-                shutil.copytree(
-                    new_cmake_macros_dir, os.path.join(output_dir, "cmake_macros")
-                )
+            output_cmake_macros_dir = os.path.join(output_dir, "cmake_macros")
+            if not os.path.exists(output_cmake_macros_dir):
+                shutil.copytree(new_cmake_macros_dir, output_cmake_macros_dir)
 
-            # Grab macros from extra machine dir if it was provided
-            if extra_machines_dir:
-                extra_cmake_macros = glob.glob(
-                    "{}/cmake_macros/*.cmake".format(extra_machines_dir)
-                )
-                for extra_cmake_macro in extra_cmake_macros:
-                    safe_copy(extra_cmake_macro, new_cmake_macros_dir)
+            copy_local_macros_to_dir(
+                output_cmake_macros_dir, extra_machdir=extra_machines_dir
+            )
 
             if form == "Makefile":
                 # Use the cmake macros to generate the make macros

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -27,7 +27,7 @@ from CIME.utils import transform_vars
 from CIME.test_status import *
 from CIME.locked_files import unlock_file, lock_file
 
-import errno, shutil, glob
+import errno, shutil
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/lib/CIME/case/case_setup.py
+++ b/scripts/lib/CIME/case/case_setup.py
@@ -20,6 +20,7 @@ from CIME.utils import (
     safe_copy,
     file_contains_python_function,
     import_from_file,
+    copy_local_macros_to_dir,
 )
 from CIME.utils import batch_jobid
 from CIME.utils import transform_vars
@@ -190,39 +191,9 @@ def _create_macros(
         _create_macros_cmake(
             caseroot, new_cmake_macros_dir, mach_obj, compiler, case_cmake_path
         )
-        # check for macros in extra_machines_dir and in .cime
-        local_macros = []
-        extra_machdir = case.get_value("EXTRA_MACHDIR")
-        if extra_machdir:
-            if os.path.isdir(os.path.join(extra_machdir, "cmake_macros")):
-                local_macros.extend(
-                    glob.glob(os.path.join(extra_machdir, "cmake_macros/*.cmake"))
-                )
-            elif os.path.isfile(os.path.join(extra_machdir, "config_compilers.xml")):
-                logger.warning(
-                    "WARNING: Found directory {} but no cmake macros within, set env variable CIME_NO_CMAKE_MACRO to use deprecated config_compilers method".format(
-                        extra_machdir
-                    )
-                )
-        dotcime = None
-        home = os.environ.get("HOME")
-        if home:
-            dotcime = os.path.join(home, ".cime")
-        if dotcime and os.path.isdir(dotcime):
-            local_macros.extend(glob.glob(dotcime + "/*.cmake"))
-
-        for macro in local_macros:
-            safe_copy(macro, case_cmake_path)
-        if (
-            dotcime
-            and os.path.isfile(os.path.join(dotcime, "config_compilers.xml"))
-            and not local_macros
-        ):
-            logger.warning(
-                "WARNING: Found directory {} but no cmake macros within, set env variable CIME_NO_CMAKE_MACRO to use deprecated config_compilers method".format(
-                    dotcime
-                )
-            )
+        copy_local_macros_to_dir(
+            case_cmake_path, extra_machdir=case.get_value("EXTRA_MACHDIR")
+        )
 
     else:
         if not os.path.isfile("Macros.make"):

--- a/scripts/lib/CIME/utils.py
+++ b/scripts/lib/CIME/utils.py
@@ -311,6 +311,47 @@ def reset_cime_config():
     _CIMECONFIG = None
 
 
+def copy_local_macros_to_dir(destination, extra_machdir=None):
+    """
+    Copy any local macros files to the path given by 'destination'.
+
+    Local macros files are potentially found in:
+    (1) extra_machdir/cmake_macros/*.cmake
+    (2) $HOME/.cime/*.cmake
+    """
+    local_macros = []
+    if extra_machdir:
+        if os.path.isdir(os.path.join(extra_machdir, "cmake_macros")):
+            local_macros.extend(
+                glob.glob(os.path.join(extra_machdir, "cmake_macros/*.cmake"))
+            )
+        elif os.path.isfile(os.path.join(extra_machdir, "config_compilers.xml")):
+            logger.warning(
+                "WARNING: Found directory {} but no cmake macros within, set env variable CIME_NO_CMAKE_MACRO to use deprecated config_compilers method".format(
+                    extra_machdir
+                )
+            )
+    dotcime = None
+    home = os.environ.get("HOME")
+    if home:
+        dotcime = os.path.join(home, ".cime")
+    if dotcime and os.path.isdir(dotcime):
+        local_macros.extend(glob.glob(dotcime + "/*.cmake"))
+    if (
+        dotcime
+        and os.path.isfile(os.path.join(dotcime, "config_compilers.xml"))
+        and not local_macros
+    ):
+        logger.warning(
+            "WARNING: Found directory {} but no cmake macros within, set env variable CIME_NO_CMAKE_MACRO to use deprecated config_compilers method".format(
+                dotcime
+            )
+        )
+
+    for macro in local_macros:
+        safe_copy(macro, destination)
+
+
 def get_python_libs_location_within_cime():
     """
     From within CIME, return subdirectory of python libraries


### PR DESCRIPTION
Extend configure to get cmake macros files from the .cime directory. This also fixes the use of cmake macros from the extra machines dir in configure, which seemed to be broken before.

This is needed for run_tests.py.

Test suite: scripts_regression_tests on cheyenne
- `ERIO_Ln11.f09_g16.X.cheyenne_intel` failed initially. Reran (directly via `create_test`) and it passed

Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#4204

User interface changes?: N

Update gh-pages html (Y/N)?: N
