### PR TITLE
Fix machine check for some unusual cases

### DIFF
--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -164,7 +164,11 @@ class Case(object):
         if self.get_value("CASEROOT") is not None:
             if not self._non_local:
                 mach = self.get_value("MACH")
-                machobj = Machines()
+                extra_machdir = self.get_value("EXTRA_MACHDIR")
+                if extra_machdir:
+                    machobj = Machines(machine=mach, extra_machines_dir=extra_machdir)
+                else:
+                    machobj = Machines(machine=mach)
                 probed_machine = machobj.probe_machine_name()
                 if probed_machine:
                     expect(


### PR DESCRIPTION
This fixes the machine check in two situations, both of which come up
when building CTSM via the LILAC build process for a user-defined
machine:

(1) If the machine name can't be probed - e.g., if it was set explicitly
in the create_newcase command because it can't be probed on this machine
- then you need to specify a machine name explicitly in order to
initialize the Machines object.

(2) If the information for this machine is specified in an
`extra_machines_dir`, then this directory needs to be provided when
initializing the Machines object (otherwise you get an error like
`ERROR: No machine YOUR_MACHINE_NAME found`).

Test suite: scripts_regression_tests on cheyenne plus manual testing to ensure that the error is still triggered when it should be (by doing `./create_newcase --case $scratch/test_case_0325b --compset I2000Clm50BgcCropQianRs --res f10_f10_mg37 --mach cheyenne --project proj` on my Mac then doing an `xmlquery` in the case: it still gives `ERROR: Current machine bishorn does not match case machine cheyenne` as it should
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N
