### PR TITLE
Error on PROJECT number starting with zero

### DIFF
--- a/scripts/lib/CIME/XML/env_batch.py
+++ b/scripts/lib/CIME/XML/env_batch.py
@@ -597,11 +597,12 @@ class EnvBatch(EnvBase):
                     else:
                         rval = val
 
+                    if flag != "-P":
                     # We don't want floating-point data
-                    try:
-                        rval = int(round(float(rval)))
-                    except ValueError:
-                        pass
+                        try:
+                            rval = int(round(float(rval)))
+                        except ValueError:
+                            pass
 
                     # need a correction for tasks per node
                     if flag == "-n" and rval <= 0:


### PR DESCRIPTION
[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Some project names on Zeus are numbers starting with zero, such as 0490.
We have to skip this check on the retrieving of the PROJECT name otherwise the name is converted into 490, which is not recognized as the correct project number.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
