### PR TITLE
add a valid PTS_DOMAIN_FILE in aquaplanet mode

### DIFF
--- a/CIME/XML/grids.py
+++ b/CIME/XML/grids.py
@@ -355,10 +355,10 @@ class Grids(GenericXML):
                         mesh_file = self.resolved_text(mesh_node)
                     if mesh_file:
                         _add_grid_info(domains, comp_name + "_DOMAIN_MESH", mesh_file)
-                    if comp_name == "LND":
-                        # Note: ONLY want to define PTS_DOMAINFILE for land
+                    if comp_name == "LND" or comp_name == 'ATM':
+                        # Note: ONLY want to define PTS_DOMAINFILE for land and ATM 
                         file_node = self.get_optional_child("file", root=domain_node)
-                        if file_node is not None:
+                        if file_node is not None and self.text(file_node) != 'unset':
                             domains["PTS_DOMAINFILE"] = self.resolved_text(file_node)
 
     def _get_gridmaps(self, component_grids, driver, compset):

--- a/CIME/XML/grids.py
+++ b/CIME/XML/grids.py
@@ -355,10 +355,10 @@ class Grids(GenericXML):
                         mesh_file = self.resolved_text(mesh_node)
                     if mesh_file:
                         _add_grid_info(domains, comp_name + "_DOMAIN_MESH", mesh_file)
-                    if comp_name == "LND" or comp_name == 'ATM':
-                        # Note: ONLY want to define PTS_DOMAINFILE for land and ATM 
+                    if comp_name == "LND" or comp_name == "ATM":
+                        # Note: ONLY want to define PTS_DOMAINFILE for land and ATM
                         file_node = self.get_optional_child("file", root=domain_node)
-                        if file_node is not None and self.text(file_node) != 'unset':
+                        if file_node is not None and self.text(file_node) != "unset":
                             domains["PTS_DOMAINFILE"] = self.resolved_text(file_node)
 
     def _get_gridmaps(self, component_grids, driver, compset):


### PR DESCRIPTION
Add a valid PTS_DOMAIN_FILE in aquaplanet mode. 
This was a problem for the CAM standard testing for SCAM.

Test suite: Verified that ./create_newcase --case test3 --compset QPC6 --res T42_T42 --run-unsupported now
has a valid PTS_DOMAIN_FILE.
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit

Fixes:None

User interface changes?: No

Update gh-pages html (Y/N)?: N
