### PR TITLE
Revert ignoring special syntax

### DIFF
--- a/.github/workflows/srt.yml
+++ b/.github/workflows/srt.yml
@@ -55,6 +55,7 @@ jobs:
       PNETCDF_PATH: ${HOME}/pnetcdf
       CIME_MODEL: cesm
       CIME_DRIVER: mct
+      CIME_TEST_PLATFORM: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/srt_nuopc.yml
+++ b/.github/workflows/srt_nuopc.yml
@@ -34,6 +34,7 @@ jobs:
       PNETCDF_PATH: ${HOME}/pnetcdf
       ESMF_VERSION: ESMF_8_3_0_beta_snapshot_05
       CIME_MODEL: cesm
+      CIME_TEST_PLATFORM: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/CIME/XML/archive.py
+++ b/CIME/XML/archive.py
@@ -81,7 +81,7 @@ class Archive(ArchiveBase):
                     "ARCHIVE_SPEC_FILE", attribute={"component": attr}
                 )
             else:
-                compval = self.get_resolved_value(self.resolved_text(comp))
+                compval = self.get_resolved_value(self.text(comp))
 
             if os.path.isfile(compval):
                 config_archive_files.append(compval)

--- a/CIME/XML/archive_base.py
+++ b/CIME/XML/archive_base.py
@@ -28,7 +28,7 @@ class ArchiveBase(GenericXML):
         for attname in attnames:
             nodes.extend(self.get_children(attname, root=archive_entry))
         for node in nodes:
-            textvals.append(self.resolved_text(node))
+            textvals.append(self.text(node))
         return textvals
 
     def get_rest_file_extensions(self, archive_entry):
@@ -65,7 +65,7 @@ class ArchiveBase(GenericXML):
         """
         node = self.get_optional_child(name, root=archive_entry)
         if node is not None:
-            return self.resolved_text(node)
+            return self.text(node)
         return None
 
     def get_latest_hist_files(

--- a/CIME/XML/batch.py
+++ b/CIME/XML/batch.py
@@ -149,7 +149,7 @@ class Batch(GenericXML):
                     name = self.get(jnode, "name")
                     jdict = {}
                     for child in self.get_children(root=jnode):
-                        jdict[self.name(child)] = self.resolved_text(child)
+                        jdict[self.name(child)] = self.text(child)
 
                     jobs.append((name, jdict))
 

--- a/CIME/XML/component.py
+++ b/CIME/XML/component.py
@@ -72,7 +72,7 @@ class Component(EntryID):
         if val_node is None:
             logger.debug("No default_value for {}".format(self.get(node, "id")))
             return val_node
-        value = self.resolved_text(val_node)
+        value = self.text(val_node)
         if value is not None and len(value) > 0 and value != "UNSET":
             match_values.append(value)
 
@@ -97,30 +97,28 @@ class Component(EntryID):
             if match_count > 0:
                 # append the current result
                 if self.get(values, "modifier") == "additive":
-                    match_values.append(self.resolved_text(valnode))
+                    match_values.append(self.text(valnode))
 
                 # replace the current result if it already contains the new value
                 # otherwise append the current result
                 elif self.get(values, "modifier") == "merge":
-                    val = self.resolved_text(valnode)
-
-                    if val in match_values:
+                    if self.text(valnode) in match_values:
                         del match_values[:]
+                    match_values.append(self.text(valnode))
 
-                    match_values.append(val)
                 else:
                     if match_type == "last":
                         # take the *last* best match
                         if match_count >= match_max:
                             del match_values[:]
                             match_max = match_count
-                            match_value = self.resolved_text(valnode)
+                            match_value = self.text(valnode)
                     elif match_type == "first":
                         # take the *first* best match
                         if match_count > match_max:
                             del match_values[:]
                             match_max = match_count
-                            match_value = self.resolved_text(valnode)
+                            match_value = self.text(valnode)
                     else:
                         expect(
                             False,
@@ -188,7 +186,7 @@ class Component(EntryID):
                             forcing, self.filename
                         ),
                     )
-                    desc = self.resolved_text(node)
+                    desc = self.text(node)
             if desc is None:
                 desc = compsetname.split("_")[0]
             return desc
@@ -197,7 +195,7 @@ class Component(EntryID):
         for node in desc_nodes:
             option = self.get(node, "option")
             if option is not None:
-                optiondesc[option] = self.resolved_text(node)
+                optiondesc[option] = self.text(node)
 
         # second pass find a comp_class match
         desc = ""
@@ -214,7 +212,7 @@ class Component(EntryID):
                     compsetname, reqset, fullset, modifier_mode
                 )
                 if match:
-                    desc = self.resolved_text(node)
+                    desc = self.text(node)
                     for opt in complist:
                         if opt in optiondesc:
                             desc += optiondesc[opt]
@@ -314,7 +312,7 @@ class Component(EntryID):
         for node in desc_nodes:
             compsetmatch = self.get(node, "compset")
             if compsetmatch is not None and re.search(compsetmatch, compsetname):
-                desc += self.resolved_text(node)
+                desc += self.text(node)
 
         return desc
 
@@ -323,12 +321,12 @@ class Component(EntryID):
         print values for help and description in target config_component.xml file
         """
         helpnode = self.get_child("help")
-        helptext = self.resolved_text(helpnode)
+        helptext = self.text(helpnode)
         logger.info(" {}".format(helptext))
         entries = self.get_children("entry")
         for entry in entries:
             name = self.get(entry, "id")
-            text = self.resolved_text(self.get_child("desc", root=entry))
+            text = self.text(self.get_child("desc", root=entry))
             logger.info("   {:20s} : {}".format(name, text.encode("utf-8")))
 
     def return_values(self):
@@ -340,19 +338,19 @@ class Component(EntryID):
         items = list()
         helpnode = self.get_optional_child("help")
         if helpnode:
-            helptext = self.resolved_text(helpnode)
+            helptext = self.text(helpnode)
         else:
             helptext = ""
         entries = self.get_children("entry")
         for entry in entries:
             item = dict()
             name = self.get(entry, "id")
-            datatype = self.resolved_text(self.get_child("type", root=entry))
+            datatype = self.text(self.get_child("type", root=entry))
             valid_values = self.get_valid_values(name)
             default_value = self.get_default_value(node=entry)
-            group = self.resolved_text(self.get_child("group", root=entry))
-            filename = self.resolved_text(self.get_child("file", root=entry))
-            text = self.resolved_text(self.get_child("desc", root=entry))
+            group = self.text(self.get_child("group", root=entry))
+            filename = self.text(self.get_child("file", root=entry))
+            text = self.text(self.get_child("desc", root=entry))
             item = {
                 "name": name,
                 "datatype": datatype,

--- a/CIME/XML/compsets.py
+++ b/CIME/XML/compsets.py
@@ -66,7 +66,7 @@ class Compsets(GenericXML):
         expect(subgroup is None, "This class does not support subgroups")
         if name == "help":
             rootnode = self.get_child("help")
-            helptext = self.resolved_text(rootnode)
+            helptext = self.text(rootnode)
             return helptext
         else:
             compsets = {}
@@ -79,9 +79,9 @@ class Compsets(GenericXML):
                         )
                     )
                     if self.name(child) == "alias":
-                        alias = self.resolved_text(child)
+                        alias = self.text(child)
                     if self.name(child) == "lname":
-                        lname = self.resolved_text(child)
+                        lname = self.text(child)
                 compsets[alias] = lname
             return compsets
 
@@ -97,8 +97,8 @@ class Compsets(GenericXML):
         for compset in compsets:
             logger.info(
                 "   {:20} : {}".format(
-                    self.resolved_text(self.get_child("alias", root=compset)),
-                    self.resolved_text(self.get_child("lname", root=compset)),
+                    self.text(self.get_child("alias", root=compset)),
+                    self.text(self.get_child("lname", root=compset)),
                 )
             )
 
@@ -106,5 +106,5 @@ class Compsets(GenericXML):
         compset_nodes = self.get_children("compset")
         longnames = []
         for comp in compset_nodes:
-            longnames.append(self.resolved_text(self.get_child("lname", root=comp)))
+            longnames.append(self.text(self.get_child("lname", root=comp)))
         return longnames

--- a/CIME/XML/env_archive.py
+++ b/CIME/XML/env_archive.py
@@ -30,9 +30,7 @@ class EnvArchive(ArchiveBase, EnvBase):
         for rpointer_node in rpointer_nodes:
             file_node = self.get_child("rpointer_file", root=rpointer_node)
             content_node = self.get_child("rpointer_content", root=rpointer_node)
-            rpointer_items.append(
-                [self.resolved_text(file_node), self.resolved_text(content_node)]
-            )
+            rpointer_items.append([self.text(file_node), self.text(content_node)])
         return rpointer_items
 
     def get_type_info(self, vid):

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -375,7 +375,7 @@ class EnvBatch(EnvBase):
 
                         logger.debug(
                             "Using walltimemax {!r} from default "
-                            "queue {!r}".format(walltime, self.resolved_text(queue))
+                            "queue {!r}".format(walltime, self.text(queue))
                         )
 
                     # Still no walltime, use the hardcoded default
@@ -401,7 +401,7 @@ class EnvBatch(EnvBase):
                             "{!r} is less than queue "
                             "{!r} minimum walltime "
                             "{!r}, job might fail".format(
-                                job, walltime, self.resolved_text(queue), walltimemin
+                                job, walltime, self.text(queue), walltimemin
                             )
                         )
 
@@ -415,7 +415,7 @@ class EnvBatch(EnvBase):
                             "{!r} is more than queue "
                             "{!r} maximum walltime "
                             "{!r}, job might fail".format(
-                                job, walltime, self.resolved_text(queue), walltimemax
+                                job, walltime, self.text(queue), walltimemax
                             )
                         )
 
@@ -426,13 +426,11 @@ class EnvBatch(EnvBase):
                 walltime = format_time(walltime_format, "%H:%M:%S", full_bab_time)
 
             env_workflow.set_value(
-                "JOB_QUEUE", self.resolved_text(queue), subgroup=job, ignore_type=False
+                "JOB_QUEUE", self.text(queue), subgroup=job, ignore_type=False
             )
             env_workflow.set_value("JOB_WALLCLOCK_TIME", walltime, subgroup=job)
             logger.debug(
-                "Job {} queue {} walltime {}".format(
-                    job, self.resolved_text(queue), walltime
-                )
+                "Job {} queue {} walltime {}".format(job, self.text(queue), walltime)
             )
 
     def _match_attribs(self, attribs, case, queue):
@@ -484,7 +482,7 @@ class EnvBatch(EnvBase):
         if self._batchtype != "none" and not queue in self._get_all_queue_names():
             unknown_queue = True
             qnode = self.get_default_queue()
-            default_queue = self.resolved_text(qnode)
+            default_queue = self.text(qnode)
         else:
             unknown_queue = False
 
@@ -1087,7 +1085,7 @@ class EnvBatch(EnvBase):
 
         queue_names = []
         for queue in all_queues:
-            queue_names.append(self.resolved_text(queue))
+            queue_names.append(self.text(queue))
 
         return queue_names
 
@@ -1107,7 +1105,7 @@ class EnvBatch(EnvBase):
             if self.queue_meets_spec(
                 qnode, num_nodes, num_tasks, walltime=walltime, job=job
             ):
-                logger.debug("Selected queue {!r}".format(self.resolved_text(qnode)))
+                logger.debug("Selected queue {!r}".format(self.text(qnode)))
 
                 return qnode
 
@@ -1180,7 +1178,7 @@ class EnvBatch(EnvBase):
             if qsnode is not None:
                 qnodes = self.get_children("queue", root=qsnode)
                 for qnode in qnodes:
-                    if name is None or self.resolved_text(qnode) == name:
+                    if name is None or self.text(qnode) == name:
                         nodes.append(qnode)
                         if self.get(qnode, "default", default="false") == "true":
                             default_idx = len(nodes) - 1
@@ -1210,7 +1208,7 @@ class EnvBatch(EnvBase):
         if batch_query is None:
             logger.warning("Batch queries not supported on this platform")
         else:
-            cmd = self.resolved_text(batch_query) + " "
+            cmd = self.text(batch_query) + " "
             if self.has(batch_query, "per_job_arg"):
                 cmd += self.get(batch_query, "per_job_arg") + " "
 
@@ -1230,7 +1228,7 @@ class EnvBatch(EnvBase):
             logger.warning("Batch cancellation not supported on this platform")
             return False
         else:
-            cmd = self.resolved_text(batch_cancel) + " " + str(jobid)
+            cmd = self.text(batch_cancel) + " " + str(jobid)
 
             status, out, err = run_cmd(cmd)
             if status != 0:
@@ -1253,7 +1251,7 @@ class EnvBatch(EnvBase):
             f1batchnodes = self.get_children(root=bnode)
             for node in f1batchnodes:
                 name = self.name(node)
-                text1 = self.resolved_text(node)
+                text1 = self.text(node)
                 text2 = ""
                 attribs = self.attrib(node)
                 f2matches = other.scan_children(name, attributes=attribs, root=f2bnode)

--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -563,13 +563,21 @@ class EnvMachSpecific(EnvBase):
         init_nodes = self.get_optional_child(
             "init_path", attributes={"lang": lang}, root=self.get_child("module_system")
         )
-        return self.text(init_nodes) if init_nodes is not None else None
+        return (
+            self.get_resolved_value(self.text(init_nodes))
+            if init_nodes is not None
+            else None
+        )
 
     def get_module_system_cmd_path(self, lang):
         cmd_nodes = self.get_optional_child(
             "cmd_path", attributes={"lang": lang}, root=self.get_child("module_system")
         )
-        return self.text(cmd_nodes) if cmd_nodes is not None else None
+        return (
+            self.get_resolved_value(self.text(cmd_nodes))
+            if cmd_nodes is not None
+            else None
+        )
 
     def get_mpirun(self, case, attribs, job, exe_only=False, overrides=None):
         """

--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -79,7 +79,7 @@ class EnvMachSpecific(EnvBase):
                         subname = machobj.name(subnode)
                         if subname == "run_exe" or subname == "run_misc_suffix":
                             if match:
-                                settings[subname] = self.resolved_text(subnode)
+                                settings[subname] = self.text(subnode)
                             self.remove_child(subnode, root=mpirunnode)
 
                     self.add_child(mpirunnode)
@@ -91,7 +91,7 @@ class EnvMachSpecific(EnvBase):
             if settings[item]:
                 value = settings[item]
             else:
-                value = self.resolved_text(
+                value = self.text(
                     machobj.get_child("default_" + item, root=default_run_suffix)
                 )
 
@@ -329,7 +329,7 @@ class EnvMachSpecific(EnvBase):
                         "Expected {} element".format(child_tag),
                     )
                     if self._match_attribs(self.attrib(child), case, job=job):
-                        val = self.resolved_text(child)
+                        val = self.text(child)
                         if val is not None:
                             # We allow a couple special substitutions for these fields
                             for repl_this, repl_with in [
@@ -563,13 +563,13 @@ class EnvMachSpecific(EnvBase):
         init_nodes = self.get_optional_child(
             "init_path", attributes={"lang": lang}, root=self.get_child("module_system")
         )
-        return self.resolved_text(init_nodes) if init_nodes is not None else None
+        return self.text(init_nodes) if init_nodes is not None else None
 
     def get_module_system_cmd_path(self, lang):
         cmd_nodes = self.get_optional_child(
             "cmd_path", attributes={"lang": lang}, root=self.get_child("module_system")
         )
-        return self.resolved_text(cmd_nodes) if cmd_nodes is not None else None
+        return self.text(cmd_nodes) if cmd_nodes is not None else None
 
     def get_mpirun(self, case, attribs, job, exe_only=False, overrides=None):
         """
@@ -644,7 +644,7 @@ class EnvMachSpecific(EnvBase):
                 arg_nodes = self.get_children("arg", root=arg_node)
                 for arg_node in arg_nodes:
                     arg_value = transform_vars(
-                        self.resolved_text(arg_node),
+                        self.text(arg_node),
                         case=case,
                         subgroup=job,
                         overrides=overrides,
@@ -654,19 +654,19 @@ class EnvMachSpecific(EnvBase):
 
         exec_node = self.get_child("executable", root=the_match)
         expect(exec_node is not None, "No executable found")
-        executable = self.resolved_text(exec_node)
+        executable = self.text(exec_node)
         run_exe = None
         run_misc_suffix = None
 
         run_exe_node = self.get_optional_child("run_exe", root=the_match)
         if run_exe_node:
-            run_exe = self.resolved_text(run_exe_node)
+            run_exe = self.text(run_exe_node)
 
         run_misc_suffix_node = self.get_optional_child(
             "run_misc_suffix", root=the_match
         )
         if run_misc_suffix_node:
-            run_misc_suffix = self.resolved_text(run_misc_suffix_node)
+            run_misc_suffix = self.text(run_misc_suffix_node)
 
         return executable, args, run_exe, run_misc_suffix
 

--- a/CIME/XML/env_test.py
+++ b/CIME/XML/env_test.py
@@ -32,18 +32,20 @@ class EnvTest(EnvBase):
         """
         tnode = self.get_child("test")
         for child in self.get_children(root=tnode):
-            child_text = self.resolved_text(child)
-
-            if child_text is not None:
+            if self.text(child) is not None:
                 logger.debug(
-                    "Setting {} to {} for test".format(self.name(child), child_text)
+                    "Setting {} to {} for test".format(
+                        self.name(child), self.text(child)
+                    )
                 )
-                if "$" in child_text:
-                    case.set_value(self.name(child), child_text, ignore_type=True)
+                if "$" in self.text(child):
+                    case.set_value(self.name(child), self.text(child), ignore_type=True)
                 else:
                     item_type = case.get_type_info(self.name(child))
                     if item_type:
-                        value = convert_to_type(child_text, item_type, self.name(child))
+                        value = convert_to_type(
+                            self.text(child), item_type, self.name(child)
+                        )
                         case.set_value(self.name(child), value)
         case.flush()
         return
@@ -68,7 +70,7 @@ class EnvTest(EnvBase):
         value = None
         idnode = self.get_optional_child(name, root=tnode)
         if idnode is not None:
-            value = self.resolved_text(idnode)
+            value = self.text(idnode)
         return value
 
     def get_step_phase_cnt(self, step):
@@ -83,14 +85,12 @@ class EnvTest(EnvBase):
         settings = []
         if node is not None:
             for child in node:
-                child_text = self.resolved_text(child)
-
                 logger.debug(
                     "Here child is {} with value {}".format(
-                        self.name(child), child_text
+                        self.name(child), self.text(child)
                     )
                 )
-                settings.append((self.name(child), child_text))
+                settings.append((self.name(child), self.text(child)))
 
         return settings
 

--- a/CIME/XML/expected_fails_file.py
+++ b/CIME/XML/expected_fails_file.py
@@ -66,7 +66,7 @@ class ExpectedFailsFile(GenericXML):
             for pnode in phase_nodes:
                 phase_name = self.attrib(pnode)["name"]
                 status_node = self.get_child("status", root=pnode)
-                status = self.resolved_text(status_node)
+                status = self.text(status_node)
                 # issue and comment elements are not currently parsed
                 if test_name not in xfails:
                     xfails[test_name] = ExpectedFails()

--- a/CIME/XML/files.py
+++ b/CIME/XML/files.py
@@ -135,7 +135,7 @@ class Files(EntryID):
         schemanode = self.get_optional_child("schema", root=node, attributes=attributes)
         if schemanode is not None:
             logger.debug("Found schema for {}".format(nodename))
-            return self.resolved_text(schemanode)
+            return self.get_resolved_value(self.text(schemanode))
         return None
 
     def get_components(self, nodename):

--- a/CIME/XML/generic_xml.py
+++ b/CIME/XML/generic_xml.py
@@ -269,9 +269,6 @@ class GenericXML(object):
     def text(self, node):
         return node.xml_element.text
 
-    def resolved_text(self, node):
-        return self.get_resolved_value(self.text(node))
-
     def add_child(self, node, root=None, position=None):
         """
         Add element node to self at root

--- a/CIME/XML/grids.py
+++ b/CIME/XML/grids.py
@@ -107,7 +107,7 @@ class Grids(GenericXML):
             compset_attrib = self.get(grid_node, "compset")
             compset_match = re.search(compset_attrib, compset)
             if compset_match is not None:
-                model_grid[name_attrib] = self.resolved_text(grid_node)
+                model_grid[name_attrib] = self.text(grid_node)
 
         # (2)loop over all of the "model grid" nodes and determine is there an alias match with the
         # input grid name -  if there is an alias match determine if the "compset" and "not_compset"
@@ -172,12 +172,12 @@ class Grids(GenericXML):
         grid_nodes = self.get_children("grid", root=model_gridnode)
         for grid_node in grid_nodes:
             name = self.get(grid_node, "name")
-            value = self.resolved_text(grid_node)
+            value = self.text(grid_node)
             if model_grid[name] != "null":
                 model_grid[name] = value
         mask_node = self.get_optional_child("mask", root=model_gridnode)
         if mask_node is not None:
-            model_grid["mask"] = self.resolved_text(mask_node)
+            model_grid["mask"] = self.text(mask_node)
         else:
             model_grid["mask"] = model_grid["ocnice"]
 
@@ -249,7 +249,7 @@ class Grids(GenericXML):
                 )
                 # Now obtain the mesh for the mask for the domain node for that component grid
                 mesh_node = self.get_child("mesh", root=mask_domain_node)
-                domains["MASK_MESH"] = self.resolved_text(mesh_node)
+                domains["MASK_MESH"] = self.text(mesh_node)
 
         return domains
 
@@ -325,15 +325,15 @@ class Grids(GenericXML):
                         if mask_name is not None:
                             mask_match = mask_name == mask_attrib
                         if grid_match is not None and mask_match:
-                            domain_file = self.resolved_text(file_node)
+                            domain_file = self.text(file_node)
                     elif grid_attrib is not None:
                         grid_match = re.search(comp_name.lower(), grid_attrib)
                         if grid_match is not None:
-                            domain_file = self.resolved_text(file_node)
+                            domain_file = self.text(file_node)
                     elif mask_attrib is not None:
                         mask_match = mask_name == mask_attrib
                         if mask_match:
-                            domain_file = self.resolved_text(file_node)
+                            domain_file = self.text(file_node)
                 if domain_file:
                     _add_grid_info(
                         domains,
@@ -349,14 +349,14 @@ class Grids(GenericXML):
                     mesh_nodes = self.get_children("mesh", root=domain_node)
                     mesh_file = ""
                     for mesh_node in mesh_nodes:
-                        mesh_file = self.resolved_text(mesh_node)
+                        mesh_file = self.text(mesh_node)
                     if mesh_file:
                         _add_grid_info(domains, comp_name + "_DOMAIN_MESH", mesh_file)
                     if comp_name == "LND" or comp_name == "ATM":
                         # Note: ONLY want to define PTS_DOMAINFILE for land and ATM
                         file_node = self.get_optional_child("file", root=domain_node)
                         if file_node is not None and self.text(file_node) != "unset":
-                            domains["PTS_DOMAINFILE"] = self.resolved_text(file_node)
+                            domains["PTS_DOMAINFILE"] = self.text(file_node)
         # set up dictionary of domain files for every component
         _add_grid_info(domains, comp_name + "_GRID", grid_name)
 
@@ -418,7 +418,7 @@ class Grids(GenericXML):
             ):
                 continue
             required_gridmap_nodes.append(node)
-            mapname = self.resolved_text(node)
+            mapname = self.text(node)
             if mapname not in gridmaps:
                 gridmaps[mapname] = _get_unset_gridmap_value(
                     mapname, component_grids, driver
@@ -441,8 +441,7 @@ class Grids(GenericXML):
                     and grid1_value != "null"
                     and grid2_value != "null"
                 ):
-                    name = self.resolved_text(node)
-                    map_ = gridmaps[name]
+                    map_ = gridmaps[self.text(node)]
                     if map_ == "idmap":
                         if comp1_name == "ocn" and grid1_value == atm_gridvalue:
                             logger.debug(
@@ -450,11 +449,11 @@ class Grids(GenericXML):
                             )
                         else:
                             if driver == "nuopc":
-                                gridmaps[name] = "unset"
+                                gridmaps[self.text(node)] = "unset"
                             else:
                                 logger.warning(
                                     "Warning: missing non-idmap {} for {}, {} and {} {} ".format(
-                                        name,
+                                        self.text(node),
                                         comp1_name,
                                         grid1_value,
                                         comp2_name,
@@ -512,7 +511,7 @@ class Grids(GenericXML):
             map_nodes = self.get_children("map", root=gridmap_node)
             for map_node in map_nodes:
                 name = self.get(map_node, "name")
-                value = self.resolved_text(map_node)
+                value = self.text(map_node)
                 if name is not None and value is not None:
                     these_gridmaps[name] = value
                     logger.debug(" gridmap name,value are {}: {}".format(name, value))
@@ -545,7 +544,7 @@ class Grids(GenericXML):
             for grid_node in grid_nodes:
                 name = self.get(grid_node, "name")
                 compset = self.get(grid_node, "compset")
-                value = self.resolved_text(grid_node)
+                value = self.text(grid_node)
                 logger.info("     {:6s}   {:15s}   {:10s}".format(name, compset, value))
         logger.info(
             "{:5s}-------------------------------------------------------------".format(
@@ -560,11 +559,11 @@ class Grids(GenericXML):
                 name = self.get(domain_node, "name")
                 if name == "null":
                     continue
-                desc = self.resolved_text(self.get_child("desc", root=domain_node))
+                desc = self.text(self.get_child("desc", root=domain_node))
                 files = ""
                 file_nodes = self.get_children("file", root=domain_node)
                 for file_node in file_nodes:
-                    filename = self.resolved_text(file_node)
+                    filename = self.text(file_node)
                     mask_attrib = self.get(file_node, "mask")
                     grid_attrib = self.get(file_node, "grid")
                     files += "\n       " + filename
@@ -598,13 +597,12 @@ class Grids(GenericXML):
             grids = ""
             gridnames = []
             for grid_node in grid_nodes:
-                grid_name = self.resolved_text(grid_node)
-                gridnames.append(grid_name)
-                grids += self.get(grid_node, "name") + ":" + grid_name + "  "
+                gridnames.append(self.text(grid_node))
+                grids += self.get(grid_node, "name") + ":" + self.text(grid_node) + "  "
             logger.info("       non-default grids are: {}".format(grids))
             mask_nodes = self.get_children("mask", root=model_grid_node)
             for mask_node in mask_nodes:
-                logger.info("       mask is: {}".format(self.resolved_text(mask_node)))
+                logger.info("       mask is: {}".format(self.text(mask_node)))
             if long_output is not None:
                 gridnames = set(gridnames)
                 for gridname in gridnames:

--- a/CIME/XML/inputdata.py
+++ b/CIME/XML/inputdata.py
@@ -53,27 +53,23 @@ class Inputdata(GenericXML):
                     self._servernode = None
 
             if self._servernode:
-                protocol = self.resolved_text(
-                    self.get_child("protocol", root=self._servernode)
-                )
-                address = self.resolved_text(
-                    self.get_child("address", root=self._servernode)
-                )
+                protocol = self.text(self.get_child("protocol", root=self._servernode))
+                address = self.text(self.get_child("address", root=self._servernode))
                 unode = self.get_optional_child("user", root=self._servernode)
                 if unode:
-                    user = self.resolved_text(unode)
+                    user = self.text(unode)
                 invnode = self.get_optional_child("inventory", root=self._servernode)
                 if invnode:
-                    inventory = self.resolved_text(invnode)
+                    inventory = self.text(invnode)
 
                 pnode = self.get_optional_child("password", root=self._servernode)
                 if pnode:
-                    passwd = self.resolved_text(pnode)
+                    passwd = self.text(pnode)
                 csnode = self.get_optional_child("checksum", root=self._servernode)
                 if csnode:
-                    chksum_file = self.resolved_text(csnode)
+                    chksum_file = self.text(csnode)
                 icnode = self.get_optional_child("ic_filepath", root=self._servernode)
                 if icnode:
-                    ic_filepath = self.resolved_text(icnode)
+                    ic_filepath = self.text(icnode)
 
         return protocol, address, user, passwd, chksum_file, ic_filepath, inventory

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -381,9 +381,10 @@ class Machines(GenericXML):
         result = False
         batch_system = self.get_optional_child("BATCH_SYSTEM", root=self.machine_node)
         if batch_system is not None:
-            batch_system_value = self.resolved_text(batch_system)
-
-            result = batch_system_value is not None and batch_system_value != "none"
+            result = (
+                self.text(batch_system) is not None
+                and self.text(batch_system) != "none"
+            )
         logger.debug("Machine {} has batch: {}".format(self.machine, result))
         return result
 
@@ -392,7 +393,7 @@ class Machines(GenericXML):
         if node is not None:
             suffix_node = self.get_optional_child(suffix_type, root=node)
             if suffix_node is not None:
-                return self.resolved_text(suffix_node)
+                return self.text(suffix_node)
 
         return None
 
@@ -415,17 +416,15 @@ class Machines(GenericXML):
             )
             max_gpus_per_node = self.get_child("MAX_GPUS_PER_NODE", root=machine)
 
-            print("  {} : {} ".format(name, self.resolved_text(desc)))
-            print("      os             ", self.resolved_text(os_))
-            print("      compilers      ", self.resolved_text(compilers))
+            print("  {} : {} ".format(name, self.text(desc)))
+            print("      os             ", self.text(os_))
+            print("      compilers      ", self.text(compilers))
             if max_mpitasks_per_node is not None:
-                print(
-                    "      pes/node       ", self.resolved_text(max_mpitasks_per_node)
-                )
+                print("      pes/node       ", self.text(max_mpitasks_per_node))
             if max_tasks_per_node is not None:
-                print("      max_tasks/node ", self.resolved_text(max_tasks_per_node))
+                print("      max_tasks/node ", self.text(max_tasks_per_node))
             if max_gpus_per_node is not None:
-                print("      max_gpus/node ", self.resolved_text(max_gpus_per_node))
+                print("      max_gpus/node ", self.text(max_gpus_per_node))
 
     def return_values(self):
         """return a dictionary of machine info
@@ -437,24 +436,20 @@ class Machines(GenericXML):
         for machine in machines:
             name = self.get(machine, "MACH")
             desc = self.get_child("DESC", root=machine)
-            mach_dict[(name, "description")] = self.resolved_text(desc)
+            mach_dict[(name, "description")] = self.text(desc)
             os_ = self.get_child("OS", root=machine)
-            mach_dict[(name, "os")] = self.resolved_text(os_)
+            mach_dict[(name, "os")] = self.text(os_)
             compilers = self.get_child("COMPILERS", root=machine)
-            mach_dict[(name, "compilers")] = self.resolved_text(compilers)
+            mach_dict[(name, "compilers")] = self.text(compilers)
             max_tasks_per_node = self.get_child("MAX_TASKS_PER_NODE", root=machine)
-            mach_dict[(name, "max_tasks_per_node")] = self.resolved_text(
-                max_tasks_per_node
-            )
+            mach_dict[(name, "max_tasks_per_node")] = self.text(max_tasks_per_node)
             max_mpitasks_per_node = self.get_child(
                 "MAX_MPITASKS_PER_NODE", root=machine
             )
-            mach_dict[(name, "max_mpitasks_per_node")] = self.resolved_text(
+            mach_dict[(name, "max_mpitasks_per_node")] = self.text(
                 max_mpitasks_per_node
             )
             max_gpus_per_node = self.get_child("MAX_GPUS_PER_NODE", root=machine)
-            mach_dict[(name, "max_gpus_per_node")] = self.resolved_text(
-                max_gpus_per_node
-            )
+            mach_dict[(name, "max_gpus_per_node")] = self.text(max_gpus_per_node)
 
         return mach_dict

--- a/CIME/XML/pes.py
+++ b/CIME/XML/pes.py
@@ -139,32 +139,30 @@ class Pes(GenericXML):
                                         vid = self.name(node)
                                         logger.info("vid is {}".format(vid))
                                         if "comment" in vid:
-                                            comment = self.resolved_text(node)
+                                            comment = self.text(node)
                                         elif "ntasks" in vid:
                                             for child in self.get_children(root=node):
                                                 pes_ntasks[
                                                     self.name(child).upper()
-                                                ] = int(self.resolved_text(child))
+                                                ] = int(self.text(child))
                                         elif "nthrds" in vid:
                                             for child in self.get_children(root=node):
                                                 pes_nthrds[
                                                     self.name(child).upper()
-                                                ] = int(self.resolved_text(child))
+                                                ] = int(self.text(child))
                                         elif "rootpe" in vid:
                                             for child in self.get_children(root=node):
                                                 pes_rootpe[
                                                     self.name(child).upper()
-                                                ] = int(self.resolved_text(child))
+                                                ] = int(self.text(child))
                                         elif "pstrid" in vid:
                                             for child in self.get_children(root=node):
                                                 pes_pstrid[
                                                     self.name(child).upper()
-                                                ] = int(self.resolved_text(child))
+                                                ] = int(self.text(child))
                                         # if the value is already upper case its something else we are trying to set
                                         elif vid == self.name(node):
-                                            other_settings[vid] = self.resolved_text(
-                                                node
-                                            )
+                                            other_settings[vid] = self.text(node)
 
                                 else:
                                     if points > max_points:
@@ -205,32 +203,24 @@ class Pes(GenericXML):
                 vid = self.name(node)
                 logger.debug("vid is {}".format(vid))
                 if "comment" in vid:
-                    comment = self.resolved_text(node)
+                    comment = self.text(node)
                 elif "ntasks" in vid:
                     for child in self.get_children(root=node):
-                        pes_ntasks[self.name(child).upper()] = int(
-                            self.resolved_text(child)
-                        )
+                        pes_ntasks[self.name(child).upper()] = int(self.text(child))
                 elif "nthrds" in vid:
                     for child in self.get_children(root=node):
-                        pes_nthrds[self.name(child).upper()] = int(
-                            self.resolved_text(child)
-                        )
+                        pes_nthrds[self.name(child).upper()] = int(self.text(child))
                 elif "rootpe" in vid:
                     for child in self.get_children(root=node):
-                        pes_rootpe[self.name(child).upper()] = int(
-                            self.resolved_text(child)
-                        )
+                        pes_rootpe[self.name(child).upper()] = int(self.text(child))
                 elif "pstrid" in vid:
                     for child in self.get_children(root=node):
-                        pes_pstrid[self.name(child).upper()] = int(
-                            self.resolved_text(child)
-                        )
+                        pes_pstrid[self.name(child).upper()] = int(self.text(child))
                 # if the value is already upper case its something else we are trying to set
                 elif vid == self.name(node):
-                    text = self.resolved_text(node).strip()
+                    text = self.text(node).strip()
                     if len(text):
-                        other_settings[vid] = self.resolved_text(node)
+                        other_settings[vid] = self.text(node)
             if grid_choice != "any" or logger.isEnabledFor(logging.DEBUG):
                 logger.info("Pes setting: grid match    is {} ".format(grid_choice))
             if mach_choice != "any" or logger.isEnabledFor(logging.DEBUG):

--- a/CIME/XML/testlist.py
+++ b/CIME/XML/testlist.py
@@ -125,9 +125,7 @@ class Testlist(GenericXML):
                     this_test["options"] = {}
 
                     for onode in optionnodes:
-                        this_test["options"][
-                            self.get(onode, "name")
-                        ] = self.resolved_text(onode)
+                        this_test["options"][self.get(onode, "name")] = self.text(onode)
 
                     # Now get options specific to this machine/compiler
                     options = self.get_optional_child("options", root=mach)
@@ -137,9 +135,7 @@ class Testlist(GenericXML):
                         else self.get_children("option", root=options)
                     )
                     for onode in optionnodes:
-                        this_test["options"][
-                            self.get(onode, "name")
-                        ] = self.resolved_text(onode)
+                        this_test["options"][self.get(onode, "name")] = self.text(onode)
 
                     tests.append(this_test)
 

--- a/CIME/XML/tests.py
+++ b/CIME/XML/tests.py
@@ -30,7 +30,7 @@ class Tests(GenericXML):
     def get_test_node(self, testname):
         logger.debug("Get settings for {}".format(testname))
         node = self.get_child("test", {"NAME": testname})
-        logger.debug("Found {}".format(self.resolved_text(node)))
+        logger.debug("Found {}".format(self.text(node)))
         return node
 
     def print_values(self, skip_infrastructure_tests=True):

--- a/CIME/XML/workflow.py
+++ b/CIME/XML/workflow.py
@@ -71,18 +71,14 @@ class Workflow(GenericXML):
                             attrib = self.attrib(child)
                             if attrib and attrib == {"MACH": machine}:
                                 for rtchild in self.get_children(root=child):
-                                    jdict[self.name(rtchild)] = self.resolved_text(
-                                        rtchild
-                                    )
+                                    jdict[self.name(rtchild)] = self.text(rtchild)
                             elif not attrib:
                                 for rtchild in self.get_children(root=child):
                                     if self.name(rtchild) not in jdict:
-                                        jdict[self.name(rtchild)] = self.resolved_text(
-                                            rtchild
-                                        )
+                                        jdict[self.name(rtchild)] = self.text(rtchild)
 
                         else:
-                            jdict[self.name(child)] = self.resolved_text(child)
+                            jdict[self.name(child)] = self.text(child)
 
                 jobs.append((name, jdict))
 

--- a/CIME/tests/test_unit_xml_env_mach_specific.py
+++ b/CIME/tests/test_unit_xml_env_mach_specific.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import unittest
+import tempfile
+from unittest import mock
+
+from CIME.XML.env_mach_specific import EnvMachSpecific
+
+# pylint: disable=unused-argument
+
+
+class TestXMLEnvMachSpecific(unittest.TestCase):
+    @mock.patch("CIME.XML.env_mach_specific.EnvMachSpecific.get_optional_child")
+    @mock.patch("CIME.XML.env_mach_specific.EnvMachSpecific.text")
+    @mock.patch.dict("os.environ", {"TEST_VALUE": "/testexec"})
+    def test_init_path(self, text, get_optional_child):
+        text.return_value = "$ENV{TEST_VALUE}/init/python"
+
+        mach_specific = EnvMachSpecific()
+
+        value = mach_specific.get_module_system_init_path("python")
+
+        assert value == "/testexec/init/python"
+
+    @mock.patch("CIME.XML.env_mach_specific.EnvMachSpecific.get_optional_child")
+    @mock.patch("CIME.XML.env_mach_specific.EnvMachSpecific.text")
+    @mock.patch.dict("os.environ", {"TEST_VALUE": "/testexec"})
+    def test_cmd_path(self, text, get_optional_child):
+        text.return_value = "$ENV{TEST_VALUE}/python"
+
+        mach_specific = EnvMachSpecific()
+
+        value = mach_specific.get_module_system_cmd_path("python")
+
+        assert value == "/testexec/python"


### PR DESCRIPTION
Originally intended to fix #4077 and update all configuration fields to
resolve their values. This ended up breaking other features. The fix
from #4209 has been reverted so the only fix that remains is for 
`init_path` and `cmd_path` from the original issue.

Adds CIME_TEST_PLATFORM environment variable to testing 
workflows.

Test suite: scripts_regression_tests
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4213 
User interface changes?: N
Update gh-pages html (Y/N)?: N
