### PR TITLE
Add help to the --driver option in create_newcase, for CESM, change options for it for CESM and E3SM. leave off for UFS

### DIFF
--- a/CIME/scripts/create_newcase.py
+++ b/CIME/scripts/create_newcase.py
@@ -233,8 +233,13 @@ def parse_command_line(args, cimeroot, description):
     )
     if model == "cesm":
         drv_choices = ("mct", "nuopc")
+        drv_help = (
+            "Override the top level driver type and use this one "
+            + "(changes xml variable COMP_INTERFACE) [this is an advanced option]"
+        )
     elif model == "e3sm":
         drv_choices = ("mct", "moab")
+        drv_help = argparse.SUPPRESS
     else:
         drv_choices = None
 
@@ -243,8 +248,7 @@ def parse_command_line(args, cimeroot, description):
             "--driver",
             default=get_cime_default_driver(),
             choices=drv_choices,
-            help="Override the top level driver type and use this one "
-            "(changes xml variable COMP_INTERFACE) [this is an advanced option]",
+            help=drv_help,
         )
 
     parser.add_argument(

--- a/CIME/scripts/create_newcase.py
+++ b/CIME/scripts/create_newcase.py
@@ -232,10 +232,17 @@ def parse_command_line(args, cimeroot, description):
         help="Use a non-default location for input files. This will change the xml value of DIN_LOC_ROOT.",
     )
     if model == "cesm":
+        drv_choices = ("mct", "nuopc")
+    elif model == "e3sm":
+        drv_choices = ("mct", "moab")
+    else:
+        drv_choices = None
+
+    if drv_choices is not None:
         parser.add_argument(
             "--driver",
             default=get_cime_default_driver(),
-            choices=("mct", "nuopc", "moab"),
+            choices=drv_choices,
             help="Override the top level driver type and use this one "
             "(changes xml variable COMP_INTERFACE) [this is an advanced option]",
         )

--- a/CIME/scripts/create_newcase.py
+++ b/CIME/scripts/create_newcase.py
@@ -238,7 +238,7 @@ def parse_command_line(args, cimeroot, description):
             choices=("mct", "nuopc", "moab"),
             help="Override the top level driver type and use this one "
             "(changes xml variable COMP_INTERFACE) [this is an advanced option]",
-    )
+        )
 
     parser.add_argument(
         "-n",

--- a/CIME/scripts/create_newcase.py
+++ b/CIME/scripts/create_newcase.py
@@ -231,11 +231,13 @@ def parse_command_line(args, cimeroot, description):
         "--input-dir",
         help="Use a non-default location for input files. This will change the xml value of DIN_LOC_ROOT.",
     )
-    parser.add_argument(
-        "--driver",
-        default=get_cime_default_driver(),
-        choices=("mct", "nuopc", "moab"),
-        help=argparse.SUPPRESS,
+    if model == "cesm":
+        parser.add_argument(
+            "--driver",
+            default=get_cime_default_driver(),
+            choices=("mct", "nuopc", "moab"),
+            help="Override the top level driver type and use this one "
+            "(changes xml variable COMP_INTERFACE) [this is an advanced option]",
     )
 
     parser.add_argument(


### PR DESCRIPTION
Add help to --driver option, but only for the CESM model

Adds help to the --driver option, for CESM and only allow nuopc and mct. For E3SM leave help suppressed, and only allow mct and moad. For UFS leave the option off.

Test namelist changes: none
Test status: bit-for-bit

Ran ./create_newcase --help

Fixes #4220 

User interface changes?: Y

Update gh-pages html (Y/N)?: N
