### PR TITLE
fix error in parsing ESMF_Profile.summary in ESMF 8.3

### DIFF
--- a/CIME/get_timing.py
+++ b/CIME/get_timing.py
@@ -108,8 +108,12 @@ class _TimingParser:
     def _gettime2_nuopc(self):
         self.nprocs = 0
         self.ncount = 0
-        #        expression = re.compile(r'\s*\MED:\s*\(med_phases_profile\)\s+(\d+)\s+(\d+)')
-        expression = re.compile(r"\s*\[ATM]\s*RunPhase1\s+(\d+)\s+(\d+)")
+        if self.version < 0:
+            self._get_esmf_profile_version()
+        if self.version == 0:
+            expression = re.compile(r"\s*\[ATM]\s*RunPhase1\s+(\d+)\s+(\d+)")
+        else:
+            expression = re.compile(r"\s*\[ATM]\s*RunPhase1\s+\d+\s+(\d+)\s+(\d+)")
 
         for line in self.finlines:
             match = expression.match(line)
@@ -450,7 +454,6 @@ class _TimingParser:
             nsteps = ncount / nprocs
         elif self._driver == "nuopc":
             nprocs, nsteps = self.gettime2("")
-
         adays = nsteps * tlen / ncpl
         odays = nsteps * tlen / ncpl
         if ocn_ncpl and inittype == "TRUE":


### PR DESCRIPTION
The cesm_timing file had an incorrect value for nsteps when using ESMF 8.3.0

Test suite: PFS.f19_g17.F2000climo.cheyenne_intel
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4223

User interface changes?:

Update gh-pages html (Y/N)?:
