### PR TITLE
only do this check on ncar systems

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -184,12 +184,13 @@ class Case(object):
                     machobj = Machines(machine=mach, extra_machines_dir=extra_machdir)
                 else:
                     machobj = Machines(machine=mach)
-                probed_machine = machobj.probe_machine_name()
-                if probed_machine:
-                    expect(
-                        mach == probed_machine,
-                        f"Current machine {probed_machine} does not match case machine {mach}.",
-                    )
+                if "NCAR_HOST" in os.environ:
+                    probed_machine = machobj.probe_machine_name()
+                    if probed_machine:
+                        expect(
+                            mach == probed_machine,
+                            f"Current machine {probed_machine} does not match case machine {mach}.",
+                        )
             self.initialize_derived_attributes()
 
     def check_if_comp_var(self, vid):


### PR DESCRIPTION
This check should only be done on systems with a common filesystem but separate login nodes (ncar)
Test suite: Ran SMS.f19_g17.X.cheyenne_intel and tried to run on casper, ran  ./create_test SMS.f19_g17.X.cori-knl_intel SMS.f19_g17.X on cori.   
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4226 

User interface changes?:

Update gh-pages html (Y/N)?:
