### PR TITLE
remove custom_tag

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -18,4 +18,4 @@ jobs:
           default_bump: patch
           dry_run: false
           tag_prefix: cime
-          custom_tag: 5.6.40
+


### PR DESCRIPTION
Final configuration for maint-5.6 bumpversion.   From now on all PR's to this branch will get tags created automatically.
Test suite: NA
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
