### PR TITLE
Genf90 is no longer an external, it's in the repo

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -48,12 +48,5 @@ repo_url = https://github.com/NCAR/ParallelIO
 local_path = libraries/parallelio
 required = True
 
-[genf90]
-protocol = git
-repo_url = https://github.com/PARALLELIO/genf90
-branch = master
-local_path = CIME/non_py/externals/genf90
-required = True
-
 [externals_description]
 schema_version = 1.0.01


### PR DESCRIPTION
Test suite: none
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes #4240 

User interface changes?:

Update gh-pages html (Y/N)?:
