### PR TITLE
Set component-specific config_pes in E3SM

### DIFF
--- a/CIME/data/config/e3sm/config_files.xml
+++ b/CIME/data/config/e3sm/config_files.xml
@@ -282,12 +282,12 @@
     <values>
       <value component="allactive">$SRCROOT/cime_config/allactive/config_pesall.xml</value>
       <value component="drv"      >$COMP_ROOT_DIR_CPL/cime_config/config_pes.xml</value>
-      <value component="eam"      >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
-      <value component="elm"      >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
-      <value component="cice"     >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
-      <value component="mpaso"    >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
-      <value component="mali"     >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
-      <value component="mpassi"   >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
+      <value component="eam"      >$SRCROOT/components/eam/cime_config/config_pes.xml</value>
+      <value component="elm"      >$SRCROOT/components/elm/cime_config/config_pes.xml</value>
+      <value component="cice"     >$SRCROOT/components/cice/cime_config/config_pes.xml</value>
+      <value component="mpaso"    >$SRCROOT/components/mpas-ocean/cime_config/config_pes.xml</value>
+      <value component="mali"     >$SRCROOT/components/mpas-albany-landice/cime_config/config_pes.xml</value>
+      <value component="mpassi"   >$SRCROOT/components/mpas-seaice/cime_config/config_pes.xml</value>
       <value component="ww3"      >$SRCROOT/cime_config/allactive/config_pesall.xml</value>
     </values>
     <group>case_last</group>


### PR DESCRIPTION
Set component-specific config_pes in E3SM.

Test suite: e3sm_integration, e3sm_prod
Test baseline: master
Test namelist changes: none
Test status: bit for bit

User interface changes?: none

Update gh-pages html (Y/N)?: N