### PR TITLE
Fix E3SM provenance

### DIFF
--- a/CIME/provenance.py
+++ b/CIME/provenance.py
@@ -411,6 +411,7 @@ def _save_prerun_timing_e3sm(case, lid):
         "Depends.{}.{}".format(mach, compiler),
         "software_environment.txt",
     ]
+
     for glob_to_copy in globs_to_copy:
         for item in glob.glob(os.path.join(caseroot, glob_to_copy)):
             safe_copy(
@@ -422,9 +423,32 @@ def _save_prerun_timing_e3sm(case, lid):
             )
 
     # Copy some items from build provenance
-    blddir_globs_to_copy = ["GIT_LOGS_HEAD", "build_environment.txt", "build_times.txt"]
+    blddir_globs_to_copy = [
+        "GIT_LOGS_HEAD",
+        "GIT_STATUS",
+        "GIT_DIFF",
+        "GIT_LOG",
+        "GIT_REMOTE",
+        "GIT_CONFIG",
+        "GIT_SUBMODULE_STATUS",
+        "build_environment.txt",
+        "build_times.txt",
+    ]
+
     for blddir_glob_to_copy in blddir_globs_to_copy:
         for item in glob.glob(os.path.join(blddir, blddir_glob_to_copy)):
+            safe_copy(
+                item,
+                os.path.join(full_timing_dir, os.path.basename(item) + "." + lid),
+                preserve_meta=False,
+            )
+
+    rundir_globs_to_copy = [
+        "preview_run.log",
+    ]
+
+    for rundir_glob_to_copy in rundir_globs_to_copy:
+        for item in glob.glob(os.path.join(rundir, rundir_glob_to_copy)):
             safe_copy(
                 item,
                 os.path.join(full_timing_dir, os.path.basename(item) + "." + lid),
@@ -665,18 +689,6 @@ def _save_postrun_timing_e3sm(case, lid):
     globs_to_copy.append("CaseStatus")
     globs_to_copy.append(os.path.join(rundir, "spio_stats.{}.tar.gz".format(lid)))
     globs_to_copy.append(os.path.join(caseroot, "replay.sh"))
-    # Can't use a single glob, similar files e.g. {filename}.{lid} get picked up.
-    bld_filenames = [
-        "GIT_STATUS",
-        "GIT_DIFF",
-        "GIT_LOG",
-        "GIT_REMOTE",
-        "GIT_CONFIG",
-        "GIT_SUBMODULE_STATUS",
-    ]
-    bld_globs = map(lambda x: f"bld/{x}", bld_filenames)
-    globs_to_copy.extend(bld_globs)
-    globs_to_copy.append("run/preview_run.log")
 
     for glob_to_copy in globs_to_copy:
         for item in glob.glob(os.path.join(caseroot, glob_to_copy)):

--- a/CIME/provenance.py
+++ b/CIME/provenance.py
@@ -16,6 +16,7 @@ from CIME.utils import (
     run_cmd,
     run_cmd_no_fail,
     safe_copy,
+    copy_globs,
 )
 
 import tarfile, getpass, signal, glob, shutil, sys
@@ -412,15 +413,7 @@ def _save_prerun_timing_e3sm(case, lid):
         "software_environment.txt",
     ]
 
-    for glob_to_copy in globs_to_copy:
-        for item in glob.glob(os.path.join(caseroot, glob_to_copy)):
-            safe_copy(
-                item,
-                os.path.join(
-                    case_docs, "{}.{}".format(os.path.basename(item).lstrip("."), lid)
-                ),
-                preserve_meta=False,
-            )
+    copy_globs([os.path.join(caseroot, x) for x in globs_to_copy], case_docs, lid)
 
     # Copy some items from build provenance
     blddir_globs_to_copy = [
@@ -435,25 +428,17 @@ def _save_prerun_timing_e3sm(case, lid):
         "build_times.txt",
     ]
 
-    for blddir_glob_to_copy in blddir_globs_to_copy:
-        for item in glob.glob(os.path.join(blddir, blddir_glob_to_copy)):
-            safe_copy(
-                item,
-                os.path.join(full_timing_dir, os.path.basename(item) + "." + lid),
-                preserve_meta=False,
-            )
+    copy_globs(
+        [os.path.join(blddir, x) for x in blddir_globs_to_copy], full_timing_dir, lid
+    )
 
     rundir_globs_to_copy = [
         "preview_run.log",
     ]
 
-    for rundir_glob_to_copy in rundir_globs_to_copy:
-        for item in glob.glob(os.path.join(rundir, rundir_glob_to_copy)):
-            safe_copy(
-                item,
-                os.path.join(full_timing_dir, os.path.basename(item) + "." + lid),
-                preserve_meta=False,
-            )
+    copy_globs(
+        [os.path.join(rundir, x) for x in rundir_globs_to_copy], full_timing_dir, lid
+    )
 
     # Save state of repo
     from_repo = (

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -1312,6 +1312,30 @@ def get_current_submodule_status(recursive=False, repo=None):
     return output if rc == 0 else "unknown"
 
 
+def copy_globs(globs_to_copy, output_directory, lid=None):
+    """
+    Takes a list of globs and copies all files to `output_directory`.
+
+    Hiddens files become unhidden i.e. removing starting dot.
+
+    Output filename is derviced from the basename of the input path and can
+    be appended with the `lid`.
+
+    """
+    for glob_to_copy in globs_to_copy:
+        for item in glob.glob(glob_to_copy):
+            item_basename = os.path.basename(item).lstrip(".")
+
+            if lid is None:
+                filename = item_basename
+            else:
+                filename = f"{item_basename}.{lid}"
+
+            safe_copy(
+                item, os.path.join(output_directory, filename), preserve_meta=False
+            )
+
+
 def safe_copy(src_path, tgt_path, preserve_meta=True):
     """
     A flexbile and safe copy routine. Will try to copy file and metadata, but this


### PR DESCRIPTION
Fixes copying GIT_* and preview_run.log into E3SM performance
archives.

Test suite: scripts_regression_tests
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4229 
User interface changes?: n
Update gh-pages html (Y/N)?: n
