### PR TITLE
Maint 5.6 archer2 port

### DIFF
--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -16,7 +16,7 @@
 
   <server>
     <protocol>wget</protocol>
-    <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata</address>
+    <address>ftp://ftp.cgd.ucar.edu/cesm/inputdata/</address>
     <user>anonymous</user>
     <password>user@example.edu</password>
     <checksum>../inputdata_checksum.dat</checksum>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -221,6 +221,41 @@
     </queues>
   </batch_system>
 
+  <batch_system MACH="archer2" type="slurm" >
+    <batch_submit>sbatch</batch_submit>
+    <submit_args>
+      <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-q" name="$JOB_QUEUE"/>
+      <arg flag="--account" name="$PROJECT"/>
+    </submit_args>
+
+    <directives queue="standard">
+      <directive>--partition=standard</directive>
+      <directive>--qos=standard</directive>
+      <directive>--export=none</directive>
+    </directives>
+
+    <directives queue="short">
+      <directive>--partition=standard</directive>
+      <directive>--qos=short</directive>
+      <directive>--export=none</directive>
+    </directives>
+
+    <directives queue="serial">
+      <directive>--partition=serial</directive>
+      <directive>--qos=serial</directive>
+      <directive>--export=none</directive>
+    </directives>
+
+    <!-- following will need updating as system develops -->
+    <queues>
+      <queue walltimemax="24:00:00" nodemin="1" nodemax="1024" default="true">standard</queue>
+      <!-- <queue walltimemin="24:00:00" walltimemax="48:00:00" nodemin="1" nodemax="64" >long</queue> -->
+      <queue walltimemax="00:20:00" nodemin="1" nodemax="32">short</queue>
+      <queue walltimemax="24:00:00" nodemin="1" nodemax="1">serial</queue>
+    </queues>
+  </batch_system>
+
   <!-- athena is lsf -->
   <batch_system MACH="athena" type="lsf">
     <batch_env>none</batch_env>

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -227,26 +227,24 @@
       <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
       <arg flag="-q" name="$JOB_QUEUE"/>
       <arg flag="--account" name="$PROJECT"/>
+      <arg flag="--export=ALL"/>
     </submit_args>
 
     <directives queue="standard">
       <directive>--partition=standard</directive>
       <directive>--qos=standard</directive>
-      <directive>--export=none</directive>
       <directive>--cpus-per-task={{ thread_count }}</directive>
     </directives>
 
     <directives queue="short">
       <directive>--partition=standard</directive>
       <directive>--qos=short</directive>
-      <directive>--export=none</directive>
       <directive>--cpus-per-task={{ thread_count }}</directive>
     </directives>
 
     <directives queue="serial">
       <directive>--partition=serial</directive>
       <directive>--qos=serial</directive>
-      <directive>--export=none</directive>
     </directives>
 
     <!-- following will need updating as system develops -->

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -233,12 +233,14 @@
       <directive>--partition=standard</directive>
       <directive>--qos=standard</directive>
       <directive>--export=none</directive>
+      <directive>--cpus-per-task={{ thread_count }}</directive>
     </directives>
 
     <directives queue="short">
       <directive>--partition=standard</directive>
       <directive>--qos=short</directive>
       <directive>--export=none</directive>
+      <directive>--cpus-per-task={{ thread_count }}</directive>
     </directives>
 
     <directives queue="serial">

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -514,7 +514,7 @@ using a fortran linker.
 </compiler>
 <compiler MACH="archer2" COMPILER="gnu">
   <FFLAGS>
-    <base>  -mcmodel=medium -std=gnu99 -fcray-pointer -frecursive </base>
+    <base>  -mcmodel=medium -std=legacy -fcray-pointer -frecursive </base>
     <append compile_threaded="true"> -fopenmp </append>
     <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=zero,overflow -fcheck=bounds </append>
     <append DEBUG="FALSE"> -O2 </append>

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -493,6 +493,45 @@ using a fortran linker.
   <ESMF_LIBDIR>$ENV{ESMF_LIBDIR}</ESMF_LIBDIR>
 </compiler>
 
+<compiler MACH="archer2">
+  <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
+  <NETCDF_PATH>$ENV{NETCDF_DIR}</NETCDF_PATH>
+  <PNETCDF_PATH  MPILIB="mpich">$ENV{PNETCDF_DIR}</PNETCDF_PATH>
+
+  <LDFLAGS>
+     <append MPILIB="mpich"> -dynamic -L${NETCDF_PATH}/lib -lnetcdff -lnetcdf  -Wl,-rpath,${NETCDF_PATH}/lib </append>
+     <append MPILIB="mpich"> -L${PNETCDF_PATH}/lib -lpnetcdf -Wl,-rpath,${PNETCDF_PATH}/lib </append>
+  </LDFLAGS>
+
+  <SLIBS>
+     <append MPILIB="mpi-serial"> -L${NETCDF_PATH}/lib -lnetcdff -lnetcdf -Wl,-rpath,${NETCDF_PATH}/lib </append>
+  </SLIBS>
+
+  <SLIBS>
+     <append> -Wl,-rpath,${NETCDF_PATH}/lib </append>
+  </SLIBS>
+
+</compiler>
+<compiler MACH="archer2" COMPILER="gnu">
+  <FFLAGS>
+    <base>  -mcmodel=medium -std=legacy -fcray-pointer -frecursive </base>
+    <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=zero,overflow -fcheck=bounds </append>
+    <append DEBUG="FALSE"> -O2 </append>
+    <append>  -fallow-argument-mismatch -fallow-invalid-boz </append>
+    <append>  -fconvert=big-endian -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none</append>
+    <!--<append> -ftree-loop-vectorize -ffast-math </append>-->
+  </FFLAGS>
+  <CFLAGS>
+    <base>  -mcmodel=medium</base>
+    <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=zero,overflow -fcheck=bounds </append>
+    <append DEBUG="FALSE"> -O2 </append>
+  </CFLAGS>
+  <ESMF_LIBDIR>/work/n02/shared/ESMF/esmf_8.2.0/lib/libO/Linux.gfortran.64.mpich.archer2</ESMF_LIBDIR>
+  <SLIBS>
+    <append>-L/work/n02/shared/ESMF/esmf_8.2.0/lib/libO/Linux.gfortran.64.mpich.archer2/ -ldl </append>
+  </SLIBS>
+</compiler>
+
 <compiler MACH="athena">
   <CPPDEFS>
     <!-- these flags enable nano timers -->

--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -514,16 +514,17 @@ using a fortran linker.
 </compiler>
 <compiler MACH="archer2" COMPILER="gnu">
   <FFLAGS>
-    <base>  -mcmodel=medium -std=legacy -fcray-pointer -frecursive </base>
+    <base>  -mcmodel=medium -std=gnu99 -fcray-pointer -frecursive </base>
+    <append compile_threaded="true"> -fopenmp </append>
     <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=zero,overflow -fcheck=bounds </append>
     <append DEBUG="FALSE"> -O2 </append>
-    <append>  -fallow-argument-mismatch -fallow-invalid-boz </append>
-    <append>  -fconvert=big-endian -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none</append>
-    <!--<append> -ftree-loop-vectorize -ffast-math </append>-->
+    <append> -fallow-argument-mismatch -fallow-invalid-boz </append>
+    <append> -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none</append>
   </FFLAGS>
   <CFLAGS>
-    <base>  -mcmodel=medium</base>
-    <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=zero,overflow -fcheck=bounds </append>
+    <base> -std=gnu99 -mcmodel=medium</base>
+    <append compile_threaded="true"> -fopenmp </append>
+    <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=bounds </append>
     <append DEBUG="FALSE"> -O2 </append>
   </CFLAGS>
   <ESMF_LIBDIR>/work/n02/shared/ESMF/esmf_8.2.0/lib/libO/Linux.gfortran.64.mpich.archer2</ESMF_LIBDIR>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -220,7 +220,7 @@ This allows using a different mpirun command to launch unit tests
     </module_system>
 
     <environment_variables>
-      <env name="PERL5LIB">/work/n02/n02/dcase/perl/5.26.2</env>
+      <env name="PERL5LIB">/work/n02/shared/perl/5.26.2</env>
       <env name="OMP_NUM_THREADS">{{ thread_count }} </env>
       <env name="OMP_PLACES">cores </env>
       <env name="OMP_STACKSIZE">2G</env>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -167,6 +167,70 @@ This allows using a different mpirun command to launch unit tests
     </resource_limits>
   </machine>
 
+  <machine MACH="archer2">
+    <DESC>two CrayAMD EPYC Zen2, 128 pes/node, batch system is SLURM</DESC>
+    <NODENAME_REGEX>(ln\d{2}$|nid\d{6}$)</NODENAME_REGEX>
+    <OS>CNL</OS>
+    <COMPILERS>gnu,cray</COMPILERS>
+    <MPILIBS>mpich,mpi-serial</MPILIBS>
+    <CIME_OUTPUT_ROOT>$ENV{CESM_ROOT}/runs</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>$ENV{CESM_ROOT}/cesm_inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>$ENV{CESM_ROOT}/cesm_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$ENV{CESM_ROOT}/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$ENV{CESM_ROOT}/ccsm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>$ENV{CIMEROOT}/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>8</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>leeds.ac.uk</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+       <arg name="cpubind"> --distribution=block:block --hint=nomultithread</arg>
+       <!--<arg name="cpubind"> -ZZ-cpu-bind=cores</arg> -->
+      </arguments>
+    </mpirun>
+    <module_system type="module"  allow_error="true">
+      <init_path lang="perl">/usr/share/lmod/lmod/init/perl</init_path>
+      <init_path lang="python">/usr/share/lmod/lmod/init/env_modules_python.py</init_path>
+      <init_path lang="csh">/usr/share/lmod/lmod/init/csh</init_path>
+      <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
+      <cmd_path lang="perl">/usr/share/lmod/lmod/libexec/lmod perl</cmd_path>
+      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+
+      <modules compiler="gnu">
+        <command name="load"> PrgEnv-gnu</command>
+        <command name="load"> cray-hdf5-parallel</command>
+        <command name="load"> cray-netcdf-hdf5parallel</command>
+        <command name="load"> cray-parallel-netcdf</command>
+        <command name="load"> cray-libsci</command>
+      </modules>
+      <modules mpilib="mpi-serial">
+        <command name="rm"> cray-netcdf-hdf5parallel</command>
+        <command name="rm"> cray-hdf5-parallel</command>
+        <command name="rm"> cray-parallel-netcdf</command>
+        <command name="load"> cray-hdf5</command>
+        <command name="load">cray-netcdf</command>
+      </modules>
+    </module_system>
+
+    <environment_variables>
+      <env name="PERL5LIB">/work/n02/n02/dcase/perl/5.26.2</env>
+      <env name="OMP_NUM_THREADS">{{ thread_count }} </env>
+      <env name="OMP_PLACES">cores </env>
+      <env name="OMP_STACKSIZE">2G</env>
+      <!--<env name="PATH">/work/n02/n02/csymonds/sw/conda/cesmenv2/bin:$ENV{PATH}</env>-->
+    </environment_variables>
+
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
+  </machine>
+
   <machine MACH="athena">
     <DESC> CMCC IBM iDataPlex, os is Linux, 16 pes/node, batch system is LSFd mpich</DESC>
     <NODENAME_REGEX>.*.cluster.net</NODENAME_REGEX>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -182,8 +182,9 @@ This allows using a different mpirun command to launch unit tests
     <GMAKE_J>8</GMAKE_J>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>leeds.ac.uk</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>64</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>64</MAX_MPITASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>srun</executable>
       <arguments>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -175,7 +175,7 @@ This allows using a different mpirun command to launch unit tests
     <MPILIBS>mpich,mpi-serial</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{CESM_ROOT}/runs</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{CESM_ROOT}/cesm_inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>$ENV{CESM_ROOT}/cesm_inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT_CLMFORC>${DIN_LOC_ROOT}/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$ENV{CESM_ROOT}/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>$ENV{CESM_ROOT}/ccsm_baselines</BASELINE_ROOT>
     <CCSM_CPRNC>$ENV{CIMEROOT}/tools/cprnc/cprnc</CCSM_CPRNC>


### PR DESCRIPTION
Added configs for ARCHER2 machine. Config tested using F2000, ETEST, B1850 and FX2000, and confirmed a working port

Additional change made to wget block in config_inputdata.xml, adding trailing / to ftp address as was shown in https://bb.cgd.ucar.edu/cesm/threads/porting-to-a-local-machine-cant-automatically-download-the-input-data.5608/

Setting as draft initially while I await confirmation from a colleague about the changes to optimisation level