### PR TITLE
Allow any case env to be used as a directives selector

### DIFF
--- a/CIME/data/config/xml_schemas/config_batch.xsd
+++ b/CIME/data/config/xml_schemas/config_batch.xsd
@@ -146,10 +146,7 @@
       <xs:sequence>
         <xs:element maxOccurs="unbounded" ref="directive"/>
       </xs:sequence>
-      <xs:attribute ref="queue"/>
-      <xs:attribute name="compiler"/>
-      <xs:attribute name="mpilib"/>
-      <xs:attribute name="threaded" type="xs:boolean"/>
+      <xs:anyAttribute processContents="skip"/>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
Some users want to be able to select directives based on compset. It is a lot easier to skip XSD attribute verification for directives element rather than list every possible case env setting.

Test suite: ./scripts-regression-tests
Test baseline:
Test namelist changes:
Test status:  bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
