### PR TITLE
remove this warning for MAX_GPUS to debug output only

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1373,6 +1373,10 @@ class Case(object):
                 dmax = machobj.get_value(name)
             if dmax:
                 self.set_value(name, dmax)
+            elif name is "MAX_GPUS_PER_NODE":
+                logger.debug(
+                    "Variable {} not defined for machine {}".format(name, machine_name)
+                )
             else:
                 logger.warning(
                     "Variable {} not defined for machine {}".format(name, machine_name)


### PR DESCRIPTION
Remove the warning Variable MAX_GPUS_PER_NODE not defined for machine xxx
which is apparently causing some confusion on machines with no GPUS. 

Test suite: tested by hand on cheyenne
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
