### PR TITLE
Fix DAE test.

### DIFF
--- a/CIME/SystemTests/dae.py
+++ b/CIME/SystemTests/dae.py
@@ -54,7 +54,7 @@ class DAE(SystemTestsCompareTwo):
         if len(self._case.get_value("DATA_ASSIMILATION_SCRIPT")) == 0:
             # We need to find the scripts/data_assimilation directory
             # LIB_DIR should be our parent dir
-            da_dir = os.path.join(os.path.dirname(sms.LIB_DIR), "data_assimilation")
+            da_dir = os.path.join(self._case.get_value("CIMEROOT"), "scripts/data_assimilation")
             expect(
                 os.path.isdir(da_dir),
                 "ERROR: da_dir, '{}', does not exist".format(da_dir),


### PR DESCRIPTION
After PR #4162, the DAE was referencing scripts/data_assimilation directory
incorrectly.


Test suite: DAE_C2_D_Lh12.f10_f10_mg37.I2000Clm50BgcCrop.cheyenne_intel.clm-DA_multidrv
Test baseline:
Test namelist changes:
Test status: BFB

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
