### PR TITLE
e3sm: Fix build time provenance

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1373,7 +1373,7 @@ class Case(object):
                 dmax = machobj.get_value(name)
             if dmax:
                 self.set_value(name, dmax)
-            elif name is "MAX_GPUS_PER_NODE":
+            elif name == "MAX_GPUS_PER_NODE":
                 logger.debug(
                     "Variable {} not defined for machine {}".format(name, machine_name)
                 )

--- a/CIME/provenance.py
+++ b/CIME/provenance.py
@@ -55,7 +55,7 @@ def _extract_times(zipfiles, target_file):
                     target, the_time = items[1], items[-2]
                     contents += "{} {}\n".format(target, the_time)
 
-        stat, output, _ = run_cmd("zgrep -E '^user [0-9.]+$' {}".format(zipfile))
+        stat, output, _ = run_cmd("zgrep -E '^real [0-9.]+$' {}".format(zipfile))
         if stat == 0:
             for line in output.splitlines():
                 line = line.strip()
@@ -64,7 +64,7 @@ def _extract_times(zipfiles, target_file):
 
     with open(target_file, "w") as fd:
         fd.write(contents)
-        fd.write("Total_Build {}".format(str(total_build_time)))
+        fd.write("Total_Elapsed_Time {}".format(str(total_build_time)))
 
 
 def _run_git_cmd_recursively(cmd, srcroot, output):


### PR DESCRIPTION
We should be grabbing 'real' times, not 'user' times.

Test suite: by-hand
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
