### PR TITLE
Fix buildlib.pio genf90 path for scorpio

### DIFF
--- a/CIME/build_scripts/buildlib.pio
+++ b/CIME/build_scripts/buildlib.pio
@@ -97,7 +97,11 @@ def buildlib(bldroot, installpath, case):
     casetools = case.get_value("CASETOOLS")
     if scorpio_src_root_dir:
         # Use old genf90 until "short" type is supported
-        cmake_opts = '"-D GENF90_PATH=' + os.path.join(scorpio_src_root_dir, scorpio_dir, "src/genf90") + '" '
+        cmake_opts = (
+            '"-D GENF90_PATH='
+            + os.path.join(scorpio_src_root_dir, scorpio_dir, "src/genf90")
+            + '" '
+        )
     elif pio_version == 1:
         cmake_opts = '"-D GENF90_PATH=$CIMEROOT/CIME/non_py/externals/genf90 "'
     else:


### PR DESCRIPTION
The path was incorrect. The error was hidden because scorpio uses its internal
genf90 if GENF90_PATH is not found but this does not work for scorpio_classic.

Test suite: by-hand
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
