### PR TITLE
create_test: Print correct project

### DIFF
--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -253,9 +253,7 @@ class TestScheduler(object):
         self._output_root = output_root
         # Figure out what project to use
         if project is None:
-            self._project = get_project()
-            if self._project is None:
-                self._project = self._machobj.get_value("PROJECT")
+            self._project = get_project(machobj=self._machobj)
         else:
             self._project = project
 


### PR DESCRIPTION
When the project was coming from machobj (config_machines.xml), create_test
was printing 'No project info available' instead of the correct project.

Test suite: by-hand
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
