### PR TITLE
Fix ww3dev baseline generation

### DIFF
--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -588,8 +588,6 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
     num_gen = 0
     for model in _iter_model_file_substrs(case):
 
-        if model == "ww3dev":
-            model = "ww3"
         comments += "  generating for model '{}'\n".format(model)
 
         hists = archive.get_latest_hist_files(
@@ -597,6 +595,10 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
         )
         logger.debug("latest_files: {}".format(hists))
         num_gen += len(hists)
+
+        if model == "ww3dev":
+            model = "ww3"
+
         for hist in hists:
             offset = hist.rfind(model)
             expect(


### PR DESCRIPTION
This PR brings a minor change in hist_utils.py to fix the baseline generator for ww3dev.

Test suite: ERS.TL319_t061_wt061.GMOM_JRA_WD.cheyenne_intel
Test baseline:
Test namelist changes: none
Test status: [bit for bit, roundoff, climate changing] b4b

Fixes [CIME Github issue #]

User interface changes?: none

Update gh-pages html (Y/N)?: N
