### PR TITLE
Add --pes-file option to bless_test_results

### DIFF
--- a/CIME/Tools/bless_test_results
+++ b/CIME/Tools/bless_test_results
@@ -122,6 +122,12 @@ OR
     )
 
     parser.add_argument(
+        "--pes-file",
+        help="Full pathname of an optional pes specification file. The file"
+        "\ncan follow either the config_pes.xml or the env_mach_pes.xml format.",
+    )
+
+    parser.add_argument(
         "bless_tests",
         nargs="*",
         help="When blessing, limit the bless to tests matching these regex",
@@ -148,6 +154,7 @@ OR
         args.hist_only,
         args.report_only,
         args.force,
+        args.pes_file,
         args.bless_tests,
         args.no_skip_pass,
         args.new_test_root,
@@ -168,6 +175,7 @@ def _main_func(description):
         hist_only,
         report_only,
         force,
+        pes_file,
         bless_tests,
         no_skip_pass,
         new_test_root,
@@ -184,6 +192,7 @@ def _main_func(description):
         hist_only=hist_only,
         report_only=report_only,
         force=force,
+        pesfile=pes_file,
         bless_tests=bless_tests,
         no_skip_pass=no_skip_pass,
         new_test_root=new_test_root,

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -20,6 +20,7 @@ def bless_namelists(
     test_name,
     report_only,
     force,
+    pesfile,
     baseline_name,
     baseline_root,
     new_test_root=None,
@@ -47,6 +48,9 @@ def bless_namelists(
             )
         if new_test_id is not None:
             create_test_gen_args += " -t {}".format(new_test_id)
+
+        if pesfile is not None:
+            create_test_gen_args += " --pesfile {}".format(pesfile)
 
         stat, out, _ = run_cmd(
             "{}/create_test {} --namelists-only {} --baseline-root {} -o".format(
@@ -109,6 +113,7 @@ def bless_test_results(
     hist_only=False,
     report_only=False,
     force=False,
+    pesfile=None,
     bless_tests=None,
     no_skip_pass=False,
     new_test_root=None,
@@ -255,6 +260,7 @@ def bless_test_results(
                             test_name,
                             report_only,
                             force,
+                            pesfile,
                             baseline_name_resolved,
                             baseline_root_resolved,
                             new_test_root=new_test_root,


### PR DESCRIPTION
Add --pes-file option to bless_test_results.

Test suite: e3sm_prod_bench
Test baseline: e3sm master
Test namelist changes: none
Test status: bit for bit

User interface changes?: this adds --pes-file option to `CIME/Tools/bless_test_results`

Update gh-pages html (Y/N)?: N
