### PR TITLE
remove new $RUNDIR/init_generated_files when tests are running

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -368,6 +368,12 @@ class SystemTestsCommon(object):
         for compout in glob.iglob(os.path.join(rundir, "*.cprnc.out")):
             os.remove(compout)
 
+        # remove all files in init_generated_files directory if it exists
+        init_generated_files_dir = os.path.join(rundir, "init_generated_files")
+        if (os.path.isdir(init_generated_files_dir)):
+            for init_file in glob.iglob(os.path.join(init_generated_files_dir,"*")):
+                os.remove(init_file)
+
         infostr = "doing an {:d} {} {} test".format(stop_n, stop_option, run_type)
 
         rest_option = self._case.get_value("REST_OPTION")


### PR DESCRIPTION
remove new $RUNDIR/init_generated_files when tests are running

New additions have been added to CTSM to have interpolated finidat files and the land mask/fraction file generated in $RUNDIR/init_generated_files. If those files are there and the run is a startup run - the files are not regenerated. When running tests however, this directory should be removed since the assumption for testing is that each time a test is rerun it should be rerun exactly the same way.

Test suite: CTSM aux_clm test suite (using a new branch off of ctsm5.1.dev099)
Test baseline: ./run_sys_tests -s aux_clm -c ctsm5.1.dev098 --skip-generate
Test namelist changes: 
Test status: bit for bit

Fixes: None
User interface changes?: No
Update gh-pages html (Y/N)?: No
