### PR TITLE
Add deprecation warning for MCT in CESM

### DIFF
--- a/CIME/scripts/create_newcase.py
+++ b/CIME/scripts/create_newcase.py
@@ -313,6 +313,16 @@ def parse_command_line(args, cimeroot, description):
     elif cime_config and cime_config.has_option("main", "input_dir"):
         args.input_dir = os.path.abspath(cime_config.get("main", "input_dir"))
 
+    if model == "cesm" and args.driver == "mct":
+        logger.warning(
+            """========================================================================
+WARNING: The MCT-based driver and data models will be removed from CESM
+WARNING: on September 30, 2022.
+WARNING: Please contact members of the CESM Software Engineering Group
+WARNING: if you need support migrating to the ESMF/NUOPC infrastructure.
+========================================================================"""
+        )
+
     return (
         args.case,
         args.compset,


### PR DESCRIPTION
Creating a CESM case with `--driver mct` will now produce this output at the beginning of the create_newcase output to stdout:

```
========================================================================
WARNING: The MCT-based driver and data models will be removed from CESM
WARNING: on September 30, 2022.
WARNING: Please contact members of the CESM Software Engineering Group
WARNING: if you need support migrating to the ESMF/NUOPC infrastructure.
========================================================================
```

Thanks to @adrifoster for suggesting this deprecation notice.

@mvertens helped come up with the date. We figure September 30 will be the earliest possible date for removal. I wanted to state this in a definitive way rather than something more ambiguous like "as early as September 30", since I was worried that the latter would lead people to procrastinate more. I'm open to suggestions on the wording and formatting of this message, though.

Test suite: Just manual testing (with and without `--driver mct`)
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N
