### PR TITLE
Add driver info to timing file. 

### DIFF
--- a/CIME/get_timing.py
+++ b/CIME/get_timing.py
@@ -486,6 +486,10 @@ class _TimingParser:
         self.write("  Timeroot    : {}/Tools\n".format(self.caseroot))
         self.write("  User        : {}\n".format(user))
         self.write("  Curr Date   : {}\n".format(now))
+        if self._driver == "nuopc":
+            self.write("  Driver      : CMEPS\n")
+        elif self._driver == "mct":
+            self.write("  Driver      : CPL7\n")
 
         self.write("  grid        : {}\n".format(grid))
         self.write("  compset     : {}\n".format(compset))


### PR DESCRIPTION
Add driver information to the timing file, this is needed for the cesm timing database.

Test suite: scripts_regression_tests 
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 
User interface changes?:

Update gh-pages html (Y/N)?:
