### PR TITLE
Add a new system test type, REUSEINITFILES

### DIFF
--- a/CIME/SystemTests/reuseinitfiles.py
+++ b/CIME/SystemTests/reuseinitfiles.py
@@ -1,0 +1,60 @@
+"""
+Implementation of the CIME REUSEINITFILES test
+
+This test does two runs:
+
+(1) A standard initial run
+
+(2) A run that reuses the init-generated files from run (1).
+
+This verifies that it works to reuse these init-generated files, and that you can get
+bit-for-bit results by doing so. This is important because these files are typically
+reused whenever a user reruns an initial case.
+"""
+
+import os
+import shutil
+from CIME.XML.standard_module_setup import *
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
+from CIME.SystemTests.system_tests_common import INIT_GENERATED_FILES_DIRNAME
+
+
+class REUSEINITFILES(SystemTestsCompareTwo):
+    def __init__(self, case):
+        SystemTestsCompareTwo.__init__(
+            self,
+            case,
+            separate_builds=False,
+            run_two_suffix="reuseinit",
+            run_one_description="standard initial run",
+            run_two_description="reuse init-generated files from run 1",
+            # The following line is a key part of this test: we will copy the
+            # init_generated_files from case1 and then need to make sure they are NOT
+            # deleted like is normally done for tests:
+            case_two_keep_init_generated_files=True,
+        )
+
+    def _case_one_setup(self):
+        pass
+
+    def _case_two_setup(self):
+        pass
+
+    def _case_two_custom_prerun_action(self):
+        case1_igf_dir = os.path.join(
+            self._case1.get_value("RUNDIR"), INIT_GENERATED_FILES_DIRNAME
+        )
+        case2_igf_dir = os.path.join(
+            self._case2.get_value("RUNDIR"), INIT_GENERATED_FILES_DIRNAME
+        )
+
+        expect(
+            os.path.isdir(case1_igf_dir),
+            "ERROR: Expected a directory named {} in case1's rundir".format(
+                INIT_GENERATED_FILES_DIRNAME
+            ),
+        )
+        if os.path.isdir(case2_igf_dir):
+            shutil.rmtree(case2_igf_dir)
+
+        shutil.copytree(case1_igf_dir, case2_igf_dir)

--- a/CIME/SystemTests/system_tests_compare_two.py
+++ b/CIME/SystemTests/system_tests_compare_two.py
@@ -65,6 +65,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         run_two_description="",
         multisubmit=False,
         ignore_fieldlist_diffs=False,
+        case_two_keep_init_generated_files=False,
     ):
         """
         Initialize a SystemTestsCompareTwo object. Individual test cases that
@@ -89,11 +90,19 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 has some diagnostic fields that are missing from the other case), treat
                 the two cases as identical. (This is needed for tests where one case
                 exercises an option that produces extra diagnostic fields.)
+            case_two_keep_init_generated_files (bool): If True, then do NOT remove the
+                init_generated_files subdirectory of the case2 run directory before
+                running case2. This should typically be kept at its default (False) so
+                that rerunning a test gives the same behavior as in the initial run rather
+                than reusing init_generated_files in the second run. However, this option
+                is provided for the sake of specific tests, e.g., a test of the behavior
+                of running with init_generated_files in place.
         """
         SystemTestsCommon.__init__(self, case)
 
         self._separate_builds = separate_builds
         self._ignore_fieldlist_diffs = ignore_fieldlist_diffs
+        self._case_two_keep_init_generated_files = case_two_keep_init_generated_files
 
         # run_one_suffix is just used as the suffix for the netcdf files
         # produced by the first case; we may eventually remove this, but for now
@@ -295,7 +304,10 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                     self._case2.check_case()
 
                 self._case_two_custom_prerun_action()
-                self.run_indv(suffix=self._run_two_suffix)
+                self.run_indv(
+                    suffix=self._run_two_suffix,
+                    keep_init_generated_files=self._case_two_keep_init_generated_files,
+                )
                 self._case_two_custom_postrun_action()
             # Compare results
             # Case1 is the "main" case, and we need to do the comparisons from there

--- a/CIME/data/config/config_tests.xml
+++ b/CIME/data/config/config_tests.xml
@@ -41,6 +41,8 @@ SBN    smoke build-namelist test (just run preview_namelist and check_input_data
 
 REP    reproducibility: do two identical runs give the same results?
 
+REUSEINITFILES do we get identical results when reusing init-generated files?
+
 ======================================================================
     Restart Tests
 ======================================================================
@@ -662,6 +664,16 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
 
   <test NAME="REP">
     <DESC>reproducibility test: do two runs give the same answers?</DESC>
+    <INFO_DBUG>1</INFO_DBUG>
+    <DOUT_S>FALSE</DOUT_S>
+    <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <REST_OPTION>never</REST_OPTION>
+    <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
+    <HIST_N>$STOP_N</HIST_N>
+  </test>
+
+  <test NAME="REUSEINITFILES">
+    <DESC>do we get identical results when reusing init-generated files?</DESC>
     <INFO_DBUG>1</INFO_DBUG>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>

--- a/CIME/tests/test_unit_compare_two.py
+++ b/CIME/tests/test_unit_compare_two.py
@@ -161,7 +161,13 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
     # SystemTestsCommon
     # ------------------------------------------------------------------------
 
-    def run_indv(self, suffix="base", st_archive=False, submit_resubmits=None):
+    def run_indv(
+        self,
+        suffix="base",
+        st_archive=False,
+        submit_resubmits=None,
+        keep_init_generated_files=False,
+    ):
         """
         This fake implementation appends to the log and raises an exception if
         it's supposed to


### PR DESCRIPTION
This test does two runs:

(1) A standard initial run

(2) A run that reuses the init-generated files from run (1).

This verifies that it works to reuse these init-generated files, and that you can get
bit-for-bit results by doing so. This is important because these files are typically
reused whenever a user reruns an initial case.

Test suite:
- Manual testing, ensuring the test passes but fails when it should (test `REUSEINITFILES_D_Ld1_P8x1.f10_f10_mg37.I2000Clm50BgcCropQianRs.green_gnu.clm-default`)
- scripts_regression_tests on cheyenne
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N
