### PR TITLE
Update stampede2 modules for maint-5.6

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2586,7 +2586,7 @@ This allows using a different mpirun command to launch unit tests
       <modules>
 	<command name="purge"></command>
 	<command name="load">TACC</command>
-	<command name="load">python/2.7.13</command>
+	<command name="load">python2/2.7.15</command>
 	<command name="load">intel/18.0.2</command>
 	<command name="load">cmake/3.16.1</command>
       </modules>
@@ -2644,9 +2644,9 @@ This allows using a different mpirun command to launch unit tests
       <modules>
 	<command name="purge"></command>
 	<command name="load">TACC</command>
-	<command name="load">python/2.7.13</command>
+	<command name="load">python2/2.7.15</command>
 	<command name="load">intel/17.0.4</command>
-	<command name="load">cmake/3.10.2</command>
+	<command name="load">cmake/3.20.2</command>
       </modules>
       <modules mpilib="mvapich2">
 	<command name="load">mvapich2/2.3b</command>


### PR DESCRIPTION
Update module loads for stampede2.

Test suite: SMS.f19_g17.X.stampede2-skx, SMS.f19_g17.X.stampede2-knl
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
