### PR TITLE
Fixes testreporter path

### DIFF
--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -1375,7 +1375,7 @@ class TestScheduler(object):
             if self._cime_model == "cesm":
                 template_file = os.path.join(template_path, "testreporter.template")
                 template = open(template_file, "r").read()
-                template = template.replace("<PATH>", self._cime_root)
+                template = template.replace("<PATH>", get_tools_path())
                 testreporter_file = os.path.join(self._test_root, "testreporter")
                 with open(testreporter_file, "w") as fd:
                     fd.write(template)

--- a/CIME/tests/scripts_regression_tests.py
+++ b/CIME/tests/scripts_regression_tests.py
@@ -272,7 +272,7 @@ OR
         test_suite = unittest.defaultTestLoader.discover(test_root)
     else:
         # Fixes handling shell expansion e.g. test_unit_*, by removing python extension
-        tests = [x.replace(".py", "") for x in ns.tests]
+        tests = [x.replace(".py", "").replace("/", ".") for x in ns.tests]
 
         # Try to load tests by just names
         test_suite = unittest.defaultTestLoader.loadTestsFromNames(tests)


### PR DESCRIPTION
Fixes setting correct path when creating `testreporter` from the
`testreporter.template` template. Before the fix this would set `<PATH>`
to `$CIMEROOT/` but now sets `$CIMEROOT/CIME/Tools`
i.e. get_tools_dir(), the correct location of `testresporter.py`.

Test suite: scripts_regression_tests.py
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4273

User interface changes?: N
Update gh-pages html (Y/N)?: N
