### PR TITLE
Open TSC user nls mode w+ to truncate before write

### DIFF
--- a/CIME/SystemTests/tsc.py
+++ b/CIME/SystemTests/tsc.py
@@ -106,10 +106,12 @@ class TSC(SystemTestsCommon):
         nstep_output = OUT_FREQ // dtime
         for iinst in range(1, NINST + 1):
             fatm_in = os.path.join(
-                csmdata_atm, INIT_COND_FILE_TEMPLATE.format(self.atmmodIC, "i", iinst),
+                csmdata_atm,
+                INIT_COND_FILE_TEMPLATE.format(self.atmmodIC, "i", iinst),
             )
             flnd_in = os.path.join(
-                csmdata_lnd, INIT_COND_FILE_TEMPLATE.format(self.lndmodIC, "r", iinst),
+                csmdata_lnd,
+                INIT_COND_FILE_TEMPLATE.format(self.lndmodIC, "r", iinst),
             )
 
             with open(f"user_nl_{self.atmmod}_{iinst:04d}", "w+") as atmnlfile:

--- a/CIME/SystemTests/tsc.py
+++ b/CIME/SystemTests/tsc.py
@@ -105,24 +105,16 @@ class TSC(SystemTestsCommon):
 
         nstep_output = OUT_FREQ // dtime
         for iinst in range(1, NINST + 1):
-            with open(
-                f"user_nl_{self.atmmod}_" + str(iinst).zfill(4), "w"
-            ) as atmnlfile, open(
-                f"user_nl_{self.lndmod}_" + str(iinst).zfill(4), "w"
-            ) as lndnlfile:
+            fatm_in = os.path.join(
+                csmdata_atm, INIT_COND_FILE_TEMPLATE.format(self.atmmodIC, "i", iinst),
+            )
+            flnd_in = os.path.join(
+                csmdata_lnd, INIT_COND_FILE_TEMPLATE.format(self.lndmodIC, "r", iinst),
+            )
 
-                fatm_in = os.path.join(
-                    csmdata_atm,
-                    INIT_COND_FILE_TEMPLATE.format(self.atmmodIC, "i", iinst),
-                )
-                flnd_in = os.path.join(
-                    csmdata_lnd,
-                    INIT_COND_FILE_TEMPLATE.format(self.lndmodIC, "r", iinst),
-                )
+            with open(f"user_nl_{self.atmmod}_{iinst:04d}", "w+") as atmnlfile:
+
                 atmnlfile.write("ncdata  = '{}' \n".format(fatm_in))
-                lndnlfile.write("finidat = '{}' \n".format(flnd_in))
-
-                lndnlfile.write("dtime = {} \n".format(dtime))
 
                 atmnlfile.write("dtime = {} \n".format(dtime))
                 atmnlfile.write("se_tstep = {} \n".format(se_tstep))
@@ -139,6 +131,10 @@ class TSC(SystemTestsCommon):
                         "".join(["'{}',".format(s) for s in VAR_LIST])[:-1]
                     )
                 )
+
+            with open(f"user_nl_{self.lndmod}_{iinst:04d}", "w+") as lndnlfile:
+                lndnlfile.write("finidat = '{}' \n".format(flnd_in))
+                lndnlfile.write("dtime = {} \n".format(dtime))
 
         # Force rebuild namelists
         self._skip_pnl = False


### PR DESCRIPTION
TSC user namelists are written at run-time, rather than
build time, so they already exist and should be overwritten.
See: https://github.com/E3SM-Project/E3SM/issues/5072

Test suite: e3sm_atm_nbfb_next_intel

User interface changes?: N

Update gh-pages html (Y/N)?: N
