### PR TITLE
CONTINUE_RUN with prereq

### DIFF
--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -50,7 +50,13 @@ def _submit(
         hasMediator = False
 
     # Check if CONTINUE_RUN value makes sense
-    if job != "case.test" and case.get_value("CONTINUE_RUN") and hasMediator:
+    # if submitted with a prereq don't do this check
+    if (
+        job != "case.test"
+        and case.get_value("CONTINUE_RUN")
+        and hasMediator
+        and not prereq
+    ):
         rundir = case.get_value("RUNDIR")
         expect(
             os.path.isdir(rundir),


### PR DESCRIPTION
Allow CONTINUE_RUN without existing rpointer if prereq is used 

Test suite: scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes #4286 

User interface changes?:

Update gh-pages html (Y/N)?:
