### PR TITLE
fix regex pattern for arc4

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -118,7 +118,7 @@ This allows using a different mpirun command to launch unit tests
 
   <machine MACH="arc4">
     <DESC>A port of CEM to the Leeds ARC4 machine, batch system is sge. CEMAC.</DESC>
-    <NODENAME_REGEX>.*.arc*</NODENAME_REGEX>
+    <NODENAME_REGEX>.*.arc.*</NODENAME_REGEX>
     <OS>LINUX</OS>
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>intelmpi,openmpi,mpich</MPILIBS>


### PR DESCRIPTION
the regex pattern for arc4 was matching on cheyenne 

Test suite: by hand
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
