### PR TITLE
create_test: fix compiler inferring

### DIFF
--- a/CIME/Tools/get_case_env
+++ b/CIME/Tools/get_case_env
@@ -60,8 +60,9 @@ def _main_func(description):
     ###############################################################################
     casename = parse_command_line(sys.argv, description)
 
-    compiler = parse_test_name(casename)[5]
-    machine = CIME.get_tests.infer_machine_name_from_tests([casename])
+    machine, compiler = CIME.get_tests.infer_arch_from_tests([casename])
+    expect(len(compiler) <= 1, "How did we get multiple compilers from one test case?")
+    compiler = compiler[0] if len(compiler) == 1 else None
     mach_obj = Machines(machine=machine)
     compiler = mach_obj.get_default_compiler() if compiler is None else compiler
     full_test_name = CIME.get_tests.get_full_test_names(

--- a/CIME/get_tests.py
+++ b/CIME/get_tests.py
@@ -300,27 +300,37 @@ def get_build_groups(tests):
 
 
 ###############################################################################
-def infer_machine_name_from_tests(testargs):
+def infer_arch_from_tests(testargs):
     ###############################################################################
     """
-    >>> infer_machine_name_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu"])
-    'melvin'
-    >>> infer_machine_name_from_tests(["NCK.f19_g16_rx1.A"])
-    >>> infer_machine_name_from_tests(["NCK.f19_g16_rx1.A", "NCK.f19_g16_rx1.A.melvin_gnu"])
-    'melvin'
-    >>> infer_machine_name_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu", "NCK.f19_g16_rx1.A.melvin_gnu"])
-    'melvin'
+    Return a tuple (machine, [compilers]) that can be inferred from the test args
+
+    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu"])
+    ('melvin', ['gnu'])
+    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A"])
+    (None, [])
+    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A", "NCK.f19_g16_rx1.A.melvin_gnu"])
+    ('melvin', ['gnu'])
+    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu", "NCK.f19_g16_rx1.A.melvin_gnu"])
+    ('melvin', ['gnu'])
+    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu9", "NCK.f19_g16_rx1.A.melvin_gnu"])
+    ('melvin', ['gnu9', 'gnu'])
+    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu", "NCK.f19_g16_rx1.A.mappy_gnu"])
+    Traceback (most recent call last):
+        ...
+    CIMEError: ERROR: Must have consistent machine 'melvin' != 'mappy'
     """
     e3sm_test_suites = get_test_suites()
 
     machine = None
+    compilers = []
     for testarg in testargs:
         testarg = testarg.strip()
         if testarg.startswith("^"):
             testarg = testarg[1:]
 
         if testarg not in e3sm_test_suites:
-            machine_for_this_test = parse_test_name(testarg)[4]
+            machine_for_this_test, compiler_for_this_test = parse_test_name(testarg)[4:6]
             if machine_for_this_test is not None:
                 if machine is None:
                     machine = machine_for_this_test
@@ -331,7 +341,10 @@ def infer_machine_name_from_tests(testargs):
                         % (machine, machine_for_this_test),
                     )
 
-    return machine
+            if compiler_for_this_test is not None and compiler_for_this_test not in compilers:
+                compilers.append(compiler_for_this_test)
+
+    return machine, compilers
 
 
 ###############################################################################

--- a/CIME/get_tests.py
+++ b/CIME/get_tests.py
@@ -330,7 +330,9 @@ def infer_arch_from_tests(testargs):
             testarg = testarg[1:]
 
         if testarg not in e3sm_test_suites:
-            machine_for_this_test, compiler_for_this_test = parse_test_name(testarg)[4:6]
+            machine_for_this_test, compiler_for_this_test = parse_test_name(testarg)[
+                4:6
+            ]
             if machine_for_this_test is not None:
                 if machine is None:
                     machine = machine_for_this_test
@@ -341,7 +343,10 @@ def infer_arch_from_tests(testargs):
                         % (machine, machine_for_this_test),
                     )
 
-            if compiler_for_this_test is not None and compiler_for_this_test not in compilers:
+            if (
+                compiler_for_this_test is not None
+                and compiler_for_this_test not in compilers
+            ):
                 compilers.append(compiler_for_this_test)
 
     return machine, compilers

--- a/CIME/get_tests.py
+++ b/CIME/get_tests.py
@@ -318,7 +318,7 @@ def infer_arch_from_tests(testargs):
     >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu", "NCK.f19_g16_rx1.A.mappy_gnu"])
     Traceback (most recent call last):
         ...
-    CIMEError: ERROR: Must have consistent machine 'melvin' != 'mappy'
+    CIME.utils.CIMEError: ERROR: Must have consistent machine 'melvin' != 'mappy'
     """
     e3sm_test_suites = get_test_suites()
 

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -631,13 +631,21 @@ def parse_command_line(args, description):
 
         logger.info("Testnames: %s" % test_names)
     else:
+        inf_machine, inf_compilers = get_tests.infer_arch_from_tests(args.testargs)
         if args.machine is None:
-            args.machine = get_tests.infer_machine_name_from_tests(args.testargs)
+            args.machine = inf_machine
 
         mach_obj = Machines(machine=args.machine)
-        args.compiler = (
-            mach_obj.get_default_compiler() if args.compiler is None else args.compiler
-        )
+        if args.compiler is None:
+            if len(inf_compilers) == 0:
+                args.compiler = mach_obj.get_default_compiler()
+            elif len(inf_compilers) == 1:
+                args.compiler = inf_compilers[0]
+            else:
+                # User has multiple compiler specifications in their testargs
+                args.compiler = inf_compilers[0]
+                expect(not args.compare and not args.generate,
+                       "It is not safe to do baseline operations with heterogenous compiler set: {}".format(inf_compilers))
 
         test_names = get_tests.get_full_test_names(
             args.testargs, mach_obj.get_machine_name(), args.compiler

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -644,8 +644,12 @@ def parse_command_line(args, description):
             else:
                 # User has multiple compiler specifications in their testargs
                 args.compiler = inf_compilers[0]
-                expect(not args.compare and not args.generate,
-                       "It is not safe to do baseline operations with heterogenous compiler set: {}".format(inf_compilers))
+                expect(
+                    not args.compare and not args.generate,
+                    "It is not safe to do baseline operations with heterogenous compiler set: {}".format(
+                        inf_compilers
+                    ),
+                )
 
         test_names = get_tests.get_full_test_names(
             args.testargs, mach_obj.get_machine_name(), args.compiler

--- a/CIME/tests/base.py
+++ b/CIME/tests/base.py
@@ -62,6 +62,9 @@ class BaseTestCase(unittest.TestCase):
         self._do_teardown = not self.NO_TEARDOWN
         self._root_dir = os.getcwd()
 
+        customize_path = os.path.join(utils.get_src_root(), "cime_config", "customize")
+        config = Config.load(customize_path)
+
     def tearDown(self):
         self.kill_subprocesses()
 

--- a/CIME/tests/base.py
+++ b/CIME/tests/base.py
@@ -195,7 +195,7 @@ class BaseTestCase(unittest.TestCase):
     def kill_python_subprocesses(self, sig=signal.SIGKILL, expected_num_killed=None):
         self.kill_subprocesses("[Pp]ython", sig, expected_num_killed)
 
-    def _create_test(self, extra_args, test_id=None, run_errors=False, env_changes=""):
+    def _create_test(self, extra_args, test_id=None, run_errors=False, env_changes="", default_baseline_area=False):
         """
         Convenience wrapper around create_test. Returns list of full paths to created cases. If multiple cases,
         the order of the returned list is not guaranteed to match the order of the arguments.
@@ -213,7 +213,8 @@ class BaseTestCase(unittest.TestCase):
             else test_id
         )
         extra_args.append("-t {}".format(test_id))
-        extra_args.append("--baseline-root {}".format(self._baseline_area))
+        if not default_baseline_area:
+            extra_args.append("--baseline-root {}".format(self._baseline_area))
         if self.NO_BATCH:
             extra_args.append("--no-batch")
         if self.TEST_COMPILER and (

--- a/CIME/tests/base.py
+++ b/CIME/tests/base.py
@@ -195,7 +195,14 @@ class BaseTestCase(unittest.TestCase):
     def kill_python_subprocesses(self, sig=signal.SIGKILL, expected_num_killed=None):
         self.kill_subprocesses("[Pp]ython", sig, expected_num_killed)
 
-    def _create_test(self, extra_args, test_id=None, run_errors=False, env_changes="", default_baseline_area=False):
+    def _create_test(
+        self,
+        extra_args,
+        test_id=None,
+        run_errors=False,
+        env_changes="",
+        default_baseline_area=False,
+    ):
         """
         Convenience wrapper around create_test. Returns list of full paths to created cases. If multiple cases,
         the order of the returned list is not guaranteed to match the order of the arguments.

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -451,7 +451,7 @@ class TestTestScheduler(base.BaseTestCase):
         self._create_test(args)
 
     def test_e_test_inferred_compiler(self):
-        if Config.instance().test_mode != "e3sm" and self._machine != "docker":
+        if Config.instance().test_mode != "e3sm" or self._machine != "docker":
             self.skipTest("Skipping create_test test. Depends on E3SM settings")
 
         args = ["SMS.f19_g16_rx1.A.docker_gnuX", "--no-setup"]

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -451,7 +451,7 @@ class TestTestScheduler(base.BaseTestCase):
         self._create_test(args)
 
     def test_e_test_inferred_compiler(self):
-        if Config.instance().test_mode != "e3sm":
+        if Config.instance().test_mode != "e3sm" and self._machine != "docker":
             self.skipTest("Skipping create_test test. Depends on E3SM settings")
 
         args = [

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -460,7 +460,7 @@ class TestTestScheduler(base.BaseTestCase):
         result = self.run_cmd_assert_result(
             "./xmlquery --value BASELINE_ROOT", from_dir=case
         )
-        self.assertEqual(result, "/storage/baselines/gnuX")
+        self.assertEqual(os.path.split(result)[1], "gnuX")
 
 
 if __name__ == "__main__":

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -454,11 +454,11 @@ class TestTestScheduler(base.BaseTestCase):
         if Config.instance().test_mode != "e3sm" and self._machine != "docker":
             self.skipTest("Skipping create_test test. Depends on E3SM settings")
 
-        args = ["SMS.f19_g16_rx1.A.docker_gnuX", "--no-build"]
+        args = ["SMS.f19_g16_rx1.A.docker_gnuX", "--no-setup"]
 
         case = self._create_test(args)
         result = self.run_cmd_assert_result(
-            "./xmlquery --value BASELINE_ROOT", from_dir=case
+            "./xmlquery --value BASELINE_ROOT", from_dir=case, default_baseline_area=True
         )
         self.assertEqual(os.path.split(result)[1], "gnuX")
 

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -456,11 +456,10 @@ class TestTestScheduler(base.BaseTestCase):
 
         args = ["SMS.f19_g16_rx1.A.docker_gnuX", "--no-setup"]
 
-        case = self._create_test(args)
+        case = self._create_test(args, default_baseline_area=True)
         result = self.run_cmd_assert_result(
             "./xmlquery --value BASELINE_ROOT",
-            from_dir=case,
-            default_baseline_area=True,
+            from_dir=case
         )
         self.assertEqual(os.path.split(result)[1], "gnuX")
 

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -454,14 +454,14 @@ class TestTestScheduler(base.BaseTestCase):
         if Config.instance().test_mode != "e3sm" and self._machine != "docker":
             self.skipTest("Skipping create_test test. Depends on E3SM settings")
 
-        args = [
-            "SMS.f19_g16_rx1.A.docker_gnuX",
-            "--no-build"
-        ]
+        args = ["SMS.f19_g16_rx1.A.docker_gnuX", "--no-build"]
 
         case = self._create_test(args)
-        result = self.run_cmd_assert_result("./xmlquery --value BASELINE_ROOT", from_dir=case)
+        result = self.run_cmd_assert_result(
+            "./xmlquery --value BASELINE_ROOT", from_dir=case
+        )
         self.assertEqual(result, "/storage/baselines/gnuX")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -450,6 +450,18 @@ class TestTestScheduler(base.BaseTestCase):
 
         self._create_test(args)
 
+    def test_e_test_inferred_compiler(self):
+        if Config.instance().test_mode != "e3sm":
+            self.skipTest("Skipping create_test test. Depends on E3SM settings")
+
+        args = [
+            "SMS.f19_g16_rx1.A.docker_gnuX",
+            "--no-build"
+        ]
+
+        case = self._create_test(args)
+        result = self.run_cmd_assert_result("./xmlquery --value BASELINE_ROOT", from_dir=case)
+        self.assertEqual(result, "/storage/baselines/gnuX")
 
 if __name__ == "__main__":
     unittest.main()

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -458,8 +458,7 @@ class TestTestScheduler(base.BaseTestCase):
 
         case = self._create_test(args, default_baseline_area=True)
         result = self.run_cmd_assert_result(
-            "./xmlquery --value BASELINE_ROOT",
-            from_dir=case
+            "./xmlquery --value BASELINE_ROOT", from_dir=case
         )
         self.assertEqual(os.path.split(result)[1], "gnuX")
 

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -458,7 +458,9 @@ class TestTestScheduler(base.BaseTestCase):
 
         case = self._create_test(args)
         result = self.run_cmd_assert_result(
-            "./xmlquery --value BASELINE_ROOT", from_dir=case, default_baseline_area=True
+            "./xmlquery --value BASELINE_ROOT",
+            from_dir=case,
+            default_baseline_area=True,
         )
         self.assertEqual(os.path.split(result)[1], "gnuX")
 

--- a/docker/config_machines.xml
+++ b/docker/config_machines.xml
@@ -6,7 +6,7 @@
     <NODENAME_REGEX>docker</NODENAME_REGEX>
     <OS>LINUX</OS>
     <PROXY />
-    <COMPILERS>gnu</COMPILERS>
+    <COMPILERS>gnu,gnuX</COMPILERS>
     <MPILIBS>openmpi</MPILIBS>
     <PROJECT>CIME</PROJECT>
     <SAVE_TIMING_DIR>/storage/timings</SAVE_TIMING_DIR>
@@ -15,7 +15,7 @@
     <DIN_LOC_ROOT>/storage/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/storage/inputdata-clmforc</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/storage/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/storage/baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>/storage/baselines/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/storage/tools/cprnc</CCSM_CPRNC>
     <GMAKE>make</GMAKE>
     <GMAKE_J>4</GMAKE_J>


### PR DESCRIPTION
If the user does this: create_test SMS.GRID.CASE.mappy_gnu9
... create_test should not assume the compiler is gnu even though
that's the default compiler for mappy. It should behave as if the
user provided --compiler=gnu9 which will allow the test to find
the correct baselines.

Also, mappy testing was in a bad state due to tests not loading the correct E3SM config.py library. This PR fixes that also.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
