### PR TITLE
Expand capability to exclude files from build using .exclude

### DIFF
--- a/CIME/Tools/mkSrcfiles
+++ b/CIME/Tools/mkSrcfiles
@@ -22,17 +22,17 @@ if ( open(FILEPATH,"< Filepath") ) {
 chomp @paths;
 unshift(@paths, '.');
 
-my $excludeDir = '';
 my $foundExclude = 0;
 foreach $dir (@paths) {  # (could check that directories exist here)
 
-    # Set up .excludes if exists
     if ( (-e "$dir/.exclude") && (open(EXCLUDE,"$dir/.exclude") ) ) {
-        push @excludes, <EXCLUDE>;
-        close( EXCLUDE );
-        $excludeDir = $dir;
+       # Flag .exclude file as found and add content to excludes array
         $foundExclude = 1;
-        print "Found .exclude in: $excludeDir\n";
+        print "Found .exclude file in $dir\n";
+        foreach $exclude (<EXCLUDE>) {
+            push(@excludes, ("$dir/$exclude"));
+        }
+        close( EXCLUDE );
     }
 
     $dir =~ s!/?\s*$!!;  # remove / and any whitespace at end of directory name
@@ -40,41 +40,31 @@ foreach $dir (@paths) {  # (could check that directories exist here)
 }
 
 if ($foundExclude) {
-    print "List of files to be excluded:\n @excludes\n\n";
+    print "List of files in .exclude files:\n @excludes\n\n";
 }
 
 # Loop through the directories and add each filename as a hash key.  This
-# automatically eliminates redunancies.
+# automatically eliminates redundancies. Ignore files found in excludes array.
 %src = ();
 my $skip_prefix = $ENV{mkSrcfiles_skip_prefix};
 
 foreach $dir (@paths) {
-    my $useExclude = 0;
-    if ($foundExclude) {
-        if (index($dir, $excludeDir) != -1) {
-            $useExclude = 1;
-        }
-    }
     @filenames = (glob("$dir/*.[Ffc]"), glob("$dir/*.[Ff]90"), glob("$dir/*.cpp"));
     foreach $filename (@filenames) {
+        if ($foundExclude) {
+            if ( grep { /$filename/ } @excludes ) {
+                print "WARNING: Skipping file $filename (Source files in .exclude are ignored)\n";
+                next;
+            }
+        }
         $filename =~ s!.*/!!;                   # remove part before last slash
         if (defined $skip_prefix){
             if ($filename =~ /^${skip_prefix}/){
-            print "WARNING: Skipping file $dir/$filename Source files beginning in $skip_prefix are ignored\n";
-            next;
+                print "WARNING: Skipping file $dir/$filename (Source files beginning in $skip_prefix are ignored\n)";
+                next;
             }
         }
-        # If filename is in local .exclude file, do not add to list
-        if ($useExclude) {
-            my $matches = grep { /$filename/ } @excludes;
-            if ($matches) {
-                print "Exclusion matched file, $filename in $dir\n\n";
-            }else{
-                $src{$filename} = 1;
-            }
-        }else{
-            $src{$filename} = 1;
-        }
+        $src{$filename} = 1;
     }
 
     # No exclusion func for templates


### PR DESCRIPTION
Updates in this PR expand the capability of using an optional `.exclude`
file to list files in the sub-tree to skip during compilation. That
feature was originally submitted and merged as https://github.com/ESMCI/cime/pull/4180 for use with
GEOS-Chem in CESM. A limitation of the feature was recently
discovered when a second `.exclude` file was added for use with HEMCO.
The content of only one of the files was excluded during build.

This PR features the following improvements in using .`exclude`:
1. Using more than one `.exclude` file in CESM is now possible.
2. Skipping one file when more than one file of the same name exists
is now possible.

It is important to note that `.exclude` must now contain the relative
path of the file to exclude. Previously only the filename
was present regardless of where it existed in the sub-tree.

Test suite: **none yet**
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #] No associated issue 

User interface changes?: N

Update gh-pages html (Y/N)?: N
