### PR TITLE
Updates config_batch.xml to facilitate queue specific flags

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -675,11 +675,7 @@ class EnvBatch(EnvBase):
             if flag == "-n" and rval <= 0:
                 rval = 1
 
-            if (
-                flag == "-q"
-                and rval == "batch"
-                and case.get_value("MACH") == "blues"
-            ):
+            if flag == "-q" and rval == "batch" and case.get_value("MACH") == "blues":
                 # Special case. Do not provide '-q batch' for blues
                 raise ValueError()
 

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -596,6 +596,14 @@ class EnvBatch(EnvBase):
             if flag is None:
                 flag = self.text(arg)
 
+                job_queue_restriction = self.get(arg, "job_queue")
+
+                if (
+                    job_queue_restriction is not None
+                    and job_queue_restriction != case.get_value("JOB_QUEUE")
+                ):
+                    continue
+
             if self._batchtype == "cobalt" and job == "case.st_archive":
                 if flag == "-n":
                     name = "task_count"

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -578,7 +578,7 @@ class EnvBatch(EnvBase):
                         check_paths.append(user_config_path)
 
                     logger.warning(
-                        'Deprecated "arg" node detected in {1}, check files {2}'.format(
+                        'Deprecated "arg" node detected in {}, check files {}'.format(
                             self.filename, ", ".join(check_paths)
                         )
                     )

--- a/CIME/data/config/xml_schemas/config_batch.xsd
+++ b/CIME/data/config/xml_schemas/config_batch.xsd
@@ -127,17 +127,17 @@
 
   <xs:element name="submit_args">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="arg"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-
-
-  <xs:element name="arg">
-    <xs:complexType>
-      <xs:attribute name="flag" use="required"/>
-      <xs:attribute name="name"/>
+      <xs:choice>
+        <xs:element name="arg" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:attribute name="flag" use="required"/>
+            <xs:attribute name="name"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="argument" maxOccurs="unbounded">
+          <xs:complexType mixed="true" />
+        </xs:element>
+      </xs:choice>
     </xs:complexType>
   </xs:element>
 

--- a/CIME/data/config/xml_schemas/config_batch.xsd
+++ b/CIME/data/config/xml_schemas/config_batch.xsd
@@ -135,7 +135,9 @@
           </xs:complexType>
         </xs:element>
         <xs:element name="argument" maxOccurs="unbounded">
-          <xs:complexType mixed="true" />
+          <xs:complexType mixed="true">
+            <xs:attribute name="job_queue"/>
+          </xs:complexType>
         </xs:element>
       </xs:choice>
     </xs:complexType>

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+import os
 import unittest
+import tempfile
 from unittest import mock
 
 from CIME.XML.env_batch import EnvBatch
@@ -9,6 +11,85 @@ from CIME.XML.env_batch import EnvBatch
 
 
 class TestXMLEnvBatch(unittest.TestCase):
+    def test_get_submit_args(self):
+        with tempfile.NamedTemporaryFile() as tfile:
+            tfile.write(b"""<?xml version="1.0"?>
+<file id="env_batch.xml" version="2.0">
+  <header>
+      These variables may be changed anytime during a run, they
+      control arguments to the batch submit command.
+    </header>
+  <group id="config_batch">
+    <entry id="BATCH_SYSTEM" value="slurm">
+      <type>char</type>
+      <valid_values>miller_slurm,nersc_slurm,lc_slurm,moab,pbs,lsf,slurm,cobalt,cobalt_theta,none</valid_values>
+      <desc>The batch system type to use for this machine.</desc>
+    </entry>
+  </group>
+  <group id="job_submission">
+    <entry id="PROJECT_REQUIRED" value="FALSE">
+      <type>logical</type>
+      <valid_values>TRUE,FALSE</valid_values>
+      <desc>whether the PROJECT value is required on this machine</desc>
+    </entry>
+  </group>
+  <batch_system type="slurm">
+    <batch_query per_job_arg="-j">squeue</batch_query>
+    <batch_submit>sbatch</batch_submit>
+    <batch_cancel>scancel</batch_cancel>
+    <batch_directive>#SBATCH</batch_directive>
+    <jobid_pattern>(\d+)$</jobid_pattern>
+    <depend_string>--dependency=afterok:jobid</depend_string>
+    <depend_allow_string>--dependency=afterany:jobid</depend_allow_string>
+    <depend_separator>:</depend_separator>
+    <walltime_format>%H:%M:%S</walltime_format>
+    <batch_mail_flag>--mail-user</batch_mail_flag>
+    <batch_mail_type_flag>--mail-type</batch_mail_type_flag>
+    <batch_mail_type>none, all, begin, end, fail</batch_mail_type>
+    <submit_args>
+      <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-p" name="$JOB_QUEUE"/>
+      <arg flag="--account" name="$PROJECT"/>
+    </submit_args>
+    <directives>
+      <directive> --job-name={{ job_id }}</directive>
+      <directive> --nodes={{ num_nodes }}</directive>
+      <directive> --output={{ job_id }}.%j </directive>
+      <directive> --exclusive </directive>
+    </directives>
+  </batch_system>
+  <batch_system MACH="docker" type="slurm">
+    <submit_args>
+      <argument>-w docker</argument>
+    </submit_args>
+    <queues>
+      <queue walltimemax="01:00:00" nodemax="1">long</queue>
+      <queue walltimemax="00:30:00" nodemax="1" default="true">short</queue>
+    </queues>
+  </batch_system>
+</file>
+""")
+            tfile.seek(0)
+
+            batch = EnvBatch(infile=tfile.name)
+
+            case = mock.MagicMock()
+
+            case.get_value.side_effect = [
+                os.path.dirname(tfile.name),
+                "00:30:00",
+                "long",
+                "CIME",
+            ]
+
+            case.filename = mock.PropertyMock(return_value=tfile.name)
+
+            submit_args = batch.get_submit_args(case, ".case.run")
+
+            expected_args = "  --time 00:30:00 -p long --account CIME -w docker"
+
+            assert submit_args == expected_args
+
     @mock.patch("CIME.XML.env_batch.EnvBatch.get")
     def test_get_queue_specs(self, get):
         node = mock.MagicMock()

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -13,7 +13,8 @@ from CIME.XML.env_batch import EnvBatch
 class TestXMLEnvBatch(unittest.TestCase):
     def test_get_submit_args(self):
         with tempfile.NamedTemporaryFile() as tfile:
-            tfile.write(b"""<?xml version="1.0"?>
+            tfile.write(
+                b"""<?xml version="1.0"?>
 <file id="env_batch.xml" version="2.0">
   <header>
       These variables may be changed anytime during a run, they
@@ -68,7 +69,8 @@ class TestXMLEnvBatch(unittest.TestCase):
     </queues>
   </batch_system>
 </file>
-""")
+"""
+            )
             tfile.seek(0)
 
             batch = EnvBatch(infile=tfile.name)

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -65,6 +65,7 @@ class TestXMLEnvBatch(unittest.TestCase):
 
             assert submit_args == expected_args
 
+    @mock.patch.dict(os.environ, {"TEST": "GOOD"})
     def test_get_submit_args(self):
         with tempfile.NamedTemporaryFile() as tfile:
             tfile.write(
@@ -105,6 +106,8 @@ class TestXMLEnvBatch(unittest.TestCase):
       <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
       <arg flag="-p" name="$JOB_QUEUE"/>
       <arg flag="--account" name="$PROJECT"/>
+      <arg flag="--no-arg" />
+      <arg flag="--path" name="$$ENV{TEST}" />
     </submit_args>
     <directives>
       <directive> --job-name={{ job_id }}</directive>
@@ -139,11 +142,14 @@ class TestXMLEnvBatch(unittest.TestCase):
                 "CIME",
             ]
 
+            # value for --path
+            case.get_resolved_value.return_value = "/test"
+
             case.filename = mock.PropertyMock(return_value=tfile.name)
 
             submit_args = batch.get_submit_args(case, ".case.run")
 
-            expected_args = "  --time 00:30:00 -p long --account CIME -w docker"
+            expected_args = "  --time 00:30:00 -p long --account CIME --no-arg --path /test -w docker"
 
             assert submit_args == expected_args
 

--- a/docker/config_machines.xml
+++ b/docker/config_machines.xml
@@ -22,8 +22,8 @@
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
     <SUPPORTED_BY>boutte3@llnl.gov</SUPPORTED_BY>
-    <MAX_TASKS_PER_NODE>4</MAX_TASKS_PER_NODE>
-    <MAX_MPITASKS_PER_NODE>4</MAX_MPITASKS_PER_NODE>
+    <MAX_TASKS_PER_NODE>8</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>8</MAX_MPITASKS_PER_NODE>
     <mpirun mpilib="openmpi">
       <executable>mpiexec</executable>
       <arguments>

--- a/docker/slurm/config_batch.xml
+++ b/docker/slurm/config_batch.xml
@@ -1,32 +1,12 @@
 <?xml version="1.0"?>
 <config_batch version="2.0">
   <batch_system MACH="docker" type="slurm">
-		<batch_query per_job_arg="-j">squeue</batch_query>
-    <batch_submit>sbatch</batch_submit>
-    <batch_cancel>scancel</batch_cancel>
-    <batch_directive>#SBATCH</batch_directive>
-    <jobid_pattern>(\d+)$</jobid_pattern>
-    <depend_string>--dependency=afterok:jobid</depend_string>
-    <depend_allow_string>--dependency=afterany:jobid</depend_allow_string>
-    <depend_separator>:</depend_separator>
-    <walltime_format>%H:%M:%S</walltime_format>
-    <batch_mail_flag>--mail-user</batch_mail_flag>
-    <batch_mail_type_flag>--mail-type</batch_mail_type_flag>
-    <batch_mail_type>none, all, begin, end, fail</batch_mail_type>
     <submit_args>
-      <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
-      <arg flag="-p" name="$JOB_QUEUE"/>
-      <arg flag="--account" name="$PROJECT"/>
+      <argument>-w docker</argument>
     </submit_args>
-    <directives>
-      <directive> --job-name={{ job_id }}</directive>
-      <directive> --nodes={{ num_nodes }}</directive>
-      <directive> --output={{ job_id }}.%j </directive>
-      <directive> --exclusive </directive>
-    </directives>
     <queues>
-      <queue walltimemax="01:00:00" nodemax="1" default="true" strict="true">debug</queue>
-      <queue walltimemax="500:00:00" nodemax="1">debug</queue>
+      <queue walltimemax="01:00:00" nodemax="1">long</queue>
+      <queue walltimemax="00:30:00" nodemax="1" default="true">short</queue>
     </queues>
   </batch_system>
 </config_batch>

--- a/docker/slurm/config_batch.xml
+++ b/docker/slurm/config_batch.xml
@@ -5,8 +5,8 @@
       <argument>-w docker</argument>
     </submit_args>
     <queues>
-      <queue walltimemax="01:00:00" nodemax="1">long</queue>
-      <queue walltimemax="00:30:00" nodemax="1" default="true">short</queue>
+      <queue walltimemax="01:00:00" nodemax="1" default="true">long</queue>
+      <queue walltimemax="00:30:00" nodemax="1" default="false">short</queue>
     </queues>
   </batch_system>
 </config_batch>

--- a/docker/slurm/slurm.conf
+++ b/docker/slurm/slurm.conf
@@ -145,4 +145,8 @@ SlurmdLogFile=/var/log/slurmd.log
 
 # COMPUTE NODES
 NodeName=docker CPUs=4 State=UNKNOWN
-PartitionName=debug Nodes=ALL Default=YES MaxTime=01:00:00 State=UP
+
+# Partitions
+PartitionName=DEFAULT Nodes=ALL Shared=FORCE:1 MaxTime=INFINITY State=UP
+PartitionName=long Nodes=ALL MaxTime=01:00:00 Default=YES
+PartitionName=short Nodes=ALL MaxTime=00:30:00 Default=NO


### PR DESCRIPTION
Updates `config_batch.xml` to facilitate queue specific flags e.g. 
`<argument job_queue="long">-w docker</argument>` would only
apply when the queue name is `long`. The behavior of `argument`
is now inline with the rest of the XML system, i.e. the argument is
now stored in the XML nodes text not in attributes of the node.

Test suite: scripts_regression_tests.py
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4120 
User interface changes?: n/a
Update gh-pages html (Y/N)?: N
