### PR TITLE
Updates workflow to build and push containers for PRs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,44 +43,46 @@ jobs:
       all_changed_and_modified_files: ${{ steps.get-changed-files.outputs.all_changed_and_modified_files }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Get changed files
         id: get-changed-files
-        uses: tj-actions/changed-files@v17.2
+        uses: tj-actions/changed-files@v29
         with:
           files: docker/*
 
   # Only build container if there has been a change.
-  # Only upload container when merging into master and there has been a change.
   build-containers:
     runs-on: ubuntu-latest
     needs: check-dockerfile-changed
-    if: ${{ needs.check-dockerfile-changed.outputs.all_changed_and_modified_files != '' }}
+    if: ${{ needs.check-dockerfile-changed.outputs.any_changed }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: jasonb87/cime
           tags: |
             type=raw,value=latest
             type=sha,prefix={{ date 'YYYYMMDD' }}_,format=short
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           target: base
           context: docker/
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
When the workflow would trigger a container build it was not pushed
and used for subsequent testing.

Test suite: n/a
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4298 
User interface changes?: n/a
Update gh-pages html (Y/N)?: N
