### PR TITLE
PEM: fix potential invalid rootpe

### DIFF
--- a/CIME/SystemTests/pem.py
+++ b/CIME/SystemTests/pem.py
@@ -31,6 +31,8 @@ class PEM(SystemTestsCompareTwo):
     def _case_two_setup(self):
         for comp in self._case.get_values("COMP_CLASSES"):
             ntasks = self._case.get_value("NTASKS_{}".format(comp))
+            rootpe = self._case1.get_value("ROOTPE_{}".format(comp))
             if ntasks > 1:
                 self._case.set_value("NTASKS_{}".format(comp), int(ntasks / 2))
+                self._case.set_value("ROOTPE_{}".format(comp), int(rootpe / 2))
         self._case.case_setup(test_mode=True, reset=True)


### PR DESCRIPTION
We had a case where rootpe was > ntasks after ntasks was halved for the second run.

Test suite: PEM by hand
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
