### PR TITLE
Add SLIM as a valid land component

### DIFF
--- a/CIME/BuildTools/configure.py
+++ b/CIME/BuildTools/configure.py
@@ -165,8 +165,9 @@ class FakeCase(object):
         return self._vals[attrib]
 
     def set_value(self, attrib, value):
-       """ Sets a given variable value for the case"""
-       self._vals[attrib] = value
+        """Sets a given variable value for the case"""
+        self._vals[attrib] = value
+
 
 def generate_env_mach_specific(
     output_dir,

--- a/CIME/BuildTools/configure.py
+++ b/CIME/BuildTools/configure.py
@@ -153,6 +153,10 @@ class FakeCase(object):
     def get_build_threaded(self):
         return self.get_value("SMP_PRESENT")
 
+    def get_case_root(self):
+        """Returns the root directory for this case."""
+        return self.get_value("CASEROOT")
+
     def get_value(self, attrib):
         expect(
             attrib in self._vals,
@@ -160,6 +164,9 @@ class FakeCase(object):
         )
         return self._vals[attrib]
 
+    def set_value(self, attrib, value):
+       """ Sets a given variable value for the case"""
+       self._vals[attrib] = value
 
 def generate_env_mach_specific(
     output_dir,

--- a/CIME/data/config/cesm/config_files.xml
+++ b/CIME/data/config/cesm/config_files.xml
@@ -104,6 +104,7 @@
       <value>$CIMEROOT/CIME/data/config/config_tests.xml</value>
       <!-- component specific config_tests files -->
       <value component="clm">$COMP_ROOT_DIR_LND/cime_config/config_tests.xml</value>
+      <value component="slim">$COMP_ROOT_DIR_LND/cime_config/config_tests.xml</value>
       <value component="cam">$COMP_ROOT_DIR_ATM/cime_config/config_tests.xml</value>
       <value component="cism">$COMP_ROOT_DIR_GLC/cime_config/config_tests.xml</value>
       <value component="mom">$COMP_ROOT_DIR_OCN/cime_config/config_tests.xml</value>
@@ -252,6 +253,7 @@
     <default_value>unset</default_value>
     <values>
       <value component="clm"                         >$SRCROOT/components/clm/</value>
+      <value component="slim"                        >$SRCROOT/components/slim/</value>
       <value component="dlnd" comp_interface="mct"   >$SRCROOT/components/cpl7/components/data_comps_$COMP_INTERFACE/dlnd</value>
       <value component="dlnd" comp_interface="nuopc" >$SRCROOT/components/cdeps/dlnd</value>
       <value component="slnd" comp_interface="mct"   >$SRCROOT/components/cpl7/components/stub_comps_$COMP_INTERFACE/slnd</value>
@@ -305,6 +307,7 @@
       <value component="ufsatm"    >$COMP_ROOT_DIR_ATM/cime_config/config_compsets.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/config_compsets.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/config_compsets.xml</value>
+      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/config_compsets.xml</value>
       <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
@@ -327,6 +330,7 @@
       <value component="ufsatm"    >$COMP_ROOT_DIR_ATM/cime_config/config_pes.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/config_pes.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/config_pes.xml</value>
+      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/config_pes.xml</value>
       <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
@@ -355,6 +359,7 @@
       <value component="cam"       >$COMP_ROOT_DIR_ATM/cime_config/config_archive.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/config_archive.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/config_archive.xml</value>
+      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/config_archive.xml</value>
       <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
@@ -376,6 +381,7 @@
     <values>
       <value component="any"       >$CIMEROOT/CIME/SystemTests</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/SystemTests</value>
+      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/SystemTests</value>
       <value component="cam"       >$COMP_ROOT_DIR_ATM/cime_config/SystemTests</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
@@ -401,6 +407,7 @@
       <value component="cam"       >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testlist_cam.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/testdefs/testlist_cism.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/testdefs/testlist_clm.xml</value>
+      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/testdefs/testlist_clm.xml</value>
       <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testlist_cice.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testlist_cice.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_pop.xml</value>
@@ -431,6 +438,7 @@
       <value component="cam"       >$COMP_ROOT_DIR_ATM/cime_config/testdefs/testmods_dirs</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/testdefs/testmods_dirs</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/testdefs/testmods_dirs</value>
+      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/testdefs/testmods_dirs</value>
       <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testmods_dirs</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/testdefs/testmods_dirs</value>
       <value component="rtm"       >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
@@ -460,6 +468,7 @@
       <value component="cam"      >$COMP_ROOT_DIR_ATM/cime_config/usermods_dirs</value>
       <value component="cism"     >$COMP_ROOT_DIR_GLC/cime_config/usermods_dirs</value>
       <value component="clm"      >$COMP_ROOT_DIR_LND/cime_config/usermods_dirs</value>
+      <value component="slim"     >$COMP_ROOT_DIR_LND/cime_config/usermods_dirs</value>
       <value component="cice5"    >$COMP_ROOT_DIR_ICE/cime_config/usermods_dirs</value>
       <value component="cice"     >$COMP_ROOT_DIR_ICE/cime_config/usermods_dirs</value>
       <value component="rtm"      >$COMP_ROOT_DIR_ROF/cime_config/usermods_dirs</value>
@@ -498,6 +507,7 @@
       <value component="mom"  >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_mom.xml</value>
       <value component="nemo" >$COMP_ROOT_DIR_OCN/bld/namelist_files/namelist_definition_nemo.xml</value>
       -->
+      <value component="slim" >$COMP_ROOT_DIR_LND/bld/namelist_files/namelist_definition_slim.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>


### PR DESCRIPTION
Add SLIM as a valid LAND component option

Testing:  Ran a simple Slim test case: 
   SMS_Vmct_D.f19_g17.IHistSlimQianRsGs.cheyenne_intel.slim-realistic_fromCLM5_1850
   This is with a branch version of SLIM that works with the latest cime
slim hash: a3ceeff39e90dc2f2b10e75caf7d8888472aeccb
tag = ccs_config_cesm0.0.36
tag = cpl7.0.14
tag = share1.0.12
tag = MCT_2.11.0
tag = pio2_5_7

Fixes #4191 
Fixes #4292

User interface changes?:

Update gh-pages html (Y/N)?: N
