### PR TITLE
if the submit option cannot be resolved do not add the flag

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -80,7 +80,7 @@ class EnvBatch(EnvBase):
         node = self.get_optional_child(item, attribute)
         if item in ("BATCH_SYSTEM", "PROJECT_REQUIRED"):
             return super(EnvBatch, self).get_value(item, attribute, resolved)
-        
+
         if not node:
             # this will take the last instance of item listed in all batch_system elements
             bs_nodes = self.get_children("batch_system")
@@ -618,7 +618,7 @@ class EnvBatch(EnvBase):
                 if " " in flag:
                     flag, name = flag.split()
                 if name:
-                    if '$' in name:
+                    if "$" in name:
                         rflag = self._resolve_argument(case, flag, name, job)
                         if len(rflag) > len(flag):
                             submitargs += " {}".format(rflag)

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -614,7 +614,11 @@ class EnvBatch(EnvBase):
                     continue
 
             if name is None:
-                flag, name = flag.split()
+                try:
+                    flag, name = flag.split()
+                except ValueError:
+                    name = None
+                    continue
                 if name:
                     rflag = self._resolve_argument(case, flag, name, job)
                     if len(rflag) > len(flag):

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -76,12 +76,11 @@ class EnvBatch(EnvBase):
         """
         Must default subgroup to something in order to provide single return value
         """
-
         value = None
         node = self.get_optional_child(item, attribute)
         if item in ("BATCH_SYSTEM", "PROJECT_REQUIRED"):
             return super(EnvBatch, self).get_value(item, attribute, resolved)
-
+        
         if not node:
             # this will take the last instance of item listed in all batch_system elements
             bs_nodes = self.get_children("batch_system")
@@ -601,6 +600,8 @@ class EnvBatch(EnvBase):
         submitargs = " "
 
         for arg in submit_arg_nodes:
+            name = None
+            flag = None
             try:
                 flag, name = self._get_argument(case, arg)
             except ValueError:
@@ -614,15 +615,15 @@ class EnvBatch(EnvBase):
                     continue
 
             if name is None:
-                try:
+                if " " in flag:
                     flag, name = flag.split()
-                except ValueError:
-                    name = None
-                    continue
                 if name:
-                    rflag = self._resolve_argument(case, flag, name, job)
-                    if len(rflag) > len(flag):
-                        submitargs += " {}".format(rflag)
+                    if '$' in name:
+                        rflag = self._resolve_argument(case, flag, name, job)
+                        if len(rflag) > len(flag):
+                            submitargs += " {}".format(rflag)
+                    else:
+                        submitargs += " {} {}".format(flag, name)
                 else:
                     submitargs += " {}".format(flag)
             else:
@@ -687,7 +688,6 @@ class EnvBatch(EnvBase):
             if flag == "-q" and rval == "batch" and case.get_value("MACH") == "blues":
                 # Special case. Do not provide '-q batch' for blues
                 raise ValueError()
-
             if (
                 flag.rfind("=", len(flag) - 1, len(flag)) >= 0
                 or flag.rfind(":", len(flag) - 1, len(flag)) >= 0

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -614,7 +614,13 @@ class EnvBatch(EnvBase):
                     continue
 
             if name is None:
-                submitargs += " {}".format(flag)
+                flag, name = flag.split()
+                if name:
+                    rflag = self._resolve_argument(case, flag, name, job)
+                    if len(rflag) > len(flag):
+                        submitargs += " {}".format(rflag)
+                else:
+                    submitargs += " {}".format(flag)
             else:
                 try:
                     submitargs += self._resolve_argument(case, flag, name, job)
@@ -631,7 +637,6 @@ class EnvBatch(EnvBase):
         # if flag is None then we dealing with new `argument`
         if flag is None:
             flag = self.text(arg)
-
             job_queue_restriction = self.get(arg, "job_queue")
 
             if (

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -451,6 +451,7 @@ class Case(object):
 
     def get_value(self, item, attribute=None, resolved=True, subgroup=None):
         result = None
+        print(f"item is {item}")
         for env_file in self._files:
             # Wait and resolve in self rather than in env_file
             result = env_file.get_value(

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -451,7 +451,6 @@ class Case(object):
 
     def get_value(self, item, attribute=None, resolved=True, subgroup=None):
         result = None
-        print(f"item is {item}")
         for env_file in self._files:
             # Wait and resolve in self rather than in env_file
             result = env_file.get_value(

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -56,7 +56,7 @@ class TestXMLEnvBatch(unittest.TestCase):
 
             case = mock.MagicMock()
 
-            case.get_value.return_value = "long"
+            case.get_value.side_effect = ("long", "long", None)
 
             case.filename = mock.PropertyMock(return_value=tfile.name)
 

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -39,6 +39,7 @@ class TestXMLEnvBatch(unittest.TestCase):
       <argument>-w default</argument>
       <argument job_queue="short">-w short</argument>
       <argument job_queue="long">-w long</argument>
+      <argument>-A $VARIABLE_THAT_DOES_NOT_EXIST</argument>
     </submit_args>
     <queues>
       <queue walltimemax="01:00:00" nodemax="1">long</queue>


### PR DESCRIPTION
Fixes an issue introduced in PR #4307 
when $PROJECT isn't defined the project flag should not be used. 

Test suite: scripts regression tests
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes

User interface changes?:

Update gh-pages html (Y/N)?:
