### PR TITLE
a fix for building cesm with no models specified (clm only)

### DIFF
--- a/CIME/build.py
+++ b/CIME/build.py
@@ -311,8 +311,9 @@ def _build_model(
 ):
     ###############################################################################
     logs = []
-
     thread_bad_results = []
+    libroot = os.path.join(exeroot, "lib")
+    bldroot = None
     for model, comp, nthrds, _, config_dir in complist:
         if buildlist is not None and model.lower() not in buildlist:
             continue
@@ -336,9 +337,8 @@ def _build_model(
 
         smp = nthrds > 1 or build_threaded
 
-        bldroot = os.path.join(exeroot, model, "obj")
-        libroot = os.path.join(exeroot, "lib")
         file_build = os.path.join(exeroot, "{}.bldlog.{}".format(model, lid))
+        bldroot = os.path.join(exeroot, model, "obj")
         logger.debug("bldroot is {}".format(bldroot))
         logger.debug("libroot is {}".format(libroot))
 
@@ -413,7 +413,6 @@ def _build_model(
                 cime_model, config_dir, file_build
             )
         )
-
         with open(file_build, "w") as fd:
             stat = run_cmd(
                 "{}/buildexe {} {} {} ".format(config_dir, caseroot, libroot, bldroot),


### PR DESCRIPTION
When compiling compset SATM_CLM50%SP_SICE_SOCN_SROF_SGLC_SWAV_SESP we ran into a problem because clm is treated as a shared library and there are no models to compile - this caused the link step to be skipped.  This change solves that issue.

Test suite: scripts_regression_tests on cheyenne.    SMS_Ln9.mpasa3p75_mpasa3p75_mt13.2000_SATM_CLM50%SP_SICE_SOCN_SROF_SGLC_SWAV_SESP.cheyenne_intel
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes

User interface changes?:

Update gh-pages html (Y/N)?:
