### PR TITLE
add logic for aprun for narwhal, warhawk, onyx

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -2011,7 +2011,7 @@ directory, NOT in this subdirectory."""
         if (
             executable is not None
             and "aprun" in executable
-            and not "theta" in self.get_value("MACH")
+            and not "theta" in self.get_value("MACH") and not "onyx" in self.get_value("MACH") and not "warhawk" in self.get_value("MACH") and not "narwhal" in self.get_value("MACH")
         ):
             aprun_args, num_nodes = get_aprun_cmd_for_case(
                 self, run_exe, overrides=overrides


### PR DESCRIPTION
Add support for narwhal, warhawk, and onxy for use of aprun.

This should ultimately NOT be required for porting cime, it would be nice if whatever this piece of code is doing were generalized or fixed, so modifications per machine were not needed.

A few test cases were run on narwhal, warhawk, and onyx.

Test suite:
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N
