### PR TITLE
Add ww3dev testlist file in config_files.xml

### DIFF
--- a/CIME/data/config/cesm/config_files.xml
+++ b/CIME/data/config/cesm/config_files.xml
@@ -409,6 +409,7 @@
       <value component="rtm"       >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_rtm.xml</value>
       <value component="mosart"    >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_mosart.xml</value>
       <value component="mizuroute" >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_mizuRoute.xml</value>
+      <value component="ww3dev"    >$COMP_ROOT_DIR_WAV/cime_config/testdefs/testlist_ww3dev.xml</value>
       <value component="datm"      >$SRCROOT/components/cdeps/datm/cime_config/testdefs/testlist_datm.xml</value>
       <value component="dice"      >$SRCROOT/components/cdeps/dice/cime_config/testdefs/testlist_dice.xml</value>
       <value component="dlnd"      >$SRCROOT/components/cdeps/dlnd/cime_config/testdefs/testlist_dlnd.xml</value>


### PR DESCRIPTION
Adds ww3dev testlist file in config_files.xml. This testlist file was recently added in WW3_interface: https://github.com/ESCOMP/WW3_interface/pull/2/files

Test suite: aux_ww3dev
Test baseline: n/a
Test namelist changes: n/a
Test status: b4b

Fixes [CIME Github issue #] n/a

User interface changes?: n

Update gh-pages html (Y/N)?: N
