### PR TITLE
Updates aprun behavior

### DIFF
--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -581,16 +581,12 @@ class EnvMachSpecific(EnvBase):
             else None
         )
 
-    def get_mpirun(self, case, attribs, job, exe_only=False, overrides=None):
-        """
-        Find best match, return (executable, {arg_name : text})
-        """
+    def _find_best_mpirun_match(self, attribs):
         mpirun_nodes = self.get_children("mpirun")
         best_match = None
         best_num_matched = -1
         default_match = None
         best_num_matched_default = -1
-        args = []
         for mpirun_node in mpirun_nodes:
             xml_attribs = self.attrib(mpirun_node)
             all_match = True
@@ -638,14 +634,51 @@ class EnvMachSpecific(EnvBase):
             and attribs["mpilib"] == "mpi-serial"
             and best_match is None
         ):
-            return "", [], None, None
+            raise ValueError()
 
         expect(
             best_match is not None or default_match is not None,
             "Could not find a matching MPI for attributes: {}".format(attribs),
         )
 
-        the_match = best_match if best_match is not None else default_match
+        return best_match if best_match is not None else default_match
+
+    def get_aprun_mode(self, attribs):
+        default_mode = "ignore"
+        valid_modes = ("ignore", "default")
+
+        try:
+            the_match = self._find_best_mpirun_match(attribs)
+        except ValueError:
+            return default_mode
+
+        mode_node = self.get_children("aprun_mode", root=the_match)
+
+        if len(mode_node) == 0:
+            return default_mode
+
+        expect(len(mode_node) == 1, 'Found multiple "aprun_mode" elements.')
+
+        # should have only one element to select from
+        mode = self.text(mode_node[0])
+
+        expect(
+            mode in valid_modes,
+            f"Value {mode!r} for \"aprun_mode\" is not valid, options are {', '.join(valid_modes)!r}",
+        )
+
+        return mode
+
+    def get_mpirun(self, case, attribs, job, exe_only=False, overrides=None):
+        """
+        Find best match, return (executable, {arg_name : text})
+        """
+        args = []
+
+        try:
+            the_match = self._find_best_mpirun_match(attribs)
+        except ValueError:
+            return "", [], None, None
 
         # Now that we know the best match, compute the arguments
         if not exe_only:

--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -686,7 +686,7 @@ class EnvMachSpecific(EnvBase):
                 position = self.get(arg_node, "position")
 
                 if position is None:
-                    continue
+                    position = "per"
 
                 arg_value = transform_vars(
                     self.text(arg_node),

--- a/CIME/aprun.py
+++ b/CIME/aprun.py
@@ -22,6 +22,7 @@ def _get_aprun_cmd_for_case_impl(
     compiler,
     machine,
     run_exe,
+    extra_args,
 ):
     ###############################################################################
     """
@@ -38,19 +39,22 @@ def _get_aprun_cmd_for_case_impl(
     >>> compiler = "pgi"
     >>> machine = "titan"
     >>> run_exe = "e3sm.exe"
-    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
-    (' -S 4 -n 680 -N 8 -d 2 e3sm.exe : -S 2 -n 128 -N 4 -d 4 e3sm.exe ', 117, 808, 4, 4)
+    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe, None)
+    ('  -S 4 -n 680 -N 8 -d 2  e3sm.exe : -S 2 -n 128 -N 4 -d 4  e3sm.exe ', 117, 808, 4, 4)
     >>> compiler = "intel"
-    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
-    (' -S 4 -cc numa_node -n 680 -N 8 -d 2 e3sm.exe : -S 2 -cc numa_node -n 128 -N 4 -d 4 e3sm.exe ', 117, 808, 4, 4)
+    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe, None)
+    ('  -S 4 -cc numa_node -n 680 -N 8 -d 2  e3sm.exe : -S 2 -cc numa_node -n 128 -N 4 -d 4  e3sm.exe ', 117, 808, 4, 4)
 
     >>> ntasks = [64, 64, 64, 64, 64, 64, 64, 64, 1]
     >>> nthreads = [1, 1, 1, 1, 1, 1, 1, 1, 1]
     >>> rootpes = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     >>> pstrids = [1, 1, 1, 1, 1, 1, 1, 1, 1]
-    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe)
-    (' -S 8 -cc numa_node -n 64 -N 16 -d 1 e3sm.exe ', 4, 64, 16, 1)
+    >>> _get_aprun_cmd_for_case_impl(ntasks, nthreads, rootpes, pstrids, max_tasks_per_node, max_mpitasks_per_node, pio_numtasks, pio_async_interface, compiler, machine, run_exe, None)
+    ('  -S 8 -cc numa_node -n 64 -N 16 -d 1  e3sm.exe ', 4, 64, 16, 1)
     """
+    if extra_args is None:
+        extra_args = {}
+
     max_tasks_per_node = 1 if max_tasks_per_node < 1 else max_tasks_per_node
 
     total_tasks = 0
@@ -78,6 +82,12 @@ def _get_aprun_cmd_for_case_impl(
         if maxt[c1] < 1:
             maxt[c1] = 1
 
+    global_flags = " ".join(
+        [x for x, y in extra_args.items() if y["position"] == "global"]
+    )
+
+    per_flags = " ".join([x for x, y in extra_args.items() if y["position"] == "per"])
+
     # Compute task and thread settings for batch commands
     (
         tasks_per_node,
@@ -88,7 +98,7 @@ def _get_aprun_cmd_for_case_impl(
         total_node_count,
         total_task_count,
         aprun_args,
-    ) = (0, max_mpitasks_per_node, 1, maxt[0], maxt[0], 0, 0, "")
+    ) = (0, max_mpitasks_per_node, 1, maxt[0], maxt[0], 0, 0, f" {global_flags}")
     c1list = list(range(1, total_tasks))
     c1list.append(None)
     for c1 in c1list:
@@ -107,10 +117,11 @@ def _get_aprun_cmd_for_case_impl(
                 if compiler == "intel":
                     aprun_args += " -cc numa_node"
 
-            aprun_args += " -n {:d} -N {:d} -d {:d} {} {}".format(
+            aprun_args += " -n {:d} -N {:d} -d {:d} {} {} {}".format(
                 task_count,
                 tasks_per_node,
                 thread_count,
+                per_flags,
                 run_exe,
                 "" if c1 is None else ":",
             )
@@ -140,7 +151,7 @@ def _get_aprun_cmd_for_case_impl(
 
 
 ###############################################################################
-def get_aprun_cmd_for_case(case, run_exe, overrides=None):
+def get_aprun_cmd_for_case(case, run_exe, overrides=None, extra_args=None):
     ###############################################################################
     """
     Given a case, construct and return the aprun command and optimized node count
@@ -179,4 +190,5 @@ def get_aprun_cmd_for_case(case, run_exe, overrides=None):
         case.get_value("COMPILER"),
         case.get_value("MACH"),
         run_exe,
+        extra_args,
     )

--- a/CIME/aprun.py
+++ b/CIME/aprun.py
@@ -156,6 +156,7 @@ def get_aprun_cmd_for_case(case, run_exe, overrides=None):
             the_list.append(case.get_value("_".join([item_name, model])))
     max_tasks_per_node = case.get_value("MAX_TASKS_PER_NODE")
     if overrides:
+        overrides = {x: y if isinstance(y, int) or y is None else int(y) for x, y in overrides.items()}
         if "max_tasks_per_node" in overrides:
             max_tasks_per_node = overrides["max_tasks_per_node"]
         if "total_tasks" in overrides:

--- a/CIME/aprun.py
+++ b/CIME/aprun.py
@@ -156,7 +156,10 @@ def get_aprun_cmd_for_case(case, run_exe, overrides=None):
             the_list.append(case.get_value("_".join([item_name, model])))
     max_tasks_per_node = case.get_value("MAX_TASKS_PER_NODE")
     if overrides:
-        overrides = {x: y if isinstance(y, int) or y is None else int(y) for x, y in overrides.items()}
+        overrides = {
+            x: y if isinstance(y, int) or y is None else int(y)
+            for x, y in overrides.items()
+        }
         if "max_tasks_per_node" in overrides:
             max_tasks_per_node = overrides["max_tasks_per_node"]
         if "total_tasks" in overrides:

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -2020,10 +2020,15 @@ directory, NOT in this subdirectory."""
             and aprun_mode != "ignore"
             # and not "theta" in self.get_value("MACH")
         ):
+            extra_args = env_mach_specific.get_aprun_args(
+                self, mpi_attribs, job, overrides=overrides
+            )
+
             aprun_args, num_nodes, _, _, _ = get_aprun_cmd_for_case(
                 self,
                 run_exe,
                 overrides=overrides,
+                extra_args=extra_args,
             )
             if job in ("case.run", "case.test"):
                 expect(

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -2011,15 +2011,18 @@ directory, NOT in this subdirectory."""
             )
             run_misc_suffix = custom_run_misc_suffix
 
+        aprun_mode = env_mach_specific.get_aprun_mode(mpi_attribs)
+
         # special case for aprun
         if (
             executable is not None
             and "aprun" in executable
-            and not "theta" in self.get_value("MACH")
+            and aprun_mode != "ignore"
+            # and not "theta" in self.get_value("MACH")
         ):
-            aprun_args, num_nodes = get_aprun_cmd_for_case(
-                self, run_exe, overrides=overrides
-            )[0:2]
+            aprun_args, num_nodes, _, _, _ = get_aprun_cmd_for_case(
+                self, run_exe, overrides=overrides,
+            )
             if job in ("case.run", "case.test"):
                 expect(
                     (num_nodes + self.spare_nodes) == self.num_nodes,

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -2021,7 +2021,9 @@ directory, NOT in this subdirectory."""
             # and not "theta" in self.get_value("MACH")
         ):
             aprun_args, num_nodes, _, _, _ = get_aprun_cmd_for_case(
-                self, run_exe, overrides=overrides,
+                self,
+                run_exe,
+                overrides=overrides,
             )
             if job in ("case.run", "case.test"):
                 expect(

--- a/CIME/data/config/xml_schemas/config_machines.xsd
+++ b/CIME/data/config/xml_schemas/config_machines.xsd
@@ -194,6 +194,7 @@
   <xs:element name="mpirun">
     <xs:complexType>
       <xs:sequence>
+        <xs:element name="aprun_mode" type="xs:string" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="executable"/>
         <xs:element ref="arguments" minOccurs="0"/>
         <!-- run_exe: The run executable to use; overrides default_run_exe -->

--- a/CIME/data/config/xml_schemas/env_mach_specific.xsd
+++ b/CIME/data/config/xml_schemas/env_mach_specific.xsd
@@ -151,6 +151,7 @@
   <xs:element name="mpirun">
     <xs:complexType>
       <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="1" name="aprun_mode" type="xs:string"/>
         <xs:element ref="executable"/>
         <xs:element minOccurs="0" maxOccurs="1" ref="arguments"/>
         <xs:element minOccurs="0" maxOccurs="1" name="run_exe" type="xs:string"/>

--- a/CIME/tests/test_unit_aprun.py
+++ b/CIME/tests/test_unit_aprun.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest import mock
+
+from CIME import aprun
+
+# NTASKS, NTHRDS, ROOTPE, PSTRID
+DEFAULT_COMP_ATTRS = [
+    512, 2, 0, 1,
+    675, 2, 0, 1,
+    168, 2, 512, 1,
+    512, 2, 0, 1,
+    128, 4, 680, 1,
+    168, 2, 512, 1,
+    168, 2, 512, 1,
+    512, 2, 0, 1,
+    1, 1, 0, 1,
+]
+
+# MAX_TASKS_PER_NODE, MAX_MPITASKS_PER_NODE, PIO_NUMTASKS, PIO_ASYNC_INTERFACE, COMPILER, MACH
+DEFAULT_ARGS = [
+    16,
+    16,
+    -1,
+    False,
+    "gnu",
+    "docker",
+]
+
+
+class TestUnitAprun(unittest.TestCase):
+    def test_aprun_extra_args(self):
+        case = mock.MagicMock()
+
+        case.get_values.return_value = ["CPL", "ATM", "LND", "ICE", "OCN", "ROF", "GLC", "WAV", "IAC"]
+
+        case.get_value.side_effect = DEFAULT_COMP_ATTRS + DEFAULT_ARGS
+
+        extra_args = {
+            "-e DEBUG=true": {"position": "global"},
+            "-j 20": {"position": "per"},
+        }
+
+        aprun_args, total_node_count, total_task_count, min_tasks_per_node, max_thread_count = aprun.get_aprun_cmd_for_case(case, "e3sm.exe", extra_args=extra_args)
+
+        assert aprun_args == " -e DEBUG=true -n 680 -N 8 -d 2 -j 20 e3sm.exe : -n 128 -N 4 -d 4 -j 20 e3sm.exe "
+        assert total_node_count == 117
+        assert total_task_count == 808
+        assert min_tasks_per_node == 4
+        assert max_thread_count == 4
+
+    def test_aprun(self):
+        case = mock.MagicMock()
+
+        case.get_values.return_value = ["CPL", "ATM", "LND", "ICE", "OCN", "ROF", "GLC", "WAV", "IAC"]
+
+        case.get_value.side_effect = DEFAULT_COMP_ATTRS + DEFAULT_ARGS
+
+        aprun_args, total_node_count, total_task_count, min_tasks_per_node, max_thread_count = aprun.get_aprun_cmd_for_case(case, "e3sm.exe")
+
+        assert aprun_args == "  -n 680 -N 8 -d 2  e3sm.exe : -n 128 -N 4 -d 4  e3sm.exe "
+        assert total_node_count == 117
+        assert total_task_count == 808
+        assert min_tasks_per_node == 4
+        assert max_thread_count == 4

--- a/CIME/tests/test_unit_aprun.py
+++ b/CIME/tests/test_unit_aprun.py
@@ -5,15 +5,42 @@ from CIME import aprun
 
 # NTASKS, NTHRDS, ROOTPE, PSTRID
 DEFAULT_COMP_ATTRS = [
-    512, 2, 0, 1,
-    675, 2, 0, 1,
-    168, 2, 512, 1,
-    512, 2, 0, 1,
-    128, 4, 680, 1,
-    168, 2, 512, 1,
-    168, 2, 512, 1,
-    512, 2, 0, 1,
-    1, 1, 0, 1,
+    512,
+    2,
+    0,
+    1,
+    675,
+    2,
+    0,
+    1,
+    168,
+    2,
+    512,
+    1,
+    512,
+    2,
+    0,
+    1,
+    128,
+    4,
+    680,
+    1,
+    168,
+    2,
+    512,
+    1,
+    168,
+    2,
+    512,
+    1,
+    512,
+    2,
+    0,
+    1,
+    1,
+    1,
+    0,
+    1,
 ]
 
 # MAX_TASKS_PER_NODE, MAX_MPITASKS_PER_NODE, PIO_NUMTASKS, PIO_ASYNC_INTERFACE, COMPILER, MACH
@@ -31,7 +58,17 @@ class TestUnitAprun(unittest.TestCase):
     def test_aprun_extra_args(self):
         case = mock.MagicMock()
 
-        case.get_values.return_value = ["CPL", "ATM", "LND", "ICE", "OCN", "ROF", "GLC", "WAV", "IAC"]
+        case.get_values.return_value = [
+            "CPL",
+            "ATM",
+            "LND",
+            "ICE",
+            "OCN",
+            "ROF",
+            "GLC",
+            "WAV",
+            "IAC",
+        ]
 
         case.get_value.side_effect = DEFAULT_COMP_ATTRS + DEFAULT_ARGS
 
@@ -40,9 +77,18 @@ class TestUnitAprun(unittest.TestCase):
             "-j 20": {"position": "per"},
         }
 
-        aprun_args, total_node_count, total_task_count, min_tasks_per_node, max_thread_count = aprun.get_aprun_cmd_for_case(case, "e3sm.exe", extra_args=extra_args)
+        (
+            aprun_args,
+            total_node_count,
+            total_task_count,
+            min_tasks_per_node,
+            max_thread_count,
+        ) = aprun.get_aprun_cmd_for_case(case, "e3sm.exe", extra_args=extra_args)
 
-        assert aprun_args == " -e DEBUG=true -n 680 -N 8 -d 2 -j 20 e3sm.exe : -n 128 -N 4 -d 4 -j 20 e3sm.exe "
+        assert (
+            aprun_args
+            == " -e DEBUG=true -n 680 -N 8 -d 2 -j 20 e3sm.exe : -n 128 -N 4 -d 4 -j 20 e3sm.exe "
+        )
         assert total_node_count == 117
         assert total_task_count == 808
         assert min_tasks_per_node == 4
@@ -51,13 +97,31 @@ class TestUnitAprun(unittest.TestCase):
     def test_aprun(self):
         case = mock.MagicMock()
 
-        case.get_values.return_value = ["CPL", "ATM", "LND", "ICE", "OCN", "ROF", "GLC", "WAV", "IAC"]
+        case.get_values.return_value = [
+            "CPL",
+            "ATM",
+            "LND",
+            "ICE",
+            "OCN",
+            "ROF",
+            "GLC",
+            "WAV",
+            "IAC",
+        ]
 
         case.get_value.side_effect = DEFAULT_COMP_ATTRS + DEFAULT_ARGS
 
-        aprun_args, total_node_count, total_task_count, min_tasks_per_node, max_thread_count = aprun.get_aprun_cmd_for_case(case, "e3sm.exe")
+        (
+            aprun_args,
+            total_node_count,
+            total_task_count,
+            min_tasks_per_node,
+            max_thread_count,
+        ) = aprun.get_aprun_cmd_for_case(case, "e3sm.exe")
 
-        assert aprun_args == "  -n 680 -N 8 -d 2  e3sm.exe : -n 128 -N 4 -d 4  e3sm.exe "
+        assert (
+            aprun_args == "  -n 680 -N 8 -d 2  e3sm.exe : -n 128 -N 4 -d 4  e3sm.exe "
+        )
         assert total_node_count == 117
         assert total_task_count == 808
         assert min_tasks_per_node == 4

--- a/CIME/tests/test_unit_xml_env_mach_specific.py
+++ b/CIME/tests/test_unit_xml_env_mach_specific.py
@@ -4,12 +4,265 @@ import unittest
 import tempfile
 from unittest import mock
 
+from CIME import utils
 from CIME.XML.env_mach_specific import EnvMachSpecific
 
 # pylint: disable=unused-argument
 
 
 class TestXMLEnvMachSpecific(unittest.TestCase):
+    def test_get_aprun_mode_not_valid(self):
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(
+                b"""<?xml version="1.0"?>
+<file id="env_mach_specific.xml" version="2.0">
+  <header>
+    These variables control the machine dependent environment including
+    the paths to compilers and libraries external to cime such as netcdf,
+    environment variables for use in the running job should also be set here.
+    </header>
+  <group id="compliant_values">
+    <entry id="run_exe" value="${EXEROOT}/e3sm.exe ">
+      <type>char</type>
+      <desc>executable name</desc>
+    </entry>
+    <entry id="run_misc_suffix" value=" &gt;&gt; e3sm.log.$LID 2&gt;&amp;1 ">
+      <type>char</type>
+      <desc>redirect for job output</desc>
+    </entry>
+  </group>
+  <module_system type="none"/>
+  <environment_variables>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT">1</env>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT_CONFIRM">1</env>
+  </environment_variables>
+  <mpirun mpilib="openmpi">
+    <aprun_mode>custom</aprun_mode>
+    <executable>aprun</executable>
+    <arguments>
+      <arg name="ntasks">-n {{ total_tasks }}</arg>
+      <arg name="oversubscribe">--oversubscribe</arg>
+    </arguments>
+  </mpirun>
+</file>
+"""
+            )
+            temp.seek(0)
+
+            mach_specific = EnvMachSpecific(infile=temp.name)
+
+            attribs = {"compiler": "gnu", "mpilib": "openmpi", "threaded": False}
+
+            with self.assertRaises(utils.CIMEError) as e:
+                mach_specific.get_aprun_mode(attribs)
+
+            assert (
+                str(e.exception)
+                == "ERROR: Value 'custom' for \"aprun_mode\" is not valid, options are 'ignore, default'"
+            )
+
+    def test_get_aprun_mode_user_defined(self):
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(
+                b"""<?xml version="1.0"?>
+<file id="env_mach_specific.xml" version="2.0">
+  <header>
+    These variables control the machine dependent environment including
+    the paths to compilers and libraries external to cime such as netcdf,
+    environment variables for use in the running job should also be set here.
+    </header>
+  <group id="compliant_values">
+    <entry id="run_exe" value="${EXEROOT}/e3sm.exe ">
+      <type>char</type>
+      <desc>executable name</desc>
+    </entry>
+    <entry id="run_misc_suffix" value=" &gt;&gt; e3sm.log.$LID 2&gt;&amp;1 ">
+      <type>char</type>
+      <desc>redirect for job output</desc>
+    </entry>
+  </group>
+  <module_system type="none"/>
+  <environment_variables>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT">1</env>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT_CONFIRM">1</env>
+  </environment_variables>
+  <mpirun mpilib="openmpi">
+    <aprun_mode>default</aprun_mode>
+    <executable>aprun</executable>
+    <arguments>
+      <arg name="ntasks">-n {{ total_tasks }}</arg>
+      <arg name="oversubscribe">--oversubscribe</arg>
+    </arguments>
+  </mpirun>
+</file>
+"""
+            )
+            temp.seek(0)
+
+            mach_specific = EnvMachSpecific(infile=temp.name)
+
+            attribs = {"compiler": "gnu", "mpilib": "openmpi", "threaded": False}
+
+            aprun_mode = mach_specific.get_aprun_mode(attribs)
+
+            assert aprun_mode == "default"
+
+    def test_get_aprun_mode_default(self):
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(
+                b"""<?xml version="1.0"?>
+<file id="env_mach_specific.xml" version="2.0">
+  <header>
+    These variables control the machine dependent environment including
+    the paths to compilers and libraries external to cime such as netcdf,
+    environment variables for use in the running job should also be set here.
+    </header>
+  <group id="compliant_values">
+    <entry id="run_exe" value="${EXEROOT}/e3sm.exe ">
+      <type>char</type>
+      <desc>executable name</desc>
+    </entry>
+    <entry id="run_misc_suffix" value=" &gt;&gt; e3sm.log.$LID 2&gt;&amp;1 ">
+      <type>char</type>
+      <desc>redirect for job output</desc>
+    </entry>
+  </group>
+  <module_system type="none"/>
+  <environment_variables>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT">1</env>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT_CONFIRM">1</env>
+  </environment_variables>
+  <mpirun mpilib="openmpi">
+    <executable>aprun</executable>
+    <arguments>
+      <arg name="ntasks">-n {{ total_tasks }}</arg>
+      <arg name="oversubscribe">--oversubscribe</arg>
+    </arguments>
+  </mpirun>
+</file>
+"""
+            )
+            temp.seek(0)
+
+            mach_specific = EnvMachSpecific(infile=temp.name)
+
+            attribs = {"compiler": "gnu", "mpilib": "openmpi", "threaded": False}
+
+            aprun_mode = mach_specific.get_aprun_mode(attribs)
+
+            assert aprun_mode == "ignore"
+
+    def test_find_best_mpirun_match(self):
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(
+                b"""<?xml version="1.0"?>
+<file id="env_mach_specific.xml" version="2.0">
+  <header>
+    These variables control the machine dependent environment including
+    the paths to compilers and libraries external to cime such as netcdf,
+    environment variables for use in the running job should also be set here.
+    </header>
+  <group id="compliant_values">
+    <entry id="run_exe" value="${EXEROOT}/e3sm.exe ">
+      <type>char</type>
+      <desc>executable name</desc>
+    </entry>
+    <entry id="run_misc_suffix" value=" &gt;&gt; e3sm.log.$LID 2&gt;&amp;1 ">
+      <type>char</type>
+      <desc>redirect for job output</desc>
+    </entry>
+  </group>
+  <module_system type="none"/>
+  <environment_variables>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT">1</env>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT_CONFIRM">1</env>
+  </environment_variables>
+  <mpirun mpilib="openmpi">
+    <executable>aprun</executable>
+    <arguments>
+      <arg name="ntasks">-n {{ total_tasks }}</arg>
+      <arg name="oversubscribe">--oversubscribe</arg>
+    </arguments>
+  </mpirun>
+  <mpirun mpilib="openmpi" compiler="gnu">
+    <executable>srun</executable>
+  </mpirun>
+</file>
+"""
+            )
+            temp.seek(0)
+
+            mach_specific = EnvMachSpecific(infile=temp.name)
+
+            mock_case = mock.MagicMock()
+
+            type(mock_case).total_tasks = mock.PropertyMock(return_value=4)
+
+            attribs = {"compiler": "gnu", "mpilib": "openmpi", "threaded": False}
+
+            executable, args, run_exe, run_misc_suffix = mach_specific.get_mpirun(
+                mock_case, attribs, "case.run"
+            )
+
+            assert executable == "srun"
+            assert args == []
+            assert run_exe is None
+            assert run_misc_suffix is None
+
+    def test_get_mpirun(self):
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(
+                b"""<?xml version="1.0"?>
+<file id="env_mach_specific.xml" version="2.0">
+  <header>
+    These variables control the machine dependent environment including
+    the paths to compilers and libraries external to cime such as netcdf,
+    environment variables for use in the running job should also be set here.
+    </header>
+  <group id="compliant_values">
+    <entry id="run_exe" value="${EXEROOT}/e3sm.exe ">
+      <type>char</type>
+      <desc>executable name</desc>
+    </entry>
+    <entry id="run_misc_suffix" value=" &gt;&gt; e3sm.log.$LID 2&gt;&amp;1 ">
+      <type>char</type>
+      <desc>redirect for job output</desc>
+    </entry>
+  </group>
+  <module_system type="none"/>
+  <environment_variables>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT">1</env>
+    <env name="OMPI_ALLOW_RUN_AS_ROOT_CONFIRM">1</env>
+  </environment_variables>
+  <mpirun mpilib="openmpi">
+    <executable>aprun</executable>
+    <arguments>
+      <arg name="ntasks">-n {{ total_tasks }}</arg>
+      <arg name="oversubscribe">--oversubscribe</arg>
+    </arguments>
+  </mpirun>
+</file>
+"""
+            )
+            temp.seek(0)
+
+            mach_specific = EnvMachSpecific(infile=temp.name)
+
+            mock_case = mock.MagicMock()
+
+            type(mock_case).total_tasks = mock.PropertyMock(return_value=4)
+
+            attribs = {"compiler": "gnu", "mpilib": "openmpi", "threaded": False}
+
+            executable, args, run_exe, run_misc_suffix = mach_specific.get_mpirun(
+                mock_case, attribs, "case.run"
+            )
+
+            assert executable == "aprun"
+            assert args == ["-n 4", "--oversubscribe"]
+            assert run_exe is None
+            assert run_misc_suffix is None
+
     @mock.patch("CIME.XML.env_mach_specific.EnvMachSpecific.get_optional_child")
     @mock.patch("CIME.XML.env_mach_specific.EnvMachSpecific.text")
     @mock.patch.dict("os.environ", {"TEST_VALUE": "/testexec"})

--- a/doc/source/users_guide/machine.rst
+++ b/doc/source/users_guide/machine.rst
@@ -57,9 +57,35 @@ Each ``<machine>`` tag requires the following input:
   * May have optional attributes of ``compiler``, ``mpilib`` and/or ``threaded``
   * May have an optional ``<arguments>`` element which in turn contains one or more ``<arg>`` elements.
     These specify the arguments to the mpi executable and are dependent on your mpi library implementation.
-  * May have an option ``<run_exe>`` element which overrides the ``default_run_exe``
-  * May have an option ``<run_misc_suffix>`` element which overrides the ``default_run_misc_suffix``
+  * May have an optional ``<run_exe>`` element which overrides the ``default_run_exe``
+  * May have an optional ``<run_misc_suffix>`` element which overrides the ``default_run_misc_suffix``
+  * May have an optional ``<aprun_mode>`` element which controls how CIME generates arguments when ``<executable>`` contains ``aprun``. 
 
+  The ``<aprun_mode>`` element can be one of the following. The default value is ``ignore``.
+
+  * ``ignore`` will cause CIME to ignore it's aprun module and join the values found in ``<arguments>``.
+  * ``default`` will use CIME's aprun module to generate arguments.
+  * ``override`` behaves the same as ``default`` expect it will use ``<arguments>`` to mutate the generated arguments. When using this mode a ``position`` attribute can be placed on ``<arg>`` tags to specify how it's used.
+
+  The ``position`` attribute on ``<arg>`` can take one of the following values. The default value is ``per``.
+
+  * ``global`` causes the value of the ``<arg>`` element to be used as a global argument for ``aprun``.
+  * ``per`` causes the value of the ``<arg>`` element to be appended to each separate binaries arguments.
+
+  Example using ``override``:
+  ::
+
+    <executable>aprun</executable>
+    <aprun_mode>override</aprun_mode>
+    <arguments>
+      <arg position="global">-e DEBUG=true</arg>
+      <arg>-j 20</arg>
+    </arguments>
+
+  Sample command output:
+  ::
+
+    aprun -e DEBUG=true ... -j 20 e3sm.exe : ... -j 20 e3sm.exe
 
 * ``module_system``: How and what modules to load on this system. Module systems allow you to easily load multiple compiler environments on a machine. CIME provides support for two types of module tools: `module <http://www.tacc.utexas.edu/tacc-projects/mclay/lmod>`_ and `soft  <http://www.mcs.anl.gov/hs/software/systems/softenv/softenv-intro.html>`_. If neither of these is available on your machine, simply set ``<module_system type="none"\>``.
 


### PR DESCRIPTION
This PR update's CIME to be more flexible when using aprun. Currently
there is a specific case for the `theta` machine that uses `aprun` but 
cannot utilize CIME's aprun capabilities due to the `-j` flag not being 
supported. A new element `aprun_mode` is added to control the CIME's
behavior when a machine uses `aprun`. The `ignore` mode will skip using
CIME's aprun module and concatenate the `arg` elements, this is the
behavior for `theta` and the machines from #4332. The `default` mode 
will ignore the `arg` elements and utilize CIME's aprun module to generate
the arguments. Lastly the `override` mode will use CIME's aprun module
and mutate the output using `arg` elements.

Test suite: scripts_regression_tests.py
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #2024 
User interface changes?: N
Update gh-pages html (Y/N)?: Y
