### PR TITLE
improve float detection in argument resolution of the batch environment

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -675,11 +675,9 @@ class EnvBatch(EnvBase):
             else:
                 rval = val
 
-            # We don't want floating-point data
-            try:
+            # We don't want floating-point data (ignore anything else)
+            if str(rval).replace(".", "", 1).isdigit():
                 rval = int(round(float(rval)))
-            except ValueError:
-                pass
 
             # need a correction for tasks per node
             if flag == "-n" and rval <= 0:


### PR DESCRIPTION
Fixes #4341 

The underlying cause of the issue is that all arguments are converted to integers. Since a project string of the form `2022_123` is a valid number in Python syntax, it gets converted to `2022123` without going through this exception.

I suggest to replace this indiscriminate conversion of arguments into a more specific test on floats and only convert to integers those arguments that are floats.