### PR TITLE
Fixes skipping docs preview

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,6 @@ jobs:
     needs: check-changes
     if: |
       needs.check-changes.outputs.any_changed == 'true' &&
-      # skip if the PR is from a fork
       github.event.pull_request.head.repo.full_name == github.repository
     name: Build and deploy documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,10 @@ jobs:
       contents: write  #  for peaceiris/actions-gh-pages to push
       pull-requests: write  #  to comment on pull requests
     needs: check-changes
-    if: needs.check-changes.outputs.any_changed == 'true'
+    if: |
+      needs.check-changes.outputs.any_changed == 'true' &&
+      # skip if the PR is from a fork
+      github.event.pull_request.head.repo.full_name == github.repository
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When changes are made to the docs, a preview is built and pushed to the
gh-pages branch. If the PR responsible for the changes is from a fork
the workflow will fail since it does not have the appropriate permissions
to push to the branch. This fix allows the preview workflow to be skipped
when the PR is from a fork.

Test suite: n/a
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes? n/a
Update gh-pages html (Y/N)?: n/a
