### PR TITLE
correct the rpointer name for nuopc cases

### DIFF
--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -52,7 +52,12 @@ def _submit(
     # Check if CONTINUE_RUN value makes sense
     # if submitted with a prereq don't do this check
     testcase = case.get_value("TESTCASE")
-    if (not testcase or testcase not in ("PET", "NCK")) and case.get_value("CONTINUE_RUN") and hasMediator and not prereq:
+    if (
+        (not testcase or testcase not in ("PET", "NCK"))
+        and case.get_value("CONTINUE_RUN")
+        and hasMediator
+        and not prereq
+    ):
         rundir = case.get_value("RUNDIR")
         expect(
             os.path.isdir(rundir),

--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -51,7 +51,8 @@ def _submit(
 
     # Check if CONTINUE_RUN value makes sense
     # if submitted with a prereq don't do this check
-    if case.get_value("CONTINUE_RUN") and hasMediator and not prereq:
+    testcase = case.get_value("TESTCASE")
+    if (not testcase or testcase not in ("PET", "NCK")) and case.get_value("CONTINUE_RUN") and hasMediator and not prereq:
         rundir = case.get_value("RUNDIR")
         expect(
             os.path.isdir(rundir),

--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -51,12 +51,7 @@ def _submit(
 
     # Check if CONTINUE_RUN value makes sense
     # if submitted with a prereq don't do this check
-    if (
-        job != "case.test"
-        and case.get_value("CONTINUE_RUN")
-        and hasMediator
-        and not prereq
-    ):
+    if case.get_value("CONTINUE_RUN") and hasMediator and not prereq:
         rundir = case.get_value("RUNDIR")
         expect(
             os.path.isdir(rundir),
@@ -67,7 +62,8 @@ def _submit(
             rpointer = "rpointer.cpl"
         else:
             rpointer = "rpointer.drv"
-        if case.get_value("MULTI_DRIVER"):
+        # Variable MULTI_DRIVER is always true for nuopc so we need to also check NINST > 1
+        if case.get_value("MULTI_DRIVER") and case.get_value("NINST") > 1:
             rpointer = rpointer + "_0001"
         expect(
             os.path.exists(os.path.join(rundir, rpointer)),


### PR DESCRIPTION
Restarts are broken for nuopc cases since tag cime6.0.64 due to code which is explicitly not being tested. 
I have removed the conditional that causes this code block not to be tested so that this doesn't happen again - 
but I'm not sure why that block was there in the first place - can we be more specific about tests that should not use this code block?

Test suite:
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4346 

User interface changes?:

Update gh-pages html (Y/N)?:
