### PR TITLE
need to make sure that asyncio_interface is true

### DIFF
--- a/CIME/XML/env_mach_pes.py
+++ b/CIME/XML/env_mach_pes.py
@@ -105,7 +105,7 @@ class EnvMachPes(EnvBase):
                 max_threads = threads
         return max_threads
 
-    def get_total_tasks(self, comp_classes):
+    def get_total_tasks(self, comp_classes, async_interface=False):
         total_tasks = 0
         maxinst = self.get_value("NINST")
         asyncio_ntasks = 0
@@ -114,9 +114,10 @@ class EnvMachPes(EnvBase):
         asyncio_tasks = []
         if maxinst:
             comp_interface = "nuopc"
-            asyncio_ntasks = self.get_value("PIO_ASYNCIO_NTASKS")
-            asyncio_rootpe = self.get_value("PIO_ASYNCIO_ROOTPE")
-            asyncio_stride = self.get_value("PIO_ASYNCIO_STRIDE")
+            if async_interface:
+                asyncio_ntasks = self.get_value("PIO_ASYNCIO_NTASKS")
+                asyncio_rootpe = self.get_value("PIO_ASYNCIO_ROOTPE")
+                asyncio_stride = self.get_value("PIO_ASYNCIO_STRIDE")
             logger.debug(
                 "asyncio ntasks {} rootpe {} stride {}".format(
                     asyncio_ntasks, asyncio_rootpe, asyncio_stride

--- a/CIME/XML/env_mach_pes.py
+++ b/CIME/XML/env_mach_pes.py
@@ -154,11 +154,11 @@ class EnvMachPes(EnvBase):
             tt = rootpe + nthrds * ((ntasks - 1) * pstrid + 1)
             maxrootpe = max(maxrootpe, rootpe)
             total_tasks = max(tt, total_tasks)
+        if asyncio_tasks:
+            total_tasks = total_tasks + len(asyncio_tasks)
         if self.get_value("MULTI_DRIVER"):
             total_tasks *= maxinst
         logger.debug("asyncio_tasks {}".format(asyncio_tasks))
-        if asyncio_tasks:
-            return total_tasks + len(asyncio_tasks)
         return total_tasks
 
     def get_tasks_per_node(self, total_tasks, max_thread_count):

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -224,8 +224,11 @@ class Case(object):
         comp_classes = self.get_values("COMP_CLASSES")
         max_mpitasks_per_node = self.get_value("MAX_MPITASKS_PER_NODE")
         self.async_io = {}
+        asyncio = False
         for comp in comp_classes:
             self.async_io[comp] = self.get_value("PIO_ASYNC_INTERFACE", subgroup=comp)
+            if self.async_io[comp]:
+                asyncio = True
 
         self.iotasks = (
             self.get_value("PIO_ASYNCIO_NTASKS")
@@ -254,7 +257,7 @@ class Case(object):
             self.spare_nodes = env_mach_pes.get_spare_nodes(self.num_nodes)
             self.num_nodes += self.spare_nodes
         else:
-            self.total_tasks = env_mach_pes.get_total_tasks(comp_classes)
+            self.total_tasks = env_mach_pes.get_total_tasks(comp_classes, asyncio)
             self.tasks_per_node = env_mach_pes.get_tasks_per_node(
                 self.total_tasks, self.thread_count
             )

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -623,7 +623,7 @@ def parse_command_line(args, description):
                 xml_testlist=args.xml_testlist,
                 machine=machine_name,
                 compiler=args.compiler,
-                driver="nuopc",
+                driver=args.xml_driver,
             )
             test_names = [item["name"] for item in test_data]
             for test_datum in test_data:

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -623,7 +623,7 @@ def parse_command_line(args, description):
                 xml_testlist=args.xml_testlist,
                 machine=machine_name,
                 compiler=args.compiler,
-                driver=args.xml_driver,
+                driver="nuopc",
             )
             test_names = [item["name"] for item in test_data]
             for test_datum in test_data:

--- a/CIME/test_utils.py
+++ b/CIME/test_utils.py
@@ -38,10 +38,15 @@ def get_tests_from_xml(
         )
         testlistfiles.append(xml_testlist)
     else:
-        files = Files()
+        files = Files(comp_interface=driver)
         comps = files.get_components("TESTS_SPEC_FILE")
         for comp in comps:
             test_spec_file = files.get_value("TESTS_SPEC_FILE", {"component": comp})
+            logger.info(
+                "Adding tests for component {} from test_spec_file {}".format(
+                    comp, test_spec_file
+                )
+            )
             if os.path.isfile(test_spec_file):
                 testlistfiles.append(test_spec_file)
 

--- a/CIME/test_utils.py
+++ b/CIME/test_utils.py
@@ -49,6 +49,11 @@ def get_tests_from_xml(
             )
             if os.path.isfile(test_spec_file):
                 testlistfiles.append(test_spec_file)
+        if not driver:
+            files = Files(comp_interface="nuopc")
+            test_spec_file = files.get_value("TESTS_SPEC_FILE", {"component": "drv"})
+            if os.path.isfile(test_spec_file):
+                testlistfiles.append(test_spec_file)
 
     for testlistfile in testlistfiles:
         thistestlistfile = Testlist(testlistfile)

--- a/CIME/test_utils.py
+++ b/CIME/test_utils.py
@@ -38,22 +38,17 @@ def get_tests_from_xml(
         )
         testlistfiles.append(xml_testlist)
     else:
-        files = Files(comp_interface=driver)
+        files = Files()
         comps = files.get_components("TESTS_SPEC_FILE")
         for comp in comps:
             test_spec_file = files.get_value("TESTS_SPEC_FILE", {"component": comp})
-            logger.info(
-                "Adding tests for component {} from test_spec_file {}".format(
-                    comp, test_spec_file
-                )
-            )
             if os.path.isfile(test_spec_file):
                 testlistfiles.append(test_spec_file)
-        if not driver:
-            files = Files(comp_interface="nuopc")
-            test_spec_file = files.get_value("TESTS_SPEC_FILE", {"component": "drv"})
-            if os.path.isfile(test_spec_file):
-                testlistfiles.append(test_spec_file)
+        # We need to make nuopc the default for cesm testing, then we can remove this block
+        files = Files(comp_interface="nuopc")
+        test_spec_file = files.get_value("TESTS_SPEC_FILE", {"component": "drv"})
+        if os.path.isfile(test_spec_file):
+            testlistfiles.append(test_spec_file)
 
     for testlistfile in testlistfiles:
         thistestlistfile = Testlist(testlistfile)


### PR DESCRIPTION
If the PIO_ASYNC_INTERFACE is FALSE for all components then the variables PIO_ASYNCIO_* are 
not set in buildnml, but they are still used in env_mach_pes.py to set processor count,  this fixes that problem.

Test suite: cesm prealpha tests 
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
