### PR TITLE
Check number of hist file comparisons in system_test_common

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -482,7 +482,8 @@ class SystemTestsCommon(object):
             success = not success
 
         if (
-            self._expected_num_cmp is not None and num_compared is not None
+            self._expected_num_cmp is not None
+            and num_compared is not None
             and self._expected_num_cmp != num_compared
         ):
             comments = comments.replace("PASS", "")
@@ -490,7 +491,9 @@ class SystemTestsCommon(object):
 Expected to compare {} hist files, but only compared {}. It's possible
 that the hist_file_extension entry in config_archive.xml is not correct
 for some of your components.
-""".format(self._expected_num_cmp, num_compared)
+""".format(
+                self._expected_num_cmp, num_compared
+            )
             success = False
 
         append_testlog(comments, self._orig_caseroot)

--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -60,6 +60,8 @@ def copy_histfiles(case, suffix):
 
     case - The case containing the files you want to save
     suffix - The string suffix you want to add to saved files, this can be used to find them later.
+
+    returns (comments, num_copied)
     """
     rundir = case.get_value("RUNDIR")
     ref_case = case.get_value("RUN_REFCASE")
@@ -104,7 +106,7 @@ def copy_histfiles(case, suffix):
         "copy_histfiles failed: no hist files found in rundir '{}'".format(rundir),
     )
 
-    return comments
+    return comments, num_copied
 
 
 def rename_all_hist_files(case, suffix):
@@ -265,6 +267,11 @@ def _compare_hists(
     outfile_suffix="",
     ignore_fieldlist_diffs=False,
 ):
+    """
+    Compares two sets of history files
+
+    Returns (success (True if all matched), comments, num_compared)
+    """
     if from_dir1 == from_dir2:
         expect(suffix1 != suffix2, "Comparing files to themselves?")
 
@@ -352,6 +359,7 @@ def _compare_hists(
                         )
 
                 all_success = False
+
     # Some tests don't save history files.
     if num_compared == 0 and testcase not in NO_HIST_TESTS:
         all_success = False
@@ -359,7 +367,7 @@ def _compare_hists(
 
     comments += "PASS" if all_success else "FAIL"
 
-    return all_success, comments
+    return all_success, comments, num_compared
 
 
 def compare_test(case, suffix1, suffix2, ignore_fieldlist_diffs=False):
@@ -374,7 +382,7 @@ def compare_test(case, suffix1, suffix2, ignore_fieldlist_diffs=False):
         diagnostic fields that are missing from the other case), treat the two cases as
         identical.
 
-    returns (SUCCESS, comments)
+    returns (SUCCESS, comments, num_compared)
     """
     rundir = case.get_value("RUNDIR")
 
@@ -517,7 +525,7 @@ def compare_baseline(case, baseline_dir=None, outfile_suffix=""):
                 TEST_NO_BASELINES_COMMENT, bdir
             )
 
-    success, comments = _compare_hists(
+    success, comments, _ = _compare_hists(
         case, rundir, basecmp_dir, outfile_suffix=outfile_suffix
     )
     if Config.instance().create_bless_log:

--- a/CIME/tests/test_unit_compare_two.py
+++ b/CIME/tests/test_unit_compare_two.py
@@ -194,7 +194,7 @@ class SystemTestsCompareTwoFake(SystemTestsCompareTwo):
         This fake implementation allows controlling whether compare_test
         passes or fails
         """
-        return (self.compare_should_pass, "no comment")
+        return (self.compare_should_pass, "no comment", None)
 
     def _check_for_memleak(self):
         pass


### PR DESCRIPTION
Every file that gets copied by copy_histfiles should later be compared by compare_test. We ran into a situation where the hist_file_extension for a component worked when suffix="" but not when suffix!="". This caused hist files for that component to get silently skipped in various system tests that do internal compares.

This PR will make the scenario above be reported as a failed comparison so it can't go unnoticed.

Test suite: script_regression_tests
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
