### PR TITLE
need to modify import of importlib

### DIFF
--- a/CIME/config.py
+++ b/CIME/config.py
@@ -1,7 +1,8 @@
 import sys
 import glob
 import logging
-import importlib
+import importlib.machinery
+import importlib.util
 
 from CIME import utils
 


### PR DESCRIPTION
Python version 3.10.8 seems to require this change.  I am using github testing to make sure that it's backward compatible.  

Test suite: github workflows.
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes

User interface changes?:

Update gh-pages html (Y/N)?:
