### PR TITLE
Fix exception chain in import_and_run_sub_or_cmd

### DIFF
--- a/CIME/tests/test_unit_utils.py
+++ b/CIME/tests/test_unit_utils.py
@@ -247,7 +247,9 @@ class TestUtils(unittest.TestCase):
     def test_import_and_run_sub_or_cmd_run(self, func, isfile):
         isfile.return_value = True
 
-        func.side_effect = Exception("ERROR: /tmp/buildnml arg1 arg2 -vvv FAILED, see above") 
+        func.side_effect = Exception(
+            "ERROR: /tmp/buildnml arg1 arg2 -vvv FAILED, see above"
+        )
 
         with self.assertRaisesRegex(
             Exception, "ERROR: /tmp/buildnml arg1 arg2 -vvv FAILED, see above"

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -644,7 +644,9 @@ def import_and_run_sub_or_cmd(
 
         # TODO shouldn't need to use logger.isEnabledFor for debug logging
         if isinstance(e, ModuleNotFoundError) and logger.isEnabledFor(logging.DEBUG):
-            logger.info(f"WARNING: Could not import module '{compname}_cime_py'")
+            logger.info(
+                "WARNING: Could not import module '{}_cime_py'".format(compname)
+            )
 
         try:
             run_sub_or_cmd(

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -641,7 +641,13 @@ def import_and_run_sub_or_cmd(
             os.path.isfile(cmd),
             f"Could not find {subname} file for component {compname}",
         )
-        run_sub_or_cmd(cmd, cmdargs, subname, subargs, logfile, case, from_dir, timeout)
+
+        try:
+            run_sub_or_cmd(
+                cmd, cmdargs, subname, subargs, logfile, case, from_dir, timeout
+            )
+        except Exception as e:
+            raise e from None
     except Exception:
         if logfile:
             with open(logfile, "a") as log_fd:

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -633,7 +633,7 @@ def import_and_run_sub_or_cmd(
     try:
         mod = importlib.import_module(f"{compname}_cime_py")
         getattr(mod, subname)(*subargs)
-    except (ModuleNotFoundError, AttributeError) as _:
+    except (ModuleNotFoundError, AttributeError) as e:
         # * ModuleNotFoundError if importlib can not find module,
         # * AttributeError if importlib finds the module but
         #   {subname} is not defined in the module
@@ -641,6 +641,10 @@ def import_and_run_sub_or_cmd(
             os.path.isfile(cmd),
             f"Could not find {subname} file for component {compname}",
         )
+
+        # TODO shouldn't need to use logger.isEnabledFor for debug logging
+        if isinstance(e, ModuleNotFoundError) and logger.isEnabledFor(logging.DEBUG):
+            logger.info(f"WARNING: Could not import module '{compname}_cime_py'")
 
         try:
             run_sub_or_cmd(


### PR DESCRIPTION
Fixes an exception chain in `import_and_run_sub_or_cmd` that causes
misleading error. This is caused when `{compname}_cime_py` cannot 
be imported and `run_sub_or_cmd` raises an error from the file imports
or runs. 

This would cause an exception chain with the first being 
`ModuleNotFoundError: No module named '{compname}_cime_py'` and 
the second being the real exception. The new behavior is to only expose
the second as to not hide the real error and a debug message has been
added when `{compname}_cime_py` cannot be imported.

Test suite: scripts_regression_tests.py
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?: N
Update gh-pages html (Y/N)?: N
