### PR TITLE
Have sys tests use same config

### DIFF
--- a/CIME/tests/base.py
+++ b/CIME/tests/base.py
@@ -63,7 +63,7 @@ class BaseTestCase(unittest.TestCase):
         self._root_dir = os.getcwd()
 
         customize_path = os.path.join(utils.get_src_root(), "cime_config", "customize")
-        config = Config.load(customize_path)
+        self._config = Config.load(customize_path)
 
     def tearDown(self):
         self.kill_subprocesses()
@@ -153,7 +153,7 @@ class BaseTestCase(unittest.TestCase):
 
     def assert_dashboard_has_build(self, build_name, expected_count=1):
         # Do not test E3SM dashboard if model is CESM
-        if Config.instance().test_mode == "e3sm":
+        if self._config.test_mode == "e3sm":
             time.sleep(10)  # Give chance for cdash to update
 
             wget_file = tempfile.mktemp()

--- a/CIME/tests/test_sys_bless_tests_results.py
+++ b/CIME/tests/test_sys_bless_tests_results.py
@@ -6,10 +6,7 @@ import os
 import stat
 
 from CIME import utils
-from CIME.config import Config
 from CIME.tests import base
-
-config = Config.instance()
 
 
 class TestBlessTestResults(base.BaseTestCase):
@@ -43,7 +40,7 @@ class TestBlessTestResults(base.BaseTestCase):
 
         # Generate some baselines
         for test_name in test_names:
-            if config.create_test_flag_mode == "e3sm":
+            if self._config.create_test_flag_mode == "e3sm":
                 genargs = ["-g", "-o", "-b", self._baseline_name, test_name]
                 compargs = ["-c", "-b", self._baseline_name, test_name]
             else:
@@ -107,7 +104,7 @@ class TestBlessTestResults(base.BaseTestCase):
         if self.NO_FORTRAN_RUN:
             self.skipTest("Skipping fortran test")
         test_to_change = "TESTRUNPASS_P1.f19_g16_rx1.A"
-        if config.create_test_flag_mode == "e3sm":
+        if self._config.create_test_flag_mode == "e3sm":
             genargs = ["-g", "-o", "-b", self._baseline_name, "cime_test_only_pass"]
             compargs = ["-c", "-b", self._baseline_name, "cime_test_only_pass"]
         else:

--- a/CIME/tests/test_sys_cime_case.py
+++ b/CIME/tests/test_sys_cime_case.py
@@ -8,12 +8,9 @@ import sys
 import time
 
 from CIME import utils
-from CIME.config import Config
 from CIME.tests import base
 from CIME.case.case import Case
 from CIME.XML.env_run import EnvRun
-
-config = Config.instance()
 
 
 class TestCimeCase(base.BaseTestCase):
@@ -64,7 +61,7 @@ class TestCimeCase(base.BaseTestCase):
         args = "--case {name} --script-root {testdir} --compset X --res f19_g16 --handle-preexisting-dirs=r --output-root {testdir}".format(
             name=testcase_name, testdir=testdir
         )
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
 
         self.run_cmd_assert_result(
@@ -313,7 +310,7 @@ class TestCimeCase(base.BaseTestCase):
         self.assertEqual(result, "-opt1 -opt2")
 
     def test_cime_case_test_walltime_mgmt_1(self):
-        if config.test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS.f19_g16_rx1.A"
@@ -335,7 +332,7 @@ class TestCimeCase(base.BaseTestCase):
         self.assertEqual(result, "biggpu")
 
     def test_cime_case_test_walltime_mgmt_2(self):
-        if config.test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS_P64.f19_g16_rx1.A"
@@ -357,7 +354,7 @@ class TestCimeCase(base.BaseTestCase):
         self.assertEqual(result, "biggpu")
 
     def test_cime_case_test_walltime_mgmt_3(self):
-        if config.test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS_P64.f19_g16_rx1.A"
@@ -385,7 +382,7 @@ class TestCimeCase(base.BaseTestCase):
         self.assertEqual(result, "biggpu")  # Not smart enough to select faster queue
 
     def test_cime_case_test_walltime_mgmt_4(self):
-        if config.test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS_P1.f19_g16_rx1.A"
@@ -413,7 +410,7 @@ class TestCimeCase(base.BaseTestCase):
         self.assertEqual(result, "biggpu")
 
     def test_cime_case_test_walltime_mgmt_5(self):
-        if config.test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "ERS_P1.f19_g16_rx1.A"
@@ -504,7 +501,7 @@ class TestCimeCase(base.BaseTestCase):
                 self.assertEqual(result, "421:32:11")
 
     def test_cime_case_test_walltime_mgmt_8(self):
-        if config.test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
         test_name = "SMS_P25600.f19_g16_rx1.A"
@@ -536,7 +533,7 @@ class TestCimeCase(base.BaseTestCase):
     def test_cime_case_test_custom_project(self):
         test_name = "ERS_P1.f19_g16_rx1.A"
         # have to use a machine both models know and one that doesn't put PROJECT in any key paths
-        machine = config.test_custom_project_machine
+        machine = self._config.test_custom_project_machine
         compiler = "gnu"
         casedir = self._create_test(
             [

--- a/CIME/tests/test_sys_create_newcase.py
+++ b/CIME/tests/test_sys_create_newcase.py
@@ -7,12 +7,9 @@ import shutil
 import sys
 
 from CIME import utils
-from CIME.config import Config
 from CIME.tests import base
 from CIME.case.case import Case
 from CIME.build import CmakeTmpBuildDir
-
-config = Config.instance()
 
 
 class TestCreateNewcase(base.BaseTestCase):
@@ -37,7 +34,7 @@ class TestCreateNewcase(base.BaseTestCase):
             testdir,
             cls._testroot,
         )
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
         if self.TEST_COMPILER is not None:
             args = args + " --compiler %s" % self.TEST_COMPILER
@@ -151,7 +148,7 @@ class TestCreateNewcase(base.BaseTestCase):
             " --case %s --compset X --user-mods-dir %s --output-root %s --handle-preexisting-dirs=r"
             % (testdir, user_mods_dir, cls._testroot)
         )
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
         if self.TEST_COMPILER is not None:
             args = args + " --compiler %s" % self.TEST_COMPILER
@@ -325,7 +322,7 @@ class TestCreateNewcase(base.BaseTestCase):
 
         cls._testdirs.append(testdir)
 
-        if config.test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             if utils.get_cime_default_driver() == "nuopc":
                 pesfile = os.path.join(
                     utils.get_src_root(),
@@ -352,7 +349,7 @@ class TestCreateNewcase(base.BaseTestCase):
             "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV  --pesfile %s --res f19_g16 --output-root %s --handle-preexisting-dirs=r"
             % (testdir, pesfile, cls._testroot)
         )
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
         if self.TEST_COMPILER is not None:
             args += " --compiler %s" % self.TEST_COMPILER
@@ -385,7 +382,7 @@ class TestCreateNewcase(base.BaseTestCase):
             "--case %s --compset 2000_SATM_XLND_SICE_SOCN_XROF_XGLC_SWAV --pesfile %s --res f19_g16 --output-root %s --handle-preexisting-dirs=r"
             % (testdir, pesfile, cls._testroot)
         )
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
         if self.TEST_COMPILER is not None:
             args += " --compiler %s" % self.TEST_COMPILER
@@ -422,7 +419,7 @@ class TestCreateNewcase(base.BaseTestCase):
             " --case CreateNewcaseTest --script-root %s --compset X --output-root %s --handle-preexisting-dirs u"
             % (testdir, cls._testroot)
         )
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
         if self.TEST_COMPILER is not None:
             args += " --compiler %s" % self.TEST_COMPILER
@@ -544,7 +541,7 @@ class TestCreateNewcase(base.BaseTestCase):
             args += " --res f19_g17 "
         else:
             args += " --res f19_g16 "
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
         if self.TEST_COMPILER is not None:
             args += " --compiler %s" % self.TEST_COMPILER
@@ -585,7 +582,7 @@ class TestCreateNewcase(base.BaseTestCase):
             args += " --res f19_g17 "
         else:
             args += " --res f19_g16 "
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
         if self.TEST_COMPILER is not None:
             args += " --compiler %s" % self.TEST_COMPILER
@@ -701,7 +698,7 @@ set(NETCDF_PATH /my/netcdf/path)
                 extra_machines_dir=extra_machines_dir,
             )
         )
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
 
         if utils.get_cime_default_driver() == "nuopc":
@@ -736,7 +733,7 @@ set(NETCDF_PATH /my/netcdf/path)
         cls = self.__class__
 
         # TODO refactor
-        if config.test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             alternative_driver = ("nuopc",)
         else:
             alternative_driver = ("moab",)
@@ -761,7 +758,7 @@ set(NETCDF_PATH /my/netcdf/path)
             args = " --driver {} --case {} --compset X --res f19_g16 --output-root {} --handle-preexisting-dirs=r".format(
                 driver, testdir, cls._testroot
             )
-            if config.allow_unsupported:
+            if self._config.allow_unsupported:
                 args += " --run-unsupported"
             if self.TEST_COMPILER is not None:
                 args = args + " --compiler %s" % self.TEST_COMPILER
@@ -796,7 +793,7 @@ set(NETCDF_PATH /my/netcdf/path)
             " --case %s --compset InvalidCompsetName --output-root %s --handle-preexisting-dirs=r "
             % (testdir, cls._testroot)
         )
-        if config.allow_unsupported:
+        if self._config.allow_unsupported:
             args += " --run-unsupported"
         if self.TEST_COMPILER is not None:
             args = args + " --compiler %s" % self.TEST_COMPILER

--- a/CIME/tests/test_sys_grid_generation.py
+++ b/CIME/tests/test_sys_grid_generation.py
@@ -5,7 +5,6 @@ import shutil
 import sys
 
 from CIME import utils
-from CIME.config import Config
 from CIME.tests import base
 
 
@@ -17,7 +16,7 @@ class TestGridGeneration(base.BaseTestCase):
         cls._testdirs = []
 
     def test_gen_domain(self):
-        if Config.instance().test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             self.skipTest("Skipping gen_domain test. Depends on E3SM tools")
         cime_root = utils.get_cime_root()
         inputdata = self.MACHINE.get_value("DIN_LOC_ROOT")

--- a/CIME/tests/test_sys_jenkins_generic_job.py
+++ b/CIME/tests/test_sys_jenkins_generic_job.py
@@ -9,17 +9,15 @@ import time
 
 from CIME import get_tests
 from CIME import utils
-from CIME.config import Config
 from CIME.tests import base
-
-config = Config.instance()
 
 
 class TestJenkinsGenericJob(base.BaseTestCase):
     def setUp(self):
-        if config.test_mode == "cesm":
-            self.skipTest("Skipping Jenkins tests. E3SM feature")
         super().setUp()
+
+        if self._config.test_mode == "cesm":
+            self.skipTest("Skipping Jenkins tests. E3SM feature")
 
         # Need to run in a subdir in order to not have CTest clash. Name it
         # such that it should be cleaned up by the parent tearDown
@@ -42,7 +40,7 @@ class TestJenkinsGenericJob(base.BaseTestCase):
             extra_args += " --no-batch"
 
         # Need these flags to test dashboard if e3sm
-        if config.test_mode == "e3sm" and build_name is not None:
+        if self._config.test_mode == "e3sm" and build_name is not None:
             extra_args += (
                 " -p ACME_test --submit-to-cdash --cdash-build-group=Nightly -c %s"
                 % build_name

--- a/CIME/tests/test_sys_manage_and_query.py
+++ b/CIME/tests/test_sys_manage_and_query.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from CIME import utils
-from CIME.config import Config
 from CIME.tests import base
 from CIME.XML.files import Files
 
@@ -10,10 +9,10 @@ class TestManageAndQuery(base.BaseTestCase):
     """Tests various scripts to manage and query xml files"""
 
     def setUp(self):
-        if Config.instance().test_mode == "e3sm":
-            self.skipTest("Skipping XML test management tests. E3SM does not use this.")
-
         super().setUp()
+
+        if self._config.test_mode == "e3sm":
+            self.skipTest("Skipping XML test management tests. E3SM does not use this.")
 
     def _run_and_assert_query_testlist(self, extra_args=""):
         """Ensure that query_testlist runs successfully with the given extra arguments"""

--- a/CIME/tests/test_sys_save_timings.py
+++ b/CIME/tests/test_sys_save_timings.py
@@ -6,11 +6,8 @@ import os
 
 from CIME import provenance
 from CIME import utils
-from CIME.config import Config
 from CIME.tests import base
 from CIME.case.case import Case
-
-config = Config.instance()
 
 
 class TestSaveTimings(base.BaseTestCase):
@@ -49,7 +46,7 @@ class TestSaveTimings(base.BaseTestCase):
             self.run_cmd_assert_result(
                 "cd %s && %s/save_provenance postrun" % (casedir, self.TOOLS_DIR)
             )
-        if config.test_mode == "e3sm":
+        if self._config.test_mode == "e3sm":
             provenance_glob = os.path.join(
                 timing_dir,
                 "performance_archive",
@@ -107,7 +104,7 @@ class TestSaveTimings(base.BaseTestCase):
             self.assertEqual(exp_last_pass, commit, msg="Should never")
 
     def test_success_recording(self):
-        if config.test_mode == "e3sm":
+        if self._config.test_mode == "e3sm":
             self.skipTest("Skipping success recording tests. E3SM feature")
 
         fake_test1 = "faketest1"

--- a/CIME/tests/test_sys_single_submit.py
+++ b/CIME/tests/test_sys_single_submit.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from CIME import utils
-from CIME.config import Config
 from CIME.tests import base
 
 
@@ -10,7 +9,7 @@ class TestSingleSubmit(base.BaseTestCase):
         # Skip unless on a batch system and users did not select no-batch
         if not self._hasbatch:
             self.skipTest("Skipping single submit. Not valid without batch")
-        if Config.instance().test_mode == "cesm":
+        if self._config.test_mode == "cesm":
             self.skipTest("Skipping single submit. E3SM experimental feature")
         if self._machine not in ["sandiatoss3"]:
             self.skipTest("Skipping single submit. Only works on sandiatoss3")

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -10,14 +10,13 @@ from CIME import get_tests
 from CIME import utils
 from CIME import test_status
 from CIME import test_scheduler
-from CIME.config import Config
 from CIME.tests import base
 
 
 class TestTestScheduler(base.BaseTestCase):
     @mock.patch("time.strftime", return_value="00:00:00")
     def test_chksum(self, strftime):  # pylint: disable=unused-argument
-        if Config.instance().test_mode == "e3sm":
+        if self._config.test_mode == "e3sm":
             self.skipTest("Skipping chksum test. Depends on CESM settings")
 
         ts = test_scheduler.TestScheduler(
@@ -451,7 +450,7 @@ class TestTestScheduler(base.BaseTestCase):
         self._create_test(args)
 
     def test_e_test_inferred_compiler(self):
-        if Config.instance().test_mode != "e3sm" or self._machine != "docker":
+        if self._config.test_mode != "e3sm" or self._machine != "docker":
             self.skipTest("Skipping create_test test. Depends on E3SM settings")
 
         args = ["SMS.f19_g16_rx1.A.docker_gnuX", "--no-setup"]

--- a/CIME/tests/test_sys_wait_for_tests.py
+++ b/CIME/tests/test_sys_wait_for_tests.py
@@ -9,15 +9,14 @@ import threading
 
 from CIME import utils
 from CIME import test_status
-from CIME.config import Config
 from CIME.tests import base
 from CIME.tests import utils as test_utils
-
-config = Config.instance()
 
 
 class TestWaitForTests(base.BaseTestCase):
     def setUp(self):
+        super().setUp()
+
         self._testroot = os.path.join(self.TEST_ROOT, "TestWaitForTests")
         self._timestamp = utils.get_timestamp()
 
@@ -103,20 +102,17 @@ class TestWaitForTests(base.BaseTestCase):
         self._thread_error = None
 
     def tearDown(self):
+        super().tearDown()
+
         do_teardown = sys.exc_info() == (None, None, None) and not self.NO_TEARDOWN
 
         if do_teardown:
             for testdir in self._testdirs:
                 shutil.rmtree(testdir)
 
-        self.kill_subprocesses()
-
-        if self._unset_proxy:
-            del os.environ["http_proxy"]
-
     def simple_test(self, testdir, expected_results, extra_args="", build_name=None):
         # Need these flags to test dashboard if e3sm
-        if config.create_test_flag_mode == "e3sm" and build_name is not None:
+        if self._config.create_test_flag_mode == "e3sm" and build_name is not None:
             extra_args += " -b %s" % build_name
 
         expected_stat = 0
@@ -300,7 +296,7 @@ class TestWaitForTests(base.BaseTestCase):
 
         self.assert_dashboard_has_build(build_name)
 
-        if config.test_mode == "e3sm":
+        if self._config.test_mode == "e3sm":
             cdash_result_dir = os.path.join(self._testdir_unfinished, "Testing")
             tag_file = os.path.join(cdash_result_dir, "TAG")
             self.assertTrue(os.path.isdir(cdash_result_dir))


### PR DESCRIPTION
I ran into problems trying to run individual tests because they were grabbing Config.instance() before the model-specific config had been loaded.

Tried to remove confusion by just having all the tests use the Base class' config as a member.

Test suite: scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
