### PR TITLE
Switch file compare count mismatch to a warning

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -487,14 +487,13 @@ class SystemTestsCommon(object):
             and self._expected_num_cmp != num_compared
         ):
             comments = comments.replace("PASS", "")
-            comments += """FAIL
+            comments += """\nWARNING
 Expected to compare {} hist files, but only compared {}. It's possible
 that the hist_file_extension entry in config_archive.xml is not correct
 for some of your components.
 """.format(
                 self._expected_num_cmp, num_compared
             )
-            success = False
 
         append_testlog(comments, self._orig_caseroot)
 


### PR DESCRIPTION
... instead of an error.

Too many E3SM components have problems in their config_archive.xml settings.

Test suite: by-hand.
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
