### PR TITLE
bless_test_results: improve error checking of bless_tests args

### DIFF
--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -156,9 +156,7 @@ def bless_test_results(
         if test_name is None:
             case_dir = os.path.basename(test_dir)
             test_name = CIME.utils.normalize_case_id(case_dir)
-            if not bless_tests or CIME.utils.match_any(
-                test_name, bless_tests_counts
-            ):
+            if not bless_tests or CIME.utils.match_any(test_name, bless_tests_counts):
                 broken_blesses.append(
                     (
                         "unknown",
@@ -309,11 +307,14 @@ def bless_test_results(
     if bless_tests:
         for bless_test, bless_count in bless_tests_counts.items():
             if bless_count == 0:
-                logger.warning("""
+                logger.warning(
+                    """
 bless test arg '{}' did not match any tests in test_root {} with
 compiler {} and test_id {}. It's possible that one of these arguments
-had a mistake (likely compiler or testid).""".format(bless_test,
-test_root, compiler, test_id))
+had a mistake (likely compiler or testid).""".format(
+                        bless_test, test_root, compiler, test_id
+                    )
+                )
 
     # Make sure user knows that some tests were not blessed
     success = True

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -137,6 +137,10 @@ def bless_test_results(
     most_recent = sorted(timestamps)[-1]
     logger.info("Matched test batch is {}".format(most_recent))
 
+    bless_tests_counts = None
+    if bless_tests:
+        bless_tests_counts = dict([(bless_test, 0) for bless_test in bless_tests])
+
     broken_blesses = []
     for test_status_file in test_status_files:
         if not most_recent in test_status_file:
@@ -152,8 +156,8 @@ def bless_test_results(
         if test_name is None:
             case_dir = os.path.basename(test_dir)
             test_name = CIME.utils.normalize_case_id(case_dir)
-            if bless_tests in [[], None] or CIME.utils.match_any(
-                test_name, bless_tests
+            if not bless_tests or CIME.utils.match_any(
+                test_name, bless_tests_counts
             ):
                 broken_blesses.append(
                     (
@@ -300,6 +304,16 @@ def bless_test_results(
 
                         if not success:
                             broken_blesses.append((test_name, reason))
+
+    # Emit a warning if items in bless_tests did not match anything
+    if bless_tests:
+        for bless_test, bless_count in bless_tests_counts.items():
+            if bless_count == 0:
+                logger.warning("""
+bless test arg '{}' did not match any tests in test_root {} with
+compiler {} and test_id {}. It's possible that one of these arguments
+had a mistake (likely compiler or testid).""".format(bless_test,
+test_root, compiler, test_id))
 
     # Make sure user knows that some tests were not blessed
     success = True

--- a/CIME/compare_test_results.py
+++ b/CIME/compare_test_results.py
@@ -90,7 +90,9 @@ def compare_test_results(
 
     compare_tests_counts = None
     if compare_tests:
-        compare_tests_counts = dict([(compare_test, 0) for compare_test in compare_tests])
+        compare_tests_counts = dict(
+            [(compare_test, 0) for compare_test in compare_tests]
+        )
 
     for test_status_file in test_status_files:
         test_dir = os.path.dirname(test_status_file)
@@ -100,9 +102,7 @@ def compare_test_results(
         testopts = [] if testopts is None else testopts
         build_only = "B" in testopts
 
-        if not compare_tests or CIME.utils.match_any(
-            test_name, compare_tests_counts
-        ):
+        if not compare_tests or CIME.utils.match_any(test_name, compare_tests_counts):
 
             if not hist_only:
                 nl_compare_result = None
@@ -211,10 +211,13 @@ def compare_test_results(
     if compare_tests:
         for compare_test, compare_count in compare_tests_counts.items():
             if compare_count == 0:
-                logger.warning("""
+                logging.warning(
+                    """
 compare test arg '{}' did not match any tests in test_root {} with
 compiler {} and test_id {}. It's possible that one of these arguments
-had a mistake (likely compiler or testid).""".format(compare_test,
-test_root, compiler, test_id))
+had a mistake (likely compiler or testid).""".format(
+                        compare_test, test_root, compiler, test_id
+                    )
+                )
 
     return all_pass_or_skip

--- a/CIME/compare_test_results.py
+++ b/CIME/compare_test_results.py
@@ -88,6 +88,10 @@ def compare_test_results(
 
     all_pass_or_skip = True
 
+    compare_tests_counts = None
+    if compare_tests:
+        compare_tests_counts = dict([(compare_test, 0) for compare_test in compare_tests])
+
     for test_status_file in test_status_files:
         test_dir = os.path.dirname(test_status_file)
         ts = TestStatus(test_dir=test_dir)
@@ -96,8 +100,8 @@ def compare_test_results(
         testopts = [] if testopts is None else testopts
         build_only = "B" in testopts
 
-        if compare_tests in [[], None] or CIME.utils.match_any(
-            test_name, compare_tests
+        if not compare_tests or CIME.utils.match_any(
+            test_name, compare_tests_counts
         ):
 
             if not hist_only:
@@ -202,5 +206,15 @@ def compare_test_results(
                 append_status_cprnc_log(
                     "Detailed comments:\n" + detailed_comments, logfile_name, test_dir
                 )
+
+    # Emit a warning if items in compare_tests did not match anything
+    if compare_tests:
+        for compare_test, compare_count in compare_tests_counts.items():
+            if compare_count == 0:
+                logger.warning("""
+compare test arg '{}' did not match any tests in test_root {} with
+compiler {} and test_id {}. It's possible that one of these arguments
+had a mistake (likely compiler or testid).""".format(compare_test,
+test_root, compiler, test_id))
 
     return all_pass_or_skip

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -1288,13 +1288,15 @@ def start_buffering_output():
     sys.stdout = os.fdopen(sys.stdout.fileno(), "w")
 
 
-def match_any(item, re_list):
+def match_any(item, re_counts):
     """
-    Return true if item matches any regex in re_list
+    Return true if item matches any regex in re_counts' keys. Increments
+    count if a match was found.
     """
-    for regex_str in re_list:
+    for regex_str in re_counts:
         regex = re.compile(regex_str)
         if regex.match(item):
+            re_counts[regex_str] += 1
             return True
 
     return False


### PR DESCRIPTION
Emit a warning when user-provided bless_test args don't
match anything since that is likely because they made
a mistake in the compiler or test-id.

Test suite: scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: bit for bit 

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
