### PR TITLE
Avoid reading in the same config tests file multiple times

### DIFF
--- a/CIME/XML/tests.py
+++ b/CIME/XML/tests.py
@@ -20,10 +20,19 @@ class Tests(GenericXML):
             infile = files.get_value("CONFIG_TESTS_FILE")
         GenericXML.__init__(self, infile)
         # append any component specific config_tests.xml files
+        infiles_read = set()
         for comp in files.get_components("CONFIG_TESTS_FILE"):
             if comp is None:
                 continue
             infile = files.get_value("CONFIG_TESTS_FILE", attribute={"component": comp})
+
+            # avoid reading the same file twice; this can be an issue when, for example,
+            # multiple land components have CONFIG_TESTS_FILE entries
+            if infile in infiles_read:
+                continue
+            else:
+                infiles_read.add(infile)
+
             if os.path.isfile(infile):
                 self.read(infile)
 


### PR DESCRIPTION
Resolves ESMCI/cime#4373. See that issue for details.

Test suite: `pre-commit run -a` and `pytest -vvv CIME/tests/test_unit*`; `scripts_regression_tests` (latter had one failure; passes when run from the command-line)
Test baseline: none
Test namelist changes: none
Test status: bit for bit

Fixes ESMCI/cime#4373

User interface changes?: N

Update gh-pages html (Y/N)?: N
