### PR TITLE
 Loosen the XSD xml specification for config_machines.xsd to be consistent with env_mach_specific.xsd

### DIFF
--- a/CIME/data/config/xml_schemas/config_machines.xsd
+++ b/CIME/data/config/xml_schemas/config_machines.xsd
@@ -252,7 +252,7 @@
   </xs:element>
   <xs:element name="command">
     <xs:complexType mixed="true">
-      <xs:attribute ref="name" use="required"/>
+      <xs:attribute name="name" use="required" type="xs:string"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="environment_variables">


### PR DESCRIPTION
[ Loosen the XSD xml specification for config_machines.xsd to be consistent with env_mach_specific.xsd]

Loosen the XSD specifications so machines added through `config_machines.xml` in `.cime` or `ccs_config` with module systems that require `--xxxx` options for module commands (f.e. `module --force purge` or `module --quiet restore`)  can be successfully added that way instead of doing manipulations with `env_mach_specific.xml`. The same way it has already been done [there](https://github.com/ESMCI/cime/commit/4c2c3213d6b1a957f33587e4eafbfdec1a4e7a05). 

It might be better to give an optional attribute for the `command` element in both places but I am not sure.

Tested on `saga.sigma2.no`.


Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
