### PR TITLE
Revert "Avoid reading in the same config tests file multiple times"

### DIFF
--- a/CIME/XML/tests.py
+++ b/CIME/XML/tests.py
@@ -20,19 +20,10 @@ class Tests(GenericXML):
             infile = files.get_value("CONFIG_TESTS_FILE")
         GenericXML.__init__(self, infile)
         # append any component specific config_tests.xml files
-        infiles_read = set()
         for comp in files.get_components("CONFIG_TESTS_FILE"):
             if comp is None:
                 continue
             infile = files.get_value("CONFIG_TESTS_FILE", attribute={"component": comp})
-
-            # avoid reading the same file twice; this can be an issue when, for example,
-            # multiple land components have CONFIG_TESTS_FILE entries
-            if infile in infiles_read:
-                continue
-            else:
-                infiles_read.add(infile)
-
             if os.path.isfile(infile):
                 self.read(infile)
 


### PR DESCRIPTION
This reverts commit 5d392bf1b0c9e6ad3eca508cecfaac7865b5a922.

I realized that the correct fix is a change in CTSM - https://github.com/billsacks/ctsm/commit/a022f80e9dafa80824d3b4a316470113e23c3ce6
- so this CIME change is unnecessary.

See https://github.com/ESMCI/cime/issues/4373#issuecomment-1481209827 for details.

Test suite: none
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: N

Update gh-pages html (Y/N)?: N
