### PR TITLE
should not test timestep of stub components

### DIFF
--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -307,6 +307,10 @@ def check_case(self, skip_pnl=False, chksum=False):
         for comp in self.get_values("COMP_CLASSES"):
             if comp == "CPL":
                 continue
+            compname = self.get_value("COMP_{}".format(comp))
+            # ignore stub components in this test.
+            if compname.startswith("S"):
+                continue
             ncpl = self.get_value("{}_NCPL".format(comp))
             if ncpl and maxncpl > ncpl:
                 maxncpl = ncpl

--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -310,7 +310,7 @@ def check_case(self, skip_pnl=False, chksum=False):
             compname = self.get_value("COMP_{}".format(comp))
 
             # ignore stub components in this test.
-            if compname.startswith("s"):
+            if compname == "s{}".format(comp.lower()):
                 ncpl = None
             else:
                 ncpl = self.get_value("{}_NCPL".format(comp))

--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -308,10 +308,13 @@ def check_case(self, skip_pnl=False, chksum=False):
             if comp == "CPL":
                 continue
             compname = self.get_value("COMP_{}".format(comp))
+
             # ignore stub components in this test.
-            if compname.startswith("S"):
-                continue
-            ncpl = self.get_value("{}_NCPL".format(comp))
+            if compname.startswith("s"):
+                ncpl = None
+            else:
+                ncpl = self.get_value("{}_NCPL".format(comp))
+
             if ncpl and maxncpl > ncpl:
                 maxncpl = ncpl
                 maxcomp = comp


### PR DESCRIPTION
This test was over conservative giving an error in aquaplanet cases for ROF_NCPL, since
ROF is not a part of an aquaplanet case we don't need this check.

Test suite:
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
