### PR TITLE
Add a note in SourceMods/src.cdeps/README

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1723,7 +1723,10 @@ class Case(object):
         if self._comp_interface == "nuopc":
             components.extend(["cdeps"])
 
-        readme_message = """Put source mods for the {component} library in this directory.
+        readme_message_start = (
+            "Put source mods for the {component} library in this directory."
+        )
+        readme_message_end = """
 
 WARNING: SourceMods are not kept under version control, and can easily
 become out of date if changes are made to the source code on which they
@@ -1757,7 +1760,18 @@ leveraging version control (git or svn).
                 # to fail).
                 readme_file = os.path.join(directory, "README")
                 with open(readme_file, "w") as fd:
-                    fd.write(readme_message.format(component=component))
+                    fd.write(readme_message_start.format(component=component))
+
+                    if component == "cdeps":
+                        readme_message_extra = """
+
+Note that this subdirectory should only contain files from CDEPS's
+dshr and streams source code directories.
+Files related to specific data models should go in SourceMods subdirectories
+for those data models (e.g., src.datm)."""
+                        fd.write(readme_message_extra)
+
+                    fd.write(readme_message_end)
 
         if config.copy_cism_source_mods:
             # Note: this is CESM specific, given that we are referencing cism explitly


### PR DESCRIPTION
Clarify what goes here vs. in other directories like src.datm.

This clarification was suggested by @olyson, who ran into problems when he put some datm SourceMods in src.cdeps (which seemed like an intuitive place to put them) and found that they weren't taking effect.

The resulting SourceMods/src.cdeps/README file looks like this:

```
Put source mods for the cdeps library in this directory.

Note that this subdirectory should only contain files from CDEPS's
dshr and streams source code directories.
Files related to specific data models should go in SourceMods subdirectories
for those data models (e.g., src.datm).

WARNING: SourceMods are not kept under version control, and can easily
become out of date if changes are made to the source code on which they
are based. We only recommend using SourceMods for small, short-term
changes that just apply to one or two cases. For larger or longer-term
changes, including gradual, incremental changes towards a final
solution, we highly recommend making changes in the main source tree,
leveraging version control (git or svn).
```

All other README files are unchanged

Test suite: Ran pre-commit -a; and manually checked SourceMods README files in all directories in an I compset from CTSM
Test baseline: N/A
Test namelist changes: none
Test status: bit for bit

Fixes none

User interface changes?: No

Update gh-pages html (Y/N)?: N
