### PR TITLE
Fix create_test --single-exe option

### DIFF
--- a/CIME/SystemTests/dae.py
+++ b/CIME/SystemTests/dae.py
@@ -27,7 +27,7 @@ class DAE(SystemTestsCompareTwo):
     """
 
     ###########################################################################
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         ###########################################################################
         SystemTestsCompareTwo.__init__(
             self,
@@ -36,6 +36,7 @@ class DAE(SystemTestsCompareTwo):
             run_two_suffix="da",
             run_one_description="no data assimilation",
             run_two_description="data assimilation",
+            **kwargs,
         )
 
     ###########################################################################

--- a/CIME/SystemTests/eri.py
+++ b/CIME/SystemTests/eri.py
@@ -38,11 +38,11 @@ def _helper(dout_sr, refdate, refsec, rundir):
 
 
 class ERI(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the ERI system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
         self._testname = "ERI"
 
     def run_phase(self):

--- a/CIME/SystemTests/erio.py
+++ b/CIME/SystemTests/erio.py
@@ -10,11 +10,11 @@ logger = logging.getLogger(__name__)
 
 
 class ERIO(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to file env_test.xml in the case directory
         """
-        SystemTestsCommon.__init__(self, case, expected=["TEST"])
+        SystemTestsCommon.__init__(self, case, expected=["TEST"], **kwargs)
 
         self._pio_types = self._case.get_env("run").get_valid_values("PIO_TYPENAME")
         self._stop_n = self._case.get_value("STOP_N")

--- a/CIME/SystemTests/erp.py
+++ b/CIME/SystemTests/erp.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class ERP(RestartTest):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize a test object
         """
@@ -26,6 +26,7 @@ class ERP(RestartTest):
             run_two_suffix="rest",
             run_one_description="initial",
             run_two_description="restart",
+            **kwargs
         )
 
     def _case_two_setup(self):

--- a/CIME/SystemTests/err.py
+++ b/CIME/SystemTests/err.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class ERR(RestartTest):
-    def __init__(self, case):  # pylint: disable=super-init-not-called
+    def __init__(self, case, **kwargs):  # pylint: disable=super-init-not-called
         """
         initialize an object interface to the ERR system test
         """
@@ -22,6 +22,7 @@ class ERR(RestartTest):
             run_one_description="initial",
             run_two_description="restart",
             multisubmit=True,
+            **kwargs
         )
 
     def _case_one_setup(self):

--- a/CIME/SystemTests/erri.py
+++ b/CIME/SystemTests/erri.py
@@ -12,11 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 class ERRI(ERR):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the ERU system test
         """
-        ERR.__init__(self, case)
+        ERR.__init__(self, case, **kwargs)
 
     def _case_two_custom_postrun_action(self):
         rundir = self._case.get_value("RUNDIR")

--- a/CIME/SystemTests/ers.py
+++ b/CIME/SystemTests/ers.py
@@ -9,11 +9,11 @@ logger = logging.getLogger(__name__)
 
 
 class ERS(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the ERS system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
 
     def _ers_first_phase(self):
         stop_n = self._case.get_value("STOP_N")

--- a/CIME/SystemTests/ers2.py
+++ b/CIME/SystemTests/ers2.py
@@ -8,11 +8,11 @@ logger = logging.getLogger(__name__)
 
 
 class ERS2(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the ERS2 system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
 
     def _ers2_first_phase(self):
         stop_n = self._case.get_value("STOP_N")

--- a/CIME/SystemTests/ert.py
+++ b/CIME/SystemTests/ert.py
@@ -10,11 +10,11 @@ logger = logging.getLogger(__name__)
 
 
 class ERT(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the ERT system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
 
     def _ert_first_phase(self):
 

--- a/CIME/SystemTests/funit.py
+++ b/CIME/SystemTests/funit.py
@@ -12,11 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 class FUNIT(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the FUNIT system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
         case.load_env()
 
     def build_phase(self, sharedlib_only=False, model_only=False):

--- a/CIME/SystemTests/homme.py
+++ b/CIME/SystemTests/homme.py
@@ -2,6 +2,6 @@ from CIME.SystemTests.hommebaseclass import HommeBase
 
 
 class HOMME(HommeBase):
-    def __init__(self, case):
-        HommeBase.__init__(self, case)
+    def __init__(self, case, **kwargs):
+        HommeBase.__init__(self, case, **kwargs)
         self.cmakesuffix = ""

--- a/CIME/SystemTests/hommebaseclass.py
+++ b/CIME/SystemTests/hommebaseclass.py
@@ -14,11 +14,11 @@ logger = logging.getLogger(__name__)
 
 
 class HommeBase(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the SMS system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
         case.load_env()
         self.csnd = "not defined"
         self.cmakesuffix = self.csnd

--- a/CIME/SystemTests/hommebfb.py
+++ b/CIME/SystemTests/hommebfb.py
@@ -2,6 +2,6 @@ from CIME.SystemTests.hommebaseclass import HommeBase
 
 
 class HOMMEBFB(HommeBase):
-    def __init__(self, case):
-        HommeBase.__init__(self, case)
+    def __init__(self, case, **kwargs):
+        HommeBase.__init__(self, case, **kwargs)
         self.cmakesuffix = "-bfb"

--- a/CIME/SystemTests/icp.py
+++ b/CIME/SystemTests/icp.py
@@ -6,11 +6,11 @@ from CIME.SystemTests.system_tests_common import SystemTestsCommon
 
 
 class ICP(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to file env_test.xml in the case directory
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
 
     def build_phase(self, sharedlib_only=False, model_only=False):
         self._case.set_value("CICE_AUTO_DECOMP", "false")

--- a/CIME/SystemTests/irt.py
+++ b/CIME/SystemTests/irt.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class IRT(RestartTest):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         RestartTest.__init__(
             self,
             case,
@@ -28,6 +28,7 @@ class IRT(RestartTest):
             run_one_description="initial",
             run_two_description="restart",
             multisubmit=False,
+            **kwargs
         )
         self._skip_pnl = False
 

--- a/CIME/SystemTests/ldsta.py
+++ b/CIME/SystemTests/ldsta.py
@@ -30,11 +30,11 @@ def _date_to_datetime(date_obj):
 
 
 class LDSTA(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the SMS system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
 
     def run_phase(self):
         archive_dir = self._case.get_value("DOUT_S_ROOT")

--- a/CIME/SystemTests/mcc.py
+++ b/CIME/SystemTests/mcc.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class MCC(SystemTestsCompareTwo):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         self._comp_classes = []
         self._test_instances = 3
         SystemTestsCompareTwo.__init__(
@@ -21,6 +21,7 @@ class MCC(SystemTestsCompareTwo):
             run_two_suffix="single_instance",
             run_two_description="single instance",
             run_one_description="multi driver",
+            **kwargs
         )
 
     def _case_one_setup(self):

--- a/CIME/SystemTests/mvk.py
+++ b/CIME/SystemTests/mvk.py
@@ -28,11 +28,11 @@ NINST = 30
 
 
 class MVK(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the MVK test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
 
         if self._case.get_value("MODEL") == "e3sm":
             self.component = "eam"

--- a/CIME/SystemTests/nck.py
+++ b/CIME/SystemTests/nck.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class NCK(SystemTestsCompareTwo):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         self._comp_classes = []
         SystemTestsCompareTwo.__init__(
             self,
@@ -24,6 +24,7 @@ class NCK(SystemTestsCompareTwo):
             run_two_suffix="multiinst",
             run_one_description="one instance",
             run_two_description="two instances",
+            **kwargs,
         )
 
     def _common_setup(self):

--- a/CIME/SystemTests/ncr.py
+++ b/CIME/SystemTests/ncr.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class NCR(SystemTestsCompareTwo):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an NCR test
         """
@@ -26,6 +26,7 @@ class NCR(SystemTestsCompareTwo):
             run_two_suffix="singleinst",
             run_one_description="two instances, each with the same number of tasks",
             run_two_description="default build",
+            **kwargs
         )
 
     def _comp_classes(self):

--- a/CIME/SystemTests/nodefail.py
+++ b/CIME/SystemTests/nodefail.py
@@ -9,11 +9,11 @@ logger = logging.getLogger(__name__)
 
 
 class NODEFAIL(ERS):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the ERS system test
         """
-        ERS.__init__(self, case)
+        ERS.__init__(self, case, **kwargs)
 
         self._fail_sentinel = os.path.join(case.get_value("RUNDIR"), "FAIL_SENTINEL")
         self._fail_str = case.get_value("NODE_FAIL_REGEX")

--- a/CIME/SystemTests/pea.py
+++ b/CIME/SystemTests/pea.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class PEA(SystemTestsCompareTwo):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         SystemTestsCompareTwo.__init__(
             self,
             case,
@@ -22,6 +22,7 @@ class PEA(SystemTestsCompareTwo):
             run_two_suffix="mpi-serial",
             run_one_description="default mpi library",
             run_two_description="mpi-serial",
+            **kwargs,
         )
 
     def _common_setup(self):

--- a/CIME/SystemTests/pem.py
+++ b/CIME/SystemTests/pem.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class PEM(SystemTestsCompareTwo):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         SystemTestsCompareTwo.__init__(
             self,
             case,
@@ -23,6 +23,7 @@ class PEM(SystemTestsCompareTwo):
             run_two_suffix="modpes",
             run_one_description="default pe counts",
             run_two_description="halved pe counts",
+            **kwargs
         )
 
     def _case_one_setup(self):

--- a/CIME/SystemTests/pet.py
+++ b/CIME/SystemTests/pet.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class PET(SystemTestsCompareTwo):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize a test object
         """
@@ -25,6 +25,7 @@ class PET(SystemTestsCompareTwo):
             run_two_suffix="single_thread",
             run_one_description="default threading",
             run_two_description="threads set to 1",
+            **kwargs
         )
 
     def _case_one_setup(self):

--- a/CIME/SystemTests/pfs.py
+++ b/CIME/SystemTests/pfs.py
@@ -11,11 +11,11 @@ logger = logging.getLogger(__name__)
 
 
 class PFS(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the PFS system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
 
     def run_phase(self):
         logger.info("doing an 20 day initial test, no restarts written")

--- a/CIME/SystemTests/pgn.py
+++ b/CIME/SystemTests/pgn.py
@@ -50,11 +50,11 @@ INSTANCE_FILE_TEMPLATE = "{}{}_{:04d}.h0.0001-01-01-00000{}.nc"
 
 
 class PGN(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the PGN test
         """
-        super(PGN, self).__init__(case)
+        super(PGN, self).__init__(case, **kwargs)
         if self._case.get_value("MODEL") == "e3sm":
             self.atmmod = "eam"
             self.lndmod = "elm"

--- a/CIME/SystemTests/pre.py
+++ b/CIME/SystemTests/pre.py
@@ -25,7 +25,7 @@ class PRE(SystemTestsCompareTwo):
     """
 
     ###########################################################################
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         ###########################################################################
         SystemTestsCompareTwo.__init__(
             self,
@@ -34,6 +34,7 @@ class PRE(SystemTestsCompareTwo):
             run_two_suffix="pr",
             run_one_description="no pause/resume",
             run_two_description="pause/resume",
+            **kwargs
         )
         self._stopopt = ""
         self._stopn = 0

--- a/CIME/SystemTests/rep.py
+++ b/CIME/SystemTests/rep.py
@@ -8,9 +8,9 @@ from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 
 
 class REP(SystemTestsCompareTwo):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         SystemTestsCompareTwo.__init__(
-            self, case, separate_builds=False, run_two_suffix="rep2"
+            self, case, separate_builds=False, run_two_suffix="rep2", **kwargs
         )
 
     def _case_one_setup(self):

--- a/CIME/SystemTests/restart_tests.py
+++ b/CIME/SystemTests/restart_tests.py
@@ -18,6 +18,7 @@ class RestartTest(SystemTestsCompareTwo):
         run_one_description="initial",
         run_two_description="restart",
         multisubmit=False,
+        **kwargs
     ):
         SystemTestsCompareTwo.__init__(
             self,
@@ -27,6 +28,7 @@ class RestartTest(SystemTestsCompareTwo):
             run_one_description=run_one_description,
             run_two_description=run_two_description,
             multisubmit=multisubmit,
+            **kwargs
         )
 
     def _case_one_setup(self):

--- a/CIME/SystemTests/reuseinitfiles.py
+++ b/CIME/SystemTests/reuseinitfiles.py
@@ -20,7 +20,7 @@ from CIME.SystemTests.system_tests_common import INIT_GENERATED_FILES_DIRNAME
 
 
 class REUSEINITFILES(SystemTestsCompareTwo):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         SystemTestsCompareTwo.__init__(
             self,
             case,
@@ -32,6 +32,7 @@ class REUSEINITFILES(SystemTestsCompareTwo):
             # init_generated_files from case1 and then need to make sure they are NOT
             # deleted like is normally done for tests:
             case_two_keep_init_generated_files=True,
+            **kwargs
         )
 
     def _case_one_setup(self):

--- a/CIME/SystemTests/seq.py
+++ b/CIME/SystemTests/seq.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class SEQ(SystemTestsCompareTwo):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to file env_test.xml in the case directory
         """
@@ -19,6 +19,7 @@ class SEQ(SystemTestsCompareTwo):
             run_two_suffix="seq",
             run_one_description="base",
             run_two_description="sequence",
+            **kwargs
         )
 
     def _case_one_setup(self):

--- a/CIME/SystemTests/sms.py
+++ b/CIME/SystemTests/sms.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 
 class SMS(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the SMS system test
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -76,7 +76,9 @@ def is_single_exe_case(case):
 
 
 class SystemTestsCommon(object):
-    def __init__(self, case, expected=None):
+    def __init__(
+        self, case, expected=None, **kwargs
+    ):  # pylint: disable=unused-argument
         """
         initialize a CIME system test object, if the locked env_run.orig.xml
         does not exist copy the current env_run.xml file.  If it does exist restore values
@@ -874,8 +876,8 @@ class FakeTest(SystemTestsCommon):
     in utils.py will work with these classes.
     """
 
-    def __init__(self, case, expected=None):
-        super(FakeTest, self).__init__(case, expected=expected)
+    def __init__(self, case, expected=None, **kwargs):
+        super(FakeTest, self).__init__(case, expected=expected, **kwargs)
         self._script = None
         self._requires_exe = False
         self._case._non_local = True
@@ -1093,8 +1095,8 @@ class TESTBUILDFAIL(TESTRUNPASS):
 
 
 class TESTBUILDFAILEXC(FakeTest):
-    def __init__(self, case):
-        FakeTest.__init__(self, case)
+    def __init__(self, case, **kwargs):
+        FakeTest.__init__(self, case, **kwargs)
         raise RuntimeError("Exception from init")
 
 

--- a/CIME/SystemTests/system_tests_compare_n.py
+++ b/CIME/SystemTests/system_tests_compare_n.py
@@ -40,7 +40,7 @@ In addition, they MAY require the following methods:
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.SystemTests.system_tests_common import SystemTestsCommon, fix_single_exe_case
 from CIME.case import Case
 from CIME.config import Config
 from CIME.test_status import *
@@ -504,6 +504,7 @@ class SystemTestsCompareN(SystemTestsCommon):
         self._activate_case(i)
         self._common_setup()
         self._case_setup(i)
+        fix_single_exe_case(self._cases[i])
         if i == 0:
             # Flush the case so that, if errors occur later, then at least base case is
             # in a correct, post-setup state. This is important because the mere
@@ -516,6 +517,7 @@ class SystemTestsCompareN(SystemTestsCommon):
             # This assures that case one namelists are populated
             # and creates the case.test script
             self._case.case_setup(test_mode=False, reset=True)
+            fix_single_exe_case(self._case)
         else:
             # Go back to base case to ensure that's where we are for any following code
             self._activate_case(0)

--- a/CIME/SystemTests/system_tests_compare_n.py
+++ b/CIME/SystemTests/system_tests_compare_n.py
@@ -60,6 +60,8 @@ class SystemTestsCompareN(SystemTestsCommon):
         run_descriptions=None,
         multisubmit=False,
         ignore_fieldlist_diffs=False,
+        dry_run=False,
+        **kwargs
     ):
         """
         Initialize a SystemTestsCompareN object. Individual test cases that
@@ -84,7 +86,7 @@ class SystemTestsCompareN(SystemTestsCommon):
                 the cases as identical. (This is needed for tests where one case
                 exercises an option that produces extra diagnostic fields.)
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
 
         self._separate_builds = separate_builds
         self._ignore_fieldlist_diffs = ignore_fieldlist_diffs
@@ -129,7 +131,8 @@ class SystemTestsCompareN(SystemTestsCommon):
         self._cases[0] = self._case
         self._caseroots = self._get_caseroots()
 
-        self._setup_cases_if_not_yet_done()
+        if not dry_run:
+            self._setup_cases_if_not_yet_done()
 
         self._multisubmit = (
             multisubmit and self._cases[0].get_value("BATCH_SYSTEM") != "none"

--- a/CIME/SystemTests/system_tests_compare_two.py
+++ b/CIME/SystemTests/system_tests_compare_two.py
@@ -45,7 +45,7 @@ In addition, they MAY require the following methods:
 """
 
 from CIME.XML.standard_module_setup import *
-from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.SystemTests.system_tests_common import SystemTestsCommon, fix_single_exe_case
 from CIME.case import Case
 from CIME.config import Config
 from CIME.test_status import *
@@ -548,12 +548,15 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # This assures that case one namelists are populated
         # and creates the case.test script
         self._case.case_setup(test_mode=False, reset=True)
+        fix_single_exe_case(self._case)
 
         # Set up case 2
         with self._case2:
             self._activate_case2()
             self._common_setup()
             self._case_two_setup()
+
+        fix_single_exe_case(self._case2)
 
         # Go back to case 1 to ensure that's where we are for any following code
         self._activate_case1()

--- a/CIME/SystemTests/system_tests_compare_two.py
+++ b/CIME/SystemTests/system_tests_compare_two.py
@@ -66,6 +66,8 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         multisubmit=False,
         ignore_fieldlist_diffs=False,
         case_two_keep_init_generated_files=False,
+        dry_run=False,
+        **kwargs
     ):
         """
         Initialize a SystemTestsCompareTwo object. Individual test cases that
@@ -98,7 +100,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
                 is provided for the sake of specific tests, e.g., a test of the behavior
                 of running with init_generated_files in place.
         """
-        SystemTestsCommon.__init__(self, case)
+        SystemTestsCommon.__init__(self, case, **kwargs)
 
         self._separate_builds = separate_builds
         self._ignore_fieldlist_diffs = ignore_fieldlist_diffs
@@ -136,7 +138,9 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         # _setup_cases_if_not_yet_done
         self._case2 = None
 
-        self._setup_cases_if_not_yet_done()
+        # Prevent additional setup_case calls when detecting support for `--single-exe`
+        if not dry_run:
+            self._setup_cases_if_not_yet_done()
 
         self._multisubmit = (
             multisubmit and self._case1.get_value("BATCH_SYSTEM") != "none"

--- a/CIME/SystemTests/tsc.py
+++ b/CIME/SystemTests/tsc.py
@@ -49,11 +49,11 @@ P_THRESHOLD = 0.005
 
 
 class TSC(SystemTestsCommon):
-    def __init__(self, case):
+    def __init__(self, case, **kwargs):
         """
         initialize an object interface to the TSC test
         """
-        super(TSC, self).__init__(case)
+        super(TSC, self).__init__(case, **kwargs)
         if self._case.get_value("MODEL") == "e3sm":
             self.atmmod = "eam"
             self.lndmod = "elm"

--- a/CIME/XML/tests.py
+++ b/CIME/XML/tests.py
@@ -3,6 +3,7 @@ Interface to the config_tests.xml file.  This class inherits from GenericEntry
 """
 from CIME.XML.standard_module_setup import *
 
+from CIME import utils
 from CIME.XML.generic_xml import GenericXML
 from CIME.XML.files import Files
 
@@ -26,6 +27,30 @@ class Tests(GenericXML):
             infile = files.get_value("CONFIG_TESTS_FILE", attribute={"component": comp})
             if os.path.isfile(infile):
                 self.read(infile)
+
+    def support_single_exe(self, testnames):
+        valid, invalid = [], []
+
+        for testname in testnames:
+            parsed_testname = utils.parse_test_name(testname)
+
+            test_node = self.get_test_node(parsed_testname[0])
+
+            try:
+                single_exe_node = self.get_child("SINGLE_EXE", root=test_node)
+            except utils.CIMEError:
+                single_exe_supported = False
+            else:
+                single_exe_supported = utils.convert_to_type(
+                    self.text(single_exe_node), "logical"
+                )
+
+            if single_exe_supported:
+                valid.append(testname)
+            else:
+                invalid.append(testname)
+
+        return valid, invalid
 
     def get_test_node(self, testname):
         logger.debug("Get settings for {}".format(testname))

--- a/CIME/XML/tests.py
+++ b/CIME/XML/tests.py
@@ -37,7 +37,7 @@ class Tests(GenericXML):
             test_node = self.get_test_node(parsed_testname[0])
 
             try:
-                single_exe_node = self.get_child("SINGLE_EXE", root=test_node)
+                single_exe_node = self.get_child("ALLOW_SINGLE_EXE", root=test_node)
             except utils.CIMEError:
                 single_exe_supported = False
             else:

--- a/CIME/XML/tests.py
+++ b/CIME/XML/tests.py
@@ -40,7 +40,7 @@ class Tests(GenericXML):
         testname = case.get_value("TESTCASE")
 
         try:
-            test = find_system_test(testname, case)(case)
+            test = find_system_test(testname, case)(case, dry_run=True)
         except Exception as e:
             raise e
         else:

--- a/CIME/XML/tests.py
+++ b/CIME/XML/tests.py
@@ -37,7 +37,7 @@ class Tests(GenericXML):
             test_node = self.get_test_node(parsed_testname[0])
 
             try:
-                single_exe_node = self.get_child("ALLOW_SINGLE_EXE", root=test_node)
+                single_exe_node = self.get_child("SINGLE_EXE", root=test_node)
             except utils.CIMEError:
                 single_exe_supported = False
             else:

--- a/CIME/data/config/config_tests.xml
+++ b/CIME/data/config/config_tests.xml
@@ -233,6 +233,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>ndays</HIST_OPTION>
     <HIST_N>1</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERI">
@@ -307,6 +308,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S_SAVE_INTERIM_RESTART_FILES>TRUE</DOUT_S_SAVE_INTERIM_RESTART_FILES>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERIO">
@@ -330,6 +332,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <RESUBMIT>1</RESUBMIT>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERRI">
@@ -344,6 +347,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>TRUE</DOUT_S>
     <RESUBMIT>1</RESUBMIT>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERT">
@@ -409,6 +413,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>nhours</HIST_OPTION>
     <HIST_N>1</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="TESTBUILDFAIL" INFRASTRUCTURE_TEST="TRUE">
@@ -602,6 +607,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_N>$STOP_N</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
     <RESUBMIT>1</RESUBMIT>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="PFS">
@@ -682,6 +688,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>never</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="REUSEINITFILES">
@@ -692,6 +699,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>never</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="SBN">

--- a/CIME/data/config/config_tests.xml
+++ b/CIME/data/config/config_tests.xml
@@ -251,6 +251,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <HIST_OPTION>never</HIST_OPTION>
     <HIST_N>-999</HIST_N>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERP">
@@ -278,6 +279,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERS2">
@@ -291,6 +293,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="IRT">
@@ -313,6 +316,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERR">
@@ -350,6 +354,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <AVGHIST_OPTION>nmonths</AVGHIST_OPTION>
     <AVGHIST_N>1</AVGHIST_N>
     <DOUT_S>FALSE</DOUT_S>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="HOMME">
@@ -359,6 +364,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="HOMMEBFB">
@@ -368,6 +374,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="FUNIT">
@@ -377,6 +384,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="LDSTA">
@@ -390,6 +398,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_N>1</REST_N>
     <RUN_STARTDATE>0001-12-29</RUN_STARTDATE>
     <DOUT_S>FALSE</DOUT_S>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="PRE">
@@ -558,6 +567,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <COMP_RUN_BARRIERS>TRUE</COMP_RUN_BARRIERS>
     <DOUT_S>FALSE</DOUT_S>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="PEA">
@@ -603,6 +613,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <OCN_DIAG_MODE>none</OCN_DIAG_MODE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="MCC">
@@ -628,6 +639,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
     <RESUBMIT>0</RESUBMIT>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="NCK">
@@ -709,6 +721,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="TSC">
@@ -717,6 +730,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <REST_OPTION>none</REST_OPTION>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="SMS">
@@ -727,6 +741,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
 </config_test>

--- a/CIME/data/config/config_tests.xml
+++ b/CIME/data/config/config_tests.xml
@@ -233,7 +233,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>ndays</HIST_OPTION>
     <HIST_N>1</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="ERI">
@@ -252,7 +252,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <HIST_OPTION>never</HIST_OPTION>
     <HIST_N>-999</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="ERP">
@@ -280,7 +280,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="ERS2">
@@ -294,7 +294,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="IRT">
@@ -308,7 +308,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S_SAVE_INTERIM_RESTART_FILES>TRUE</DOUT_S_SAVE_INTERIM_RESTART_FILES>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="ERIO">
@@ -318,7 +318,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="ERR">
@@ -332,7 +332,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <RESUBMIT>1</RESUBMIT>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="ERRI">
@@ -347,7 +347,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>TRUE</DOUT_S>
     <RESUBMIT>1</RESUBMIT>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="ERT">
@@ -358,7 +358,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <AVGHIST_OPTION>nmonths</AVGHIST_OPTION>
     <AVGHIST_N>1</AVGHIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="HOMME">
@@ -368,7 +368,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="HOMMEBFB">
@@ -378,7 +378,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="FUNIT">
@@ -388,7 +388,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="LDSTA">
@@ -402,7 +402,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_N>1</REST_N>
     <RUN_STARTDATE>0001-12-29</RUN_STARTDATE>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="PRE">
@@ -413,7 +413,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>nhours</HIST_OPTION>
     <HIST_N>1</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="TESTBUILDFAIL" INFRASTRUCTURE_TEST="TRUE">
@@ -572,7 +572,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <COMP_RUN_BARRIERS>TRUE</COMP_RUN_BARRIERS>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="PEA">
@@ -607,7 +607,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_N>$STOP_N</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
     <RESUBMIT>1</RESUBMIT>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="PFS">
@@ -619,7 +619,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <OCN_DIAG_MODE>none</OCN_DIAG_MODE>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="MCC">
@@ -645,7 +645,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
     <RESUBMIT>0</RESUBMIT>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="NCK">
@@ -688,7 +688,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>never</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="REUSEINITFILES">
@@ -699,7 +699,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>never</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="SBN">
@@ -729,7 +729,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="TSC">
@@ -738,7 +738,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <REST_OPTION>none</REST_OPTION>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
   <test NAME="SMS">
@@ -749,7 +749,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
   </test>
 
 </config_test>

--- a/CIME/data/config/config_tests.xml
+++ b/CIME/data/config/config_tests.xml
@@ -233,7 +233,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>ndays</HIST_OPTION>
     <HIST_N>1</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERI">
@@ -252,7 +252,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <HIST_OPTION>never</HIST_OPTION>
     <HIST_N>-999</HIST_N>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERP">
@@ -280,7 +280,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERS2">
@@ -294,7 +294,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="IRT">
@@ -308,7 +308,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S_SAVE_INTERIM_RESTART_FILES>TRUE</DOUT_S_SAVE_INTERIM_RESTART_FILES>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERIO">
@@ -318,7 +318,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERR">
@@ -332,7 +332,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <RESUBMIT>1</RESUBMIT>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERRI">
@@ -347,7 +347,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>TRUE</DOUT_S>
     <RESUBMIT>1</RESUBMIT>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERT">
@@ -358,7 +358,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <AVGHIST_OPTION>nmonths</AVGHIST_OPTION>
     <AVGHIST_N>1</AVGHIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="HOMME">
@@ -368,7 +368,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="HOMMEBFB">
@@ -378,7 +378,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="FUNIT">
@@ -388,7 +388,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="LDSTA">
@@ -402,7 +402,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_N>1</REST_N>
     <RUN_STARTDATE>0001-12-29</RUN_STARTDATE>
     <DOUT_S>FALSE</DOUT_S>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="PRE">
@@ -413,7 +413,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>nhours</HIST_OPTION>
     <HIST_N>1</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="TESTBUILDFAIL" INFRASTRUCTURE_TEST="TRUE">
@@ -572,7 +572,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <COMP_RUN_BARRIERS>TRUE</COMP_RUN_BARRIERS>
     <DOUT_S>FALSE</DOUT_S>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="PEA">
@@ -607,7 +607,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_N>$STOP_N</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
     <RESUBMIT>1</RESUBMIT>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="PFS">
@@ -619,7 +619,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <OCN_DIAG_MODE>none</OCN_DIAG_MODE>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="MCC">
@@ -645,7 +645,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
     <RESUBMIT>0</RESUBMIT>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="NCK">
@@ -688,7 +688,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>never</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="REUSEINITFILES">
@@ -699,7 +699,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>never</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="SBN">
@@ -729,7 +729,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="TSC">
@@ -738,7 +738,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <REST_OPTION>none</REST_OPTION>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="SMS">
@@ -749,7 +749,7 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <ALLOW_SINGLE_EXE>TRUE</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
 </config_test>

--- a/CIME/data/config/config_tests.xml
+++ b/CIME/data/config/config_tests.xml
@@ -233,7 +233,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>ndays</HIST_OPTION>
     <HIST_N>1</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERI">
@@ -305,7 +304,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S_SAVE_INTERIM_RESTART_FILES>TRUE</DOUT_S_SAVE_INTERIM_RESTART_FILES>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERIO">
@@ -328,7 +326,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <RESUBMIT>1</RESUBMIT>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERRI">
@@ -343,7 +340,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>TRUE</DOUT_S>
     <RESUBMIT>1</RESUBMIT>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERT">
@@ -404,7 +400,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>nhours</HIST_OPTION>
     <HIST_N>1</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="TESTBUILDFAIL" INFRASTRUCTURE_TEST="TRUE">
@@ -597,7 +592,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_N>$STOP_N</HIST_N>
     <DOUT_S>FALSE</DOUT_S>
     <RESUBMIT>1</RESUBMIT>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="PFS">
@@ -676,7 +670,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>never</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="REUSEINITFILES">
@@ -687,7 +680,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>never</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="SBN">

--- a/CIME/data/config/config_tests.xml
+++ b/CIME/data/config/config_tests.xml
@@ -252,7 +252,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <HIST_OPTION>never</HIST_OPTION>
     <HIST_N>-999</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERP">
@@ -280,7 +279,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERS2">
@@ -294,7 +292,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="IRT">
@@ -318,7 +315,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="ERR">
@@ -358,7 +354,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <AVGHIST_OPTION>nmonths</AVGHIST_OPTION>
     <AVGHIST_N>1</AVGHIST_N>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="HOMME">
@@ -368,7 +363,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="HOMMEBFB">
@@ -378,7 +372,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="FUNIT">
@@ -388,7 +381,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <STOP_N>11</STOP_N>
     <CHECK_TIMING>FALSE</CHECK_TIMING>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="LDSTA">
@@ -402,7 +394,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_N>1</REST_N>
     <RUN_STARTDATE>0001-12-29</RUN_STARTDATE>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="PRE">
@@ -572,7 +563,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <COMP_RUN_BARRIERS>TRUE</COMP_RUN_BARRIERS>
     <DOUT_S>FALSE</DOUT_S>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="PEA">
@@ -619,7 +609,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <OCN_DIAG_MODE>none</OCN_DIAG_MODE>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="MCC">
@@ -645,7 +634,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
     <RESUBMIT>0</RESUBMIT>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="NCK">
@@ -729,7 +717,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="TSC">
@@ -738,7 +725,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <DOUT_S>FALSE</DOUT_S>
     <CONTINUE_RUN>FALSE</CONTINUE_RUN>
     <REST_OPTION>none</REST_OPTION>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
   <test NAME="SMS">
@@ -749,7 +735,6 @@ NODEFAIL          Tests restart upon detected node failure. Generates fake failu
     <REST_OPTION>none</REST_OPTION>
     <HIST_OPTION>$STOP_OPTION</HIST_OPTION>
     <HIST_N>$STOP_N</HIST_N>
-    <SINGLE_EXE>TRUE</SINGLE_EXE>
   </test>
 
 </config_test>

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -42,6 +42,7 @@ from CIME.config import Config
 from CIME.XML.machines import Machines
 from CIME.case import Case
 from CIME.test_utils import get_tests_from_xml
+from CIME.XML.tests import Tests
 from argparse import RawTextHelpFormatter
 
 import argparse, math, glob
@@ -653,6 +654,16 @@ def parse_command_line(args, description):
 
         test_names = get_tests.get_full_test_names(
             args.testargs, mach_obj.get_machine_name(), args.compiler
+        )
+
+    if args.single_exe:
+        tests = Tests()
+
+        _, invalid = tests.support_single_exe(test_names)
+
+        expect(
+            len(invalid) == 0,
+            f"Found tests that do not support `--single-exe`: {', '.join(invalid)}",
         )
 
     expect(

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -42,7 +42,6 @@ from CIME.config import Config
 from CIME.XML.machines import Machines
 from CIME.case import Case
 from CIME.test_utils import get_tests_from_xml
-from CIME.XML.tests import Tests
 from argparse import RawTextHelpFormatter
 
 import argparse, math, glob
@@ -654,16 +653,6 @@ def parse_command_line(args, description):
 
         test_names = get_tests.get_full_test_names(
             args.testargs, mach_obj.get_machine_name(), args.compiler
-        )
-
-    if args.single_exe:
-        tests = Tests()
-
-        _, invalid = tests.support_single_exe(test_names)
-
-        expect(
-            len(invalid) == 0,
-            f"Found tests that do not support `--single-exe`: {', '.join(invalid)}",
         )
 
     expect(

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -224,7 +224,10 @@ class TestScheduler(object):
         self._input_dir = input_dir
         self._pesfile = pesfile
         self._allow_baseline_overwrite = allow_baseline_overwrite
-        self._allow_pnl = allow_pnl
+        if single_exe:
+            self._allow_pnl = True
+        else:
+            self._allow_pnl = allow_pnl
         self._non_local = non_local
         self._build_groups = []
         self._workflow = workflow

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -1003,7 +1003,12 @@ class TestScheduler(object):
             with Case(self._get_test_dir(test), read_only=False) as case:
                 tests = Tests()
 
-                tests.support_single_exe(case)
+                try:
+                    tests.support_single_exe(case)
+                except Exception:
+                    self._update_test_status_file(test, SETUP_PHASE, TEST_FAIL_STATUS)
+
+                    raise
 
         return rv
 

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -224,7 +224,8 @@ class TestScheduler(object):
         self._input_dir = input_dir
         self._pesfile = pesfile
         self._allow_baseline_overwrite = allow_baseline_overwrite
-        if single_exe:
+        self._single_exe = single_exe
+        if self._single_exe:
             self._allow_pnl = True
         else:
             self._allow_pnl = allow_pnl
@@ -997,6 +998,12 @@ class TestScheduler(object):
                 cmdstat in [0, TESTS_FAILED_ERR_CODE],
                 "Fatal error in case.cmpgen_namelists: {}".format(output),
             )
+
+        if self._single_exe:
+            with Case(self._get_test_dir(test), read_only=False) as case:
+                tests = Tests()
+
+                tests.support_single_exe(case)
 
         return rv
 

--- a/CIME/tests/test_unit_compare_two.py
+++ b/CIME/tests/test_unit_compare_two.py
@@ -15,6 +15,7 @@ import functools
 import os
 import shutil
 import tempfile
+from unittest import mock
 
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 import CIME.test_status as test_status
@@ -286,6 +287,40 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
             test_status.COMPARE_PHASE, run_one_suffix, run_two_suffix
         )
         return compare_phase_name
+
+    def test_resetup_case_single_exe(self):
+        # Setup
+        case1root = os.path.join(self.tempdir, "case1")
+        case1 = CaseFake(case1root)
+
+        mytest = SystemTestsCompareTwoFake(case1)
+
+        case1.set_value = mock.MagicMock()
+
+        case1.get_value = mock.MagicMock()
+        case1.get_value.side_effect = ["/tmp", "/tmp/bld", False]
+
+        mytest._resetup_case(test_status.RUN_PHASE, reset=True)
+
+        case1.set_value.assert_not_called()
+
+        case1.get_value.side_effect = ["/tmp", "/tmp/bld", True]
+
+        mytest._resetup_case(test_status.RUN_PHASE, reset=True)
+
+        case1.set_value.assert_not_called()
+
+        case1.get_value.side_effect = ["/tmp", "/other/bld", False]
+
+        mytest._resetup_case(test_status.RUN_PHASE, reset=True)
+
+        case1.set_value.assert_not_called()
+
+        case1.get_value.side_effect = ["/tmp", "/other/bld", True]
+
+        mytest._resetup_case(test_status.RUN_PHASE, reset=True)
+
+        case1.set_value.assert_called_with("BUILD_COMPLETE", True)
 
     def test_setup(self):
         # Ensure that test setup properly sets up case 1 and case 2

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+import os
+from re import A
+import unittest
+from unittest import mock
+from pathlib import Path
+
+from CIME.SystemTests.system_tests_common import SystemTestsCommon
+from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
+from CIME.SystemTests.system_tests_compare_n import SystemTestsCompareN
+
+class TestCaseSubmit(unittest.TestCase):
+    def test_kwargs(self):
+        case = mock.MagicMock()
+
+        case.get_value.side_effect = (
+            "/caseroot",
+            "SMS.f19_g16.S",
+            "cpl",
+            "/caseroot",
+            "SMS.f19_g16.S",
+        )
+
+        _ = SystemTestsCommon(case, something="random")
+
+        case = mock.MagicMock()
+
+        case.get_value.side_effect = (
+            "/caseroot",
+            "SMS.f19_g16.S",
+            "cpl",
+            "/caseroot",
+            "SMS.f19_g16.S",
+        )
+
+        SystemTestsCompareTwo._get_caseroot = mock.MagicMock()
+        SystemTestsCompareTwo._get_caseroot2 = mock.MagicMock()
+
+        _ = SystemTestsCompareTwo(case, something="random")
+
+        case = mock.MagicMock()
+
+        case.get_value.side_effect = (
+            "/caseroot",
+            "SMS.f19_g16.S",
+            "cpl",
+            "/caseroot",
+            "SMS.f19_g16.S",
+        )
+
+        SystemTestsCompareN._get_caseroots = mock.MagicMock()
+
+        _ = SystemTestsCompareN(case, something="random")
+
+    def test_dry_run(self):
+        case = mock.MagicMock()
+
+        case.get_value.side_effect = (
+            "/caseroot",
+            "SMS.f19_g16.S",
+            "cpl",
+            "/caseroot",
+            "SMS.f19_g16.S",
+        )
+
+        SystemTestsCompareTwo._setup_cases_if_not_yet_done = mock.MagicMock()
+
+        system_test = SystemTestsCompareTwo(case, dry_run=True)
+
+        system_test._setup_cases_if_not_yet_done.assert_not_called()
+
+        case = mock.MagicMock()
+
+        case.get_value.side_effect = (
+            "/caseroot",
+            "SMS.f19_g16.S",
+            "cpl",
+            "/caseroot",
+            "SMS.f19_g16.S",
+        )
+
+        system_test = SystemTestsCompareTwo(case)
+
+        system_test._setup_cases_if_not_yet_done.assert_called()
+
+        SystemTestsCompareN._setup_cases_if_not_yet_done = mock.MagicMock()
+
+        case = mock.MagicMock()
+
+        case.get_value.side_effect = (
+            "/caseroot",
+            "SMS.f19_g16.S",
+            "cpl",
+            "/caseroot",
+            "SMS.f19_g16.S",
+        )
+
+        system_test = SystemTestsCompareN(case, dry_run=True)
+
+        system_test._setup_cases_if_not_yet_done.assert_not_called()
+
+        case = mock.MagicMock()
+
+        case.get_value.side_effect = (
+            "/caseroot",
+            "SMS.f19_g16.S",
+            "cpl",
+            "/caseroot",
+            "SMS.f19_g16.S",
+        )
+
+        system_test = SystemTestsCompareN(case)
+
+        system_test._setup_cases_if_not_yet_done.assert_called()

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -35,10 +35,16 @@ class TestCaseSubmit(unittest.TestCase):
             "SMS.f19_g16.S",
         )
 
+        orig1 = SystemTestsCompareTwo._get_caseroot
+        orig2 = SystemTestsCompareTwo._get_caseroot2
+
         SystemTestsCompareTwo._get_caseroot = mock.MagicMock()
         SystemTestsCompareTwo._get_caseroot2 = mock.MagicMock()
 
         _ = SystemTestsCompareTwo(case, something="random")
+
+        SystemTestsCompareTwo._get_caseroot = orig1
+        SystemTestsCompareTwo._get_caseroot2 = orig2
 
         case = mock.MagicMock()
 
@@ -50,9 +56,13 @@ class TestCaseSubmit(unittest.TestCase):
             "SMS.f19_g16.S",
         )
 
+        orig = SystemTestsCompareN._get_caseroots
+
         SystemTestsCompareN._get_caseroots = mock.MagicMock()
 
         _ = SystemTestsCompareN(case, something="random")
+
+        SystemTestsCompareN._get_caseroots = orig
 
     def test_dry_run(self):
         case = mock.MagicMock()
@@ -64,6 +74,8 @@ class TestCaseSubmit(unittest.TestCase):
             "/caseroot",
             "SMS.f19_g16.S",
         )
+
+        orig = SystemTestsCompareTwo._setup_cases_if_not_yet_done
 
         SystemTestsCompareTwo._setup_cases_if_not_yet_done = mock.MagicMock()
 
@@ -84,6 +96,10 @@ class TestCaseSubmit(unittest.TestCase):
         system_test = SystemTestsCompareTwo(case)
 
         system_test._setup_cases_if_not_yet_done.assert_called()
+
+        SystemTestsCompareTwo._setup_cases_if_not_yet_done = orig
+
+        orig = SystemTestsCompareN._setup_cases_if_not_yet_done
 
         SystemTestsCompareN._setup_cases_if_not_yet_done = mock.MagicMock()
 
@@ -114,3 +130,5 @@ class TestCaseSubmit(unittest.TestCase):
         system_test = SystemTestsCompareN(case)
 
         system_test._setup_cases_if_not_yet_done.assert_called()
+
+        SystemTestsCompareN._setup_cases_if_not_yet_done = orig

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -10,6 +10,7 @@ from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.SystemTests.system_tests_compare_n import SystemTestsCompareN
 
+
 class TestCaseSubmit(unittest.TestCase):
     def test_kwargs(self):
         case = mock.MagicMock()

--- a/CIME/tests/test_unit_xml_tests.py
+++ b/CIME/tests/test_unit_xml_tests.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+import unittest
+import io
+
+from CIME.XML import tests
+
+SINGLE_EXE_DEFAULT_INVALID = """<?xml version="1.0"?>
+<config_test>
+  <test NAME="AAA">
+    <INFO_DBUG>1</INFO_DBUG>
+    <STOP_OPTION>ndays</STOP_OPTION>
+    <STOP_N>4</STOP_N>
+    <HIST_OPTION>ndays</HIST_OPTION>
+    <HIST_N>1</HIST_N>
+    <DOUT_S>FALSE</DOUT_S>
+  </test>
+</config_test>
+"""
+
+SINGLE_EXE_VALID = """<?xml version="1.0"?>
+<config_test>
+  <test NAME="AAA">
+    <SINGLE_EXE>true</SINGLE_EXE>
+    <INFO_DBUG>1</INFO_DBUG>
+    <STOP_OPTION>ndays</STOP_OPTION>
+    <STOP_N>4</STOP_N>
+    <HIST_OPTION>ndays</HIST_OPTION>
+    <HIST_N>1</HIST_N>
+    <DOUT_S>FALSE</DOUT_S>
+  </test>
+</config_test>
+"""
+
+SINGLE_EXE_INVALID = """<?xml version="1.0"?>
+<config_test>
+  <test NAME="AAA">
+    <SINGLE_EXE>false</SINGLE_EXE>
+    <INFO_DBUG>1</INFO_DBUG>
+    <STOP_OPTION>ndays</STOP_OPTION>
+    <STOP_N>4</STOP_N>
+    <HIST_OPTION>ndays</HIST_OPTION>
+    <HIST_N>1</HIST_N>
+    <DOUT_S>FALSE</DOUT_S>
+  </test>
+</config_test>
+"""
+
+
+class TestXMLTests(unittest.TestCase):
+    def setUp(self):
+        # reset file caching
+        tests.Tests._FILEMAP = {}
+
+    def test_support_single_exe_default_invalid(self):
+        buffer = io.StringIO(SINGLE_EXE_DEFAULT_INVALID)
+
+        xml_tests = tests.Tests()
+
+        xml_tests.read_fd(buffer)
+
+        valid, invalid = xml_tests.support_single_exe(["AAA.f19_g16.A"])
+
+        assert valid == []
+        assert invalid == ["AAA.f19_g16.A"]
+
+    def test_support_single_exe_valid(self):
+        buffer = io.StringIO(SINGLE_EXE_VALID)
+
+        xml_tests = tests.Tests()
+
+        xml_tests.read_fd(buffer)
+
+        valid, invalid = xml_tests.support_single_exe(["AAA.f19_g16.A"])
+
+        assert valid == ["AAA.f19_g16.A"]
+        assert invalid == []
+
+    def test_support_single_exe_invalid(self):
+        buffer = io.StringIO(SINGLE_EXE_INVALID)
+
+        xml_tests = tests.Tests()
+
+        xml_tests.read_fd(buffer)
+
+        valid, invalid = xml_tests.support_single_exe(["AAA.f19_g16.A"])
+
+        assert valid == []
+        assert invalid == ["AAA.f19_g16.A"]
+
+if __name__ == "__main__":
+    unittest.main()

--- a/CIME/tests/test_unit_xml_tests.py
+++ b/CIME/tests/test_unit_xml_tests.py
@@ -21,7 +21,7 @@ SINGLE_EXE_DEFAULT_INVALID = """<?xml version="1.0"?>
 SINGLE_EXE_VALID = """<?xml version="1.0"?>
 <config_test>
   <test NAME="AAA">
-    <SINGLE_EXE>true</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>true</ALLOW_SINGLE_EXE>
     <INFO_DBUG>1</INFO_DBUG>
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>4</STOP_N>
@@ -35,7 +35,7 @@ SINGLE_EXE_VALID = """<?xml version="1.0"?>
 SINGLE_EXE_INVALID = """<?xml version="1.0"?>
 <config_test>
   <test NAME="AAA">
-    <SINGLE_EXE>false</SINGLE_EXE>
+    <ALLOW_SINGLE_EXE>false</ALLOW_SINGLE_EXE>
     <INFO_DBUG>1</INFO_DBUG>
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>4</STOP_N>

--- a/CIME/tests/test_unit_xml_tests.py
+++ b/CIME/tests/test_unit_xml_tests.py
@@ -88,5 +88,6 @@ class TestXMLTests(unittest.TestCase):
         assert valid == []
         assert invalid == ["AAA.f19_g16.A"]
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/CIME/tests/test_unit_xml_tests.py
+++ b/CIME/tests/test_unit_xml_tests.py
@@ -1,92 +1,93 @@
 #!/usr/bin/env python3
 
+import re
 import unittest
-import io
+import tempfile
+from pathlib import Path
+from unittest import mock
 
-from CIME.XML import tests
-
-SINGLE_EXE_DEFAULT_INVALID = """<?xml version="1.0"?>
-<config_test>
-  <test NAME="AAA">
-    <INFO_DBUG>1</INFO_DBUG>
-    <STOP_OPTION>ndays</STOP_OPTION>
-    <STOP_N>4</STOP_N>
-    <HIST_OPTION>ndays</HIST_OPTION>
-    <HIST_N>1</HIST_N>
-    <DOUT_S>FALSE</DOUT_S>
-  </test>
-</config_test>
-"""
-
-SINGLE_EXE_VALID = """<?xml version="1.0"?>
-<config_test>
-  <test NAME="AAA">
-    <SINGLE_EXE>true</SINGLE_EXE>
-    <INFO_DBUG>1</INFO_DBUG>
-    <STOP_OPTION>ndays</STOP_OPTION>
-    <STOP_N>4</STOP_N>
-    <HIST_OPTION>ndays</HIST_OPTION>
-    <HIST_N>1</HIST_N>
-    <DOUT_S>FALSE</DOUT_S>
-  </test>
-</config_test>
-"""
-
-SINGLE_EXE_INVALID = """<?xml version="1.0"?>
-<config_test>
-  <test NAME="AAA">
-    <SINGLE_EXE>false</SINGLE_EXE>
-    <INFO_DBUG>1</INFO_DBUG>
-    <STOP_OPTION>ndays</STOP_OPTION>
-    <STOP_N>4</STOP_N>
-    <HIST_OPTION>ndays</HIST_OPTION>
-    <HIST_N>1</HIST_N>
-    <DOUT_S>FALSE</DOUT_S>
-  </test>
-</config_test>
-"""
+from CIME.XML.tests import Tests
 
 
 class TestXMLTests(unittest.TestCase):
     def setUp(self):
         # reset file caching
-        tests.Tests._FILEMAP = {}
+        Tests._FILEMAP = {}
 
-    def test_support_single_exe_default_invalid(self):
-        buffer = io.StringIO(SINGLE_EXE_DEFAULT_INVALID)
+    # skip hard to mock function call
+    @mock.patch(
+        "CIME.SystemTests.system_tests_compare_two.SystemTestsCompareTwo._setup_cases_if_not_yet_done"
+    )
+    def test_support_single_exe(self, _setup_cases_if_not_yet_done):
+        with tempfile.TemporaryDirectory() as tdir:
+            test_file = Path(tdir) / "sms.py"
 
-        xml_tests = tests.Tests()
+            test_file.touch(exist_ok=True)
 
-        xml_tests.read_fd(buffer)
+            caseroot = Path(tdir) / "caseroot1"
 
-        valid, invalid = xml_tests.support_single_exe(["AAA.f19_g16.A"])
+            caseroot.mkdir(exist_ok=True)
 
-        assert valid == []
-        assert invalid == ["AAA.f19_g16.A"]
+            case = mock.MagicMock()
 
-    def test_support_single_exe_valid(self):
-        buffer = io.StringIO(SINGLE_EXE_VALID)
+            case.get_compset_components.return_value = ()
 
-        xml_tests = tests.Tests()
+            case.get_value.side_effect = (
+                "SMS",
+                tdir,
+                f"{caseroot}",
+                "SMS.f19_g16.S",
+                "cpl",
+                "SMS.f19_g16.S",
+                f"{caseroot}",
+                "SMS.f19_g16.S",
+            )
 
-        xml_tests.read_fd(buffer)
+            tests = Tests()
 
-        valid, invalid = xml_tests.support_single_exe(["AAA.f19_g16.A"])
+            tests.support_single_exe(case)
 
-        assert valid == ["AAA.f19_g16.A"]
-        assert invalid == []
+    # skip hard to mock function call
+    @mock.patch(
+        "CIME.SystemTests.system_tests_compare_two.SystemTestsCompareTwo._setup_cases_if_not_yet_done"
+    )
+    def test_support_single_exe_error(self, _setup_cases_if_not_yet_done):
+        with tempfile.TemporaryDirectory() as tdir:
+            test_file = Path(tdir) / "pem.py"
 
-    def test_support_single_exe_invalid(self):
-        buffer = io.StringIO(SINGLE_EXE_INVALID)
+            test_file.touch(exist_ok=True)
 
-        xml_tests = tests.Tests()
+            caseroot = Path(tdir) / "caseroot1"
 
-        xml_tests.read_fd(buffer)
+            caseroot.mkdir(exist_ok=True)
 
-        valid, invalid = xml_tests.support_single_exe(["AAA.f19_g16.A"])
+            case = mock.MagicMock()
 
-        assert valid == []
-        assert invalid == ["AAA.f19_g16.A"]
+            case.get_compset_components.return_value = ()
+
+            case.get_value.side_effect = (
+                "PEM",
+                tdir,
+                f"{caseroot}",
+                "PEM.f19_g16.S",
+                "cpl",
+                "PEM.f19_g16.S",
+                f"{caseroot}",
+                "PEM.f19_g16.S",
+            )
+
+            tests = Tests()
+
+            with self.assertRaises(Exception) as e:
+                tests.support_single_exe(case)
+
+            assert (
+                re.search(
+                    r"does not support the '--single-exe' option as it requires separate builds",
+                    f"{e.exception}",
+                )
+                is not None
+            ), f"{e.exception}"
 
 
 if __name__ == "__main__":

--- a/CIME/tests/test_unit_xml_tests.py
+++ b/CIME/tests/test_unit_xml_tests.py
@@ -21,7 +21,7 @@ SINGLE_EXE_DEFAULT_INVALID = """<?xml version="1.0"?>
 SINGLE_EXE_VALID = """<?xml version="1.0"?>
 <config_test>
   <test NAME="AAA">
-    <ALLOW_SINGLE_EXE>true</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>true</SINGLE_EXE>
     <INFO_DBUG>1</INFO_DBUG>
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>4</STOP_N>
@@ -35,7 +35,7 @@ SINGLE_EXE_VALID = """<?xml version="1.0"?>
 SINGLE_EXE_INVALID = """<?xml version="1.0"?>
 <config_test>
   <test NAME="AAA">
-    <ALLOW_SINGLE_EXE>false</ALLOW_SINGLE_EXE>
+    <SINGLE_EXE>false</SINGLE_EXE>
     <INFO_DBUG>1</INFO_DBUG>
     <STOP_OPTION>ndays</STOP_OPTION>
     <STOP_N>4</STOP_N>


### PR DESCRIPTION
Adds a check in the `test_scheduler` for a tests ability to work with the 
`--single-exe` option. Checks if the test is not a compare two/n or does
not require separate builds.

Fixes `BUILD_COMPLETE` resetting to False when `--single-exe` is used
with SystemTestsCompareTwo and SystemTestsCompareN.

Test suite: pytest
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4376 

User interface changes?:
Update gh-pages html (Y/N)?:
