### PR TITLE
Preserve test ordering in suites with shared builds

### DIFF
--- a/CIME/get_tests.py
+++ b/CIME/get_tests.py
@@ -381,8 +381,8 @@ def get_full_test_names(testargs, machine, compiler):
     expect(compiler is not None, "Must define a compiler")
     e3sm_test_suites = get_test_suites()
 
-    tests_to_run = set()
-    negations = set()
+    tests_to_run = []
+    negations = []
 
     for testarg in testargs:
         # remove any whitespace in name
@@ -390,10 +390,10 @@ def get_full_test_names(testargs, machine, compiler):
         if testarg.startswith("^"):
             negations.add(testarg[1:])
         elif testarg in e3sm_test_suites:
-            tests_to_run.update(get_test_suite(testarg, machine, compiler))
+            tests_to_run += get_test_suite(testarg, machine, compiler)
         else:
             try:
-                tests_to_run.add(
+                tests_to_run.append(
                     CIME.utils.get_full_test_name(
                         testarg, machine=machine, compiler=compiler
                     )
@@ -406,7 +406,7 @@ def get_full_test_names(testargs, machine, compiler):
 
     for negation in negations:
         if negation in e3sm_test_suites:
-            tests_to_run -= set(get_test_suite(negation, machine, compiler))
+            tests_to_run -= get_test_suite(negation, machine, compiler)
         else:
             fullname = CIME.utils.get_full_test_name(
                 negation, machine=machine, compiler=compiler
@@ -414,7 +414,7 @@ def get_full_test_names(testargs, machine, compiler):
             if fullname in tests_to_run:
                 tests_to_run.remove(fullname)
 
-    return list(sorted(tests_to_run))
+    return tests_to_run
 
 
 ###############################################################################

--- a/CIME/get_tests.py
+++ b/CIME/get_tests.py
@@ -129,6 +129,7 @@ _CIME_TESTS = {
 
 _ALL_TESTS.update(_CIME_TESTS)
 
+
 ###############################################################################
 def _get_key_data(raw_dict, key, the_type):
     ###############################################################################
@@ -375,7 +376,7 @@ def get_full_test_names(testargs, machine, compiler):
     ['ERS.f19_g16_rx1.A.melvin_gnu']
 
     >>> get_full_test_names(["cime_test_multi_inherit"], "melvin", "gnu")
-    ['TESTBUILDFAILEXC_P1.f19_g16_rx1.A.melvin_gnu', 'TESTBUILDFAIL_P1.f19_g16_rx1.A.melvin_gnu', 'TESTMEMLEAKFAIL_P1.f09_g16.X.melvin_gnu', 'TESTMEMLEAKPASS_P1.f09_g16.X.melvin_gnu', 'TESTRUNDIFF_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNFAILEXC_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNFAIL_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P1.f45_g37_rx1.A.melvin_gnu', 'TESTRUNPASS_P1.ne30_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P2.ne30_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P4.f45_g37_rx1.A.melvin_gnu', 'TESTRUNSTARCFAIL_P1.f19_g16_rx1.A.melvin_gnu', 'TESTTESTDIFF_P1.f19_g16_rx1.A.melvin_gnu']
+    ['TESTRUNPASS_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P2.ne30_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P4.f45_g37_rx1.A.melvin_gnu', 'TESTRUNPASS_P1.ne30_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P1.f45_g37_rx1.A.melvin_gnu', 'TESTRUNDIFF_P1.f19_g16_rx1.A.melvin_gnu', 'TESTBUILDFAIL_P1.f19_g16_rx1.A.melvin_gnu', 'TESTBUILDFAILEXC_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNFAIL_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNSTARCFAIL_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNFAILEXC_P1.f19_g16_rx1.A.melvin_gnu', 'TESTTESTDIFF_P1.f19_g16_rx1.A.melvin_gnu', 'TESTMEMLEAKFAIL_P1.f09_g16.X.melvin_gnu', 'TESTMEMLEAKPASS_P1.f09_g16.X.melvin_gnu']
     """
     expect(machine is not None, "Must define a machine")
     expect(compiler is not None, "Must define a compiler")
@@ -388,7 +389,7 @@ def get_full_test_names(testargs, machine, compiler):
         # remove any whitespace in name
         testarg = testarg.strip()
         if testarg.startswith("^"):
-            negations.add(testarg[1:])
+            negations.append(testarg[1:])
         elif testarg in e3sm_test_suites:
             tests_to_run += get_test_suite(testarg, machine, compiler)
         else:

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -355,8 +355,8 @@ class TestScheduler(object):
                     "Use -o to avoid this error".format(existing_baselines),
                 )
 
-        if self._config.sort_tests:
-            _order_tests_by_runtime(test_names, self._baseline_root)
+        #if self._config.sort_tests:
+        #    _order_tests_by_runtime(test_names, self._baseline_root)
 
         # This is the only data that multiple threads will simultaneously access
         # Each test has it's own value and setting/retrieving items from a dict

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -62,6 +62,7 @@ PHASES = [
     RUN_PHASE,
 ]  # Order matters
 
+
 ###############################################################################
 def _translate_test_names_for_new_pecount(test_names, force_procs, force_threads):
     ###############################################################################
@@ -129,6 +130,8 @@ def _translate_test_names_for_new_pecount(test_names, force_procs, force_threads
 
 
 _TIME_CACHE = {}
+
+
 ###############################################################################
 def _get_time_est(test, baseline_root, as_int=False, use_cache=False, raw=False):
     ###############################################################################
@@ -355,8 +358,8 @@ class TestScheduler(object):
                     "Use -o to avoid this error".format(existing_baselines),
                 )
 
-        #if self._config.sort_tests:
-        #    _order_tests_by_runtime(test_names, self._baseline_root)
+        if self._config.sort_tests and not self._config.share_exes:
+            _order_tests_by_runtime(test_names, self._baseline_root)
 
         # This is the only data that multiple threads will simultaneously access
         # Each test has it's own value and setting/retrieving items from a dict
@@ -858,7 +861,6 @@ class TestScheduler(object):
         if case_opts is not None:
             logger.debug("case_opts are {} ".format(case_opts))
             for opt in case_opts:  # pylint: disable=not-an-iterable
-
                 logger.debug("case_opt is {}".format(opt))
                 if opt == "D":
                     envtest.set_test_parameter("DEBUG", "TRUE")


### PR DESCRIPTION
If all tests in a suite can share a single executable, it's desirable
to know which test's exe will be used by other tests in the suite: e.g.
```
    "e3sm_superbfb_ocn_opt" : {
        "share"   : True,
        "PEM.T62_oQU120.CMPASO-NYF.pemod-omp1",
        "ERS.T62_oQU120.CMPASO-NYF.pemod-omp1",
```
Currently, test scheduler re-orders tests alphanumerically and further sorts
by expected test run-times. It leads to unexpected pick of which
test gets built. This PR preserves test ordering in shared build suites:
build once, build the test listed first.

Test suite: `e3sm_superbfb_ocn`
Test baseline: same suite with `"share" : False`
Test namelist changes: none
Test status: bit for bit

User interface changes?: none

Update gh-pages html (Y/N)?: N