### PR TITLE
do not allow EXEROOT or OBJDIR or LIBROOT to be CASEROOT

### DIFF
--- a/CIME/XML/env_build.py
+++ b/CIME/XML/env_build.py
@@ -18,4 +18,19 @@ class EnvBuild(EnvBase):
         initialize an object interface to file env_build.xml in the case directory
         """
         schema = os.path.join(utils.get_schema_path(), "env_entry_id.xsd")
+        self._caseroot = case_root
         EnvBase.__init__(self, case_root, infile, schema=schema, read_only=read_only)
+
+    def set_value(self, vid, value, subgroup=None, ignore_type=False):
+        """
+        Set the value of an entry-id field to value
+        Returns the value or None if not found
+        subgroup is ignored in the general routine and applied in specific methods
+        """
+        # Do not allow any of these to be the same as CASEROOT
+        if vid in ("EXEROOT", "OBJDIR", "LIBROOT"):
+            utils.expect(value != self._caseroot, f"Cannot set {vid} to CASEROOT")
+
+        return super(EnvBuild, self).set_value(
+            vid, value, subgroup=subgroup, ignore_type=ignore_type
+        )


### PR DESCRIPTION
Do not allow EXEROOT, OBJDIR or LIBROOT to be CASEROOT.

Test suite: hand testing, SMS.f19_g17.x
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4313 

User interface changes?:

Update gh-pages html (Y/N)?:
