### PR TITLE
port to python 3.10, remove depricated shr_file_ log stuff

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -99,7 +99,7 @@ jobs:
     container: jasonb87/cime:latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -99,7 +99,7 @@ jobs:
     container: jasonb87/cime:latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,6 +183,8 @@ jobs:
         if: ${{ failure() }}
         shell: bash
         run: tar -czvf /testing-logs-${GITHUB_RUN_NUMBER}.tar.gz /storage/cases/
+        # How to download artifacts:
+        # https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts
       - name: Upload testing logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -165,6 +165,7 @@ def generate_makefile_macro(case, caseroot):
                 "gptl",
                 "csm_share",
                 "csm_share_cpl7",
+                "mpi-serial",
             ]
         )
         cmake_macro = os.path.join(caseroot, "Macros.cmake")

--- a/CIME/non_py/src/components/xcpl_comps_nuopc/xatm/src/atm_comp_nuopc.F90
+++ b/CIME/non_py/src/components/xcpl_comps_nuopc/xatm/src/atm_comp_nuopc.F90
@@ -14,7 +14,7 @@ module atm_comp_nuopc
   use NUOPC_Model       , only : NUOPC_ModelGet, SetVM
   use shr_sys_mod       , only : shr_sys_abort
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_file_mod      , only : shr_file_getlogunit, shr_file_setlogunit
+  use shr_log_mod      , only : shr_log_getlogunit, shr_log_setlogunit
   use dead_methods_mod  , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod  , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod    , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
@@ -270,7 +270,7 @@ contains
     end if
 
     ! Reset shr logging to original values
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeAdvertise
 
@@ -295,8 +295,8 @@ contains
     rc = ESMF_SUCCESS
 
     ! Reset shr logging to my log file
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logUnit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logUnit)
 
     ! generate the mesh
     call NUOPC_CompAttributeGet(gcomp, name='mesh_atm', value=cvalue, rc=rc)
@@ -349,7 +349,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeRealize
 
@@ -375,8 +375,8 @@ contains
     end if
     call memcheck(subname, 3, mastertask)
 
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logunit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logunit)
 
     !--------------------------------
     ! Pack export state
@@ -405,7 +405,7 @@ contains
        endif
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine ModelAdvance
 

--- a/CIME/non_py/src/components/xcpl_comps_nuopc/xglc/src/glc_comp_nuopc.F90
+++ b/CIME/non_py/src/components/xcpl_comps_nuopc/xglc/src/glc_comp_nuopc.F90
@@ -14,7 +14,7 @@ module glc_comp_nuopc
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_sys_mod      , only : shr_sys_abort
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_file_mod     , only : shr_file_getlogunit, shr_file_setlogunit
+  use shr_log_mod     , only : shr_log_getlogunit, shr_log_setlogunit
   use dead_methods_mod , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod   , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock

--- a/CIME/non_py/src/components/xcpl_comps_nuopc/xice/src/ice_comp_nuopc.F90
+++ b/CIME/non_py/src/components/xcpl_comps_nuopc/xice/src/ice_comp_nuopc.F90
@@ -14,7 +14,7 @@ module ice_comp_nuopc
   use NUOPC_Model       , only : NUOPC_ModelGet, SetVM
   use shr_sys_mod       , only : shr_sys_abort
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_file_mod      , only : shr_file_getlogunit, shr_file_setlogunit
+  use shr_log_mod      , only : shr_log_getlogunit, shr_log_setlogunit
   use dead_methods_mod  , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod  , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod    , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
@@ -281,7 +281,7 @@ contains
     ! Reset shr logging to original values
     !----------------------------------------------------------------------------
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeAdvertise
 
@@ -305,8 +305,8 @@ contains
     ! Reset shr logging to my log file
     !----------------------------------------------------------------------------
 
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logUnit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logUnit)
 
     !--------------------------------
     ! generate the mesh
@@ -368,7 +368,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeRealize
 
@@ -390,8 +390,8 @@ contains
     call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
     call memcheck(subname, 3, mastertask)
 
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logunit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logunit)
 
     !--------------------------------
     ! Pack export state
@@ -416,7 +416,7 @@ contains
        endif
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
     call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 

--- a/CIME/non_py/src/components/xcpl_comps_nuopc/xlnd/src/lnd_comp_nuopc.F90
+++ b/CIME/non_py/src/components/xcpl_comps_nuopc/xlnd/src/lnd_comp_nuopc.F90
@@ -14,7 +14,7 @@ module lnd_comp_nuopc
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_sys_mod      , only : shr_sys_abort
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_file_mod     , only : shr_file_getlogunit, shr_file_setlogunit
+  use shr_log_mod     , only : shr_log_getlogunit, shr_log_setlogunit
   use dead_methods_mod , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod   , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
@@ -292,7 +292,7 @@ contains
     ! Reset shr logging to original values
     !----------------------------------------------------------------------------
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeAdvertise
 
@@ -319,8 +319,8 @@ contains
     ! Reset shr logging to my log file
     !----------------------------------------------------------------------------
 
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logUnit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logUnit)
 
     !--------------------------------
     ! generate the mesh
@@ -382,7 +382,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
     if (dbug > 5) call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 
@@ -406,8 +406,8 @@ contains
     call ESMF_LogWrite(subname//' called', ESMF_LOGMSG_INFO, rc=rc)
     call memcheck(subname, 3, mastertask)
 
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logunit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logunit)
 
     !--------------------------------
     ! Pack export state
@@ -432,7 +432,7 @@ contains
        endif
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
     call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)
 

--- a/CIME/non_py/src/components/xcpl_comps_nuopc/xocn/src/ocn_comp_nuopc.F90
+++ b/CIME/non_py/src/components/xcpl_comps_nuopc/xocn/src/ocn_comp_nuopc.F90
@@ -14,7 +14,7 @@ module ocn_comp_nuopc
   use NUOPC_Model      , only : NUOPC_ModelGet, SetVM
   use shr_sys_mod      , only : shr_sys_abort
   use shr_kind_mod     , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_file_mod     , only : shr_file_getlogunit, shr_file_setlogunit
+  use shr_log_mod     , only : shr_log_getlogunit, shr_log_setlogunit
   use dead_methods_mod , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod   , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
@@ -238,7 +238,7 @@ contains
     end if
 
     ! Reset shr logging to original values
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeAdvertise
 
@@ -260,8 +260,8 @@ contains
     rc = ESMF_SUCCESS
 
     ! Reset shr logging to my log file
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logunit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logunit)
 
     ! generate the mesh
     call NUOPC_CompAttributeGet(gcomp, name='mesh_ocn', value=cvalue, rc=rc)
@@ -306,7 +306,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeRealize
 
@@ -328,8 +328,8 @@ contains
 
     call memcheck(subname, 3, mastertask)
 
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logunit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logunit)
 
     ! Pack export state
     call NUOPC_ModelGet(gcomp, modelClock=clock, exportState=exportState, rc=rc)
@@ -343,7 +343,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine ModelAdvance
 

--- a/CIME/non_py/src/components/xcpl_comps_nuopc/xrof/src/rof_comp_nuopc.F90
+++ b/CIME/non_py/src/components/xcpl_comps_nuopc/xrof/src/rof_comp_nuopc.F90
@@ -14,7 +14,7 @@ module rof_comp_nuopc
   use NUOPC_Model       , only : NUOPC_ModelGet, SetVM
   use shr_sys_mod       , only : shr_sys_abort
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_file_mod      , only : shr_file_getlogunit, shr_file_setlogunit
+  use shr_log_mod      , only : shr_log_getlogunit, shr_log_setlogunit
   use dead_methods_mod  , only : chkerr, state_setscalar, state_diagnose, alarmInit, memcheck
   use dead_methods_mod  , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod    , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
@@ -229,7 +229,7 @@ contains
     ! Reset shr logging to original values
     !----------------------------------------------------------------------------
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeAdvertise
 
@@ -251,8 +251,8 @@ contains
     rc = ESMF_SUCCESS
 
     ! Reset shr logging to my log file
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logUnit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logUnit)
 
 
     ! generate the mesh
@@ -304,7 +304,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeRealize
 
@@ -329,8 +329,8 @@ contains
     end if
     call memcheck(subname, 3, mastertask)
 
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logunit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logunit)
 
     ! Pack export state
     call NUOPC_ModelGet(gcomp, modelClock=clock, exportState=exportState, rc=rc)
@@ -348,7 +348,7 @@ contains
        endif
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
     if (dbug > 5) then
        call ESMF_LogWrite(subname//' done', ESMF_LOGMSG_INFO, rc=rc)

--- a/CIME/non_py/src/components/xcpl_comps_nuopc/xshare/dead_methods_mod.F90
+++ b/CIME/non_py/src/components/xcpl_comps_nuopc/xshare/dead_methods_mod.F90
@@ -22,7 +22,7 @@ module dead_methods_mod
   use NUOPC_Model  , only : NUOPC_ModelGet
   use shr_kind_mod , only : r8 => shr_kind_r8, cl=>shr_kind_cl, cs=>shr_kind_cs
   use shr_sys_mod  , only : shr_sys_abort
-  use shr_file_mod , only : shr_file_setlogunit, shr_file_getLogUnit
+  use shr_log_mod , only : shr_log_setlogunit, shr_log_getLogUnit
 
   implicit none
   private
@@ -157,7 +157,7 @@ contains
        logUnit = 6
     endif
 
-    call shr_file_setLogUnit (logunit)
+    call shr_log_setLogUnit (logunit)
 
     call ESMF_GridCompGet(gcomp, name=name, rc=rc)
     if (chkerr(rc,__LINE__,u_FILE_u)) return

--- a/CIME/non_py/src/components/xcpl_comps_nuopc/xwav/src/wav_comp_nuopc.F90
+++ b/CIME/non_py/src/components/xcpl_comps_nuopc/xwav/src/wav_comp_nuopc.F90
@@ -14,7 +14,7 @@ module wav_comp_nuopc
   use NUOPC_Model       , only : NUOPC_ModelGet, SetVM
   use shr_sys_mod       , only : shr_sys_abort
   use shr_kind_mod      , only : r8=>shr_kind_r8, i8=>shr_kind_i8, cl=>shr_kind_cl, cs=>shr_kind_cs
-  use shr_file_mod      , only : shr_file_getlogunit, shr_file_setlogunit
+  use shr_log_mod      , only : shr_log_getlogunit, shr_log_setlogunit
   use dead_methods_mod  , only : chkerr, state_setscalar,  state_diagnose, alarmInit, memcheck
   use dead_methods_mod  , only : set_component_logging, get_component_instance, log_clock_advance
   use dead_nuopc_mod    , only : dead_read_inparms, ModelInitPhase, ModelSetRunClock
@@ -228,7 +228,7 @@ contains
     if (chkerr(rc,__LINE__,u_FILE_u)) return
 
     ! Reset shr logging to original values
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeAdvertise
 
@@ -250,8 +250,8 @@ contains
     rc = ESMF_SUCCESS
 
     ! Reset shr logging to my log file
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logunit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logunit)
 
     ! generate the mesh
     call NUOPC_CompAttributeGet(gcomp, name='mesh_wav', value=cvalue, rc=rc)
@@ -296,7 +296,7 @@ contains
        if (chkerr(rc,__LINE__,u_FILE_u)) return
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine InitializeRealize
 
@@ -318,8 +318,8 @@ contains
 
     call memcheck(subname, 3, mastertask)
 
-    call shr_file_getLogUnit (shrlogunit)
-    call shr_file_setLogUnit (logunit)
+    call shr_log_getLogUnit (shrlogunit)
+    call shr_log_setLogUnit (logunit)
 
     ! Pack export state
     call NUOPC_ModelGet(gcomp, modelClock=clock, exportState=exportState, rc=rc)
@@ -337,7 +337,7 @@ contains
        endif
     endif
 
-    call shr_file_setLogUnit (shrlogunit)
+    call shr_log_setLogUnit (shrlogunit)
 
   end subroutine ModelAdvance
 

--- a/CIME/non_py/src/timing/perf_mod.F90
+++ b/CIME/non_py/src/timing/perf_mod.F90
@@ -30,7 +30,7 @@ module perf_mod
    use shr_kind_mod,      only: SHR_KIND_CS, SHR_KIND_CM, SHR_KIND_CX, &
                                 SHR_KIND_R8, SHR_KIND_I8
    use shr_mpi_mod,       only: shr_mpi_barrier, shr_mpi_bcast
-   use shr_file_mod,      only: shr_file_getUnit, shr_file_freeUnit
+   use shr_log_mod,      only: shr_log_getUnit, shr_log_freeUnit
    use namelist_utils,    only: find_group_name
 #endif
    use mpi
@@ -1186,7 +1186,7 @@ contains
      fname(i:i) = " "
    enddo
 
-   unitn = shr_file_getUnit()
+   unitn = shr_log_getUnit()
 
    ! determine what the current output mode is (append or write)
    if (GPTLprint_mode_query() == GPTLprint_write) then
@@ -1391,7 +1391,7 @@ contains
 
    endif
 
-   call shr_file_freeUnit( unitn )
+   call shr_log_freeUnit( unitn )
 
    ! reset GPTL output mode
    if (pr_write) then
@@ -1539,7 +1539,7 @@ contains
        ! Read in the prof_inparm namelist from NLFilename if it exists
 
        write(p_logunit,*) '(t_initf) Read in prof_inparm namelist from: '//trim(NLFilename)
-       unitn = shr_file_getUnit()
+       unitn = shr_log_getUnit()
 
        ierr = 1
        open( unitn, file=trim(NLFilename), status="OLD", form="FORMATTED", access="SEQUENTIAL", iostat=ierr )
@@ -1560,7 +1560,7 @@ contains
           close(unitn)
 
        endif
-       call shr_file_freeUnit( unitn )
+       call shr_log_freeUnit( unitn )
 
     endif
 
@@ -1611,7 +1611,7 @@ contains
           ! Read in the papi_inparm namelist from NLFilename if it exists
 
           write(p_logunit,*) '(t_initf) Read in papi_inparm namelist from: '//trim(NLFilename)
-          unitn = shr_file_getUnit()
+          unitn = shr_log_getUnit()
 
           ierr = 1
           open( unitn, file=trim(NLFilename), status="OLD", form="FORMATTED", access="SEQUENTIAL", iostat=ierr )
@@ -1631,7 +1631,7 @@ contains
              close(unitn)
 
           endif
-          call shr_file_freeUnit( unitn )
+          call shr_log_freeUnit( unitn )
 
           ! if enabled and nothing set, use "defaults"
           if ((papi_ctr1_str(1:11) .eq. "PAPI_NO_CTR") .and. &

--- a/CIME/non_py/src/timing/perf_utils.F90
+++ b/CIME/non_py/src/timing/perf_utils.F90
@@ -26,8 +26,8 @@ module perf_utils
    public perfutils_setunit
    public shr_sys_abort
    public shr_mpi_barrier
-   public shr_file_getUnit
-   public shr_file_freeUnit
+   public shr_log_getUnit
+   public shr_log_freeUnit
    public find_group_name
    public to_lower
    public shr_mpi_bcast
@@ -322,11 +322,11 @@ END SUBROUTINE shr_mpi_bcastl0
 
 !===============================================================================
 
-!================== Routines from csm_share/shr/shr_file_mod.F90 ===============
+!================== Routines from csm_share/shr/shr_log_mod.F90 ===============
 !===============================================================================
 !BOP ===========================================================================
 !
-! !IROUTINE: shr_file_getUnit -- Get a free FORTRAN unit number
+! !IROUTINE: shr_log_getUnit -- Get a free FORTRAN unit number
 !
 ! !DESCRIPTION: Get the next free FORTRAN unit number.
 !
@@ -336,47 +336,47 @@ END SUBROUTINE shr_mpi_bcastl0
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-INTEGER FUNCTION shr_file_getUnit ()
+INTEGER FUNCTION shr_log_getUnit ()
 
    implicit none
 
 !EOP
 
    !----- local parameters -----
-   integer(SHR_KIND_IN),parameter :: shr_file_minUnit = 10      ! Min unit number to give
-   integer(SHR_KIND_IN),parameter :: shr_file_maxUnit = 99      ! Max unit number to give
+   integer(SHR_KIND_IN),parameter :: shr_log_minUnit = 10      ! Min unit number to give
+   integer(SHR_KIND_IN),parameter :: shr_log_maxUnit = 99      ! Max unit number to give
 
    !----- local variables -----
    integer(SHR_KIND_IN)   :: n      ! loop index
    logical                :: opened ! If unit opened or not
 
    !----- formats -----
-   character(*),parameter :: subName = '(shr_file_getUnit) '
-   character(*),parameter :: F00   = "('(shr_file_getUnit) ',A,I4,A)"
+   character(*),parameter :: subName = '(shr_log_getUnit) '
+   character(*),parameter :: F00   = "('(shr_log_getUnit) ',A,I4,A)"
 
 !-------------------------------------------------------------------------------
 ! Notes:
 !-------------------------------------------------------------------------------
 
    ! --- Choose first available unit other than 0, 5, or 6  ------
-   do n=shr_file_minUnit, shr_file_maxUnit
+   do n=shr_log_minUnit, shr_log_maxUnit
       inquire( n, opened=opened )
       if (n == 5 .or. n == 6 .or. opened) then
          cycle
       end if
-      shr_file_getUnit = n
+      shr_log_getUnit = n
       return
    end do
 
    call shr_sys_abort( subName//': Error: no available units found' )
 
-END FUNCTION shr_file_getUnit
+END FUNCTION shr_log_getUnit
 !===============================================================================
 
 !===============================================================================
 !BOP ===========================================================================
 !
-! !IROUTINE: shr_file_freeUnit -- Free up a FORTRAN unit number
+! !IROUTINE: shr_log_freeUnit -- Free up a FORTRAN unit number
 !
 ! !DESCRIPTION: Free up the given unit number
 !
@@ -386,7 +386,7 @@ END FUNCTION shr_file_getUnit
 !
 ! !INTERFACE: ------------------------------------------------------------------
 
-SUBROUTINE shr_file_freeUnit ( unit)
+SUBROUTINE shr_log_freeUnit ( unit)
 
    implicit none
 
@@ -397,18 +397,18 @@ SUBROUTINE shr_file_freeUnit ( unit)
 !EOP
 
    !----- local parameters -----
-   integer(SHR_KIND_IN),parameter :: shr_file_minUnit = 10      ! Min unit number to give
-   integer(SHR_KIND_IN),parameter :: shr_file_maxUnit = 99      ! Max unit number to give
+   integer(SHR_KIND_IN),parameter :: shr_log_minUnit = 10      ! Min unit number to give
+   integer(SHR_KIND_IN),parameter :: shr_log_maxUnit = 99      ! Max unit number to give
 
    !----- formats -----
-   character(*), parameter :: subName = '(shr_file_freeUnit) '
-   character(*), parameter :: F00 =   "('(shr_file_freeUnit) ',A,I4,A)"
+   character(*), parameter :: subName = '(shr_log_freeUnit) '
+   character(*), parameter :: F00 =   "('(shr_log_freeUnit) ',A,I4,A)"
 
 !-------------------------------------------------------------------------------
 ! Notes:
 !-------------------------------------------------------------------------------
 
-   if (unit < 0 .or. unit > shr_file_maxUnit) then
+   if (unit < 0 .or. unit > shr_log_maxUnit) then
 !pw   if (s_loglev > 0) write(pu_logunit,F00) 'invalid unit number request:', unit
    else if (unit == 0 .or. unit == 5 .or. unit == 6) then
       call shr_sys_abort( subName//': Error: units 0, 5, and 6 must not be freed' )
@@ -416,7 +416,7 @@ SUBROUTINE shr_file_freeUnit ( unit)
 
    return
 
-END SUBROUTINE shr_file_freeUnit
+END SUBROUTINE shr_log_freeUnit
 !===============================================================================
 
 !============= Routines from atm/cam/src/utils/namelist_utils.F90 ==============

--- a/CIME/tests/test_sys_cime_case.py
+++ b/CIME/tests/test_sys_cime_case.py
@@ -12,6 +12,11 @@ from CIME.tests import base
 from CIME.case.case import Case
 from CIME.XML.env_run import EnvRun
 
+try:
+    collectionsAbc = collections.abc
+except AttributeError:
+    collectionsAbc = collections
+
 
 class TestCimeCase(base.BaseTestCase):
     def test_cime_case(self):
@@ -86,7 +91,7 @@ class TestCimeCase(base.BaseTestCase):
                 prereq=prereq_name, job=job_name, skip_pnl=True, dry_run=True
             )
             self.assertTrue(
-                isinstance(batch_commands, collections.Sequence),
+                isinstance(batch_commands, collectionsAbc.Sequence),
                 "case.submit_jobs did not return a sequence for a dry run",
             )
             self.assertTrue(
@@ -99,7 +104,7 @@ class TestCimeCase(base.BaseTestCase):
             # The prerequisite should be applied to all jobs, though we're only expecting one
             for batch_cmd in batch_commands:
                 self.assertTrue(
-                    isinstance(batch_cmd, collections.Sequence),
+                    isinstance(batch_cmd, collectionsAbc.Sequence),
                     "case.submit_jobs did not return a sequence of sequences",
                 )
                 self.assertTrue(
@@ -161,7 +166,7 @@ class TestCimeCase(base.BaseTestCase):
                 dry_run=True,
             )
             self.assertTrue(
-                isinstance(batch_commands, collections.Sequence),
+                isinstance(batch_commands, collectionsAbc.Sequence),
                 "case.submit_jobs did not return a sequence for a dry run",
             )
             num_submissions = 1
@@ -190,7 +195,7 @@ class TestCimeCase(base.BaseTestCase):
                 job=job_name, skip_pnl=True, dry_run=True, resubmit_immediate=True
             )
             self.assertTrue(
-                isinstance(batch_commands, collections.Sequence),
+                isinstance(batch_commands, collectionsAbc.Sequence),
                 "case.submit_jobs did not return a sequence for a dry run",
             )
             if case.get_value("DOUT_S"):


### PR DESCRIPTION
Port to python 3.10 and remove deprecated shr_file interface, replacing with shr_log 

Test suite: scripts_regression_tests.py 
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
