### PR TITLE
BATCH_COMMAND_FLAGS was not in env_batch, change self to case

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -962,7 +962,7 @@ class EnvBatch(EnvBase):
             return
 
         submitargs = self.get_submit_args(case, job)
-        args_override = self.get_value("BATCH_COMMAND_FLAGS", subgroup=job)
+        args_override = case.get_value("BATCH_COMMAND_FLAGS", subgroup=job)
         if args_override:
             submitargs = args_override
 


### PR DESCRIPTION
Variable BATCH_COMMAND_FLAGS is in env_workflow but is being queried in env_batch and so must use env_workflow or case and not self. 

Test suite: Tested by hand using ERR.f19_g17.X.cheyenne_intel
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes https://github.com/ESCOMP/CMEPS/issues/373

User interface changes?:

Update gh-pages html (Y/N)?:
