### PR TITLE
cce/15.0.1 compiler did not link properly without this change, no adv…

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -911,7 +911,7 @@ GENF90 ?= $(CIMEROOT)/CIME/non_py/externals/genf90/genf90.pl
 
 ifeq ($(MPILIB),mpi-serial)
   MPISERIAL = $(INSTALL_SHAREDPATH)/lib/libmpi-serial.a
-  MLIBS += $(MPISERIAL)
+  MLIBS += -L$(INSTALL_SHAREDPATH)/lib -lmpi-serial
   CMAKE_OPTS += -DMPI_C_INCLUDE_PATH=$(INSTALL_SHAREDPATH)/include \
       -DMPI_Fortran_INCLUDE_PATH=$(INSTALL_SHAREDPATH)/include \
       -DMPI_C_LIBRARIES=$(INSTALL_SHAREDPATH)/lib/libmpi-serial.a \


### PR DESCRIPTION
…erse affects noted on other compilers


Test suite: RUNNING TESTS:
  SMS_Mmpi-serial.f19_g16.X.gust_cray
  SMS_Mmpi-serial.f19_g16.X.gust_gnu
  SMS_Mmpi-serial.f19_g16.X.gust_intel
  SMS_Mmpi-serial.f19_g16.X.gust_intel-classic
  SMS_Mmpi-serial.f19_g16.X.gust_intel-oneapi
  SMS_Mmpi-serial.f19_g16.X.gust_nvhpc

Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
