### PR TITLE
case_clone: Fix bug in srcroot determination

### DIFF
--- a/CIME/case/case_clone.py
+++ b/CIME/case/case_clone.py
@@ -54,7 +54,10 @@ def create_clone(
     if os.path.isdir(os.path.join(newcase_cimeroot, "share")) and get_model() == "cesm":
         srcroot = newcase_cimeroot
     else:
-        srcroot = os.path.join(newcase_cimeroot, "..")
+        srcroot = self.get_value("SRCROOT")
+        if not srcroot:
+            srcroot = os.path.join(newcase_cimeroot, "..")
+
     newcase = self.copy(newcasename, newcaseroot, newsrcroot=srcroot)
     with newcase:
         newcase.set_value("CIMEROOT", newcase_cimeroot)


### PR DESCRIPTION
SRCROOT should match the original case if possible. This bug was causing multi-build tests, like PEM, to not respect a custom --srcroot argument to create_test.

This was a pretty serious bug since it, in many cases, silently built files from the wrong case when using create_test --srcroot.

Test suite: by-hand
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes #4393 
