### PR TITLE
Use compiler info when looking for test status files

### DIFF
--- a/CIME/test_utils.py
+++ b/CIME/test_utils.py
@@ -150,7 +150,9 @@ def test_to_string(
 
 def get_test_status_files(test_root, compiler, test_id=None):
     test_id_glob = (
-        "*{}*".format(compiler) if test_id is None else "*{}*".format(test_id)
+        "*{}*".format(compiler)
+        if test_id is None
+        else "*{}*{}*".format(compiler, test_id)
     )
     test_status_files = glob.glob(
         "{}/{}/{}".format(test_root, test_id_glob, TEST_STATUS_FILENAME)

--- a/CIME/tests/test_unit_compare_test_results.py
+++ b/CIME/tests/test_unit_compare_test_results.py
@@ -41,7 +41,7 @@ class TestCaseFake(unittest.TestCase):
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def _compare_test_results(self, baseline, test_id, phases, **kwargs):
-        test_status_root = os.path.join(self.test_root, test_id)
+        test_status_root = os.path.join(self.test_root, "gnu." + test_id)
         os.makedirs(test_status_root)
 
         with TestStatus(test_status_root, "test") as status:


### PR DESCRIPTION
When test_id was being provided, compiler was being ignored. This was causing bless_test_results to match multiple sets of cases when the machine was running the same suite with multiple compilers.

Test suite: test_sys_bless_tests_results.TestBlessTestResults
Test baseline:
Test namelist changes:
Test status: bit for bit
