### PR TITLE
add which to find ncdump and an error message if not found

### DIFF
--- a/CIME/case/case_st_archive.py
+++ b/CIME/case/case_st_archive.py
@@ -364,8 +364,10 @@ def get_histfiles_for_restarts(
     histfiles = set()
     rest_hist_varname = archive.get_entry_value("rest_history_varname", archive_entry)
     if rest_hist_varname != "unset":
-        cmd = "ncdump -v {} {} ".format(
-            rest_hist_varname, os.path.join(rundir, restfile)
+        ncdump = shutil.which("ncdump")
+        expect(ncdump, "ncdump not found in path")
+        cmd = "{} -v {} {} ".format(
+            ncdump, rest_hist_varname, os.path.join(rundir, restfile)
         )
         if testonly:
             out = "{} =".format(rest_hist_varname)


### PR DESCRIPTION
Use shutils.which to find ncdump, issue an error if it's not in the path.

Test suite: ERR.f19_g17.X.cheyenne_intel
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4173 

User interface changes?:

Update gh-pages html (Y/N)?:
