### PR TITLE
rename xml-driver to driver

### DIFF
--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -218,7 +218,7 @@ def parse_command_line(args, description):
         )
 
         parser.add_argument(
-            "--xml-driver",
+            "--driver",
             choices=("mct", "nuopc", "moab"),
             help="Override driver specified in tests and use this one.",
         )
@@ -623,7 +623,7 @@ def parse_command_line(args, description):
                 xml_testlist=args.xml_testlist,
                 machine=machine_name,
                 compiler=args.compiler,
-                driver=args.xml_driver,
+                driver=args.driver,
             )
             test_names = [item["name"] for item in test_data]
             for test_datum in test_data:


### PR DESCRIPTION
Renames create_test argument --xml-driver to --driver to be more consistant with other option names.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #3979 

User interface changes?:

Update gh-pages html (Y/N)?:
