### PR TITLE
Fixes caching test files in container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,12 @@ ENV LOGNAME=root
 
 SHELL ["/bin/bash", "-c"]
 
+# First layer as they never change, required for E3SM testing, TODO: fix in unittesting as well
+RUN mkdir -p /cache/cpl/gridmaps/oQU240 /cache/share/domains && \
+    wget -O /cache/cpl/gridmaps/oQU240/map_oQU240_to_ne4np4_aave.160614.nc https://portal.nersc.gov/project/e3sm/inputdata/cpl/gridmaps/oQU240/map_oQU240_to_ne4np4_aave.160614.nc && \
+    wget -O /cache/share/domains/domain.ocn.ne4np4_oQU240.160614.nc https://portal.nersc.gov/project/e3sm/inputdata/share/domains/domain.ocn.ne4np4_oQU240.160614.nc && \
+    wget -O /cache/share/domains/domain.lnd.ne4np4_oQU240.160614.nc https://portal.nersc.gov/project/e3sm/inputdata/share/domains/domain.lnd.ne4np4_oQU240.160614.nc
+
 # Install common packages
 RUN mamba install --yes -c conda-forge \
             cmake \
@@ -33,6 +39,7 @@ RUN mamba install --yes -c conda-forge \
             pytest-cov\
             pyyaml \
             vim \
+            rsync \
             openssh && \
             rm -rf /opt/conda/pkgs/*
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -106,15 +106,7 @@ function init_e3sm() {
 
     update_cime "${install_path}/cime"
 
-    curl -L --create-dirs \
-        -o ${cache_path}/cpl/gridmaps/oQU240/map_oQU240_to_ne4np4_aave.160614.nc \
-        https://web.lcrc.anl.gov/public/e3sm/inputdata/cpl/gridmaps/oQU240/map_oQU240_to_ne4np4_aave.160614.nc
-    curl -L --create-dirs \
-        -o ${cache_path}/share/domains/domain.ocn.ne4np4_oQU240.160614.nc \
-        https://web.lcrc.anl.gov/public/e3sm/inputdata/share/domains/domain.ocn.ne4np4_oQU240.160614.nc
-    curl -L --create-dirs \
-        -o ${cache_path}/share/domains/domain.lnd.ne4np4_oQU240.160614.nc \
-        https://web.lcrc.anl.gov/public/e3sm/inputdata/share/domains/domain.lnd.ne4np4_oQU240.160614.nc
+    rsync -vr /cache/ /storage/inputdata/
 
     cd "${install_path}/cime"
 }


### PR DESCRIPTION
Fixes caching E3SM test files in the container.

Test suite: pytest --machine docker in container
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes? N
Update gh-pages html (Y/N)?: N
