### PR TITLE
change method of detecting fv3 dycore in cam and path to libfv3.a

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -541,7 +541,7 @@ cospsimulator_intr.o: $(COSP_LIBDIR)/libcosp.a
 endif
 
 ifdef FV3CORE_LIBDIR
-$(FV3CORE_LIBDIR)/libfv3core.a: $(EXEROOT)/FMS/libfms.a
+$(FV3CORE_LIBDIR)/libfv3core.a: $(LIBROOT)/libfms.a
 	$(MAKE) -C $(FV3CORE_LIBDIR) complib COMPLIB='$(FV3CORE_LIBDIR)/libfv3core.a' F90='$(FC)' CC='$(CC)' FFLAGS='$(FFLAGS) $(FC_AUTO_R8)'  CFLAGS='$(CFLAGS)' INCLDIR='$(INCLDIR)' FC_TYPE='$(COMPILER)'
 
 dyn_grid.o: $(FV3CORE_LIBDIR)/libfv3core.a
@@ -875,7 +875,7 @@ endif
 
 ifdef FV3CORE_LIBDIR
   ULIBDEP += $(FV3CORE_LIBDIR)/libfv3core.a
-  ULIBDEP += $(EXEROOT)/FMS/libfms.a
+  ULIBDEP += $(LIBROOT)/libfms.a
 endif
 
 ifdef MPAS_LIBDIR

--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -41,6 +41,5 @@ os.environ["CIMEROOT"] = cimeroot
 
 import CIME.utils
 
-
 CIME.utils.stop_buffering_output()
 import logging, argparse

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -248,8 +248,8 @@ def get_standard_cmake_args(case, sharedpath):
     )
 
     ocn_model = case.get_value("COMP_OCN")
-    atm_model = case.get_value("COMP_ATM")
-    if ocn_model == "mom" or atm_model == "fv3gfs":
+    atm_dycore = case.get_value("CAM_DYCORE")
+    if ocn_model == "mom" or (atm_dycore and atm_dycore == "fv3"):
         cmake_args += " -DUSE_FMS=TRUE "
 
     cmake_args += " -DINSTALL_SHAREDPATH={} ".format(
@@ -266,6 +266,7 @@ def get_standard_cmake_args(case, sharedpath):
     for var in _CMD_ARGS_FOR_BUILD:
         cmake_args += xml_to_make_variable(case, var, cmake=True)
 
+    atm_model = case.get_value("COMP_ATM")
     if atm_model == "scream":
         cmake_args += xml_to_make_variable(case, "HOMME_TARGET", cmake=True)
 
@@ -757,8 +758,9 @@ def _build_libraries(
         libs.append("CDEPS")
 
     ocn_model = case.get_value("COMP_OCN")
-    atm_model = case.get_value("COMP_ATM")
-    if ocn_model == "mom" or atm_model == "fv3gfs":
+
+    atm_dycore = case.get_value("CAM_DYCORE")
+    if ocn_model == "mom" or (atm_dycore and atm_dycore == "fv3"):
         libs.append("FMS")
 
     files = Files(comp_interface=comp_interface)


### PR DESCRIPTION
Improve shared build of FMS library and detection of need for that library in cam.

Test suite:  qcmd -- ./create_test SMS.T62_g16.CMOM_IAF.cheyenne_intel.mom-debug ERS.T62_g16.CMOM_IAF.cheyenne_intel.mom-debug SMS.C96_C96_mg17.F2000climo.cheyenne_intel.cam-outfrq9s_mg3
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
