### PR TITLE
jenkins_generic_job: Add flag for ignoring memleaks

### DIFF
--- a/CIME/Tools/jenkins_generic_job
+++ b/CIME/Tools/jenkins_generic_job
@@ -175,6 +175,12 @@ OR
     )
 
     parser.add_argument(
+        "--ignore-memleak",
+        action="store_true",
+        help="Do not fail if there are memleaks",
+    )
+
+    parser.add_argument(
         "--pes-file",
         help="Full pathname of an optional pes specification file. The file"
         "\ncan follow either the config_pes.xml or the env_mach_pes.xml format.",
@@ -252,6 +258,7 @@ OR
         args.update_success,
         args.check_throughput,
         args.check_memory,
+        args.ignore_memleak,
         args.pes_file,
         args.jenkins_id,
         args.queue,
@@ -281,6 +288,7 @@ def _main_func(description):
         update_success,
         check_throughput,
         check_memory,
+        ignore_memleak,
         pes_file,
         jenkins_id,
         queue,
@@ -308,6 +316,7 @@ def _main_func(description):
             update_success,
             check_throughput,
             check_memory,
+            ignore_memleak,
             pes_file,
             jenkins_id,
             queue,

--- a/CIME/jenkins_generic_job.py
+++ b/CIME/jenkins_generic_job.py
@@ -278,6 +278,7 @@ def jenkins_generic_job(
     update_success,
     check_throughput,
     check_memory,
+    ignore_memleak,
     pes_file,
     jenkins_id,
     queue,
@@ -417,6 +418,7 @@ def jenkins_generic_job(
         check_throughput=check_throughput,
         check_memory=check_memory,
         ignore_namelists=False,  # don't ignore namelist diffs
+        ignore_memleak=ignore_memleak,
         cdash_build_name=cdash_build_name,
         cdash_project=cdash_project,
         cdash_build_group=cdash_build_group,


### PR DESCRIPTION
Anticipating that we might want this flag in the near future.

Test suite: scripts_regression_tests test_sys_jenkins_generic_job.TestJenkinsGenericJob
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
