### PR TITLE
Fix context issue

### DIFF
--- a/CIME/tests/test_unit_compare_two.py
+++ b/CIME/tests/test_unit_compare_two.py
@@ -292,11 +292,11 @@ class TestSystemTestsCompareTwo(unittest.TestCase):
         # Setup
         case1root = os.path.join(self.tempdir, "case1")
         case1 = CaseFake(case1root)
+        case1._read_only_mode = False
 
         mytest = SystemTestsCompareTwoFake(case1)
 
         case1.set_value = mock.MagicMock()
-
         case1.get_value = mock.MagicMock()
         case1.get_value.side_effect = ["/tmp", "/tmp/bld", False]
 


### PR DESCRIPTION
Fixes issue causing case context to exit early. This would result in
`ERROR: Cannot modify case, read_only...` errors.

Test suite: pytest and create_test with PET and --single-exe
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?: N
Update gh-pages html (Y/N)?: N
