### PR TITLE
rpath needs an = for cray compiler

### DIFF
--- a/CIME/non_py/cprnc/Makefile
+++ b/CIME/non_py/cprnc/Makefile
@@ -38,7 +38,7 @@ NETCDF_PATH ?= $(NETCDF_FORTRAN_PATH)
 # Default for the netcdf library and include directories
 LIB_NETCDF := $(NETCDF_PATH)/lib
 INC_NETCDF := $(NETCDF_PATH)/include
-LDFLAGS = -L$(LIB_NETCDF) -lnetcdff -Wl,-rpath $(LIB_NETCDF)
+LDFLAGS = -L$(LIB_NETCDF) -lnetcdff -Wl,-rpath=$(LIB_NETCDF)
 
 # Determine platform
 UNAMES := $(shell uname -s)


### PR DESCRIPTION
One line change -rpath in Makefile needs an = sign for cray compiler.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes 
User interface changes?:

Update gh-pages html (Y/N)?:
