### PR TITLE
always use BATCH_COMMAND_FLAGS

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -961,10 +961,7 @@ class EnvBatch(EnvBase):
 
             return
 
-        submitargs = self.get_submit_args(case, job)
-        args_override = case.get_value("BATCH_COMMAND_FLAGS", subgroup=job)
-        if args_override:
-            submitargs = args_override
+        submitargs = case.get_value("BATCH_COMMAND_FLAGS", subgroup=job)
 
         if dep_jobs is not None and len(dep_jobs) > 0:
             logger.debug("dependencies: {}".format(dep_jobs))

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1586,6 +1586,13 @@ class Case(object):
             )
 
         env_batch.set_job_defaults(bjobs, self)
+        # Set BATCH_COMMAND_FLAGS to the default values
+
+        for job in bjobs:
+            if test and job[0] == "case.run" or not test and job[0] == "case.test":
+                continue
+            submitargs = env_batch.get_submit_args(self, job[0])
+            self.set_value("BATCH_COMMAND_FLAGS", submitargs, subgroup=job[0])
 
         # Make sure that parallel IO is not specified if total_tasks==1
         if self.total_tasks == 1:


### PR DESCRIPTION
Always use the BATCH_COMMAND_FLAGS argument.
This allows users to alter with xmlchange and append with --append

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes #4439 

User interface changes?:

Update gh-pages html (Y/N)?:
