### PR TITLE
Feature rebuild tests

### DIFF
--- a/CIME/Tools/cs.status
+++ b/CIME/Tools/cs.status
@@ -103,6 +103,13 @@ def parse_command_line(args, description):
         help="Test root used when --test-id is given",
     )
 
+    parser.add_argument(
+        "--force-rebuild",
+        action="store_true",
+        help="When used with 'test-id', the"
+        "tests will have their 'BUILD_SHAREDLIB' phase reset to 'PEND'.",
+    )
+
     args = parser.parse_args(args[1:])
 
     _validate_args(args)
@@ -120,10 +127,17 @@ def parse_command_line(args, description):
         args.expected_fails_file,
         args.test_id,
         args.test_root,
+        args.force_rebuild,
     )
 
 
 def _validate_args(args):
+    if args.force_rebuild:
+        expect(
+            args.test_id != [],
+            "Cannot force a rebuild without 'test-id'",
+        )
+
     expect(
         not (args.summary and args.count_fails),
         "--count-fails cannot be specified with --summary",
@@ -158,6 +172,7 @@ def _main_func(description):
         expected_fails_file,
         test_ids,
         test_root,
+        force_rebuild,
     ) = parse_command_line(sys.argv, description)
     for test_id in test_ids:
         test_paths.extend(
@@ -172,6 +187,7 @@ def _main_func(description):
         check_throughput=check_throughput,
         check_memory=check_memory,
         expected_fails_filepath=expected_fails_file,
+        force_rebuild=force_rebuild,
     )
 
 

--- a/CIME/cs_status.py
+++ b/CIME/cs_status.py
@@ -6,7 +6,7 @@ of the tests in one or more test suites
 from __future__ import print_function
 from CIME.XML.standard_module_setup import *
 from CIME.XML.expected_fails_file import ExpectedFailsFile
-from CIME.test_status import TestStatus
+from CIME.test_status import TestStatus, SHAREDLIB_BUILD_PHASE, TEST_PEND_STATUS
 import os
 import sys
 from collections import defaultdict
@@ -20,6 +20,7 @@ def cs_status(
     check_throughput=False,
     check_memory=False,
     expected_fails_filepath=None,
+    force_rebuild=False,
     out=sys.stdout,
 ):
     """Print the test statuses of all tests in test_paths. The default
@@ -56,6 +57,11 @@ def cs_status(
     for test_path in test_paths:
         test_dir = os.path.dirname(test_path)
         ts = TestStatus(test_dir=test_dir)
+
+        if force_rebuild:
+            with ts:
+                ts.set_status(SHAREDLIB_BUILD_PHASE, TEST_PEND_STATUS)
+
         test_id = os.path.basename(test_dir).split(".")[-1]
         if summary:
             output = _overall_output(

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -473,11 +473,24 @@ def parse_command_line(args, description):
         f"The default is {srcroot_default}",
     )
 
+    parser.add_argument(
+        "--force-rebuild",
+        action="store_true",
+        help="When used with 'use-existing' and 'test-id', the"
+        "tests will have their 'BUILD_SHAREDLIB' phase reset to 'PEND'.",
+    )
+
     CIME.utils.add_mail_type_args(parser)
 
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     CIME.utils.resolve_mail_type_args(args)
+
+    if args.force_rebuild:
+        expect(
+            args.use_existing and args.test_id,
+            "Cannot force a rebuild without 'use-existing' and 'test-id'",
+        )
 
     # generate and compare flags may not point to the same directory
     if model_config.create_test_flag_mode == "cesm":
@@ -754,6 +767,7 @@ def parse_command_line(args, description):
         args.single_exe,
         args.workflow,
         args.chksum,
+        args.force_rebuild,
     )
 
 
@@ -913,6 +927,7 @@ def create_test(
     single_exe,
     workflow,
     chksum,
+    force_rebuild,
 ):
     ###############################################################################
     impl = TestScheduler(
@@ -953,6 +968,7 @@ def create_test(
         single_exe=single_exe,
         workflow=workflow,
         chksum=chksum,
+        force_rebuild=force_rebuild,
     )
 
     success = impl.run_tests(
@@ -1054,6 +1070,7 @@ def _main_func(description=None):
         single_exe,
         workflow,
         chksum,
+        force_rebuild,
     ) = parse_command_line(sys.argv, description)
 
     success = False
@@ -1105,6 +1122,7 @@ def _main_func(description=None):
             single_exe,
             workflow,
             chksum,
+            force_rebuild,
         )
         run_count += 1
 

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -209,6 +209,7 @@ class TestScheduler(object):
         single_exe=False,
         workflow=None,
         chksum=False,
+        force_rebuild=False,
     ):
         ###########################################################################
         self._cime_root = get_cime_root()
@@ -396,6 +397,9 @@ class TestScheduler(object):
         if use_existing:
             for test in self._tests:
                 with TestStatus(self._get_test_dir(test)) as ts:
+                    if force_rebuild:
+                        ts.set_status(SHAREDLIB_BUILD_PHASE, TEST_PEND_STATUS)
+
                     for phase, status in ts:
                         if phase in CORE_PHASES:
                             if status in [TEST_PEND_STATUS, TEST_FAIL_STATUS]:

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -279,6 +279,60 @@ class TestTestScheduler(base.BaseTestCase):
                         test_status.TEST_PASS_STATUS,
                     )
 
+    def test_force_rebuild(self):
+        tests = get_tests.get_full_test_names(
+            [
+                "TESTBUILDFAIL_P1.f19_g16_rx1.A",
+                "TESTRUNFAIL_P1.f19_g16_rx1.A",
+                "TESTRUNPASS_P1.f19_g16_rx1.A",
+            ],
+            self._machine,
+            self._compiler,
+        )
+        test_id = "%s-%s" % (self._baseline_name, utils.get_timestamp())
+        ct = test_scheduler.TestScheduler(
+            tests,
+            test_id=test_id,
+            no_batch=self.NO_BATCH,
+            test_root=self._testroot,
+            output_root=self._testroot,
+            compiler=self._compiler,
+            mpilib=self.TEST_MPILIB,
+            machine_name=self.MACHINE.get_machine_name(),
+        )
+
+        log_lvl = logging.getLogger().getEffectiveLevel()
+        logging.disable(logging.CRITICAL)
+        try:
+            ct.run_tests()
+        finally:
+            logging.getLogger().setLevel(log_lvl)
+
+        ct = test_scheduler.TestScheduler(
+            tests,
+            test_id=test_id,
+            no_batch=self.NO_BATCH,
+            test_root=self._testroot,
+            output_root=self._testroot,
+            compiler=self._compiler,
+            mpilib=self.TEST_MPILIB,
+            machine_name=self.MACHINE.get_machine_name(),
+            force_rebuild=True,
+            use_existing=True,
+        )
+
+        test_statuses = glob.glob("%s/*%s/TestStatus" % (self._testroot, test_id))
+
+        for x in test_statuses:
+            casedir = os.path.dirname(x)
+
+            ts = test_status.TestStatus(test_dir=casedir)
+
+            self.assertTrue(
+                ts.get_status(test_status.SHAREDLIB_BUILD_PHASE)
+                == test_status.TEST_PEND_STATUS
+            )
+
     def test_c_use_existing(self):
         tests = get_tests.get_full_test_names(
             [

--- a/CIME/tests/test_unit_cs_status.py
+++ b/CIME/tests/test_unit_cs_status.py
@@ -71,6 +71,23 @@ class TestCsStatus(CustomAssertionsTestStatus):
     # Begin actual tests
     # ------------------------------------------------------------------------
 
+    def test_force_rebuild(self):
+        test_name = "my.test.name"
+        test_dir = "my.test.name.testid"
+        test_dir_path = self.create_test_dir(test_dir)
+        self.create_test_status_core_passes(test_dir_path, test_name)
+        cs_status(
+            [os.path.join(test_dir_path, "TestStatus")],
+            force_rebuild=True,
+            out=self._output,
+        )
+        self.assert_status_of_phase(
+            self._output.getvalue(),
+            test_status.TEST_PEND_STATUS,
+            test_status.SHAREDLIB_BUILD_PHASE,
+            test_name,
+        )
+
     def test_single_test(self):
         """cs_status for a single test should include some minimal expected output"""
         test_name = "my.test.name"


### PR DESCRIPTION
Adds the `force-rebuild` argument to `create_test` and `cs.status`. 
This argument will set the `SHAREDLIB_BUILD_PHASE` to `PEND`
for all tests.

When using `create_test` and `force-rebuild` a user must also specify
`use-existing` and `test-id`. 

Test suite: pytest CIME/tests/test_sys_test_scheduler.py
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4338 
User interface changes?: n/a
Update gh-pages html (Y/N)?: N
