### PR TITLE
Do not re-invoke make on repeat case.build calls

### DIFF
--- a/CIME/build.py
+++ b/CIME/build.py
@@ -467,6 +467,7 @@ def _build_model_cmake(
     # Components-specific cmake args. Cmake requires all component inputs to be available
     # regardless of requested build list. We do not want to re-invoke cmake
     # if it has already been called.
+    do_timing = "/usr/bin/time -p " if os.path.exists("/usr/bin/time") else ""
     if not os.path.exists(os.path.join(bldroot, "CMakeCache.txt")):
         cmp_cmake_args = ""
         all_models = []
@@ -496,7 +497,6 @@ def _build_model_cmake(
         #  - common (i.e. project-wide) cmake args
         #  - component-specific cmake args
         #  - path to src folder
-        do_timing = "/usr/bin/time -p " if os.path.exists("/usr/bin/time") else ""
         cmake_cmd = "{} {}cmake {} {} {}/components".format(
             cmake_env, do_timing, cmake_args, cmp_cmake_args, srcroot
         )

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -509,7 +509,9 @@ def _build_model_cmake(
                     cime_model, bldlog
                 )
             )
-            logger.info("   Calling cmake directly, see top of log file for specific call")
+            logger.info(
+                "   Calling cmake directly, see top of log file for specific call"
+            )
             with open(bldlog, "w") as fd:
                 fd.write("Configuring with cmake cmd:\n{}\n\n".format(cmake_cmd))
 

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -465,59 +465,61 @@ def _build_model_cmake(
             os.makedirs(build_dir)
 
     # Components-specific cmake args. Cmake requires all component inputs to be available
-    # regardless of requested build list
-    cmp_cmake_args = ""
-    all_models = []
-    files = Files(comp_interface=comp_interface)
-    for model, _, _, _, config_dir in complist:
-        # Create the Filepath and CIME_cppdefs files
-        if model == "cpl":
-            config_dir = os.path.join(
-                files.get_value("COMP_ROOT_DIR_CPL"), "cime_config"
+    # regardless of requested build list. We do not want to re-invoke cmake
+    # if it has already been called.
+    if not os.path.exists(os.path.join(bldroot, "CMakeCache.txt")):
+        cmp_cmake_args = ""
+        all_models = []
+        files = Files(comp_interface=comp_interface)
+        for model, _, _, _, config_dir in complist:
+            # Create the Filepath and CIME_cppdefs files
+            if model == "cpl":
+                config_dir = os.path.join(
+                    files.get_value("COMP_ROOT_DIR_CPL"), "cime_config"
+                )
+
+            cmp_cmake_args += _create_build_metadata_for_component(
+                config_dir, libroot, bldroot, case
             )
+            all_models.append(model)
 
-        cmp_cmake_args += _create_build_metadata_for_component(
-            config_dir, libroot, bldroot, case
+        # Call CMake
+        cmake_args = get_standard_cmake_args(case, sharedpath)
+        cmake_env = ""
+        ninja_path = os.path.join(srcroot, "externals/ninja/bin")
+        if ninja:
+            cmake_args += " -GNinja "
+            cmake_env += "PATH={}:$PATH ".format(ninja_path)
+
+        # Glue all pieces together:
+        #  - cmake environment
+        #  - common (i.e. project-wide) cmake args
+        #  - component-specific cmake args
+        #  - path to src folder
+        do_timing = "/usr/bin/time -p " if os.path.exists("/usr/bin/time") else ""
+        cmake_cmd = "{} {}cmake {} {} {}/components".format(
+            cmake_env, do_timing, cmake_args, cmp_cmake_args, srcroot
         )
-        all_models.append(model)
-
-    # Call CMake
-    cmake_args = get_standard_cmake_args(case, sharedpath)
-    cmake_env = ""
-    ninja_path = os.path.join(srcroot, "externals/ninja/bin")
-    if ninja:
-        cmake_args += " -GNinja "
-        cmake_env += "PATH={}:$PATH ".format(ninja_path)
-
-    # Glue all pieces together:
-    #  - cmake environment
-    #  - common (i.e. project-wide) cmake args
-    #  - component-specific cmake args
-    #  - path to src folder
-    do_timing = "/usr/bin/time -p " if os.path.exists("/usr/bin/time") else ""
-    cmake_cmd = "{} {}cmake {} {} {}/components".format(
-        cmake_env, do_timing, cmake_args, cmp_cmake_args, srcroot
-    )
-    stat = 0
-    if dry_run:
-        logger.info("CMake cmd:\ncd {} && {}\n\n".format(bldroot, cmake_cmd))
-    else:
-        logger.info(
-            "Configuring full {} model with output to file {}".format(
-                cime_model, bldlog
+        stat = 0
+        if dry_run:
+            logger.info("CMake cmd:\ncd {} && {}\n\n".format(bldroot, cmake_cmd))
+        else:
+            logger.info(
+                "Configuring full {} model with output to file {}".format(
+                    cime_model, bldlog
+                )
             )
-        )
-        logger.info("   Calling cmake directly, see top of log file for specific call")
-        with open(bldlog, "w") as fd:
-            fd.write("Configuring with cmake cmd:\n{}\n\n".format(cmake_cmd))
+            logger.info("   Calling cmake directly, see top of log file for specific call")
+            with open(bldlog, "w") as fd:
+                fd.write("Configuring with cmake cmd:\n{}\n\n".format(cmake_cmd))
 
-        # Add logging before running
-        cmake_cmd = "({}) >> {} 2>&1".format(cmake_cmd, bldlog)
-        stat = run_cmd(cmake_cmd, from_dir=bldroot)[0]
-        expect(
-            stat == 0,
-            "BUILD FAIL: cmake config {} failed, cat {}".format(cime_model, bldlog),
-        )
+            # Add logging before running
+            cmake_cmd = "({}) >> {} 2>&1".format(cmake_cmd, bldlog)
+            stat = run_cmd(cmake_cmd, from_dir=bldroot)[0]
+            expect(
+                stat == 0,
+                "BUILD FAIL: cmake config {} failed, cat {}".format(cime_model, bldlog),
+            )
 
     # Set up buildlist
     if not buildlist:


### PR DESCRIPTION
Re-invoking with a full arg list can mess up the cmake cache.

Test suite: by-hand
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
