### PR TITLE
Fixes creating directory for input data

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -106,6 +106,8 @@ function init_e3sm() {
 
     update_cime "${install_path}/cime"
 
+    mkdir -p /storage/inputdata
+
     rsync -vr /cache/ /storage/inputdata/
 
     cd "${install_path}/cime"


### PR DESCRIPTION
Fixes issue when `/storage/inputdata` doesn't exist and the cached 
test files cannot be populated, causing the testing workflow to fail.

Test suite: n/a
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?: n/a
Update gh-pages html (Y/N)?: n/a
