### PR TITLE
Use standard Fortran functions for getting command-line arguments

### DIFF
--- a/tools/mapping/gen_domain_files/INSTALL
+++ b/tools/mapping/gen_domain_files/INSTALL
@@ -3,7 +3,7 @@ HOW TO BUILD
 ============
 
 (1) $ cd src
-(2) $ ../../../configure --macros-format Makefile --mpilib mpi-serial
+(2) $ ../../../../CIME/scripts/configure --macros-format Makefile --mpilib mpi-serial
 Bash users:
 (3) $ (. ./.env_mach_specific.sh ; gmake)
 csh users:

--- a/tools/mapping/gen_domain_files/src/gen_domain.F90
+++ b/tools/mapping/gen_domain_files/src/gen_domain.F90
@@ -53,7 +53,7 @@ program fmain
   set_omask   = .false.
 
   ! Make sure we have arguments
-  nargs = iargc()
+  nargs = command_argument_count()
   if (nargs == 0) then
      write(6,*)'invoke gen_domain -h for usage'
      stop
@@ -64,47 +64,47 @@ program fmain
   n = 1
   do while (n <= nargs)
     arg = ' '
-    call getarg (n, arg)
+    call get_command_argument (n, arg)
     n = n + 1
 
     select case (arg)
     case ('-m')
        ! input mapping file
-       call getarg (n, arg)
+       call get_command_argument (n, arg)
        n = n + 1
        fmap = trim(arg)
        cmdline = trim(cmdline) // ' -m ' // trim(arg)
     case ('-o')
        ! output ocean grid name
-       call getarg (n, arg)
+       call get_command_argument (n, arg)
        n = n + 1
        fn1_out = trim(arg)
        cmdline = trim(cmdline) // ' -o ' // trim(arg)
     case ('-l')
        ! output land grid name
-       call getarg (n, arg)
+       call get_command_argument (n, arg)
        n = n + 1
        fn2_out = trim(arg)
        cmdline = trim(cmdline) // ' -l ' // trim(arg)
     case ('-p')
        ! set pole on this grid [0,1,2]
-       call getarg (n, arg)
+       call get_command_argument (n, arg)
        n = n + 1
        set_fv_pole_yc = ichar(trim(arg))-48
        write(6,*)'set_fv_pole_yc is ',set_fv_pole_yc
     case ('--fminval')
        ! set fminval (min allowable land fraction)
-       call getarg (n, arg)
+       call get_command_argument (n, arg)
        n = n + 1
        read(arg,*) fminval
     case ('--fmaxval')
        ! set fminval (min allowable land fraction)
-       call getarg (n, arg)
+       call get_command_argument (n, arg)
        n = n + 1
        read(arg,*) fmaxval
     case ('-c')
        ! user comment
-       call getarg (n, arg)
+       call get_command_argument (n, arg)
        n = n + 1
        usercomment = trim(arg)
     case ('--set-omask')


### PR DESCRIPTION
Test suite: Manual testing: compared before and after output from printing args with these diffs:
```diff
diff --git a/tools/mapping/gen_domain_files/src/gen_domain.F90 b/tools/mapping/gen_domain_files/src/gen_domain.F90
index f0b97f20e..289fbce6b 100644
--- a/tools/mapping/gen_domain_files/src/gen_domain.F90
+++ b/tools/mapping/gen_domain_files/src/gen_domain.F90
@@ -118,6 +118,15 @@ program fmain
     end select
   end do
 
+  print *, 'fmap = ', trim(fmap)
+  print *, 'fn1_out = ', trim(fn1_out)
+  print *, 'fn2_out = ', trim(fn2_out)
+  print *, 'set_fv_pole_yc = ', set_fv_pole_yc
+  print *, 'fminval = ', fminval
+  print *, 'fmaxval = ', fmaxval
+  print *, 'usercomment = ', trim(usercomment)
+  print *, 'set_omask = ', set_omask
+
   if (fmap == 'null' .or. fn1_out == 'null' .or. fn2_out== 'null') then
     call usage_exit ('Must specify all the following arguments')
   end if
```
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit

Fixes #4455 

User interface changes?: N

Update gh-pages html (Y/N)?: N
