### PR TITLE
Removes check-changes and reorders jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,25 +18,40 @@ on:
 permissions:
   contents: read
 jobs:
-  check-changes:
-    name: Check for changes to documentation
+  cleanup:
+    permissions:
+      contents: write  #  for git push
+    name: Cleanup branch previews
     runs-on: ubuntu-latest
-    outputs:
-      any_changed: ${{ steps.changed-check.outputs.any_changed }}
+    if: ${{ github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 2
-      - uses: tj-actions/changed-files@v37
-        id: changed-check
-        with:
-          files: doc/**
+          ref: 'gh-pages'
+          fetch-depth: 0
+          lfs: true
+          path: gh-pages
+      - name: Remove branch previews
+        run: |
+          for name in `ls branch/`
+          do
+            if [[ -z "$(git show-ref --quiet ${name})" ]]
+            then
+              git rm -rf branch/${name}
+            fi
+          done
+      - name: Commit and push local changes to gh-pages
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+          git commit -m "Clean up branch previews"
+          git push
   build-and-deploy:
     permissions:
       contents: write  #  for peaceiris/actions-gh-pages to push
       pull-requests: write  #  to comment on pull requests
-    needs: check-changes
-    if: needs.check-changes.outputs.any_changed == 'true'
+    needs: cleanup
+    if: ${{ always() }}
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     steps:
@@ -104,31 +119,3 @@ jobs:
           destination_dir: './versions/master/html'
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
-  cleanup:
-    permissions:
-      contents: write  #  for git push
-    needs: build-and-deploy
-    name: Cleanup branch previews
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: 'gh-pages'
-          fetch-depth: 0
-          lfs: true
-      - name: Remove branch previews
-        run: |
-          for name in `ls branch/`
-          do
-            if [[ -z "$(git show-ref --quiet ${name})" ]]
-            then
-              git rm -rf branch/${name}
-            fi
-          done
-      - name: Commit and push local changes to gh-pages
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-          git commit -m "Clean up branch previews"
-          git push

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,8 +11,6 @@ The Common Infrastructure for Modeling the Earth (CIME - pronounced
 Earth system models, data and stub model components, a driver and associated tools
 and libraries.
 
-Test
-
 Table of contents
 -----------------
 .. toctree::


### PR DESCRIPTION
Removes check-changes since the triggers are filter by
paths. Runs the cleanup job first, to prevent the new commit
from cancelling existing doc deployment workflow.

Test suite: n/a
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?: N
Update gh-pages html (Y/N)?: Y
