### PR TITLE
Adds query_config driver argument

### DIFF
--- a/CIME/scripts/create_newcase.py
+++ b/CIME/scripts/create_newcase.py
@@ -239,6 +239,8 @@ def parse_command_line(args, cimeroot, description):
 
     parser.add_argument(
         "--driver",
+        # use get_cime_default_driver rather than config.driver_default as it considers
+        # environment, user config then config.driver_default
         default=get_cime_default_driver(),
         choices=drv_choices,
         help=drv_help,

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -219,7 +219,7 @@ def parse_command_line(args, description):
 
         parser.add_argument(
             "--driver",
-            choices=("mct", "nuopc", "moab"),
+            choices=model_config.driver_choices,
             help="Override driver specified in tests and use this one.",
         )
 

--- a/CIME/scripts/query_config.py
+++ b/CIME/scripts/query_config.py
@@ -314,7 +314,7 @@ def parse_command_line(args, description):
 
     parser.add_argument(
         "--comp_interface",
-        choices=supported_comp_interfaces, # same as config.driver_choices
+        choices=supported_comp_interfaces,  # same as config.driver_choices
         default="mct",
         action=deprecate_action(", use --driver argument"),
         help="DEPRECATED: Use --driver argument",

--- a/CIME/scripts/query_config.py
+++ b/CIME/scripts/query_config.py
@@ -8,7 +8,7 @@ information will be listed for each.
 
 from CIME.Tools.standard_script_setup import *
 import re
-from CIME.utils import expect
+from CIME.utils import expect, get_cime_default_driver, deprecate_action
 from CIME.XML.files import Files
 from CIME.XML.component import Component
 from CIME.XML.compsets import Compsets
@@ -314,8 +314,16 @@ def parse_command_line(args, description):
 
     parser.add_argument(
         "--comp_interface",
-        choices=supported_comp_interfaces,
+        choices=supported_comp_interfaces, # same as config.driver_choices
         default="mct",
+        action=deprecate_action(", use --driver argument"),
+        help="DEPRECATED: Use --driver argument",
+    )
+
+    parser.add_argument(
+        "--driver",
+        choices=config.driver_choices,
+        default=get_cime_default_driver(),
         help="Coupler/Driver interface",
     )
 
@@ -332,7 +340,7 @@ def parse_command_line(args, description):
         args.machines,
         args.long,
         args.xml,
-        files[args.comp_interface],
+        files[args.driver],
     )
 
 

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -8,6 +8,7 @@ import io, logging, gzip, sys, os, time, re, shutil, glob, string, random, impor
 import importlib.util
 import errno, signal, warnings, filecmp
 import stat as statlib
+from argparse import Action
 from contextlib import contextmanager
 
 from distutils import file_util
@@ -20,6 +21,12 @@ logger = logging.getLogger(__name__)
 # where it's used to resolve $SRCROOT in XML config files.
 GLOBAL = {}
 
+
+def deprecate_action(message):
+    class ActionStoreDeprecated(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            raise DeprecationWarning(f"{option_string} is deprecated{message}")
+    return ActionStoreDeprecated
 
 def import_from_file(name, file_path):
     loader = importlib.machinery.SourceFileLoader(name, file_path)

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -26,7 +26,9 @@ def deprecate_action(message):
     class ActionStoreDeprecated(Action):
         def __call__(self, parser, namespace, values, option_string=None):
             raise DeprecationWarning(f"{option_string} is deprecated{message}")
+
     return ActionStoreDeprecated
+
 
 def import_from_file(name, file_path):
     loader = importlib.machinery.SourceFileLoader(name, file_path)


### PR DESCRIPTION
- Adds --driver to query_config
- Deprecates --comp_interface for query_config
- Fixes driver_choices in create_test

Test suite: pytest CIME/tests/test_unit*
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4456 
User interface changes?: N
Update gh-pages html (Y/N)?: N
