### PR TITLE
if the config_machines.xml file cannot be found give a meaningful error

### DIFF
--- a/CIME/XML/grids.py
+++ b/CIME/XML/grids.py
@@ -27,7 +27,7 @@ class Grids(GenericXML):
         schema = files.get_schema("GRIDS_SPEC_FILE")
         expect(
             os.path.isfile(infile) and os.access(infile, os.R_OK),
-            f"ERROR: grid file not found {infile}",
+            f" grid file not found {infile}",
         )
         try:
             GenericXML.__init__(self, infile, schema)

--- a/CIME/XML/grids.py
+++ b/CIME/XML/grids.py
@@ -25,6 +25,10 @@ class Grids(GenericXML):
             infile = files.get_value("GRIDS_SPEC_FILE")
         logger.debug(" Grid specification file is {}".format(infile))
         schema = files.get_schema("GRIDS_SPEC_FILE")
+        expect(
+            os.path.isfile(infile) and os.access(infile, os.R_OK),
+            f"ERROR: grid file not found {infile}",
+        )
         try:
             GenericXML.__init__(self, infile, schema)
         except:

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -41,9 +41,12 @@ class Machines(GenericXML):
         logger.debug("Verifying using schema {}".format(schema))
 
         self.machines_dir = os.path.dirname(infile)
+        if os.path.exists(infile):
+            checked_files.append(infile)
+        else:
+            expect(False, f"file not found {infile}")
 
         GenericXML.__init__(self, infile, schema)
-        checked_files.append(infile)
 
         # Append the contents of $HOME/.cime/config_machines.xml if it exists.
         #

--- a/CIME/tests/test_unit_xml_machines.py
+++ b/CIME/tests/test_unit_xml_machines.py
@@ -140,8 +140,8 @@ MACHINE_TEST_XML = """<config_machines version="2.0">
 class TestUnitXMLMachines(unittest.TestCase):
     def setUp(self):
         Machines._FILEMAP = {}
-
-        self.machine = Machines()
+        # read_only=False for github testing
+        self.machine = Machines(machine="centos7-linux")
 
         self.machine.read_fd(io.StringIO(MACHINE_TEST_XML))
 


### PR DESCRIPTION
Gives a meaningful error if config_grids.xml or config_machines.xml cannot be found.

Test suite:scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4468 

User interface changes?:

Update gh-pages html (Y/N)?:
