### PR TITLE
Fixes hist_files excluding components during actual compare

### DIFF
--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -72,6 +72,8 @@ def copy_histfiles(case, suffix, match_suffix=None):
     num_copied = 0
     for model in _iter_model_file_substrs(case):
         if case.get_value("TEST") and archive.exclude_testing(model):
+            logger.info("Case is a test and component %r is excluded from comparison")
+
             continue
         comments += "  Copying hist files for model '{}'\n".format(model)
         test_hists = archive.get_latest_hist_files(
@@ -289,6 +291,10 @@ def _compare_hists(
     archive = case.get_env("archive")
     ref_case = case.get_value("RUN_REFCASE")
     for model in _iter_model_file_substrs(case):
+        if case.get_value("TEST") and archive.exclude_testing(model):
+            logger.info("Case is a test and component %r is excluded from comparison")
+
+            continue
         if model == "cpl" and suffix2 == "multiinst":
             multiinst_driver_compare = True
         comments += "  comparing model '{}'\n".format(model)

--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -72,7 +72,9 @@ def copy_histfiles(case, suffix, match_suffix=None):
     num_copied = 0
     for model in _iter_model_file_substrs(case):
         if case.get_value("TEST") and archive.exclude_testing(model):
-            logger.info("Case is a test and component %r is excluded from comparison")
+            logger.info(
+                "Case is a test and component %r is excluded from comparison", model
+            )
 
             continue
         comments += "  Copying hist files for model '{}'\n".format(model)
@@ -292,7 +294,9 @@ def _compare_hists(
     ref_case = case.get_value("RUN_REFCASE")
     for model in _iter_model_file_substrs(case):
         if case.get_value("TEST") and archive.exclude_testing(model):
-            logger.info("Case is a test and component %r is excluded from comparison")
+            logger.info(
+                "Case is a test and component %r is excluded from comparison", model
+            )
 
             continue
         if model == "cpl" and suffix2 == "multiinst":

--- a/CIME/tests/test_unit_xml_machines.py
+++ b/CIME/tests/test_unit_xml_machines.py
@@ -141,7 +141,8 @@ class TestUnitXMLMachines(unittest.TestCase):
     def setUp(self):
         Machines._FILEMAP = {}
         # read_only=False for github testing
-        self.machine = Machines(machine="centos7-linux")
+        # MACHINE IS SET BELOW TO USE DEFINITION IN "MACHINE_TEST_XML"
+        self.machine = Machines()
 
         self.machine.read_fd(io.StringIO(MACHINE_TEST_XML))
 


### PR DESCRIPTION
We were only excluding components during the `copy_histfiles`, 
need to exclude during `_compare_hists` as well otherwise
`compare_phase` complains it cannot find counterpart of old
baseline files.

Test suite: pytest  CIME/tests/*
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?: N
Update gh-pages html (Y/N)?: N
