### PR TITLE
gpu_enabled needs to be true only when gpu is used

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -458,7 +458,10 @@ class Case(object):
     def get_value(self, item, attribute=None, resolved=True, subgroup=None):
         if item == "GPU_ENABLED":
             if not self.gpu_enabled:
-                if self.get_value("GPU_TYPE") != "none":
+                if (
+                    self.get_value("GPU_TYPE") != "none"
+                    and self.get_value("NGPUS_PER_NODE") > 0
+                ):
                     self.gpu_enabled = True
             return "true" if self.gpu_enabled else "false"
 


### PR DESCRIPTION
Only set gpu_enabled if gpus are actually used. 

Test suite: PFS_Ld5.ne30pg3_ne30pg3_mg17.FLTHIST_v0d.derecho_intel
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes #4476 

User interface changes?:

Update gh-pages html (Y/N)?:
