### PR TITLE
support wildcard for machine and compiler name with meaning current d…

### DIFF
--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -1149,9 +1149,6 @@ def get_full_test_name(
     ]
 
     result = partial_test
-    print(
-        f"partial_testcase {partial_testcase} partial_machine {partial_machine} partial_compiler {partial_compiler}"
-    )
     for partial_val, arg_val, name in required_fields:
         if partial_val is None:
             # Add to result based on args
@@ -1161,7 +1158,6 @@ def get_full_test_name(
                     partial_test, name
                 ),
             )
-            print(f"name = {name} result = {result}")
             if name == "machine" and "*_" in result:
                 result = result.replace("*_", arg_val + "_")
             elif name == "compiler" and "_*" in result:
@@ -1220,9 +1216,7 @@ def get_full_test_name(
                 partial_test, partial_caseopts, caseopts
             ),
         )
-    print(
-        f" partial_test {partial_test} machine {machine} compiler {compiler} result {result}"
-    )
+
     return result
 
 

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -271,7 +271,7 @@ def _read_cime_config_file():
     cime_config_file = os.path.abspath(
         os.path.join(os.path.expanduser("~"), ".cime", "config")
     )
-    cime_config = configparser.SafeConfigParser()
+    cime_config = configparser.ConfigParser()
     if os.path.isfile(cime_config_file):
         cime_config.read(cime_config_file)
         for section in cime_config.sections():
@@ -661,8 +661,8 @@ def import_and_run_sub_or_cmd(
             run_sub_or_cmd(
                 cmd, cmdargs, subname, subargs, logfile, case, from_dir, timeout
             )
-        except Exception as e:
-            raise e from None
+        except Exception as e1:
+            raise e1 from None
     except Exception:
         if logfile:
             with open(logfile, "a") as log_fd:
@@ -1014,6 +1014,12 @@ def parse_test_name(test_name):
     ['ERS', None, 'fe12_123', 'JGF', 'machine', 'compiler', None]
     >>> parse_test_name('ERS.fe12_123.JGF.machine_compiler.test-mods')
     ['ERS', None, 'fe12_123', 'JGF', 'machine', 'compiler', ['test/mods']]
+    >>> parse_test_name('ERS.fe12_123.JGF.*_compiler.test-mods')
+    ['ERS', None, 'fe12_123', 'JGF', None, 'compiler', ['test/mods']]
+    >>> parse_test_name('ERS.fe12_123.JGF.machine_*.test-mods')
+    ['ERS', None, 'fe12_123', 'JGF', 'machine', None, ['test/mods']]
+    >>> parse_test_name('ERS.fe12_123.JGF.*_*.test-mods')
+    ['ERS', None, 'fe12_123', 'JGF', None, None, ['test/mods']]
     >>> parse_test_name('ERS.fe12_123.JGF.machine_compiler.test-mods--other-dir-path--and-one-more')
     ['ERS', None, 'fe12_123', 'JGF', 'machine', 'compiler', ['test/mods', 'other/dir/path', 'and/one/more']]
     >>> parse_test_name('SMS.f19_g16.2000_DATM%QI.A_XLND_SICE_SOCN_XROF_XGLC_SWAV.mach-ine_compiler.test-mods') # doctest: +IGNORE_EXCEPTION_DETAIL
@@ -1047,6 +1053,10 @@ def parse_test_name(test_name):
             ),
         )
         rv[4:5] = rv[4].split("_")
+        if rv[4] == "*":
+            rv[4] = None
+        if rv[5] == "*":
+            rv[5] = None
         rv.pop()
 
     if rv[-1] is not None:
@@ -1139,7 +1149,9 @@ def get_full_test_name(
     ]
 
     result = partial_test
-
+    print(
+        f"partial_testcase {partial_testcase} partial_machine {partial_machine} partial_compiler {partial_compiler}"
+    )
     for partial_val, arg_val, name in required_fields:
         if partial_val is None:
             # Add to result based on args
@@ -1149,9 +1161,15 @@ def get_full_test_name(
                     partial_test, name
                 ),
             )
-            result = "{}{}{}".format(
-                result, "_" if name == "compiler" else ".", arg_val
-            )
+            print(f"name = {name} result = {result}")
+            if name == "machine" and "*_" in result:
+                result = result.replace("*_", arg_val + "_")
+            elif name == "compiler" and "_*" in result:
+                result = result.replace("_*", "_" + arg_val)
+            else:
+                result = "{}{}{}".format(
+                    result, "_" if name == "compiler" else ".", arg_val
+                )
         elif arg_val is not None and partial_val != partial_compiler:
             expect(
                 arg_val == partial_val,
@@ -1202,7 +1220,9 @@ def get_full_test_name(
                 partial_test, partial_caseopts, caseopts
             ),
         )
-
+    print(
+        f" partial_test {partial_test} machine {machine} compiler {compiler} result {result}"
+    )
     return result
 
 


### PR DESCRIPTION
…efault is used

Allow machine and compiler names * in testname syntax to indicate default machine and/or compiler name.   

Test suite:
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #2107 

User interface changes?:

Update gh-pages html (Y/N)?:
