### PR TITLE
Set GPU variables correctly for CESM

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1587,9 +1587,9 @@ class Case(object):
             )
 
         # Set these two GPU XML variables here to overwrite the default values
-        if gpu_type:
+        # Only set them for "cesm" model
+        if self._cime_model == "cesm":
             self.set_value("GPU_TYPE", str(gpu_type).lower())
-        if gpu_offload:
             self.set_value("GPU_OFFLOAD", str(gpu_offload).lower())
 
         self.initialize_derived_attributes()


### PR DESCRIPTION
I got a runtime error when I tried to run a case on Derecho's CPU node with the NVHPC compiler. The error message said that "No cuda shared library is found on the node".

The underlying reason is that the `GPU_OFFLOAD` variable is not set (https://github.com/ESMCI/cime/blob/master/CIME/case/case.py#L1592-L1593) if we do not explicitly provide the `--gpu-offload` option for a CPU build, which will unexpectedly load the CUDA module even if we are building a pure-CPU case (https://github.com/ESMCI/ccs_config_cesm/blob/main/machines/config_machines.xml#L1340-L1342).

This PR fixes the issue and now a CPU run on Derecho with the NVHPC compiler works as expected.