### PR TITLE
Moves check_input_data to SystemTestsCommon when running a test

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -441,6 +441,15 @@ class SystemTestsCommon(object):
         stop_option = self._case.get_value("STOP_OPTION")
         run_type = self._case.get_value("RUN_TYPE")
         rundir = self._case.get_value("RUNDIR")
+        try:
+            self._case.check_all_input_data()
+        except CIMEError:
+            caseroot = self._case.get_value("CASEROOT")
+            raise CIMEError(
+                "Could not find all inputdata on any server, try "
+                "manually running `./check_input_data --download "
+                f"--versbose` from {caseroot!r}."
+            ) from None
         if submit_resubmits is None:
             do_resub = self._case.get_value("BATCH_SYSTEM") != "none"
         else:

--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -287,7 +287,8 @@ def check_case(self, skip_pnl=False, chksum=False):
     if not skip_pnl:
         self.create_namelists()  # Must be called before check_all_input_data
     logger.info("Checking that inputdata is available as part of case submission")
-    self.check_all_input_data(chksum=chksum)
+    if not self.get_value("TEST"):
+        self.check_all_input_data(chksum=chksum)
 
     if self.get_value("COMP_WAV") == "ww":
         # the ww3 buildnml has dependencies on inputdata so we must run it again

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -22,6 +22,16 @@ def make_valid_case(path):
 class TestCaseSubmit(unittest.TestCase):
     def test_check_case(self):
         case = mock.MagicMock()
+        # get_value arguments TEST, COMP_WAV, COMP_INTERFACE, BUILD_COMPLETE
+        case.get_value.side_effect = [False, "", "", True]
+        case_submit.check_case(case, chksum=True)
+
+        case.check_all_input_data.assert_called_with(chksum=True)
+
+    def test_check_case_test(self):
+        case = mock.MagicMock()
+        # get_value arguments TEST, COMP_WAV, COMP_INTERFACE, BUILD_COMPLETE
+        case.get_value.side_effect = [True, "", "", True]
         case_submit.check_case(case, chksum=True)
 
         case.check_all_input_data.assert_called_with(chksum=True)

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -34,7 +34,7 @@ class TestCaseSubmit(unittest.TestCase):
         case.get_value.side_effect = [True, "", "", True]
         case_submit.check_case(case, chksum=True)
 
-        case.check_all_input_data.assert_called_with(chksum=True)
+        case.check_all_input_data.assert_not_called()
 
     @mock.patch("CIME.case.case_submit.lock_file")
     @mock.patch("CIME.case.case_submit.unlock_file")


### PR DESCRIPTION
When running a test, `check_all_input_data` is called from `run_indv`
of `SystemTestsCommon` rather than `case.submit`. This will solve
issues when the second or nth case of a test needs additional data.
If the test cannot download the data, the user is presented an error
suggesting to run `./check_input_data` manually from within the 
`caseroot`.

Test suite: pytest tests
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4400 
User interface changes?: N
Update gh-pages html (Y/N)?: N
