### PR TITLE
Removes capture all between hist_file_extension and suffix

### DIFF
--- a/CIME/XML/archive_base.py
+++ b/CIME/XML/archive_base.py
@@ -146,7 +146,7 @@ class ArchiveBase(GenericXML):
             string = model + r"\d?_?(\d{4})?\." + ext
             if has_suffix:
                 if not suffix in string:
-                    string += r".*\." + suffix + "$"
+                    string += r"\." + suffix + "$"
 
                 if not string.endswith("$"):
                     string += "$"

--- a/CIME/tests/test_unit_xml_archive_base.py
+++ b/CIME/tests/test_unit_xml_archive_base.py
@@ -12,7 +12,7 @@ from CIME.XML.archive_base import ArchiveBase
 
 TEST_CONFIG = """<components version="2.0">
   <comp_archive_spec compname="eam" compclass="atm">
-    <hist_file_extension>unique\.name\.unique</hist_file_extension>
+    <hist_file_extension>unique\.name\.unique.*</hist_file_extension>
   </comp_archive_spec>
 </components>"""
 


### PR DESCRIPTION
Removes `.*` between `hist_file_extension` and `suffix` in `get_all_hist_files`.
This would cause ERIO test to fail by not finding the correct files to compare
due to the extra text allowed between the extension and suffix. If there is 
expected text between the extension and suffix this should be defined in
`hist_file_extension`.

Test suite: pytest -vvv
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?: n/a
Update gh-pages html (Y/N)?: N
