### PR TITLE
env_batch: Fix flag/val separator

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -15,6 +15,7 @@ from CIME.utils import (
     get_batch_script_for_job,
     get_logging_options,
     format_time,
+    add_flag_to_cmd,
 )
 from CIME.locked_files import lock_file, unlock_file
 from collections import OrderedDict
@@ -607,6 +608,7 @@ class EnvBatch(EnvBase):
                 flag, name = self._get_argument(case, arg)
             except ValueError:
                 continue
+
             if self._batchtype == "cobalt" and job == "case.st_archive":
                 if flag == "-n":
                     name = "task_count"
@@ -626,7 +628,7 @@ class EnvBatch(EnvBase):
                         if len(rflag) > len(flag):
                             submitargs += " {}".format(rflag)
                     else:
-                        submitargs += " {} {}".format(flag, name)
+                        submitargs += " " + add_flag_to_cmd(flag, name)
                 else:
                     submitargs += " {}".format(flag)
             else:
@@ -636,7 +638,7 @@ class EnvBatch(EnvBase):
                     except ValueError:
                         continue
                 else:
-                    submitargs += " {} {}".format(flag, name)
+                    submitargs += " " + add_flag_to_cmd(flag, name)
 
         return submitargs
 
@@ -702,13 +704,8 @@ class EnvBatch(EnvBase):
             if flag == "-q" and rval == "batch" and case.get_value("MACH") == "blues":
                 # Special case. Do not provide '-q batch' for blues
                 raise ValueError()
-            if (
-                flag.rfind("=", len(flag) - 1, len(flag)) >= 0
-                or flag.rfind(":", len(flag) - 1, len(flag)) >= 0
-            ):
-                submitargs = " {}{}".format(flag, str(rval).strip())
-            else:
-                submitargs = " {} {}".format(flag, str(rval).strip())
+
+            submitargs = " " + add_flag_to_cmd(flag, rval)
 
         return submitargs
 

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -2691,6 +2691,7 @@ def clear_folder(_dir):
             except Exception as e:
                 print(e)
 
+
 def add_flag_to_cmd(flag, val):
     """
     Given a flag and value for a shell command, return a string

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -2690,3 +2690,27 @@ def clear_folder(_dir):
                     os.rmdir(file_path)
             except Exception as e:
                 print(e)
+
+def add_flag_to_cmd(flag, val):
+    """
+    Given a flag and value for a shell command, return a string
+
+    >>> add_flag_to_cmd("-f", "hi")
+    '-f hi'
+    >>> add_flag_to_cmd("--foo", 42)
+    '--foo 42'
+    >>> add_flag_to_cmd("--foo=", 42)
+    '--foo=42'
+    >>> add_flag_to_cmd("--foo:", 42)
+    '--foo:42'
+    >>> add_flag_to_cmd("--foo:", " hi ")
+    '--foo:hi'
+    """
+    no_space_chars = "=:"
+    no_space = False
+    for item in no_space_chars:
+        if flag.endswith(item):
+            no_space = True
+
+    separator = "" if no_space else " "
+    return "{}{}{}".format(flag, separator, str(val).strip())


### PR DESCRIPTION
One of the code paths for computing submit args was assuming a whitespace separator was needed, which is not right when the flag ends with '=' or ':'. This PR adds a new function that encapsulates this concept and calls it in the appropriate places in env_batch.

Test suite: scripts-regression-tests
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
