### PR TITLE
Add new 'perf' test property

### DIFF
--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -13,7 +13,7 @@ import traceback, stat, threading, time, glob
 from collections import OrderedDict
 
 from CIME.XML.standard_module_setup import *
-from CIME.get_tests import get_recommended_test_time, get_build_groups
+from CIME.get_tests import get_recommended_test_time, get_build_groups, is_perf_test
 from CIME.utils import (
     append_status,
     append_testlog,
@@ -967,7 +967,10 @@ class TestScheduler(object):
                 )
             envtest.set_initial_values(case)
             case.set_value("TEST", True)
-            case.set_value("SAVE_TIMING", self._save_timing)
+            if is_perf_test(test):
+                case.set_value("SAVE_TIMING", True)
+            else:
+                case.set_value("SAVE_TIMING", self._save_timing)
 
             # handle single-exe here, all cases will use the EXEROOT from
             # the first case in the build group


### PR DESCRIPTION
This will be used to mark suites as performance test suites.

I think this is the best way to approach the issue of performance testing. It will allow us to mark a handful of tests in our common test suites as performance tests so we can piggyback on the current testing jobs. The idea would be to select a few tests in the integration suite, pull them into their own suite, mark them as perf=True, then have the original suite inherit the new suite.

Test suite: doctests
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
