### PR TITLE
Updates performance baselines

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -129,7 +129,7 @@ jobs:
 
           init_cime
 
-          pytest -vvv --machine docker --no-fortran-run CIME/tests/test_unit*
+          pytest -vvv --cov=CIME --machine docker --no-fortran-run CIME/tests/test_unit*
 
   # Run system tests
   system-testing:
@@ -182,7 +182,7 @@ jobs:
 
           conda activate base
 
-          pytest -vvv --machine docker --no-fortran-run --no-teardown CIME/tests/test_sys*
+          pytest -vvv --cov=CIME --machine docker --no-fortran-run --no-teardown CIME/tests/test_sys*
       - name: Create testing log archive
         if: ${{ failure() }}
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ scripts/Tools/JENKINS*
 components
 libraries
 share
+test_coverage/**

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -775,6 +775,10 @@ for some of your components.
                     tolerance = self._case.get_value("TEST_MEMLEAK_TOLERANCE")
                     if tolerance is None:
                         tolerance = 0.1
+                    comment = "MEMCOMP: Memory usage highwater has changed by {:.2f}% relative to baseline".format(
+                        diff * 100
+                    )
+                    append_testlog(comment, self._orig_caseroot)
                     if (
                         diff < tolerance
                         and self._test_status.get_status(MEMCOMP_PHASE) is None

--- a/CIME/Tools/bless_test_results
+++ b/CIME/Tools/bless_test_results
@@ -60,6 +60,12 @@ OR
     )
 
     parser.add_argument(
+        "--tput-only", action="store_true", help="Only analyze throughput."
+    )
+
+    parser.add_argument("--mem-only", action="store_true", help="Only analyze memory.")
+
+    parser.add_argument(
         "-b",
         "--baseline-name",
         help="Name of baselines to use. Default will use BASELINE_NAME_CMP first if possible, otherwise branch name.",
@@ -140,7 +146,7 @@ OR
         "Makes no sense to use -r and -f simultaneously",
     )
     expect(
-        not (args.namelists_only and args.hist_only),
+        sum([args.namelists_only, args.hist_only, args.tput_only, args.mem_only]) <= 1,
         "Makes no sense to use --namelists-only and --hist-only simultaneously",
     )
 
@@ -152,6 +158,8 @@ OR
         args.test_id,
         args.namelists_only,
         args.hist_only,
+        args.tput_only,
+        args.mem_only,
         args.report_only,
         args.force,
         args.pes_file,
@@ -173,6 +181,8 @@ def _main_func(description):
         test_id,
         namelists_only,
         hist_only,
+        tput_only,
+        mem_only,
         report_only,
         force,
         pes_file,
@@ -190,6 +200,8 @@ def _main_func(description):
         test_id=test_id,
         namelists_only=namelists_only,
         hist_only=hist_only,
+        tput_only=tput_only,
+        mem_only=mem_only,
         report_only=report_only,
         force=force,
         pesfile=pes_file,

--- a/CIME/baselines.py
+++ b/CIME/baselines.py
@@ -1,0 +1,320 @@
+import os
+import glob
+import re
+import gzip
+import logging
+from CIME.utils import expect
+
+logger = logging.getLogger(__name__)
+
+def get_latest_cpl_logs(case):
+    """
+    find and return the latest cpl log file in the run directory
+    """
+    coupler_log_path = case.get_value("RUNDIR")
+    cpllog_name = "drv" if case.get_value("COMP_INTERFACE") == "nuopc" else "cpl"
+    cpllogs = glob.glob(
+        os.path.join(coupler_log_path, "{}*.log.*".format(cpllog_name))
+    )
+    lastcpllogs = []
+    if cpllogs:
+        lastcpllogs.append(max(cpllogs, key=os.path.getctime))
+        basename = os.path.basename(lastcpllogs[0])
+        suffix = basename.split(".", 1)[1]
+        for log in cpllogs:
+            if log in lastcpllogs:
+                continue
+
+            if log.endswith(suffix):
+                lastcpllogs.append(log)
+
+    return lastcpllogs
+
+def compare_memory(case):
+    baseline_root = case.get_value("BASELINE_ROOT")
+
+    baseline_name = case.get_value("BASECMP_CASE")
+
+    baseline_dir = os.path.join(baseline_root, baseline_name)
+
+    latest_cpl_logs = get_latest_cpl_logs(case)
+
+    diff, baseline, current = [None]*3
+
+    for cpllog in latest_cpl_logs:
+        try:
+            baseline = read_baseline_mem(baseline_dir)
+        except FileNotFoundError as e:
+            logger.debug("Could not read baseline memory usage: %s", e)
+
+            continue
+
+        if baseline is None:
+            baseline = 0.0
+
+        memlist = get_mem_usage(cpllog)
+
+        if len(memlist) <= 3:
+            logger.debug(f"Found {len(memlist)} memory usage samples, need atleast 4")
+
+            continue
+
+        current = memlist[-1][1]
+
+        try:
+            diff = (current - baseline) / baseline
+        except ZeroDivisionError:
+            diff = 0.0
+
+    tolerance = case.get_value("TEST_MEMLEAK_TOLERANCE")
+
+    if tolerance is None:
+        tolerance = 0.1
+
+    # Should we check if tolerance is above 0
+    below_tolerance = None
+
+    if diff is not None:
+        below_tolerance = diff < tolerance
+
+    return below_tolerance, diff, tolerance, baseline, current
+
+def compare_throughput(case):
+    baseline_root = case.get_value("BASELINE_ROOT")
+
+    baseline_name = case.get_value("BASECMP_CASE")
+
+    baseline_dir = os.path.join(baseline_root, baseline_name)
+
+    latest_cpl_logs = get_latest_cpl_logs(case)
+
+    diff, baseline, current = [None]*3
+
+    # Do we need this loop, when are there multiple cpl logs?
+    for cpllog in latest_cpl_logs:
+        try:
+            baseline = read_baseline_tput(baseline_dir)
+        except (FileNotFoundError, IndexError, ValueError) as e:
+            logger.debug("Could not read baseline throughput: %s", e)
+
+            continue
+
+        current = get_throughput(cpllog)
+
+        try:
+            # comparing ypd so bigger is better
+            diff = (baseline - current) / baseline
+        except (ValueError, TypeError):
+            # Should we default the diff to 0.0 as with _compare_current_memory?
+            logger.debug(
+                "Could not determine change in throughput between baseline %s and current %s",
+                baseline,
+                current,
+            )
+
+            continue
+
+    tolerance = case.get_value("TEST_TPUT_TOLERANCE")
+
+    if tolerance is None:
+        tolerance = 0.1
+
+    expect(
+        tolerance > 0.0,
+        "Bad value for throughput tolerance in test",
+    )
+
+    below_tolerance = None
+
+    if diff is not None:
+        below_tolerance = diff < tolerance
+
+    return below_tolerance, diff, tolerance, baseline, current
+
+def write_baseline_tput(baseline_dir, cpllog):
+    """
+    Writes baseline throughput to file.
+
+    A "-1" indicates that no throughput data was available from the coupler log.
+
+    Parameters
+    ----------
+    baseline_dir : str
+        Path to the baseline directory.
+    cpllog : str
+        Path to the current coupler log.
+    """
+    tput_file = os.path.join(baseline_dir, "cpl-tput.log")
+
+    tput = get_throughput(cpllog)
+
+    with open(tput_file, "w") as fd:
+        fd.write("# Throughput in simulated years per compute day\n")
+        fd.write(
+            "# A -1 indicates no throughput data was available from the test\n"
+        )
+
+        if tput is None:
+            fd.write("-1")
+        else:
+            fd.write(str(tput))
+
+def write_baseline_mem(baseline_dir, cpllog):
+    """
+    Writes baseline memory usage highwater to file.
+
+    A "-1" indicates that no memory usage data was available from the coupler log.
+
+    Parameters
+    ----------
+    baseline_dir : str
+        Path to the baseline directory.
+    cpllog : str
+        Path to the current coupler log.
+    """
+    mem_file = os.path.join(baseline_dir, "cpl-mem.log")
+
+    mem = get_mem_usage(cpllog)
+
+    with open(mem_file, "w") as fd:
+        fd.write("# Memory usage highwater\n")
+        fd.write(
+            "# A -1 indicates no memory usage data was available from the test\n"
+        )
+
+        try:
+            fd.write(str(mem[-1][1]))
+        except IndexError:
+            fd.write("-1")
+
+def read_baseline_tput(baseline_dir):
+    """
+    Reads throughput baseline.
+
+    Parameters
+    ----------
+    baseline_dir : str
+        Path to the baseline directory.
+
+    Returns
+    -------
+    float
+        Value of the throughput.
+
+    Raises
+    ------
+    FileNotFoundError
+        If baseline file does not exist.
+    IndexError
+        If no throughput value is found.
+    ValueError
+        If throughput value is not a float.
+    """
+    try:
+        tput = read_baseline_value(os.path.join(baseline_dir, "cpl-tput.log"))
+    except (IndexError, ValueError):
+        tput = None
+
+    if tput == -1:
+        tput = None
+
+    return tput
+
+def read_baseline_mem(baseline_dir):
+    """
+    Reads memory usage highwater baseline.
+
+    The default behvaior was to return 0 if no usage data was found.
+
+    Parameters
+    ----------
+    baseline_dir : str
+        Path to the baseline directory.
+
+    Returns
+    -------
+    float
+        Value of the highwater memory usage.
+
+    Raises
+    ------
+    FileNotFoundError
+        If baseline file does not exist.
+    """
+    try:
+        memory = read_baseline_value(
+            os.path.join(baseline_dir, "cpl-mem.log")
+        )
+    except (IndexError, ValueError):
+        memory = 0
+
+    if memory == -1:
+        memory = 0
+
+    return memory
+
+def read_baseline_value(baseline_file):
+    """
+    Read baseline value from file.
+
+    Parameters
+    ----------
+    baseline_file : str
+        Path to baseline file.
+
+    Returns
+    -------
+    float
+        Baseline value.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``baseline_file`` is not found.
+    IndexError
+        If not values are present in ``baseline_file``.
+    ValueError
+        If value in ``baseline_file`` is not a float.
+    """
+    with open(baseline_file) as fd:
+        lines = [x for x in fd.readlines() if not x.startswith("#")]
+
+    return float(lines[0])
+
+def get_mem_usage(cpllog):
+    """
+    Examine memory usage as recorded in the cpl log file and look for unexpected
+    increases.
+    """
+    memlist = []
+    meminfo = re.compile(
+        r".*model date =\s+(\w+).*memory =\s+(\d+\.?\d+).*highwater"
+    )
+    if cpllog is not None and os.path.isfile(cpllog):
+        if ".gz" == cpllog[-3:]:
+            fopen = gzip.open
+        else:
+            fopen = open
+        with fopen(cpllog, "rb") as f:
+            for line in f:
+                m = meminfo.match(line.decode("utf-8"))
+                if m:
+                    memlist.append((float(m.group(1)), float(m.group(2))))
+    # Remove the last mem record, it's sometimes artificially high
+    if len(memlist) > 0:
+        memlist.pop()
+    return memlist
+
+def get_throughput(cpllog):
+    """
+    Examine memory usage as recorded in the cpl log file and look for unexpected
+    increases.
+    """
+    if cpllog is not None and os.path.isfile(cpllog):
+        with gzip.open(cpllog, "rb") as f:
+            cpltext = f.read().decode("utf-8")
+            m = re.search(r"# simulated years / cmp-day =\s+(\d+\.\d+)\s", cpltext)
+            if m:
+                return float(m.group(1))
+    return None
+

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -11,9 +11,93 @@ from CIME.test_status import *
 from CIME.hist_utils import generate_baseline, compare_baseline
 from CIME.case import Case
 from CIME.test_utils import get_test_status_files
+from CIME.baselines import (
+    get_latest_cpl_logs,
+    get_mem_usage,
+    get_throughput,
+    compare_throughput,
+    compare_memory,
+    write_baseline_tput,
+    write_baseline_mem,
+)
 import os, time
 
 logger = logging.getLogger(__name__)
+
+
+def bless_throughput(
+    case,
+    test_name,
+    baseline_root,
+    baseline_name,
+    report_only,
+    force,
+):
+    success = True
+    reason = None
+
+    baseline_dir = os.path.join(
+        baseline_root, baseline_name, case.get_value("CASEBASEID")
+    )
+
+    below_threshold, comment = compare_throughput(case, baseline_dir=baseline_dir)
+
+    if below_threshold:
+        logger.info("Diff appears to have been already resolved.")
+    else:
+        logger.info(comment)
+
+        if not report_only and (
+            force or input("Update this diff (y/n)? ").upper() in ["Y", "YES"]
+        ):
+            try:
+                latest_cpl_logs = get_latest_cpl_logs(case)
+                current = get_throughput(latest_cpl_logs[0])
+                write_baseline_tput(baseline_dir, current)
+            except Exception as e:
+                success = False
+
+                reason = f"Failed to write baseline throughput for {test_name!r}: {e!s}"
+
+    return success, reason
+
+
+def bless_memory(
+    case,
+    test_name,
+    baseline_root,
+    baseline_name,
+    report_only,
+    force,
+):
+    success = True
+    reason = None
+
+    baseline_dir = os.path.join(
+        baseline_root, baseline_name, case.get_value("CASEBASEID")
+    )
+
+    below_threshold, comment = compare_memory(case, baseline_dir=baseline_dir)
+
+    if below_threshold:
+        logger.info("Diff appears to have been already resolved.")
+    else:
+        logger.info(comment)
+
+        if not report_only and (
+            force or input("Update this diff (y/n)? ").upper() in ["Y", "YES"]
+        ):
+            try:
+                latest_cpl_logs = get_latest_cpl_logs(case)
+                current = get_mem_usage(latest_cpl_logs[0])
+                write_baseline_mem(baseline_dir, current)
+            except Exception as e:
+                success = False
+
+                reason = f"Failed to write baseline memory usage for test {test_name!r}: {e!s}"
+
+    return success, reason
+
 
 ###############################################################################
 def bless_namelists(
@@ -112,6 +196,8 @@ def bless_test_results(
     test_id=None,
     namelists_only=False,
     hist_only=False,
+    tput_only=False,
+    mem_only=False,
     report_only=False,
     force=False,
     pesfile=None,
@@ -172,9 +258,15 @@ def bless_test_results(
         if bless_tests in [[], None] or CIME.utils.match_any(
             test_name, bless_tests_counts
         ):
-            overall_result, phase = ts.get_overall_test_status(
-                ignore_namelists=True, ignore_memleak=True
-            )
+            ts_kwargs = dict(ignore_namelists=True, ignore_memleak=True)
+
+            if tput_only:
+                ts_kwargs["check_throughput"] = True
+
+            if mem_only:
+                ts_kwargs["check_memory"] = True
+
+            overall_result, phase = ts.get_overall_test_status(**ts_kwargs)
 
             # See if we need to bless namelist
             if not hist_only:
@@ -219,14 +311,13 @@ def bless_test_results(
                 hist_bless = False
 
             # Now, do the bless
-            if not nl_bless and not hist_bless:
+            if not nl_bless and not hist_bless and not tput_only and not mem_only:
                 logger.info(
                     "Nothing to bless for test: {}, overall status: {}".format(
                         test_name, overall_result
                     )
                 )
             else:
-
                 logger.info(
                     "###############################################################################"
                 )
@@ -301,6 +392,32 @@ def bless_test_results(
                                 report_only,
                                 force,
                             )
+
+                        if not success:
+                            broken_blesses.append((test_name, reason))
+
+                    if tput_only:
+                        success, reason = bless_throughput(
+                            case,
+                            test_name,
+                            baseline_root,
+                            baseline_name,
+                            report_only,
+                            force,
+                        )
+
+                        if not success:
+                            broken_blesses.append((test_name, reason))
+
+                    if mem_only:
+                        success, reason = bless_memory(
+                            case,
+                            test_name,
+                            baseline_root,
+                            baseline_name,
+                            report_only,
+                            force,
+                        )
 
                         if not success:
                             broken_blesses.append((test_name, reason))

--- a/CIME/test_status.py
+++ b/CIME/test_status.py
@@ -460,7 +460,7 @@ class TestStatus(object):
                     if rv == TEST_PASS_STATUS:
                         rv = NAMELIST_FAIL_STATUS
 
-                elif phase == BASELINE_PHASE:
+                elif phase in [BASELINE_PHASE, THROUGHPUT_PHASE, MEMCOMP_PHASE]:
                     if rv in [NAMELIST_FAIL_STATUS, TEST_PASS_STATUS]:
                         phase_responsible_for_status = phase
                         rv = TEST_DIFF_STATUS
@@ -512,7 +512,9 @@ class TestStatus(object):
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A TPUTCOMP')
         ('PASS', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A TPUTCOMP', check_throughput=True)
-        ('FAIL', 'TPUTCOMP')
+        ('DIFF', 'TPUTCOMP')
+        >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A MEMCOMP', check_memory=True)
+        ('DIFF', 'MEMCOMP')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPASS ERS.foo.A RUN\nFAIL ERS.foo.A NLCOMP')
         ('NLFAIL', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPEND ERS.foo.A RUN\nFAIL ERS.foo.A NLCOMP')

--- a/CIME/tests/test_unit_baselines.py
+++ b/CIME/tests/test_unit_baselines.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+
+import gzip
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+from CIME import baselines
+from CIME.tests.test_unit_system_tests import CPLLOG
+
+def create_mock_case(tempdir, get_latest_cpl_logs):
+    caseroot = Path(tempdir, "0", "caseroot")
+    rundir = caseroot / "run"
+
+    get_latest_cpl_logs.return_value = (
+        str(rundir / "cpl.log.gz"),
+    )
+
+    baseline_root = Path(tempdir, "baselines")
+
+    case = mock.MagicMock()
+
+    return case, caseroot, rundir, baseline_root
+
+class TestUnitBaseline(unittest.TestCase):
+    def test_get_throughput_no_file(self):
+        throughput = baselines.get_throughput("/tmp/cpl.log")
+
+        assert throughput is None
+
+    def test_get_throughput(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            cpl_log_path = Path(tempdir, "cpl.log.gz")
+
+            with gzip.open(cpl_log_path, "w") as fd:
+                fd.write(CPLLOG.encode("utf-8"))
+
+            throughput = baselines.get_throughput(str(cpl_log_path))
+
+        assert throughput == 719.635
+
+    def test_get_mem_usage_gz(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            cpl_log_path = Path(tempdir, "cpl.log.gz")
+
+            with gzip.open(cpl_log_path, "w") as fd:
+                fd.write(CPLLOG.encode("utf-8"))
+
+            mem_usage = baselines.get_mem_usage(str(cpl_log_path))
+
+        assert mem_usage == [(10102.0, 1673.89), (10103.0, 1673.89), (10104.0, 1673.89), (10105.0, 1673.89)]
+
+    @mock.patch("CIME.baselines.os.path.isfile")
+    def test_get_mem_usage(self, isfile):
+        isfile.return_value = True
+
+        with mock.patch("builtins.open", mock.mock_open(read_data=CPLLOG.encode("utf-8"))) as mock_file:
+            mem_usage = baselines.get_mem_usage("/tmp/cpl.log")
+
+        assert mem_usage == [(10102.0, 1673.89), (10103.0, 1673.89), (10104.0, 1673.89), (10105.0, 1673.89)]
+
+    def test_read_baseline_mem_empty(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data="")) as mock_file:
+            baseline = baselines.read_baseline_mem("/tmp/cpl-mem.log")
+
+        assert baseline is 0
+
+    def test_read_baseline_mem_none(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data="-1")) as mock_file:
+            baseline = baselines.read_baseline_mem("/tmp/cpl-mem.log")
+
+        assert baseline is 0
+
+    def test_read_baseline_mem(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data="200")) as mock_file:
+            baseline = baselines.read_baseline_mem("/tmp/cpl-mem.log")
+
+        assert baseline == 200
+
+    def test_read_baseline_tput_empty(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data="")) as mock_file:
+            baseline = baselines.read_baseline_tput("/tmp/cpl-tput.log")
+
+        assert baseline is None
+
+    def test_read_baseline_tput_none(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data="-1")) as mock_file:
+            baseline = baselines.read_baseline_tput("/tmp/cpl-tput.log")
+
+        assert baseline is None
+
+    def test_read_baseline_tput(self):
+        with mock.patch("builtins.open", mock.mock_open(read_data="200")) as mock_file:
+            baseline = baselines.read_baseline_tput("/tmp/cpl-tput.log")
+
+        assert baseline == 200
+
+    @mock.patch("CIME.baselines.get_mem_usage")
+    def test_write_baseline_mem_no_value(self, get_mem_usage):
+        get_mem_usage.return_value = []
+
+        with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+            baselines.write_baseline_mem("/tmp", "/tmp/cpl.log")
+
+        mock_file.assert_called_with("/tmp/cpl-mem.log", "w")
+        mock_file.return_value.write.assert_called_with("-1")
+
+    @mock.patch("CIME.baselines.get_mem_usage")
+    def test_write_baseline_mem(self, get_mem_usage):
+        get_mem_usage.return_value = [(1, 200)]
+
+        with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+            baselines.write_baseline_mem("/tmp", "/tmp/cpl.log")
+
+        mock_file.assert_called_with("/tmp/cpl-mem.log", "w")
+        mock_file.return_value.write.assert_called_with("200")
+
+    @mock.patch("CIME.baselines.get_throughput")
+    def test_write_baseline_tput_no_value(self, get_throughput):
+        get_throughput.return_value = None
+
+        with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+            baselines.write_baseline_tput("/tmp", "/tmp/cpl.log")
+
+        mock_file.assert_called_with("/tmp/cpl-tput.log", "w")
+        mock_file.return_value.write.assert_called_with("-1")
+
+    @mock.patch("CIME.baselines.get_throughput")
+    def test_write_baseline_tput(self, get_throughput):
+        get_throughput.return_value = 200
+
+        with mock.patch("builtins.open", mock.mock_open()) as mock_file:
+            baselines.write_baseline_tput("/tmp", "/tmp/cpl.log")
+
+        mock_file.assert_called_with("/tmp/cpl-tput.log", "w")
+        mock_file.return_value.write.assert_called_with("200")
+
+    @mock.patch("CIME.baselines.get_throughput")
+    @mock.patch("CIME.baselines.read_baseline_tput")
+    @mock.patch("CIME.baselines.get_latest_cpl_logs")
+    def test_compare_throughput_no_baseline_file(self, get_latest_cpl_logs, read_baseline_tput, get_throughput):
+        read_baseline_tput.side_effect = FileNotFoundError
+
+        get_throughput.return_value = 504
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
+
+            case.get_value.side_effect = (
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                0.05,
+            )
+
+            below_tolerance, diff, tolerance,  baseline, current = baselines.compare_throughput(case)
+
+        assert below_tolerance is None
+        assert diff == None
+        assert tolerance == 0.05
+        assert baseline == None
+        assert current == None
+
+    @mock.patch("CIME.baselines.get_throughput")
+    @mock.patch("CIME.baselines.read_baseline_tput")
+    @mock.patch("CIME.baselines.get_latest_cpl_logs")
+    def test_compare_throughput_no_baseline(self, get_latest_cpl_logs, read_baseline_tput, get_throughput):
+        read_baseline_tput.return_value = None
+
+        get_throughput.return_value = 504
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
+
+            case.get_value.side_effect = (
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                0.05,
+            )
+
+            below_tolerance, diff, tolerance,  baseline, current = baselines.compare_throughput(case)
+
+        assert below_tolerance is None
+        assert diff == None
+        assert tolerance == 0.05
+        assert baseline == None
+        assert current == 504
+
+    @mock.patch("CIME.baselines.get_throughput")
+    @mock.patch("CIME.baselines.read_baseline_tput")
+    @mock.patch("CIME.baselines.get_latest_cpl_logs")
+    def test_compare_throughput_no_tolerance(self, get_latest_cpl_logs, read_baseline_tput, get_throughput):
+        read_baseline_tput.return_value = 500
+
+        get_throughput.return_value = 504
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
+
+            case.get_value.side_effect = (
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                None
+            )
+
+            below_tolerance, diff, tolerance,  baseline, current = baselines.compare_throughput(case)
+
+        assert below_tolerance
+        assert diff == -0.008
+        assert tolerance == 0.1
+        assert baseline == 500
+        assert current == 504
+
+    @mock.patch("CIME.baselines.get_throughput")
+    @mock.patch("CIME.baselines.read_baseline_tput")
+    @mock.patch("CIME.baselines.get_latest_cpl_logs")
+    def test_compare_throughput(self, get_latest_cpl_logs, read_baseline_tput, get_throughput):
+        read_baseline_tput.return_value = 500
+
+        get_throughput.return_value = 504
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
+
+            case.get_value.side_effect = (
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                0.05,
+            )
+
+            below_tolerance, diff, tolerance,  baseline, current = baselines.compare_throughput(case)
+
+        assert below_tolerance
+        assert diff == -0.008
+        assert tolerance == 0.05
+        assert baseline == 500
+        assert current == 504
+
+    @mock.patch("CIME.baselines.get_mem_usage")
+    @mock.patch("CIME.baselines.read_baseline_mem")
+    @mock.patch("CIME.baselines.get_latest_cpl_logs")
+    def test_compare_memory_no_baseline(self, get_latest_cpl_logs, read_baseline_mem, get_mem_usage):
+        read_baseline_mem.return_value = None
+
+        get_mem_usage.return_value = [
+            (1, 1000.0),
+            (2, 1001.0),
+            (3, 1002.0),
+            (4, 1003.0),
+        ]
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
+
+            case.get_value.side_effect = (
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                0.05,
+            )
+
+            below_tolerance, diff, tolerance,  baseline, current = baselines.compare_memory(case)
+
+        assert below_tolerance
+        assert diff == 0.0
+        assert tolerance == 0.05
+        assert baseline == 0.0
+        assert current == 1003.0
+
+    @mock.patch("CIME.baselines.get_mem_usage")
+    @mock.patch("CIME.baselines.read_baseline_mem")
+    @mock.patch("CIME.baselines.get_latest_cpl_logs")
+    def test_compare_memory_not_enough_samples(self, get_latest_cpl_logs, read_baseline_mem, get_mem_usage):
+        read_baseline_mem.return_value = 1000.0
+
+        get_mem_usage.return_value = [
+            (1, 1000.0),
+            (2, 1001.0),
+        ]
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
+
+            case.get_value.side_effect = (
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                0.05,
+            )
+
+            below_tolerance, diff, tolerance,  baseline, current = baselines.compare_memory(case)
+
+        assert below_tolerance is None
+        assert diff == None
+        assert tolerance == 0.05
+        assert baseline == 1000.0
+        assert current == None
+
+    @mock.patch("CIME.baselines.get_mem_usage")
+    @mock.patch("CIME.baselines.read_baseline_mem")
+    @mock.patch("CIME.baselines.get_latest_cpl_logs")
+    def test_compare_memory_no_baseline_file(self, get_latest_cpl_logs, read_baseline_mem, get_mem_usage):
+        read_baseline_mem.side_effect = FileNotFoundError
+
+        get_mem_usage.return_value = [
+            (1, 1000.0),
+            (2, 1001.0),
+            (3, 1002.0),
+            (4, 1003.0),
+        ]
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
+
+            case.get_value.side_effect = (
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                0.05,
+            )
+
+            below_tolerance, diff, tolerance,  baseline, current = baselines.compare_memory(case)
+
+        assert below_tolerance is None
+        assert diff == None
+        assert tolerance == 0.05
+        assert baseline == None
+        assert current == None
+
+    @mock.patch("CIME.baselines.get_mem_usage")
+    @mock.patch("CIME.baselines.read_baseline_mem")
+    @mock.patch("CIME.baselines.get_latest_cpl_logs")
+    def test_compare_memory_no_tolerance(self, get_latest_cpl_logs, read_baseline_mem, get_mem_usage):
+        read_baseline_mem.return_value = 1000.0
+
+        get_mem_usage.return_value = [
+            (1, 1000.0),
+            (2, 1001.0),
+            (3, 1002.0),
+            (4, 1003.0),
+        ]
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
+
+            case.get_value.side_effect = (
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                None,
+            )
+
+            below_tolerance, diff, tolerance, baseline, current = baselines.compare_memory(case)
+
+        assert below_tolerance
+        assert diff == 0.003
+        assert tolerance == 0.1
+        assert baseline == 1000.0
+        assert current == 1003.0
+
+    @mock.patch("CIME.baselines.get_mem_usage")
+    @mock.patch("CIME.baselines.read_baseline_mem")
+    @mock.patch("CIME.baselines.get_latest_cpl_logs")
+    def test_compare_memory(self, get_latest_cpl_logs, read_baseline_mem, get_mem_usage):
+        read_baseline_mem.return_value = 1000.0
+
+        get_mem_usage.return_value = [
+            (1, 1000.0),
+            (2, 1001.0),
+            (3, 1002.0),
+            (4, 1003.0),
+        ]
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
+
+            case.get_value.side_effect = (
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                0.05,
+            )
+
+            below_tolerance, diff, tolerance, baseline, current = baselines.compare_memory(case)
+
+        assert below_tolerance
+        assert diff == 0.003
+        assert tolerance == 0.05
+        assert baseline == 1000.0
+        assert current == 1003.0
+
+    def test_get_latest_cpl_logs_found_multiple(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            run_dir = Path(tempdir) / "run"
+            run_dir.mkdir(parents=True, exist_ok=False)
+
+            cpl_log_path = run_dir / "cpl.log.gz"
+            cpl_log_path.touch()
+
+            cpl_log_2_path = run_dir / "cpl-2023-01-01.log.gz"
+            cpl_log_2_path.touch()
+
+            case = mock.MagicMock()
+            case.get_value.side_effect = (
+                str(run_dir),
+                "mct",
+            )
+
+            latest_cpl_logs = baselines.get_latest_cpl_logs(case)
+
+        assert len(latest_cpl_logs) == 2
+        assert sorted(latest_cpl_logs) == sorted([str(cpl_log_path), str(cpl_log_2_path)])
+
+    def test_get_latest_cpl_logs_found_single(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            run_dir = Path(tempdir) / "run"
+            run_dir.mkdir(parents=True, exist_ok=False)
+
+            cpl_log_path = run_dir / "cpl.log.gz"
+            cpl_log_path.touch()
+
+            case = mock.MagicMock()
+            case.get_value.side_effect = (
+                str(run_dir),
+                "mct",
+            )
+
+            latest_cpl_logs = baselines.get_latest_cpl_logs(case)
+
+        assert len(latest_cpl_logs) == 1
+        assert latest_cpl_logs[0] == str(cpl_log_path)
+
+    def test_get_latest_cpl_logs(self):
+        case = mock.MagicMock()
+        case.get_value.side_effect = (
+            f"/tmp/run",
+            "mct",
+        )
+
+        latest_cpl_logs = baselines.get_latest_cpl_logs(case)
+
+        assert len(latest_cpl_logs) == 0

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -69,7 +69,10 @@ class TestCaseSubmit(unittest.TestCase):
     @mock.patch("CIME.SystemTests.system_tests_common.compare_throughput")
     @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
     def test_compare_throughput(self, append_testlog, compare_throughput):
-        compare_throughput.return_value = (True, 0.02, 0.05, 200, 201)
+        compare_throughput.return_value = (
+            True,
+            "TPUTCOMP: Computation time changed by 2.00% relative to baseline",
+        )
 
         with tempfile.TemporaryDirectory() as tempdir:
             caseroot = Path(tempdir) / "caseroot"
@@ -96,7 +99,7 @@ class TestCaseSubmit(unittest.TestCase):
     @mock.patch("CIME.SystemTests.system_tests_common.compare_throughput")
     @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
     def test_compare_throughput_error_diff(self, append_testlog, compare_throughput):
-        compare_throughput.return_value = (None, 0.02, 0.05, 200, 201)
+        compare_throughput.return_value = (None, "Error diff value")
 
         with tempfile.TemporaryDirectory() as tempdir:
             caseroot = Path(tempdir) / "caseroot"
@@ -120,7 +123,10 @@ class TestCaseSubmit(unittest.TestCase):
     @mock.patch("CIME.SystemTests.system_tests_common.compare_throughput")
     @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
     def test_compare_throughput_fail(self, append_testlog, compare_throughput):
-        compare_throughput.return_value = (False, 0.02, 0.05, 200, 201)
+        compare_throughput.return_value = (
+            False,
+            "Error: TPUTCOMP: Computation time increase > 5% from baseline",
+        )
 
         with tempfile.TemporaryDirectory() as tempdir:
             caseroot = Path(tempdir) / "caseroot"
@@ -140,10 +146,6 @@ class TestCaseSubmit(unittest.TestCase):
         assert common._test_status.get_overall_test_status() == ("PASS", None)
 
         append_testlog.assert_any_call(
-            "TPUTCOMP: Computation time changed by 2.00% relative to baseline",
-            str(caseroot),
-        )
-        append_testlog.assert_any_call(
             "Error: TPUTCOMP: Computation time increase > 5% from baseline",
             str(caseroot),
         )
@@ -151,7 +153,10 @@ class TestCaseSubmit(unittest.TestCase):
     @mock.patch("CIME.SystemTests.system_tests_common.compare_memory")
     @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
     def test_compare_memory(self, append_testlog, compare_memory):
-        compare_memory.return_value = (True, 0.02, 0.05, 1000, 1002)
+        compare_memory.return_value = (
+            True,
+            "MEMCOMP: Memory usage highwater has changed by 2.00% relative to baseline",
+        )
 
         with tempfile.TemporaryDirectory() as tempdir:
             caseroot = Path(tempdir) / "caseroot"
@@ -178,7 +183,7 @@ class TestCaseSubmit(unittest.TestCase):
     @mock.patch("CIME.SystemTests.system_tests_common.compare_memory")
     @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
     def test_compare_memory_erorr_diff(self, append_testlog, compare_memory):
-        compare_memory.return_value = (None, 0.02, 0.05, 1000, 1002)
+        compare_memory.return_value = (None, "Error diff value")
 
         with tempfile.TemporaryDirectory() as tempdir:
             caseroot = Path(tempdir) / "caseroot"
@@ -202,7 +207,10 @@ class TestCaseSubmit(unittest.TestCase):
     @mock.patch("CIME.SystemTests.system_tests_common.compare_memory")
     @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
     def test_compare_memory_erorr_fail(self, append_testlog, compare_memory):
-        compare_memory.return_value = (False, 0.02, 0.05, 1000, 1002)
+        compare_memory.return_value = (
+            False,
+            "Error: Memory usage increase >5% from baseline's 1000.000000 to 1002.000000",
+        )
 
         with tempfile.TemporaryDirectory() as tempdir:
             caseroot = Path(tempdir) / "caseroot"
@@ -221,10 +229,6 @@ class TestCaseSubmit(unittest.TestCase):
 
         assert common._test_status.get_overall_test_status() == ("PASS", None)
 
-        append_testlog.assert_any_call(
-            "MEMCOMP: Memory usage highwater has changed by 2.00% relative to baseline",
-            str(caseroot),
-        )
         append_testlog.assert_any_call(
             "Error: Memory usage increase >5% from baseline's 1000.000000 to 1002.000000",
             str(caseroot),

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import os
+import tempfile
+import gzip
 from re import A
 import unittest
 from unittest import mock
@@ -10,8 +12,273 @@ from CIME.SystemTests.system_tests_common import SystemTestsCommon
 from CIME.SystemTests.system_tests_compare_two import SystemTestsCompareTwo
 from CIME.SystemTests.system_tests_compare_n import SystemTestsCompareN
 
+CPLLOG = """
+ tStamp_write: model date =   00010102       0 wall clock = 2023-09-19 19:39:42 avg dt =     0.33 dt =     0.33
+ memory_write: model date =   00010102       0 memory =    1673.89 MB (highwater)        387.77 MB (usage)  (pe=    0 comps= cpl ATM LND ICE OCN GLC ROF WAV IAC ESP)
+ tStamp_write: model date =   00010103       0 wall clock = 2023-09-19 19:39:42 avg dt =     0.33 dt =     0.33
+ memory_write: model date =   00010103       0 memory =    1673.89 MB (highwater)        390.09 MB (usage)  (pe=    0 comps= cpl ATM LND ICE OCN GLC ROF WAV IAC ESP)
+ tStamp_write: model date =   00010104       0 wall clock = 2023-09-19 19:39:42 avg dt =     0.33 dt =     0.33
+ memory_write: model date =   00010104       0 memory =    1673.89 MB (highwater)        391.64 MB (usage)  (pe=    0 comps= cpl ATM LND ICE OCN GLC ROF WAV IAC ESP)
+ tStamp_write: model date =   00010105       0 wall clock = 2023-09-19 19:39:43 avg dt =     0.33 dt =     0.33
+ memory_write: model date =   00010105       0 memory =    1673.89 MB (highwater)        392.67 MB (usage)  (pe=    0 comps= cpl ATM LND ICE OCN GLC ROF WAV IAC ESP)
+ tStamp_write: model date =   00010106       0 wall clock = 2023-09-19 19:39:43 avg dt =     0.33 dt =     0.33
+ memory_write: model date =   00010106       0 memory =    1673.89 MB (highwater)        393.44 MB (usage)  (pe=    0 comps= cpl ATM LND ICE OCN GLC ROF WAV IAC ESP)
+
+(seq_mct_drv): ===============          SUCCESSFUL TERMINATION OF CPL7-e3sm ===============
+(seq_mct_drv): ===============        at YMD,TOD =   00010106       0       ===============
+(seq_mct_drv): ===============  # simulated days (this run) =        5.000  ===============
+(seq_mct_drv): ===============  compute time (hrs)          =        0.000  ===============
+(seq_mct_drv): ===============  # simulated years / cmp-day =      719.635  ===============
+(seq_mct_drv): ===============  pes min memory highwater  (MB)     851.957  ===============
+(seq_mct_drv): ===============  pes max memory highwater  (MB)    1673.891  ===============
+(seq_mct_drv): ===============  pes min memory last usage (MB)     182.742  ===============
+(seq_mct_drv): ===============  pes max memory last usage (MB)     393.441  ===============
+"""
+
+
+def create_mock_case(tempdir, idx=None, cpllog_data=None):
+    if idx is None:
+        idx = 0
+
+    case = mock.MagicMock()
+
+    caseroot = Path(tempdir, str(idx), "caseroot")
+    baseline_root = caseroot.parent / "baselines"
+    run_dir = caseroot / "run"
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    if cpllog_data is not None:
+        cpllog = run_dir / "cpl.log.gz"
+
+        with gzip.open(cpllog, "w") as fd:
+            fd.write(cpllog_data.encode("utf-8"))
+
+        case.get_latest_cpl_log.return_value = str(cpllog)
+
+    hist_file = run_dir / "cpl.hi.2023-01-01.nc"
+    hist_file.touch()
+
+    case.get_env.return_value.get_latest_hist_files.return_value = [str(hist_file)]
+
+    case.get_compset_components.return_value = []
+
+    return case, caseroot, baseline_root, run_dir
+
 
 class TestCaseSubmit(unittest.TestCase):
+    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
+    def test_compare_throughput(self, append_testlog):
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, caseroot, baseline_root, run_dir = create_mock_case(
+                tempdir, cpllog_data=CPLLOG
+            )
+
+            base_case, base_caseroot, _, _ = create_mock_case(
+                tempdir, idx=1, cpllog_data=CPLLOG
+            )
+
+            case.get_value.side_effect = (
+                str(caseroot),
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "mct",
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                str(baseline_root),
+                str(run_dir),
+                0.05,
+            )
+
+            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+            baseline_dir.mkdir(parents=True, exist_ok=False)
+            baseline_mem = baseline_dir / "cpl-mem.log"
+
+            with open(baseline_mem, "w") as fd:
+                fd.write(str("1673.89"))
+
+            common = SystemTestsCommon(case)
+
+            common._compare_memory()
+
+            assert common._test_status.get_overall_test_status() == ("PASS", None)
+
+            append_testlog.assert_any_call(
+                "MEMCOMP: Memory usage highwater has changed by 0.00% relative to baseline",
+                str(caseroot),
+            )
+
+    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
+    def test_compare_throughput_fail(self, append_testlog):
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, caseroot, baseline_root, run_dir = create_mock_case(
+                tempdir, cpllog_data=CPLLOG
+            )
+
+            base_case, base_caseroot, _, _ = create_mock_case(
+                tempdir, idx=1, cpllog_data=CPLLOG
+            )
+
+            case.get_value.side_effect = (
+                str(caseroot),
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "mct",
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                str(baseline_root),
+                str(run_dir),
+                0.05,
+            )
+
+            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+            baseline_dir.mkdir(parents=True, exist_ok=False)
+            baseline_mem = baseline_dir / "cpl-mem.log"
+
+            with open(baseline_mem, "w") as fd:
+                fd.write(str("1473.89"))
+
+            common = SystemTestsCommon(case)
+
+            common._compare_memory()
+
+            assert common._test_status.get_overall_test_status() == ("PASS", None)
+
+            append_testlog.assert_any_call(
+                "MEMCOMP: Memory usage highwater has changed by 13.57% relative to baseline",
+                str(caseroot),
+            )
+            append_testlog.assert_any_call(
+                "Error: Memory usage increase >5% from baseline's 1473.890000 to 1673.890000",
+                str(caseroot),
+            )
+
+    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
+    def test_compare_memory(self, append_testlog):
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, caseroot, baseline_root, run_dir = create_mock_case(
+                tempdir, cpllog_data=CPLLOG
+            )
+
+            base_case, base_caseroot, _, _ = create_mock_case(
+                tempdir, idx=1, cpllog_data=CPLLOG
+            )
+
+            case.get_value.side_effect = (
+                str(caseroot),
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "mct",
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                str(baseline_root),
+                str(run_dir),
+                0.05,
+            )
+
+            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+            baseline_dir.mkdir(parents=True, exist_ok=False)
+            baseline_tput = baseline_dir / "cpl-tput.log"
+
+            with open(baseline_tput, "w") as fd:
+                fd.write(str("719.635"))
+
+            common = SystemTestsCommon(case)
+
+            common._compare_throughput()
+
+            assert common._test_status.get_overall_test_status() == ("PASS", None)
+
+            append_testlog.assert_any_call(
+                "TPUTCOMP: Computation time changed by 0.00% relative to baseline",
+                str(caseroot),
+            )
+
+    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
+    def test_compare_memory_fail(self, append_testlog):
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, caseroot, baseline_root, run_dir = create_mock_case(
+                tempdir, cpllog_data=CPLLOG
+            )
+
+            base_case, base_caseroot, _, _ = create_mock_case(
+                tempdir, idx=1, cpllog_data=CPLLOG
+            )
+
+            case.get_value.side_effect = (
+                str(caseroot),
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "mct",
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                str(baseline_root),
+                str(run_dir),
+                0.05,
+            )
+
+            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+            baseline_dir.mkdir(parents=True, exist_ok=False)
+            baseline_tput = baseline_dir / "cpl-tput.log"
+
+            with open(baseline_tput, "w") as fd:
+                fd.write(str("900.635"))
+
+            common = SystemTestsCommon(case)
+
+            common._compare_throughput()
+
+            assert common._test_status.get_overall_test_status() == ("PASS", None)
+
+            append_testlog.assert_any_call(
+                "TPUTCOMP: Computation time changed by 20.10% relative to baseline",
+                str(caseroot),
+            )
+            append_testlog.assert_any_call(
+                "Error: TPUTCOMP: Computation time increase > 5% from baseline",
+                str(caseroot),
+            )
+
+    def test_generate_baseline(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            case, caseroot, baseline_root, run_dir = create_mock_case(
+                tempdir, cpllog_data=CPLLOG
+            )
+
+            case.get_value.side_effect = (
+                str(caseroot),
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "mct",
+                str(run_dir),
+                "case.std",
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16_rx1.A.docker_gnu.G.20230919_193255_z9hg2w",
+                "mct",
+                str(run_dir),
+                "ERIO",
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                os.getcwd(),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                str(baseline_root),
+                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                str(run_dir),
+            )
+
+            common = SystemTestsCommon(case)
+
+            common._generate_baseline()
+
+            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+
+            assert (baseline_dir / "cpl.log.gz").exists()
+            assert (baseline_dir / "cpl-tput.log").exists()
+            assert (baseline_dir / "cpl-mem.log").exists()
+            assert (baseline_dir / "cpl.hi.2023-01-01.nc").exists()
+
+            with open(baseline_dir / "cpl-tput.log") as fd:
+                lines = fd.readlines()
+
+            assert len(lines) == 3
+            assert lines[-1] == "719.635"
+
+            with open(baseline_dir / "cpl-mem.log") as fd:
+                lines = fd.readlines()
+
+            assert len(lines) == 3
+            assert lines[-1] == "1673.89"
+
     def test_kwargs(self):
         case = mock.MagicMock()
 

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -66,169 +66,169 @@ def create_mock_case(tempdir, idx=None, cpllog_data=None):
 
 
 class TestCaseSubmit(unittest.TestCase):
+    @mock.patch("CIME.SystemTests.system_tests_common.compare_throughput")
     @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
-    def test_compare_throughput(self, append_testlog):
+    def test_compare_throughput(self, append_testlog, compare_throughput):
+        compare_throughput.return_value = (True, 0.02, 0.05, 200, 201)
+
         with tempfile.TemporaryDirectory() as tempdir:
-            case, caseroot, baseline_root, run_dir = create_mock_case(
-                tempdir, cpllog_data=CPLLOG
-            )
+            caseroot = Path(tempdir) / "caseroot"
+            caseroot.mkdir(parents=True, exist_ok=False)
 
-            base_case, base_caseroot, _, _ = create_mock_case(
-                tempdir, idx=1, cpllog_data=CPLLOG
-            )
-
+            case = mock.MagicMock()
             case.get_value.side_effect = (
-                str(caseroot),
+                str(Path(tempdir) / "caseroot"),
                 "ERIO.ne30_g16_rx1.A.docker_gnu",
                 "mct",
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
-                str(baseline_root),
-                str(run_dir),
-                0.05,
             )
-
-            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
-            baseline_dir.mkdir(parents=True, exist_ok=False)
-            baseline_mem = baseline_dir / "cpl-mem.log"
-
-            with open(baseline_mem, "w") as fd:
-                fd.write(str("1673.89"))
-
-            common = SystemTestsCommon(case)
-
-            common._compare_memory()
-
-            assert common._test_status.get_overall_test_status() == ("PASS", None)
-
-            append_testlog.assert_any_call(
-                "MEMCOMP: Memory usage highwater has changed by 0.00% relative to baseline",
-                str(caseroot),
-            )
-
-    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
-    def test_compare_throughput_fail(self, append_testlog):
-        with tempfile.TemporaryDirectory() as tempdir:
-            case, caseroot, baseline_root, run_dir = create_mock_case(
-                tempdir, cpllog_data=CPLLOG
-            )
-
-            base_case, base_caseroot, _, _ = create_mock_case(
-                tempdir, idx=1, cpllog_data=CPLLOG
-            )
-
-            case.get_value.side_effect = (
-                str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
-                "mct",
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
-                str(baseline_root),
-                str(run_dir),
-                0.05,
-            )
-
-            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
-            baseline_dir.mkdir(parents=True, exist_ok=False)
-            baseline_mem = baseline_dir / "cpl-mem.log"
-
-            with open(baseline_mem, "w") as fd:
-                fd.write(str("1473.89"))
-
-            common = SystemTestsCommon(case)
-
-            common._compare_memory()
-
-            assert common._test_status.get_overall_test_status() == ("PASS", None)
-
-            append_testlog.assert_any_call(
-                "MEMCOMP: Memory usage highwater has changed by 13.57% relative to baseline",
-                str(caseroot),
-            )
-            append_testlog.assert_any_call(
-                "Error: Memory usage increase >5% from baseline's 1473.890000 to 1673.890000",
-                str(caseroot),
-            )
-
-    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
-    def test_compare_memory(self, append_testlog):
-        with tempfile.TemporaryDirectory() as tempdir:
-            case, caseroot, baseline_root, run_dir = create_mock_case(
-                tempdir, cpllog_data=CPLLOG
-            )
-
-            base_case, base_caseroot, _, _ = create_mock_case(
-                tempdir, idx=1, cpllog_data=CPLLOG
-            )
-
-            case.get_value.side_effect = (
-                str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
-                "mct",
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
-                str(baseline_root),
-                str(run_dir),
-                0.05,
-            )
-
-            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
-            baseline_dir.mkdir(parents=True, exist_ok=False)
-            baseline_tput = baseline_dir / "cpl-tput.log"
-
-            with open(baseline_tput, "w") as fd:
-                fd.write(str("719.635"))
 
             common = SystemTestsCommon(case)
 
             common._compare_throughput()
 
-            assert common._test_status.get_overall_test_status() == ("PASS", None)
+        assert common._test_status.get_overall_test_status() == ("PASS", None)
 
-            append_testlog.assert_any_call(
-                "TPUTCOMP: Computation time changed by 0.00% relative to baseline",
-                str(caseroot),
-            )
+        append_testlog.assert_any_call(
+            "TPUTCOMP: Computation time changed by 2.00% relative to baseline",
+            str(caseroot),
+        )
 
+    @mock.patch("CIME.SystemTests.system_tests_common.compare_throughput")
     @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
-    def test_compare_memory_fail(self, append_testlog):
+    def test_compare_throughput_error_diff(self, append_testlog, compare_throughput):
+        compare_throughput.return_value = (None, 0.02, 0.05, 200, 201)
+
         with tempfile.TemporaryDirectory() as tempdir:
-            case, caseroot, baseline_root, run_dir = create_mock_case(
-                tempdir, cpllog_data=CPLLOG
-            )
+            caseroot = Path(tempdir) / "caseroot"
+            caseroot.mkdir(parents=True, exist_ok=False)
 
-            base_case, base_caseroot, _, _ = create_mock_case(
-                tempdir, idx=1, cpllog_data=CPLLOG
-            )
-
+            case = mock.MagicMock()
             case.get_value.side_effect = (
-                str(caseroot),
+                str(Path(tempdir) / "caseroot"),
                 "ERIO.ne30_g16_rx1.A.docker_gnu",
                 "mct",
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
-                str(baseline_root),
-                str(run_dir),
-                0.05,
             )
-
-            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
-            baseline_dir.mkdir(parents=True, exist_ok=False)
-            baseline_tput = baseline_dir / "cpl-tput.log"
-
-            with open(baseline_tput, "w") as fd:
-                fd.write(str("900.635"))
 
             common = SystemTestsCommon(case)
 
             common._compare_throughput()
 
-            assert common._test_status.get_overall_test_status() == ("PASS", None)
+        assert common._test_status.get_overall_test_status() == ("PASS", None)
 
-            append_testlog.assert_any_call(
-                "TPUTCOMP: Computation time changed by 20.10% relative to baseline",
-                str(caseroot),
+        append_testlog.assert_not_called()
+
+    @mock.patch("CIME.SystemTests.system_tests_common.compare_throughput")
+    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
+    def test_compare_throughput_fail(self, append_testlog, compare_throughput):
+        compare_throughput.return_value = (False, 0.02, 0.05, 200, 201)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            caseroot = Path(tempdir) / "caseroot"
+            caseroot.mkdir(parents=True, exist_ok=False)
+
+            case = mock.MagicMock()
+            case.get_value.side_effect = (
+                str(Path(tempdir) / "caseroot"),
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "mct",
             )
-            append_testlog.assert_any_call(
-                "Error: TPUTCOMP: Computation time increase > 5% from baseline",
+
+            common = SystemTestsCommon(case)
+
+            common._compare_throughput()
+
+        assert common._test_status.get_overall_test_status() == ("PASS", None)
+
+        append_testlog.assert_any_call(
+            "TPUTCOMP: Computation time changed by 2.00% relative to baseline",
+            str(caseroot),
+        )
+        append_testlog.assert_any_call(
+            "Error: TPUTCOMP: Computation time increase > 5% from baseline",
+            str(caseroot),
+        )
+
+    @mock.patch("CIME.SystemTests.system_tests_common.compare_memory")
+    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
+    def test_compare_memory(self, append_testlog, compare_memory):
+        compare_memory.return_value = (True, 0.02, 0.05, 1000, 1002)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            caseroot = Path(tempdir) / "caseroot"
+            caseroot.mkdir(parents=True, exist_ok=False)
+
+            case = mock.MagicMock()
+            case.get_value.side_effect = (
                 str(caseroot),
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "mct",
             )
+
+            common = SystemTestsCommon(case)
+
+            common._compare_memory()
+
+        assert common._test_status.get_overall_test_status() == ("PASS", None)
+
+        append_testlog.assert_any_call(
+            "MEMCOMP: Memory usage highwater has changed by 2.00% relative to baseline",
+            str(caseroot),
+        )
+
+    @mock.patch("CIME.SystemTests.system_tests_common.compare_memory")
+    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
+    def test_compare_memory_erorr_diff(self, append_testlog, compare_memory):
+        compare_memory.return_value = (None, 0.02, 0.05, 1000, 1002)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            caseroot = Path(tempdir) / "caseroot"
+            caseroot.mkdir(parents=True, exist_ok=False)
+
+            case = mock.MagicMock()
+            case.get_value.side_effect = (
+                str(caseroot),
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "mct",
+            )
+
+            common = SystemTestsCommon(case)
+
+            common._compare_memory()
+
+        assert common._test_status.get_overall_test_status() == ("PASS", None)
+
+        append_testlog.assert_not_called()
+
+    @mock.patch("CIME.SystemTests.system_tests_common.compare_memory")
+    @mock.patch("CIME.SystemTests.system_tests_common.append_testlog")
+    def test_compare_memory_erorr_fail(self, append_testlog, compare_memory):
+        compare_memory.return_value = (False, 0.02, 0.05, 1000, 1002)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            caseroot = Path(tempdir) / "caseroot"
+            caseroot.mkdir(parents=True, exist_ok=False)
+
+            case = mock.MagicMock()
+            case.get_value.side_effect = (
+                str(caseroot),
+                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "mct",
+            )
+
+            common = SystemTestsCommon(case)
+
+            common._compare_memory()
+
+        assert common._test_status.get_overall_test_status() == ("PASS", None)
+
+        append_testlog.assert_any_call(
+            "MEMCOMP: Memory usage highwater has changed by 2.00% relative to baseline",
+            str(caseroot),
+        )
+        append_testlog.assert_any_call(
+            "Error: Memory usage increase >5% from baseline's 1000.000000 to 1002.000000",
+            str(caseroot),
+        )
 
     def test_generate_baseline(self):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -254,6 +254,7 @@ class TestCaseSubmit(unittest.TestCase):
                 str(baseline_root),
                 "master/ERIO.ne30_g16_rx1.A.docker_gnu",
                 str(run_dir),
+                "mct",
             )
 
             common = SystemTestsCommon(case)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ console_scripts =
 
 [tool:pytest]
 junit_family=xunit2
-addopts = --cov=CIME --cov-report term-missing --cov-report html:test_coverage/html --cov-report xml:test_coverage/coverage.xml -s
 python_files = test_*.py
 testpaths =
     CIME/tests


### PR DESCRIPTION
Updates how performance baselines are created and compared.

Before
- Baseline generation stores `cpl.log`
- Comparison parses baseline and testcase `cpl.log` and compares throughput/memory
- `--check-throughput` and `--check-memory` will `PASS` even if `MEMCOMP` or `TPUTCOMP` fail
- `bless_test_results --hist-only` will update the baseline `cpl.log` 

After
- Baseline generation stores throughput in `cpl-tput.log` and memory usage in `cpl-mem.log`
- Comparison parses testcase `cpl.log` and compares the baselines respective files
- `--check-throughput` and `--check-memory` will `DIFF`  if `MEMCOMP` or `TPUTCOMP` fail
- `bless_test_results` now has `--tput-only` and `--mem-only` to bless individual performance `DIFF`
- Fixes logging throughput/memory comparison results in `TestStatus.log`

Test suite: pytest -vvv CIME/tests
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes https://github.com/E3SM-Project/E3SM/issues/5885

User interface changes?: N
Update gh-pages html (Y/N)?: N
