### PR TITLE
Copy only necessary cmake macros to case

### DIFF
--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -142,27 +142,26 @@ def _create_macros_cmake(
     if not os.path.isfile(os.path.join(caseroot, "Macros.cmake")):
         safe_copy(os.path.join(cmake_macros_dir, "Macros.cmake"), caseroot)
 
-    mach = mach_obj.get_machine_name()
-    if Config.instance().copy_all_cmake_macros:
-        if not os.path.exists(case_cmake_path):
-            shutil.copytree(cmake_macros_dir, case_cmake_path)
-    else:
-        if not os.path.exists(case_cmake_path):
-            os.mkdir(case_cmake_path)
+    if not os.path.exists(case_cmake_path):
+        os.mkdir(case_cmake_path)
 
-        # This impl is coupled to contents of Macros.cmake
-        macros = [
-            "universal.cmake",
-            compiler + ".cmake",
-            mach + ".cmake",
-            "{}_{}.cmake".format(compiler, mach),
-            "CMakeLists.txt",
-        ]
-        for macro in macros:
-            repo_macro = os.path.join(cmake_macros_dir, macro)
-            case_macro = os.path.join(case_cmake_path, macro)
-            if not os.path.exists(case_macro) and os.path.exists(repo_macro):
-                safe_copy(repo_macro, case_cmake_path)
+    # This impl is coupled to contents of Macros.cmake
+    os_  = mach_obj.get_value("OS")
+    mach = mach_obj.get_machine_name()
+    macros = [
+        "universal.cmake",
+        os_ + ".cmake",
+        compiler + ".cmake",
+        "{}_{}.cmake".format(compiler, os),
+        mach + ".cmake",
+        "{}_{}.cmake".format(compiler, mach),
+        "CMakeLists.txt",
+    ]
+    for macro in macros:
+        repo_macro = os.path.join(cmake_macros_dir, macro)
+        case_macro = os.path.join(case_cmake_path, macro)
+        if not os.path.exists(case_macro) and os.path.exists(repo_macro):
+            safe_copy(repo_macro, case_cmake_path)
 
     copy_depends_files(mach, mach_obj.machines_dir, caseroot, compiler)
 

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -146,7 +146,7 @@ def _create_macros_cmake(
         os.mkdir(case_cmake_path)
 
     # This impl is coupled to contents of Macros.cmake
-    os_  = mach_obj.get_value("OS")
+    os_ = mach_obj.get_value("OS")
     mach = mach_obj.get_machine_name()
     macros = [
         "universal.cmake",

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -141,12 +141,30 @@ def _create_macros_cmake(
     ###############################################################################
     if not os.path.isfile(os.path.join(caseroot, "Macros.cmake")):
         safe_copy(os.path.join(cmake_macros_dir, "Macros.cmake"), caseroot)
-    if not os.path.exists(os.path.join(caseroot, "cmake_macros")):
-        shutil.copytree(cmake_macros_dir, case_cmake_path)
 
-    copy_depends_files(
-        mach_obj.get_machine_name(), mach_obj.machines_dir, caseroot, compiler
-    )
+    mach = mach_obj.get_machine_name()
+    if Config.instance().copy_all_cmake_macros:
+        if not os.path.exists(case_cmake_path):
+            shutil.copytree(cmake_macros_dir, case_cmake_path)
+    else:
+        if not os.path.exists(case_cmake_path):
+            os.mkdir(case_cmake_path)
+
+        # This impl is coupled to contents of Macros.cmake
+        macros = [
+            "universal.cmake",
+            compiler + ".cmake",
+            mach + ".cmake",
+            "{}_{}.cmake".format(compiler, mach),
+            "CMakeLists.txt",
+        ]
+        for macro in macros:
+            repo_macro = os.path.join(cmake_macros_dir, macro)
+            case_macro = os.path.join(case_cmake_path, macro)
+            if not os.path.exists(case_macro) and os.path.exists(repo_macro):
+                safe_copy(repo_macro, case_cmake_path)
+
+    copy_depends_files(mach, mach_obj.machines_dir, caseroot, compiler)
 
 
 ###############################################################################

--- a/CIME/config.py
+++ b/CIME/config.py
@@ -73,11 +73,6 @@ class Config:
             desc="If set to `True` the model is built using using CMake otherwise Make is used.",
         )
         self._set_attribute(
-            "copy_all_cmake_macros",
-            True,
-            desc="If set to `True` copies all cmake_macros to case without trying to filter based on need.",
-        )
-        self._set_attribute(
             "build_cime_component_lib",
             True,
             desc="If set to `True` then `Filepath`, `CIME_cppdefs` and `CCSM_cppdefs` directories are copied from CASEBUILD directory to BUILDROOT in order to build CIME's internal components.",

--- a/CIME/config.py
+++ b/CIME/config.py
@@ -73,6 +73,11 @@ class Config:
             desc="If set to `True` the model is built using using CMake otherwise Make is used.",
         )
         self._set_attribute(
+            "copy_all_cmake_macros",
+            True,
+            desc="If set to `True` copies all cmake_macros to case without trying to filter based on need.",
+        )
+        self._set_attribute(
             "build_cime_component_lib",
             True,
             desc="If set to `True` then `Filepath`, `CIME_cppdefs` and `CCSM_cppdefs` directories are copied from CASEBUILD directory to BUILDROOT in order to build CIME's internal components.",


### PR DESCRIPTION
This implementation makes some assumptions about the context of /.../Macros.cmake, so I am only turning this on for E3SM.

I think this is a nice improvement. This will reduce the number of macros that get copied from nearly 100 to just a handful, making it easier for the user to view and edit their macros from the case.

Test suite: by-hand
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
