### PR TITLE
Fixes workflow job dependencies

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -796,7 +796,8 @@ class EnvBatch(EnvBase):
         for _ in range(num_submit):
             for job, dependency in jobs:
                 if dependency is not None:
-                    deps = dependency.split()
+                    # Match all words, excluding "and" and "or"
+                    deps = re.findall(r"\b(?!and\b|or\b)\w+(?:\.\w+)?\b", dependency)
                 else:
                     deps = []
                 dep_jobs = []


### PR DESCRIPTION
CIME would fail to set batch dependencies when a job's dependency
was set to certain values.

CIME doesn't support any advanced syntax for this value. It would 
simply split this value by " " and check if those jobs are defined for
the case. A working value would be `case.run or case.test` and a 
non-working value would be `(case.run and case.post_run_io) or case.test`. 
The latter fails for cases since `(case.run` and `case.post_run_io)`
are not a valid job names, while it would work for tests since `case.test`
is valid.

There isn't a need for advanced syntax here since `case.setup` 
controls which batch files are written for a case and the current
logical that builds the batch commands simply checks if a
dependency's batch file is present. A list of possible dependencies
works, ordering doesn't matter.

This PR fixes parsing the `dependency` value by updating to a 
regex that will match any words except `and/or`. This retains 
backwards comparability but the value should be updated to 
space separated list of possible dependencies, e.g. 
`case.run case.post_run_io case.test`.

Test suite: pytest -vvv
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes https://github.com/E3SM-Project/E3SM/issues/5901

User interface changes?: N
Update gh-pages html (Y/N)?: N
