### PR TITLE
Remove deprecated 'distutils' package from ParamGen.

### DIFF
--- a/CIME/ParamGen/paramgen.py
+++ b/CIME/ParamGen/paramgen.py
@@ -4,6 +4,7 @@ import re
 from copy import deepcopy
 import logging
 import subprocess
+import shutil
 
 try:
     from paramgen_utils import is_logical_expr, is_formula, has_unexpanded_var
@@ -136,9 +137,7 @@ class ParamGen:
         """
 
         # First check whether the given xml file conforms to the entry_id_pg.xsd schema
-        from distutils.spawn import find_executable
-
-        xmllint = find_executable("xmllint")
+        xmllint = shutil.which("xmllint")
         if xmllint is None:
             logger.warning("Couldn't find xmllint. Skipping schema check")
         else:


### PR DESCRIPTION
Replaces the `find_executable` command, which is no longer available in python 3.12, with `shutil.which`, which appears to provide the same functionality (and is supported in 3.12).

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes #4499

User interface changes?:

Update gh-pages html (Y/N)?:
