### PR TITLE
reduce the number of times env_batch is rewriten

### DIFF
--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -94,8 +94,10 @@ def _submit(
         batch_system = "none"
     else:
         batch_system = env_batch.get_batch_system_type()
-    unlock_file(os.path.basename(env_batch.filename), caseroot=caseroot)
-    case.set_value("BATCH_SYSTEM", batch_system)
+
+    if batch_system != case.get_value("BATCH_SYSTEM"):
+        unlock_file(os.path.basename(env_batch.filename), caseroot=caseroot)
+        case.set_value("BATCH_SYSTEM", batch_system)
 
     env_batch_has_changed = False
     if not external_workflow:


### PR DESCRIPTION
Check if BATCH_SYSTEM needs to be updated before unlocking env_batch.xml and updating.
This should reduce the number of times env_batch.xml is overwritten.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4503 

User interface changes?: No

Update gh-pages html (Y/N)?: N
