### PR TITLE
Updates cmake macros

### DIFF
--- a/docker/config_machines.xml
+++ b/docker/config_machines.xml
@@ -37,8 +37,8 @@
     <environment_variables>
       <env name="OMPI_ALLOW_RUN_AS_ROOT">1</env>
       <env name="OMPI_ALLOW_RUN_AS_ROOT_CONFIRM">1</env>
-      <env name="NETCDF_PATH">/opt/conda</env>
-      <env name="PNETCDF_PATH">/opt/conda</env>
+      <env name="NETCDF_C_PATH">/opt/conda</env>
+      <env name="NETCDF_FORTRAN_PATH">/opt/conda</env>
     </environment_variables>
   </machine>
 </config_machines>

--- a/docker/docker.cmake
+++ b/docker/docker.cmake
@@ -1,9 +1,15 @@
 string(APPEND CXXFLAGS " -std=c++14")
 string(APPEND CXX_LIBS " -lstdc++")
-string(APPEND FFLAGS " -I/opt/conda/include")
+
+# DEBUGGING variables
+# get_cmake_property(_variableNames VARIABLES)
+# foreach (_variableName ${_variableNames})
+#     message("${_variableName}=${${_variableName}}")
+# endforeach()
+# message( FATAL_ERROR "EXIT")
+
 # required for grid generation tests that use make
+if (CMAKE_SOURCE_DIR MATCHES "^.*TestGridGeneration.*$")
+string(APPEND FFLAGS " -I/opt/conda/include")
 string(APPEND SLIBS " -L/opt/conda/lib -lnetcdf -lnetcdff")
-set(MPI_PATH "/opt/conda")
-if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-  string(APPEND FFLAGS " -fallow-argument-mismatch  -fallow-invalid-boz ")
 endif()


### PR DESCRIPTION
Fixes failing tests failing due to E3SM cmake update.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
