### PR TITLE
Yet another btr update

### DIFF
--- a/CIME/Tools/bless_test_results
+++ b/CIME/Tools/bless_test_results
@@ -108,8 +108,6 @@ def create_bless_options(parser):
 
     mutual_bless_group = bless_group.add_mutually_exclusive_group()
 
-    mutual_std_group = mutual_bless_group.add_mutually_exclusive_group()
-
     mutual_bless_group.add_argument(
         "-n", "--namelists-only", action="store_true", help="Only analyze namelists."
     )
@@ -118,14 +116,22 @@ def create_bless_options(parser):
         "--hist-only", action="store_true", help="Only analyze history files."
     )
 
-    mutual_perf_group = mutual_bless_group.add_mutually_exclusive_group()
+    mutual_perf_group = bless_group.add_mutually_exclusive_group()
 
     mutual_perf_group.add_argument(
-        "--bless-throughput", action="store_true", help="Bless throughput"
+        "--bless-tput",
+        action="store_true",
+        help="Bless throughput, use `--bless-perf` to bless throughput and memory",
     )
 
     mutual_perf_group.add_argument(
-        "--bless-memory", action="store_true", help="Bless memory"
+        "--bless-mem",
+        action="store_true",
+        help="Bless memory, use `--bless-perf` to bless throughput and memory",
+    )
+
+    bless_group.add_argument(
+        "--bless-perf", action="store_true", help="Bless both throughput and memory"
     )
 
 

--- a/CIME/Tools/bless_test_results
+++ b/CIME/Tools/bless_test_results
@@ -108,6 +108,8 @@ def create_bless_options(parser):
 
     mutual_bless_group = bless_group.add_mutually_exclusive_group()
 
+    mutual_std_group = mutual_bless_group.add_mutually_exclusive_group()
+
     mutual_bless_group.add_argument(
         "-n", "--namelists-only", action="store_true", help="Only analyze namelists."
     )
@@ -116,12 +118,14 @@ def create_bless_options(parser):
         "--hist-only", action="store_true", help="Only analyze history files."
     )
 
-    mutual_bless_group.add_argument(
-        "--tput-only", action="store_true", help="Only analyze throughput."
+    mutual_perf_group = mutual_bless_group.add_mutually_exclusive_group()
+
+    mutual_perf_group.add_argument(
+        "--bless-throughput", action="store_true", help="Bless throughput"
     )
 
-    mutual_bless_group.add_argument(
-        "--mem-only", action="store_true", help="Only analyze memory."
+    mutual_perf_group.add_argument(
+        "--bless-memory", action="store_true", help="Bless memory"
     )
 
 

--- a/CIME/baselines/performance.py
+++ b/CIME/baselines/performance.py
@@ -129,6 +129,8 @@ def perf_write_baseline(case, basegen_dir, throughput=True, memory=True):
 
             write_baseline_file(baseline_file, tput)
 
+            logger.info("Updated throughput baseline to {!s}".format(tput))
+
     if memory:
         try:
             mem = perf_get_memory(case, config)
@@ -138,6 +140,8 @@ def perf_write_baseline(case, basegen_dir, throughput=True, memory=True):
             baseline_file = os.path.join(basegen_dir, "cpl-mem.log")
 
             write_baseline_file(baseline_file, mem)
+
+            logger.info("Updated memory usage baseline to {!s}".format(mem))
 
 
 def load_coupler_customization(case):

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -211,11 +211,12 @@ def bless_test_results(
     new_test_root=None,
     new_test_id=None,
     exclude=None,
-    bless_throughput=False,
-    bless_memory=False,
+    bless_tput=False,
+    bless_mem=False,
+    bless_perf=False,
     **_,  # Capture all for extra
 ):
-    bless_all = not ((namelists_only | hist_only) or (bless_throughput | bless_memory))
+    bless_all = not (namelists_only | hist_only)
 
     test_status_files = get_test_status_files(test_root, compiler, test_id=test_id)
 
@@ -308,13 +309,13 @@ def bless_test_results(
             if hist_only or bless_all:
                 hist_bless = bless_needed
 
-            if bless_throughput:
+            if bless_tput or bless_perf:
                 tput_bless = bless_needed
 
                 if not tput_bless:
                     tput_bless = ts.get_status(THROUGHPUT_PHASE) != TEST_PASS_STATUS
 
-            if bless_memory:
+            if bless_mem or bless_perf:
                 mem_bless = bless_needed
 
                 if not mem_bless:
@@ -328,6 +329,12 @@ def bless_test_results(
                 )
             )
         else:
+            logger.debug("Determined blesses for {!r}".format(test_name))
+            logger.debug("nl_bless     = {}".format(nl_bless))
+            logger.debug("hist_bless   = {}".format(hist_bless))
+            logger.debug("tput_bless   = {}".format(tput_bless))
+            logger.debug("mem_bless    = {}".format(mem_bless))
+
             logger.info(
                 "###############################################################################"
             )

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -294,7 +294,7 @@ def bless_test_results(
         excluded = exclude.match(test_name) if exclude else False
 
         if (not has_no_tests and not match_test_name) or excluded:
-            logger.info("Skipping {!r}".format(test_name))
+            logger.debug("Skipping {!r}".format(test_name))
 
             continue
 

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -22,7 +22,7 @@ import os, time
 logger = logging.getLogger(__name__)
 
 
-def bless_throughput(
+def _bless_throughput(
     case,
     test_name,
     baseline_root,
@@ -32,6 +32,7 @@ def bless_throughput(
 ):
     success = True
     reason = None
+    below_threshold = False
 
     baseline_dir = os.path.join(
         baseline_root, baseline_name, case.get_value("CASEBASEID")
@@ -42,19 +43,9 @@ def bless_throughput(
             case, baseline_dir=baseline_dir
         )
     except FileNotFoundError as e:
-        success = False
-
         comment = f"Could not read throughput file: {e!s}"
     except Exception as e:
-        success = False
-
         comment = f"Error comparing throughput baseline: {e!s}"
-
-    # fail early
-    if not success:
-        logger.info(comment)
-
-        return success, comment
 
     if below_threshold:
         logger.info("Throughput diff appears to have been already resolved.")
@@ -74,7 +65,7 @@ def bless_throughput(
     return success, reason
 
 
-def bless_memory(
+def _bless_memory(
     case,
     test_name,
     baseline_root,
@@ -84,6 +75,7 @@ def bless_memory(
 ):
     success = True
     reason = None
+    below_threshold = False
 
     baseline_dir = os.path.join(
         baseline_root, baseline_name, case.get_value("CASEBASEID")
@@ -94,19 +86,9 @@ def bless_memory(
             case, baseline_dir=baseline_dir
         )
     except FileNotFoundError as e:
-        success = False
-
         comment = f"Could not read memory usage file: {e!s}"
     except Exception as e:
-        success = False
-
         comment = f"Error comparing memory baseline: {e!s}"
-
-    # fail early
-    if not success:
-        logger.info(comment)
-
-        return success, comment
 
     if below_threshold:
         logger.info("Memory usage diff appears to have been already resolved.")
@@ -221,8 +203,6 @@ def bless_test_results(
     test_id=None,
     namelists_only=False,
     hist_only=False,
-    tput_only=False,
-    mem_only=False,
     report_only=False,
     force=False,
     pes_file=None,
@@ -231,9 +211,11 @@ def bless_test_results(
     new_test_root=None,
     new_test_id=None,
     exclude=None,
+    bless_throughput=False,
+    bless_memory=False,
     **_,  # Capture all for extra
 ):
-    bless_all = not (namelists_only | hist_only | tput_only | mem_only)
+    bless_all = not ((namelists_only | hist_only) or (bless_throughput | bless_memory))
 
     test_status_files = get_test_status_files(test_root, compiler, test_id=test_id)
 
@@ -301,8 +283,8 @@ def bless_test_results(
         overall_result, phase = ts.get_overall_test_status(
             ignore_namelists=True,
             ignore_memleak=True,
-            check_throughput=True,
-            check_memory=True,
+            check_throughput=False,
+            check_memory=False,
         )
 
         # See if we need to bless namelist
@@ -326,13 +308,13 @@ def bless_test_results(
             if hist_only or bless_all:
                 hist_bless = bless_needed
 
-            if tput_only or bless_all:
+            if bless_throughput:
                 tput_bless = bless_needed
 
                 if not tput_bless:
                     tput_bless = ts.get_status(THROUGHPUT_PHASE) != TEST_PASS_STATUS
 
-            if mem_only or bless_all:
+            if bless_memory:
                 mem_bless = bless_needed
 
                 if not mem_bless:
@@ -366,8 +348,9 @@ def bless_test_results(
                 if baseline_name is None:
                     baseline_name_resolved = case.get_value("BASELINE_NAME_CMP")
                     if not baseline_name_resolved:
+                        cime_root = CIME.utils.get_cime_root()
                         baseline_name_resolved = CIME.utils.get_current_branch(
-                            repo=CIME.utils.get_cime_root()
+                            repo=cime_root
                         )
                 else:
                     baseline_name_resolved = baseline_name
@@ -423,7 +406,7 @@ def bless_test_results(
                         broken_blesses.append((test_name, reason))
 
                 if tput_bless:
-                    success, reason = bless_throughput(
+                    success, reason = _bless_throughput(
                         case,
                         test_name,
                         baseline_root_resolved,
@@ -436,7 +419,7 @@ def bless_test_results(
                         broken_blesses.append((test_name, reason))
 
                 if mem_bless:
-                    success, reason = bless_memory(
+                    success, reason = _bless_memory(
                         case,
                         test_name,
                         baseline_root_resolved,

--- a/CIME/test_status.py
+++ b/CIME/test_status.py
@@ -460,7 +460,7 @@ class TestStatus(object):
                     if rv == TEST_PASS_STATUS:
                         rv = NAMELIST_FAIL_STATUS
 
-                elif phase == BASELINE_PHASE:
+                elif phase in [BASELINE_PHASE, THROUGHPUT_PHASE, MEMCOMP_PHASE]:
                     if rv in [NAMELIST_FAIL_STATUS, TEST_PASS_STATUS]:
                         phase_responsible_for_status = phase
                         rv = TEST_DIFF_STATUS
@@ -512,7 +512,9 @@ class TestStatus(object):
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A TPUTCOMP')
         ('PASS', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A TPUTCOMP', check_throughput=True)
-        ('FAIL', 'TPUTCOMP')
+        ('DIFF', 'TPUTCOMP')
+        >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A MEMCOMP', check_memory=True)
+        ('DIFF', 'MEMCOMP')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPASS ERS.foo.A RUN\nFAIL ERS.foo.A NLCOMP')
         ('NLFAIL', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPEND ERS.foo.A RUN\nFAIL ERS.foo.A NLCOMP')

--- a/CIME/test_status.py
+++ b/CIME/test_status.py
@@ -460,7 +460,7 @@ class TestStatus(object):
                     if rv == TEST_PASS_STATUS:
                         rv = NAMELIST_FAIL_STATUS
 
-                elif phase in [BASELINE_PHASE, THROUGHPUT_PHASE, MEMCOMP_PHASE]:
+                elif phase == BASELINE_PHASE:
                     if rv in [NAMELIST_FAIL_STATUS, TEST_PASS_STATUS]:
                         phase_responsible_for_status = phase
                         rv = TEST_DIFF_STATUS
@@ -512,9 +512,7 @@ class TestStatus(object):
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A TPUTCOMP')
         ('PASS', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A TPUTCOMP', check_throughput=True)
-        ('DIFF', 'TPUTCOMP')
-        >>> _test_helper2('PASS ERS.foo.A RUN\nFAIL ERS.foo.A MEMCOMP', check_memory=True)
-        ('DIFF', 'MEMCOMP')
+        ('FAIL', 'TPUTCOMP')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPASS ERS.foo.A RUN\nFAIL ERS.foo.A NLCOMP')
         ('NLFAIL', 'RUN')
         >>> _test_helper2('PASS ERS.foo.A MODEL_BUILD\nPEND ERS.foo.A RUN\nFAIL ERS.foo.A NLCOMP')

--- a/CIME/tests/test_unit_bless_test_results.py
+++ b/CIME/tests/test_unit_bless_test_results.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 from CIME.bless_test_results import (
     bless_test_results,
-    bless_throughput,
-    bless_memory,
+    _bless_throughput,
+    _bless_memory,
     bless_history,
     bless_namelists,
     is_bless_needed,
@@ -232,7 +232,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = mock.MagicMock()
 
-        success, comment = bless_memory(
+        success, comment = _bless_memory(
             case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, True
         )
 
@@ -252,7 +252,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = mock.MagicMock()
 
-        success, comment = bless_memory(
+        success, comment = _bless_memory(
             case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, True
         )
 
@@ -266,38 +266,44 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = mock.MagicMock()
 
-        success, comment = bless_memory(
+        success, comment = _bless_memory(
             case, "SMS.f19_g16.S", "/tmp/baselines", "master", True, False
         )
 
         assert success
         assert comment is None
 
+    @mock.patch("CIME.bless_test_results.perf_write_baseline")
     @mock.patch("CIME.bless_test_results.perf_compare_memory_baseline")
-    def test_bless_memory_general_error(self, perf_compare_memory_baseline):
+    def test_bless_memory_general_error(
+        self, perf_compare_memory_baseline, perf_write_baseline
+    ):
         perf_compare_memory_baseline.side_effect = Exception
 
         case = mock.MagicMock()
 
-        success, comment = bless_memory(
-            case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, False
+        success, comment = _bless_memory(
+            case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, True
         )
 
-        assert not success
-        assert comment == "Error comparing memory baseline: "
+        assert success
+        assert comment is None
 
+    @mock.patch("CIME.bless_test_results.perf_write_baseline")
     @mock.patch("CIME.bless_test_results.perf_compare_memory_baseline")
-    def test_bless_memory_file_not_found_error(self, perf_compare_memory_baseline):
+    def test_bless_memory_file_not_found_error(
+        self, perf_compare_memory_baseline, perf_write_baseline
+    ):
         perf_compare_memory_baseline.side_effect = FileNotFoundError
 
         case = mock.MagicMock()
 
-        success, comment = bless_memory(
-            case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, False
+        success, comment = _bless_memory(
+            case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, True
         )
 
-        assert not success
-        assert comment == "Could not read memory usage file: "
+        assert success
+        assert comment is None
 
     @mock.patch("CIME.bless_test_results.perf_compare_memory_baseline")
     def test_bless_memory(self, perf_compare_memory_baseline):
@@ -305,7 +311,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = mock.MagicMock()
 
-        success, comment = bless_memory(
+        success, comment = _bless_memory(
             case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, False
         )
 
@@ -322,7 +328,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = mock.MagicMock()
 
-        success, comment = bless_throughput(
+        success, comment = _bless_throughput(
             case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, True
         )
 
@@ -339,7 +345,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = mock.MagicMock()
 
-        success, comment = bless_throughput(
+        success, comment = _bless_throughput(
             case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, True
         )
 
@@ -353,7 +359,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = mock.MagicMock()
 
-        success, comment = bless_throughput(
+        success, comment = _bless_throughput(
             case, "SMS.f19_g16.S", "/tmp/baselines", "master", True, False
         )
 
@@ -366,27 +372,30 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = mock.MagicMock()
 
-        success, comment = bless_throughput(
-            case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, False
+        success, comment = _bless_throughput(
+            case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, True
         )
 
-        assert not success
-        assert comment == "Error comparing throughput baseline: "
+        assert success
+        assert comment is None
 
+    @mock.patch("CIME.bless_test_results.perf_write_baseline")
     @mock.patch("CIME.bless_test_results.perf_compare_throughput_baseline")
     def test_bless_throughput_file_not_found_error(
-        self, perf_compare_throughput_baseline
+        self,
+        perf_compare_throughput_baseline,
+        perf_write_baseline,
     ):
         perf_compare_throughput_baseline.side_effect = FileNotFoundError
 
         case = mock.MagicMock()
 
-        success, comment = bless_throughput(
-            case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, False
+        success, comment = _bless_throughput(
+            case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, True
         )
 
-        assert not success
-        assert comment == "Could not read throughput file: "
+        assert success
+        assert comment is None
 
     @mock.patch("CIME.bless_test_results.perf_compare_throughput_baseline")
     def test_bless_throughput(self, perf_compare_throughput_baseline):
@@ -394,13 +403,13 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = mock.MagicMock()
 
-        success, comment = bless_throughput(
+        success, comment = _bless_throughput(
             case, "SMS.f19_g16.S", "/tmp/baselines", "master", False, False
         )
 
         assert success
 
-    @mock.patch("CIME.bless_test_results.bless_memory")
+    @mock.patch("CIME.bless_test_results._bless_memory")
     @mock.patch("CIME.bless_test_results.Case")
     @mock.patch("CIME.bless_test_results.TestStatus")
     @mock.patch("CIME.bless_test_results.get_test_status_files")
@@ -409,7 +418,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
         get_test_status_files,
         TestStatus,
         Case,
-        bless_memory,
+        _bless_memory,
     ):
         get_test_status_files.return_value = [
             "/tmp/cases/SMS.f19_g16.S.docker_gnu/TestStatus",
@@ -422,7 +431,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         case = Case.return_value.__enter__.return_value
 
-        bless_memory.return_value = (True, "")
+        _bless_memory.return_value = (True, "")
 
         success = bless_test_results(
             "master",
@@ -430,13 +439,13 @@ class TestUnitBlessTestResults(unittest.TestCase):
             "/tmp/cases",
             "gnu",
             force=True,
-            mem_only=True,
+            bless_memory=True,
         )
 
         assert success
-        bless_memory.assert_called()
+        _bless_memory.assert_called()
 
-    @mock.patch("CIME.bless_test_results.bless_throughput")
+    @mock.patch("CIME.bless_test_results._bless_throughput")
     @mock.patch("CIME.bless_test_results.Case")
     @mock.patch("CIME.bless_test_results.TestStatus")
     @mock.patch("CIME.bless_test_results.get_test_status_files")
@@ -445,7 +454,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
         get_test_status_files,
         TestStatus,
         Case,
-        bless_throughput,
+        _bless_throughput,
     ):
         get_test_status_files.return_value = [
             "/tmp/cases/SMS.f19_g16.S.docker_gnu/TestStatus",
@@ -454,11 +463,11 @@ class TestUnitBlessTestResults(unittest.TestCase):
         ts = TestStatus.return_value
         ts.get_name.return_value = "SMS.f19_g16.S.docker_gnu"
         ts.get_overall_test_status.return_value = ("PASS", "RUN")
-        ts.get_status.side_effect = ["PASS", "FAIL"]
+        ts.get_status.side_effect = ["PASS", "PASS", "FAIL"]
 
         case = Case.return_value.__enter__.return_value
 
-        bless_throughput.return_value = (True, "")
+        _bless_throughput.return_value = (True, "")
 
         success = bless_test_results(
             "master",
@@ -466,11 +475,11 @@ class TestUnitBlessTestResults(unittest.TestCase):
             "/tmp/cases",
             "gnu",
             force=True,
-            tput_only=True,
+            bless_throughput=True,
         )
 
         assert success
-        bless_throughput.assert_called()
+        _bless_throughput.assert_called()
 
     @mock.patch("CIME.bless_test_results.bless_namelists")
     @mock.patch("CIME.bless_test_results.Case")
@@ -571,8 +580,8 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         assert success
 
-    @mock.patch("CIME.bless_test_results.bless_memory")
-    @mock.patch("CIME.bless_test_results.bless_throughput")
+    @mock.patch("CIME.bless_test_results._bless_memory")
+    @mock.patch("CIME.bless_test_results._bless_throughput")
     @mock.patch("CIME.bless_test_results.bless_history")
     @mock.patch("CIME.bless_test_results.bless_namelists")
     @mock.patch("CIME.bless_test_results.Case")
@@ -585,12 +594,12 @@ class TestUnitBlessTestResults(unittest.TestCase):
         Case,
         bless_namelists,
         bless_history,
-        bless_throughput,
-        bless_memory,
+        _bless_throughput,
+        _bless_memory,
     ):
-        bless_memory.return_value = (False, "")
+        _bless_memory.return_value = (False, "")
 
-        bless_throughput.return_value = (False, "")
+        _bless_throughput.return_value = (False, "")
 
         bless_history.return_value = (False, "")
 
@@ -619,8 +628,8 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         assert not success
 
-    @mock.patch("CIME.bless_test_results.bless_memory")
-    @mock.patch("CIME.bless_test_results.bless_throughput")
+    @mock.patch("CIME.bless_test_results._bless_memory")
+    @mock.patch("CIME.bless_test_results._bless_throughput")
     @mock.patch("CIME.bless_test_results.bless_history")
     @mock.patch("CIME.bless_test_results.bless_namelists")
     @mock.patch("CIME.bless_test_results.Case")
@@ -633,12 +642,12 @@ class TestUnitBlessTestResults(unittest.TestCase):
         Case,
         bless_namelists,
         bless_history,
-        bless_throughput,
-        bless_memory,
+        _bless_throughput,
+        _bless_memory,
     ):
-        bless_memory.return_value = (False, "")
+        _bless_memory.return_value = (False, "")
 
-        bless_throughput.return_value = (False, "")
+        _bless_throughput.return_value = (False, "")
 
         bless_history.return_value = (False, "")
 
@@ -667,8 +676,8 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         assert not success
 
-    @mock.patch("CIME.bless_test_results.bless_memory")
-    @mock.patch("CIME.bless_test_results.bless_throughput")
+    @mock.patch("CIME.bless_test_results._bless_memory")
+    @mock.patch("CIME.bless_test_results._bless_throughput")
     @mock.patch("CIME.bless_test_results.bless_history")
     @mock.patch("CIME.bless_test_results.bless_namelists")
     @mock.patch("CIME.bless_test_results.Case")
@@ -681,12 +690,12 @@ class TestUnitBlessTestResults(unittest.TestCase):
         Case,
         bless_namelists,
         bless_history,
-        bless_throughput,
-        bless_memory,
+        _bless_throughput,
+        _bless_memory,
     ):
-        bless_memory.return_value = (True, "")
+        _bless_memory.return_value = (True, "")
 
-        bless_throughput.return_value = (True, "")
+        _bless_throughput.return_value = (True, "")
 
         bless_history.return_value = (True, "")
 

--- a/CIME/tests/test_unit_bless_test_results.py
+++ b/CIME/tests/test_unit_bless_test_results.py
@@ -409,6 +409,48 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         assert success
 
+    @mock.patch("CIME.bless_test_results._bless_throughput")
+    @mock.patch("CIME.bless_test_results._bless_memory")
+    @mock.patch("CIME.bless_test_results.Case")
+    @mock.patch("CIME.bless_test_results.TestStatus")
+    @mock.patch("CIME.bless_test_results.get_test_status_files")
+    def test_bless_perf(
+        self,
+        get_test_status_files,
+        TestStatus,
+        Case,
+        _bless_memory,
+        _bless_throughput,
+    ):
+        get_test_status_files.return_value = [
+            "/tmp/cases/SMS.f19_g16.S.docker_gnu/TestStatus",
+        ]
+
+        ts = TestStatus.return_value
+        ts.get_name.return_value = "SMS.f19_g16.S.docker_gnu"
+        ts.get_overall_test_status.return_value = ("PASS", "RUN")
+        ts.get_status.side_effect = ["PASS", "PASS", "PASS", "FAIL", "FAIL"]
+
+        case = Case.return_value.__enter__.return_value
+
+        _bless_memory.return_value = (True, "")
+
+        _bless_throughput.return_value = (True, "")
+
+        success = bless_test_results(
+            "master",
+            "/tmp/baseline",
+            "/tmp/cases",
+            "gnu",
+            force=True,
+            bless_perf=True,
+        )
+
+        assert success
+        _bless_memory.assert_called()
+        _bless_throughput.assert_called()
+
+    @mock.patch("CIME.bless_test_results._bless_throughput")
     @mock.patch("CIME.bless_test_results._bless_memory")
     @mock.patch("CIME.bless_test_results.Case")
     @mock.patch("CIME.bless_test_results.TestStatus")
@@ -419,6 +461,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
         TestStatus,
         Case,
         _bless_memory,
+        _bless_throughput,
     ):
         get_test_status_files.return_value = [
             "/tmp/cases/SMS.f19_g16.S.docker_gnu/TestStatus",
@@ -427,7 +470,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
         ts = TestStatus.return_value
         ts.get_name.return_value = "SMS.f19_g16.S.docker_gnu"
         ts.get_overall_test_status.return_value = ("PASS", "RUN")
-        ts.get_status.side_effect = ["PASS", "FAIL"]
+        ts.get_status.side_effect = ["PASS", "PASS", "PASS", "FAIL"]
 
         case = Case.return_value.__enter__.return_value
 
@@ -439,13 +482,15 @@ class TestUnitBlessTestResults(unittest.TestCase):
             "/tmp/cases",
             "gnu",
             force=True,
-            bless_memory=True,
+            bless_mem=True,
         )
 
         assert success
         _bless_memory.assert_called()
+        _bless_throughput.assert_not_called()
 
     @mock.patch("CIME.bless_test_results._bless_throughput")
+    @mock.patch("CIME.bless_test_results._bless_memory")
     @mock.patch("CIME.bless_test_results.Case")
     @mock.patch("CIME.bless_test_results.TestStatus")
     @mock.patch("CIME.bless_test_results.get_test_status_files")
@@ -454,6 +499,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
         get_test_status_files,
         TestStatus,
         Case,
+        _bless_memory,
         _bless_throughput,
     ):
         get_test_status_files.return_value = [
@@ -463,7 +509,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
         ts = TestStatus.return_value
         ts.get_name.return_value = "SMS.f19_g16.S.docker_gnu"
         ts.get_overall_test_status.return_value = ("PASS", "RUN")
-        ts.get_status.side_effect = ["PASS", "PASS", "FAIL"]
+        ts.get_status.side_effect = ["PASS", "PASS", "PASS", "FAIL"]
 
         case = Case.return_value.__enter__.return_value
 
@@ -475,10 +521,11 @@ class TestUnitBlessTestResults(unittest.TestCase):
             "/tmp/cases",
             "gnu",
             force=True,
-            bless_throughput=True,
+            bless_tput=True,
         )
 
         assert success
+        _bless_memory.assert_not_called()
         _bless_throughput.assert_called()
 
     @mock.patch("CIME.bless_test_results.bless_namelists")


### PR DESCRIPTION
- Reverts to original behavior, `bless_test_results` with no flags will bless hist and nml
- Adds performance flags `--bless-tput`, `--bless-mem`, and `--bles-perf` (both tput and mem)

Test suite: pytest -vvv CIME/tests/test_unit*
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]
User interface changes?:
Update gh-pages html (Y/N)?:
