### PR TITLE
Add GPU flags to MPAS dycore through the CIME infrastructure

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -561,6 +561,10 @@ ifdef MPAS_LIBDIR
 # this isn't necessary, since libmpas should never be an actual file (the library that is created
 # is named libmpas.a), but adding the PHONY declaration provides an extra bit of safety
 .PHONY: libmpas
+# The CASEROOT, COMPILER and MACH are added so that the Depends file could be visible to
+# the MPAS dycore.
+# The GPUFLAGS is added so that the GPU flags defined in ccs_config_cesm could also be
+# used to build the MPAS dycore if needed.
 libmpas: cam_abortutils.o physconst.o
 	$(MAKE) -C $(MPAS_LIBDIR) CC="$(CC)" FC="$(FC)" PIODEF="$(PIODEF)" \
         FFLAGS='$(FREEFLAGS) $(FFLAGS)' GPUFLAGS='$(GPUFLAGS)' \

--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -562,8 +562,10 @@ ifdef MPAS_LIBDIR
 # is named libmpas.a), but adding the PHONY declaration provides an extra bit of safety
 .PHONY: libmpas
 libmpas: cam_abortutils.o physconst.o
-	$(MAKE) -C $(MPAS_LIBDIR) CC="$(CC)" FC="$(FC)" PIODEF="$(PIODEF)" FFLAGS='$(FREEFLAGS) $(FFLAGS)' \
-	FCINCLUDES='$(INCLDIR) $(INCS) -I$(ABS_INSTALL_SHAREDPATH)/include -I$(ABS_ESMF_PATH)/include'
+	$(MAKE) -C $(MPAS_LIBDIR) CC="$(CC)" FC="$(FC)" PIODEF="$(PIODEF)" \
+        FFLAGS='$(FREEFLAGS) $(FFLAGS)' GPUFLAGS='$(GPUFLAGS)' \
+        CASEROOT='$(CASEROOT)' COMPILER='$(COMPILER)' MACH='$(MACH)' \
+        FCINCLUDES='$(INCLDIR) $(INCS) -I$(ABS_INSTALL_SHAREDPATH)/include -I$(ABS_ESMF_PATH)/include'
 
 dyn_comp.o: libmpas
 dyn_grid.o: libmpas


### PR DESCRIPTION
This PR:
- makes the GPU flags defined in `ccs_config_cesm` visible to the MPAS dycore
- exports some environment variables so that the `Depends` file can be used during the compilation of MPAS dycore later