### PR TITLE
Add --ignore-namelists to Jenkins scripts

### DIFF
--- a/CIME/Tools/jenkins_generic_job
+++ b/CIME/Tools/jenkins_generic_job
@@ -181,6 +181,12 @@ OR
     )
 
     parser.add_argument(
+        "--ignore-namelists",
+        action="store_true",
+        help="Do not fail if there are namelist diffs",
+    )
+
+    parser.add_argument(
         "--save-timing",
         action="store_true",
         help="Tell create_test to save timings of tests",
@@ -265,6 +271,7 @@ OR
         args.check_throughput,
         args.check_memory,
         args.ignore_memleak,
+        args.ignore_namelists,
         args.save_timing,
         args.pes_file,
         args.jenkins_id,
@@ -296,6 +303,7 @@ def _main_func(description):
         check_throughput,
         check_memory,
         ignore_memleak,
+        ignore_namelists,
         save_timing,
         pes_file,
         jenkins_id,
@@ -325,6 +333,7 @@ def _main_func(description):
             check_throughput,
             check_memory,
             ignore_memleak,
+            ignore_namelists,
             save_timing,
             pes_file,
             jenkins_id,

--- a/CIME/jenkins_generic_job.py
+++ b/CIME/jenkins_generic_job.py
@@ -279,6 +279,7 @@ def jenkins_generic_job(
     check_throughput,
     check_memory,
     ignore_memleak,
+    ignore_namelists,
     save_timing,
     pes_file,
     jenkins_id,
@@ -421,7 +422,7 @@ def jenkins_generic_job(
         no_wait=not use_batch,  # wait if using queue
         check_throughput=check_throughput,
         check_memory=check_memory,
-        ignore_namelists=False,  # don't ignore namelist diffs
+        ignore_namelists=ignore_namelists,
         ignore_memleak=ignore_memleak,
         cdash_build_name=cdash_build_name,
         cdash_project=cdash_project,


### PR DESCRIPTION
This is needed for performance tests launched by Jenkins scripts.

Test suite: CIME/Tools/jenkins_generic_job
Test baseline: n/a
Test namelist changes: none
Test status: bit for bit
User interface changes?: none
Update gh-pages html (Y/N)?: N
