### PR TITLE
Update e3smv3 pgn and tsc tests with L80 ICs for atm and lnd

### DIFF
--- a/CIME/SystemTests/pgn.py
+++ b/CIME/SystemTests/pgn.py
@@ -45,7 +45,7 @@ PERTURBATIONS = OrderedDict(
     ]
 )
 FCLD_NC = "cam.h0.cloud.nc"
-INIT_COND_FILE_TEMPLATE = "20210915.v2.ne4_oQU240.F2010.{}.{}.0002-{:02d}-01-00000.nc"
+INIT_COND_FILE_TEMPLATE = "20231105.v3b01.F2010.ne4_oQU240.chrysalis.{}.{}.0002-{:02d}-01-00000.nc"
 INSTANCE_FILE_TEMPLATE = "{}{}_{:04d}.h0.0001-01-01-00000{}.nc"
 
 
@@ -95,8 +95,8 @@ class PGN(SystemTestsCommon):
         logger.debug("PGN_INFO: Updating user_nl_* files")
 
         csmdata_root = self._case.get_value("DIN_LOC_ROOT")
-        csmdata_atm = os.path.join(csmdata_root, "atm/cam/inic/homme/ne4_v2_init")
-        csmdata_lnd = os.path.join(csmdata_root, "lnd/clm2/initdata/ne4_oQU240_v2_init")
+        csmdata_atm = os.path.join(csmdata_root, "atm/cam/inic/homme/ne4_v3_init")
+        csmdata_lnd = os.path.join(csmdata_root, "lnd/clm2/initdata/ne4_oQU240_v3_init")
 
         iinst = 1
         for icond in range(1, NUMBER_INITIAL_CONDITIONS + 1):

--- a/CIME/SystemTests/pgn.py
+++ b/CIME/SystemTests/pgn.py
@@ -45,7 +45,9 @@ PERTURBATIONS = OrderedDict(
     ]
 )
 FCLD_NC = "cam.h0.cloud.nc"
-INIT_COND_FILE_TEMPLATE = "20231105.v3b01.F2010.ne4_oQU240.chrysalis.{}.{}.0002-{:02d}-01-00000.nc"
+INIT_COND_FILE_TEMPLATE = (
+    "20231105.v3b01.F2010.ne4_oQU240.chrysalis.{}.{}.0002-{:02d}-01-00000.nc"
+)
 INSTANCE_FILE_TEMPLATE = "{}{}_{:04d}.h0.0001-01-01-00000{}.nc"
 
 

--- a/CIME/SystemTests/tsc.py
+++ b/CIME/SystemTests/tsc.py
@@ -32,7 +32,7 @@ NINST = 12
 SIM_LENGTH = 600  # seconds
 OUT_FREQ = 10  # seconds
 INSPECT_AT = [300, 450, 600]  # seconds
-INIT_COND_FILE_TEMPLATE = "20210915.v2.ne4_oQU240.F2010.{}.{}.0002-{:02d}-01-00000.nc"
+INIT_COND_FILE_TEMPLATE = "20231105.v3b01.F2010.ne4_oQU240.chrysalis.{}.{}.0002-{:02d}-01-00000.nc"
 VAR_LIST = [
     "T",
     "Q",
@@ -100,8 +100,8 @@ class TSC(SystemTestsCommon):
         self._case.set_value("STOP_OPTION", "nsteps")
 
         csmdata_root = self._case.get_value("DIN_LOC_ROOT")
-        csmdata_atm = os.path.join(csmdata_root, "atm/cam/inic/homme/ne4_v2_init")
-        csmdata_lnd = os.path.join(csmdata_root, "lnd/clm2/initdata/ne4_oQU240_v2_init")
+        csmdata_atm = os.path.join(csmdata_root, "atm/cam/inic/homme/ne4_v3_init")
+        csmdata_lnd = os.path.join(csmdata_root, "lnd/clm2/initdata/ne4_oQU240_v3_init")
 
         nstep_output = OUT_FREQ // dtime
         for iinst in range(1, NINST + 1):

--- a/CIME/SystemTests/tsc.py
+++ b/CIME/SystemTests/tsc.py
@@ -32,7 +32,9 @@ NINST = 12
 SIM_LENGTH = 600  # seconds
 OUT_FREQ = 10  # seconds
 INSPECT_AT = [300, 450, 600]  # seconds
-INIT_COND_FILE_TEMPLATE = "20231105.v3b01.F2010.ne4_oQU240.chrysalis.{}.{}.0002-{:02d}-01-00000.nc"
+INIT_COND_FILE_TEMPLATE = (
+    "20231105.v3b01.F2010.ne4_oQU240.chrysalis.{}.{}.0002-{:02d}-01-00000.nc"
+)
 VAR_LIST = [
     "T",
     "Q",


### PR DESCRIPTION
E3SMv3 atmosphere model default configuration is changed to use 80
vertical levels. The atm initial conditions for PGN and TSC with ne4 grid
need to be updated with those from an EAMv3-based F2010 run. The
land initial conditions are also replaced from the same run.

[NBFB] for PGN and TSC tests. Baseline comparison will have an exception
            as the number of vertical levels in atm history output files differs

Test suite: chrysalis_atm_nbfb
Test baseline: chrys/intel/master
Test namelist changes: atm and lnd ICs (ncdata and finidat)
Test status: [bit for bit, roundoff, climate changing]: climate changing for these specific tests.

Fixes [CIME Github issue #] N/A

User interface changes?:N/A

Update gh-pages html (Y/N)?:N
