### PR TITLE
Fixes separating std and performance blessing

### DIFF
--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -216,7 +216,7 @@ def bless_test_results(
     bless_perf=False,
     **_,  # Capture all for extra
 ):
-    bless_all = not (namelists_only | hist_only)
+    bless_all = not (namelists_only | hist_only | bless_tput | bless_mem | bless_perf)
 
     test_status_files = get_test_status_files(test_root, compiler, test_id=test_id)
 

--- a/CIME/tests/test_unit_bless_test_results.py
+++ b/CIME/tests/test_unit_bless_test_results.py
@@ -429,7 +429,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
         ts = TestStatus.return_value
         ts.get_name.return_value = "SMS.f19_g16.S.docker_gnu"
         ts.get_overall_test_status.return_value = ("PASS", "RUN")
-        ts.get_status.side_effect = ["PASS", "PASS", "PASS", "FAIL", "FAIL"]
+        ts.get_status.side_effect = ["PASS", "PASS", "FAIL", "FAIL", "FAIL"]
 
         case = Case.return_value.__enter__.return_value
 
@@ -470,7 +470,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
         ts = TestStatus.return_value
         ts.get_name.return_value = "SMS.f19_g16.S.docker_gnu"
         ts.get_overall_test_status.return_value = ("PASS", "RUN")
-        ts.get_status.side_effect = ["PASS", "PASS", "PASS", "FAIL"]
+        ts.get_status.side_effect = ["PASS", "PASS", "FAIL", "FAIL"]
 
         case = Case.return_value.__enter__.return_value
 
@@ -509,7 +509,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
         ts = TestStatus.return_value
         ts.get_name.return_value = "SMS.f19_g16.S.docker_gnu"
         ts.get_overall_test_status.return_value = ("PASS", "RUN")
-        ts.get_status.side_effect = ["PASS", "PASS", "PASS", "FAIL"]
+        ts.get_status.side_effect = ["PASS", "PASS", "FAIL", "FAIL"]
 
         case = Case.return_value.__enter__.return_value
 


### PR DESCRIPTION
When blessing performance diffs, the default hist and namelists would
be run as well. This PR separates these, there is now two distinct blessing
paths; standard (hist and namelists) and performance.

Test suite: pytest CIME/tests/test_unit*
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?: N
Update gh-pages html (Y/N)?: N
