### PR TITLE
Include ESMF lib on derecho

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -736,6 +736,10 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">parallelio/2.6.2</command>
       </modules>
 
+      <modules>
+        <command name="load">esmf/8.5.0</command>
+      </modules>
+
     </module_system>
 
     <environment_variables>


### PR DESCRIPTION
ESMF lib is needed for waccmx compsets.  

Test suite:
  PASS ERC_D_Ln9.f19_f19_mg17.QPC6.derecho_intel.cam-outfrq9s
  PASS SMS_D_Ln9.f09_f09_mg17.FSD.derecho_intel.cam-outfrq9s
  PASS SMS_D_Ln9.f19_f19_mg17.FXHIST.derecho_intel.cam-outfrq9s

Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
