### PR TITLE
derecho updates -- emsf lib for waccmx and intel compiler flags for E…

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -755,7 +755,14 @@ using a fortran linker.
     <append> -lnetcdff -lnetcdf </append>
   </SLIBS>
 </compiler>
-
+<compiler MACH="derecho" COMPILER="intel">
+  <CFLAGS>
+    <append> -march=core-avx2 -no-fma</append>
+  </CFLAGS>
+  <FFLAGS>
+    <append> -march=core-avx2 -no-fma</append>
+  </FFLAGS>
+</compiler>
 
 <compiler MACH="eastwind" COMPILER="intel">
   <CFLAGS>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1174,6 +1174,10 @@ This allows using a different mpirun command to launch unit tests
 	<command name="load">parallel-netcdf/1.12.3</command>
       </modules>
 
+      <modules>
+        <command name="load">esmf/8.5.0</command>
+      </modules>
+
     </module_system>
 
     <environment_variables>


### PR DESCRIPTION
Derecho updates for cesm2.1 
  - load module esmf for waccmx compsets
  - include intel compiler flags "-march=core-avx2 -no-fma"

        modified:   config/cesm/machines/config_compilers.xml
        modified:   config/cesm/machines/config_machines.xml

Is there a reason for not including these intel flags?  Should they be included in the cesm2.2 cime branch as well?  Without these flags ERP tests fail.

Test suite:
  PASS ERP_Ld3.f09_f09_mg17.FC2000climo.derecho_intel.cam-outfrq1d
  PASS ERS_Ln9.f19_f19_mg16.FX2000.derecho_intel.cam-outfrq9s
  PASS SMS_D_Ln9.f09_f09_mg17.FWSD.derecho_intel.cam-outfrq9s
  PASS SMS_D_Ln9.f19_f19_mg16.FXHIST.derecho_intel.cam-outfrq9s


Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
