### PR TITLE
increase wallclock and set line-buffer for derecho

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -398,7 +398,7 @@
       <directive> -l select={{ num_nodes }}:ncpus={{ max_tasks_per_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}</directive>
     </directives>
     <queues>
-      <queue walltimemax="4:00:00" nodemin="1" nodemax="2488" default="true">main</queue>
+      <queue walltimemax="12:00:00" nodemin="1" nodemax="2488" default="true">main</queue>
     </queues>
   </batch_system>
 

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -1112,6 +1112,7 @@ This allows using a different mpirun command to launch unit tests
       <executable>mpiexec</executable>
       <arguments>
 	<arg name="label"> --label</arg>
+	<arg name="buffer"> --line-buffer</arg>
 	<arg name="num_tasks" > -n {{ total_tasks }}</arg>
       </arguments>
     </mpirun>


### PR DESCRIPTION
Increase wallclock to 12:00:00 and add -line-buffer flag to mpirun

Test suite: tested by hand on derecho
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
