### PR TITLE
allow an external install of the mpi-serial library

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -373,7 +373,13 @@ ifeq ($(strip $(MPILIB)), mpi-serial)
   MPIFC	  := $(SFC)
   MPICC	  := $(SCC)
   MPICXX  := $(SCXX)
-  CONFIG_ARGS += MCT_PATH=$(SHAREDLIBROOT)/$(SHAREDPATH)/mct/mpi-serial
+  ifndef MPI_SERIAL_PATH
+    CONFIG_ARGS += MCT_PATH=$(SHAREDLIBROOT)/$(SHAREDPATH)/mct/mpi-serial
+  else
+    CONFIG_ARGS += MCT_PATH=$(MPI_SERIAL_PATH)
+    INC_MPI := $(MPI_SERIAL_PATH)/include
+    LIB_MPI := $(MPI_SERIAL_PATH)/lib
+  endif
 else
   CC  := $(MPICC)
   FC  := $(MPIFC)
@@ -567,9 +573,9 @@ ifdef MPAS_LIBDIR
 # used to build the MPAS dycore if needed.
 libmpas: cam_abortutils.o physconst.o
 	$(MAKE) -C $(MPAS_LIBDIR) CC="$(CC)" FC="$(FC)" PIODEF="$(PIODEF)" \
-        FFLAGS='$(FREEFLAGS) $(FFLAGS)' GPUFLAGS='$(GPUFLAGS)' \
-        CASEROOT='$(CASEROOT)' COMPILER='$(COMPILER)' MACH='$(MACH)' \
-        FCINCLUDES='$(INCLDIR) $(INCS) -I$(ABS_INSTALL_SHAREDPATH)/include -I$(ABS_ESMF_PATH)/include'
+	FFLAGS='$(FREEFLAGS) $(FFLAGS)' GPUFLAGS='$(GPUFLAGS)' \
+	CASEROOT='$(CASEROOT)' COMPILER='$(COMPILER)' MACH='$(MACH)' \
+	FCINCLUDES='$(INCLDIR) $(INCS) -I$(ABS_INSTALL_SHAREDPATH)/include -I$(ABS_ESMF_PATH)/include'
 
 dyn_comp.o: libmpas
 dyn_grid.o: libmpas

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -12,7 +12,14 @@ logger = logging.getLogger(__name__)
 
 
 class Machines(GenericXML):
-    def __init__(self, infile=None, files=None, machine=None, extra_machines_dir=None):
+    def __init__(
+        self,
+        infile=None,
+        files=None,
+        machine=None,
+        extra_machines_dir=None,
+        read_only=True,
+    ):
         """
         initialize an object
         if a filename is provided it will be used,
@@ -46,7 +53,7 @@ class Machines(GenericXML):
         else:
             expect(False, f"file not found {infile}")
 
-        GenericXML.__init__(self, infile, schema)
+        GenericXML.__init__(self, infile, schema, read_only=read_only)
 
         # Append the contents of $HOME/.cime/config_machines.xml if it exists.
         #

--- a/CIME/build_scripts/buildlib.mpi-serial
+++ b/CIME/build_scripts/buildlib.mpi-serial
@@ -50,6 +50,11 @@ def buildlib(bldroot, installpath, case):
     ###############################################################################
     caseroot = case.get_value("CASEROOT")
     srcroot = case.get_value("SRCROOT")
+    # check to see if MPI_SERIAL is installed
+    with open(os.path.join(caseroot, "Macros.make"), "r") as f:
+        for line in f:
+            if "MPI_SERIAL_PATH" in line:
+                return
 
     customize_path = os.path.join(srcroot, "cime_config", "customize")
 

--- a/CIME/non_py/src/timing/Makefile
+++ b/CIME/non_py/src/timing/Makefile
@@ -52,7 +52,11 @@ ifeq ($(strip $(MPILIB)), mpi-serial)
   FC      := $(SFC)
   MPIFC   := $(SFC)
   MPICC   := $(SCC)
-  INCLDIR += -I$(GPTL_LIBDIR)/../mct/mpi-serial
+  ifdef MPI_SERIAL_PATH
+    INCLDIR += -I$(MPI_SERIAL_PATH)/include
+  else
+    INCLDIR += -I$(GPTL_LIBDIR)/../mct/mpi-serial
+  endif
 else
   CC := $(MPICC)
   FC := $(MPIFC)


### PR DESCRIPTION
Updates the mpi-serial buildlib and the gptl and primary Makefile to support a preinstalled mpi-serial library.
mpi-serial is available via spack and installed on derecho.

Test suite:  mpi-serial tests are failing until https://github.com/NCAR/spack-derecho/issues/18 is addressed
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes https://github.com/ESMCI/ccs_config_cesm/issues/130

User interface changes?: 

Update gh-pages html (Y/N)?:
