### PR TITLE
Revert PR 4497

### DIFF
--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -422,14 +422,6 @@ def _case_setup_impl(
                 run_cmd_no_fail(
                     "{}/cime_config/cism.template {}".format(glcroot, caseroot)
                 )
-            if comp == "cam":
-                camroot = case.get_value("COMP_ROOT_DIR_ATM")
-                logger.debug("Running cam.case_setup.py")
-                run_cmd_no_fail(
-                    "python {cam}/cime_config/cam.case_setup.py {cam} {case}".format(
-                        cam=camroot, case=caseroot
-                    )
-                )
 
         _build_usernl_files(case, "drv", "cpl")
 


### PR DESCRIPTION
Revert PR #4497 since it's break all of the cam tests.  These changes will be added back in with a different PR.

Test suite:  By hand
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
