### PR TITLE
Add back changes from PR4497

### DIFF
--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -422,6 +422,14 @@ def _case_setup_impl(
                 run_cmd_no_fail(
                     "{}/cime_config/cism.template {}".format(glcroot, caseroot)
                 )
+            if comp == "cam":
+                camroot = case.get_value("COMP_ROOT_DIR_ATM")
+                logger.debug("Running cam.case_setup.py")
+                run_cmd_no_fail(
+                    "python {cam}/cime_config/cam.case_setup.py {cam} {case}".format(
+                    cam=camroot, case=caseroot
+                    ) 
+                )
 
         _build_usernl_files(case, "drv", "cpl")
 

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -427,8 +427,8 @@ def _case_setup_impl(
                 logger.debug("Running cam.case_setup.py")
                 run_cmd_no_fail(
                     "python {cam}/cime_config/cam.case_setup.py {cam} {case}".format(
-                    cam=camroot, case=caseroot
-                    ) 
+                        cam=camroot, case=caseroot
+                    )
                 )
 
         _build_usernl_files(case, "drv", "cpl")


### PR DESCRIPTION
Put back in changes for PR #4497.  

From PR #4497.
The update is needed for use with GEOS-Chem chemistry so that run-time configuration files can be copied to the case directory upon case setup. **This PR should be merged along with CAM PR https://github.com/ESCOMP/CAM/pull/484 at the same time.**

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
