### PR TITLE
Reformat config machines

### DIFF
--- a/CIME/XML/files.py
+++ b/CIME/XML/files.py
@@ -138,7 +138,6 @@ class Files(EntryID):
         node = self.get_optional_child("entry", {"id": nodename})
 
         schemanode = self.get_optional_child("schema", root=node, attributes=attributes)
-        logger.debug("Found schema for {} {}".format(nodename, self.text(schemanode)))
 
         if schemanode is not None:
             logger.debug("Found schema for {}".format(nodename))

--- a/CIME/XML/files.py
+++ b/CIME/XML/files.py
@@ -136,7 +136,10 @@ class Files(EntryID):
 
     def get_schema(self, nodename, attributes=None):
         node = self.get_optional_child("entry", {"id": nodename})
+
         schemanode = self.get_optional_child("schema", root=node, attributes=attributes)
+        logger.debug("Found schema for {} {}".format(nodename, self.text(schemanode)))
+
         if schemanode is not None:
             logger.debug("Found schema for {}".format(nodename))
             return self.get_resolved_value(self.text(schemanode))

--- a/CIME/XML/generic_xml.py
+++ b/CIME/XML/generic_xml.py
@@ -105,7 +105,8 @@ class GenericXML(object):
 
     def read(self, infile, schema=None):
         """
-        Read and parse an xml file into the object
+        Read and parse an xml file into the object.  The schema variable can either be a path to an xsd schema file or
+        a dictionary of paths to files by version.
         """
         cached_read = False
         if not self.DISABLE_CACHING and infile in self._FILEMAP:

--- a/CIME/XML/generic_xml.py
+++ b/CIME/XML/generic_xml.py
@@ -690,8 +690,13 @@ class GenericXML(object):
         """
         validate an XML file against a provided schema file using pylint
         """
-        expect(os.path.isfile(filename), "xml file not found {}".format(filename))
-        expect(os.path.isfile(schema), "schema file not found {}".format(schema))
+        expect(
+            filename and os.path.isfile(filename),
+            "xml file not found {}".format(filename),
+        )
+        expect(
+            schema and os.path.isfile(schema), "schema file not found {}".format(schema)
+        )
         xmllint = which("xmllint")
 
         expect(

--- a/CIME/XML/generic_xml.py
+++ b/CIME/XML/generic_xml.py
@@ -8,7 +8,7 @@ from CIME.utils import safe_copy, get_src_root
 import xml.etree.ElementTree as ET
 
 # pylint: disable=import-error
-from distutils.spawn import find_executable
+from shutil import which
 import getpass
 from copy import deepcopy
 from collections import namedtuple
@@ -126,8 +126,10 @@ class GenericXML(object):
             logger.debug("read: {}".format(infile))
             with open(infile, "r", encoding="utf-8") as fd:
                 self.read_fd(fd)
-
-            if schema is not None and self.get_version() > 1.0:
+            version = str(self.get_version())
+            if type(schema) is dict:
+                self.validate_xml_file(infile, schema[version])
+            elif schema is not None and self.get_version() > 1.0:
                 self.validate_xml_file(infile, schema)
 
             logger.debug("File version is {}".format(str(self.get_version())))
@@ -472,7 +474,7 @@ class GenericXML(object):
         xmlstr = self.get_raw_record()
 
         # xmllint provides a better format option for the output file
-        xmllint = find_executable("xmllint")
+        xmllint = which("xmllint")
 
         if xmllint:
             if isinstance(outfile, str):
@@ -690,7 +692,7 @@ class GenericXML(object):
         """
         expect(os.path.isfile(filename), "xml file not found {}".format(filename))
         expect(os.path.isfile(schema), "schema file not found {}".format(schema))
-        xmllint = find_executable("xmllint")
+        xmllint = which("xmllint")
 
         expect(
             xmllint and os.path.isfile(xmllint),

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -137,10 +137,19 @@ class Machines(GenericXML):
         Return a list of machines defined for a given CIME_MODEL
         """
         machines = []
-        nodes = self.get_children("machine")
-        for node in nodes:
-            mach = self.get(node, "MACH")
-            machines.append(mach)
+        if self.version < 3:
+            nodes = self.get_children("machine")
+            for node in nodes:
+                mach = self.get(node, "MACH")
+                machines.append(mach)
+        else:
+            machines = [
+                os.path.basename(f.path)
+                for f in os.scandir(self.machines_dir)
+                if f.is_dir()
+            ]
+            machines.remove("cmake_macros")
+        machines.sort()
         return machines
 
     def probe_machine_name(self, warn=True):

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -59,6 +59,7 @@ class Machines(GenericXML):
                 "MACHINES_SPEC_FILE", attributes={"version": "2.0"}
             ),
         }
+        logger.debug("Verifying using schema {}".format(schema))
 
         GenericXML.__init__(self, infile, schema, read_only=read_only)
 

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -291,11 +291,15 @@ class Machines(GenericXML):
         if machine == "Query":
             return machine
         elif self.version == 3:
-            GenericXML.read(
-                self,
-                os.path.join(self.machines_dir, machine, "config_machines.xml"),
-                schema=schema,
+            machines_file = os.path.join(
+                self.machines_dir, machine, "config_machines.xml"
             )
+            if os.path.isfile(machines_file):
+                GenericXML.read(
+                    self,
+                    machines_file,
+                    schema=schema,
+                )
         self.machine_node = super(Machines, self).get_child(
             "machine",
             {"MACH": machine},

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -60,7 +60,7 @@ class Machines(GenericXML):
             ),
         }
         # Before v3 there was but one choice
-        if not schema:
+        if not schema["3.0"]:
             schema = files.get_schema("MACHINES_SPEC_FILE")
 
         logger.debug("Verifying using schema {}".format(schema))

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -30,6 +30,9 @@ class Machines(GenericXML):
         additional directory that will be searched for a config_machines.xml file; if
         found, the contents of this file will be appended to the standard
         config_machines.xml. An empty string is treated the same as None.
+
+        The schema variable can be passed as a path to an xsd schema file or a dictionary of paths
+        with version number as keys.
         """
 
         self.machine_node = None

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -188,7 +188,7 @@ class Machines(GenericXML):
     def _probe_machine_name_one_guess_v2(self, nametomatch):
 
         nodes = self.get_children("machine")
-
+        machine = None
         for node in nodes:
             machtocheck = self.get(node, "MACH")
             logger.debug("machine is " + machtocheck)

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -59,6 +59,10 @@ class Machines(GenericXML):
                 "MACHINES_SPEC_FILE", attributes={"version": "2.0"}
             ),
         }
+        # Before v3 there was but one choice
+        if not schema:
+            schema = files.get_schema("MACHINES_SPEC_FILE")
+
         logger.debug("Verifying using schema {}".format(schema))
 
         GenericXML.__init__(self, infile, schema, read_only=read_only)

--- a/CIME/data/config/cesm/config_files.xml
+++ b/CIME/data/config/cesm/config_files.xml
@@ -43,7 +43,8 @@
     <group>case_last</group>
     <file>env_case.xml</file>
     <desc>file containing machine specifications for target model primary component (for documentation only - DO NOT EDIT)</desc>
-    <schema>$CIMEROOT/CIME/data/config/xml_schemas/config_machines.xsd</schema>
+    <schema version="2.0">$CIMEROOT/CIME/data/config/xml_schemas/config_machines.xsd</schema>
+    <schema version="3.0">$CIMEROOT/CIME/data/config/xml_schemas/config_machines_version3.xsd</schema>
   </entry>
 
   <entry id="BATCH_SPEC_FILE">

--- a/CIME/data/config/xml_schemas/config_machines_version3.xsd
+++ b/CIME/data/config/xml_schemas/config_machines_version3.xsd
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <!-- attributes -->
+  <xs:attribute name="version" type="xs:string"/>
+  <xs:attribute name="MACH" type="xs:NCName"/>
+  <xs:attribute name="compiler" type="xs:string"/>
+  <xs:attribute name="mpilib" type="xs:string"/>
+  <xs:attribute name="comp_interface" type="xs:string"/>
+  <xs:attribute name="gpu_type" type="xs:string"/>
+  <xs:attribute name="gpu_offload" type="xs:string"/>
+  <xs:attribute name="queue" type="xs:string"/>
+  <xs:attribute name="DEBUG" type="upperBoolean"/>
+  <xs:attribute name="PIO_VERSION" type="xs:integer"/>
+  <xs:attribute name="threaded" type="xs:boolean"/>
+  <xs:attribute name="allow_error" type="xs:boolean"/>
+  <xs:attribute name="unit_testing" type="xs:boolean"/>
+  <xs:attribute name="type" type="xs:NCName"/>
+  <xs:attribute name="lang" type="xs:NCName"/>
+  <xs:attribute name="name" type="xs:NCName"/>
+  <xs:attribute name="source" type="xs:NCName"/>
+
+  <!-- simple elements -->
+  <xs:simpleType name="upperBoolean">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="TRUE"/>
+      <xs:enumeration value="FALSE"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:element name="DESC" type="xs:string"/>
+<!--  <xs:element name="NODENAME_REGEX" type="xs:string"/> -->
+  <xs:element name="NODE_FAIL_REGEX" type="xs:string"/>
+  <xs:element name="MPIRUN_RETRY_REGEX" type="xs:string"/>
+  <xs:element name="MPIRUN_RETRY_COUNT" type="xs:integer"/>
+  <xs:element name="OS" type="xs:NCName"/>
+  <xs:element name="PROXY" type="xs:string"/>
+  <xs:element name="COMPILERS" type="xs:string"/>
+  <xs:element name="MPILIBS" type="AttrElement"/>
+  <xs:element name="PROJECT" type="xs:NCName"/>
+  <xs:element name="CHARGE_ACCOUNT" type="xs:NCName"/>
+  <xs:element name="SAVE_TIMING_DIR" type="xs:string"/>
+  <xs:element name="SAVE_TIMING_DIR_PROJECTS" type="xs:string"/>
+  <xs:element name="CIME_OUTPUT_ROOT" type="xs:string"/>
+  <xs:element name="CIME_HTML_ROOT" type="xs:string"/>
+  <xs:element name="CIME_URL_ROOT" type="xs:string"/>
+  <xs:element name="DIN_LOC_ROOT" type="xs:string"/>
+  <xs:element name="DIN_LOC_ROOT_CLMFORC" type="xs:string"/>
+  <xs:element name="DOUT_S_ROOT" type="xs:string"/>
+  <xs:element name="BASELINE_ROOT" type="xs:string"/>
+  <xs:element name="CCSM_CPRNC" type="xs:string"/>
+  <xs:element name="PERL5LIB" type="xs:string"/>
+  <xs:element name="GMAKE" type="xs:string"/>
+  <xs:element name="GMAKE_J" type="xs:integer"/>
+  <xs:element name="TESTS" type="xs:string"/>
+  <xs:element name="NTEST_PARALLEL_JOBS" type="xs:integer"/>
+  <xs:element name="BATCH_SYSTEM" type="xs:NCName"/>
+  <xs:element name="ALLOCATE_SPARE_NODES" type="upperBoolean"/>
+  <xs:element name="SUPPORTED_BY" type="xs:string"/>
+  <xs:element name="MAX_TASKS_PER_NODE" type="AttrElement"/>
+  <xs:element name="MAX_GPUS_PER_NODE" type="AttrElement"/>
+  <xs:element name="MAX_MPITASKS_PER_NODE" type="AttrElement"/>
+  <xs:element name="MAX_CPUTASKS_PER_GPU_NODE" type="AttrElement"/>
+  <xs:element name="GPU_TYPE" type="AttrElement"/>
+  <xs:element name="GPU_OFFLOAD" type="AttrElement"/>
+  <xs:element name="MPI_GPU_WRAPPER_SCRIPT" type="AttrElement"/>
+  <xs:element name="COSTPES_PER_NODE" type="xs:integer"/>
+  <xs:element name="PROJECT_REQUIRED" type="xs:NCName"/>
+  <xs:element name="executable" type="xs:string"/>
+  <xs:element name="default_run_exe" type="xs:string"/>
+  <xs:element name="default_run_misc_suffix" type="xs:string"/>
+  <xs:element name="run_exe" type="xs:string"/>
+  <xs:element name="run_misc_suffix" type="xs:string"/>
+  <xs:element name="RUNDIR" type="xs:string"/>
+  <xs:element name="EXEROOT" type="xs:string"/>
+  <xs:element name="TEST_TPUT_TOLERANCE" type="xs:string"/>
+  <xs:element name="TEST_MEMLEAK_TOLERANCE" type="xs:string"/>
+  <xs:element name="MAX_GB_OLD_TEST_DATA" type="xs:string"/>
+
+
+  <!-- complex elements -->
+
+  <xs:complexType name="AttrElement">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="compiler">
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:element name="value">
+    <xs:complexType>
+      <xs:simpleContent>
+	<xs:extension base="xs:string">
+	  <xs:anyAttribute processContents="lax"/>
+	</xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="config_machines">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="NODENAME_REGEX" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="machine" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="default_run_suffix" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+      <xs:attribute ref="version"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="NODENAME_REGEX">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="value" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="machine">
+    <xs:complexType>
+      <xs:sequence>
+        <!-- DESC: a text description of the machine, this field is current not used-->
+        <xs:element ref="DESC" minOccurs="1" maxOccurs="1"/>
+        <!-- regex to look for in log files that will triger retry of mpirun
+             command on extra allocated nodes -->
+        <xs:element ref="NODE_FAIL_REGEX" minOccurs="0" maxOccurs="1"/>
+        <!-- regex to look for in log files that will triger retry of mpirun command -->
+        <xs:element ref="MPIRUN_RETRY_REGEX" minOccurs="0" maxOccurs="1"/>
+        <!-- Number of retry attempts to make if MPIRUN_RETRY_REGEX matches   -->
+        <xs:element ref="MPIRUN_RETRY_COUNT" minOccurs="0" maxOccurs="1"/>
+        <!-- OS: the operating system of this machine. -->
+        <xs:element ref="OS" minOccurs="1" maxOccurs="1"/>
+        <!-- PROXY: optional http proxy for access to the internet-->
+        <xs:element ref="PROXY" minOccurs="0" maxOccurs="1"/>
+        <!-- COMPILERS: compilers supported on this machine, comma seperated list, first is default -->
+        <xs:element ref="COMPILERS" minOccurs="1" maxOccurs="1"/>
+        <!-- MPILIBS: mpilibs supported on this machine, comma seperated list, first is default -->
+        <xs:element ref="MPILIBS" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- PROJECT: A project or account number used for batch jobs
+          can be overridden in environment or $HOME/.cime/config -->
+        <xs:element ref="PROJECT" minOccurs="0" maxOccurs="1"/>
+        <!-- CHARGE_ACCOUNT: The name of the account to charge for batch jobs
+          can be overridden in environment or $HOME/.cime/config -->
+        <xs:element ref="CHARGE_ACCOUNT" minOccurs="0" maxOccurs="1"/>
+        <!-- SAVE_TIMING_DIR: (Acme only) directory for archiving timing output -->
+        <xs:element ref="SAVE_TIMING_DIR" minOccurs="0" maxOccurs="1"/>
+        <!-- SAVE_TIMING_DIR_PROJECTS: (Acme only) projects whose jobs archive timing output -->
+        <xs:element ref="SAVE_TIMING_DIR_PROJECTS" minOccurs="0" maxOccurs="1"/>
+        <!-- CIME_OUTPUT_ROOT: Base directory for case output,
+             the bld and run directories are written below here -->
+        <xs:element ref="CIME_OUTPUT_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- CIME_HTML_ROOT: Base directory for CIME SystemTest output websites-->
+        <xs:element ref="CIME_HTML_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- CIME_URL_ROOT: Base URL for CIME SystemTest output websites-->
+        <xs:element ref="CIME_URL_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- DIN_LOC_ROOT: location of the inputdata directory -->
+        <xs:element ref="DIN_LOC_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- DIN_LOC_ROOT_CLMFORC: optional input location for clm forcing data  -->
+        <xs:element ref="DIN_LOC_ROOT_CLMFORC" minOccurs="0" maxOccurs="1"/>
+        <!-- DOUT_S_ROOT: root directory of short term archive files -->
+        <xs:element ref="DOUT_S_ROOT" minOccurs="1" maxOccurs="1"/>
+        <!-- BASELINE_ROOT:  Root directory for system test baseline files -->
+        <xs:element ref="BASELINE_ROOT" minOccurs="0" maxOccurs="1"/>
+        <!-- CCSM_CPRNC: location of the cprnc tool, compares model output in testing-->
+        <xs:element ref="CCSM_CPRNC" minOccurs="0" maxOccurs="1"/>
+        <!-- PERL5LIB: location of external PERL modules (this variable is deprecated) -->
+        <xs:element ref="PERL5LIB" minOccurs="0" maxOccurs="1"/>
+        <!-- GMAKE: gnu compatible make tool, default is 'gmake' -->
+        <xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
+        <!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
+        <xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
+        <!-- TESTS: (acme only) list of tests to run on this machine -->
+        <xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
+        <!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->
+        <xs:element ref="NTEST_PARALLEL_JOBS" minOccurs="0" maxOccurs="1"/>
+        <!-- BATCH_SYSTEM: batch system used on this machine (none is okay) -->
+        <xs:element ref="BATCH_SYSTEM" minOccurs="1" maxOccurs="1"/>
+        <!-- ALLOCATE_SPARE_NODES: allocate spare nodes when job is launched default False-->
+        <xs:element ref="ALLOCATE_SPARE_NODES" minOccurs="0" maxOccurs="1"/>
+        <!-- SUPPORTED_BY: contact information for support for this system -->
+        <xs:element ref="SUPPORTED_BY" minOccurs="1" maxOccurs="1"/>
+        <!-- MAX_TASKS_PER_NODE: maximum number of threads*tasks per
+             shared memory node on this machine-->
+        <xs:element ref="MAX_TASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- MAX_GPUS_PER_NODE: maximum number of GPUs per node on this machine-->
+        <xs:element ref="MAX_GPUS_PER_NODE" minOccurs="0" maxOccurs="1"/>
+        <!-- MAX_MPITASKS_PER_NODE: number of physical PES per shared node on
+             this machine, in practice the MPI tasks per node will not exceed this value -->
+        <xs:element ref="MAX_MPITASKS_PER_NODE" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- MAX_CPUTASKS_PER_GPU_NODE: number of physical PES per GPU node on
+             this machine, in practice the MPI tasks per node will not exceed this value -->
+        <xs:element ref="MAX_CPUTASKS_PER_GPU_NODE" minOccurs="0" maxOccurs="unbounded"/>
+	<!-- GPU_TYPE: the type of GPU hardware available on this machine -->
+        <xs:element ref="GPU_TYPE" minOccurs="0" maxOccurs="unbounded"/>
+	<!-- GPU_OFFLOAD: the GPU programming model used for GPU porting -->
+        <xs:element ref="GPU_OFFLOAD" minOccurs="0" maxOccurs="unbounded"/>
+	<!-- MPI_GPU_WRAPPER_SCRIPT: a wrapper script that will be attached to the MPI run
+	     command and map different MPI ranks to different GPUs within the same node -->
+        <xs:element ref="MPI_GPU_WRAPPER_SCRIPT" minOccurs="0" maxOccurs="1"/>
+        <!-- Optional cost factor per node unit -->
+        <xs:element ref="COSTPES_PER_NODE" minOccurs="0" maxOccurs="1"/>
+        <!-- PROJECT_REQUIRED: Does this machine require a project to be specified to
+             the batch system?  See PROJECT above -->
+        <xs:element ref="PROJECT_REQUIRED" minOccurs="0" maxOccurs="1"/>
+        <!-- mpirun: The mpi exec to start a job on this machine
+             see detail below-->
+        <xs:element ref="mpirun" minOccurs="1" maxOccurs="unbounded"/>
+        <!-- module_system: how and what modules to load on this system ,
+             see detail below -->
+        <xs:element ref="module_system" minOccurs="1" maxOccurs="1"/>
+        <!-- environment_variables: environment_variables to set on this system,
+          see detail below-->
+        <xs:element ref="RUNDIR" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="EXEROOT" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="TEST_TPUT_TOLERANCE" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="TEST_MEMLEAK_TOLERANCE" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="MAX_GB_OLD_TEST_DATA" minOccurs="0" maxOccurs="1"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="environment_variables"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="resource_limits"/>
+      </xs:sequence>
+      <xs:attribute ref="MACH" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="mpirun">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="aprun_mode" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="executable"/>
+        <xs:element ref="arguments" minOccurs="0"/>
+        <!-- run_exe: The run executable to use; overrides default_run_exe -->
+        <xs:element ref="run_exe" minOccurs="0"/>
+        <!-- run_misc_suffix: the misc run suffix to use; overrides default_run_misc_suffix -->
+        <xs:element ref="run_misc_suffix" minOccurs="0"/>
+      </xs:sequence>
+      <xs:attribute ref="compiler"/>
+      <xs:attribute ref="queue"/>
+      <xs:attribute ref="mpilib"/>
+      <xs:attribute ref="threaded"/>
+      <xs:attribute ref="unit_testing"/>
+      <xs:attribute ref="comp_interface"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="arguments">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="arg" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="module_system">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="init_path"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="cmd_path"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="modules"/>
+      </xs:sequence>
+      <xs:attribute ref="type" use="required"/>
+      <xs:attribute ref="allow_error"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="init_path">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="lang" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="cmd_path">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="lang" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="modules">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="command"/>
+      </xs:sequence>
+      <xs:attribute ref="compiler"/>
+      <xs:attribute ref="DEBUG"/>
+      <xs:attribute ref="PIO_VERSION"/>
+      <xs:attribute ref="mpilib"/>
+      <xs:attribute ref="comp_interface"/>
+      <xs:attribute ref="gpu_offload"/>
+      <xs:attribute ref="gpu_type"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="command">
+    <xs:complexType mixed="true">
+      <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="environment_variables">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="env"/>
+      </xs:sequence>
+      <xs:anyAttribute processContents="skip"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="resource_limits">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="resource"/>
+      </xs:sequence>
+      <xs:attribute ref="DEBUG"/>
+      <xs:attribute ref="mpilib"/>
+      <xs:attribute ref="compiler"/>
+      <xs:attribute ref="unit_testing"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="env">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="name" />
+      <xs:attribute ref="source"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="resource">
+    <xs:complexType mixed="true">
+      <xs:attribute ref="name" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="default_run_suffix">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="default_run_exe"/>
+        <xs:element ref="default_run_misc_suffix"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -20,22 +20,22 @@ class TestTestScheduler(base.BaseTestCase):
             self.skipTest("Skipping chksum test. Depends on CESM settings")
 
         ts = test_scheduler.TestScheduler(
-            ["SEQ_Ln9.f19_g16_rx1.A.cori-haswell_gnu"],
-            machine_name="cori-haswell",
+            ["SEQ_Ln9.f19_g16_rx1.A.perlmutter_gnu"],
+            machine_name="perlmutter",
             chksum=True,
             test_root="/tests",
         )
 
         with mock.patch.object(ts, "_shell_cmd_for_phase") as _shell_cmd_for_phase:
             ts._run_phase(
-                "SEQ_Ln9.f19_g16_rx1.A.cori-haswell_gnu"
+                "SEQ_Ln9.f19_g16_rx1.A.perlmutter_gnu"
             )  # pylint: disable=protected-access
 
             _shell_cmd_for_phase.assert_called_with(
-                "SEQ_Ln9.f19_g16_rx1.A.cori-haswell_gnu",
+                "SEQ_Ln9.f19_g16_rx1.A.perlmutter_gnu",
                 "./case.submit --skip-preview-namelist --chksum",
                 "RUN",
-                from_dir="/tests/SEQ_Ln9.f19_g16_rx1.A.cori-haswell_gnu.00:00:00",
+                from_dir="/tests/SEQ_Ln9.f19_g16_rx1.A.perlmutter_gnu.00:00:00",
             )
 
     def test_a_phases(self):

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -232,14 +232,14 @@ class TestCase(unittest.TestCase):
                     self.srcroot,
                     "A",
                     "f19_g16_rx1",
-                    machine_name="cori-haswell",
+                    machine_name="perlmutter",
                 )
 
                 # Check that they're all called
                 configure.assert_called_with(
                     "A",
                     "f19_g16_rx1",
-                    machine_name="cori-haswell",
+                    machine_name="perlmutter",
                     project=None,
                     pecount=None,
                     compiler=None,
@@ -309,14 +309,14 @@ class TestCase(unittest.TestCase):
                     self.srcroot,
                     "A",
                     "f19_g16_rx1",
-                    machine_name="cori-haswell",
+                    machine_name="perlmutter",
                 )
 
                 # Check that they're all called
                 configure.assert_called_with(
                     "A",
                     "f19_g16_rx1",
-                    machine_name="cori-haswell",
+                    machine_name="perlmutter",
                     project=None,
                     pecount=None,
                     compiler=None,


### PR DESCRIPTION
Reformats config machines so that the primary file contains only the regex field for machine name matching.   The
details for each machine are then read from files in machines/_machinename_/config_machines.xml
This is v3 of config_machines.xml, this change is backward compatible with v2.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
