### PR TITLE
remove SMP_PRESENT and replace with BUILD_THREADED

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -108,6 +108,9 @@ jobs:
           # exclude nuopc driver when running e3sm tests
           - model: "e3sm"
             driver: "nuopc"
+          # exclude mct driver when running cesm tests
+          - model: "cesm"
+            driver: "mct"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           INIT: "false"
           CIME_MODEL: "cesm"
-          CIME_DRIVER: "mct"
+          CIME_DRIVER: "nuopc"
           UPDATE_CIME: "true"
           GIT_SHALLOW: "true"
           CIME_TEST_PLATFORM: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -101,6 +101,8 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     strategy:
+      # allow all jobs to finish
+      fail-fast: false
       matrix:
         model: ["e3sm", "cesm"]
         driver: ["mct", "nuopc"]

--- a/CIME/BuildTools/configure.py
+++ b/CIME/BuildTools/configure.py
@@ -145,13 +145,13 @@ class FakeCase(object):
             "DEBUG": debug,
             "COMP_INTERFACE": comp_interface,
             "PIO_VERSION": 2,
-            "SMP_PRESENT": threading,
+            "BUILD_THREADED": threading,
             "MODEL": get_model(),
             "SRCROOT": get_src_root(),
         }
 
     def get_build_threaded(self):
-        return self.get_value("SMP_PRESENT")
+        return self.get_value("BUILD_THREADED")
 
     def get_case_root(self):
         """Returns the root directory for this case."""

--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -48,7 +48,7 @@ ifeq ($(strip $(SMP)),TRUE)
    THREADDIR = threads
    compile_threaded = TRUE
 else
-   ifeq ($(strip $(SMP_PRESENT)),TRUE)
+   ifeq ($(strip $(BUILD_THREADED)),TRUE)
       THREADDIR = threads
       compile_threaded = TRUE
    else

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -162,6 +162,7 @@ class Machines(GenericXML):
                 if f.is_dir()
             ]
             machines.remove("cmake_macros")
+            machines.remove("userdefined_laptop_template")
         machines.sort()
         return machines
 

--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -150,19 +150,22 @@ class Machines(GenericXML):
         Return a list of machines defined for a given CIME_MODEL
         """
         machines = []
-        if self.get_version() < 3:
-            nodes = self.get_children("machine")
-            for node in nodes:
-                mach = self.get(node, "MACH")
-                machines.append(mach)
-        else:
-            machines = [
+        nodes = self.get_children("machine")
+        for node in nodes:
+            mach = self.get(node, "MACH")
+            machines.append(mach)
+        if self.get_version() == 3.0:
+            machdirs = [
                 os.path.basename(f.path)
                 for f in os.scandir(self.machines_dir)
                 if f.is_dir()
             ]
-            machines.remove("cmake_macros")
-            machines.remove("userdefined_laptop_template")
+            machdirs.remove("cmake_macros")
+            machdirs.remove("userdefined_laptop_template")
+            for mach in machdirs:
+                if mach not in machines:
+                    machines.append(mach)
+
         machines.sort()
         return machines
 

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -45,7 +45,7 @@ _CMD_ARGS_FOR_BUILD = (
     "OS",
     "PIO_VERSION",
     "SHAREDLIBROOT",
-    "SMP_PRESENT",
+    "BUILD_THREADED",
     "USE_ESMF_LIB",
     "USE_MOAB",
     "CAM_CONFIG_OPTS",

--- a/CIME/case/case_clone.py
+++ b/CIME/case/case_clone.py
@@ -107,7 +107,7 @@ def create_clone(
         if exeroot is not None:
             expect(
                 not keepexe,
-                "create_case_clone: if keepexe is True, " "then exeroot cannot be set",
+                "create_case_clone: if keepexe is True, then exeroot cannot be set",
             )
             newcase.set_value("EXEROOT", exeroot)
         if rundir is not None:
@@ -218,8 +218,6 @@ def create_clone(
                 newcasename, clonename
             )
         )
-
-        newcase.case_setup()
 
     return newcase
 

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -345,7 +345,7 @@ def _case_setup_impl(
 
             case.initialize_derived_attributes()
 
-            case.set_value("SMP_PRESENT", case.get_build_threaded())
+            case.set_value("BUILD_THREADED", case.get_build_threaded())
 
         else:
             case.check_pelayouts_require_rebuild(models)
@@ -361,7 +361,7 @@ def _case_setup_impl(
             cost_per_node = case.get_value("COSTPES_PER_NODE")
             case.set_value("COST_PES", case.num_nodes * cost_per_node)
             threaded = case.get_build_threaded()
-            case.set_value("SMP_PRESENT", threaded)
+            case.set_value("BUILD_THREADED", threaded)
             if threaded and case.total_tasks * case.thread_count > cost_per_node:
                 smt_factor = max(
                     1.0, int(case.get_value("MAX_TASKS_PER_NODE") / cost_per_node)

--- a/CIME/data/config/xml_schemas/config_machines_template.xml
+++ b/CIME/data/config/xml_schemas/config_machines_template.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0"?>
 <!-- This is an ordered list, not all fields are required, optional fields are noted below. -->
-<config_machines version="2.0">
+<config_machines version="3.0">
 <!-- MACH is the name that you will use in machine options -->
   <machine MACH="mymachine">
 
     <!-- DESC: a text description of the machine, this field is current not used in code-->
     <DESC>SITE VENDOR platform, os is ---, xx pes/node, batch system is ---</DESC>
-
-	<!-- NODENAME_REGEX: a regular expression used to identify this machine
-	  it must work on compute nodes as well as login nodes, use machine option
-	  to create_test or create_newcase if this flag is not available -->
-    <NODENAME_REGEX>.*.cheyenne.ucar.edu</NODENAME_REGEX>
 
     <!-- OS: the operating system of this machine. Passed to cppflags for
 	 compiled programs as -DVALUE  recognized are LINUX, AIX, Darwin, CNL -->

--- a/CIME/data/config/xml_schemas/env_mach_specific.xsd
+++ b/CIME/data/config/xml_schemas/env_mach_specific.xsd
@@ -11,7 +11,7 @@
 <xs:attribute name="comp_interface" type="xs:string"/>
 <xs:attribute name="gpu_type" type="xs:string"/>
 <xs:attribute name="gpu_offload" type="xs:string"/>
-<xs:attribute name="SMP_PRESENT" type="xs:string"/>
+<xs:attribute name="BUILD_THREADED" type="xs:string"/>
 <xs:attribute name="value" type="xs:string"/>
 <xs:attribute name="unit_testing" type="xs:boolean"/>
 <xs:attribute name="queue" type="xs:string"/>
@@ -138,7 +138,7 @@
       <xs:attribute ref="mpilib"/>
       <xs:attribute ref="compiler"/>
       <xs:attribute ref="unit_testing"/>
-      <xs:attribute ref="SMP_PRESENT"/>
+      <xs:attribute ref="BUILD_THREADED"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="resource">

--- a/CIME/tests/test_sys_cime_case.py
+++ b/CIME/tests/test_sys_cime_case.py
@@ -236,7 +236,7 @@ class TestCimeCase(base.BaseTestCase):
         )
 
         with Case(casedir, read_only=False) as case:
-            build_threaded = case.get_value("SMP_PRESENT")
+            build_threaded = case.get_value("BUILD_THREADED")
             self.assertFalse(build_threaded)
 
             build_threaded = case.get_build_threaded()
@@ -254,7 +254,7 @@ class TestCimeCase(base.BaseTestCase):
         )
 
         with Case(casedir, read_only=False) as case:
-            build_threaded = case.get_value("SMP_PRESENT")
+            build_threaded = case.get_value("BUILD_THREADED")
             self.assertTrue(build_threaded)
 
             build_threaded = case.get_build_threaded()

--- a/CIME/tests/test_sys_create_newcase.py
+++ b/CIME/tests/test_sys_create_newcase.py
@@ -109,10 +109,12 @@ class TestCreateNewcase(base.BaseTestCase):
             new_batch_command = case.get_value(
                 "BATCH_COMMAND_FLAGS", subgroup="case.run"
             )
-            self.assertTrue(
-                "fred" in new_batch_command,
-                msg="Failed to update JOB_QUEUE in BATCH_COMMAND_FLAGS",
-            )
+        self.assertTrue(
+            "fred" in new_batch_command,
+            msg="Failed to update JOB_QUEUE in BATCH_COMMAND_FLAGS {}".format(
+                new_batch_command
+            ),
+        )
 
         # Trying to set values outside of context manager should fail
         case = Case(testdir, read_only=False)

--- a/CIME/tests/test_unit_xml_machines.py
+++ b/CIME/tests/test_unit_xml_machines.py
@@ -78,10 +78,10 @@ MACHINE_TEST_XML = """<config_machines version="2.0">
       <env name="NETCDF_FORTRAN_PATH">/opt/ubuntu/pe/netcdf-hdf5parallel/4.8.1.3/gnu/9.1/</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>
     </environment_variables>
   </machine>
@@ -126,10 +126,10 @@ MACHINE_TEST_XML = """<config_machines version="2.0">
       <env name="NETCDF_FORTRAN_PATH">/opt/ubuntu/pe/netcdf-hdf5parallel/4.8.1.3/gnu/9.1/</env>
       <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE">
+    <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
     </environment_variables>
-    <environment_variables SMP_PRESENT="TRUE" compiler="gnu">
+    <environment_variables BUILD_THREADED="TRUE" compiler="gnu">
       <env name="OMP_PLACES">cores</env>
     </environment_variables>
   </machine>

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,19 +1,19 @@
 [ccs_config]
-tag = ccs_config_cesm0.0.76
+tag = ccs_config_cesm0.0.88
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm
 local_path = ccs_config
 required = True
 
 [cmeps]
-tag = cmeps0.14.38
+tag = cmeps0.14.47
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps1.0.19
+tag = cdeps1.0.26
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -21,7 +21,7 @@ externals = Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl77.0.6
+tag = cpl77.0.8
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
@@ -42,7 +42,7 @@ local_path = libraries/mct
 required = True
 
 [parallelio]
-tag = pio2_6_0
+tag = pio2_6_2
 protocol = git
 repo_url = https://github.com/NCAR/ParallelIO
 local_path = libraries/parallelio

--- a/docker/config_machines.xml
+++ b/docker/config_machines.xml
@@ -3,7 +3,7 @@
 <config_machines version="2.0">
   <machine MACH="docker">
     <DESC>Docker</DESC>
-    <NODENAME_REGEX>docker</NODENAME_REGEX>
+<!--    <NODENAME_REGEX>docker</NODENAME_REGEX> -->
     <OS>LINUX</OS>
     <PROXY />
     <COMPILERS>gnu,gnuX</COMPILERS>

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -27,7 +27,7 @@ function clone_repo() {
         extras="${extras} --depth 1"
     fi
 
-    echo "Cloning branch ${branch} of ${repo} into ${path} using ${flags}"
+    echo "Cloning branch ${branch} of ${repo} into ${path} with flags: ${flags}"
 
     git clone -b "${branch}" ${extras} "${repo}" "${path}" || true
 }
@@ -156,17 +156,21 @@ function init_cesm() {
         clone_repo "${CESM_REPO}" "${install_path}" "${CESM_BRANCH:-master}"
     fi
 
-    cd "${install_path}"
+    pushd "${install_path}"
 
-    echo "Checking out externals"
+    pushd "${install_path}/cime"
 
-    "${install_path}/manage_externals/checkout_externals"
+    echo "Checking out externals from `pwd`"
+
+    "${install_path}/manage_externals/checkout_externals" -v
+
+    popd
 
     fixup_mct "${install_path}/libraries/mct"
 
     update_cime "${install_path}/cime/"
 
-    cd "${install_path}/cime"
+    pushd "${install_path}/cime"
 
     # Need to run manage_externals again incase branch changes externals instructions
     # "${install_path}/manage_externals/checkout_externals -e cime/Externals_cime.cfg"
@@ -203,7 +207,7 @@ function init_cime() {
 
     cd "${install_path}"
 
-    "/src/CESM/manage_externals/checkout_externals"
+    "/src/CESM/manage_externals/checkout_externals" -v
 
     fixup_mct "${install_path}/libraries/mct"
 


### PR DESCRIPTION
SMP_PRESENT and BUILD_THREADED were both used in the same way and having two variables to do the same thing is confusing at best.  This replaces all instances of SMP_PRESENT with BUILD_THREADED.   Note that this may require changes in E3SM outside of CIME.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes #4544 
User interface changes?: xml variable SMP_PRESENT is removed. 

Update gh-pages html (Y/N)?:
