### PR TITLE
add develop queue on derecho

### DIFF
--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -399,6 +399,7 @@
     </directives>
     <queues>
       <queue walltimemax="12:00:00" nodemin="1" nodemax="2488" default="true">main</queue>
+      <queue walltimemax="1:00:00" nodemin="1" nodemax="2">develop</queue>
     </queues>
   </batch_system>
 


### PR DESCRIPTION
Add the develop queue for shared node jobs.

Test suite: hand testing on derecho
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
