### PR TITLE
just update externals

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,19 +1,19 @@
 [ccs_config]
-tag = ccs_config_cesm0.0.76
+tag = ccs_config_cesm0.0.88
 protocol = git
 repo_url = https://github.com/ESMCI/ccs_config_cesm
 local_path = ccs_config
 required = True
 
 [cmeps]
-tag = cmeps0.14.38
+tag = cmeps0.14.47
 protocol = git
 repo_url = https://github.com/ESCOMP/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cdeps]
-tag = cdeps1.0.19
+tag = cdeps1.0.26
 protocol = git
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
@@ -21,7 +21,7 @@ externals = Externals_CDEPS.cfg
 required = True
 
 [cpl7]
-tag = cpl77.0.6
+tag = cpl77.0.8
 protocol = git
 repo_url = https://github.com/ESCOMP/CESM_CPL7andDataComps
 local_path = components/cpl7
@@ -42,7 +42,7 @@ local_path = libraries/mct
 required = True
 
 [parallelio]
-tag = pio2_6_0
+tag = pio2_6_2
 protocol = git
 repo_url = https://github.com/NCAR/ParallelIO
 local_path = libraries/parallelio


### PR DESCRIPTION
Just update the Externals.cfg file so that docker can use the new externals when running tests on the replace_smp_present branch.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
