### PR TITLE
Automatically call case_setup for case2 in compareTwo

### DIFF
--- a/CIME/SystemTests/erp.py
+++ b/CIME/SystemTests/erp.py
@@ -42,10 +42,6 @@ class ERP(RestartTest):
                 self._case.set_value("ROOTPE_{}".format(comp), int(rootpe / 2))
 
         RestartTest._case_two_setup(self)
-        self._case.case_setup(test_mode=True, reset=True)
-        # Note, some components, like CESM-CICE, have
-        # decomposition information in env_build.xml that
-        # needs to be regenerated for the above new tasks and thread counts
 
     def _case_one_custom_postrun_action(self):
         self.copy_case1_restarts_to_case2()

--- a/CIME/SystemTests/nck.py
+++ b/CIME/SystemTests/nck.py
@@ -61,4 +61,3 @@ class NCK(SystemTestsCompareTwo):
             if rootpe > 1:
                 self._case.set_value("ROOTPE_{}".format(comp), int(rootpe - ntasks))
             self._case.set_value("NTASKS_{}".format(comp), ntasks * 2)
-        self._case.case_setup(test_mode=True, reset=True)

--- a/CIME/SystemTests/pea.py
+++ b/CIME/SystemTests/pea.py
@@ -48,4 +48,3 @@ class PEA(SystemTestsCompareTwo):
 
         if os.path.isfile("Macros"):
             os.remove("Macros")
-        self._case.case_setup(test_mode=True, reset=True)

--- a/CIME/SystemTests/pem.py
+++ b/CIME/SystemTests/pem.py
@@ -42,4 +42,3 @@ class PEM(SystemTestsCompareTwo):
             if ntasks > 1:
                 self._case.set_value("NTASKS_{}".format(comp), int(ntasks / 2))
                 self._case.set_value("ROOTPE_{}".format(comp), int(rootpe / 2))
-        self._case.case_setup(test_mode=True, reset=True)

--- a/CIME/SystemTests/pet.py
+++ b/CIME/SystemTests/pet.py
@@ -34,12 +34,7 @@ class PET(SystemTestsCompareTwo):
             if self._case.get_value("NTHRDS_{}".format(comp)) <= 1:
                 self._case.set_value("NTHRDS_{}".format(comp), 2)
 
-        # Need to redo case_setup because we may have changed the number of threads
-
     def _case_two_setup(self):
         # Do a run with all threads set to 1
         for comp in self._case.get_values("COMP_CLASSES"):
             self._case.set_value("NTHRDS_{}".format(comp), 1)
-
-        # Need to redo case_setup because we may have changed the number of threads
-        self._case.case_setup(reset=True, test_mode=True)

--- a/CIME/SystemTests/seq.py
+++ b/CIME/SystemTests/seq.py
@@ -49,4 +49,3 @@ class SEQ(SystemTestsCompareTwo):
                     rootpe += newntasks
 
         self._case.flush()
-        self._case.case_setup(test_mode=True, reset=True)

--- a/CIME/SystemTests/system_tests_compare_two.py
+++ b/CIME/SystemTests/system_tests_compare_two.py
@@ -24,6 +24,9 @@ Classes that inherit from this are REQUIRED to implement the following methods:
 (2) _case_two_setup
     This method will be called to set up case 2, the "test" case
 
+Note that the base class will always call case_setup(reset=True) on
+both case1 and case2 during setup.
+
 In addition, they MAY require the following methods:
 
 (1) _common_setup
@@ -559,6 +562,7 @@ class SystemTestsCompareTwo(SystemTestsCommon):
             self._activate_case2()
             self._common_setup()
             self._case_two_setup()
+            self._case2.case_setup(test_mode=True, reset=True)
 
         fix_single_exe_case(self._case2)
 

--- a/CIME/case/case_clone.py
+++ b/CIME/case/case_clone.py
@@ -219,8 +219,6 @@ def create_clone(
             )
         )
 
-        newcase.case_setup()
-
     return newcase
 
 

--- a/CIME/case/case_clone.py
+++ b/CIME/case/case_clone.py
@@ -219,6 +219,8 @@ def create_clone(
             )
         )
 
+        newcase.case_setup()
+
     return newcase
 
 


### PR DESCRIPTION
It's removal in #4546 seems to have broken a number of less-common test types (ERR, MCC, IRT, PRE).

```
MCC_P1.f19_g16_rx1.A
ERROR: ERROR: must invoke case.setup script before calling build script
ERR_Ln9.f45_g37_rx1.A
Exception from case_test: [Errno 2] No such file or directory: '/scratch/jenkins-slave/workspace/CIME_DEVELOPER_TESTS_MASTER/archive/ERR_Ln9.f45_g37_rx1.A.anlgce_gnu.20240102_114925_1cza5r/rest'
Exception from case_test: [Errno 20] Not a directory: '/scratch/jenkins-slave/workspace/CIME_DEVELOPER_TESTS_MASTER/ERR_Ln9.f45_g37_rx1.A.anlgce_gnu.20240102_114925_1cza5r/run/case2run/timing'
IRT_N2_Vmct_Ln9.f19_g16_rx1.A
Exception from case_test: [Errno 20] Not a directory: '/scratch/jenkins-slave/workspace/CIME_DEVELOPER_TESTS_MASTER/IRT_N2_Vmct_Ln9.f19_g16_rx1.A.anlgce_gnu.20240102_114925_1cza5r/run/case2run/timing'
PRE.f19_f19.ADESP
Exception from case_test: ERROR: Do not know about batch job case.test
```

Test suite: the test cases above, by hand
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
