### PR TITLE
Fix .env_mach_specific.sh when unsetting env

### DIFF
--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -277,19 +277,25 @@ class EnvMachSpecific(EnvBase):
                         if env_value.startswith("sh"):
                             lines.append("{}".format(env_name))
                     else:
-                        lines.append("export {}={}".format(env_name, env_value))
+                        if env_value is None:
+                            lines.append("unset {}".format(env_name))
+                        else:
+                            lines.append("export {}={}".format(env_name, env_value))
 
                 elif shell == "csh":
                     if env_name == "source":
                         if env_value.startswith("csh"):
                             lines.append("{}".format(env_name))
                     else:
-                        lines.append("setenv {} {}".format(env_name, env_value))
+                        if env_value is None:
+                            lines.append("unsetenv {}".format(env_name))
+                        else:
+                            lines.append("setenv {} {}".format(env_name, env_value))
                 else:
                     expect(False, "Unknown shell type: '{}'".format(shell))
 
         with open(os.path.join(output_dir, filename), "w") as fd:
-            fd.write("\n".join(lines))
+            fd.write("\n".join(lines) + "\n")
 
     # Private API
 


### PR DESCRIPTION
When an env var value is None, this tells CIME to unset the environment. This use case was not being handled in the creation of .env_mach_specific.sh.

Test suite: by-hand
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
