### PR TITLE
Enable threading and improve IO performance for normal resolutions for cesm2.2 on derecho

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -671,9 +671,12 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>mpiexec</executable>
       <arguments>
-        <arg name="label"> --label</arg>
-        <arg name="buffer"> --line-buffer</arg>
-        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
+        <arg name="label">--label</arg>
+        <arg name="buffer">--line-buffer</arg>
+	<arg name="cpu_bind">--cpu-bind depth</arg>
+        <arg name="num_tasks" >-n {{ total_tasks }}</arg>
+        <arg name="tasks_per_node">-ppn {{ tasks_per_node }}</arg>
+	<arg name="thread_count">-d $ENV{OMP_NUM_THREADS}</arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
@@ -747,13 +750,17 @@ This allows using a different mpirun command to launch unit tests
     </module_system>
 
     <environment_variables>
-      <env name="OMP_STACKSIZE">64M</env>
+      <env name="OMP_STACKSIZE">256M</env>
+      <env name="OMP_PLACES">threads</env>
+      <env name="OMP_PROC_BIND">close</env>
       <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
       <env name="FI_MR_CACHE_MONITOR">memhooks</env>
     </environment_variables>
+   <!--
     <environment_variables mpilib="mpich">
       <env name="MPICH_MPIIO_HINTS">*:romio_cb_read=enable:romio_cb_write=enable:striping_factor=24</env>
     </environment_variables>
+    -->
   </machine>
 
   <machine MACH="eastwind">

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -669,14 +669,11 @@ This allows using a different mpirun command to launch unit tests
     <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
-      <executable>mpiexec</executable>
+      <executable>mpibind</executable>
       <arguments>
-        <arg name="label">--label</arg>
-        <arg name="buffer">--line-buffer</arg>
-	<arg name="cpu_bind">--cpu-bind depth</arg>
-        <arg name="num_tasks" >-n {{ total_tasks }}</arg>
-        <arg name="tasks_per_node">-ppn {{ tasks_per_node }}</arg>
-	<arg name="thread_count">-d $ENV{OMP_NUM_THREADS}</arg>
+        <arg name="label"> --label</arg>
+	<arg name="buffer"> --line-buffer</arg>
+	<arg name="separator"> -- </arg>
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
@@ -750,17 +747,13 @@ This allows using a different mpirun command to launch unit tests
     </module_system>
 
     <environment_variables>
-      <env name="OMP_STACKSIZE">256M</env>
-      <env name="OMP_PLACES">threads</env>
-      <env name="OMP_PROC_BIND">close</env>
+      <env name="OMP_STACKSIZE">64M</env>
       <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
       <env name="FI_MR_CACHE_MONITOR">memhooks</env>
     </environment_variables>
-   <!--
     <environment_variables mpilib="mpich">
-      <env name="MPICH_MPIIO_HINTS">*:romio_cb_read=enable:romio_cb_write=enable:striping_factor=24</env>
+      <env name="MPICH_MPIIO_HINTS">*:romio_cb_read=enable:romio_cb_write=enable:striping_factor=4:striping_unit=16777216</env>
     </environment_variables>
-    -->
   </machine>
 
   <machine MACH="eastwind">


### PR DESCRIPTION
Enable threading on derecho.
Remove the default setting of MPICH_MPIIO_HINTS on derecho which seems to degrade performance of IO for normal resolution configurations.

Test suite:
```
  PASS ERC_D_Ln9.ne16_ne16_mg17.QPC5HIST.derecho_intel.cam-outfrq3s_usecase
  PASS ERC_Ln9_P64x4.f19_f19_mg17.QPC6.derecho_intel.cam-outfrq9s
  PASS ERP_Ln9_P512x4.f09_f09_mg17.FX2000.derecho_intel.cam-outfrq9s
  PASS SMS_D_Ln9.f09_f09_mg17.FCvbsxHIST.derecho_intel.cam-outfrq9s
  PASS SMS_D_Ln9.f19_f19_mg17.FWma2000climo.derecho_intel.cam-outfrq9s
  PASS SMS_D_Ln9_P512x4.f19_f19_mg17.FX2000.derecho_intel.cam-outfrq9s
  PASS SMS_Ld1.ne30pg3_ne30pg3_mg17.FC2010climo.derecho_intel.cam-outfrq1d
  PASS SMS_Lm13.f10_f10_mg37.F2000climo.derecho_intel.cam-outfrq1m
```
Test baseline:
```
    PASS ERC_D_Ln9.ne16_ne16_mg17.QPC5HIST.derecho_intel.cam-outfrq3s_usecase BASELINE cam_cesm2_2_rel_09:
    PASS SMS_D_Ln9.f09_f09_mg17.FCvbsxHIST.derecho_intel.cam-outfrq9s BASELINE cam_cesm2_2_rel_09:
    PASS SMS_D_Ln9.f19_f19_mg17.FWma2000climo.derecho_intel.cam-outfrq9s BASELINE cam_cesm2_2_rel_09:
    PASS SMS_Ld1.ne30pg3_ne30pg3_mg17.FC2010climo.derecho_intel.cam-outfrq1d BASELINE cam_cesm2_2_rel_09:
    PASS SMS_Lm13.f10_f10_mg37.F2000climo.derecho_intel.cam-outfrq1m BASELINE cam_cesm2_2_rel_09:
```

Test namelist changes: N/A

Test status: bit for bit unchanged

