### PR TITLE
If chksum is off, don't try to download_checksum_file

### DIFF
--- a/CIME/case/check_input_data.py
+++ b/CIME/case/check_input_data.py
@@ -212,7 +212,7 @@ def _check_all_input_data_impl(
                 chksum=chksum and chksum_found,
             )
         if download and not success:
-            if not chksum:
+            if chksum:
                 chksum_found = _download_checksum_file(self.get_value("RUNDIR"))
             success = _downloadfromserver(self, input_data_root, data_list_dir)
 


### PR DESCRIPTION
I think
```
            if not chksum:
                chksum_found = _download_checksum_file(self.get_value("RUNDIR"))
```

Should be:
```
            if chksum:
                chksum_found = _download_checksum_file(self.get_value("RUNDIR"))
```

Or:

```
            if not chksum_found:
                chksum_found = _download_checksum_file(self.get_value("RUNDIR"))
```

I'm not 100% sure which, but I am pretty sure we don't want to download checksum files if chksum=False.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
