### PR TITLE
Loosen type for module command to allow options to be passed before subcommand

### DIFF
--- a/config/xml_schemas/config_machines.xsd
+++ b/config/xml_schemas/config_machines.xsd
@@ -217,7 +217,7 @@
   </xs:element>
   <xs:element name="command">
     <xs:complexType mixed="true">
-      <xs:attribute ref="name" use="required"/>
+      <xs:attribute name="name" use="required" type="xs:string"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="environment_variables">


### PR DESCRIPTION
This is needed for some versions of lua, since otherwise it will not recognize options like `--force` and `--quiet` which will not allow a case to be created. NCName, on the other hand does not allow to `--` to be start of the `name`.

Similar to #4375

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:
N
Update gh-pages html (Y/N)?:
N