### PR TITLE
jenkins_generic_job: Should probe branch of main src repo, not cime repo

### DIFF
--- a/CIME/Tools/jenkins_generic_job
+++ b/CIME/Tools/jenkins_generic_job
@@ -38,7 +38,7 @@ OR
 
     CIME.utils.setup_standard_logging_options(parser)
 
-    default_baseline = CIME.utils.get_current_branch(repo=CIME.utils.get_cime_root())
+    default_baseline = CIME.utils.get_current_branch(repo=CIME.utils.get_src_root())
     if default_baseline is not None:
         default_baseline = default_baseline.replace(".", "_").replace(
             "/", "_"


### PR DESCRIPTION
Test suite: ./scripts_regression_tests.py test_sys_jenkins_generic_job
Test baseline:
Test namelist changes:
Test status: bit for bit 

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
