### PR TITLE
Switch from drv.log to med.log for nuopc COMP tests.

### DIFF
--- a/CIME/SystemTests/nodefail.py
+++ b/CIME/SystemTests/nodefail.py
@@ -24,7 +24,7 @@ class NODEFAIL(ERS):
         exeroot = self._case.get_value("EXEROOT")
         driver = self._case.get_value("COMP_INTERFACE")
         if driver == "nuopc":
-            logname = "drv"
+            logname = "med"
         else:
             logname = "cpl"
         fake_exe = """#!/bin/bash

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -110,7 +110,7 @@ class SystemTestsCommon(object):
         self._init_locked_files(caseroot, expected)
         self._skip_pnl = False
         self._cpllog = (
-            "drv" if self._case.get_value("COMP_INTERFACE") == "nuopc" else "cpl"
+            "med" if self._case.get_value("COMP_INTERFACE") == "nuopc" else "cpl"
         )
         self._ninja = False
         self._dry_run = False

--- a/CIME/baselines/performance.py
+++ b/CIME/baselines/performance.py
@@ -329,7 +329,7 @@ def get_latest_cpl_logs(case):
     """
     coupler_log_path = case.get_value("RUNDIR")
 
-    cpllog_name = "drv" if case.get_value("COMP_INTERFACE") == "nuopc" else "cpl"
+    cpllog_name = "med" if case.get_value("COMP_INTERFACE") == "nuopc" else "cpl"
 
     cpllogs = glob.glob(os.path.join(coupler_log_path, "{}*.log.*".format(cpllog_name)))
 

--- a/CIME/case/case_run.py
+++ b/CIME/case/case_run.py
@@ -304,7 +304,7 @@ def _post_run_check(case, lid):
         if fv3_standalone:
             file_prefix = model
         else:
-            file_prefix = "drv"
+            file_prefix = "med"
     else:
         file_prefix = "cpl"
 


### PR DESCRIPTION
The timing and memory usage information was moved from drv.log to med.log for nuopc runs.
This allows the creating of the baselines cpl-mem.log and cpl-tput.log files.

I had several tests fail for scripts_regression tests on derecho, but they also failed for the cime master.

test_self_build_cprnc (test_sys_cime_case.TestCimeCase) ... FAIL
test_full_system (test_sys_full_system.TestFullSystem) ... FAIL
test_run_restart (test_sys_run_restart.TestRunRestart) ... FAIL

test_b_cime_f90_unit_tests (test_sys_unittest.TestUnitTest) ... ERROR
test_generate_baseline (test_unit_system_tests.TestUnitSystemTests) ... ERROR
test_has_batch_system (test_unit_xml_machines.TestUnitXMLMachines) ... ERROR
test_is_valid_MPIlib (test_unit_xml_machines.TestUnitXMLMachines) ... ERROR
test_is_valid_compiler (test_unit_xml_machines.TestUnitXMLMachines) ... ERROR
 

Test suite: scripts_regression_tests, SMS.f09_f09_mg17.QPC6.derecho_intel
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
