### PR TITLE
case.submit: Fix no-batch mode.

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -1124,8 +1124,14 @@ class EnvBatch(EnvBase):
                 jobid_pattern is not None,
                 "Could not find jobid_pattern in env_batch.xml",
             )
+
+            # If no output was provided, skip the search. This could
+            # be because --no-batch was provided.
+            if not output:
+                return output
         else:
             return output
+
         search_match = re.search(jobid_pattern, output)
         expect(
             search_match is not None,

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -1413,7 +1413,7 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
                 tgt_path,
                 preserve_mode=preserve_meta,
                 preserve_times=preserve_meta,
-                verbose=0
+                verbose=0,
             )
         else:
             # I am not the owner, just copy file contents
@@ -1427,7 +1427,7 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
             tgt_path,
             preserve_mode=preserve_meta,
             preserve_times=preserve_meta,
-            verbose=0
+            verbose=0,
         )
 
     # If src file was executable, then the tgt file should be too

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -1413,6 +1413,7 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
                 tgt_path,
                 preserve_mode=preserve_meta,
                 preserve_times=preserve_meta,
+                verbose=0
             )
         else:
             # I am not the owner, just copy file contents
@@ -1426,6 +1427,7 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
             tgt_path,
             preserve_mode=preserve_meta,
             preserve_times=preserve_meta,
+            verbose=0
         )
 
     # If src file was executable, then the tgt file should be too


### PR DESCRIPTION
No output fron the batch env is provided to get_job_id when no_batch is on. Treat that case the same as if batchtype is none.

Also, update cprnc submodule.

We also never want file_util.copy_file to be verbose. It was cluttering the output coming from create_test on some platforms.

Test suite: by-hand.
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
