### PR TITLE
Fix a string that should be raw

### DIFF
--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -201,7 +201,7 @@ def check_name(fullname, additional_chars=None, fullpath=False):
     False
     """
 
-    chars = "+*?<>/{}[\]~`@:"  # pylint: disable=anomalous-backslash-in-string
+    chars = r"+*?<>/{}[\]~`@:"
     if additional_chars is not None:
         chars += additional_chars
     if fullname.endswith("/"):


### PR DESCRIPTION
The `\` character was not intended to be escaping anything, so the string should have been raw.

Test suite: pylint
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
