### PR TITLE
Standalone component

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -13,6 +13,7 @@ from CIME.utils import (
     expect,
     get_current_commit,
     SharedArea,
+    is_comp_standalone,
 )
 from CIME.test_status import *
 from CIME.hist_utils import (
@@ -289,10 +290,12 @@ class SystemTestsCommon(object):
             if self._case.get_value("COMPARE_BASELINE"):
                 if do_baseline_ops:
                     self._phase_modifying_call(BASELINE_PHASE, self._compare_baseline)
-                    self._phase_modifying_call(MEMCOMP_PHASE, self._compare_memory)
-                    self._phase_modifying_call(
-                        THROUGHPUT_PHASE, self._compare_throughput
-                    )
+                    comp_standalone, _ = is_comp_standalone(self._case)
+                    if not comp_standalone:
+                        self._phase_modifying_call(MEMCOMP_PHASE, self._compare_memory)
+                        self._phase_modifying_call(
+                            THROUGHPUT_PHASE, self._compare_throughput
+                        )
                 else:
                     with self._test_status:
                         self._test_status.set_status(BASELINE_PHASE, TEST_PEND_STATUS)

--- a/CIME/case/case_run.py
+++ b/CIME/case/case_run.py
@@ -320,9 +320,6 @@ def _post_run_check(case, lid):
     cpl_logfile = cpl_logs[0]
     # find the last model.log and cpl.log
     model_logfile = os.path.join(rundir, model + ".log." + lid)
-    print(
-        f"driver {driver} cpl_logfile {cpl_logfile} model_logfile {model_logfile} comp_standalone {comp_standalone}"
-    )
     if not os.path.isfile(model_logfile):
         expect(False, "Model did not complete, no {} log file ".format(model_logfile))
     elif os.stat(model_logfile).st_size == 0:
@@ -330,7 +327,6 @@ def _post_run_check(case, lid):
     else:
         count_ok = 0
         for cpl_logfile in cpl_logs:
-            print(f"cpl_logfile {cpl_logfile}")
             if not os.path.isfile(cpl_logfile):
                 break
             with open(cpl_logfile, "r") as fd:

--- a/CIME/case/case_run.py
+++ b/CIME/case/case_run.py
@@ -5,7 +5,7 @@ from CIME.XML.standard_module_setup import *
 from CIME.config import Config
 from CIME.utils import gzip_existing_file, new_lid, run_and_log_case_status
 from CIME.utils import run_sub_or_cmd, append_status, safe_copy, model_log, CIMEError
-from CIME.utils import get_model, batch_jobid
+from CIME.utils import batch_jobid, is_comp_standalone
 from CIME.get_timing import get_timing
 
 import shutil, time, sys, os, glob
@@ -292,16 +292,12 @@ def _post_run_check(case, lid):
     ###############################################################################
 
     rundir = case.get_value("RUNDIR")
-    model = case.get_value("MODEL")
     driver = case.get_value("COMP_INTERFACE")
-    model = get_model()
 
-    fv3_standalone = False
+    comp_standalone, model = is_comp_standalone(case)
 
-    if "CPL" not in case.get_values("COMP_CLASSES"):
-        fv3_standalone = True
     if driver == "nuopc":
-        if fv3_standalone:
+        if comp_standalone:
             file_prefix = model
         else:
             file_prefix = "med"
@@ -322,9 +318,11 @@ def _post_run_check(case, lid):
         cpl_logs = [os.path.join(rundir, file_prefix + ".log." + lid)]
 
     cpl_logfile = cpl_logs[0]
-
     # find the last model.log and cpl.log
     model_logfile = os.path.join(rundir, model + ".log." + lid)
+    print(
+        f"driver {driver} cpl_logfile {cpl_logfile} model_logfile {model_logfile} comp_standalone {comp_standalone}"
+    )
     if not os.path.isfile(model_logfile):
         expect(False, "Model did not complete, no {} log file ".format(model_logfile))
     elif os.stat(model_logfile).st_size == 0:
@@ -336,11 +334,16 @@ def _post_run_check(case, lid):
             if not os.path.isfile(cpl_logfile):
                 break
             with open(cpl_logfile, "r") as fd:
-                if fv3_standalone and "HAS ENDED" in fd.read():
+                logfile = fd.read()
+                if (
+                    comp_standalone
+                    and "HAS ENDED" in logfile
+                    or "END OF MODEL RUN" in logfile
+                ):
                     count_ok += 1
-                elif not fv3_standalone and "SUCCESSFUL TERMINATION" in fd.read():
+                elif not comp_standalone and "SUCCESSFUL TERMINATION" in logfile:
                     count_ok += 1
-        if count_ok != cpl_ninst:
+        if count_ok < cpl_ninst:
             expect(False, "Model did not complete - see {} \n ".format(cpl_logfile))
 
 

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -424,12 +424,13 @@ def _case_setup_impl(
                 )
             if comp == "cam":
                 camroot = case.get_value("COMP_ROOT_DIR_ATM")
-                logger.debug("Running cam.case_setup.py")
-                run_cmd_no_fail(
-                    "python {cam}/cime_config/cam.case_setup.py {cam} {case}".format(
-                        cam=camroot, case=caseroot
+                if os.path.exists(os.path.join(camroot, "cam.case_setup.py")):
+                    logger.debug("Running cam.case_setup.py")
+                    run_cmd_no_fail(
+                        "python {cam}/cime_config/cam.case_setup.py {cam} {case}".format(
+                            cam=camroot, case=caseroot
+                        )
                     )
-                )
 
         _build_usernl_files(case, "drv", "cpl")
 

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -11,6 +11,7 @@ import stat as statlib
 from argparse import Action
 from contextlib import contextmanager
 
+# pylint: disable=deprecated-module
 from distutils import file_util
 
 # Return this error code if the scripts worked but tests failed
@@ -2736,3 +2737,21 @@ def add_flag_to_cmd(flag, val):
 
     separator = "" if no_space else " "
     return "{}{}{}".format(flag, separator, str(val).strip())
+
+
+def is_comp_standalone(case):
+    """
+    Test if the case is a single component standalone
+    such as FKESSLER
+    """
+    stubcnt = 0
+    classes = case.get_values("COMP_CLASSES")
+    for comp in classes:
+        if case.get_value("COMP_{}".format(comp)) == "s{}".format(comp.lower()):
+            stubcnt = stubcnt + 1
+        else:
+            model = comp.lower()
+    numclasses = len(classes)
+    if stubcnt >= numclasses - 2:
+        return True, model
+    return False, get_model()


### PR DESCRIPTION
standalone component tests do not produce a cpl log file and so looking there for test completion of these components is a mistake.  This change will cause case_run.py to look in the component log for the completion stamp and will cause memory and performance baseline comparisons to be skipped since memory and performance data is not collected.

Test suite: cesm2.3.alpha17b
Test baseline:
Test namelist changes:
Test status: bit for bit,

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
