### PR TITLE
case.submit: Always try to download input data

### DIFF
--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -290,9 +290,9 @@ def check_case(self, skip_pnl=False, chksum=False):
     self.check_lockedfiles()
     if not skip_pnl:
         self.create_namelists()  # Must be called before check_all_input_data
+
     logger.info("Checking that inputdata is available as part of case submission")
-    if not self.get_value("TEST"):
-        self.check_all_input_data(chksum=chksum)
+    self.check_all_input_data(chksum=chksum)
 
     if self.get_value("COMP_WAV") == "ww":
         # the ww3 buildnml has dependencies on inputdata so we must run it again

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -23,7 +23,7 @@ class TestCaseSubmit(unittest.TestCase):
     def test_check_case(self):
         case = mock.MagicMock()
         # get_value arguments TEST, COMP_WAV, COMP_INTERFACE, BUILD_COMPLETE
-        case.get_value.side_effect = [False, "", "", True]
+        case.get_value.side_effect = ["", "", True]
         case_submit.check_case(case, chksum=True)
 
         case.check_all_input_data.assert_called_with(chksum=True)

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -28,14 +28,6 @@ class TestCaseSubmit(unittest.TestCase):
 
         case.check_all_input_data.assert_called_with(chksum=True)
 
-    def test_check_case_test(self):
-        case = mock.MagicMock()
-        # get_value arguments TEST, COMP_WAV, COMP_INTERFACE, BUILD_COMPLETE
-        case.get_value.side_effect = [True, "", "", True]
-        case_submit.check_case(case, chksum=True)
-
-        case.check_all_input_data.assert_not_called()
-
     @mock.patch("CIME.case.case_submit.lock_file")
     @mock.patch("CIME.case.case_submit.unlock_file")
     @mock.patch("os.path.basename")


### PR DESCRIPTION
We don't want test cases downloading data while on a compute node if it can be avoided. It's harmless to call check_all_input_data twice, so let's have the case.submit call handle the 99% of cases where the main case will download all the inputs needed for the case/test. We keep the download calls in system_tests_common.py just in case case2 of a compare-two test needs more inputs.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
