### PR TITLE
need to make sure the directory exists before linking to it

### DIFF
--- a/CIME/SystemTests/eri.py
+++ b/CIME/SystemTests/eri.py
@@ -26,7 +26,8 @@ def _get_rest_date(archive_root):
 
 def _helper(dout_sr, refdate, refsec, rundir):
     rest_path = os.path.join(dout_sr, "rest", "{}-{}".format(refdate, refsec))
-
+    if not os.path.exists(rundir):
+        os.makedirs(rundir)
     for item in glob.glob("{}/*{}*".format(rest_path, refdate)):
         dst = os.path.join(rundir, os.path.basename(item))
         if os.path.exists(dst):


### PR DESCRIPTION
The ERI test was failing after running the first ref case, its because the second run directory wasn't created and thus it wasn't possible to create links within it, I added code to create this directory if it doesn't already exist.  

Test suite:scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
