### PR TITLE
Fixes finding termination message in logs

### DIFF
--- a/CIME/case/case_run.py
+++ b/CIME/case/case_run.py
@@ -10,6 +10,8 @@ from CIME.get_timing import get_timing
 
 import shutil, time, sys, os, glob
 
+TERMINATION_TEXT = ("HAS ENDED", "END OF MODEL RUN", "SUCCESSFUL TERMINATION")
+
 logger = logging.getLogger(__name__)
 
 ###############################################################################
@@ -331,13 +333,7 @@ def _post_run_check(case, lid):
                 break
             with open(cpl_logfile, "r") as fd:
                 logfile = fd.read()
-                if (
-                    comp_standalone
-                    and "HAS ENDED" in logfile
-                    or "END OF MODEL RUN" in logfile
-                ):
-                    count_ok += 1
-                elif not comp_standalone and "SUCCESSFUL TERMINATION" in logfile:
+                if any([x in logfile for x in TERMINATION_TEXT]):
                     count_ok += 1
         if count_ok < cpl_ninst:
             expect(False, "Model did not complete - see {} \n ".format(cpl_logfile))

--- a/CIME/tests/test_unit_case_run.py
+++ b/CIME/tests/test_unit_case_run.py
@@ -5,20 +5,18 @@ from CIME.utils import CIMEError
 from CIME.case.case_run import TERMINATION_TEXT
 from CIME.case.case_run import _post_run_check
 
+
 def _case_post_run_check():
     case = mock.MagicMock()
 
     # RUNDIR, COMP_INTERFACE, COMP_CPL, COMP_ATM, COMP_OCN, MULTI_DRIVER
-    case.get_value.side_effect = (
-        "/tmp/run", "mct",
-        "cpl", "satm", "socn",
-        False
-    )
+    case.get_value.side_effect = ("/tmp/run", "mct", "cpl", "satm", "socn", False)
 
     # COMP_CLASSES
     case.get_values.return_value = ("CPL", "ATM", "OCN")
 
     return case
+
 
 class TestCaseSubmit(unittest.TestCase):
     @mock.patch("os.stat")
@@ -45,5 +43,8 @@ class TestCaseSubmit(unittest.TestCase):
         case = _case_post_run_check()
 
         with self.assertRaises(CIMEError):
-            with mock.patch("builtins.open", mock.mock_open(read_data="I DONT HAVE A TERMINATION MESSAGE")) as mock_file:
+            with mock.patch(
+                "builtins.open",
+                mock.mock_open(read_data="I DONT HAVE A TERMINATION MESSAGE"),
+            ) as mock_file:
                 _post_run_check(case, "1234")

--- a/CIME/tests/test_unit_case_run.py
+++ b/CIME/tests/test_unit_case_run.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest import mock
+
+from CIME.utils import CIMEError
+from CIME.case.case_run import TERMINATION_TEXT
+from CIME.case.case_run import _post_run_check
+
+def _case_post_run_check():
+    case = mock.MagicMock()
+
+    # RUNDIR, COMP_INTERFACE, COMP_CPL, COMP_ATM, COMP_OCN, MULTI_DRIVER
+    case.get_value.side_effect = (
+        "/tmp/run", "mct",
+        "cpl", "satm", "socn",
+        False
+    )
+
+    # COMP_CLASSES
+    case.get_values.return_value = ("CPL", "ATM", "OCN")
+
+    return case
+
+class TestCaseSubmit(unittest.TestCase):
+    @mock.patch("os.stat")
+    @mock.patch("os.path.isfile")
+    def test_post_run_check(self, isfile, stat):
+        isfile.return_value = True
+
+        stat.return_value.st_size = 1024
+
+        # no exceptions means success
+        for x in TERMINATION_TEXT:
+            case = _case_post_run_check()
+
+            with mock.patch("builtins.open", mock.mock_open(read_data=x)) as mock_file:
+                _post_run_check(case, "1234")
+
+    @mock.patch("os.stat")
+    @mock.patch("os.path.isfile")
+    def test_post_run_check_no_termination(self, isfile, stat):
+        isfile.return_value = True
+
+        stat.return_value.st_size = 1024
+
+        case = _case_post_run_check()
+
+        with self.assertRaises(CIMEError):
+            with mock.patch("builtins.open", mock.mock_open(read_data="I DONT HAVE A TERMINATION MESSAGE")) as mock_file:
+                _post_run_check(case, "1234")


### PR DESCRIPTION
This PR fixes finding termination text in logs. Before this fix
an `S` compset was considered a standalone component
and for E3SM would not check for correct termination text.
Now the log is checked for all possible termination text.

Test suite: pytest CIME/tests/test*
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?:
Update gh-pages html (Y/N)?:
