### PR TITLE
Initialize machine to None

### DIFF
--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -263,6 +263,7 @@ class Machines(GenericXML):
 
         children = [y for x in nodes for y in self.get_children(root=x)]
 
+        machine = None
         for child in children:
             machtocheck = self.get(child, "MACH")
             regex_str = self.text(child)


### PR DESCRIPTION
This follows the logic in the _v2 version of this function, as well as the documentation in "_probe_machine_name_one_guess" ("Returns None if no match is found").

Test suite: None (just manually tested the issue documented in #4588 ).
Test baseline: none
Test namelist changes: none
Test status: bit for bit

Fixes #4588 

User interface changes?: N

Update gh-pages html (Y/N)?: N
