### PR TITLE
Resolve issue #4576

### DIFF
--- a/CIME/code_checker.py
+++ b/CIME/code_checker.py
@@ -44,7 +44,7 @@ def _run_pylint(all_files, interactive):
     #     cmd_options +=",relative-import"
 
     # add init-hook option
-    cmd_options += ' --init-hook=\'sys.path.extend(("%s","%s","%s","%s"))\'' % (
+    cmd_options += ' --init-hook=\'import sys; sys.path.extend(("%s","%s","%s","%s"))\'' % (
         os.path.join(cimeroot, "CIME"),
         os.path.join(cimeroot, "CIME", "Tools"),
         os.path.join(cimeroot, "scripts", "fortran_unit_testing", "python"),


### PR DESCRIPTION
Fixes pylint failures when running regression tests.

### SUMMARY
This patch fixes the pylint failures observed when running the regression tests using python 3.9.2.

### ISSUE
While running the regression script, the pylint checks are failing due
to Python being unable to resolve the sys module. The failure occurs
in `line 30` of `cime/scripts/lib/CIME/code_checker.py`.

### RESOLUTION
Line 30 was modified to include `import sys;` prior to the invocation
of `sys.path.extend`.

Test suite: scripts_regression_test
Test baseline: failing pylint checks
Test namelist changes: none
Test status: passing pylint checks

Fixes CIME issue #4576 

User interface changes?: none

Update gh-pages html (Y/N)?: N