### PR TITLE
Fix undefined machine on cime6.0.217_httpsbranch branch

### DIFF
--- a/CIME/XML/machines.py
+++ b/CIME/XML/machines.py
@@ -263,6 +263,7 @@ class Machines(GenericXML):
 
         children = [y for x in nodes for y in self.get_children(root=x)]
 
+        machine = None
         for child in children:
             machtocheck = self.get(child, "MACH")
             regex_str = self.text(child)


### PR DESCRIPTION
Initialize machine to None to prevent not initializing it to anything. This is cherry-picked
from #4596

Testing: Run CTSM python testing (which was failing before this change)
               ./scripts_regression_tests.py (currently running)
Test status: bit-for-bit

Fix for ESMCI/cime#4588 on the httpsbranch branch.

This fixes issues in CTSM discussed here:

https://github.com/ESCOMP/CTSM/pull/2385#issuecomment-1961657972

User interface changes?: None

Update gh-pages html (Y/N)?: N
