### PR TITLE
Update server name for the test database.

### DIFF
--- a/CIME/XML/test_reporter.py
+++ b/CIME/XML/test_reporter.py
@@ -76,7 +76,7 @@ class TestReporter(GenericXML):
         os.system("stty echo")
         print()
         params = {"username": username, "password": password, "testXML": xmlstr}
-        url = "https://csegweb.cgd.ucar.edu/testdb/cgi-bin/processXMLtest.cgi"
+        url = "https://cseg.cgd.ucar.edu/testdb/cgi-bin/processXMLtest.cgi"
         data = urllib.parse.urlencode(params)
         data = data.encode("ascii")
         req = urllib.request.Request(url, data)


### PR DESCRIPTION
The server name for the test database was updated from csegweb.cgd.ucar.edu to cseg.cgd.ucar.edu.

Test suite: Manually ran testreporter
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
