### PR TITLE
Fix bug in path to CAM script cam.case_setup.py

### DIFF
--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -424,8 +424,10 @@ def _case_setup_impl(
                 )
             if comp == "cam":
                 camroot = case.get_value("COMP_ROOT_DIR_ATM")
-                if os.path.exists(os.path.join(camroot, "cam.case_setup.py")):
-                    logger.debug("Running cam.case_setup.py")
+                if os.path.exists(
+                    os.path.join(camroot, "cime_config/cam.case_setup.py")
+                ):
+                    logger.info("Running cam.case_setup.py")
                     run_cmd_no_fail(
                         "python {cam}/cime_config/cam.case_setup.py {cam} {case}".format(
                             cam=camroot, case=caseroot


### PR DESCRIPTION
Just prior to the `cime6.0.217` tag there was a change in the original code to call `cam.case_setup.py` 
during case setup. The change added a conditional for file path existence, but the file path added was 
incorrect. This causes the script to never be called and GEOS-Chem compsets will subsequently all fail.

Tagging @cacraigucar since this bug makes me wonder if GEOS-Chem tests are running, or if I am missing something else that changed that would make the existing code work.

Test suite: N/A
Test baseline: N/A
Test namelist changes: N/A
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #] none

User interface changes?: N

Update gh-pages html (Y/N)?: N
