### PR TITLE
Disables ghcr-prune workflow

### DIFF
--- a/.github/workflows/ghcr-prune.yml
+++ b/.github/workflows/ghcr-prune.yml
@@ -1,9 +1,5 @@
 name: Prune ghcr.io container images
 on:
-  schedule:
-    # run once a day
-    - cron: '0 2 * * *'
-
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
This workflow keeps removing the latest tag causing 
testing workflows to fail. Disabling until I can come up
with a permanent fix.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
