### PR TITLE
need to make sure ref2 run dir exists

### DIFF
--- a/CIME/SystemTests/eri.py
+++ b/CIME/SystemTests/eri.py
@@ -29,8 +29,11 @@ def _helper(dout_sr, refdate, refsec, rundir):
 
     for item in glob.glob("{}/*{}*".format(rest_path, refdate)):
         dst = os.path.join(rundir, os.path.basename(item))
-        if os.path.exists(dst):
+        if not os.path.exists(rundir):
+            os.mkdir(rundir)
+        elif os.path.exists(dst):
             os.remove(dst)
+
         os.symlink(item, dst)
 
     for item in glob.glob("{}/*rpointer*".format(rest_path)):


### PR DESCRIPTION
Sometimes the ref2 run directory was not created before trying to copy files into it. 

Test suite:ERI_D_Ln18.T5_T5_mg37.QPC4.izumi_gnu.cam-co2rmp
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
