### PR TITLE
Fixes config ignoring paths containing tests

### DIFF
--- a/CIME/config.py
+++ b/CIME/config.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import glob
 import logging
@@ -39,9 +40,11 @@ class ConfigBase:
 
         customize_files = glob.glob(f"{customize_path}/**/*.py", recursive=True)
 
+        ignore_pattern = re.compile(f"{customize_path}/(?:tests|conftest|test_)")
+
         # filter out any tests
         customize_files = [
-            x for x in customize_files if "tests" not in x and "conftest" not in x
+            x for x in customize_files if ignore_pattern.search(x) is None
         ]
 
         customize_module_spec = importlib.machinery.ModuleSpec("cime_customize", None)


### PR DESCRIPTION
When CIME's customize config would load it would ignore paths
containing `tests`. This PR fixes the ignore pattern and only applies
it under the `cime_config/customize` directory.

Test suite: pytest CIME/tests/test_unit*
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4611 
User interface changes?: N
Update gh-pages html (Y/N)?: N
