### PR TITLE
Update documentation for basic usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ buildnmlc
 buildlib.*c
 CIME.egg-info/
 build/
+_build/
 dist/
 .coverage
 

--- a/doc/source/users_guide/cime-dir.rst
+++ b/doc/source/users_guide/cime-dir.rst
@@ -25,25 +25,22 @@ CIME's content is split into several subdirectories. Users should start in the *
    ========================== ==================================================================
    Directory or Filename               Description
    ========================== ==================================================================
+   **CIME/**	              **The main CIME source**
+   CIME/ParamGen              Python tool for generating runtime params
+   CIME/Servers		      Scripts to interact with input data servers
+   CIME/SystemTests           Scripts for create_test tests.
+   CIME/Tools		      Auxillary tools, scripts and functions.
    CMakeLists.txt	      For building with CMake
+   CONTRIBUTING.md            Guide for contributing to CIME
    ChangeLog		      Developer-maintained record of changes to CIME
    ChangeLog_template	      Template for an entry in ChangeLog
    LICENSE.TXT		      The CIME license
-   README		      Brief intro to CIME
+   MANIFEST.in                
    README.md		      README in markdown language
-   README.unit_testing	      Instructions for running unit tests with CIME
-   **config/**		      **Shared and model-specific configuration files**
-   config/cesm/	              CESM-specific configuration options
-   config/e3sm/	              E3SM-specific configuration options
+   conftest.py
+   doc			      Documentation for CIME in rst format
+   docker		      Container for CIME testing
    **scripts/**		      **The CIME user interface**
-   scripts/lib/  	      Infrastructure source code for CIME scripts and functions
-   scripts/Tools/	      Auxiliary tools; scripts and functions
-   **src/**		      **Model source code provided by CIME**
-   src/components/	      CIME-provided components including data and stub models
-   src/drivers/  	      CIME-provided main driver for a climate model
-   src/externals/	      Software provided with CIME for building a climate model
-   src/share/    	      Model source code provided by CIME and used by multiple components
-   **tests/**		      **Tests**
    **tools/**		      **Standalone climate modeling tools**
    utils/		      Some Perl source code needed by some prognostic components
    ========================== ==================================================================

--- a/doc/source/users_guide/create-a-case.rst
+++ b/doc/source/users_guide/create-a-case.rst
@@ -63,7 +63,7 @@ In the argument to ``--case``, the case name is taken from the string after the 
 The output from create_newcase includes information such as.
 
 - The compset longname is ``2000_DATM%NYF_SLND_DICE%SSMI_DOCN%DOM_DROF%NYF_SGLC_SWAV``
-- The model resolution is ``a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null``
+- The grid set is ``a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%null_w%null``
 
 `create_newcase  <../Tools_user/create_newcase.html>`_ installs files in ``$CASEROOT`` that will build and run the model and to optionally archive the case on the target platform.
 
@@ -74,23 +74,26 @@ Running `create_newcase  <../Tools_user/create_newcase.html>`_ creates the follo
 - `case.build  <../Tools_user/case.build.html>`_
      Script to build component and utility libraries and model executable.
 
+- `case.cmpgen_namelist <../Tools_user/case.submit.html>`_
+     Script to perform namelist baseline operations (compare, generate, or both)."
+
+-  case.qstatus
+    Script to query the queue on any queue system.
+
 - `case.setup  <../Tools_user/case.setup.html>`_
     Script used to set up the case (create the case.run script, Macros file and user_nl_xxx files).
-
-- `case.st_archive <../Tools_user/case.st_archive.html>`_
-     Script to perform short term archiving to disk for your case output. Note that this script is run automatically by the normal CIME workflow.
 
 - `case.submit <../Tools_user/case.submit.html>`_
      Script to submit the case to run using the machine's batch queueing system.
 
-- `case.cmpgen_namelist <../Tools_user/case.submit.html>`_
-     Script to perform namelist baseline operations (compare, generate, or both)."
+- `check_case <../Tools_user/check_case.html>`_
+     Script to verify case is set up correctly.
 
-- `xmlchange <../Tools_user/xmlchange.html>`_
-     Script to modify values in the xml files.
+- `check_input_data <../Tools_user/check_input_data.html>`_
+     Script for checking for various input data sets and moving them into place.
 
-- `xmlquery <../Tools_user/xmlquery.html>`_
-     Script to query values in the xml files.
+- `pelayout <../Tools_user/pelayout.html>`_
+     Script to query and modify the NTASKS, ROOTPE, and NTHRDS for each component model.
 
 - `preview_namelists <../Tools_user/preview_namelists.html>`_
      Script for users to see their component namelists in ``$CASEROOT/CaseDocs`` before running the model.
@@ -98,15 +101,12 @@ Running `create_newcase  <../Tools_user/create_newcase.html>`_ creates the follo
 - `preview_run <../Tools_user/preview_run.html>`_
      Script for users to see batch submit and mpirun command."
 
-- `check_input_data <../Tools_user/check_input_data.html>`_
-     Script for checking for various input data sets and moving them into place.
+- `xmlchange <../Tools_user/xmlchange.html>`_
+     Script to modify values in the xml files.
 
-- `check_case <../Tools_user/check_case.html>`_
-     Script to verify case is set up correctly.
+- `xmlquery <../Tools_user/xmlquery.html>`_
+     Script to query values in the xml files.
 
-- `pelayout <../Tools_user/pelayout.html>`_
-     Script to query and modify the NTASKS, ROOTPE, and NTHRDS for each component model.
-     This a convenience script that can be used in place of `xmlchange <../Tools_user/xmlchange.html>`_ and `xmlquery <../Tools_user/xmlquery.html>`_.
 
 **XML Files**
 
@@ -114,24 +114,30 @@ Running `create_newcase  <../Tools_user/create_newcase.html>`_ creates the follo
    Defines patterns of files to be sent to the short-term archive.
    You can edit this file at any time. You **CANNOT** use `xmlchange <../Tools_user/xmlchange.html>`_  to modify variables in this file."
 
-- env_mach_specific.xml
-   Sets a number of machine-specific environment variables for building and/or running.
-   You **CANNOT** use `xmlchange <../Tools_user/xmlchange.html>`_  to modify variables in this file.
+- env_batch.xml
+   Sets batch system settings such as wallclock time and queue name."
 
 - env_build.xml
    Sets model build settings. This includes component resolutions and component compile-time configuration options.
    You must run the case.build command after changing this file.
 
-- env_run.xml
-   Sets runtime settings such as length of run, frequency of restarts, output of coupler diagnostics, and short-term and long-term archiving.
-   This file can be edited at any time before a job starts.
+- env_case.xml
+   Parameters set by create_newcase
 
 - env_mach_pes.xml
    Sets component machine-specific processor layout (see changing pe layout ).
    The settings in this are critical to a well-load-balanced simulation (see :ref:`load balancing <optimizing-processor-layout>`).
 
-- env_batch.xml
-   Sets batch system settings such as wallclock time and queue name."
+- env_mach_specific.xml
+   Sets a number of machine-specific environment variables for building and/or running.
+   You **CANNOT** use `xmlchange <../Tools_user/xmlchange.html>`_  to modify variables in this file.
+
+- env_run.xml
+   Sets runtime settings such as length of run, frequency of restarts, output of coupler diagnostics, and short-term and long-term archiving.
+   This file can be edited at any time before a job starts.
+
+- env_workflow.xml
+   Sets paramateres for the runtime workflow.
 
 **User Source Mods Directory**
 

--- a/doc/source/users_guide/index.rst
+++ b/doc/source/users_guide/index.rst
@@ -6,7 +6,7 @@
 .. _users-guide1:
 
 #######################################
-Case Control System Part 1: Basic Usage
+Using the Case Control System
 #######################################
 
 .. toctree::
@@ -22,12 +22,13 @@ Case Control System Part 1: Basic Usage
    cime-change-namelist.rst
    cime-config.rst
    cime-customize.rst
+   testing.rst
    troubleshooting.rst
 
 .. _users-guide2:
 
 #######################################################################################
-Case Control System Part 2: Configuration, Porting, Testing and Use Cases
+Configuring the Case Control System
 #######################################################################################
 
 .. toctree::
@@ -40,8 +41,6 @@ Case Control System Part 2: Configuration, Porting, Testing and Use Cases
    machine.rst
    pes-threads.rst
    porting-cime.rst
-   timers.rst
-   testing.rst
    unit_testing.rst
    multi-instance.rst
    workflows.rst

--- a/doc/source/users_guide/setting-up-a-case.rst
+++ b/doc/source/users_guide/setting-up-a-case.rst
@@ -16,22 +16,39 @@ After creating a case or changing aspects of a case, such as the pe-layout, call
 This creates the following additional files and directories in ``$CASEROOT``:
 
    =============================   ===============================================================================================================================
-   .case.run                       A (hidden) file with the commands that will be used to run the model (such as “mpirun”) and any batch directives needed.
-                                   The directive values are generated using the contents
-                                   of **env_mach_pes.xml**. Running `case.setup --clean <../Tools_user/case.setup.html>`_  will remove this file.
-				   This file should not be edited directly and instead controlled through XML variables in **env_batch.xml**. It should also
-				   *never* be run directly.
+   .case.run                       A (hidden) file with the commands that will be used to run the model (such as “mpirun”)
 
-   Macros.make                     File containing machine-specific makefile directives for your target platform/compiler.
+                                   and any batch directives needed.  The directive values are generated using the contents
+
+                                   of **env_mach_pes.xml**. Running `case.setup --clean <../Tools_user/case.setup.html>`_
+
+				   will remove this file.  This file should not be edited directly and instead controlled
+
+				   through XML variables in **env_batch.xml**. It should also *never* be run directly.
+
+   CaseStatus                      File containing a list of operations done in the current case.
+
+   case.st_archive                 Script to perform short term archiving to disk for your case
+
+                                   output. Note that this script is run automatically by the normal CIME workflow.
+
+   Depends.*                       Lists of source code files that needs special build options.
+
+   Macros.cmake                    File containing machine-specific makefile directives for your target platform/compiler.
+
                                    This file is created if it does not already exist.
 
                                    The user can modify the file to change certain aspects of the build, such as compiler flags.
+
                                    Running `case.setup --clean <../Tools_user/case.setup.html>`_  will not remove the file once it has been created.
-                                   However. if you remove or rename the Macros.make file, running `case.setup <../Tools_user/case.setup.html>`_ recreates it.
+                                   However. if you remove or rename the Macros.make file, running
+
+				   `case.setup <../Tools_user/case.setup.html>`_ recreates it.
 
    user_nl_xxx[_NNNN]              Files where all user modifications to component namelists are made.
 
                                    **xxx** is any one of the set of components targeted for the case.
+
                                    For example, for a full active CESM compset, **xxx** is cam, clm or rtm, and so on.
 
                                    NNNN goes from 0001 to the number of instances of that component.
@@ -45,17 +62,22 @@ This creates the following additional files and directories in ``$CASEROOT``:
                                    Calling `case.setup --clean <../Tools_user/case.setup.html>`_ will *not remove* any user_nl files.
 
                                    Changing the number of instances in the **env_mach_pes.xml** file will cause only
+
                                    new user_nl files to be added to ``$CASEROOT``.
 
    CaseDocs/                       Directory that contains all the component namelists for the run.
 
                                    This is for reference only and files in this directory SHOULD NOT BE EDITED since they will
+
                                    be overwritten at build time and runtime.
 
    .env_mach_specific.*            Files summarizing the **module load** commands and environment variables that are set when
+
                                    the scripts in ``$CASEROOT`` are called. These files are not used by the case but can be
+
                                    useful for debugging **module load** and environment settings.
 
    software_environment.txt        This file records some aspects of the computing system on which the case is built,
+
                                    such as the shell environment.
    =============================   ===============================================================================================================================

--- a/doc/source/what_cime/index.rst
+++ b/doc/source/what_cime/index.rst
@@ -17,12 +17,15 @@
 Overview
 *********
 
-CIME, pronounced "SEAM", primarily consists of a Case Control System that supports the configuration, compilation, execution, system testing and unit testing of an Earth System Model. The two main components of the Case Control System are:
+CIME (Common Infrastructure for Modeling the Earth, pronounced "SEAM") primarily consists of a Case Control System that supports the configuration, compilation, execution, system testing and unit testing of an Earth System Model. The three main components of the Case Control System are:
 
-1. Scripts to enable simple generation of model executables and associated input files for different scientific cases, component resolutions and combinations of full, data and stub components with a handful of commands.
-2. Testing utilities to run defined system tests and report results for different configurations of the coupled system.
+1. XML files that  describe the available machines, models and model configurations.
+2. Python scripts that take user commands and parse the XML files to configure a set of models with their
+   build and runtime options for a specified machine and the provide additional commands to build executables and
+   submit jobs.
+3. Testing utilities to run defined system tests and report results for different configurations of the coupled system.
 
-CIME also contains additional stand-alone tools, including:
+CIME also contains additional stand-alone tools useful for Earth system modeling including:
 
 1. Parallel regridding weight generation program
 2. Scripts to automate off-line load-balancing.


### PR DESCRIPTION
Update the documentation for the basic usage of CCS.
Define more key concepts.  Add table for compset alias one-letter case names.
Make sure files created after create_newcase and ./case.setup match current function.
Change titles of two major sections to be about using CCS and configuring CCS.

Test suite: build locally using sphinx.
Test baseline: N/A
Test namelist changes: N/A
Test status: bit for bit


User interface changes?:  N

Update gh-pages html Y.
