### PR TITLE
Remove the standard_name length restriction for CAM-SIMA 

### DIFF
--- a/CIME/ParamGen/xml_schema/entry_id_pg.xsd
+++ b/CIME/ParamGen/xml_schema/entry_id_pg.xsd
@@ -9,7 +9,7 @@
   <!-- simple types -->
   <xs:simpleType name="identifier_type">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[A-Za-z][A-Za-z0-9_]+"/>
+      <xs:pattern value="[A-Za-z][A-Za-z0-9_]*"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/CIME/ParamGen/xml_schema/entry_id_pg.xsd
+++ b/CIME/ParamGen/xml_schema/entry_id_pg.xsd
@@ -9,7 +9,7 @@
   <!-- simple types -->
   <xs:simpleType name="identifier_type">
     <xs:restriction base="xs:string">
-      <xs:pattern value="[A-Za-z][A-Za-z0-9_]{0,63}"/>
+      <xs:pattern value="[A-Za-z][A-Za-z0-9_]+"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
Remove the standard_name 64 character length restriction and allow strings of 1 or more characters. This corrects a CAM-SIMA error for the new dadadj CCPP routine which contains a namelist entry with a standard name greater than the current 63 character limit. The new pattern match removes a length restriction but is consistent with the [Guidelines for Construction of CF Standard Names](https://cfconventions.org/Data/cf-standard-names/docs/guidelines.html#id2797697) which is adopted in the [CCPP Standard Name Rules](https://github.com/ESCOMP/CCPPStandardNames/blob/main/StandardNamesRules.rst#ccpp-standard-name-rules) (rule 2).

Test suite: Built and ran a CAM-SIMA snapshot test with the new routine and I also ran a create_test case with CAM on izumi.
Test baseline: cime6.0.236_httpsbranch01
Test namelist changes: N/A
Test status: bit for bit

Fixes #4625 

User interface changes?:Remove string length restriction for standard_name type.

Update gh-pages html (Y/N)?:N
