### PR TITLE
cesm3 will not use manage-externals

### DIFF
--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -534,7 +534,9 @@ def get_model():
     if model is None:
         srcroot = get_src_root()
 
-        if os.path.isfile(os.path.join(srcroot, "Externals.cfg")):
+        if os.path.isfile(os.path.join(srcroot, "bin", "git-fleximod")):
+            model = "cesm"
+        elif os.path.isfile(os.path.join(srcroot, "Externals.cfg")):
             model = "cesm"
             with open(os.path.join(srcroot, "Externals.cfg")) as fd:
                 for line in fd:


### PR DESCRIPTION
Add a new method to detect cesm model when it no longer uses manage externals
Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
