### PR TITLE
remove reference to cice5 and ww3dev, no longer required

### DIFF
--- a/CIME/XML/archive_base.py
+++ b/CIME/XML/archive_base.py
@@ -127,10 +127,6 @@ class ArchiveBase(GenericXML):
         # remove when component name is changed
         if model == "fv3gfs":
             model = "fv3"
-        if model == "cice5":
-            model = "cice"
-        if model == "ww3dev":
-            model = "ww3"
 
         hist_files = []
         extensions = self.get_hist_file_extensions(self.get_entry(dmodel))
@@ -237,10 +233,7 @@ def _get_extension(model, filepath, ext_regexes):
     # Remove with component namechange
     if model == "fv3gfs":
         model = "fv3"
-    if model == "cice5":
-        model = "cice"
-    if model == "ww3dev":
-        model = "ww3"
+
     basename = os.path.basename(filepath)
     m = None
     if ext_regexes is None:

--- a/CIME/case/case_st_archive.py
+++ b/CIME/case/case_st_archive.py
@@ -533,10 +533,6 @@ def _archive_restarts_date_comp(
     # the compname is drv but the files are named cpl
     if compname == "drv":
         compname = "cpl"
-    if compname == "cice5":
-        compname = "cice"
-    if compname == "ww3dev":
-        compname = "ww3"
 
     # get file_extension suffixes
     for suffix in archive.get_rest_file_extensions(archive_entry):

--- a/CIME/data/config/cesm/config_files.xml
+++ b/CIME/data/config/cesm/config_files.xml
@@ -179,7 +179,6 @@
     <default_value>unset</default_value>
     <values>
       <value component="ww3"                         >$SRCROOT/components/ww3/</value>
-      <value component="ww3dev"                      >$SRCROOT/components/ww3dev</value>
       <value component="dwav" comp_interface="mct"   >$SRCROOT/components/cpl7/components/data_comps_$COMP_INTERFACE/dwav</value>
       <value component="dwav" comp_interface="nuopc" >$SRCROOT/components/cdeps/dwav</value>
       <value component="swav" comp_interface="mct"   >$SRCROOT/components/cpl7/components/stub_comps_$COMP_INTERFACE/swav</value>
@@ -309,14 +308,12 @@
       <value component="ufsatm"    >$COMP_ROOT_DIR_ATM/cime_config/config_compsets.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/config_compsets.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/config_compsets.xml</value>
-      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/config_compsets.xml</value>
-      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/config_compsets.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
       <value component="nemo"      >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
       <value component="blom"      >$COMP_ROOT_DIR_OCN/cime_config/config_compsets.xml</value>
-      <value component="ww3dev"    >$COMP_ROOT_DIR_WAV/cime_config/config_compsets.xml</value>
+      <value component="ww3"       >$COMP_ROOT_DIR_WAV/cime_config/config_compsets.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -334,14 +331,12 @@
       <value component="ufsatm"    >$COMP_ROOT_DIR_ATM/cime_config/config_pes.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/config_pes.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/config_pes.xml</value>
-      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/config_pes.xml</value>
-      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/config_pes.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
       <value component="nemo"      >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
       <value component="blom"      >$COMP_ROOT_DIR_OCN/cime_config/config_pes.xml</value>
-      <value component="ww3dev"    >$COMP_ROOT_DIR_WAV/cime_config/config_pes.xml</value>
+      <value component="ww3"       >$COMP_ROOT_DIR_WAV/cime_config/config_pes.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -366,8 +361,6 @@
       <value component="cam"       >$COMP_ROOT_DIR_ATM/cime_config/config_archive.xml</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/config_archive.xml</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/config_archive.xml</value>
-      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/config_archive.xml</value>
-      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/config_archive.xml</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/config_archive.xml</value>
@@ -376,7 +369,7 @@
       <value component="rtm"       >$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
       <value component="mosart"    >$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
       <value component="mizuroute" >$COMP_ROOT_DIR_ROF/cime_config/config_archive.xml</value>
-      <value component="ww3dev"    >$COMP_ROOT_DIR_WAV/cime_config/config_archive.xml</value>
+      <value component="ww3"       >$COMP_ROOT_DIR_WAV/cime_config/config_archive.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -389,18 +382,17 @@
     <values>
       <value component="any"       >$CIMEROOT/CIME/SystemTests</value>
       <value component="clm"       >$COMP_ROOT_DIR_LND/cime_config/SystemTests</value>
-      <value component="slim"      >$COMP_ROOT_DIR_LND/cime_config/SystemTests</value>
       <value component="cam"       >$COMP_ROOT_DIR_ATM/cime_config/SystemTests</value>
       <value component="pop"       >$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
       <value component="mom"       >$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
       <value component="nemo"      >$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
       <value component="blom"      >$COMP_ROOT_DIR_OCN/cime_config/SystemTests</value>
-      <value component="cice5"     >$COMP_ROOT_DIR_ICE/cime_config/SystemTests</value>
       <value component="cice"      >$COMP_ROOT_DIR_ICE/cime_config/SystemTests</value>
       <value component="cism"      >$COMP_ROOT_DIR_GLC/cime_config/SystemTests</value>
       <value component="rtm"       >$COMP_ROOT_DIR_ROF/cime_config/SystemTests</value>
       <value component="mosart"    >$COMP_ROOT_DIR_ROF/cime_config/SystemTests</value>
       <value component="mizuroute" >$COMP_ROOT_DIR_ROF/cime_config/SystemTests</value>
+      <value component="ww3"       >$COMP_ROOT_DIR_WAV/cime_config/SystemTests</value>
     </values>
     <group>test</group>
     <file>env_test.xml</file>
@@ -426,7 +418,7 @@
       <value component="rtm"       >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_rtm.xml</value>
       <value component="mosart"    >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_mosart.xml</value>
       <value component="mizuroute" >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_mizuRoute.xml</value>
-      <value component="ww3dev"    >$COMP_ROOT_DIR_WAV/cime_config/testdefs/testlist_ww3dev.xml</value>
+      <value component="ww3"       >$COMP_ROOT_DIR_WAV/cime_config/testdefs/testlist_ww3.xml</value>
       <value component="datm"      >$SRCROOT/components/cdeps/datm/cime_config/testdefs/testlist_datm.xml</value>
       <value component="dice"      >$SRCROOT/components/cdeps/dice/cime_config/testdefs/testlist_dice.xml</value>
       <value component="dlnd"      >$SRCROOT/components/cdeps/dlnd/cime_config/testdefs/testlist_dlnd.xml</value>

--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -181,9 +181,6 @@ def _hists_match(model, hists1, hists2, suffix1="", suffix2=""):
     multi_normalized1, multi_normalized2 = [], []
     multiinst = False
 
-    if model == "ww3dev":
-        model = "ww3"
-
     for hists, suffix, normalized, multi_normalized in [
         (hists1, suffix1, normalized1, multi_normalized1),
         (hists2, suffix2, normalized2, multi_normalized2),
@@ -629,9 +626,6 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
         )
         logger.debug("latest_files: {}".format(hists))
         num_gen += len(hists)
-
-        if model == "ww3dev":
-            model = "ww3"
 
         for hist in hists:
             offset = hist.rfind(model)


### PR DESCRIPTION
Removes reference to cice5 and ww3dev, these components are no longer part of cesm.  

Test suite:
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes

User interface changes?:

Update gh-pages html (Y/N)?:
