### PR TITLE
Update runoff to ocn install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "CIME/non_py/cprnc"]
 	path = CIME/non_py/cprnc
-	url = git@github.com:ESMCI/cprnc
+	url = https://github.com/ESMCI/cprnc

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "CIME/non_py/cprnc"]
 	path = CIME/non_py/cprnc
-	url = https://github.com/ESMCI/cprnc
+	url = git@github.com:ESMCI/cprnc

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/INSTALL
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/INSTALL
@@ -3,11 +3,11 @@ HOW TO BUILD
 ============
 
 (1) $ cd src
-(2) $ ../../../../configure --macros-format Makefile --mpilib mpi-serial
+(2) $ ../../../../../CIME/scripts/configure --macros-format Makefile --mpilib mpi-serial
 Bash users:
-(3) $ (. ./.env_mach_specific.sh ; gmake)
+(3) $ (. ./.env_mach_specific.sh ; gmake NETCDF_PATH=$NETCDF SLIBS="-L$NETCDF/lib -lnetcdf -lnetcdff")
 csh users:
-(3) $ (source ./.env_mach_specific.csh ; gmake)
+(3) $ (source ./.env_mach_specific.csh ; gmake NETCDF_PATH=$NETCDF SLIBS="-L$NETCDF/lib -lnetcdf -lnetcdff")
 
 Note: in the second step, you may need to include "--machine [machine name]",
 where [machine name] is the name of the machine you are building on. In most

--- a/tools/mapping/gen_mapping_files/runoff_to_ocn/tools/makdep.c
+++ b/tools/mapping/gen_mapping_files/runoff_to_ocn/tools/makdep.c
@@ -51,7 +51,7 @@ static struct node *suffix_list;      /* List of Fortran suffixes to look for */
 static void check (char *, struct node *, char *, int);
 static int already_found (char *, struct node *);
 
-main (int argc, char **argv)
+int main (int argc, char **argv)
 {
   int lastdot;             /* points to the last . in fname */
   int c;                   /* return from getopt */


### PR DESCRIPTION
Updates the INSTALL for runoff_to_ocn tool, the instructions are out of date and still reflect a previous directory structure. 

Test suite: Hand tested on derecho
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
