### PR TITLE
Fix list_e3sm_tests tool

### DIFF
--- a/CIME/Tools/list_e3sm_tests
+++ b/CIME/Tools/list_e3sm_tests
@@ -8,8 +8,9 @@ list tested grids, compsets, etc.
 from standard_script_setup import *
 from CIME import utils
 from CIME import get_tests
+from CIME.XML.files import Files
+from CIME.XML.compsets import Compsets
 
-import sys
 import argparse
 import logging
 
@@ -44,8 +45,6 @@ f19_g16_rx1"""
         description=description, formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
-    utils.setup_standard_logging_options(parser)
-
     parser.add_argument(
         "suites",
         nargs="*",
@@ -57,8 +56,16 @@ f19_g16_rx1"""
         "--term",
         choices=("compsets", "grids", "testcases", "tests"),
         default="tests",
-        help="The term from a testname to print.",
+        help="Term of the test name to print.",
     )
+
+    compsets_group = parser.add_argument_group("Compset options")
+
+    compsets_group.add_argument(
+        "-l", "--long", action="store_true", help="Prints the longname of compsets."
+    )
+
+    utils.setup_standard_logging_options(parser)
 
     kwargs = vars(parser.parse_args())
 
@@ -67,9 +74,7 @@ f19_g16_rx1"""
     return kwargs
 
 
-def list_tests(term, suites, **_):
-    things = set()
-
+def list_tests(term, suites, long, **_):
     values = [x for s in suites for x in get_tests.get_test_suite(s)]
 
     if term != "tests":
@@ -81,9 +86,29 @@ def list_tests(term, suites, **_):
 
         values = set(x[index] for x in terms)
 
+        if long and term == "compsets":
+            compset_longnames = get_compset_longnames()
+
+            values = set(compset_longnames[x] for x in values)
+
     print("\n".join(sorted(values)))
 
     logger.info(f"Found {len(values)!r} {term}")
+
+
+def get_compset_longnames():
+    files = Files()
+
+    names = files.get_components("COMPSETS_SPEC_FILE")
+
+    values = {}
+
+    for n in names:
+        comp_file = files.get_value("COMPSETS_SPEC_FILE", attribute={"component": n})
+
+        values.update({x for x in Compsets(comp_file)})
+
+    return values
 
 
 def _main_func():

--- a/CIME/Tools/list_e3sm_tests
+++ b/CIME/Tools/list_e3sm_tests
@@ -6,90 +6,87 @@ list tested grids, compsets, etc.
 """
 
 from standard_script_setup import *
-from CIME.utils import expect
+from CIME import utils
 from CIME import get_tests
 
-import sys, argparse, os
+import sys
+import argparse
 
-###############################################################################
-def parse_command_line(args, description):
-    ###############################################################################
+
+def parse_command_line(args):
+    description = """
+%(prog)r will gather all tests from `suites` and print the unique term values.
+
+Examples
+--------
+>>> %(prog)s e3sm_developer
+ERS.f19_g16_rx1.A.docker_gnu
+NCK.f19_g16_rx1.A.docker_gnu
+
+>>> %(prog)s -t compsets e3sm_developer
+A
+F2010
+I1850ELM"""
+
     parser = argparse.ArgumentParser(
-        usage="""\n{0} <thing-to-list> [<test category> <test category> ...] [--verbose]
-OR
-{0} --help
-
-\033[1mEXAMPLES:\033[0m
-    \033[1;32m# List all tested compsets \033[0m
-    > {0} compsets
-    \033[1;32m# List all compsets tested by e3sm_developer \033[0m
-    > {0} compsets e3sm_developer
-    \033[1;32m# List all grids tested by e3sm_developer \033[0m
-    > {0} grid e3sm_developer
-""".format(
-            os.path.basename(args[0])
-        ),
-        description=description,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=description, formatter_class=argparse.RawDescriptionHelpFormatter
     )
 
-    CIME.utils.setup_standard_logging_options(parser)
+    utils.setup_standard_logging_options(parser)
 
     parser.add_argument(
         "suites",
         nargs="+",
-        help="The tests suites to list. Test suites: {}".format(
-            ", ".join(get_tests.get_test_suites())
-        ),
+        help="The test suites to list.",
     )
 
     parser.add_argument(
         "-t",
-        "--thing-to-list",
+        "--term",
         choices=("compsets", "grids", "testcases", "tests"),
         default="tests",
-        help="The thing you want to list",
+        help="The term from a testname to print.",
     )
 
-    args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
+    try:
+        args = utils.parse_args_and_handle_standard_logging_options(args, parser)
+    except SystemExit:
+        parser.print_help()
 
-    if not args.suites:
-        args.suites = get_tests.get_test_suites()
+        sys.exit(0)
 
-    return args.thing_to_list, args.suites
+    return vars(args)
 
 
-###############################################################################
-def list_tests(thing_to_list, suites):
-    ###############################################################################
+def list_tests(term, suites, **_):
     things = set()
+
     for suite in suites:
         tests = get_tests.get_test_suite(suite)
         for test in tests:
-            testcase, _, grid, compset = CIME.utils.parse_test_name(test)[:4]
-            if thing_to_list == "compsets":
+            testcase, _, grid, compset = utils.parse_test_name(test)[:4]
+            if term == "compsets":
                 things.add(compset)
-            elif thing_to_list == "grids":
+            elif term == "grids":
                 things.add(grid)
-            elif thing_to_list == "testcases":
+            elif term == "testcases":
                 things.add(testcase)
-            elif thing_to_list == "tests":
+            elif term == "tests":
                 things.add(test)
             else:
-                expect(False, "Unrecognized thing to list '{}'".format(thing_to_list))
+                utils.expect(False, "Unrecognized thing to list '{}'".format(term))
 
-    print("Tested {} for test suites: {}".format(thing_to_list, ", ".join(suites)))
+    print("Tested {} for test suites: {}".format(term, ", ".join(suites)))
+
     for item in sorted(things):
         print("  {}".format(item))
 
 
-###############################################################################
-def _main_func(description):
-    ###############################################################################
-    thing_to_list, suites = parse_command_line(sys.argv, description)
+def _main_func():
+    args = parse_command_line(sys.argv)
 
-    list_tests(thing_to_list, suites)
+    list_tests(**args)
 
 
 if __name__ == "__main__":
-    _main_func(__doc__)
+    _main_func()

--- a/CIME/Tools/list_e3sm_tests
+++ b/CIME/Tools/list_e3sm_tests
@@ -11,14 +11,23 @@ from CIME import get_tests
 
 import sys
 import argparse
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def parse_command_line():
-    description = """
-%(prog)r will gather all tests from `suites` and print the unique term values.
+    description = """This tool will print all test suite names.
+
+If any test suite names are provided, then all `term` values for the tests in the suites will be listed.
 
 Examples
 --------
+>>> %(prog)s
+e3sm_developer
+cime_tiny
+
 >>> %(prog)s e3sm_developer
 ERS.f19_g16_rx1.A.docker_gnu
 NCK.f19_g16_rx1.A.docker_gnu
@@ -26,7 +35,10 @@ NCK.f19_g16_rx1.A.docker_gnu
 >>> %(prog)s -t compsets e3sm_developer
 A
 F2010
-I1850ELM"""
+I1850ELM
+
+>>> %(prog)s -t grids e3sm_developer
+f19_g16_rx1"""
 
     parser = argparse.ArgumentParser(
         description=description, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -34,33 +46,19 @@ I1850ELM"""
 
     utils.setup_standard_logging_options(parser)
 
-    subparsers = parser.add_subparsers(dest="subcommand")
-
-    subparsers.add_parser("list", help="Lists available test suites.")
-
-    suites_parser = subparsers.add_parser(
-        "suites", help="List term values for test suites."
-    )
-
-    suites_parser.add_argument(
+    parser.add_argument(
         "suites",
-        nargs="+",
+        nargs="*",
         help="The test suites to list.",
     )
 
-    suites_parser.add_argument(
+    parser.add_argument(
         "-t",
         "--term",
         choices=("compsets", "grids", "testcases", "tests"),
         default="tests",
         help="The term from a testname to print.",
     )
-
-    # Print help instead of usage.
-    if len(sys.argv) == 1:
-        parser.print_help()
-
-        sys.exit(0)
 
     kwargs = vars(parser.parse_args())
 
@@ -88,28 +86,22 @@ def list_tests(term, suites, **_):
                 elif term == "testcases":
                     things.add(testcase)
 
-    print(f"Listing {term!r} for test suites: {', '.join(suites)}")
-
     for item in sorted(things):
-        print("  {}".format(item))
+        print(item)
 
-    print(f"Found {len(things)} {term!r}")
-
-
-def list_suites():
-    test_suites = sorted(get_tests.get_test_suites())
-
-    for suite in test_suites:
-        print(suite)
-
-    print(f"Found {len(test_suites)} test suites")
+    logger.info(f"Found {len(things)!r} {term}")
 
 
 def _main_func():
     args = parse_command_line()
 
-    if args["subcommand"] == "list":
-        list_suites()
+    if len(args["suites"]) == 0:
+        test_suites = sorted(get_tests.get_test_suites())
+
+        for suite in test_suites:
+            print(suite)
+
+        logger.info(f"Found {len(test_suites)!r} test suites")
     else:
         list_tests(**args)
 

--- a/CIME/Tools/list_e3sm_tests
+++ b/CIME/Tools/list_e3sm_tests
@@ -13,7 +13,7 @@ import sys
 import argparse
 
 
-def parse_command_line(args):
+def parse_command_line():
     description = """
 %(prog)r will gather all tests from `suites` and print the unique term values.
 
@@ -41,6 +41,10 @@ I1850ELM"""
     )
 
     parser.add_argument(
+        "-c", action="store_true", help="Prints the count for each value."
+    )
+
+    parser.add_argument(
         "-t",
         "--term",
         choices=("compsets", "grids", "testcases", "tests"),
@@ -48,14 +52,17 @@ I1850ELM"""
         help="The term from a testname to print.",
     )
 
-    try:
-        args = utils.parse_args_and_handle_standard_logging_options(args, parser)
-    except SystemExit:
+    # Print help instead of usage.
+    if len(sys.argv) == 1:
         parser.print_help()
 
         sys.exit(0)
 
-    return vars(args)
+    kwargs = vars(parser.parse_args())
+
+    utils.configure_logging(**kwargs)
+
+    return kwargs
 
 
 def list_tests(term, suites, **_):
@@ -63,8 +70,10 @@ def list_tests(term, suites, **_):
 
     for suite in suites:
         tests = get_tests.get_test_suite(suite)
+
         for test in tests:
             testcase, _, grid, compset = utils.parse_test_name(test)[:4]
+
             if term == "compsets":
                 things.add(compset)
             elif term == "grids":
@@ -73,8 +82,6 @@ def list_tests(term, suites, **_):
                 things.add(testcase)
             elif term == "tests":
                 things.add(test)
-            else:
-                utils.expect(False, "Unrecognized thing to list '{}'".format(term))
 
     print("Tested {} for test suites: {}".format(term, ", ".join(suites)))
 
@@ -83,7 +90,7 @@ def list_tests(term, suites, **_):
 
 
 def _main_func():
-    args = parse_command_line(sys.argv)
+    args = parse_command_line()
 
     list_tests(**args)
 

--- a/CIME/Tools/list_e3sm_tests
+++ b/CIME/Tools/list_e3sm_tests
@@ -80,10 +80,12 @@ def list_tests(term, suites, **_):
                 elif term == "testcases":
                     things.add(testcase)
 
-    print(f"Found {term!r} for test suites: {', '.join(suites)}")
+    print(f"Listing {term!r} for test suites: {', '.join(suites)}")
 
     for item in sorted(things):
         print("  {}".format(item))
+
+    print(f"Found {len(things)} {term!r}")
 
 
 def _main_func():

--- a/CIME/Tools/list_e3sm_tests
+++ b/CIME/Tools/list_e3sm_tests
@@ -41,10 +41,6 @@ I1850ELM"""
     )
 
     parser.add_argument(
-        "-c", action="store_true", help="Prints the count for each value."
-    )
-
-    parser.add_argument(
         "-t",
         "--term",
         choices=("compsets", "grids", "testcases", "tests"),
@@ -71,17 +67,18 @@ def list_tests(term, suites, **_):
     for suite in suites:
         tests = get_tests.get_test_suite(suite)
 
-        for test in tests:
-            testcase, _, grid, compset, *_ = utils.parse_test_name(test)
+        if term == "tests":
+            things |= set(tests)
+        else:
+            for test in tests:
+                testcase, _, grid, compset, *_ = utils.parse_test_name(test)
 
-            if term == "compsets":
-                things.add(compset)
-            elif term == "grids":
-                things.add(grid)
-            elif term == "testcases":
-                things.add(testcase)
-            elif term == "tests":
-                things.add(test)
+                if term == "compsets":
+                    things.add(compset)
+                elif term == "grids":
+                    things.add(grid)
+                elif term == "testcases":
+                    things.add(testcase)
 
     print(f"Found {term!r} for test suites: {', '.join(suites)}")
 

--- a/CIME/Tools/list_e3sm_tests
+++ b/CIME/Tools/list_e3sm_tests
@@ -34,13 +34,21 @@ I1850ELM"""
 
     utils.setup_standard_logging_options(parser)
 
-    parser.add_argument(
+    subparsers = parser.add_subparsers(dest="subcommand")
+
+    subparsers.add_parser("list", help="Lists available test suites.")
+
+    suites_parser = subparsers.add_parser(
+        "suites", help="List term values for test suites."
+    )
+
+    suites_parser.add_argument(
         "suites",
         nargs="+",
         help="The test suites to list.",
     )
 
-    parser.add_argument(
+    suites_parser.add_argument(
         "-t",
         "--term",
         choices=("compsets", "grids", "testcases", "tests"),
@@ -88,10 +96,22 @@ def list_tests(term, suites, **_):
     print(f"Found {len(things)} {term!r}")
 
 
+def list_suites():
+    test_suites = sorted(get_tests.get_test_suites())
+
+    for suite in test_suites:
+        print(suite)
+
+    print(f"Found {len(test_suites)} test suites")
+
+
 def _main_func():
     args = parse_command_line()
 
-    list_tests(**args)
+    if args["subcommand"] == "list":
+        list_suites()
+    else:
+        list_tests(**args)
 
 
 if __name__ == "__main__":

--- a/CIME/Tools/list_e3sm_tests
+++ b/CIME/Tools/list_e3sm_tests
@@ -70,26 +70,20 @@ f19_g16_rx1"""
 def list_tests(term, suites, **_):
     things = set()
 
-    for suite in suites:
-        tests = get_tests.get_test_suite(suite)
+    values = [x for s in suites for x in get_tests.get_test_suite(s)]
 
-        if term == "tests":
-            things |= set(tests)
-        else:
-            for test in tests:
-                testcase, _, grid, compset, *_ = utils.parse_test_name(test)
+    if term != "tests":
+        terms = [utils.parse_test_name(x) for x in values]
 
-                if term == "compsets":
-                    things.add(compset)
-                elif term == "grids":
-                    things.add(grid)
-                elif term == "testcases":
-                    things.add(testcase)
+        index_map = {"compsets": 3, "grids": 2, "testcases": 0}
 
-    for item in sorted(things):
-        print(item)
+        index = index_map[term]
 
-    logger.info(f"Found {len(things)!r} {term}")
+        values = set(x[index] for x in terms)
+
+    print("\n".join(sorted(values)))
+
+    logger.info(f"Found {len(values)!r} {term}")
 
 
 def _main_func():

--- a/CIME/Tools/list_e3sm_tests
+++ b/CIME/Tools/list_e3sm_tests
@@ -72,7 +72,7 @@ def list_tests(term, suites, **_):
         tests = get_tests.get_test_suite(suite)
 
         for test in tests:
-            testcase, _, grid, compset = utils.parse_test_name(test)[:4]
+            testcase, _, grid, compset, *_ = utils.parse_test_name(test)
 
             if term == "compsets":
                 things.add(compset)
@@ -83,7 +83,7 @@ def list_tests(term, suites, **_):
             elif term == "tests":
                 things.add(test)
 
-    print("Tested {} for test suites: {}".format(term, ", ".join(suites)))
+    print(f"Found {term!r} for test suites: {', '.join(suites)}")
 
     for item in sorted(things):
         print("  {}".format(item))

--- a/CIME/XML/compsets.py
+++ b/CIME/XML/compsets.py
@@ -16,6 +16,8 @@ class Compsets(GenericXML):
             files = Files()
         schema = files.get_schema("COMPSETS_SPEC_FILE")
         GenericXML.__init__(self, infile, schema=schema)
+        self._index = 0
+        self._compsets = None
 
     def get_compset_match(self, name):
         """

--- a/CIME/XML/compsets.py
+++ b/CIME/XML/compsets.py
@@ -108,3 +108,23 @@ class Compsets(GenericXML):
         for comp in compset_nodes:
             longnames.append(self.text(self.get_child("lname", root=comp)))
         return longnames
+
+    def __iter__(self):
+        self._index = 0
+        self._compsets = self.get_children("compset")
+
+        return self
+
+    def __next__(self):
+        if self._index >= len(self._compsets):
+            raise StopIteration()
+
+        value = self._compsets[self._index]
+
+        alias = self.text(self.get_child("alias", root=value))
+
+        lname = self.text(self.get_child("lname", root=value))
+
+        self._index += 1
+
+        return alias, lname

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -2,6 +2,7 @@
 Common functions used by cime python scripts
 Warning: you cannot use CIME Classes in this module as it causes circular dependencies
 """
+
 import shlex
 import configparser
 import io, logging, gzip, sys, os, time, re, shutil, glob, string, random, importlib, fnmatch
@@ -1666,7 +1667,7 @@ class _LessThanFilter(logging.Filter):
         return 1 if record.levelno < self.max_level else 0
 
 
-def configure_logging(verbose, debug, silent):
+def configure_logging(verbose, debug, silent, **_):
     root_logger = logging.getLogger()
 
     verbose_formatter = logging.Formatter(


### PR DESCRIPTION
Fixes `list_e3sm_tests` tool.
- Adds description with examples
- Adds option to print compset long names
- Fixes listing test suites by default
- Removes use of `parse_args_and_handle_standard_logging_options`
- Removes custom usage

Test suite: n/a
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4628 

User interface changes?:
Update gh-pages html (Y/N)?:
