### PR TITLE
no longer required, remove from unit testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.14)
 include(ExternalProject)
 set(CIME_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,13 +37,5 @@ else()
   include_directories(${SRC_ROOT}/share/include)
 endif()
 
-# esmf_wrf_timemgr not built here because it depends on csm_share.
-if (EXISTS ${SRC_ROOT}/share/esmf_wrf_timemgr)
-  add_subdirectory(${SRC_ROOT}/share/esmf_wrf_timemgr esmf_wrf_timemgr)
-  include_directories(${SRC_ROOT}/share/esmf_wrf_timemgr)
-else()
-  message("esmf_wrf_timemgr not found, assuming you are linking an esmf library")
-endif()
-
 # Now the actual test directories.
 add_subdirectory(${SRC_ROOT}/share/test/unit ${CMAKE_BINARY_DIR}/unittests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,14 +37,5 @@ else()
   include_directories(${SRC_ROOT}/share/include)
 endif()
 
-# esmf_wrf_timemgr not built here because it depends on csm_share.
-if (EXISTS ${SRC_ROOT}/share/src/esmf_wrf_timemgr)
-  add_subdirectory(${SRC_ROOT}/share/src/esmf_wrf_timemgr esmf_wrf_timemgr)
-  include_directories(${SRC_ROOT}/share/src/esmf_wrf_timemgr)
-else()
-  add_subdirectory(${SRC_ROOT}/share/esmf_wrf_timemgr esmf_wrf_timemgr)
-  include_directories(${SRC_ROOT}/share/esmf_wrf_timemgr)
-endif()
-
 # Now the actual test directories.
 add_subdirectory(${SRC_ROOT}/share/test/unit ${CMAKE_BINARY_DIR}/unittests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,5 +37,13 @@ else()
   include_directories(${SRC_ROOT}/share/include)
 endif()
 
+# esmf_wrf_timemgr not built here because it depends on csm_share.
+if (EXISTS ${SRC_ROOT}/share/esmf_wrf_timemgr)
+  add_subdirectory(${SRC_ROOT}/share/esmf_wrf_timemgr esmf_wrf_timemgr)
+  include_directories(${SRC_ROOT}/share/esmf_wrf_timemgr)
+else()
+  message("esmf_wrf_timemgr not found, assuming you are linking an esmf library")
+endif()
+
 # Now the actual test directories.
 add_subdirectory(${SRC_ROOT}/share/test/unit ${CMAKE_BINARY_DIR}/unittests)


### PR DESCRIPTION
esmf_wrf_time_manager was code to replace esmf in certain tests, 
it is no longer needed by cesm and these tests were never used in e3sm 

Test suite: github workflow
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
