### PR TITLE
Fixes check_lockedfiles call in xmlchange

### DIFF
--- a/CIME/Tools/xmlchange
+++ b/CIME/Tools/xmlchange
@@ -229,10 +229,6 @@ def xmlchange_single_value(
 
         if xmlfile is not None:
             xmlfile = [xmlfile]
-        # Pass caseroot, in cases where --file is used and case does not have access to env_case.xml
-        check_lockedfiles(
-            case, skip=["env_case"], quiet=True, caseroot=caseroot, whitelist=xmlfile
-        )
     else:
         logger.warning("'%s' = '%s'", xmlid, xmlval)
 
@@ -312,6 +308,13 @@ def xmlchange(
                 caseroot,
                 xmlfile,
             )
+
+        check_lockedfiles(
+            case,
+            skip=["env_case"],
+            caseroot=caseroot,
+            whitelist=xmlfile,
+        )
 
     if not noecho:
         argstr = ""

--- a/CIME/XML/entry_id.py
+++ b/CIME/XML/entry_id.py
@@ -500,7 +500,7 @@ class EntryID(GenericXML):
                                 "{}_{}".format(vid, comp), resolved=False
                             )
                             if f1val != f2val:
-                                xmldiffs[vid] = [f1val, f2val]
+                                xmldiffs[f"{vid}_{comp}"] = [f1val, f2val]
                         else:
                             if node != f2match:
                                 f1value_nodes = self.get_children("value", root=node)


### PR DESCRIPTION
- Fixes `check_lockedfiles` only being called once when multiple settings
are changed.
- Fixes reporting settings that are component specific

Test suite: n/a
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4643 

User interface changes?: n/a
Update gh-pages html (Y/N)?: n
