### PR TITLE
add support for new ccs_config structure - backward compatible

### DIFF
--- a/CIME/BuildTools/configure.py
+++ b/CIME/BuildTools/configure.py
@@ -28,7 +28,7 @@ from CIME.XML.env_mach_specific import EnvMachSpecific
 from CIME.XML.files import Files
 from CIME.build import CmakeTmpBuildDir
 
-import shutil
+import shutil, glob
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +72,12 @@ def configure(
         output_cmake_macros_dir = os.path.join(output_dir, "cmake_macros")
         if not os.path.exists(output_cmake_macros_dir):
             shutil.copytree(new_cmake_macros_dir, output_cmake_macros_dir)
+            ccs_mach_dir = os.path.join(
+                new_cmake_macros_dir, "..", machobj.get_machine_name()
+            )
+            for f in glob.iglob(os.path.join(ccs_mach_dir, "*.cmake")):
+                print(f"copying {f} to {output_dir}")
+                safe_copy(f, output_dir)
 
         copy_local_macros_to_dir(
             output_cmake_macros_dir, extra_machdir=extra_machines_dir

--- a/CIME/XML/batch.py
+++ b/CIME/XML/batch.py
@@ -34,6 +34,8 @@ class Batch(GenericXML):
         if infile is None:
             infile = files.get_value("BATCH_SPEC_FILE")
 
+        config_dir = os.path.dirname(infile)
+
         schema = files.get_schema("BATCH_SPEC_FILE")
 
         GenericXML.__init__(self, infile, schema=schema)
@@ -50,12 +52,20 @@ class Batch(GenericXML):
         #
         # This could cause problems if node matches are repeated when only one is expected.
         infile = os.path.join(os.environ.get("HOME"), ".cime", "config_batch.xml")
+        usehome = False
         if os.path.exists(infile):
             GenericXML.read(self, infile)
+            usehome = True
+        useextra = False
         if extra_machines_dir:
             infile = os.path.join(extra_machines_dir, "config_batch.xml")
             if os.path.exists(infile):
                 GenericXML.read(self, infile)
+                useextra = True
+        if not usehome and not useextra:
+            batchfile = os.path.join(config_dir, self.machine, "config_batch.xml")
+            if os.path.exists(batchfile):
+                GenericXML.read(self, batchfile)
 
         if self.batch_system is not None:
             self.set_batch_system(self.batch_system, machine=machine)

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -160,9 +160,13 @@ def _create_macros_cmake(
     ]
     for macro in macros:
         repo_macro = os.path.join(cmake_macros_dir, macro)
+        mach_repo_macro = os.path.join(cmake_macros_dir, "..", mach, macro)
         case_macro = os.path.join(case_cmake_path, macro)
-        if not os.path.exists(case_macro) and os.path.exists(repo_macro):
-            safe_copy(repo_macro, case_cmake_path)
+        if not os.path.exists(case_macro):
+            if os.path.exists(mach_repo_macro):
+                safe_copy(mach_repo_macro, case_cmake_path)
+            elif os.path.exists(repo_macro):
+                safe_copy(repo_macro, case_cmake_path)
 
     copy_depends_files(mach, mach_obj.machines_dir, caseroot, compiler)
 

--- a/CIME/tests/test_sys_unittest.py
+++ b/CIME/tests/test_sys_unittest.py
@@ -24,6 +24,7 @@ class TestUnitTest(base.BaseTestCase):
 
     def _has_unit_test_support(self):
         cmake_macros_dir = Files().get_value("CMAKE_MACROS_DIR")
+        cmake_machine_macros_dir = os.path.join(cmake_macros_dir, "..", self._machine)
 
         macros_to_check = [
             os.path.join(
@@ -39,6 +40,11 @@ class TestUnitTest(base.BaseTestCase):
             os.path.join(
                 os.environ.get("HOME"), ".cime", "{}.cmake".format(self._machine)
             ),
+            os.path.join(
+                cmake_machine_macros_dir,
+                "{}_{}.cmake".format(self._compiler, self._machine),
+            ),
+            os.path.join(cmake_machine_macros_dir, "{}.cmake".format(self._machine)),
         ]
 
         for macro_to_check in macros_to_check:


### PR DESCRIPTION
This allows the machine specific part of config_batch.xml to be split into an individual machine directory.  It is a backward compatible change.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
