### PR TITLE
fixes detection of pfunit_path by making sure it exists

### DIFF
--- a/CIME/tests/test_sys_unittest.py
+++ b/CIME/tests/test_sys_unittest.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import sys
+import re
 
 from CIME import utils
 from CIME.tests import base
@@ -40,12 +41,27 @@ class TestUnitTest(base.BaseTestCase):
                 os.environ.get("HOME"), ".cime", "{}.cmake".format(self._machine)
             ),
         ]
+        env_ref_re = re.compile(r"\$ENV\{(\w+)\}")
 
         for macro_to_check in macros_to_check:
             if os.path.exists(macro_to_check):
-                macro_text = open(macro_to_check, "r").read()
-                if "PFUNIT_PATH" in macro_text:
-                    return True
+                with open(macro_to_check, "r") as f:
+                    while True:
+                        line = f.readline().strip()
+                        if not line:
+                            break
+                        if "PFUNIT_PATH" in line:
+                            path = line.split(" ")[1][1:-2]
+                            m = env_ref_re.match(path)
+                            if m:
+                                env_var = m.groups()[0]
+                                env_var_exists = env_var in os.environ
+                                if env_var_exists:
+                                    path = path.replace(
+                                        "$ENV{" + env_var + "}", os.environ[env_var]
+                                    )
+                            if os.path.exists(path):
+                                return True
 
         return False
 


### PR DESCRIPTION
Improve detection of PFUNIT_PATH by parsing the variable and insuring that the path exists. 

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
