### PR TITLE
Fixes test_sys_create_newcase.TestCreateNewcase.test_d_create_clone_new_user

### DIFF
--- a/CIME/Tools/xmlchange
+++ b/CIME/Tools/xmlchange
@@ -318,6 +318,7 @@ def xmlchange(
             skip=["env_case"],
             caseroot=caseroot,
             whitelist=xmlfile,
+            quiet=True
         )
 
     if not noecho:

--- a/CIME/Tools/xmlchange
+++ b/CIME/Tools/xmlchange
@@ -66,6 +66,7 @@ import re
 # Set logger
 logger = logging.getLogger("xmlchange")
 
+
 ###############################################################################
 def parse_command_line(args, description):
     ###############################################################################
@@ -259,7 +260,6 @@ def xmlchange(
     dryrun,
     non_local,
 ):
-
     with Case(caseroot, read_only=False, record=True, non_local=non_local) as case:
         comp_classes = case.get_values("COMP_CLASSES")
         env_test = None
@@ -279,7 +279,6 @@ def xmlchange(
 
             # Change values
             for setting in listofsettings:
-
                 pair = setting.split("=", 1)
                 expect(
                     len(pair) == 2,
@@ -314,11 +313,7 @@ def xmlchange(
             )
 
         check_lockedfiles(
-            case,
-            skip=["env_case"],
-            caseroot=caseroot,
-            whitelist=xmlfile,
-            quiet=True
+            case, skip=["env_case"], caseroot=caseroot, whitelist=xmlfile, quiet=True
         )
 
     if not noecho:


### PR DESCRIPTION
It looks like before https://github.com/ESMCI/cime/pull/4650, the check_lockedfiles call in xmlchange had `quiet=True`. 4650 moved this call but also removed the quiet setting. The quiet setting appears to be necessary for some of the create_newcase tests to pass.

Test suite: TestCreateNewcase.test_d_create_clone_new_user
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
