### PR TITLE
support append in config_pes.xml overrides field

### DIFF
--- a/CIME/XML/pes.py
+++ b/CIME/XML/pes.py
@@ -27,11 +27,13 @@ class Pes(GenericXML):
         opes_pstrid = {}
         oother_settings = {}
         other_settings = {}
+        append = {}
         o_grid_nodes = []
         comments = None
         # Get any override nodes
         overrides = self.get_optional_child("overrides")
         ocomments = None
+        
         if overrides is not None:
             o_grid_nodes = self.get_children("grid", root=overrides)
             (
@@ -40,11 +42,11 @@ class Pes(GenericXML):
                 opes_rootpe,
                 opes_pstrid,
                 oother_settings,
+                append,
                 ocomments,
             ) = self._find_matches(
                 o_grid_nodes, grid, compset, machine, pesize_opts, True
             )
-
         # Get all the nodes
         grid_nodes = self.get_children("grid")
         if o_grid_nodes:
@@ -59,6 +61,7 @@ class Pes(GenericXML):
             pes_rootpe,
             pes_pstrid,
             other_settings,
+            os_append,
             comments,
         ) = self._find_matches(grid_nodes, grid, compset, machine, pesize_opts, False)
         pes_ntasks.update(opes_ntasks)
@@ -66,6 +69,7 @@ class Pes(GenericXML):
         pes_rootpe.update(opes_rootpe)
         pes_pstrid.update(opes_pstrid)
         other_settings.update(oother_settings)
+        os_append.update(append)
         if ocomments is not None:
             comments = ocomments
 
@@ -84,10 +88,11 @@ class Pes(GenericXML):
         logger.info("Pes setting: rootpe      is {} ".format(pes_rootpe))
         logger.info("Pes setting: pstrid      is {} ".format(pes_pstrid))
         logger.info("Pes other settings: {}".format(other_settings))
+        logger.info("Pes other settings append: {}".format(os_append))
         if comments is not None:
             logger.info("Pes comments: {}".format(comments))
-
-        return pes_ntasks, pes_nthrds, pes_rootpe, pes_pstrid, other_settings, comments
+            
+        return pes_ntasks, pes_nthrds, pes_rootpe, pes_pstrid, other_settings, os_append, comments
 
     def _find_matches(
         self, grid_nodes, grid, compset, machine, pesize_opts, override=False
@@ -97,7 +102,8 @@ class Pes(GenericXML):
         compset_choice = None
         pesize_choice = None
         max_points = -1
-        pes_ntasks, pes_nthrds, pes_rootpe, pes_pstrid, other_settings = (
+        pes_ntasks, pes_nthrds, pes_rootpe, pes_pstrid, other_settings, append = (
+            {},
             {},
             {},
             {},
@@ -161,9 +167,9 @@ class Pes(GenericXML):
                                                     self.name(child).upper()
                                                 ] = int(self.text(child))
                                         # if the value is already upper case its something else we are trying to set
-                                        elif vid == self.name(node):
+                                        else:
                                             other_settings[vid] = self.text(node)
-
+                                            append[vid] = self.get(node,"append",default="false")
                                 else:
                                     if points > max_points:
                                         pe_select = pes_node
@@ -230,4 +236,4 @@ class Pes(GenericXML):
             if pesize_choice != "any" or logger.isEnabledFor(logging.DEBUG):
                 logger.info("Pes setting: pesize match  is {} ".format(pesize_choice))
 
-        return pes_ntasks, pes_nthrds, pes_rootpe, pes_pstrid, other_settings, comment
+        return pes_ntasks, pes_nthrds, pes_rootpe, pes_pstrid, other_settings, append, comment

--- a/CIME/XML/pes.py
+++ b/CIME/XML/pes.py
@@ -33,7 +33,7 @@ class Pes(GenericXML):
         # Get any override nodes
         overrides = self.get_optional_child("overrides")
         ocomments = None
-        
+
         if overrides is not None:
             o_grid_nodes = self.get_children("grid", root=overrides)
             (
@@ -91,8 +91,16 @@ class Pes(GenericXML):
         logger.info("Pes other settings append: {}".format(os_append))
         if comments is not None:
             logger.info("Pes comments: {}".format(comments))
-            
-        return pes_ntasks, pes_nthrds, pes_rootpe, pes_pstrid, other_settings, os_append, comments
+
+        return (
+            pes_ntasks,
+            pes_nthrds,
+            pes_rootpe,
+            pes_pstrid,
+            other_settings,
+            os_append,
+            comments,
+        )
 
     def _find_matches(
         self, grid_nodes, grid, compset, machine, pesize_opts, override=False
@@ -133,7 +141,6 @@ class Pes(GenericXML):
                                 compset_match == "any"
                                 or re.search(compset_match, compset)
                             ):
-
                                 points = (
                                     int(grid_match != "any") * 3
                                     + int(mach_match != "any") * 7
@@ -169,7 +176,9 @@ class Pes(GenericXML):
                                         # if the value is already upper case its something else we are trying to set
                                         else:
                                             other_settings[vid] = self.text(node)
-                                            append[vid] = self.get(node,"append",default="false")
+                                            append[vid] = self.get(
+                                                node, "append", default="false"
+                                            )
                                 else:
                                     if points > max_points:
                                         pe_select = pes_node
@@ -236,4 +245,12 @@ class Pes(GenericXML):
             if pesize_choice != "any" or logger.isEnabledFor(logging.DEBUG):
                 logger.info("Pes setting: pesize match  is {} ".format(pesize_choice))
 
-        return pes_ntasks, pes_nthrds, pes_rootpe, pes_pstrid, other_settings, append, comment
+        return (
+            pes_ntasks,
+            pes_nthrds,
+            pes_rootpe,
+            pes_pstrid,
+            other_settings,
+            append,
+            comment,
+        )

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1219,14 +1219,23 @@ class Case(object):
         mach_pes_obj.add_comment(comment)
 
         if other is not None:
-            logger.info("setting additional fields from config_pes: {}, append {}".format(other,append))
+            logger.info(
+                "setting additional fields from config_pes: {}, append {}".format(
+                    other, append
+                )
+            )
             for key, value in list(other.items()):
                 ovalue = ""
-                if value.startswith('"') and value.endswith('"') or value.startswith('\'') and value.endswith('\''):
+                if (
+                    value.startswith('"')
+                    and value.endswith('"')
+                    or value.startswith("'")
+                    and value.endswith("'")
+                ):
                     value = value[1:-1]
                 if append[key]:
                     ovalue = self.get_value(key)
-                
+
                 self.set_value(key, value + " " + ovalue)
 
         totaltasks = []

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1163,6 +1163,7 @@ class Case(object):
         pes_rootpe = {}
         pes_pstrid = {}
         other = {}
+        append = {}
         comment = None
         force_tasks = None
         force_thrds = None

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1191,6 +1191,7 @@ class Case(object):
                 pes_rootpe,
                 pes_pstrid,
                 other,
+                append,
                 comment,
             ) = pesobj.find_pes_layout(
                 self._gridname,
@@ -1218,9 +1219,15 @@ class Case(object):
         mach_pes_obj.add_comment(comment)
 
         if other is not None:
-            logger.info("setting additional fields from config_pes: {}".format(other))
+            logger.info("setting additional fields from config_pes: {}, append {}".format(other,append))
             for key, value in list(other.items()):
-                self.set_value(key, value)
+                ovalue = ""
+                if value.startswith('"') and value.endswith('"') or value.startswith('\'') and value.endswith('\''):
+                    value = value[1:-1]
+                if append[key]:
+                    ovalue = self.get_value(key)
+                
+                self.set_value(key, value + " " + ovalue)
 
         totaltasks = []
         for comp_class in self._component_classes:


### PR DESCRIPTION
The config_pes.xml file has a little used feature which allows setting abritrary xml variables from the overrides field.   This change allows the append option to be used in these settings.  

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
