### PR TITLE
Generalize _hists_match for mom6 files

### DIFF
--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -202,10 +202,13 @@ def _hists_match(model, hists1, hists2, suffix1="", suffix2=""):
                     : len(normalized_name) - len(suffix) - 1
                 ]
 
-            m = re.search("(.+)_[0-9]{4}(.+.nc)", normalized_name)
+            m = re.search("(.+)_[0-9]{4}(.*.nc)", normalized_name)
             if m is not None:
                 multiinst = True
-                multi_normalized.append(m.group(1) + m.group(2))
+                if m.group(1).endswith(".") and m.group(2).startswith("."):
+                    multi_normalized.append(m.group(1) + m.group(2)[1:])
+                else:
+                    multi_normalized.append(m.group(1) + m.group(2))
 
             normalized.append(normalized_name)
 


### PR DESCRIPTION
Changes in _hists_match to fix the failures encountered in comparison phases of MOM6 MCC tests:
- Extend matching to files without datestamps.
- Support matching instance numbers formatted as ._000X.

Test suite: aux_mom 
Test baseline: 30beta02
Test namelist changes: none
Test status: [bit for bit, roundoff, climate changing] b4b

Fixes [CIME Github issue #] https://github.com/ESCOMP/MOM_interface/issues/169

User interface changes?: none

Update gh-pages html (Y/N)?: N
