### PR TITLE
fix the restart tests by using ceil instead of int

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -38,7 +38,7 @@ from CIME.baselines.performance import (
 )
 import CIME.build as build
 
-import glob, gzip, time, traceback, os
+import glob, gzip, time, traceback, os, math
 from contextlib import ExitStack
 
 logger = logging.getLogger(__name__)
@@ -173,8 +173,8 @@ class SystemTestsCommon(object):
         else:
             expect(False, f"stop_option {stop_option} not available for this test")
 
-        stop_n = int(stop_n * factor // coupling_secs)
-        rest_n = int((stop_n // 2 + 1) * coupling_secs / factor)
+        stop_n = math.ceil(stop_n * factor // coupling_secs)
+        rest_n = math.ceil((stop_n // 2 + 1) * coupling_secs / factor)
 
         expect(stop_n > 0, "Bad STOP_N: {:d}".format(stop_n))
 

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -173,7 +173,7 @@ class SystemTestsCommon(object):
         else:
             expect(False, f"stop_option {stop_option} not available for this test")
 
-        stop_n = math.ceil(stop_n * factor // coupling_secs)
+        stop_n = stop_n * factor // coupling_secs
         rest_n = math.ceil((stop_n // 2 + 1) * coupling_secs / factor)
 
         expect(stop_n > 0, "Bad STOP_N: {:d}".format(stop_n))

--- a/CIME/code_checker.py
+++ b/CIME/code_checker.py
@@ -45,11 +45,14 @@ def _run_pylint(all_files, interactive):
     #     cmd_options +=",relative-import"
 
     # add init-hook option
-    cmd_options += ' --init-hook=\'import sys; sys.path.extend(("%s","%s","%s","%s"))\'' % (
-        os.path.join(cimeroot, "CIME"),
-        os.path.join(cimeroot, "CIME", "Tools"),
-        os.path.join(cimeroot, "scripts", "fortran_unit_testing", "python"),
-        os.path.join(srcroot, "components", "cmeps", "cime_config", "runseq"),
+    cmd_options += (
+        ' --init-hook=\'import sys; sys.path.extend(("%s","%s","%s","%s"))\''
+        % (
+            os.path.join(cimeroot, "CIME"),
+            os.path.join(cimeroot, "CIME", "Tools"),
+            os.path.join(cimeroot, "scripts", "fortran_unit_testing", "python"),
+            os.path.join(srcroot, "components", "cmeps", "cime_config", "runseq"),
+        )
     )
 
     files = " ".join(all_files)


### PR DESCRIPTION
int was rounding down, but this calculation should round up. 

Test suite: ERS.f19_g17.A.derecho_intel
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4667 

User interface changes?:

Update gh-pages html (Y/N)?:
