### PR TITLE
Fixes black formatting

### DIFF
--- a/CIME/code_checker.py
+++ b/CIME/code_checker.py
@@ -45,11 +45,14 @@ def _run_pylint(all_files, interactive):
     #     cmd_options +=",relative-import"
 
     # add init-hook option
-    cmd_options += ' --init-hook=\'import sys; sys.path.extend(("%s","%s","%s","%s"))\'' % (
-        os.path.join(cimeroot, "CIME"),
-        os.path.join(cimeroot, "CIME", "Tools"),
-        os.path.join(cimeroot, "scripts", "fortran_unit_testing", "python"),
-        os.path.join(srcroot, "components", "cmeps", "cime_config", "runseq"),
+    cmd_options += (
+        ' --init-hook=\'import sys; sys.path.extend(("%s","%s","%s","%s"))\''
+        % (
+            os.path.join(cimeroot, "CIME"),
+            os.path.join(cimeroot, "CIME", "Tools"),
+            os.path.join(cimeroot, "scripts", "fortran_unit_testing", "python"),
+            os.path.join(srcroot, "components", "cmeps", "cime_config", "runseq"),
+        )
     )
 
     files = " ".join(all_files)


### PR DESCRIPTION
Fixes black formatting.

Local cached versions of black were out of sync with github actions.
This caused it to pass locally but fail in GitHub actions. Running
`pre-commit clean` followed by `pre-commit run -a` solves the issue
by clearing the pre-commit cache.

Test suite: n/a
Test baseline: n/a
Test namelist changes: n/a
Test status:  n/a

Fixes n/a
User interface changes?:
Update gh-pages html (Y/N)?:
