### PR TITLE
Fix shutils typo

### DIFF
--- a/CIME/SystemTests/mvk.py
+++ b/CIME/SystemTests/mvk.py
@@ -10,7 +10,7 @@ import os
 import json
 import logging
 
-from shutils import copytree
+from shutil import copytree
 
 import CIME.test_status
 import CIME.utils

--- a/CIME/SystemTests/pgn.py
+++ b/CIME/SystemTests/pgn.py
@@ -16,7 +16,7 @@ import shutil
 import logging
 
 from collections import OrderedDict
-from shutils import copytree
+from shutil import copytree
 
 import pandas as pd
 import numpy as np


### PR DESCRIPTION
Import the shutil module rather than the "shutils" module typo

User interface changes?: N

Update gh-pages html (Y/N)?: N
