### PR TITLE
make the hidden status of batch jobs xml dependent 

### DIFF
--- a/CIME/Tools/xmlchange
+++ b/CIME/Tools/xmlchange
@@ -55,7 +55,6 @@ from standard_script_setup import *
 from CIME.utils import (
     expect,
     convert_to_type,
-    get_batch_script_for_job,
     Timeout,
 )
 from CIME.status import append_case_status

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -32,6 +32,7 @@ class EnvBatch(EnvBase):
         initialize an object interface to file env_batch.xml in the case directory
         """
         self._batchtype = None
+        self._hidden_batch_script = {}
         # This arbitrary setting should always be overwritten
         self._default_walltime = "00:20:00"
         schema = os.path.join(utils.get_schema_path(), "env_batch.xsd")
@@ -257,7 +258,9 @@ class EnvBatch(EnvBase):
             subgroup=job,
             overrides=overrides,
         )
-        output_name = get_batch_script_for_job(job) if outfile is None else outfile
+        env_workflow = case.get_env("workflow")
+        self._hidden_batch_script[job] = env_workflow.get_value("hidden", subgroup=job)
+        output_name = get_batch_script_for_job(job, hidden=self._hidden_batch_script[job]) if outfile is None else outfile
         logger.info("Creating file {}".format(output_name))
         with open(output_name, "w") as fd:
             fd.write(output_text)
@@ -745,7 +748,7 @@ class EnvBatch(EnvBase):
         alljobs = [
             j
             for j in alljobs
-            if os.path.isfile(os.path.join(self._caseroot, get_batch_script_for_job(j)))
+            if os.path.isfile(os.path.join(self._caseroot, get_batch_script_for_job(j, hidden=self._hidden_batch_script[j])))
         ]
 
         startindex = 0
@@ -1071,7 +1074,7 @@ class EnvBatch(EnvBase):
                 batchsubmit,
                 submitargs,
                 batchredirect,
-                get_batch_script_for_job(job),
+                get_batch_script_for_job(job, hidden=self._hidden_batch_script[job]),
             )
         elif batch_env_flag:
             sequence = (
@@ -1079,14 +1082,14 @@ class EnvBatch(EnvBase):
                 submitargs,
                 run_args,
                 batchredirect,
-                os.path.join(self._caseroot, get_batch_script_for_job(job)),
+                os.path.join(self._caseroot, get_batch_script_for_job(job, hidden=self._hidden_batch_script[job])),
             )
         else:
             sequence = (
                 batchsubmit,
                 submitargs,
                 batchredirect,
-                os.path.join(self._caseroot, get_batch_script_for_job(job)),
+                os.path.join(self._caseroot, get_batch_script_for_job(job, hidden=self._hidden_batch_script[job])),
                 run_args,
             )
 

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -259,7 +259,13 @@ class EnvBatch(EnvBase):
             overrides=overrides,
         )
         env_workflow = case.get_env("workflow")
-        self._hidden_batch_script[job] = env_workflow.get_value("hidden", subgroup=job)
+
+        hidden = env_workflow.get_value("hidden", subgroup=job)
+        if hidden is None or hidden == "True" or hidden == "true":
+            self._hidden_batch_script[job] = True
+        else:
+            self._hidden_batch_script[job] = False
+
         output_name = (
             get_batch_script_for_job(
                 job,

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -260,7 +260,18 @@ class EnvBatch(EnvBase):
         )
         env_workflow = case.get_env("workflow")
         self._hidden_batch_script[job] = env_workflow.get_value("hidden", subgroup=job)
-        output_name = get_batch_script_for_job(job, hidden=self._hidden_batch_script[job]) if outfile is None else outfile
+        output_name = (
+            get_batch_script_for_job(
+                job,
+                hidden=(
+                    self._hidden_batch_script[job]
+                    if job in self._hidden_batch_script
+                    else None
+                ),
+            )
+            if outfile is None
+            else outfile
+        )
         logger.info("Creating file {}".format(output_name))
         with open(output_name, "w") as fd:
             fd.write(output_text)
@@ -748,7 +759,17 @@ class EnvBatch(EnvBase):
         alljobs = [
             j
             for j in alljobs
-            if os.path.isfile(os.path.join(self._caseroot, get_batch_script_for_job(j, hidden=self._hidden_batch_script[j])))
+            if os.path.isfile(
+                os.path.join(
+                    self._caseroot,
+                    get_batch_script_for_job(
+                        j,
+                        hidden=self._hidden_batch_script[j]
+                        if j in self._hidden_batch_script
+                        else None,
+                    ),
+                )
+            )
         ]
 
         startindex = 0
@@ -1074,7 +1095,14 @@ class EnvBatch(EnvBase):
                 batchsubmit,
                 submitargs,
                 batchredirect,
-                get_batch_script_for_job(job, hidden=self._hidden_batch_script[job]),
+                get_batch_script_for_job(
+                    job,
+                    hidden=(
+                        self._hidden_batch_script[job]
+                        if job in self._hidden_batch_script
+                        else None
+                    ),
+                ),
             )
         elif batch_env_flag:
             sequence = (
@@ -1082,14 +1110,34 @@ class EnvBatch(EnvBase):
                 submitargs,
                 run_args,
                 batchredirect,
-                os.path.join(self._caseroot, get_batch_script_for_job(job, hidden=self._hidden_batch_script[job])),
+                os.path.join(
+                    self._caseroot,
+                    get_batch_script_for_job(
+                        job,
+                        hidden=(
+                            self._hidden_batch_script[job]
+                            if job in self._hidden_batch_script
+                            else None
+                        ),
+                    ),
+                ),
             )
         else:
             sequence = (
                 batchsubmit,
                 submitargs,
                 batchredirect,
-                os.path.join(self._caseroot, get_batch_script_for_job(job, hidden=self._hidden_batch_script[job])),
+                os.path.join(
+                    self._caseroot,
+                    get_batch_script_for_job(
+                        job,
+                        hidden=(
+                            self._hidden_batch_script[job]
+                            if job in self._hidden_batch_script
+                            else None
+                        ),
+                    ),
+                ),
                 run_args,
             )
 

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -261,7 +261,12 @@ class EnvBatch(EnvBase):
         env_workflow = case.get_env("workflow")
 
         hidden = env_workflow.get_value("hidden", subgroup=job)
-        if hidden is None or hidden == "True" or hidden == "true":
+        # case.st_archive is not hidden for backward compatibility
+        if (
+            (job != "case.st_archive" and hidden is None)
+            or hidden == "True"
+            or hidden == "true"
+        ):
             self._hidden_batch_script[job] = True
         else:
             self._hidden_batch_script[job] = False

--- a/CIME/data/config/xml_schemas/config_workflow.xsd
+++ b/CIME/data/config/xml_schemas/config_workflow.xsd
@@ -13,6 +13,7 @@
 
   <!-- simple elements -->
   <xs:element name="template" type="xs:anyURI"/>
+  <xs:element name="hidden" type="xs:string" default="True"/>
   <xs:element name="task_count" type="xs:string"/>
   <xs:element name="tasks_per_node" type="xs:string"/>
   <xs:element name="walltime" type="xs:string"/>
@@ -57,6 +58,7 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="template"/>
+        <xs:element ref="hidden" minOccurs="0"/>
         <xs:element minOccurs="0" ref="dependency"/>
         <xs:element ref="prereq"/>
 	<xs:element ref="runtime_parameters" minOccurs="0" maxOccurs="unbounded"/>

--- a/CIME/data/config/xml_schemas/config_workflow.xsd
+++ b/CIME/data/config/xml_schemas/config_workflow.xsd
@@ -13,7 +13,7 @@
 
   <!-- simple elements -->
   <xs:element name="template" type="xs:anyURI"/>
-  <xs:element name="hidden" type="xs:string" default="True"/>
+  <xs:element name="hidden" type="xs:string"/>
   <xs:element name="task_count" type="xs:string"/>
   <xs:element name="tasks_per_node" type="xs:string"/>
   <xs:element name="walltime" type="xs:string"/>

--- a/CIME/tests/test_sys_cime_case.py
+++ b/CIME/tests/test_sys_cime_case.py
@@ -731,7 +731,8 @@ class TestCimeCase(base.BaseTestCase):
         )
 
         self.run_cmd_assert_result(
-            "./xmlchange CCSM_CPRNC=this_is_a_broken_cprnc", from_dir=casedir
+            "./xmlchange CCSM_CPRNC=this_is_a_broken_cprnc --file env_test.xml",
+            from_dir=casedir,
         )
         self.run_cmd_assert_result("./case.build", from_dir=casedir)
         self.run_cmd_assert_result("./case.submit", from_dir=casedir)

--- a/CIME/tests/test_sys_create_newcase.py
+++ b/CIME/tests/test_sys_create_newcase.py
@@ -74,7 +74,7 @@ class TestCreateNewcase(base.BaseTestCase):
         # on systems (like github workflow) that do not have batch, set this for the next test
         if batch_system == "none":
             self.run_cmd_assert_result(
-                './xmlchange --subgroup case.run BATCH_COMMAND_FLAGS="-q \$JOB_QUEUE"',
+                r'./xmlchange --subgroup case.run BATCH_COMMAND_FLAGS="-q \$JOB_QUEUE"',
                 from_dir=testdir,
             )
 

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -2530,8 +2530,11 @@ def run_bld_cmd_ensure_logging(cmd, arg_logger, from_dir=None, timeout=None):
     expect(stat == 0, filter_unicode(errput))
 
 
-def get_batch_script_for_job(job):
-    return job if "st_archive" in job else "." + job
+def get_batch_script_for_job(job, hidden="True"):
+    # this if statement is for backward compatibility
+    if job == "case.st_archive" and not hidden:
+        hidden = "False"
+    return "." + job if not hidden or hidden == "True" else job
 
 
 def string_in_list(_string, _list):

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -2530,11 +2530,11 @@ def run_bld_cmd_ensure_logging(cmd, arg_logger, from_dir=None, timeout=None):
     expect(stat == 0, filter_unicode(errput))
 
 
-def get_batch_script_for_job(job, hidden="True"):
+def get_batch_script_for_job(job, hidden=None):
     # this if statement is for backward compatibility
-    if job == "case.st_archive" and not hidden:
-        hidden = "False"
-    return "." + job if not hidden or hidden == "True" else job
+    if hidden is None:
+        hidden = job != "case.st_archive"
+    return "." + job if hidden else job
 
 
 def string_in_list(_string, _list):


### PR DESCRIPTION
Currently this is harded for case.st_archive only.  This change
makes the hidden status of job scripts an xml variable in the config_workflow.xml file.
The default is hidden and case.st_archive is still an exception so this change is backward
compatible.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
