### PR TITLE
Fix BFAILs, they need to be considered DIFF

### DIFF
--- a/CIME/test_status.py
+++ b/CIME/test_status.py
@@ -468,8 +468,8 @@ class TestStatus(object):
                     if rv in [NAMELIST_FAIL_STATUS, TEST_PASS_STATUS]:
                         phase_responsible_for_status = phase
                         # need to further inspect message to determine
-                        # phase status
-                        if "DIFF" in data[1]:
+                        # phase status. BFAILs need to be a DIFF
+                        if "DIFF" in data[1] or TEST_NO_BASELINES_COMMENT in data[1]:
                             rv = TEST_DIFF_STATUS
                         elif "ERROR" in data[1]:
                             rv = TEST_FAIL_STATUS


### PR DESCRIPTION
Having BFAILs resolve to overall FAIL prevent bless_test_results and other tools from working properly. For E3SM, a BFAIL has always been considered a DIFF.

Test suite: by-hand
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
