### PR TITLE
Mark SETUP as FAIL if case.cmpgen_namelists fails

### DIFF
--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -1020,10 +1020,14 @@ class TestScheduler(object):
                 from_dir=test_dir,
                 env=env,
             )
-            expect(
-                cmdstat in [0, TESTS_FAILED_ERR_CODE],
-                "Fatal error in case.cmpgen_namelists: {}".format(output),
-            )
+            try:
+                expect(
+                    cmdstat in [0, TESTS_FAILED_ERR_CODE],
+                    "Fatal error in case.cmpgen_namelists: {}".format(output),
+                )
+            except Exception:
+                self._update_test_status_file(test, SETUP_PHASE, TEST_FAIL_STATUS)
+                raise
 
         if self._single_exe:
             with Case(self._get_test_dir(test), read_only=False) as case:


### PR DESCRIPTION
Mark SETUP as FAIL rather than PEND if case.cmpgen_namelists fails.

Branched from ~~`cime6.0.246`~~ `cime6.1.26`.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes #4680

**User interface changes?:** No

**Update gh-pages html (Y/N)?:** N
