### PR TITLE
avoid breaking Python environment by prepending CIME paths to PYTHONPATH

### DIFF
--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -820,12 +820,10 @@ def run_cmd(
     # or build a relative path and append `sys.path` to import
     # `standard_script_setup`. Providing `PYTHONPATH` fixes protential
     # broken paths in external python.
-    env.update(
-        {
-            "CIMEROOT": f"{get_cime_root()}",
-            "PYTHONPATH": f"{get_cime_root()}:{get_tools_path()}",
-        }
-    )
+    env_pythonpath = os.environ.get("PYTHONPATH", "").split(":")
+    cime_pythonpath = [f"{get_cime_root()}", f"{get_tools_path()}"] + env_pythonpath
+    env["PYTHONPATH"] = ":".join(filter(None, cime_pythonpath))
+    env["CIMEROOT"] = f"{get_cime_root()}"
 
     if timeout:
         with Timeout(timeout):


### PR DESCRIPTION
CIME currently carries out a full reset of the `PYTHONPATH` environment variable. This is bad practice as other software in the user's session might rely on their paths being present in `PYTHONPATH` to be usable.

For instance, in HPC clusters it's very common to use _modules_ to load software packages on-demand and those modules will add the paths of the loaded Python software to `PYTHONPATH`. In our case, we provide `lxml` as a module, which is one of the dependencies of CIME. Therefore, CIME is breaking itself by resetting `PYTHONPATH` .

This PR changes how CIME handles `PYTHONPATH` by prepending `cime_root` and `tools_path` to `PYTHONPATH` instead of fully replacing it. This achieves the same goal of ensuring that external python can correctly import the CIME module, without breaking the rest of the Python ecosystem in the user's session.

Test suite: n/a
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes: no open issue, but I can make a new one if you wish

User interface changes?: N

Update gh-pages html (Y/N)?: N
