### PR TITLE
refine the git interface to handle no git and old git

### DIFF
--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -527,37 +527,27 @@ def case_setup(self, clean=False, test_mode=False, reset=False, keep=None):
 
 
 def _create_case_repo(self, caseroot):
-    version = run_cmd_no_fail("git --version")
-    result = re.findall(r"([0-9]+)\.([0-9]+)\.?[0-9]*", version)
-    major = int(result[0][0])
-    minor = int(result[0][1])
 
-    # gitinterface needs git version 2.28 or newer
-    if major > 2 or (major == 2 and minor >= 28):
-        self._gitinterface = GitInterface(
-            caseroot, logger, branch=self.get_value("CASE")
+    self._gitinterface = GitInterface(caseroot, logger, branch=self.get_value("CASE"))
+    if self._gitinterface and not os.path.exists(os.path.join(caseroot, ".gitignore")):
+        safe_copy(
+            os.path.join(
+                self.get_value("CIMEROOT"),
+                "CIME",
+                "data",
+                "templates",
+                "gitignore.template",
+            ),
+            os.path.join(caseroot, ".gitignore"),
         )
-        if not os.path.exists(os.path.join(caseroot, ".gitignore")):
-            safe_copy(
-                os.path.join(
-                    self.get_value("CIMEROOT"),
-                    "CIME",
-                    "data",
-                    "templates",
-                    "gitignore.template",
-                ),
-                os.path.join(caseroot, ".gitignore"),
-            )
-            append_case_status(
-                "", "", "local git repository created", gitinterface=self._gitinterface
-            )
+        append_case_status(
+            "", "", "local git repository created", gitinterface=self._gitinterface
+        )
         # add all files in caseroot to local repository
         self._gitinterface._git_command("add", "*")
-    else:
-        logger.warning("git interface requires git version 2.28 or newer")
-
+    elif not self._gitinterface:
         append_case_status(
             "",
             "",
-            f"local git version too old for cime git interface {major}.{minor}",
+            "Local git version too old for cime git interface, version 2.28 or newer required.",
         )

--- a/CIME/gitinterface.py
+++ b/CIME/gitinterface.py
@@ -1,10 +1,23 @@
-import sys
+import sys, shutil, re
 from CIME.utils import run_cmd_no_fail
 from pathlib import Path
 
 
 class GitInterface:
     def __init__(self, repo_path, logger, branch=None):
+        major = 0
+        minor = 0
+        if shutil.which("git"):
+            version = run_cmd_no_fail("git --version")
+            result = re.findall(r"([0-9]+)\.([0-9]+)\.?[0-9]*", version)
+            major = int(result[0][0])
+            minor = int(result[0][1])
+        if major < 2 or (major == 2 and minor < 28):
+            logger.warning(
+                "Git not found or git version too old for cesm git interface"
+            )
+            return None
+
         logger.debug("Initialize GitInterface for {}".format(repo_path))
         if isinstance(repo_path, str):
             self.repo_path = Path(repo_path).resolve()

--- a/CIME/gitinterface.py
+++ b/CIME/gitinterface.py
@@ -41,7 +41,7 @@ class GitInterface:
             if not (self.repo_path / ".git").exists():
                 self._init_git_repo(branch=branch)
             msg = "Using shell interface to git"
-        self.logger.debug(msg)
+        logger.debug(msg)
 
     def _git_command(self, operation, *args):
         self.logger.debug(operation)

--- a/CIME/gitinterface.py
+++ b/CIME/gitinterface.py
@@ -16,7 +16,9 @@ class GitInterface:
             minor = int(result[0][1])
         if major < 2 or (major == 2 and minor < 28):
             logger.warning(
-                "Git not found or git version too old for cesm git interface"
+                "Git not found or git version too old for cesm git interface {} {}".format(
+                    major, minor
+                )
             )
             return
 

--- a/CIME/status.py
+++ b/CIME/status.py
@@ -39,18 +39,20 @@ def append_case_status(phase, status, msg=None, caseroot=".", gitinterface=None)
     if gitinterface:
         filelist = gitinterface.git_operation(
             "ls-files", "--deleted", "--exclude-standard"
-        ).splitlines()
+        )
         # First delete files that have been removed
-        for f in filelist:
-            logger.debug("removing file {}".format(f))
-            gitinterface.git_operation("rm", f)
+        if filelist:
+            for f in filelist.splitlines():
+                logger.debug("removing file {}".format(f))
+                gitinterface.git_operation("rm", f)
         filelist = gitinterface.git_operation(
             "ls-files", "--others", "--modified", "--exclude-standard"
-        ).splitlines()
+        )
         # Files that should not be added should have been excluded by the .gitignore file
-        for f in filelist:
-            logger.debug("adding file {}".format(f))
-            gitinterface.git_operation("add", f)
+        if filelist:
+            for f in filelist.splitlines():
+                logger.debug("adding file {}".format(f))
+                gitinterface.git_operation("add", f)
         msg = msg if msg else " no message provided"
         gitinterface.git_operation("commit", "-m", '"' + msg + '"')
         remote = gitinterface.git_operation("remote")


### PR DESCRIPTION
It may be that the installed git is too old for the cesm git interface or that
git is missing on a system (for example not available on compute nodes).  This PR makes the git interface conditional on git being present and above a minimum version

Test suite:scripts_regression_tests
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
