### PR TITLE
Fixes test status reporting errors during successful baseline comparison

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,20 +39,20 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/ESMCI/cime
           tags: |
@@ -60,7 +60,7 @@ jobs:
             type=ref,event=pr,enable=${{ github.event_name == 'pull_request' }}
             type=sha,format=long
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           target: base
           context: docker/
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up python
         uses: actions/setup-python@v2
         with:
@@ -102,7 +102,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tests
         shell: bash
         env:
@@ -149,7 +149,7 @@ jobs:
             driver: "mct"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache inputdata
         uses: actions/cache@v2
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -174,6 +174,14 @@ jobs:
 
           conda activate base
 
+          # container libnetcdf is 4.9.2 as cesm requires esmf >8.6.1
+          # e3sm scorpio incompatible with 4.9.2, downgrade to 4.9.1
+          # only reference found about scorpio incompatibility with 4.9.2 (https://github.com/E3SM-Project/scorpio/issues/554#issuecomment-1877361470)
+          # TODO open scorpio issue, possible solutions; 1. support two conda environments in container 2. maybe move from conda to spack? build all libraries in image
+          if [[ "${CIME_MODEL}" == "e3sm" ]]; then
+            mamba install -y 'libnetcdf=4.9.1'
+          fi
+
           pytest -vvv --cov=CIME --machine docker --no-fortran-run --no-teardown CIME/tests/test_sys*
       - uses: mxschmitt/action-tmate@v3
         if: ${{ !always() }}

--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -740,7 +740,7 @@ def get_ts_synopsis(comments):
     >>> get_ts_synopsis('file1=\nfile2=\nFailed to open file\n')
     'ERROR CPRNC failed to open files'
     >>> get_ts_synopsis('file1=\nfile2=\nSome other error\n')
-    'Could not interpret CPRNC output'
+    'ERROR Could not interpret CPRNC output'
     """
     comments = comments.strip()
 
@@ -779,6 +779,6 @@ def get_ts_synopsis(comments):
     elif open_fail:
         synopsis = "ERROR CPRNC failed to open files"
     else:
-        synopsis = "Could not interpret CPRNC output"
+        synopsis = "ERROR Could not interpret CPRNC output"
 
     return synopsis

--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -37,6 +37,7 @@ NO_ORIGINAL = "had no original counterpart"
 FIELDLISTS_DIFFER = "had a different field list from"
 DIFF_COMMENT = "did NOT match"
 FAILED_OPEN = "Failed to open file"
+IDENTICAL = "the two files seem to be IDENTICAL"
 # COMPARISON_COMMENT_OPTIONS should include all of the above: these are any of the special
 # comment strings that describe the reason for a comparison failure
 COMPARISON_COMMENT_OPTIONS = set(
@@ -719,6 +720,8 @@ def get_ts_synopsis(comments):
 
     >>> get_ts_synopsis('')
     ''
+    >>> get_ts_synopsis('\n')
+    ''
     >>> get_ts_synopsis('big error')
     'big error'
     >>> get_ts_synopsis('big error\n')
@@ -741,11 +744,17 @@ def get_ts_synopsis(comments):
     'ERROR CPRNC failed to open files'
     >>> get_ts_synopsis('file1=\nfile2=\nSome other error\n')
     'ERROR Could not interpret CPRNC output'
+    >>> get_ts_synopsis('file1=\nfile2=\n  diff_test: the two files seem to be IDENTICAL \n')
+    ''
     """
     comments = comments.strip()
 
     if comments == "" or "\n" not in comments:
         return comments
+
+    # Empty synopsis when files are identicial
+    if re.search(IDENTICAL, comments) is not None:
+        return ""
 
     fieldlist_differences = re.search(FIELDLISTS_DIFFER, comments) is not None
     baseline_fail = re.search(NO_COMPARE, comments) is not None

--- a/docker/cime.yaml
+++ b/docker/cime.yaml
@@ -16,12 +16,12 @@ dependencies:
   - openssh
   - lapack
   - blas
-  - libnetcdf=4.9.1=*openmpi*
+  - libnetcdf=4.9.2=*openmpi*
   - netcdf-fortran=*=*openmpi*
   - esmf=*=*openmpi*
-  - gcc_linux-64=10.*
-  - gxx_linux-64=10.*
-  - gfortran_linux-64=10.*
+  - gcc_linux-64=12.*
+  - gxx_linux-64=12.*
+  - gfortran_linux-64=12.*
   - openmpi-mpifort
   - gcc
   - gxx


### PR DESCRIPTION
The `get_ts_synopsis` function's catch-all would report an error when
the baseline comparison was actually success and had a `PASS` state.

This PR fixes the issue by explicitly checking if the the CPRNC output
reports identical files first. This allows the catch-all to still function for
unknown errors that may appear in the CPRNC output.

Test suite: doctests
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes #4685 
User interface changes?: n
Update gh-pages html (Y/N)?: n
