### PR TITLE
Remove distutils

### DIFF
--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -1417,10 +1417,15 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
             # I am not the owner, just copy file contents
             shutil.copyfile(src_path, tgt_path)
 
-    else:
+    elif preserve_meta:
         # We are making a new file, copy file contents, permissions, and metadata.
         # This can fail if the underlying directory is not writable by current user.
         shutil.copy2(
+            src_path,
+            tgt_path,
+        )
+    else:
+        shutil.copy(
             src_path,
             tgt_path,
         )

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -12,9 +12,6 @@ import stat as statlib
 from argparse import Action
 from contextlib import contextmanager
 
-# pylint: disable=deprecated-module
-from distutils import file_util
-
 # Return this error code if the scripts worked but tests failed
 TESTS_FAILED_ERR_CODE = 100
 logger = logging.getLogger(__name__)
@@ -1412,12 +1409,9 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
 
         if owner_uid == os.getuid():
             # I am the owner, copy file contents, permissions, and metadata
-            file_util.copy_file(
+            shutil.copy2(
                 src_path,
                 tgt_path,
-                preserve_mode=preserve_meta,
-                preserve_times=preserve_meta,
-                verbose=0,
             )
         else:
             # I am not the owner, just copy file contents
@@ -1426,12 +1420,9 @@ def safe_copy(src_path, tgt_path, preserve_meta=True):
     else:
         # We are making a new file, copy file contents, permissions, and metadata.
         # This can fail if the underlying directory is not writable by current user.
-        file_util.copy_file(
+        shutil.copy2(
             src_path,
             tgt_path,
-            preserve_mode=preserve_meta,
-            preserve_times=preserve_meta,
-            verbose=0,
         )
 
     # If src file was executable, then the tgt file should be too


### PR DESCRIPTION
distutils is deprecated in python 3.12 and needs to be removed. 

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
