### PR TITLE
Remove GPU options from the Python workflow and move them to XML files for CESM

### DIFF
--- a/CIME/XML/env_mach_pes.py
+++ b/CIME/XML/env_mach_pes.py
@@ -222,6 +222,8 @@ class EnvMachPes(EnvBase):
             ngpus_per_node = self.get_value("NGPUS_PER_NODE")
             if ngpus_per_node and ngpus_per_node > 0:
                 num_nodes = int(math.ceil(float(total_tasks) / ngpus_per_node))
+            else:
+                num_nodes = int(math.ceil(float(total_tasks) / tasks_per_node))
         return num_nodes, self.get_spare_nodes(num_nodes)
 
     def get_spare_nodes(self, num_nodes):

--- a/CIME/XML/env_mach_pes.py
+++ b/CIME/XML/env_mach_pes.py
@@ -44,7 +44,7 @@ class EnvMachPes(EnvBase):
         max_mpitasks_per_node=None,
         max_cputasks_per_gpu_node=None,
         ngpus_per_node=None,
-        oversubscribe_gpu=False
+        oversubscribe_gpu=False,
     ):  # pylint: disable=arguments-differ
         # Special variable NINST_MAX is used to determine the number of
         # drivers in multi-driver mode.

--- a/CIME/XML/env_mach_pes.py
+++ b/CIME/XML/env_mach_pes.py
@@ -177,7 +177,8 @@ class EnvMachPes(EnvBase):
             "totaltasks > 0 expected, totaltasks = {}".format(total_tasks),
         )
         if self._comp_interface == "nuopc" and self.get_value("ESMF_AWARE_THREADING"):
-            if self.get_value("NGPUS_PER_NODE") > 0:
+            ngpus_per_node = self.get_value("NGPUS_PER_NODE")
+            if ngpus_per_node and ngpus_per_node > 0:
                 if self.get_value("OVERSUBSCRIBE_GPU"):
                     tasks_per_node = self.get_value("MAX_CPUTASKS_PER_GPU_NODE")
                 else:

--- a/CIME/XML/env_mach_pes.py
+++ b/CIME/XML/env_mach_pes.py
@@ -41,10 +41,6 @@ class EnvMachPes(EnvBase):
         attribute=None,
         resolved=True,
         subgroup=None,
-        max_mpitasks_per_node=None,
-        max_cputasks_per_gpu_node=None,
-        ngpus_per_node=None,
-        oversubscribe_gpu=False,
     ):  # pylint: disable=arguments-differ
         # Special variable NINST_MAX is used to determine the number of
         # drivers in multi-driver mode.
@@ -59,12 +55,9 @@ class EnvMachPes(EnvBase):
         value = EnvBase.get_value(self, vid, attribute, resolved, subgroup)
 
         if "NTASKS" in vid or "ROOTPE" in vid:
-            if max_mpitasks_per_node is None:
-                max_mpitasks_per_node = self.get_value("MAX_MPITASKS_PER_NODE")
-            if max_cputasks_per_gpu_node is None:
-                max_cputasks_per_gpu_node = self.get_value("MAX_CPUTASKS_PER_GPU_NODE")
-            if ngpus_per_node is None:
-                ngpus_per_node = self.get_value("NGPUS_PER_NODE")
+            max_mpitasks_per_node = self.get_value("MAX_MPITASKS_PER_NODE")
+            max_cputasks_per_gpu_node = self.get_value("MAX_CPUTASKS_PER_GPU_NODE")
+            ngpus_per_node = self.get_value("NGPUS_PER_NODE")
             if (ngpus_per_node and value) and value < 0:
                 value = -1 * value * max_cputasks_per_gpu_node
             elif value and value < 0:

--- a/CIME/XML/env_mach_pes.py
+++ b/CIME/XML/env_mach_pes.py
@@ -182,6 +182,7 @@ class EnvMachPes(EnvBase):
                     tasks_per_node = self.get_value("MAX_CPUTASKS_PER_GPU_NODE")
                 else:
                     tasks_per_node = self.get_value("NGPUS_PER_NODE")
+                    self.set_value("MAX_CPUTASKS_PER_GPU_NODE", tasks_per_node)
             else:
                 tasks_per_node = self.get_value("MAX_MPITASKS_PER_NODE")
         else:
@@ -198,7 +199,8 @@ class EnvMachPes(EnvBase):
                         self.get_value("MAX_TASKS_PER_NODE") // max_thread_count,
                         self.get_value("NGPUS_PER_NODE"),
                         total_tasks,
-                    ) 
+                    )
+                    self.set_value("MAX_CPUTASKS_PER_GPU_NODE", tasks_per_node)
             else:
                 tasks_per_node = min(
                     self.get_value("MAX_TASKS_PER_NODE") // max_thread_count,

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -249,7 +249,8 @@ def get_standard_cmake_args(case, sharedpath):
     gpu_type = case.get_value("GPU_TYPE")
     openacc_gpu_offload = case.get_value("OPENACC_GPU_OFFLOAD")
     openmp_gpu_offload = case.get_value("OPENMP_GPU_OFFLOAD")
-    cmake_args += f" -DGPU_TYPE={gpu_type} -DOPENACC_GPU_OFFLOAD={openacc_gpu_offload} -DOPENMP_GPU_OFFLOAD={openmp_gpu_offload} "
+    kokkos_gpu_offload = case.get_value("KOKKOS_GPU_OFFLOAD")
+    cmake_args += f" -DGPU_TYPE={gpu_type} -DOPENACC_GPU_OFFLOAD={openacc_gpu_offload} -DOPENMP_GPU_OFFLOAD={openmp_gpu_offload} -DKOKKOS_GPU_OFFLOAD={kokkos_gpu_offload} "
 
     ocn_model = case.get_value("COMP_OCN")
     atm_dycore = case.get_value("CAM_DYCORE")

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -247,18 +247,9 @@ def get_standard_cmake_args(case, sharedpath):
     )
     # check settings for GPU
     gpu_type = case.get_value("GPU_TYPE")
-    gpu_offload = case.get_value("GPU_OFFLOAD")
-    if gpu_type != "none":
-        expect(
-            gpu_offload != "none",
-            "Both GPU_TYPE and GPU_OFFLOAD must be defined if either is",
-        )
-        cmake_args += f" -DGPU_TYPE={gpu_type} -DGPU_OFFLOAD={gpu_offload}"
-    else:
-        expect(
-            gpu_offload == "none",
-            "Both GPU_TYPE and GPU_OFFLOAD must be defined if either is",
-        )
+    openacc_gpu_offload = case.get_value("OPENACC_GPU_OFFLOAD")
+    openmp_gpu_offload = case.get_value("OPENMP_GPU_OFFLOAD")
+    cmake_args += f" -DGPU_TYPE={gpu_type} -DOPENACC_GPU_OFFLOAD={openacc_gpu_offload} -DOPENMP_GPU_OFFLOAD={openmp_gpu_offload} "
 
     ocn_model = case.get_value("COMP_OCN")
     atm_dycore = case.get_value("CAM_DYCORE")

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1301,9 +1301,6 @@ class Case(object):
         non_local=False,
         extra_machines_dir=None,
         case_group=None,
-        ngpus_per_node=0,
-        gpu_type=None,
-        gpu_offload=None,
     ):
         expect(
             check_name(compset_name, additional_chars="."),
@@ -1563,12 +1560,15 @@ class Case(object):
 
         # ----------------------------------------------------------------------------------------------------------
         # Sanity check for a GPU run:
-        #        1. GPU_TYPE and GPU_OFFLOAD must both be defined to use GPUS
-        #        2. if ngpus_per_node argument is larger than the value of MAX_GPUS_PER_NODE, the NGPUS_PER_NODE
-        #             XML variable in the env_mach_pes.xml file would be set to MAX_GPUS_PER_NODE automatically.
-        #        3. if ngpus-per-node argument is equal to 0, it will be updated to 1 automatically.
+        #        1. GPU_TYPE and GPU_OFFLOAD must both be defined to use GPUs
+        #        2. If the NGPUS_PER_NODE XML variable in the env_mach_pes.xml file is larger than 
+        #           the value of MAX_GPUS_PER_NODE, set it to MAX_GPUS_PER_NODE automatically.
+        #        3. If the NGPUS_PER_NODE XML variable is equal to 0, it will be updated to 1 automatically.
         # ----------------------------------------------------------------------------------------------------------
         max_gpus_per_node = self.get_value("MAX_GPUS_PER_NODE")
+        gpu_type = self.get_value("GPU_TYPE")
+        gpu_offload = self.get_value("GPU_OFFLOAD")
+        ngpus_per_node = self.get_value("NGPUS_PER_NODE")
         if gpu_type and str(gpu_type).lower() != "none":
             expect(
                 max_gpus_per_node,
@@ -1579,20 +1579,8 @@ class Case(object):
                 "Both gpu-type and gpu-offload must be defined if either is defined",
             )
             expect(
-                compiler in ["nvhpc", "cray"],
-                f"Only nvhpc and cray compilers are expected for a GPU run; the user given compiler is {compiler}, ",
-            )
-            valid_gpu_type = self.get_value("GPU_TYPE").split(",")
-            valid_gpu_type.remove("none")
-            expect(
-                gpu_type in valid_gpu_type,
-                f"Unsupported GPU type is given: {gpu_type} ; valid values are {valid_gpu_type}",
-            )
-            valid_gpu_offload = self.get_value("GPU_OFFLOAD").split(",")
-            valid_gpu_offload.remove("none")
-            expect(
-                gpu_offload in valid_gpu_offload,
-                f"Unsupported GPU programming model is given: {gpu_offload} ; valid values are {valid_gpu_offload}",
+                compiler in ["gnu", "nvhpc", "cray"],
+                f"Only gnu, nvhpc and cray compilers are expected for a GPU run; the user given compiler is {compiler}, ",
             )
             self.gpu_enabled = True
             if ngpus_per_node >= 0:
@@ -1612,12 +1600,6 @@ class Case(object):
                 False,
                 f"ngpus_per_node is expected to be 0 for a pure CPU run ; {ngpus_per_node} is provided instead ;",
             )
-
-        # Set these two GPU XML variables here to overwrite the default values
-        # Only set them for "cesm" model
-        if self._cime_model == "cesm":
-            self.set_value("GPU_TYPE", str(gpu_type).lower())
-            self.set_value("GPU_OFFLOAD", str(gpu_offload).lower())
 
         self.initialize_derived_attributes()
 
@@ -2440,9 +2422,6 @@ directory, NOT in this subdirectory."""
         non_local=False,
         extra_machines_dir=None,
         case_group=None,
-        ngpus_per_node=0,
-        gpu_type=None,
-        gpu_offload=None,
     ):
         try:
             # Set values for env_case.xml
@@ -2515,9 +2494,6 @@ directory, NOT in this subdirectory."""
                 non_local=non_local,
                 extra_machines_dir=extra_machines_dir,
                 case_group=case_group,
-                ngpus_per_node=ngpus_per_node,
-                gpu_type=gpu_type,
-                gpu_offload=gpu_offload,
             )
 
             self.create_caseroot()

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1558,48 +1558,6 @@ class Case(object):
         if test:
             self.set_value("TEST", True)
 
-        # ----------------------------------------------------------------------------------------------------------
-        # Sanity check for a GPU run:
-        #        1. GPU_TYPE and GPU_OFFLOAD must both be defined to use GPUs
-        #        2. If the NGPUS_PER_NODE XML variable in the env_mach_pes.xml file is larger than 
-        #           the value of MAX_GPUS_PER_NODE, set it to MAX_GPUS_PER_NODE automatically.
-        #        3. If the NGPUS_PER_NODE XML variable is equal to 0, it will be updated to 1 automatically.
-        # ----------------------------------------------------------------------------------------------------------
-        max_gpus_per_node = self.get_value("MAX_GPUS_PER_NODE")
-        gpu_type = self.get_value("GPU_TYPE")
-        openacc_gpu_offload = self.get_value("OPENACC_GPU_OFFLOAD")
-        openmp_gpu_offload = self.get_value("OPENMP_GPU_OFFLOAD")
-        kokkos_gpu_offload = self.get_value("KOKKOS_GPU_OFFLOAD")
-        gpu_offload = (openacc_gpu_offload or openmp_gpu_offload or kokkos_gpu_offload)
-        ngpus_per_node = self.get_value("NGPUS_PER_NODE")
-        if str(gpu_type).lower() != "none":
-            expect(
-                max_gpus_per_node,
-                f"MAX_GPUS_PER_NODE is not defined for machine={machine_name} and compiler={compiler}",
-            )
-            expect(
-                gpu_offload,
-                "GPU_TYPE is defined but none of the GPU OFFLOAD options are enabled",
-            )
-            self.gpu_enabled = True
-            if ngpus_per_node >= 0:
-                self.set_value(
-                    "NGPUS_PER_NODE",
-                    max(1, ngpus_per_node)
-                    if ngpus_per_node <= max_gpus_per_node
-                    else max_gpus_per_node,
-                )
-        elif gpu_offload:
-            expect(
-                False,
-                "GPU_TYPE is not defined but at least one GPU OFFLOAD option is enabled",
-            )
-        elif ngpus_per_node != 0:
-            expect(
-                False,
-                f"ngpus_per_node is expected to be 0 for a pure CPU run ; {ngpus_per_node} is provided instead ;",
-            )
-
         self.initialize_derived_attributes()
 
         # --------------------------------------------

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1567,16 +1567,18 @@ class Case(object):
         # ----------------------------------------------------------------------------------------------------------
         max_gpus_per_node = self.get_value("MAX_GPUS_PER_NODE")
         gpu_type = self.get_value("GPU_TYPE")
-        gpu_offload = self.get_value("GPU_OFFLOAD")
+        openacc_gpu_offload = self.get_value("OPENACC_GPU_OFFLOAD")
+        openmp_gpu_offload = self.get_value("OPENMP_GPU_OFFLOAD")
+        gpu_offload = (openacc_gpu_offload or openmp_gpu_offload)
         ngpus_per_node = self.get_value("NGPUS_PER_NODE")
         if gpu_type and str(gpu_type).lower() != "none":
             expect(
                 max_gpus_per_node,
-                f"GPUS are not defined for machine={machine_name} and compiler={compiler}",
+                f"MAX_GPUS_PER_NODE is not defined for machine={machine_name} and compiler={compiler}",
             )
             expect(
                 gpu_offload,
-                "Both gpu-type and gpu-offload must be defined if either is defined",
+                "GPU_TYPE is defined but none of the GPU OFFLOAD options are enabled",
             )
             expect(
                 compiler in ["gnu", "nvhpc", "cray"],
@@ -1590,10 +1592,10 @@ class Case(object):
                     if ngpus_per_node <= max_gpus_per_node
                     else max_gpus_per_node,
                 )
-        elif gpu_offload and str(gpu_offload).lower() != "none":
+        elif gpu_offload:
             expect(
                 False,
-                "Both gpu-type and gpu-offload must be defined if either is defined",
+                "GPU_TYPE is not defined but at least one GPU OFFLOAD option is enabled",
             )
         elif ngpus_per_node != 0:
             expect(

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1569,9 +1569,10 @@ class Case(object):
         gpu_type = self.get_value("GPU_TYPE")
         openacc_gpu_offload = self.get_value("OPENACC_GPU_OFFLOAD")
         openmp_gpu_offload = self.get_value("OPENMP_GPU_OFFLOAD")
-        gpu_offload = (openacc_gpu_offload or openmp_gpu_offload)
+        kokkos_gpu_offload = self.get_value("KOKKOS_GPU_OFFLOAD")
+        gpu_offload = (openacc_gpu_offload or openmp_gpu_offload or kokkos_gpu_offload)
         ngpus_per_node = self.get_value("NGPUS_PER_NODE")
-        if gpu_type and str(gpu_type).lower() != "none":
+        if str(gpu_type).lower() != "none":
             expect(
                 max_gpus_per_node,
                 f"MAX_GPUS_PER_NODE is not defined for machine={machine_name} and compiler={compiler}",
@@ -1579,10 +1580,6 @@ class Case(object):
             expect(
                 gpu_offload,
                 "GPU_TYPE is defined but none of the GPU OFFLOAD options are enabled",
-            )
-            expect(
-                compiler in ["gnu", "nvhpc", "cray"],
-                f"Only gnu, nvhpc and cray compilers are expected for a GPU run; the user given compiler is {compiler}, ",
             )
             self.gpu_enabled = True
             if ngpus_per_node >= 0:

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -407,7 +407,7 @@ def _case_setup_impl(
                 if max_gpus_per_node <= 0:
                     raise RuntimeError(f"MAX_GPUS_PER_NODE must be larger than 0 for machine={mach} and compiler={compiler} in order to configure a GPU run")
                 if not gpu_offload:
-                    raise RuntimeError(f"GPU_TYPE is defined but none of the GPU OFFLOAD options are enabled")
+                    raise RuntimeError("GPU_TYPE is defined but none of the GPU OFFLOAD options are enabled")
                 case.gpu_enabled = True
                 if ngpus_per_node >= 0:
                     case.set_value(
@@ -417,7 +417,7 @@ def _case_setup_impl(
                         else max_gpus_per_node,
                     )
             elif gpu_offload:
-                raise RuntimeError(f"GPU_TYPE is not defined but at least one GPU OFFLOAD option is enabled")
+                raise RuntimeError("GPU_TYPE is not defined but at least one GPU OFFLOAD option is enabled")
             elif ngpus_per_node and ngpus_per_node != 0:
                 raise RuntimeError(f"ngpus_per_node is expected to be 0 for a pure CPU run ; {ngpus_per_node} is provided instead ;")
 

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -403,7 +403,7 @@ def _case_setup_impl(
             kokkos_gpu_offload = case.get_value("KOKKOS_GPU_OFFLOAD")
             gpu_offload = (openacc_gpu_offload or openmp_gpu_offload or kokkos_gpu_offload)
             ngpus_per_node = case.get_value("NGPUS_PER_NODE")
-            if str(gpu_type).lower() != "none":
+            if gpu_type and str(gpu_type).lower() != "none":
                 if max_gpus_per_node <= 0:
                     raise RuntimeError(f"MAX_GPUS_PER_NODE must be larger than 0 for machine={mach} and compiler={compiler} in order to configure a GPU run")
                 if not gpu_offload:
@@ -418,7 +418,7 @@ def _case_setup_impl(
                     )
             elif gpu_offload:
                 raise RuntimeError(f"GPU_TYPE is not defined but at least one GPU OFFLOAD option is enabled")
-            elif ngpus_per_node != 0:
+            elif ngpus_per_node and ngpus_per_node != 0:
                 raise RuntimeError(f"ngpus_per_node is expected to be 0 for a pure CPU run ; {ngpus_per_node} is provided instead ;")
 
             # May need to select new batch settings if pelayout changed (e.g. problem is now too big for prev-selected queue)

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -392,7 +392,7 @@ def _case_setup_impl(
             # ----------------------------------------------------------------------------------------------------------
             # Sanity check for a GPU run:
             #        1. GPU_TYPE and GPU_OFFLOAD must both be defined to use GPUs
-            #        2. If the NGPUS_PER_NODE XML variable in the env_mach_pes.xml file is larger than 
+            #        2. If the NGPUS_PER_NODE XML variable in the env_mach_pes.xml file is larger than
             #           the value of MAX_GPUS_PER_NODE, set it to MAX_GPUS_PER_NODE automatically.
             #        3. If the NGPUS_PER_NODE XML variable is equal to 0, it will be updated to 1 automatically.
             # ----------------------------------------------------------------------------------------------------------
@@ -401,13 +401,19 @@ def _case_setup_impl(
             openacc_gpu_offload = case.get_value("OPENACC_GPU_OFFLOAD")
             openmp_gpu_offload = case.get_value("OPENMP_GPU_OFFLOAD")
             kokkos_gpu_offload = case.get_value("KOKKOS_GPU_OFFLOAD")
-            gpu_offload = (openacc_gpu_offload or openmp_gpu_offload or kokkos_gpu_offload)
+            gpu_offload = (
+                openacc_gpu_offload or openmp_gpu_offload or kokkos_gpu_offload
+            )
             ngpus_per_node = case.get_value("NGPUS_PER_NODE")
             if gpu_type and str(gpu_type).lower() != "none":
                 if max_gpus_per_node <= 0:
-                    raise RuntimeError(f"MAX_GPUS_PER_NODE must be larger than 0 for machine={mach} and compiler={compiler} in order to configure a GPU run")
+                    raise RuntimeError(
+                        f"MAX_GPUS_PER_NODE must be larger than 0 for machine={mach} and compiler={compiler} in order to configure a GPU run"
+                    )
                 if not gpu_offload:
-                    raise RuntimeError("GPU_TYPE is defined but none of the GPU OFFLOAD options are enabled")
+                    raise RuntimeError(
+                        "GPU_TYPE is defined but none of the GPU OFFLOAD options are enabled"
+                    )
                 case.gpu_enabled = True
                 if ngpus_per_node >= 0:
                     case.set_value(
@@ -417,9 +423,13 @@ def _case_setup_impl(
                         else max_gpus_per_node,
                     )
             elif gpu_offload:
-                raise RuntimeError("GPU_TYPE is not defined but at least one GPU OFFLOAD option is enabled")
+                raise RuntimeError(
+                    "GPU_TYPE is not defined but at least one GPU OFFLOAD option is enabled"
+                )
             elif ngpus_per_node and ngpus_per_node != 0:
-                raise RuntimeError(f"ngpus_per_node is expected to be 0 for a pure CPU run ; {ngpus_per_node} is provided instead ;")
+                raise RuntimeError(
+                    f"ngpus_per_node is expected to be 0 for a pure CPU run ; {ngpus_per_node} is provided instead ;"
+                )
 
             # May need to select new batch settings if pelayout changed (e.g. problem is now too big for prev-selected queue)
             env_batch = case.get_env("batch")
@@ -559,7 +569,6 @@ def case_setup(self, clean=False, test_mode=False, reset=False, keep=None):
 
 
 def _create_case_repo(self, caseroot):
-
     self._gitinterface = GitInterface(caseroot, logger, branch=self.get_value("CASE"))
     if self._gitinterface and not os.path.exists(os.path.join(caseroot, ".gitignore")):
         safe_copy(

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -389,6 +389,38 @@ def _case_setup_impl(
                     + case.iotasks,
                 )
 
+            # ----------------------------------------------------------------------------------------------------------
+            # Sanity check for a GPU run:
+            #        1. GPU_TYPE and GPU_OFFLOAD must both be defined to use GPUs
+            #        2. If the NGPUS_PER_NODE XML variable in the env_mach_pes.xml file is larger than 
+            #           the value of MAX_GPUS_PER_NODE, set it to MAX_GPUS_PER_NODE automatically.
+            #        3. If the NGPUS_PER_NODE XML variable is equal to 0, it will be updated to 1 automatically.
+            # ----------------------------------------------------------------------------------------------------------
+            max_gpus_per_node = case.get_value("MAX_GPUS_PER_NODE")
+            gpu_type = case.get_value("GPU_TYPE")
+            openacc_gpu_offload = case.get_value("OPENACC_GPU_OFFLOAD")
+            openmp_gpu_offload = case.get_value("OPENMP_GPU_OFFLOAD")
+            kokkos_gpu_offload = case.get_value("KOKKOS_GPU_OFFLOAD")
+            gpu_offload = (openacc_gpu_offload or openmp_gpu_offload or kokkos_gpu_offload)
+            ngpus_per_node = case.get_value("NGPUS_PER_NODE")
+            if str(gpu_type).lower() != "none":
+                if max_gpus_per_node <= 0:
+                    raise RuntimeError(f"MAX_GPUS_PER_NODE must be larger than 0 for machine={mach} and compiler={compiler} in order to configure a GPU run")
+                if not gpu_offload:
+                    raise RuntimeError(f"GPU_TYPE is defined but none of the GPU OFFLOAD options are enabled")
+                case.gpu_enabled = True
+                if ngpus_per_node >= 0:
+                    case.set_value(
+                        "NGPUS_PER_NODE",
+                        max(1, ngpus_per_node)
+                        if ngpus_per_node <= max_gpus_per_node
+                        else max_gpus_per_node,
+                    )
+            elif gpu_offload:
+                raise RuntimeError(f"GPU_TYPE is not defined but at least one GPU OFFLOAD option is enabled")
+            elif ngpus_per_node != 0:
+                raise RuntimeError(f"ngpus_per_node is expected to be 0 for a pure CPU run ; {ngpus_per_node} is provided instead ;")
+
             # May need to select new batch settings if pelayout changed (e.g. problem is now too big for prev-selected queue)
             env_batch = case.get_env("batch")
             env_batch.set_job_defaults([(case.get_primary_job(), {})], case)

--- a/CIME/data/config/xml_schemas/config_machines.xsd
+++ b/CIME/data/config/xml_schemas/config_machines.xsd
@@ -6,8 +6,6 @@
   <xs:attribute name="compiler" type="xs:string"/>
   <xs:attribute name="mpilib" type="xs:string"/>
   <xs:attribute name="comp_interface" type="xs:string"/>
-  <xs:attribute name="gpu_type" type="xs:string"/>
-  <xs:attribute name="gpu_offload" type="xs:string"/>
   <xs:attribute name="queue" type="xs:string"/>
   <xs:attribute name="DEBUG" type="upperBoolean"/>
   <xs:attribute name="PIO_VERSION" type="xs:integer"/>
@@ -59,8 +57,6 @@
   <xs:element name="MAX_GPUS_PER_NODE" type="AttrElement"/>
   <xs:element name="MAX_MPITASKS_PER_NODE" type="AttrElement"/>
   <xs:element name="MAX_CPUTASKS_PER_GPU_NODE" type="AttrElement"/>
-  <xs:element name="GPU_TYPE" type="AttrElement"/>
-  <xs:element name="GPU_OFFLOAD" type="AttrElement"/>
   <xs:element name="MPI_GPU_WRAPPER_SCRIPT" type="AttrElement"/>
   <xs:element name="COSTPES_PER_NODE" type="xs:integer"/>
   <xs:element name="PROJECT_REQUIRED" type="xs:NCName"/>
@@ -175,10 +171,6 @@
         <!-- MAX_CPUTASKS_PER_GPU_NODE: number of physical PES per GPU node on
              this machine, in practice the MPI tasks per node will not exceed this value -->
         <xs:element ref="MAX_CPUTASKS_PER_GPU_NODE" minOccurs="0" maxOccurs="unbounded"/>
-	<!-- GPU_TYPE: the type of GPU hardware available on this machine -->
-        <xs:element ref="GPU_TYPE" minOccurs="0" maxOccurs="unbounded"/>
-	<!-- GPU_OFFLOAD: the GPU programming model used for GPU porting -->
-        <xs:element ref="GPU_OFFLOAD" minOccurs="0" maxOccurs="unbounded"/>
 	<!-- MPI_GPU_WRAPPER_SCRIPT: a wrapper script that will be attached to the MPI run
 	     command and map different MPI ranks to different GPUs within the same node -->
         <xs:element ref="MPI_GPU_WRAPPER_SCRIPT" minOccurs="0" maxOccurs="1"/>
@@ -265,8 +257,6 @@
       <xs:attribute ref="PIO_VERSION"/>
       <xs:attribute ref="mpilib"/>
       <xs:attribute ref="comp_interface"/>
-      <xs:attribute ref="gpu_offload"/>
-      <xs:attribute ref="gpu_type"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="command">

--- a/CIME/data/config/xml_schemas/config_machines.xsd
+++ b/CIME/data/config/xml_schemas/config_machines.xsd
@@ -6,6 +6,7 @@
   <xs:attribute name="compiler" type="xs:string"/>
   <xs:attribute name="mpilib" type="xs:string"/>
   <xs:attribute name="comp_interface" type="xs:string"/>
+  <xs:attribute name="gpu_type" type="xs:string"/>
   <xs:attribute name="queue" type="xs:string"/>
   <xs:attribute name="DEBUG" type="upperBoolean"/>
   <xs:attribute name="PIO_VERSION" type="xs:integer"/>
@@ -257,6 +258,7 @@
       <xs:attribute ref="PIO_VERSION"/>
       <xs:attribute ref="mpilib"/>
       <xs:attribute ref="comp_interface"/>
+      <xs:attribute ref="gpu_type"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="command">

--- a/CIME/data/config/xml_schemas/entry_id_base.xsd
+++ b/CIME/data/config/xml_schemas/entry_id_base.xsd
@@ -13,12 +13,21 @@
   <!-- simple elements -->
   <xs:element name="help" type="xs:string"/>
   <xs:element name="default_value" type="xs:string"/>
-  <xs:element name="valid_values" type="xs:string"/>
   <xs:element name="category" type="xs:string"/>
   <xs:element name="header" type="xs:string"/>
 
   <!-- complex elements -->
   <xs:element name="value">
+    <xs:complexType>
+      <xs:simpleContent>
+	<xs:extension base="xs:string">
+	  <xs:anyAttribute processContents="lax"/>
+	</xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="valid_values">
     <xs:complexType>
       <xs:simpleContent>
 	<xs:extension base="xs:string">

--- a/CIME/data/config/xml_schemas/env_mach_specific.xsd
+++ b/CIME/data/config/xml_schemas/env_mach_specific.xsd
@@ -9,8 +9,6 @@
 <xs:attribute name="PIO_VERSION" type="xs:integer"/>
 <xs:attribute name="mpilib" type="xs:string"/>
 <xs:attribute name="comp_interface" type="xs:string"/>
-<xs:attribute name="gpu_type" type="xs:string"/>
-<xs:attribute name="gpu_offload" type="xs:string"/>
 <xs:attribute name="BUILD_THREADED" type="xs:string"/>
 <xs:attribute name="value" type="xs:string"/>
 <xs:attribute name="unit_testing" type="xs:boolean"/>
@@ -104,8 +102,6 @@
       <xs:attribute ref="PIO_VERSION" />
       <xs:attribute ref="mpilib"/>
       <xs:attribute ref="comp_interface"/>
-      <xs:attribute ref="gpu_type"/>
-      <xs:attribute ref="gpu_offload"/>
     </xs:complexType>
   </xs:element>
 

--- a/CIME/data/config/xml_schemas/env_mach_specific.xsd
+++ b/CIME/data/config/xml_schemas/env_mach_specific.xsd
@@ -9,6 +9,7 @@
 <xs:attribute name="PIO_VERSION" type="xs:integer"/>
 <xs:attribute name="mpilib" type="xs:string"/>
 <xs:attribute name="comp_interface" type="xs:string"/>
+<xs:attribute name="gpu_type" type="xs:string"/>
 <xs:attribute name="BUILD_THREADED" type="xs:string"/>
 <xs:attribute name="value" type="xs:string"/>
 <xs:attribute name="unit_testing" type="xs:boolean"/>
@@ -102,6 +103,7 @@
       <xs:attribute ref="PIO_VERSION" />
       <xs:attribute ref="mpilib"/>
       <xs:attribute ref="comp_interface"/>
+      <xs:attribute ref="gpu_type"/>
     </xs:complexType>
   </xs:element>
 

--- a/CIME/scripts/create_newcase.py
+++ b/CIME/scripts/create_newcase.py
@@ -264,25 +264,6 @@ def parse_command_line(args, cimeroot, description):
 
     parser.add_argument("--case-group", help="Add this case to a case group")
 
-    parser.add_argument(
-        "--ngpus-per-node",
-        default=0,
-        type=int,
-        help="Specify number of GPUs used for simulation. ",
-    )
-
-    parser.add_argument(
-        "--gpu-type",
-        default=None,
-        help="Specify type of GPU hardware - currently supported are v100, a100, mi250",
-    )
-
-    parser.add_argument(
-        "--gpu-offload",
-        default=None,
-        help="Specify gpu offload method - currently supported are openacc, openmp, combined",
-    )
-
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.srcroot is not None:
@@ -358,9 +339,6 @@ WARNING: if you need support migrating to the ESMF/NUOPC infrastructure.
         args.non_local,
         args.extra_machines_dir,
         args.case_group,
-        args.ngpus_per_node,
-        args.gpu_type,
-        args.gpu_offload,
     )
 
 
@@ -397,9 +375,6 @@ def _main_func(description=None):
         non_local,
         extra_machines_dir,
         case_group,
-        ngpus_per_node,
-        gpu_type,
-        gpu_offload,
     ) = parse_command_line(sys.argv, cimeroot, description)
 
     if script_root is None:
@@ -464,9 +439,6 @@ def _main_func(description=None):
             non_local=non_local,
             extra_machines_dir=extra_machines_dir,
             case_group=case_group,
-            ngpus_per_node=ngpus_per_node,
-            gpu_type=gpu_type,
-            gpu_offload=gpu_offload,
         )
 
         # Called after create since casedir does not exist yet

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -670,18 +670,6 @@ class TestScheduler(object):
                 elif case_opt.startswith("P"):
                     pesize = case_opt[1:]
                     create_newcase_cmd += " --pecount {}".format(pesize)
-                elif case_opt.startswith("G"):
-                    if "-" in case_opt:
-                        ngpus_per_node, gpu_type, gpu_offload = case_opt[1:].split("-")
-                    else:
-                        error = "GPU test argument format is ngpus_per_node-gpu_type-gpu_offload"
-                        self._log_output(test, error)
-                        return False, error
-                    create_newcase_cmd += (
-                        " --ngpus-per-node {} --gpu-type {} --gpu-offload {}".format(
-                            ngpus_per_node, gpu_type, gpu_offload
-                        )
-                    )
                 elif case_opt.startswith("V"):
                     driver = case_opt[1:]
 

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -253,9 +253,6 @@ class TestCase(unittest.TestCase):
                     non_local=False,
                     extra_machines_dir=None,
                     case_group=None,
-                    ngpus_per_node=0,
-                    gpu_type=None,
-                    gpu_offload=None,
                 )
                 create_caseroot.assert_called()
                 apply_user_mods.assert_called()
@@ -330,9 +327,6 @@ class TestCase(unittest.TestCase):
                     non_local=False,
                     extra_machines_dir=None,
                     case_group=None,
-                    ngpus_per_node=0,
-                    gpu_type=None,
-                    gpu_offload=None,
                 )
                 create_caseroot.assert_called()
                 apply_user_mods.assert_called()


### PR DESCRIPTION
As discussed in https://github.com/ESMCI/cime/pull/4687, it is better remove the GPU options from the Python workflow in CIME and use XML files instead to configure them for CESM.

This PR does this and it works for CESM CPU & GPU runs according to my tests on Derecho.

The general build procedure for building a CESM GPU run on Derecho now looks like (the other machines can modify the settings for their specific hardware accordingly):
```
1. create a new case as normal
2. go to the case directory
3. ./xmlchange GPU_TYPE=a100
4. ./xmlchange OPENACC_GPU_OFFLOAD=TRUE
5. ./xmlchange OVERSUBSCRIBE_GPU=TRUE
6. ./xmlchange NGPUS_PER_NODE=4
7. ./case.setup
8. ./case.build
```

It should work together with the following PRs:
- CMEPS: https://github.com/ESCOMP/CMEPS/pull/512
- ccs_config_cesm: https://github.com/ESMCI/ccs_config_cesm/pull/189