### PR TITLE
do not report memcomp if no baseline exists

### DIFF
--- a/CIME/baselines/performance.py
+++ b/CIME/baselines/performance.py
@@ -431,6 +431,8 @@ def read_baseline_file(baseline_file):
     str
         Value stored in baseline file without comments.
     """
+    if not os.path.exists(baseline_file):
+        return "\nNO file {} found".format(baseline_file)
     with open(baseline_file) as fd:
         lines = [x.strip() for x in fd.readlines() if not x.startswith("#") and x != ""]
 

--- a/CIME/tests/test_unit_baselines_performance.py
+++ b/CIME/tests/test_unit_baselines_performance.py
@@ -139,6 +139,8 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
         assert baseline == "sha:1df0 date:2023 1000.0\nsha:3b05 date:2023 2000.0"
 
     def test_read_baseline_file_content(self):
+        if not os.path.exists("/tmp/cpl-mem.log"):
+            os.mknod("/tmp/cpl-mem.log")
         with mock.patch(
             "builtins.open", mock.mock_open(read_data="sha:1df0 date:2023 1000.0")
         ) as mock_file:

--- a/CIME/tests/test_unit_baselines_performance.py
+++ b/CIME/tests/test_unit_baselines_performance.py
@@ -3,6 +3,7 @@
 import gzip
 import tempfile
 import unittest
+import os
 from unittest import mock
 from pathlib import Path
 


### PR DESCRIPTION
This PR changes the test error:
 `FAIL SMS_D_Ld3_PS.f09_g17.I1850Clm60SpNoAnthro.derecho_intel.clm-decStart1851_noinitial--clm-nofireemis MEMCOMP [Errno 2] No such file or directory: '/glade/campaign/cesm/cesmdata/cesm_baselines/cesm3_0_beta03/SMS_D_Ld3_PS.f09_g17.I1850Clm60SpNoAnthro.derecho_intel.clm-decStart1851_noinitial--clm-nofireemis/cpl-mem.log'` and does not report
MEMCOMP if no baseline cpl-mem.log exists.

Test suite: scripts_regression_tests.py, cesm prealpha
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4590 

User interface changes?: N

Update gh-pages html (Y/N)?:
