### PR TITLE
correct the cmake path for configuring tools like fortran_unit_tests

### DIFF
--- a/CIME/BuildTools/configure.py
+++ b/CIME/BuildTools/configure.py
@@ -77,7 +77,7 @@ def configure(
             )
             for f in glob.iglob(os.path.join(ccs_mach_dir, "*.cmake")):
                 print(f"copying {f} to {output_dir}")
-                safe_copy(f, output_dir)
+                safe_copy(f, output_cmake_macros_dir)
 
         copy_local_macros_to_dir(
             output_cmake_macros_dir, extra_machdir=extra_machines_dir


### PR DESCRIPTION
The cmake path for external tools was incorrect based on ccs_config_cesm1.0.4 and newer.  This should not adversely affect e3sm.

Test suite: This problem was found when running the ctsm unit test suite,
that suite now works correctly. cime/scripts/fortran_unit_testing/run_tests.py --build-dir unit_tests 
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
