### PR TITLE
skip three files when staging refcase files to avoid a rmtree error

### DIFF
--- a/CIME/case/check_input_data.py
+++ b/CIME/case/check_input_data.py
@@ -350,7 +350,8 @@ def stage_refcase(self, input_data_root=None, data_list_dir=None):
 
         for rcfile in glob.iglob(os.path.join(refdir, "*")):
             rcbaseline = os.path.basename(rcfile)
-            if not os.path.exists("{}/{}".format(rundir, rcbaseline)):
+            skipfiles = 'timing' in rcbaseline or 'spio_stats' in rcbaseline or 'memory.' in rcbaseline
+            if not os.path.exists("{}/{}".format(rundir, rcbaseline)) and not skipfiles:
                 logger.info("Staging file {}".format(rcfile))
                 os.symlink(rcfile, "{}/{}".format(rundir, rcbaseline))
         # Backward compatibility, some old refcases have cam2 in the name

--- a/CIME/case/check_input_data.py
+++ b/CIME/case/check_input_data.py
@@ -350,7 +350,11 @@ def stage_refcase(self, input_data_root=None, data_list_dir=None):
 
         for rcfile in glob.iglob(os.path.join(refdir, "*")):
             rcbaseline = os.path.basename(rcfile)
-            skipfiles = 'timing' in rcbaseline or 'spio_stats' in rcbaseline or 'memory.' in rcbaseline
+            skipfiles = (
+                "timing" in rcbaseline
+                or "spio_stats" in rcbaseline
+                or "memory." in rcbaseline
+            )
             if not os.path.exists("{}/{}".format(rundir, rcbaseline)) and not skipfiles:
                 logger.info("Staging file {}".format(rcfile))
                 os.symlink(rcfile, "{}/{}".format(rundir, rcbaseline))


### PR DESCRIPTION
Skip linking the three files ('timing', 'spio_stats', and 'memory.*') when
staging files from refcase directory to the branch run directory.

Test suite: NA
Test baseline: NA
Test namelist changes: None
Test status: [bit for bit]

Fixes #4697, E3SM-Project/E3SM#6704

User interface changes?: No

Update gh-pages html (Y/N)?: N
