### PR TITLE
logic was incorrect for mct driver

### DIFF
--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -65,11 +65,12 @@ def _submit(
         # only checks for the first instance in a multidriver case
         if case.get_value("COMP_INTERFACE") == "nuopc":
             rpointer = "rpointer.cpl"
+            if case.get_value("NINST") > 1:
+                rpointer = rpointer + "_0001"
         else:
             rpointer = "rpointer.drv"
-        # Variable MULTI_DRIVER is always true for nuopc so we need to also check NINST > 1
-        if case.get_value("MULTI_DRIVER") and case.get_value("NINST") > 1:
-            rpointer = rpointer + "_0001"
+            if case.get_value("MULTI_DRIVER"):
+                rpointer = rpointer + "_0001"
         expect(
             os.path.exists(os.path.join(rundir, rpointer)),
             "CONTINUE_RUN is true but this case does not appear to have restart files staged in {} {}".format(


### PR DESCRIPTION


The original logic was only valid for the nuopc driver, this change will work for both supported drivers.

Test suite: ERR_C3.ne30pg3_t232.BLT1850.derecho_intel.allactive-defaultio
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4700

User interface changes?:

Update gh-pages html (Y/N)?:
