### PR TITLE
Remove unused GPU options for CESM

### DIFF
--- a/CIME/data/config/xml_schemas/config_machines_version3.xsd
+++ b/CIME/data/config/xml_schemas/config_machines_version3.xsd
@@ -7,7 +7,6 @@
   <xs:attribute name="mpilib" type="xs:string"/>
   <xs:attribute name="comp_interface" type="xs:string"/>
   <xs:attribute name="gpu_type" type="xs:string"/>
-  <xs:attribute name="gpu_offload" type="xs:string"/>
   <xs:attribute name="queue" type="xs:string"/>
   <xs:attribute name="DEBUG" type="upperBoolean"/>
   <xs:attribute name="PIO_VERSION" type="xs:integer"/>
@@ -61,8 +60,6 @@
   <xs:element name="MAX_GPUS_PER_NODE" type="AttrElement"/>
   <xs:element name="MAX_MPITASKS_PER_NODE" type="AttrElement"/>
   <xs:element name="MAX_CPUTASKS_PER_GPU_NODE" type="AttrElement"/>
-  <xs:element name="GPU_TYPE" type="AttrElement"/>
-  <xs:element name="GPU_OFFLOAD" type="AttrElement"/>
   <xs:element name="MPI_GPU_WRAPPER_SCRIPT" type="AttrElement"/>
   <xs:element name="COSTPES_PER_NODE" type="xs:integer"/>
   <xs:element name="PROJECT_REQUIRED" type="xs:NCName"/>
@@ -197,10 +194,6 @@
         <!-- MAX_CPUTASKS_PER_GPU_NODE: number of physical PES per GPU node on
              this machine, in practice the MPI tasks per node will not exceed this value -->
         <xs:element ref="MAX_CPUTASKS_PER_GPU_NODE" minOccurs="0" maxOccurs="unbounded"/>
-	<!-- GPU_TYPE: the type of GPU hardware available on this machine -->
-        <xs:element ref="GPU_TYPE" minOccurs="0" maxOccurs="unbounded"/>
-	<!-- GPU_OFFLOAD: the GPU programming model used for GPU porting -->
-        <xs:element ref="GPU_OFFLOAD" minOccurs="0" maxOccurs="unbounded"/>
 	<!-- MPI_GPU_WRAPPER_SCRIPT: a wrapper script that will be attached to the MPI run
 	     command and map different MPI ranks to different GPUs within the same node -->
         <xs:element ref="MPI_GPU_WRAPPER_SCRIPT" minOccurs="0" maxOccurs="1"/>
@@ -287,7 +280,6 @@
       <xs:attribute ref="PIO_VERSION"/>
       <xs:attribute ref="mpilib"/>
       <xs:attribute ref="comp_interface"/>
-      <xs:attribute ref="gpu_offload"/>
       <xs:attribute ref="gpu_type"/>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
@jedwards4b pointed out an error in my previous [PR](https://github.com/ESMCI/cime/pull/4690) that the xml schema for CESM was not updated correctly for the new GPU workflow. Fixed here.