### PR TITLE
If batch script is already executable, don't chmod it

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -298,10 +298,14 @@ class EnvBatch(EnvBase):
             fd.write(output_text)
 
         # make sure batch script is exectuble
-        os.chmod(
-            output_name,
-            os.stat(output_name).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
-        )
+        if not os.access(output_name, os.X_OK):
+            os.chmod(
+                output_name,
+                os.stat(output_name).st_mode
+                | stat.S_IXUSR
+                | stat.S_IXGRP
+                | stat.S_IXOTH,
+            )
 
     def set_job_defaults(self, batch_jobs, case):
         if self._batchtype is None:


### PR DESCRIPTION
Linux won't let you chmod files you don't own, so the old impl can cause permissions problems when sharing cases.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
