### PR TITLE
Add timing to git

### DIFF
--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -565,7 +565,7 @@ def case_setup(self, clean=False, test_mode=False, reset=False, keep=None):
             caseroot=caseroot,
             is_batch=is_batch,
         )
-    self._create_case_repo(caseroot)
+        self._create_case_repo(caseroot)
 
 
 def _create_case_repo(self, caseroot):

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -565,7 +565,7 @@ def case_setup(self, clean=False, test_mode=False, reset=False, keep=None):
             caseroot=caseroot,
             is_batch=is_batch,
         )
-        self._create_case_repo(caseroot)
+    self._create_case_repo(caseroot)
 
 
 def _create_case_repo(self, caseroot):

--- a/CIME/get_timing.py
+++ b/CIME/get_timing.py
@@ -934,6 +934,6 @@ def get_timing(case, lid):
     append_case_status(
         "",
         "",
-        msg="Timing files created for run at {}".format(lid),
+        msg="Timing files created for run {}".format(lid),
         gitinterface=case._gitinterface,
     )

--- a/CIME/get_timing.py
+++ b/CIME/get_timing.py
@@ -7,6 +7,7 @@ information from a run.
 
 from CIME.XML.standard_module_setup import *
 from CIME.utils import safe_copy
+from CIME.status import append_case_status
 
 import datetime, re
 
@@ -928,3 +929,11 @@ class _TimingParser:
 def get_timing(case, lid):
     parser = _TimingParser(case, lid)
     parser.getTiming()
+    if case._gitinterface:
+        case._gitinterface._git_command("add", "*." + lid)
+    append_case_status(
+        "",
+        "",
+        msg="Timing files created for run at {}".format(lid),
+        gitinterface=case._gitinterface,
+    )


### PR DESCRIPTION
Add the timing files to the case git repository.  

Test suite: tested on derecho using ./create_newcase --case foo --compset A --res f19_g17  --run-unsupported and DOUT_S=FALSE

Also updates cprnc with a minor CMakeLists.txt change

Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
