### PR TITLE
make sure file exists before assigning

### DIFF
--- a/CIME/case/case_run.py
+++ b/CIME/case/case_run.py
@@ -502,8 +502,9 @@ def case_run(self, skip_pnl=False, set_continue_run=False, submit_resubmits=Fals
         if drv_restart_pointer:
             pattern = os.path.join(rundir, "rpointer.cpl*")
             files = sorted(glob.glob(pattern), key=os.path.getmtime)
-            drv_ptr = os.path.basename(files[-1])
-            self.set_value("DRV_RESTART_POINTER", drv_ptr)
+            if files:
+                drv_ptr = os.path.basename(files[-1])
+                self.set_value("DRV_RESTART_POINTER", drv_ptr)
         model_log(
             "e3sm",
             logger,

--- a/CIME/wait_for_tests.py
+++ b/CIME/wait_for_tests.py
@@ -3,7 +3,6 @@ import queue
 import os, time, threading, socket, signal, shutil, glob
 
 # pylint: disable=import-error
-from distutils.spawn import find_executable
 import logging
 import xml.etree.ElementTree as xmlet
 
@@ -516,7 +515,7 @@ CurlOptions: CURLOPT_SSL_VERIFYPEER_OFF;CURLOPT_SSL_VERIFYHOST_OFF
             hostname,
             cdash_build_name,
             cdash_project,
-            find_executable("scp"),
+            shutil.which("scp"),
             cdash_timestamp,
             drop_method,
         )


### PR DESCRIPTION
In some cases no drv rpointer file exists, in this case do not attempt to assign variable DRV_RESTART_POINTER

Test suite: SMS_D_Ld2.f19_f19_mg17.QPC5HIST.derecho_intel.cam-volc_usecase
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
