### PR TITLE
docker is not a machine, ubuntu_latest is

### DIFF
--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -1583,7 +1583,7 @@ def get_charge_account(machobj=None, project=None):
 
     >>> import CIME
     >>> import CIME.XML.machines
-    >>> machobj = CIME.XML.machines.Machines(machine="docker")
+    >>> machobj = CIME.XML.machines.Machines(machine="ubuntu-latest")
     >>> project = get_project(machobj)
     >>> charge_account = get_charge_account(machobj, project)
     >>> project == charge_account


### PR DESCRIPTION
Machine docker only works for github testing since no machine docker is defined in cesm.

Test suite: scripts_regression_test
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
