### PR TITLE
correct rpointer name in resubmit

### DIFF
--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -64,9 +64,11 @@ def _submit(
         )
         # only checks for the first instance in a multidriver case
         if case.get_value("COMP_INTERFACE") == "nuopc":
-            rpointer = "rpointer.cpl"
-            if case.get_value("NINST") > 1:
-                rpointer = rpointer + "_0001"
+            rpointer = self.get_value("DRV_RESTART_POINTER")
+            if not rpointer:
+                rpointer = "rpointer.cpl"
+                if case.get_value("NINST") > 1:
+                    rpointer = rpointer + "_0001"
         else:
             rpointer = "rpointer.drv"
             if case.get_value("MULTI_DRIVER"):

--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -64,7 +64,7 @@ def _submit(
         )
         # only checks for the first instance in a multidriver case
         if case.get_value("COMP_INTERFACE") == "nuopc":
-            rpointer = self.get_value("DRV_RESTART_POINTER")
+            rpointer = case.get_value("DRV_RESTART_POINTER")
             if not rpointer:
                 rpointer = "rpointer.cpl"
                 if case.get_value("NINST") > 1:


### PR DESCRIPTION
For CONTINUE_RUN need to update the name of the rpointer file. 

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
