### PR TITLE
add try except clauses to reduce errors in testing

### DIFF
--- a/CIME/case/case_run.py
+++ b/CIME/case/case_run.py
@@ -499,7 +499,7 @@ def case_run(self, skip_pnl=False, set_continue_run=False, submit_resubmits=Fals
 
         # get the most recent cpl restart pointer file
         rundir = self.get_value("RUNDIR")
-        if drv_restart_pointer:
+        if drv_restart_pointer and not self._read_only_mode:
             pattern = os.path.join(rundir, "rpointer.cpl*")
             files = sorted(glob.glob(pattern), key=os.path.getmtime)
             if files:

--- a/CIME/status.py
+++ b/CIME/status.py
@@ -54,9 +54,15 @@ def append_case_status(phase, status, msg=None, caseroot=".", gitinterface=None)
                 logger.debug("adding file {}".format(f))
                 gitinterface.git_operation("add", f)
         msg = msg if msg else " no message provided"
-        gitinterface.git_operation("commit", "-m", '"' + msg + '"')
+        push = True
+        try:
+            gitinterface.git_operation("commit", "-m", '"' + msg + '"')
+        except Exception as e:
+            print(e)
+            push = False
+
         remote = gitinterface.git_operation("remote")
-        if remote:
+        if remote and push:
             with Timeout(30):
                 gitinterface.git_operation("push", remote)
 


### PR DESCRIPTION
Avoid errors by not attempting to change read only case and using try except on git commit so that if there is nothing to commit no error is issued.  Fixes CTSM SSP tests.

Test suite: SSP_Ld4.f09_g17.I1850Clm50BgcCrop.derecho_intel.clm-ciso_rtmColdSSP
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
