### PR TITLE
fix an eronious message from cprnc

### DIFF
--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -759,6 +759,9 @@ def get_ts_synopsis(comments):
     if comments == "" or "\n" not in comments:
         return comments
 
+    if comments.endswith("PASS"):
+        return ""
+
     # Empty synopsis when files are identicial
     if re.search(IDENTICAL, comments) is not None:
         return ""


### PR DESCRIPTION
In some cases baseline cprnc comparisons were resulting in 
ERROR Could not interpret CPRNC output and PASS at the same time.  
This PR corrects the behavior. 

Test suite:SMS_D_Ln9.f19_f19_mg17.QPC5M7.derecho_intel.cam-outfrq9s with --compare
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
