### PR TITLE
Some updates for E3SM

### DIFF
--- a/CIME/Tools/bless_test_results
+++ b/CIME/Tools/bless_test_results
@@ -69,6 +69,13 @@ OR
         "This option forces the bless to happen regardless.",
     )
 
+    parser.add_argument(
+        "-l",
+        "--lock-baselines",
+        action="store_true",
+        help="Turn off group write access for baselines",
+    )
+
     mutual_execution = parser.add_mutually_exclusive_group()
 
     mutual_execution.add_argument(

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -208,6 +208,7 @@ def bless_test_results(
     pes_file=None,
     bless_tests=None,
     no_skip_pass=False,
+    lock_baselines=False,
     new_test_root=None,
     new_test_id=None,
     exclude=None,
@@ -441,6 +442,21 @@ def bless_test_results(
 
                     if not success:
                         broken_blesses.append((test_name, reason))
+
+                if lock_baselines:
+                    baseline_full_dir = os.path.join(
+                        baseline_root_resolved,
+                        baseline_name_resolved,
+                        case.get_value("CASEBASEID"),
+                    )
+                    stat, out, _ = run_cmd(
+                        f"chmod -R g-w {baseline_full_dir}", combine_output=True
+                    )
+                    if stat != 0:
+                        msg = (
+                            f"Failed to lock baselines for {baseline_full_dir}:\n{out}"
+                        )
+                        logger.warning(msg)
 
     # Emit a warning if items in bless_tests did not match anything
     if bless_tests:

--- a/CIME/jenkins_generic_job.py
+++ b/CIME/jenkins_generic_job.py
@@ -432,12 +432,13 @@ def jenkins_generic_job(
         update_success=update_success,
     )
 
-    logging.info("TEST ARCHIVER: Waiting for archiver thread")
-    archiver_thread.join()
-    logging.info("TEST ARCHIVER: Waiting for archiver finished")
-
     if use_batch and CIME.wait_for_tests.SIGNAL_RECEIVED:
         # Cleanup
         cleanup_queue(test_root, test_id)
+
+    if not CIME.wait_for_tests.SIGNAL_RECEIVED:
+        logging.info("TEST ARCHIVER: Waiting for archiver thread")
+        archiver_thread.join()
+        logging.info("TEST ARCHIVER: Waiting for archiver finished")
 
     return tests_passed

--- a/CIME/wait_for_tests.py
+++ b/CIME/wait_for_tests.py
@@ -21,6 +21,7 @@ SLEEP_INTERVAL_SEC = 0.1
 ###############################################################################
 def signal_handler(*_):
     ###############################################################################
+    logging.warning("RECEIVED SIGNAL!")
     global SIGNAL_RECEIVED
     SIGNAL_RECEIVED = True
 


### PR DESCRIPTION
jenkins: Canceling batch jobs needs to happen immediately when a signal occurs.
bless_test_results: Add option to lock baselines (remove group write)

Test suite: by hand
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
