### PR TITLE
ERS: ninst might be None

### DIFF
--- a/CIME/SystemTests/ers.py
+++ b/CIME/SystemTests/ers.py
@@ -38,7 +38,7 @@ class ERS(SystemTestsCommon):
             )
         ninst = self._case.get_value("NINST")
         drvrest = "rpointer.cpl"
-        if ninst > 1:
+        if ninst is not None and ninst > 1:
             drvrest += "_0001"
         drvrest += self._rest_time
 


### PR DESCRIPTION
The CIME update broke all E3SM ERS tests. This PR fixes them.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
