### PR TITLE
Allow skipping tests that have a baseline already

### DIFF
--- a/CIME/Tools/component_generate_baseline
+++ b/CIME/Tools/component_generate_baseline
@@ -44,20 +44,28 @@ OR
         "existing baseline directories to be silently overwritten.",
     )
 
+    parser.add_argument(
+        "--allow-baseline-skip",
+        action="store_true",
+        help="By default an attempt to overwrite an existing baseline directory "
+        "will raise an error. Specifying this option allows tests with "
+        "existing baseline directories to be silently skipped.",
+    )
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
-    return args.caseroot, args.baseline_dir, args.allow_baseline_overwrite
+    return args.caseroot, args.baseline_dir, args.allow_baseline_overwrite, args.allow_baseline_skip
 
 
 ###############################################################################
 def _main_func(description):
     ###############################################################################
-    caseroot, baseline_dir, allow_baseline_overwrite = parse_command_line(
+    caseroot, baseline_dir, allow_baseline_overwrite, allow_baseline_skip = parse_command_line(
         sys.argv, description
     )
     with Case(caseroot) as case:
         success, comments = generate_baseline(
-            case, baseline_dir, allow_baseline_overwrite
+            case, baseline_dir, allow_baseline_overwrite, allow_baseline_skip
         )
         print(comments)
 

--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -635,7 +635,7 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
 
     if os.path.isdir(os.path.join(basegen_dir, testcase)):
         if allow_baseline_skip:
-            return False, " Skipping"
+            return True, " Skipping"
         if not allow_baseline_overwrite:
             expect(False, " Cowardly refusing to overwrite existing baseline directory")
 

--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -609,13 +609,14 @@ def generate_teststatus(testdir, baseline_dir):
         )
 
 
-def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=False):
+def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=False, allow_baseline_skip=False):
     """
     copy the current test output to baseline result
 
     case - The case containing the hist files to be copied into baselines
     baseline_dir - Optionally, specify a specific baseline dir, otherwise it will be computed from case config
-    allow_baseline_overwrite must be true to generate baselines to an existing directory.
+    allow_baseline_overwrite must be true to generate baselines to an existing directory. allow_baseline_skip
+    will result in tests with existing baselines being skipped
 
     returns (SUCCESS, comments)
     """
@@ -632,11 +633,11 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
     if not os.path.isdir(basegen_dir):
         os.makedirs(basegen_dir)
 
-    if (
-        os.path.isdir(os.path.join(basegen_dir, testcase))
-        and not allow_baseline_overwrite
-    ):
-        expect(False, " Cowardly refusing to overwrite existing baseline directory")
+    if os.path.isdir(os.path.join(basegen_dir, testcase)):
+        if allow_baseline_skip:
+            return False, " Skipping"
+        if not allow_baseline_overwrite:
+            expect(False, " Cowardly refusing to overwrite existing baseline directory")
 
     comments = "Generating baselines into '{}'\n".format(basegen_dir)
     num_gen = 0
@@ -710,12 +711,13 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
     return True, comments
 
 
-def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False):
+def generate_baseline(case, baseline_dir=None, allow_baseline_overwrite=False, allow_baseline_skip=False):
     with SharedArea():
         return _generate_baseline_impl(
             case,
             baseline_dir=baseline_dir,
             allow_baseline_overwrite=allow_baseline_overwrite,
+            allow_baseline_skip=allow_baseline_skip,
         )
 
 

--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -635,7 +635,7 @@ def _generate_baseline_impl(case, baseline_dir=None, allow_baseline_overwrite=Fa
 
     if os.path.isdir(os.path.join(basegen_dir, testcase)):
         if allow_baseline_skip:
-            return True, " Skipping"
+            return False, " Skipping"
         if not allow_baseline_overwrite:
             expect(False, " Cowardly refusing to overwrite existing baseline directory")
 

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -351,6 +351,10 @@ def parse_command_line(args, description):
         config, "ALLOW_BASELINE_OVERWRITE", False, check_main=False
     )
 
+    default = get_default_setting(
+        config, "ALLOW_BASELINE_SKIP", False, check_main=False
+    )
+
     parser.add_argument(
         "-o",
         "--allow-baseline-overwrite",
@@ -359,6 +363,15 @@ def parse_command_line(args, description):
         help="If the --generate option is given, then an attempt to overwrite "
         "\nan existing baseline directory will raise an error. WARNING: Specifying this "
         "\noption will allow existing baseline directories to be silently overwritten.",
+    )
+
+    parser.add_argument(
+        "--allow-baseline-skip",
+        action="store_true",
+        default=default,
+        help="If the --generate option is given, then an attempt to overwrite "
+        "\nan existing baseline directory will raise an error. WARNING: Specifying this "
+        "\noption will allow tests with existing baseline directories to be silently skipped.",
     )
 
     default = get_default_setting(config, "WAIT", False, check_main=False)
@@ -502,6 +515,12 @@ def parse_command_line(args, description):
             args.use_existing and args.test_id,
             "Cannot force a rebuild without 'use-existing' and 'test-id'",
         )
+
+    # baseline overwrite and skip can't be simultaneously specified
+    expect(
+        not (args.allow_baseline_overwrite and args.allow_baseline_skip),
+        "Cannot skip and overwrite baselines at the same time",
+    )
 
     # generate and compare flags may not point to the same directory
     if model_config.create_test_flag_mode == "cesm":
@@ -759,6 +778,7 @@ def parse_command_line(args, description):
         args.save_timing,
         args.queue,
         args.allow_baseline_overwrite,
+        args.allow_baseline_skip,
         args.output_root,
         args.wait,
         args.force_procs,
@@ -921,6 +941,7 @@ def create_test(
     save_timing,
     queue,
     allow_baseline_overwrite,
+    allow_baseline_skip,
     output_root,
     wait,
     force_procs,
@@ -969,6 +990,7 @@ def create_test(
         save_timing=save_timing,
         queue=queue,
         allow_baseline_overwrite=allow_baseline_overwrite,
+        allow_baseline_skip=allow_baseline_skip,
         output_root=output_root,
         force_procs=force_procs,
         force_threads=force_threads,
@@ -1068,6 +1090,7 @@ def _main_func(description=None):
         save_timing,
         queue,
         allow_baseline_overwrite,
+        allow_baseline_skip,
         output_root,
         wait,
         force_procs,
@@ -1122,6 +1145,7 @@ def _main_func(description=None):
             save_timing,
             queue,
             allow_baseline_overwrite,
+            allow_baseline_skip,
             output_root,
             wait,
             force_procs,

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -196,6 +196,7 @@ class TestScheduler(object):
         save_timing=False,
         queue=None,
         allow_baseline_overwrite=False,
+        allow_baseline_skip=False,
         output_root=None,
         force_procs=None,
         force_threads=None,
@@ -227,6 +228,7 @@ class TestScheduler(object):
         self._input_dir = input_dir
         self._pesfile = pesfile
         self._allow_baseline_overwrite = allow_baseline_overwrite
+        self._allow_baseline_skip = allow_baseline_skip
         self._single_exe = single_exe
         if self._single_exe:
             self._allow_pnl = True
@@ -358,9 +360,9 @@ class TestScheduler(object):
                             else:
                                 clear_folder(test_baseline)
                 expect(
-                    allow_baseline_overwrite or len(existing_baselines) == 0,
+                    allow_baseline_overwrite or len(existing_baselines) == 0 or allow_baseline_skip,
                     "Baseline directories already exists {}\n"
-                    "Use -o to avoid this error".format(existing_baselines),
+                    "Use -o or --allow-baseline-skip to avoid this error".format(existing_baselines),
                 )
 
         if self._config.sort_tests:

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -359,6 +359,9 @@ class TestScheduler(object):
                                 clear_folder(os.path.join(test_baseline, "CaseDocs"))
                             else:
                                 clear_folder(test_baseline)
+                print(f"allow_baseline_overwrite: {allow_baseline_overwrite}")
+                print(f"len(existing_baselines): {len(existing_baselines)}")
+                print(f"allow_baseline_skip: {allow_baseline_skip}")
                 expect(
                     allow_baseline_overwrite or len(existing_baselines) == 0 or allow_baseline_skip,
                     "Baseline directories already exists {}\n"

--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -260,6 +260,7 @@ def _read_cime_config_file():
         "walltime",
         "job_queue",
         "allow_baseline_overwrite",
+        "allow_baseline_skip",
         "wait",
         "force_procs",
         "force_threads",


### PR DESCRIPTION
Adds `--allow-baseline-skip` (after `--allow-baseline-overwrite`) that skips any tests with a baseline already.

Based on `cime6.1.59` and includes some diagnostic printouts. If this idea is acceptable, I will rebase to the latest CIME and remove the diagnostic printouts.

I've tested only as part of our CTSM testing.