### PR TITLE
Fix so that the "rel:<namelist_var>" option can be used for input_pathname in namelist definition files

### DIFF
--- a/CIME/data/config/xml_schemas/entry_id_namelist.xsd
+++ b/CIME/data/config/xml_schemas/entry_id_namelist.xsd
@@ -9,7 +9,8 @@
 
   <!-- simple elements -->
   <xs:element name="type" type="xs:string"/>
-  <xs:element name="input_pathname" type="xs:NCName"/>
+  <!-- NOTE: input_pathname needs to be a type that allows colons (NCName used elsewhere explicitly does NOT) -->
+  <xs:element name="input_pathname" type="xs:Name"/>
   <xs:element name="group" type="xs:NCName"/>
   <xs:element name="file" type="xs:NCName"/>
 


### PR DESCRIPTION
Fix the relative path option for input_pathname in namelist definition files. This now allows using a "rel:" prefix for it.
The usage is to use that prefix in front of a namelist variable name that will be used as the relative path for the pathname of the file. 

So for example (if rundir is added to the namelist definiton file to be from the XML variable RUNDIR), you can do something like:

```
<input_pathname>rel:rundir</input_pathname>

```

Which will then prepend the filename for that variable with the RUNDIR directory, and also add it to the relevant <component>.input_data_list file so that filename will be checked for existence.

Test suite: So far only tested a single case with a CMEPS PR that includes a namelist item with a rel: option for input_pathname
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes #4738
User interface changes?: No

Update gh-pages html (Y/N)?: No
