### PR TITLE
Create env_postprocessing.xml in case root

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Cache inputdata
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /storage/inputdata
           key: inputdata-2

--- a/CIME/XML/env_postprocessing.py
+++ b/CIME/XML/env_postprocessing.py
@@ -6,7 +6,6 @@ from CIME.XML.standard_module_setup import *
 from CIME.XML.env_base import EnvBase
 
 from CIME import utils
-from CIME.utils import convert_to_type
 
 logger = logging.getLogger(__name__)
 

--- a/CIME/XML/env_postprocessing.py
+++ b/CIME/XML/env_postprocessing.py
@@ -1,0 +1,23 @@
+"""
+Interface to the env_postprocessing.xml file.  This class inherits from EnvBase
+"""
+from CIME.XML.standard_module_setup import *
+
+from CIME.XML.env_base import EnvBase
+
+from CIME import utils
+from CIME.utils import convert_to_type
+
+logger = logging.getLogger(__name__)
+
+
+class EnvPostprocessing(EnvBase):
+    def __init__(
+        self, case_root=None, infile="env_postprocessing.xml", read_only=False
+    ):
+        """
+        initialize an object interface to file env_postprocessing.xml in the case directory
+        """
+        schema = os.path.join(utils.get_schema_path(), "env_entry_id.xsd")
+
+        EnvBase.__init__(self, case_root, infile, schema=schema, read_only=read_only)

--- a/CIME/XML/postprocessing.py
+++ b/CIME/XML/postprocessing.py
@@ -19,7 +19,10 @@ class Postprocessing(EntryID):
             files = Files()
         if infile is None:
             infile = files.get_value("POSTPROCESSING_SPEC_FILE")
-        self.file_exists = os.path.isfile(infile)
+        if infile is not None:
+            self.file_exists = os.path.isfile(infile)
+        else:
+            self.file_exists = False
         if not self.file_exists:
             return
         expect(infile, "No postprocessing file defined in {}".format(files.filename))

--- a/CIME/XML/postprocessing.py
+++ b/CIME/XML/postprocessing.py
@@ -19,6 +19,9 @@ class Postprocessing(EntryID):
             files = Files()
         if infile is None:
             infile = files.get_value("POSTPROCESSING_SPEC_FILE")
+        self._file_exists = os.path.isfile(infile)
+        if not self._file_exists:
+            return
         expect(infile, "No postprocessing file defined in {}".format(files.filename))
 
         schema = files.get_schema("POSTPROCESSING_SPEC_FILE")
@@ -27,6 +30,8 @@ class Postprocessing(EntryID):
 
         # Append the contents of $HOME/.cime/config_postprocessing.xml if it exists
         # This could cause problems if node matchs are repeated when only one is expected
-        infile = os.path.join(os.environ.get("HOME"), ".cime", "config_postprocessing.xml")
+        infile = os.path.join(
+            os.environ.get("HOME"), ".cime", "config_postprocessing.xml"
+        )
         if os.path.exists(infile):
             EntryID.read(self, infile)

--- a/CIME/XML/postprocessing.py
+++ b/CIME/XML/postprocessing.py
@@ -1,0 +1,32 @@
+"""
+Interface to the config_postprocessing.xml file.  This class inherits from EntryID
+"""
+
+from CIME.XML.standard_module_setup import *
+from CIME.XML.entry_id import EntryID
+from CIME.XML.files import Files
+from CIME.utils import expect
+
+logger = logging.getLogger(__name__)
+
+
+class Postprocessing(EntryID):
+    def __init__(self, infile=None, files=None):
+        """
+        initialize an object
+        """
+        if files is None:
+            files = Files()
+        if infile is None:
+            infile = files.get_value("POSTPROCESSING_SPEC_FILE")
+        expect(infile, "No postprocessing file defined in {}".format(files.filename))
+
+        schema = files.get_schema("POSTPROCESSING_SPEC_FILE")
+
+        EntryID.__init__(self, infile, schema=schema)
+
+        # Append the contents of $HOME/.cime/config_postprocessing.xml if it exists
+        # This could cause problems if node matchs are repeated when only one is expected
+        infile = os.path.join(os.environ.get("HOME"), ".cime", "config_postprocessing.xml")
+        if os.path.exists(infile):
+            EntryID.read(self, infile)

--- a/CIME/XML/postprocessing.py
+++ b/CIME/XML/postprocessing.py
@@ -19,8 +19,8 @@ class Postprocessing(EntryID):
             files = Files()
         if infile is None:
             infile = files.get_value("POSTPROCESSING_SPEC_FILE")
-        self._file_exists = os.path.isfile(infile)
-        if not self._file_exists:
+        self.file_exists = os.path.isfile(infile)
+        if not self.file_exists:
             return
         expect(infile, "No postprocessing file defined in {}".format(files.filename))
 

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -435,6 +435,14 @@ class Case(object):
             # do not flush if caseroot wasnt created
             return
 
+        if not os.path.isfile(self.get_value('POSTPROCESSING_SPEC_FILE')):
+            # Remove env_postprocessing.xml from self._files
+            self._files = [
+                file
+                for file in self._files
+                if file.get_id() != "env_postprocessing.xml"
+            ]
+
         for env_file in self._files:
             env_file.write(force_write=flushall)
 
@@ -1586,13 +1594,6 @@ class Case(object):
         if postprocessing._file_exists:
             env_postprocessing = self.get_env("postprocessing")
             env_postprocessing.add_elements_by_group(srcobj=postprocessing)
-        else:
-            # if env_postprocessing does not exist, remove from self._files
-            self._files = [
-                file
-                for file in self._files
-                if file.get_id() != "env_postprocessing.xml"
-            ]
 
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
 

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -29,6 +29,7 @@ from CIME.XML.compsets import Compsets
 from CIME.XML.grids import Grids
 from CIME.XML.batch import Batch
 from CIME.XML.workflow import Workflow
+from CIME.XML.postprocessing import Postprocessing
 from CIME.XML.pio import PIO
 from CIME.XML.archive import Archive
 from CIME.XML.env_test import EnvTest
@@ -40,6 +41,7 @@ from CIME.XML.env_run import EnvRun
 from CIME.XML.env_archive import EnvArchive
 from CIME.XML.env_batch import EnvBatch
 from CIME.XML.env_workflow import EnvWorkflow
+from CIME.XML.env_postprocessing import EnvPostprocessing
 from CIME.XML.generic_xml import GenericXML
 from CIME.user_mod_support import apply_user_mods
 from CIME.aprun import get_aprun_cmd_for_case
@@ -355,6 +357,9 @@ class Case(object):
         )
         self._env_entryid_files.append(
             EnvWorkflow(self._caseroot, read_only=self._force_read_only)
+        )
+        self._env_entryid_files.append(
+            EnvPostprocessing(self._caseroot, read_only=self._force_read_only)
         )
 
         if os.path.isfile(os.path.join(self._caseroot, "env_test.xml")):
@@ -1577,6 +1582,10 @@ class Case(object):
 
         workflow = Workflow(files=files)
 
+        env_postprocessing = self.get_env("postprocessing")
+        postprocessing = Postprocessing(files=files)
+        env_postprocessing.add_elements_by_group(srcobj=postprocessing)
+
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
 
         bjobs = workflow.get_workflow_jobs(machine=machine_name, workflowid=workflowid)
@@ -2216,6 +2225,8 @@ directory, NOT in this subdirectory."""
                     new_env_file = EnvBatch(infile=xmlfile)
                 elif ftype == "env_workflow.xml":
                     new_env_file = EnvWorkflow(infile=xmlfile)
+                elif ftype == "env_postprocessing.xml":
+                    new_env_file = EnvPostprocessing(infile=xmlfile)
                 elif ftype == "env_test.xml":
                     new_env_file = EnvTest(infile=xmlfile)
                 elif ftype == "env_archive.xml":

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -437,7 +437,12 @@ class Case(object):
             # do not flush if caseroot wasnt created
             return
 
-        if not os.path.isfile(self.get_value("POSTPROCESSING_SPEC_FILE")):
+        _postprocessing_spec_file = self.get_value("POSTPROCESSING_SPEC_FILE")
+        if _postprocessing_spec_file is not None:
+            have_postprocessing = os.path.isfile(_postprocessing_spec_file)
+        else:
+            have_postprocessing = False
+        if not have_postprocessing:
             # Remove env_postprocessing.xml from self._files
             self._files = [
                 file

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -435,7 +435,7 @@ class Case(object):
             # do not flush if caseroot wasnt created
             return
 
-        if not os.path.isfile(self.get_value('POSTPROCESSING_SPEC_FILE')):
+        if not os.path.isfile(self.get_value("POSTPROCESSING_SPEC_FILE")):
             # Remove env_postprocessing.xml from self._files
             self._files = [
                 file

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1586,6 +1586,13 @@ class Case(object):
         if postprocessing._file_exists:
             env_postprocessing = self.get_env("postprocessing")
             env_postprocessing.add_elements_by_group(srcobj=postprocessing)
+        else:
+            # if env_postprocessing does not exist, remove from self._files
+            self._files = [
+                file
+                for file in self._files
+                if file.get_id() != "env_postprocessing.xml"
+            ]
 
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
 

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1582,9 +1582,10 @@ class Case(object):
 
         workflow = Workflow(files=files)
 
-        env_postprocessing = self.get_env("postprocessing")
         postprocessing = Postprocessing(files=files)
-        env_postprocessing.add_elements_by_group(srcobj=postprocessing)
+        if postprocessing._file_exists:
+            env_postprocessing = self.get_env("postprocessing")
+            env_postprocessing.add_elements_by_group(srcobj=postprocessing)
 
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
 

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -111,6 +111,7 @@ class Case(object):
                 case_root
             ),
         )
+        self._existing_case = os.path.isdir(case_root)
 
         self._caseroot = case_root
         logger.debug("Initializing Case.")
@@ -358,9 +359,10 @@ class Case(object):
         self._env_entryid_files.append(
             EnvWorkflow(self._caseroot, read_only=self._force_read_only)
         )
-        self._env_entryid_files.append(
-            EnvPostprocessing(self._caseroot, read_only=self._force_read_only)
-        )
+        if not self._existing_case or os.path.isfile("env_postprocessing.xml"):
+            self._env_entryid_files.append(
+                EnvPostprocessing(self._caseroot, read_only=self._force_read_only)
+            )
 
         if os.path.isfile(os.path.join(self._caseroot, "env_test.xml")):
             self._env_entryid_files.append(
@@ -1591,7 +1593,7 @@ class Case(object):
         workflow = Workflow(files=files)
 
         postprocessing = Postprocessing(files=files)
-        if postprocessing._file_exists:
+        if postprocessing.file_exists:
             env_postprocessing = self.get_env("postprocessing")
             env_postprocessing.add_elements_by_group(srcobj=postprocessing)
 

--- a/CIME/data/config/cesm/config_files.xml
+++ b/CIME/data/config/cesm/config_files.xml
@@ -55,6 +55,15 @@
     <schema>$CIMEROOT/CIME/data/config/xml_schemas/config_batch.xsd</schema>
   </entry>
 
+  <entry id="POSTPROCESSING_SPEC_FILE">
+    <type>char</type>
+    <default_value>$SRCROOT/tools/CUPiD/cime_config/config_tool.xml</default_value>
+    <group>case_last</group>
+    <file>env_case.xml</file>
+    <desc>file containing postprocessing XML configuration (for documentation only - DO NOT EDIT)</desc>
+    <schema>$CIMEROOT/CIME/data/config/xml_schemas/entry_id.xsd</schema>
+  </entry>
+
   <entry id="WORKFLOW_SPEC_FILE">
     <type>char</type>
     <default_value>$SRCROOT/ccs_config/machines/config_workflow.xml</default_value>

--- a/CIME/data/config/config_headers.xml
+++ b/CIME/data/config/config_headers.xml
@@ -17,6 +17,13 @@
     </header>
   </file>
 
+  <file name="env_postprocessing.xml">
+    <header>
+      These variables may be changed anytime during a run, they
+      control jobs that are dependent on case.run.
+    </header>
+  </file>
+
   <file name="env_case.xml">
     <header>
     These variables CANNOT BE CHANGED once a case has been created.


### PR DESCRIPTION
The contents of this new file are based on a config file in CUPiD (cime_config/config_tool.xml) that is comparable to a component's config_component.xml file

I will mark this as ready for review after I've had a chance to run test suites and fix any issues raised by those tests. For example, if there is no `tools/CUPiD/cime_config/config_tool.xml` then it raises the following error:

```
ERROR: Makes no sense to have empty read-only file: /glade/work/mlevy/codes/CESM/cesm3_0_alpha05d/tools/CUPiD/cime_config/config_tool.xml
```

[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
