### PR TITLE
ERS fix for buildnml/skip_pnl

### DIFF
--- a/CIME/SystemTests/ers.py
+++ b/CIME/SystemTests/ers.py
@@ -17,6 +17,9 @@ class ERS(SystemTestsCommon):
 
     def _ers_first_phase(self):
         self._rest_n = self._set_restart_interval()
+        # set_restart_interval can change case settings that buildnmls may depend on
+        # so ensure buildnmls will not be skipped during case_run
+        self._skip_pnl = False
         self.run_indv()
 
     def _ers_second_phase(self):


### PR DESCRIPTION
Another fix for E3SM. set_restart_interval makes changes to case settings (REST_N) that some of our components' (eamxx) buildnmls depend on. The default for all tests is to skip the first buildnml, so we must explicitly tell ERS not to do that.

Test suite: by hand
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
