### PR TITLE
add a command line option to case.setup --disable-git

### DIFF
--- a/CIME/Tools/case.setup
+++ b/CIME/Tools/case.setup
@@ -73,6 +73,12 @@ def parse_command_line(args, description):
     )
 
     parser.add_argument(
+        "--disable-git",
+        action="store_true",
+        help="Disable the interface to git, this will result in reduced provenance for your case.",
+    )
+
+    parser.add_argument(
         "-N",
         "--non-local",
         action="store_true",
@@ -88,6 +94,7 @@ def parse_command_line(args, description):
         args.test_mode,
         args.reset,
         args.keep,
+        args.disable_git,
         args.non_local,
     )
 
@@ -95,11 +102,23 @@ def parse_command_line(args, description):
 ###############################################################################
 def _main_func(description):
     ###############################################################################
-    caseroot, clean, test_mode, reset, keep, non_local = parse_command_line(
-        sys.argv, description
-    )
+    (
+        caseroot,
+        clean,
+        test_mode,
+        reset,
+        keep,
+        disable_git,
+        non_local,
+    ) = parse_command_line(sys.argv, description)
     with Case(caseroot, read_only=False, record=True, non_local=non_local) as case:
-        case.case_setup(clean=clean, test_mode=test_mode, reset=reset, keep=keep)
+        case.case_setup(
+            clean=clean,
+            test_mode=test_mode,
+            reset=reset,
+            keep=keep,
+            disable_git=disable_git,
+        )
 
 
 if __name__ == "__main__":

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -521,7 +521,9 @@ def _case_setup_impl(
 
 
 ###############################################################################
-def case_setup(self, clean=False, test_mode=False, reset=False, keep=None):
+def case_setup(
+    self, clean=False, test_mode=False, reset=False, keep=None, disable_git=False
+):
     ###############################################################################
     caseroot, casebaseid = self.get_value("CASEROOT"), self.get_value("CASEBASEID")
     phase = "setup.clean" if clean else "case.setup"
@@ -565,7 +567,8 @@ def case_setup(self, clean=False, test_mode=False, reset=False, keep=None):
             caseroot=caseroot,
             is_batch=is_batch,
         )
-        self._create_case_repo(caseroot)
+        if not disable_git and not reset:
+            self._create_case_repo(caseroot)
 
 
 def _create_case_repo(self, caseroot):


### PR DESCRIPTION
Add a command line option to case.setup --disable-git to disable the creation of a local git repository for the case.  

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
