### PR TITLE
Allow blessing if test only failed GENERATE

### DIFF
--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -513,7 +513,9 @@ def is_hist_bless_needed(
                 if phase_result is TEST_FAIL_STATUS:
                     only_failed_generate = False
                     break
-        if not only_failed_generate:
+        if only_failed_generate:
+            needed = True
+        else:
             broken_blesses.append((test_name, "test did not pass"))
             logger.warning(
                 "Test '{}' did not pass due to phase {}, not safe to bless, test status = {}".format(

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -504,6 +504,7 @@ def is_hist_bless_needed(
     elif overall_result == TEST_FAIL_STATUS:
         # Sometimes a test might fail only during the generate phase; e.g., if the user doesn't have
         # write permissions in the baseline directory. We still want to bless those tests.
+        only_failed_generate = False
         if ts.get_status(GENERATE_PHASE) == TEST_FAIL_STATUS:
             only_failed_generate = True
             for p in ALL_PHASES:

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -489,18 +489,6 @@ def is_hist_bless_needed(
 
     run_result = ts.get_status(RUN_PHASE)
 
-    # Sometimes a test might fail only during the generate phase; e.g., if the user doesn't have
-    # write permissions in the baseline directory. We still want to bless those tests.
-    if ts.get_status(GENERATE_PHASE) == TEST_FAIL_STATUS:
-        only_failed_generate = True
-        for p in ALL_PHASES:
-            if p == GENERATE_PHASE:
-                continue
-            phase_result = ts.get_status(p)
-            if phase_result is TEST_FAIL_STATUS:
-                only_failed_generate = False
-                break
-
     if run_result is None:
         broken_blesses.append((test_name, "no run phase"))
         logger.warning("Test '{}' did not make it to run phase".format(test_name))
@@ -513,14 +501,26 @@ def is_hist_bless_needed(
             )
         )
         needed = False
-    elif overall_result == TEST_FAIL_STATUS and not only_failed_generate:
-        broken_blesses.append((test_name, "test did not pass"))
-        logger.warning(
-            "Test '{}' did not pass due to phase {}, not safe to bless, test status = {}".format(
-                test_name, phase, ts.phase_statuses_dump()
+    elif overall_result == TEST_FAIL_STATUS:
+        # Sometimes a test might fail only during the generate phase; e.g., if the user doesn't have
+        # write permissions in the baseline directory. We still want to bless those tests.
+        if ts.get_status(GENERATE_PHASE) == TEST_FAIL_STATUS:
+            only_failed_generate = True
+            for p in ALL_PHASES:
+                if p == GENERATE_PHASE:
+                    continue
+                phase_result = ts.get_status(p)
+                if phase_result is TEST_FAIL_STATUS:
+                    only_failed_generate = False
+                    break
+        if not only_failed_generate:
+            broken_blesses.append((test_name, "test did not pass"))
+            logger.warning(
+                "Test '{}' did not pass due to phase {}, not safe to bless, test status = {}".format(
+                    test_name, phase, ts.phase_statuses_dump()
+                )
             )
-        )
-        needed = False
+            needed = False
 
     elif no_skip_pass:
         needed = True

--- a/CIME/tests/test_unit_bless_test_results.py
+++ b/CIME/tests/test_unit_bless_test_results.py
@@ -12,7 +12,7 @@ from CIME.bless_test_results import (
     bless_namelists,
     is_hist_bless_needed,
 )
-from CIME.test_status import ALL_PHASES
+from CIME.test_status import ALL_PHASES, GENERATE_PHASE
 
 
 class TestUnitBlessTestResults(unittest.TestCase):
@@ -975,6 +975,27 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
         assert not needed
         assert broken_blesses == [("SMS.f19_g16.A", "test did not pass")]
+
+    def test_is_bless_needed_generate_fail(self):
+        ts = mock.MagicMock()
+
+        # First two get_status() calls in is_hist_bless_needed()
+        side_effect = [
+            "PASS",  # Check of RUN_PHASE at top of function
+            "FAIL",  # Check of GENERATE_PHASE
+        ]
+        # Checks in `for p in ALL_PHASES` loop
+        side_effect += ["PASS" for p in ALL_PHASES if p != GENERATE_PHASE]
+        # Save
+        ts.get_status.side_effect = side_effect
+
+        broken_blesses = []
+
+        needed = is_hist_bless_needed(
+            "SMS.f19_g16.A", ts, broken_blesses, "FAIL", False, "RUN"
+        )
+
+        assert needed
 
     def test_is_bless_needed_baseline_fail(self):
         ts = mock.MagicMock()

--- a/CIME/tests/test_unit_bless_test_results.py
+++ b/CIME/tests/test_unit_bless_test_results.py
@@ -960,9 +960,7 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
     def test_is_bless_needed_overall_fail(self):
         ts = mock.MagicMock()
-        ts.get_status.side_effect = [
-            "PASS", "FAIL"
-        ] + ["PASS"] * (len(ALL_PHASES) - 1)
+        ts.get_status.side_effect = ["PASS", "FAIL"] + ["PASS"] * (len(ALL_PHASES) - 1)
 
         broken_blesses = []
 

--- a/CIME/tests/test_unit_bless_test_results.py
+++ b/CIME/tests/test_unit_bless_test_results.py
@@ -12,6 +12,7 @@ from CIME.bless_test_results import (
     bless_namelists,
     is_hist_bless_needed,
 )
+from CIME.test_status import ALL_PHASES
 
 
 class TestUnitBlessTestResults(unittest.TestCase):
@@ -960,8 +961,8 @@ class TestUnitBlessTestResults(unittest.TestCase):
     def test_is_bless_needed_overall_fail(self):
         ts = mock.MagicMock()
         ts.get_status.side_effect = [
-            "PASS",
-        ]
+            "PASS", "FAIL"
+        ] + ["PASS"] * (len(ALL_PHASES) - 1)
 
         broken_blesses = []
 

--- a/CIME/tests/test_unit_bless_test_results.py
+++ b/CIME/tests/test_unit_bless_test_results.py
@@ -960,7 +960,12 @@ class TestUnitBlessTestResults(unittest.TestCase):
 
     def test_is_bless_needed_overall_fail(self):
         ts = mock.MagicMock()
-        ts.get_status.side_effect = ["PASS", "FAIL"] + ["PASS"] * (len(ALL_PHASES) - 1)
+
+        # get_status() calls in is_hist_bless_needed()
+        ts.get_status.side_effect = [
+            "PASS",  # Check of RUN_PHASE at top of function
+            "PASS",  # Check of GENERATE_PHASE
+        ]
 
         broken_blesses = []
 


### PR DESCRIPTION
Sometimes a test might fail only in the GENERATE step; for example, if the user doesn't have write permissions in the baseline directory. This PR makes it so that `bless_test_results` does try to bless things in such cases.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

**Fixes:** None

**User interface changes?:** No

**Update gh-pages html (Y/N)?:** No
