### PR TITLE
make compset names case insensitive but retain user prefered case

### DIFF
--- a/CIME/XML/compsets.py
+++ b/CIME/XML/compsets.py
@@ -33,7 +33,8 @@ class Compsets(GenericXML):
         for node in nodes:
             alias = self.get_element_text("alias", root=node)
             lname = self.get_element_text("lname", root=node)
-            if alias == name or lname == name:
+            # Users may include case for clarity, but comparisons are case insensitive.
+            if alias.upper() == name.upper() or lname.upper() == name.upper():
                 science_support_nodes = self.get_children("science_support", root=node)
                 for snode in science_support_nodes:
                     science_support.append(self.get(snode, "grid"))

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -994,7 +994,7 @@ class Case(object):
             if ":" in element:
                 element = element[4:]
             # ignore the possible BGC or TEST modifier
-            if element.startswith("BGC%") or element.startswith("TEST"):
+            if element.upper().startswith("BGC%") or element.upper().startswith("TEST"):
                 continue
             else:
                 element_component = element.split("%")[0].lower()


### PR DESCRIPTION
Compset names and Aliases can have mixed case but requiring mixed case may make things unnecessarily complicated.   This PR ignores case in performing comparisons of compsets but retains the users case preferences. 

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
