### PR TITLE
Fix ERR test for E3SM

### DIFF
--- a/CIME/SystemTests/err.py
+++ b/CIME/SystemTests/err.py
@@ -5,7 +5,7 @@ ERR tests short term archiving and restart capabilities
 import glob, os
 from CIME.XML.standard_module_setup import *
 from CIME.SystemTests.restart_tests import RestartTest
-from CIME.utils import safe_copy
+from CIME.utils import safe_copy, ls_sorted_by_mtime
 
 logger = logging.getLogger(__name__)
 
@@ -36,10 +36,20 @@ class ERR(RestartTest):
     def _case_two_custom_prerun_action(self):
         dout_s_root = self._case1.get_value("DOUT_S_ROOT")
         self._drv_restart_pointer = self._case2.get_value("DRV_RESTART_POINTER")
-        resttime = self._drv_restart_pointer[-16:]
-        rest_root = os.path.abspath(os.path.join(dout_s_root, "rest", resttime))
-        expect(os.path.isdir(rest_root), "None such directory {}".format(rest_root))
-        self._case.restore_from_archive(rest_dir=rest_root)
+        if self._drv_restart_pointer is None:
+            rest_root = os.path.abspath(os.path.join(dout_s_root, "rest"))
+            restart_list = ls_sorted_by_mtime(rest_root)
+            expect(
+                len(restart_list) >= 1, "No restart files found in {}".format(rest_root)
+            )
+            self._case.restore_from_archive(
+                rest_dir=os.path.join(rest_root, restart_list[0])
+            )
+        else:
+            resttime = self._drv_restart_pointer[-16:]
+            rest_root = os.path.abspath(os.path.join(dout_s_root, "rest", resttime))
+            expect(os.path.isdir(rest_root), "None such directory {}".format(rest_root))
+            self._case.restore_from_archive(rest_dir=rest_root)
 
     def _case_two_custom_postrun_action(self):
         # Link back to original case1 name


### PR DESCRIPTION
E3SM does not use DRV_RESTART_POINTER.

Test suite: by hand, ERR case
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
