### PR TITLE
Fix bless when cprnc file is not created

### DIFF
--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -496,6 +496,7 @@ def cprnc(
         cpr_stat, out, _ = run_cmd(
             "{} -m {} {}".format(cprnc_exe, file1, file2), combine_output=True
         )
+        output_filename = None
     else:
         # Remove existing output file if it exists
         if os.path.exists(output_filename):


### PR DESCRIPTION
`hist_utils._compare_hists` expects the `cprnc_log_file` to be None if the log file is not created and `success = False`

Currently results in the error when blessing MVKO test:

```
ERROR: Command: 
'/bin/cp -f /lcrc/group/e3sm2/e3smtest/scratch/chrys/MVKO_PS.T62_oQU240.GMPAS-NYF.chrysalis_intel.C.JNextNbfb20250317_010637/run/MVKO_PS.T62_oQU240.GMPAS-NYF.chrysalis_intel.C.JNextNbfb20250317_010637.cpl.hi.0003-01-01-00000.nc.cprnc.out /lcrc/group/e3sm2/e3smtest/scratch/chrys/J/MVKO_PS.T62_oQU240.GMPAS-NYF.chrysalis_intel.C.JNextNbfb20250317_010637/MVKO_PS.T62_oQU240.GMPAS-NYF.chrysalis_intel.C.JNextNbfb20250317_010637.cpl.hi.0003-01-01-00000.nc.cprnc.out' failed with error '/bin/cp: cannot stat '/lcrc/group/e3sm2/e3smtest/scratch/chrys/MVKO_PS.T62_oQU240.GMPAS-NYF.chrysalis_intel.C.JNextNbfb20250317_010637/run/MVKO_PS.T62_oQU240.GMPAS-NYF.chrysalis_intel.C.JNextNbfb20250317_010637.cpl.hi.0003-01-01-00000.nc.cprnc.out': No such file or directory' from dir '/gpfs/fs1/home/e3smtest/jenkins/workspace/ACME_chrysalis_bless/E3SM/cime'
```