### PR TITLE
redo REST_N calculation for IRT test

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -192,8 +192,10 @@ class SystemTestsCommon(object):
         else:
             expect(False, f"stop_option {stop_option} not available for this test")
         stop_n = int(stop_n * factor // coupling_secs)
-
-        rest_n = math.ceil((stop_n // 2 + 1) * coupling_secs / factor)
+        if self._case.get_value("TESTCASE") == "IRT":
+            rest_n = math.ceil((stop_n // 3) * coupling_secs / factor)
+        else:
+            rest_n = math.ceil((stop_n // 2 + 1) * coupling_secs / factor)
         expect(stop_n > 0, "Bad STOP_N: {:d}".format(stop_n))
         expect(stop_n > 2, "ERROR: stop_n value {:d} too short".format(stop_n))
         if not starttime:


### PR DESCRIPTION
The change to calculating REST_N in system_tests_common instead of hardcoding it in config_tests.xml messed up the IRT test but this was masked by the addition of the end of run restart in cesm.  This modification fixes the test for E3SM.

Test suite:IRT_C2_Ln9.f19_g16_rx1.A.derecho_intel
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes #

User interface changes?:

Update gh-pages html (Y/N)?:
