### PR TITLE
fix debug flags for intel compiler

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -731,6 +731,7 @@ CMAKE_ENV_VARS += CC=$(CC) \
 		  FC=$(FC) \
 		  LDFLAGS="$(LDFLAGS)"
 
+F90_LDFLAGS += $(FFLAGS)
 
 # We declare GLCMakefile to be a phony target so that cmake is
 # always rerun whenever invoking 'make GLCMakefile'; this is


### PR DESCRIPTION
The new ifx compiler from intel requires the flag -check uninit to be on the link line as well as the compile line, however adding the flag to LDFLAGS creates problems with autoconf and cmake in intermediate build steps.  Adding it here bypasses those intermediate steps and only uses it on the final link line.

Test suite: scripts_regression_tests.py
Test baseline:
Test namelist changes:
Test status: bit for bit
Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
