### PR TITLE
Ensure two related messages are printed together.

### DIFF
--- a/CIME/case/check_input_data.py
+++ b/CIME/case/check_input_data.py
@@ -482,16 +482,15 @@ def _check_input_data_impl(
                         # rel_path, and so cannot download the file. If it already exists, we can
                         # proceed
                         if not os.path.exists(full_path):
-                            print(
-                                "Model {} missing file {} = '{}'".format(
-                                    model, description, full_path
-                                )
+                            msg = "Model {} missing file {} = '{}'".format(
+                                model, description, full_path
                             )
                             # Data download path must be DIN_LOC_ROOT, DIN_LOC_IC or RUNDIR
 
                             rundir = case.get_value("RUNDIR")
                             if download:
                                 if full_path.startswith(rundir):
+                                    print(msg)
                                     filepath = os.path.dirname(full_path)
                                     if not os.path.exists(filepath):
                                         logger.info(
@@ -508,12 +507,14 @@ def _check_input_data_impl(
                                     )
                                     no_files_missing = success
                                 else:
+                                    # Ensure that msg and warning text are together in TestStatus.log
                                     logger.warning(
-                                        "    Cannot download file since it lives outside of the input_data_root '{}'".format(
-                                            input_data_root
+                                        msg + "\n    Cannot download file since it lives outside of the input_data_root '{}': '{}'".format(
+                                            input_data_root, full_path
                                         )
                                     )
                             else:
+                                print(msg)
                                 no_files_missing = False
                         else:
                             logger.debug("  Found input file: '{}'".format(full_path))


### PR DESCRIPTION
On multiple processors, it's possible for the "Model datm missing file" and "Cannot download file" messages for a file to be separated by many lines. This change makes it so that they're always printed together.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

**Fixes [CIME Github issue #]:** None

**User interface changes?:** None

**Update gh-pages html (Y/N)?:** N
