### PR TITLE
rudementary support for years > 9999

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -138,6 +138,7 @@ class SystemTestsCommon(object):
             stop_option = self._case.get_value("STOP_OPTION")
 
         self._case.set_value("REST_OPTION", stop_option)
+
         # We need to make sure the run is long enough and to set REST_N to a
         # value that makes sense for all components
         maxncpl = 10000
@@ -198,20 +199,30 @@ class SystemTestsCommon(object):
             rest_n = math.ceil((stop_n // 2 + 1) * coupling_secs / factor)
         expect(stop_n > 0, "Bad STOP_N: {:d}".format(stop_n))
         expect(stop_n > 2, "ERROR: stop_n value {:d} too short".format(stop_n))
+        cal = self._case.get_value("CALENDAR")
         if not starttime:
             starttime = self._case.get_value("START_TOD")
         if not startdate:
             startdate = self._case.get_value("RUN_STARTDATE")
-        if "-" in startdate:
-            startdatetime = datetime.strptime(startdate, "%Y-%m-%d") + timedelta(
-                seconds=int(starttime)
-            )
-        else:
-            startdatetime = datetime.strptime(startdate, "%Y%m%d") + timedelta(
-                seconds=int(starttime)
-            )
+        addyr = 0
 
-        cal = self._case.get_value("CALENDAR")
+        if "-" in startdate:
+            syr, smon, sday = startdate.split("-")
+            syr = int(syr)
+            smon = int(smon)
+            sday = int(sday)
+        else:
+            syr = int(startdate) / 10000
+            smon = int(startdate) - syr * 10000 / 100
+            sday = int(startdate) - syr * 10000 - smon * 100
+
+        while syr > 9999:
+            syr = syr - 9999
+            addyr = addyr + 1
+
+        startdatetime = datetime.strptime(
+            f"{syr:04d}{smon:02d}{sday:02d}", "%Y%m%d"
+        ) + timedelta(seconds=int(starttime))
 
         if stop_option == "nsteps":
             rtd = timedelta(seconds=rest_n * factor)
@@ -233,10 +244,11 @@ class SystemTestsCommon(object):
             restdatetime = restdatetime + self._leap_year_correction(
                 startdatetime, restdatetime
             )
-
-        self._rest_time = (
-            f".{restdatetime.year:04d}-{restdatetime.month:02d}-{restdatetime.day:02d}-"
-        )
+        ryr = int(restdatetime.year)
+        while addyr > 0:
+            ryr += 9999
+            addyr = addyr - 1
+        self._rest_time = f".{ryr:04d}-{restdatetime.month:02d}-{restdatetime.day:02d}-"
         h = restdatetime.hour
         m = restdatetime.minute
         s = restdatetime.second

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -204,7 +204,6 @@ class SystemTestsCommon(object):
             starttime = self._case.get_value("START_TOD")
         if not startdate:
             startdate = self._case.get_value("RUN_STARTDATE")
-        addyr = 0
 
         if "-" in startdate:
             syr, smon, sday = startdate.split("-")
@@ -216,9 +215,8 @@ class SystemTestsCommon(object):
             smon = int(startdate) - syr * 10000 / 100
             sday = int(startdate) - syr * 10000 - smon * 100
 
-        while syr > 9999:
-            syr = syr - 9999
-            addyr = addyr + 1
+        addyr = syr // 10000
+        syr = syr % 10000
 
         startdatetime = datetime.strptime(
             f"{syr:04d}{smon:02d}{sday:02d}", "%Y%m%d"
@@ -245,9 +243,7 @@ class SystemTestsCommon(object):
                 startdatetime, restdatetime
             )
         ryr = int(restdatetime.year)
-        while addyr > 0:
-            ryr += 9999
-            addyr = addyr - 1
+        ryr += 10000 * addyr
         self._rest_time = f".{ryr:04d}-{restdatetime.month:02d}-{restdatetime.day:02d}-"
         h = restdatetime.hour
         m = restdatetime.minute

--- a/CIME/get_tests.py
+++ b/CIME/get_tests.py
@@ -31,36 +31,36 @@ _CIME_TESTS = {
     "cime_tiny": {
         "time": "0:10:00",
         "tests": (
-            "ERS.f19_g16_rx1.A",
-            "NCK.f19_g16_rx1.A",
+            "ERS.f19_g16.A",
+            "NCK.f19_g16.A",
         ),
     },
     "cime_test_only_pass": {
         "time": "0:10:00",
         "tests": (
-            "TESTRUNPASS_P1.f19_g16_rx1.A",
-            "TESTRUNPASS_P1.ne30_g16_rx1.A",
-            "TESTRUNPASS_P1.f45_g37_rx1.A",
+            "TESTRUNPASS_P1.f19_g16.A",
+            "TESTRUNPASS_P1.ne30_g16.A",
+            "TESTRUNPASS_P1.f45_g37.A",
         ),
     },
     "cime_test_only_slow_pass": {
         "time": "0:10:00",
         "tests": (
-            "TESTRUNSLOWPASS_P1.f19_g16_rx1.A",
-            "TESTRUNSLOWPASS_P1.ne30_g16_rx1.A",
-            "TESTRUNSLOWPASS_P1.f45_g37_rx1.A",
+            "TESTRUNSLOWPASS_P1.f19_g16.A",
+            "TESTRUNSLOWPASS_P1.ne30_g16.A",
+            "TESTRUNSLOWPASS_P1.f45_g37.A",
         ),
     },
     "cime_test_only": {
         "time": "0:10:00",
         "tests": (
-            "TESTBUILDFAIL_P1.f19_g16_rx1.A",
-            "TESTBUILDFAILEXC_P1.f19_g16_rx1.A",
-            "TESTRUNFAIL_P1.f19_g16_rx1.A",
-            "TESTRUNSTARCFAIL_P1.f19_g16_rx1.A",
-            "TESTRUNFAILEXC_P1.f19_g16_rx1.A",
-            "TESTRUNPASS_P1.f19_g16_rx1.A",
-            "TESTTESTDIFF_P1.f19_g16_rx1.A",
+            "TESTBUILDFAIL_P1.f19_g16.A",
+            "TESTBUILDFAILEXC_P1.f19_g16.A",
+            "TESTRUNFAIL_P1.f19_g16.A",
+            "TESTRUNSTARCFAIL_P1.f19_g16.A",
+            "TESTRUNFAILEXC_P1.f19_g16.A",
+            "TESTRUNPASS_P1.f19_g16.A",
+            "TESTTESTDIFF_P1.f19_g16.A",
             "TESTMEMLEAKFAIL_P1.f09_g16.X",
             "TESTMEMLEAKPASS_P1.f09_g16.X",
         ),
@@ -68,26 +68,26 @@ _CIME_TESTS = {
     "cime_test_all": {
         "inherit": "cime_test_only",
         "time": "0:10:00",
-        "tests": "TESTRUNDIFF_P1.f19_g16_rx1.A",
+        "tests": "TESTRUNDIFF_P1.f19_g16.A",
     },
     "cime_test_share": {
         "time": "0:10:00",
         "share": True,
         "tests": (
-            "SMS_P2.f19_g16_rx1.A",
-            "SMS_P4.f19_g16_rx1.A",
-            "SMS_P8.f19_g16_rx1.A",
-            "SMS_P16.f19_g16_rx1.A",
+            "SMS_P2.f19_g16.A",
+            "SMS_P4.f19_g16.A",
+            "SMS_P8.f19_g16.A",
+            "SMS_P16.f19_g16.A",
         ),
     },
     "cime_test_share2": {
         "time": "0:10:00",
         "share": True,
         "tests": (
-            "SMS_P2.f19_g16_rx1.X",
-            "SMS_P4.f19_g16_rx1.X",
-            "SMS_P8.f19_g16_rx1.X",
-            "SMS_P16.f19_g16_rx1.X",
+            "SMS_P2.f19_g16.X",
+            "SMS_P4.f19_g16.X",
+            "SMS_P8.f19_g16.X",
+            "SMS_P16.f19_g16.X",
         ),
     },
     "cime_test_perf": {
@@ -106,14 +106,14 @@ _CIME_TESTS = {
     },
     "cime_test_repeat": {
         "tests": (
-            "TESTRUNPASS_P1.f19_g16_rx1.A",
-            "TESTRUNPASS_P2.ne30_g16_rx1.A",
-            "TESTRUNPASS_P4.f45_g37_rx1.A",
+            "TESTRUNPASS_P1.f19_g16.A",
+            "TESTRUNPASS_P2.ne30_g16.A",
+            "TESTRUNPASS_P4.f45_g37.A",
         )
     },
     "cime_test_time": {
         "time": "0:13:00",
-        "tests": ("TESTRUNPASS_P69.f19_g16_rx1.A.testmod",),
+        "tests": ("TESTRUNPASS_P69.f19_g16.A.testmod",),
     },
     "cime_test_multi_inherit": {
         "inherit": ("cime_test_repeat", "cime_test_only_pass", "cime_test_all")
@@ -121,22 +121,22 @@ _CIME_TESTS = {
     "cime_developer": {
         "time": "0:15:00",
         "tests": (
-            "NCK_Ld3.f45_g37_rx1.A",
+            "NCK_Ld3.f45_g37.A",
             "ERI_Ln9.f09_g16.X",
             "ERIO_Ln11.f09_g16.X",
-            "SEQ_Ln9.f19_g16_rx1.A",
-            "ERS.ne30_g16_rx1.A",
-            "IRT_N2_Vmct_Ln9.f19_g16_rx1.A",
-            "ERR_Ln9.f45_g37_rx1.A",
-            "ERP_Ln9.f45_g37_rx1.A",
-            "SMS_D_Ln9_Mmpi-serial.f19_g16_rx1.A",
+            "SEQ_Ln9.f19_g16.A",
+            "ERS.ne30_g16.A",
+            "IRT_N2_Vmct_Ln9.f19_g16.A",
+            "ERR_Ln9.f45_g37.A",
+            "ERP_Ln9.f45_g37.A",
+            "SMS_D_Ln9_Mmpi-serial.f19_g16.A",
             "PET_Ln9_P4.f19_f19.A",
             "PEM_Ln9_P4.f19_f19.A",
             "SMS_Ln3.T42_T42.S",
             "PRE.f19_f19.ADESP",
             "PRE.f19_f19.ADESP_TEST",
-            "MCC_P1.f19_g16_rx1.A",
-            "LDSTA.f45_g37_rx1.A",
+            "MCC_P1.f19_g16.A",
+            "LDSTA.f45_g37.A",
         ),
     },
 }
@@ -274,9 +274,9 @@ def get_build_groups(tests):
     Given a list of tests, return a list of lists, with each list representing
     a group of tests that can share executables.
 
-    >>> tests = ["SMS_P2.f19_g16_rx1.A.melvin_gnu", "SMS_P4.f19_g16_rx1.A.melvin_gnu", "SMS_P2.f19_g16_rx1.X.melvin_gnu", "SMS_P4.f19_g16_rx1.X.melvin_gnu", "TESTRUNSLOWPASS_P1.f19_g16_rx1.A.melvin_gnu", "TESTRUNSLOWPASS_P1.ne30_g16_rx1.A.melvin_gnu"]
+    >>> tests = ["SMS_P2.f19_g16.A.melvin_gnu", "SMS_P4.f19_g16.A.melvin_gnu", "SMS_P2.f19_g16.X.melvin_gnu", "SMS_P4.f19_g16.X.melvin_gnu", "TESTRUNSLOWPASS_P1.f19_g16.A.melvin_gnu", "TESTRUNSLOWPASS_P1.ne30_g16.A.melvin_gnu"]
     >>> get_build_groups(tests)
-    [('SMS_P2.f19_g16_rx1.A.melvin_gnu', 'SMS_P4.f19_g16_rx1.A.melvin_gnu'), ('SMS_P2.f19_g16_rx1.X.melvin_gnu', 'SMS_P4.f19_g16_rx1.X.melvin_gnu'), ('TESTRUNSLOWPASS_P1.f19_g16_rx1.A.melvin_gnu',), ('TESTRUNSLOWPASS_P1.ne30_g16_rx1.A.melvin_gnu',)]
+    [('SMS_P2.f19_g16.A.melvin_gnu', 'SMS_P4.f19_g16.A.melvin_gnu'), ('SMS_P2.f19_g16.X.melvin_gnu', 'SMS_P4.f19_g16.X.melvin_gnu'), ('TESTRUNSLOWPASS_P1.f19_g16.A.melvin_gnu',), ('TESTRUNSLOWPASS_P1.ne30_g16.A.melvin_gnu',)]
     """
     build_groups = []  # list of tuples ([tests], set(suites))
 
@@ -322,9 +322,9 @@ def is_perf_test(test):
 
     >>> is_perf_test("SMS_P2.T42_T42.S.melvin_gnu")
     True
-    >>> is_perf_test("SMS_P2.f19_g16_rx1.X.melvin_gnu")
+    >>> is_perf_test("SMS_P2.f19_g16.X.melvin_gnu")
     False
-    >>> is_perf_test("PFS_P2.f19_g16_rx1.X.melvin_gnu")
+    >>> is_perf_test("PFS_P2.f19_g16.X.melvin_gnu")
     True
     """
     # Get a list of performance suites
@@ -346,17 +346,17 @@ def infer_arch_from_tests(testargs):
     """
     Return a tuple (machine, [compilers]) that can be inferred from the test args
 
-    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu"])
+    >>> infer_arch_from_tests(["NCK.f19_g16.A.melvin_gnu"])
     ('melvin', ['gnu'])
-    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A"])
+    >>> infer_arch_from_tests(["NCK.f19_g16.A"])
     (None, [])
-    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A", "NCK.f19_g16_rx1.A.melvin_gnu"])
+    >>> infer_arch_from_tests(["NCK.f19_g16.A", "NCK.f19_g16.A.melvin_gnu"])
     ('melvin', ['gnu'])
-    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu", "NCK.f19_g16_rx1.A.melvin_gnu"])
+    >>> infer_arch_from_tests(["NCK.f19_g16.A.melvin_gnu", "NCK.f19_g16.A.melvin_gnu"])
     ('melvin', ['gnu'])
-    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu9", "NCK.f19_g16_rx1.A.melvin_gnu"])
+    >>> infer_arch_from_tests(["NCK.f19_g16.A.melvin_gnu9", "NCK.f19_g16.A.melvin_gnu"])
     ('melvin', ['gnu9', 'gnu'])
-    >>> infer_arch_from_tests(["NCK.f19_g16_rx1.A.melvin_gnu", "NCK.f19_g16_rx1.A.mappy_gnu"])
+    >>> infer_arch_from_tests(["NCK.f19_g16.A.melvin_gnu", "NCK.f19_g16.A.mappy_gnu"])
     Traceback (most recent call last):
         ...
     CIME.utils.CIMEError: ERROR: Must have consistent machine 'melvin' != 'mappy'
@@ -404,19 +404,19 @@ def get_full_test_names(testargs, machine, compiler):
     Testargs can be categories or test names and support the NOT symbol '^'
 
     >>> get_full_test_names(["cime_tiny"], "melvin", "gnu")
-    ['ERS.f19_g16_rx1.A.melvin_gnu', 'NCK.f19_g16_rx1.A.melvin_gnu']
+    ['ERS.f19_g16.A.melvin_gnu', 'NCK.f19_g16.A.melvin_gnu']
 
-    >>> get_full_test_names(["cime_tiny", "PEA_P1_M.f45_g37_rx1.A"], "melvin", "gnu")
-    ['ERS.f19_g16_rx1.A.melvin_gnu', 'NCK.f19_g16_rx1.A.melvin_gnu', 'PEA_P1_M.f45_g37_rx1.A.melvin_gnu']
+    >>> get_full_test_names(["cime_tiny", "PEA_P1_M.f45_g37.A"], "melvin", "gnu")
+    ['ERS.f19_g16.A.melvin_gnu', 'NCK.f19_g16.A.melvin_gnu', 'PEA_P1_M.f45_g37.A.melvin_gnu']
 
-    >>> get_full_test_names(['ERS.f19_g16_rx1.A', 'NCK.f19_g16_rx1.A', 'PEA_P1_M.f45_g37_rx1.A'], "melvin", "gnu")
-    ['ERS.f19_g16_rx1.A.melvin_gnu', 'NCK.f19_g16_rx1.A.melvin_gnu', 'PEA_P1_M.f45_g37_rx1.A.melvin_gnu']
+    >>> get_full_test_names(['ERS.f19_g16.A', 'NCK.f19_g16.A', 'PEA_P1_M.f45_g37.A'], "melvin", "gnu")
+    ['ERS.f19_g16.A.melvin_gnu', 'NCK.f19_g16.A.melvin_gnu', 'PEA_P1_M.f45_g37.A.melvin_gnu']
 
-    >>> get_full_test_names(["cime_tiny", "^NCK.f19_g16_rx1.A"], "melvin", "gnu")
-    ['ERS.f19_g16_rx1.A.melvin_gnu']
+    >>> get_full_test_names(["cime_tiny", "^NCK.f19_g16.A"], "melvin", "gnu")
+    ['ERS.f19_g16.A.melvin_gnu']
 
     >>> get_full_test_names(["cime_test_multi_inherit"], "melvin", "gnu")
-    ['TESTBUILDFAILEXC_P1.f19_g16_rx1.A.melvin_gnu', 'TESTBUILDFAIL_P1.f19_g16_rx1.A.melvin_gnu', 'TESTMEMLEAKFAIL_P1.f09_g16.X.melvin_gnu', 'TESTMEMLEAKPASS_P1.f09_g16.X.melvin_gnu', 'TESTRUNDIFF_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNFAILEXC_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNFAIL_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P1.f19_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P1.f45_g37_rx1.A.melvin_gnu', 'TESTRUNPASS_P1.ne30_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P2.ne30_g16_rx1.A.melvin_gnu', 'TESTRUNPASS_P4.f45_g37_rx1.A.melvin_gnu', 'TESTRUNSTARCFAIL_P1.f19_g16_rx1.A.melvin_gnu', 'TESTTESTDIFF_P1.f19_g16_rx1.A.melvin_gnu']
+    ['TESTBUILDFAILEXC_P1.f19_g16.A.melvin_gnu', 'TESTBUILDFAIL_P1.f19_g16.A.melvin_gnu', 'TESTMEMLEAKFAIL_P1.f09_g16.X.melvin_gnu', 'TESTMEMLEAKPASS_P1.f09_g16.X.melvin_gnu', 'TESTRUNDIFF_P1.f19_g16.A.melvin_gnu', 'TESTRUNFAILEXC_P1.f19_g16.A.melvin_gnu', 'TESTRUNFAIL_P1.f19_g16.A.melvin_gnu', 'TESTRUNPASS_P1.f19_g16.A.melvin_gnu', 'TESTRUNPASS_P1.f45_g37.A.melvin_gnu', 'TESTRUNPASS_P1.ne30_g16.A.melvin_gnu', 'TESTRUNPASS_P2.ne30_g16.A.melvin_gnu', 'TESTRUNPASS_P4.f45_g37.A.melvin_gnu', 'TESTRUNSTARCFAIL_P1.f19_g16.A.melvin_gnu', 'TESTTESTDIFF_P1.f19_g16.A.melvin_gnu']
     """
     expect(machine is not None, "Must define a machine")
     expect(compiler is not None, "Must define a compiler")
@@ -462,10 +462,10 @@ def get_full_test_names(testargs, machine, compiler):
 def get_recommended_test_time(test_full_name):
     ###############################################################################
     """
-    >>> get_recommended_test_time("ERS.f19_g16_rx1.A.melvin_gnu")
+    >>> get_recommended_test_time("ERS.f19_g16.A.melvin_gnu")
     '0:10:00'
 
-    >>> get_recommended_test_time("TESTRUNPASS_P69.f19_g16_rx1.A.melvin_gnu.testmod")
+    >>> get_recommended_test_time("TESTRUNPASS_P69.f19_g16.A.melvin_gnu.testmod")
     '0:13:00'
 
     >>> get_recommended_test_time("PET_Ln20.ne30_ne30.FC5.sandiatoss3_intel.cam-outfrq9s")

--- a/CIME/tests/base.py
+++ b/CIME/tests/base.py
@@ -212,7 +212,7 @@ class BaseTestCase(unittest.TestCase):
         # All stub model not supported in nuopc driver
         if self._driver == "nuopc" and "cime_developer" in extra_args:
             extra_args.append(
-                " ^SMS_Ln3.T42_T42.S ^PRE.f19_f19.ADESP_TEST ^PRE.f19_f19.ADESP ^DAE.ww3a.ADWAV ^IRT_N2_Vmct_Ln9.f19_g16_rx1.A"
+                " ^SMS_Ln3.T42_T42.S ^PRE.f19_f19.ADESP_TEST ^PRE.f19_f19.ADESP ^DAE.ww3a.ADWAV ^IRT_N2_Vmct_Ln9.f19_g16.A"
             )
 
         test_id = (

--- a/CIME/tests/test_sys_bless_tests_results.py
+++ b/CIME/tests/test_sys_bless_tests_results.py
@@ -36,11 +36,11 @@ class TestBlessTestResults(base.BaseTestCase):
         # Test resubmit scenario if Machine has a batch system
         if self.MACHINE.has_batch_system():
             test_names = [
-                "TESTRUNDIFFRESUBMIT_Mmpi-serial.f19_g16_rx1.A",
-                "TESTRUNDIFF_Mmpi-serial.f19_g16_rx1.A",
+                "TESTRUNDIFFRESUBMIT_Mmpi-serial.f19_g16.A",
+                "TESTRUNDIFF_Mmpi-serial.f19_g16.A",
             ]
         else:
-            test_names = ["TESTRUNDIFF_P1.f19_g16_rx1.A"]
+            test_names = ["TESTRUNDIFF_P1.f19_g16.A"]
 
         # Generate some baselines
         for test_name in test_names:
@@ -107,7 +107,7 @@ class TestBlessTestResults(base.BaseTestCase):
         # Generate some namelist baselines
         if self.NO_FORTRAN_RUN:
             self.skipTest("Skipping fortran test")
-        test_to_change = "TESTRUNPASS_P1.f19_g16_rx1.A"
+        test_to_change = "TESTRUNPASS_P1.f19_g16.A"
         if self._config.create_test_flag_mode == "e3sm":
             genargs = ["-g", "-o", "-b", self._baseline_name, "cime_test_only_pass"]
             compargs = ["-c", "-b", self._baseline_name, "cime_test_only_pass"]

--- a/CIME/tests/test_sys_build_system.py
+++ b/CIME/tests/test_sys_build_system.py
@@ -6,7 +6,7 @@ from CIME.tests import base
 class TestBuildSystem(base.BaseTestCase):
     def test_clean_rebuild(self):
         casedir = self._create_test(
-            ["--no-run", "SMS.f19_g16_rx1.A"], test_id=self._baseline_name
+            ["--no-run", "SMS.f19_g16.A"], test_id=self._baseline_name
         )
 
         # Clean a component and a sharedlib

--- a/CIME/tests/test_sys_cime_case.py
+++ b/CIME/tests/test_sys_cime_case.py
@@ -21,7 +21,7 @@ except AttributeError:
 class TestCimeCase(base.BaseTestCase):
     def test_cime_case(self):
         casedir = self._create_test(
-            ["--no-build", "TESTRUNPASS_P1.f19_g16_rx1.A"], test_id=self._baseline_name
+            ["--no-build", "TESTRUNPASS_P1.f19_g16.A"], test_id=self._baseline_name
         )
 
         self.assertEqual(type(self.MACHINE.get_value("MAX_TASKS_PER_NODE")), int)
@@ -231,7 +231,7 @@ class TestCimeCase(base.BaseTestCase):
 
     def test_cime_case_build_threaded_1(self):
         casedir = self._create_test(
-            ["--no-build", "TESTRUNPASS_P1x1.f19_g16_rx1.A"],
+            ["--no-build", "TESTRUNPASS_P1x1.f19_g16.A"],
             test_id=self._baseline_name,
         )
 
@@ -249,7 +249,7 @@ class TestCimeCase(base.BaseTestCase):
 
     def test_cime_case_build_threaded_2(self):
         casedir = self._create_test(
-            ["--no-build", "TESTRUNPASS_P1x2.f19_g16_rx1.A"],
+            ["--no-build", "TESTRUNPASS_P1x2.f19_g16.A"],
             test_id=self._baseline_name,
         )
 
@@ -262,7 +262,7 @@ class TestCimeCase(base.BaseTestCase):
 
     def test_cime_case_mpi_serial(self):
         casedir = self._create_test(
-            ["--no-build", "TESTRUNPASS_Mmpi-serial_P10.f19_g16_rx1.A"],
+            ["--no-build", "TESTRUNPASS_Mmpi-serial_P10.f19_g16.A"],
             test_id=self._baseline_name,
         )
 
@@ -282,7 +282,7 @@ class TestCimeCase(base.BaseTestCase):
                 "--no-build",
                 "--force-procs=16",
                 "--force-threads=8",
-                "TESTRUNPASS.f19_g16_rx1.A",
+                "TESTRUNPASS.f19_g16.A",
             ],
             test_id=self._baseline_name,
         )
@@ -294,7 +294,7 @@ class TestCimeCase(base.BaseTestCase):
 
     def test_cime_case_xmlchange_append(self):
         casedir = self._create_test(
-            ["--no-build", "TESTRUNPASS_P1x1.f19_g16_rx1.A"],
+            ["--no-build", "TESTRUNPASS_P1x1.f19_g16.A"],
             test_id=self._baseline_name,
         )
 
@@ -318,7 +318,7 @@ class TestCimeCase(base.BaseTestCase):
         if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
-        test_name = "ERS.f19_g16_rx1.A"
+        test_name = "ERS.f19_g16.A"
         casedir = self._create_test(
             ["--no-setup", "--machine=blues", "--non-local", test_name],
             test_id=self._baseline_name,
@@ -340,7 +340,7 @@ class TestCimeCase(base.BaseTestCase):
         if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
-        test_name = "ERS_P64.f19_g16_rx1.A"
+        test_name = "ERS_P64.f19_g16.A"
         casedir = self._create_test(
             ["--no-setup", "--machine=blues", "--non-local", test_name],
             test_id=self._baseline_name,
@@ -362,7 +362,7 @@ class TestCimeCase(base.BaseTestCase):
         if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
-        test_name = "ERS_P64.f19_g16_rx1.A"
+        test_name = "ERS_P64.f19_g16.A"
         casedir = self._create_test(
             [
                 "--no-setup",
@@ -390,7 +390,7 @@ class TestCimeCase(base.BaseTestCase):
         if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
-        test_name = "ERS_P1.f19_g16_rx1.A"
+        test_name = "ERS_P1.f19_g16.A"
         casedir = self._create_test(
             [
                 "--no-setup",
@@ -418,7 +418,7 @@ class TestCimeCase(base.BaseTestCase):
         if self._config.test_mode == "cesm":
             self.skipTest("Skipping walltime test. Depends on E3SM batch settings")
 
-        test_name = "ERS_P1.f19_g16_rx1.A"
+        test_name = "ERS_P1.f19_g16.A"
         casedir = self._create_test(
             ["--no-setup", "--machine=blues", "--non-local", test_name],
             test_id=self._baseline_name,
@@ -451,7 +451,7 @@ class TestCimeCase(base.BaseTestCase):
         if not self._hasbatch:
             self.skipTest("Skipping walltime test. Depends on batch system")
 
-        test_name = "ERS_P1.f19_g16_rx1.A"
+        test_name = "ERS_P1.f19_g16.A"
         casedir = self._create_test(
             ["--no-build", test_name],
             test_id=self._baseline_name,
@@ -480,7 +480,7 @@ class TestCimeCase(base.BaseTestCase):
         if not self._hasbatch:
             self.skipTest("Skipping walltime test. Depends on batch system")
 
-        test_name = "ERS_P1.f19_g16_rx1.A"
+        test_name = "ERS_P1.f19_g16.A"
         casedir = self._create_test(
             ["--no-build", "--walltime=01:00:00", test_name],
             test_id=self._baseline_name,
@@ -511,7 +511,7 @@ class TestCimeCase(base.BaseTestCase):
 
         # Frontier has 56 MAX_MPITASKS_PER_NODE so 5600 should require 100 nodes
         # which should land us in 6 hour queue
-        test_name = "SMS_P5600.f19_g16_rx1.A"
+        test_name = "SMS_P5600.f19_g16.A"
         machine, compiler = "frontier", "craygnu"
         casedir = self._create_test(
             [
@@ -538,7 +538,7 @@ class TestCimeCase(base.BaseTestCase):
         self.assertEqual(result, "batch")
 
     def test_cime_case_test_custom_project(self):
-        test_name = "ERS_P1.f19_g16_rx1.A"
+        test_name = "ERS_P1.f19_g16.A"
         # have to use a machine both models know and one that doesn't put PROJECT in any key paths
         machine = self._config.test_custom_project_machine
         compiler = "gnu"
@@ -572,7 +572,7 @@ class TestCimeCase(base.BaseTestCase):
             self.skipTest("Skipping env load test - Only works on mappy")
 
         casedir = self._create_test(
-            ["--no-build", "TESTRUNPASS.f19_g16_rx1.A"], test_id=self._baseline_name
+            ["--no-build", "TESTRUNPASS.f19_g16.A"], test_id=self._baseline_name
         )
 
         with Case(casedir, read_only=True) as case:
@@ -632,7 +632,7 @@ class TestCimeCase(base.BaseTestCase):
 
     def test_xml_caching(self):
         casedir = self._create_test(
-            ["--no-build", "TESTRUNPASS.f19_g16_rx1.A"], test_id=self._baseline_name
+            ["--no-build", "TESTRUNPASS.f19_g16.A"], test_id=self._baseline_name
         )
 
         active = os.path.join(casedir, "env_run.xml")
@@ -725,7 +725,7 @@ class TestCimeCase(base.BaseTestCase):
         if self.TEST_COMPILER and "gpu" in self.TEST_COMPILER:
             self.skipTest("Skipping cprnc test for gpu compiler")
 
-        testname = "ERS_Ln7.f19_g16_rx1.A"
+        testname = "ERS_Ln7.f19_g16.A"
         casedir = self._create_test(
             [testname, "--no-build"], test_id=self._baseline_name
         )
@@ -740,7 +740,7 @@ class TestCimeCase(base.BaseTestCase):
         self._wait_for_tests(self._baseline_name, always_wait=True)
 
     def test_case_clean(self):
-        testname = "ERS_Ln7.f19_g16_rx1.A"
+        testname = "ERS_Ln7.f19_g16.A"
         casedir = self._create_test(
             [testname, "--no-build"], test_id=self._baseline_name
         )
@@ -750,7 +750,7 @@ class TestCimeCase(base.BaseTestCase):
         self.run_cmd_assert_result("./case.setup", from_dir=casedir)
 
     def test_skip_run_with_existing_baseline(self):
-        test_name = "TESTRUNPASS_P1.f19_g16_rx1.A"
+        test_name = "TESTRUNPASS_P1.f19_g16.A"
 
         if self._config.test_mode == "cesm":
             create_test_extra_args = ["--generate", "baseline", "--no-build", test_name]

--- a/CIME/tests/test_sys_full_system.py
+++ b/CIME/tests/test_sys_full_system.py
@@ -47,7 +47,7 @@ class TestFullSystem(base.BaseTestCase):
                 "PRE.f19_f19.ADESP_TEST",
                 "PRE.f19_f19.ADESP",
                 "DAE.ww3a.ADWAV",
-                "IRT_N2_Vmct_Ln9.f19_g16_rx1.A",
+                "IRT_N2_Vmct_Ln9.f19_g16.A",
             ]
         tests = get_tests.get_test_suite(
             "cime_developer",

--- a/CIME/tests/test_sys_save_timings.py
+++ b/CIME/tests/test_sys_save_timings.py
@@ -21,7 +21,7 @@ class TestSaveTimings(base.BaseTestCase):
         else:
             walltime = "00:30:00"
         self._create_test(
-            ["SMS_Ln9_P1.f19_g16_rx1.A", timing_flag, "--walltime=" + walltime],
+            ["SMS_Ln9_P1.f19_g16.A", timing_flag, "--walltime=" + walltime],
             test_id=self._baseline_name,
         )
 

--- a/CIME/tests/test_sys_single_submit.py
+++ b/CIME/tests/test_sys_single_submit.py
@@ -16,6 +16,6 @@ class TestSingleSubmit(base.BaseTestCase):
 
         # Keep small enough for now that we don't have to worry about load balancing
         self._create_test(
-            ["--single-submit", "SMS_Ln9_P8.f45_g37_rx1.A", "SMS_Ln9_P8.f19_g16_rx1.A"],
+            ["--single-submit", "SMS_Ln9_P8.f45_g37.A", "SMS_Ln9_P8.f19_g16.A"],
             env_changes="unset CIME_GLOBAL_WALLTIME &&",
         )

--- a/CIME/tests/test_sys_test_scheduler.py
+++ b/CIME/tests/test_sys_test_scheduler.py
@@ -22,10 +22,10 @@ class TestTestScheduler(base.BaseTestCase):
                 "cime_test_only",
                 "^TESTMEMLEAKFAIL_P1.f09_g16.X",
                 "^TESTMEMLEAKPASS_P1.f09_g16.X",
-                "^TESTRUNSTARCFAIL_P1.f19_g16_rx1.A",
-                "^TESTTESTDIFF_P1.f19_g16_rx1.A",
-                "^TESTBUILDFAILEXC_P1.f19_g16_rx1.A",
-                "^TESTRUNFAILEXC_P1.f19_g16_rx1.A",
+                "^TESTRUNSTARCFAIL_P1.f19_g16.A",
+                "^TESTTESTDIFF_P1.f19_g16.A",
+                "^TESTBUILDFAILEXC_P1.f19_g16.A",
+                "^TESTRUNFAILEXC_P1.f19_g16.A",
             ],
             self._machine,
             self._compiler,
@@ -37,7 +37,7 @@ class TestTestScheduler(base.BaseTestCase):
             self.skipTest("Skipping chksum test. Depends on CESM settings")
 
         ts = test_scheduler.TestScheduler(
-            ["SEQ_Ln9.f19_g16_rx1.A.perlmutter_gnu"],
+            ["SEQ_Ln9.f19_g16.A.perlmutter_gnu"],
             machine_name="perlmutter",
             chksum=True,
             test_root="/tests",
@@ -45,14 +45,14 @@ class TestTestScheduler(base.BaseTestCase):
 
         with mock.patch.object(ts, "_shell_cmd_for_phase") as _shell_cmd_for_phase:
             ts._run_phase(
-                "SEQ_Ln9.f19_g16_rx1.A.perlmutter_gnu"
+                "SEQ_Ln9.f19_g16.A.perlmutter_gnu"
             )  # pylint: disable=protected-access
 
             _shell_cmd_for_phase.assert_called_with(
-                "SEQ_Ln9.f19_g16_rx1.A.perlmutter_gnu",
+                "SEQ_Ln9.f19_g16.A.perlmutter_gnu",
                 "./case.submit --skip-preview-namelist --chksum",
                 "RUN",
-                from_dir="/tests/SEQ_Ln9.f19_g16_rx1.A.perlmutter_gnu.00:00:00",
+                from_dir="/tests/SEQ_Ln9.f19_g16.A.perlmutter_gnu.00:00:00",
             )
 
     def test_testmods(self):
@@ -70,9 +70,7 @@ class TestTestScheduler(base.BaseTestCase):
         )
 
         with mock.patch.object(ct, "_shell_cmd_for_phase"):
-            ct._create_newcase_phase(
-                "TESTRUNPASS_P1.f19_g16_rx1.A.docker_gnu.eam-rrtmgp"
-            )
+            ct._create_newcase_phase("TESTRUNPASS_P1.f19_g16.A.docker_gnu.eam-rrtmgp")
 
             create_newcase_cmd = ct._shell_cmd_for_phase.call_args.args[1]
 
@@ -94,7 +92,7 @@ class TestTestScheduler(base.BaseTestCase):
 
         with mock.patch.object(ct, "_shell_cmd_for_phase"):
             success, message = ct._create_newcase_phase(
-                "TESTRUNPASS_P1.f19_g16_rx1.A.docker_gnu.notacomponent?fun"
+                "TESTRUNPASS_P1.f19_g16.A.docker_gnu.notacomponent?fun"
             )
 
             assert not success
@@ -116,7 +114,7 @@ class TestTestScheduler(base.BaseTestCase):
 
         with mock.patch.object(ct, "_shell_cmd_for_phase"):
             success, message = ct._create_newcase_phase(
-                "TESTRUNPASS_P1.f19_g16_rx1.A.docker_gnu.notacomponent-fun"
+                "TESTRUNPASS_P1.f19_g16.A.docker_gnu.notacomponent-fun"
             )
 
             assert not success
@@ -355,9 +353,9 @@ class TestTestScheduler(base.BaseTestCase):
     def test_force_rebuild(self):
         tests = get_tests.get_full_test_names(
             [
-                "TESTBUILDFAIL_P1.f19_g16_rx1.A",
-                "TESTRUNFAIL_P1.f19_g16_rx1.A",
-                "TESTRUNPASS_P1.f19_g16_rx1.A",
+                "TESTBUILDFAIL_P1.f19_g16.A",
+                "TESTRUNFAIL_P1.f19_g16.A",
+                "TESTRUNPASS_P1.f19_g16.A",
             ],
             self._machine,
             self._compiler,
@@ -409,9 +407,9 @@ class TestTestScheduler(base.BaseTestCase):
     def test_c_use_existing(self):
         tests = get_tests.get_full_test_names(
             [
-                "TESTBUILDFAIL_P1.f19_g16_rx1.A",
-                "TESTRUNFAIL_P1.f19_g16_rx1.A",
-                "TESTRUNPASS_P1.f19_g16_rx1.A",
+                "TESTBUILDFAIL_P1.f19_g16.A",
+                "TESTRUNFAIL_P1.f19_g16.A",
+                "TESTRUNPASS_P1.f19_g16.A",
             ],
             self._machine,
             self._compiler,
@@ -568,9 +566,9 @@ class TestTestScheduler(base.BaseTestCase):
 
     def test_d_retry(self):
         args = [
-            "TESTBUILDFAIL_P1.f19_g16_rx1.A",
-            "TESTRUNFAILRESET_P1.f19_g16_rx1.A",
-            "TESTRUNPASS_P1.f19_g16_rx1.A",
+            "TESTBUILDFAIL_P1.f19_g16.A",
+            "TESTRUNFAILRESET_P1.f19_g16.A",
+            "TESTRUNPASS_P1.f19_g16.A",
             "--retry=1",
         ]
 
@@ -580,7 +578,7 @@ class TestTestScheduler(base.BaseTestCase):
         if self._config.test_mode != "e3sm" or self._machine != "docker":
             self.skipTest("Skipping create_test test. Depends on E3SM settings")
 
-        args = ["SMS.f19_g16_rx1.A.docker_gnuX", "--no-setup"]
+        args = ["SMS.f19_g16.A.docker_gnuX", "--no-setup"]
 
         case = self._create_test(args, default_baseline_area=True)
         result = self.run_cmd_assert_result(

--- a/CIME/tests/test_unit_baselines_performance.py
+++ b/CIME/tests/test_unit_baselines_performance.py
@@ -271,7 +271,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
 
             case.get_value.side_effect = (
                 str(baseline_root),
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                "master/ERIO.ne30_g16.A.docker_gnu",
                 "/tmp/components/cpl",
                 0.05,
             )
@@ -293,7 +293,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
             case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
 
             case.get_baseline_dir.return_value = str(
-                baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+                baseline_root / "master" / "ERIO.ne30_g16.A.docker_gnu"
             )
 
             case.get_value.side_effect = (
@@ -325,7 +325,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
             case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
 
             case.get_baseline_dir.return_value = str(
-                baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+                baseline_root / "master" / "ERIO.ne30_g16.A.docker_gnu"
             )
 
             case.get_value.side_effect = (
@@ -357,7 +357,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
             case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
 
             case.get_baseline_dir.return_value = str(
-                baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+                baseline_root / "master" / "ERIO.ne30_g16.A.docker_gnu"
             )
 
             case.get_value.side_effect = (
@@ -389,7 +389,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
             case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
 
             case.get_baseline_dir.return_value = str(
-                baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+                baseline_root / "master" / "ERIO.ne30_g16.A.docker_gnu"
             )
 
             case.get_value.side_effect = (
@@ -426,7 +426,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
             case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
 
             case.get_baseline_dir.return_value = str(
-                baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+                baseline_root / "master" / "ERIO.ne30_g16.A.docker_gnu"
             )
 
             case.get_value.side_effect = (
@@ -460,7 +460,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
 
             case.get_value.side_effect = (
                 str(baseline_root),
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                "master/ERIO.ne30_g16.A.docker_gnu",
                 "/tmp/components/cpl",
                 0.05,
             )
@@ -490,7 +490,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
 
             case.get_value.side_effect = (
                 str(baseline_root),
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                "master/ERIO.ne30_g16.A.docker_gnu",
                 "/tmp/components/cpl",
                 0.05,
             )
@@ -517,7 +517,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
             case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
 
             case.get_baseline_dir.return_value = str(
-                baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+                baseline_root / "master" / "ERIO.ne30_g16.A.docker_gnu"
             )
 
             case.get_value.side_effect = (
@@ -552,7 +552,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
             case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
 
             case.get_baseline_dir.return_value = str(
-                baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+                baseline_root / "master" / "ERIO.ne30_g16.A.docker_gnu"
             )
 
             case.get_value.side_effect = (
@@ -587,7 +587,7 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
             case, _, _, baseline_root = create_mock_case(tempdir, get_latest_cpl_logs)
 
             case.get_baseline_dir.return_value = str(
-                baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+                baseline_root / "master" / "ERIO.ne30_g16.A.docker_gnu"
             )
 
             case.get_value.side_effect = (

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -224,14 +224,14 @@ class TestCase(unittest.TestCase):
                     "test1",
                     self.srcroot,
                     "A",
-                    "f19_g16_rx1",
+                    "f19_g16",
                     machine_name="perlmutter",
                 )
 
                 # Check that they're all called
                 configure.assert_called_with(
                     "A",
-                    "f19_g16_rx1",
+                    "f19_g16",
                     machine_name="perlmutter",
                     project=None,
                     pecount=None,
@@ -298,14 +298,14 @@ class TestCase(unittest.TestCase):
                     "test1",
                     self.srcroot,
                     "A",
-                    "f19_g16_rx1",
+                    "f19_g16",
                     machine_name="perlmutter",
                 )
 
                 # Check that they're all called
                 configure.assert_called_with(
                     "A",
-                    "f19_g16_rx1",
+                    "f19_g16",
                     machine_name="perlmutter",
                     project=None,
                     pecount=None,

--- a/CIME/tests/test_unit_system_tests.py
+++ b/CIME/tests/test_unit_system_tests.py
@@ -101,7 +101,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 "rpointer.cpl",
                 0.01,
@@ -155,7 +155,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 None,
                 0.01,
@@ -211,7 +211,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 None,
                 0.01,
@@ -269,7 +269,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 None,
                 0.01,
@@ -302,7 +302,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(Path(tempdir) / "caseroot"),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 None,
             )
@@ -332,7 +332,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(Path(tempdir) / "caseroot"),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 "rpointer.cpl.0001-01-01",
             )
@@ -362,7 +362,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(Path(tempdir) / "caseroot"),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 None,
             )
@@ -393,7 +393,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 "rpointer.cpl",
             )
@@ -423,7 +423,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 None,
             )
@@ -453,7 +453,7 @@ class TestUnitSystemTests(unittest.TestCase):
             case = mock.MagicMock()
             case.get_value.side_effect = (
                 str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 "rpointer.cpl",
             )
@@ -477,22 +477,22 @@ class TestUnitSystemTests(unittest.TestCase):
 
             get_value_calls = [
                 str(caseroot),
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
                 "mct",
                 None,
                 str(run_dir),
                 "case.std",
                 str(baseline_root),
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
-                "ERIO.ne30_g16_rx1.A.docker_gnu.G.20230919_193255_z9hg2w",
+                "master/ERIO.ne30_g16.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu.G.20230919_193255_z9hg2w",
                 "ERIO",
                 "mct",
                 str(run_dir),
                 "ERIO",
-                "ERIO.ne30_g16_rx1.A.docker_gnu",
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                "ERIO.ne30_g16.A.docker_gnu",
+                "master/ERIO.ne30_g16.A.docker_gnu",
                 str(baseline_root),
-                "master/ERIO.ne30_g16_rx1.A.docker_gnu",
+                "master/ERIO.ne30_g16.A.docker_gnu",
                 str(run_dir),
                 "mct",
                 "/tmp/components/cpl",
@@ -511,7 +511,7 @@ class TestUnitSystemTests(unittest.TestCase):
 
             common._generate_baseline()
 
-            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16_rx1.A.docker_gnu"
+            baseline_dir = baseline_root / "master" / "ERIO.ne30_g16.A.docker_gnu"
             assert (baseline_dir / "cpl.log.gz").exists()
             assert (baseline_dir / "cpl-tput.log").exists()
             assert (baseline_dir / "cpl-mem.log").exists()

--- a/CIME/tests/test_unit_xml_grids.py
+++ b/CIME/tests/test_unit_xml_grids.py
@@ -57,7 +57,7 @@ TEST_CONFIG = """<grid_data version="2.0">
             <grid name="wav">null</grid>
             <mask>gx1v6</mask>
         </model_grid>
-        <model_grid alias="T31_g37_rx1" compset="_DROF">
+        <model_grid alias="T31_g37" compset="_DROF">
             <grid name="atm">T31</grid>
             <grid name="lnd">T31</grid>
             <grid name="ocnice">gx3v7</grid>
@@ -131,7 +131,7 @@ class TestXMLGrids(unittest.TestCase):
             ):
                 grids._read_config_grids("f05_g16", "DATM")
 
-            lname = grids._read_config_grids("T31_g37_rx1", "_DROF")
+            lname = grids._read_config_grids("T31_g37", "_DROF")
 
             assert lname == "a%T31_l%T31_oi%gx3v7_r%rx1_g%null_w%null_z%null_m%gx3v7"
 


### PR DESCRIPTION
Allows for years beyond 9999.   Rudimentary support - probably doesn't handle leap years correctly. 

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
