### PR TITLE
change from only noting the last jobid, to all of them

### DIFF
--- a/CIME/case/case_submit.py
+++ b/CIME/case/case_submit.py
@@ -287,7 +287,7 @@ def submit(
             functor,
             "case.submit",
             caseroot=caseroot,
-            custom_success_msg_functor=lambda x: x.split(":")[-1],
+            custom_success_msg_functor=lambda x: x,
             is_batch=is_batch,
             gitinterface=self._gitinterface,
         )


### PR DESCRIPTION
case.submit was only recording the last job submitted when multiple jobs were submitted, this change records all of the submitted jobs instead of just the last one.

Test suite:
Test baseline:
Test namelist changes:
Test status: bit for bit,

Fixes #4777 

User interface changes?:

Update gh-pages html (Y/N)?:
