### PR TITLE
updates needed for cesm, does not affect e3sm

### DIFF
--- a/CIME/build_scripts/buildlib.mpi-serial
+++ b/CIME/build_scripts/buildlib.mpi-serial
@@ -80,10 +80,11 @@ def buildlib(bldroot, installpath, case):
     run_bld_cmd_ensure_logging(cmd, logger)
 
     # Now we run the mpi-serial make command
-    gmake_opts = "-f {} ".format(os.path.join(bldroot, "Makefile"))
+    gmake_opts = "-f {} ".format(os.path.join(mpi_serial_path, "Makefile"))
     gmake_opts += " -C {} ".format(bldroot)
     gmake_opts += " -j {} ".format(case.get_value("GMAKE_J"))
-    gmake_opts += " SRCDIR={} ".format(os.path.join(mpi_serial_path))
+    gmake_opts += " SRCDIR={} ".format(mpi_serial_path)
+    gmake_opts += " VPATH={}".format(mpi_serial_path)
 
     cmd = "{} {}".format(gmake_cmd, gmake_opts)
     run_bld_cmd_ensure_logging(cmd, logger)


### PR DESCRIPTION
Update needed to build mpi-serial MPIserial_2.5.3 and newer in cesm.

Test suite:SMS_Mmpi-serial.f19_g17.A.izumi (gnu, intel, nag)
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes 

User interface changes?:

Update gh-pages html (Y/N)?:
