### PR TITLE
fix mem per node on derecho

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -245,13 +245,8 @@ class EnvBatch(EnvBase):
         )
         max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
         if mem_per_task and total_tasks <= max_tasks_per_node:
-            mem_per_node = total_tasks
-            if mem_per_node < mem_per_task:
-                mem_per_node = mem_per_task
-            elif mem_per_node > max_mem_per_node:
-                mem_per_node = max_mem_per_node
             overrides["mem_per_node"] = int(
-                total_tasks / max_tasks_per_node * max_mem_per_node
+                float(total_tasks) / float(max_tasks_per_node) * max_mem_per_node
             )
         elif max_mem_per_node:
             overrides["mem_per_node"] = max_mem_per_node

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -238,15 +238,21 @@ class EnvBatch(EnvBase):
         # make it general enough that it can be used on other systems by defining MEM_PER_TASK and MAX_MEM_PER_NODE in config_machines.xml
         # and adding {{ mem_per_node }} in config_batch.xml
         mem_per_task = case.get_value("MEM_PER_TASK")
-        mtpn = case.get_value("MAX_TASKS_PER_NODE")
+        max_tasks_per_node = case.get_value("MAX_TASKS_PER_NODE")
+        expect(
+            max_tasks_per_node > 0,
+            "Error MAX_TASKS_PER_NODE not set or set incorrectly",
+        )
         max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
-        if mem_per_task and total_tasks <= mtpn:
+        if mem_per_task and total_tasks <= max_tasks_per_node:
             mem_per_node = total_tasks
             if mem_per_node < mem_per_task:
                 mem_per_node = mem_per_task
             elif mem_per_node > max_mem_per_node:
                 mem_per_node = max_mem_per_node
-            overrides["mem_per_node"] = int(total_tasks / mtpn * max_mem_per_node)
+            overrides["mem_per_node"] = int(
+                total_tasks / max_tasks_per_node * max_mem_per_node
+            )
         elif max_mem_per_node:
             overrides["mem_per_node"] = max_mem_per_node
 

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -237,21 +237,18 @@ class EnvBatch(EnvBase):
         # when developed this variable was only needed on derecho, but I have tried to
         # make it general enough that it can be used on other systems by defining MEM_PER_TASK and MAX_MEM_PER_NODE in config_machines.xml
         # and adding {{ mem_per_node }} in config_batch.xml
-        try:
-            mem_per_task = case.get_value("MEM_PER_TASK")
-            max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
+        mem_per_task = case.get_value("MEM_PER_TASK")
+        mtpn = case.get_value("MAX_TASKS_PER_NODE")
+        max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
+        if mem_per_task and total_tasks <= mtpn:
             mem_per_node = total_tasks
-
             if mem_per_node < mem_per_task:
                 mem_per_node = mem_per_task
             elif mem_per_node > max_mem_per_node:
                 mem_per_node = max_mem_per_node
-            overrides["mem_per_node"] = mem_per_node
-        except TypeError:
-            # ignore this, the variables are not defined for this machine
-            pass
-        except Exception as error:
-            print("An exception occured:", error)
+            overrides["mem_per_node"] = int(total_tasks / mtpn * max_mem_per_node)
+        elif max_mem_per_node:
+            overrides["mem_per_node"] = max_mem_per_node
 
         overrides["ngpus_per_node"] = ngpus_per_node
         overrides["mpirun"] = case.get_mpirun_cmd(job=job, overrides=overrides)


### PR DESCRIPTION
Currently the mem_per_node variable is only used on derecho, this change improves
the functionality of that variable by accounting for intentionally under-subscribing.

Test suite:SMS.f19_g17.A.derecho_intel, SMS.f19_g17.A.casper_intel
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes: https://github.com/ESMCI/ccs_config_cesm/issues/228

User interface changes?:

Update gh-pages html (Y/N)?:
