### PR TITLE
Downgrades required python version

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.8", "3.10", "3.12"]
+        python-version: ["3.8", "3.10", "3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.6", "3.8", "3.10", "3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -20,7 +20,6 @@ def check_minimum_python_version(major, minor):
     ):
         print(
             f"You're running an out-of-date python version {sys.version_info.major}.{sys.version_info.minor}.\nCIME may not work as expected, consider upgrading to python > {major}.{minor}.",
-            file=sys.stderr,
         )
 
 

--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -30,7 +30,7 @@ def check_minimum_python_version(major, minor):
     ), msg
 
 
-check_minimum_python_version(3, 8)
+check_minimum_python_version(3, 6)
 
 real_file_dir = os.path.dirname(os.path.realpath(__file__))
 cimeroot = os.path.abspath(os.path.join(real_file_dir, "..", ".."))

--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -18,7 +18,11 @@ def check_minimum_python_version(major, minor):
     if sys.version_info[0] < major or (
         sys.version_info[0] == major and sys.version_info[1] <= minor
     ):
-        print(f"You're running an out-of-date python version {sys.version_info.major}.{sys.version_info.minor}.\nCIME may not work as expected, consider upgrading to python > {major}.{minor}.", file=sys.stderr)
+        print(
+            f"You're running an out-of-date python version {sys.version_info.major}.{sys.version_info.minor}.\nCIME may not work as expected, consider upgrading to python > {major}.{minor}.",
+            file=sys.stderr,
+        )
+
 
 check_minimum_python_version(3, 6)
 

--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -15,21 +15,10 @@ def check_minimum_python_version(major, minor):
     >>> check_minimum_python_version(sys.version_info[0], sys.version_info[1])
     >>>
     """
-    msg = (
-        "Python "
-        + str(major)
-        + ", minor version "
-        + str(minor)
-        + " is required to run CIME. You have "
-        + str(sys.version_info[0])
-        + "."
-        + str(sys.version_info[1])
-    )
-    if sys.version_info[0] > major or (
-        sys.version_info[0] == major and sys.version_info[1] >= minor
+    if sys.version_info[0] < major or (
+        sys.version_info[0] == major and sys.version_info[1] <= minor
     ):
-        print(msg, file=sys.stderr)
-
+        print(f"You're running an out-of-date python version {sys.version_info.major}.{sys.version_info.minor}.\nCIME may not work as expected, consider upgrading to python > {major}.{minor}.", file=sys.stderr)
 
 check_minimum_python_version(3, 6)
 

--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -16,10 +16,17 @@ def check_minimum_python_version(major, minor):
     >>>
     """
     if sys.version_info[0] < major or (
-        sys.version_info[0] == major and sys.version_info[1] <= minor
+        sys.version_info[0] == major and sys.version_info[1] < minor
     ):
-        print(
-            f"You're running an out-of-date python version {sys.version_info.major}.{sys.version_info.minor}.\nCIME may not work as expected, consider upgrading to python > {major}.{minor}.",
+        sys.stdout.write(
+            f"""
+        ##########################################################################
+        *** WARNING! Your Python version {sys.version_info.major}.{sys.version_info.minor} is outdated. ***
+        ##########################################################################
+        CIME may not function correctly and has not been tested with this version.
+        Upgrade to Python {major}.{minor} or newer to ensure compatibility.
+        ##########################################################################
+            \n"""
         )
 
 

--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -24,7 +24,7 @@ def check_minimum_python_version(major, minor):
         )
 
 
-check_minimum_python_version(3, 6)
+check_minimum_python_version(3, 8)
 
 real_file_dir = os.path.dirname(os.path.realpath(__file__))
 cimeroot = os.path.abspath(os.path.join(real_file_dir, "..", ".."))

--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -25,9 +25,10 @@ def check_minimum_python_version(major, minor):
         + "."
         + str(sys.version_info[1])
     )
-    assert sys.version_info[0] > major or (
+    if sys.version_info[0] > major or (
         sys.version_info[0] == major and sys.version_info[1] >= minor
-    ), msg
+    ):
+        print(msg, file=sys.stderr)
 
 
 check_minimum_python_version(3, 6)


### PR DESCRIPTION
Per slack discussion, goal is to not support 3.6 but not prevent running.

- Backs down required python to 3.6 
- Removes assert and adds warning.

Test suite: 
Test baseline: n/a
Test namelist changes: n/a
Test status: n/a

Fixes n/a
User interface changes?: n/a
Update gh-pages html (Y/N)?: n/a
