### PR TITLE
Clean up some CAM-specific Kokkos changes in CIME

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -655,13 +655,12 @@ ULIBS += -L$(INSTALL_SHAREDPATH)/lib
 
 ULIBS += -lcsm_share -L$(INSTALL_SHAREDPATH)/lib $(PIOLIBNAME) -lgptl
 
-# Add Kokkos header files and libraries for SE-NH dycore
-ifdef USE_KOKKOS
-  CAM_TARGET ?= $(shell $(CASEROOT)/xmlquery --caseroot $(CASEROOT) CAM_TARGET --value)
-  ifeq ($(filter $(CAM_TARGET),theta-l theta-l_kokkos),$(CAM_TARGET))
-    ULIBS += -L$(INSTALL_SHAREDPATH)/lib64 -lkokkoscontainers -lkokkoscore -lkokkossimd
-  endif
+# Include Kokkos Makefile to add necessary flags for a Makefile system
+kokkos_makefile=$(shell find $(SRCROOT) -name Makefile.kokkos) 
+ifneq ($(strip $(kokkos_makefile)),)
+  include $(kokkos_makefile)
 endif
+CXXFLAGS += $(KOKKOS_CXXFLAGS)
 
 #------------------------------------------------------------------------------
 # Drive cmake script for cism and pio

--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -655,14 +655,6 @@ ULIBS += -L$(INSTALL_SHAREDPATH)/lib
 
 ULIBS += -lcsm_share -L$(INSTALL_SHAREDPATH)/lib $(PIOLIBNAME) -lgptl
 
-# Include Kokkos Makefile to add necessary flags for a Makefile system
-kokkos_makefile=$(shell find $(SRCROOT) -name Makefile.kokkos) 
-ifneq ($(strip $(kokkos_makefile)),)
-  export KOKKOS_PATH=$(dir $(kokkos_makefile))
-  include $(kokkos_makefile)
-  CXXFLAGS += $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS)
-endif
-
 #------------------------------------------------------------------------------
 # Drive cmake script for cism and pio
 #------------------------------------------------------------------------------

--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -660,7 +660,7 @@ kokkos_makefile=$(shell find $(SRCROOT) -name Makefile.kokkos)
 ifneq ($(strip $(kokkos_makefile)),)
   export KOKKOS_PATH=$(dir $(kokkos_makefile))
   include $(kokkos_makefile)
-  CXXFLAGS += $(KOKKOS_CXXFLAGS)
+  CXXFLAGS += $(KOKKOS_CXXFLAGS) $(KOKKOS_CPPFLAGS)
 endif
 
 #------------------------------------------------------------------------------

--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -658,9 +658,10 @@ ULIBS += -lcsm_share -L$(INSTALL_SHAREDPATH)/lib $(PIOLIBNAME) -lgptl
 # Include Kokkos Makefile to add necessary flags for a Makefile system
 kokkos_makefile=$(shell find $(SRCROOT) -name Makefile.kokkos) 
 ifneq ($(strip $(kokkos_makefile)),)
+  export KOKKOS_PATH=$(dir $(kokkos_makefile))
   include $(kokkos_makefile)
+  CXXFLAGS += $(KOKKOS_CXXFLAGS)
 endif
-CXXFLAGS += $(KOKKOS_CXXFLAGS)
 
 #------------------------------------------------------------------------------
 # Drive cmake script for cism and pio

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -755,7 +755,7 @@ def _build_libraries(
     if mpilib == "mpi-serial":
         libs.insert(0, mpilib)
 
-    if uses_kokkos(case):
+    if uses_kokkos(case) and comp_interface == "mct":
         libs.append("kokkos")
 
     # Build shared code of CDEPS nuopc data models

--- a/CIME/data/config/cesm/config_files.xml
+++ b/CIME/data/config/cesm/config_files.xml
@@ -647,7 +647,6 @@
   <entry id="BUILD_LIB_FILE">
     <type>char</type>
     <values>
-      <value lib="kokkos">$SRCROOT/libraries/build_scripts/buildlib.kokkos</value>
       <value lib="FMS">$SRCROOT/libraries/FMS/buildlib</value>
       <value lib="CDEPS">$SRCROOT/components/cdeps/cime_config/buildlib</value>
       <value lib="CMEPS">$SRCROOT/components/cmeps/cime_config/buildlib</value>


### PR DESCRIPTION
After discussion with @jedwards4b and @jtruesdal , it is better to move some CAM-specific Kokkos setups to a CAM-specific place, keeping CIME model agnostic.