### PR TITLE
Softly warn users about using python <3.8

### DIFF
--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -8,29 +8,38 @@ import sys, os
 import __main__ as main
 
 
-def check_minimum_python_version(major, minor):
+def check_minimum_python_version(major, minor, warn_only=False):
     """
     Check your python version.
 
-    >>> check_minimum_python_version(sys.version_info[0], sys.version_info[1])
+    >>> check_minimum_python_version(3, 5)
     >>>
     """
+    check = sys.version_info[0] > major or (
+        sys.version_info[0] == major and sys.version_info[1] >= minor
+    )
+    if check:
+        return
     msg = (
         "Python "
         + str(major)
-        + ", minor version "
+        + "."
         + str(minor)
         + " is required to run CIME. You have "
         + str(sys.version_info[0])
         + "."
         + str(sys.version_info[1])
     )
-    assert sys.version_info[0] > major or (
-        sys.version_info[0] == major and sys.version_info[1] >= minor
-    ), msg
+    if warn_only:
+        print(msg.replace("required", "recommended") + ".")
+        return
+    raise RuntimeError(msg + " - please use a newer version of Python.")
 
 
-check_minimum_python_version(3, 8)
+# Require users to be using >=3.6
+check_minimum_python_version(3, 6)
+# Warn users if they are using <3.8
+check_minimum_python_version(3, 8, warn_only=True)
 
 real_file_dir = os.path.dirname(os.path.realpath(__file__))
 cimeroot = os.path.abspath(os.path.join(real_file_dir, "..", ".."))


### PR DESCRIPTION
Softy warn users using python<3.8 about no support.


---

Test suite: n/a
Test baseline: n/a
Test namelist changes: n/a
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: no

Update gh-pages html (Y/N)?: N

---

example usage:

```
(xgns) mahf708@we46965 cime % python ./CIME/Tools/standard_script_setup.py
Python 3, minor version 15 is recommended to run CIME. You have 3.13. Consider upgrading.
```