### PR TITLE
Revert mct guard for kokkos

### DIFF
--- a/CIME/build.py
+++ b/CIME/build.py
@@ -755,7 +755,7 @@ def _build_libraries(
     if mpilib == "mpi-serial":
         libs.insert(0, mpilib)
 
-    if uses_kokkos(case) and comp_interface == "mct":
+    if uses_kokkos(case):
         libs.append("kokkos")
 
     # Build shared code of CDEPS nuopc data models

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -755,7 +755,7 @@ def _build_libraries(
     if mpilib == "mpi-serial":
         libs.insert(0, mpilib)
 
-    if uses_kokkos(case):
+    if uses_kokkos(case) and comp_interface != "nuopc":
         libs.append("kokkos")
 
     # Build shared code of CDEPS nuopc data models


### PR DESCRIPTION
We have MOAB tests that use Kokkos, so we need to revert this change.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
