### PR TITLE
Modified code to make st-archive handle DART files

### DIFF
--- a/CIME/XML/archive_base.py
+++ b/CIME/XML/archive_base.py
@@ -139,7 +139,7 @@ class ArchiveBase(GenericXML):
         for ext in extensions:
             if ext.endswith("$") and has_suffix:
                 ext = ext[:-1]
-            string = model + r"\d?_?(\d{4})?\." + ext
+            string = model + r"\d?_?(\d{4})?(_d\d{2})?\." + ext
             if has_suffix:
                 if not suffix in string:
                     string += r"\." + suffix + "$"


### PR DESCRIPTION
Doing data assimilation with CESM+DART generates many new types of output files,
which st-archive should archive, assuming they are named according to CESM conventions.  
Many of the new files will be handled by the esp component code, but others are 
more closely associated  with the geophysical components and should be archived 
with their files. We've chosen new file names in such a way that this can be done
with very small changes to
   $component/cime_config/config_archive.xml
   cime/CIME/XML/archive_base.py
A second small change is to make st-archive handle compressed files (*.gz).
This has no effect on model calculations or existing output.

Test suite: 
cesm3.0_alphabranch (cesm3_0_beta03-121-g0a50f32) in a B compset 
(HISTC_CAM70%LT_CLM60%BGC-CROP_CICE_MOM6_MOSART_SGLC_SWAV,
a%ne30np4.pg3_l%ne30np4.pg3_oi%tx2_3v2_r%r05_g%null_w%null_z%null_m%tx2_3v2).
The test used the tags listed in .gitmodules (fxtag = cime6.1.87) 
with no development branches checked out. 
It was set up to create the greatest variety of files possible (I probably missed some).  
The interface to DART is not complete, so files that will result from running DART 
were created artificially, since the contents don't matter to st_archive (except for 
the restart files which contain the names of restart history files).   The script used to create
these files is attached.
[dart_files2arch.csh.txt](https://github.com/user-attachments/files/19855993/dart_files2arch.csh.txt)
The test consisted of running a 24 hour forecast, adding the DART files to RUNDIR, 
running st_archive, and running a second day to check the restart capability.

The changes were added to a feature branch based on this component's development branch.

Test namelist changes: None
Test status: bit for bit

Partially fixes [[CIME Github issue #4451]](https://github.com/ESMCI/cime/issues/4451)

User interface changes?: None

Update gh-pages html (Y/N)?: None yet.  I don't know if they're needed.
The capability is increased, but it requires nothing from users.
