### PR TITLE
bless_test_results: fix stale file use case

### DIFF
--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -187,7 +187,9 @@ def bless_history(test_name, case, baseline_name, baseline_root, report_only, fo
                         file_to_remove = (
                             line.split(NO_ORIGINAL)[0].split()[-1].strip("'")
                         )
-                        logger.info(f"Remove stale baseline file {file_to_remove}")
+                        logger.info(
+                            "Removing stale baseline file {}".format(file_to_remove)
+                        )
                         os.remove(os.path.join(baseline_full_dir, file_to_remove))
 
                 gen_result, gen_comments = generate_baseline(

--- a/CIME/bless_test_results.py
+++ b/CIME/bless_test_results.py
@@ -9,7 +9,7 @@ from CIME.utils import (
 )
 from CIME.config import Config
 from CIME.test_status import *
-from CIME.hist_utils import generate_baseline, compare_baseline
+from CIME.hist_utils import generate_baseline, compare_baseline, NO_ORIGINAL
 from CIME.case import Case
 from CIME.test_utils import get_test_status_files
 from CIME.baselines.performance import (
@@ -180,6 +180,16 @@ def bless_history(test_name, case, baseline_name, baseline_root, report_only, fo
             if not report_only and (
                 force or input("Update this diff (y/n)? ").upper() in ["Y", "YES"]
             ):
+                # Sometimes, in order to get things passing, files have to be removed
+                # from the baseline area.
+                for line in cmp_comments.splitlines():
+                    if NO_ORIGINAL in line:
+                        file_to_remove = (
+                            line.split(NO_ORIGINAL)[0].split()[-1].strip("'")
+                        )
+                        logger.info(f"Remove stale baseline file {file_to_remove}")
+                        os.remove(os.path.join(baseline_full_dir, file_to_remove))
+
                 gen_result, gen_comments = generate_baseline(
                     case, baseline_dir=baseline_full_dir
                 )


### PR DESCRIPTION
Sometimes, files reside in the baseline area that are no longer relevant. Btr needs to remove these files when blessing so that the "no original counterpart" error goes away.

Test suite: by hand
Test baseline:
Test namelist changes:
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
