### PR TITLE
Output GPTL timing info when using NUOPC driver

### DIFF
--- a/CIME/non_py/src/timing/perf_mod.F90
+++ b/CIME/non_py/src/timing/perf_mod.F90
@@ -1162,7 +1162,7 @@ contains
 !-----------------------------------------------------------------------
 !
    if (.not. timing_initialized) return
-#ifdef NUOPC_INTERFACE
+#if defined NUOPC_INTERFACE && ! (defined MODEL_THETA_L && defined HOMME_ENABLE_COMPOSE)
    return
 #endif
 


### PR DESCRIPTION
This PR allows to output the detailed GPTL timing information when using the NUOPC driver but the Kokkos NH-SE dycore, thanks to @jedwards4b's help.