### PR TITLE
Change min mem for batch and fix fake_case

### DIFF
--- a/CIME/BuildTools/configure.py
+++ b/CIME/BuildTools/configure.py
@@ -142,7 +142,9 @@ def copy_depends_files(machine_name, machines_dir, output_dir, compiler):
 
 
 class FakeCase(object):
-    def __init__(self, compiler, mpilib, debug, comp_interface, threading=False, gpu_type="none"):
+    def __init__(
+        self, compiler, mpilib, debug, comp_interface, threading=False, gpu_type="none"
+    ):
         # PIO_VERSION is needed to parse config_machines.xml but isn't otherwise used
         # by FakeCase
         self._vals = {

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -241,12 +241,12 @@ class EnvBatch(EnvBase):
         mtpn = case.get_value("MAX_TASKS_PER_NODE")
         max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
         if mem_per_task and total_tasks <= mtpn:
-            mem_per_node = total_tasks
+            mem_per_node = total_tasks * mem_per_task
             if mem_per_node < mem_per_task:
                 mem_per_node = mem_per_task
             elif mem_per_node > max_mem_per_node:
                 mem_per_node = max_mem_per_node
-            overrides["mem_per_node"] = int(total_tasks / mtpn * max_mem_per_node)
+            overrides["mem_per_node"] = max( mem_per_node, int(total_tasks / mtpn * max_mem_per_node) )
         elif max_mem_per_node:
             overrides["mem_per_node"] = max_mem_per_node
 

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -237,21 +237,18 @@ class EnvBatch(EnvBase):
         # when developed this variable was only needed on derecho, but I have tried to
         # make it general enough that it can be used on other systems by defining MEM_PER_TASK and MAX_MEM_PER_NODE in config_machines.xml
         # and adding {{ mem_per_node }} in config_batch.xml
-        try:
-            mem_per_task = case.get_value("MEM_PER_TASK")
-            max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
+        mem_per_task = case.get_value("MEM_PER_TASK")
+        mtpn = case.get_value("MAX_TASKS_PER_NODE")
+        max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
+        if mem_per_task and total_tasks <= mtpn:
             mem_per_node = total_tasks
-
             if mem_per_node < mem_per_task:
                 mem_per_node = mem_per_task
             elif mem_per_node > max_mem_per_node:
                 mem_per_node = max_mem_per_node
-            overrides["mem_per_node"] = mem_per_node
-        except TypeError:
-            # ignore this, the variables are not defined for this machine
-            pass
-        except Exception as error:
-            print("An exception occured:", error)
+            overrides["mem_per_node"] = int(total_tasks / mtpn * max_mem_per_node)
+        elif max_mem_per_node:
+            overrides["mem_per_node"] = max_mem_per_node
 
         overrides["ngpus_per_node"] = ngpus_per_node
         overrides["mpirun"] = case.get_mpirun_cmd(job=job, overrides=overrides)

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -244,8 +244,8 @@ class EnvBatch(EnvBase):
             "Error MAX_TASKS_PER_NODE not set or set incorrectly",
         )
         max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
-        if mem_per_task and total_tasks <= max_tasks_per_node:
-            mem_per_node = total_tasks * mem_per_task
+        if mem_per_task and int(total_tasks) <= max_tasks_per_node:
+            mem_per_node = int(total_tasks) * mem_per_task
             mem_per_node = min(mem_per_node, max_mem_per_node)
             overrides["mem_per_node"] = max(
                 mem_per_node,

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -245,10 +245,10 @@ class EnvBatch(EnvBase):
         )
         max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
         if mem_per_task and total_tasks <= max_tasks_per_node:
-            # Use memory per task until about a fifth of the machine and then use the fraction of total memory
+            # Use memory per task until about a 10th of the node and then use the fraction of total memory
             mem_per_node = total_tasks * mem_per_task
             mem_per_node = min(mem_per_node, max_mem_per_node)
-            if total_tasks > max_tasks_per_node / 5:
+            if total_tasks > max_tasks_per_node / 10:
                 mem_per_node = int(
                     float(total_tasks) / float(max_tasks_per_node) * max_mem_per_node
                 )

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -246,10 +246,11 @@ class EnvBatch(EnvBase):
         max_mem_per_node = case.get_value("MAX_MEM_PER_NODE")
         if mem_per_task and total_tasks <= max_tasks_per_node:
             mem_per_node = total_tasks * mem_per_task
-            mem_per_node = min( mem_per_node, max_mem_per_node )
-            overrides["mem_per_node"] = max( mem_per_node, int(
-                float(total_tasks) / float(max_tasks_per_node) * max_mem_per_node
-            ) )
+            mem_per_node = min(mem_per_node, max_mem_per_node)
+            overrides["mem_per_node"] = max(
+                mem_per_node,
+                int(float(total_tasks) / float(max_tasks_per_node) * max_mem_per_node),
+            )
         elif max_mem_per_node:
             overrides["mem_per_node"] = max_mem_per_node
 

--- a/CIME/XML/files.py
+++ b/CIME/XML/files.py
@@ -56,7 +56,7 @@ class Files(EntryID):
             self.read(model_config_files)
             self.overwrite_existing_entries()
 
-    def get_value(self, vid, attribute=None, resolved=True, subgroup=None):
+    def get_value(self, vid, attribute=None, resolved=True, subgroup=None, attribute_required=False):
         if vid == "COMP_ROOT_DIR_CPL":
             if self._cpl_comp:
                 attribute = self._cpl_comp
@@ -82,6 +82,8 @@ class Files(EntryID):
             value = super(Files, self).get_value(
                 vid, attribute=attribute, resolved=False, subgroup=subgroup
             )
+            if attribute_required:
+                return value
         if value is None:
             value = super(Files, self).get_value(
                 vid, attribute=None, resolved=False, subgroup=subgroup

--- a/CIME/XML/files.py
+++ b/CIME/XML/files.py
@@ -91,8 +91,9 @@ class Files(EntryID):
             value = super(Files, self).get_value(
                 vid, attribute=attribute, resolved=False, subgroup=subgroup
             )
-            if attribute_required:
-                return value
+            if not value:
+                if attribute_required:
+                    return value
         if value is None:
             value = super(Files, self).get_value(
                 vid, attribute=None, resolved=False, subgroup=subgroup

--- a/CIME/XML/files.py
+++ b/CIME/XML/files.py
@@ -56,6 +56,7 @@ class Files(EntryID):
             self.read(model_config_files)
             self.overwrite_existing_entries()
 
+    # pylint: disable=arguments-differ
     def get_value(self, vid, attribute=None, resolved=True, subgroup=None, attribute_required=False):
         if vid == "COMP_ROOT_DIR_CPL":
             if self._cpl_comp:

--- a/CIME/XML/files.py
+++ b/CIME/XML/files.py
@@ -1,6 +1,7 @@
 """
 Interface to the config_files.xml file.  This class inherits from EntryID.py
 """
+
 import re
 import os
 from CIME.XML.standard_module_setup import *
@@ -57,7 +58,14 @@ class Files(EntryID):
             self.overwrite_existing_entries()
 
     # pylint: disable=arguments-differ
-    def get_value(self, vid, attribute=None, resolved=True, subgroup=None, attribute_required=False):
+    def get_value(
+        self,
+        vid,
+        attribute=None,
+        resolved=True,
+        subgroup=None,
+        attribute_required=False,
+    ):
         if vid == "COMP_ROOT_DIR_CPL":
             if self._cpl_comp:
                 attribute = self._cpl_comp

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -820,7 +820,7 @@ def _build_libraries(
             continue
 
         file_build = os.path.join(exeroot, "{}.bldlog.{}".format(lib, lid))
-        logger.info("Building {} with output to file {}, my_file is {my_file}".format(lib, file_build))
+        logger.info("Building {} with output to file {}".format(lib, file_build))
         # pio build creates its own directory
         if lib != "pio" and not os.path.isdir(full_lib_path):
             os.makedirs(full_lib_path)

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -775,7 +775,7 @@ def _build_libraries(
 
     files = Files(comp_interface=comp_interface)
     for lib in libs:
-        build_script[lib] = files.get_value("BUILD_LIB_FILE", {"lib": lib})
+        build_script[lib] = files.get_value("BUILD_LIB_FILE", {"lib": lib}, attribute_required=True)
 
     sharedlibroot = os.path.abspath(case.get_value("SHAREDLIBROOT"))
     # Check if we need to build our own cprnc

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1,6 +1,7 @@
 """
 functions for building CIME models
 """
+
 import glob, shutil, time, threading, subprocess
 from pathlib import Path
 from CIME.XML.standard_module_setup import *
@@ -775,7 +776,9 @@ def _build_libraries(
 
     files = Files(comp_interface=comp_interface)
     for lib in libs:
-        build_script[lib] = files.get_value("BUILD_LIB_FILE", {"lib": lib}, attribute_required=True)
+        build_script[lib] = files.get_value(
+            "BUILD_LIB_FILE", {"lib": lib}, attribute_required=True
+        )
 
     sharedlibroot = os.path.abspath(case.get_value("SHAREDLIBROOT"))
     # Check if we need to build our own cprnc

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -807,7 +807,6 @@ def _build_libraries(
         else:
             full_lib_path = os.path.join(sharedlibroot, sharedpath, lib)
 
-        file_build = os.path.join(exeroot, "{}.bldlog.{}".format(lib, lid))
         if lib in build_script.keys():
             my_file = build_script[lib]
         else:
@@ -820,6 +819,7 @@ def _build_libraries(
             )
             continue
 
+        file_build = os.path.join(exeroot, "{}.bldlog.{}".format(lib, lid))
         logger.info("Building {} with output to file {}".format(lib, file_build))
         # pio build creates its own directory
         if lib != "pio" and not os.path.isdir(full_lib_path):

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -820,7 +820,7 @@ def _build_libraries(
             continue
 
         file_build = os.path.join(exeroot, "{}.bldlog.{}".format(lib, lid))
-        logger.info("Building {} with output to file {}".format(lib, file_build))
+        logger.info("Building {} with output to file {}, my_file is {my_file}".format(lib, file_build))
         # pio build creates its own directory
         if lib != "pio" and not os.path.isdir(full_lib_path):
             os.makedirs(full_lib_path)

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -816,6 +816,8 @@ def _build_libraries(
             my_file = os.path.join(
                 cimeroot, "CIME", "build_scripts", "buildlib.{}".format(lib)
             )
+        if not my_file:
+            continue
         if not os.path.exists(my_file):
             logger.warning(
                 "Build script {} for component {} not found.".format(my_file, lib)

--- a/CIME/tests/test_unit_configure.py
+++ b/CIME/tests/test_unit_configure.py
@@ -11,14 +11,13 @@ from CIME.XML.machines import Machines
 class TestConfigure(unittest.TestCase):
 
     def setUp(self):
-        self.compiler = "intel"
-        self.mpilib = "mpich"
+        self.mach_obj = Machines()
+        self.compiler = self.mach_obj.get_default_compiler()
+        self.sysos = self.mach_obj.get_value("OS")
+        self.mpilib = self.mach_obj.get_default_MPIlib(attributes={"compiler": self.compiler})
         self.debug = "FALSE"
         self.comp_interface = "nuopc"
-        self.sysos = "CNL"
-        mach = "derecho"
 
-        self.mach_obj = Machines(machine=mach)
 
         self.tempdir = tempfile.mkdtemp()
         self.caseroot = os.path.join( self.tempdir, "newcase" )
@@ -47,4 +46,3 @@ class TestConfigure(unittest.TestCase):
               unit_testing = False,
               threaded = False
           )
-

--- a/CIME/tests/test_unit_configure.py
+++ b/CIME/tests/test_unit_configure.py
@@ -1,0 +1,50 @@
+import os
+import unittest
+import tempfile
+import shutil
+
+from CIME.utils import expect
+
+from CIME.BuildTools.configure import generate_env_mach_specific 
+from CIME.XML.machines import Machines
+
+class TestConfigure(unittest.TestCase):
+
+    def setUp(self):
+        self.compiler = "intel"
+        self.mpilib = "mpich"
+        self.debug = "FALSE"
+        self.comp_interface = "nuopc"
+        self.sysos = "CNL"
+        mach = "derecho"
+
+        self.mach_obj = Machines(machine=mach)
+
+        self.tempdir = tempfile.mkdtemp()
+        self.caseroot = os.path.join( self.tempdir, "newcase" )
+        os.mkdir( self.caseroot )
+        self.cwd = os.getcwd()
+        os.chdir( self.caseroot )
+
+    def tearDown(self):
+        # Make sure we aren't in the temp directory to remove
+        
+        os.chdir( self.cwd )
+        if os.getcwd() == self.tempdir:
+            expect( False, "CWD is the tempdir to be removed" )
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def test_generate_env_mach_specific(self):
+
+        generate_env_mach_specific(
+              self.caseroot,
+              self.mach_obj,
+              self.compiler,
+              self.mpilib,
+              self.debug,
+              self.comp_interface,
+              self.sysos,
+              unit_testing = False,
+              threaded = False
+          )
+

--- a/CIME/tests/test_unit_configure.py
+++ b/CIME/tests/test_unit_configure.py
@@ -5,44 +5,45 @@ import shutil
 
 from CIME.utils import expect
 
-from CIME.BuildTools.configure import generate_env_mach_specific 
+from CIME.BuildTools.configure import generate_env_mach_specific
 from CIME.XML.machines import Machines
 
-class TestConfigure(unittest.TestCase):
 
+class TestConfigure(unittest.TestCase):
     def setUp(self):
         self.mach_obj = Machines()
         self.compiler = self.mach_obj.get_default_compiler()
         self.sysos = self.mach_obj.get_value("OS")
-        self.mpilib = self.mach_obj.get_default_MPIlib(attributes={"compiler": self.compiler})
+        self.mpilib = self.mach_obj.get_default_MPIlib(
+            attributes={"compiler": self.compiler}
+        )
         self.debug = "FALSE"
         self.comp_interface = "nuopc"
 
-
         self.tempdir = tempfile.mkdtemp()
-        self.caseroot = os.path.join( self.tempdir, "newcase" )
-        os.mkdir( self.caseroot )
+        self.caseroot = os.path.join(self.tempdir, "newcase")
+        os.mkdir(self.caseroot)
         self.cwd = os.getcwd()
-        os.chdir( self.caseroot )
+        os.chdir(self.caseroot)
 
     def tearDown(self):
         # Make sure we aren't in the temp directory to remove
-        
-        os.chdir( self.cwd )
+
+        os.chdir(self.cwd)
         if os.getcwd() == self.tempdir:
-            expect( False, "CWD is the tempdir to be removed" )
+            expect(False, "CWD is the tempdir to be removed")
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
     def test_generate_env_mach_specific(self):
 
         generate_env_mach_specific(
-              self.caseroot,
-              self.mach_obj,
-              self.compiler,
-              self.mpilib,
-              self.debug,
-              self.comp_interface,
-              self.sysos,
-              unit_testing = False,
-              threaded = False
-          )
+            self.caseroot,
+            self.mach_obj,
+            self.compiler,
+            self.mpilib,
+            self.debug,
+            self.comp_interface,
+            self.sysos,
+            unit_testing=False,
+            threaded=False,
+        )

--- a/CIME/tests/test_unit_fake_case.py
+++ b/CIME/tests/test_unit_fake_case.py
@@ -22,10 +22,19 @@ class TestFakeCase(unittest.TestCase):
         self.srcroot = "."
         os.environ["SRCROOT"] = self.srcroot
 
-    def create_fake_case(self, compiler, mpilib, debug, comp_interface, threading=False, gpu_type="none"):
+    def create_fake_case(
+        self, compiler, mpilib, debug, comp_interface, threading=False, gpu_type="none"
+    ):
 
         pio_version = 2
-        fake_case = FakeCase(compiler, mpilib, debug, comp_interface, threading=threading, gpu_type=gpu_type)
+        fake_case = FakeCase(
+            compiler,
+            mpilib,
+            debug,
+            comp_interface,
+            threading=threading,
+            gpu_type=gpu_type,
+        )
 
         # Verify
         self.assertEqual(compiler, fake_case.get_value("COMPILER"))
@@ -36,25 +45,34 @@ class TestFakeCase(unittest.TestCase):
         self.assertEqual(pio_version, fake_case.get_value("PIO_VERSION"))
         self.assertEqual(self.model, fake_case.get_value("MODEL"))
         self.assertEqual(self.srcroot, fake_case.get_value("SRCROOT"))
-        self.assertEqual(threading, fake_case.get_build_threaded() )
+        self.assertEqual(threading, fake_case.get_build_threaded())
 
         return fake_case
 
     def test_create_simple(self):
-        fake_case = self.create_fake_case(self.compiler, self.mpilib, self.debug, self.comp_interface)
+        fake_case = self.create_fake_case(
+            self.compiler, self.mpilib, self.debug, self.comp_interface
+        )
 
     def test_get_bad_setting(self):
-        fake_case = self.create_fake_case(self.compiler, self.mpilib, self.debug, self.comp_interface)
+        fake_case = self.create_fake_case(
+            self.compiler, self.mpilib, self.debug, self.comp_interface
+        )
 
-        with self.assertRaisesRegex(CIMEError, "ERROR: FakeCase does not support getting value of 'ZZTOP'" ):
+        with self.assertRaisesRegex(
+            CIMEError, "ERROR: FakeCase does not support getting value of 'ZZTOP'"
+        ):
             fake_case.get_value("ZZTOP")
-        
-    def test_get_case_root(self):
-        fake_case = self.create_fake_case(self.compiler, self.mpilib, self.debug, self.comp_interface)
 
-        caseroot = os.path.join( self.srcroot, "newcase" )
+    def test_get_case_root(self):
+        fake_case = self.create_fake_case(
+            self.compiler, self.mpilib, self.debug, self.comp_interface
+        )
+
+        caseroot = os.path.join(self.srcroot, "newcase")
         fake_case.set_value("CASEROOT", caseroot)
-        self.assertEqual( fake_case.get_case_root(), caseroot )
+        self.assertEqual(fake_case.get_case_root(), caseroot)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/CIME/tests/test_unit_fake_case.py
+++ b/CIME/tests/test_unit_fake_case.py
@@ -7,7 +7,7 @@ This is seperate from FakeCase that's under CIME/tests
 
 import unittest
 import os
-from CIME.utils import get_model, CIMEError, GLOBAL
+from CIME.utils import get_model, CIMEError, GLOBAL, get_src_root
 
 from CIME.BuildTools.configure import FakeCase
 
@@ -19,8 +19,7 @@ class TestFakeCase(unittest.TestCase):
         self.debug = "FALSE"
         self.comp_interface = "nuopc"
         self.model = get_model()
-        self.srcroot = os.path.abspath("../../..")
-        GLOBAL["SRCROOT"] = self.srcroot
+        self.srcroot = get_src_root()
 
     def create_fake_case(
         self, compiler, mpilib, debug, comp_interface, threading=False, gpu_type="none"

--- a/CIME/tests/test_unit_fake_case.py
+++ b/CIME/tests/test_unit_fake_case.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+"""
+This module contains unit tests of FakeCase from configure
+This is seperate from FakeCase that's under CIME/tests
+"""
+
+import unittest
+
+from CIME.BuildTools.configure import FakeCase
+
+
+class TestFakeCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def create_fake_case(self, compiler, mpilib, debug, comp_interface, threading=False, gpu_type="none"):
+
+        casedir = "."
+        pio_version = 2
+        fake_case = FakeCase(compiler, mpilib, debug, comp_interface, threading=threading, gpu_type=gpu_type)
+
+        # Verify
+        self.assertEqual(compiler, fake_case.get_value("COMPILER"))
+        self.assertEqual(mpilib, fake_case.get_value("MPILIB"))
+        self.assertEqual(debug, fake_case.get_value("DEBUG"))
+        self.assertEqual(comp_interface, fake_case.get_value("COMP_INTERFACE"))
+        self.assertEqual(gpu_type, fake_case.get_value("GPU_TYPE"))
+        self.assertEqual(pio_version, fake_case.get_value("PIO_VERSION"))
+        self.assertEqual(threading, fake_case.get_build_threaded() )
+        #self.assertEqual(casedir, fake_case.get_case_root() )
+
+    def test_create_simple(self):
+        # Setup
+        compiler = "intel"
+        mpilib = "mpich"
+        debug = "FALSE"
+        comp_interface = "nuopc"
+
+        self.create_fake_case(compiler, mpilib, debug, comp_interface)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/CIME/tests/test_unit_fake_case.py
+++ b/CIME/tests/test_unit_fake_case.py
@@ -7,7 +7,7 @@ This is seperate from FakeCase that's under CIME/tests
 
 import unittest
 import os
-from CIME.utils import get_model, CIMEError
+from CIME.utils import get_model, CIMEError, GLOBAL
 
 from CIME.BuildTools.configure import FakeCase
 
@@ -19,8 +19,8 @@ class TestFakeCase(unittest.TestCase):
         self.debug = "FALSE"
         self.comp_interface = "nuopc"
         self.model = get_model()
-        self.srcroot = "."
-        os.environ["SRCROOT"] = self.srcroot
+        self.srcroot = os.path.abspath("../../..")
+        GLOBAL["SRCROOT"] = self.srcroot
 
     def create_fake_case(
         self, compiler, mpilib, debug, comp_interface, threading=False, gpu_type="none"

--- a/CIME/tests/test_unit_fake_case.py
+++ b/CIME/tests/test_unit_fake_case.py
@@ -49,6 +49,12 @@ class TestFakeCase(unittest.TestCase):
         with self.assertRaisesRegex(CIMEError, "ERROR: FakeCase does not support getting value of 'ZZTOP'" ):
             fake_case.get_value("ZZTOP")
         
+    def test_get_case_root(self):
+        fake_case = self.create_fake_case(self.compiler, self.mpilib, self.debug, self.comp_interface)
+
+        caseroot = os.path.join( self.srcroot, "newcase" )
+        fake_case.set_value("CASEROOT", caseroot)
+        self.assertEqual( fake_case.get_case_root(), caseroot )
 
 if __name__ == "__main__":
     unittest.main()

--- a/CIME/tests/test_unit_fake_case.py
+++ b/CIME/tests/test_unit_fake_case.py
@@ -6,20 +6,24 @@ This is seperate from FakeCase that's under CIME/tests
 """
 
 import unittest
+import os
+from CIME.utils import get_model, CIMEError
 
 from CIME.BuildTools.configure import FakeCase
 
 
 class TestFakeCase(unittest.TestCase):
     def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
+        self.compiler = "intel"
+        self.mpilib = "mpich"
+        self.debug = "FALSE"
+        self.comp_interface = "nuopc"
+        self.model = get_model()
+        self.srcroot = "."
+        os.environ["SRCROOT"] = self.srcroot
 
     def create_fake_case(self, compiler, mpilib, debug, comp_interface, threading=False, gpu_type="none"):
 
-        casedir = "."
         pio_version = 2
         fake_case = FakeCase(compiler, mpilib, debug, comp_interface, threading=threading, gpu_type=gpu_type)
 
@@ -30,18 +34,21 @@ class TestFakeCase(unittest.TestCase):
         self.assertEqual(comp_interface, fake_case.get_value("COMP_INTERFACE"))
         self.assertEqual(gpu_type, fake_case.get_value("GPU_TYPE"))
         self.assertEqual(pio_version, fake_case.get_value("PIO_VERSION"))
+        self.assertEqual(self.model, fake_case.get_value("MODEL"))
+        self.assertEqual(self.srcroot, fake_case.get_value("SRCROOT"))
         self.assertEqual(threading, fake_case.get_build_threaded() )
-        #self.assertEqual(casedir, fake_case.get_case_root() )
+
+        return fake_case
 
     def test_create_simple(self):
-        # Setup
-        compiler = "intel"
-        mpilib = "mpich"
-        debug = "FALSE"
-        comp_interface = "nuopc"
+        fake_case = self.create_fake_case(self.compiler, self.mpilib, self.debug, self.comp_interface)
 
-        self.create_fake_case(compiler, mpilib, debug, comp_interface)
+    def test_get_bad_setting(self):
+        fake_case = self.create_fake_case(self.compiler, self.mpilib, self.debug, self.comp_interface)
 
+        with self.assertRaisesRegex(CIMEError, "ERROR: FakeCase does not support getting value of 'ZZTOP'" ):
+            fake_case.get_value("ZZTOP")
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -1099,6 +1099,109 @@ class TestXMLEnvBatch(unittest.TestCase):
         self.assertEqual(overrides["thread_count"], str(thread_count))
         self.assertEqual(overrides["num_nodes"], 1)
 
+    def test_get_job_overrides_two_tasks(self):
+        """Test that get_job_overrides gives expected results for a case with two tasks"""
+        task_count = 2
+        thread_count = 1
+        mem_per_task = 10
+        tasks_per_node = task_count
+        max_mem = 235
+        # import pdb; pdb.set_trace()
+        overrides = self.run_get_job_overrides(
+            task_count, thread_count, mem_per_task, tasks_per_node, max_mem
+        )
+        self.assertEqual(overrides["mem_per_node"], mem_per_task * task_count)
+        self.assertEqual(overrides["tasks_per_node"], task_count)
+        self.assertEqual(overrides["max_tasks_per_node"], task_count)
+        self.assertEqual(overrides["mpirun"], "mpirun")
+        self.assertEqual(overrides["thread_count"], str(thread_count))
+        self.assertEqual(overrides["num_nodes"], 1)
+
+    def test_get_job_overrides_sixteen_tasks(self):
+        """Test that get_job_overrides gives expected results for a case with sixteen tasks"""
+        task_count = 16
+        thread_count = 1
+        mem_per_task = 10
+        tasks_per_node = task_count
+        max_mem = 235
+        overrides = self.run_get_job_overrides(
+            task_count, thread_count, mem_per_task, tasks_per_node, max_mem
+        )
+        self.assertEqual(overrides["mem_per_node"], mem_per_task * task_count)
+        self.assertEqual(overrides["tasks_per_node"], task_count)
+        self.assertEqual(overrides["max_tasks_per_node"], task_count)
+        self.assertEqual(overrides["mpirun"], "mpirun")
+        self.assertEqual(overrides["thread_count"], str(thread_count))
+        self.assertEqual(overrides["num_nodes"], 1)
+
+    def test_get_job_overrides_eight_tasks_eight_threads(self):
+        """Test that get_job_overrides gives expected results for a case with 8 tasks and 8 threads"""
+        task_count = 8
+        thread_count = 8
+        mem_per_task = 10
+        tasks_per_node = task_count
+        max_mem = 235
+        overrides = self.run_get_job_overrides(
+            task_count, thread_count, mem_per_task, tasks_per_node, max_mem
+        )
+        self.assertEqual(overrides["mem_per_node"], int(max_mem / 2))
+        self.assertEqual(overrides["tasks_per_node"], task_count)
+        self.assertEqual(overrides["max_tasks_per_node"], task_count * thread_count)
+        self.assertEqual(overrides["mpirun"], "mpirun")
+        self.assertEqual(overrides["thread_count"], str(thread_count))
+        self.assertEqual(overrides["num_nodes"], 1)
+
+    def test_get_job_overrides_sixtyfour_tasks(self):
+        """Test that get_job_overrides gives expected results for a case with 64 tasks"""
+        task_count = 64
+        thread_count = 1
+        mem_per_task = 10
+        tasks_per_node = task_count
+        max_mem = 235
+        overrides = self.run_get_job_overrides(
+            task_count, thread_count, mem_per_task, tasks_per_node, max_mem
+        )
+        self.assertEqual(overrides["mem_per_node"], int(max_mem / 2))
+        self.assertEqual(overrides["tasks_per_node"], task_count)
+        self.assertEqual(overrides["max_tasks_per_node"], task_count)
+        self.assertEqual(overrides["mpirun"], "mpirun")
+        self.assertEqual(overrides["thread_count"], str(thread_count))
+        self.assertEqual(overrides["num_nodes"], 1)
+
+    def test_get_job_overrides_ninetysix_tasks(self):
+        """Test that get_job_overrides gives expected results for a case with ninetysix tasks"""
+        task_count = 96
+        thread_count = 1
+        mem_per_task = 10
+        tasks_per_node = task_count
+        max_mem = 235
+        overrides = self.run_get_job_overrides(
+            task_count, thread_count, mem_per_task, tasks_per_node, max_mem
+        )
+        self.assertEqual(overrides["mem_per_node"], int(max_mem * 3 / 4))
+        self.assertEqual(overrides["tasks_per_node"], task_count)
+        self.assertEqual(overrides["max_tasks_per_node"], task_count)
+        self.assertEqual(overrides["mpirun"], "mpirun")
+        self.assertEqual(overrides["thread_count"], str(thread_count))
+        self.assertEqual(overrides["num_nodes"], 1)
+
+    def test_get_job_overrides_hundredtwentyseven_tasks(self):
+        """Test that get_job_overrides gives expected results for a case with 127 tasks"""
+        task_count = 127
+        thread_count = 1
+        mem_per_task = 10
+        tasks_per_node = task_count
+        max_mem = 235
+        overrides = self.run_get_job_overrides(
+            task_count, thread_count, mem_per_task, tasks_per_node, max_mem
+        )
+        self.assertEqual(overrides["mem_per_node"], int(max_mem * task_count / 128))
+        self.assertEqual(overrides["tasks_per_node"], task_count)
+        self.assertEqual(overrides["max_tasks_per_node"], task_count)
+        self.assertEqual(overrides["mpirun"], "mpirun")
+        self.assertEqual(overrides["thread_count"], str(thread_count))
+        self.assertEqual(overrides["num_nodes"], 1)
+
     def run_get_job_overrides(
         self, task_count, thread_count, mem_per_task, tasks_per_node, max_mem
     ):
@@ -1106,9 +1209,12 @@ class TestXMLEnvBatch(unittest.TestCase):
 
         env_batch = EnvBatch()
         # NOTE: GPU_TYPE is assumed to be none, so no GPU settings will be done
+        mpilib = "mpich"
+        if task_count == 1:
+            mpilib = "mpi-serial"
         case = FakeCaseWWorkflow(
             compiler="intel",
-            mpilib="mpi-serial",
+            mpilib=mpilib,
             debug="FALSE",
             comp_interface="nuopc",
             task_count=task_count,

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -1134,6 +1134,24 @@ class TestXMLEnvBatch(unittest.TestCase):
         self.assertEqual(overrides["thread_count"], str(thread_count))
         self.assertEqual(overrides["num_nodes"], 1)
 
+    def test_get_job_overrides_twentyfive_tasks(self):
+        """Test that get_job_overrides gives expected results for a case with 25 tasks"""
+        # This test is mportant for the CTSM regional amazon case that can use 25 tasks
+        task_count = 25
+        thread_count = 1
+        mem_per_task = 10
+        tasks_per_node = task_count
+        max_mem = 235
+        overrides = self.run_get_job_overrides(
+            task_count, thread_count, mem_per_task, tasks_per_node, max_mem
+        )
+        self.assertEqual(overrides["mem_per_node"], int(max_mem * task_count / 128))
+        self.assertEqual(overrides["tasks_per_node"], task_count)
+        self.assertEqual(overrides["max_tasks_per_node"], task_count)
+        self.assertEqual(overrides["mpirun"], "mpirun")
+        self.assertEqual(overrides["thread_count"], str(thread_count))
+        self.assertEqual(overrides["num_nodes"], 1)
+
     def test_get_job_overrides_eight_tasks_eight_threads(self):
         """Test that get_job_overrides gives expected results for a case with 8 tasks and 8 threads"""
         task_count = 8

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -212,6 +212,12 @@ def _open_temp_file(stack, data):
 
 
 class FakeCaseWWorkflow(FakeCase):
+    """
+    Extend the FakeCase class to have the functions needed for testing get_jobs_overrides
+    Use FakeCase rather than a class mock in order to return a more complex and dynamic
+    env_workflow object
+    """
+
     def __init__(
         self,
         compiler,

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -1127,7 +1127,7 @@ class TestXMLEnvBatch(unittest.TestCase):
         overrides = self.run_get_job_overrides(
             task_count, thread_count, mem_per_task, tasks_per_node, max_mem
         )
-        self.assertEqual(overrides["mem_per_node"], mem_per_task * task_count)
+        self.assertEqual(overrides["mem_per_node"], int(max_mem * task_count / 128))
         self.assertEqual(overrides["tasks_per_node"], task_count)
         self.assertEqual(overrides["max_tasks_per_node"], task_count)
         self.assertEqual(overrides["mpirun"], "mpirun")

--- a/CIME/tests/test_unit_xml_env_batch.py
+++ b/CIME/tests/test_unit_xml_env_batch.py
@@ -1057,39 +1057,37 @@ class TestXMLEnvBatch(unittest.TestCase):
 
     def test_get_job_overrides_mpi_serial_single_task(self):
         """Test that get_job_overrides gives expected results for an mpi-serial case with a single task"""
-        env_batch = EnvBatch()
-        case = FakeCaseWWorkflow(
-            compiler="intel", mpilib="mpi-serial", debug="FALSE", comp_interface="nuopc"
-        )
         totalpes = 1
+        thread_count = 1
         mem_per_task = 10
         max_mem = 235
-        case.set_value("TOTALPES", totalpes)
-        case.set_value("MAX_TASKS_PER_NODE", 128)
-        case.set_value("MAX_GPUS_PER_NODE", 128)
-        case.set_value("NGPUS_PER_NODE", 0)
-        case.set_value("MEM_PER_TASK", mem_per_task)
-        case.set_value("MAX_MEM_PER_NODE", max_mem)
-        self.assertEqual(case.get_value("TOTALPES"), int(totalpes))
-        self.assertEqual(case.get_value("MAX_TASKS_PER_NODE"), 128)
-        overrides = {}
-        overrides["ngpus_per_node"] = 0
-        overrides["mem_per_node"] = max_mem
-        overrides["tasks_per_node"] = totalpes
-        overrides["max_tasks_per_node"] = 128
-        overrides["mpirun"] = ""
-        overrides["thread_count"] = 1
-        overrides["num_nodes"] = 1
-
-        overrides = env_batch.get_job_overrides("case.test", case)
+        overrides = self.run_get_job_overrides(
+            totalpes, thread_count, mem_per_task, max_mem
+        )
         self.assertEqual(overrides["ngpus_per_node"], 0)
         self.assertEqual(overrides["mem_per_node"], mem_per_task)
         self.assertEqual(overrides["tasks_per_node"], totalpes)
         self.assertEqual(overrides["max_tasks_per_node"], totalpes)
         self.assertEqual(overrides["mpirun"], "")
-        self.assertEqual(overrides["thread_count"], "1")
+        self.assertEqual(overrides["thread_count"], str(thread_count))
         self.assertEqual(overrides["ngpus_per_node"], 0)
         self.assertEqual(overrides["num_nodes"], 1)
+
+    def run_get_job_overrides(self, totalpes, thread_count, mem_per_task, max_mem):
+        env_batch = EnvBatch()
+        case = FakeCaseWWorkflow(
+            compiler="intel", mpilib="mpi-serial", debug="FALSE", comp_interface="nuopc"
+        )
+        case.set_value("TOTALPES", totalpes)
+        case.set_value("MAX_TASKS_PER_NODE", 128)
+        case.set_value("MAX_GPUS_PER_NODE", 4)
+        case.set_value("MAX_CPUTASKS_PER_GPU_NODE", 64)
+        case.set_value("NGPUS_PER_NODE", 0)
+        case.set_value("MEM_PER_TASK", mem_per_task)
+        case.set_value("MAX_MEM_PER_NODE", max_mem)
+        overrides = env_batch.get_job_overrides("case.test", case)
+
+        return overrides
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes two issues. One for minimum memory amount for batch (especially for mpi-serial on Derecho). And also fix a problem for FUNIT testing on Derecho. I've added some unit testing for the second, and will add unit testing for the first.

Test suite: list of tests
Test baseline: ctsm5.3.041
Test namelist changes: none
Test status: bit-for-bit

Fixes #4800 
Fixes #4796

User interface changes?: No

Update gh-pages html (Y/N)?: N

So far ran a list of tests:

ERP_D_Ld5_P48x1.f10_f10_mg37.I2000Clm50BgcCru.derecho_intel.clm-flexCN_FUN_BNF			
ERP_P64x2_D_Ld5.f10_f10_mg37.I1850Clm50Bgc.derecho_intel.clm-ciso			
ERS_D_Ld5_Mmpi-serial.1x1_mexicocityMEX.I1PtClm60SpRs.derecho_gnu.clm-CLM1PTStartDate			
ERS_D_Ld7_Mmpi-serial.1x1_smallvilleIA.IHistClm50BgcCropRs.derecho_intel.clm-decStart1851_noinitial			
ERS_D_Mmpi-serial_Ld5.5x5_amazon.I2000Clm50FatesRs.derecho_gnu.clm-FatesCold			
ERS_D_Mmpi-serial_Ld5.5x5_amazon.I2000Clm60FatesRs.derecho_intel.clm-FatesCold			
ERS_Ld1640_Mmpi-serial.1x1_numaIA.I2000Clm50BgcCrop.derecho_intel.clm-ciso_monthly_matrixcn_spinup			
ERS_Ld600_Mmpi-serial.1x1_smallvilleIA.I1850Clm50BgcCrop.derecho_gnu.clm-cropMonthlyNoinitial			
ERS_Ly5_Mmpi-serial.1x1_smallvilleIA.I1850Clm50BgcCrop.derecho_gnu.clm-ciso_monthly			
ERS_Ly5_Mmpi-serial.1x1_smallvilleIA.I1850Clm50BgcCrop.derecho_gnu.clm-ciso_monthly--clm-matrixcnOn			
FUNITCTSM_P1x1.f10_f10_mg37.I2000Clm50Sp.derecho_intel			
MKSURFDATAESMF_P128x1.f10_f10_mg37.I1850Clm50BgcCrop.derecho_intel			
PEM_D_Ld20.5x5_amazon.I2000Clm50FatesRs.derecho_gnu.clm-FatesCold
PEM_D_P25x1_Ld5.5x5_amazon.I2000Clm60Bgc.derecho_gnu.clm-HillslopeC			
PEM_P16x1_D.f10_f10_mg37.I1850Clm50BgcCrop.derecho_intel.clm-default			
PEM_P64x1_D.f10_f10_mg37.I1850Clm50BgcCrop.derecho_intel.clm-default			
PET_P64x2_D.f10_f10_mg37.I1850Clm50BgcCrop.derecho_intel.clm-default			
SMS.f10_f10_mg37.I2000Clm50BgcCrop.derecho_nvhpc.clm-crop			
SMS.f45_f45_mg37.I2000Clm60FatesSpRsGs.derecho_nvhpc.clm-FatesColdSatPhen			
SMS_D.1x1_brazil.I1850Clm60BgcCrop.derecho_gnu.clm-mimics_matrixcn			
SMS_D.1x1_brazil.I2000Clm60FatesSpCruRsGs.derecho_gnu.clm-FatesColdDryDepSatPhen			
SMS_D.1x1_brazil.I2000Clm60FatesSpCruRsGs.derecho_gnu.clm-FatesColdMeganSatPhen			
SMS_D_Ld20.5x5_amazon.I2000Clm50FatesRs.derecho_gnu.clm-FatesColdSeedDisp			
SMS_D_Ld5.5x5_amazon.I2000Clm60Bgc.derecho_gnu.clm-HillslopeC			
SMS_D_Ld5.f10_f10_mg37.ISSP245Clm50BgcCrop.derecho_gnu.clm-ciso_dec2050Start			
SMS_D_Mmpi-serial_Ld5.5x5_amazon.I2000Clm60Bgc.derecho_gnu.clm-Hillslope			
SMS_D_P25x1_Ld5.5x5_amazon.I2000Clm60Bgc.derecho_gnu.clm-HillslopeC			
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_gnu.clm-NEON-MOAB--clm-PRISM
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_gnu.clm-default--clm-NEON-HARV
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60Bgc.derecho_gnu.clm-default--clm-NEON-HARV--clm-matrixcnOn			
SMS_Ld10_D_Mmpi-serial.CLM_USRDAT.I1PtClm60SpRs.derecho_intel.clm-default--clm-NEON-TOOL			
SMS_Ld12_Mmpi-serial.1x1_vancouverCAN.I1PtClm60SpRs.derecho_gnu.clm-output_sp_highfreq			
SMS_Ld5.f10_f10_mg37.ISSP245Clm50BgcCrop.derecho_gnu.clm-ciso_dec2050Start			
SMS_Ld5_Mmpi-serial.1x1_brazil.IHistClm60Bgc.derecho_gnu.clm-mimics			
SMS_Ly1_Mmpi-serial.1x1_brazil.IHistClm60BgcQianRs.derecho_intel.clm-output_bgc_highfreq			
SMS_Ly5_Mmpi-serial.1x1_smallvilleIA.IHistClm60BgcCropQianRs.derecho_gnu.clm-gregorian_cropMonthOutput
