### PR TITLE
Revert "Output GPTL timing info when using NUOPC driver"

### DIFF
--- a/CIME/non_py/src/timing/perf_mod.F90
+++ b/CIME/non_py/src/timing/perf_mod.F90
@@ -1162,7 +1162,7 @@ contains
 !-----------------------------------------------------------------------
 !
    if (.not. timing_initialized) return
-#if defined NUOPC_INTERFACE && ! (defined MODEL_THETA_L && defined HOMME_ENABLE_COMPOSE)
+#ifdef NUOPC_INTERFACE
    return
 #endif
 


### PR DESCRIPTION
Reverts ESMCI/cime#4791