### PR TITLE
Update Makefile to add RTTOV libraries via CAM_CONFIG_OPTS.

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -879,6 +879,10 @@ endif
 ifdef COSP_LIBDIR
   ifeq ($(CIME_MODEL),cesm)
     ULIBDEP += $(COSP_LIBDIR)/libcosp.a
+    # Additionally include RTTOV if asked via CAM_CONFIG_OPTS.
+    ifeq ($(findstring -rttov,$(CAM_CONFIG_OPTS)),-rttov)
+      ULIBDEP += $(COSP_LIBDIR)/librttov_wrapper.a $(COSP_LIBDIR)/librttov_mw_scatt.a $(COSP_LIBDIR)/librttov_brdf_atlas.a $(COSP_LIBDIR)/librttov_emis_atlas.a  $(COSP_LIBDIR)/librttov_other.a $(COSP_LIBDIR)/librttov_parallel.a $(COSP_LIBDIR)/librttov_coef_io.a $(COSP_LIBDIR)/librttov_hdf.a $(COSP_LIBDIR)/librttov_main.a
+    endif
   endif
 endif
 


### PR DESCRIPTION
This Makefile change allows CESM to link with an existing build 
of the RTTOV radiative transfer model. COSP-RTTOV can then
be run to produce satellite-like diagnostic outputs. This update
is associated with CAM issue [1324](https://github.com/ESCOMP/CAM/issues/1324). 
Getting CESM to successfully link with and run RTTOV also
required changes to the ccs_config_cesm repository.

Test suite:
Test baseline:
Test namelist changes: n/A
Test status:
This change enables new diagnostic output provided by COSP-RTTOV,
answers are not changed.

Fixes [CIME Github issue #]
#4808  

User interface changes?: 
No, though the user may now add a new argument ("rttov")
to "CAM_CONFIG_OPTS" to trigger linking with RTTOV.

Update gh-pages html (Y/N)?:
No.
