### PR TITLE
archiver: Make entire special regex optional

### DIFF
--- a/CIME/XML/archive_base.py
+++ b/CIME/XML/archive_base.py
@@ -139,21 +139,28 @@ class ArchiveBase(GenericXML):
         for ext in extensions:
             if ext.endswith("$") and has_suffix:
                 ext = ext[:-1]
-            string = model + r"\d?_?(\d{4})?(_d\d{2})?\.?" + ext
+
+            # Build the regex that will identify history files
+            re_string = model  # We expect the model name to be in the filename
+            re_string += (
+                r"\d?_?(\d{4})?(_d\d{2})?"  # Need this for potential DART files?
+            )
+            re_string += r"\." + ext  # We expect a dot to precede the extension
+
             if has_suffix:
-                if not suffix in string:
-                    string += r"\." + suffix + "$"
+                if not suffix in re_string:
+                    re_string += r"\." + suffix + "$"
 
-                if not string.endswith("$"):
-                    string += "$"
+                if not re_string.endswith("$"):
+                    re_string += "$"
 
-            logger.debug("Regex is {}".format(string))
-            pfile = re.compile(string)
+            logger.debug("Regex is {}".format(re_string))
+            regex = re.compile(re_string)
             hist_files.extend(
                 [
                     f
                     for f in os.listdir(from_dir)
-                    if pfile.search(f)
+                    if regex.search(f)
                     and (
                         (f.startswith(casename) or f.startswith(model))
                         and not f.endswith("cprnc.out")

--- a/CIME/XML/archive_base.py
+++ b/CIME/XML/archive_base.py
@@ -139,7 +139,7 @@ class ArchiveBase(GenericXML):
         for ext in extensions:
             if ext.endswith("$") and has_suffix:
                 ext = ext[:-1]
-            string = model + r"\d?_?(\d{4})?(_d\d{2})?\." + ext
+            string = model + r"\d?_?(\d{4})?(_d\d{2})?\.?" + ext
             if has_suffix:
                 if not suffix in string:
                     string += r"\." + suffix + "$"

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1696,6 +1696,7 @@ class Case(object):
             os.path.join(toolsdir, "xmlchange"),
             os.path.join(toolsdir, "xmlquery"),
             os.path.join(toolsdir, "pelayout"),
+            os.path.join(toolsdir, "wait_for_tests"),
         )
         try:
             for exefile in exefiles:


### PR DESCRIPTION
The problem with the original line of code:
`string = model + r"\d?_?(\d{4})?(_d\d{2})?\." + ext`

... is that the `.` at the end is not optional, which will mean files like:

`ERS_Ln3.ne4_ne4.F2010-SCREAMv1.mappy_gnu.20250701_125457_1nse3o.scream.h.AVERAGE.nsteps_x3.0001-01-01-00000.nc`

Will not match regexes like

`<hist_file_extension>.*\.h\.(?!rhist\.).*\.nc$</hist_file_extension>`

Because there's only one `.` between the model (scream) and the hist extension `h`.

I think, since the added regex is intended to be optional, is to make all of it optional via another `?`.

Also, add wait_for_tests to the list of tools that gets copied to the case.

Test suite: by-hand
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
