### PR TITLE
Fix resolving reference variables in mixed subgroups

### DIFF
--- a/CIME/XML/entry_id.py
+++ b/CIME/XML/entry_id.py
@@ -394,7 +394,7 @@ class EntryID(GenericXML):
             val = self.get_default_value(node)
 
         if resolved:
-            val = self.get_resolved_value(val)
+            val = self.get_resolved_value(val, subgroup=subgroup)
 
         return val
 

--- a/CIME/XML/entry_id.py
+++ b/CIME/XML/entry_id.py
@@ -313,7 +313,7 @@ class EntryID(GenericXML):
         )
         node = self.get_optional_child("entry", {"id": vid}, root=root)
         if node is not None:
-            val = self._set_value(node, value, vid, subgroup, ignore_type)
+            val = self._set_value(node, value, vid, None, ignore_type)
         return val
 
     def get_values(self, vid, attribute=None, resolved=True, subgroup=None):

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -100,9 +100,9 @@ class EnvBatch(EnvBase):
 
     def get_type_info(self, vid):
         gnodes = self.get_children("group")
+        type_info = None
         for gnode in gnodes:
             nodes = self.get_children("entry", {"id": vid}, root=gnode)
-            type_info = None
             for node in nodes:
                 new_type_info = self._get_type_info(node)
                 if type_info is None:

--- a/CIME/XML/env_workflow.py
+++ b/CIME/XML/env_workflow.py
@@ -77,7 +77,6 @@ class EnvWorkflow(EnvBase):
         type_info = None
         for gnode in gnodes:
             nodes = self.get_children("entry", {"id": vid}, root=gnode)
-            type_info = None
             for node in nodes:
                 new_type_info = self._get_type_info(node)
                 if type_info is None:

--- a/CIME/XML/generic_xml.py
+++ b/CIME/XML/generic_xml.py
@@ -650,7 +650,7 @@ class GenericXML(object):
         True
         """
         logger.debug("raw_value {}".format(raw_value))
-        reference_re = re.compile(r"\${?(\w+)}?")
+        reference_re = re.compile(r"\${?(?:(.*)::)?(\w+)}?")
         env_ref_re = re.compile(r"\$ENV\{(\w+)\}")
         shell_ref_re = re.compile(r"\$SHELL\{([^}]+)\}")
         math_re = re.compile(r"\s[+-/*]\s")
@@ -677,12 +677,17 @@ class GenericXML(object):
             item_data = item_data.replace(s.group(), run_cmd_no_fail(shell_cmd))
 
         for m in reference_re.finditer(item_data):
-            var = m.groups()[0]
-            logger.debug("find: {}".format(var))
+            _subgroup, var = m.groups()
+
+            logger.debug("find: {} in group {}".format(var, _subgroup))
+
+            if _subgroup is None:
+                _subgroup = subgroup
+
             # The overridden versions of this method do not simply return None
             # so the pylint should not be flagging this
             # pylint: disable=assignment-from-none
-            ref = self.get_value(var, subgroup=subgroup)
+            ref = self.get_value(var, subgroup=_subgroup)
 
             if ref is not None:
                 logger.debug("resolve: " + str(ref))

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -508,6 +508,10 @@ class Case(object):
                 if resolved and isinstance(result, str):
                     result = self.get_resolved_value(result, subgroup=subgroup)
 
+                    if "$" in result:
+                        # last ditch effort to get variable from any group
+                        result = self.get_resolved_value(result)
+
                     # If still not resolved, we have a problem
                     expect(
                         "$" not in result, "Could not resolve variable {}".format(item)

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -635,10 +635,11 @@ class Case(object):
             "Case must be opened with read_only=False and can only be modified within a context manager",
         )
 
-        expect(
-            len(value.split("::")) <= 2,
-            f"Value {value!r} is not valid, a namespaced reference must be in the form $SUBGROUP::VARIABLE",
-        )
+        if isinstance(value, str):
+            expect(
+                len(value.split("::")) <= 2,
+                f"Value {value!r} is not valid, a namespaced reference must be in the form $SUBGROUP::VARIABLE",
+            )
 
         if item == "CASEROOT":
             self._caseroot = value
@@ -1099,9 +1100,9 @@ class Case(object):
         )
         drv_comp_model_specific = Component(drv_config_file_model_specific, "CPL")
 
-        self._component_description[
-            "forcing"
-        ] = drv_comp_model_specific.get_forcing_description(self._compsetname)
+        self._component_description["forcing"] = (
+            drv_comp_model_specific.get_forcing_description(self._compsetname)
+        )
         logger.info(
             "Compset forcing is {}".format(self._component_description["forcing"])
         )

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1624,8 +1624,10 @@ class Case(object):
             env_postprocessing.add_elements_by_group(srcobj=postprocessing)
             # Add cupid related fields to env_mach_pes.xml
             env_mach_pes = self.get_env("mach_pes")
-            env_mach_pes.add_elements_by_group(srcobj=postprocessing)
-
+            if env_mach_pes.get_value("CUPID_NTASKS") is None:
+                env_mach_pes.unlock()
+                env_mach_pes.add_elements_by_group(srcobj=postprocessing)
+                env_mach_pes.lock()
         env_batch.set_batch_system(batch, batch_system_type=batch_system_type)
 
         bjobs = workflow.get_workflow_jobs(machine=machine_name, workflowid=workflowid)

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -1100,9 +1100,9 @@ class Case(object):
         )
         drv_comp_model_specific = Component(drv_config_file_model_specific, "CPL")
 
-        self._component_description["forcing"] = (
-            drv_comp_model_specific.get_forcing_description(self._compsetname)
-        )
+        self._component_description[
+            "forcing"
+        ] = drv_comp_model_specific.get_forcing_description(self._compsetname)
         logger.info(
             "Compset forcing is {}".format(self._component_description["forcing"])
         )

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -14,7 +14,7 @@ from CIME.XML.standard_module_setup import *
 from CIME import utils
 from CIME.config import Config
 from CIME.status import append_status
-from CIME.utils import expect, get_cime_root
+from CIME.utils import CIMEError, expect, get_cime_root
 from CIME.utils import convert_to_type, get_model, set_model
 from CIME.utils import get_project, get_charge_account, check_name
 from CIME.utils import get_current_commit, safe_copy, get_cime_default_driver
@@ -461,19 +461,13 @@ class Case(object):
             )
             if len(results) > 0:
                 new_results = []
+
                 if resolved:
                     for result in results:
                         if isinstance(result, str):
-                            result = self.get_resolved_value(result)
-                            vtype = env_file.get_type_info(item)
-                            if vtype is not None or vtype != "char":
-                                result = convert_to_type(result, vtype, item)
+                            result = self._resolve_variable(item, result, env_file)
 
-                            new_results.append(result)
-
-                        else:
-                            new_results.append(result)
-
+                        new_results.append(result)
                 else:
                     new_results = results
 
@@ -501,26 +495,43 @@ class Case(object):
 
             if result is not None:
                 if resolved and isinstance(result, str):
-                    # Try to resolve using the current subgroup
-                    result = self.get_resolved_value(result, subgroup=subgroup)
-
-                    # If that didn't work, try to resolve without a subgroup
-                    if "$" in result:
-                        result = self.get_resolved_value(result)
-
-                    # If still not resolved, we have a problem
-                    expect(
-                        "$" not in result, "Could not resolve variable {}".format(item)
-                    )
-
-                    vtype = env_file.get_type_info(item)
-
-                    if vtype is not None and vtype != "char":
-                        result = convert_to_type(result, vtype, item)
+                    result = self._resolve_variable(item, result, env_file)
 
                 return result
 
         return None
+
+    def _resolve_variable(self, name, value, env_file, subgroup=None):
+        _value = value
+
+        if "::" in _value:
+            try:
+                subgroup, _value = _value.split("::")
+            except ValueError:
+                raise CIMEError(
+                    f"Variable {name!r} with {value!r} from {env_file.filename!r} is not valid, the format must be $VAR or $SUBGROUP::VAR"
+                ) from None
+
+            subgroup = subgroup.replace("$", "")
+
+            _value = f"${_value}"
+
+        # Try to resolve using the current subgroup
+        resolved_value = self.get_resolved_value(_value, subgroup=subgroup)
+
+        # If that didn't work, try to resolve without a subgroup
+        if "$" in resolved_value:
+            resolved_value = self.get_resolved_value(resolved_value)
+
+        # If still not resolved, we have a problem
+        expect("$" not in resolved_value, "Could not resolve variable {}".format(name))
+
+        vtype = env_file.get_type_info(name)
+
+        if vtype is not None and vtype != "char":
+            resolved_value = convert_to_type(resolved_value, vtype, name)
+
+        return resolved_value
 
     def get_record_fields(self, variable, field):
         """get_record_fields gets individual requested field from an entry_id file
@@ -622,6 +633,11 @@ class Case(object):
             not self._read_only_mode,
             "Cannot modify case, read_only. "
             "Case must be opened with read_only=False and can only be modified within a context manager",
+        )
+
+        expect(
+            len(value.split("::")) <= 2,
+            f"Value {value!r} is not valid, a namespaced reference must be in the form $SUBGROUP::VARIABLE",
         )
 
         if item == "CASEROOT":

--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -495,7 +495,9 @@ class Case(object):
 
             if result is not None:
                 if resolved and isinstance(result, str):
-                    result = self._resolve_variable(item, result, env_file)
+                    result = self._resolve_variable(
+                        item, result, env_file, subgroup=subgroup
+                    )
 
                 return result
 

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -7,7 +7,8 @@ import tempfile
 
 from CIME.case import case_submit
 from CIME.case import Case
-from CIME import utils as cime_utils
+from CIME import utils
+from CIME.tests.utils import mock_case
 
 
 def make_valid_case(path):
@@ -82,22 +83,12 @@ class TestCaseSubmit(unittest.TestCase):
             )
 
 
-def mock_case(func):
-    @mock.patch("CIME.case.case.Case.read_xml")
-    def wrapper(self, *args, **kwargs):
-        with tempfile.TemporaryDirectory() as tempdir:
-            with Case(f"{tempdir}/case", read_only=False) as case:
-                func(self, *args, **kwargs, tempdir=tempdir, case=case)
-
-    return wrapper
-
-
 class TestCase(unittest.TestCase):
     def setUp(self):
-        self.srcroot = os.path.abspath(cime_utils.get_src_root())
+        self.srcroot = os.path.abspath(utils.get_src_root())
         self.tempdir = tempfile.TemporaryDirectory()
 
-    @mock_case
+    @mock_case()
     def test_get_value_reference(self, _, tempdir, case):
         env = mock.MagicMock()
 
@@ -115,7 +106,7 @@ class TestCase(unittest.TestCase):
 
         # test that get_resolved_value cannot resolve the reference
         with self.assertRaisesRegex(
-            cime_utils.CIMEError, "Could not resolve variable HIST_N"
+            utils.CIMEError, "Could not resolve variable HIST_N"
         ):
             case.get_value("HIST_N")
 

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -132,21 +132,16 @@ class TestCase(unittest.TestCase):
         assert hist_n == 5, hist_n
         assert isinstance(hist_n, int)
 
-    @mock_case
-    def test_get_value(self, _, tempdir, case):
-        env = mock.MagicMock()
-
-        # mock an env file with HIST_N=2
-        env.get_value.return_value = 2
-        # set the case to have one env file
-        case._files = [env]
+    @mock_case()
+    def test_get_value(self, case, test_env, **kwargs):
+        test_env.new_entry("HIST_N", "2", etype="integer")
 
         hist_n = case.get_value("HIST_N")
 
         assert hist_n == 2, hist_n
 
-    @mock_case
-    def test_get_value_no_files(self, _, tempdir, case):
+    @mock_case(empty_env=True)
+    def test_get_value_no_files(self, case, **kwargs):
         hist_n = case.get_value("HIST_N")
 
         assert hist_n == None, hist_n

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -114,9 +114,10 @@ class TestCase(unittest.TestCase):
         env.get_resolved_value.return_value = "5"
 
         # test that get_resolved_value cannot resolve the reference
-        hist_n = case.get_value("HIST_N")
-
-        assert hist_n == "$STOP_N", hist_n
+        with self.assertRaisesRegex(
+            cime_utils.CIMEError, "Could not resolve variable HIST_N"
+        ):
+            case.get_value("HIST_N")
 
         # test that get_resolved_value can resolve the reference
         with mock.patch.object(

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -111,7 +111,7 @@ class TestCase(unittest.TestCase):
         assert hist_n == "$STOP_N", hist_n
 
         env.get_type_info.return_value = None
-        env.get_resolved_value.return_value = 5
+        env.get_resolved_value.return_value = "5"
 
         # test that get_resolved_value cannot resolve the reference
         hist_n = case.get_value("HIST_N")
@@ -122,11 +122,11 @@ class TestCase(unittest.TestCase):
         with mock.patch.object(
             case, "get_resolved_value", wraps=case.get_resolved_value
         ) as grv:
-            grv.return_value = 5
+            grv.return_value = "5"
 
             hist_n = case.get_value("HIST_N")
 
-        assert hist_n == 5, hist_n
+        assert hist_n == "5", hist_n
 
         # test that get_resolved_value can resolve the reference and convert to type
         env.get_type_info.return_value = "real"

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -116,6 +116,12 @@ class TestCase(unittest.TestCase):
 
         assert hist_n == 5, hist_n
 
+        case.set_value("HIST_N", 10)
+
+        hist_n = case.get_value("HIST_N")
+
+        assert hist_n == 10, hist_n
+
     @mock_case()
     def test_get_values_namespaced_reference(self, case, test_env, **kwargs):
         test_env.new_group("test1")

--- a/CIME/tests/utils.py
+++ b/CIME/tests/utils.py
@@ -53,7 +53,7 @@ MACRO_PRESERVE_ENV = [
 ]
 
 
-def mock_case():
+def mock_case(*pargs, **pkwargs):
     def outer(func):
         @mock.patch("CIME.case.case.Case.read_xml")
         def wrapper(self, *args, **kwargs):

--- a/CIME/tests/utils.py
+++ b/CIME/tests/utils.py
@@ -7,10 +7,12 @@ import sys
 import time
 import contextlib
 from collections.abc import Iterable
+from unittest import mock
 
 from CIME import utils
 from CIME import test_status
 from CIME.utils import expect
+from CIME.case import Case
 
 MACRO_PRESERVE_ENV = [
     "ADDR2LINE",
@@ -49,6 +51,19 @@ MACRO_PRESERVE_ENV = [
     "STRINGS",
     "STRIP",
 ]
+
+
+def mock_case():
+    def outer(func):
+        @mock.patch("CIME.case.case.Case.read_xml")
+        def wrapper(self, *args, **kwargs):
+            with tempfile.TemporaryDirectory() as tempdir:
+                with Case(f"{tempdir}/case", read_only=False) as case:
+                    func(self, *args, **kwargs, tempdir=tempdir, case=case)
+
+        return wrapper
+
+    return outer
 
 
 @contextlib.contextmanager

--- a/CIME/tests/utils.py
+++ b/CIME/tests/utils.py
@@ -74,6 +74,24 @@ class TestEnv(EntryID):
 
         self.read_fd(io.StringIO(test_env_xml))
 
+    def get_type_info(self, vid):
+        gnodes = self.get_children("group")
+        type_info = None
+        for gnode in gnodes:
+            nodes = self.get_children("entry", {"id": vid}, root=gnode)
+            for node in nodes:
+                new_type_info = self._get_type_info(node)
+                if type_info is None:
+                    type_info = new_type_info
+                else:
+                    expect(
+                        type_info == new_type_info,
+                        "Inconsistent type_info for entry id={} {} {}".format(
+                            vid, new_type_info, type_info
+                        ),
+                    )
+        return type_info
+
     def new_group(self, name):
         return self.make_child("group", attributes={"id": name})
 

--- a/CIME/tests/utils.py
+++ b/CIME/tests/utils.py
@@ -82,9 +82,10 @@ class TestEnv(EntryID):
         name,
         value=None,
         subgroup=None,
-        etype="char",
+        etype="integer",
         valid_values=None,
         desc=None,
+        default_value=None,
     ):
         root_node = None
 
@@ -102,6 +103,18 @@ class TestEnv(EntryID):
         )
 
         self.make_child("type", text=etype, root=entry)
+
+        if valid_values:
+            if isinstance(valid_values, (list, tuple)):
+                valid_values = ",".join(valid_values)
+
+            self.make_child("valid_values", text=",".join(valid_values), root=entry)
+
+        if desc:
+            self.make_child("desc", text=desc, root=entry)
+
+        if default_value:
+            self.make_child("default_value", text=default_value, root=entry)
 
         return entry
 
@@ -134,7 +147,10 @@ class TestEnv(EntryID):
         return ET.tostring(self.root.xml_element, encoding="unicode", method="xml")
 
 
-def mock_case(*args, empty_env=False, **kwargs):
+def mock_case(*args, empty_env=False, filename=None, **kwargs):
+    if filename is None:
+        filename = "env_test.xml"
+
     def outer(func):
         # patch "read_xml" function since the source file usually doesn't exist
         @mock.patch("CIME.case.case.Case.read_xml")
@@ -143,6 +159,7 @@ def mock_case(*args, empty_env=False, **kwargs):
                 caseroot = f"{tempdir}/case"
                 with Case(caseroot, read_only=False) as case:
                     env = TestEnv()
+                    env.filename = f"{os.getcwd()}/{filename}"
 
                     if not empty_env:
                         case._files = [env]

--- a/CIME/tests/utils.py
+++ b/CIME/tests/utils.py
@@ -134,7 +134,7 @@ class TestEnv(EntryID):
         return ET.tostring(self.root.xml_element, encoding="unicode", method="xml")
 
 
-def mock_case(*args, **kwargs):
+def mock_case(*args, empty_env=False, **kwargs):
     def outer(func):
         # patch "read_xml" function since the source file usually doesn't exist
         @mock.patch("CIME.case.case.Case.read_xml")
@@ -144,9 +144,10 @@ def mock_case(*args, **kwargs):
                 with Case(caseroot, read_only=False) as case:
                     env = TestEnv()
 
-                    case._files = [env]
+                    if not empty_env:
+                        case._files = [env]
 
-                    case._env_entryid_files = [env]
+                        case._env_entryid_files = [env]
 
                     func(
                         self,

--- a/doc/source/ccs/setting-up-a-case.rst
+++ b/doc/source/ccs/setting-up-a-case.rst
@@ -63,6 +63,18 @@ The ``xmlchange`` command is used to modify the configuration of a case. The fol
     
     ./xmlchange <variable>=<value>
 
+The `value` can be literal or a reference to another value. When using a reference, it must be prefixed with `$`.
+
+.. code-block:: bash
+
+    ./xmlchange <variable>=$<variable>
+
+The reference can also define the `subgroup`. This is usful when a variable exists under multiple subgroups and a specific one needs to be referenced. The `subgroup` and `variable` are delimited with `::`.
+
+.. code-block:: bash
+
+    ./xmlchange <variable>=$<subgroup>::<variable>
+
 Some variables can exist in multiple groups. To change a variable in a specific group, use the ``--subgroup`` option.
 
 .. code-block:: bash


### PR DESCRIPTION
Querying a variable whose value is a reference that exists
in a different `subgroup` would fail with `ERROR: Entry
HIST_N was listed as type int but value '$STOP_N' is not
valid int`. 

This PR changes the behavior so a variable that cannot
be resolved within the current subgroup will try to resolve
from any subgroup. Finally if still not resolvable an exception
is raised.

Test suite: pytest CIME/tests/test_unit*
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes #4646 

User interface changes?:
Update gh-pages html (Y/N)?:
