### PR TITLE
Implement dependency tracking support for Fortran submodules

### DIFF
--- a/CIME/Tools/mkDepends
+++ b/CIME/Tools/mkDepends
@@ -185,8 +185,8 @@ foreach $f (@src) {
     my $file_path = find_file($f);
     open(FH, $file_path)  or die "Can't open $file_path: $!\n";
     while ( <FH> ) {
-	# Search for module definitions.
-	if ( /^\s*MODULE\s+(\w+)\s*(\!.*)?$/i ) {
+        # Search for module and submodule definitions.
+        if ( /^\s*MODULE\s+(\w+)\s*(\!.*)?$/i || /^\s*SUBMODULE\s*\(\s*\w+\s*(?:\:\s*\w+\s*)?\)\s*(\w+)/i ) {
 	    ($mod = $1) =~ tr/A-Z/a-z/;
             if ( defined $module_files{$mod} ) {
                 die "Duplicate definitions of module $mod in $module_files{$mod} and $name: $!\n";
@@ -427,22 +427,28 @@ sub find_dependencies {
 	    push @incs, $include;
 	    undef $include;
 	}
-	# Search for module dependencies.
-	elsif ( /^\s*USE(?:\s+|\s*\:\:\s*|\s*,\s*non_intrinsic\s*\:\:\s*)(\w+)/i ) {
-	    # Return dependency in the form of a .mod file
-	    ($module = $1) =~ tr/A-Z/a-z/;
-	    if ( defined $module_files{$module} ) {
-		# Check for circular dependency
-		unless ("$module_files{$module}.o" eq $target) {
-                    $modules_used{$module} = ();
-                    push @mods, "$obj_dir".mangle_modfile($module);
-		}
-	    }
-            # If we already have a .mod file around.
-            elsif ( defined $trumod_files{$module} ) {
-                push @mods, "$obj_dir".mangle_modfile($trumod_files{$module});
+        # Search for module dependencies.
+        # Module dependencies are extracted from the following patterns:
+        # 1. The "module-name" in a Fortran "USE [[, module-nature] ::] module-name" statement
+        # 2. The "ancestor-module-name" and "parent-submodule-name" in a Fortran "SUBMODULE (ancestor-module-name [: parent-submodule-name ]) submodule-name" statement
+        elsif ( /^\s*USE(?:\s+|\s*\:\:\s*|\s*,\s*non_intrinsic\s*\:\:\s*)(\w+)/i || /^\s*SUBMODULE\s*\(\s*(\w+)\s*(?:\:\s*(\w+)\s*)?\)\s*\w+/i ) {
+            # There might be one or two matches from the regexes above.
+            for my $match (grep { defined } ($1, $2)) {
+                # Return dependency in the form of a .mod file.
+                (my $module = $match) =~ tr/A-Z/a-z/;
+                if ( defined $module_files{$module} ) {
+                    # Check for circular dependency.
+                    unless ("$module_files{$module}.o" eq $target) {
+                        $modules_used{$module} = ();
+                        push @mods, "$obj_dir".mangle_modfile($module);
+                    }
+                }
+                # If we already have a .mod file around.
+                elsif ( defined $trumod_files{$module} ) {
+                    push @mods, "$obj_dir".mangle_modfile($trumod_files{$module});
+                }
             }
-	}
+        }
     }
     close( FH );
     return (\@mods, \@incs);

--- a/CIME/Tools/mkDepends
+++ b/CIME/Tools/mkDepends
@@ -476,16 +476,18 @@ sub find_file {
 
 sub rm_duplicates {
 
-# Return a list with duplicates removed.
+# Return a list with duplicates removed, preserving the original order.
 
-    my ($in) = @_;       # input arrary reference
-    my @out = ();
-    my $i;
-    my %h = ();
-    foreach $i (@$in) {
-	$h{$i} = '';
+    my ($in) = @_;
+    my @out  = ();
+    my %seen = ();
+
+    for my $item (@$in) {
+        unless ($seen{$item}++) {
+            push @out, $item;
+        }
     }
-    @out = keys %h;
+
     return \@out;
 }
 

--- a/CIME/Tools/mkDepends
+++ b/CIME/Tools/mkDepends
@@ -371,20 +371,19 @@ foreach $f (sort keys %file_modules) {
         $f =~ /(.+)\./;
 	$file = $1;
     }
-    $target = $obj_dir."$file.o";
-    print "$target : $f @{$file_modules{$f}} @{$file_includes{$f}} $additional_file \n";
+    my $target = $obj_dir."$file.o";
+    print join(" ", grep { defined } ("$target :", $f, @{$file_modules{$f}}, @{$file_includes{$f}}, $additional_file))."\n";
 }
 
 print "# The following section relates each module to the corresponding file.\n";
 $target = mangle_modfile("%");
-print "$target : \n";
+print "$target :\n";
 print "\t\@\:\n";
 
 foreach $mod (sort keys %modules_used) {
     my $mod_fname = $obj_dir.mangle_modfile($mod);
     my $obj_fname = $obj_dir.$module_files{$mod}.".o";
     print "$mod_fname : $obj_fname\n";
-
 }
 
 #--------------------------------------------------------------------------------------

--- a/CIME/Tools/mkDepends
+++ b/CIME/Tools/mkDepends
@@ -429,7 +429,7 @@ sub find_dependencies {
         # Search for module dependencies.
         # Module dependencies are extracted from the following patterns:
         # 1. The "module-name" in a Fortran "USE [[, module-nature] ::] module-name" statement
-        # 2. The "ancestor-module-name" and "parent-submodule-name" in a Fortran "SUBMODULE (ancestor-module-name [: parent-submodule-name ]) submodule-name" statement
+        # 2. The "ancestor-module-name" and "parent-submodule-name" in a Fortran "SUBMODULE (ancestor-module-name [: parent-submodule-name]) submodule-name" statement
         elsif ( /^\s*USE(?:\s+|\s*\:\:\s*|\s*,\s*non_intrinsic\s*\:\:\s*)(\w+)/i || /^\s*SUBMODULE\s*\(\s*(\w+)\s*(?:\:\s*(\w+)\s*)?\)\s*\w+/i ) {
             # There might be one or two matches from the regexes above.
             for my $match (grep { defined } ($1, $2)) {


### PR DESCRIPTION
The submodule feature was added in the Fortran 2008 language standard.
A submodule is a program unit that extends a module or another submodule.
This means that submodules can be nested. As such, compiling a submodule
requires that all of its ancestors be compiled first.

This PR enables the `mkDepends` tool to recognize the Fortran `submodule`
statement, and to correctly generate build dependencies from it.

Additional improvements included in this PR:

* The `mkDepends` tool now lists build dependencies in deterministic
  order, which is very helpful when debugging build dependency issues.
* Remove messy trailing spaces from the output, which can be observed
  in the generated `Depends` file.

-----

Test suite: Manual (e.g., compilation tests of: 1. B cases in CESM; 2. CAM-SIMA) + `pytest CIME/tests/test_unit*`
Test baseline:
Test namelist changes:
Test status: Bit for bit

Fixes [CIME Github issue #]

User interface changes?: N

Update gh-pages html (Y/N)?: N