### PR TITLE
Correct variable name, actually use OpenACC build flags in MPAS-A

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -565,11 +565,11 @@ ifdef MPAS_LIBDIR
 .PHONY: libmpas
 # The CASEROOT, COMPILER and MACH are added so that the Depends file could be visible to
 # the MPAS dycore.
-# The GPUFLAGS is added so that the GPU flags defined in ccs_config_cesm could also be
+# The OPENACC_GPU_FLAGS is added so that the GPU flags defined in ccs_config_cesm could also be
 # used to build the MPAS dycore if needed.
 libmpas: cam_abortutils.o physconst.o
 	$(MAKE) -C $(MPAS_LIBDIR) CC="$(CC)" FC="$(FC)" PIODEF="$(PIODEF)" \
-	FFLAGS='$(FREEFLAGS) $(FFLAGS)' GPUFLAGS='$(GPUFLAGS)' \
+	FFLAGS='$(FREEFLAGS) $(FFLAGS)' OPENACC_GPU_FLAGS='$(OPENACC_GPU_FLAGS)' \
 	CASEROOT='$(CASEROOT)' COMPILER='$(COMPILER)' MACH='$(MACH)' \
 	FCINCLUDES='$(INCLDIR) $(INCS) -I$(ABS_INSTALL_SHAREDPATH)/include -I$(ABS_ESMF_PATH)/include'
 


### PR DESCRIPTION
## Description
Correct a variable name in Makefile. `GPUFLAGS` --> `OPENACC_GPU_FLAGS`

## Checklist
- [x] My code follows the style guidlines of this proejct (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that exercise my feature/fix and existing tests continue to pass~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding additions and changes to the documentation~~
    - To my sense, the last few points don't apply.