### PR TITLE
Add buildconf rm to case reset

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@
 - [ ] My code follows the style guidlines of this proejct (black formatting)
 - [ ] I have performed a self-review of my own code
 - [ ] My changes generate no new warnings
-- [ ] I have added tests that excerise my feature/fix and existing tests continue to pass
+- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding additions and changes to the documentation

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -254,7 +254,7 @@ def _case_setup_impl(
 
     # Remove batch scripts
     if reset or clean:
-        # clean setup-generated files
+        # clean setup and build generated files
         batch_script = get_batch_script_for_job(case.get_primary_job())
         files_to_clean = [
             batch_script,

--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -262,6 +262,7 @@ def _case_setup_impl(
             "Macros.make",
             "Macros.cmake",
             "cmake_macros",
+            "Buildconf",
         ]
         for file_to_clean in files_to_clean:
             if os.path.exists(file_to_clean) and not (keep and file_to_clean in keep):


### PR DESCRIPTION
## Description
CAM needs to have its file Buildconf/camconf/config_cache.xml removed when case.setup --reset is called, I think that removing the entire Buildconf directory
is the correct component independent action to take.  

- Closes #4822

## Checklist
- [X] My code follows the style guidlines of this proejct (black formatting)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
