### PR TITLE
modify err test to use the midpoint restart instead of the first one

### DIFF
--- a/CIME/SystemTests/err.py
+++ b/CIME/SystemTests/err.py
@@ -28,29 +28,25 @@ class ERR(RestartTest):
     def _case_one_setup(self):
         super(ERR, self)._case_one_setup()
         self._case.set_value("DOUT_S", True)
-
+        
     def _case_two_setup(self):
         super(ERR, self)._case_two_setup()
         self._case.set_value("DOUT_S", False)
 
     def _case_two_custom_prerun_action(self):
         dout_s_root = self._case1.get_value("DOUT_S_ROOT")
-        self._drv_restart_pointer = self._case2.get_value("DRV_RESTART_POINTER")
-        if self._drv_restart_pointer is None:
-            rest_root = os.path.abspath(os.path.join(dout_s_root, "rest"))
-            restart_list = ls_sorted_by_mtime(rest_root)
-            expect(
-                len(restart_list) >= 1, "No restart files found in {}".format(rest_root)
-            )
-            self._case.restore_from_archive(
-                rest_dir=os.path.join(rest_root, restart_list[0])
-            )
-        else:
-            resttime = self._drv_restart_pointer[-16:]
-            rest_root = os.path.abspath(os.path.join(dout_s_root, "rest", resttime))
-            expect(os.path.isdir(rest_root), "None such directory {}".format(rest_root))
-            self._case.restore_from_archive(rest_dir=rest_root)
-
+        rest_root = os.path.abspath(os.path.join(dout_s_root, "rest"))
+        restart_list = ls_sorted_by_mtime(rest_root)
+        rest_cnt = len(restart_list)
+        expect(
+            rest_cnt >= 1, "No restart files found in {}".format(rest_root)
+        )
+        rest_dir = restart_list[max(1,rest_cnt//2)]
+        self._case.restore_from_archive(
+            rest_dir=os.path.join(rest_root, rest_dir)
+        )
+        self._case.set_value('DRV_RESTART_POINTER', 'rpointer.cpl.'+rest_dir)
+        
     def _case_two_custom_postrun_action(self):
         # Link back to original case1 name
         # This is needed so that the necessary files are present for


### PR DESCRIPTION
## Description
Set ERR test to use the median instead of first available restart date.

- Closes #4828

## Checklist
- [X] My code follows the style guidlines of this proejct (black formatting)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that exercise my feature/fix and existing tests continue to pass
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding additions and changes to the documentation
