### PR TITLE
correct math in rest_dir calculation

### DIFF
--- a/CIME/SystemTests/err.py
+++ b/CIME/SystemTests/err.py
@@ -39,6 +39,7 @@ class ERR(RestartTest):
         rest_root = os.path.abspath(os.path.join(dout_s_root, "rest"))
         restart_list = ls_sorted_by_fname(rest_root)
         rest_cnt = len(restart_list)
+        expect(rest_cnt >= 1, "No restart files found in {}".format(rest_root))
         rest_dir = restart_list[max(0, rest_cnt // 2)]
         self._case.restore_from_archive(rest_dir=os.path.join(rest_root, rest_dir))
         logger.info("Setting restart to {}".format(rest_dir))


### PR DESCRIPTION
## Description
Incorrect math in err.py leads to occasional crash.

- Closes #<ISSUE_NUMBER_HERE>

## Checklist
- [X] My code follows the style guidlines of this proejct (black formatting)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that excerise my feature/fix and existing tests continue to pass
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding additions and changes to the documentation
