### PR TITLE
Change Kokkos sharedlib to ekat

### DIFF
--- a/CIME/build.py
+++ b/CIME/build.py
@@ -746,6 +746,9 @@ def _build_libraries(
             cpl_in_complist = True
     if ufs_driver:
         logger.info("UFS_DRIVER is set to {}".format(ufs_driver))
+
+    # This is a bit hacky. The host model should define whatever
+    # shared libs it might need.
     if ufs_driver and ufs_driver == "nems" and not cpl_in_complist:
         libs = []
     elif case.get_value("MODEL") == "cesm":
@@ -761,7 +764,7 @@ def _build_libraries(
         libs.insert(0, mpilib)
 
     if uses_kokkos(case) and comp_interface != "nuopc":
-        libs.append("kokkos")
+        libs.append("ekat")
 
     # Build shared code of CDEPS nuopc data models
     build_script = {}


### PR DESCRIPTION
## Description

E3SM wants to use Kokkos through EKAT, so we want EKAT to be the sharedlib that gets built by CIME, not Kokkos directly.

I don't know if this will impact anyone outside of E3SM, I don't think it will..

It seems like it might be better to have the host model have a config somewhere that describes the sharedlibs it needs rather than having this hardcoded in CIME/build.py.

## Checklist
- [ x ] My code follows the style guidlines of this proejct (black formatting)
- [ x ] I have performed a self-review of my own code
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that excerise my feature/fix and existing tests continue to pass
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding additions and changes to the documentation
