### PR TITLE
correct path to mock_case

### DIFF
--- a/CIME/tests/test_unit_build.py
+++ b/CIME/tests/test_unit_build.py
@@ -6,7 +6,7 @@ from unittest import mock
 from pathlib import Path
 
 from CIME import build
-from .utils import mock_case
+from CIME.tests.utils import mock_case
 
 
 class TestBuild(unittest.TestCase):


### PR DESCRIPTION
## Description
Testing in [CMEPS](https://github.com/ESCOMP/CMEPS/actions/runs/17297852366/job/49100568011) fails due to a relative path, change the path to be relative to CIME.

- Closes #4842

## Checklist
- [X] My code follows the style guidlines of this proejct (black formatting)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that excerise my feature/fix and existing tests continue to pass
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding additions and changes to the documentation
