### PR TITLE
Restore behavior of system test compare two setup

### DIFF
--- a/CIME/SystemTests/system_tests_compare_n.py
+++ b/CIME/SystemTests/system_tests_compare_n.py
@@ -60,7 +60,6 @@ class SystemTestsCompareN(SystemTestsCommon):
         run_descriptions=None,
         multisubmit=False,
         ignore_fieldlist_diffs=False,
-        dry_run=False,
         **kwargs
     ):
         """

--- a/CIME/SystemTests/system_tests_compare_n.py
+++ b/CIME/SystemTests/system_tests_compare_n.py
@@ -131,8 +131,10 @@ class SystemTestsCompareN(SystemTestsCommon):
         self._cases[0] = self._case
         self._caseroots = self._get_caseroots()
 
-        if not dry_run:
-            self._setup_cases_if_not_yet_done()
+        if os.path.exists(self._caseroots[-1]):
+            for i in range(1, self.N):
+                caseroot_i = self._caseroots[i]
+                self._cases[i] = self._case_from_existing_caseroot(caseroot_i)
 
         self._multisubmit = (
             multisubmit and self._cases[0].get_value("BATCH_SYSTEM") != "none"
@@ -186,6 +188,8 @@ class SystemTestsCompareN(SystemTestsCommon):
         # created via clone, not a with statement, so it's not in a writeable state,
         # so we need to use a with statement here to put it in a writeable state.
         config = Config.instance()
+
+        self._setup_cases_if_not_yet_done()
 
         for i in range(1, self.N):
             with self._cases[i]:

--- a/CIME/SystemTests/system_tests_compare_two.py
+++ b/CIME/SystemTests/system_tests_compare_two.py
@@ -69,7 +69,6 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         multisubmit=False,
         ignore_fieldlist_diffs=False,
         case_two_keep_init_generated_files=False,
-        dry_run=False,
         **kwargs
     ):
         """

--- a/CIME/SystemTests/system_tests_compare_two.py
+++ b/CIME/SystemTests/system_tests_compare_two.py
@@ -139,11 +139,10 @@ class SystemTestsCompareTwo(SystemTestsCommon):
         self._caseroot2 = self._get_caseroot2()
         # Initialize self._case2; it will get set to its true value in
         # _setup_cases_if_not_yet_done
-        self._case2 = None
-
-        # Prevent additional setup_case calls when detecting support for `--single-exe`
-        if not dry_run:
-            self._setup_cases_if_not_yet_done()
+        if os.path.exists(self._caseroot2):
+            self._case2 = self._case_from_existing_caseroot(self._caseroot2)
+        else:
+            self._case2 = None
 
         self._multisubmit = (
             multisubmit and self._case1.get_value("BATCH_SYSTEM") != "none"
@@ -212,6 +211,9 @@ class SystemTestsCompareTwo(SystemTestsCommon):
     # ========================================================================
 
     def build_phase(self, sharedlib_only=False, model_only=False):
+        # Prevent additional setup_case calls when detecting support for `--single-exe`
+        self._setup_cases_if_not_yet_done()
+
         # Subtle issue: case1 is already in a writeable state since it tends to be opened
         # with a with statement in all the API entrances in CIME. case2 was created via clone,
         # not a with statement, so it's not in a writeable state, so we need to use a with


### PR DESCRIPTION
## Description
  
Now that case.setup is calling the test constructor, we don't want that constructor setting up case2 for compare-two tests. There's a weird interaction between clone and buildnml for some components. The previous behavior (just set up case1) seems preferable, so go back to that. Case2 will get set up at the start of the build phase.

The PR https://github.com/ESMCI/cime/pull/4846 broke some E3SM PEM cases.

## Checklist
- [ ] My code follows the style guidlines of this proejct (black formatting)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that excerise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
