### PR TITLE
Fixes reference validation in `set_value`

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -628,7 +628,8 @@ class Case(object):
             "Case must be opened with read_only=False and can only be modified within a context manager",
         )
 
-        if isinstance(value, str):
+        # Only validate references e.g. $<variable> or $<subgroup>::<variable>
+        if isinstance(value, str) and value.startswith("$"):
             expect(
                 len(value.split("::")) <= 2,
                 f"Value {value!r} is not valid, a namespaced reference must be in the form $SUBGROUP::VARIABLE",

--- a/CIME/tests/test_unit_case.py
+++ b/CIME/tests/test_unit_case.py
@@ -108,6 +108,7 @@ class TestCase(unittest.TestCase):
 
     @mock_case()
     def test_set_value(self, case, test_env, **kwargs):
+        test_env.new_entry("BUFFER", etype="char")
         test_env.new_entry("HIST_N", "2")
 
         case.set_value("HIST_N", "5")
@@ -121,6 +122,10 @@ class TestCase(unittest.TestCase):
         hist_n = case.get_value("HIST_N")
 
         assert hist_n == 10, hist_n
+
+        case.set_value("BUFFER", "a::unique::value")
+
+        assert case.get_value("BUFFER") == "a::unique::value"
 
     @mock_case()
     def test_get_values_group_reference(self, case, test_env, **kwargs):


### PR DESCRIPTION
## Description
<!--
    Please include a summary of the change and which issues it fixed.
    Please also include relevant motivation and context.
-->
The validation that was added for variables with reference values e.g. `$variable` or `$subgroup::variable` was being applied to all values. This broke EAMxx as it uses `::` in their `SCREAM_ATMCHANGE_BUFFER` variable. This fix limits the validation to only reference values.

- Closes #4847 

## Checklist
- [x] My code follows the style guidlines of this proejct (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that excerise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding additions and changes to the documentation
