### PR TITLE
Change default workflow for CESM/component checkouts without CUPiD

### DIFF
--- a/CIME/case/case.py
+++ b/CIME/case/case.py
@@ -2483,6 +2483,10 @@ directory, NOT in this subdirectory."""
                             gridfile = um_config_grids
                             found_um_config_grids = True
 
+            # Special handling for default cases without CUPiD checkout
+            if workflowid == "default" and not os.path.exists(os.path.join(srcroot, "tools", "CUPiD", "cime_config")):
+                workflowid = "default-no-cupid"
+
             # Configure the Case
             self.configure(
                 compset_name,


### PR DESCRIPTION
## Description
CTSM isn't ready to bring in CUPiD yet, but we need to update to ccs_config_cesm1.0.61 or later, and the case.cupid job breaks case setup. This PR fixes it when combined with PR ESMCI/ccs_config_cesm#263

## Checklist
- [ ] My code follows the style guidlines of this proejct (black formatting)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that excerise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
