### PR TITLE
Fix log message and error check in _set_restart_interval

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -200,16 +200,32 @@ class SystemTestsCommon(object):
             factor = 315360000
         else:
             expect(False, f"stop_option {stop_option} not available for this test")
-        stop_n = int(stop_n * factor // coupling_secs)
+
+        stop_n_coupling_intervals = int(stop_n * factor // coupling_secs)
+        expect(
+            stop_n_coupling_intervals > 0,
+            "Bad STOP_N: {:d} ({:d} coupling intervals)".format(
+                stop_n, stop_n_coupling_intervals
+            ),
+        )
+        expect(
+            stop_n_coupling_intervals > 2,
+            "ERROR: STOP_N value {:d} ({:d} coupling intervals) too short".format(
+                stop_n, stop_n_coupling_intervals
+            ),
+        )
+
         if self._rest_n:
             rest_n = self._rest_n
         else:
             if self._case.get_value("TESTCASE") == "IRT":
-                rest_n = math.ceil((stop_n // 3) * coupling_secs / factor)
+                rest_n = math.ceil(
+                    (stop_n_coupling_intervals // 3) * coupling_secs / factor
+                )
             else:
-                rest_n = math.ceil((stop_n // 2 + 1) * coupling_secs / factor)
-        expect(stop_n > 0, "Bad STOP_N: {:d}".format(stop_n))
-        expect(stop_n > 2, "ERROR: stop_n value {:d} too short".format(stop_n))
+                rest_n = math.ceil(
+                    (stop_n_coupling_intervals // 2 + 1) * coupling_secs / factor
+                )
 
         cal = self._case.get_value("CALENDAR")
         if not starttime:

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -208,12 +208,6 @@ class SystemTestsCommon(object):
                 stop_n, stop_n_coupling_intervals
             ),
         )
-        expect(
-            stop_n_coupling_intervals > 2,
-            "ERROR: STOP_N value {:d} ({:d} coupling intervals) too short".format(
-                stop_n, stop_n_coupling_intervals
-            ),
-        )
 
         if self._rest_n:
             rest_n = self._rest_n
@@ -226,6 +220,15 @@ class SystemTestsCommon(object):
                 rest_n = math.ceil(
                     (stop_n_coupling_intervals // 2 + 1) * coupling_secs / factor
                 )
+
+        # Note that the error message here refers to STOP_N being too short, because
+        # that's the typical root cause of this problem
+        expect(
+            rest_n > 0 and rest_n < stop_n,
+            "ERROR: STOP_N value {:d} too short: results in REST_N = {:d}".format(
+                stop_n, rest_n
+            ),
+        )
 
         cal = self._case.get_value("CALENDAR")
         if not starttime:


### PR DESCRIPTION
## Description

(1) Introduce a new variable to preserve the correct stop_n in the log message prined by _set_restart_interval. Before this fix, as an example, `ERS_D_Ld3.f10_f10_mg37.I1850Clm50BgcCrop.derecho_gnu.clm-default` printed `doing an 24 ndays initial test with restart file at 2 ndays`; now it correctly prints `doing an 3 ndays initial test with restart file at 2 ndays`.

(2) Fix the error check in this function: The previous error check for stop_n > 2 was being done on the stop_n value that was expressed in terms of coupling intervals; this is not the correct check and allows too-small stop_n values. Rather than trying to determine the correct check on the stop_n value (which is complicated now), instead check the end result: the real point of this error check seems to be to make sure that the final rest_n is between 0 and stop_n (exclusive), so check that directly.

## Checklist
- [x] My code follows the style guidlines of this proejct (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that excerise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
