### PR TITLE
Fix check of resource_nodes

### DIFF
--- a/CIME/XML/env_mach_specific.py
+++ b/CIME/XML/env_mach_specific.py
@@ -171,7 +171,7 @@ class EnvMachSpecific(EnvBase):
 
     def _set_resources_for_case(self, case):
         resource_nodes = self.get_children("resource_limits")
-        if resource_nodes is not None:
+        if resource_nodes:
             expect(
                 platform.system() != "Darwin",
                 "Mac OS does not support setting resource limits",


### PR DESCRIPTION
## Description

When there are no resource_nodes, the return value is [], not None.

Before this fix, I was consistently getting an error when trying to create a case on my Mac:

        ERROR: Mac OS does not support setting resource limits

- Closes #4869 

## Checklist
- [x] My code follows the style guidlines of this proejct (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that excerise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
