### PR TITLE
Fix tests in TestUnitBaselinesPerformance on my Mac

### DIFF
--- a/CIME/tests/test_unit_baselines_performance.py
+++ b/CIME/tests/test_unit_baselines_performance.py
@@ -3,7 +3,6 @@
 import gzip
 import tempfile
 import unittest
-import os
 from unittest import mock
 from pathlib import Path
 
@@ -128,24 +127,24 @@ class TestUnitBaselinesPerformance(unittest.TestCase):
         ]
 
     def test_read_baseline_file_multi_line(self):
-        with mock.patch(
-            "builtins.open",
-            mock.mock_open(
-                read_data="sha:1df0 date:2023 1000.0\nsha:3b05 date:2023 2000.0"
-            ),
-        ) as mock_file:
-            baseline = performance.read_baseline_file("/tmp/cpl-mem.log")
+        with mock.patch("os.path.exists", return_value=True):
+            with mock.patch(
+                "builtins.open",
+                mock.mock_open(
+                    read_data="sha:1df0 date:2023 1000.0\nsha:3b05 date:2023 2000.0"
+                ),
+            ) as mock_file:
+                baseline = performance.read_baseline_file("/tmp/cpl-mem.log")
 
         mock_file.assert_called_with("/tmp/cpl-mem.log")
         assert baseline == "sha:1df0 date:2023 1000.0\nsha:3b05 date:2023 2000.0"
 
     def test_read_baseline_file_content(self):
-        if not os.path.exists("/tmp/cpl-mem.log"):
-            os.mknod("/tmp/cpl-mem.log")
-        with mock.patch(
-            "builtins.open", mock.mock_open(read_data="sha:1df0 date:2023 1000.0")
-        ) as mock_file:
-            baseline = performance.read_baseline_file("/tmp/cpl-mem.log")
+        with mock.patch("os.path.exists", return_value=True):
+            with mock.patch(
+                "builtins.open", mock.mock_open(read_data="sha:1df0 date:2023 1000.0")
+            ) as mock_file:
+                baseline = performance.read_baseline_file("/tmp/cpl-mem.log")
 
         mock_file.assert_called_with("/tmp/cpl-mem.log")
         assert baseline == "sha:1df0 date:2023 1000.0"


### PR DESCRIPTION
## Description

The problem was that read_baseline_file returns without doing anything if not os.path.exists(baseline_file). So we need to make it think that the file exists. Previously one of the failing tests had been doing this via `os.mknod("/tmp/cpl-mem.log")`, but that was itself giving an error on my Mac.

## Checklist
- [x] My code follows the style guidlines of this proejct (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that excerise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation

## Testing
I ran `pytest ./CIME/tests/test_unit_baselines_performance.py` on both my Mac and derecho.