### PR TITLE
git ignore all files of form *.o\d+ (all pbs output)

### DIFF
--- a/CIME/data/templates/gitignore.template
+++ b/CIME/data/templates/gitignore.template
@@ -5,8 +5,8 @@ run
 *.log
 
 # queueing system output files
-run.*.o\d+
-st_archive.*.o\d+
+*.o\d+
+*.o\d+
 
 #python files
 __pycache__/


### PR DESCRIPTION
## Description
Generalize the PBS output file in .gitignore 

- Closes #4898 

## Checklist
- [X] My code follows the style guidlines of this proejct (black formatting)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
