### PR TITLE
wget server spider mode disabled

### DIFF
--- a/CIME/Servers/wget.py
+++ b/CIME/Servers/wget.py
@@ -31,13 +31,13 @@ class WGET(GenericServer):
             )
         except RuntimeError:
             logger.warning(
-                "Could not connect to repo '{0}'\nThis is most likely either a proxy, or network issue .(location 1) ".format(
+                "Could not connect to repo '{0}'\nThis is most likely either a proxy, or network issue .".format(
                     address
                 )
             )
             return None
         if "Connecting to " in errstr and "... connected" in errstr:
-            logger.warning("spider mode disabled, server otherwise okay")
+            logger.warning("Connection established with nonzero code %s", err)
         elif err:
             logger.warning(
                 "Could not connect to repo '{0}'\n{1}".format(address, errstr)


### PR DESCRIPTION
wget --spider is used by cesm to establish that the server exists without downloading anything
## Description
, but some servers have spider mode disabled so they exist and can connect but still
return an error with this command.   We can look for the key word 'connected' in the stderr of the wget command to determine if this is the issue and proceed without failing.   I think that this was the reason there was a special case for the NEON server and I have removed that special case, replacing it with this more generic handler.  

- Closes #4900 

## Checklist
- [X] My code follows the style guidlines of this proejct (black formatting)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that excerise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
