### PR TITLE
Fix issue with true/false enum if C standard >= C23

### DIFF
--- a/CIME/non_py/src/timing/private.h
+++ b/CIME/non_py/src/timing/private.h
@@ -43,7 +43,7 @@
 */
 #define MAX_AUX 9
 
-#ifndef __cplusplus
+#if !defined(__cplusplus) && __STDC_VERSION__ < 202311L
 typedef enum {false = 0, true = 1} bool;  /* mimic C++ */
 #endif
 


### PR DESCRIPTION
## Description
<!--
    Please include a summary of the change and which issues it fixed.
    Please also include relevant motivation and context.
-->
If the compiler supports C23 standard (e.g., gcc 15.2), `false` and `true` are reserved keywords, so we need to guard against this line of code.

- Closes #4902 
## Checklist
- [x] My code follows the style guidlines of this proejct (black formatting)
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that excerise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
