### PR TITLE
Pass non-local option to cam.case_setup

### DIFF
--- a/CIME/case/case_setup.py
+++ b/CIME/case/case_setup.py
@@ -484,8 +484,8 @@ def _case_setup_impl(
                 ):
                     logger.info("Running cam.case_setup.py")
                     run_cmd_no_fail(
-                        "python {cam}/cime_config/cam.case_setup.py {cam} {case}".format(
-                            cam=camroot, case=caseroot
+                        "python {cam}/cime_config/cam.case_setup.py {cam} {case} {non_local}".format(
+                            cam=camroot, case=caseroot, non_local=str(non_local)
                         )
                     )
 


### PR DESCRIPTION
## Description
The `--non-local` option for case.setup is currently broken for compsets including CAM. 

The issue arises because `cam.case_setup` does not receive the non_local flag, and it instantiates Case objects without this flag. This PR passes the `non_local` option to `cam.case_setup` to fix this issue.

This PR should be evaluated and merged in conjunction with the CAM PR: https://github.com/ESCOMP/CAM/pull/1456

## Checklist
- [x] My code follows the style guidlines of this proejct (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that excerise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
