### PR TITLE
pelayout should work with or without xstride variable

### DIFF
--- a/CIME/Tools/pelayout
+++ b/CIME/Tools/pelayout
@@ -158,6 +158,8 @@ def print_pelayout(case, ntasks, nthreads, rootpes, pstrid, xstrid, arg_format, 
     comp_classes = case.get_values("COMP_CLASSES")
 
     if header is not None:
+        if any(v is not None for v in xstrid.values()):
+            header += " XSTRIDE"
         print(header)
     # End if
     maxthrds = -1
@@ -214,6 +216,7 @@ def gather_pelayout(case):
             xstride[comp] = int(case.get_value("EXCL_STRIDE_" + comp))
         else:
             xstride[comp] = None
+
     # End for
     return ntasks, nthreads, rootpes, pstride, xstride
 


### PR DESCRIPTION
## Description
Make pelayout format work with or without xstride xml variable.

- Closes #4915 

## Checklist
- [X] My code follows the style guidelines of this project (black formatting)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
