### PR TITLE
add the CASEROOT file to the archive log directory

### DIFF
--- a/CIME/case/case_st_archive.py
+++ b/CIME/case/case_st_archive.py
@@ -285,7 +285,10 @@ def _archive_log_files(dout_s_root, rundir, archive_incomplete, archive_file_fn)
         )
         archive_file_fn(srcfile, destfile)
     # Finally copy the CASEROOT file into the archive directory
-    safe_copy(os.path.join(rundir, "CASEROOT"), archive_logdir)
+    caseroot = os.path.join(rundir, "CASEROOT")
+    logdir_caseroot = os.path.join(archive_logdir, "CASEROOT")
+    if os.path.exists(caseroot) and not os.path.exists(logdir_caseroot):
+        safe_copy(os.path.join(rundir, "CASEROOT"), archive_logdir)
 
 
 ###############################################################################


### PR DESCRIPTION
## Description
When case.st_archive is run copy the CASEROOT file from the run directory to the archive log directory. 

- Closes #4918 

## Checklist
- [X] My code follows the style guidelines of this project (black formatting)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
