### PR TITLE
Add baseline synopsis to TestStatus.log

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -1025,9 +1025,9 @@ for some of your components.
             ts_comments = (
                 os.path.dirname(baseline_name) + ": " + get_ts_synopsis(comments)
             )
-            log_comments = "============ BASELINE COMPARE SYNOPSIS ============="
-            log_comments += ts_comments
-            log_comments += "===================================================="
+            log_comments = "\n\n============ BASELINE COMPARE SYNOPSIS =============\n"
+            log_comments += ts_comments + "\n"
+            log_comments += "====================================================\n"
             append_testlog(log_comments, self._orig_caseroot)
             self._test_status.set_status(BASELINE_PHASE, status, comments=ts_comments)
 


### PR DESCRIPTION
## Description

Add the baseline synopsis to TestStatus.log (previously, only went to TestStatus). This will make quick checks easier for those who look at logs on cdash.

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
