### PR TITLE
address pio issues

### DIFF
--- a/CIME/XML/env_run.py
+++ b/CIME/XML/env_run.py
@@ -76,17 +76,23 @@ class EnvRun(EnvBase):
 
             if nvid == "PIO_TYPENAME":
                 if comp:
-                    pio_netcdf_formats = [
-                        self.get_value("PIO_NETCDF_FORMAT_{}".format(comp.upper()))
-                    ]
+                    pio_netcdf_format_val = self.get_value(
+                        "PIO_NETCDF_FORMAT_{}".format(comp.upper())
+                    )
+                    if pio_netcdf_format_val is None:
+                        pio_netcdf_format_val = ""
+                    pio_netcdf_formats = [pio_netcdf_format_val]
                 else:
                     pio_netcdf_formats = self.get_values("PIO_NETCDF_FORMAT")
                 pio_typenames = [value]
             elif nvid == "PIO_NETCDF_FORMAT":
                 if comp:
-                    pio_typenames = [
-                        self.get_value("PIO_TYPENAME_{}".format(comp.upper()))
-                    ]
+                    pio_typename_val = self.get_value(
+                        "PIO_TYPENAME_{}".format(comp.upper())
+                    )
+                    if pio_typename_val is None:
+                        pio_typename_val = ""
+                    pio_typenames = [pio_typename_val]
                 else:
                     pio_typenames = self.get_values("PIO_TYPENAME")
                 pio_netcdf_formats = [value]

--- a/CIME/XML/env_run.py
+++ b/CIME/XML/env_run.py
@@ -101,8 +101,12 @@ class EnvRun(EnvBase):
                 if pio_netcdf_format is None:
                     pio_netcdf_format = last_format
 
+                incompatible_pio_typenames = ("netcdf4p", "netcdf4c")
                 expect(
-                    not ("4" in pio_typename and "64bit_data" in pio_netcdf_format),
+                    not (
+                        pio_typename in incompatible_pio_typenames
+                        and "64bit_data" in pio_netcdf_format
+                    ),
                     "pio_typename {} is not compatible with pio_netcdf_format {}".format(
                         pio_typename, pio_netcdf_format
                     ),

--- a/CIME/XML/env_run.py
+++ b/CIME/XML/env_run.py
@@ -1,6 +1,7 @@
 """
 Interface to the env_run.xml file.  This class inherits from EnvBase
 """
+from itertools import zip_longest
 from CIME.XML.standard_module_setup import *
 
 from CIME.XML.env_base import EnvBase
@@ -66,5 +67,45 @@ class EnvRun(EnvBase):
                     self._pio_async_interface[comp] = convert_to_type(
                         value, "logical", vid
                     )
+        # PIO_NETCDF_FORMAT=64bit_data is not compatible with PIO_TYPENAME=netcdf4p
+        # make sure that this combination of options is not set
+        if "PIO_TYPENAME" in vid or "PIO_NETCDF_FORMAT" in vid:
+            nvid, comp, iscompvar = self.check_if_comp_var(vid, None)
+            pio_netcdf_formats = []
+            pio_typenames = []
+
+            if nvid == "PIO_TYPENAME":
+                if comp:
+                    pio_netcdf_formats = [
+                        self.get_value("PIO_NETCDF_FORMAT_{}".format(comp.upper()))
+                    ]
+                else:
+                    pio_netcdf_formats = self.get_values("PIO_NETCDF_FORMAT")
+                pio_typenames = [value]
+            elif nvid == "PIO_NETCDF_FORMAT":
+                if comp:
+                    pio_typenames = [
+                        self.get_value("PIO_TYPENAME_{}".format(comp.upper()))
+                    ]
+                else:
+                    pio_typenames = self.get_values("PIO_TYPENAME")
+                pio_netcdf_formats = [value]
+
+            last_format = pio_netcdf_formats[-1]
+            last_typename = pio_typenames[-1]
+            for pio_typename, pio_netcdf_format in zip_longest(
+                pio_typenames, pio_netcdf_formats
+            ):
+                if pio_typename is None:
+                    pio_typename = last_typename
+                if pio_netcdf_format is None:
+                    pio_netcdf_format = last_format
+
+                expect(
+                    not ("4" in pio_typename and "64bit_data" in pio_netcdf_format),
+                    "pio_typename {} is not compatible with pio_netcdf_format {}".format(
+                        pio_typename, pio_netcdf_format
+                    ),
+                )
 
         return EnvBase.set_value(self, vid, value, subgroup, ignore_type)

--- a/CIME/build_scripts/buildlib.pio
+++ b/CIME/build_scripts/buildlib.pio
@@ -191,9 +191,9 @@ def buildlib(bldroot, installpath, case):
                     installed_file_time = os.path.getmtime(installed_file)
                 if item_time > installed_file_time:
                     safe_copy(item, installed_file)
-        expect_string = "NetCDF_C_LIBRARY-ADVANCED"
+        expect_string = "NetCDF_C_FOUND:BOOL=TRUE"
         pnetcdf_string = "WITH_PNETCDF:BOOL=ON"
-        netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
+        netcdf4_string = "HAVE_NETCDF_PAR:INTERNAL=1"
 
     # make sure case pio_typename valid_values is set correctly
     expect_string_found = False
@@ -203,6 +203,8 @@ def buildlib(bldroot, installpath, case):
     cache_file = open(os.path.join(pio_dir, "CMakeCache.txt"), "r")
     for line in cache_file:
         if re.search(expect_string, line):
+            expect_string_found = True
+        elif re.search("NetCDF_C_LIBRARY-ADVANCED", line):
             expect_string_found = True
         if re.search(pnetcdf_string, line):
             pnetcdf_found = True

--- a/CIME/case/preview_namelists.py
+++ b/CIME/case/preview_namelists.py
@@ -114,8 +114,8 @@ def create_namelists(self, component=None):
             )
             expect(
                 not bad_pio_combo,
-                "Cannot use pio_netcdf_format {} with pio_typename {}".format(
-                    pio_netcdf_format, pio_typename
+                "pio_typename {} is not compatible with pio_netcdf_format {}".format(
+                    pio_typename, pio_netcdf_format
                 ),
             )
         logger.debug(

--- a/CIME/case/preview_namelists.py
+++ b/CIME/case/preview_namelists.py
@@ -107,8 +107,13 @@ def create_namelists(self, component=None):
             pio_netcdf_format = self.get_value(
                 "PIO_NETCDF_FORMAT_{}".format(model_str.upper())
             )
+            bad_pio_combo = (
+                pio_typename is not None
+                and "4" in pio_typename
+                and pio_netcdf_format == "64bit_data"
+            )
             expect(
-                not ("4" in pio_typename and pio_netcdf_format == "64bit_data"),
+                not bad_pio_combo,
                 "Cannot use pio_netcdf_format {} with pio_typename {}".format(
                     pio_netcdf_format, pio_typename
                 ),

--- a/CIME/case/preview_namelists.py
+++ b/CIME/case/preview_namelists.py
@@ -103,7 +103,16 @@ def create_namelists(self, component=None):
                 compname,
                 case=self,
             )
-
+            pio_typename = self.get_value("PIO_TYPENAME_{}".format(model_str.upper()))
+            pio_netcdf_format = self.get_value(
+                "PIO_NETCDF_FORMAT_{}".format(model_str.upper())
+            )
+            expect(
+                not ("4" in pio_typename and pio_netcdf_format == "64bit_data"),
+                "Cannot use pio_netcdf_format {} with pio_typename {}".format(
+                    pio_netcdf_format, pio_typename
+                ),
+            )
         logger.debug(
             "Finished creating component namelists, component {} models = {}".format(
                 component, models


### PR DESCRIPTION
## Description
Updates build process for netcdf/4.9.3 in a backward compatible manner.
Adds logic to make sure that typename netcdf4p is not combined with format 64bit_data.
 
- Closes #4924 
- Closes #4923 

## Checklist
- [X] My code follows the style guidelines of this project (black formatting)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
