### PR TITLE
Change py version warning message from print to warn

### DIFF
--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -4,7 +4,7 @@ that every script should do.
 """
 # pylint: disable=unused-import
 
-import sys, os
+import sys, os, logging
 import __main__ as main
 
 
@@ -31,8 +31,6 @@ def check_minimum_python_version(major, minor, warn_only=False):
         + str(sys.version_info[1])
     )
     if warn_only:
-        import logging
-
         logging.warning(msg.replace("required", "recommended") + ".")
         return
     raise RuntimeError(msg + " - please use a newer version of Python.")
@@ -53,4 +51,4 @@ os.environ["CIMEROOT"] = cimeroot
 import CIME.utils
 
 CIME.utils.stop_buffering_output()
-import logging, argparse
+import argparse


### PR DESCRIPTION
To avoid polluting stdout.

## Description

Printing the warning to stdout breaks usecases where the user is trying to use the output of the program, such as `var=$(xmlquery --value VAR)`. Changing the output to logging.warn means stderr will be used instead.

- Closes #<ISSUE_NUMBER_HERE>

## Checklist
- [ ] My code follows the style guidelines of this project (black formatting)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
