### PR TITLE
Change version warning output to not use logging

### DIFF
--- a/CIME/Tools/standard_script_setup.py
+++ b/CIME/Tools/standard_script_setup.py
@@ -4,7 +4,7 @@ that every script should do.
 """
 # pylint: disable=unused-import
 
-import sys, os, logging
+import sys, os
 import __main__ as main
 
 
@@ -31,7 +31,7 @@ def check_minimum_python_version(major, minor, warn_only=False):
         + str(sys.version_info[1])
     )
     if warn_only:
-        logging.warning(msg.replace("required", "recommended") + ".")
+        print(msg.replace("required", "recommended") + ".", file=sys.stderr)
         return
     raise RuntimeError(msg + " - please use a newer version of Python.")
 
@@ -51,4 +51,4 @@ os.environ["CIMEROOT"] = cimeroot
 import CIME.utils
 
 CIME.utils.stop_buffering_output()
-import argparse
+import argparse, logging


### PR DESCRIPTION
Importing logging before CIME.utils.stop_buffering_output makes all the logging.info outputs look terrible. Example:

```
INFO:CIME.test_scheduler:create_test will use up to 80 cores simultaneously
create_test will use up to 80 cores simultaneously
```

So, the output is duplicated and one of the duplications has ugly prefix text.

This is somewhat urgent as it impacts all users. I will do an emergency CIME update to E3SM when this is merged.

## Checklist
- [ ] My code follows the style guidelines of this project (black formatting)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
