### PR TITLE
Skip MOM6 .ic. history file comparison in multi-instance runs 

### DIFF
--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -101,7 +101,7 @@ def copy_histfiles(case, suffix, match_suffix=None):
                 if "ocean_geometry" in test_hist:
                     comments += "    skipping '{}'\n".format(test_hist)
                     continue
-                if "mom6.ic" in test_hist:
+                if re.search(r"mom6(_[0-9]{4})?\.ic", os.path.basename(test_hist)):
                     comments += "    skipping '{}'\n".format(test_hist)
                     continue
             comments += "  Copying hist files for model '{}'\n".format(model)


### PR DESCRIPTION
Currently, `copy_histfiles` skips the mom6 initial conditions (ic) files for single-instance files, but not for multi-instance files. This PR fixes the logic by skipping these files for both single instance and multi instance runs.

- Closes https://github.com/NCAR/MOM6/issues/407

This PR should be evaluated in conjunction with:
https://github.com/ESCOMP/FMS/pull/8
https://github.com/NCAR/MOM6/pull/409
https://github.com/ESCOMP/MOM_interface/pull/311

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that exercise my feature/fix and existing tests continue to pass