### PR TITLE
Add cupid to preview namelists

### DIFF
--- a/CIME/case/preview_namelists.py
+++ b/CIME/case/preview_namelists.py
@@ -128,19 +128,20 @@ def create_namelists(self, component=None):
         if have_postprocessing:
             config_dir = os.path.dirname(_postprocessing_spec_file)
             cmd = os.path.join(config_dir, "buildnml")
-            # NOTE: In order to name the specific postprocessing component, there would need to be
-            # a new XML variable with something like POSTPROC_NAME
-            compname = "postprocessor"
-            logger.info("Create namelist for postprocessing component {}".format(compname))
-            import_and_run_sub_or_cmd(
-                cmd,
-                (caseroot),
-                "buildnml",
-                (self, caseroot, compname),
-                config_dir,
-                compname,
-                case=self,
-            )
+            if ( os.path.exists(cmd) ):
+                # NOTE: In order to name the specific postprocessing component, there would need to be
+                # a new XML variable with something like POSTPROC_NAME
+                compname = "postprocessor"
+                logger.info("Create namelist for postprocessing component {}".format(compname))
+                import_and_run_sub_or_cmd(
+                    cmd,
+                    (caseroot),
+                    "buildnml",
+                    (self, caseroot, compname),
+                    config_dir,
+                    compname,
+                    case=self,
+                )
 
     # Save namelists to docdir
     if not os.path.isdir(docdir):


### PR DESCRIPTION
## Description

If RUN_POSTPROCESSING is TRUE and the postprocessing spec file is setup for a case, and the buildnml script exists for it -- run it as part of preview_namelists.

- Closes #4939 
- Closes #4942

The CUPiD PR that goes along with this is here: https://github.com/NCAR/CUPiD/pull/395

These changes can come in first though and don't require the CUPiD change at the same time.

## Checklist
- [ ] My code follows the style guidelines of this project (black formatting)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
