### PR TITLE
Fix regular expression used in NLCOMP test

### DIFF
--- a/CIME/simple_compare.py
+++ b/CIME/simple_compare.py
@@ -12,7 +12,7 @@ def _normalize_string_value(value, case):
     """
     # Any occurance of case must be normalized because test-ids might not match
     if case is not None:
-        case_re = re.compile(r"{}[.]([GC])[.]([^./\s]+)".format(case))
+        case_re = re.compile(r"{}[.]([GC]|GC)[.]([^./\s]+)".format(case))
         value = case_re.sub("{}.ACTION.TESTID".format(case), value)
 
     if "/" in value:

--- a/CIME/simple_compare.py
+++ b/CIME/simple_compare.py
@@ -20,7 +20,7 @@ def _normalize_string_value(value, case):
     """
     # Any occurance of case must be normalized because test-ids might not match
     if case is not None:
-        case_re = re.compile(r"{}[.]([GC]|GC)[.]([^./\s]+)".format(case))
+        case_re = re.compile(r"{}[.](GC?|C)[.]([^./\s]+)".format(case))
         value = case_re.sub("{}.ACTION.TESTID".format(case), value)
 
     if "/" in value:

--- a/CIME/simple_compare.py
+++ b/CIME/simple_compare.py
@@ -9,6 +9,14 @@ def _normalize_string_value(value, case):
     Some of the strings are inherently prone to diffs, like file
     paths, etc. This function attempts to normalize that data so that
     it will not cause diffs.
+    >>> _normalize_string_value("ERS.TL319_t232.G1850MARBL_JRA.derecho_intel.G.20260410_135953_nhg5ae","ERS.TL319_t232.G1850MARBL_JRA.derecho_intel")
+    'ERS.TL319_t232.G1850MARBL_JRA.derecho_intel.ACTION.TESTID'
+    >>> _normalize_string_value("ERS.TL319_t232.G1850MARBL_JRA.derecho_intel.GC.20260410_135953_nhg5ae","ERS.TL319_t232.G1850MARBL_JRA.derecho_intel")
+    'ERS.TL319_t232.G1850MARBL_JRA.derecho_intel.ACTION.TESTID'
+    >>> _normalize_string_value("ERS.TL319_t232.G1850MARBL_JRA.derecho_intel.C.20260410_135953_nhg5ae","ERS.TL319_t232.G1850MARBL_JRA.derecho_intel")
+    'ERS.TL319_t232.G1850MARBL_JRA.derecho_intel.ACTION.TESTID'
+    >>> _normalize_string_value("ERS.TL319_t232.G1850MARBL_JRA.derecho_intel.GG.20260410_135953_nhg5ae","ERS.TL319_t232.G1850MARBL_JRA.derecho_intel")
+    'ERS.TL319_t232.G1850MARBL_JRA.derecho_intel.GG.20260410_135953_nhg5ae'
     """
     # Any occurance of case must be normalized because test-ids might not match
     if case is not None:

--- a/CIME/tests/test_simple_compare.py
+++ b/CIME/tests/test_simple_compare.py
@@ -1,0 +1,11 @@
+import unittest
+
+from CIME.simple_compare import _normalize_string_value
+
+
+class TestSimpleCompare(unittest.TestCase):
+    def test_normalize_string_values(self):
+        test = "test.grid.compset.mach_compiler"
+        testid = "19991231_235959_abcdef"
+        for action in ['G', 'C', 'GC']:
+            assert(_normalize_string_value(f"{test}.{action}.{testid}", test) == f"{test}.ACTION.TESTID")

--- a/CIME/tests/test_simple_compare.py
+++ b/CIME/tests/test_simple_compare.py
@@ -7,11 +7,15 @@ class TestSimpleCompare(unittest.TestCase):
     def test_normalize_string_values(self):
         test = "test.grid.compset.mach_compiler"
         testid = "19991231_235959_abcdef"
+
+        # Test cases where _normalize_string_value() will normalize test
         for action in ["G", "C", "GC"]:
             assert (
                 _normalize_string_value(f"{test}.{action}.{testid}", test)
                 == f"{test}.ACTION.TESTID"
             )
+
+        # Test cases where _normalize_string_value() will not change test
         for action in ["GG", "CC", "CG"]:
             assert (
                 _normalize_string_value(f"{test}.{action}.{testid}", test)

--- a/CIME/tests/test_simple_compare.py
+++ b/CIME/tests/test_simple_compare.py
@@ -7,5 +7,8 @@ class TestSimpleCompare(unittest.TestCase):
     def test_normalize_string_values(self):
         test = "test.grid.compset.mach_compiler"
         testid = "19991231_235959_abcdef"
-        for action in ['G', 'C', 'GC']:
-            assert(_normalize_string_value(f"{test}.{action}.{testid}", test) == f"{test}.ACTION.TESTID")
+        for action in ["G", "C", "GC"]:
+            assert (
+                _normalize_string_value(f"{test}.{action}.{testid}", test)
+                == f"{test}.ACTION.TESTID"
+            )

--- a/CIME/tests/test_simple_compare.py
+++ b/CIME/tests/test_simple_compare.py
@@ -12,3 +12,8 @@ class TestSimpleCompare(unittest.TestCase):
                 _normalize_string_value(f"{test}.{action}.{testid}", test)
                 == f"{test}.ACTION.TESTID"
             )
+        for action in ["GG", "CC", "CG"]:
+            assert (
+                _normalize_string_value(f"{test}.{action}.{testid}", test)
+                == f"{test}.{action}.{testid}"
+            )


### PR DESCRIPTION
Need to capture cases when action is .G., .C., or .GC.; existing regex only caught the first two

## Description
<!--
    Please include a summary of the change and which issues it fixed.
    Please also include relevant motivation and context.
-->

- Closes #4963 

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
