### PR TITLE
add --driver option to jenkins_generic_job

### DIFF
--- a/CIME/Tools/jenkins_generic_job
+++ b/CIME/Tools/jenkins_generic_job
@@ -209,6 +209,11 @@ OR
         help="Specify an 'id' for the Jenkins jobs.",
     )
 
+    parser.add_argument(
+        "--driver",
+        help="Override the coupler driver used by create_test (e.g. mct, nuopc).",
+    )
+
     args = CIME.utils.parse_args_and_handle_standard_logging_options(args, parser)
 
     if args.no_submit:
@@ -283,6 +288,7 @@ OR
         args.pes_file,
         args.jenkins_id,
         args.queue,
+        args.driver,
     )
 
 
@@ -316,6 +322,7 @@ def _main_func(description):
         pes_file,
         jenkins_id,
         queue,
+        driver,
     ) = parse_command_line(sys.argv, description)
 
     sys.exit(
@@ -347,6 +354,7 @@ def _main_func(description):
             pes_file,
             jenkins_id,
             queue,
+            driver,
         )
         else CIME.utils.TESTS_FAILED_ERR_CODE
     )

--- a/CIME/jenkins_generic_job.py
+++ b/CIME/jenkins_generic_job.py
@@ -285,6 +285,7 @@ def jenkins_generic_job(
     pes_file,
     jenkins_id,
     queue,
+    driver,
 ):
     ###############################################################################
     """
@@ -377,6 +378,9 @@ def jenkins_generic_job(
 
     if save_timing:
         create_test_args.append("--save-timing")
+
+    if driver is not None:
+        create_test_args.append("--driver " + driver)
 
     create_test_cmd = "./create_test " + " ".join(create_test_args)
 


### PR DESCRIPTION
Allow overriding the coupler driver (e.g. mct, nuopc) passed to create_test from the Jenkins job script.

## Description
Allow passing --driver as an option to jenkins_generic_job



## Checklist
- [X ] My code follows the style guidelines of this project (black formatting)
- [ X] I have performed a self-review of my own code
- [ X] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
