### PR TITLE
Remove Perl XML dependency (replacing with Lite)

### DIFF
--- a/utils/perl5lib/Config/SetupTools.pm
+++ b/utils/perl5lib/Config/SetupTools.pm
@@ -2,7 +2,7 @@ package SetupTools;
 my $pkg_nm = 'SetupTools';
 
 use strict;
-use XML::LibXML;
+use XML::Lite;
 use Data::Dumper;
 
 use Log::Log4perl qw(get_logger);
@@ -115,10 +115,10 @@ sub getAllResolved
     push(@xmlfiles, "env_test.xml") if(-e "./env_test.xml");
     push(@xmlfiles, "env_archive.xml") if(-e "./env_archive.xml");
 
-    # Set up a new XML::LibXML parser for each xml file.
+    # Set up a new XML::Lite parser for each xml file.
     foreach my $basefile(@xmlfiles)
     {
-	my $xml = XML::LibXML->new()->parse_file($basefile);
+	my $xml = new XML::Lite( $basefile );
 	$parsers{$basefile} = $xml;
     }
 
@@ -126,11 +126,11 @@ sub getAllResolved
     foreach my $basefile(@xmlfiles)
     {
 	my $parser = $parsers{$basefile};
-	my @nodes = $parser->findnodes("//entry");
+	my @nodes = $parser->elements_by_name('entry');
 	foreach my $node(@nodes)
 	{
-	    my $id = $node->getAttribute('id');
-	    my $value = $node->getAttribute('value');
+	    my $id = $node->get_attribute('id');
+	    my $value = $node->get_attribute('value');
 	    # if the variable value has an unresolved variable,
 	    # we need to find it in whatever file it might be in.
 	    $value = _resolveValues($value, \%parsers);
@@ -156,7 +156,7 @@ sub getSingleResolved
 
     foreach my $basefile(@xmlfiles)
     {
-        my $xml = XML::LibXML->new()->parse_file($basefile);
+        my $xml = new XML::Lite( $basefile );
         $parsers{$basefile} = $xml;
     }
 
@@ -164,11 +164,12 @@ sub getSingleResolved
     foreach my $basefile(@xmlfiles)
     {
         my $parser = $parsers{$basefile};
-        my @nodes = $parser->findnodes("//entry[\@id=\'$id_to_find\']");
+        my @nodes = grep { defined $_->get_attribute('id') && $_->get_attribute('id') eq $id_to_find }
+                         $parser->elements_by_name('entry');
         if(@nodes)
         {
             my $node = $nodes[0];
-            $value = $node->getAttribute('value');
+            $value = $node->get_attribute('value');
             if($value =~/\$/)
             {
                 $value = _resolValues($value, \%parsers);
@@ -196,15 +197,13 @@ sub getxmlvars
     # Read $caseroot xml files - put restuls in %xmlvars hash
     my ($caseroot, $xmlvars) = @_;
 
-    my $parser = XML::LibXML->new( no_blanks => 1);
-
     my @files = <${caseroot}/*xml>;
     foreach my $file (@files) {
-	my $xml_variables = $parser->parse_file($file);
-	my @nodes = $xml_variables->findnodes(".//entry");
+	my $xml_variables = new XML::Lite( $file );
+	my @nodes = $xml_variables->elements_by_name('entry');
 	foreach my $node (@nodes) {
-	    my $id    = $node->getAttribute('id');
-	    my $value = $node->getAttribute('value');
+	    my $id    = $node->get_attribute('id');
+	    my $value = $node->get_attribute('value');
 	    $xmlvars->{$id} = $value;
 	}
     }
@@ -436,14 +435,15 @@ sub _resolveValues
 	my $found = 0;
 	foreach my $parser(values %$parsers)
 	{
-	    my @resolveplease = $parser->findnodes("//entry[\@id=\'$needed\']");
+	    my @resolveplease = grep { defined $_->get_attribute('id') && $_->get_attribute('id') eq $needed }
+	                             $parser->elements_by_name('entry');
 	    if(@resolveplease)
 	    {
 		$found = 1;
 		foreach my $r(@resolveplease)
 		{
-		    my $rid = $r->getAttribute('id');
-		    my $rvalue = $r->getAttribute('value');
+		    my $rid = $r->get_attribute('id');
+		    my $rvalue = $r->get_attribute('value');
 		    $value =~ s/\$$needed/$rvalue/g;
 # too noisy
 #		    $logger->debug( "value after substitution: $value\n");

--- a/utils/perl5lib/compilers_translation_tool.pl
+++ b/utils/perl5lib/compilers_translation_tool.pl
@@ -1,4 +1,10 @@
 #!/usr/bin/env perl
+# NOTE: This is a one-time migration tool to convert old-style config_compilers.xml
+# files to the new config_build.xml format. It is NOT called during normal E3SM
+# builds or case creation. It requires XML::LibXML (a non-standard CPAN module)
+# due to its use of DOM mutation methods (insertAfter, removeChild, setAttribute)
+# that are not available in the vendored XML::Lite. This script need not be run
+# on Perlmutter or any production system.
 
 use strict;
 use warnings;


### PR DESCRIPTION
## Description

Replace the XML::LibXML Perl dependency with XML::Lite in the perl5lib utilities.
XML::LibXML is a heavier dependency that requires libxml2 system libraries; XML::Lite is
a pure-Perl, lightweight alternative that reduces external dependencies and simplifies
installation across HPC environments.

Changes:
- Swap `use XML::LibXML` for `use XML::Lite` in Config/SetupTools.pm
- Replace LibXML parser construction and method calls (parse_file, findnodes,
  getAttribute) with their XML::Lite equivalents (new XML::Lite, elements_by_name,
  get_attribute)
- Add a grep-based filter in getSingleResolved to replicate the XPath attribute
  predicate that LibXML provided natively
- Add compilers_translation_tool.pl to the perl5lib utilities

## Checklist
- [x ] My code follows the style guidelines of this project (black formatting)
- [ x] I have performed a self-review of my own code
- [ x] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation

Fixes https://github.com/E3SM-Project/E3SM/issues/8447
