### PR TITLE
Add ability to offload CIME builds to batch system

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -119,6 +119,7 @@ class SystemTestsCommon(object):
         self._ninja = False
         self._dry_run = False
         self._user_separate_builds = False
+        self._batched_build_active = False
         self._expected_num_cmp = None
         self._rest_n = None
         sc_file = os.path.join(caseroot, "shell_commands")

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -419,6 +419,7 @@ class SystemTestsCommon(object):
         dry_run=False,
         separate_builds=False,
         skip_submit=False,
+        batched_build_active=False,
     ):
         """
         Do NOT override this method, this method is the framework that
@@ -429,6 +430,7 @@ class SystemTestsCommon(object):
         self._ninja = ninja
         self._dry_run = dry_run
         self._user_separate_builds = separate_builds
+        self._batched_build_active = batched_build_active
 
         was_run_pend = self._test_status.current_is(RUN_PHASE, TEST_PEND_STATUS)
 
@@ -507,6 +509,7 @@ class SystemTestsCommon(object):
             ninja=self._ninja,
             dry_run=self._dry_run,
             separate_builds=self._user_separate_builds,
+            batched_build_active=self._batched_build_active,
         )
         logger.info("build_indv complete")
 

--- a/CIME/Tools/case.build
+++ b/CIME/Tools/case.build
@@ -228,8 +228,6 @@ def _main_func(description):
         no_batch_build,
     ) = parse_command_line(sys.argv, description)
 
-    # If --no-batch-build is specified, pass batched_build_active=True to
-    # build.case_build so it skips batch submission even when BATCHED_BUILD=TRUE.
     success = True
     with Case(caseroot, read_only=False, record=True) as case:
         testname = case.get_value("TESTCASE")

--- a/CIME/Tools/case.build
+++ b/CIME/Tools/case.build
@@ -86,6 +86,13 @@ def parse_command_line(args, description):
         )
 
     parser.add_argument(
+        "--no-batch-build",
+        action="store_true",
+        help="Skip batch submission even if BATCHED_BUILD is TRUE for this machine. "
+        "Use this when you are already on a compute node or want to build interactively.",
+    )
+
+    parser.add_argument(
         "--skip-submit",
         action="store_true",
         help="Sets the current test phase to RUN, skipping the SUBMIT phase. This "
@@ -197,6 +204,7 @@ def parse_command_line(args, description):
         args.ninja,
         args.dry_run,
         args.skip_submit,
+        args.no_batch_build,
     )
 
 
@@ -217,7 +225,13 @@ def _main_func(description):
         ninja,
         dry_run,
         skip_submit,
+        no_batch_build,
     ) = parse_command_line(sys.argv, description)
+
+    # If --no-batch-build is specified, signal to build.py to skip batch submission
+    # even if BATCHED_BUILD=TRUE is set for this machine.
+    if no_batch_build:
+        os.environ["CIME_BATCHED_BUILD_ACTIVE"] = "TRUE"
 
     success = True
     with Case(caseroot, read_only=False, record=True) as case:

--- a/CIME/Tools/case.build
+++ b/CIME/Tools/case.build
@@ -228,11 +228,8 @@ def _main_func(description):
         no_batch_build,
     ) = parse_command_line(sys.argv, description)
 
-    # If --no-batch-build is specified, signal to build.py to skip batch submission
-    # even if BATCHED_BUILD=TRUE is set for this machine.
-    if no_batch_build:
-        os.environ["CIME_BATCHED_BUILD_ACTIVE"] = "TRUE"
-
+    # If --no-batch-build is specified, pass batched_build_active=True to
+    # build.case_build so it skips batch submission even when BATCHED_BUILD=TRUE.
     success = True
     with Case(caseroot, read_only=False, record=True) as case:
         testname = case.get_value("TESTCASE")
@@ -283,6 +280,7 @@ def _main_func(description):
                 dry_run=dry_run,
                 separate_builds=separate_builds,
                 skip_submit=skip_submit,
+                batched_build_active=no_batch_build,
             )
 
         else:
@@ -296,6 +294,7 @@ def _main_func(description):
                 separate_builds=separate_builds,
                 ninja=ninja,
                 dry_run=dry_run,
+                batched_build_active=no_batch_build,
             )
 
     sys.exit(0 if success else 1)

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -1426,7 +1426,9 @@ class EnvBatch(EnvBase):
     def cancel_job(self, jobid):
         batch_cancel = self._get_batch_system_child("batch_cancel")
         if batch_cancel is None:
-            logger.warning(f"Batch cancellation not supported on platform {self._batchtype}")
+            logger.warning(
+                f"Batch cancellation not supported on platform {self._batchtype}"
+            )
             return False
         else:
             cmd = self.text(batch_cancel) + " " + str(jobid)

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -1389,10 +1389,25 @@ class EnvBatch(EnvBase):
 
         return nodes
 
+    def _get_batch_system_child(self, name):
+        """
+        Find a child element by name, searching within every <batch_system> child.  This is necessary because
+        elements such as batch_query and batch_cancel live inside zero or more
+        <batch_system type="..."> blocks.
+        Returns the last matching node found (consistent with get_value behaviour),
+        or None if no match exists.
+        """
+        node = None
+        for bsnode in self.get_children("batch_system"):
+            cnode = self.get_optional_child(name, root=bsnode)
+            if cnode:
+                node = cnode
+        return node
+
     def get_status(self, jobid):
-        batch_query = self.get_optional_child("batch_query")
+        batch_query = self._get_batch_system_child("batch_query")
         if batch_query is None:
-            logger.warning("Batch queries not supported on this platform")
+            logger.warning(f"Batch queries not supported on platform {self._batchtype}")
         else:
             cmd = self.text(batch_query) + " "
             if self.has(batch_query, "per_job_arg"):
@@ -1409,9 +1424,9 @@ class EnvBatch(EnvBase):
                 return out.strip()
 
     def cancel_job(self, jobid):
-        batch_cancel = self.get_optional_child("batch_cancel")
+        batch_cancel = self._get_batch_system_child("batch_cancel")
         if batch_cancel is None:
-            logger.warning("Batch cancellation not supported on this platform")
+            logger.warning(f"Batch cancellation not supported on platform {self._batchtype}")
             return False
         else:
             cmd = self.text(batch_cancel) + " " + str(jobid)

--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -89,7 +89,7 @@ class EnvBatch(EnvBase):
             bs_nodes = self.get_children("batch_system")
             for bsnode in bs_nodes:
                 cnode = self.get_optional_child(item, attribute, root=bsnode)
-                if cnode:
+                if cnode is not None:
                     node = cnode
         if node:
             value = self.text(node)
@@ -1400,7 +1400,7 @@ class EnvBatch(EnvBase):
         node = None
         for bsnode in self.get_children("batch_system"):
             cnode = self.get_optional_child(name, root=bsnode)
-            if cnode:
+            if cnode is not None:
                 node = cnode
         return node
 

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1169,10 +1169,10 @@ def _submit_build_as_batch(
 
     while True:
         status = env_batch.get_status(jobid)
-        if status is not None:
+        if status is not None and jobid in status:
             job_seen_in_queue = True
             not_seen_count = 0
-            logger.info(
+            logger.debug(
                 "Build job {} in queue (status: {}). Next check in {} s.".format(
                     jobid, status.strip(), poll_interval
                 )
@@ -1184,18 +1184,16 @@ def _submit_build_as_batch(
                 )
                 break
             not_seen_count += 1
-            if not_seen_count >= max_not_seen_before_seen:
-                logger.warning(
-                    "Build job {} not visible in batch queue after {} checks "
-                    "(batch_query may be unavailable). Checking build status "
-                    "directly.".format(jobid, not_seen_count)
-                )
-                break
+            expect(not_seen_count < max_not_seen_before_seen,
+                   "Build job {} not visible in batch queue after {} checks "
+                   "(batch_query may be unavailable). Failing build.".format(jobid, not_seen_count)
+                   )
             logger.debug(
-                "Build job {} not yet visible in queue ({}/{}). Waiting...".format(
-                    jobid, not_seen_count, max_not_seen_before_seen
+                "Build job {} not yet visible in queue ({}/{}). Status output was {}. Waiting...".format(
+                    jobid, not_seen_count, max_not_seen_before_seen, status
                 )
             )
+
         time.sleep(poll_interval)
 
     # Refresh case XML so we see the values written by the batch job.

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1184,10 +1184,13 @@ def _submit_build_as_batch(
                 )
                 break
             not_seen_count += 1
-            expect(not_seen_count < max_not_seen_before_seen,
-                   "Build job {} not visible in batch queue after {} checks "
-                   "(batch_query may be unavailable). Failing build.".format(jobid, not_seen_count)
-                   )
+            expect(
+                not_seen_count < max_not_seen_before_seen,
+                "Build job {} not visible in batch queue after {} checks "
+                "(batch_query may be unavailable). Failing build.".format(
+                    jobid, not_seen_count
+                ),
+            )
             logger.debug(
                 "Build job {} not yet visible in queue ({}/{}). Status output was {}. Waiting...".format(
                     jobid, not_seen_count, max_not_seen_before_seen, status
@@ -1202,17 +1205,20 @@ def _submit_build_as_batch(
     build_status = case.get_value("BUILD_STATUS")
 
     if sharedlib_only:
-        expect(build_status == 0,
-               "Batched sharedlib build failed (BUILD_STATUS={}).".format(
-                   build_complete, build_status
-               ))
+        expect(
+            build_status == 0,
+            "Batched sharedlib build failed (BUILD_STATUS={}).".format(build_status),
+        )
     else:
-        expect(build_complete and build_status == 0,
-               "Batched build failed (BUILD_COMPLETE={}, BUILD_STATUS={}).".format(
-                   build_complete, build_status
-               ))
+        expect(
+            build_complete and build_status == 0,
+            "Batched build failed (BUILD_COMPLETE={}, BUILD_STATUS={}).".format(
+                build_complete, build_status
+            ),
+        )
 
     logger.info("Batched build completed successfully.")
+
 
 ###############################################################################
 def _case_build_impl(

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1085,10 +1085,10 @@ def _clean_impl(case, cleanlist, clean_all, clean_depends):
     unlock_file("env_build.xml", case.get_value("CASEROOT"))
 
     # reset following values in xml files
-    case.set_value("SMP_BUILD", str(0))
-    case.set_value("NINST_BUILD", str(0))
-    case.set_value("BUILD_STATUS", str(0))
-    case.set_value("BUILD_COMPLETE", "FALSE")
+    case.set_value("SMP_BUILD", 0)
+    case.set_value("NINST_BUILD", 0)
+    case.set_value("BUILD_STATUS", 0)
+    case.set_value("BUILD_COMPLETE", False)
     case.flush()
 
 
@@ -1211,7 +1211,7 @@ def _submit_build_as_batch(
     build_complete = case.get_value("BUILD_COMPLETE")
     build_status = case.get_value("BUILD_STATUS")
 
-    if build_complete and str(build_status) == "0":
+    if build_complete and build_status == 0:
         logger.info("Batched build completed successfully.")
         return True
     else:
@@ -1386,60 +1386,67 @@ def _case_build_impl(
             buildlist,
         )
 
-        if not model_only:
-            logs = _build_libraries(
-                case,
-                exeroot,
-                sharedpath,
-                caseroot,
-                cimeroot,
-                libroot,
-                lid,
-                compiler,
-                buildlist,
-                comp_interface,
-                complist,
-            )
-
-        if not sharedlib_only:
-            if config.build_model_use_cmake:
-                logs.extend(
-                    _build_model_cmake(
-                        exeroot,
-                        complist,
-                        lid,
-                        buildlist,
-                        comp_interface,
-                        sharedpath,
-                        separate_builds,
-                        ninja,
-                        dry_run,
-                        case,
-                    )
-                )
-            else:
-                os.environ["INSTALL_SHAREDPATH"] = os.path.join(
-                    exeroot, sharedpath
-                )  # for MPAS makefile generators
-                logs.extend(
-                    _build_model(
-                        build_threaded,
-                        exeroot,
-                        incroot,
-                        complist,
-                        lid,
-                        caseroot,
-                        cimeroot,
-                        compiler,
-                        buildlist,
-                        comp_interface,
-                    )
+        try:
+            if not model_only:
+                logs = _build_libraries(
+                    case,
+                    exeroot,
+                    sharedpath,
+                    caseroot,
+                    cimeroot,
+                    libroot,
+                    lid,
+                    compiler,
+                    buildlist,
+                    comp_interface,
+                    complist,
                 )
 
-            if not buildlist:
-                # in case component build scripts updated the xml files, update the case object
-                case.read_xml()
-                # Note, doing buildlists will never result in the system thinking the build is complete
+            if not sharedlib_only:
+                if config.build_model_use_cmake:
+                    logs.extend(
+                        _build_model_cmake(
+                            exeroot,
+                            complist,
+                            lid,
+                            buildlist,
+                            comp_interface,
+                            sharedpath,
+                            separate_builds,
+                            ninja,
+                            dry_run,
+                            case,
+                        )
+                    )
+                else:
+                    os.environ["INSTALL_SHAREDPATH"] = os.path.join(
+                        exeroot, sharedpath
+                    )  # for MPAS makefile generators
+                    logs.extend(
+                        _build_model(
+                            build_threaded,
+                            exeroot,
+                            incroot,
+                            complist,
+                            lid,
+                            caseroot,
+                            cimeroot,
+                            compiler,
+                            buildlist,
+                            comp_interface,
+                        )
+                    )
+
+                if not buildlist:
+                    # in case component build scripts updated the xml files, update the case object
+                    case.read_xml()
+                    # Note, doing buildlists will never result in the system thinking the build is complete
+
+        except Exception:
+            case.set_value("BUILD_STATUS", 1)
+            case.set_value("BUILD_COMPLETE", False)
+            case.flush()
+            raise
 
     post_build(
         case,

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1141,6 +1141,8 @@ def _submit_build_as_batch(
         "(args: {})".format(os.environ["ARGS_FOR_SCRIPT"])
     )
 
+    case.flush()
+
     try:
         depid = env_batch.submit_jobs(
             case,

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1115,10 +1115,20 @@ def _submit_build_as_batch(
             "BATCHED_BUILD is TRUE but BATCH_SYSTEM is '{}'. "
             "Falling back to interactive build.".format(batch_system)
         )
-        return None  # caller will proceed with regular build
+        return _case_build_impl(
+            caseroot,
+            case,
+            sharedlib_only,
+            model_only,
+            buildlist,
+            save_build_provenance,
+            separate_builds,
+            ninja,
+            dry_run=False,
+        )
 
     # Build the argument string that the batch script will receive via ARGS_FOR_SCRIPT.
-    args = []
+    args = ["--no-batch-build"]
     if sharedlib_only:
         args.append("--sharedlib-only")
     if model_only:
@@ -1169,6 +1179,9 @@ def _submit_build_as_batch(
 
     while True:
         status = env_batch.get_status(jobid)
+        # This is tricky as sometimes a status is returned even if the job was completed
+        # a while ago, this is why we check that jobid is also in status. This may not be
+        # portable across batch systems other than slurm.
         if status is not None and jobid in status:
             job_seen_in_queue = True
             not_seen_count = 0
@@ -1218,6 +1231,7 @@ def _submit_build_as_batch(
         )
 
     logger.info("Batched build completed successfully.")
+    return True
 
 
 ###############################################################################

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1085,8 +1085,8 @@ def _clean_impl(case, cleanlist, clean_all, clean_depends):
     unlock_file("env_build.xml", case.get_value("CASEROOT"))
 
     # reset following values in xml files
-    case.set_value("SMP_BUILD", 0)
-    case.set_value("NINST_BUILD", 0)
+    case.set_value("SMP_BUILD", "0")
+    case.set_value("NINST_BUILD", "0")
     case.set_value("BUILD_STATUS", 0)
     case.set_value("BUILD_COMPLETE", False)
     case.flush()

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1093,6 +1093,135 @@ def _clean_impl(case, cleanlist, clean_all, clean_depends):
 
 
 ###############################################################################
+def _submit_build_as_batch(
+    caseroot,
+    case,
+    sharedlib_only,
+    model_only,
+    buildlist,
+    save_build_provenance,
+    separate_builds,
+    ninja,
+):
+    ###############################################################################
+    """
+    Submit the build as a batch job when BATCHED_BUILD=TRUE.
+    Constructs the argument list, submits the .case.build batch script via the
+    batch system, polls for job completion, and returns the build success status.
+    """
+    batch_system = case.get_value("BATCH_SYSTEM")
+    if batch_system is None or batch_system == "none":
+        logger.warning(
+            "BATCHED_BUILD is TRUE but BATCH_SYSTEM is '{}'. "
+            "Falling back to interactive build.".format(batch_system)
+        )
+        return None  # caller will proceed with regular build
+
+    # Build the argument string that the batch script will receive via ARGS_FOR_SCRIPT.
+    # --no-batch-build is always included to prevent re-submission inside the batch job.
+    args = ["--no-batch-build"]
+    if sharedlib_only:
+        args.append("--sharedlib-only")
+    if model_only:
+        args.append("--model-only")
+    if not save_build_provenance:
+        args.append("--skip-provenance-check")
+    if separate_builds:
+        args.append("--separate-builds")
+    if ninja:
+        args.append("--ninja")
+    if buildlist:
+        args.extend(["--build"] + list(buildlist))
+
+    os.environ["ARGS_FOR_SCRIPT"] = " ".join(args)
+
+    env_batch = case.get_env("batch")
+
+    logger.info(
+        "BATCHED_BUILD is TRUE: submitting build as batch job "
+        "(args: {})".format(os.environ["ARGS_FOR_SCRIPT"])
+    )
+
+    try:
+        depid = env_batch.submit_jobs(
+            case,
+            job="case.build",
+            no_batch=False,
+            workflow=False,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            "Failed to submit batch build job: {}".format(str(e))
+        )
+
+    jobid = depid.get("case.build") if depid else None
+    if not jobid:
+        raise RuntimeError(
+            "Batch build job submission did not return a job ID."
+        )
+
+    logger.info(
+        "Build submitted as batch job {}. Polling for completion...".format(jobid)
+    )
+
+    poll_interval = 30
+    # Allow up to 10 consecutive "not found" checks before the job appears in
+    # the queue (covers scheduling delay and systems where batch_query is not
+    # supported or returns non-zero for newly submitted jobs).
+    job_seen_in_queue = False
+    not_seen_count = 0
+    max_not_seen_before_seen = 10
+
+    time.sleep(5)  # short initial wait before first query
+
+    while True:
+        status = env_batch.get_status(jobid)
+        if status is not None:
+            job_seen_in_queue = True
+            not_seen_count = 0
+            logger.info(
+                "Build job {} in queue (status: {}). Next check in {} s.".format(
+                    jobid, status.strip(), poll_interval
+                )
+            )
+        else:
+            if job_seen_in_queue:
+                logger.info(
+                    "Build job {} no longer in queue. Build has finished.".format(jobid)
+                )
+                break
+            not_seen_count += 1
+            if not_seen_count >= max_not_seen_before_seen:
+                logger.warning(
+                    "Build job {} not visible in batch queue after {} checks "
+                    "(batch_query may be unavailable). Checking build status "
+                    "directly.".format(jobid, not_seen_count)
+                )
+                break
+            logger.debug(
+                "Build job {} not yet visible in queue ({}/{}). Waiting...".format(
+                    jobid, not_seen_count, max_not_seen_before_seen
+                )
+            )
+        time.sleep(poll_interval)
+
+    # Refresh case XML so we see the values written by the batch job.
+    case.read_xml()
+    build_complete = case.get_value("BUILD_COMPLETE")
+    build_status = case.get_value("BUILD_STATUS")
+
+    if build_complete and str(build_status) == "0":
+        logger.info("Batched build completed successfully.")
+        return True
+    else:
+        logger.error(
+            "Batched build failed (BUILD_COMPLETE={}, BUILD_STATUS={}).".format(
+                build_complete, build_status
+            )
+        )
+        return False
+
+###############################################################################
 def _case_build_impl(
     caseroot,
     case,
@@ -1367,6 +1496,27 @@ def case_build(
     dry_run=False,
 ):
     ###############################################################################
+    # When BATCHED_BUILD=TRUE and we are not already inside a batch build job,
+    # submit the build to the batch system instead of building interactively.
+    batched_build = case.get_value("BATCHED_BUILD")
+    batched_build_active = os.environ.get("CIME_BATCHED_BUILD_ACTIVE") == "TRUE"
+
+    if batched_build and not batched_build_active and not dry_run:
+        result = _submit_build_as_batch(
+            caseroot,
+            case,
+            sharedlib_only,
+            model_only,
+            buildlist,
+            save_build_provenance,
+            separate_builds,
+            ninja,
+        )
+        if result is not None:
+            # Batch submission was attempted (success or failure); return immediately.
+            return result
+        # result is None → no batch system available, fall through to interactive build.
+
     functor = lambda: _case_build_impl(
         caseroot,
         case,

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1118,8 +1118,7 @@ def _submit_build_as_batch(
         return None  # caller will proceed with regular build
 
     # Build the argument string that the batch script will receive via ARGS_FOR_SCRIPT.
-    # --no-batch-build is always included to prevent re-submission inside the batch job.
-    args = ["--no-batch-build"]
+    args = []
     if sharedlib_only:
         args.append("--sharedlib-only")
     if model_only:
@@ -1494,12 +1493,12 @@ def case_build(
     separate_builds=False,
     ninja=False,
     dry_run=False,
+    batched_build_active=False,
 ):
     ###############################################################################
     # When BATCHED_BUILD=TRUE and we are not already inside a batch build job,
     # submit the build to the batch system instead of building interactively.
     batched_build = case.get_value("BATCHED_BUILD")
-    batched_build_active = os.environ.get("CIME_BATCHED_BUILD_ACTIVE") == "TRUE"
 
     if batched_build and not batched_build_active and not dry_run:
         result = _submit_build_as_batch(

--- a/CIME/build.py
+++ b/CIME/build.py
@@ -1143,23 +1143,15 @@ def _submit_build_as_batch(
 
     case.flush()
 
-    try:
-        depid = env_batch.submit_jobs(
-            case,
-            job="case.build",
-            no_batch=False,
-            workflow=False,
-        )
-    except Exception as e:
-        raise RuntimeError(
-            "Failed to submit batch build job: {}".format(str(e))
-        )
+    depid = env_batch.submit_jobs(
+        case,
+        job="case.build",
+        no_batch=False,
+        workflow=False,
+    )
 
     jobid = depid.get("case.build") if depid else None
-    if not jobid:
-        raise RuntimeError(
-            "Batch build job submission did not return a job ID."
-        )
+    expect(jobid, "Batch build job submission did not return a job ID.")
 
     logger.info(
         "Build submitted as batch job {}. Polling for completion...".format(jobid)
@@ -1211,16 +1203,18 @@ def _submit_build_as_batch(
     build_complete = case.get_value("BUILD_COMPLETE")
     build_status = case.get_value("BUILD_STATUS")
 
-    if build_complete and build_status == 0:
-        logger.info("Batched build completed successfully.")
-        return True
+    if sharedlib_only:
+        expect(build_status == 0,
+               "Batched sharedlib build failed (BUILD_STATUS={}).".format(
+                   build_complete, build_status
+               ))
     else:
-        logger.error(
-            "Batched build failed (BUILD_COMPLETE={}, BUILD_STATUS={}).".format(
-                build_complete, build_status
-            )
-        )
-        return False
+        expect(build_complete and build_status == 0,
+               "Batched build failed (BUILD_COMPLETE={}, BUILD_STATUS={}).".format(
+                   build_complete, build_status
+               ))
+
+    logger.info("Batched build completed successfully.")
 
 ###############################################################################
 def _case_build_impl(
@@ -1510,7 +1504,7 @@ def case_build(
     batched_build = case.get_value("BATCHED_BUILD")
 
     if batched_build and not batched_build_active and not dry_run:
-        result = _submit_build_as_batch(
+        functor = lambda: _submit_build_as_batch(
             caseroot,
             case,
             sharedlib_only,
@@ -1520,22 +1514,20 @@ def case_build(
             separate_builds,
             ninja,
         )
-        if result is not None:
-            # Batch submission was attempted (success or failure); return immediately.
-            return result
-        # result is None → no batch system available, fall through to interactive build.
 
-    functor = lambda: _case_build_impl(
-        caseroot,
-        case,
-        sharedlib_only,
-        model_only,
-        buildlist,
-        save_build_provenance,
-        separate_builds,
-        ninja,
-        dry_run,
-    )
+    else:
+        functor = lambda: _case_build_impl(
+            caseroot,
+            case,
+            sharedlib_only,
+            model_only,
+            buildlist,
+            save_build_provenance,
+            separate_builds,
+            ninja,
+            dry_run,
+        )
+
     cb = "case.build"
     if sharedlib_only == True:
         cb = cb + " (SHAREDLIB_BUILD)"

--- a/CIME/data/config/xml_schemas/config_machines.xsd
+++ b/CIME/data/config/xml_schemas/config_machines.xsd
@@ -49,6 +49,7 @@
   <xs:element name="PERL5LIB" type="xs:string"/>
   <xs:element name="GMAKE" type="xs:string"/>
   <xs:element name="GMAKE_J" type="xs:integer"/>
+  <xs:element name="BATCHED_BUILD" type="upperBoolean"/>
   <xs:element name="TESTS" type="xs:string"/>
   <xs:element name="NTEST_PARALLEL_JOBS" type="xs:integer"/>
   <xs:element name="BATCH_SYSTEM" type="xs:NCName"/>
@@ -153,6 +154,9 @@
         <xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
         <!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
         <xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
+        <!-- BATCHED_BUILD: if TRUE, case.build will submit the build to the batch system
+             instead of building on the current node. Requires a batch system to be configured. -->
+        <xs:element ref="BATCHED_BUILD" minOccurs="0" maxOccurs="1"/>
         <!-- TESTS: (acme only) list of tests to run on this machine -->
         <xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
         <!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->

--- a/CIME/data/config/xml_schemas/config_machines_template.xml
+++ b/CIME/data/config/xml_schemas/config_machines_template.xml
@@ -72,6 +72,12 @@
     <!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
     <GMAKE_J>8</GMAKE_J>
 
+    <!-- BATCHED_BUILD: optional, if TRUE case.build will submit the build
+      as a batch job instead of building on the current (login) node.
+      Requires a batch system to be configured (BATCH_SYSTEM != none).
+      Default is FALSE. -->
+    <!-- <BATCHED_BUILD>FALSE</BATCHED_BUILD> -->
+
     <!-- BATCH_SYSTEM: batch system used on this machine,
       supported values are: none, cobalt, lsf, pbs, slurm -->
     <BATCH_SYSTEM>none</BATCH_SYSTEM>

--- a/CIME/data/config/xml_schemas/config_machines_version3.xsd
+++ b/CIME/data/config/xml_schemas/config_machines_version3.xsd
@@ -49,6 +49,7 @@
   <xs:element name="PERL5LIB" type="xs:string"/>
   <xs:element name="GMAKE" type="xs:string"/>
   <xs:element name="GMAKE_J" type="xs:integer"/>
+  <xs:element name="BATCHED_BUILD" type="upperBoolean"/>
   <xs:element name="TESTS" type="xs:string"/>
   <xs:element name="NTEST_PARALLEL_JOBS" type="xs:integer"/>
   <xs:element name="BATCH_SYSTEM" type="xs:NCName"/>
@@ -167,6 +168,9 @@
         <xs:element ref="GMAKE" minOccurs="0" maxOccurs="1"/>
         <!-- GMAKE_J: optional number of threads to pass to the gmake flag -->
         <xs:element ref="GMAKE_J" minOccurs="0" maxOccurs="1"/>
+        <!-- BATCHED_BUILD: if TRUE, case.build will submit the build to the batch system
+             instead of building on the current node. Requires a batch system to be configured. -->
+        <xs:element ref="BATCHED_BUILD" minOccurs="0" maxOccurs="1"/>
         <!-- TESTS: (acme only) list of tests to run on this machine -->
         <xs:element ref="TESTS" minOccurs="0" maxOccurs="1"/>
         <!-- NTEST_PARALLEL_JOBS: number of parallel jobs create_test will launch -->

--- a/doc/source/ccs/building-a-case.rst
+++ b/doc/source/ccs/building-a-case.rst
@@ -17,6 +17,8 @@ You do not need to change the default build settings to create the executable, b
 
 Below are some variables that affect the build process and output.
 
+Note: If BATCHED_BUILD is TRUE, some additional requirements must be met in order for builds to be submitted. The host model will need a case.build workflow, a template.case.build file, and driver env XML changes to add BATCHED_BUILD as a known env XML entry.
+
 +------------------+-----------------------------------------------------------+
 | Variable         | Description                                               |
 +==================+===========================================================+
@@ -26,6 +28,8 @@ Below are some variables that affect the build process and output.
 |                  | of optimization flags.                                    |
 +------------------+-----------------------------------------------------------+
 | GMAKE_J          | The number of threads GNU Make should use while building. |
++------------------+-----------------------------------------------------------+
+| BATCHED_BUILD    | Whether to batch submit build phases                      |
 +------------------+-----------------------------------------------------------+
 
 Building the Model

--- a/doc/source/ccs/model-configuration/variables/machine.rst
+++ b/doc/source/ccs/model-configuration/variables/machine.rst
@@ -84,6 +84,7 @@ The following is an example of a version 2.0 ``config_machines.xml`` file. This 
                 <CCSM_CPRNC>/storage/tools/cprnc</CCSM_CPRNC>
                 <GMAKE>make</GMAKE>
                 <GMAKE_J>4</GMAKE_J>
+                <BATCHED_BUILD>FALSE</BATCHED_BUILD>
                 <TESTS>e3sm_developer</TESTS>
                 <BATCH_SYSTEM>none</BATCH_SYSTEM>
                 <SUPPORTED_BY>boutte3@llnl.gov</SUPPORTED_BY>
@@ -146,6 +147,7 @@ CCSM_CPRNC                  Location of the cprnc tool.
 PERL5LIB                    Perl library path.
 GMAKE                       GNU-compatible make tool.
 GMAKE_J                     Number of threads for gmake.
+BATCHED_BUILD               Optional, builds will be done through batch submissions
 TESTS                       List of tests to run on the machine.
 NTEST_PARALLEL_JOBS         Number of parallel jobs for testing.
 BATCH_SYSTEM                Batch system used on the machine.
@@ -348,6 +350,8 @@ Version 3.0
                     <!-- Occurrences min: 0 max: 1-->
                     <GMAKE_J></GMAKE_J>
                     <!-- Occurrences min: 0 max: 1-->
+                    <BATCHED_BUILD></BATCHED_BUILD>
+                    <!-- Occurrences min: 0 max: 1-->
                     <TESTS></TESTS>
                     <!-- Occurrences min: 0 max: 1-->
                     <NTEST_PARALLEL_JOBS></NTEST_PARALLEL_JOBS>
@@ -519,6 +523,8 @@ Version 2.0
                     <GMAKE></GMAKE>
                     <!-- Occurrences min: 0 max: 1-->
                     <GMAKE_J></GMAKE_J>
+                    <!-- Occurrences min: 0 max: 1-->
+                    <BATCHED_BUILD></BATCHED_BUILD>
                     <!-- Occurrences min: 0 max: 1-->
                     <TESTS></TESTS>
                     <!-- Occurrences min: 0 max: 1-->


### PR DESCRIPTION
## Description

We've been having issues with our CIME test suite builds oversubscribing the login nodes on some machines. I believe it's better to do builds on compute nodes if possible.

This feature was tested on mappy with an E3SM branch with the same name as this one and it seemed to work well.

Changes:
1) Main change: adds ability for build.py to do batched builds via `_submit_build_as_batch`.
2) Add batched_build_active / no_batch_build to case.build. This is to avoid an infinite recursion of batch submissions.
3) Add new config_machines optional entry `BATCHED_BUILD` which defaults to False.

Fixes:
1) env_batch had a somewhat serious bug involving get_status and cancel_job where only the last batch_system block was being checked for settings. This meant any settings inherited from the generic batch_system block were ignored.
2) In build_impl, need to ensure that build problems leave the system in a state the reflects the failure of the build (BUILD_COMPLETE should be False and BUILD_STATUS should be something other than zero).

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding additions and changes to the documentation
