### PR TITLE
A couple minor fixes

### DIFF
--- a/CIME/utils.py
+++ b/CIME/utils.py
@@ -175,7 +175,7 @@ def expect(condition, error_msg, exc_type=CIMEError, error_prefix="ERROR:"):
 
             pdb.set_trace()  # pylint: disable=forgotten-debug-statement
 
-        msg = error_prefix + " " + error_msg
+        msg = f"{error_prefix} {error_msg}"
         raise exc_type(msg)
 
 

--- a/CIME/wait_for_tests.py
+++ b/CIME/wait_for_tests.py
@@ -93,7 +93,6 @@ def create_cdash_xml_boiler(
     utc_time,
     current_time,
     hostname,
-    description="",
 ):
     ###############################################################################
     site_elem = xmlet.Element("Site")
@@ -104,8 +103,6 @@ def create_cdash_xml_boiler(
     site_elem.attrib["OSName"] = "Linux"
     site_elem.attrib["Hostname"] = hostname
     site_elem.attrib["OSVersion"] = "Unknown"
-    if description:
-        site_elem.attrib["Description"] = description
 
     phase_elem = xmlet.SubElement(site_elem, phase)
 
@@ -126,7 +123,6 @@ def create_cdash_config_xml(
     current_time,
     hostname,
     data_rel_path,
-    description="",
 ):
     ###############################################################################
     site_elem, config_elem = create_cdash_xml_boiler(
@@ -136,7 +132,6 @@ def create_cdash_config_xml(
         utc_time,
         current_time,
         hostname,
-        description=description,
     )
 
     xmlet.SubElement(config_elem, "ConfigureCommand").text = "namelists"
@@ -173,7 +168,6 @@ def create_cdash_build_xml(
     current_time,
     hostname,
     data_rel_path,
-    description="",
 ):
     ###############################################################################
     site_elem, build_elem = create_cdash_xml_boiler(
@@ -183,7 +177,6 @@ def create_cdash_build_xml(
         utc_time,
         current_time,
         hostname,
-        description=description,
     )
 
     xmlet.SubElement(build_elem, "ConfigureCommand").text = "case.build"
@@ -222,7 +215,6 @@ def create_cdash_test_xml(
     current_time,
     hostname,
     data_rel_path,
-    description="",
 ):
     ###############################################################################
     site_elem, testing_elem = create_cdash_xml_boiler(
@@ -232,7 +224,6 @@ def create_cdash_test_xml(
         utc_time,
         current_time,
         hostname,
-        description=description,
     )
 
     test_list_elem = xmlet.SubElement(testing_elem, "TestList")
@@ -306,7 +297,6 @@ def create_cdash_xml_fakes(
     current_time,
     hostname,
     data_rel_path,
-    description="",
 ):
     ###############################################################################
 
@@ -318,7 +308,6 @@ def create_cdash_xml_fakes(
         current_time,
         hostname,
         data_rel_path,
-        description=description,
     )
 
     create_cdash_build_xml(
@@ -329,7 +318,6 @@ def create_cdash_xml_fakes(
         current_time,
         hostname,
         data_rel_path,
-        description=description,
     )
 
     create_cdash_test_xml(
@@ -340,7 +328,6 @@ def create_cdash_xml_fakes(
         current_time,
         hostname,
         data_rel_path,
-        description=description,
     )
 
 
@@ -494,8 +481,6 @@ def create_cdash_xml(
     else:
         tmproots = [None, first_result_case, os.getcwd()]
 
-    notes = f"Commit {git_commit}\nTotal testing time {time_info} seconds\n"
-
     # Try multiple tmproots if necessary. The default /tmp will be tried first
     # unless cdash_tmproot was provided. The location of the default can be
     # modified via the TMPDIR environment variable.
@@ -518,7 +503,9 @@ def create_cdash_xml(
 
                 # Make notes file
                 with notes_file.open(mode="w") as notes_fd:
-                    notes_fd.write(notes)
+                    notes_fd.write(
+                        f"Commit {git_commit}\nTotal testing time {time_info} seconds\n"
+                    )
 
                 create_cdash_xml_fakes(
                     results,
@@ -528,7 +515,6 @@ def create_cdash_xml(
                     current_time,
                     hostname,
                     testtime_dir,
-                    description=notes,
                 )
 
                 create_cdash_upload_xml(


### PR DESCRIPTION
## Description

This reverts a PR from a couple months ago that added the build time and sha to the cdash build description (it was already being added to notes). What I did not realize is that this updated the description for all builds, not just the most recent one, so the information was incorrect for all but the most recent build. The notes file does not have this issue, so lets just use that like we were doing before.

Also, a minor upgrade to the widely-used `expect` function. The prior implementation only worked when `error_msg` was a `str`. By using `f"` instead of `+`, `expect` will now work with any stringifiable object.

## Checklist
- [ ] My code follows the style guidelines of this project (black formatting)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
