### PR TITLE
Fuse the build phase for batched builds.

### DIFF
--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -446,7 +446,11 @@ class SystemTestsCommon(object):
 
                 start_time = time.time()
                 try:
-                    if not model_only and not sharedlib_only and phase_name == SHAREDLIB_BUILD_PHASE:
+                    if (
+                        not model_only
+                        and not sharedlib_only
+                        and phase_name == SHAREDLIB_BUILD_PHASE
+                    ):
                         # Fuse!
                         pass
                     else:

--- a/CIME/SystemTests/system_tests_common.py
+++ b/CIME/SystemTests/system_tests_common.py
@@ -446,10 +446,14 @@ class SystemTestsCommon(object):
 
                 start_time = time.time()
                 try:
-                    self.build_phase(
-                        sharedlib_only=(phase_name == SHAREDLIB_BUILD_PHASE),
-                        model_only=(phase_name == MODEL_BUILD_PHASE),
-                    )
+                    if not model_only and not sharedlib_only and phase_name == SHAREDLIB_BUILD_PHASE:
+                        # Fuse!
+                        pass
+                    else:
+                        self.build_phase(
+                            sharedlib_only=sharedlib_only,
+                            model_only=model_only,
+                        )
                 except (
                     BaseException
                 ) as e:  # We want KeyboardInterrupts to generate FAIL status

--- a/CIME/scripts/create_test.py
+++ b/CIME/scripts/create_test.py
@@ -103,6 +103,13 @@ def parse_command_line(args, description):
     )
 
     parser.add_argument(
+        "--no-batch-build",
+        action="store_true",
+        help="Disable batched builds (BATCHED_BUILD) even if the machine enables"
+        "\nthem by default. Builds will run interactively on the login node.",
+    )
+
+    parser.add_argument(
         "--single-exe",
         action="store_true",
         default=False,
@@ -761,6 +768,7 @@ def parse_command_line(args, description):
         args.no_build,
         args.no_setup,
         args.no_batch,
+        args.no_batch_build,
         args.test_root,
         args.baseline_root,
         args.clean,
@@ -924,6 +932,7 @@ def create_test(
     no_build,
     no_setup,
     no_batch,
+    no_batch_build,
     test_root,
     baseline_root,
     clean,
@@ -972,6 +981,7 @@ def create_test(
         no_build=no_build,
         no_setup=no_setup,
         no_batch=no_batch,
+        no_batch_build=no_batch_build,
         test_root=test_root,
         test_id=test_id,
         baseline_root=baseline_root,
@@ -1073,6 +1083,7 @@ def _main_func(description=None):
         no_build,
         no_setup,
         no_batch,
+        no_batch_build,
         test_root,
         baseline_root,
         clean,
@@ -1128,6 +1139,7 @@ def _main_func(description=None):
             no_build,
             no_setup,
             no_batch,
+            no_batch_build,
             test_root,
             baseline_root,
             clean,

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -1057,9 +1057,12 @@ class TestScheduler(object):
         if self._batched_build and not self._config.serialize_sharedlib_builds:
             return True, ""
 
+        cmd = "./case.build --sharedlib-only"
+        if not self._batched_build:
+            cmd += " --no-batch-build"
         return self._shell_cmd_for_phase(
             test,
-            "./case.build --sharedlib-only",
+            cmd,
             SHAREDLIB_BUILD_PHASE,
             from_dir=test_dir,
         )
@@ -1104,8 +1107,11 @@ class TestScheduler(object):
                 test, "./case.build", MODEL_BUILD_PHASE, from_dir=test_dir
             )
 
+        cmd = "./case.build --model-only"
+        if not self._batched_build:
+            cmd += " --no-batch-build"
         return self._shell_cmd_for_phase(
-            test, "./case.build --model-only", MODEL_BUILD_PHASE, from_dir=test_dir
+            test, cmd, MODEL_BUILD_PHASE, from_dir=test_dir
         )
 
     ###########################################################################

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -214,6 +214,7 @@ class TestScheduler(object):
         workflow=None,
         chksum=False,
         force_rebuild=False,
+        no_batch_build=False,
         driver=None,
     ):
         ###########################################################################
@@ -246,6 +247,10 @@ class TestScheduler(object):
         self._machobj = Machines(machine=machine_name)
 
         self._config = Config.instance()
+
+        self._batched_build = self._machobj.get_value("BATCHED_BUILD")
+        if no_batch_build:
+            self._batched_build = False
 
         if self._config.calculate_mode_build_cost:
             # Current build system is unlikely to be able to productively use more than 16 cores
@@ -1045,6 +1050,13 @@ class TestScheduler(object):
                 )
 
         test_dir = self._get_test_dir(test)
+
+        # When BATCHED_BUILD is enabled and sharedlib builds are not serialized,
+        # skip the sharedlib-only step here and fuse it with the model build so
+        # the entire build runs in a single batch job submission.
+        if self._batched_build and not self._config.serialize_sharedlib_builds:
+            return True, ""
+
         return self._shell_cmd_for_phase(
             test,
             "./case.build --sharedlib-only",
@@ -1083,6 +1095,14 @@ class TestScheduler(object):
                 return False, "Cannot use build for test {} because it failed".format(
                     first_test
                 )
+
+        # When BATCHED_BUILD is enabled and sharedlib builds are not serialized,
+        # the sharedlib phase was skipped; run a full build (sharedlib + model)
+        # here in a single batch job submission.
+        if self._batched_build and not self._config.serialize_sharedlib_builds:
+            return self._shell_cmd_for_phase(
+                test, "./case.build", MODEL_BUILD_PHASE, from_dir=test_dir
+            )
 
         return self._shell_cmd_for_phase(
             test, "./case.build --model-only", MODEL_BUILD_PHASE, from_dir=test_dir

--- a/CIME/test_scheduler.py
+++ b/CIME/test_scheduler.py
@@ -1199,7 +1199,7 @@ class TestScheduler(object):
             return 1
         elif phase == MODEL_BUILD_PHASE:
             # Model builds now happen in parallel
-            return self._model_build_cost
+            return 1 if self._batched_build else self._model_build_cost
         else:
             return 1
 

--- a/CIME/tests/test_unit_get_tests.py
+++ b/CIME/tests/test_unit_get_tests.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+"""Unit tests for CIME/get_tests.py.
+
+Tests cover the share field, which accepts a bool (True/False) or a test name
+string that designates which test's build is shared across the group.
+"""
+
+import pytest
+from unittest import mock
+
+import CIME.get_tests as get_tests_module
+from CIME.get_tests import get_test_data, get_build_groups, _short_test_name
+from CIME.utils import CIMEError
+
+
+# ---------------------------------------------------------------------------
+# _short_test_name
+# ---------------------------------------------------------------------------
+
+
+class TestShortTestName:
+    """Tests for the _short_test_name helper."""
+
+    def test_strips_machine_compiler(self):
+        assert _short_test_name("SMS_P2.f19_g16.A.melvin_gnu") == "SMS_P2.f19_g16.A"
+
+    def test_preserves_testmods(self):
+        assert (
+            _short_test_name("SMS_P2.f19_g16.A.melvin_gnu.testmod")
+            == "SMS_P2.f19_g16.A.testmod"
+        )
+
+    def test_preserves_multiple_testmods_segments(self):
+        assert (
+            _short_test_name("ERS.f19_g16.A.melvin_gnu.mod1--mod2")
+            == "ERS.f19_g16.A.mod1--mod2"
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_test_data – share field
+# ---------------------------------------------------------------------------
+
+
+class TestGetTestDataShare:
+    """Tests for the share field returned by get_test_data."""
+
+    def test_share_defaults_to_false_when_absent(self):
+        _, _, share, _, _ = get_test_data("cime_tiny")
+        assert share is False
+
+    def test_share_bool_true(self):
+        _, _, share, _, _ = get_test_data("cime_test_share")
+        assert share is True
+
+    def test_share_string(self):
+        _, _, share, _, _ = get_test_data("cime_test_share3")
+        assert share == "SMS_P8.f45_g37.A"
+
+    def test_share_invalid_type_raises(self):
+        with mock.patch.dict(
+            get_tests_module._ALL_TESTS,
+            {"_invalid_share_suite": {"share": 42, "tests": ("ERS.f19_g16.A",)}},
+        ):
+            with pytest.raises(CIMEError):
+                get_test_data("_invalid_share_suite")
+
+
+# ---------------------------------------------------------------------------
+# get_build_groups – share field behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestGetBuildGroupsShare:
+    """Tests for share-related behaviour in get_build_groups."""
+
+    def test_share_true_first_in_order_is_leader(self):
+        """share=True: first test in input order is the build leader."""
+        tests = [
+            "SMS_P2.f19_g16.A.melvin_gnu",
+            "SMS_P4.f19_g16.A.melvin_gnu",
+        ]
+        groups = get_build_groups(tests)
+        assert len(groups) == 1
+        assert groups[0][0] == "SMS_P2.f19_g16.A.melvin_gnu"
+        assert set(groups[0]) == set(tests)
+
+    def test_share_true_reversed_input_keeps_first_as_leader(self):
+        """share=True: leader is always the first test encountered, regardless of suite order."""
+        tests = [
+            "SMS_P4.f19_g16.A.melvin_gnu",
+            "SMS_P2.f19_g16.A.melvin_gnu",
+        ]
+        groups = get_build_groups(tests)
+        assert groups[0][0] == "SMS_P4.f19_g16.A.melvin_gnu"
+
+    def test_share_string_designated_leader_becomes_first(self):
+        """share=<string>: the named test is placed first in the group."""
+        tests = [
+            "SMS_P2.f45_g37.A.melvin_gnu",
+            "SMS_P4.f45_g37.A.melvin_gnu",
+            "SMS_P8.f45_g37.A.melvin_gnu",
+            "SMS_P16.f45_g37.A.melvin_gnu",
+        ]
+        groups = get_build_groups(tests)
+        assert len(groups) == 1
+        assert groups[0][0] == "SMS_P8.f45_g37.A.melvin_gnu"
+        assert set(groups[0]) == set(tests)
+
+    def test_share_string_leader_at_end_of_input(self):
+        """Designated leader at end of input is still placed first in the group."""
+        tests = [
+            "SMS_P16.f45_g37.A.melvin_gnu",
+            "SMS_P2.f45_g37.A.melvin_gnu",
+            "SMS_P4.f45_g37.A.melvin_gnu",
+            "SMS_P8.f45_g37.A.melvin_gnu",
+        ]
+        groups = get_build_groups(tests)
+        assert len(groups) == 1
+        assert groups[0][0] == "SMS_P8.f45_g37.A.melvin_gnu"
+
+    def test_share_string_leader_at_start_of_input(self):
+        """Designated leader already first in input stays first in the group."""
+        tests = [
+            "SMS_P8.f45_g37.A.melvin_gnu",
+            "SMS_P2.f45_g37.A.melvin_gnu",
+            "SMS_P4.f45_g37.A.melvin_gnu",
+            "SMS_P16.f45_g37.A.melvin_gnu",
+        ]
+        groups = get_build_groups(tests)
+        assert len(groups) == 1
+        assert groups[0][0] == "SMS_P8.f45_g37.A.melvin_gnu"
+
+    def test_no_share_suite_each_test_own_group(self):
+        """Tests not in any share suite each form their own singleton group."""
+        tests = [
+            "TESTRUNSLOWPASS_P1.f19_g16.A.melvin_gnu",
+            "TESTRUNSLOWPASS_P1.ne30_g16.A.melvin_gnu",
+        ]
+        groups = get_build_groups(tests)
+        assert len(groups) == 2
+        assert all(len(g) == 1 for g in groups)
+
+    def test_share_string_designated_leader_missing_raises(self):
+        """If the designated leader is not present in the test list, raise CIMEError."""
+        with mock.patch.dict(
+            get_tests_module._ALL_TESTS,
+            {
+                "_missing_leader_suite": {
+                    "share": "SMS_P99.f19_g16.A",
+                    "tests": ("SMS_P2.f19_g16.A", "SMS_P4.f19_g16.A"),
+                }
+            },
+        ):
+            with pytest.raises(CIMEError):
+                get_build_groups(
+                    [
+                        "SMS_P2.f19_g16.A.melvin_gnu",
+                        "SMS_P4.f19_g16.A.melvin_gnu",
+                    ]
+                )

--- a/CIME/tests/test_unit_test_scheduler.py
+++ b/CIME/tests/test_unit_test_scheduler.py
@@ -73,17 +73,26 @@ class TestSharedlibBuildPhaseFusion:
             from_dir=_TEST_DIR,
         )
 
-    def test_not_bypassed_when_not_batched(self):
-        """When _batched_build is False, run sharedlib-only regardless of serialization."""
+    def test_no_batch_build_flag_appended_when_not_batched(self):
+        """When _batched_build is False, --no-batch-build is appended to prevent
+        case.build from independently submitting a batch job."""
         ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=False)
         ts._sharedlib_build_phase(_TEST_NAME)
 
         ts._shell_cmd_for_phase.assert_called_once_with(
             _TEST_NAME,
-            "./case.build --sharedlib-only",
+            "./case.build --sharedlib-only --no-batch-build",
             SHAREDLIB_BUILD_PHASE,
             from_dir=_TEST_DIR,
         )
+
+    def test_no_batch_build_flag_appended_when_serialized_and_not_batched(self):
+        """--no-batch-build is appended when both serialize=True and batched=False."""
+        ts = _make_scheduler(serialize_sharedlib_builds=True, batched_build=False)
+        ts._sharedlib_build_phase(_TEST_NAME)
+
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--no-batch-build" in cmd
 
     def test_non_first_test_unaffected(self):
         """Non-build-group-leader path is unchanged by the new fusion logic."""
@@ -120,20 +129,29 @@ class TestModelBuildPhaseFusion:
         assert cmd == "./case.build"
 
     def test_model_only_when_serialized(self):
-        """When serialize_sharedlib_builds is True, still use --model-only even if batched."""
+        """When serialize_sharedlib_builds is True, use --model-only (batched=True, no --no-batch-build)."""
         ts = _make_scheduler(serialize_sharedlib_builds=True, batched_build=True)
         ts._model_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
         assert cmd == "./case.build --model-only"
 
-    def test_model_only_when_not_batched(self):
-        """When _batched_build is False, always use --model-only."""
+    def test_no_batch_build_flag_appended_when_not_batched(self):
+        """When _batched_build is False, --no-batch-build is appended to prevent
+        case.build from independently submitting a batch job."""
         ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=False)
         ts._model_build_phase(_TEST_NAME)
 
         cmd = ts._shell_cmd_for_phase.call_args[0][1]
-        assert cmd == "./case.build --model-only"
+        assert cmd == "./case.build --model-only --no-batch-build"
+
+    def test_no_batch_build_flag_appended_when_serialized_and_not_batched(self):
+        """--no-batch-build is appended when both serialize=True and batched=False."""
+        ts = _make_scheduler(serialize_sharedlib_builds=True, batched_build=False)
+        ts._model_build_phase(_TEST_NAME)
+
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert "--no-batch-build" in cmd
 
     def test_full_build_uses_model_build_phase_label(self):
         """The fused call should still be labelled MODEL_BUILD_PHASE."""
@@ -181,20 +199,16 @@ class TestNoBatchBuildFlag:
     """Tests for the no_batch_build=True constructor behaviour."""
 
     def test_no_batch_build_disables_batched_build(self):
-        """no_batch_build=True must set _batched_build to False."""
+        """no_batch_build=True must set _batched_build to False, causing
+        --no-batch-build to be appended to case.build calls."""
         ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=True)
         # Simulate the __init__ logic: no_batch_build overrides _batched_build
         ts._batched_build = False  # as __init__ would do when no_batch_build=True
 
         ts._sharedlib_build_phase(_TEST_NAME)
 
-        # Should NOT be bypassed because _batched_build is now False
-        ts._shell_cmd_for_phase.assert_called_once_with(
-            _TEST_NAME,
-            "./case.build --sharedlib-only",
-            SHAREDLIB_BUILD_PHASE,
-            from_dir=_TEST_DIR,
-        )
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert cmd == "./case.build --sharedlib-only --no-batch-build"
 
     def test_no_batch_build_init_param_sets_attribute(self):
         """TestScheduler.__init__ sets _batched_build=False when no_batch_build=True."""

--- a/CIME/tests/test_unit_test_scheduler.py
+++ b/CIME/tests/test_unit_test_scheduler.py
@@ -179,9 +179,7 @@ class TestModelBuildPhaseFusion:
         with mock.patch("CIME.test_scheduler.post_build") as post_build_mock:
             with mock.patch("CIME.test_scheduler.Case") as MockCase:
                 case_mock = mock.MagicMock()
-                MockCase.return_value.__enter__ = mock.MagicMock(
-                    return_value=case_mock
-                )
+                MockCase.return_value.__enter__ = mock.MagicMock(return_value=case_mock)
                 MockCase.return_value.__exit__ = mock.MagicMock(return_value=False)
                 success, _ = ts._model_build_phase(follower)
 

--- a/CIME/tests/test_unit_test_scheduler.py
+++ b/CIME/tests/test_unit_test_scheduler.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+
+"""Unit tests for phase-fusion logic in TestScheduler.
+
+When BATCHED_BUILD is enabled on a machine AND serialize_sharedlib_builds is
+False on the model config, the sharedlib and model build phases are fused:
+- _sharedlib_build_phase returns (True, "") immediately (no-op).
+- _model_build_phase calls ``./case.build`` (full build) instead of
+  ``./case.build --model-only``, submitting one batch job for both phases.
+
+When either condition is not met the original two-phase behaviour is kept.
+The ``no_batch_build`` constructor flag forces ``_batched_build = False``
+regardless of the machine setting.
+"""
+
+import pytest
+from unittest import mock
+
+from CIME import test_scheduler
+from CIME.test_scheduler import TEST_START
+from CIME.test_status import TEST_PASS_STATUS, SHAREDLIB_BUILD_PHASE
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TEST_NAME = "SMS_P2.f19_g16.A.melvin_gnu"
+_TEST_DIR = "/fake/testroot/{}".format(_TEST_NAME)
+
+
+def _make_scheduler(serialize_sharedlib_builds, batched_build, build_group=None):
+    """Return a bare TestScheduler with only the attributes the build-phase
+    methods need, avoiding the heavy __init__ entirely."""
+    bg = build_group or (_TEST_NAME,)
+    ts = object.__new__(test_scheduler.TestScheduler)
+    ts._build_groups = [bg]
+    ts._tests = {t: (TEST_START, TEST_PASS_STATUS) for t in bg}
+    ts._config = mock.MagicMock()
+    ts._config.serialize_sharedlib_builds = serialize_sharedlib_builds
+    ts._batched_build = batched_build
+    ts._get_test_dir = mock.MagicMock(return_value=_TEST_DIR)
+    ts._shell_cmd_for_phase = mock.MagicMock(return_value=(True, ""))
+    return ts
+
+
+# ---------------------------------------------------------------------------
+# _sharedlib_build_phase
+# ---------------------------------------------------------------------------
+
+
+class TestSharedlibBuildPhaseFusion:
+    """Tests for _sharedlib_build_phase build-leader behaviour."""
+
+    def test_bypassed_when_batched_and_not_serialized(self):
+        """Phase should be skipped (return success) to defer to model build."""
+        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=True)
+        success, msg = ts._sharedlib_build_phase(_TEST_NAME)
+
+        assert success is True
+        assert msg == ""
+        ts._shell_cmd_for_phase.assert_not_called()
+
+    def test_not_bypassed_when_serialized(self):
+        """When serialize_sharedlib_builds is True, run sharedlib-only even if batched."""
+        ts = _make_scheduler(serialize_sharedlib_builds=True, batched_build=True)
+        ts._sharedlib_build_phase(_TEST_NAME)
+
+        ts._shell_cmd_for_phase.assert_called_once_with(
+            _TEST_NAME,
+            "./case.build --sharedlib-only",
+            SHAREDLIB_BUILD_PHASE,
+            from_dir=_TEST_DIR,
+        )
+
+    def test_not_bypassed_when_not_batched(self):
+        """When _batched_build is False, run sharedlib-only regardless of serialization."""
+        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=False)
+        ts._sharedlib_build_phase(_TEST_NAME)
+
+        ts._shell_cmd_for_phase.assert_called_once_with(
+            _TEST_NAME,
+            "./case.build --sharedlib-only",
+            SHAREDLIB_BUILD_PHASE,
+            from_dir=_TEST_DIR,
+        )
+
+    def test_non_first_test_unaffected(self):
+        """Non-build-group-leader path is unchanged by the new fusion logic."""
+        leader = "SMS_P2.f19_g16.A.melvin_gnu"
+        follower = "SMS_P4.f19_g16.A.melvin_gnu"
+        ts = _make_scheduler(
+            serialize_sharedlib_builds=False,
+            batched_build=True,
+            build_group=(leader, follower),
+        )
+        ts._tests[leader] = (SHAREDLIB_BUILD_PHASE, TEST_PASS_STATUS)
+
+        success, msg = ts._sharedlib_build_phase(follower)
+
+        assert success is True
+        ts._shell_cmd_for_phase.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _model_build_phase
+# ---------------------------------------------------------------------------
+
+
+class TestModelBuildPhaseFusion:
+    """Tests for _model_build_phase build-leader behaviour."""
+
+    def test_full_build_when_batched_and_not_serialized(self):
+        """When fused, model build should call ./case.build (no --model-only)."""
+        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=True)
+        ts._model_build_phase(_TEST_NAME)
+
+        ts._shell_cmd_for_phase.assert_called_once()
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert cmd == "./case.build"
+
+    def test_model_only_when_serialized(self):
+        """When serialize_sharedlib_builds is True, still use --model-only even if batched."""
+        ts = _make_scheduler(serialize_sharedlib_builds=True, batched_build=True)
+        ts._model_build_phase(_TEST_NAME)
+
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert cmd == "./case.build --model-only"
+
+    def test_model_only_when_not_batched(self):
+        """When _batched_build is False, always use --model-only."""
+        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=False)
+        ts._model_build_phase(_TEST_NAME)
+
+        cmd = ts._shell_cmd_for_phase.call_args[0][1]
+        assert cmd == "./case.build --model-only"
+
+    def test_full_build_uses_model_build_phase_label(self):
+        """The fused call should still be labelled MODEL_BUILD_PHASE."""
+        from CIME.test_status import MODEL_BUILD_PHASE
+
+        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=True)
+        ts._model_build_phase(_TEST_NAME)
+
+        phase_arg = ts._shell_cmd_for_phase.call_args[0][2]
+        assert phase_arg == MODEL_BUILD_PHASE
+
+    def test_non_first_test_unaffected(self):
+        """Non-build-group-leader uses post_build path; fusion does not apply."""
+        from CIME.test_status import TEST_PASS_STATUS, MODEL_BUILD_PHASE
+
+        leader = "SMS_P2.f19_g16.A.melvin_gnu"
+        follower = "SMS_P4.f19_g16.A.melvin_gnu"
+        ts = _make_scheduler(
+            serialize_sharedlib_builds=False,
+            batched_build=True,
+            build_group=(leader, follower),
+        )
+        ts._tests[leader] = (MODEL_BUILD_PHASE, TEST_PASS_STATUS)
+
+        with mock.patch("CIME.test_scheduler.post_build") as post_build_mock:
+            with mock.patch("CIME.test_scheduler.Case") as MockCase:
+                case_mock = mock.MagicMock()
+                MockCase.return_value.__enter__ = mock.MagicMock(
+                    return_value=case_mock
+                )
+                MockCase.return_value.__exit__ = mock.MagicMock(return_value=False)
+                success, _ = ts._model_build_phase(follower)
+
+        assert success is True
+        post_build_mock.assert_called_once()
+        ts._shell_cmd_for_phase.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# no_batch_build constructor flag
+# ---------------------------------------------------------------------------
+
+
+class TestNoBatchBuildFlag:
+    """Tests for the no_batch_build=True constructor behaviour."""
+
+    def test_no_batch_build_disables_batched_build(self):
+        """no_batch_build=True must set _batched_build to False."""
+        ts = _make_scheduler(serialize_sharedlib_builds=False, batched_build=True)
+        # Simulate the __init__ logic: no_batch_build overrides _batched_build
+        ts._batched_build = False  # as __init__ would do when no_batch_build=True
+
+        ts._sharedlib_build_phase(_TEST_NAME)
+
+        # Should NOT be bypassed because _batched_build is now False
+        ts._shell_cmd_for_phase.assert_called_once_with(
+            _TEST_NAME,
+            "./case.build --sharedlib-only",
+            SHAREDLIB_BUILD_PHASE,
+            from_dir=_TEST_DIR,
+        )
+
+    def test_no_batch_build_init_param_sets_attribute(self):
+        """TestScheduler.__init__ sets _batched_build=False when no_batch_build=True."""
+        # We test the init logic in isolation by checking the attribute assignment
+        # path (lines 250-251 of test_scheduler.py) with a minimal mock.
+        with mock.patch.object(
+            test_scheduler.TestScheduler,
+            "__init__",
+            lambda self, *a, **kw: None,
+        ):
+            ts = test_scheduler.TestScheduler.__new__(test_scheduler.TestScheduler)
+
+        # Replicate exactly what __init__ does for this flag:
+        ts._batched_build = True  # pretend machine says True
+        no_batch_build = True
+        if no_batch_build:
+            ts._batched_build = False
+
+        assert ts._batched_build is False

--- a/CIME/tests/test_unit_test_scheduler.py
+++ b/CIME/tests/test_unit_test_scheduler.py
@@ -13,7 +13,6 @@ The ``no_batch_build`` constructor flag forces ``_batched_build = False``
 regardless of the machine setting.
 """
 
-import pytest
 from unittest import mock
 
 from CIME import test_scheduler


### PR DESCRIPTION
## Description

To reduce the number of jobs going into the batch system when BATCHED_BUILDS is on, we should do a single submission for both the shared and model builds and do them both in this same job.

Other changes:
1) Add no-batch-build flag to create_test to disable batched builds.
2) Make sure the proc cost for builds is 1 when batched builds are on (since there is no cost to the interactive node)
3) Add a test I forgot to add for a recent get_tests PR

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that exercise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
