### PR TITLE
Fix get_ts_synopsis catch-all triggered by bless trailer after PASS

### DIFF
--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -786,13 +786,18 @@ def get_ts_synopsis(comments):
     'ERROR Could not interpret CPRNC output'
     >>> get_ts_synopsis('file1=\nfile2=\n  diff_test: the two files seem to be IDENTICAL \n')
     ''
+    >>> get_ts_synopsis('Comparing hists\nPASS\n  Most recent bless: sha:abc\n')
+    ''
     """
     comments = comments.strip()
 
     if comments == "" or "\n" not in comments:
         return comments
 
-    if comments.endswith("PASS"):
+    # Check if comments indicate a passing comparison
+    # Comments end with "PASS" directly, or have "PASS" on its own line
+    # (the latter happens when bless messages are appended after PASS)
+    if comments.endswith("PASS") or re.search(r"\nPASS\n", comments):
         return ""
 
     # Empty synopsis when files are identicial

--- a/CIME/hist_utils.py
+++ b/CIME/hist_utils.py
@@ -794,10 +794,11 @@ def get_ts_synopsis(comments):
     if comments == "" or "\n" not in comments:
         return comments
 
-    # Check if comments indicate a passing comparison
-    # Comments end with "PASS" directly, or have "PASS" on its own line
-    # (the latter happens when bless messages are appended after PASS)
-    if comments.endswith("PASS") or re.search(r"\nPASS\n", comments):
+    # Comparison passed if a line consisting of exactly "PASS" appears.
+    # _compare_hists writes this token verbatim; any other casing (Pass, pass,
+    # PASSING, ...) is not a status marker and must fall through. The optional
+    # \r tolerates CRLF line endings without weakening the exact-match check.
+    if re.search(r"^PASS\r?$", comments, re.MULTILINE):
         return ""
 
     # Empty synopsis when files are identicial

--- a/CIME/tests/test_unit_hist_utils.py
+++ b/CIME/tests/test_unit_hist_utils.py
@@ -83,3 +83,31 @@ def test_get_ts_synopsis_pass_on_own_line_with_multiple_lines_after():
     """
     comments = "Comparing hists\nPASS\nBless info line 1\nBless info line 2\n"
     assert get_ts_synopsis(comments) == ""
+
+
+def test_get_ts_synopsis_pass_is_case_sensitive_and_exact():
+    """Only the exact token 'PASS' on its own line marks success.
+
+    Variants like 'Pass', 'pass', 'PASSING', or indented '  PASS' must NOT
+    short-circuit to an empty synopsis. _compare_hists is the sole producer
+    of the PASS marker and always writes it verbatim and unindented; anything
+    else falls through to the normal failure-detection logic (and ultimately
+    the catch-all if nothing matches).
+    """
+    catch_all = "ERROR Could not interpret CPRNC output"
+    for variant in ("Pass", "pass", "PASSING", "passed", "  PASS", "PASS extra"):
+        assert (
+            get_ts_synopsis(f"header\n{variant}") == catch_all
+        ), f"variant {variant!r} should not short-circuit"
+
+
+def test_get_ts_synopsis_pass_handles_crlf_line_endings():
+    """PASS on a CRLF-terminated line is still recognized as success.
+
+    In practice _compare_hists writes LF-terminated strings on Unix, but the
+    regex tolerates an optional CR so that comments originating from any
+    platform-normalized source (Windows-edited bless logs, etc.) are not
+    misreported as 'ERROR Could not interpret CPRNC output'.
+    """
+    assert get_ts_synopsis("header\r\nPASS\r\n") == ""
+    assert get_ts_synopsis("header\r\nPASS\r\n  Most recent bless: abc123\r\n") == ""

--- a/CIME/tests/test_unit_hist_utils.py
+++ b/CIME/tests/test_unit_hist_utils.py
@@ -2,6 +2,8 @@ import io
 import unittest
 from unittest import mock
 
+import pytest
+
 from CIME.hist_utils import copy_histfiles, get_ts_synopsis
 from CIME.XML.archive import Archive
 
@@ -85,7 +87,11 @@ def test_get_ts_synopsis_pass_on_own_line_with_multiple_lines_after():
     assert get_ts_synopsis(comments) == ""
 
 
-def test_get_ts_synopsis_pass_is_case_sensitive_and_exact():
+@pytest.mark.parametrize(
+    "variant",
+    ["Pass", "pass", "PASSING", "passed", "  PASS", "PASS extra"],
+)
+def test_get_ts_synopsis_pass_is_case_sensitive_and_exact(variant):
     """Only the exact token 'PASS' on its own line marks success.
 
     Variants like 'Pass', 'pass', 'PASSING', or indented '  PASS' must NOT
@@ -95,10 +101,7 @@ def test_get_ts_synopsis_pass_is_case_sensitive_and_exact():
     the catch-all if nothing matches).
     """
     catch_all = "ERROR Could not interpret CPRNC output"
-    for variant in ("Pass", "pass", "PASSING", "passed", "  PASS", "PASS extra"):
-        assert (
-            get_ts_synopsis(f"header\n{variant}") == catch_all
-        ), f"variant {variant!r} should not short-circuit"
+    assert get_ts_synopsis(f"header\n{variant}") == catch_all
 
 
 def test_get_ts_synopsis_pass_handles_crlf_line_endings():

--- a/CIME/tests/test_unit_hist_utils.py
+++ b/CIME/tests/test_unit_hist_utils.py
@@ -2,7 +2,7 @@ import io
 import unittest
 from unittest import mock
 
-from CIME.hist_utils import copy_histfiles
+from CIME.hist_utils import copy_histfiles, get_ts_synopsis
 from CIME.XML.archive import Archive
 
 
@@ -64,3 +64,22 @@ class TestHistUtils(unittest.TestCase):
             comments, num_copied = copy_histfiles(case, "base")
 
         assert num_copied == 1
+
+
+def test_get_ts_synopsis_pass_at_end():
+    """Comments ending with PASS should return empty string."""
+    assert get_ts_synopsis("stuff\nPASS") == ""
+
+
+def test_get_ts_synopsis_pass_on_own_line_with_multiple_lines_after():
+    """PASS on its own line followed by multiple lines of content.
+
+    Fix for #4932: When baseline comparison passes but additional content
+    (like bless messages) is appended after the PASS line, the synopsis
+    should still be empty.
+
+    Note: Most cases are covered by doctests in hist_utils.py. These tests
+    cover additional edge cases.
+    """
+    comments = "Comparing hists\nPASS\nBless info line 1\nBless info line 2\n"
+    assert get_ts_synopsis(comments) == ""


### PR DESCRIPTION
## Description

Fixes the `master: ERROR Could not interpret CPRNC output` message that has been appearing in `TestStatus.log` for passing baseline comparisons across entire integration suites.

### Root cause

`compare_baseline` (`CIME/hist_utils.py:592-598`) appends a bless trailer after the `PASS` token emitted by `_compare_hists`:

```
Comparing hists for case '...'
  ...matched...
PASS
  Most recent bless: <sha>
```

`get_ts_synopsis` only handled the case where `comments` ended exactly with `"PASS"`, so once any trailer was present the function fell through every recognized pattern and landed on the catch-all `ERROR Could not interpret CPRNC output`.

This became a near-universal symptom after #4952 (`Preserve TestStatus and bless_log`) added `BLESS_LOG_NAME` to the preserve list, so prior bless lines now persist across baseline regeneration and the trailer is appended on essentially every comparison.

### Fix

Replace the brittle `endswith("PASS")` check with a single multiline regex that recognizes the verbatim `PASS` token regardless of where it sits in the comments and tolerates CRLF line endings without weakening the exact-match guarantee:

```python
# Comparison passed if a line consisting of exactly "PASS" appears.
# _compare_hists writes this token verbatim; any other casing (Pass, pass,
# PASSING, ...) is not a status marker and must fall through. The optional
# \r tolerates CRLF line endings without weakening the exact-match check.
if re.search(r"^PASS\r?$", comments, re.MULTILINE):
    return ""
```

### Tests

- New doctest in `get_ts_synopsis` covering the realistic production string `'Comparing hists\nPASS\n  Most recent bless: sha:abc\n'`.
- Four unit tests in `CIME/tests/test_unit_hist_utils.py`:
  - `test_get_ts_synopsis_pass_at_end` — PASS at end-of-string.
  - `test_get_ts_synopsis_pass_on_own_line_with_multiple_lines_after` — PASS followed by a bless trailer.
  - `test_get_ts_synopsis_pass_is_case_sensitive_and_exact` — pins that variants like `Pass`, `pass`, `PASSING`, `passed`, `  PASS`, and `PASS extra` do NOT short-circuit.
  - `test_get_ts_synopsis_pass_handles_crlf_line_endings` — PASS on a CRLF-terminated line is recognized, both standalone and with a bless trailer.
- All hist_utils unit tests + doctests pass locally.

- Closes #4932

## Checklist
- [x] My code follows the style guidelines of this project (black formatting)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that exercise my feature/fix and existing tests continue to pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
