### PR TITLE
Do NOT auto-pass first job

### DIFF
--- a/CIME/XML/env_batch.py
+++ b/CIME/XML/env_batch.py
@@ -816,7 +816,6 @@ class EnvBatch(EnvBase):
 
         startindex = 0
         jobs = []
-        firstjob = job
         if job is not None:
             expect(job in alljobs, "Do not know about batch job {}".format(job))
             startindex = alljobs.index(job)
@@ -830,12 +829,7 @@ class EnvBatch(EnvBase):
                 prereq = self._env_workflow.get_value(
                     "prereq", subgroup=job, resolved=False
                 )
-                if (
-                    external_workflow
-                    or prereq is None
-                    or job == firstjob
-                    or (dry_run and prereq == "$BUILD_COMPLETE")
-                ):
+                if external_workflow or prereq is None or dry_run:
                     prereq = True
                 else:
                     prereq = case.get_resolved_value(prereq)


### PR DESCRIPTION
## Description

Even though this is a small code change, this is a significant change to how CIME works. For reasons I don't understand, we had the first job in the workflow list skip the prereq check. I had no idea why we did this since it's easy to not provide a prereq if you don't want one. This design lead to surprises, like my case.build running at SUBMIT even though I had prereq set to False (since I never want to run it during SUBMIT).

This needs to be merged quickly so I can update E3SM's cime because a lot of stuff is broken there.

CESM folks may want to double-check their workflow XML to make sure this won't break you.


## Checklist
- [ ] My code follows the style guidelines of this project (black formatting)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that exercise my feature/fix and existing tests continue to pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding additions and changes to the documentation
